### PR TITLE
Enforce abstract method param/return types

### DIFF
--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -379,7 +379,9 @@ guessArgumentTypes(core::Context ctx, core::SymbolRef methodSymbol, unique_ptr<c
     return argTypesForBBToPass[cfg->deadBlock()->id];
 }
 
-core::SymbolRef closestOverridenMethod(core::Context ctx, core::SymbolRef enclosingClassSymbol, core::NameRef name) {
+} // namespace
+
+core::SymbolRef SigSuggestion::closestOverridenMethod(core::Context ctx, core::SymbolRef enclosingClassSymbol, core::NameRef name) {
     auto enclosingClass = enclosingClassSymbol.data(ctx);
     ENFORCE(enclosingClass->isClassLinearizationComputed(), "Should have been linearized by resolver");
 
@@ -405,7 +407,7 @@ core::SymbolRef closestOverridenMethod(core::Context ctx, core::SymbolRef enclos
     }
 }
 
-bool parentNeedsOverridable(core::Context ctx, core::SymbolRef childSymbol, core::SymbolRef parentSymbol) {
+bool SigSuggestion::parentNeedsOverridable(core::Context ctx, core::SymbolRef childSymbol, core::SymbolRef parentSymbol) {
     return
         // We're overriding a method...
         parentSymbol.exists() &&
@@ -424,8 +426,6 @@ bool parentNeedsOverridable(core::Context ctx, core::SymbolRef childSymbol, core
         // and is wasn't DSL synthesized (beause we can't change DSL'd sigs)
         !parentSymbol.data(ctx)->isDSLSynthesized();
 }
-
-} // namespace
 
 bool SigSuggestion::maybeSuggestSig(core::Context ctx, core::ErrorBuilder &e, unique_ptr<cfg::CFG> &cfg,
                                     const shared_ptr<core::Type> &methodReturnType, core::TypeConstraint &constr) {

--- a/infer/SigSuggestion.h
+++ b/infer/SigSuggestion.h
@@ -6,6 +6,8 @@
 namespace sorbet::infer {
 class SigSuggestion final {
 public:
+    static core::SymbolRef closestOverridenMethod(core::Context ctx, core::SymbolRef enclosingClassSymbol, core::NameRef name);
+    static bool parentNeedsOverridable(core::Context ctx, core::SymbolRef childSymbol, core::SymbolRef parentSymbol);
     static bool maybeSuggestSig(core::Context ctx, core::ErrorBuilder &e, std::unique_ptr<cfg::CFG> &cfg,
                                 const std::shared_ptr<core::Type> &methodReturnType, core::TypeConstraint &constr);
 };


### PR DESCRIPTION
## Summary

Currently there's [no checks](https://sorbet.run/#module%20Fooable%0A%20%20extend%20T%3A%3AHelpers%0A%20%20interface!%0A%20%20%0A%20%20sig%20%7B%20abstract.returns(String)%20%7D%0A%20%20def%20foo%0A%20%20end%0Aend%0A%0Aclass%20GoodFooable%0A%20%20include%20Fooable%0A%20%20extend%20T%3A%3AHelpers%0A%0A%20%20sig%20%7B%20implementation.returns(String)%20%7D%0A%20%20def%20foo%0A%20%20%20%20'd'%0A%20%20end%0Aend%0A%0Aclass%20BadFooable%0A%20%20include%20Fooable%0A%20%20extend%20T%3A%3AHelpers%0A%20%20%0A%20%20sig%20%7B%20implementation.returns(Symbol)%20%7D%0A%20%20def%20foo%0A%20%20%20%20%3Ad%0A%20%20end%0Aend%0A%0Ad%20%3D%20BadFooable.new%0AT.reveal_type(d.foo)%0A) that an abstract method implementation matches the abstract type signature.

This change implements this by checking:
- The return type of the child method matches or is a subclass of the parent method's return type
- All parent optional arguments remain optional on the child
- The child does not add any new required arguments
- Keyword arguments on the parent exist on the child
- Argument types on the parent match or are subclasses of the child's defined argument types

TODO:
- [ ] Add tests
- [ ] Add new error types?
- [ ] Don't depend on `SigSuggestion` for this?
- [ ] Enforce that `.implementation` is added to abstract method implementation signatures?
- [ ] Optionally roll out to non-abstract method overrides?

This PR is simply an implementation of an idea that would be valuable to us. Not tied to the implementation at all, happy for it to be refactored / replaced with similar functionality.

 ## Reviewers
r? @stripe-internal/ruby-types