### PR TITLE
Start emitting error histograms in prod builds

### DIFF
--- a/common/Counters.h
+++ b/common/Counters.h
@@ -84,6 +84,8 @@ void prodCategoryCounterInc(ConstExprStr category, ConstExprStr counter);
 void prodCategoryCounterAdd(ConstExprStr category, ConstExprStr counter, unsigned long value);
 void histogramInc(ConstExprStr histogram, int key);
 void histogramAdd(ConstExprStr histogram, int key, unsigned long value);
+void prodHistogramInc(ConstExprStr histogram, int key);
+void prodHistogramAdd(ConstExprStr histogram, int key, unsigned long value);
 /* Does not aggregate over measures, instead, reports them separately.
  * Use with care, as it can make us report a LOT of data. */
 void timingAdd(ConstExprStr measure, unsigned long nanos);

--- a/common/Counters_impl.h
+++ b/common/Counters_impl.h
@@ -18,6 +18,7 @@ struct CounterImpl {
     const char *internKey(const char *str);
 
     void histogramAdd(const char *histogram, int key, unsigned long value);
+    void prodHistogramAdd(const char *histogram, int key, unsigned long value);
 
     void categoryCounterAdd(const char *category, const char *counter, unsigned long value);
     void prodCategoryCounterAdd(const char *category, const char *counter, unsigned long value);

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1121,7 +1121,7 @@ bool GlobalState::hadCriticalError() const {
 ErrorBuilder GlobalState::beginError(Loc loc, ErrorClass what) const {
     bool reportForFile = shouldReportErrorOn(loc, what);
     if (reportForFile) {
-        histogramAdd("error", what.code, 1);
+        prodHistogramAdd("error", what.code, 1);
     }
     bool report = (what == errors::Internal::InternalError) || (reportForFile && !this->silenceErrors);
     return ErrorBuilder(*this, report, loc, what);


### PR DESCRIPTION
 ## Summary
In order to get error histograms on prod builds of sorbet, this change adds "prod" versions of `HistogramInc` and `HistogramAdd` methods and uses the prod versions for emitting error metrics.

 ## Reviewers
r? @stripe-internal/ruby-types
