### PR TITLE
Fix string-keyed shape type example

### DIFF
--- a/website/docs/shapes.md
+++ b/website/docs/shapes.md
@@ -8,7 +8,7 @@ title: Shapes
 ```ruby
 {symbol1: Type1, symbol2: Type2}
 
-{'string1': Type1, 'string2': Type2}
+{'string1' => Type1, 'string2' => Type2}
 ```
 
 This creates a fixed hash type (also referred to as a record), which is a hash


### PR DESCRIPTION
The `'foo':` syntax actually still creates a symbol; it's used for quoting symbols that wouldn't tokenize otherwise.

 ## Summary


 ## Reviewers
r? @stripe-internal/ruby-types
