### PR TITLE
Support for defining DSL plugins

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1010,6 +1010,7 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     result->lspTypecheckCount = this->lspTypecheckCount;
     result->suppressed_error_classes = this->suppressed_error_classes;
     result->only_error_classes = this->only_error_classes;
+    result->dslPlugins = this->dslPlugins;
     result->names.reserve(this->names.capacity());
     if (keepId) {
         result->names.resize(this->names.size());
@@ -1155,6 +1156,18 @@ void GlobalState::suppressErrorClass(int code) {
 void GlobalState::onlyShowErrorClass(int code) {
     ENFORCE(suppressed_error_classes.empty());
     only_error_classes.insert(code);
+}
+
+void GlobalState::addDslPlugin(string method, string command) {
+    dslPlugins[method] = command;
+}
+
+optional<string> GlobalState::findDslPlugin(string method) const {
+    UnorderedMap<string, string>::const_iterator found = dslPlugins.find(method);
+    if (found != dslPlugins.end()) {
+        return found->second;
+    }
+    return {};
 }
 
 bool GlobalState::shouldReportErrorOn(Loc loc, ErrorClass what) const {

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -142,6 +142,9 @@ public:
     void suppressErrorClass(int code);
     void onlyShowErrorClass(int code);
 
+    void addDslPlugin(std::string method, std::string command);
+    std::optional<std::string> findDslPlugin(std::string method) const;
+
 private:
     bool shouldReportErrorOn(Loc loc, ErrorClass what) const;
     static constexpr int STRINGS_PAGE_SIZE = 4096;
@@ -155,6 +158,7 @@ private:
     std::vector<std::shared_ptr<File>> files;
     UnorderedSet<int> suppressed_error_classes;
     UnorderedSet<int> only_error_classes;
+    UnorderedMap<std::string, std::string> dslPlugins;
     bool wasModified_ = false;
 
     mutable absl::Mutex annotations_mtx;

--- a/dsl/BUILD
+++ b/dsl/BUILD
@@ -18,7 +18,9 @@ cc_library(
         "//ast",
         "//ast/treemap",
         "//ast/verifier",
+        "//ast/desugar",
         "//common",
         "//core",
+        "//parser",
     ],
 )

--- a/dsl/Plugin.cc
+++ b/dsl/Plugin.cc
@@ -1,0 +1,45 @@
+#include "dsl/Plugin.h"
+#include "ast/Helpers.h"
+#include "ast/ast.h"
+#include "ast/desugar/Desugar.h"
+#include "core/Context.h"
+#include "core/Names.h"
+#include "core/core.h"
+#include "dsl/helpers.h"
+#include "dsl/util.h"
+#include "parser/parser.h"
+#include "absl/strings/str_replace.h"
+
+using namespace std;
+
+string exec(string cmd);
+
+namespace sorbet::dsl {
+
+vector<unique_ptr<ast::Expression>> Plugin::replaceDSL(core::MutableContext ctx, unique_ptr<ast::ClassDef> &classDef, ast::Send *send) {
+    vector<unique_ptr<ast::Expression>> stats;
+
+    auto funName = send->fun.toString(ctx.state);
+    auto command = ctx.state.findDslPlugin(funName);
+
+    if (command) {
+        auto className = classDef->name->loc.source(ctx.state);
+        auto sendSource = send->loc.source(ctx.state);
+        auto cmd = fmt::format(
+            "{} --class \"{}\" --method \"{}\" \"{}\"",
+            *command,
+            absl::StrReplaceAll(className, {{"\"", "\\\""}}),
+            absl::StrReplaceAll(funName, {{"\"", "\\\""}}),
+            absl::StrReplaceAll(sendSource, {{"\"", "\\\""}})
+        );
+        auto output = exec(cmd);
+        core::FileRef file = ctx.state.enterFile(string(send->loc.file().data(ctx.state).path()), output);
+        auto nodes = parser::Parser::run(ctx.state, file);
+        auto ast = ast::desugar::node2Tree(ctx, move(nodes));
+        stats.emplace_back(move(ast));
+    }
+
+    return stats;
+}
+
+}; // namespace sorbet::dsl

--- a/dsl/Plugin.h
+++ b/dsl/Plugin.h
@@ -1,0 +1,16 @@
+#ifndef SORBET_DSL_PLUGIN_H
+#define SORBET_DSL_PLUGIN_H
+#include "ast/ast.h"
+
+namespace sorbet::dsl {
+
+class Plugin final {
+public:
+    static std::vector<std::unique_ptr<ast::Expression>> replaceDSL(core::MutableContext ctx, std::unique_ptr<ast::ClassDef> &classDef, ast::Send *send);
+
+    Plugin() = delete;
+};
+
+} // namespace sorbet::dsl
+
+#endif

--- a/dsl/dsl.cc
+++ b/dsl/dsl.cc
@@ -9,6 +9,7 @@
 #include "dsl/Sinatra.h"
 #include "dsl/Struct.h"
 #include "dsl/attr_reader.h"
+#include "dsl/Plugin.h"
 
 using namespace std;
 
@@ -54,6 +55,13 @@ public:
 
                          // This one is different: it gets an extra prevStat argument.
                          nodes = AttrReader::replaceDSL(ctx, send, prevStat);
+                         if (!nodes.empty()) {
+                             replaceNodes[stat.get()] = std::move(nodes);
+                             return;
+                         }
+
+                         // This one is also different: it gets the classDef.
+                         nodes = Plugin::replaceDSL(ctx, classDef, send);
                          if (!nodes.empty()) {
                              replaceNodes[stat.get()] = std::move(nodes);
                              return;

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -78,6 +78,7 @@ struct Options {
     std::vector<std::string> configatronDirs;
     std::vector<std::string> configatronFiles;
     UnorderedMap<std::string, core::StrictLevel> strictnessOverrides;
+    UnorderedMap<std::string, std::string> dslPlugins;
     std::string storeState = "";
     bool enableCounters = false;
     std::vector<std::string> someCounters;

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -240,6 +240,10 @@ int realmain(int argc, char *argv[]) {
     for (auto code : opts.errorCodeBlackList) {
         gs->suppressErrorClass(code);
     }
+    for (auto &plugin : opts.dslPlugins) {
+        gs->addDslPlugin(plugin.first, plugin.second);
+    }
+
     logger->trace("done building initial global state");
 
     if (opts.runLSP) {


### PR DESCRIPTION
 ## Summary
Currently adding custom DSLs is pretty heavy-weight: one needs to implement DSL support in C++ and re-compile a custom sorbet binary.

This PR implements a plugin system that allows a mapping of DSL methods (e.g. `prop` or `field`) to a binary/script that outputs Ruby code that represents the generated code. This mapping of method->script is defined in a YAML file passed to the `--dsl-plugins` argument.

## Todo
 - We probably don't want to start another process every time we hit a DSL method.
 - Performance. IMO it's desired to allow people to define their DSLs in Ruby, but is it possible to do this in a performant way? I played with embedding https://github.com/mruby/mruby in the Sorbet binary... this could be a workaround, but the syntax is limited compared to MRI.

## Example for `Mongoid::Document.field`:

_Sorbet command_
```
sorbet example.rb --dsl-plugins plugins.yaml
```

_example.rb_
```ruby
# typed: true

class Hello
  field :awesome, type: String
end

Hello.new.awesome
```

_plugins.yaml_
```yaml
field: ./generate_field.rb
```

_generate_field.rb_
```ruby
#!/usr/bin/env ruby

require 'optparse'

options = {}
OptionParser.new do |opts|
  opts.on("-cCLASS", "--class=CLASS", "Class name") { |v| options[:class_name] = v }
  opts.on("-mMETHOD", "--method=METHOD", "Method name") { |v| options[:method_name] = v }
end.parse!

class FieldGenerator
  def initialize(options)
    @options = options
  end

  def field(name, *opts)
    <<~HEREDOC
      def #{name}; end
      def #{name}_before_type_cast; end
      def #{name}=(value); end
      def #{name}?; end
      def #{name}_change; end
      def #{name}_changed?; end
      def #{name}_will_change!; end
      def #{name}_changed_from_default?; end
      def #{name}_was; end
      def reset_#{name}!; end
      def reset_#{name}_to_default!; end
      def #{name}_previously_changed?; end
      def #{name}_previous_change; end
    HEREDOC
  end
end

puts FieldGenerator.new(options).instance_eval(ARGV.first)
```

 ## Reviewers
r? @stripe-internal/ruby-types
