### PR TITLE
Embed MRI Ruby

### DIFF
--- a/main/BUILD
+++ b/main/BUILD
@@ -80,5 +80,6 @@ cc_library(
         "//main/pipeline",
         "//payload/binary",
         "//payload/text",
+        "@ruby",
     ],
 )

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -20,6 +20,7 @@
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "version/version.h"
+#include "ruby.h"
 
 #include <csignal>
 #include <poll.h>
@@ -41,6 +42,18 @@ shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> make_stderr_color_sink() {
 }
 
 shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderr_color_sink = make_stderr_color_sink();
+
+struct RubyVM {
+    RubyVM() {
+        logger->debug("Starting Ruby VM");
+        ruby_init();
+    }
+
+    ~RubyVM() {
+        logger->debug("Stopping Ruby VM");
+        ruby_cleanup(0);
+    }
+};
 
 constexpr string_view GLOBAL_STATE_KEY = "GlobalState"sv;
 
@@ -194,6 +207,9 @@ int realmain(int argc, char *argv[]) {
             logger->trace("Trace logging enabled");
             break;
     }
+
+    // start a Ruby VM
+    RubyVM rubyVM;
 
     {
         string argsConcat(argv[0]);

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -228,3 +228,10 @@ package(default_visibility = ["//visibility:public"])
         remote = "https://github.com/jmillikin/rules_m4",
         commit = "ae19f8df57f680c6dbad4887e162ca17ee97a13e",
     )
+
+    new_git_repository(
+        name = "ruby",
+        remote = "https://github.com/ruby/ruby.git",
+        tag = "v2_4_5",
+        build_file = "//third_party:ruby.BUILD",
+    )

--- a/third_party/ruby.BUILD
+++ b/third_party/ruby.BUILD
@@ -1,0 +1,35 @@
+genrule(
+    name = "ruby_genrule",
+    srcs = glob(["**"]),
+    cmd = """
+            # find autoconf on mac
+            export PATH="/usr/local/bin:$$PATH"
+
+            # copy the ruby source to a temporary directory to prevent concurrent builds causing side-effects
+            DIR=$$(mktemp -d $${TMPDIR-/tmp}/tmp.XXXXXXX)
+            (cd `dirname $(location Makefile.in)` && cp -fRL . $$DIR)
+
+            # configure and compile
+            (cd $$DIR && autoconf && ./configure --with-soname=ruby --without-gmp && make)
+
+            # copy the static lib and generated platform header
+            cp $$DIR/libruby-static.a $(location lib/libruby-static.a)
+            cp $$(find $$DIR/.ext -path "**/ruby/config.h" -print -quit) $(location .ext/include/ruby/config.h)
+    """,
+    outs = ["lib/libruby-static.a", ".ext/include/ruby/config.h"],
+    local = 1,
+)
+
+cc_library(
+    name = "ruby",
+    srcs = [":ruby_genrule"] + glob(["include/**/*.h"]),
+    hdrs = ["include/ruby.h"],
+    includes = ["include", ".ext/include"],
+    linkopts = select({
+        "@com_stripe_ruby_typer//tools/config:linux": ["-lcrypt"],
+        "@com_stripe_ruby_typer//tools/config:darwin": ["-framework CoreFoundation"],
+        "//conditions:default": [],
+    }),
+    linkstatic = 1,
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
 ## Summary
With #172 introducing DSL plugins, we discussed embedding Ruby (MRI) in the Sorbet binary. This PR builds Ruby from source, links to the static Ruby library `libruby-static.a`, and starts and stops a Ruby VM in the `sorbet` main method.

Tested on both Linux and Mac... although it adds an extra 15 minutes to the build.

 ## Reviewers
r? @stripe-internal/ruby-types
