### PR TITLE
Don't use fully_static_link when trying to link dynamically

### DIFF
--- a/main/BUILD
+++ b/main/BUILD
@@ -11,10 +11,6 @@ cc_binary(
     srcs = [
         "main.cc",
     ],
-    features = select({
-        "//tools/config:linkshared": ["fully_static_link"],
-        "//conditions:default": [],
-    }),
     # When changing this, you should also update the REQUIRED_STACK_SIZE variable in common/os/os.cc.
     linkopts = select({
         "//tools/config:darwindbg": [


### PR DESCRIPTION
 ## Summary

~This clause is unnecessary as we set linkstatic below~, also, it was breaking `bazel build //main:sorbet --config sanitize` as that configuration enables `//tools/config:linkshared`, causing bazel to attempt to statically link a binary, which is not officially supported on MacOS. (It fails with `ld: library not found for -lcrt0.o`) 

EDIT: actually, `fully_static_link` isn't the same as linkstatic=True, but we weren't using it anyways since `//tools/config:linkshared` is defined as https://github.com/stripe/sorbet/blob/d3f055faf625de442c656924da49bcb1193e45cf/tools/config/BUILD#L42-L49
which means it is only turned on for Darwin

 ## Reviewers
r? @stripe-internal/ruby-types
