### PR TITLE
Fill progress bar when ProgressIndicators exit

### DIFF
--- a/main/pipeline/ProgressIndicator.cc
+++ b/main/pipeline/ProgressIndicator.cc
@@ -15,6 +15,7 @@ void ProgressIndicator::reportProgress(int current) {
 
 ProgressIndicator::~ProgressIndicator() {
     if (enabled) {
+        progressbar_update(progress.get(), progressExpected);
         progressbar_finish(progress.release());
     }
 }


### PR DESCRIPTION
Before:

```
#> sorbetdev -P -e ''
👋 Hey there! Heads up that this is not a release build of sorbet.
Release builds are faster and more well-supported by the Sorbet team.
Check out the README to learn how to build Sorbet in release mode.
To forcibly silence this error, either pass --silence-dev-message,
or set SORBET_SILENCE_DEV_MESSAGE=1 in your shell environment.

Naming |=========================================================| ETA: 0h00m00s
Resolving |                                                      | ETA: 0h00m00s
CFG+Inference |==================================================| ETA: 0h00m00s
No errors! Great job.
```

After:

```
👋 Hey there! Heads up that this is not a release build of sorbet.
Release builds are faster and more well-supported by the Sorbet team.
Check out the README to learn how to build Sorbet in release mode.
To forcibly silence this error, either pass --silence-dev-message,
or set SORBET_SILENCE_DEV_MESSAGE=1 in your shell environment.

Naming |=========================================================| ETA: 0h00m00s
Resolving |======================================================| ETA: 0h00m00s
CFG+Inference |==================================================| ETA: 0h00m00s
No errors! Great job.
```

 ## Summary


 ## Reviewers
r? @stripe-internal/ruby-types
