### PR TITLE
Fix various --typed=ruby references

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -213,7 +213,7 @@ cxxopts::Options buildOptions() {
     options.add_options("dev")("error-black-list", "Blacklist of errors to be reported", cxxopts::value<vector<int>>(),
                                "errorCodes");
     options.add_options("dev")("typed", "Force all code to specified strictness level",
-                               cxxopts::value<string>()->default_value("auto"), "{ruby,true,strict,strong,[auto]}");
+                               cxxopts::value<string>()->default_value("auto"), "{false,true,strict,strong,[auto]}");
     options.add_options("dev")("typed-override", "Yaml config that overrides strictness levels on files",
                                cxxopts::value<string>()->default_value(""), "filepath.yaml");
     options.add_options("dev")("store-state", "Store state into file", cxxopts::value<string>()->default_value(""),

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -293,7 +293,7 @@ int realmain(int argc, char *argv[]) {
                 auto file = gs->enterFile(string("-e"), opts.inlineInput + '\n');
                 inputFiles.emplace_back(file);
                 if (opts.forceMaxStrict < core::StrictLevel::Typed) {
-                    logger->error("`-e` is incompatible with `--typed=ruby`");
+                    logger->error("`-e` is incompatible with `--typed=false`");
                     return 1;
                 }
                 file.data(*gs).strictLevel = core::StrictLevel::Typed;

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -79,7 +79,7 @@ Usage:
                                 Whitelist of errors to be reported
       --error-black-list errorCodes
                                 Blacklist of errors to be reported
-      --typed {ruby,true,strict,strong,[auto]}
+      --typed {false,true,strict,strong,[auto]}
                                 Force all code to specified strictness level
                                 (default: auto)
       --typed-override filepath.yaml


### PR DESCRIPTION
 ## Summary

There seems to be a few left-over `--typed=ruby` references, which are not valid anymore. This was especially confusing in the help output.

 ## Reviewers
r? @stripe-internal/ruby-types
