### PR TITLE
 Fix error when using sorbet-runtime with rspec

### DIFF
--- a/gems/sorbet-runtime/lib/sorbet-runtime.rb
+++ b/gems/sorbet-runtime/lib/sorbet-runtime.rb
@@ -96,3 +96,5 @@ require_relative 'types/props/pretty_printable'
 require_relative 'types/props/serializable'
 require_relative 'types/props/type_validation'
 require_relative 'types/struct'
+
+require_relative 'types/compatibility_patches'

--- a/gems/sorbet-runtime/lib/types/compatibility_patches.rb
+++ b/gems/sorbet-runtime/lib/types/compatibility_patches.rb
@@ -1,0 +1,37 @@
+# typed: ignore
+
+require_relative 'private/methods/_methods'
+
+# Work around an interaction bug with sorbet-runtime and rspec-mocks,
+# which occurs when using *_any_instance_of and and_call_original.
+#
+# When a sig is defined, sorbet-runtime will replace the sigged method
+# with a wrapper that, upon first invocation, re-wraps the method with a faster
+# implementation.
+#
+# When expect_any_instance_of is used, rspec stores a reference to the first wrapper,
+# to be restored later.
+#
+# The first wrapper is invoked as part of the test and sorbet-runtime replaces
+# the method definition with the second wrapper.
+#
+# But when mocks are cleaned up, rspec restores back to the first wrapper.
+# Upon subsequent invocations, the first wrapper is called, and sorbet-runtime
+# throws a runtime error, since this is an unexpected state.
+#
+# We work around this by forcing re-wrapping before rspec stores a reference
+# to the method.
+if defined? ::RSpec::Mocks::AnyInstance
+  module T
+    module CompatibilityPatches
+      module RecorderExtensions
+        def observe!(method_name)
+          method = @klass.instance_method(method_name.to_sym)
+          T::Private::Methods.maybe_run_sig_block_for_method(method)
+          super(method_name)
+        end
+      end
+      ::RSpec::Mocks::AnyInstance::Recorder.prepend(RecorderExtensions)
+    end
+  end
+end


### PR DESCRIPTION
Hey folks, I thought I'd throw up a PR that fixes https://github.com/stripe/sorbet/issues/227. 

It feels kind of hacky, but this is how we're currently working around the failure in our own codebase. 

Feedback appreciated! 

 ## Summary

Work around an interaction bug with sorbet-runtime and rspec-mocks,
which occurs when using *_any_instance_of and and_call_original.

When a sig is defined, sorbet-runtime will replace the sigged method
with a wrapper that, upon first invocation, re-wraps the method again with a faster
implementation.

When expect_any_instance_of is used, rspec stores a reference to the first wrapper,
to be restored later.

The first wrapper is invoked as part of the test and sorbet-runtime replaces
the method definition with the second wrapper.

But when mocks are cleaned up, rspec restores back to the first wrapper.
Upon subsequent invocations, the first wrapper is called, and sorbet-runtime
throws a runtime error, since this is an unexpected state.

We work around this by forcing re-wrapping before rspec stores a reference
to the method.

**How has it been tested?**

I tested with a minimal test case: 

```ruby
describe 'sig consistency error' do
  class Foo
    sig { returns(String) }
    def bar
      'hello'
    end
  end

  it 'does not error' do
    expect_any_instance_of(Foo).to receive(:bar).and_call_original
    Foo.new.bar
  end

  it 'should not error' do
    Foo.new.bar # <- Raises RuntimeError without the fix
  end
end
```

 ## Reviewers
r? @stripe-internal/ruby-types