### PR TITLE
Fix crash when --typed-override fails to read YAML file

### DIFF
--- a/test/cli/override-typed-bad/bad-filename.yaml
+++ b/test/cli/override-typed-bad/bad-filename.yaml
@@ -1,0 +1,2 @@
+true:
+  - not a: string

--- a/test/cli/override-typed-bad/bad-list.yaml
+++ b/test/cli/override-typed-bad/bad-list.yaml
@@ -1,0 +1,2 @@
+true:
+  i am: a map

--- a/test/cli/override-typed-bad/bad-strictness.yaml
+++ b/test/cli/override-typed-bad/bad-strictness.yaml
@@ -1,0 +1,2 @@
+not a level:
+  - 'test/cli/override-typed/override-typed.rb'

--- a/test/cli/override-typed-bad/bad-top-level.yaml
+++ b/test/cli/override-typed-bad/bad-top-level.yaml
@@ -1,0 +1,1 @@
+"not a map"

--- a/test/cli/override-typed-bad/override-typed-bad.out
+++ b/test/cli/override-typed-bad/override-typed-bad.out
@@ -11,3 +11,13 @@ test/cli/override-typed-bad/override-typed-bad.rb:2: `String("s")` doesn't match
      2 |1 + "s"
             ^^^
 Errors: 2
+----
+Failed to read strictness override file "file-that-does-not-exist". Does it exist?
+----
+Cannot parse strictness override format. Map is expected on top level.
+----
+Unknown strictness level: `not a level`
+----
+Cannot parse strictness override format. File names should be specified as a sequence.
+----
+Cannot parse strictness override format. Invalid file name.

--- a/test/cli/override-typed-bad/override-typed-bad.sh
+++ b/test/cli/override-typed-bad/override-typed-bad.sh
@@ -1,2 +1,12 @@
 #!/bin/bash
 main/sorbet --silence-dev-message --typed-override=test/cli/override-typed-bad/override-typed-bad.yaml test/cli/override-typed-bad/override-typed-bad.rb 2>&1
+echo ----
+main/sorbet --silence-dev-message --typed-override=file-that-does-not-exist 2>&1 -e ''
+echo ----
+main/sorbet --silence-dev-message --typed-override=test/cli/override-typed-bad/bad-top-level.yaml 2>&1 -e ''
+echo ----
+main/sorbet --silence-dev-message --typed-override=test/cli/override-typed-bad/bad-strictness.yaml 2>&1 -e ''
+echo ----
+main/sorbet --silence-dev-message --typed-override=test/cli/override-typed-bad/bad-list.yaml 2>&1 -e ''
+echo ----
+main/sorbet --silence-dev-message --typed-override=test/cli/override-typed-bad/bad-filename.yaml 2>&1 -e ''


### PR DESCRIPTION
Also add tests.

Note: Current behavior:
```
$ sorbetdev -e '' --typed-override=bad-file
Backtrace:
__cxa_get_exception_ptr (in libc++abi.dylib) + 0
__cxa_get_globals (in libc++abi.dylib) + 0
YAML::LoadFile(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) (in sorbet) (parse.cpp:35)
sorbet::realmain::options::extractStricnessOverrides(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::shared_ptr<spdlog::logger>) (in sorbet) (options.cc:85)
sorbet::realmain::options::readOptions(sorbet::realmain::options::Options&, int, char**, std::__1::shared_ptr<spdlog::logger>) (in sorbet) (options.cc:538)
sorbet::realmain::realmain(int, char**) (in sorbet) (realmain.cc:166)
main (in sorbet) (main.cc:7)
start (in libdyld.dylib) + 1
0x00000004 (in sorbet)

libc++abi.dylib: terminate_handler unexpectedly returned
fish: 'sorbetdev -e '' --typed-overrid…' terminated by signal SIGABRT (Abort)
```

 ## Reviewers
r? @stripe-internal/ruby-types
