### PR TITLE
Show errors from plugin generated code

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -533,7 +533,7 @@ IndexResult indexPluginFiles(IndexResult firstPass, const options::Options &opts
         for (auto result = pluginFileq->try_pop(job); !result.done(); result = pluginFileq->try_pop(job)) {
             if (result.gotItem()) {
                 core::FileRef file = job;
-                decideStrictLevel(*localGs, file, opts);
+                file.data(*localGs).strictLevel = decideStrictLevel(*localGs, file, opts);
                 threadResult.res.trees.emplace_back(indexOne(opts, *localGs, file, kvstore, logger));
             }
         }
@@ -591,7 +591,7 @@ vector<ast::ParsedFile> index(unique_ptr<core::GlobalState> &gs, vector<core::Fi
                 {
                     core::UnfreezeFileTable fileTableAccess(*gs);
                     pluginFileRef = gs->enterFile(pluginFile);
-                    decideStrictLevel(*gs, pluginFileRef, opts);
+                    pluginFileRef.data(*gs).strictLevel = decideStrictLevel(*gs, pluginFileRef, opts);
                 }
                 ret.emplace_back(indexOne(opts, *gs, pluginFileRef, kvstore, logger));
             }

--- a/test/cli/subprocess-plugin/bad_plugin.rb
+++ b/test/cli/subprocess-plugin/bad_plugin.rb
@@ -1,0 +1,1 @@
+puts "end end end end"

--- a/test/cli/subprocess-plugin/bad_plugin.yaml
+++ b/test/cli/subprocess-plugin/bad_plugin.yaml
@@ -1,0 +1,1 @@
+bad: test/cli/subprocess-plugin/bad_plugin.rb

--- a/test/cli/subprocess-plugin/subprocess-plugin.out
+++ b/test/cli/subprocess-plugin/subprocess-plugin.out
@@ -471,3 +471,10 @@ class ::<root> < ::Object () @ (test/cli/subprocess-plugin/multi1.rb:3, https://
     method ::<Class:Something>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi3.rb:3
       argument ::<Class:Something>#<static-init>#<blk><block> @ test/cli/subprocess-plugin/multi3.rb
 
+------ Bad plugin output on single file
+test/cli/subprocess-plugin/trigger_bad_plugin.rb//plugin-generated|0:2: Parse Error: unexpected token: syntax error http://go/e/2001
+     2 |end end end end
+            ^^^
+Errors: 1
+------ Bad plugin output on many files
+test/cli/subprocess-plugin/trigger_bad_plugin.rb//plugin-generated|0:2: Parse Error: unexpected token: syntax error http://go/e/2001

--- a/test/cli/subprocess-plugin/subprocess-plugin.sh
+++ b/test/cli/subprocess-plugin/subprocess-plugin.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 # Check that the subprocess is getting good arguments
 echo ------ Arguments
 main/sorbet --silence-dev-message --dsl-plugins test/cli/subprocess-plugin/echo_argv.yaml --print plugin-generated-code test/cli/subprocess-plugin/permute.rb
@@ -9,3 +7,9 @@ echo ------ Multi file generated code
 main/sorbet --silence-dev-message --dsl-plugins test/cli/subprocess-plugin/multi_empty.yaml --print plugin-generated-code test/cli/subprocess-plugin/multi*.rb
 echo ------ Multi file symbol table
 main/sorbet --silence-dev-message --dsl-plugins test/cli/subprocess-plugin/multi.yaml --print symbol-table test/cli/subprocess-plugin/multi*.rb
+echo ------ Bad plugin output on single file
+# we go through a different code path when there is a small number of files
+main/sorbet --silence-dev-message --dsl-plugins test/cli/subprocess-plugin/bad_plugin.yaml test/cli/subprocess-plugin/trigger_bad_plugin.rb 2>&1
+echo ------ Bad plugin output on many files
+main/sorbet --silence-dev-message --dsl-plugins test/cli/subprocess-plugin/bad_plugin.yaml test/cli/subprocess-plugin/trigger_bad_plugin.rb a b c d e f 2>&1 \
+  | grep 'Parse Error: unexpected token: syntax error'

--- a/test/cli/subprocess-plugin/trigger_bad_plugin.rb
+++ b/test/cli/subprocess-plugin/trigger_bad_plugin.rb
@@ -1,0 +1,6 @@
+class A
+  def self.bad
+  end
+
+  bad
+end


### PR DESCRIPTION
When I changed decideStrictLevel to return a StrictLevel rather
than mutating the file passed to it, I didn't change all the callsites.

This lead to plugin generated files having StrictLevel of None, which
silences a lot of errors, including parse errors. 🙈 

 ## Reviewers
r? @stripe-internal/ruby-types
