### PR TITLE
Make subprocess spawning debuggable

### DIFF
--- a/common/Subprocess.cc
+++ b/common/Subprocess.cc
@@ -68,7 +68,7 @@ optional<string> sorbet::Subprocess::spawn(string executable, vector<string> arg
     }
     FileCloser closeRead(readWrite[0]);
     {
-        FileCloser closeRead(readWrite[1]);
+        FileCloser closeWrite(readWrite[1]);
 
         FileActions fileActions;
         if (!fileActions.initialized()) {
@@ -83,7 +83,6 @@ optional<string> sorbet::Subprocess::spawn(string executable, vector<string> arg
         // close the read end of the pipe
         ret = posix_spawn_file_actions_addclose(fileActions, readWrite[0]);
         if (ret) {
-            close(readWrite[1]);
             return nullopt;
         }
 


### PR DESCRIPTION
I noticed that running subprocess plugins under lldb
is flaky. It turns out that this is due to lldb interrupting
the read syscall, to implement breakpoint and thread monitoring.

See https://sourceware.org/gdb/onlinedocs/gdb/Interrupted-System-Calls.html

 ## Reviewers
r? @stripe-internal/ruby-types
