### PR TITLE
fix error spew

### DIFF
--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -47,7 +47,6 @@ popd
 
 echo "--- releasing stripe.dev/sorbet"
 git fetch origin gh-pages
-git branch -D gh-pages || true
 current_rev=$(git rev-parse HEAD)
 git checkout gh-pages
 tar -xjf _out_/website/website.tar.bz2 .
@@ -73,7 +72,6 @@ rm -rf sorbet-repo
 git clone git@github.com:stripe/sorbet-repo.git
 pushd sorbet-repo
 git fetch origin gh-pages
-git branch -D gh-pages || true
 git checkout gh-pages
 mkdir -p super-secret-private-beta/gems/
 cp -R ../_out_/gems/*.gem super-secret-private-beta/gems/


### PR DESCRIPTION
 ## Summary
I think I would rather this fail loudly if we are in a scenario with already having the branch vs spewing on every build

E.g. https://buildkite.com/sorbet/sorbet/builds/248#ae6604bd-77c6-47e8-a516-060936817e6b

```

From github.com:stripe/sorbet
--
  | * branch              gh-pages   -> FETCH_HEAD
  | error: branch 'gh-pages' not found.


```

 ## Reviewers
r? @stripe-internal/ruby-types
