### PR TITLE
Add missing `extend T::Sig`s in "Abstract Classes and Interfaces" document

### DIFF
--- a/website/docs/abstract.md
+++ b/website/docs/abstract.md
@@ -149,6 +149,7 @@ module A
 
   module ClassMethods
     extend T::Sig
+    extend T::Helpers
     abstract!
 
     sig {abstract.returns(Integer)}


### PR DESCRIPTION
The provided example codes don't work with `T::Helpers`, they work with `T::Sig`, which is what should be used, AFAIK. Let me know if I am mistaken though.

Here is a sample code from the original form of this doc that doesn't work: https://sorbet.run/#module%20Runnable%0A%20%20extend%20T%3A%3AHelpers%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20(1)%0A%20%20interface!%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20(2)%0A%0A%20%20sig%20%7Babstract.params(args%3A%20T%3A%3AArray%5BString%5D).void%7D%20%20%20%23%20(3)%0A%20%20def%20main(args)%3B%20end%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20(4)%0Aend%0A%0A%0Aclass%20HelloWorld%0A%20%20include%20Runnable%0A%0A%20%20sig%20%7Bimplementation.params(args%3A%20T%3A%3AArray%5BString%5D).void%7D%0A%20%20def%20main(args)%0A%20%20%20%20puts%20'Hello%2C%20world!'%0A%20%20end%0Aend



