### PR TITLE
Change codecov configuration

### DIFF
--- a/.buildkite/codecov.yml
+++ b/.buildkite/codecov.yml
@@ -5,7 +5,7 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "70...100"
+  range: "80...100"
 
   status:
     project: off


### PR DESCRIPTION
Based on @jez's feedback.
Review commit by commit.
Though codecov docs indicate that first commit is the default configuration: I don't trust them. We shoudn't have seen the svg image for this default.