### PR TITLE
Don't change mainContainer

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -75,9 +75,6 @@ class Index extends React.Component {
               </div>
             </div>
           </div>
-        </div>
-
-        <div className="mainContainer">
           <Container align="center">
             <GridBlock
               align="center"

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -31,8 +31,7 @@
 }
 
 /* Full bleed overrides */
-.homeContainer,
-.mainContainer {
+.homeContainer {
   background: #4F4397;
   color: #ffffff;
 }
@@ -41,13 +40,11 @@
   color: #ffffff;
 }
 
-.homeContainer .button,
-.mainContainer .button {
+.homeContainer .button {
   border-color: #ffffff;
   color: #ffffff;
 }
 
-.homeContainer a,
-.mainContainer a {
+.homeContainer a {
   color: #B4A8FF;
 }


### PR DESCRIPTION
mainContainer is used both on the home page and the docs pages.
We were accidentally making the main content on all docs pages have a
purple background.



