### PR TITLE
Don't add an include if ancestor_name is the same as class_name

### DIFF
--- a/gems/sorbet/lib/serialize.rb
+++ b/gems/sorbet/lib/serialize.rb
@@ -65,6 +65,7 @@ class Sorbet::Private::Serialize
       break if ancestor == superclass
       ancestor_name = constant_cache.name_by_class(ancestor)
       next unless ancestor_name
+      next if ancestor_name == class_name
       if ancestor.is_a?(Class)
         ret << "  # Skipping `include #{ancestor_name}` because it is a Class\n"
         next


### PR DESCRIPTION
For the `RedCloth` gem, the following is true:

```
(ins)irb(main):002:0> RedCloth::VERSION.ancestors
=> [RedCloth::VERSION]
(ins)irb(main):003:0> RedCloth::VERSION.ancestors[0] == RedCloth::VERSION
=> false
(ins)irb(main):004:0> RedCloth::VERSION.ancestors[0] == RedCloth::VERSION.ancestors[0]
=> false
```

This means that we end up serializing the following:
```
module RedCloth::VERSION
  include ::RedCloth::VERSION
end
```

This then leads to a `Circular dependency` error.