### PR TITLE
Adjust type declarations for URI.join

### DIFF
--- a/rbi/core/uri.rbi
+++ b/rbi/core/uri.rbi
@@ -70,7 +70,7 @@ module URI
     params(
         str: T.any(URI::Generic, String),
     )
-    .returns(URI::HTTP)
+    .returns(URI::Generic)
   end
   def self.join(*str); end
 


### PR DESCRIPTION
I ran into a minor problem with the `URI.join` method whose behavior I validated in ruby 2.4 source code:

* `URI.join` does accept `URI::Generic` arguments
* I adjusted the return type to `URI::Generic`, as it's not guaranteed to return a `URI::HTTP`... it's not ideal, but seems like the better thing to do than mandating HTTP urls everywhere.