### PR TITLE
use real Module methods

### DIFF
--- a/gems/sorbet/lib/gem-generator-tracepoint/tracer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracer.rb
@@ -147,7 +147,7 @@ module Sorbet::Private
 
               singleton = tp.method_id == :singleton_method_added
               receiver = singleton ? tp.self.singleton_class : tp.self
-              methods = receiver.instance_methods(false) + receiver.private_instance_methods(false)
+              methods = Sorbet::Private::RealStdlib.real_instance_methods(receiver, false) + Sorbet::Private::RealStdlib.real_private_instance_methods(receiver, false)
               set = @modules[Sorbet::Private::RealStdlib.real_object_id(receiver)] ||= Set.new
               added = methods.find { |m| !set.include?(m) }
               if added.nil?

--- a/gems/sorbet/lib/real_stdlib.rb
+++ b/gems/sorbet/lib/real_stdlib.rb
@@ -26,4 +26,14 @@ module Sorbet::Private::RealStdlib
     @real_ancestors ||= Module.instance_method(:ancestors)
     @real_ancestors.bind(mod).call
   end
+
+  def self.real_instance_methods(mod, arg)
+    @real_ancestors ||= Module.instance_method(:instance_methods)
+    @real_ancestors.bind(mod).call(arg)
+  end
+
+  def self.real_private_instance_methods(mod, arg)
+    @real_ancestors ||= Module.instance_method(:private_instance_methods)
+    @real_ancestors.bind(mod).call(arg)
+  end
 end


### PR DESCRIPTION
The traceback from tripplebyte implicated this

```

	 8: from /Users/guillaume/.rvm/gems/ruby-2.6.2@bloom/gems/exifr-1.3.3/lib/exifr/tiff.rb:7:in `<main>'
	 7: from /Users/guillaume/.rvm/gems/ruby-2.6.2@bloom/gems/exifr-1.3.3/lib/exifr/tiff.rb:39:in `<module:EXIFR>'
	 6: from /Users/guillaume/.rvm/gems/ruby-2.6.2@bloom/gems/exifr-1.3.3/lib/exifr/tiff.rb:446:in `<class:TIFF>'
	 5: from /Users/guillaume/.rvm/gems/ruby-2.6.2@bloom/gems/sorbet-0.4.3709/lib/gem-generator-tracepoint/tracer.rb:150:in `block in install_tracepoints'
	 4: from /Users/guillaume/.rvm/gems/ruby-2.6.2@bloom/gems/exifr-1.3.3/lib/exifr/tiff.rb:441:in `instance_methods'
	 3: from /Users/guillaume/.rvm/gems/ruby-2.6.2@bloom/gems/bootsnap-1.4.2/lib/bootsnap/load_path_cache/core_ext/active_support.rb:58:in `load_missing_constant'
	 2: from /Users/guillaume/.rvm/gems/ruby-2.6.2@bloom/gems/bootsnap-1.4.2/lib/bootsnap/load_path_cache/core_ext/active_support.rb:79:in `rescue in load_missing_constant'
	 1: from /Users/guillaume/.rvm/gems/ruby-2.6.2@bloom/gems/bootsnap-1.4.2/lib/bootsnap/load_path_cache/core_ext/active_support.rb:8:in `without_bootsnap_cache'
/Users/guillaume/.rvm/gems/ruby-2.6.2@bloom/gems/bootsnap-1.4.2/lib/bootsnap/load_path_cache/core_ext/active_support.rb:79:in `block in load_missing_constant': uninitialized constant IFD (NameError)```
