### PR TITLE
Let plugin subprocess inherit the parent's enviornment

### DIFF
--- a/common/Subprocess.cc
+++ b/common/Subprocess.cc
@@ -10,6 +10,8 @@
 
 using namespace std;
 
+extern char **environ;
+
 namespace {
 class FileCloser {
 public:
@@ -94,7 +96,7 @@ optional<string> sorbet::Subprocess::spawn(string executable, vector<string> arg
         }
         argv.push_back(nullptr);
 
-        ret = posix_spawnp(&childPid, executable.data(), fileActions, nullptr, argv.data(), nullptr);
+        ret = posix_spawnp(&childPid, executable.data(), fileActions, nullptr, argv.data(), environ);
         if (ret) {
             return nullopt;
         }


### PR DESCRIPTION
The main usecase for this is `RUBYOPT`, which can be used
to disable loading rubygems on boot. This gave a hefty
speed boost to type checking our monolith.



