### PR TITLE
add google analytics to sorbet.org

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -90,6 +90,8 @@ const siteConfig = {
     indexName: 'stripe_sorbet',
     algoliaOptions: {} // Optional, if provided by Algolia
   },
+
+  gaTrackingId: 'UA-119877071-2',
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
I now see:
```

<script>
--
  | (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]\|\|function(){
  | (i[r].q=i[r].q\|\|[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
  | m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
  | })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
  |  
  | ga('create', 'UA-119877071-2', 'auto');
  | ga('send', 'pageview');
  | </script>


```