### PR TITLE
use real_is_a more

### DIFF
--- a/gems/sorbet/lib/hidden-definition-finder.rb
+++ b/gems/sorbet/lib/hidden-definition-finder.rb
@@ -286,7 +286,7 @@ class Sorbet::Private::HiddenMethodFinder
       fqn = real_name(my_klass)
       if fqn
         klass_str = String.new
-        klass_str << (my_klass.is_a?(Class) ? "class #{fqn}\n" : "module #{fqn}\n")
+        klass_str << (Sorbet::Private::RealStdlib.real_is_a?(my_klass, Class) ? "class #{fqn}\n" : "module #{fqn}\n")
         klass_str << includes.join("\n")
         klass_str << "\n" unless klass_str.end_with?("\n")
         klass_str << methods.join("\n")

--- a/gems/sorbet/lib/serialize.rb
+++ b/gems/sorbet/lib/serialize.rb
@@ -106,8 +106,8 @@ class Sorbet::Private::Serialize
         ret << "# Failed to load #{class_name}::#{const_sym}\n"
         next
       end
-      # next if !value.is_a?(T::Types::TypeVariable)
-      next if value.is_a?(Module)
+      # next if !Sorbet::Private::RealStdlib.real_is_a?(value, T::Types::TypeVariable)
+      next if Sorbet::Private::RealStdlib.real_is_a?(value, Module)
       next if !comparable?(value)
       [const_sym, value]
     end
@@ -120,7 +120,7 @@ class Sorbet::Private::Serialize
         ret << "# Failed to load #{class_name}::#{const_sym}\n"
         next
       end
-      next if value.is_a?(Module)
+      next if Sorbet::Private::RealStdlib.real_is_a?(value, Module)
       next if !comparable?(value)
       [const_sym, value]
     end
@@ -183,9 +183,9 @@ class Sorbet::Private::Serialize
   end
 
   def comparable?(value)
-    return false if value.is_a?(BigDecimal) && value.nan?
-    return false if value.is_a?(Float) && value.nan?
-    return false if value.is_a?(Complex)
+    return false if Sorbet::Private::RealStdlib.real_is_a?(value, BigDecimal) && value.nan?
+    return false if Sorbet::Private::RealStdlib.real_is_a?(value, Float) && value.nan?
+    return false if Sorbet::Private::RealStdlib.real_is_a?(value, Complex)
     true
   end
 
@@ -213,9 +213,9 @@ class Sorbet::Private::Serialize
   end
 
   def constant(const, value)
-    #if value.is_a?(T::Types::TypeTemplate)
+    #if Sorbet::Private::RealStdlib.real_is_a?(value, T::Types::TypeTemplate)
       #"  #{const} = type_template"
-    #elsif value.is_a?(T::Types::TypeMember)
+    #elsif Sorbet::Private::RealStdlib.real_is_a?(value, T::Types::TypeMember)
       #"  #{const} = type_member"
     #else
       #"  #{const} = ::T.let(nil, ::T.untyped)"


### PR DESCRIPTION
I wanted to audit any other calls we were doing on user's constants. Turns out we were only doing `is_a?` and that isn't too likely to be monkeypatched but better safe than sorry