### PR TITLE
Interpret `null` optional fields as missing for EMacs compatibility.

### DIFF
--- a/main/lsp/tools/generate_lsp_messages.h
+++ b/main/lsp/tools/generate_lsp_messages.h
@@ -678,7 +678,8 @@ public:
     void emitFromJSONValue(fmt::memory_buffer &out, std::string_view from, AssignLambda assign,
                            std::string_view fieldName) {
         // Check for presence of field.
-        fmt::format_to(out, "if ({}) {{\n", from);
+        // N.B.: Treat null fields as missing. Emacs fills in optional fields with `null` values.
+        fmt::format_to(out, "if ({0} && !(*{0})->IsNull()) {{\n", from);
         const std::string innerCPPType = innerType->getCPPType();
         AssignLambda assignOptional = [innerCPPType, assign](fmt::memory_buffer &out, std::string_view from) -> void {
             assign(out, fmt::format("std::make_optional<{}>({})", innerCPPType, from));


### PR DESCRIPTION
## Summary

Interpret `null` optional fields as missing for EMacs compatibility.

cc @asf-stripe 

The EMacs language server support sends `null` values for empty optional fields. This is against the standard. However, since `null` carries no meaningful information from the client, this seems to be a peaceful change to make in the name of compatibility.