### PR TITLE
Update plugin config in a test that was left behind

### DIFF
--- a/test/cli/subprocess-plugin/bad_plugin.yaml
+++ b/test/cli/subprocess-plugin/bad_plugin.yaml
@@ -1,1 +1,2 @@
-bad: test/cli/subprocess-plugin/bad_plugin.rb
+triggers:
+  bad: test/cli/subprocess-plugin/bad_plugin.rb

--- a/test/cli/subprocess-plugin/subprocess-plugin.out
+++ b/test/cli/subprocess-plugin/subprocess-plugin.out
@@ -653,5 +653,9 @@ class ::<root> < ::Object () @ (test/cli/subprocess-plugin/multi1.rb:3, https://
       argument ::<Class:Something>#<static-init>#<blk><block> @ test/cli/subprocess-plugin/multi3.rb
 
 ------ Bad plugin output on single file
-test/cli/subprocess-plugin/bad_plugin.yaml: Required key `triggers` must be a map
+test/cli/subprocess-plugin/trigger_bad_plugin.rb//plugin-generated|0:2: Parse Error: unexpected token: syntax error http://go/e/2001
+     2 |end end end end
+            ^^^
+Errors: 1
 ------ Bad plugin output on many files
+test/cli/subprocess-plugin/trigger_bad_plugin.rb//plugin-generated|0:2: Parse Error: unexpected token: syntax error http://go/e/2001


### PR DESCRIPTION
When putting together #307 I based my branch off of a
version that was really old and did not have this file.

Perhaps we can run CI on a post-merge version of PRs if we
care about preventing this from happening in the future.

Sorry again!



