### PR TITLE
support non-builder sigs

### DIFF
--- a/test/testdata/resolver/non_builder_sig.rb
+++ b/test/testdata/resolver/non_builder_sig.rb
@@ -1,0 +1,10 @@
+# typed: true
+extend T::Sig
+sig do
+  params(x: Integer)
+  returns(Integer)
+end
+def foo(x)
+  x
+end
+foo(3)


### PR DESCRIPTION
There was some discussion about switching to this. The runtime supports it so I think we should support it statically too for option value.