### PR TITLE
Turn log messages about unsupported LSP notifications into debug messages.

### DIFF
--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -123,8 +123,8 @@ LSPResult LSPLoop::processRequestInternal(unique_ptr<core::GlobalState> gs, cons
         if (method == LSPMethod::SorbetError) {
             auto &errorInfo = get<unique_ptr<SorbetErrorParams>>(params);
             if (errorInfo->code == (int)LSPErrorCodes::MethodNotFound) {
-                // Not an error; we just don't care about this notification type.
-                logger->info(errorInfo->message);
+                // Not an error; we just don't care about this notification type (e.g. TextDocumentDidSave).
+                logger->debug(errorInfo->message);
             } else {
                 logger->error(errorInfo->message);
             }


### PR DESCRIPTION
## Summary

Turn log messages about unsupported LSP notifications into debug messages.

As an `info` message, it appears in the VS Code extension's console -- which is confusing, because 1) it's not an error (it's expected), and 2) it's not actionable. 

It's not an error because we only parse the messages we actually do something about, and there are some notifications (like `textDocument/didSave`) that we don't do anything about. It's valid to ignore notifications, as they do not require a response like requests do.

By making it a debug message, it'll appear in debug logs (which are in Splunk) but won't display to the user. It's nice to have this info in debug logs because it tells us which client messages Sorbet is outright ignoring.