### PR TITLE
Change the sidebar entry for "Builtin Generics" to be more skimmable

### DIFF
--- a/website/docs/stdlib-generics.md
+++ b/website/docs/stdlib-generics.md
@@ -1,7 +1,7 @@
 ---
 id: stdlib-generics
-title: Arrays, Hashes and other generics
-sidebar_label: Arrays, Hashes and other generics
+title: Arrays, Hashes, and Generics in the Standard Library
+sidebar_label: Arrays & Hashes
 ---
 
 > TODO: This page is still a fragment. Contributions welcome!


### PR DESCRIPTION
The heading "Builtin Generics" is not reader-friendly, as most people won't think "how do I use built in generics?" but rather "how do I type an Array/Hash/etc."

I was looking to look up what the syntax was for an Array, and scanned the docs sidebar for "array", but couldn't find it.

While it is technically correct that an array is a built-in generic, the reference for Array would be much easier to find if the title in the sidebar was "Arrays, Hashes, Sets" or something else so I don't need to think as hard about what kind of thing the thing is.



