### PR TITLE
Add an issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--
+This issue template is for reporting bugs in the static component of Sorbet.
+If that is not the kind of issue you'd like to make, please delete this template.
+-->
+
+[→ View on sorbet.run](#TODO-replace-this-with-your-sorbet.run-link)
+
+Input:
+
+```ruby
+# TODO in addition to the sorbet.run link, replace this comment with your code
+# (makes it easier to search for issues)
+```
+
+Observed output:
+
+```
+TODO replace this with the output in sorbet.run
+(sorbet.run output changes over time)
+```
+
+Expected behavior:
+
+<!-- TODO briefly explain what the expected behavior should be on this example -->
+
+- - -
+
+<!-- If there is any additional information you'd like to include, include it here. -->
+


### PR DESCRIPTION
Looks like GitHub supports multiple issue templates:

https://github.blog/2018-01-25-multiple-issue-and-pull-request-templates/

but they don't allow you to select one from a dropdown menu. Instead, you have to change the URL to redirect you to the right issue template. It might be nice to have different kinds of issue templates (this one is specific to bugs in the static component of Sorbet which can be reproduced in sorbet.run), but since that's by far the most common kind of issue we make, I think it's fine to make this the default.

In particular, I'd like us to get in the habit of copy / pasting the sorbet.run output (i.e., errors) into the issue, because it makes it easier to know when an issue has been actually fixed, or whether it's gotten worse or better in the mean time.