### PR TITLE
Improve test coverage of uncommon resolve trees

### DIFF
--- a/test/testdata/resolver/resolve_tree_printing.rb
+++ b/test/testdata/resolver/resolve_tree_printing.rb
@@ -1,0 +1,40 @@
+# typed: true
+class A
+  def has_while
+    while 1
+      has_while
+    end
+  end
+
+  def has_constant_with_resolution_scope
+    DOES_NOT_EXIST # error: Unable to resolve constant
+  end
+
+  def has_global_field
+    $S
+  end
+
+  def has_class_field
+    @@f
+  end
+  
+  def has_next
+    loop do
+      next
+    end
+  end
+
+  def has_break
+    loop do
+      break
+    end
+  end
+
+  def has_return
+    return 1
+  end
+
+  def has_cast
+    T.cast(nil, T.nilable(Integer))
+  end
+end

--- a/test/testdata/resolver/resolve_tree_printing.rb.resolve-tree-raw.exp
+++ b/test/testdata/resolver/resolve_tree_printing.rb.resolve-tree-raw.exp
@@ -1,0 +1,211 @@
+InsSeq{
+  stats = [
+    Send{
+      recv = ConstantLit{
+        orig = nullptr
+        symbol = ::Sorbet::Private::Static
+      }
+      fun = <U keep_for_ide>
+      block = nullptr
+      args = [
+        ConstantLit{
+          orig = UnresolvedConstantLit{
+            scope = EmptyTree
+            cnst = <C <U A>>
+          }
+          symbol = ::A
+        }
+      ]
+    }
+    ClassDef{
+      kind = class
+      name = ConstantLit{
+        orig = UnresolvedConstantLit{
+          scope = EmptyTree
+          cnst = <C <U A>>
+        }
+        symbol = ::A
+      }<<C <U A>>>
+      ancestors = [ConstantLit{
+          orig = nullptr
+          symbol = ::<todo sym>
+        }]
+      rhs = [
+        EmptyTree
+
+        EmptyTree
+
+        EmptyTree
+
+        EmptyTree
+
+        EmptyTree
+
+        EmptyTree
+
+        EmptyTree
+
+        EmptyTree
+
+        MethodDef{
+          flags = 0
+          name = <U has_while><<U has_while>>
+          args = [Local{
+              localVariable = <U <blk>>
+            }]
+          rhs = While{
+            cond = Literal{ value = 1 }
+            body = Send{
+              recv = Local{
+                localVariable = <U <self>>
+              }
+              fun = <U has_while>
+              block = nullptr
+              args = [
+              ]
+            }
+          }
+        }
+
+        MethodDef{
+          flags = 0
+          name = <U has_constant_with_resolution_scope><<U has_constant_with_resolution_scope>>
+          args = [Local{
+              localVariable = <U <blk>>
+            }]
+          rhs = ConstantLit{
+            orig = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U DOES_NOT_EXIST>>
+            }
+            symbol = ::Sorbet::Private::Static::StubModule
+            resolutionScope = ::A
+          }
+        }
+
+        MethodDef{
+          flags = 0
+          name = <U has_global_field><<U has_global_field>>
+          args = [Local{
+              localVariable = <U <blk>>
+            }]
+          rhs = Field{
+            symbol = <U $S>
+          }
+        }
+
+        MethodDef{
+          flags = 0
+          name = <U has_class_field><<U has_class_field>>
+          args = [Local{
+              localVariable = <U <blk>>
+            }]
+          rhs = UnresolvedIdent{
+            kind = Class
+            name = <U @@f>
+          }
+        }
+
+        MethodDef{
+          flags = 0
+          name = <U has_next><<U has_next>>
+          args = [Local{
+              localVariable = <U <blk>>
+            }]
+          rhs = Send{
+            recv = Local{
+              localVariable = <U <self>>
+            }
+            fun = <U loop>
+            block = Block {
+              args = [
+              ]
+              body = Next{ expr = EmptyTree }
+            }
+            args = [
+            ]
+          }
+        }
+
+        MethodDef{
+          flags = 0
+          name = <U has_break><<U has_break>>
+          args = [Local{
+              localVariable = <U <blk>>
+            }]
+          rhs = Send{
+            recv = Local{
+              localVariable = <U <self>>
+            }
+            fun = <U loop>
+            block = Block {
+              args = [
+              ]
+              body = Break{ expr = EmptyTree }
+            }
+            args = [
+            ]
+          }
+        }
+
+        MethodDef{
+          flags = 0
+          name = <U has_return><<U has_return>>
+          args = [Local{
+              localVariable = <U <blk>>
+            }]
+          rhs = Return{ expr = Literal{ value = 1 } }
+        }
+
+        MethodDef{
+          flags = 0
+          name = <U has_cast><<U has_cast>>
+          args = [Local{
+              localVariable = <U <blk>>
+            }]
+          rhs = InsSeq{
+            stats = [
+              Send{
+                recv = ConstantLit{
+                  orig = nullptr
+                  symbol = ::Sorbet::Private::Static
+                }
+                fun = <U keep_for_typechecking>
+                block = nullptr
+                args = [
+                  Send{
+                    recv = ConstantLit{
+                      orig = UnresolvedConstantLit{
+                        scope = EmptyTree
+                        cnst = <C <U T>>
+                      }
+                      symbol = ::T
+                    }
+                    fun = <U nilable>
+                    block = nullptr
+                    args = [
+                      ConstantLit{
+                        orig = UnresolvedConstantLit{
+                          scope = EmptyTree
+                          cnst = <C <U Integer>>
+                        }
+                        symbol = ::Integer
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            expr = Cast{
+                cast = <U cast>,
+                arg = Literal{ value = nil }
+                type = Integer | NilClass,
+            }
+
+          }
+        }
+      ]
+    }
+  ],
+  expr = EmptyTree
+}


### PR DESCRIPTION
I'd like most code to run under sanitizer in tests at least once.
This testcase covers more code.