### PR TITLE
Add flag to ignore config file

### DIFF
--- a/main/options/FileFlatMapper.cc
+++ b/main/options/FileFlatMapper.cc
@@ -36,11 +36,14 @@ FileFlatMapper::FileFlatMapper(int &argc, char **&argv, shared_ptr<spdlog::logge
         stringArgs.emplace_back(argv[0]);
     }
 
-    // Look for .sorbet/config before all other args, so that the CLI args can overwrite the config file
-    auto configFilename = "sorbet/config";
-    if (FileOps::exists(configFilename)) {
-        // TODO(jez) Recurse upwards to find file in parent directory
-        readArgsFromFile(logger, configFilename);
+    auto ignoreConfig = argc > 1 && string_view(argv[1]) == "--ignore-config";
+    if (!ignoreConfig) {
+        // Look for .sorbet/config before all other args, so that the CLI args can overwrite the config file
+        auto configFilename = "sorbet/config";
+        if (FileOps::exists(configFilename)) {
+            // TODO(jez) Recurse upwards to find file in parent directory
+            readArgsFromFile(logger, configFilename);
+        }
     }
 
     for (int i = 1; i < argc; i++) {

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -262,6 +262,7 @@ cxxopts::Options buildOptions() {
                                     "error code with this string.",
                                     cxxopts::value<string>()->default_value("https://sorbet.org/docs/error-reference#"),
                                     "url-base");
+    options.add_options("advanced")("ignore-config", "Ignore any options in sorbet/config");
     // Developer options
     options.add_options("dev")("p,print", to_string(all_prints), cxxopts::value<vector<string>>(), "type");
     options.add_options("dev")("stop-after", to_string(all_stop_after),

--- a/test/cli/config-file/config-file.out
+++ b/test/cli/config-file/config-file.out
@@ -4,3 +4,17 @@ config-file.rb:2: Method `+` does not exist on `Symbol` component of `Symbol(:"s
 Errors: 1
 ------------------------------
 No errors! Great job.
+------------------------------
+You must pass either `-e` or at least one folder or ruby file.
+
+Typechecker for Ruby
+Usage:
+  sorbet [OPTION...] <path 1> <path 2> ...
+
+  -e, string     Parse an inline ruby string (default: )
+  -q, --quiet    Silence all non-critical errors
+  -v, --verbose  Verbosity level [0-3]
+  -h,            Show short help
+      --help     Show long help
+      --version  Show version
+

--- a/test/cli/config-file/config-file.sh
+++ b/test/cli/config-file/config-file.sh
@@ -11,3 +11,8 @@ echo ------------------------------
 
 # CLI args override config file args
 "$cwd/main/sorbet" --typed=false 2>&1
+
+echo ------------------------------
+
+# completely ignore config file
+"$cwd/main/sorbet" --ignore-config 2>&1


### PR DESCRIPTION
The only way around this right now is to cd to a different directory or
to move the config file out of the way. I think we should have an option
to opt out of this if people want it. It's also something we can suggest
people do when reproducing issues.

Requesting from @DarkDimius because he has expressed disdain for complex config file features in the past, and I have a hunch he might not like this one.

