### PR TITLE
Check SRB_YES before prompting

### DIFF
--- a/gems/sorbet/bin/srb-rbi
+++ b/gems/sorbet/bin/srb-rbi
@@ -66,23 +66,25 @@ actions:
     #{cyan("# typed: true")}, depending on how many errors were found in that file.)
 
 "
-    STDOUT.write(emojify("❔", "Would you like to continue? [Y/n] "))
-    if STDIN.isatty
-      begin
-        input = Kernel.gets&.strip
-        if input.nil? || (input != '' && input != 'y' && input != 'Y')
+    if ENV['SRB_YES'] != nil
+      puts "SRB_YES set, continuing"
+    else
+      STDOUT.write(emojify("❔", "Would you like to continue? [Y/n] "))
+      if STDIN.isatty && STDOUT.isatty
+        begin
+          input = Kernel.gets&.strip
+          if input.nil? || (input != '' && input != 'y' && input != 'Y')
+            puts "\nAborting"
+            Kernel.exit(1)
+          end
+        rescue Interrupt
           puts "\nAborting"
           Kernel.exit(1)
         end
-      rescue Interrupt
-        puts "\nAborting"
+      else
+        puts "\nNot running interactivly. Set SRB_YES=1 environment variable to proceed"
         Kernel.exit(1)
       end
-    elsif ENV['SRB_YES']
-      puts "\nSRB_YES set, proceeding"
-    else
-      puts "\nNot running interactivly. Set SRB_YES=1 environment variable to proceed"
-      Kernel.exit(1)
     end
 
     # Create sorbet/config file

--- a/gems/sorbet/test/srb-rbi/empty/empty.out
+++ b/gems/sorbet/test/srb-rbi/empty/empty.out
@@ -22,8 +22,7 @@ actions:
 2.  It will add a comment to the top of every file (like # typed: false or
     # typed: true, depending on how many errors were found in that file.)
 
-Would you like to continue? [Y/n] 
-SRB_YES set, proceeding
+SRB_YES set, continuing
 Generating: sorbet/config
 Generating: sorbet/rbi/sorbet-typed/
 Generating: sorbet/rbi/gems/


### PR DESCRIPTION
Motivation is twofold:

- There was a bug, in that we were checking only whether STDIN.isatty,
  not STDIN.isatty && STDOUT.isatty.

  So `srb init > out.log` would hang indefinitely, and have effectively
  hidden the prompt.

- Despite this, I couldn't even set SRB_YES to get past this, because
  it's checked AFTER STDIN.isatty was checked.