### PR TITLE
only print for things not in the pwd

### DIFF
--- a/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
@@ -98,7 +98,7 @@ module Sorbet::Private
         files.each_with_object({}) do |(path, defined), gem_class_defs|
           gem = gem_from_location(path)
           if gem.nil?
-            warn("Can't find gem for #{path}")
+            warn("Can't find gem for #{path}") unless path.start_with?(Dir.pwd)
             next
           end
           next if gem[:gem] == 'ruby'


### PR DESCRIPTION
@jez had this great idea to only print if it is in some weird place and won't be considered by normal sorbet config which has `.` in it