### PR TITLE
Fix broken test after non-rebased PR #419

### DIFF
--- a/test/testdata/parser/complement_literal.rb.ast.exp
+++ b/test/testdata/parser/complement_literal.rb.ast.exp
@@ -1,9 +1,9 @@
-class <emptyTree><<C <U <root>>>> < ()
+class <emptyTree><<C <root>>> < ()
   -11
 
-  <U x> = 10
+  x = 10
 
-  <U x>.<U ~>()
+  x.~()
 
-  1.000000.<U ~>()
+  1.000000.~()
 end


### PR DESCRIPTION
There had been some changes to name printing between #419 passing CI, and being merged to master. This PR fixes the test failure that resulted from it not being rebased first.