### PR TITLE
check deploy isn't broken by PRs

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -44,13 +44,13 @@ steps:
     agents:
       os: linux
   - wait: ~
-  - label: "All tests and builds succeeded"
-    command: .buildkite/all-succeeded.sh
   - label: "Deploy"
     command: .buildkite/publish.sh
     agents:
       os: linux
   - wait: ~
+  - label: "All tests and builds succeeded"
+    command: .buildkite/all-succeeded.sh
   - block: "Run optional code coverage"
   - wait: ~
   - label: "Coverage: sorbet-static on Mac"


### PR DESCRIPTION
Why does it say all builds pass before we try to build all the gems? I would think either we should wait for this, or no-op it on branches. In my PR before I made it not a no-op, so lets wait for it?

Also, I was always confused why the "all good" job ran in parallel with coverage. Just for a nicer UI can I have a wait here?