### PR TITLE
Be quiet about Structs in files without sigil again

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -265,6 +265,7 @@ public:
         auto sig = Send0(loc, Constant(loc, core::Symbols::Sorbet()), core::Names::sig());
         auto sigSend = ast::cast_tree<ast::Send>(sig.get());
         sigSend->block = Block0(loc, std::move(void_));
+        sigSend->flags |= ast::Send::DSL_SYNTHESIZED;
         return sig;
     }
 

--- a/test/cli/forgot-typed/permit-dsl-sig.rb
+++ b/test/cli/forgot-typed/permit-dsl-sig.rb
@@ -1,2 +1,1 @@
-# typed: true
 A = Struct.new(:foo)


### PR DESCRIPTION
6087d01 raced with c95ec83 and broke master. This
tweaks c95ec83 to do what 6087d01 tries to do.