### PR TITLE
lsp jump to untyped

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -922,7 +922,6 @@ const InlinedVector<Loc, 2> &Symbol::locs() const {
 }
 
 void Symbol::addLoc(const core::GlobalState &gs, core::Loc loc) {
-    ENFORCE(ref(gs) != Symbols::untyped());
     if (!loc.file().exists()) {
         return;
     }

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -38,7 +38,7 @@ LSPResult LSPLoop::handleTextDocumentDefinition(unique_ptr<core::GlobalState> gs
                 result.push_back(loc2Location(*gs, defResp->termLoc));
             } else {
                 for (auto &component : resp->getDispatchComponents()) {
-                    if (component.method.exists()) {
+                    if (component.method.exists() && !component.receiver->isUntyped()) {
                         addLocIfExists(*gs, result, component.method.data(*gs)->loc());
                     }
                 }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -385,9 +385,7 @@ public:
             klass->symbol.data(ctx)->setSuperClass(core::Symbols::todo());
         }
 
-        if (klass->symbol != core::Symbols::untyped()) {
-            klass->symbol.data(ctx)->addLoc(ctx, klass->declLoc);
-        }
+        klass->symbol.data(ctx)->addLoc(ctx, klass->declLoc);
         klass->symbol.data(ctx)->singletonClass(ctx); // force singleton class into existence
 
         auto toRemove = remove_if(klass->rhs.begin(), klass->rhs.end(),


### PR DESCRIPTION
Fixes #339: this change ensures that we don't add extra locations for `T.untyped` when the user happens to redefine things that we treat as identical to `untyped` (i.e. `T::Utils::RuntimeProfiled`) appears in the code.