### PR TITLE
make coverage optional

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -50,6 +50,9 @@ steps:
     command: .buildkite/publish.sh
     agents:
       os: linux
+  - wait: ~
+  - block: "Run optional code coverage"
+  - wait: ~
   - label: "Coverage: sorbet-static on Mac"
     command: .buildkite/coverage-static-sanitized.sh
     artifact_paths: _out_/**/*


### PR DESCRIPTION
an alternative to not running code coverage is to just run it when the user wants. This will keep a list of a bajillion jobs "Running" but maybe that is worth it? Maybe we can time them out after a day or something too...