### PR TITLE
delete deps

### DIFF
--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -6,9 +6,6 @@ if [ "schedule" == "${BUILDKITE_SOURCE}" ]; then
 fi
 
 echo "--- setup"
-apt-get update
-apt-get install -yy curl jq
-
 git config --global user.email "sorbet+bot@stripe.com"
 git config --global user.name "Sorbet build farm"
 


### PR DESCRIPTION
do we need these anymore? I don't see any calls to `curl` or `jq` in the job