### PR TITLE
Add comment about bazel clean being needed

### DIFF
--- a/.buildkite/coverage-static-sanitized.sh
+++ b/.buildkite/coverage-static-sanitized.sh
@@ -25,6 +25,7 @@ fi
 
 git checkout .bazelrc
 
+# This clean sidesteps a bug in bazel not re-building correct coverage for cached items
 ./bazel clean
 
 rm -f bazel-*


### PR DESCRIPTION
Maybe this is why coverage reports take so long? No other steps do this, why here?

And if we are actually in a world where we want coverage to not use the cache, we should wipe the cache when it is done since it is now optional