### PR TITLE
Split `OverloadNotAllowed` errors from `InvalidMethodSignature`

### DIFF
--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -43,6 +43,8 @@ constexpr ErrorClass EnumerableParentTypeNotDeclared{5036, StrictLevel::Strict};
 constexpr ErrorClass BadAliasMethod{5037, StrictLevel::Typed};
 constexpr ErrorClass SigInFileWithoutSigil{5038, StrictLevel::Stripe};
 constexpr ErrorClass RevealTypeInUntypedFile{5039, StrictLevel::Stripe};
+
+constexpr ErrorClass OverloadNotAllowed{5040, StrictLevel::Stripe};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -927,7 +927,7 @@ private:
                     if (!lastSigs.empty()) {
                         if (!ctx.permitOverloadDefinitions()) {
                             if (auto e = ctx.state.beginError(lastSigs[0]->loc,
-                                                              core::errors::Resolver::InvalidMethodSignature)) {
+                                                              core::errors::Resolver::OverloadNotAllowed)) {
                                 e.setHeader("Unused type annotation. No method def before next annotation");
                                 e.addErrorLine(send->loc, "Type annotation that will be used instead");
                             }


### PR DESCRIPTION
As suggested by @ptarjan [here](https://github.com/stripe/sorbet/pull/446#issuecomment-491364695):

> 5003 is InvalidMethodSignature which is actually thrown in a ton of places. I think you should cut that one into two errors. The current one and OverloadNotAllowed (or something) and then only allow that one while still forcing the stdlib to have syntactically valid type signatures.

This PR introduce a new kind of error: `OverloadNotAllowed` (`5040`) which is raised when Sorbet find more than one signature for a method. Before this kind of error was mixed in `InvalidMethodSignature` (`5003`).

I attached this error to the `typed: false` level like it was for `InvalidMethodSignature`.

This allows the end user to differentiate between overloads and actually invalid signatures:

```
srb --error-black-list 5040 rbi/ my_file.rb
```

Signed-off-by: Alexandre Terrasa <alexandre.terrasa@shopify.com>



