### PR TITLE
Remove obsolete readme block about PATH for pay-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ If you are at Stripe, you might also want to see:
   - [Set up autogen locally](#set-up-autogen-locally)
   - [Make sure `sorbet` is on your PATH](#make-sure-sorbet-is-on-your-path)
   - [Run `sorbet/scripts/typecheck_devel`](#run-sorbetscriptstypecheck_devel)
-- [C++ conventions](#c-conventions)
 - [Debugging and profiling](#debugging-and-profiling)
   - [Debugging](#debugging)
   - [Profiling](#profiling)


### PR DESCRIPTION
The readme block, "Make sure `sorbet` is on your PATH," for running on pay-server, is no longer needed, because the sorbet/scripts/typecheck_devel script in pay-server does this for you.
see: https://git.corp.stripe.com/stripe-internal/pay-server/blob/845d32f14/sorbet/scripts/typecheck_devel#L8

(This block is also confusing, and, in the case of the symlink, makes the use of the development copy _permanent_, whereas I normally want to use the default/published version of Sorbet.)