### PR TITLE
don't cache coverage

### DIFF
--- a/.buildkite/coverage-static-sanitized.sh
+++ b/.buildkite/coverage-static-sanitized.sh
@@ -32,8 +32,6 @@ mkdir -p /usr/local/var/bazelcache/output-bases/coverage /usr/local/var/bazelcac
 {
   echo 'common --curses=no --color=yes'
   echo 'startup --output_base=/usr/local/var/bazelcache/output-bases/coverage'
-  echo 'build  --disk_cache=/usr/local/var/bazelcache/build --repository_cache=/usr/local/var/bazelcache/repos'
-  echo 'test   --disk_cache=/usr/local/var/bazelcache/build --repository_cache=/usr/local/var/bazelcache/repos'
 } >> .bazelrc
 
 ./bazel version


### PR DESCRIPTION
I have a sneaking suspicion that the coverage build is polluting the normal cache? It seems to be built and run with different flags so maybe they can't be in the same cache? If so, should this be a whole separate dir or is leaving it out ok?