### PR TITLE
remove json_types from lsp header

### DIFF
--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -7,7 +7,6 @@
 #include "core/ErrorQueue.h"
 #include "core/core.h"
 #include "main/lsp/LSPMessage.h"
-#include "main/lsp/json_types.h"
 #include "main/options/options.h"
 #include <chrono>
 #include <deque>


### PR DESCRIPTION
This isn't needed, yay. Should help with compile speedups?