### PR TITLE
Silence host build warning

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -43,6 +43,7 @@ build --host_copt=-O1
 build --host_cxxopt=-DFORCE_DEBUG
 build --host_copt=-DFORCE_DEBUG
 build --host_cxxopt=-Wno-unused-variable --host_cxxopt=-Wno-overloaded-virtual --host_cxxopt=-Wno-unused-const-variable # ragel violates those and we want a silent build
+build --host_cxxopt=-Wno-pass-failed # host build doesn't have enough optimizations enabled for clang to vectorize this loop reliably
 
 # The MacOS CROSSTOOL in bazel defines _FORTIFY_SOURCE both on
 # <command line>:1:9: and <built-in>:355:9: so sadly we turn them all off


### PR DESCRIPTION
Remove 4 copies of 
```
INFO: From Compiling core/Symbols.cc [for host]:
  | In file included from core/Symbols.cc:4:
  | In file included from ./core/GlobalState.h:8:
  | ./core/Hashing.h:22:21: warning: loop not unrolled: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering [-Wpass-failed=transform-warning]
  | inline unsigned int _hash(std::string_view utf8) {
  | ^
  | 1 warning generated.
```