### PR TITLE
Introduce RBI for `Comparable`

### DIFF
--- a/rbi/core/compar.rbi
+++ b/rbi/core/compar.rbi
@@ -1,4 +1,24 @@
 # typed: true
 
 module Comparable
+  sig { params(other: T.untyped).returns(T::Boolean) }
+  def <(other); end
+
+  sig { params(other: T.untyped).returns(T::Boolean) }
+  def <=(other); end
+
+  sig { params(other: T.untyped).returns(T::Boolean) }
+  def ==(other); end
+
+  sig { params(other: T.untyped).returns(T::Boolean) }
+  def >(other); end
+
+  sig { params(other: T.untyped).returns(T::Boolean) }
+  def >=(other); end
+
+  sig { params(min: T.untyped, max: T.untyped).returns(T::Boolean) }
+  def between?(min, max); end
+
+  sig { params(min: T.untyped, max: T.untyped).returns(T.untyped) }
+  def clamp(min, max); end
 end


### PR DESCRIPTION
## What am I trying to do?

While most of the core classes were defined with the `<`, `>`, etc. operators, custom classes including `Comparable` did not have these definitions according to Sorbet: https://sorbet.run/#%23%20typed%3A%20true%0A%0Aclass%20Version%0A%20%20include%20Comparable%0A%0A%20%20attr_reader%20%20%3Astr%0A%0A%20%20def%20initialize(str)%0A%20%20%20%20%40str%20%3D%20str%0A%20%20end%0A%0A%20%20def%20%3C%3D%3E(other)%0A%20%20%20%20self.str%20%3C%3D%3E%20other.str%0A%20%20end%0Aend%0A%0Aa1%20%3D%20Version.new(%221.0.0%22)%0Aa2%20%3D%20Version.new(%222.0.0%22)%0Aputs%20a1%20%3C%20a2

This PR introduces all the missing definitions in `Comparable`.