### PR TITLE
fix release builds on my laptop

### DIFF
--- a/third_party/jemalloc.BUILD
+++ b/third_party/jemalloc.BUILD
@@ -55,6 +55,9 @@ genrule(
             "**/*.sub",
             "**/install-sh",
         ],
+        exclude = [
+        "include/jemalloc/jemalloc.h",
+        ],
     ),
     outs = [
         "lib/libjemalloc.a",


### PR DESCRIPTION
Without this when I try to build on my laptop I get
```
$ bazel build main:sorbet --config=release-mac
WARNING: The following rc files are no longer being read, please transfer their contents or import their path into one of the standard rc files:
/var/folders/c5/r629fx_91qg1rh64kgpp1x0m0000gn/T//bazel_bazel_rc_1557868494
WARNING: The following configs were expanded more than once: [debugsymbols, static-libs, versioned, release-common]. For repeatable flags, repeats are counted twice and may lead to unexpected behavior.
INFO: Invocation ID: 2d2bed40-cc80-49f1-8167-8033a4691c9d
ERROR: /private/var/tmp/_bazel_pt/c51f80ec16d60d18b63f6e83b48c4884/external/jemalloc/BUILD.bazel:42:1: rule 'jemalloc_genrule' has file 'include/jemalloc/jemalloc.h' as both an input and an output
ERROR: /Users/pt/stripe/sorbet/main/BUILD:9:1: Target '@jemalloc//:jemalloc' contains an error and its package is in error and referenced by '//main:sorbet'
ERROR: Analysis of target '//main:sorbet' failed; build aborted: Cannot compute config conditions
INFO: Elapsed time: 0.120s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded, 0 targets configured)
```