### PR TITLE
don't typecheck inside defined

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1557,7 +1557,9 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
             },
             [&](parser::Defined *defined) {
                 auto res = MK::Send1(loc, MK::Constant(loc, core::Symbols::Magic()), core::Names::defined_p(),
-                                     node2TreeImpl(dctx, std::move(defined->value)));
+                                     // Intentionally drop the defined->value since we shouldn't typecheck if it exists
+                                     // or not node2TreeImpl(dctx, std::move(defined->value)));
+                                     MK::Nil(loc));
                 result.swap(res);
             },
             [&](parser::LineLiteral *line) {

--- a/test/testdata/desugar/defined.rb
+++ b/test/testdata/desugar/defined.rb
@@ -1,3 +1,2 @@
-# typed: false
-defined?(foo)
-defined_(foo)
+# typed: true
+defined?(FOO)

--- a/test/testdata/desugar/defined.rb.ast.exp
+++ b/test/testdata/desugar/defined.rb.ast.exp
@@ -1,5 +1,3 @@
 class <emptyTree><<C <root>>> < ()
-  ::<Magic>.defined?(<self>.foo())
-
-  <self>.defined_(<self>.foo())
+  ::<Magic>.defined?(nil)
 end

--- a/test/testdata/deviations/defined.rb
+++ b/test/testdata/deviations/defined.rb
@@ -1,2 +1,0 @@
-# typed: true
-defined?(JUNK) # error: Unable to resolve constant

--- a/test/testdata/parser/misc.rb
+++ b/test/testdata/parser/misc.rb
@@ -71,7 +71,7 @@ next 1
 next 1,2
 
 # defined
-defined?(X) # error: Unable to resolve
+defined?(X)
 
 
 # zsuper

--- a/test/testdata/parser/misc.rb.ast.exp
+++ b/test/testdata/parser/misc.rb.ast.exp
@@ -103,7 +103,7 @@ class <emptyTree><<C <root>>> < ()
 
   next([1, 2])
 
-  ::<Magic>.defined?(<emptyTree>::<C X>)
+  ::<Magic>.defined?(nil)
 
   <self>.super(ZSuperArgs)
 


### PR DESCRIPTION
In an even better world we should define the constant inside the block. Can we do that?