### PR TITLE
only load before version 2.0.0

### DIFF
--- a/gems/sorbet/lib/gem_loader.rb
+++ b/gems/sorbet/lib/gem_loader.rb
@@ -200,9 +200,14 @@ class Sorbet::Private::GemLoader
     'roo' => proc do
       my_require 'roo'
       [
-        Roo::Excel,
         Roo::Spreadsheet,
       ]
+      version = Bundler.load.specs['roo'][0].stub.version
+      if !Gem::Requirement.create('2.0.0').satisfied_by?(version)
+        [
+          Roo::Excel,
+        ]
+      end
     end,
     'rack-protection' => proc do
       my_require 'rack-protection'


### PR DESCRIPTION
This constant was deleted in version 2.0.0 so we should only try to load it if your bundler is older than that.

https://github.com/roo-rb/roo/commit/a7edbec2eb44344611f82cff89a82dac31ec0d79

I wrote the code in `pry` like this:
```
[dev] main:0> version = Bundler.load.specs['roo'][0].stub.version
=> Gem::Version.new("1.13.2")
[dev] main:0> Gem::Requirement.create('2.0.0').satisfied_by?(version)
=> false
```