### PR TITLE
Allow *args in destructure in typed: false

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -220,7 +220,8 @@ unique_ptr<Expression> desugarMlhs(DesugarContext dctx, core::Loc loc, parser::M
             } else {
                 unique_ptr<Expression> lh = node2TreeImpl(dctx, std::move(c));
                 if (auto restArg = ast::cast_tree<ast::RestArg>(lh.get())) {
-                    if (auto e = dctx.ctx.state.beginError(lh->loc, core::errors::Desugar::UnsupportedNode)) {
+                    if (auto e =
+                            dctx.ctx.state.beginError(lh->loc, core::errors::Desugar::UnsupportedRestArgsDestructure)) {
                         e.setHeader("Unsupported rest args in destructure");
                     }
                     lh = move(restArg->expr);

--- a/core/errors/desugar.h
+++ b/core/errors/desugar.h
@@ -11,6 +11,7 @@ constexpr ErrorClass NoConstantReassignment{3005, StrictLevel::Typed};
 // constexpr ErrorClass SimpleSuperclass{3006, StrictLevel::Typed};
 constexpr ErrorClass UnnamedBlockParameter{3007, StrictLevel::Strict};
 constexpr ErrorClass UndefUsage{3008, StrictLevel::Strict};
+constexpr ErrorClass UnsupportedRestArgsDestructure{3009, StrictLevel::Typed};
 } // namespace sorbet::core::errors::Desugar
 
 #endif

--- a/test/testdata/desugar/destructure_rest.rb
+++ b/test/testdata/desugar/destructure_rest.rb
@@ -1,0 +1,2 @@
+# typed: false
+[].map { |(*_)| }


### PR DESCRIPTION
This error is in `typed: false` so that means that these files end up `typed: ignore` which seems wrong since it is an error about types not syntax. Should I 
1) Move this error up to `typed: true`
2) Allow as we have been doing without the error. The types don't seem wrong?
https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0Asig%20%7Bparams(blk%3A%20T.proc.params(args%3A%20Integer).void).void%7D%0Adef%20foo(%26blk)%0Aend%0A%0Afoo%20do%20%7C(*args)%7C%0A%20%20T.reveal_type(args)%20%23%20error%3A%20Revealed%20type%3A%20%60Integer%60%0Aend
