### PR TITLE
Shutdown bazel after builds in CI.

### DIFF
--- a/.buildkite/build-emscripten.sh
+++ b/.buildkite/build-emscripten.sh
@@ -26,6 +26,12 @@ elif [[ "mac" == "$platform" ]]; then
 fi
 
 git checkout .bazelrc
+
+function finish {
+  ./bazel shutdown
+}
+trap finish EXIT
+
 rm -f bazel-*
 mkdir -p /usr/local/var/bazelcache/output-bases/emscripten /usr/local/var/bazelcache/build /usr/local/var/bazelcache/repos
 {

--- a/.buildkite/coverage-static-sanitized.sh
+++ b/.buildkite/coverage-static-sanitized.sh
@@ -11,6 +11,11 @@ echo "--- Pre-setup :bazel:"
 
 git checkout .bazelrc
 
+function finish {
+  ./bazel shutdown
+}
+trap finish EXIT
+
 # This clean sidesteps a bug in bazel not re-building correct coverage for cached items
 ./bazel clean
 

--- a/.buildkite/linters.sh
+++ b/.buildkite/linters.sh
@@ -10,6 +10,12 @@ fi
 echo "--- Pre-setup :bazel:"
 
 git checkout .bazelrc
+
+function finish {
+  ./bazel shutdown
+}
+trap finish EXIT
+
 rm -f bazel-*
 mkdir -p /usr/local/var/bazelcache/output-bases/linters /usr/local/var/bazelcache/build /usr/local/var/bazelcache/repos
 {

--- a/.buildkite/release-static.sh
+++ b/.buildkite/release-static.sh
@@ -28,6 +28,12 @@ fi
 echo will run with $CONFIG_OPTS
 
 git checkout .bazelrc
+
+function finish {
+  ./bazel shutdown
+}
+trap finish EXIT
+
 rm -f bazel-*
 mkdir -p /usr/local/var/bazelcache/output-bases/release /usr/local/var/bazelcache/build /usr/local/var/bazelcache/repos
 {

--- a/.buildkite/test-static-sanitized.sh
+++ b/.buildkite/test-static-sanitized.sh
@@ -27,6 +27,12 @@ fi
 echo will run with $CONFIG_OPTS
 
 git checkout .bazelrc
+
+function finish {
+  ./bazel shutdown
+}
+trap finish EXIT
+
 rm -f bazel-*
 mkdir -p /usr/local/var/bazelcache/output-bases/test-pr /usr/local/var/bazelcache/build /usr/local/var/bazelcache/repos
 {


### PR DESCRIPTION
I think bazel is keeping file descriptors to files open and thus deleteing them from disk isn't freeing up space



