### PR TITLE
Make Context & MutableContext fields immutable.

### DIFF
--- a/core/Context.cc
+++ b/core/Context.cc
@@ -54,8 +54,7 @@ void MutableContext::trace(string_view msg) const {
 }
 
 Context Context::withOwner(SymbolRef sym) const {
-    Context r = Context(state, sym);
-    return r;
+    return Context(state, sym);
 }
 
 GlobalSubstitution::GlobalSubstitution(const GlobalState &from, GlobalState &to,

--- a/core/Context.h
+++ b/core/Context.h
@@ -56,8 +56,7 @@ public:
     bool permitOverloadDefinitions() const;
 
     MutableContext withOwner(SymbolRef sym) const {
-        MutableContext r = MutableContext(state, sym);
-        return r;
+        return MutableContext(state, sym);
     }
 
     void trace(std::string_view msg) const;


### PR DESCRIPTION
This makes it easier to reason about them. They are immuable and pass-by-value.



