### PR TITLE
LSP: Let the client know when starting other expensive operations

### DIFF
--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -16,6 +16,7 @@ LSPResult LSPLoop::handleTextDocumentReferences(unique_ptr<core::GlobalState> gs
         return LSPResult::make(move(gs), move(response));
     }
 
+    ShowOperation op(*this, "References", "Finding all references...");
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.references");
 
     auto result = setupLSPQueryByLoc(move(gs), params.textDocument->uri, *params.position,

--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -32,6 +32,7 @@ LSPResult LSPLoop::handleWorkspaceSymbols(unique_ptr<core::GlobalState> gs, cons
 
     vector<unique_ptr<SymbolInformation>> result;
     string_view searchString = params.query;
+    ShowOperation op(*this, "WorkspaceSymbols", fmt::format("Searching for symbol `{}`...", searchString));
 
     for (u4 idx = 1; idx < gs->symbolsUsed(); idx++) {
         core::SymbolRef ref(gs.get(), idx);

--- a/main/lsp/updates.cc
+++ b/main/lsp/updates.cc
@@ -120,7 +120,7 @@ vector<core::FileHash> LSPLoop::computeStateHashes(const vector<shared_ptr<core:
 }
 
 void LSPLoop::reIndexFromFileSystem() {
-    ShowOperation op(*this, "Indexing", "Sorbet: Indexing files...");
+    ShowOperation op(*this, "Indexing", "Indexing files...");
     Timer timeit(logger, "reIndexFromFileSystem");
     indexed.clear();
     vector<core::FileRef> inputFiles = pipeline::reserveFiles(initialGS, opts.inputFileNames);
@@ -156,7 +156,7 @@ void tryApplyDefLocSaver(const core::GlobalState &gs, vector<ast::ParsedFile> &i
 }
 
 LSPLoop::TypecheckRun LSPLoop::runSlowPath(const vector<shared_ptr<core::File>> &changedFiles) {
-    ShowOperation slowPathOp(*this, "SlowPath", "Sorbet: Typechecking...");
+    ShowOperation slowPathOp(*this, "SlowPath", "Typechecking...");
     Timer timeit(logger, "slow_path");
     ENFORCE(initialGS->errorQueue->isEmpty());
     prodCategoryCounterInc("lsp.updates", "slowpath");


### PR DESCRIPTION
## Summary

Typechecking isn't the only expensive operation in the language server. Find All References searches through every file in the project, and WorkspaceSymbols searches through every symbol. Both are experimental features, but some users turn them on and don't realize when they are degrading their experience.

This change also removes the "Sorbet: " prefix from operation messages sent to the client, and should not be merged until https://git.corp.stripe.com/stripe-internal/pay-server/pull/149392 does.