### PR TITLE
fix footnote links in blog post

### DIFF
--- a/website/blog/2019-05-16-State-of-Sorbet-May-2019.md
+++ b/website/blog/2019-05-16-State-of-Sorbet-May-2019.md
@@ -3,11 +3,11 @@ id: state-of-sorbet-may-2019
 title: State of Sorbet May 2019
 ---
 
-Stripe uses Ruby extensively[1]. It’s the main language we use to build the business logic behind our APIs, and our Ruby codebase is on the order of millions of lines of code. At that scale and with our expected rapid growth rate two things are true: 1) we need all the tooling help we can get to understand and modify that much code, and 2) a total rewrite in a statically typed language would be a massive undertaking.
+Stripe uses Ruby extensively[[1](#1)]. It’s the main language we use to build the business logic behind our APIs, and our Ruby codebase is on the order of millions of lines of code. At that scale and with our expected rapid growth rate two things are true: 1) we need all the tooling help we can get to understand and modify that much code, and 2) a total rewrite in a statically typed language would be a massive undertaking.
 
-With that in mind, in October 2017 a small team of engineers conceived of building Sorbet, a gradual static type system for Ruby. Static type systems look for certain classes of potential errors without running your code. A gradual static type system allows you to gradually add static typing, leaving some parts of your code purely dynamically typed. Other examples of gradual static type systems that have been added onto existing dynamically typed languages are [Flow](https://flow.org/) and [Type](https://www.typescriptlang.org/)[S](https://www.typescriptlang.org/)[cript](https://www.typescriptlang.org/) for Javascript; and [Hack](https://hacklang.org/) for PHP.
+With that in mind, in October 2017 a small team of engineers conceived of building Sorbet, a gradual static type system for Ruby. Static type systems look for certain classes of potential errors without running your code. A gradual static type system allows you to gradually add static typing, leaving some parts of your code purely dynamically typed. Other examples of gradual static type systems that have been added onto existing dynamically typed languages are [Flow](https://flow.org/) and [Type](https://www.typescriptlang.org/)[Script](https://www.typescriptlang.org/) for Javascript; and [Hack](https://hacklang.org/) for PHP.
 
-Sorbet has come a long way since its original design, thanks in no small part to some very helpful collaborators. We now run Sorbet’s type checking as a part of every build in Stripe’s Ruby codebase, and our developers have come to rely on its feedback. Having proven out Sorbet’s value internally, we’re now getting ready to share it with the rest of the Ruby community as open source. We’ve also begun beta testing an editor integration which you can play with at [sorbet.run](https://sorbet.run) (if you’re on a desktop browser[[2](http://#2)]). You can read more about how Sorbet works in our [documentation](http://sorbet.org/docs/overview).
+Sorbet has come a long way since its original design, thanks in no small part to some very helpful collaborators. We now run Sorbet’s type checking as a part of every build in Stripe’s Ruby codebase, and our developers have come to rely on its feedback. Having proven out Sorbet’s value internally, we’re now getting ready to share it with the rest of the Ruby community as open source. We’ve also begun beta testing an editor integration which you can play with at [sorbet.run](https://sorbet.run) (if you’re on a desktop browser[[2](#2)]). You can read more about how Sorbet works in our [documentation](http://sorbet.org/docs/overview).
 
 
 ## Where Sorbet is now
@@ -48,7 +48,7 @@ editor.rb:10: Method `greet` does not exist on `Hello`
           ^^^^^^^^^^^^^^^
 ```
 
-And 63% of call sites[[3](http://#3)] are calling methods with type signatures allowing us to find mismatches in the types of parameters or return values:
+And 63% of call sites[[3](#3)] are calling methods with type signatures allowing us to find mismatches in the types of parameters or return values:
 
 ```Ruby
 # typed: true
@@ -191,7 +191,7 @@ It’s worth mentioning that even with `# typed: false` Sorbet will still find i
 
 ### Editor integration
 
-We’ve built a beta integration with VS Code, which you can use in a desktop browser[[2](http://#4)] at [sorbet.run](https://sorbet.run). As we stabilize our editor integration we plan to roll it out to Stripe's engineering team and eventually open source it. Here’s a quick walkthrough of some of its features.
+We’ve built a beta integration with VS Code, which you can use in a desktop browser[[2]](#2) at [sorbet.run](https://sorbet.run). As we stabilize our editor integration we plan to roll it out to Stripe's engineering team and eventually open source it. Here’s a quick walkthrough of some of its features.
 
 Error squiggles details behind the error on hover:
 


### PR DESCRIPTION

When I created the original blog post PR I forgot that I needed to fix the footnote links that Paper exports. This PR takes care of them. 