### PR TITLE
Fix DateTime parent in `rbi/stdlib`

### DIFF
--- a/rbi/stdlib/date.rbi
+++ b/rbi/stdlib/date.rbi
@@ -385,7 +385,7 @@ class Date
   def self.jisx0301(*arg0); end
 end
 
-class DateTime
+class DateTime < Date
   sig {returns(T.untyped)}
   def min(); end
 


### PR DESCRIPTION
@ptarjan: I messed up my refactoring and cut out the `Date` parent.



