### PR TITLE
Move new generics-related errors to `typed: true` and higher

### DIFF
--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -566,7 +566,7 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
                 if (usedOnSourceClass && ((isTypeTemplate && ctxIsSingleton) || !(isTypeTemplate || ctxIsSingleton))) {
                     result.type = core::make_type<core::LambdaParam>(sym);
                 } else {
-                    if (auto e = ctx.state.beginError(i->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                    if (auto e = ctx.state.beginError(i->loc, core::errors::Resolver::InvalidTypeDeclarationTyped)) {
                         string typeSource = isTypeTemplate ? "type_template" : "type_member";
                         string typeStr = sym.show(ctx);
 


### PR DESCRIPTION
The new generics errors that I introduced earlier today were being raised when `typed: false` was present, while the old errors would only raise at `typed: true` or higher. This change restores the old functionality.