### PR TITLE
Mark Thread::Backtrace::Location accessors nilable

### DIFF
--- a/rbi/core/thread.rbi
+++ b/rbi/core/thread.rbi
@@ -24,19 +24,19 @@ class Thread::Backtrace < Object
 end
 
 class Thread::Backtrace::Location
-  sig {returns(String)}
+  sig {returns(T.nilable(String))}
   def absolute_path(); end
 
-  sig {returns(String)}
+  sig {returns(T.nilable(String))}
   def base_label(); end
 
-  sig {returns(String)}
+  sig {returns(T.nilable(String))}
   def label(); end
 
   sig {returns(Integer)}
   def lineno(); end
 
-  sig {returns(String)}
+  sig {returns(T.nilable(String))}
   def path(); end
 end
 


### PR DESCRIPTION
I haven't quite been able to trace the backtrace/iseq code to figure out when these are `nil`. All of them seem to resolve to a C struct with members of type `VALUE`, so certainly all of them are capable of carrying `nil`.

The specific case I caught in the wild seemed to be related to minitest's constructed stack frames - I got a frame that looked something like:

```
    /src/test/_lib/parallel_runner/runner.rb -- /src/test/integration/redacted.rb > Critic::Integration::RedactedTest > on some condition::does some thing:1:in `each'
```

and it had a `nil` value for `path`

r? @pt-stripe 