### PR TITLE
use https to fetch sorbet-typed

### DIFF
--- a/gems/sorbet/lib/fetch-rbis.rb
+++ b/gems/sorbet/lib/fetch-rbis.rb
@@ -19,7 +19,7 @@ class Sorbet::Private::FetchRBIs
   XDG_CACHE_HOME = ENV['XDG_CACHE_HOME'] || "#{ENV['HOME']}/.cache"
   RBI_CACHE_DIR = "#{XDG_CACHE_HOME}/sorbet/sorbet-typed"
 
-  SORBET_TYPED_REPO = 'git@github.com:sorbet/sorbet-typed.git'
+  SORBET_TYPED_REPO = 'https://github.com/sorbet/sorbet-typed.git'
 
   HEADER = Sorbet::Private::Serialize.header(false, 'sorbet-typed')
 


### PR DESCRIPTION
Thom from Fastly is running in a docker without ssh. He suggested this is a better default