### PR TITLE
Reintroduce Read: log line that debug prints received LSP messages

### DIFF
--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -72,6 +72,7 @@ unique_ptr<LSPMessage> getNewRequest(const shared_ptr<spd::logger> &logger, int 
 
     string json = buffer.substr(0, length);
     buffer.erase(0, length);
+    logger->debug("Read: {}\n", json);
     return LSPMessage::fromClient(json);
 }
 


### PR DESCRIPTION
## Summary

Reintroduce Read: log line that debug prints received LSP messages.

These messages are useful for debugging (and for tracking adoption stats in Splunk), and were accidentally removed when I made input reads non-blocking.