### PR TITLE
don't talk about T.type_alias in ancestors

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -383,7 +383,7 @@ private:
                 return false;
             }
             if (auto e = ctx.state.beginError(job.ancestor->loc, core::errors::Resolver::DynamicSuperclass)) {
-                e.setHeader("Superclasses and mixins may only use simple aliases to classes like `{}`", "A = Integer");
+                e.setHeader("Superclasses and mixins may only use class aliases like `{}`", "A = Integer");
             }
             resolved = core::Symbols::StubAncestor();
         }

--- a/test/testdata/autogen/dynamic_superclass.rb
+++ b/test/testdata/autogen/dynamic_superclass.rb
@@ -5,5 +5,5 @@ A = Class.new
 # resolve it because we replace `A` with `StubModule` and we would
 # interpret B as unresolved.
 
-class B < A # error: Superclasses and mixins may only use simple aliases to classes like `A = Integer`
+class B < A # error: Superclasses and mixins may only use class aliases like `A = Integer`
 end


### PR DESCRIPTION
Brought up in https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1558559170207900

I don't think this is talking about `T.type_alias` and instead is just talking about simple aliases, right?