### PR TITLE
don't crash on webmock

### DIFF
--- a/gems/sorbet/lib/gem_loader.rb
+++ b/gems/sorbet/lib/gem_loader.rb
@@ -511,6 +511,12 @@ class Sorbet::Private::GemLoader
         ClearanceMailer,
       ]
     end,
+    'webmock' => proc do
+      my_require 'webmock'
+      WebMock.singleton_class.send(:define_method, :enable!) do
+        puts "\nWebMock.enable! is incompatible with Sorbet. Please don't unconditionally do it on requiring this file."
+      end
+    end,
   }
 
   # This is so that the autoloader doesn't treat these as manditory requires


### PR DESCRIPTION
This gem is nutzo. 

```
[] main:0> Net::WebMockNetBufferedIO.superclass
=> Net::BufferedIO
[] main:0> Net::WebMockNetBufferedIO.superclass == Net::BufferedIO
=> false
[] main:0> Net::BufferedIO
=> Net::WebMockNetBufferedIO
```
https://github.com/bblimke/webmock/blob/8820c9d23f169af35ca2348036d76a15c8ce71d5/lib/webmock/http_lib_adapters/net_http.rb#L16-L21

Tested with:
```
$ bundle exec ~/stripe/sorbet/gems/sorbet/lib/hidden-definition-finder.rb
Requiring all of your code
[1/1] require_relative /Users/pt/stripe/sorbet-tests/webmock/net.rb
WebMock.enable! is incompatible with Sorbet. Please don't unconditionally do it on requiring this file.

Naming all Modules
Generating /tmp/sorbet-hidden-definitions/reflection.rbi with 1110 modules and 47 aliases
Printing your code's symbol table into /tmp/sorbet-hidden-definitions/from-source.json
Printing /tmp/sorbet-hidden-definitions/reflection.rbi's symbol table into /tmp/sorbet-hidden-definitions/reflection.json
Reading /tmp/sorbet-hidden-definitions/from-source.json
Reading /tmp/sorbet-hidden-definitions/reflection.json
Requiring all of your code
[1/1] require_relative /Users/pt/stripe/sorbet-tests/webmock/net.rb
Building rbi id to symbol map
Building source id to symbol map
Writing /tmp/sorbet-hidden-definitions/hidden.rbi.tmp
Generating split RBIs into sorbet/rbi/hidden-definitions/
$ cat net.rb
# frozen_string_literal: true
# typed: strong

require 'webmock'
include WebMock::API
WebMock.enable!
```
