### PR TITLE
requires throw LoadError which isn't default caught

### DIFF
--- a/gems/sorbet/lib/require_everything.rb
+++ b/gems/sorbet/lib/require_everything.rb
@@ -19,7 +19,7 @@ class Sorbet::Private::RequireEverything
     return unless File.exist?('config/application.rb')
     begin
       require 'rails'
-    rescue
+    rescue LoadError
       return false
     end
     require './config/application'
@@ -33,7 +33,7 @@ class Sorbet::Private::RequireEverything
     return unless File.exist?('Gemfile')
     begin
       require 'bundler'
-    rescue
+    rescue LoadError
       return
     end
     Sorbet::Private::GemLoader.require_all_gems


### PR DESCRIPTION
Mentioned by https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1558564749229000

I don't think this was ever tested. Sometimes the presence of this file isn't enough to determine rails so we should handle the false-positive case better
