### PR TITLE
RFC: Better rvLoc using backEdges

### DIFF
--- a/test/testdata/cfg/rvloc.rb
+++ b/test/testdata/cfg/rvloc.rb
@@ -1,0 +1,48 @@
+# typed: true
+extend T::Sig
+
+sig {returns(String)}
+def ex1
+  unanalyzable = T.unsafe(nil)
+  if unanalyzable
+    ''
+  end
+end
+
+sig {returns(T::Boolean)}
+def ex2
+  puts "hello, world!"
+  puts "hello, world!"
+  puts "hello, world!"
+  puts "hello, world!"
+  puts "hello, world!"
+  puts "hello, world!"
+  value = "foobaR"
+  return if value !~
+
+  true
+end
+
+sig {returns(String)}
+def ex3
+  return true if T.unsafe(nil)
+  return false if T.unsafe(nil)
+  return 0 if T.unsafe(nil)
+  return :symbol if T.unsafe(nil)
+  ''
+end
+
+sig {returns(String)}
+def ex4
+  if T.unsafe(nil)
+    true
+  elsif T.unsafe(nil)
+    false
+  elsif T.unsafe(nil)
+    0
+  elsif T.unsafe(nil)
+    :symbol
+  else
+    ''
+  end
+end


### PR DESCRIPTION
### Motivation

Originally motivated by @zanker-stripe:
https://stripe.slack.com/archives/CC4SH3RD5/p1558810730001500

If the last statement a return came from an `if`, we previously weren't
smart enough to figure out the Loc for the binding that holds the return
value (because the basic block would be empty of statements, but have
multiple in-edges). In such cases, we fell back to using the Loc of the
entire method (which might be many, many lines long).

This manifested as error messages in LSP that turned the entire body of
the method red. And since LSP is fast now, it feels really intrusive to
have the entire WIP method body turn red.

### Summary

This change adds a heuristic based approach to attempt to find a better
loc. Specifically, when there are no exprs in the last block, but it has
back edges (i.e., there are other blocks with forward edges here) we
pick one of these edges and use it.

This is a bad heuristic. If there are multiple blocks that could jump to
the return val, we should show them all when there's a type error in the
method return. I haven't though through how to do this properly, which
means we could still get bad error message locations.

**This is an RFC.** If we like this approach and want to pursue it
further, I'm happy digging in a little more, or helping you dig in a
little more.

An open question: can we think of an example where there are more than
two back-edges in the return value block? Specifically, we compute this
block **before simplification**, so it's not the case that we might
collapse multiple empty blocks to point at this block. This would have
to be specifically from the raw result of builder_walk.

### Test plan

I've included some testdata tests that were useful to me when
prototyping this.

Do we have a way to write testdata tests that **assert multi-line
errors**? If so, I'd love to learn how.


---

### Output after change

<details>
<summary> Click to expand </summary>

Example 1:

```
test/testdata/cfg/rvloc.rb:7: Returning value that does not conform to method result type https://sorbet.org/docs/error-reference#7005
     7 |  if unanalyzable
     8 |    ''
     9 |  end
  Expected String
    test/testdata/cfg/rvloc.rb:5: Method ex1 has return type String
     5 |def ex1
        ^^^^^^^
  Got T.nilable(String) originating from:
    test/testdata/cfg/rvloc.rb:5:
     5 |def ex1
        ^^^^^^^
    test/testdata/cfg/rvloc.rb:8:
     8 |    ''
            ^^
```

Example 2:

```
test/testdata/cfg/rvloc.rb:21: Returning value that does not conform to method result type https://sorbet.org/docs/error-reference#7005
    21 |  return if value !~
    22 |
    23 |  true
  Expected T::Boolean
    test/testdata/cfg/rvloc.rb:13: Method ex2 has return type T::Boolean
    13 |def ex2
        ^^^^^^^
  Got NilClass originating from:
    test/testdata/cfg/rvloc.rb:13:
    13 |def ex2
        ^^^^^^^

test/testdata/cfg/rvloc.rb:21: Returning value that does not conform to method result type https://sorbet.org/docs/error-reference#7005
    21 |  return if value !~
          ^^^^^^
  Expected T::Boolean
    test/testdata/cfg/rvloc.rb:13: Method ex2 has return type T::Boolean
    13 |def ex2
        ^^^^^^^
  Got NilClass originating from:
    test/testdata/cfg/rvloc.rb:13:
    13 |def ex2
        ^^^^^^^
```
Example 3:
```
test/testdata/cfg/rvloc.rb:31: Returning value that does not conform to method result type https://sorbet.org/docs/error-reference#7005
    31 |  return :symbol if T.unsafe(nil)
          ^^^^^^^^^^^^^^
  Expected String
    test/testdata/cfg/rvloc.rb:27: Method ex3 has return type String
    27 |def ex3
        ^^^^^^^
  Got Symbol(:"symbol") originating from:
    test/testdata/cfg/rvloc.rb:31:
    31 |  return :symbol if T.unsafe(nil)
                 ^^^^^^^

test/testdata/cfg/rvloc.rb:30: Returning value that does not conform to method result type https://sorbet.org/docs/error-reference#7005
    30 |  return 0 if T.unsafe(nil)
          ^^^^^^^^
  Expected String
    test/testdata/cfg/rvloc.rb:27: Method ex3 has return type String
    27 |def ex3
        ^^^^^^^
  Got Integer(0) originating from:
    test/testdata/cfg/rvloc.rb:30:
    30 |  return 0 if T.unsafe(nil)
                 ^

test/testdata/cfg/rvloc.rb:29: Returning value that does not conform to method result type https://sorbet.org/docs/error-reference#7005
    29 |  return false if T.unsafe(nil)
          ^^^^^^^^^^^^
  Expected String
    test/testdata/cfg/rvloc.rb:27: Method ex3 has return type String
    27 |def ex3
        ^^^^^^^
  Got FalseClass originating from:
    test/testdata/cfg/rvloc.rb:29:
    29 |  return false if T.unsafe(nil)
                 ^^^^^

test/testdata/cfg/rvloc.rb:28: Returning value that does not conform to method result type https://sorbet.org/docs/error-reference#7005
    28 |  return true if T.unsafe(nil)
          ^^^^^^^^^^^
  Expected String
    test/testdata/cfg/rvloc.rb:27: Method ex3 has return type String
    27 |def ex3
        ^^^^^^^
  Got TrueClass originating from:
    test/testdata/cfg/rvloc.rb:28:
    28 |  return true if T.unsafe(nil)
                 ^^^^
```
Example 4:
```
test/testdata/cfg/rvloc.rb:37: Returning value that does not conform to method result type https://sorbet.org/docs/error-reference#7005
    37 |  if T.unsafe(nil)
    38 |    true
    39 |  elsif T.unsafe(nil)
    40 |    false
    41 |  elsif T.unsafe(nil)
       |...
    43 |  elsif T.unsafe(nil)
    44 |    :symbol
    45 |  else
    46 |    ''
    47 |  end
  Expected String
    test/testdata/cfg/rvloc.rb:36: Method ex4 has return type String
    36 |def ex4
        ^^^^^^^
  Got T.any(String, Symbol, Integer, FalseClass, TrueClass) originating from:
    test/testdata/cfg/rvloc.rb:38:
    38 |    true
            ^^^^
    test/testdata/cfg/rvloc.rb:40:
    40 |    false
            ^^^^^
    test/testdata/cfg/rvloc.rb:42:
    42 |    0
            ^
    test/testdata/cfg/rvloc.rb:44:
    44 |    :symbol
            ^^^^^^^
    test/testdata/cfg/rvloc.rb:46:
    46 |    ''
            ^^
Errors: 8
```

</details>

---

### Visualizing the CFG's

This is a picture of the final CFG for example 1 in the test case, pre-simplification:

<details>
<summary> Click to see CFG </summary>

<img width="1237" alt="Screen Shot 2019-05-26 at 1 21 23 PM" src="https://user-images.githubusercontent.com/5544532/58386772-73345e80-7fb9-11e9-983b-f0ee3288d70b.png">


</details>