### PR TITLE
Always use absolute paths in srb test harness

### DIFF
--- a/gems/sorbet/test/snapshot/driver.sh
+++ b/gems/sorbet/test/snapshot/driver.sh
@@ -2,10 +2,12 @@
 
 set -euo pipefail
 
-cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 1
+pushd "$(dirname "${BASH_SOURCE[0]}")/../.." &> /dev/null
+root_dir="$(realpath "$PWD")"
+popd &> /dev/null
 
-# shellcheck disable=SC1091
-source "test/snapshot/logging.sh"
+# shellcheck disable=SC1090
+source "$root_dir/test/snapshot/logging.sh"
 
 # ----- Option parsing -----
 
@@ -59,11 +61,16 @@ fi
 passing_tests=()
 failing_tests=()
 
-for test_dir in test/snapshot/{partial,total}/*; do
-  if test/snapshot/test_one.sh "$test_dir" $VERBOSE $UPDATE; then
-    passing_tests+=("test/snapshot/test_one.sh $test_dir $VERBOSE $UPDATE")
+for test_dir in "$root_dir/test/snapshot"/{partial,total}/*; do
+  test_exe="$root_dir/test/snapshot/test_one.sh"
+
+  relative_test_exe="$(realpath --relative-to="$PWD" "$test_exe")"
+  relative_test_dir="$(realpath --relative-to="$PWD" "$test_dir")"
+
+  if "$test_exe" "$test_dir" $VERBOSE $UPDATE; then
+    passing_tests+=("$relative_test_exe $relative_test_dir $VERBOSE $UPDATE")
   else
-    failing_tests+=("test/snapshot/test_one.sh $test_dir $VERBOSE $UPDATE")
+    failing_tests+=("$relative_test_exe $relative_test_dir $VERBOSE $UPDATE")
   fi
 done
 


### PR DESCRIPTION
Fixes #630

### Motivation

pt does all of his work in the root folder of the project and never `cd`s.
jez does his `srb init`-related work while `cd`'d into `gems/sorbet/`.

The existing test harness already partially supported both flows.
Before running, both `driver.sh` and `test_one.sh` would `cd` into the
appropriate folder, so that these commands could be run from anywhere.

The problem was: despite this, all CLI arguments and all paths printed in
messages were still relative to the post-cd location. So for example, pt
couldn't copy / paste the "run test again" output, nor use tab completion to
complete run a test.

### Summary

In this change, we fix the above problem by never `cd`ing. Instead, at the
interface boundary all relative paths are made absolute. We also use the handy
`realpath --relative-to ...` command, which lets us take an absolute path and
make it relative again (for the times when we'd like to print pretty paths for
a user).

### Test plan

I tested this manually by running:

```bash
# root
gems/sorbet/test/snapshot/driver.sh

# root copy / paste test_one
gems/sorbet/test/snapshot/test_one.sh gems/sorbet/test/snapshot/partial/bad-hash

# non-root
cd gems/sorbet
test/snapshot/driver.sh

# non-root copy / paste test_one
test/snapshot/test_one.sh test/snapshot/partial/bad-hash
```