### PR TITLE
Make fast/slow path decision avoid mutation.

### DIFF
--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -161,8 +161,8 @@ class LSPLoop {
     /** Conservatively rerun entire pipeline without caching any trees */
     TypecheckRun runSlowPath(const std::vector<std::shared_ptr<core::File>> &changedFiles);
     /** Returns `true` if the given changes can run on the fast path. */
-    bool canRunFastPath(const std::vector<std::shared_ptr<core::File>> &changedFiles,
-                        const std::vector<core::FileHash> &hashes);
+    bool canTakeFastPath(const std::vector<std::shared_ptr<core::File>> &changedFiles,
+                         const std::vector<core::FileHash> &hashes) const;
     /** Apply conservative heuristics to see if we can run a fast path, if not, bail out and run slowPath */
     TypecheckRun tryFastPath(std::unique_ptr<core::GlobalState> gs,
                              std::vector<std::shared_ptr<core::File>> &changedFiles, bool allFiles = false);


### PR DESCRIPTION
## Summary

Make fast/slow path decision avoid mutation.

Pre-requisite for cancelable slow paths (lets other threads speculatively check if new changes would run on slow path).

Should result in no observable difference in behavior.


