### PR TITLE
suggest bundle exec

### DIFF
--- a/gems/sorbet/sorbet.gemspec
+++ b/gems/sorbet/sorbet.gemspec
@@ -19,12 +19,12 @@ Gem::Specification.new do |s|
   s.post_install_message = %q{
   Thanks for installing Sorbet! To use it in your project, first run:
 
-    srb init
+    bundle exec srb init
 
   which will get your project ready to use with Sorbet.
   After that whenever you want to typecheck your code, run:
 
-    srb tc
+    bundle exec srb tc
 
   For more docs see: https://sorbet.org/docs/adopting
 }


### PR DESCRIPTION
Our guidance is to put `sorbet` in their `Gemfile`. If you install that way, you need to run `bundle exec srb init`. If instead we suggested `gem install sorbet` this current guidance would be right. I asked Gusto what they would suggest and they said since we want everyone on the same version of sorbet to put it in the `Gemfile`.