### PR TITLE
Don't require expected/sorbet/ to exist for partial test

### DIFF
--- a/gems/sorbet/test/snapshot/test_one.sh
+++ b/gems/sorbet/test/snapshot/test_one.sh
@@ -316,7 +316,7 @@ diff_partial() {
 
 if [ -z "$is_partial" ]; then
   diff_total
-elif [ -d "$test_dir/expected" ]; then
+elif [ -d "$test_dir/expected/sorbet" ]; then
   diff_partial
 elif [ -n "$UPDATE" ]; then
   warn "├─ Treating empty partial test as total for the sake of updating."


### PR DESCRIPTION
Note that a few lines up the `diff_partial` and `diff_total` helpers are
only for diffing the `sorbet/` folder. All other expected / actual
diffing (out.log, err.log, etc.) is handled explicitly.

So we actually want to check `expected/sorbet/` explicitly before
running `diff_partial`.