### PR TITLE
Fix err.log in snapshot tests

### DIFF
--- a/gems/sorbet/test/snapshot/test_one.sh
+++ b/gems/sorbet/test/snapshot/test_one.sh
@@ -202,10 +202,10 @@ cp -r "$test_dir/src"/* "$actual"
     fi
   fi
 
-  if ! SRB_YES=1 bundle exec "$srb" init | \
+  # note: redirects stderr before the pipe
+  if ! SRB_YES=1 bundle exec "$srb" init 2> "$actual/err.log" | \
       sed -e 's/with [0-9]* modules and [0-9]* aliases/with X modules and Y aliases/' \
-      > "$actual/out.log" \
-      2> "$actual/err.log"; then
+      > "$actual/out.log"; then
     error "├─ srb init failed."
     if [ -z "$VERBOSE" ]; then
       error "├─ stdout: $actual/out.log"


### PR DESCRIPTION
We were redirecting stderr in the wrong process. We wanted the one from
before the pipe.

### Test plan

I tested manually against pt-double-require (the branch with the "failing" test
and no fix). It actually fails now:

<img width="1182" alt="Screen Shot 2019-05-29 at 3 41 55 PM" src="https://user-images.githubusercontent.com/5544532/58596297-69646280-8228-11e9-9b19-092eb2dffbde.png">
