### PR TITLE
stop saying ignoring at_exit

### DIFF
--- a/gems/sorbet/lib/require_everything.rb
+++ b/gems/sorbet/lib/require_everything.rb
@@ -101,7 +101,7 @@ class Sorbet::Private::RequireEverything
         super
         return proc {}
       end
-      puts "Ignoring at_exit: #{block}"
+      # puts "Ignoring at_exit: #{block}"
       proc {}
     end
   end


### PR DESCRIPTION
Someone (rightly) complained they had no idea what this output means. I don't know what they could learn from it. When it actually runs we print, but stubbing it seems like not a printable moment. I'm leaving it comment out incase we grow a `--verbose`