### PR TITLE
Workaround for weird python@2 Homebrew lldb errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,7 @@ In general,
 - to debug a normal build of sorbet?
   - `lldb bazel-bin/main/sorbet -- <args> ...`
   - (Consider using `--config=static-libs` for better debug symbols)
+  - If you see weird Python errors on macOS, try `PATH=/usr/bin lldb`.
 - to debug something in pay-server?
   - See the section on “Local development” using `typecheck_devel`
 - to debug an existing Sorbet process (i.e., LSP)


### PR DESCRIPTION
Using `python@2` from Homebrew with the XCode version of LLDB seems to
cause problems. Using this trick to set the `PATH` can make the problems
go away by forcing XCode LLDB to use the system Python version.