### PR TITLE
Add --debug flag for binding.pry usage

### DIFF
--- a/gems/sorbet/test/snapshot/test_one.sh
+++ b/gems/sorbet/test/snapshot/test_one.sh
@@ -77,18 +77,22 @@ fi
 VERBOSE=
 UPDATE=
 DEBUG=
+FLAGS=()
 while [[ $# -gt 0 ]]; do
   case $1 in
     --verbose)
       VERBOSE="--verbose"
+      FLAGS+=("$VERBOSE")
       shift
       ;;
     --update)
       UPDATE="--update"
+      FLAGS+=("$UPDATE")
       shift
       ;;
     --debug)
       DEBUG="--debug"
+      FLAGS+=("$DEBUG")
       shift
       ;;
     -*)
@@ -110,7 +114,7 @@ done
 # ----- Stage the test sandbox directory -----
 
 relative_test_exe="$(realpath --relative-to="$PWD" "$0")"
-info "Running test:  $relative_test_exe $relative_test_dir $VERBOSE $UPDATE $DEBUG"
+info "Running test:  $relative_test_exe $relative_test_dir ${FLAGS[*]}"
 
 actual="$(mktemp -d)"
 


### PR DESCRIPTION
You'll usually need to add `gem 'pry'` to the Gemfile of the test that
you're trying to test. This should fail with an error when you forget.

Fixes #675