### PR TITLE
allow the ruby version to be prefixed by ruby-

### DIFF
--- a/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
@@ -207,7 +207,7 @@ module Sorbet::Private
         match =
           location&.match(/^.*\/(ruby)\/([\d.]+)\//) || # ruby stdlib
           location&.match(/^.*\/(site_ruby)\/([\d.]+)\//) || # rubygems
-          location&.match(/^.*\/gems\/[\d.]+(?:\/bundler)?\/gems\/([^\/]+)-([^-\/]+)\//i) # gem
+          location&.match(/^.*\/gems\/(?:ruby-)?[\d.]+(?:\/bundler)?\/gems\/([^\/]+)-([^-\/]+)\//i) # gem
         if match.nil?
           # uncomment to generate files for methods outside of gems
           # {


### PR DESCRIPTION
Reported in https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1559323371074000

```
[] main:0> location = '/Users/[homename]/.rvm/gems/ruby-2.5.3/gems/actionpack-5.1.6.2/lib/action_dispatch/routing/inspector.rb'
=> "/Users/[homename]/.rvm/gems/ruby-2.5.3/gems/actionpack-5.1.6.2/lib/action_dispatch/routing/inspector.rb"
[] main:0> location.match?(/^.*\/gems\/[\d.]+(?:\/bundler)?\/gems\/([^\/]+)-([^-\/]+)\//i)
=> false
[] main:0> location.match?(/^.*\/gems\/(?:ruby-)?[\d.]+(?:\/bundler)?\/gems\/([^\/]+)-([^-\/]+)\//i)
=> true
```