### PR TITLE
Work around arrays in bash 3

### DIFF
--- a/gems/sorbet/test/snapshot/driver.sh
+++ b/gems/sorbet/test/snapshot/driver.sh
@@ -26,22 +26,22 @@ usage() {
 VERBOSE=
 UPDATE=
 RECORD=
-FLAGS=()
+FLAGS=""
 while [[ $# -gt 0 ]]; do
   case $1 in
     --verbose)
       VERBOSE="--verbose"
-      FLAGS+=("$VERBOSE")
+      FLAGS="$FLAGS $VERBOSE"
       shift
       ;;
     --update)
       UPDATE="--update"
-      FLAGS+=("$UPDATE")
+      FLAGS="$FLAGS $UPDATE"
       shift
       ;;
     --record)
       RECORD="--record"
-      FLAGS+=("$RECORD")
+      FLAGS="$FLAGS $RECORD"
       shift
       ;;
     -*)
@@ -59,13 +59,9 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Make this script compatible with Bash 3 and Bash 4+
-# https://stackoverflow.com/a/7577209
-flags_str="${FLAGS[*]+"${FLAGS[*]}"}"
-
 # ----- Discover and run all the tests -----
 
-info "Running suite: $0 $flags_str"
+info "Running suite: $0 $FLAGS"
 
 if [ -z "$VERBOSE" ]; then
   info "(re-run with --verbose for more information)"
@@ -82,11 +78,17 @@ for test_dir in "$root_dir/test/snapshot"/{partial,total}/*; do
   relative_test_exe="$(realpath --relative-to="$PWD" "$test_exe")"
   relative_test_dir="$(realpath --relative-to="$PWD" "$test_dir")"
 
-  # FLAGS: https://stackoverflow.com/a/7577209
-  if "$test_exe" "$test_dir" ${FLAGS[@]+"${FLAGS[@]}"}; then
-    passing_tests+=("$relative_test_exe $relative_test_dir $flags_str")
+  # We're explicitly relying on word splitting here, because Bash 3 arrays
+  # don't work well for empty arrays. An alternative would be to use arrays +
+  # use this workaround (https://stackoverflow.com/a/7577209).
+  #
+  # This means that FLAGS cannot contain shell special characters.
+  #
+  # shellcheck disable=SC2086
+  if "$test_exe" "$test_dir" $FLAGS; then
+    passing_tests+=("$relative_test_exe $relative_test_dir $FLAGS")
   else
-    failing_tests+=("$relative_test_exe $relative_test_dir $flags_str")
+    failing_tests+=("$relative_test_exe $relative_test_dir $FLAGS")
   fi
 done
 

--- a/gems/sorbet/test/snapshot/test_one.sh
+++ b/gems/sorbet/test/snapshot/test_one.sh
@@ -80,27 +80,27 @@ VERBOSE=
 UPDATE=
 RECORD=
 DEBUG=
-FLAGS=()
+FLAGS=""
 while [[ $# -gt 0 ]]; do
   case $1 in
     --verbose)
       VERBOSE="--verbose"
-      FLAGS+=("$VERBOSE")
+      FLAGS="$FLAGS $VERBOSE"
       shift
       ;;
     --update)
       UPDATE="--update"
-      FLAGS+=("$UPDATE")
+      FLAGS="$FLAGS $UPDATE"
       shift
       ;;
     --record)
       RECORD="--record"
-      FLAGS+=("$RECORD")
+      FLAGS="$FLAGS $RECORD"
       shift
       ;;
     --debug)
       DEBUG="--debug"
-      FLAGS+=("$DEBUG")
+      FLAGS="$FLAGS $DEBUG"
       shift
       ;;
     -*)
@@ -123,15 +123,11 @@ if ! [ -z "$RECORD" ] && [ -z "$UPDATE" ]; then
   exit 1
 fi
 
-# Make this script compatible with Bash 3 and Bash 4+
-# https://stackoverflow.com/a/7577209
-flags_str="${FLAGS[*]+"${FLAGS[*]}"}"
-
 
 # ----- Stage the test sandbox directory -----
 
 relative_test_exe="$(realpath --relative-to="$PWD" "$0")"
-info "Running test:  $relative_test_exe $relative_test_dir $flags_str"
+info "Running test:  $relative_test_exe $relative_test_dir $FLAGS"
 
 actual="$(mktemp -d)"
 


### PR DESCRIPTION
In Bash 3, `"${arr[@]}"` is an error if `arr` has 0 items.
In Bash 4+, this is not an error.

There's a helpful Stack Overflow that documents how to work around it.