### PR TITLE
master -> origin/master

### DIFF
--- a/gems/sorbet/lib/fetch-rbis.rb
+++ b/gems/sorbet/lib/fetch-rbis.rb
@@ -20,7 +20,7 @@ class Sorbet::Private::FetchRBIs
   RBI_CACHE_DIR = "#{XDG_CACHE_HOME}/sorbet/sorbet-typed"
 
   SORBET_TYPED_REPO = 'https://github.com/sorbet/sorbet-typed.git'
-  SORBET_TYPED_REVISION = ENV['SRB_SORBET_TYPED_REVISION'] || 'master'
+  SORBET_TYPED_REVISION = ENV['SRB_SORBET_TYPED_REVISION'] || 'origin/master'
 
   HEADER = Sorbet::Private::Serialize.header(false, 'sorbet-typed')
 


### PR DESCRIPTION
We don't pull anymore (we only `fetch`), which means we don't merge
`origin/master` into `master`. This would have been a silent bug where the next
time we had updated `sorbet-typed`, we would have fetched an update, but not
checked it out, and then someone would have complained to us about not being
able to see the updates they pushed.


### Test plan

I can't think of a way to add a regression test that would have
exercised the bad behavior except doing something like writing a script
that goes into the sorbet-typed cache folder and mucks with it to make
sure that `fetch-rbis` properly unmucks it after this change.

Open to suggestions.