### PR TITLE
Make DelegateClass optional

### DIFF
--- a/gems/sorbet/lib/gem-generator-tracepoint/tracer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracer.rb
@@ -5,11 +5,13 @@ require_relative '../real_stdlib'
 
 require 'set'
 
-alias DelegateClass_without_rbi_generator DelegateClass
-def DelegateClass(superclass)
-  result = DelegateClass_without_rbi_generator(superclass)
-  Sorbet::Private::GemGeneratorTracepoint::Tracer.register_delegate_class(superclass, result)
-  result
+if defined?(DelegateClass)
+  alias DelegateClass_without_rbi_generator DelegateClass
+  def DelegateClass(superclass)
+    result = DelegateClass_without_rbi_generator(superclass)
+    Sorbet::Private::GemGeneratorTracepoint::Tracer.register_delegate_class(superclass, result)
+    result
+  end
 end
 
 module Sorbet::Private


### PR DESCRIPTION
After reading this code, I think its goal is to just monkeypatch DelegateClass if it is present. If it isn't there, we can skip this?