### PR TITLE
Fix use-after-move in Struct DSL pass

### DIFF
--- a/dsl/Struct.cc
+++ b/dsl/Struct.cc
@@ -73,18 +73,6 @@ vector<unique_ptr<ast::Expression>> Struct::replaceDSL(core::MutableContext ctx,
     ast::Hash::ENTRY_store sigValues;
     ast::ClassDef::RHS_store body;
 
-    if (send->block != nullptr) {
-        // Steal the trees, because the replaceDSL is going to remove the original send node from the tree anyway.
-        if (auto insSeq = ast::cast_tree<ast::InsSeq>(send->block->body.get())) {
-            for (auto &&stat : insSeq->stats) {
-                body.emplace_back(move(stat));
-            }
-            body.emplace_back(move(insSeq->expr));
-        } else {
-            body.emplace_back(move(send->block->body));
-        }
-    }
-
     // Elem = type_member(fixed: T.untyped)
     body.emplace_back(ast::MK::Assign(
         loc, ast::MK::UnresolvedConstant(loc, ast::MK::EmptyTree(), core::Names::Constants::Elem()),
@@ -135,6 +123,17 @@ vector<unique_ptr<ast::Expression>> Struct::replaceDSL(core::MutableContext ctx,
     ast::ClassDef::ANCESTORS_store ancestors;
     ancestors.emplace_back(ast::MK::UnresolvedConstant(loc, ast::MK::Constant(loc, core::Symbols::root()),
                                                        core::Names::Constants::Struct()));
+    if (send->block != nullptr) {
+        // Steal the trees, because the replaceDSL is going to remove the original send node from the tree anyway.
+        if (auto insSeq = ast::cast_tree<ast::InsSeq>(send->block->body.get())) {
+            for (auto &&stat : insSeq->stats) {
+                body.emplace_back(move(stat));
+            }
+            body.emplace_back(move(insSeq->expr));
+        } else {
+            body.emplace_back(move(send->block->body));
+        }
+    }
 
     vector<unique_ptr<ast::Expression>> stats;
     stats.emplace_back(make_unique<ast::ClassDef>(loc, loc, core::Symbols::todo(), std::move(asgn->lhs),

--- a/test/testdata/dsl/struct.rb
+++ b/test/testdata/dsl/struct.rb
@@ -14,6 +14,7 @@ end
 class RealStruct
     A = Struct.new(:foo, :bar)
     KeywordInit = Struct.new(:foo, :bar, keyword_init: true)
+    Named = Struct.new("Named") {}
 end
 class RealStructDesugar
     class A < Struct

--- a/test/testdata/dsl/struct.rb.dsl-tree.exp
+++ b/test/testdata/dsl/struct.rb.dsl-tree.exp
@@ -69,6 +69,10 @@ class <emptyTree><<C <root>>> < ()
         ::T.cast(::T.unsafe(nil), <emptyTree>::<C KeywordInit>)
       end
     end
+
+    <emptyTree>::<C Named> = <emptyTree>::<C Struct>.new("Named") do ||
+      <emptyTree>
+    end
   end
 
   class <emptyTree>::<C RealStructDesugar><<C <todo sym>>> < (::<todo sym>)
@@ -185,12 +189,6 @@ class <emptyTree><<C <root>>> < ()
     end
 
     class <emptyTree>::<C MyStruct><<C <todo sym>>> < (::<root>::<C Struct>)
-      <self>.include(<emptyTree>::<C MyMixin>)
-
-      <self>.new().x()
-
-      <self>.new().foo()
-
       <emptyTree>::<C Elem> = <self>.type_member({:"fixed" => ::T.untyped()})
 
       def x<<C <todo sym>>>(&<blk>)
@@ -208,19 +206,15 @@ class <emptyTree><<C <root>>> < ()
       def initialize<<C <todo sym>>>(x = nil, &<blk>)
         ::T.cast(::T.unsafe(nil), <emptyTree>::<C MyStruct>)
       end
-    end
 
-    class <emptyTree>::<C MyKeywordInitStruct><<C <todo sym>>> < (::<root>::<C Struct>)
       <self>.include(<emptyTree>::<C MyMixin>)
 
       <self>.new().x()
 
       <self>.new().foo()
+    end
 
-      <self>.new(1, 2)
-
-      <self>.new({:"giberish" => 1})
-
+    class <emptyTree>::<C MyKeywordInitStruct><<C <todo sym>>> < (::<root>::<C Struct>)
       <emptyTree>::<C Elem> = <self>.type_member({:"fixed" => ::T.untyped()})
 
       def x<<C <todo sym>>>(&<blk>)
@@ -238,6 +232,16 @@ class <emptyTree><<C <root>>> < ()
       def initialize<<C <todo sym>>>(x: = nil, &<blk>)
         ::T.cast(::T.unsafe(nil), <emptyTree>::<C MyKeywordInitStruct>)
       end
+
+      <self>.include(<emptyTree>::<C MyMixin>)
+
+      <self>.new().x()
+
+      <self>.new().foo()
+
+      <self>.new(1, 2)
+
+      <self>.new({:"giberish" => 1})
     end
 
     <emptyTree>::<C MyKeywordInitStruct>.new(1, 2)


### PR DESCRIPTION
We used to steal the block of the `Struct.new` `send` at the
beginning of the pass. It could happen that we decide to bail out
later, in which case we would leave the block of the `send` in an
unknown state, resulting in a crash later.

Fix #723



