### PR TITLE
Update dsl exp testing to happen before local naming

### DIFF
--- a/test/testdata/dsl/prop.rb.dsl-tree-raw.exp
+++ b/test/testdata/dsl/prop.rb.dsl-tree-raw.exp
@@ -17,10 +17,12 @@ ClassDef{
         MethodDef{
           flags = self
           name = <U prop><<C <U <todo sym>>>>
-          args = [RestArg{ expr = Local{
-              localVariable = <U args>
-            } }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [RestArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U args>
+            } }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = EmptyTree
         }
@@ -315,8 +317,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U foo><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -392,10 +395,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U foo=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -463,8 +468,9 @@ ClassDef{
         MethodDef{
           flags = 0
           name = <U foo2><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = UnresolvedConstantLit{
@@ -549,10 +555,12 @@ ClassDef{
         MethodDef{
           flags = 0
           name = <U foo2=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = UnresolvedConstantLit{
@@ -639,8 +647,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U default><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -716,10 +725,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U default=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -798,8 +809,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U t_nilable><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -905,10 +917,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U t_nilable=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -987,8 +1001,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U type><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -1064,10 +1079,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U type=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -1136,8 +1153,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U object><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -1213,10 +1231,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U object=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -1285,8 +1305,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U array><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -1362,10 +1383,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U array=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -1449,10 +1472,12 @@ ClassDef{
             MethodDef{
               flags = dsl
               name = <U array=><<C <U <todo sym>>>>
-              args = [Local{
-                  localVariable = <U arg0>
-                }, BlockArg{ expr = Local{
-                  localVariable = <U <blk>>
+              args = [UnresolvedIdent{
+                  kind = Local
+                  name = <U arg0>
+                }, BlockArg{ expr = UnresolvedIdent{
+                  kind = Local
+                  name = <U <blk>>
                 } }]
               rhs = Send{
                 recv = ConstantLit{
@@ -1542,8 +1567,9 @@ ClassDef{
             MethodDef{
               flags = dsl
               name = <U array><<C <U <todo sym>>>>
-              args = [BlockArg{ expr = Local{
-                  localVariable = <U <blk>>
+              args = [BlockArg{ expr = UnresolvedIdent{
+                  kind = Local
+                  name = <U <blk>>
                 } }]
               rhs = Send{
                 recv = ConstantLit{
@@ -1655,8 +1681,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U array_of><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -1762,10 +1789,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U array_of=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -1844,8 +1873,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U array_of_explicit><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -1921,10 +1951,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U array_of_explicit=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -2008,10 +2040,12 @@ ClassDef{
             MethodDef{
               flags = dsl
               name = <U array_of_explicit=><<C <U <todo sym>>>>
-              args = [Local{
-                  localVariable = <U arg0>
-                }, BlockArg{ expr = Local{
-                  localVariable = <U <blk>>
+              args = [UnresolvedIdent{
+                  kind = Local
+                  name = <U arg0>
+                }, BlockArg{ expr = UnresolvedIdent{
+                  kind = Local
+                  name = <U <blk>>
                 } }]
               rhs = Send{
                 recv = ConstantLit{
@@ -2101,8 +2135,9 @@ ClassDef{
             MethodDef{
               flags = dsl
               name = <U array_of_explicit><<C <U <todo sym>>>>
-              args = [BlockArg{ expr = Local{
-                  localVariable = <U <blk>>
+              args = [BlockArg{ expr = UnresolvedIdent{
+                  kind = Local
+                  name = <U <blk>>
                 } }]
               rhs = Send{
                 recv = ConstantLit{
@@ -2217,8 +2252,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U t_array><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -2333,10 +2369,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U t_array=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -2459,10 +2497,12 @@ ClassDef{
             MethodDef{
               flags = dsl
               name = <U t_array=><<C <U <todo sym>>>>
-              args = [Local{
-                  localVariable = <U arg0>
-                }, BlockArg{ expr = Local{
-                  localVariable = <U <blk>>
+              args = [UnresolvedIdent{
+                  kind = Local
+                  name = <U arg0>
+                }, BlockArg{ expr = UnresolvedIdent{
+                  kind = Local
+                  name = <U <blk>>
                 } }]
               rhs = Send{
                 recv = ConstantLit{
@@ -2559,8 +2599,9 @@ ClassDef{
             MethodDef{
               flags = dsl
               name = <U t_array><<C <U <todo sym>>>>
-              args = [BlockArg{ expr = Local{
-                  localVariable = <U <blk>>
+              args = [BlockArg{ expr = UnresolvedIdent{
+                  kind = Local
+                  name = <U <blk>>
                 } }]
               rhs = Send{
                 recv = ConstantLit{
@@ -2673,8 +2714,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U hash_of><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -2801,10 +2843,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U hash_of=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -2939,10 +2983,12 @@ ClassDef{
             MethodDef{
               flags = dsl
               name = <U hash_of=><<C <U <todo sym>>>>
-              args = [Local{
-                  localVariable = <U arg0>
-                }, BlockArg{ expr = Local{
-                  localVariable = <U <blk>>
+              args = [UnresolvedIdent{
+                  kind = Local
+                  name = <U arg0>
+                }, BlockArg{ expr = UnresolvedIdent{
+                  kind = Local
+                  name = <U <blk>>
                 } }]
               rhs = Send{
                 recv = ConstantLit{
@@ -3047,8 +3093,9 @@ ClassDef{
             MethodDef{
               flags = dsl
               name = <U hash_of><<C <U <todo sym>>>>
-              args = [BlockArg{ expr = Local{
-                  localVariable = <U <blk>>
+              args = [BlockArg{ expr = UnresolvedIdent{
+                  kind = Local
+                  name = <U <blk>>
                 } }]
               rhs = Send{
                 recv = ConstantLit{
@@ -3148,8 +3195,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U const_explicit><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -3218,8 +3266,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U const><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -3288,8 +3337,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U no_class_arg><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -3373,10 +3423,12 @@ ClassDef{
             MethodDef{
               flags = dsl
               name = <U no_class_arg=><<C <U <todo sym>>>>
-              args = [Local{
-                  localVariable = <U arg0>
-                }, BlockArg{ expr = Local{
-                  localVariable = <U <blk>>
+              args = [UnresolvedIdent{
+                  kind = Local
+                  name = <U arg0>
+                }, BlockArg{ expr = UnresolvedIdent{
+                  kind = Local
+                  name = <U <blk>>
                 } }]
               rhs = Send{
                 recv = ConstantLit{
@@ -3466,8 +3518,9 @@ ClassDef{
             MethodDef{
               flags = dsl
               name = <U no_class_arg><<C <U <todo sym>>>>
-              args = [BlockArg{ expr = Local{
-                  localVariable = <U <blk>>
+              args = [BlockArg{ expr = UnresolvedIdent{
+                  kind = Local
+                  name = <U <blk>>
                 } }]
               rhs = Send{
                 recv = ConstantLit{
@@ -3575,8 +3628,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U enum_prop><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -3631,8 +3685,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U foreign><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -3708,10 +3763,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U foreign=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -3803,10 +3860,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U foreign_><<C <U <todo sym>>>>
-          args = [RestArg{ expr = KeywordArg{ expr = Local{
-              localVariable = <U opts>
-            } } }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U opts>
+            } } }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -3874,10 +3933,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U foreign_!><<C <U <todo sym>>>>
-          args = [RestArg{ expr = KeywordArg{ expr = Local{
-              localVariable = <U opts>
-            } } }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U opts>
+            } } }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -3932,8 +3993,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U foreign_lazy><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -4009,10 +4071,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U foreign_lazy=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -4104,10 +4168,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U foreign_lazy_><<C <U <todo sym>>>>
-          args = [RestArg{ expr = KeywordArg{ expr = Local{
-              localVariable = <U opts>
-            } } }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U opts>
+            } } }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -4175,10 +4241,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U foreign_lazy_!><<C <U <todo sym>>>>
-          args = [RestArg{ expr = KeywordArg{ expr = Local{
-              localVariable = <U opts>
-            } } }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U opts>
+            } } }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -4233,8 +4301,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U foreign_proc><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -4310,10 +4379,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U foreign_proc=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -4405,10 +4476,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U foreign_proc_><<C <U <todo sym>>>>
-          args = [RestArg{ expr = KeywordArg{ expr = Local{
-              localVariable = <U opts>
-            } } }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U opts>
+            } } }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -4476,10 +4549,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U foreign_proc_!><<C <U <todo sym>>>>
-          args = [RestArg{ expr = KeywordArg{ expr = Local{
-              localVariable = <U opts>
-            } } }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U opts>
+            } } }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -4534,8 +4609,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U foreign_invalid><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -4611,10 +4687,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U foreign_invalid=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -4702,10 +4780,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U foreign_invalid_><<C <U <todo sym>>>>
-          args = [RestArg{ expr = KeywordArg{ expr = Local{
-              localVariable = <U opts>
-            } } }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U opts>
+            } } }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -4779,10 +4859,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U foreign_invalid_!><<C <U <todo sym>>>>
-          args = [RestArg{ expr = KeywordArg{ expr = Local{
-              localVariable = <U opts>
-            } } }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U opts>
+            } } }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -4837,8 +4919,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U ifunset><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -4914,10 +4997,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U ifunset=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -4996,8 +5081,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U ifunset_nilable><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -5103,10 +5189,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U ifunset_nilable=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -5198,8 +5286,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U token><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -5275,10 +5364,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U token=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -5347,8 +5438,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U created><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -5424,10 +5516,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U created=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -5509,8 +5603,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U token><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -5586,10 +5681,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U token=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -5658,8 +5755,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U created><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -5741,8 +5839,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U merchant><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -5834,8 +5933,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U foo><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -5939,8 +6039,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U encrypted_foo><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -6061,10 +6162,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U foo=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -6200,10 +6303,12 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U encrypted_foo=><<C <U <todo sym>>>>
-          args = [Local{
-              localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -6307,8 +6412,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U bar><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -6412,8 +6518,9 @@ ClassDef{
         MethodDef{
           flags = dsl
           name = <U encrypted_bar><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = Local{
-              localVariable = <U <blk>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
             } }]
           rhs = Send{
             recv = ConstantLit{
@@ -6472,8 +6579,9 @@ ClassDef{
     MethodDef{
       flags = 0
       name = <U main><<C <U <todo sym>>>>
-      args = [BlockArg{ expr = Local{
-          localVariable = <U <blk>>
+      args = [BlockArg{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U <blk>>
         } }]
       rhs = InsSeq{
         stats = [


### PR DESCRIPTION
This fixes a small problem where regenerating the exp tests would result in a failed test as a result of [PR 722](https://github.com/stripe/sorbet/pull/722).