### PR TITLE
Remove merge noise in cache-keeps-print-options test

### DIFF
--- a/test/cli/cache-keeps-print-options/cache-keeps-print-options.out
+++ b/test/cli/cache-keeps-print-options/cache-keeps-print-options.out
@@ -16,3 +16,15 @@ end
 class <emptyTree>::<C CCCCCCCCC><<C <todo sym>>> < (::<todo sym>)
   <emptyTree>
 end
+class <emptyTree>::<C CCCCCCCCC><<C <todo sym>>> < (::<todo sym>)
+  <emptyTree>
+end
+class <emptyTree>::<C CCCCCCCCC><<C <todo sym>>> < (::<todo sym>)
+  <emptyTree>
+end
+class <emptyTree>::<C CCCCCCCCC><<C <todo sym>>> < (::<todo sym>)
+  <emptyTree>
+end
+class <emptyTree>::<C CCCCCCCCC><<C <todo sym>>> < (::<todo sym>)
+  <emptyTree>
+end

--- a/test/cli/cache-keeps-print-options/cache-keeps-print-options.sh
+++ b/test/cli/cache-keeps-print-options/cache-keeps-print-options.sh
@@ -10,14 +10,9 @@ main/sorbet --silence-dev-message -p ast --cache-dir="$CACHE" test/cli/cache-kee
 main/sorbet --silence-dev-message -p ast --cache-dir="$CACHE" test/cli/cache-keeps-print-options/cache-keeps-print-options.rb 2>/dev/null
 rm -rf "$CACHE"/*.mdb
 
-<<<<<<< HEAD
-main/sorbet --silence-dev-message -p dsl-tree --cache-dir="$CACHE" test/cli/cache-keeps-print-options/cache-keeps-print-options.rb 2>&1
-main/sorbet --silence-dev-message -p dsl-tree --cache-dir="$CACHE" test/cli/cache-keeps-print-options/cache-keeps-print-options.rb 2>&1
+main/sorbet --silence-dev-message -p dsl-tree --cache-dir="$CACHE" test/cli/cache-keeps-print-options/cache-keeps-print-options.rb 2>/dev/null
+main/sorbet --silence-dev-message -p dsl-tree --cache-dir="$CACHE" test/cli/cache-keeps-print-options/cache-keeps-print-options.rb 2>/dev/null
 rm -rf "$CACHE"/*.mdb
 
-main/sorbet --silence-dev-message -p index-tree --cache-dir="$CACHE" test/cli/cache-keeps-print-options/cache-keeps-print-options.rb 2>&1
-main/sorbet --silence-dev-message -p index-tree --cache-dir="$CACHE" test/cli/cache-keeps-print-options/cache-keeps-print-options.rb 2>&1
-=======
-main/sorbet --silence-dev-message -p dsl-tree --cache-dir="$CACHE" test/cli/cache-keeps-print-options/cache-keeps-print-options.rb 2>/dev/null
-main/sorbet --silence-dev-message -p dsl-tree --cache-dir="$CACHE" test/cli/cache-keeps-print-options/cache-keeps-print-options.rb 2>/dev/null
->>>>>>> Remove flushing and fix tests instead
+main/sorbet --silence-dev-message -p index-tree --cache-dir="$CACHE" test/cli/cache-keeps-print-options/cache-keeps-print-options.rb 2>/dev/null
+main/sorbet --silence-dev-message -p index-tree --cache-dir="$CACHE" test/cli/cache-keeps-print-options/cache-keeps-print-options.rb 2>/dev/null


### PR DESCRIPTION
The CLI test `cache-keeps-print-options` had some traces of a git merge left in it. This removes them.