### PR TITLE
Deduplicate list of input files to prevent race condition

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -516,6 +516,9 @@ void readOptions(Options &opts, int argc, char *argv[],
                 } else {
                     opts.rawInputFileNames.push_back(file);
                     opts.inputFileNames.push_back(file);
+                    fast_sort(opts.inputFileNames);
+                    opts.inputFileNames.erase(unique(opts.inputFileNames.begin(), opts.inputFileNames.end()),
+                                              opts.inputFileNames.end());
                 }
             }
         }

--- a/test/cli/dedup-input-files/dedup-input-files.out
+++ b/test/cli/dedup-input-files/dedup-input-files.out
@@ -1,0 +1,2 @@
+dummy: File Not Found https://sorbet.org/docs/error-reference#1001
+Errors: 1

--- a/test/cli/dedup-input-files/dedup-input-files.sh
+++ b/test/cli/dedup-input-files/dedup-input-files.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+main/sorbet --silence-dev-message dummy dummy dummy dummy dummy dummy 2>&1


### PR DESCRIPTION
Duplicate input files can trigger a race condition when multiple threads process duplicate input files. The GlobalStates associated with each thread are merged together using GlobalSubstitution. GlobalSubstitution asserts that each file has only been read once, and having duplicates fails that assertion.

This resolves https://github.com/stripe/sorbet/issues/203

-- @gwu-stripe and @beala-stripe 