### PR TITLE
Only run mac tests on master

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -24,7 +24,7 @@ steps:
     command: .buildkite/linters.sh
     <<: *elastic
 
-  - label: ":mac: test-static-sanitized.sh(master only)"
+  - label: ":mac: test-static-sanitized.sh (master only)"
     command: .buildkite/test-static-sanitized.sh
     branches: "master"
     agents:


### PR DESCRIPTION
Mac tests very rarely fail without linux tests failing, while mac CI is curretly a bottleneck.
This way, we'll get a faster CI at cost of low frequency of master failures due to mac-specific errors.



