### PR TITLE
fix braces in mailto in code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ a project may be further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at (sorbet@stripe.com)[mailto:sorbet@stripe.com]. All
+reported by contacting the project team at [sorbet@stripe.com](mailto:sorbet@stripe.com). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
### Motivation
Had the braces in a link backwards on the code of conduct. This PR fixes them


### Test plan
Visual verification after deploy