### PR TITLE
exit from debug mode with message

### DIFF
--- a/gems/sorbet/test/snapshot/test_one.sh
+++ b/gems/sorbet/test/snapshot/test_one.sh
@@ -237,8 +237,9 @@ export SRB_SORBET_TYPED_REVISION
 
   if [ "$DEBUG" != "" ]; then
     # Don't redirect anything, so that binding.pry and friends work
-    bundle exec "$srb" init
-    exit
+    SRB_YES=1 bundle exec "$srb" init
+    error "Exiting since debug mode doesn't run tests"
+    exit 1
   else
     # Uses /dev/null for stdin so any binding.pry would exit immediately
     # (otherwise, pry will be waiting for input, but it's impossible to tell


### PR DESCRIPTION
I was perplexed why debug mode wasn't close to verbose. Can we make it closer?

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? -->

ran it locally