### PR TITLE
replace "RbiGenerator" "GemGeneratorTracepoint::Tracer"

### DIFF
--- a/gems/sorbet/lib/serialize.rb
+++ b/gems/sorbet/lib/serialize.rb
@@ -254,9 +254,9 @@ class Sorbet::Private::Serialize
       return false if piece[0].upcase != piece[0]
     end
     return false if [
-      'Sorbet::Private::RbiGenerator::ClassOverride',
-      'Sorbet::Private::RbiGenerator::ModuleOverride',
-      'Sorbet::Private::RbiGenerator::ObjectOverride',
+      'Sorbet::Private::GemGeneratorTracepoint::Tracer::ClassOverride',
+      'Sorbet::Private::GemGeneratorTracepoint::Tracer::ModuleOverride',
+      'Sorbet::Private::GemGeneratorTracepoint::Tracer::ObjectOverride',
     ].include?(name)
     true
   end

--- a/gems/sorbet/test/hidden-method-finder/simple.rb
+++ b/gems/sorbet/test/hidden-method-finder/simple.rb
@@ -31,6 +31,7 @@ class Sorbet::Private::HiddenMethodFinder::Test::Simple < MiniTest::Spec
       # assert_equal(File.read(olddir + '/simple.errors.txt'), File.read('rbi/hidden-definitions/errors.txt'))
       # assert_equal(File.read(olddir + '/simple.hidden.rbi'), File.read('rbi/hidden-definitions/hidden.rbi'))
       assert_match("class Foo\n  def bar()", File.read('sorbet/rbi/hidden-definitions/hidden.rbi'))
+      refute_match("ClassOverride", File.read('sorbet/rbi/hidden-definitions/hidden.rbi'))
     end
   end
 end


### PR DESCRIPTION
This class was renamed but the string reference wasn't updated

### Motivation
https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1560285331093300

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? -->

See included automated tests.
