### PR TITLE
Pass shared_ptrs by const ref to getResultType and methodDetails.

### DIFF
--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -262,9 +262,9 @@ std::optional<std::string> findDocumentation(std::string_view sourceCode, int be
 bool hasSimilarName(const core::GlobalState &gs, core::NameRef name, std::string_view pattern);
 bool hideSymbol(const core::GlobalState &gs, core::SymbolRef sym);
 std::string methodDetail(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver,
-                         core::TypePtr retType, std::shared_ptr<core::TypeConstraint> constraint);
+                         core::TypePtr retType, const std::shared_ptr<core::TypeConstraint> &constraint);
 core::TypePtr getResultType(const core::GlobalState &gs, core::SymbolRef ofWhat, core::TypePtr receiver,
-                            std::shared_ptr<core::TypeConstraint> constr);
+                            const std::shared_ptr<core::TypeConstraint> &constr);
 SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef);
 std::unique_ptr<Range> loc2Range(const core::GlobalState &gs, core::Loc loc);
 

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -124,7 +124,7 @@ bool hasSimilarName(const core::GlobalState &gs, core::NameRef name, string_view
 }
 
 string methodDetail(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver, core::TypePtr retType,
-                    shared_ptr<core::TypeConstraint> constraint) {
+                    const shared_ptr<core::TypeConstraint> &constraint) {
     ENFORCE(method.exists());
     // handle this case anyways so that we don't crash in prod when this method is mis-used
     if (!method.exists()) {
@@ -161,7 +161,7 @@ string methodDetail(const core::GlobalState &gs, core::SymbolRef method, core::T
 }
 
 core::TypePtr getResultType(const core::GlobalState &gs, core::SymbolRef ofWhat, core::TypePtr receiver,
-                            shared_ptr<core::TypeConstraint> constr) {
+                            const shared_ptr<core::TypeConstraint> &constr) {
     core::Context ctx(gs, core::Symbols::root());
     auto resultType = ofWhat.data(gs)->resultType;
     if (auto *proxy = core::cast_type<core::ProxyType>(receiver.get())) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Pass shared_ptrs by const ref to getResultType and methodDetails.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Avoids needless reference counter increments.

Separated from https://github.com/stripe/sorbet/pull/790/files

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? -->

N/A
