### PR TITLE
delete coverage

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -84,15 +84,3 @@ steps:
   - label: "All tests and builds succeeded"
     command: .buildkite/all-succeeded.sh
   - wait: ~
-
-# Optional Phase - Run optional things
-  - block: "Run optional code coverage"
-  - wait: ~
-  - label: ":linux::cloud: coverage-static-sanitized.sh"
-    command: .buildkite/coverage-static-sanitized.sh
-    artifact_paths: _out_/**/*
-    retry:
-      automatic: true
-    soft_fail:
-      - exit_status: "*"
-    <<: *elastic


### PR DESCRIPTION
This is broken so I'd like to not show it to our users. I'm leaving the shell scripts in there so they don't atrophy, but I can be convinced to delete them now if you want.

If we fix this, then please revert this, but having it in a known broken state does't feel great

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? -->
None
