### PR TITLE
Display method flag info on hover / autocomplete / etc. 

### DIFF
--- a/test/testdata/lsp/hover.rb
+++ b/test/testdata/lsp/hover.rb
@@ -7,7 +7,7 @@ class BigFoo; extend T::Sig
     # ^ hover: Integer(3)
     end
   end
-                
+
   class LittleFoo2; extend T::Sig
     sig {returns(Integer)}
     def bar
@@ -19,7 +19,7 @@ class BigFoo; extend T::Sig
       # ^ hover: sig {params(num: Integer).returns(Integer)}
     end
   end
-                        
+
   sig {generated.params(num1: Integer, num2: String).returns(Integer)}
   def self.bar(num1, num2)
     4 + num1 + num2.to_i
@@ -33,15 +33,25 @@ class BigFoo; extend T::Sig
   def baz(arg)
     arg + self.class.bar(1, "2").to_s
   end
-          
+
   sig {params(num: Integer).returns(String)}
-  def quux(num)
+  private def quux(num)
+            # ^ hover: private sig {params(num: Integer).returns(String)}
     if num < 10
       s = 1
     else
       s = "1"
     end
     s.to_s
+  end
+
+  sig {void}
+  protected def protected_fun; end;
+              # ^ hover: protected sig {void}
+
+  sig { returns([Integer, String]) }
+  def self.anotherFunc()
+    [1, "hello"]
   end
 end
 
@@ -50,4 +60,6 @@ def main
         # ^ hover: sig {generated.params(num1: Integer, num2: String).returns(Integer)}
   BigFoo.baz
         # ^ hover: sig {generated.void}
+  l = BigFoo.anotherFunc
+# ^ hover: [Integer, String] (2-tuple)
 end

--- a/test/testdata/lsp/hover_abstract.rb
+++ b/test/testdata/lsp/hover_abstract.rb
@@ -1,0 +1,20 @@
+# typed: true
+class AbstractItem
+  extend T::Sig
+  extend T::Helpers
+  abstract!
+
+  sig {abstract.returns(String)}
+  def self.name; end
+    # ^ hover: sig {abstract.returns(String)}
+end
+
+class Dog < AbstractItem
+  extend T::Sig
+
+  sig {implementation.returns(String)}
+  def self.name
+    # ^ hover: sig {implementation.returns(String)}
+    'Dog'
+  end
+end

--- a/test/testdata/lsp/hover_method.rb
+++ b/test/testdata/lsp/hover_method.rb
@@ -18,6 +18,21 @@ class Foo
 
   sig {params(arg0: String).returns(Integer)}
   def baz(arg0)
+    no_args_and_void
+  # ^ hover: void
+    Foo::bat(1)
+  # ^ hover: Foo
+       # ^ hover: params(i: Integer).returns(Integer)
+           # ^ hover: Integer(1)
     arg0.to_i
+  end
+
+  sig {params(i: Integer).returns(Integer)}
+  def self.bat(i)
+    10
+  end
+
+  sig {void}
+  def no_args_and_void
   end
 end

--- a/test/testdata/lsp/hover_override.rb
+++ b/test/testdata/lsp/hover_override.rb
@@ -1,0 +1,18 @@
+# typed: true
+class Animal
+  extend T::Sig
+
+  sig {overridable.returns(String)}
+  def self.name; "Animal"; end
+    # ^ hover: sig {overridable.returns(String)}
+end
+
+class Dog < Animal
+  extend T::Sig
+
+  sig {override.returns(String)}
+  def self.name
+    # ^ hover: sig {override.returns(String)}
+    'Dog'
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Display method flag info on hover / autocomplete / etc. 

Extracted from https://github.com/stripe/sorbet/pull/790

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

More accurate hover (and other features).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? -->

See included automated tests.
