### PR TITLE
Fix zip type definition

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -737,7 +737,7 @@ class Array < Object
     type_parameters(:U).params(
         arg0: T::Array[T.type_parameter(:U)],
     )
-    .returns(T::Array[[T.nilable(Elem), T.nilable(T.type_parameter(:U))]])
+    .returns(T::Array[[Elem, T.nilable(T.type_parameter(:U))]])
   end
   def zip(*arg0); end
 

--- a/rbi/light.rbi
+++ b/rbi/light.rbi
@@ -460,7 +460,7 @@ class Array < Object
     type_parameters(:U).params(
         arg0: T::Array[T.type_parameter(:U)],
     )
-    .returns(T::Array[[T.nilable(Elem), T.nilable(T.type_parameter(:U))]])
+    .returns(T::Array[[Elem, T.nilable(T.type_parameter(:U))]])
   end
   def zip(*arg0); end
 end

--- a/test/testdata/rbi/array.rb
+++ b/test/testdata/rbi/array.rb
@@ -16,7 +16,7 @@ T.assert_type!([1].sum(1.0) {|t| t.to_f}, Float)
 T.assert_type!(T::Array[Float].new.sum('a') {|t| 1.0}, T.any(Float, String))
 
 # Zip can zip up nils if arrays are diff lengths
-T.assert_type!([1,2].zip([2]), T::Array[[T.nilable(Integer), T.nilable(Integer)]])
+T.assert_type!([1,2].zip([2]), T::Array[[Integer, T.nilable(Integer)]])
 
 [1, 2] - [1, nil]
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

https://sorbet.run/#class%20A%20%0A%20%20def%20run%0A%20%20%20%20puts%20%22hi!%22%0A%20%20end%20%0Aend%20%0Adef%20main%0A%20%20a%20%3D%20%5BA.new()%2C%20A.new()%2C%20A.new()%5D%0A%20%20b%20%3D%20%5BA.new()%2C%20A.new()%5D%0A%20%20c%20%3D%20a.zip(b)%0A%20%20c.each%20do%20%7Cx%7C%20%0A%20%20%20%20x1%20%3D%20x%5B0%5D%0A%20%20%20%20x2%20%3D%20x%5B1%5D%0A%20%20%20%20if%20!(x1.nil%3F)%20%26%26%20!(x2.nil%3F)%0A%20%20%20%20%20%20x1.run%0A%20%20%20%20%20%20x2.run%20%0A%20%20%20%20end%0A%20%20end%0Aend

In this example, sorbet thinks that its impossible for x1 and x2 both to be nonnil, which is confusing because they should both be nonnil most of the time. I suspect it actually means that it thinks x1 and x2 are *always* nonnil, which is also incorrect, but more likely. 
This is because zip adds nil if the lists are not the same length[0]. Aka, T.reveal_type(c) should return Array[[T.nilable(A), T.nilable(A)]], not Array[[A,A]]

This PR fixes the zip definition issue

[0] https://apidock.com/ruby/Array/zip

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Correctness

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? -->

See included automated tests. 