### PR TITLE
use md5

### DIFF
--- a/gems/sorbet/bin/srb
+++ b/gems/sorbet/bin/srb
@@ -33,8 +33,7 @@ shift
 srb_path="${BASH_SOURCE[0]}"
 
 compute_md5() {
-  if command -v md5sum >/dev/null
-  then
+  if command -v md5sum > /dev/null; then
     md5sum "$1"
   else
     md5 -r "$1"


### PR DESCRIPTION
It looks like `md5sum` is from coreutils which isn't present on every mac. 

### Motivation
https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1560368691107100

### Test plan
```
~/stripe/sorbet pt-md5sum $ md5 -r /tmp/a.rb | awk '{ print $1 }'
37fe0d670aa0c92517f88cb19275be7a
~/stripe/sorbet pt-md5sum $ md5sum /tmp/a.rb | awk '{ print $1 }'
37fe0d670aa0c92517f88cb19275be7a
```