### PR TITLE
Add JS snippet to say when error has no docs

### DIFF
--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -4,6 +4,25 @@ title: Sorbet Error Reference
 sidebar_label: Error Reference
 ---
 
+<style>
+#missing-doc-for-error-code-box.is-hidden {
+  display: none;
+}
+</style>
+
+<div class="is-hidden" id="missing-doc-for-error-code-box">
+
+> **Heads up**: There aren't any docs yet for <span id="missing-error-code">this
+> error code</span>. If you have suggestions for what would have helped you
+> solve this problem, click the "Edit" button above to contribute! Otherwise,
+> try using the search above to find an answer.
+
+</div>
+
+> **Note**: This list is not exhaustive! Some errors are very context dependent
+> and other error codes are not common enough to know how to generally suggest
+> help. Contributions to this list are welcome!
+
 This is one of three docs aimed at helping answer common questions about Sorbet:
 
 1.  [Troubleshooting](troubleshooting.md)
@@ -11,10 +30,6 @@ This is one of three docs aimed at helping answer common questions about Sorbet:
 1.  [Sorbet Error Reference](error-reference.md) (this doc)
 
 This page contains tips and tricks for common errors from `srb`.
-
-> **Note**: This list is not exhaustive! Some errors are very context dependent
-> and other error codes are not common enough to know how to generally suggest
-> help. Contributions to this list are welcome!
 
 ## 1001
 
@@ -121,34 +136,34 @@ like the constant is related to a gem, maybe one of these helps:
 Another thing it could be: Sorbet explicitly does not support resolving
 constants through ancestors (both mixins or superclasses).
 
-- Concretely, here's an example of code rejected and accepted by Sorbet:
+Concretely, here's an example of code rejected and accepted by Sorbet:
 
-  ```ruby
-  class Parent
-    MY_CONST = 91
-  end
+```ruby
+class Parent
+  MY_CONST = 91
+end
 
-  class Child < Parent; end
+class Child < Parent; end
 
-  Child::MY_CONST    # error
-  Parent::MY_CONST   # ok
-  ```
+Child::MY_CONST    # error
+Parent::MY_CONST   # ok
+```
 
-- Alternatively, if it's much more preferable to access the constant on the
-  child, we can set up an explicit alias:
+Alternatively, if it's much more preferable to access the constant on the child,
+we can set up an explicit alias:
 
-  ```ruby
-  class Parent
-    MY_CONST = 91
-  end
+```ruby
+class Parent
+  MY_CONST = 91
+end
 
-  class Child < Parent
-    MY_CONST = Parent::MY_CONST
-  end
+class Child < Parent
+  MY_CONST = Parent::MY_CONST
+end
 
-  Child::MY_CONST    # ok
-  Parent::MY_CONST   # ok
-  ```
+Child::MY_CONST    # ok
+Parent::MY_CONST   # ok
+```
 
 ## 5005
 
@@ -635,3 +650,5 @@ end
 ```
 
 [report an issue]: https://github.com/stripe/sorbet/issues
+
+<script src="/js/error-reference.js"></script>

--- a/website/static/js/error-reference.js
+++ b/website/static/js/error-reference.js
@@ -1,0 +1,17 @@
+(() => {
+  // Validate the string because we're about to inject it into the page.
+  const errorCode = window.location.hash.substring(1);
+  if (errorCode == null || errorCode.match(/\d\d\d\d/) == null) {
+    return;
+  }
+
+  if (document.getElementById(errorCode) != null) {
+    return;
+  }
+
+  const msg = `error code <strong>${errorCode}</strong>`;
+  document.getElementById('missing-error-code').innerHTML = msg;
+
+  const box = document.getElementById('missing-doc-for-error-code-box');
+  box.classList.toggle('is-hidden');
+})();


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We don't like that some error codes aren't documented yet. The experience is
bad, and it trains people to never click on the error-reference links.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? -->

<img width="818" alt="Screen Shot 2019-06-12 at 4 16 20 PM" src="https://user-images.githubusercontent.com/5544532/59392704-75264d80-8d2d-11e9-8a1a-e79acbf70373.png">
