### PR TITLE
Fix hover for proc parameters.

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -325,12 +325,16 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::Expression *what, BasicBlock 
                             continue;
                         }
 
+                        // Inserting a statement that does not directly map to any source text. Make its loc
+                        // 0-length so LSP ignores it in queries.
+                        core::Loc zeroLengthLoc(arg.loc.file(), arg.loc.beginPos(), arg.loc.beginPos());
                         bodyBlock->exprs.emplace_back(
-                            idxTmp, arg.loc, make_unique<Literal>(core::make_type<core::LiteralType>(int64_t(i))));
+                            idxTmp, zeroLengthLoc,
+                            make_unique<Literal>(core::make_type<core::LiteralType>(int64_t(i))));
                         InlinedVector<core::LocalVariable, 2> idxVec{idxTmp};
-                        InlinedVector<core::Loc, 2> locs{arg.loc};
+                        InlinedVector<core::Loc, 2> locs{zeroLengthLoc};
                         bodyBlock->exprs.emplace_back(
-                            argLoc, arg.loc,
+                            argLoc, zeroLengthLoc,
                             make_unique<Send>(argTemp, core::Names::squareBrackets(), s->block->loc, idxVec, locs));
                     }
 

--- a/test/testdata/lsp/hover_untyped_proc_arg.rb
+++ b/test/testdata/lsp/hover_untyped_proc_arg.rb
@@ -1,0 +1,17 @@
+# typed: true
+
+def main
+  a = T.let([], T.untyped)
+  a.map do |foo, bar|
+          # ^ hover: T.untyped
+                # ^ hover: T.untyped
+  end
+  b = T.let([], T::Array[T.untyped])
+  b.map do |foo|
+          # ^ hover: T.untyped
+  end
+  c = T.let([], T::Array[String])
+  c.map do |foo|
+          # ^ hover: String
+  end
+end


### PR DESCRIPTION
Fix hover for proc parameters.

Assign a 0-length loc to proc argument logic expanded in CFG. Fixes a bug where hovering over a proc parameter shows an integer rather than its type.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This isn't correct:
![Screen Shot 2019-06-13 at 9 04 08 AM](https://user-images.githubusercontent.com/43145439/59448532-39859500-8dba-11e9-8781-6b416c3a6d2b.png)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? -->

See included automated tests.
