### PR TITLE
Change class -> className

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -182,7 +182,7 @@ class Index extends React.Component {
         </PageSection>
         <PageSection short>
           <div className="pageSectionColumns">
-            <p class="logos">
+            <p className="logos">
               <a href="https://stripe.com/">
                 <img src={`${baseUrl}img/stripe-logo.svg`} alt="Stripe Logo" />
               </a>


### PR DESCRIPTION
### Motivation

It's called className in React ([for now][1]).

A warning was issued in the build logs. This should silence that warning.

[1]: https://github.com/facebook/react/issues/13525#issuecomment-417818906

### Test plan

No new tests.