### PR TITLE
Forbid sub-subclassing `T::Struct`

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -271,6 +271,9 @@ void GlobalState::initEmpty() {
     id = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Enumerator());
     ENFORCE(id == Symbols::T_Enumerator());
 
+    id = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Struct());
+    ENFORCE(id == Symbols::T_Struct());
+
     // Root members
     Symbols::root().dataAllowingNone(*this)->members()[core::Names::Constants::NoSymbol()] = Symbols::noSymbol();
     Symbols::root().dataAllowingNone(*this)->members()[core::Names::Constants::Top()] = Symbols::top();

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -374,6 +374,10 @@ public:
         return SymbolRef(nullptr, 75);
     }
 
+    static SymbolRef T_Struct() {
+        return SymbolRef(nullptr, 76);
+    }
+
     static constexpr int MAX_PROC_ARITY = 10;
     static SymbolRef Proc0() {
         return SymbolRef(nullptr, MAX_SYNTHETIC_SYMBOLS - MAX_PROC_ARITY * 2 - 2);

--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -45,6 +45,7 @@ constexpr ErrorClass SigInFileWithoutSigil{5038, StrictLevel::False};
 constexpr ErrorClass RevealTypeInUntypedFile{5039, StrictLevel::False};
 
 constexpr ErrorClass OverloadNotAllowed{5040, StrictLevel::False};
+constexpr ErrorClass SubclassingNotAllowed{5041, StrictLevel::False};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -413,7 +413,7 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, GlobalState *gs) {
             return make_type<SelfType>();
         }
         default:
-            Exception::raise("Uknown type tag {}", tag);
+            Exception::raise("Unknown type tag {}", tag);
     }
 }
 

--- a/gems/sorbet-runtime/lib/types/private/abstract/declare.rb
+++ b/gems/sorbet-runtime/lib/types/private/abstract/declare.rb
@@ -18,6 +18,10 @@ module T::Private::Abstract::Declare
     mod.extend(T::InterfaceWrapper::Helpers)
 
     if mod.is_a?(Class)
+      if mod < T::Struct
+        raise "#{mod.name} is a subclass of T::Struct and cannot be declared abstract"
+      end
+
       if type == :interface
         # Since `interface!` is just `abstract!` with some extra validation, we could technically
         # allow this, but it's unclear there are good use cases, and it might be confusing.

--- a/gems/sorbet-runtime/lib/types/struct.rb
+++ b/gems/sorbet-runtime/lib/types/struct.rb
@@ -1,8 +1,18 @@
 # frozen_string_literal: true
 # typed: true
 
-class T::Struct
+class T::InexactStruct
   include T::Props
   include T::Props::Serializable
   include T::Props::Constructor
+end
+
+class T::Struct < T::InexactStruct
+  def self.inherited(subclass)
+    super(subclass)
+    T::Private::ClassUtils.replace_method(subclass.singleton_class, :inherited) do |s|
+      super(s)
+      raise "#{self.name} is a subclass of T::Struct and cannot be subclassed"
+    end
+  end
 end

--- a/gems/sorbet-runtime/test/types/struct.rb
+++ b/gems/sorbet-runtime/test/types/struct.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+class Opus::Types::Test::StructValidationTest < Critic::Unit::UnitTest
+  it "forbids subclassing a Struct" do
+    c = Class.new(T::Struct)
+    err = assert_raises(RuntimeError) do
+      Class.new(c)
+    end
+    assert_includes(err.message, "is a subclass of T::Struct and cannot be subclassed")
+  end
+end

--- a/gems/sorbet-runtime/test/types/struct.rb
+++ b/gems/sorbet-runtime/test/types/struct.rb
@@ -9,4 +9,14 @@ class Opus::Types::Test::StructValidationTest < Critic::Unit::UnitTest
     end
     assert_includes(err.message, "is a subclass of T::Struct and cannot be subclassed")
   end
+
+  it "forbids declaring a Struct as abstract" do
+    err = assert_raises(RuntimeError) do
+      Class.new(T::Struct) do
+        extend T::Helpers
+        abstract!
+      end
+    end
+    assert_includes(err.message, "is a subclass of T::Struct and cannot be declared abstract")
+  end
 end

--- a/test/testdata/resolver/t_struct_subclass.rb
+++ b/test/testdata/resolver/t_struct_subclass.rb
@@ -2,3 +2,6 @@
 
 class IS < T::InexactStruct; end
 class Yep < IS; end
+
+class S < T::Struct; end
+class Nope < S; end # error: Subclassing `S` is not allowed

--- a/test/testdata/resolver/t_struct_subclass.rb
+++ b/test/testdata/resolver/t_struct_subclass.rb
@@ -1,0 +1,4 @@
+# typed: true
+
+class IS < T::InexactStruct; end
+class Yep < IS; end


### PR DESCRIPTION
This forbids subclassing a subclass of `T::Struct` in the static and runtime system.

This PR is WIP because:

- In the runtime system, I didn't modify `T::Struct` and instead created `T::UninheritableStruct` with these new checks. This is merely because I wanted to make sure the runtime tests were working and committed. The actual plan is to put the checks directly on `T::Struct` and introduce a new `T::DeprecatedInheritableStruct` (or something) without these new checks.
- I wasn't sure exactly where to put the checks in the static system. method_checks.cc was doing things related to abstract, etc which seems related, but this is more of a class check, not a method check. @jez suggested renaming this file to symbol_checks.cc. @gdritter-stripe any thoughts here? (I know you are working on this area of the codebase right now.)

### Motivation

It's a step towards having better static types for the `initialize` method on subclasses of `T::Struct`.

### Test plan

See included automated tests.