### PR TITLE
Remove even more Stripe internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,8 @@ might also want to:
 - Watch the [talks we've given](https://sorbet.org/docs/talks/talks) about Sorbet
 - Try the [Sorbet playground](https://sorbet.run) online
 
-If you are at Stripe, you might also want to see:
-
-- The Sorbet [design doc](https://hackpad.corp.stripe.com/Design-Doc-sorbet-zd1LGHPfpvW)
-- Dmitry's talk about [Sorbet's internals](https://stripe.exceedlms.com/student/activity/372979)
+If you are at Stripe, you might also want to see <http://go/types/internals> for
+docs about Stripe-specific development workflows and historical Stripe context.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

:rip: Hackpad

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Someone pointed out that we had a dead Hackpad link. I'd already converted it
to Confluence. And honestly, if a Stripe employee is reading the README, I'd
like to link them to the whole Confluence folder of internal docs.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? -->

See included automated tests.