### PR TITLE
Fix React warning about missing key prop

### DIFF
--- a/website/pages/en/community.js
+++ b/website/pages/en/community.js
@@ -30,7 +30,7 @@ const PageSection = (props) => {
 };
 
 const TalkListItem = (props) => (
-  <li>
+  <li key={props.link}>
     <a href={props.link}>{props.title}</a> at {props.venue}
   </li>
 );
@@ -44,7 +44,7 @@ const ProjectListItem = (props) => {
   }
 
   return (
-    <li>
+    <li key={props.link}>
       <a href={props.link}>{props.title}</a>
       {description}
     </li>


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

^

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This text no longer appears in the `yarn start` output:

    Warning: Each child in a list should have a unique "key" prop.

    Check the top-level render call using <ul>. See https://fb.me/react-warning-keys for more information.
        in li
        in ProjectList
        in div
        in div
        in div
        in PageSection
        in div
        in Index
        in div
        in body
        in html
        in Site