### PR TITLE
Move .wrapper override to overrides

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -20,10 +20,6 @@
   padding: 4em 20px;
 }
 
-.wrapper {
-  max-width: 1100px;
-}
-
 .homeContainer .homeWrapper .projectLogo {
   padding: 0;
 }
@@ -32,17 +28,17 @@
   width: 200px;
 }
 
-.container .wrapper .threeByGridBlock {
+.container .threeByGridBlock {
   text-align: left;
   margin-bottom: 20px;
 }
 
-.container .wrapper .threeByGridBlock h2 {
+.container .threeByGridBlock h2 {
   margin-top: 0;
   text-align: left;
 }
 
-.container .wrapper .threeByGridBlock h2 p {
+.container .threeByGridBlock h2 p {
   margin-top: 0;
   text-align: left;
   margin-bottom: 0;
@@ -83,7 +79,7 @@
   background: var(--sorbet-purple-3);
 }
 
-.featuresContainer .wrapper .threeByGridBlock {
+.featuresContainer .threeByGridBlock {
   margin-bottom: 0;
 }
 

--- a/website/static/css/overrides.css
+++ b/website/static/css/overrides.css
@@ -66,7 +66,14 @@ sup {
   }
 }
 
-@media only screen and (max-width: 1023px) {
+/*
+ * The .wrapper class defaults to max-width: 1400px on large screens (>1500px).
+ * We never want to use more than 1100px, even at that breakpoint.
+ */
+@media only screen and (min-width: 1500px) {
+  .wrapper {
+    max-width: 1100px;
+  }
 }
 
 /*


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We have overrides.css for Docusaurus specific overrides. It look like `.wrapper` snuck into `custom.css` instead, which is for CSS styles that we don't share at all with Docusaurus elements.

Also, simplifies some CSS to rely less on Docusaurus built-in classes. The `.wrapper`s in those selectors were redundant.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested locally; no visible changes.