### PR TITLE
fix hidden definition finder

### DIFF
--- a/gems/sorbet/lib/hidden-definition-finder.rb
+++ b/gems/sorbet/lib/hidden-definition-finder.rb
@@ -56,7 +56,7 @@ class Sorbet::Private::HiddenMethodFinder
   end
 
   def rm_dir
-    FileUtils.rmdir(TMP_PATH)
+    FileUtils.rm_r(TMP_PATH)
   end
 
   def require_everything


### PR DESCRIPTION
I think this will fix it. I don't know why this doesn't fail tests... I can't run the test locally since:

```
$ ruby test/hidden-method-finder/simple.rb
Run options: --seed 63841

# Running:

/Users/pt/stripe/sorbet/gems/sorbet/test/hidden-method-finder/../../lib/hidden-definition-finder.rb:117:in `write_constants': Your source can't be read by Sorbet. (RuntimeError)
You can try `srb tc --print=symbol-table-json -vvvv --max-threads 1` and hopefully the last file it is processing before it dies is the culprit.
If not, maybe the errors in this file will help: /var/folders/c5/r629fx_91qg1rh64kgpp1x0m0000gn/T/d20190614-95750-1ad5bkz/from-source.json.err
	from /Users/pt/stripe/sorbet/gems/sorbet/test/hidden-method-finder/../../lib/hidden-definition-finder.rb:47:in `main'
	from /Users/pt/stripe/sorbet/gems/sorbet/test/hidden-method-finder/../../lib/hidden-definition-finder.rb:38:in `main'
	from /Users/pt/stripe/sorbet/gems/sorbet/test/hidden-method-finder/../../lib/hidden-definition-finder.rb:440:in `<main>'
F

Finished in 0.619009s, 1.6155 runs/s, 1.6155 assertions/s.

  1) Failure:
Sorbet::Private::HiddenMethodFinder::Test::Simple#test_0001_works on a simple example [test/hidden-method-finder/simple.rb:28]:
Expected: true
  Actual: false

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```

When I get some time I can try to debug the test

### Motivation
https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1560517706128900

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
