### PR TITLE
Add zero length loc helper to Loc.

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -214,7 +214,7 @@ unique_ptr<Block> symbol2Proc(DesugarContext dctx, unique_ptr<Expression> expr) 
     core::NameRef name(dctx.ctx, core::cast_type<core::LiteralType>(lit->value.get())->value);
     MethodDef::ARGS_store args;
     // `temp` does not refer to any specific source text, so give it a 0-length Loc so LSP ignores it.
-    core::Loc zeroLengthLoc = loc.zeroLength();
+    core::Loc zeroLengthLoc = loc.copyWithZeroLength();
     args.emplace_back(MK::Local(zeroLengthLoc, temp));
     unique_ptr<Expression> recv = MK::Local(zeroLengthLoc, temp);
     unique_ptr<Expression> body = MK::Send0(loc, std::move(recv), name);
@@ -398,7 +398,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 auto rec = node2TreeImpl(dctx, std::move(send->receiver));
                 if (isa_tree<EmptyTree>(rec.get())) {
                     // 0-sized Loc, since `self.` doesn't appear in the original file.
-                    rec = MK::Self(loc.zeroLength());
+                    rec = MK::Self(loc.copyWithZeroLength());
                     flags |= Send::PRIVATE_OK;
                 }
                 if (absl::c_any_of(send->args, [](auto &arg) { return parser::isa_node<parser::Splat>(arg.get()); })) {
@@ -757,8 +757,8 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 core::Loc recvLoc = csend->receiver->loc;
                 // Assign some desugar-produced nodes with zero-length Locs so IDE ignores them when mapping text
                 // location to node.
-                core::Loc zeroLengthLoc = loc.zeroLength();
-                core::Loc zeroLengthRecvLoc = recvLoc.zeroLength();
+                core::Loc zeroLengthLoc = loc.copyWithZeroLength();
+                core::Loc zeroLengthRecvLoc = recvLoc.copyWithZeroLength();
 
                 // NOTE(dug): We actually desugar into a call to `== nil`. If an
                 // object has overridden `==`, this technically will not match

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -327,7 +327,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::Expression *what, BasicBlock 
 
                         // Inserting a statement that does not directly map to any source text. Make its loc
                         // 0-length so LSP ignores it in queries.
-                        core::Loc zeroLengthLoc = arg.loc.zeroLength();
+                        core::Loc zeroLengthLoc = arg.loc.copyWithZeroLength();
                         bodyBlock->exprs.emplace_back(
                             idxTmp, zeroLengthLoc,
                             make_unique<Literal>(core::make_type<core::LiteralType>(int64_t(i))));

--- a/core/Loc.h
+++ b/core/Loc.h
@@ -110,7 +110,7 @@ public:
     std::pair<Loc, u4> findStartOfLine(const GlobalState &ctx) const;
 
     // For a given Loc, returns a zero-length version that starts at the same location.
-    Loc zeroLength() const {
+    Loc copyWithZeroLength() const {
         return Loc(file(), beginPos(), beginPos());
     }
 };


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Add zero length loc helper to Loc.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I use zero length locs to mark nodes as "ignorable" to the IDE, as they are inserted by Sorbet to desugar Ruby syntax. Before, I wrote the same code in multiple places, which isn't very DRY.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests will check that the changed code is working as intended.
