### PR TITLE
stop mentioning sorbet-repo in release notes

### DIFF
--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -155,9 +155,7 @@ files=()
 while IFS='' read -r line; do files+=("$line"); done < <(find . -type f | sed 's#^./##')
 release_notes="To use Sorbet add this line to your Gemfile:
 \`\`\`
-source 'https://stripe.dev/sorbet-repo/super-secret-private-beta/' do
-  gem 'sorbet', '$prefix.$git_commit_count'
-end
+gem 'sorbet', '$prefix.$git_commit_count'
 \`\`\`"
 if [ "$dryrun" = "" ]; then
     echo "$release_notes" | ../.buildkite/tools/gh-release.sh sorbet/sorbet "${long_release_version}" -- "${files[@]}"


### PR DESCRIPTION
Do we want to keep releases? I was going to kill them but then I thought you'd want the binaries there or something.

E.g. https://github.com/sorbet/sorbet/releases/tag/0.4.4230.20190618163852-34c6f93ac

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
