### PR TITLE
Fix weird quoting issue

### DIFF
--- a/website/docs/talks/ruby-kaigi-2018.md
+++ b/website/docs/talks/ruby-kaigi-2018.md
@@ -1,7 +1,7 @@
 ---
 id: ruby-kaigi-2018
-title: 'A practical type system for Ruby at Stripe'
-sidebar_label: 'RubyKaigi 2018'
+title: A practical type system for Ruby at Stripe
+sidebar_label: RubyKaigi 2018
 ---
 
 - [→ Talk page](https://rubykaigi.org/2018/presentations/DarkDimius.html#may31)

--- a/website/docs/talks/ruby-kaigi-2019.md
+++ b/website/docs/talks/ruby-kaigi-2019.md
@@ -1,7 +1,7 @@
 ---
 id: ruby-kaigi-2019
-title: 'State of Sorbet: A type checker for Ruby'
-sidebar_label: 'RubyKaigi 2019'
+title: State of Sorbet: A type checker for Ruby
+sidebar_label: RubyKaigi 2019
 ---
 
 - [→ Talk page](https://rubykaigi.org/2019/presentations/jez.html#apr19)

--- a/website/docs/talks/strange-loop-2018.md
+++ b/website/docs/talks/strange-loop-2018.md
@@ -1,7 +1,7 @@
 ---
 id: strange-loop-2018
-title: 'Gradual typing of Ruby at Scale'
-sidebar_label: 'Strange Loop 2018'
+title: Gradual typing of Ruby at Scale
+sidebar_label: Strange Loop 2018
 ---
 
 - [→ Talk page](https://www.thestrangeloop.com/2018/gradual-typing-of-ruby-at-scale.html)

--- a/website/pages/en/community.js
+++ b/website/pages/en/community.js
@@ -75,7 +75,7 @@ class Index extends React.Component {
         </div>
         <PageSection short>
           <div>
-            <h1>Talks</h1>
+            <h1 id="talks">Talks</h1>
             <p>
               The Sorbet team has given a number of talks that are available
               online:
@@ -101,7 +101,7 @@ class Index extends React.Component {
             />
           </div>
           <div>
-            <h1>Projects</h1>
+            <h1 id="projects">Projects</h1>
             <p>
               These are some community-maintained projects built on top of or
               alongside the core Sorbet tooling:
@@ -128,7 +128,7 @@ class Index extends React.Component {
             </p>
           </div>
           <div>
-            <h1>Legal</h1>
+            <h1 id="legal">Legal</h1>
             <ul>
               <li>
                 <a href="/docs/legal/trademark-policy">Trademark Policy</a>


### PR DESCRIPTION
It looks like Docusaurus doesn't actually properly parse YAML
frontmatter...

Also add IDs so that I can link to the Talks section.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Before:

<img width="949" alt="Screen Shot 2019-06-19 at 12 21 58 PM" src="https://user-images.githubusercontent.com/5544532/59794032-e06fa280-928c-11e9-8d23-e17e83662b47.png">

After:

<img width="927" alt="Screen Shot 2019-06-19 at 12 21 53 PM" src="https://user-images.githubusercontent.com/5544532/59794033-e06fa280-928c-11e9-9ed0-e5da60fa02a8.png">
