### PR TITLE
Make hover tests stricter, add type narrowing test, fix up proc hover.

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -334,7 +334,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::Expression *what, BasicBlock 
                         InlinedVector<core::LocalVariable, 2> idxVec{idxTmp};
                         InlinedVector<core::Loc, 2> locs{zeroLengthLoc};
                         bodyBlock->exprs.emplace_back(
-                            argLoc, zeroLengthLoc,
+                            argLoc, arg.loc,
                             make_unique<Send>(argTemp, core::Names::squareBrackets(), s->block->loc, idxVec, locs));
                     }
 

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -50,4 +50,5 @@ unique_ptr<ast::MethodDef> DefLocSaver::postTransformMethodDef(core::Context ctx
 
     return methodDef;
 }
+
 } // namespace sorbet::realmain::lsp

--- a/test/testdata/lsp/hover_conditional_type_narrowing.rb
+++ b/test/testdata/lsp/hover_conditional_type_narrowing.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+a = T.let(nil, T.nilable(String))
+
+if !a.nil?
+  puts a
+     # ^ hover: String
+else
+  puts a
+     # ^ hover: NilClass
+end

--- a/test/testdata/lsp/hover_method.rb
+++ b/test/testdata/lsp/hover_method.rb
@@ -7,8 +7,8 @@ class Foo
     # ^ hover: sig {returns(Integer)}
     # N.B. Checking two positions on below function call as they used to return different strings.
     baz("1")
-  # ^ hover: params(arg0: String).returns(Integer)
-   # ^ hover: params(arg0: String).returns(Integer)
+  # ^ hover: sig {params(arg0: String).returns(Integer)}
+   # ^ hover: sig {params(arg0: String).returns(Integer)}
   end
 
   sig {params(a: String).void}
@@ -19,10 +19,10 @@ class Foo
   sig {params(arg0: String).returns(Integer)}
   def baz(arg0)
     no_args_and_void
-  # ^ hover: void
+  # ^ hover: sig {void}
     Foo::bat(1)
-  # ^ hover: Foo
-       # ^ hover: params(i: Integer).returns(Integer)
+  # ^ hover: T.class_of(Foo)
+       # ^ hover: sig {params(i: Integer).returns(Integer)}
            # ^ hover: Integer(1)
     arg0.to_i
   end

--- a/test/testdata/lsp/hover_untyped_proc_arg.rb
+++ b/test/testdata/lsp/hover_untyped_proc_arg.rb
@@ -3,15 +3,15 @@
 def main
   a = T.let([], T.untyped)
   a.map do |foo, bar|
-          # ^ hover: T.untyped
-                # ^ hover: T.untyped
+          # ^ hover: sig {returns(T.untyped)}
+                # ^ hover: sig {returns(T.untyped)}
   end
   b = T.let([], T::Array[T.untyped])
   b.map do |foo|
-          # ^ hover: T.untyped
+          # ^ hover: sig {returns(T.untyped)}
   end
   c = T.let([], T::Array[String])
   c.map do |foo|
-          # ^ hover: String
+          # ^ hover: sig {returns(String)}
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Make hover tests stricter, add a type narrowing test, fix up proc hover.

This change makes hover tests match against *whole lines* and not just a substring of the entire hover contents.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Without this change, I can't assert that something is `String` and not `T.nilable(String)`.

This change also surfaced a bug in hover on proc arguments. We had a test that was passing when it should have been failing.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
