### PR TITLE
Use a const set reference for extensions passed to `listFilesInDir`.

### DIFF
--- a/common/FileOps.h
+++ b/common/FileOps.h
@@ -18,7 +18,7 @@ public:
      * Returns a list of all files in the given directory. Returns paths that include the path to directory.
      * Throws FileNotFoundException if path does not exist, and FileNotDirException if path is not a directory.
      */
-    static std::vector<std::string> listFilesInDir(std::string_view path, UnorderedSet<std::string> extensions,
+    static std::vector<std::string> listFilesInDir(std::string_view path, const UnorderedSet<std::string> &extensions,
                                                    bool recursive,
                                                    const std::vector<std::string> &absoluteIgnorePatterns,
                                                    const std::vector<std::string> &relativeIgnorePatterns);

--- a/common/FileSystem.cc
+++ b/common/FileSystem.cc
@@ -12,8 +12,8 @@ void OSFileSystem::writeFile(string_view filename, string_view text) {
     return FileOps::write(filename, text);
 }
 
-vector<string> OSFileSystem::listFilesInDir(string_view path, UnorderedSet<std::string> extensions, bool recursive,
-                                            const std::vector<std::string> &absoluteIgnorePatterns,
+vector<string> OSFileSystem::listFilesInDir(string_view path, const UnorderedSet<std::string> &extensions,
+                                            bool recursive, const std::vector<std::string> &absoluteIgnorePatterns,
                                             const std::vector<std::string> &relativeIgnorePatterns) const {
     return FileOps::listFilesInDir(path, extensions, recursive, absoluteIgnorePatterns, relativeIgnorePatterns);
 }

--- a/common/FileSystem.h
+++ b/common/FileSystem.h
@@ -30,7 +30,7 @@ public:
      *
      * Throws FileNotFoundException if path does not exist, and FileNotDirException if path is not a directory.
      */
-    virtual std::vector<std::string> listFilesInDir(std::string_view path, UnorderedSet<std::string> extensions,
+    virtual std::vector<std::string> listFilesInDir(std::string_view path, const UnorderedSet<std::string> &extensions,
                                                     bool recursive,
                                                     const std::vector<std::string> &absoluteIgnorePatterns,
                                                     const std::vector<std::string> &relativeIgnorePatterns) const = 0;
@@ -45,8 +45,8 @@ public:
 
     std::string readFile(std::string_view path) const override;
     void writeFile(std::string_view filename, std::string_view text) override;
-    std::vector<std::string> listFilesInDir(std::string_view path, UnorderedSet<std::string> extensions, bool recursive,
-                                            const std::vector<std::string> &absoluteIgnorePatterns,
+    std::vector<std::string> listFilesInDir(std::string_view path, const UnorderedSet<std::string> &extensions,
+                                            bool recursive, const std::vector<std::string> &absoluteIgnorePatterns,
                                             const std::vector<std::string> &relativeIgnorePatterns) const override;
 };
 

--- a/common/common.cc
+++ b/common/common.cc
@@ -234,7 +234,7 @@ void appendFilesInDir(string_view basePath, string_view path, const sorbet::Unor
     closedir(dir);
 }
 
-vector<string> sorbet::FileOps::listFilesInDir(string_view path, UnorderedSet<string> extensions, bool recursive,
+vector<string> sorbet::FileOps::listFilesInDir(string_view path, const UnorderedSet<string> &extensions, bool recursive,
                                                const std::vector<std::string> &absoluteIgnorePatterns,
                                                const std::vector<std::string> &relativeIgnorePatterns) {
     vector<string> result;

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -482,12 +482,11 @@ void Options::flushPrinters() {
 }
 
 void addFilesFromDir(Options &opts, string_view dir) {
-    UnorderedSet<string> acceptableExtensions = {".rb", ".rbi"};
     auto fileNormalized = stripTrailingSlashes(dir);
     opts.rawInputDirNames.emplace_back(fileNormalized);
     // Expand directory into list of files.
-    auto containedFiles = opts.fs->listFilesInDir(fileNormalized, acceptableExtensions, true,
-                                                  opts.absoluteIgnorePatterns, opts.relativeIgnorePatterns);
+    auto containedFiles = opts.fs->listFilesInDir(fileNormalized, {".rb", ".rbi"}, true, opts.absoluteIgnorePatterns,
+                                                  opts.relativeIgnorePatterns);
     opts.inputFileNames.reserve(opts.inputFileNames.size() + containedFiles.size());
     opts.inputFileNames.insert(opts.inputFileNames.end(), std::make_move_iterator(containedFiles.begin()),
                                std::make_move_iterator(containedFiles.end()));

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -43,7 +43,7 @@ void MockFileSystem::deleteFile(string_view filename) {
     }
 }
 
-vector<string> MockFileSystem::listFilesInDir(string_view path, UnorderedSet<string> extensions, bool recursive,
+vector<string> MockFileSystem::listFilesInDir(string_view path, const UnorderedSet<string> &extensions, bool recursive,
                                               const std::vector<std::string> &absoluteIgnorePatterns,
                                               const std::vector<std::string> &relativeIgnorePatterns) const {
     Exception::raise("Not implemented.");

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -26,8 +26,8 @@ public:
     std::string readFile(std::string_view path) const override;
     void writeFile(std::string_view filename, std::string_view text) override;
     void deleteFile(std::string_view filename);
-    std::vector<std::string> listFilesInDir(std::string_view path, UnorderedSet<std::string> extensions, bool recursive,
-                                            const std::vector<std::string> &absoluteIgnorePatterns,
+    std::vector<std::string> listFilesInDir(std::string_view path, const UnorderedSet<std::string> &extensions,
+                                            bool recursive, const std::vector<std::string> &absoluteIgnorePatterns,
                                             const std::vector<std::string> &relativeIgnorePatterns) const override;
 };
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Use a const set reference for extensions passed to `listFilesInDir`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Reduces copying.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

N/A. If there's a problem, one of the existing CLI tests should find it.
