### PR TITLE
Add `-p autogen-subclasses` to print all superclasses and their subclasses

### DIFF
--- a/main/autogen/autogen.h
+++ b/main/autogen/autogen.h
@@ -47,6 +47,7 @@ struct Definition {
     DefinitionRef id;
 
     Type type;
+    std::string_view typeAsStringView();
     bool defines_behavior;
     bool is_empty;
 
@@ -82,6 +83,7 @@ struct ParsedFile {
     std::string toString(core::Context ctx);
     std::string toMsgpack(core::Context ctx, int version);
     void classlist(core::Context ctx, std::vector<std::string> &out);
+    void subclasses(core::Context ctx, std::map<std::string, std::set<std::string>> &out);
 
 private:
     std::vector<core::NameRef> showFullName(core::Context ctx, DefinitionRef id);

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -72,6 +72,7 @@ struct Printers {
     PrinterConfig Autogen;
     PrinterConfig AutogenMsgPack;
     PrinterConfig AutogenClasslist;
+    PrinterConfig AutogenSubclasses;
     PrinterConfig PluginGeneratedCode;
     // Ensure everything here is in PrinterConfig::printers().
 

--- a/test/cli/autogen-subclasses/a.rb
+++ b/test/cli/autogen-subclasses/a.rb
@@ -1,0 +1,22 @@
+# typed: true
+
+module Opus
+  class DupChild < Parent; end
+  class Child < Parent; end
+end
+
+class Opus::Parent; end
+
+module Opus::Mixin; end
+
+class Opus::Mixed
+  include Opus::Mixin
+end
+
+module Opus::MixedModule
+  include Opus::Mixin
+end
+
+class OtherChild < NonexistentParent; end
+
+class Opus::DupChild < Opus::Parent; end # Only appears once in output

--- a/test/cli/autogen-subclasses/autogen-subclasses.out
+++ b/test/cli/autogen-subclasses/autogen-subclasses.out
@@ -1,0 +1,7 @@
+--- autogen-subclasses ---
+Opus::Mixin
+ Opus::Mixed,class
+ Opus::MixedModule,module
+Opus::Parent
+ Opus::Child,class
+ Opus::DupChild,class

--- a/test/cli/autogen-subclasses/autogen-subclasses.sh
+++ b/test/cli/autogen-subclasses/autogen-subclasses.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -eu
+
+echo "--- autogen-subclasses ---"
+main/sorbet --silence-dev-message --stop-after=resolver -p autogen-subclasses test/cli/autogen-subclasses/a.rb

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -120,7 +120,7 @@ Usage:
                                 missing-constants, flattened-tree,
                                 flattened-tree-raw, cfg, cfg-json, cfg-proto, autogen,
                                 autogen-msgpack, autogen-classlist,
-                                plugin-generated-code]
+                                autogen-subclasses, plugin-generated-code]
       --stop-after phase        Stop After: [init, parser, desugarer, dsl,
                                 local-vars, namer, resolver, cfg, inferencer]
                                 (default: inferencer)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Essentially ports pay-server's `DescendantsMap` to Sorbet.
Supplying `-p autogen-subclasses` will output a file `subclasses.txt` which contains a list of all superclasses and their immediate subclasses, e.g.,

```
Parent1
 Child1,class
 Child2,module
Parent2
 Child3,class
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Implementing `InheritedClassesStep` in Sorbet.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
