### PR TITLE
Deduplicate file names without ordering them

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -481,21 +481,34 @@ void Options::flushPrinters() {
     }
 }
 
-void addFilesFromDir(Options &opts, string_view dir) {
+void addFile(Options &opts, UnorderedSet<string> &knownFileNames, string_view file) {
+    if (knownFileNames.find(file) == knownFileNames.end()) {
+        knownFileNames.emplace(file);
+        opts.inputFileNames.emplace_back(file);
+    }
+}
+
+void addFiles(Options &opts, UnorderedSet<string> &knownFileNames, vector<string> files) {
+    opts.inputFileNames.reserve(opts.inputFileNames.size() + files.size());
+    for (auto file : files) {
+        addFile(opts, knownFileNames, file);
+    }
+}
+
+void addFilesFromDir(Options &opts, UnorderedSet<string> &knownFileNames, string_view dir) {
     auto fileNormalized = stripTrailingSlashes(dir);
     opts.rawInputDirNames.emplace_back(fileNormalized);
     // Expand directory into list of files.
     auto containedFiles = opts.fs->listFilesInDir(fileNormalized, {".rb", ".rbi"}, true, opts.absoluteIgnorePatterns,
                                                   opts.relativeIgnorePatterns);
-    opts.inputFileNames.reserve(opts.inputFileNames.size() + containedFiles.size());
-    opts.inputFileNames.insert(opts.inputFileNames.end(), std::make_move_iterator(containedFiles.begin()),
-                               std::make_move_iterator(containedFiles.end()));
+    addFiles(opts, knownFileNames, containedFiles);
 }
 
 void readOptions(Options &opts, int argc, char *argv[],
                  shared_ptr<spdlog::logger> logger) noexcept(false) { // throw(EarlyReturnWithCode)
     Timer timeit(*logger, "readOptions");
     cxxopts::Options options = buildOptions();
+    UnorderedSet<string> knownFileNames; // Used to deduplicate list
     try {
         cxxopts::ParseResult raw = ConfigParser::parseConfig(logger, argc, argv, options);
         if (raw["simulate-crash"].as<bool>()) {
@@ -521,10 +534,10 @@ void readOptions(Options &opts, int argc, char *argv[],
             struct stat s;
             for (auto &file : rawFiles) {
                 if (stat(file.c_str(), &s) == 0 && s.st_mode & S_IFDIR) {
-                    addFilesFromDir(opts, file);
+                    addFilesFromDir(opts, knownFileNames, file);
                 } else {
                     opts.rawInputFileNames.push_back(file);
-                    opts.inputFileNames.push_back(file);
+                    addFile(opts, knownFileNames, file);
                 }
             }
         }
@@ -532,7 +545,7 @@ void readOptions(Options &opts, int argc, char *argv[],
         if (raw.count("file") > 0) {
             auto files = raw["file"].as<vector<string>>();
             opts.rawInputFileNames.insert(opts.rawInputFileNames.end(), files.begin(), files.end());
-            opts.inputFileNames.insert(opts.inputFileNames.end(), files.begin(), files.end());
+            addFiles(opts, knownFileNames, files);
         }
 
         if (raw.count("dir") > 0) {
@@ -540,7 +553,7 @@ void readOptions(Options &opts, int argc, char *argv[],
             for (auto &dir : rawDirs) {
                 // Since we don't stat here, we're unsure if the directory exists / is a directory.
                 try {
-                    addFilesFromDir(opts, dir);
+                    addFilesFromDir(opts, knownFileNames, dir);
                 } catch (sorbet::FileNotFoundException) {
                     logger->error("Directory `{}` not found", dir);
                     throw EarlyReturnWithCode(1);
@@ -556,9 +569,6 @@ void readOptions(Options &opts, int argc, char *argv[],
             // default path prefix is that directory.
             opts.pathPrefix = fmt::format("{}/", opts.rawInputDirNames.at(0));
         }
-        fast_sort(opts.inputFileNames);
-        opts.inputFileNames.erase(unique(opts.inputFileNames.begin(), opts.inputFileNames.end()),
-                                  opts.inputFileNames.end());
 
         bool enableAllLSPFeatures = raw["enable-all-experimental-lsp-features"].as<bool>();
         opts.lspAutocompleteEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-autocomplete"].as<bool>();

--- a/test/cli/dedup-input-files/dedup-input-files.out
+++ b/test/cli/dedup-input-files/dedup-input-files.out
@@ -1,2 +1,16 @@
 dummy: File Not Found https://srb.help/1004
 Errors: 1
+------------------------------
+No errors! Great job.
+------------------------------
+foo/stdlib.rbi:10: Method `Foo#foo` redefined without matching argument count. Expected: `2`, got: `1` https://srb.help/4010
+    10 |  def foo(a); end
+          ^^^^^^^^^^
+    foo/foo.rb:4: Previous definition
+     4 |  def foo(a, b); end
+          ^^^^^^^^^^^^^
+Errors: 1
+------------------------------
+No errors! Great job.
+------------------------------
+No errors! Great job.

--- a/test/cli/dedup-input-files/dedup-input-files.out
+++ b/test/cli/dedup-input-files/dedup-input-files.out
@@ -14,3 +14,11 @@ Errors: 1
 No errors! Great job.
 ------------------------------
 No errors! Great job.
+------------------------------
+foo/foo.rb:4: Method `Foo#foo` redefined without matching argument count. Expected: `1`, got: `2` https://srb.help/4010
+     4 |  def foo(a, b); end
+          ^^^^^^^^^^^^^
+    foo/stdlib.rbi:10: Previous definition
+    10 |  def foo(a); end
+          ^^^^^^^^^^
+Errors: 1

--- a/test/cli/dedup-input-files/dedup-input-files.sh
+++ b/test/cli/dedup-input-files/dedup-input-files.sh
@@ -25,3 +25,8 @@ echo ------------------------------
 
 # Dedup config files
 "$cwd/main/sorbet" --silence-dev-message --no-config @sorbet/config @sorbet/config 2>&1
+
+echo ------------------------------
+
+# Dedup files and keep ordering
+"$cwd/main/sorbet" --silence-dev-message --no-config foo/stdlib.rbi foo/foo.rb foo/stdlib.rbi foo/foo.rb 2>&1

--- a/test/cli/dedup-input-files/dedup-input-files.sh
+++ b/test/cli/dedup-input-files/dedup-input-files.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
-main/sorbet --silence-dev-message dummy dummy dummy dummy dummy dummy 2>&1
+cwd="$(pwd)"
+cd test/cli/dedup-input-files || exit 1
+
+# Dedup dummy files
+"$cwd/main/sorbet" --silence-dev-message dummy dummy dummy dummy dummy dummy 2>&1

--- a/test/cli/dedup-input-files/dedup-input-files.sh
+++ b/test/cli/dedup-input-files/dedup-input-files.sh
@@ -5,3 +5,23 @@ cd test/cli/dedup-input-files || exit 1
 
 # Dedup dummy files
 "$cwd/main/sorbet" --silence-dev-message dummy dummy dummy dummy dummy dummy 2>&1
+
+echo ------------------------------
+
+# Dedup real files
+"$cwd/main/sorbet" --silence-dev-message foo/stdlib.rbi foo/stdlib.rbi foo/stdlib.rbi 2>&1
+
+echo ------------------------------
+
+# Dedup directories
+"$cwd/main/sorbet" --silence-dev-message --no-config foo/ foo/ foo/ 2>&1
+
+echo ------------------------------
+
+# Dedup files from config
+"$cwd/main/sorbet" --silence-dev-message 2>&1
+
+echo ------------------------------
+
+# Dedup config files
+"$cwd/main/sorbet" --silence-dev-message --no-config @sorbet/config @sorbet/config 2>&1

--- a/test/cli/dedup-input-files/foo/foo.rb
+++ b/test/cli/dedup-input-files/foo/foo.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+class Foo
+  def foo(a, b); end
+end

--- a/test/cli/dedup-input-files/foo/stdlib.rbi
+++ b/test/cli/dedup-input-files/foo/stdlib.rbi
@@ -1,0 +1,11 @@
+# typed: true
+
+class A
+end
+
+class Foo
+  extend T::Sig
+
+  sig { params(a: A).void }
+  def foo(a); end
+end

--- a/test/cli/dedup-input-files/sorbet/config
+++ b/test/cli/dedup-input-files/sorbet/config
@@ -1,0 +1,3 @@
+foo/stdlib.rbi
+foo/stdlib.rbi
+foo/stdlib.rbi


### PR DESCRIPTION
While fixing issue #203, the PR #755 removed the ability for the user to control the file loading order.
This PR accomplish the same thing than #755 while keeping them as specified by the user.

### Motivation

Be the following RBI file in a `foo/` directory:

~~~ruby
# foo/stdlib.rbi
# typed: true

class A
end

class Foo
  extend T::Sig

  sig { params(a: A).void }
  def foo(a); end
end
~~~

And Ruby a module using it:

~~~ruby
# foo/foo.rb
# typed: true

class Foo
  def foo(a, b); end
end
~~~

Because of the file names, when passing `foo/` to Sorbet, we will get this error message:

~~~bash
# Loading `foo` only gives the bad order
$ sorbet foo/

stdlib.rbi:10: Method Foo#foo redefined without matching argument count. Expected: 2, got: 1
    10 |  def foo(a); end
          ^^^^^^^^^^
    foo.rb:4: Previous definition
     4 |  def foo(a, b); end
          ^^^^^^^^^^^^^
Errors: 1
~~~

Notice that `stdlib.rbi` is wrongly presented in the error as the redefinition from `foo.rb`.


Before #755 (commit db452936f1b2c91301503b2442ddd72b7a94616f), it was possible to go around this by specifying the order of the arguments:

~~~bash
# Changing the arguments order works
$ sorbet foo/stdlib.rbi foo/foo.rb

foo/foo.rb:4: Method Foo#foo redefined without matching argument count. Expected: 1, got: 2
     4 |  def foo(a, b); end
          ^^^^^^^^^^^^^
    foo/stdlib.rbi:10: Previous definition
    10 |  def foo(a); end
          ^^^^^^^^^^
Errors: 1
~~~

After #755 (commit 0fc29b4c38a01f9663a14a1ccfb89f883373938a), the fix for #203 removed this ability:

~~~bash
# Changing the order doesn't work anymore
$ sorbet foo/stdlib.rbi foo/foo.rb

foo/stdlib.rbi:10: Method Foo#foo redefined without matching argument count. Expected: 2, got: 1
    10 |  def foo(a); end
          ^^^^^^^^^^
    foo/foo.rb:4: Previous definition
     4 |  def foo(a, b); end
          ^^^^^^^^^^^^^
Errors: 1
~~~

This PR (commit 2097f831fa72fff09c50ebebc2043e84fb5c5cd6) adds it back:

~~~bash
# Changing the arguments order works again
$ sorbet foo/stdlib.rbi foo/foo.rb

foo/foo.rb:4: Method Foo#foo redefined without matching argument count. Expected: 1, got: 2
     4 |  def foo(a, b); end
          ^^^^^^^^^^^^^
    foo/stdlib.rbi:10: Previous definition
    10 |  def foo(a); end
          ^^^^^^^^^^
Errors: 1
~~~

### Benchmarks

I benchmarked the solution by loading the content of `rbi/` with the following command:

~~~bash
find rbi -name "*.rbi" | grep -v light.rbi > benchfiles
bazel-bin/main/sorbet --no-stdlib @benchfiles
~~~

The following table gives the average loading time over 10 runs sor each version of Sorbet:

| desc.			| commit									| time (s)	|
|---------------|-------------------------------------------|-----------|
| before-755	| db452936f1b2c91301503b2442ddd72b7a94616f	| 2.280		|
| after-755	| 0fc29b4c38a01f9663a14a1ccfb89f883373938a	| 2.143		|
| this-pr		| 2097f831fa72fff09c50ebebc2043e84fb5c5cd6	| 2.118		|

### Test plan

I added a tests showing the behaviour before/after on dummy files as well as real ones, directories and config files.