### PR TITLE
Docs: Add `bundle exec` to getting started commands`

### DIFF
--- a/website/docs/adopting.md
+++ b/website/docs/adopting.md
@@ -25,10 +25,10 @@ gem 'sorbet-runtime'
 To test that everything is working so far, we can run these commands:
 
 ```plaintext
-❯ srb
+❯ bundle exec srb
 [help output]
 
-❯ srb typecheck -e 'puts "Hello, world!"'
+❯ bundle exec srb typecheck -e 'puts "Hello, world!"'
 No errors! Great job.
 
 ❯ bundle exec ruby -e 'puts(require "sorbet-runtime")'


### PR DESCRIPTION
Very excited to see this open source! Congratulations on the release and thanks so much for sharing. I gave it a try and thought I'd make a suggestion for the docs while it's on my mind.

I followed these verbatim, but hit an error: 

```ruby
~/code/graphql-ruby $ srb typecheck -e 'puts "Hello, world!"'
-bash: srb: command not found
```

It was better when I added `bundle exec` 

```ruby
~/code/graphql-ruby $ bundle exec srb typecheck -e 'puts "Hello, world!"'
mkdir: /Users/rmosolgo/.cache/sorbet: No such file or directory
No errors! Great job.
```

