### PR TITLE
Rename DeprecatedInheritableStruct -> InexactStruct

### DIFF
--- a/rbi/light.rbi
+++ b/rbi/light.rbi
@@ -191,11 +191,11 @@ end
 module T::Enumerator
   def self.[](type); end
 end
-class T::DeprecatedInheritableStruct
+class T::InexactStruct
   def prop(name, type, rules={}); end
   def const(name, type, rules={}); end
 end
-class T::Struct < T::DeprecatedInheritableStruct; end
+class T::Struct < T::InexactStruct; end
 T::Boolean = T.type_alias(T.any(TrueClass, FalseClass))
 module Comparable
 end

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -102,10 +102,10 @@ end
 module T::CFGExport
 end
 
-class T::DeprecatedInheritableStruct
+class T::InexactStruct
   def prop(name, type, rules={}); end
   def const(name, type, rules={}); end
 end
-class T::Struct < T::DeprecatedInheritableStruct; end
+class T::Struct < T::InexactStruct; end
 
 T::Boolean = T.type_alias(T.any(TrueClass, FalseClass))


### PR DESCRIPTION
This runs

```sh
git ls-files -z '*.rb' '*.rbi' | xargs -0 sed -i '' 's/T::DeprecatedInheritableStruct/T::InexactStruct/g'
```
across the codebase.

### Motivation

We don't want to deprecate inheritable structs.

The new name "inexact" comes from the fact that in the future, `T::Struct` will have static types for `initialize` but `T::InexactStruct` will not, given our implementation strategy.

Related to #847.

Rollout plan is: bump pay-server to this, then merge in the big pay-server PR, then merge #847, then bump pay-server to that.

### Test plan

Nope.
