### PR TITLE
Add error 5023: Missing definition for abstract method

### DIFF
--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -295,6 +295,29 @@ end
 
 The same thing holds for type templates.
 
+## 5023
+
+Some modules require specific functionality in the receiving class to work. For example `Enumerable` needs a `each` method in the target class.
+
+Failing example in [sorbet.run](https://sorbet.run/#class%20Example%0A%20%20include%20Enumerable%0Aend):
+```
+class Example
+  include Enumerable
+end
+```
+
+To fix this, implement the required abstract methods in your class to provide the required functionality.
+
+Passing example in [sorbet.run](https://sorbet.run/#class%20Example%0A%20%20include%20Enumerable%0A%0A%20%20def%20each(%26blk)%0A%0A%20%20end%0Aend):
+```
+class Example
+  include Enumerable
+
+  def each(&blk)
+  end
+end
+```
+
 ## 5028
 
 In `# typed: strict` files, Sorbet requires that all constants are annotated


### PR DESCRIPTION
This is a docs-only change reflecting my new-found understanding of this error.