### PR TITLE
Fix metrics file counters when using DSL plugins

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -376,6 +376,10 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
         level = core::StrictLevel::False;
     }
 
+    return level;
+}
+
+void incrementStrictLevelCounter(core::StrictLevel level) {
     switch (level) {
         case core::StrictLevel::None:
             Exception::raise("Should never happen");
@@ -408,8 +412,6 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
             prodCounterInc("types.input.files.sigil.stdlib");
             break;
     }
-
-    return level;
 }
 
 void readFileWithStrictnessOverrides(unique_ptr<core::GlobalState> &gs, core::FileRef file,
@@ -453,7 +455,9 @@ void readFileWithStrictnessOverrides(unique_ptr<core::GlobalState> &gs, core::Fi
         fileData.sourceType = core::File::PayloadGeneration;
     }
 
-    fileData.strictLevel = decideStrictLevel(*gs, file, opts);
+    auto level = decideStrictLevel(*gs, file, opts);
+    fileData.strictLevel = level;
+    incrementStrictLevelCounter(level);
 }
 
 struct IndexResult {

--- a/test/cli/metrics-file/metrics-file.out
+++ b/test/cli/metrics-file/metrics-file.out
@@ -6,3 +6,9 @@ Cannot write metrics file at `foo/bar/metrics2.json`
 ------------------------------
 No errors! Great job.
 Cannot write metrics file at `baz/metrics3.json`
+------------------------------
+No errors! Great job.
+   "name": "ruby_typer.unknown..types.input.files",
+   "value": 1
+   "name": "ruby_typer.unknown..types.input.files.sigil.true",
+   "value": 1

--- a/test/cli/metrics-file/metrics-file.sh
+++ b/test/cli/metrics-file/metrics-file.sh
@@ -7,10 +7,21 @@ echo ------------------------------
 
 # Sorbet does not crash if the metrics directory does not exist
 main/sorbet --silence-dev-message -e 'class Foo; end' --metrics-file=foo/bar/metrics2.json 2>&1
-grep status foo/bar/metrics2.json
 
 echo ------------------------------
 
 # Sorbet produce a clean error if the metrics path is not a directory
 touch baz
 main/sorbet --silence-dev-message -e 'class Foo; end' --metrics-file=baz/metrics3.json 2>&1
+
+echo ------------------------------
+
+# Sorbet produce correct file counters with plugins
+main/sorbet --silence-dev-message \
+            --dsl-plugins test/cli/metrics-file/sorbet/triggers.yml \
+            --metrics-file=metrics4.json \
+            test/cli/metrics-file/test.rb 2>&1
+
+grep -A1 "\"ruby_typer.unknown..types.input.files\"" metrics4.json
+grep -A1 "\"ruby_typer.unknown..types.input.files.sigil.false\"" metrics4.json
+grep -A1 "\"ruby_typer.unknown..types.input.files.sigil.true\"" metrics4.json

--- a/test/cli/metrics-file/sorbet/plugin.rb
+++ b/test/cli/metrics-file/sorbet/plugin.rb
@@ -1,0 +1,29 @@
+require 'optparse'
+
+module SorbetPlugins
+  def self.parse_args
+    klass, method, source = nil
+    OptionParser.new do |opts|
+      opts.on('--class CLASS', 'Immediate outer class') do |v|
+        klass = v
+      end
+      opts.on('--method METHOD', 'Method trigger') do |v|
+        method = v
+      end
+      opts.on('--source SOURCE', 'Source code for the enter method call') do |v|
+        source = v
+      end
+    end.parse!
+    [klass, method, source]
+  end
+
+  _klass, _method, source = SorbetPlugins.parse_args
+
+  class << self
+    def delegate(*methods, to: nil, prefix: nil, allow_nil: nil, private: nil)
+      puts "def foo; end"
+    end
+  end
+
+  module_eval(source)
+end

--- a/test/cli/metrics-file/sorbet/triggers.yml
+++ b/test/cli/metrics-file/sorbet/triggers.yml
@@ -1,0 +1,4 @@
+ruby_extra_args:
+  - "--disable-gems"
+triggers:
+  delegate: test/cli/metrics-file/sorbet/plugin.rb

--- a/test/cli/metrics-file/test.rb
+++ b/test/cli/metrics-file/test.rb
@@ -1,0 +1,14 @@
+# typed: true
+
+class Foo
+  def foo
+    puts "foo"
+  end
+end
+
+class Bar
+  delegate :foo, to: :foo
+end
+
+Foo.new.foo
+Bar.new.foo


### PR DESCRIPTION
### Motivation

Before this PR, the test provided in `test/cli/metrics-file` was returning wrong counters such as:

~~~
    ruby_typer.unknown..types.input.files: 1
    ruby_typer.unknown..types.input.files.sigil.false: 1
    ruby_typer.unknown..types.input.files.sigil.true: 1
~~~

This PR avoid incrementing file counters from a DSL plugins:

~~~
    ruby_typer.unknown..types.input.files: 1
    ruby_typer.unknown..types.input.files.sigil.false: 0
    ruby_typer.unknown..types.input.files.sigil.true: 1
~~~

### Test plan

See included automated tests.
