### PR TITLE
Allow rest args in `Enumerator::Yielder#yield`

### DIFF
--- a/rbi/core/enumerator.rbi
+++ b/rbi/core/enumerator.rbi
@@ -121,7 +121,7 @@ class Enumerator::Yielder < Object
     )
     .void
   end
-  def <<(arg0); end
+  def <<(*arg0); end
 
   sig do
     params(
@@ -129,5 +129,5 @@ class Enumerator::Yielder < Object
     )
     .void
   end
-  def yield(arg0); end
+  def yield(*arg0); end
 end


### PR DESCRIPTION
See the examples in https://stackoverflow.com/questions/5071802

### Motivation

The types were wrong and they should be right.

cc @ptarjan 

### Test plan

I tried to write a test, and ran into issues with light.rbi. Should I fix light.rbi or defer until when it's deleted?