### PR TITLE
change suggestion from -vvvv

### DIFF
--- a/gems/sorbet/lib/hidden-definition-finder.rb
+++ b/gems/sorbet/lib/hidden-definition-finder.rb
@@ -114,7 +114,7 @@ class Sorbet::Private::HiddenMethodFinder
     )
     File.write(SOURCE_CONSTANTS, io.read)
     io.close
-    raise "Your source can't be read by Sorbet.\nYou can try `srb tc --print=symbol-table-json -vvvv --max-threads 1` and hopefully the last file it is processing before it dies is the culprit.\nIf not, maybe the errors in this file will help: #{SOURCE_CONSTANTS_ERR}" if File.read(SOURCE_CONSTANTS).empty?
+    raise "Your source can't be read by Sorbet.\nYou can try `rm sorbet/config; find . -type f | xargs -L 1 -t srb tc --error-white-list 1000` and hopefully the last file it is processing before it dies is the culprit.\nIf not, maybe the errors in this file will help: #{SOURCE_CONSTANTS_ERR}" if File.read(SOURCE_CONSTANTS).empty?
 
     puts "Printing #{TMP_RBI}'s symbol table into #{RBI_CONSTANTS}"
     # Change dir to deal with you having a sorbet/config in your cwd


### PR DESCRIPTION
Our `-vvvv` output isn't useful for debugging this. It doesn't print the filename anymore and only gives timings. What do you think about this advice instead?

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
