### PR TITLE
[968] Rubyisms - Add support for `===`

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/base.rb
+++ b/gems/sorbet-runtime/lib/types/types/base.rb
@@ -19,6 +19,10 @@ module T::Types
       raise NotImplementedError
     end
 
+    def ===(obj)
+      valid?(obj)
+    end
+
     # @return [T::Boolean] This method must be implemented to return whether the subclass is a subtype
     # of `type`. This should only be called by `subtype_of?`, which guarantees that `type` will be
     # a "single" type, by which we mean it won't be a Union or an Intersection (c.f.


### PR DESCRIPTION
Adds support for the `===` operator as referenced in #968. This will
allow for Sorbet types to be used in conjunction with various Rubyisms
like case statememts, `any?` type predicate methods, `grep`, and several
others.

### Motivation

`===` is one of the most powerful and expressive features of Ruby. Adding it to a type definition unlocks an entire world of potential usecases.

### Test plan

Tests can be added, but this is effectively just aliasing the `valid?` method and associated tests.