### PR TITLE
Do not allow installing sorbet on Ruby < 2.3 and >= 2.7

### DIFF
--- a/gems/sorbet-runtime/sorbet-runtime.gemspec
+++ b/gems/sorbet-runtime/sorbet-runtime.gemspec
@@ -8,6 +8,8 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://sorbet.run'
   s.license     = 'Apache-2.0'
 
+  s.required_ruby_version = ['>= 2.3.0', '< 2.7.0.preview1']
+
   s.add_development_dependency 'minitest', '~> 5.11'
   s.add_development_dependency 'mocha', '~> 1.7'
   s.add_development_dependency 'rake'

--- a/gems/sorbet-static/sorbet-static.gemspec
+++ b/gems/sorbet-static/sorbet-static.gemspec
@@ -12,4 +12,6 @@ Gem::Specification.new do |s|
 
   # We include a pre-built binary (in libexec/), making us platform dependent.
   s.platform = Gem::Platform::CURRENT
+
+  s.required_ruby_version = ['>= 2.3.0', '< 2.7.0.preview1']
 end

--- a/gems/sorbet/sorbet.gemspec
+++ b/gems/sorbet/sorbet.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'sorbet-static', '0.0.0'
 
+  s.required_ruby_version = ['>= 2.3.0', '< 2.7.0.preview1']
+
   s.add_development_dependency 'minitest', '~> 5.11'
   s.add_development_dependency 'mocha', '~> 1.7'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Sorbet doesn't work on Ruby < 2.3 and we still don't support Ruby 2.7

Closes #976.


### Test plan
`gem build gem/sorbet/sorbet.gemspec` and `gem install gem/sorbet/sorbet*.gem` in a version of Ruby < 2.3 or in Ruby 2.7.