### PR TITLE
Fix return type of `IO.select`

### DIFF
--- a/rbi/core/io.rbi
+++ b/rbi/core/io.rbi
@@ -544,7 +544,7 @@ class IO < Object
         error_array: T::Array[IO],
         timeout: Integer,
     )
-    .returns(T.nilable(T::Array[IO]))
+    .returns(T.nilable(T::Array[T::Array[IO]]))
   end
   def self.select(read_array, write_array=T.unsafe(nil), error_array=T.unsafe(nil), timeout=T.unsafe(nil)); end
 


### PR DESCRIPTION
`IO.select` returns either [nil][1], [an empty array][2] or [an array of an array of IO objects][2].

[1]: https://github.com/ruby/ruby/blob/v2_6_3/io.c#L9149
[2]: https://github.com/ruby/ruby/blob/v2_6_3/io.c#L9097
[3]: https://github.com/ruby/ruby/blob/v2_6_3/io.c#L9099-L9147
