### PR TITLE
Show VS Code progress animation when we compute state hashes during initialization.

### DIFF
--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -93,6 +93,7 @@ LSPResult LSPLoop::processRequestInternal(unique_ptr<core::GlobalState> gs, cons
             LSPResult result = pushDiagnostics(runSlowPath(move(changedFiles)));
             ENFORCE(result.gs);
             if (!disableFastPath) {
+                ShowOperation stateHashOp(*this, "GlobalStateHash", "Finishing initialization...");
                 this->globalStateHashes = computeStateHashes(result.gs->getFiles());
             }
             initialized = true;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Show IDE progress when we compute state hashes during initialization.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Before, VS Code said "Sorbet: Idle" despite Sorbet being non-responsive for a few seconds.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested manually with VS Code.
