### PR TITLE
Return false in SelfTypeParam::derivesFrom() instead of crashing

### DIFF
--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -654,8 +654,7 @@ bool LambdaParam::derivesFrom(const GlobalState &gs, SymbolRef klass) const {
 }
 
 bool SelfTypeParam::derivesFrom(const GlobalState &gs, SymbolRef klass) const {
-    Exception::raise(
-        "SelfTypeParam::derivesFrom not implemented, not clear what it should do. Let's see this fire first.");
+    return false;
 }
 
 TypePtr LambdaParam::getCallArguments(Context ctx, NameRef name) {

--- a/test/testdata/infer/self_type_param.rb
+++ b/test/testdata/infer/self_type_param.rb
@@ -1,0 +1,28 @@
+# typed: true
+
+class GenricClass
+  extend(T::Sig)
+  extend(T::Generic)
+
+  Elem = type_member
+
+  sig {returns(Elem)}
+  def return_type_member; T.unsafe(nil) end
+
+  sig {params(block: T.proc.params(arg0: Elem).void).void}
+  def yield_type_member(&block); end
+
+  def kwargs(b: 1); end
+
+  def block_arg
+    yield_type_member { |x, y, z| }
+  end
+
+  def as_optional_hash
+    kwargs(return_type_member) # error: Too many positional arguments provided
+  end
+
+  def splat_expand
+    a, b = return_type_member
+  end
+end


### PR DESCRIPTION
We intentionally crash in `SelfTypeParam::derivesFrom()` while
there are a few ways `SelfTypeParam::derivesFrom()` can get called.
I included three ways this can happen as tests, but there are probably
more ways out there.

Unlike other types that raise in `derivesFrom()`, having `SelfTypeParam`
show up during infer doesn't seem like an indication of a logic error.
Judging from the fact that we don't re-typecheck method bodies in
generic classes for each instantiation of the generic class, it seems
natural that we encounter with values with `SelfTypeParam` during
inference.

### Motivation

To not crash in a surprising manner

### Test plan

See included automated tests.
