### PR TITLE
Make LSP Hover non-experimental (removes `--enable-experimental-lsp-hover`)

### DIFF
--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -167,7 +167,7 @@ LSPResult LSPLoop::processRequestInternal(unique_ptr<core::GlobalState> gs, cons
             serverCap->definitionProvider = opts.lspGoToDefinitionEnabled;
             serverCap->documentSymbolProvider = opts.lspDocumentSymbolEnabled;
             serverCap->workspaceSymbolProvider = opts.lspWorkspaceSymbolsEnabled;
-            serverCap->hoverProvider = opts.lspHoverEnabled;
+            serverCap->hoverProvider = true;
             serverCap->referencesProvider = opts.lspFindReferencesEnabled;
 
             if (opts.lspSignatureHelpEnabled) {

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -30,12 +30,6 @@ unique_ptr<MarkupContent> formatRubyCode(MarkupKind markupKind, string str) {
 LSPResult LSPLoop::handleTextDocumentHover(unique_ptr<core::GlobalState> gs, const MessageId &id,
                                            const TextDocumentPositionParams &params) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentHover);
-    if (!opts.lspHoverEnabled) {
-        response->error = make_unique<ResponseError>(
-            (int)LSPErrorCodes::InvalidRequest, "The `Hover` LSP feature is experimental and disabled by default.");
-        return LSPResult::make(move(gs), move(response));
-    }
-
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.hover");
 
     auto result =

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -92,7 +92,6 @@ int LSPWrapper::getTypecheckCount() const {
 }
 
 void LSPWrapper::enableAllExperimentalFeatures() {
-    enableExperimentalFeature(LSPExperimentalFeature::Hover);
     enableExperimentalFeature(LSPExperimentalFeature::GoToDefinition);
     enableExperimentalFeature(LSPExperimentalFeature::FindReferences);
     enableExperimentalFeature(LSPExperimentalFeature::Autocomplete);
@@ -103,9 +102,6 @@ void LSPWrapper::enableAllExperimentalFeatures() {
 
 void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
     switch (feature) {
-        case LSPExperimentalFeature::Hover:
-            opts.lspHoverEnabled = true;
-            break;
         case LSPExperimentalFeature::GoToDefinition:
             opts.lspGoToDefinitionEnabled = true;
             break;

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -39,7 +39,6 @@ private:
 
 public:
     enum class LSPExperimentalFeature {
-        Hover = 1,
         GoToDefinition = 2,
         FindReferences = 3,
         Autocomplete = 4,

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -311,7 +311,6 @@ cxxopts::Options buildOptions() {
     options.add_options("advanced")("watchman-path",
                                     "Path to watchman executable. Defaults to using `watchman` on your PATH.",
                                     cxxopts::value<string>()->default_value(empty.watchmanPath));
-    options.add_options("advanced")("enable-experimental-lsp-hover", "Enable experimental LSP feature: Hover");
     options.add_options("advanced")("enable-experimental-lsp-go-to-definition",
                                     "Enable experimental LSP feature: Go-to-definition");
     options.add_options("advanced")("enable-experimental-lsp-find-references",
@@ -570,7 +569,6 @@ void readOptions(Options &opts, int argc, char *argv[],
         opts.lspDocumentSymbolEnabled =
             enableAllLSPFeatures || raw["enable-experimental-lsp-document-symbol"].as<bool>();
         opts.lspSignatureHelpEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-signature-help"].as<bool>();
-        opts.lspHoverEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-hover"].as<bool>();
 
         opts.cacheDir = raw["cache-dir"].as<string>();
         if (!extractPrinters(raw, opts, logger)) {

--- a/main/options/test/options_test.cc
+++ b/main/options/test/options_test.cc
@@ -71,7 +71,6 @@ TEST(OptionsTest, DefaultConstructorMatchesReadOptions) {
     EXPECT_EQ(empty.lspWorkspaceSymbolsEnabled, opts.lspWorkspaceSymbolsEnabled);
     EXPECT_EQ(empty.lspDocumentSymbolEnabled, opts.lspDocumentSymbolEnabled);
     EXPECT_EQ(empty.lspSignatureHelpEnabled, opts.lspSignatureHelpEnabled);
-    EXPECT_EQ(empty.lspHoverEnabled, opts.lspHoverEnabled);
     EXPECT_EQ(empty.inlineInput, opts.inlineInput);
     EXPECT_EQ(empty.debugLogFile, opts.debugLogFile);
     EXPECT_EQ(empty.webTraceFile, opts.webTraceFile);

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -74,8 +74,6 @@ Usage:
                                 disable file watching via Watchman
       --watchman-path arg       Path to watchman executable. Defaults to
                                 using `watchman` on your PATH. (default: watchman)
-      --enable-experimental-lsp-hover
-                                Enable experimental LSP feature: Hover
       --enable-experimental-lsp-go-to-definition
                                 Enable experimental LSP feature:
                                 Go-to-definition


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Make LSP Hover non-experimental.

Hover works well enough to be enabled for everyone. If there is a bug, it is easy to add a new test case to Sorbet and iterate on a solution. The only bug I am currently aware of involves hover information for proc arguments *at their declaration sites*.

In real-world use, hover does not appear to cause any issues with editor responsiveness. In particular, VS Code cancels hover if you move your mouse away, so mousing over many things during a slow path won't dramatically interrupt edit batching.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Stabilizing IDE features.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Automated tests already exist.

Note that this is going to break those who passed `--enable-experimental-lsp-hover` before.