### PR TITLE
Add Sord and sorbet-rails to FAQ

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -111,7 +111,9 @@ Also see the [Community] page for more community-maintained projects!
 
 ## Can I convert from YARD docs to Sorbet signatures?
 
-[Sord](https://github.com/AaronC81/sord) is a community-maintained project which
-can generate Sorbet RBI files from YARD docs.
+[Sord] is a community-maintained project which can generate Sorbet RBI files
+from YARD docs.
 
 Also see the [Community] page for more community-maintained projects!
+
+[sord]: https://github.com/AaronC81/sord

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -101,8 +101,17 @@ There is currently no Windows support.
 
 ## Does Sorbet support ActiveRecord (and Rails?)
 
-There is an open-source gem which could help you to integrate Sorbet into a Rails project: [sorbet-rails](https://github.com/chanzuckerberg/sorbet-rails)
+[sorbet-rails] is a community-maintained project which can help generate RBI
+files for certain Rails constructs.
+
+Also see the [Community] page for more community-maintained projects!
+
+[sorbet-rails]: https://github.com/chanzuckerberg/sorbet-rails
+[community]: /en/community
 
 ## Can I convert from YARD docs to Sorbet signatures?
 
-There is a community-maintained project which allows you to generate Sorbet RBI files from YARD docs: [Sord](https://github.com/AaronC81/sord).
+[Sord](https://github.com/AaronC81/sord) is a community-maintained project which
+can generate Sorbet RBI files from YARD docs.
+
+Also see the [Community] page for more community-maintained projects!

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -98,3 +98,11 @@ distributions. We use static linking on both platforms, so it should not depend
 on system libraries.
 
 There is currently no Windows support.
+
+## Does Sorbet support ActiveRecord (and Rails?)
+
+There is an open-source gem which could help you to integrate Sorbet into a Rails project: [sorbet-rails](https://github.com/chanzuckerberg/sorbet-rails)
+
+## Can I convert from YARD docs to Sorbet signatures?
+
+There is a community-maintained project which allows you to generate Sorbet RBI files from YARD docs: [Sord](https://github.com/AaronC81/sord).


### PR DESCRIPTION
### Motivation

"Community" page is not indexable and is not a part of the documentation, thus making it harder to find the information about these tools ([example](https://twitter.com/fxn/status/1142702180597719040)).

By adding a note about it to the FAQ page we make it easier to answer the questions "How to use the existing YARD annotations to generate RBIs?" and "How to start using Sorbet with Rails?".