### PR TITLE
[prework] Add types to struct initialize

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,9 @@
   "editor.rulers": [
     120
   ],
+  "files.associations": {
+    "*.rbi": "ruby"
+  },
   "[cpp]": {
     "editor.tabSize": 4,
     "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -293,8 +293,7 @@ public:
                 return Unsafe(loc, Nil(loc));
             }
         }
-        return Send2(loc, Constant(loc, core::Symbols::T()), core::Names::cast(), Unsafe(loc, Nil(loc)),
-                     std::move(type));
+        return Send2(loc, T(loc), core::Names::cast(), Unsafe(loc, Nil(loc)), std::move(type));
     }
 
     static std::unique_ptr<Expression> T(core::Loc loc) {

--- a/dsl/ChalkODMProp.cc
+++ b/dsl/ChalkODMProp.cc
@@ -154,7 +154,6 @@ optional<ChalkODMProp::NodesAndProp> ChalkODMProp::replaceDSL(core::MutableConte
         if (ASTUtil::hasHashValue(ctx, *rules, core::Names::immutable())) {
             isImmutable = true;
         }
-
         // e.g. `const :foo, type, computed_by: :method_name`
         if (ASTUtil::hasHashValue(ctx, *rules, core::Names::computedBy())) {
             auto [key, val] = ASTUtil::extractHashValue(ctx, *rules, core::Names::computedBy());
@@ -170,7 +169,6 @@ optional<ChalkODMProp::NodesAndProp> ChalkODMProp::replaceDSL(core::MutableConte
                 }
             }
         }
-
         if (foreign == nullptr) {
             auto [fk, foreignTree] = ASTUtil::extractHashValue(ctx, *rules, core::Names::foreign());
             foreign = move(foreignTree);

--- a/dsl/ChalkODMProp.cc
+++ b/dsl/ChalkODMProp.cc
@@ -145,8 +145,7 @@ optional<ChalkODMProp::NodesAndProp> ChalkODMProp::replaceDSL(core::MutableConte
     auto getType = ASTUtil::dupType(type.get());
     ENFORCE(getType != nullptr);
 
-    // From this point, we can't `return std::nullopt` anymore since we're going to be
-    // consuming the tree.
+    // From this point, we can't `return std::nullopt` anymore since we're going to be consuming the tree.
 
     ChalkODMProp::NodesAndProp ret;
 

--- a/dsl/ChalkODMProp.h
+++ b/dsl/ChalkODMProp.h
@@ -35,11 +35,21 @@ namespace sorbet::dsl {
  *
  * Any deviation from this expected shape stops the desugaring.
  *
+ * Most other `replaceDSL`s return just nodes, but we also want to keep track of the prop information so that at the end
+ * of the DSL pass on the classDef, we can construct an `initialize` method with good static types.
+ *
  */
 class ChalkODMProp final {
 public:
-    static std::optional<std::vector<std::unique_ptr<ast::Expression>>> replaceDSL(core::MutableContext ctx,
-                                                                                   ast::Send *send);
+    struct Prop {};
+
+    struct NodesAndProp {
+        // invariant: !nodes.empty().
+        std::vector<std::unique_ptr<ast::Expression>> nodes;
+        Prop prop;
+    };
+
+    static std::optional<NodesAndProp> replaceDSL(core::MutableContext ctx, ast::Send *send);
 
     ChalkODMProp() = delete;
 };

--- a/dsl/ChalkODMProp.h
+++ b/dsl/ChalkODMProp.h
@@ -34,7 +34,6 @@ public:
     struct Prop {};
 
     struct NodesAndProp {
-        // invariant: !nodes.empty().
         std::vector<std::unique_ptr<ast::Expression>> nodes;
         Prop prop;
     };

--- a/dsl/ChalkODMProp.h
+++ b/dsl/ChalkODMProp.h
@@ -7,33 +7,23 @@ namespace sorbet::dsl {
 /**
  * This class desugars things of the form
  *
- *   prop :foo, String
+ *   prop :foo, Type
  *
  * into
  *
- *   sig {returns(T.nilable(String))}
- *   def foo; T.cast(nil, T.nilable(String)); end
- *   sig {params(arg0: String).returns(NilClass)}
- *   def foo=(arg0); end
+ *   sig {returns(Type)}
+ *   def foo; ...; end
+ *   sig {params(x: Type).returns(Type)}
+ *   def foo=(x); ...; end
  *   class Mutator < Chalk::ODM::Mutator
- *     sig {params(arg0: String).returns(NilClass)}
- *     def foo=(arg0); end
+ *     sig {returns(Type)}
+ *     def foo(x); end
+ *     sig {params(x: Type).returns(Type)}
+ *     def foo=(x); end
  *   end
  *
- * We try to implement a simple approximation of the functionality that
- * Chalk::ODM::Document.prop has. This isn't full fidelity, but we're trying to
- * straddle the line between complexity and usefulness. Specifically:
- *
- * Any `prop` method call in a class body whose shape matches is considered.
- * `const ...` is the same as `prop ..., immutable: true`.
- * The getter will return `T.nilable(TheType)` and the setter will take `TheType`.
- * In the last param if there is a:
- *   type: TheType - overrides the second param.
- *   array: TheType - overrides the second param and makes it an `Array[TheValue]`.
- *   default: - the getter isn't nilable anymore.
- *   factory: - same as default:.
- *
- * Any deviation from this expected shape stops the desugaring.
+ * We try to implement a simple approximation of the functionality that Chalk::ODM::Document.prop has. Any deviation
+ * from the expected shape stops the desugaring.
  *
  * Most other `replaceDSL`s return just nodes, but we also want to keep track of the prop information so that at the end
  * of the DSL pass on the classDef, we can construct an `initialize` method with good static types.

--- a/dsl/ChalkODMProp.h
+++ b/dsl/ChalkODMProp.h
@@ -38,7 +38,8 @@ namespace sorbet::dsl {
  */
 class ChalkODMProp final {
 public:
-    static std::vector<std::unique_ptr<ast::Expression>> replaceDSL(core::MutableContext ctx, ast::Send *send);
+    static std::optional<std::vector<std::unique_ptr<ast::Expression>>> replaceDSL(core::MutableContext ctx,
+                                                                                   ast::Send *send);
 
     ChalkODMProp() = delete;
 };

--- a/dsl/ChalkODMProp.h
+++ b/dsl/ChalkODMProp.h
@@ -17,7 +17,7 @@ namespace sorbet::dsl {
  *   def foo=(arg0); ...; end
  *   class Mutator < Chalk::ODM::Mutator
  *     sig {returns(Type)}
- *     def foo(arg0); end
+ *     def foo; end
  *     sig {params(arg0: Type).returns(Type)}
  *     def foo=(arg0); end
  *   end

--- a/dsl/ChalkODMProp.h
+++ b/dsl/ChalkODMProp.h
@@ -13,13 +13,13 @@ namespace sorbet::dsl {
  *
  *   sig {returns(Type)}
  *   def foo; ...; end
- *   sig {params(x: Type).returns(Type)}
- *   def foo=(x); ...; end
+ *   sig {params(arg0: Type).returns(Type)}
+ *   def foo=(arg0); ...; end
  *   class Mutator < Chalk::ODM::Mutator
  *     sig {returns(Type)}
- *     def foo(x); end
- *     sig {params(x: Type).returns(Type)}
- *     def foo=(x); end
+ *     def foo(arg0); end
+ *     sig {params(arg0: Type).returns(Type)}
+ *     def foo=(arg0); end
  *   end
  *
  * We try to implement a simple approximation of the functionality that Chalk::ODM::Document.prop has. Any deviation

--- a/dsl/dsl.cc
+++ b/dsl/dsl.cc
@@ -32,6 +32,7 @@ public:
 
         ast::Expression *prevStat = nullptr;
         UnorderedMap<ast::Expression *, vector<unique_ptr<ast::Expression>>> replaceNodes;
+        vector<ChalkODMProp::Prop> props;
         for (auto &stat : classDef->rhs) {
             typecase(
                 stat.get(),
@@ -61,6 +62,7 @@ public:
                     if (nodesAndProp.has_value()) {
                         ENFORCE(!nodesAndProp->nodes.empty(), "nodesAndProp with value must not have nodes be empty");
                         replaceNodes[stat.get()] = std::move(nodesAndProp->nodes);
+                        props.push_back(std::move(nodesAndProp->prop));
                         return;
                     }
 

--- a/dsl/dsl.cc
+++ b/dsl/dsl.cc
@@ -56,10 +56,11 @@ public:
                 },
 
                 [&](ast::Send *send) {
-                    auto nodesOpt = ChalkODMProp::replaceDSL(ctx, send);
-                    if (nodesOpt.has_value()) {
-                        ENFORCE(!nodesOpt->empty(), "optional with vec must not have vec be empty");
-                        replaceNodes[stat.get()] = std::move(*nodesOpt);
+                    // This one is different: it returns nodes and a prop.
+                    auto nodesAndProp = ChalkODMProp::replaceDSL(ctx, send);
+                    if (nodesAndProp.has_value()) {
+                        ENFORCE(!nodesAndProp->nodes.empty(), "nodesAndProp with value must not have nodes be empty");
+                        replaceNodes[stat.get()] = std::move(nodesAndProp->nodes);
                         return;
                     }
 

--- a/dsl/dsl.cc
+++ b/dsl/dsl.cc
@@ -113,12 +113,12 @@ public:
         classDef->rhs.reserve(oldRHS.size());
 
         for (auto &stat : oldRHS) {
-            if (replaceNodes.find(stat.get()) != replaceNodes.end()) {
+            if (replaceNodes.find(stat.get()) == replaceNodes.end()) {
+                classDef->rhs.emplace_back(std::move(stat));
+            } else {
                 for (auto &newNode : replaceNodes.at(stat.get())) {
                     classDef->rhs.emplace_back(std::move(newNode));
                 }
-            } else {
-                classDef->rhs.emplace_back(std::move(stat));
             }
         }
         return classDef;

--- a/dsl/dsl.cc
+++ b/dsl/dsl.cc
@@ -56,13 +56,14 @@ public:
                 },
 
                 [&](ast::Send *send) {
-                    auto nodes = ChalkODMProp::replaceDSL(ctx, send);
-                    if (!nodes.empty()) {
-                        replaceNodes[stat.get()] = std::move(nodes);
+                    auto nodesOpt = ChalkODMProp::replaceDSL(ctx, send);
+                    if (nodesOpt.has_value()) {
+                        ENFORCE(!nodesOpt->empty(), "optional with vec must not have vec be empty");
+                        replaceNodes[stat.get()] = std::move(*nodesOpt);
                         return;
                     }
 
-                    nodes = MixinEncryptedProp::replaceDSL(ctx, send);
+                    auto nodes = MixinEncryptedProp::replaceDSL(ctx, send);
                     if (!nodes.empty()) {
                         replaceNodes[stat.get()] = std::move(nodes);
                         return;

--- a/dsl/helpers.cc
+++ b/dsl/helpers.cc
@@ -2,7 +2,6 @@
 #include "ast/ast.h"
 #include "core/Context.h"
 #include "core/core.h"
-#include "dsl/ChalkODMProp.h"
 #include "dsl/helpers.h"
 #include "dsl/util.h"
 

--- a/gems/sorbet-runtime/lib/types/props/_props.rb
+++ b/gems/sorbet-runtime/lib/types/props/_props.rb
@@ -87,7 +87,7 @@ module T::Props
     #   hash. This will not affect objects loaded by {.from_hash}.
     # @option rules [Proc] :factory A `Proc` that will be called to
     #   generate an initial value for this prop on {#initialize}, if
-    #   none is providede.
+    #   none is provided.
     # @option rules [T::Boolean] :immutable If true, this prop cannot be
     #   modified after an instance is created or loaded from a hash.
     # @option rules [Class,T::Props::CustomType] :array If set, specifies the


### PR DESCRIPTION
This is pre-work for #986, which was getting to be big. @DarkDimius requested that the work which doesn't change the observable behavior of the statics be pulled out into pre-work. When this is merged, #986 will be rebased on top of it.

Things changed:

- Rm unused include
- Avoid `if !cond then ... else ...`
- Instead of returning a `std::vector` with empty meaning "no value", return an `std::optional` with `std::nullopt` meaning "no value" and `ENFORCE` that if the optional contains a vector, that vector is not empty
- Introduce `NodesAndProp` (but don't put anything in `Prop` yet, that's for later)
- Update an outdated comment
- Fix misc ws and typos
- Use a `T` helper to be more concise
- Update vscode settings to treat .rbi as Ruby

### Motivation

To prepare for #986.

### Test plan

No changes to behavior. No tests.