### PR TITLE
Statically link libc++ and libc++abi on OSX

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -141,7 +141,7 @@ package(default_visibility = ["//visibility:public"])
     git_repository(
         name = "com_grail_bazel_toolchain",
         remote = "https://github.com/DarkDimius/bazel-toolchain.git",
-        commit = "7110338e4804c49073b41abc1dcda6b14405ef8a",
+        commit = "fc345f29d7a2b5dd431be006b36be1b3d3936987",
     )
 
     git_repository(

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -138,6 +138,8 @@ package(default_visibility = ["//visibility:public"])
         build_file = "//third_party:parser.BUILD",
     )
 
+    # NOTE: using this branch:
+    # https://github.com/DarkDimius/bazel-toolchain/tree/dp-srb-now
     git_repository(
         name = "com_grail_bazel_toolchain",
         remote = "https://github.com/DarkDimius/bazel-toolchain.git",


### PR DESCRIPTION
This statically links a consistent version of the c++ standard library on OSX, to support newer features across older releases.

### Motivation
To resolve #946

### Test plan
I ran `otool -L` on the resulting binary to ensure that it wasn't relying on the system `libc++` or `libc++abi`.