### PR TITLE
Use `patchDSL` for prop

### DIFF
--- a/dsl/OpusEnum.cc
+++ b/dsl/OpusEnum.cc
@@ -64,8 +64,7 @@ void OpusEnum::patchDSL(core::MutableContext ctx, ast::ClassDef *klass) {
         }
 
         auto loc = asgn->rhs->loc;
-        auto T = ast::MK::Constant(loc, core::Symbols::T());
-        asgn->rhs = ast::MK::Send2(loc, move(T), core::Names::let(), move(asgn->rhs), ast::MK::Self(loc));
+        asgn->rhs = ast::MK::Send2(loc, ast::MK::T(loc), core::Names::let(), move(asgn->rhs), ast::MK::Self(loc));
     }
 }
 

--- a/dsl/Prop.cc
+++ b/dsl/Prop.cc
@@ -20,10 +20,6 @@ struct NodesAndPropInfo {
 };
 
 optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send) {
-    if (ctx.state.runningUnderAutogen) {
-        // TODO(jez) Verify whether this DSL pass is safe to run in for autogen
-        return std::nullopt;
-    }
     bool isImmutable = false; // Are there no setters?
     unique_ptr<ast::Expression> type;
     unique_ptr<ast::Expression> foreign;
@@ -312,6 +308,10 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
 } // namespace
 
 void Prop::patchDSL(core::MutableContext ctx, ast::ClassDef *klass) {
+    if (ctx.state.runningUnderAutogen) {
+        // TODO(jez) Verify whether this DSL pass is safe to run in for autogen
+        return;
+    }
     UnorderedMap<ast::Expression *, vector<unique_ptr<ast::Expression>>> replaceNodes;
     vector<PropInfo> props;
     for (auto &stat : klass->rhs) {

--- a/dsl/Prop.cc
+++ b/dsl/Prop.cc
@@ -1,4 +1,4 @@
-#include "dsl/ChalkODMProp.h"
+#include "dsl/Prop.h"
 #include "ast/Helpers.h"
 #include "ast/ast.h"
 #include "core/Context.h"
@@ -10,13 +10,20 @@
 using namespace std;
 
 namespace sorbet::dsl {
+namespace {
 
-optional<ChalkODMProp::NodesAndProp> ChalkODMProp::replaceDSL(core::MutableContext ctx, ast::Send *send) {
+struct PropInfo {};
+
+struct NodesAndPropInfo {
+    vector<unique_ptr<ast::Expression>> nodes;
+    PropInfo propInfo;
+};
+
+optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send) {
     if (ctx.state.runningUnderAutogen) {
         // TODO(jez) Verify whether this DSL pass is safe to run in for autogen
         return std::nullopt;
     }
-
     bool isImmutable = false; // Are there no setters?
     unique_ptr<ast::Expression> type;
     unique_ptr<ast::Expression> foreign;
@@ -147,7 +154,7 @@ optional<ChalkODMProp::NodesAndProp> ChalkODMProp::replaceDSL(core::MutableConte
 
     // From this point, we can't `return std::nullopt` anymore since we're going to be consuming the tree.
 
-    ChalkODMProp::NodesAndProp ret;
+    NodesAndPropInfo ret;
 
     // Compute the getters
     if (rules) {
@@ -301,6 +308,37 @@ optional<ChalkODMProp::NodesAndProp> ChalkODMProp::replaceDSL(core::MutableConte
     }
 
     return ret;
+}
+} // namespace
+
+void Prop::patchDSL(core::MutableContext ctx, ast::ClassDef *klass) {
+    UnorderedMap<ast::Expression *, vector<unique_ptr<ast::Expression>>> replaceNodes;
+    vector<PropInfo> props;
+    for (auto &stat : klass->rhs) {
+        auto *send = ast::cast_tree<ast::Send>(stat.get());
+        if (send == nullptr) {
+            continue;
+        }
+        auto nodesAndPropInfo = processProp(ctx, send);
+        if (!nodesAndPropInfo.has_value()) {
+            continue;
+        }
+        ENFORCE(!nodesAndPropInfo->nodes.empty(), "nodesAndPropInfo with value must have nodes be non empty");
+        replaceNodes[stat.get()] = std::move(nodesAndPropInfo->nodes);
+        props.emplace_back(nodesAndPropInfo->propInfo);
+    }
+    auto oldRHS = std::move(klass->rhs);
+    klass->rhs.clear();
+    klass->rhs.reserve(oldRHS.size());
+    for (auto &stat : oldRHS) {
+        if (replaceNodes.find(stat.get()) == replaceNodes.end()) {
+            klass->rhs.emplace_back(std::move(stat));
+        } else {
+            for (auto &newNode : replaceNodes.at(stat.get())) {
+                klass->rhs.emplace_back(std::move(newNode));
+            }
+        }
+    }
 }
 
 }; // namespace sorbet::dsl

--- a/dsl/Prop.h
+++ b/dsl/Prop.h
@@ -29,18 +29,11 @@ namespace sorbet::dsl {
  * of the DSL pass on the classDef, we can construct an `initialize` method with good static types.
  *
  */
-class ChalkODMProp final {
+class Prop final {
 public:
-    struct Prop {};
+    static void patchDSL(core::MutableContext ctx, ast::ClassDef *klass);
 
-    struct NodesAndProp {
-        std::vector<std::unique_ptr<ast::Expression>> nodes;
-        Prop prop;
-    };
-
-    static std::optional<NodesAndProp> replaceDSL(core::MutableContext ctx, ast::Send *send);
-
-    ChalkODMProp() = delete;
+    Prop() = delete;
 };
 
 } // namespace sorbet::dsl


### PR DESCRIPTION
This is more pre-work for #986. I recommend reviewing by commit.

After discussing with @jez, we decided that the current implementation of #986 is suboptimal. The reason for this is that I significantly added to dsl.cc by including the logic that decides whether or not to synthesize an initialize method for the class def right there in dsl.cc. This logic should be moved somewhere else.

We discussed some possible options:

1. Put everything concerning props and `T::Struct` into one `patchDSL`.
    - pro: contain all related logic in just one place.
    - con: need to duplicate logic with the for.
2. Pull out logic to synthesize `initialize` into its own `patchDSLWithProps`, which would be run after the big `for`-`typecase` in dsl.cc.
    - pro: keeps DSLing `prop` and synthesizing `initialize` separate.
    - con: not same signature as other `patchDSL`.
    - con: need to thread info from `ChalkODMProp::replaceDSL` to vector in dsl.cc, then back into `patchDSLWithProps`.
3. Pull out logic to parse a prop into a helper, then use that helper in `ChalkODMProp::replaceDSL`.
    - pro: no (explicit) threading of information across function calls.
    - con: double the calls to the helper.

After discussion, I decided to go with 1.

This is pre-work, so no observable behavior should change. As discussed above, the new implementation in this PR duplicates the logic in dsl.cc (with having an UnorderedMap to map old nodes to the vector of new translated nodes, etc etc).

### Motivation

To prepare for #986.

### Test plan

No changes to behavior, just refactoring. No tests.
