### PR TITLE
rbis/ doesn't work

### DIFF
--- a/website/docs/rbi.md
+++ b/website/docs/rbi.md
@@ -178,8 +178,8 @@ way to include RBI files into a project.
 
 The way this works is that when `srb` will load a project's `Gemfile` to find
 the source folders for every gem in a project. If any gems have a top-level
-`rbi/` or `rbis/` folder, `srb` will collect the paths to any such folders into
-a file (`sorbet/rbi_list`) and mention this file in the `sorbet/config` file.
+`rbi/` folder, `srb` will collect the paths to any such folders into a file
+(`sorbet/rbi_list`) and mention this file in the `sorbet/config` file.
 
 ## The Hidden Definition RBI
 


### PR DESCRIPTION
The new runner doesn't use the `rbis/` dir (I didn't know we should support that). I kind of like having one way if we're driving the ecosystem.

https://github.com/sorbet/sorbet/blob/pt-rbis/gems/sorbet/lib/find-gem-rbis.rb#L17

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
