### PR TITLE
Fix the parsing of `foo.(x)`

### DIFF
--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -391,7 +391,8 @@ public:
 
         core::NameRef method;
         if (selector == nullptr) {
-            method = core::Names::bang();
+            // when the selector is missing, this is a use of the `call` method.
+            method = core::Names::call();
         } else {
             method = gs_.enterNameUTF8(selector->string());
         }

--- a/test/testdata/parser/whitequark/parse_send_call.rb.parse-tree.exp
+++ b/test/testdata/parser/whitequark/parse_send_call.rb.parse-tree.exp
@@ -12,7 +12,7 @@ Begin {
         args = [
         ]
       }
-      method = <U !>
+      method = <U call>
       args = [
         Integer {
           val = "1"

--- a/test/testdata/parser/whitequark/parse_send_call_1.rb.parse-tree.exp
+++ b/test/testdata/parser/whitequark/parse_send_call_1.rb.parse-tree.exp
@@ -12,7 +12,7 @@ Begin {
         args = [
         ]
       }
-      method = <U !>
+      method = <U call>
       args = [
         Integer {
           val = "1"


### PR DESCRIPTION
The parsing of `foo.(x)` is not correct.

### Motivation
To resolve #1029 

### Test plan
The tests for the parse of the call method have been updated.

See included automated tests.