### PR TITLE
Rename DANGER_enable_checking_in_tests

### DIFF
--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -2,6 +2,21 @@
 # frozen_string_literal: true
 
 module T::Configuration
+  # Announces to Sorbet that we are currently in a test environment, so it
+  # should treat any sigs which are marked `.checked(:tests)` as if they were
+  # just a normal sig.
+  #
+  # If this method is not called, sigs marked `.checked(:tests)` will not be
+  # checked. In fact, such methods won't even be wrapped--the runtime will put
+  # back the original method.
+  #
+  # Note: Due to the way sigs are evaluated and methods are wrapped, this
+  # method MUST be called before any code calls `sig`. This method raises if
+  # it has been called too late.
+  def self.enable_checking_for_sigs_marked_checked_tests
+    T::Private::RuntimeLevels.enable_checking_in_tests
+  end
+
   # Set a handler to handle `TypeError`s raised by any in-line type assertions,
   # including `T.must`, `T.let`, `T.cast`, and `T.assert_type!`.
   #

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -110,10 +110,6 @@ module T::Utils
     end
   end
 
-  def self.DANGER_enable_checking_in_tests
-    T::Private::RuntimeLevels.enable_checking_in_tests
-  end
-
   # Returns the arity of a method, unwrapping the sig if needed
   def self.arity(method)
     arity = method.arity # rubocop:disable PrisonGuard/NoArity

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -292,7 +292,7 @@ module Opus::Types::Test
             mod.test_method(1) # invocation ensures it's wrapped
 
             err = assert_raises(RuntimeError) do
-              T::Utils.DANGER_enable_checking_in_tests
+              T::Configuration.enable_checking_for_sigs_marked_checked_tests
             end
             assert_match(/Toggle `:tests`-level runtime type checking earlier/, err.message)
           end


### PR DESCRIPTION
This moves `T::Utils.DANGER_enable_checking_in_tests` to
`T::Configuration.enable_checking_for_checked_tests_sigs!`.

I'm happy to drop the `!`. I only added it because it used to say
`DANGER`. Moving to `T::Configuration` is the only change I care about.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is on the blocking path to re-enabling soft / checked / generated
in open-source.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.