### PR TITLE
Allow `<` and `>` in strings when using `--no-stdlib`

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -506,8 +506,6 @@ void GlobalState::initEmpty() {
     freezeSymbolTable();
     freezeFileTable();
     sanityCheck();
-
-    isInitialized = true;
 }
 
 void GlobalState::installIntrinsics() {
@@ -717,7 +715,7 @@ ArgInfo &GlobalState::enterMethodArgumentSymbol(Loc loc, SymbolRef owner, NameRe
 }
 
 string_view GlobalState::enterString(string_view nm) {
-    DEBUG_ONLY(if (isInitialized) {
+    DEBUG_ONLY(if (ensureCleanStrings) {
         if (nm != "<" && nm != "<<" && nm != "<=" && nm != "<=>" && nm != ">" && nm != ">>" && nm != ">=") {
             ENFORCE(nm.find("<") == string::npos);
             ENFORCE(nm.find(">") == string::npos);
@@ -1142,7 +1140,7 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     result->silenceErrors = this->silenceErrors;
     result->autocorrect = this->autocorrect;
     result->suggestRuntimeProfiledType = this->suggestRuntimeProfiledType;
-    result->isInitialized = this->isInitialized;
+    result->ensureCleanStrings = this->ensureCleanStrings;
     result->runningUnderAutogen = this->runningUnderAutogen;
     result->censorRawLocsWithinPayload = this->censorRawLocsWithinPayload;
 

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -137,7 +137,14 @@ public:
     bool silenceErrors = false;
     bool autocorrect = false;
     bool suggestRuntimeProfiledType = false;
-    bool isInitialized = false;
+
+    // We have a lot of internal names of form `<something>` that's chosen with `<` and `>` as you can't make
+    // this into a valid ruby identifier without suffering.
+    // We want to make sure we don't round-trip through strings for those names.
+    //
+    // If this attribute is set to `true`, all strings will be checked for `<` and `>` characters in them.
+    bool ensureCleanStrings = false;
+
     // So we can know whether we're running in autogen mode.
     // Right now this is only used to turn certain DSL passes on or off.
     // Think very hard before looking at this value in namer / resolver!

--- a/payload/payload.cc
+++ b/payload/payload.cc
@@ -37,6 +37,7 @@ void createInitialGlobalState(unique_ptr<core::GlobalState> &gs, const realmain:
     const u1 *const nameTablePayload = getNameTablePayload;
     if (nameTablePayload == nullptr) {
         gs->initEmpty();
+        gs->ensureCleanStrings = true;
         Timer timeit(gs->tracer(), "read_global_state.source");
 
         vector<core::FileRef> payloadFiles;
@@ -52,6 +53,7 @@ void createInitialGlobalState(unique_ptr<core::GlobalState> &gs, const realmain:
         auto workers = WorkerPool::create(emptyOpts.threads, gs->tracer());
         auto indexed = realmain::pipeline::index(gs, payloadFiles, emptyOpts, *workers, kvstore);
         realmain::pipeline::resolve(gs, move(indexed), emptyOpts, *workers); // result is thrown away
+        gs->ensureCleanStrings = false;
     } else {
         Timer timeit(gs->tracer(), "read_global_state.binary");
         core::serialize::Serializer::loadGlobalState(*gs, nameTablePayload);

--- a/test/cli/no-stdlib/no-stdlib.out
+++ b/test/cli/no-stdlib/no-stdlib.out
@@ -1,0 +1,6 @@
+No errors! Great job.
+------------------------------
+-e:1: Method `puts` does not exist on `T.class_of(<root>)` https://srb.help/7003
+     1 |puts 'Hello > World'
+        ^^^^^^^^^^^^^^^^^^^^
+Errors: 1

--- a/test/cli/no-stdlib/no-stdlib.sh
+++ b/test/cli/no-stdlib/no-stdlib.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+main/sorbet --silence-dev-message -e "puts 'Hello > World'" 2>&1
+
+echo ------------------------------
+
+main/sorbet --silence-dev-message --no-stdlib -e "puts 'Hello > World'" 2>&1


### PR DESCRIPTION
### Motivation

Running the following command gives no error which is as expected:

~~~bash
$ sorbet -e "puts 'Hello > World'"
~~~

While running the same command with `--no-stdlib` gives:

~~~bash
$ sorbet --no-stdlib -e "puts 'Hello > World'"
Exception::raise(): core/GlobalState.cc:723 enforced condition nm.find(">") == string::npos has failed: (no message provided)

Backtrace:
sorbet::Exception::enforce_handler(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, int) (in librealmain.so) + 106
sorbet::core::GlobalState::enterString(std::__1::basic_string_view<char, std::__1::char_traits<char> >) (in libcore.so) (GlobalState.cc:720)
sorbet::core::GlobalState::enterNameUTF8(std::__1::basic_string_view<char, std::__1::char_traits<char> >) (in libcore.so) (GlobalState.cc:794)
sorbet::parser::Builder::Impl::string(ruby_parser::token const*) (in libparser.so) + 107
(anonymous namespace)::string_(void const*, ruby_parser::token const*) (in libparser.so) + 60
ruby_parser::bison::typedruby25::parser::parse() (in libparser.so) + 82416
ruby_parser::typedruby25::parse(void const*) (in libparser.so) + 50
sorbet::parser::Builder::build(ruby_parser::base_driver*) (in libparser.so) + 113
sorbet::parser::Parser::run(sorbet::core::GlobalState&, sorbet::core::FileRef) (in libparser.so) + 290
sorbet::realmain::pipeline::runParser(sorbet::core::GlobalState&, sorbet::core::FileRef, sorbet::realmain::options::Printers const&) (in libpipeline.so) + 507
sorbet::realmain::pipeline::indexOneWithPlugins(sorbet::realmain::options::Options const&, sorbet::core::GlobalState&, sorbet::core::FileRef, std::__1::unique_ptr<sorbet::KeyValueStore, std::__1::default_delete<sorbet::KeyValueStore> >&) (in libpipeline.so) + 1005
sorbet::realmain::pipeline::index(std::__1::unique_ptr<sorbet::core::GlobalState, std::__1::default_delete<sorbet::core::GlobalState> >&, std::__1::vector<sorbet::core::FileRef, std::__1::allocator<sorbet::core::FileRef> >, sorbet::realmain::options::Options const&, sorbet::WorkerPool&, std::__1::unique_ptr<sorbet::KeyValueStore, std::__1::default_delete<sorbet::KeyValueStore> >&) (in libpipeline.so) + 476
sorbet::realmain::realmain(int, char**) (in librealmain.so) + 6186
main (in sorbet) (main.cc:7)
start (in libdyld.dylib) + 1

-e: Exception parsing file: -e (backtrace is above) https://srb.help/1001
Errors: 1
~~~

Instead of:

~~~
-e:1: Method puts does not exist on T.class_of(<root>) https://srb.help/7003
     1 |puts "Hello > World"
        ^^^^^^^^^^^^^^^^^^^^
Errors: 1
~~~

See added tests in `test/cli/no-stdlib`.

### Approach

I tracked down the problem to `GlobalState::enterString` which is called by `enterNameUTF8` to build strings (`Builder.cc`): 

https://github.com/sorbet/sorbet/blob/ea80b0490f18f61f91170adefc682ba510556b0e/core/GlobalState.cc#L720-L725

This was introduced by commit fb09ecd887bd7703550e0648298c516723bc4b76 (cc. @ptarjan) and the commit message says it's to prevent `>` and `<` in *names* but apparently also applies to *strings*.

Reverting the commit makes Sorbet behave correctly and doesn't break any test so my question is: "Why do we need this check?". It seems to be related to some internal things Sorbet might be doing since the parser will already raise an error if a name contains `>` or `<`.

### Test plan

See included automated tests.
