### PR TITLE
wip: Attempt to model msgclass ancestors better

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -206,6 +206,8 @@ NameDef names[] = {
     {"Google", "Google", true},
     {"Protobuf", "Protobuf", true},
     {"DescriptorPool", "DescriptorPool", true},
+    {"MessageExts", "MessageExts", true},
+    {"ClassMethods", "ClassMethods", true},
     {"generatedPool", "generated_pool"},
     {"lookup"},
     {"msgclass"},

--- a/dsl/ProtobufDescriptorPool.cc
+++ b/dsl/ProtobufDescriptorPool.cc
@@ -53,6 +53,16 @@ vector<unique_ptr<ast::Expression>> ProtobufDescriptorPool::replaceDSL(core::Mut
     rhs.emplace_back(asgn->rhs->deepCopy());
 
     if (sendMsgclass->fun == core::Names::msgclass()) {
+        // ::Google::Protobuf::MessageExts::ClassMethods
+        auto root = ast::MK::Constant(asgn->loc, core::Symbols::root());
+        auto g = ast::MK::UnresolvedConstant(asgn->loc, std::move(root), core::Names::Constants::Google());
+        auto gp = ast::MK::UnresolvedConstant(asgn->loc, std::move(g), core::Names::Constants::Protobuf());
+        auto gpme = ast::MK::UnresolvedConstant(asgn->loc, std::move(gp), core::Names::Constants::MessageExts());
+        auto gpmecm = ast::MK::UnresolvedConstant(asgn->loc, gpme->deepCopy(), core::Names::Constants::ClassMethods());
+
+        rhs.emplace_back(ast::MK::Send1(asgn->loc, ast::MK::Self(asgn->loc), core::Names::include(), std::move(gpme)));
+        rhs.emplace_back(ast::MK::Send1(asgn->loc, ast::MK::Self(asgn->loc), core::Names::extend(), std::move(gpmecm)));
+
         auto arg0 = ast::MK::Local(asgn->loc, core::Names::arg0());
         auto arg = ast::MK::OptionalArg(asgn->loc, std::move(arg0), ast::MK::Hash0(asgn->loc));
         rhs.emplace_back(

--- a/dsl/ProtobufDescriptorPool.h
+++ b/dsl/ProtobufDescriptorPool.h
@@ -13,6 +13,8 @@ namespace sorbet::dsl {
  * into
  *
  *   class A
+ *     include ::Google::Protobuf::MessageExts
+ *     extend ::Google::Protobuf::MessageExts::ClassMethods
  *     ::Google::Protobuf::DescriptorPool.generated_pool.lookup("...").msgclass
  *   end
  *


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This was an attempt to make it clear that the msgclass things from
Protobuf have certain includes in them:

<https://github.com/protocolbuffers/protobuf/blob/8041dd4034dc83/ruby/ext/google/protobuf_c/message.c#L724-L726>

@djudd-stripe eventually ended up working around the problem another way.

I couldn't get it working on pay-server with autogen and I wasn't sure
why, but I can imagine myself potentially wanting to get this working in
the future.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I hadn't written any tests yet. I was testing with `scripts/bin/autogen` in
pay-server.