### PR TITLE
Add `hasTruthyHashValue`

### DIFF
--- a/dsl/DSLBuilder.cc
+++ b/dsl/DSLBuilder.cc
@@ -62,16 +62,16 @@ vector<unique_ptr<ast::Expression>> DSLBuilder::replaceDSL(core::MutableContext 
         opts = ast::cast_tree<ast::Hash>(send->args[2].get());
     }
     if (opts != nullptr) {
-        if (ASTUtil::hasHashValue(ctx, *opts, core::Names::default_())) {
+        if (ASTUtil::hasTruthyHashValue(ctx, *opts, core::Names::default_())) {
             nilable = false;
         }
-        if (ASTUtil::hasHashValue(ctx, *opts, core::Names::implied())) {
+        if (ASTUtil::hasTruthyHashValue(ctx, *opts, core::Names::implied())) {
             implied = true;
         }
-        if (ASTUtil::hasHashValue(ctx, *opts, core::Names::skipGetter())) {
+        if (ASTUtil::hasTruthyHashValue(ctx, *opts, core::Names::skipGetter())) {
             skipGetter = true;
         }
-        if (ASTUtil::hasHashValue(ctx, *opts, core::Names::skipSetter())) {
+        if (ASTUtil::hasTruthyHashValue(ctx, *opts, core::Names::skipSetter())) {
             skipSetter = true;
         }
     }

--- a/dsl/DSLBuilder.cc
+++ b/dsl/DSLBuilder.cc
@@ -62,7 +62,7 @@ vector<unique_ptr<ast::Expression>> DSLBuilder::replaceDSL(core::MutableContext 
         opts = ast::cast_tree<ast::Hash>(send->args[2].get());
     }
     if (opts != nullptr) {
-        if (ASTUtil::hasTruthyHashValue(ctx, *opts, core::Names::default_())) {
+        if (ASTUtil::hasHashValue(ctx, *opts, core::Names::default_())) {
             nilable = false;
         }
         if (ASTUtil::hasTruthyHashValue(ctx, *opts, core::Names::implied())) {

--- a/dsl/MixinEncryptedProp.cc
+++ b/dsl/MixinEncryptedProp.cc
@@ -59,7 +59,7 @@ vector<unique_ptr<ast::Expression>> MixinEncryptedProp::replaceDSL(core::Mutable
     }
 
     if (rules) {
-        if (ASTUtil::hasHashValue(ctx, *rules, core::Names::immutable())) {
+        if (ASTUtil::hasTruthyHashValue(ctx, *rules, core::Names::immutable())) {
             isImmutable = true;
         }
     }

--- a/dsl/Prop.cc
+++ b/dsl/Prop.cc
@@ -116,7 +116,7 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
     }
 
     if (type == nullptr) {
-        if (ASTUtil::hasHashValue(ctx, *rules, core::Names::enum_())) {
+        if (ASTUtil::hasTruthyHashValue(ctx, *rules, core::Names::enum_())) {
             // Handle enum: by setting the type to untyped, so that we'll parse
             // the declaration. Don't allow assigning it from typed code by deleting setter
             type = ast::MK::Send0(loc, ast::MK::T(loc), core::Names::untyped());
@@ -154,11 +154,11 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
 
     // Compute the getters
     if (rules) {
-        if (ASTUtil::hasHashValue(ctx, *rules, core::Names::immutable())) {
+        if (ASTUtil::hasTruthyHashValue(ctx, *rules, core::Names::immutable())) {
             isImmutable = true;
         }
         // e.g. `const :foo, type, computed_by: :method_name`
-        if (ASTUtil::hasHashValue(ctx, *rules, core::Names::computedBy())) {
+        if (ASTUtil::hasTruthyHashValue(ctx, *rules, core::Names::computedBy())) {
             auto [key, val] = ASTUtil::extractHashValue(ctx, *rules, core::Names::computedBy());
             if (auto *lit = ast::cast_tree<ast::Literal>(val.get())) {
                 if (lit->isSymbol(ctx)) {

--- a/dsl/util.cc
+++ b/dsl/util.cc
@@ -67,7 +67,7 @@ unique_ptr<ast::Expression> ASTUtil::dupType(const ast::Expression *orig) {
     return ast::MK::UnresolvedConstant(cons->loc, std::move(scope), cons->cnst);
 }
 
-bool ASTUtil::hasHashValue(core::MutableContext ctx, const ast::Hash &hash, core::NameRef name) {
+bool ASTUtil::hasTruthyHashValue(core::MutableContext ctx, const ast::Hash &hash, core::NameRef name) {
     int i = -1;
     for (const auto &keyExpr : hash.keys) {
         i++;

--- a/dsl/util.cc
+++ b/dsl/util.cc
@@ -67,6 +67,16 @@ unique_ptr<ast::Expression> ASTUtil::dupType(const ast::Expression *orig) {
     return ast::MK::UnresolvedConstant(cons->loc, std::move(scope), cons->cnst);
 }
 
+bool ASTUtil::hasHashValue(core::MutableContext ctx, const ast::Hash &hash, core::NameRef name) {
+    for (const auto &keyExpr : hash.keys) {
+        auto *key = ast::cast_tree_const<ast::Literal>(keyExpr.get());
+        if (key && key->isSymbol(ctx) && key->asSymbol(ctx) == name) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool ASTUtil::hasTruthyHashValue(core::MutableContext ctx, const ast::Hash &hash, core::NameRef name) {
     int i = -1;
     for (const auto &keyExpr : hash.keys) {

--- a/dsl/util.h
+++ b/dsl/util.h
@@ -9,6 +9,7 @@ namespace sorbet::dsl {
 class ASTUtil {
 public:
     static std::unique_ptr<ast::Expression> dupType(const ast::Expression *orig);
+    static bool hasHashValue(core::MutableContext ctx, const ast::Hash &hash, core::NameRef name);
     static bool hasTruthyHashValue(core::MutableContext ctx, const ast::Hash &hash, core::NameRef name);
 
     /** Removes the key, value matching key with symbol `name` from hash and returns it */

--- a/dsl/util.h
+++ b/dsl/util.h
@@ -9,7 +9,7 @@ namespace sorbet::dsl {
 class ASTUtil {
 public:
     static std::unique_ptr<ast::Expression> dupType(const ast::Expression *orig);
-    static bool hasHashValue(core::MutableContext ctx, const ast::Hash &hash, core::NameRef name);
+    static bool hasTruthyHashValue(core::MutableContext ctx, const ast::Hash &hash, core::NameRef name);
 
     /** Removes the key, value matching key with symbol `name` from hash and returns it */
     static std::pair<std::unique_ptr<ast::Expression>, std::unique_ptr<ast::Expression>>


### PR DESCRIPTION
### Motivation

I got bitten by this while working on #986.

Before, `hasHashValue` would return false if the value was present in the hash, but falsy. This is not good when e.g. we have something of the form `prop :foo, T::Boolean, default: false` and want to know if the key `:default` is in the `rules` hash for `prop` (as I did).

### Test plan

A test that essentially tests for this will be added to #986.
