### PR TITLE
return T.untyped from `self.class`

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -54,7 +54,17 @@ module Kernel
   def catch(tag=Object.new, &blk); end
 
   sig do
-    returns(Class)
+    # In a perfect world this should be:
+    #
+    #   returns(T.class_of(T.self_type))
+    #
+    # but that doesn't work (yet). Even making it:
+    #
+    #   returns(Class)
+    #
+    # is very surprising since users expect their methods to be present.
+    # So we settle for untyped.
+    returns(T.untyped)
   end
   def class; end
 

--- a/test/cli/cache-dsl/cache-dsl.out
+++ b/test/cli/cache-dsl/cache-dsl.out
@@ -2,28 +2,28 @@ No errors! Great job.
 test/cli/cache-dsl/attr_accessor.rb:7: Method `prop=` does not exist on `A` https://srb.help/7003
      7 |a.prop = 7
         ^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L672: Did you mean: `Kernel#proc`?
-     672 |  def proc(&blk); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L682: Did you mean: `Kernel#proc`?
+     682 |  def proc(&blk); end
             ^^^^^^^^^^^^^^
 
 test/cli/cache-dsl/attr_accessor.rb:8: Method `prop` does not exist on `A` https://srb.help/7003
      8 |a.prop
         ^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L672: Did you mean: `Kernel#proc`?
-     672 |  def proc(&blk); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L682: Did you mean: `Kernel#proc`?
+     682 |  def proc(&blk); end
             ^^^^^^^^^^^^^^
 Errors: 2
 test/cli/cache-dsl/attr_accessor.rb:7: Method `prop=` does not exist on `A` https://srb.help/7003
      7 |a.prop = 7
         ^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L672: Did you mean: `Kernel#proc`?
-     672 |  def proc(&blk); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L682: Did you mean: `Kernel#proc`?
+     682 |  def proc(&blk); end
             ^^^^^^^^^^^^^^
 
 test/cli/cache-dsl/attr_accessor.rb:8: Method `prop` does not exist on `A` https://srb.help/7003
      8 |a.prop
         ^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L672: Did you mean: `Kernel#proc`?
-     672 |  def proc(&blk); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L682: Did you mean: `Kernel#proc`?
+     682 |  def proc(&blk); end
             ^^^^^^^^^^^^^^
 Errors: 2

--- a/test/cli/errors/errors.out
+++ b/test/cli/errors/errors.out
@@ -5,8 +5,8 @@ test/cli/errors/errors.rb:4: Unable to resolve constant `MissingConstant` https:
 test/cli/errors/errors.rb:14: `Integer` does not match `String` for argument `arg0` https://srb.help/7002
     14 |    raise arg # raise is defined by stdlib
             ^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L840: Method `Kernel#raise (overload.1)` has specified `arg0` as `String`
-     840 |        arg0: String,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L850: Method `Kernel#raise (overload.1)` has specified `arg0` as `String`
+     850 |        arg0: String,
                   ^^^^
   Got Integer originating from:
     test/cli/errors/errors.rb:12:
@@ -52,8 +52,8 @@ test/cli/errors/errors.rb:4: Unable to resolve constant `MissingConstant` https:
 test/cli/errors/errors.rb:14: `Integer` does not match `String` for argument `arg0` https://srb.help/7002
     14 |    raise arg # raise is defined by stdlib
             ^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L840: Method `Kernel#raise (overload.1)` has specified `arg0` as `String`
-     840 |        arg0: String,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L850: Method `Kernel#raise (overload.1)` has specified `arg0` as `String`
+     850 |        arg0: String,
                   ^^^^
   Got Integer originating from:
     test/cli/errors/errors.rb:12:
@@ -99,8 +99,8 @@ test/cli/errors/errors.rb:4: Unable to resolve constant `MissingConstant` https:
 test/cli/errors/errors.rb:14: `Integer` does not match `String` for argument `arg0` https://srb.help/7002
     14 |    raise arg # raise is defined by stdlib
             ^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L840: Method `Kernel#raise (overload.1)` has specified `arg0` as `String`
-     840 |        arg0: String,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L850: Method `Kernel#raise (overload.1)` has specified `arg0` as `String`
+     850 |        arg0: String,
                   ^^^^
   Got Integer originating from:
     test/cli/errors/errors.rb:12:

--- a/test/cli/suggest-kernel/suggest-kernel.out
+++ b/test/cli/suggest-kernel/suggest-kernel.out
@@ -2,7 +2,7 @@ test/cli/suggest-kernel/suggest-kernel.rb:4: Method `raise` does not exist on `F
      4 |    raise "hi"
             ^^^^^^^^^^
   Did you mean to `include Kernel` in this module?
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L860: Did you mean: `Kernel#raise`?
-     860 |  def raise(arg0=T.unsafe(nil), arg1=T.unsafe(nil), arg2=T.unsafe(nil)); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L870: Did you mean: `Kernel#raise`?
+     870 |  def raise(arg0=T.unsafe(nil), arg1=T.unsafe(nil), arg2=T.unsafe(nil)); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
I think this might have been why we didn't have it? I tried bumping this in pay-server and 63 of the callers seemed like they wanted methods on the `Class`. If I made it return something dumb like `Integer` I got 147 errors. Is that high enough of a caller % to go to untyped?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
