### PR TITLE
Make the docs for `include Kernel` easier to reference

### DIFF
--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -479,7 +479,8 @@ This error indicates a call to a method we believe does not exist (a la Ruby's
 
     See the [RBI](rbi.md) docs for how to regenerate the `*.rbi` files.
 
-1.  <a class="anchor" aria-hidden="true" id="include-kernel"></a>Sorbet will complain about this code:
+1.  <a class="anchor" aria-hidden="true" id="include-kernel"></a>Sorbet will
+    complain about this code:
 
     ```ruby
     module MyModule; end

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -479,7 +479,7 @@ This error indicates a call to a method we believe does not exist (a la Ruby's
 
     See the [RBI](rbi.md) docs for how to regenerate the `*.rbi` files.
 
-1.  <a id="include-kernel">Sorbet will complain about this code:</a>
+1.  <a class="anchor" aria-hidden="true" id="include-kernel"></a>Sorbet will complain about this code:
 
     ```ruby
     module MyModule; end

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -479,7 +479,7 @@ This error indicates a call to a method we believe does not exist (a la Ruby's
 
     See the [RBI](rbi.md) docs for how to regenerate the `*.rbi` files.
 
-1.  Sorbet will complain about this code:
+1.  <a id="include-kernel">Sorbet will complain about this code:</a>
 
     ```ruby
     module MyModule; end

--- a/website/static/docs/include-kernel.html
+++ b/website/static/docs/include-kernel.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<meta charset="utf-8">
+<title>Redirecting…</title>
+<link rel="canonical" href="https://sorbet.org/docs/error-reference#include-kernel">
+<meta http-equiv="refresh" content="0; url=error-reference#include-kernel">
+<a href="error-reference#include-kernel">Click here if you are not redirected.</a>
+</html>


### PR DESCRIPTION
Add an anchor to the `include Kernel` part of the description of error code 7003, and a quick redirect link as `https://sorbet.org/docs/include-kernel.html`.

### Motivation
We've had a number of questions recently that are answered by this section, so this change makes it easier to reference.

### Test plan
There are no visible changes to the website.