### PR TITLE
Use the ruby implementation of MD5

### DIFF
--- a/gems/sorbet/bin/srb
+++ b/gems/sorbet/bin/srb
@@ -33,7 +33,14 @@ shift
 srb_path="${BASH_SOURCE[0]}"
 
 compute_md5() {
-  ruby -e "require 'digest'; puts Digest::MD5.hexdigest(File.read(ARGV[0]))" "$1"
+  if command -v md5sum > /dev/null; then
+    md5sum "$1"
+  elif command -v md5 > /dev/null; then
+    md5 -r "$1"
+  else
+    # this is quite a bit slower
+    ruby -e 'require "digest"; puts Digest::MD5.hexdigest(File.read(ARGV[0]))' "$1"
+  fi
 }
 
 typecheck() {
@@ -42,7 +49,7 @@ typecheck() {
 
   if [ -f Gemfile.lock ]; then
     [ -d "$cache_dir" ] || mkdir -p "$cache_dir"
-    cache_hash=$(compute_md5 Gemfile.lock)
+    cache_hash=$(compute_md5 Gemfile.lock | awk '{ print $1 }')
     cache_file="${cache_dir}/${cache_hash}"
     if [ ! -f "$cache_file" ]; then
       $0 rbi find-gem-rbis > /dev/null

--- a/gems/sorbet/bin/srb
+++ b/gems/sorbet/bin/srb
@@ -33,11 +33,7 @@ shift
 srb_path="${BASH_SOURCE[0]}"
 
 compute_md5() {
-  if command -v md5sum > /dev/null; then
-    md5sum "$1"
-  else
-    md5 -r "$1"
-  fi
+  ruby -e "require 'digest'; puts Digest::MD5.hexdigest(File.read(ARGV[0]))" "$1"
 }
 
 typecheck() {
@@ -46,7 +42,7 @@ typecheck() {
 
   if [ -f Gemfile.lock ]; then
     [ -d "$cache_dir" ] || mkdir -p "$cache_dir"
-    cache_hash=$(compute_md5 Gemfile.lock | awk '{ print $1 }')
+    cache_hash=$(compute_md5 Gemfile.lock)
     cache_file="${cache_dir}/${cache_hash}"
     if [ ! -f "$cache_file" ]; then
       $0 rbi find-gem-rbis > /dev/null


### PR DESCRIPTION
md5sum/md5 isn't present int the bazel sandbox, and we know ruby will be
present. This change adds a fall back on the ruby version of MD5.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This allows `srb` to run (although with a significant slowdown) in contexts where `md5` and `md5sum` is missing.


### Test plan
The `srb init` tests will exercise this change.

