### PR TITLE
Do not add profiling time traces that are shorter than 250microseconds

### DIFF
--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -28,6 +28,7 @@ CFG::CFG() {
 }
 
 CFG::ReadsAndWrites CFG::findAllReadsAndWrites(core::Context ctx) {
+    Timer timeit(ctx.state.tracer(), "findAllReadsAndWrites");
     CFG::ReadsAndWrites target;
     target.reads.resize(maxBasicBlockId);
     target.writes.resize(maxBasicBlockId);
@@ -89,6 +90,8 @@ CFG::ReadsAndWrites CFG::findAllReadsAndWrites(core::Context ctx) {
     UnorderedMap<core::LocalVariable, pair<int, int>> usageCounts;
 
     {
+        Timer timeit(ctx.state.tracer(), "privates1");
+
         for (auto blockId = 0; blockId < maxBasicBlockId; blockId++) {
             for (auto &el : readsAndWrites[blockId]) {
                 usageCounts.try_emplace(el, make_pair(0, blockId)).first->second.first += 1;
@@ -96,6 +99,7 @@ CFG::ReadsAndWrites CFG::findAllReadsAndWrites(core::Context ctx) {
         }
     }
     {
+        Timer timeit(ctx.state.tracer(), "privates2");
         for (const auto &[local, usages] : usageCounts) {
             if (usages.first == 1) {
                 target.writes[usages.second].erase(local);

--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -328,6 +328,7 @@ void CFGBuilder::fillInBlockArguments(core::Context ctx, const CFG::ReadsAndWrit
     vector<UnorderedSet<core::LocalVariable>> upperBounds1(cfg.maxBasicBlockId);
     bool changed = true;
     {
+        Timer timeit(ctx.state.tracer(), "upperBounds1");
         for (BasicBlock *bb : cfg.forwardsTopoSort) {
             auto &upperBoundsForBlock = upperBounds1[bb->id];
             upperBoundsForBlock.insert(readsByBlock[bb->id].begin(), readsByBlock[bb->id].end());
@@ -366,6 +367,7 @@ void CFGBuilder::fillInBlockArguments(core::Context ctx, const CFG::ReadsAndWrit
 
     changed = true;
     {
+        Timer timeit(ctx.state.tracer(), "upperBounds2");
         while (changed) {
             changed = false;
             for (auto it = cfg.forwardsTopoSort.rbegin(); it != cfg.forwardsTopoSort.rend(); ++it) {
@@ -383,6 +385,7 @@ void CFGBuilder::fillInBlockArguments(core::Context ctx, const CFG::ReadsAndWrit
         }
     }
     {
+        Timer timeit(ctx.state.tracer(), "upperBoundsMerge");
         /** Combine two upper bounds */
         for (auto &it : cfg.basicBlocks) {
             auto set2 = upperBounds2[it->id];

--- a/common/Timer.cc
+++ b/common/Timer.cc
@@ -36,9 +36,13 @@ FlowId Timer::getFlowEdge() {
 
 Timer::~Timer() {
     auto clock = chrono::steady_clock::now();
-    auto dur = std::chrono::duration<double, std::milli>(clock - start);
-    log.debug("{}: {}ms", this->name.str, dur.count());
-    sorbet::timingAdd(this->name, start, clock, move(args), self, prev);
+    auto dur = clock - start;
+    if (dur > std::chrono::microseconds(250)) {
+        // the trick ^^^ is to skip double comparison in the common case and use the most efficient represnetation.
+        auto dur = std::chrono::duration<double, std::milli>(clock - start);
+        log.debug("{}: {}ms", this->name.str, dur.count());
+        sorbet::timingAdd(this->name, start, clock, move(args), self, prev);
+    }
 }
 
 } // namespace sorbet

--- a/common/Timer.cc
+++ b/common/Timer.cc
@@ -37,7 +37,7 @@ FlowId Timer::getFlowEdge() {
 Timer::~Timer() {
     auto clock = chrono::steady_clock::now();
     auto dur = clock - start;
-    if (dur > std::chrono::microseconds(250)) {
+    if (dur > std::chrono::milliseconds(1)) {
         // the trick ^^^ is to skip double comparison in the common case and use the most efficient represnetation.
         auto dur = std::chrono::duration<double, std::milli>(clock - start);
         log.debug("{}: {}ms", this->name.str, dur.count());


### PR DESCRIPTION
Please only review last 2 commits. All others are part of #1043 
### Motivation
I'd like to be able to cheaply add tracing to functions that are normally very fast but have bad worst-case behaviors. Prompted by #1043 

### Test plan
Ran on pay-server, ran with `-e 1`, in both cases interesting parts of traces remained.

Putting @jvilk-stripe as a reviewer, as this might affect some of your metrics as "super fast" requests will no longer be included in distributions. 
