### PR TITLE
Use `--no-config` option instead of a directory change

### DIFF
--- a/gems/sorbet/lib/hidden-definition-finder.rb
+++ b/gems/sorbet/lib/hidden-definition-finder.rb
@@ -117,30 +117,29 @@ class Sorbet::Private::HiddenMethodFinder
     raise "Your source can't be read by Sorbet.\nYou can try `find . -type f | xargs -L 1 -t srb tc --no-config --error-white-list 1000` and hopefully the last file it is processing before it dies is the culprit.\nIf not, maybe the errors in this file will help: #{SOURCE_CONSTANTS_ERR}" if File.read(SOURCE_CONSTANTS).empty?
 
     puts "Printing #{TMP_RBI}'s symbol table into #{RBI_CONSTANTS}"
-    # Change dir to deal with you having a sorbet/config in your cwd
-    Dir.chdir(TMP_PATH) do
-      io = IO.popen(
-        [
-          File.realpath("#{__dir__}/../bin/srb"),
-          'tc',
-          '--print=symbol-table-json',
-          # Method redefined with mismatched argument is ok since sometime
-          # people monkeypatch over method
-          '--error-black-list=4010',
-          # Redefining constant is needed because we serialize things both as
-          # aliases and in-class constants.
-          '--error-black-list=4012',
-          # Invalid nesting is ok because we don't generate all the intermediate
-          # namespaces for aliases
-          '--error-black-list=4015',
-          '--stdout-hup-hack',
-          '--silence-dev-message',
-          '--no-error-count',
-          TMP_RBI,
-        ],
-        err: RBI_CONSTANTS_ERR
-      )
-    end
+    io = IO.popen(
+      [
+        File.realpath("#{__dir__}/../bin/srb"),
+        'tc',
+        # Make sure we don't load a sorbet/config in your cwd
+        '--no-config',
+        '--print=symbol-table-json',
+        # Method redefined with mismatched argument is ok since sometime
+        # people monkeypatch over method
+        '--error-black-list=4010',
+        # Redefining constant is needed because we serialize things both as
+        # aliases and in-class constants.
+        '--error-black-list=4012',
+        # Invalid nesting is ok because we don't generate all the intermediate
+        # namespaces for aliases
+        '--error-black-list=4015',
+        '--stdout-hup-hack',
+        '--silence-dev-message',
+        '--no-error-count',
+        TMP_RBI,
+      ],
+      err: RBI_CONSTANTS_ERR
+    )
     File.write(RBI_CONSTANTS, io.read)
     io.close
     raise "#{TMP_RBI} had unexpected errors. Check this file for a clue: #{RBI_CONSTANTS_ERR}" unless $?.success?


### PR DESCRIPTION
The code was changing to the temp directory to avoid the presence of a `sorbet/config` file in the current path, but this is no longer necessary since we have the `--no-config` flag now.

### Motivation

Changing to temp directories is a hacky workaround that obfuscates the real intent of the code. `--no-config` reveals that intent in a nicer way.

### Test plan

The current test should be enough to catch the error since the fixture already includes a `sorbet/config` file in the current folder.
