### PR TITLE
Unbreak master

### DIFF
--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -47,6 +47,8 @@ pushd gems/sorbet
 sed -i.bak "s/0\\.0\\.0/${release_version}/" sorbet.gemspec
 gem build sorbet.gemspec
 if [[ "mac" == "$platform" ]]; then
+  rbenv exec gem uninstall --all --executables --ignore-dependencies sorbet sorbet-static
+  trap 'rbenv exec gem uninstall --all --executables --ignore-dependencies sorbet sorbet-static' EXIT
   rbenv exec gem install ../../gems/sorbet-static/sorbet-static-*-universal-darwin-18.gem
   rbenv exec gem install sorbet-*.gem
 
@@ -66,8 +68,6 @@ if [[ "mac" == "$platform" ]]; then
 
   rbenv exec bundle
   rbenv exec bundle exec rake test
-
-  rbenv exec gem uninstall --all --executables --ignore-dependencies sorbet sorbet-static
 fi
 popd
 


### PR DESCRIPTION
Because we didn't have a `Gemfile`, `rbenv exec srb` just runs whichever
version of `srb` is installed for the current Ruby version in
`.ruby-version`.

In particular, because the `~/.rbenv` folder is shared across tests, it
might have artifacts from other people's branches (specifically when the
tests failed, and we didn't get to the line to delete the existing
gems). And because our version numbers are just "how many commits since
the beginning of time", 0.4.FOO might be the same number as 0.4.BAR in
someone else's branch, even though those two versions are completely
unrelated, and **also** completely unrelated to the gems that will
EVENTUALLY be published with that as the Canonical Version.

I chose to both remove before each run and also trap EXIT just in case,
because in no cases do we want these gems to persist on the mac machine
after a CI run.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Unbreak master.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

CI should pass now.