### PR TITLE
LSP: Don't take the slow path after fixing a syntax error.

### DIFF
--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -94,8 +94,8 @@ string prettyPrintRangeComment(string_view sourceLine, const Range &range, strin
         return "";
     }
     string sourceLineNumber = fmt::format("{}", range.start->line + 1);
-    EXPECT_EQ(range.start->line, range.end->line) << "Multi-line ranges are not supported at this time.";
     if (range.start->line != range.end->line) {
+        // Multi-line ranges are not supported at this time.
         return string(comment);
     }
 

--- a/test/testdata/lsp/fast_path/syntax_error_fast_path.1.rbupdate
+++ b/test/testdata/lsp/fast_path/syntax_error_fast_path.1.rbupdate
@@ -1,0 +1,13 @@
+# typed: true
+# assert-fast-path: syntax_error_fast_path.rb
+
+class A extend T::Sig
+  sig {void}
+  def bar
+    y = T.let(nil
+  end # error: Parse Error: unexpected token: syntax error
+
+  def foo(y)
+
+  end
+end # error: Parse Error: unexpected token: syntax error

--- a/test/testdata/lsp/fast_path/syntax_error_fast_path.2.rbupdate
+++ b/test/testdata/lsp/fast_path/syntax_error_fast_path.2.rbupdate
@@ -1,0 +1,13 @@
+# typed: true
+# assert-fast-path: syntax_error_fast_path.rb
+
+class A extend T::Sig
+  sig {void}
+  def bar
+    y = T.let(nil, T.nilable(String))
+  end
+
+  def foo(y)
+
+  end
+end

--- a/test/testdata/lsp/fast_path/syntax_error_fast_path.rb
+++ b/test/testdata/lsp/fast_path/syntax_error_fast_path.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+class A extend T::Sig
+  sig {void}
+  def bar
+    y = nil
+  end
+
+  def foo(y)
+
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

LSP: Don't take the slow path after fixing a syntax error.

Effectively refuses to store the "invalid hash" value for files as their previous hash value when they syntax error, so if a file goes from hierarchy hash A -> Invalid Hash -> A, we still take the fast path.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Typing `T.let(` is ~guaranteed to cause a syntax error and take the slow path. It's infuriating when typing untyped code.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
