### PR TITLE
Update example on nillable_types.md

### DIFF
--- a/website/docs/nilable-types.md
+++ b/website/docs/nilable-types.md
@@ -86,7 +86,7 @@ sig {params(x: Integer).void}
 def doesnt_take_nil(x); end
 
 sig {params(key: Symbol, options: T::Hash[Symbol, Integer]).void}
-def foo(options)
+def foo(key, options)
   val = options[key]
   doesnt_take_nil(val) # error: `T.nilable(Integer)` doesn't match `Integer` for argument `x`
 end


### PR DESCRIPTION
Example was missing the parameter `key` on the function `foo`.

### Motivation
Updated documentation is always good.


### Test plan

N/A
