### PR TITLE
Stop duplicating bazel options when compiling C++

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,8 +13,8 @@ common:test --test_env=GTEST_INSTALL_FAILURE_SIGNAL_HANDLER=1
 ##
 ##  Custom toolchain.
 ##
-build --crosstool_top=@llvm_toolchain//:toolchain --cxxopt=-D_LIBCPP_ENABLE_NODISCARD
-test --crosstool_top=@llvm_toolchain//:toolchain --cxxopt=-D_LIBCPP_ENABLE_NODISCARD
+build --crosstool_top=@llvm_toolchain//:toolchain --copt=-D_LIBCPP_ENABLE_NODISCARD
+test --crosstool_top=@llvm_toolchain//:toolchain --copt=-D_LIBCPP_ENABLE_NODISCARD
 
 ##
 ##  Common build options across all build configurations
@@ -28,20 +28,14 @@ build --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
 # Developer laptops run skylake, devboxes run skylake-avx512
 # however some AWS instances in our fleet still run Sandy Bridge (Skylake predecessor)
 build --copt=-march=sandybridge
-build --cxxopt=-march=sandybridge
 
 build --copt=-fno-omit-frame-pointer
-build --cxxopt=-fno-omit-frame-pointer
 
 build --copt=-fstack-protector
-build --cxxopt=-fstack-protector
 
 build --copt=-Werror --copt=-Wimplicit-fallthrough
-build --cxxopt=-Werror --cxxopt=-Wimplicit-fallthrough
 
-build --host_cxxopt=-O1
 build --host_copt=-O1
-build --host_cxxopt=-DFORCE_DEBUG
 build --host_copt=-DFORCE_DEBUG
 build --host_cxxopt=-Wno-unused-variable --host_cxxopt=-Wno-overloaded-virtual --host_cxxopt=-Wno-unused-const-variable # ragel violates those and we want a silent build
 build --host_cxxopt=-Wno-pass-failed # host build doesn't have enough optimizations enabled for clang to vectorize this loop reliably
@@ -49,13 +43,11 @@ build --host_cxxopt=-Wno-pass-failed # host build doesn't have enough optimizati
 # The MacOS CROSSTOOL in bazel defines _FORTIFY_SOURCE both on
 # <command line>:1:9: and <built-in>:355:9: so sadly we turn them all off
 build --copt=-Wno-macro-redefined
-build --cxxopt=-Wno-macro-redefined
 
 ##
 ## debug configuration
 ##
 build:dbg --copt=-O0
-build:dbg --cxxopt=-O0
 build:dbg --compilation_mode=dbg
 build:dbg --config=debugsymbols
 
@@ -91,13 +83,13 @@ build:release-debug-mac --config=release-mac
 build:release-debug-mac --config=forcedebug
 build:release-debug-mac --config=dbg
 
-build:release-sanitized-linux --copt=-O2 --cxxopt=-O2
+build:release-sanitized-linux --copt=-O2
 build:release-sanitized-linux --config=sanitize-linux
 build:release-sanitized-linux --define jemalloc=false
 build:release-sanitized-linux --config=debugsymbols
 build:release-sanitized-linux --config=forcedebug
 
-build:release-sanitized-mac --copt=-O2 --cxxopt=-O2
+build:release-sanitized-mac --copt=-O2
 build:release-sanitized-mac --config=forcedebug
 build:release-sanitized-mac --config=debugsymbols
 build:release-sanitized-mac --config=sanitize-mac
@@ -115,10 +107,10 @@ build:test-sanitized-mac --config=release-sanitized-mac --config=dbg --nostamp -
 test:test-sanitized-mac --config=release-sanitized-mac --config=dbg --nostamp --define release=false
 test:test-sanitized-mac --test_env="UBSAN_OPTIONS=print_stacktrace=1"
 
-build:reduce-intermediate-file-size --copt=-g0 --linkopt=-g0 --cxxopt=-g0 # used by buildfarm to have less debug information on disk
-build:reduce-intermediate-file-size --copt=-Os --linkopt=-Os --cxxopt=-Os
+build:reduce-intermediate-file-size --copt=-g0 --linkopt=-g0 # used by buildfarm to have less debug information on disk
+build:reduce-intermediate-file-size --copt=-Os --linkopt=-Os
 build:reduce-intermediate-file-size --strip=always
-build:reduce-intermediate-file-size --copt=-fno-standalone-debug --linkopt=-fno-standalone-debug --cxxopt=-fno-standalone-debug # used by buildfarm to have less debug information on disk
+build:reduce-intermediate-file-size --copt=-fno-standalone-debug --linkopt=-fno-standalone-debug # used by buildfarm to have less debug information on disk
 build:reduce-intermediate-file-size --config=shared-libs
 
 build:buildfarm --curses=no --config=reduce-intermediate-file-size
@@ -143,11 +135,9 @@ test:travis --test_output=errors
 # DEBUG_MODE is set by default for all builds except --config=release.
 # Use this flag to set DEBUG_MODE even for --config=release.
 build:forcedebug --copt=-DFORCE_DEBUG
-build:forcedebug --cxxopt=-DFORCE_DEBUG
 
 # LTO build. Much longer compilation time. Smaller size and better perf.
 build:lto --copt=-flto=thin
-build:lto --cxxopt=-flto=thin
 build:lto --linkopt=-flto=thin
 build:lto --config=static-libs
 
@@ -158,14 +148,14 @@ build:lto-linux --config=lto
 # By default, we make static builds, but we can also use dynamic linking if asked to.
 # Note that dynamic linking is not fully supported by some of our toolchains and thus it may not always work.
 build --define=linkshared=false
-build:shared-libs --define=linkshared=true --cxxopt=-fPIC --copt=-fPIC --linkopt=-fPIC
+build:shared-libs --define=linkshared=true --copt=-fPIC --linkopt=-fPIC
 
 # By default, we make dynamicly linked builds, while release builds are statically linked.
 # Note that dynamic linking is not fully supported by some of our toolchains and thus it may not always work.
 # Still, we try to use it by default as it has lower iteration time in dev
-build --define=linkshared=true --cxxopt=-fPIC --copt=-fPIC --linkopt=-fPIC
-build:static-libs --define=linkshared=false --cxxopt=-fno-PIC --copt=-fno-PIC --linkopt=-fno-PIC
-build:static-libs --linkopt=-fno-pie --copt=-fno-pie --cxxopt=-fno-pie
+build --define=linkshared=true --copt=-fPIC --linkopt=-fPIC
+build:static-libs --define=linkshared=false --copt=-fno-PIC --linkopt=-fno-PIC
+build:static-libs --linkopt=-fno-pie --copt=-fno-pie
 
 # It's useful to be able to write `config_setting` rules for "this is
 # an unsanitized build", but we can't express "copt does not contain
@@ -177,17 +167,15 @@ build --define unsanitized=true
 build:sanitize --config=asan --config=ubsan
 
 build:asan --copt=-fsanitize=address --copt=-fsanitize-address-use-after-scope
-build:asan --cxxopt=-fsanitize=address --cxxopt=-fsanitize-address-use-after-scope
 build:asan --linkopt=-fsanitize=address --linkopt=-fsanitize-address-use-after-scope
-build:asan --cxxopt=-DADDRESS_SANITIZER # used by abseil
-build:asan --cxxopt=-DHAS_SANITIZER
+build:asan --copt=-DADDRESS_SANITIZER # used by abseil
+build:asan --copt=-DHAS_SANITIZER
 build:asan --define unsanitized=false
 
 build:ubsan --copt=-fsanitize=undefined --copt=-fno-sanitize-recover=undefined
-build:ubsan --cxxopt=-fsanitize=undefined --copt=-fno-sanitize-recover=undefined
 build:ubsan --linkopt=-fsanitize=undefined --copt=-fno-sanitize-recover=undefined
 build:ubsan --define unsanitized=false
-build:ubsan --cxxopt=-DHAS_SANITIZER
+build:ubsan --copt=-DHAS_SANITIZER
 
 # Bazel links C++ files with $CC, not $CXX, this breaks UBSan
 build:sanitize-linux --linkopt=external/llvm_toolchain/lib/clang/8.0.0/lib/linux/libclang_rt.asan_cxx-x86_64.a
@@ -201,7 +189,6 @@ build:sanitize-mac --config=sanitize
 test:sanitize-mac --config=sanitize
 
 build:tsan --copt=-fsanitize=thread
-build:tsan --cxxopt=-fsanitize=thread
 build:tsan --linkopt=-fsanitize=thread
 
 # Build optimized for executable size. Can be faster if size of executable code is a bottleneck.
@@ -212,7 +199,6 @@ build:size --copt=-Os --config=lto
 # From https://github.com/RobotLocomotion/drake/blob/master/tools/cc_toolchain/bazel.rc
 # See https://github.com/bazelbuild/bazel/issues/2537
 build:debugsymbols --copt=-g3 --copt=-fstandalone-debug --copt=-DDEBUG_SYMBOLS --copt=-glldb
-build:debugsymbols --cxxopt=-g3 --cxxopt=-fstandalone-debug --cxxopt=-DDEBUG_SYMBOLS --cxxopt=-glldb
 build:debugsymbols --linkopt=-g3 --linkopt=-fstandalone-debug --linkopt=-DDEBUG_SYMBOLS --linkopt=-glldb
 build:debugsymbols --spawn_strategy=standalone
 build:debugsymbols --genrule_strategy=standalone
@@ -226,9 +212,9 @@ common --show_progress_rate_limit=0.25
 ##
 ## Fuzzing
 ##
-build:fuzz --copt=-fsanitize=fuzzer --cxxopt=-fsanitize=fuzzer --linkopt=-fsanitize=fuzzer --config=asan
+build:fuzz --copt=-fsanitize=fuzzer --linkopt=-fsanitize=fuzzer --config=asan
 build:fuzz --config=forcedebug --config=debugsymbols
-build:fuzz --copt=-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION --cxxopt=-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+build:fuzz --copt=-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 
 ##
 ## Webasm config. Please use either of those depending on your platform
@@ -238,12 +224,12 @@ build:webasm-darwin --crosstool_top=//tools/toolchain/webasm-darwin --config=web
 
 # common webasm config
 # Use --cpu as a differentiator.
-build:webasm --cpu=webasm --spawn_strategy=standalone --genrule_strategy=standalone --copt=-Oz --cxxopt=-Oz --linkopt=-Oz --copt=-DMDB_USE_ROBUST=0 --cxxopt=-DMDB_USE_ROBUST=0
+build:webasm --cpu=webasm --spawn_strategy=standalone --genrule_strategy=standalone --copt=-Oz --linkopt=-Oz --copt=-DMDB_USE_ROBUST=0
 build:webasm --define release=true
 build:webasm --config=versioned
 build:webasm --compilation_mode=opt
-build:webasm --copt=-DNDEBUG --cxxopt=-DNDEBUG --linkopt=-DNDEBUG # for some reason emscripten doesn't pass those when -O2\-Oz are specified
-build:webasm --copt=--llvm-lto --copt=3 --cxxopt=--llvm-lto --cxxopt=3 --linkopt=--llvm-lto --linkopt=3
+build:webasm --copt=-DNDEBUG --linkopt=-DNDEBUG # for some reason emscripten doesn't pass those when -O2\-Oz are specified
+build:webasm --copt=--llvm-lto --copt=3 --linkopt=--llvm-lto --linkopt=3
 # Specify a "sane" C++ toolchain for the host platform.
 build:webasm --host_crosstool_top=@llvm_toolchain//:toolchain
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
After re-reading the spec `-copt` is also passed to C++ rules, (whereas I expected it to work the way `-coptonly` works).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
