### PR TITLE
Optimize `T.must`

### DIFF
--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -178,6 +178,11 @@ module T
   #
   # sig {params(arg: T.nilable(A), msg: T.nilable(String)).returns(A)}
   def self.must(arg, msg=nil)
+    # Avoid a method call by inlining the behavior of
+    # > return arg unless arg.nil?
+    return arg if arg
+    return arg if arg == False
+
     begin
       if msg
         if !T.unsafe(msg).is_a?(String)
@@ -186,11 +191,9 @@ module T
       else
         msg = "Passed `nil` into T.must"
       end
-      raise TypeError.new(msg) if arg.nil?
-      arg
+      raise TypeError.new(msg)
     rescue TypeError => e # raise into rescue to ensure e.backtrace is populated
       T::Private::ErrorHandler.handle_inline_type_error(e)
-      arg
     end
   end
 

--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -178,10 +178,12 @@ module T
   #
   # sig {params(arg: T.nilable(A), msg: T.nilable(String)).returns(A)}
   def self.must(arg, msg=nil)
-    # Avoid a method call by inlining the behavior of
-    # > return arg unless arg.nil?
-    return arg if arg
-    return arg if arg == False
+    # an alternrate implementation could be:
+    # > return arg if arg
+    # > return arg if arg == False
+    # as this would skiop a method call for nil? in the common case. However, as
+    # nil? could be overridden on arg, we don't do that.
+    return arg unless arg.nil?
 
     begin
       if msg

--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -178,12 +178,8 @@ module T
   #
   # sig {params(arg: T.nilable(A), msg: T.nilable(String)).returns(A)}
   def self.must(arg, msg=nil)
-    # an alternrate implementation could be:
-    # > return arg if arg
-    # > return arg if arg == False
-    # as this would skiop a method call for nil? in the common case. However, as
-    # nil? could be overridden on arg, we don't do that.
-    return arg unless arg.nil?
+    return arg if arg
+    return arg if arg == false
 
     begin
       if msg

--- a/gems/sorbet-runtime/test/types/must.rb
+++ b/gems/sorbet-runtime/test/types/must.rb
@@ -8,6 +8,9 @@ module Opus::Types::Test
       assert_equal(0, T.must(0))
       assert_equal("", T.must(""))
       assert_equal(false, T.must(false))
+
+      # NOTE: the second argument is only checked if the first argument is `nil`
+      assert_equal(:a, T.must(:a, 10))
     end
 
     it 'disallows nil' do
@@ -26,7 +29,9 @@ module Opus::Types::Test
 
     it 'does not allow custom classes' do
       e = assert_raises(TypeError) do
-        T.must(:a, RuntimeError.new('hi'))
+        # NOTE: the second argument is only checked if the first argument is
+        # `nil`
+        T.must(nil, RuntimeError.new('hi'))
       end
       assert_equal('T.must expects a string as second argument', e.message)
     end


### PR DESCRIPTION
`T.must` checks the type of its optional message argument before testing its first argument for `nil`. This change 

### Motivation
Resolves #1101

### Test plan
See included automated tests.
