### PR TITLE
Introduce T::FinalStruct

### DIFF
--- a/gems/sorbet-runtime/lib/types/struct.rb
+++ b/gems/sorbet-runtime/lib/types/struct.rb
@@ -1,6 +1,22 @@
 # frozen_string_literal: true
 # typed: true
 
+module T::FinalStruct
+  def self.included(other)
+    T::Private::ClassUtils.replace_method(other.singleton_class, :inherited) do |s|
+      super(s)
+
+      reason = if self.ancestors.include?(T::Struct)
+        "is a subclass of T::Struct"
+      else
+        "includes T::FinalStruct"
+      end
+
+      raise "#{self.name} #{reason} and cannot be subclassed"
+    end
+  end
+end
+
 class T::InexactStruct
   include T::Props
   include T::Props::Serializable
@@ -10,9 +26,6 @@ end
 class T::Struct < T::InexactStruct
   def self.inherited(subclass)
     super(subclass)
-    T::Private::ClassUtils.replace_method(subclass.singleton_class, :inherited) do |s|
-      super(s)
-      raise "#{self.name} is a subclass of T::Struct and cannot be subclassed"
-    end
+    subclass.include(T::FinalStruct)
   end
 end

--- a/gems/sorbet-runtime/test/types/struct.rb
+++ b/gems/sorbet-runtime/test/types/struct.rb
@@ -9,4 +9,30 @@ class Opus::Types::Test::StructValidationTest < Critic::Unit::UnitTest
     end
     assert_includes(err.message, "is a subclass of T::Struct and cannot be subclassed")
   end
+
+  it "allows subclassing an InexactStruct" do
+    c = Class.new(T::InexactStruct)
+    Class.new(c)
+  end
+
+  it "forbids subclassing an InexactStruct that includes FinalStruct" do
+    c = Class.new(T::InexactStruct) do
+      include T::FinalStruct
+    end
+    err = assert_raises(RuntimeError) do
+      Class.new(c)
+    end
+    assert_includes(err.message, "includes T::FinalStruct and cannot be subclassed")
+  end
+
+  it "forbids subclassing a deep subclass of InexactStruct that includes FinalStruct" do
+    c1 = Class.new(T::InexactStruct)
+    c2 = Class.new(c1) do
+      include T::FinalStruct
+    end
+    err = assert_raises(RuntimeError) do
+      Class.new(c2)
+    end
+    assert_includes(err.message, "includes T::FinalStruct and cannot be subclassed")
+  end
 end


### PR DESCRIPTION
### Motivation

This is testing an approach to solve an issue I opened #1106. This is pre-work for allowing subclasses of `T::InexactStruct` to have their the `initialize` signature auto-generated. The idea would be that if a class had `include T::FinalStruct` it would tell sorbet to synthesize its initialize sig.

### Test plan

See included automated tests.
