### PR TITLE
Add `require 'delegate'` to the tracepoint_serializer module

### DIFF
--- a/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
@@ -6,6 +6,7 @@ require_relative '../real_stdlib'
 
 require 'set'
 require 'fileutils'
+require 'delegate'
 
 
 module Sorbet::Private


### PR DESCRIPTION
`require 'delegate'` happens automatically with full ruby builds, but
the version that we're building in bazel lacks `did_you_mean`, which
requires the delegate library. Requiring 'delegate' here will be a no-op
in most cases, but will allow the snapshot testing in bazel to proceed
without digging into the ruby build further.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Further supporting the bazel snapshot testing.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
