### PR TITLE
auto-assign to oncall

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,4 @@
 # It uses the same pattern rule for gitignore file
 # https://git-scm.com/docs/gitignore#_pattern_format
 
-**/*                  @sorbet/sorbet-reviewer-roundrobin
-
-# This group actually forwards to @sorbet/core reviewers via https://github.com/marketplace/pull-panda
+**/*                  @sorbet/sorbet-on-call


### PR DESCRIPTION
Today PR pick someone from our normal rotation which is a bit interuptive. What do you think about having an alias that gets assigned all ticket? This will force us to internally pick the round-robin assigner by hand which I don't love but I don't see another way.

I used the word oncall since that is more publicly known than onrun.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
