### PR TITLE
Remove the `msg` parameter from `T.must`

### DIFF
--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -176,20 +176,13 @@ module T
   # Intended to be used to promise sorbet that a given nilable value happens
   # to contain a non-nil value at this point.
   #
-  # sig {params(arg: T.nilable(A), msg: T.nilable(String)).returns(A)}
-  def self.must(arg, msg=nil)
+  # sig {params(arg: T.nilable(A)).returns(A)}
+  def self.must(arg)
     return arg if arg
     return arg if arg == false
 
     begin
-      if msg
-        if !T.unsafe(msg).is_a?(String)
-          raise TypeError.new("T.must expects a string as second argument")
-        end
-      else
-        msg = "Passed `nil` into T.must"
-      end
-      raise TypeError.new(msg)
+      raise TypeError.new("Passed `nil` into T.must")
     rescue TypeError => e # raise into rescue to ensure e.backtrace is populated
       T::Private::ErrorHandler.handle_inline_type_error(e)
     end

--- a/gems/sorbet-runtime/test/types/must.rb
+++ b/gems/sorbet-runtime/test/types/must.rb
@@ -8,9 +8,6 @@ module Opus::Types::Test
       assert_equal(0, T.must(0))
       assert_equal("", T.must(""))
       assert_equal(false, T.must(false))
-
-      # NOTE: the second argument is only checked if the first argument is `nil`
-      assert_equal(:a, T.must(:a, 10))
     end
 
     it 'disallows nil' do
@@ -18,22 +15,6 @@ module Opus::Types::Test
         T.must(nil)
       end
       assert_equal('Passed `nil` into T.must', e.message)
-    end
-
-    it 'takes a custom message' do
-      e = assert_raises(TypeError) do
-        T.must(nil, "booo")
-      end
-      assert_equal('booo', e.message)
-    end
-
-    it 'does not allow custom classes' do
-      e = assert_raises(TypeError) do
-        # NOTE: the second argument is only checked if the first argument is
-        # `nil`
-        T.must(nil, RuntimeError.new('hi'))
-      end
-      assert_equal('T.must expects a string as second argument', e.message)
     end
   end
 end

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -57,8 +57,8 @@ module T
   def self.self_type; end
   def self.type_alias(type); end
 
-  sig {params(arg: T.untyped, msg: T.nilable(String)).returns(T.untyped)}
-  def self.must(arg, msg=nil); end
+  sig {params(arg: T.untyped).returns(T.untyped)}
+  def self.must(arg); end
 
   def self.coerce(type); end
 end

--- a/test/testdata/infer/must.rb
+++ b/test/testdata/infer/must.rb
@@ -4,8 +4,7 @@ def test_must # error: does not have a `sig`
   x = T.cast(nil, T.nilable(String)) # error: Useless cast
   T.assert_type!(T.must(x), String)
 
-  T.must(x, "hi")
+  T.must(x)
   T.must()  # error: Not enough arguments
-  T.must(x, "hi", 0)  # error: Expected: `1..2`, got: `3`
-  T.must(x, :foo)  # error: Expected `T.nilable(String)` but found `Symbol(:"foo")` for argument `msg`
+  T.must(x, 0)  # error: Expected: `1`, got: `2`
 end


### PR DESCRIPTION
Remove the `msg` parameter from `T.must`

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The `msg` parameter does not get much use, and is undocumented on https://sorbet.org. Removing it allows us to simplify the implementation of `T.must` a bit.

### Test plan
See included automated tests.