### PR TITLE
Add `symbol-table-full-json` print option

### DIFF
--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -41,7 +41,7 @@ com::stripe::rubytyper::Symbol::ArgumentInfo Proto::toProto(const GlobalState &g
 
     return argProto;
 }
-com::stripe::rubytyper::Symbol Proto::toProto(const GlobalState &gs, SymbolRef sym) {
+com::stripe::rubytyper::Symbol Proto::toProto(const GlobalState &gs, SymbolRef sym, bool showFull) {
     com::stripe::rubytyper::Symbol symbolProto;
     const auto data = sym.data(gs);
 
@@ -94,7 +94,20 @@ com::stripe::rubytyper::Symbol Proto::toProto(const GlobalState &gs, SymbolRef s
             continue;
         }
 
-        *symbolProto.add_children() = toProto(gs, pair.second);
+        if (!showFull && pair.second.data(gs)->isHiddenFromPrinting(gs)) {
+            bool hadPrintableChild = false;
+            for (auto childPair : pair.second.data(gs)->members()) {
+                if (!childPair.second.data(gs)->isHiddenFromPrinting(gs)) {
+                    hadPrintableChild = true;
+                    break;
+                }
+            }
+            if (!hadPrintableChild) {
+                continue;
+            }
+        }
+
+        *symbolProto.add_children() = toProto(gs, pair.second, showFull);
     }
 
     return symbolProto;

--- a/core/proto/proto.h
+++ b/core/proto/proto.h
@@ -20,7 +20,7 @@ public:
     static com::stripe::rubytyper::Name toProto(const GlobalState &gs, NameRef name);
 
     static com::stripe::rubytyper::Symbol::ArgumentInfo toProto(const GlobalState &gs, const ArgInfo &arg);
-    static com::stripe::rubytyper::Symbol toProto(const GlobalState &gs, SymbolRef sym);
+    static com::stripe::rubytyper::Symbol toProto(const GlobalState &gs, SymbolRef sym, bool showFull);
 
     static com::stripe::rubytyper::Type::Literal toProto(const GlobalState &gs, const LiteralType &lit);
     static com::stripe::rubytyper::Type toProto(const GlobalState &gs, TypePtr typ);

--- a/gems/sorbet/lib/hidden-definition-finder.rb
+++ b/gems/sorbet/lib/hidden-definition-finder.rb
@@ -105,7 +105,7 @@ class Sorbet::Private::HiddenMethodFinder
       [
         File.realpath("#{__dir__}/../bin/srb"),
         'tc',
-        '--print=symbol-table-json',
+        '--print=symbol-table-full-json',
         '--stdout-hup-hack',
         '--silence-dev-message',
         '--no-error-count',
@@ -123,7 +123,7 @@ class Sorbet::Private::HiddenMethodFinder
         'tc',
         # Make sure we don't load a sorbet/config in your cwd
         '--no-config',
-        '--print=symbol-table-json',
+        '--print=symbol-table-full-json',
         # Method redefined with mismatched argument is ok since sometime
         # people monkeypatch over method
         '--error-black-list=4010',

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -38,6 +38,7 @@ const vector<PrintOptions> print_options({
     {"symbol-table-json", &Printers::SymbolTableJson, true},
     {"symbol-table-full", &Printers::SymbolTableFull, true},
     {"symbol-table-full-raw", &Printers::SymbolTableFullRaw, true},
+    {"symbol-table-full-json", &Printers::SymbolTableFullJson, true},
     {"name-tree", &Printers::NameTree, true},
     {"name-tree-raw", &Printers::NameTreeRaw, true},
     {"file-table-json", &Printers::FileTableJson, true},

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -55,6 +55,7 @@ struct Printers {
     PrinterConfig SymbolTableJson;
     PrinterConfig SymbolTableFull;
     PrinterConfig SymbolTableFullRaw;
+    PrinterConfig SymbolTableFullJson;
     PrinterConfig FileTableJson;
     PrinterConfig ResolveTree;
     PrinterConfig ResolveTreeRaw;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -973,6 +973,16 @@ vector<ast::ParsedFile> typecheck(unique_ptr<core::GlobalState> &gs, vector<ast:
             opts.print.SymbolTableRaw.fmt("{}\n", gs->showRaw());
         }
         if (opts.print.SymbolTableJson.enabled) {
+            auto root = core::Proto::toProto(*gs, core::Symbols::root(), false);
+            if (opts.print.SymbolTableJson.outputPath.empty()) {
+                core::Proto::toJSON(root, cout);
+            } else {
+                stringstream buf;
+                core::Proto::toJSON(root, buf);
+                opts.print.SymbolTableJson.print(buf.str());
+            }
+        }
+        if (opts.print.SymbolTableFullJson.enabled) {
             auto root = core::Proto::toProto(*gs, core::Symbols::root(), true);
             if (opts.print.SymbolTableJson.outputPath.empty()) {
                 core::Proto::toJSON(root, cout);

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -973,7 +973,7 @@ vector<ast::ParsedFile> typecheck(unique_ptr<core::GlobalState> &gs, vector<ast:
             opts.print.SymbolTableRaw.fmt("{}\n", gs->showRaw());
         }
         if (opts.print.SymbolTableJson.enabled) {
-            auto root = core::Proto::toProto(*gs, core::Symbols::root());
+            auto root = core::Proto::toProto(*gs, core::Symbols::root(), true);
             if (opts.print.SymbolTableJson.outputPath.empty()) {
                 core::Proto::toJSON(root, cout);
             } else {

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -113,12 +113,12 @@ Usage:
                                 ast-raw, dsl-tree, dsl-tree-raw, index-tree,
                                 index-tree-raw, symbol-table, symbol-table-raw,
                                 symbol-table-json, symbol-table-full,
-                                symbol-table-full-raw, name-tree, name-tree-raw,
-                                file-table-json, resolve-tree, resolve-tree-raw,
-                                missing-constants, flattened-tree,
-                                flattened-tree-raw, cfg, cfg-json, cfg-proto, autogen,
-                                autogen-msgpack, autogen-classlist,
-                                plugin-generated-code]
+                                symbol-table-full-raw, symbol-table-full-json,
+                                name-tree, name-tree-raw, file-table-json,
+                                resolve-tree, resolve-tree-raw, missing-constants,
+                                flattened-tree, flattened-tree-raw, cfg, cfg-json,
+                                cfg-proto, autogen, autogen-msgpack,
+                                autogen-classlist, plugin-generated-code]
       --stop-after phase        Stop After: [init, parser, desugarer, dsl,
                                 local-vars, namer, resolver, cfg, inferencer]
                                 (default: inferencer)

--- a/test/cli/phases/phases.sh
+++ b/test/cli/phases/phases.sh
@@ -17,7 +17,7 @@ echo "--- checking diff ---"
 diff -r out fileout | sort
 
 # Makes sure all these options don't crash us
-for p in symbol-table-json symbol-table-full symbol-table-full-raw cfg-proto; do
+for p in symbol-table-json symbol-table-full symbol-table-full-raw symbol-table-full-json cfg-proto; do
     main/sorbet --silence-dev-message -p "$p" -e '1' > /dev/null
 done
 

--- a/test/cli/symbol-table-json-alias/symbol-table-json-alias.sh
+++ b/test/cli/symbol-table-json-alias/symbol-table-json-alias.sh
@@ -1,1 +1,1 @@
-main/sorbet test/cli/symbol-table-json-alias/symbol-table-json-alias.rb -p symbol-table-json | grep aliasTo -B 5 | head -n 5
+main/sorbet test/cli/symbol-table-json-alias/symbol-table-json-alias.rb -p symbol-table-full-json | grep aliasTo -B 5 | head -n 5

--- a/test/cli/symbol-table-json/symbol-table-json.out
+++ b/test/cli/symbol-table-json/symbol-table-json.out
@@ -1,0 +1,85 @@
+{
+ "id": 3,
+ "name": {
+  "kind": "CONSTANT",
+  "name": "\u003croot\u003e"
+ },
+ "kind": "CLASS",
+ "superClass": 6,
+ "children": [
+  {
+   "id": 4,
+   "name": {
+    "kind": "UNIQUE",
+    "name": "\u003cClass:\u003croot\u003e\u003e"
+   },
+   "kind": "CLASS",
+   "superClass": 96,
+   "children": [
+    {
+     "id": 10926,
+     "name": {
+      "kind": "UNIQUE",
+      "name": "\u003cstatic-init\u003e"
+     },
+     "kind": "METHOD",
+     "arguments": [
+      {
+       "name": {
+        "kind": "UTF8",
+        "name": "\u003cblk\u003e"
+       },
+       "isBlock": true
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "id": 10922,
+   "name": {
+    "kind": "CONSTANT",
+    "name": "A"
+   },
+   "kind": "CLASS",
+   "superClass": 6
+  },
+  {
+   "id": 10923,
+   "name": {
+    "kind": "UNIQUE",
+    "name": "\u003cClass:A\u003e"
+   },
+   "kind": "CLASS",
+   "superClass": 96,
+   "children": [
+    {
+     "id": 10924,
+     "name": {
+      "kind": "UTF8",
+      "name": "\u003cstatic-init\u003e"
+     },
+     "kind": "METHOD",
+     "arguments": [
+      {
+       "name": {
+        "kind": "UTF8",
+        "name": "\u003cblk\u003e"
+       },
+       "isBlock": true
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "id": 10925,
+   "name": {
+    "kind": "CONSTANT",
+    "name": "B"
+   },
+   "kind": "STATIC_FIELD",
+   "aliasTo": 10922
+  }
+ ]
+}

--- a/test/cli/symbol-table-json/symbol-table-json.rb
+++ b/test/cli/symbol-table-json/symbol-table-json.rb
@@ -1,0 +1,4 @@
+# typed: false
+class A
+end
+B = A

--- a/test/cli/symbol-table-json/symbol-table-json.sh
+++ b/test/cli/symbol-table-json/symbol-table-json.sh
@@ -1,0 +1,1 @@
+main/sorbet test/cli/symbol-table-json/symbol-table-json.rb -p symbol-table-json


### PR DESCRIPTION
### Motivation

The current `symbol-table-json` output is too chatty since it does not filter anything from its output, i.e. it really is the JSON equivalent of `symbol-table-full` or `symbol-table-full-raw` print options.

This creates a problem for tools that want the symbol table output in an easy to consume format but don't want the full dump of the symbol table. Plus, it breaks the symmetry of the various symbol table printing options.

### Solution

- A new print option named `symbol-table-full-json` is added which behaves in exactly the same way as the current `symbol-table-json` option. 
- The behaviour of `symbol-table-json` is changed to output only the summarized version.

### Test plan

See included automated tests.
