### PR TITLE
Un-skip generated tests

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -131,9 +131,6 @@ module T::Private::Methods
     end
 
     def generated
-      if T.unsafe(true)
-        raise "The .generated API is unstable, so we don't want it used until we redesign it. To change Sorbet's runtime behavior, see https://sorbet.org/docs/tconfiguration"
-      end
       check_live!
 
       if !decl.generated.equal?(ARG_NOT_PROVIDED)

--- a/gems/sorbet-runtime/lib/types/runtime_profiled.rb
+++ b/gems/sorbet-runtime/lib/types/runtime_profiled.rb
@@ -2,35 +2,23 @@
 # frozen_string_literal: true
 
 #
-# Hey there!
+# From the static system, T::Utils::RuntimeProfiled is T.untyped.
 #
-# T::Utils::Runtime is just a random class. Chances are[^1] it's not a class
-# that your variables are instances of, which means that using it in a type
-# signature will always create a type error.
+# But from the runtime system, it's a random class (specifically, a class that
+# normal programs currently don't have any instances of).
 #
-# At first, it doesn't seem like a good thing to have a type that's sole
-# purpose is to cause type errors. The trick is that within the ruby-types
-# team, we only use T::Utils::RuntimeProfiled within 'generated' sigs.
+# Thus, T::Utils::RuntimeProfiled can be used to introduce runtime-only type
+# errors. This seems like a bad idea, but it's not. It can be used to gather
+# runtime type information from running code via a custom T::Configuration
+# handler.
 #
-# Unlike normal sigs, generated sigs never raise at runtime. They also log the
-# actual, observed type on type error to a central location. We're using these
-# observed types to refine and expand our type coverage in pay-server.
+# This process has only ever been used at Stripe, and is likely to have rough
+# edges. If you've managed to find your way here and you're curious to try it,
+# please chat with us on Slack. There are no docs.
 #
-# What does this all mean for you?
-#
-# - If you were just curious, that's it! Leave the sig as is, and carry on.
-# - If you wanted to replace this sig with a better, hand-authored one:
-#
-#   1. Remove 'generated' from the sig.
-#   2. Update the sig to your liking
-#
-# Questions? :portal-to: => #ruby-types
-#
-# [^1]: Unless you happen to be calling T::Utils::RuntimeProfiled.new directly...
+# See also: the --suggest-runtime-profiled flag to sorbet.
 #
 
 module T; end
 module T::Utils; end
-# Sorbet guesses this type instead of T.untyped when passed --suggest-runtime-profiled
-
 class T::Utils::RuntimeProfiled; end

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -165,18 +165,6 @@ module Opus::Types::Test
           assert_match(/\.soft API is unstable/, err.message)
         end
 
-        it 'raises when using generated.' do
-          err = assert_raises(RuntimeError) do
-            mod = Module.new do
-              extend T::Sig
-              sig {generated.void}
-              def self.test_method; end
-            end
-            mod.test_method
-          end
-          assert_match(/\.generated API is unstable/, err.message)
-        end
-
         it 'raises RuntimeError with invalid level' do
           skip
           err = assert_raises(ArgumentError) do

--- a/gems/sorbet-runtime/test/types/method_validation.rb
+++ b/gems/sorbet-runtime/test/types/method_validation.rb
@@ -381,88 +381,115 @@ module Opus::Types::Test
         @mod.foo
       end
 
-      it 'logs with generated' do
-        skip
-        @mod.sig {generated.returns(Symbol)}
-        def @mod.foo
-          1
+      describe 'generated' do
+        before do
+          T::Configuration.sig_validation_error_handler = lambda do |error, opts|
+            if opts[:declaration].generated || opts[:super_signature]&.generated
+              T::Configuration.log_info_handler('SIG-DECLARE-FAILED')
+            else
+              raise 'sig_validation error'
+            end
+          end
+
+          T::Configuration.call_validation_error_handler = lambda do |signature, opts|
+            if signature.generated
+              got = opts[:value].class
+              got = T.unsafe(T::Enumerable[T.untyped]).describe_obj(opts[:value]) if got < Enumerable
+              T::Configuration.log_info_handler(
+                'SIG-CHECK-FAILED',
+                {
+                  got: got,
+                },
+              )
+            else
+              raise 'call_validation error'
+            end
+          end
         end
 
-        Opus::Log.stubs(:info).once.with do |message|
-          assert_equal('SIG-CHECK-FAILED', message)
-          true
-        end
-        @mod.foo
-      end
-
-      it 'logs with generated, but only once' do
-        skip
-        @mod.sig {generated.returns(Symbol)}
-        def @mod.foo
-          1
+        after do
+          T::Configuration.sig_validation_error_handler = nil
+          T::Configuration.call_validation_error_handler = nil
         end
 
-        Opus::Log.stubs(:info).once.with do |message|
-          assert_equal('SIG-CHECK-FAILED', message)
-          true
-        end
-        @mod.foo
-        @mod.foo
-      end
-
-      it 'does not throw if malformed but with .generated' do
-        skip
-        @mod.sig {generated.returns(Integer)}
-        def @mod.foo(foo)
-          1
-        end
-
-        Opus::Log.stubs(:info).once.with do |message|
-          assert_equal('SIG-DECLARE-FAILED', message)
-          true
-        end
-        @mod.foo(2)
-        @mod.foo(2)
-      end
-
-      it 'does not throw if parent is .generated' do
-        skip
-        parent = Class.new do
-          extend T::Sig
-          sig {generated.returns(Integer)}
-          def foo
+        it 'logs with generated' do
+          @mod.sig {generated.returns(Symbol)}
+          def @mod.foo
             1
           end
-        end
 
-        child = Class.new(parent) do
-          extend T::Sig
-          sig {returns(String)}
-          def foo
-            "1"
+          T::Configuration.stubs(:log_info_handler).once.with do |message|
+            assert_equal('SIG-CHECK-FAILED', message)
+            true
           end
+          @mod.foo
         end
 
-        Opus::Log.stubs(:info).once.with do |message|
-          assert_equal('SIG-DECLARE-FAILED', message)
-          true
-        end
-        child.new.foo
-      end
+        it 'logs with generated, but only once' do
+          @mod.sig {generated.returns(Symbol)}
+          def @mod.foo
+            1
+          end
 
-      it 'logs nicely for Enumerables' do
-        skip
-        @mod.sig {generated.returns(Symbol)}
-        def @mod.foo
-          [[{a: 1}, 2], "3", 4..5]
+          T::Configuration.stubs(:log_info_handler).once.with do |message|
+            assert_equal('SIG-CHECK-FAILED', message)
+            true
+          end
+          @mod.foo
+          @mod.foo
         end
 
-        Opus::Log.stubs(:info).once.with do |message, *args|
-          assert_equal('SIG-CHECK-FAILED', message)
-          assert_equal('T::Array[T.any(String, T::Array[T.any(Integer, T::Hash[Symbol, Integer])], T::Range[Integer])]', args[0][:got])
-          true
+        it 'does not throw if malformed but with .generated' do
+          @mod.sig {generated.returns(Integer)}
+          def @mod.foo(foo)
+            1
+          end
+
+          T::Configuration.stubs(:log_info_handler).once.with do |message|
+            assert_equal('SIG-DECLARE-FAILED', message)
+            true
+          end
+          @mod.foo(2)
+          @mod.foo(2)
         end
-        @mod.foo
+
+        it 'does not throw if parent is .generated' do
+          parent = Class.new do
+            extend T::Sig
+            sig {generated.returns(Integer)}
+            def foo
+              1
+            end
+          end
+
+          child = Class.new(parent) do
+            extend T::Sig
+            sig {returns(String)}
+            def foo
+              "1"
+            end
+          end
+
+          T::Configuration.stubs(:log_info_handler).once.with do |message|
+            assert_equal('SIG-DECLARE-FAILED', message)
+            true
+          end
+          child.new.foo
+        end
+
+        it 'logs nicely for Enumerables' do
+          @mod.sig {generated.returns(Symbol)}
+          def @mod.foo
+            [[{a: 1}, 2], "3", 4..5]
+          end
+
+          T::Configuration.stubs(:log_info_handler).once.with do |message, *args|
+            assert_equal('SIG-CHECK-FAILED', message)
+            assert_equal('T::Array[T.any(String, T::Array[T.any(Integer, T::Hash[Symbol, Integer])], T::Range[Integer])]', args[0][:got])
+            true
+          end
+          @mod.foo
+        end
       end
 
       it 'handles splats' do


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This unblocks using sorbet-runtime in pay-server (because we can't make
generated raise in pay-server).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Unskips the old generated tests, and uses a `before` block to simulate behavior
that's currently only present in Stripe's T::Configuration handlers.