### PR TITLE
Add a temporary fix for `each_with_object`

### DIFF
--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -137,10 +137,12 @@ module Enumerable
   sig {returns(T::Enumerator[[Elem, Integer]])}
   def each_with_index(&blk); end
 
+  # TODO: the arg1 type in blk should be `T.type_parameter(:U)`, but because of
+  # issue #38, this won't work.
   sig do
     type_parameters(:U).params(
         arg0: T.type_parameter(:U),
-        blk: T.proc.params(arg0: Elem, arg1: T.type_parameter(:U)).returns(BasicObject),
+        blk: T.proc.params(arg0: Elem, arg1: T.untyped).returns(BasicObject),
     )
     .returns(T.type_parameter(:U))
   end

--- a/rbi/light.rbi
+++ b/rbi/light.rbi
@@ -930,6 +930,32 @@ module Enumerable
   def select(&blk); end
   sig {returns(T::Array[Elem])}
   def to_a(); end
+
+  sig do
+    params(
+        blk: T.proc.params(arg0: Elem, arg1: Integer).returns(BasicObject),
+    )
+    .returns(T::Enumerable[Elem])
+  end
+  sig {returns(T::Enumerator[[Elem, Integer]])}
+  def each_with_index(&blk); end
+
+  # TODO: the arg1 type in blk should be `T.type_parameter(:U)`, but because of
+  # issue #38, this won't work.
+  sig do
+    type_parameters(:U).params(
+        arg0: T.type_parameter(:U),
+        blk: T.proc.params(arg0: Elem, arg1: T.untyped).returns(BasicObject),
+    )
+    .returns(T.type_parameter(:U))
+  end
+  sig do
+    type_parameters(:U).params(
+        arg0: T.type_parameter(:U),
+    )
+    .returns(T::Enumerator[[Elem, T.type_parameter(:U)]])
+  end
+  def each_with_object(arg0, &blk); end
 end
 class Enumerator < Object
   include Enumerable

--- a/test/testdata/rbi/each_with_object.rb
+++ b/test/testdata/rbi/each_with_object.rb
@@ -1,0 +1,14 @@
+# typed: true
+
+arr = T.let(Array.new, T::Array[Integer])
+
+init = T.let([], T::Array[Integer])
+
+arr.each_with_object(T.let([], T::Array[Integer])) do |k, arr|
+  T.reveal_type(k) # error: Revealed type: `Integer`
+
+  # TODO: this should be `Integer`, but because of #38 is set to `T.untyped`
+  T.reveal_type(arr) # error: Revealed type: `T.untyped`
+end
+
+T.reveal_type(arr.each_with_object(T.let(0, Integer))) # error: Revealed type: `T::Enumerator[[Integer, Integer]]`


### PR DESCRIPTION
Pass the object argument to the block of `each_with_object` as `T.untyped` until issue #38 is resolved.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Before #1097, most uses of `each_with_object` would get turned into `T.untyped` as it was missing from `Enumerable`, and everything would just work out. PR #1097 fixed this, but exposed a problem with the signature that previously was only present on `Enumerator`: the type of the object passed to the proc is getting turned into `<any>` during inference (see #38). This PR resolves that by marking the argument as `T.untyped` temporarily.

### Test plan


See included automated tests.
