### PR TITLE
Censor Loc info

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1144,6 +1144,7 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     result->suggestRuntimeProfiledType = this->suggestRuntimeProfiledType;
     result->isInitialized = this->isInitialized;
     result->runningUnderAutogen = this->runningUnderAutogen;
+    result->censorRawLocsWithinPayload = this->censorRawLocsWithinPayload;
 
     if (keepId) {
         result->globalStateId = this->globalStateId;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -143,6 +143,7 @@ public:
     // Think very hard before looking at this value in namer / resolver!
     // (hint: probably you want to find an alternate solution)
     bool runningUnderAutogen = false;
+    bool censorRawLocsWithinPayload = false;
 
     std::unique_ptr<GlobalState> deepCopy(bool keepId = false) const;
     mutable std::shared_ptr<ErrorQueue> errorQueue;

--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -1,6 +1,7 @@
 // has to go first as it violates our poisons
 #include "rang.hpp"
 
+#include "absl/strings/match.h"
 #include "core/Context.h"
 #include "core/GlobalState.h"
 #include "core/Loc.h"
@@ -152,8 +153,8 @@ string Loc::showRaw(const GlobalState &gs) const {
     if (!exists()) {
         return fmt::format("Loc {{file={} start=??? end=???}}", path);
     }
-    if (path == "https://github.com/sorbet/sorbet/tree/master/rbi/light.rbi") {
-        // This is so that changing light.rbi doesn't necessarily mean invalidating every symbol-table exp test.
+    if (path == "https://github.com/sorbet/sorbet/tree/master/rbi/light.rbi" && gs.censorRawLocsWithinPayload) {
+        // This is so that changing RBIs doesn't mean invalidating every symbol-table exp test.
         return fmt::format("Loc {{file={} start=removed end=removed}}", path);
     }
     auto [start, end] = this->position(gs);

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -348,6 +348,8 @@ cxxopts::Options buildOptions() {
                                "Force incremental updates to discover resolver & namer bugs");
     options.add_options("dev")("simulate-crash", "Crash on start");
     options.add_options("dev")("silence-dev-message", "Silence \"You are running a development build\" message");
+    options.add_options("dev")("censor-raw-locs-within-payload",
+                               "When printing raw location information, don't show line numbers");
     options.add_options("dev")("error-white-list",
                                "Error code to whitelist into reporting. "
                                "Errors not mentioned will be silenced. "
@@ -649,6 +651,7 @@ void readOptions(Options &opts, int argc, char *argv[],
         opts.suggestRuntimeProfiledType = raw["suggest-runtime-profiled"].as<bool>();
         opts.enableCounters = raw["counters"].as<bool>();
         opts.silenceDevMessage = raw["silence-dev-message"].as<bool>();
+        opts.censorRawLocsWithinPayload = raw["censor-raw-locs-within-payload"].as<bool>();
         opts.statsdHost = raw["statsd-host"].as<string>();
         opts.statsdPort = raw["statsd-port"].as<int>();
         opts.statsdPrefix = raw["statsd-prefix"].as<string>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -117,6 +117,7 @@ struct Options {
     bool waitForDebugger = false;
     bool skipDSLPasses = false;
     bool suggestRuntimeProfiledType = false;
+    bool censorRawLocsWithinPayload = false;
     int threads = 0;
     int logLevel = 0; // number of time -v was passed
     int autogenVersion = 0;

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -346,6 +346,9 @@ int realmain(int argc, char *argv[]) {
     if (opts.print.Autogen.enabled || opts.print.AutogenMsgPack.enabled || opts.print.AutogenClasslist.enabled) {
         gs->runningUnderAutogen = true;
     }
+    if (opts.censorRawLocsWithinPayload) {
+        gs->censorRawLocsWithinPayload = true;
+    }
     if (opts.reserveMemKiB > 0) {
         gs->reserveMemory(opts.reserveMemKiB);
     }

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -131,6 +131,9 @@ Usage:
       --simulate-crash          Crash on start
       --silence-dev-message     Silence "You are running a development build"
                                 message
+      --censor-raw-locs-within-payload
+                                When printing raw location information, don't
+                                show line numbers
       --error-white-list errorCode
                                 Error code to whitelist into reporting.
                                 Errors not mentioned will be silenced. This option

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -146,6 +146,7 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
     auto logger = spd::stderr_color_mt("fixtures: " + inputPath);
     auto errorQueue = make_shared<core::ErrorQueue>(*logger, *logger);
     core::GlobalState gs(errorQueue);
+    gs.censorRawLocsWithinPayload = true;
     auto workers = WorkerPool::create(0, gs.tracer());
     core::serialize::Serializer::loadGlobalState(gs, getNameTablePayload);
     core::MutableContext ctx(gs, core::Symbols::root());

--- a/tools/scripts/update_exp_files.sh
+++ b/tools/scripts/update_exp_files.sh
@@ -37,7 +37,7 @@ for this_src in "${rb_src[@]}" DUMMY; do
                 if [ "$pass" = "document-symbols" ]; then 
                     echo bazel-bin/test/print_document_symbols "${srcs[@]}" \> "$candidate" 2\>/dev/null >> "$COMMAND_FILE"
                 else
-                    echo bazel-bin/main/sorbet-light --silence-dev-message  --suppress-non-critical --print "$pass" --max-threads 0 "${args[@]}" "${srcs[@]}" \> "$candidate" 2\>/dev/null >> "$COMMAND_FILE"
+                    echo bazel-bin/main/sorbet-light --silence-dev-message  --suppress-non-critical --censor-raw-locs-within-payload --print "$pass" --max-threads 0 "${args[@]}" "${srcs[@]}" \> "$candidate" 2\>/dev/null >> "$COMMAND_FILE"
                 fi
             fi
         done


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This change is a precursor to being able to remove light.rbi.
Even with light.rbi gone, we will still want to hide loc information from the
snapshot tests so that simple RBI changes don't require re-updating the world
of symbol-table exp tests.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested indirectly via the update-exp-files.sh script.