### PR TITLE
Revert "auto-assign to oncall (#1111)"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,6 @@
 # It uses the same pattern rule for gitignore file
 # https://git-scm.com/docs/gitignore#_pattern_format
 
-**/*                  @sorbet/sorbet-on-call
+**/*                  @sorbet/sorbet-reviewer-roundrobin
+
+# This group actually forwards to @sorbet/core reviewers via https://github.com/marketplace/pull-panda


### PR DESCRIPTION
This reverts commit 52be72b6977f31ff3f99e56ab76d49aca91e95da.

This doesn't seem to work. We'll have to find a different tool i think.

![image](https://user-images.githubusercontent.com/40143/60316280-b8341380-991e-11e9-94a0-a9d7d35685ea.png)


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
