### PR TITLE
We need llvm_symbolizer in path to be able to symbolize stack traces

### DIFF
--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -4,8 +4,8 @@ set -exuo pipefail
 
 # build the actual fuzz target
 bazel build //test/fuzz:fuzz_dash_e --config=fuzz -c opt
-
-export PATH=$PATH:$(pwd)/bazel-sorbet/external/llvm_toolchain/bin/
+PATH=$PATH:$(pwd)/bazel-sorbet/external/llvm_toolchain/bin/
+export PATH
 export ASAN_OPTIONS=dedup_token_length=10 # use top 10 frames to tell different errors appart
 
 
@@ -18,4 +18,4 @@ mkdir -p fuzz_crashers/original
 command -v llvm_symbolizer >/dev/null 2>&1 || { echo 'will need llvm_symbolizer' ; exit 1; }
 
 # fuzz
-nice ./bazel-bin/test/fuzz/fuzz_dash_e -use_value_profile=1 -only_ascii=1 -dict=test/fuzz/ruby.dict -artifact_prefix=fuzz_crashers/original/ fuzz_corpus/ -jobs=100 --stress-incremental-resolver
+nice ./bazel-bin/test/fuzz/fuzz_dash_e -use_value_profile=1 -only_ascii=1 -dict=test/fuzz/ruby.dict -artifact_prefix=fuzz_crashers/original/ fuzz_corpus/ --stress-incremental-resolver

--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -5,6 +5,7 @@ set -exuo pipefail
 # build the actual fuzz target
 bazel build //test/fuzz:fuzz_dash_e --config=fuzz -c opt
 
+export PATH=$PATH:$(pwd)/bazel-sorbet/external/llvm_toolchain/bin/
 export ASAN_OPTIONS=dedup_token_length=10 # use top 10 frames to tell different errors appart
 
 
@@ -13,6 +14,8 @@ mkdir -p fuzz_corpus
 find ./test/testdata/ -iname "*.rb"|grep -v disable|xargs -n 1 -I % cp % fuzz_corpus
 
 mkdir -p fuzz_crashers/original
+
+command -v llvm_symbolizer >/dev/null 2>&1 || { echo 'will need llvm_symbolizer' ; exit 1; }
 
 # fuzz
 nice ./bazel-bin/test/fuzz/fuzz_dash_e -use_value_profile=1 -only_ascii=1 -dict=test/fuzz/ruby.dict -artifact_prefix=fuzz_crashers/original/ fuzz_corpus/ -jobs=100 --stress-incremental-resolver

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -53,6 +53,9 @@ trap handler_int SIGINT
 trap handler_term SIGTERM
 
 mkdir -p "${dir}/../../fuzz_crashers/min/"
+export PATH=$PATH:$(pwd)/bazel-sorbet/external/llvm_toolchain/bin/
+
+command -v llvm_symbolizer >/dev/null 2>&1 || { echo 'will need llvm_symbolizer' ; exit 1; }
 
 (
     cd "$dir"/../..

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -53,7 +53,8 @@ trap handler_int SIGINT
 trap handler_term SIGTERM
 
 mkdir -p "${dir}/../../fuzz_crashers/min/"
-export PATH=$PATH:$(pwd)/bazel-sorbet/external/llvm_toolchain/bin/
+PATH=$PATH:$(pwd)/bazel-sorbet/external/llvm_toolchain/bin/
+export PATH
 
 command -v llvm_symbolizer >/dev/null 2>&1 || { echo 'will need llvm_symbolizer' ; exit 1; }
 


### PR DESCRIPTION
### Motivation
Fuzzer works better when it has source stacktraces.


### Test plan
Confirm with @jvilk-stripe that it helps.