### PR TITLE
Add ability to set default checked level

### DIFF
--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -17,6 +17,14 @@ module T::Configuration
     T::Private::RuntimeLevels.enable_checking_in_tests
   end
 
+  # Configure the default checked level for a sig with no explicit `.checked`
+  # builder. When unset, the default checked level is `:always`.
+  #
+  # @param [:never, :tests, :always] default_checked_level
+  def self.default_checked_level=(default_checked_level)
+    T::Private::RuntimeLevels.default_checked_level = default_checked_level
+  end
+
   # Set a handler to handle `TypeError`s raised by any in-line type assertions,
   # including `T.must`, `T.let`, `T.cast`, and `T.assert_type!`.
   #

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -20,6 +20,11 @@ module T::Configuration
   # Configure the default checked level for a sig with no explicit `.checked`
   # builder. When unset, the default checked level is `:always`.
   #
+  # Note: setting this option is potentially dangerous! Sorbet can't check all
+  # code statically. The runtime checks complement the checks that Sorbet does
+  # statically, so that methods don't have to guard themselves from being
+  # called incorrectly by untyped code.
+  #
   # @param [:never, :tests, :always] default_checked_level
   def self.default_checked_level=(default_checked_level)
     T::Private::RuntimeLevels.default_checked_level = default_checked_level

--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -249,7 +249,7 @@ module T::Private::Methods
         decl.bind = nil
       end
       if decl.checked.equal?(ARG_NOT_PROVIDED)
-        decl.checked = :always
+        decl.checked = T::Private::RuntimeLevels.default_checked_level
       end
       if decl.soft_notify.equal?(ARG_NOT_PROVIDED)
         decl.soft_notify = nil

--- a/gems/sorbet-runtime/lib/types/private/runtime_levels.rb
+++ b/gems/sorbet-runtime/lib/types/private/runtime_levels.rb
@@ -17,6 +17,9 @@ module T::Private::RuntimeLevels
   @check_tests = false
   @wrapped_tests_with_validation = false
 
+  @has_read_default_checked_level = false
+  @default_checked_level = :always
+
   def self.check_tests?
     # Assume that this code path means that some `sig.checked(:tests)`
     # has been wrapped (or not wrapped) already, which is a trapdoor
@@ -33,6 +36,18 @@ module T::Private::RuntimeLevels
     end
 
     _toggle_checking_tests(true)
+  end
+
+  def self.default_checked_level
+    @has_read_default_checked_level = true
+    @default_checked_level
+  end
+
+  def self.default_checked_level=(default_checked_level)
+    if @has_read_default_checked_level
+      raise "Set the default checked level earlier. There are already some methods whose sig blocks have evaluated which would not be affected by the new default."
+    end
+    @default_checked_level = default_checked_level
   end
 
   def self._toggle_checking_tests(checked)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

From @ptarjan:

> The two most asked for features are "how do I turn the whole thing off" and
> "how do I turn the whole thing off in production".

By giving people the ability to set a default checked level, people can opt out
of the runtime overhead. Note that in the presence of performance constraints,
just setting a T::Configuration call_validation handler is not enough. The
method will still have the runtime overhead of type checking. The only current
option is to `.checked(:never)` or `.checked(:tests)` the entire method.

I think we should also let `.soft` and `.checked` be chained, because their
behavior is non-orthogonal. `.soft` configures what options are passed to the
T::Configuration handler when it **does** fail, and whereas `.checked` controls
whether it has the ability to fail at all.

Before we add this into the documentation, I think we should be absolutely
clear about the tradeoffs here, namely that runtime checking is **incredibly**
important to dealing with untyped code.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.