### PR TITLE
 Output caching for DSL plugins

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1152,6 +1152,7 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     result->deepCloneHistory = this->deepCloneHistory;
     result->deepCloneHistory.emplace_back(DeepCloneHistoryEntry{this->globalStateId, namesUsed()});
 
+    result->wasModified_ = this->wasModified_;
     result->strings = this->strings;
     result->stringsLastPageUsed = STRINGS_PAGE_SIZE;
     result->files = this->files;

--- a/core/serialize/serialize.h
+++ b/core/serialize/serialize.h
@@ -21,10 +21,13 @@ public:
     // individual cached files, which can be loaded independently.
     static std::vector<u1> storePayloadAndNameTable(GlobalState &gs);
     static std::vector<u1> storeExpression(GlobalState &gs, std::unique_ptr<ast::Expression> &e);
+    static std::vector<u1> storeExpressionAndU4(GlobalState &gs, std::unique_ptr<ast::Expression> &e, u4);
 
     // Loads an ast::Expression saved by storeExpression. Optionally overrides
     // the saved file ID to the caller-specified ID.
     static std::unique_ptr<ast::Expression> loadExpression(GlobalState &gs, const u1 *const p, u4 forceId = 0);
+    static std::pair<std::unique_ptr<ast::Expression>, u4> loadExpressionAndU4(GlobalState &gs, const u1 *const p,
+                                                                               u4 forceId = 0);
     static void loadGlobalState(GlobalState &gs, const u1 *const data);
 };
 }; // namespace sorbet::core::serialize

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -12,10 +12,6 @@ namespace sorbet::realmain::pipeline {
 ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, core::FileRef file,
                          std::unique_ptr<KeyValueStore> &kvstore);
 
-std::pair<ast::ParsedFile, std::vector<std::shared_ptr<core::File>>>
-indexOneWithPlugins(const options::Options &opts, core::GlobalState &lgs, core::FileRef file,
-                    std::unique_ptr<KeyValueStore> &kvstore);
-
 std::vector<core::FileRef> reserveFiles(std::unique_ptr<core::GlobalState> &gs, const std::vector<std::string> &files);
 
 std::vector<ast::ParsedFile> index(std::unique_ptr<core::GlobalState> &gs, std::vector<core::FileRef> files,

--- a/plugin/SubprocessTextPlugin.cc
+++ b/plugin/SubprocessTextPlugin.cc
@@ -105,8 +105,8 @@ struct SpawningWalker {
                     format_to(generatedSource, "{}", "end;");
                 }
 
-                auto path = fmt::format("{}//plugin-generated|{}", klass->loc.file().data(ctx).path(),
-                                        subprocessResults.size());
+                auto path =
+                    SubprocessTextPlugin::pluginFilePath(klass->loc.file().data(ctx).path(), subprocessResults.size());
                 auto file = make_shared<core::File>(move(path), fmt::to_string(generatedSource), core::File::Normal);
                 file->pluginGenerated = true;
                 subprocessResults.emplace_back(move(file));
@@ -135,6 +135,10 @@ SubprocessTextPlugin::run(core::Context ctx, unique_ptr<ast::Expression> tree) {
     }
     SpawningWalker walker;
     return {ast::TreeMap::apply(ctx, walker, move(tree)), move(walker.subprocessResults)};
+}
+
+string SubprocessTextPlugin::pluginFilePath(string_view sourceFilePath, u4 invocationId) {
+    return fmt::format("{}//plugin-generated|{}", sourceFilePath, invocationId);
 }
 
 }; // namespace sorbet::plugin

--- a/plugin/SubprocessTextPlugin.h
+++ b/plugin/SubprocessTextPlugin.h
@@ -8,6 +8,8 @@ class SubprocessTextPlugin final {
 public:
     static std::pair<std::unique_ptr<ast::Expression>, std::vector<std::shared_ptr<core::File>>>
     run(core::Context ctx, std::unique_ptr<ast::Expression> tree);
+    // Plugin generated files are not stored on disk and have special paths
+    static std::string pluginFilePath(std::string_view sourceFilePath, u4 invocationId);
 
     SubprocessTextPlugin() = delete;
 };

--- a/test/cli/subprocess-plugin-caching-single-threaded/hi_plugin.rb
+++ b/test/cli/subprocess-plugin-caching-single-threaded/hi_plugin.rb
@@ -1,0 +1,1 @@
+puts("def self.how_are_you; end")

--- a/test/cli/subprocess-plugin-caching-single-threaded/subprocess-plugin-caching-single-threaded.out
+++ b/test/cli/subprocess-plugin-caching-single-threaded/subprocess-plugin-caching-single-threaded.out
@@ -1,0 +1,7 @@
+====cold cache====
+No errors! Great job.
+====hot cache====
+No errors! Great job.
+====invalidation====
+Method `how_are_you` does not exist
+Errors: 1

--- a/test/cli/subprocess-plugin-caching-single-threaded/subprocess-plugin-caching-single-threaded.sh
+++ b/test/cli/subprocess-plugin-caching-single-threaded/subprocess-plugin-caching-single-threaded.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+dir=$(mktemp -d)
+cleanup() {
+    rm -r "$dir"
+}
+trap cleanup EXIT
+
+mkdir "$dir/cache"
+cat >> "$dir/test.rb" <<EOF
+# typed: true
+class A
+  def self.hi; end
+  hi
+end
+A.how_are_you
+EOF
+
+echo ====cold cache====
+main/sorbet \
+    --silence-dev-message \
+    --dsl-plugins test/cli/subprocess-plugin-caching-single-threaded/triggers.yaml \
+    --cache-dir "$dir/cache" \
+    "$dir/test.rb" 2>&1
+echo ====hot cache====
+# since we cached the output of the plugin, it should work even though --dsl-plugins is gone.
+main/sorbet --silence-dev-message --cache-dir "$dir/cache" "$dir/test.rb" 2>&1
+echo ====invalidation====
+echo '# comment' >> "$dir/test.rb"
+output=$(main/sorbet --silence-dev-message --cache-dir "$dir/cache" "$dir/test.rb" 2>&1 || true)
+echo "$output" | grep -o 'Method `how_are_you` does not exist'
+echo "$output" | tail -n 1

--- a/test/cli/subprocess-plugin-caching-single-threaded/triggers.yaml
+++ b/test/cli/subprocess-plugin-caching-single-threaded/triggers.yaml
@@ -1,0 +1,2 @@
+triggers:
+  hi: test/cli/subprocess-plugin-caching-single-threaded/hi_plugin.rb

--- a/test/cli/subprocess-plugin-caching/hi_plugin.rb
+++ b/test/cli/subprocess-plugin-caching/hi_plugin.rb
@@ -1,0 +1,1 @@
+puts("def self.how_are_you; end")

--- a/test/cli/subprocess-plugin-caching/subprocess-plugin-caching.out
+++ b/test/cli/subprocess-plugin-caching/subprocess-plugin-caching.out
@@ -1,0 +1,7 @@
+====cold cache====
+No errors! Great job.
+====hot cache====
+No errors! Great job.
+====invalidation====
+Method `how_are_you` does not exist
+Errors: 1

--- a/test/cli/subprocess-plugin-caching/subprocess-plugin-caching.sh
+++ b/test/cli/subprocess-plugin-caching/subprocess-plugin-caching.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+dir=$(mktemp -d)
+cleanup() {
+    rm -r "$dir"
+}
+trap cleanup EXIT
+
+touch "$dir/"{a,b,c,d}
+mkdir "$dir/cache"
+cat >> "$dir/test.rb" <<EOF
+# typed: true
+class A
+  def self.hi; end
+  hi
+end
+A.how_are_you
+EOF
+
+# --max-threads 1 to work around Github #1076. Run through the paralel code path
+
+echo ====cold cache====
+main/sorbet --silence-dev-message --max-threads 1 --dsl-plugins test/cli/subprocess-plugin-caching/triggers.yaml --cache-dir "$dir/cache" "$dir/test.rb" "$dir/"{a,b,c,d} 2>&1
+echo ====hot cache====
+# since we cached the output of the plugin, it should work even though --dsl-plugins is gone.
+main/sorbet --silence-dev-message --max-threads 1 --cache-dir "$dir/cache" "$dir/test.rb" "$dir/"{a,b,c,d} 2>&1
+echo ====invalidation====
+echo '# comment' >> "$dir/test.rb"
+output=$(main/sorbet --silence-dev-message --max-threads 1 --cache-dir "$dir/cache" "$dir/test.rb" "$dir/"{a,b,c,d} 2>&1 || true)
+echo "$output" | grep -o 'Method `how_are_you` does not exist'
+echo "$output" | tail -n 1

--- a/test/cli/subprocess-plugin-caching/triggers.yaml
+++ b/test/cli/subprocess-plugin-caching/triggers.yaml
@@ -1,0 +1,2 @@
+triggers:
+  hi: test/cli/subprocess-plugin-caching/hi_plugin.rb


### PR DESCRIPTION
### Motivation
DSL plugins are extremely slow compare to other parts of Sorbet. This
commit mitigates the problem by caching the output of DSL plugins.

Before this commit, plugin outputs are only processed on cold runs. On
cached runs, no plugin outputs were considered. The output of plugins
and in term, their processed trees were not cached at all. The plugin
system generate separate virtual files which the caching system
discarded. Type checking results on cold and cache runs can be different
because of this limitation.

This commit caches the output of plugins, keyed on the hash of the file
that made the plugin call.  In addition, supplied files now cache the
number of plugin invocations they make. This is needed to compute the
cache key for each plugin output.

With these two new pieces in the cache, we avoid spawning subprocesses
when the cache is hot.

There is no cache invalidation based on the implementation of plugins at
all, as it's arbitrary Ruby code that could do wild things, including
fetching things from the internet. In fact, there is no invalidation
based on the plugin spec yaml, either. These limitations make this
system unsuitable for use during plugin development


### Test plan

See included automated tests.
