### PR TITLE
Put .checked(:never) back

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -80,9 +80,6 @@ module T::Private::Methods
     end
 
     def checked(level)
-      if T.unsafe(true)
-        raise "The .checked API is unstable, so we don't want it used until we redesign it. To change Sorbet's runtime behavior, see https://sorbet.org/docs/tconfiguration"
-      end
       check_live!
 
       if !decl.checked.equal?(ARG_NOT_PROVIDED)

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -27,7 +27,7 @@ class T::Props::Decorator
   end
 
   # prop stuff
-  sig {returns(T::Hash[Symbol, Rules])}
+  sig {returns(T::Hash[Symbol, Rules]).checked(:never)}
   def props
     @props ||= {}.freeze
   end
@@ -44,7 +44,7 @@ class T::Props::Decorator
   sig {returns(T::Array[Symbol])}
   def all_props; props.keys; end
 
-  sig {params(prop: T.any(Symbol, String)).returns(Rules)}
+  sig {params(prop: T.any(Symbol, String)).returns(Rules).checked(:never)}
   def prop_rules(prop); props[prop.to_sym] || raise("No such prop: #{prop.inspect}"); end
 
   sig {params(prop: Symbol, rules: Rules).void}
@@ -80,7 +80,7 @@ class T::Props::Decorator
     }
   end
 
-  sig {returns(DecoratedClass)}
+  sig {returns(DecoratedClass).checked(:never)}
   def decorated_class; @class; end
 
   # Accessors
@@ -94,6 +94,7 @@ class T::Props::Decorator
       rules: T.nilable(Rules)
     )
     .returns(T.untyped)
+    .checked(:never)
   end
   def get(instance, prop, rules=props[prop.to_sym])
     # For backwards compatibility, fall back to reconstructing the accessor key
@@ -111,6 +112,7 @@ class T::Props::Decorator
       rules: T.nilable(Rules)
     )
     .void
+    .checked(:never)
   end
   def set(instance, prop, value, rules=props[prop.to_sym])
     # For backwards compatibility, fall back to reconstructing the accessor key
@@ -119,7 +121,7 @@ class T::Props::Decorator
   end
 
   # Use this to validate that a value will validate for a given prop. Useful for knowing whether a value can be set on a model without setting it.
-  sig {params(prop: Symbol, val: T.untyped).void}
+  sig {params(prop: Symbol, val: T.untyped).void.checked(:never)}
   def validate_prop_value(prop, val)
     # This implements a 'public api' on document so that we don't allow callers to pass in rules
     # Rules seem like an implementation detail so it seems good to now allow people to specify them manually.
@@ -127,7 +129,7 @@ class T::Props::Decorator
   end
 
   # Passing in rules here is purely a performance optimization.
-  sig {params(prop: Symbol, val: T.untyped, rules: Rules).void}
+  sig {params(prop: Symbol, val: T.untyped, rules: Rules).void.checked(:never)}
   private def check_prop_type(prop, val, rules=prop_rules(prop))
     type_object = rules.fetch(:type_object)
     type = rules.fetch(:type)
@@ -173,6 +175,7 @@ class T::Props::Decorator
       rules: T.nilable(Rules)
     )
     .void
+    .checked(:never)
   end
   def prop_set(instance, prop, val, rules=prop_rules(prop))
     check_prop_type(prop, val, T.must(rules))
@@ -188,6 +191,7 @@ class T::Props::Decorator
       rules: T.nilable(Rules)
     )
     .returns(T.untyped)
+    .checked(:never)
   end
   def prop_get(instance, prop, rules=props[prop.to_sym])
     val = get(instance, prop, rules)
@@ -222,6 +226,7 @@ class T::Props::Decorator
       opts: Hash
     )
     .returns(T.untyped)
+    .checked(:never)
   end
   def foreign_prop_get(instance, prop, foreign_class, rules=props[prop.to_sym], opts={})
     return if !(value = prop_get(instance, prop, rules))

--- a/gems/sorbet-runtime/lib/types/props/pretty_printable.rb
+++ b/gems/sorbet-runtime/lib/types/props/pretty_printable.rb
@@ -70,6 +70,7 @@ module T::Props::PrettyPrintable
     sig do
       params(instance: T::Props::PrettyPrintable, prop: Symbol, multiline: T::Boolean, indent: String)
       .returns(String)
+      .checked(:never)
     end
     private def inspect_prop_value(instance, prop, multiline:, indent:)
       val = T.unsafe(self).get(instance, prop)

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -141,18 +141,6 @@ module Opus::Types::Test
 
     describe 'declarations' do
       describe '.checked' do
-        it 'raises when using .checked' do
-          err = assert_raises(RuntimeError) do
-            mod = Module.new do
-              extend T::Sig
-              sig {void.checked(:never)}
-              def self.test_method; end
-            end
-            mod.test_method
-          end
-          assert_match(/\.checked API is unstable/, err.message)
-        end
-
         it 'raises when using .soft' do
           err = assert_raises(RuntimeError) do
             mod = Module.new do
@@ -166,7 +154,6 @@ module Opus::Types::Test
         end
 
         it 'raises RuntimeError with invalid level' do
-          skip
           err = assert_raises(ArgumentError) do
             mod = Module.new do
               extend T::Sig
@@ -219,7 +206,6 @@ module Opus::Types::Test
           end
 
           it '`always` is checked' do
-            skip
             mod = Module.new do
               extend T::Sig
               sig do
@@ -236,7 +222,6 @@ module Opus::Types::Test
           end
 
           it '`never` is not checked' do
-            skip
             mod = Module.new do
               extend T::Sig
               sig do
@@ -263,7 +248,6 @@ module Opus::Types::Test
           end
 
           it '`tests` can be toggled to validate or not' do
-            skip
             T::Private::RuntimeLevels._toggle_checking_tests(false)
             mod = make_mod
             mod.test_method(:llamas) # wrong, but ignored
@@ -276,7 +260,6 @@ module Opus::Types::Test
           end
 
           it 'raises if `tests` is toggled on too late' do
-            skip
             T::Private::RuntimeLevels._toggle_checking_tests(false)
             mod = make_mod
             mod.test_method(1) # invocation ensures it's wrapped
@@ -367,7 +350,6 @@ module Opus::Types::Test
       end
 
       it 'forbids multiple .checked calls' do
-        skip
         ex = assert_raises do
           Class.new do
             extend T::Sig
@@ -439,7 +421,6 @@ module Opus::Types::Test
       end
 
       it 'forbids .generated and then .checked' do
-        skip
         ex = assert_raises do
           Class.new do
             extend T::Sig


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We decided not to significantly change the API of `.checked`.

The biggest blockers for disabling it were stabilizing the API to set the default checked level and to enable checking in tests, and those are both done now.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.