### PR TITLE
.soft -> .on_failure

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -103,7 +103,7 @@ NameDef names[] = {
     {"returns"},
     {"void_", "void"},
     {"checked"},
-    {"soft"},
+    {"on_failure"},
     {"generated"},
 
     {"all"},

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -44,7 +44,7 @@ module T::Private::Methods
       raise "Procs must specify a return type"
     end
     if decl.soft_notify != ARG_NOT_PROVIDED
-      raise "Procs cannot use .soft"
+      raise "Procs cannot use .on_failure"
     end
 
     if decl.params == ARG_NOT_PROVIDED

--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -119,7 +119,7 @@ module T::Private::Methods
       # TODO consider validating that :notify is a project that sentry knows about,
       # as per https://git.corp.stripe.com/stripe-internal/pay-server/blob/master/lib/event/job/sentry_job.rb#L125
       if !notify || notify == ''
-        raise BuilderError.new("You can't provide an empty notify to .soft().")
+        raise BuilderError.new("You can't provide an empty notify to .on_failure().")
       end
 
       decl.soft_notify = notify

--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -101,9 +101,6 @@ module T::Private::Methods
     end
 
     def on_failure(notify:)
-      if T.unsafe(true)
-        raise "The .on_failure API is unstable, so we don't want it used until we redesign it. To change Sorbet's runtime behavior, see https://sorbet.org/docs/tconfiguration"
-      end
       check_live!
 
       if !decl.soft_notify.equal?(ARG_NOT_PROVIDED)

--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -86,7 +86,7 @@ module T::Private::Methods
         raise BuilderError.new("You can't call .checked multiple times in a signature.")
       end
       if !decl.soft_notify.equal?(ARG_NOT_PROVIDED)
-        raise BuilderError.new("You can't use .checked with .soft.")
+        raise BuilderError.new("You can't use .checked with .on_failure.")
       end
       if !decl.generated.equal?(ARG_NOT_PROVIDED)
         raise BuilderError.new("You can't use .checked with .generated.")
@@ -100,20 +100,20 @@ module T::Private::Methods
       self
     end
 
-    def soft(notify:)
+    def on_failure(notify:)
       if T.unsafe(true)
-        raise "The .soft API is unstable, so we don't want it used until we redesign it. To change Sorbet's runtime behavior, see https://sorbet.org/docs/tconfiguration"
+        raise "The .on_failure API is unstable, so we don't want it used until we redesign it. To change Sorbet's runtime behavior, see https://sorbet.org/docs/tconfiguration"
       end
       check_live!
 
       if !decl.soft_notify.equal?(ARG_NOT_PROVIDED)
-        raise BuilderError.new("You can't call .soft multiple times in a signature.")
+        raise BuilderError.new("You can't call .on_failure multiple times in a signature.")
       end
       if !decl.checked.equal?(ARG_NOT_PROVIDED)
-        raise BuilderError.new("You can't use .soft with .checked.")
+        raise BuilderError.new("You can't use .on_failure with .checked.")
       end
       if !decl.generated.equal?(ARG_NOT_PROVIDED)
-        raise BuilderError.new("You can't use .soft with .generated.")
+        raise BuilderError.new("You can't use .on_failure with .generated.")
       end
 
       # TODO consider validating that :notify is a project that sentry knows about,
@@ -137,7 +137,7 @@ module T::Private::Methods
         raise BuilderError.new("You can't use .generated with .checked.")
       end
       if !decl.soft_notify.equal?(ARG_NOT_PROVIDED)
-        raise BuilderError.new("You can't use .generated with .soft.")
+        raise BuilderError.new("You can't use .generated with .on_failure.")
       end
 
       decl.generated = true

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -330,7 +330,6 @@ class T::Props::Decorator
     .void
   end
   def prop_defined(name, cls, rules={})
-    # TODO(jerry): Create similar soft assertions against false
     if rules[:optional] == true
       T::Configuration.hard_assert_handler(
         'Use of `optional: true` is deprecated, please use `T.nilable(...)` instead.',

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -141,7 +141,7 @@ module Opus::Types::Test
 
     describe 'declarations' do
       describe '.checked' do
-        it 'raises when using .soft' do
+        it 'raises when using .on_failure' do
           err = assert_raises(RuntimeError) do
             mod = Module.new do
               extend T::Sig
@@ -150,7 +150,7 @@ module Opus::Types::Test
             end
             mod.test_method
           end
-          assert_match(/\.soft API is unstable/, err.message)
+          assert_match(/\.on_failure API is unstable/, err.message)
         end
 
         it 'raises RuntimeError with invalid level' do
@@ -368,7 +368,7 @@ module Opus::Types::Test
         assert_includes(ex.message, "You can't call .checked multiple times in a signature.")
       end
 
-      it 'forbids multiple .soft calls' do
+      it 'forbids multiple .on_failure calls' do
         skip
         ex = assert_raises do
           Class.new do
@@ -377,10 +377,10 @@ module Opus::Types::Test
             def self.foo; end; foo
           end
         end
-        assert_includes(ex.message, "You can't call .soft multiple times in a signature.")
+        assert_includes(ex.message, "You can't call .on_failure multiple times in a signature.")
       end
 
-      it 'forbids .soft and then .checked' do
+      it 'forbids .on_failure and then .checked' do
         skip
         ex = assert_raises do
           Class.new do
@@ -389,10 +389,10 @@ module Opus::Types::Test
             def self.foo; end; foo
           end
         end
-        assert_includes(ex.message, "You can't use .checked with .soft.")
+        assert_includes(ex.message, "You can't use .checked with .on_failure.")
       end
 
-      it 'forbids .checked and then .soft' do
+      it 'forbids .checked and then .on_failure' do
         skip
         ex = assert_raises do
           Class.new do
@@ -401,7 +401,7 @@ module Opus::Types::Test
             def self.foo; end; foo
           end
         end
-        assert_includes(ex.message, "You can't use .checked with .soft.")
+        assert_includes(ex.message, "You can't use .checked with .on_failure.")
       end
 
       it 'forbids empty notify' do
@@ -421,7 +421,7 @@ module Opus::Types::Test
         ex = assert_raises(ArgumentError) do
           Class.new do
             extend T::Sig
-            sig {returns(Integer).soft}
+            sig {returns(Integer).on_failure}
             def self.foo; end; foo
           end
         end
@@ -439,7 +439,7 @@ module Opus::Types::Test
         assert_includes(ex.message, "You can't use .checked with .generated.")
       end
 
-      it 'forbids .generated and then .soft' do
+      it 'forbids .generated and then .on_failure' do
         skip
         ex = assert_raises do
           Class.new do
@@ -448,7 +448,7 @@ module Opus::Types::Test
             def self.foo; end; foo
           end
         end
-        assert_includes(ex.message, "You can't use .soft with .generated.")
+        assert_includes(ex.message, "You can't use .on_failure with .generated.")
       end
 
       it 'disallows return then void' do

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -141,18 +141,6 @@ module Opus::Types::Test
 
     describe 'declarations' do
       describe '.checked' do
-        it 'raises when using .on_failure' do
-          err = assert_raises(RuntimeError) do
-            mod = Module.new do
-              extend T::Sig
-              sig {void.on_failure(notify: 'foo')}
-              def self.test_method; end
-            end
-            mod.test_method
-          end
-          assert_match(/\.on_failure API is unstable/, err.message)
-        end
-
         it 'raises RuntimeError with invalid level' do
           err = assert_raises(ArgumentError) do
             mod = Module.new do
@@ -369,7 +357,6 @@ module Opus::Types::Test
       end
 
       it 'forbids multiple .on_failure calls' do
-        skip
         ex = assert_raises do
           Class.new do
             extend T::Sig
@@ -381,7 +368,6 @@ module Opus::Types::Test
       end
 
       it 'forbids .on_failure and then .checked' do
-        skip
         ex = assert_raises do
           Class.new do
             extend T::Sig
@@ -393,7 +379,6 @@ module Opus::Types::Test
       end
 
       it 'forbids .checked and then .on_failure' do
-        skip
         ex = assert_raises do
           Class.new do
             extend T::Sig
@@ -405,7 +390,6 @@ module Opus::Types::Test
       end
 
       it 'forbids empty notify' do
-        skip
         ex = assert_raises do
           Class.new do
             extend T::Sig
@@ -417,7 +401,6 @@ module Opus::Types::Test
       end
 
       it 'forbids unpassed notify' do
-        skip
         ex = assert_raises(ArgumentError) do
           Class.new do
             extend T::Sig
@@ -440,7 +423,6 @@ module Opus::Types::Test
       end
 
       it 'forbids .generated and then .on_failure' do
-        skip
         ex = assert_raises do
           Class.new do
             extend T::Sig

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -145,7 +145,7 @@ module Opus::Types::Test
           err = assert_raises(RuntimeError) do
             mod = Module.new do
               extend T::Sig
-              sig {void.soft(notify: 'foo')}
+              sig {void.on_failure(notify: 'foo')}
               def self.test_method; end
             end
             mod.test_method
@@ -373,7 +373,7 @@ module Opus::Types::Test
         ex = assert_raises do
           Class.new do
             extend T::Sig
-            sig {returns(Integer).soft(notify: 'me').soft(notify: 'you')}
+            sig {returns(Integer).on_failure(notify: 'me').on_failure(notify: 'you')}
             def self.foo; end; foo
           end
         end
@@ -385,7 +385,7 @@ module Opus::Types::Test
         ex = assert_raises do
           Class.new do
             extend T::Sig
-            sig {returns(Integer).soft(notify: 'me').checked(:never)}
+            sig {returns(Integer).on_failure(notify: 'me').checked(:never)}
             def self.foo; end; foo
           end
         end
@@ -397,7 +397,7 @@ module Opus::Types::Test
         ex = assert_raises do
           Class.new do
             extend T::Sig
-            sig {returns(Integer).soft(notify: 'me').checked(:never)}
+            sig {returns(Integer).on_failure(notify: 'me').checked(:never)}
             def self.foo; end; foo
           end
         end
@@ -409,11 +409,11 @@ module Opus::Types::Test
         ex = assert_raises do
           Class.new do
             extend T::Sig
-            sig {returns(Integer).soft(notify: '')}
+            sig {returns(Integer).on_failure(notify: '')}
             def self.foo; end; foo
           end
         end
-        assert_includes(ex.message, "You can't provide an empty notify to .soft().")
+        assert_includes(ex.message, "You can't provide an empty notify to .on_failure().")
       end
 
       it 'forbids unpassed notify' do
@@ -444,7 +444,7 @@ module Opus::Types::Test
         ex = assert_raises do
           Class.new do
             extend T::Sig
-            sig {generated.returns(Integer).soft(notify: '')}
+            sig {generated.returns(Integer).on_failure(notify: '')}
             def self.foo; end; foo
           end
         end

--- a/gems/sorbet-runtime/test/types/method_validation.rb
+++ b/gems/sorbet-runtime/test/types/method_validation.rb
@@ -369,7 +369,7 @@ module Opus::Types::Test
 
       it 'raises a soft_assertion when .soft is used with a notify' do
         skip
-        @mod.sig {returns(Symbol).soft(notify: 'hello')}
+        @mod.sig {returns(Symbol).on_failure(notify: 'hello')}
         def @mod.foo
           1
         end

--- a/gems/sorbet-runtime/test/types/method_validation.rb
+++ b/gems/sorbet-runtime/test/types/method_validation.rb
@@ -368,16 +368,31 @@ module Opus::Types::Test
       end
 
       it 'raises a soft_assertion when .on_failure is used with a notify' do
-        @mod.sig {returns(Symbol).on_failure(notify: 'hello')}
-        def @mod.foo
-          1
-        end
+        begin
+          T::Configuration.call_validation_error_handler = lambda do |signature, opts|
+            if signature.soft_notify
+              T::Configuration.soft_assert_handler(
+                "TypeError: #{opts[:pretty_message]}",
+                {notify: signature.soft_notify}
+              )
+            else
+              raise 'test failed'
+            end
+          end
 
-        Opus::Error.expects(:soft).with(
-          regexp_matches(/TypeError: Return value: Expected type Symbol, got type Integer with value 1\nCaller: .+\d\nDefinition: .+\d/),
-          notify: 'hello'
-        )
-        @mod.foo
+          @mod.sig {returns(Symbol).on_failure(notify: 'hello')}
+          def @mod.foo
+            1
+          end
+
+          T::Configuration.expects(:soft_assert_handler).with(
+            regexp_matches(/TypeError: Return value: Expected type Symbol, got type Integer with value 1\nCaller: .+\d\nDefinition: .+\d/),
+            notify: 'hello'
+          )
+          @mod.foo
+        ensure
+          T::Configuration.call_validation_error_handler = nil
+        end
       end
 
       describe 'generated' do

--- a/gems/sorbet-runtime/test/types/method_validation.rb
+++ b/gems/sorbet-runtime/test/types/method_validation.rb
@@ -367,7 +367,7 @@ module Opus::Types::Test
         end
       end
 
-      it 'raises a soft_assertion when .soft is used with a notify' do
+      it 'raises a soft_assertion when .on_failure is used with a notify' do
         skip
         @mod.sig {returns(Symbol).on_failure(notify: 'hello')}
         def @mod.foo

--- a/gems/sorbet-runtime/test/types/method_validation.rb
+++ b/gems/sorbet-runtime/test/types/method_validation.rb
@@ -368,7 +368,6 @@ module Opus::Types::Test
       end
 
       it 'raises a soft_assertion when .on_failure is used with a notify' do
-        skip
         @mod.sig {returns(Symbol).on_failure(notify: 'hello')}
         def @mod.foo
           1

--- a/gems/sorbet-runtime/test/types/props/decorator.rb
+++ b/gems/sorbet-runtime/test/types/props/decorator.rb
@@ -361,7 +361,7 @@ class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest
     assert_nil(MatrixStruct.new.e)
   end
 
-  it 'soft asserts if `optional` is ever specified' do
+  it 'hard asserts if `optional` is ever specified' do
     e = assert_raises do
       Class.new(T::Struct) do
         prop :optional_true, T::Boolean, optional: true

--- a/rbi/sorbet/builder.rbi
+++ b/rbi/sorbet/builder.rbi
@@ -31,7 +31,7 @@ class T::Private::Methods::DeclBuilder
   def void; end
 
   sig {params(notify: T.untyped).returns(T::Private::Methods::DeclBuilder)}
-  def soft(notify:); end
+  def on_failure(notify:); end
 
   sig {params(arg: T.untyped).returns(T::Private::Methods::DeclBuilder)}
   def checked(arg); end

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -311,7 +311,7 @@ ParsedSig TypeSyntax::parseSig(core::MutableContext ctx, ast::Send *sigSend, con
                 case core::Names::checked()._id:
                     sig.seen.checked = true;
                     break;
-                case core::Names::soft()._id:
+                case core::Names::on_failure()._id:
                     break;
                 case core::Names::generated()._id:
                     sig.seen.generated = true;

--- a/test/testdata/resolver/sig_soft.rb
+++ b/test/testdata/resolver/sig_soft.rb
@@ -4,7 +4,7 @@ class Main
     extend T::Sig
 
     sig {returns(NilClass).on_failure(notify: 'pt')}
-    def soft
+    def on_failure
     end
 
     # Since it is an experiement, all these illegal things are ok for now

--- a/test/testdata/resolver/sig_soft.rb
+++ b/test/testdata/resolver/sig_soft.rb
@@ -3,24 +3,24 @@
 class Main
     extend T::Sig
 
-    sig {returns(NilClass).soft(notify: 'pt')}
+    sig {returns(NilClass).on_failure(notify: 'pt')}
     def soft
     end
 
     # Since it is an experiement, all these illegal things are ok for now
-    sig {returns(NilClass).soft(notify: 'pt').soft(notify: 'pt')}
+    sig {returns(NilClass).on_failure(notify: 'pt').on_failure(notify: 'pt')}
     def two_soft
     end
-    sig {returns(NilClass).soft(notify: 'pt').checked(false)}
+    sig {returns(NilClass).on_failure(notify: 'pt').checked(false)}
     def soft_not_checked
     end
-    sig {returns(NilClass).checked(false).soft(notify: 'pt')}
+    sig {returns(NilClass).checked(false).on_failure(notify: 'pt')}
     def not_checked_soft
     end
-    sig {returns(NilClass).soft(notify: 'pt')}
+    sig {returns(NilClass).on_failure(notify: 'pt')}
     def soft_no_notify
     end
-    sig {returns(NilClass).soft(notify: Object.new)}
+    sig {returns(NilClass).on_failure(notify: Object.new)}
     def soft_wtf_notify
     end
 end

--- a/website/docs/runtime.md
+++ b/website/docs/runtime.md
@@ -112,7 +112,7 @@ Sometimes runtime checks don't make sense. There are two main reasons why
     have to make the compromise that adopting Sorbet doesn't affect the runtime
     behavior of the code.
 
-<!-- TODO(jez) Document .soft / .checked once API is stable. -->
+<!-- TODO(jez) Document .on_failure / .checked once API is stable. -->
 
 It's possible to change the runtime behavior by defining callbacks. See
 [Runtime Configuration](tconfiguration.md) for more about what callbacks are

--- a/website/docs/tconfiguration.md
+++ b/website/docs/tconfiguration.md
@@ -58,7 +58,7 @@ end
 
 The default error handler is to raise an error.
 
-<!-- TODO(jez) Document .soft / .checked once API is stable. -->
+<!-- TODO(jez) Document .on_failure / .checked once API is stable. -->
 
 ## Errors from invalid sig procs
 

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -218,4 +218,3 @@ the programmer know of an invariant that isn't currently expressed in the type
 system, [`T.cast`](type-assertions#tcast) is a good middle-ground.
 
 <!-- TODO(jez) Document .on_failure / .checked once API is stable. -->
-. -->

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -217,4 +217,5 @@ statically---sometimes this is more power than we need. For the cases where we
 the programmer know of an invariant that isn't currently expressed in the type
 system, [`T.cast`](type-assertions#tcast) is a good middle-ground.
 
-<!-- TODO(jez) Document .soft / .checked once API is stable. -->
+<!-- TODO(jez) Document .on_failure / .checked once API is stable. -->
+. -->


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is the first of a handful of changes to fully support `.on_failure` in the
runtime.

### Commit summary

This change is largely a codemod, so I've included my codemod'ing commands and
broke it into commits.

- `git grep --line '\.soft(' | grep -v 'Opus::Error\.soft' | fileline | multi-sub --global '\.soft' '.on_failure'` (a0c33f2d6)

- `git grep --line -w 'soft' | grep -v 'Opus::Error\.' | grep -v 'soft.assert' | fileline | multi-sub --global 'soft' 'on_failure'` (e90fe281c)

- `manual: git grep -w --line soft | fileline | vim -` (adfdc0f3e)

- **Stop raising for on_failure** (fa2fa8ede)

  This is the change where we actually stop raising in the runtime. The API
  isn't quite final yet (specifically, we're going to relax `notify:` from
  being required), but I wanted to make it stop raising so that I could get the
  confidence that the tests pass after this codemod.

- **Fix test that broke while it was skipped** (4fb21e4b5)

  This test was something that should have been fixed in a previous change
  (either the one to factor out move our `signature.soft_notify` logic into
  pay-server, or the one to add `T::Configuration.soft_notify_handler`).
  Regardless, now that it's not skipped, I fixed the test.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.