### PR TITLE
Build ruby with a more standard lib path

### DIFF
--- a/third_party/ruby/ruby-2.4.BUILD
+++ b/third_party/ruby/ruby-2.4.BUILD
@@ -24,8 +24,6 @@ config_setting(
 
 RUBY_VERSION = "2.4.3"
 RUBY_CORE_VERSION = "2.4.0"
-LIB_PREFIX = "lib/ruby/" + RUBY_CORE_VERSION
-INC_PREFIX = "lib/ruby/include"
 
 ARCH_LINUX = "x86_64-unknown-linux"
 ARCH_DARWIN = "x86_64-darwin18"
@@ -34,6 +32,19 @@ ARCH = select({
     ":linux": ARCH_LINUX,
     ":darwin": ARCH_DARWIN,
 })
+
+# NOTE: rbconfig expects to find itself in a directory of the form:
+#
+# > `lib/ruby/<RUBY_CORE_VERSION>/<ARCH>`
+#
+# as shown by the line that defines `TOPDIR`. `TOPDIR` is used when computing
+# the relative path to the rest of the standard library, the `include`
+# directory, and the `bin` directory when building gems with native code.
+# Without installing everything into a tree that matches this, there will be
+# errors when using `mkmf`.
+LIB_PREFIX = "lib/ruby/" + RUBY_CORE_VERSION
+
+INC_PREFIX = "lib/ruby/include"
 
 # configuration ################################################################
 

--- a/third_party/ruby/utils.bzl
+++ b/third_party/ruby/utils.bzl
@@ -1,4 +1,3 @@
-
 def install_file(name, src, out):
     """
     Install a single file, using `install`. Returns out, so that it can be easily
@@ -7,8 +6,8 @@ def install_file(name, src, out):
 
     native.genrule(
         name = name,
-        srcs = [ src ],
-        outs = [ out ],
+        srcs = [src],
+        outs = [out],
         cmd = "install -c -m 644 $(location {}) $(location {})".format(src, out),
     )
 
@@ -47,7 +46,7 @@ def install_dir(src_prefix, out_prefix):
         out_prefix += "/"
 
     outs = []
-    for src in native.glob([ "{}/**/*".format(src_prefix) ]):
+    for src in native.glob(["{}/**/*".format(src_prefix)]):
         out_name = "install_{}".format(src)
 
         base = src[prefix_len:]
@@ -55,6 +54,6 @@ def install_dir(src_prefix, out_prefix):
         out = out_prefix + base
         outs.append(out)
 
-        install_file(name=out_name, src=src, out=out)
+        install_file(name = out_name, src = src, out = out)
 
     return outs

--- a/third_party/ruby/utils.bzl
+++ b/third_party/ruby/utils.bzl
@@ -1,0 +1,60 @@
+
+def install_file(name, src, out):
+    """
+    Install a single file, using `install`. Returns out, so that it can be easily
+    embedded into a filegroup rule.
+    """
+
+    native.genrule(
+        name = name,
+        srcs = [ src ],
+        outs = [ out ],
+        cmd = "install -c -m 644 $(location {}) $(location {})".format(src, out),
+    )
+
+    return out
+
+def _validate_prefix(prefix, avoid):
+    """
+    Validate an install prefix.
+    """
+
+    if prefix.startswith(avoid):
+        rest = prefix[0:len(avoid)]
+        return rest != "/" and rest != ""
+
+    return True
+
+def install_dir(src_prefix, out_prefix):
+    """
+    Copy all files under `src_prefix` to `out_prefix`. Returns the list of out
+    files, for use in a `filegroup` rule.
+    """
+
+    if not _validate_prefix(src_prefix, out_prefix):
+        fail(msg = "invalid src_prefix")
+
+    if not _validate_prefix(out_prefix, src_prefix):
+        fail(msg = "invalid out_prefix")
+
+    # normalize src_prefix to end with a trailing slash
+    prefix_len = len(src_prefix)
+    if src_prefix != "" and src_prefix[-1] != "/":
+        prefix_len += 1
+
+    # normalize out_prefix to end with a trailing slash
+    if out_prefix != "" and out_prefix[-1] != "/":
+        out_prefix += "/"
+
+    outs = []
+    for src in native.glob([ "{}/**/*".format(src_prefix) ]):
+        out_name = "install_{}".format(src)
+
+        base = src[prefix_len:]
+
+        out = out_prefix + base
+        outs.append(out)
+
+        install_file(name=out_name, src=src, out=out)
+
+    return outs


### PR DESCRIPTION
The layout for the ruby lib path for the @ruby_2_4_3 package wasn't what `rbconfig.rb` was expecting at runtime.

### Motivation
This allows for some more tests to go through, and paves the road towards building gems with native code.

### Test plan
The existing ruby smoke test still passes.