### PR TITLE
`.soft_notify` -> `.on_failure`

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -43,7 +43,7 @@ module T::Private::Methods
     if decl.returns == ARG_NOT_PROVIDED
       raise "Procs must specify a return type"
     end
-    if decl.soft_notify != ARG_NOT_PROVIDED
+    if decl.on_failure != ARG_NOT_PROVIDED
       raise "Procs cannot use .on_failure"
     end
 
@@ -224,7 +224,7 @@ module T::Private::Methods
         bind: current_declaration.bind,
         mode: current_declaration.mode,
         check_level: current_declaration.checked,
-        soft_notify: current_declaration.soft_notify,
+        on_failure: current_declaration.on_failure,
         override_allow_incompatible: current_declaration.override_allow_incompatible,
         generated: current_declaration.generated,
       )

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -5,7 +5,7 @@ class T::Private::Methods::Signature
   attr_reader :method, :method_name, :arg_types, :kwarg_types, :block_type, :block_name,
               :rest_type, :rest_name, :keyrest_type, :keyrest_name, :bind,
               :return_type, :mode, :req_arg_count, :req_kwarg_names, :has_rest, :has_keyrest,
-              :check_level, :generated, :parameters, :soft_notify, :override_allow_incompatible, :ever_failed
+              :check_level, :generated, :parameters, :on_failure, :override_allow_incompatible, :ever_failed
 
   def self.new_untyped(method:, mode: T::Private::Methods::Modes.untyped, parameters: method.parameters)
     # Using `Untyped` ensures we'll get an error if we ever try validation on these.
@@ -24,7 +24,7 @@ class T::Private::Methods::Signature
       mode: mode,
       check_level: :never,
       parameters: parameters,
-      soft_notify: nil,
+      on_failure: nil,
     )
   end
 
@@ -32,7 +32,7 @@ class T::Private::Methods::Signature
     @ever_failed = true
   end
 
-  def initialize(method:, method_name:, raw_arg_types:, raw_return_type:, bind:, mode:, check_level:, parameters: method.parameters, soft_notify:, generated: false, override_allow_incompatible: false)
+  def initialize(method:, method_name:, raw_arg_types:, raw_return_type:, bind:, mode:, check_level:, parameters: method.parameters, on_failure:, generated: false, override_allow_incompatible: false)
     @method = method
     @method_name = method_name
     @arg_types = []
@@ -52,7 +52,7 @@ class T::Private::Methods::Signature
     @has_rest = false
     @has_keyrest = false
     @parameters = parameters
-    @soft_notify = soft_notify
+    @on_failure = on_failure
     @override_allow_incompatible = override_allow_incompatible
     @generated = generated
     @ever_failed = false

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -438,28 +438,6 @@ module Opus::Types::Test
         end
       end
 
-      it 'forbids empty notify' do
-        ex = assert_raises do
-          Class.new do
-            extend T::Sig
-            sig {returns(Integer).on_failure(notify: '')}
-            def self.foo; end; foo
-          end
-        end
-        assert_includes(ex.message, "You can't provide an empty notify to .on_failure().")
-      end
-
-      it 'forbids unpassed notify' do
-        ex = assert_raises(ArgumentError) do
-          Class.new do
-            extend T::Sig
-            sig {returns(Integer).on_failure}
-            def self.foo; end; foo
-          end
-        end
-        assert_includes(ex.message, "missing keyword: notify")
-      end
-
       it 'forbids .generated and then .checked' do
         ex = assert_raises do
           Class.new do

--- a/gems/sorbet-runtime/test/types/method_validation.rb
+++ b/gems/sorbet-runtime/test/types/method_validation.rb
@@ -370,10 +370,10 @@ module Opus::Types::Test
       it 'raises a soft_assertion when .on_failure is used with a notify' do
         begin
           T::Configuration.call_validation_error_handler = lambda do |signature, opts|
-            if signature.soft_notify
+            if signature.on_failure
               T::Configuration.soft_assert_handler(
                 "TypeError: #{opts[:pretty_message]}",
-                {notify: signature.soft_notify}
+                {notify: signature.on_failure[0][:notify]}
               )
             else
               raise 'test failed'

--- a/rbi/sorbet/builder.rbi
+++ b/rbi/sorbet/builder.rbi
@@ -30,8 +30,8 @@ class T::Private::Methods::DeclBuilder
   sig {returns(T::Private::Methods::DeclBuilder)}
   def void; end
 
-  sig {params(notify: T.untyped).returns(T::Private::Methods::DeclBuilder)}
-  def on_failure(notify:); end
+  sig {params(args: T.untyped).returns(T::Private::Methods::DeclBuilder)}
+  def on_failure(*args); end
 
   sig {params(arg: T.untyped).returns(T::Private::Methods::DeclBuilder)}
   def checked(arg); end

--- a/test/testdata/resolver/sig_on_failure.rb
+++ b/test/testdata/resolver/sig_on_failure.rb
@@ -9,18 +9,18 @@ class Main
 
     # Since it is an experiement, all these illegal things are ok for now
     sig {returns(NilClass).on_failure(notify: 'pt').on_failure(notify: 'pt')}
-    def two_soft
+    def two_on_failure
     end
     sig {returns(NilClass).on_failure(notify: 'pt').checked(false)}
-    def soft_not_checked
+    def on_failure_not_checked
     end
     sig {returns(NilClass).checked(false).on_failure(notify: 'pt')}
-    def not_checked_soft
+    def not_checked_on_failure
     end
     sig {returns(NilClass).on_failure(notify: 'pt')}
-    def soft_no_notify
+    def on_failure_no_notify
     end
     sig {returns(NilClass).on_failure(notify: Object.new)}
-    def soft_wtf_notify
+    def on_failure_wtf_notify
     end
 end


### PR DESCRIPTION
This changes the API we expose on signatures in the T::Configuration
handler. It's now an array of all the args that were given to this
signature's `.on_failure` builder, and doesn't special case any
knowledge of `notify:` as a keyword arg.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We renamed the `.soft` builder to `.on_failure` in #1141. This is follow up
work. It also unblocks us switching to sorbet-runtime in pay-server, so we can
have an `.on_failure` that isn't prescriptive of how the rest of the community
will use `.on_failure`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This is largely covered by the existing automated tests, because it's just a
rename. Some tests get deleted because they were specific to the `notify:`
parameter. I'll be re-introducing these as tests of our `T::Configuration`
handler in pay-server when I do that migration.