### PR TITLE
Relax error about using .on_failure and .checked

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -85,8 +85,8 @@ module T::Private::Methods
       if !decl.checked.equal?(ARG_NOT_PROVIDED)
         raise BuilderError.new("You can't call .checked multiple times in a signature.")
       end
-      if !decl.soft_notify.equal?(ARG_NOT_PROVIDED)
-        raise BuilderError.new("You can't use .checked with .on_failure.")
+      if level == :never && !decl.soft_notify.equal?(ARG_NOT_PROVIDED)
+        raise BuilderError.new("You can't use .checked(:never) with .on_failure because .on_failure will have no effect.")
       end
       if !decl.generated.equal?(ARG_NOT_PROVIDED)
         raise BuilderError.new("You can't use .checked with .generated.")
@@ -106,8 +106,8 @@ module T::Private::Methods
       if !decl.soft_notify.equal?(ARG_NOT_PROVIDED)
         raise BuilderError.new("You can't call .on_failure multiple times in a signature.")
       end
-      if !decl.checked.equal?(ARG_NOT_PROVIDED)
-        raise BuilderError.new("You can't use .on_failure with .checked.")
+      if decl.checked == :never
+        raise BuilderError.new("You can't use .on_failure with .checked(:never) because .on_failure will have no effect.")
       end
       if !decl.generated.equal?(ARG_NOT_PROVIDED)
         raise BuilderError.new("You can't use .on_failure with .generated.")
@@ -243,7 +243,11 @@ module T::Private::Methods
         decl.bind = nil
       end
       if decl.checked.equal?(ARG_NOT_PROVIDED)
-        decl.checked = T::Private::RuntimeLevels.default_checked_level
+        default_checked_level = T::Private::RuntimeLevels.default_checked_level
+        if default_checked_level == :never && !decl.soft_notify.equal?(ARG_NOT_PROVIDED)
+          raise BuilderError.new("To use .on_failure you must additionally call .checked(:tests) or .checked(:always), otherwise, the .on_failure has no effect.")
+        end
+        decl.checked = default_checked_level
       end
       if decl.soft_notify.equal?(ARG_NOT_PROVIDED)
         decl.soft_notify = nil

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -331,6 +331,19 @@ module Opus::Types::Test
             end
             assert_match(/Set the default checked level earlier/, err.message)
           end
+
+          it 'forbids .on_failure if default_checked_level is :never' do
+            T::Private::RuntimeLevels.instance_variable_set(:@default_checked_level, :never)
+
+            ex = assert_raises do
+              Class.new do
+                extend T::Sig
+                sig {void.on_failure(notify: 'me')}
+                def self.foo; end; foo
+              end
+            end
+            assert_includes(ex.message, "To use .on_failure you must additionally call .checked(:tests) or .checked(:always), otherwise, the .on_failure has no effect")
+          end
         end
       end
 

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -367,7 +367,7 @@ module Opus::Types::Test
         assert_includes(ex.message, "You can't call .on_failure multiple times in a signature.")
       end
 
-      it 'forbids .on_failure and then .checked' do
+      it 'forbids .on_failure and then .checked(:never)' do
         ex = assert_raises do
           Class.new do
             extend T::Sig
@@ -375,18 +375,54 @@ module Opus::Types::Test
             def self.foo; end; foo
           end
         end
-        assert_includes(ex.message, "You can't use .checked with .on_failure.")
+        assert_includes(ex.message, "You can't use .checked(:never) with .on_failure")
       end
 
-      it 'forbids .checked and then .on_failure' do
+      it 'allows .on_failure and then .checked(:tests)' do
+        skip
+        Class.new do
+          extend T::Sig
+          sig {returns(Integer).on_failure(notify: 'me').checked(:tests)}
+          def self.foo; end; foo
+        end
+        pass
+      end
+
+      it 'allows .on_failure and then .checked(:always)' do
+        skip
+        Class.new do
+          extend T::Sig
+          sig {returns(NilClass).on_failure(notify: 'me').checked(:always)}
+          def self.foo; end; foo
+        end
+        pass
+      end
+
+      it 'forbids .checked(:never) and then .on_failure' do
         ex = assert_raises do
           Class.new do
             extend T::Sig
-            sig {returns(Integer).on_failure(notify: 'me').checked(:never)}
+            sig {returns(Integer).checked(:never).on_failure(notify: 'me')}
             def self.foo; end; foo
           end
         end
-        assert_includes(ex.message, "You can't use .checked with .on_failure.")
+        assert_includes(ex.message, "You can't use .on_failure with .checked(:never)")
+      end
+
+      it 'allows .checked(:tests) and then .on_failure' do
+        Class.new do
+          extend T::Sig
+          sig {returns(Integer).checked(:tests).on_failure(notify: 'me')}
+          def self.foo; end; foo
+        end
+      end
+
+      it 'allows .checked(:always) and then .on_failure' do
+        Class.new do
+          extend T::Sig
+          sig {returns(NilClass).checked(:always).on_failure(notify: 'me')}
+          def self.foo; end; foo
+        end
       end
 
       it 'forbids empty notify' do


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In order to make `.on_failure` and `.checked` orthogonal, we need to
allow them to co-exist more than they can today. Specifically,
`.checked` determines WHETHER a sig is allowed to fail, and
`.on_failure` controls what happens WHEN a sig fails.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.