### PR TITLE
Fix fuzzed type member case

### DIFF
--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -526,7 +526,8 @@ InlinedVector<SymbolRef, 4> Types::alignBaseTypeArgs(Context ctx, SymbolRef what
         return currentAlignment;
     }
 
-    if (what == asIf || (asIf.data(ctx)->isClassClass() && what.data(ctx)->isClassClass())) {
+    if (what == asIf || (asIf.data(ctx)->isClassClass() && what.data(ctx)->isClassClass() &&
+                         asIf.data(ctx)->typeMembers().size() == what.data(ctx)->typeMembers().size())) {
         currentAlignment = what.data(ctx)->typeMembers();
     } else {
         currentAlignment.reserve(asIf.data(ctx)->typeMembers().size());

--- a/test/testdata/infer/bad_child_class.rb
+++ b/test/testdata/infer/bad_child_class.rb
@@ -1,4 +1,5 @@
 # typed: true
+# disable-fast-path: true
 
 # found by fuzzer: https://github.com/sorbet/sorbet/issues/1080
 

--- a/test/testdata/infer/bad_child_class.rb
+++ b/test/testdata/infer/bad_child_class.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+# found by fuzzer: https://github.com/sorbet/sorbet/issues/1080
+
+class PreChild <Parent # error: Type `K` declared by parent `Parent` must be re-declared in `PreChild`
+ ::V = type_member
+end
+
+class Parent
+  extend T::Sig
+  K = type_member
+  sig {returns(K)}
+  def foo; T.unsafe(nil); end
+  puts PreChild.new.foo() # this line previously caused a failed ENFORCE in LambdaParam::_instantiate
+end


### PR DESCRIPTION

### Motivation
Fixes #1080: an optional optimization path in `Types::alignBaseTypeArgs` was sometimes producing a vector of type arguments smaller than was needed in a subsequent call. Using that optimized path in a smaller number of situations fixes the issue.

### Test plan
See included automated tests, including the fuzzed test from #1080.
