### PR TITLE
Disable abstract signature-checking unless opted-in until we can fix `srb init`

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -180,7 +180,7 @@ void validateOverriding(const core::GlobalState &gs, core::SymbolRef method) {
         }
         if ((overridenMethod.data(gs)->isAbstract() || overridenMethod.data(gs)->isOverridable()) &&
             (method.data(gs)->isImplementation() || method.data(gs)->isOverride()) &&
-             !method.data(gs)->isIncompatibleOverride()) {
+            !method.data(gs)->isIncompatibleOverride()) {
             validateCompatibleOverride(gs, overridenMethod, method);
         }
     }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -179,7 +179,8 @@ void validateOverriding(const core::GlobalState &gs, core::SymbolRef method) {
             }
         }
         if ((overridenMethod.data(gs)->isAbstract() || overridenMethod.data(gs)->isOverridable()) &&
-            !method.data(gs)->isIncompatibleOverride()) {
+            (method.data(gs)->isImplementation() || method.data(gs)->isOverride()) &&
+             !method.data(gs)->isIncompatibleOverride()) {
             validateCompatibleOverride(gs, overridenMethod, method);
         }
     }

--- a/test/testdata/resolver/abstract_validation.rb
+++ b/test/testdata/resolver/abstract_validation.rb
@@ -85,11 +85,11 @@ class SplatParent
 end
 
 class SplatChild1 < SplatParent
-  def foo(*args); end # error: Implementation of abstract method `SplatParent#foo` must accept **`opts`
+  def foo(*args); end # TODO: Implementation of abstract method `SplatParent#foo` must accept **`opts`
 end
 
 class SplatChild2 < SplatParent
-  def foo(**opts); end # error: Implementation of abstract method `SplatParent#foo` must accept *`args`
+  def foo(**opts); end # TODO: Implementation of abstract method `SplatParent#foo` must accept *`args`
 end
 
 

--- a/test/testdata/resolver/enumerable_strict.rb
+++ b/test/testdata/resolver/enumerable_strict.rb
@@ -5,6 +5,6 @@ class A # error: Type `Elem` declared by parent `Enumerable` must be re-declared
   extend T::Sig
 
   sig {void}
-  def each # error: Implementation of abstract method `Enumerable#each` must explicitly name a block argument
+  def each # TODO: Implementation of abstract method `Enumerable#each` must explicitly name a block argument
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
`srb`- generated RBIs have been generating code that Sorbet can't deal with, so this will change those checks to be opt-in until `srb` can handle generating interface-compatible code.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
