### PR TITLE
Do not validate interface/abstract overrides in RBIs

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -179,7 +179,7 @@ void validateOverriding(const core::GlobalState &gs, core::SymbolRef method) {
             }
         }
         if ((overridenMethod.data(gs)->isAbstract() || overridenMethod.data(gs)->isOverridable()) &&
-            !method.data(gs)->isIncompatibleOverride()) {
+            !method.data(gs)->isIncompatibleOverride() && !method.data(gs)->loc().file().data(gs).isRBI()) {
             validateCompatibleOverride(gs, overridenMethod, method);
         }
     }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -178,8 +178,9 @@ void validateOverriding(const core::GlobalState &gs, core::SymbolRef method) {
                 e.addErrorLine(overridenMethod.data(gs)->loc(), "defined here");
             }
         }
+        auto isRBI = absl::c_any_of(method.data(gs)->locs(), [&](auto &loc) { return loc.file().data(gs).isRBI(); });
         if ((overridenMethod.data(gs)->isAbstract() || overridenMethod.data(gs)->isOverridable()) &&
-            !method.data(gs)->isIncompatibleOverride() && !method.data(gs)->loc().file().data(gs).isRBI()) {
+            !method.data(gs)->isIncompatibleOverride() && !isRBI) {
             validateCompatibleOverride(gs, overridenMethod, method);
         }
     }

--- a/test/cli/rbi-overrides/rbi-overrides.out
+++ b/test/cli/rbi-overrides/rbi-overrides.out
@@ -1,0 +1,4 @@
+No errors! Great job.
+No errors! Great job.
+No errors! Great job.
+No errors! Great job.

--- a/test/cli/rbi-overrides/rbi-overrides.sh
+++ b/test/cli/rbi-overrides/rbi-overrides.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+exec 2>&1
+D=test/cli/rbi-overrides
+main/sorbet --silence-dev-message $D/t1.rbi $D/t1.rb
+main/sorbet --silence-dev-message $D/t2.rbi $D/t2.rb
+main/sorbet --silence-dev-message $D/t3.rbi $D/t3.rb
+main/sorbet --silence-dev-message $D/t4.rbi $D/t4.rb

--- a/test/cli/rbi-overrides/t1.rb
+++ b/test/cli/rbi-overrides/t1.rb
@@ -1,0 +1,4 @@
+# typed: true
+class S
+  def each; end
+end

--- a/test/cli/rbi-overrides/t1.rbi
+++ b/test/cli/rbi-overrides/t1.rbi
@@ -1,0 +1,6 @@
+# typed: true
+class S
+  include Enumerable
+  sig { void }
+  def each; end
+end

--- a/test/cli/rbi-overrides/t2.rb
+++ b/test/cli/rbi-overrides/t2.rb
@@ -1,0 +1,6 @@
+# typed: true
+class S
+  extend T::Sig
+  sig { void }
+  def each; end
+end

--- a/test/cli/rbi-overrides/t2.rbi
+++ b/test/cli/rbi-overrides/t2.rbi
@@ -1,0 +1,5 @@
+# typed: true
+class S
+  include Enumerable
+  def each; end
+end

--- a/test/cli/rbi-overrides/t3.rb
+++ b/test/cli/rbi-overrides/t3.rb
@@ -1,0 +1,4 @@
+# typed: true
+class S
+  def each; end
+end

--- a/test/cli/rbi-overrides/t3.rbi
+++ b/test/cli/rbi-overrides/t3.rbi
@@ -1,0 +1,5 @@
+# typed: true
+class S
+  include Enumerable
+  def each; end
+end

--- a/test/cli/rbi-overrides/t4.rb
+++ b/test/cli/rbi-overrides/t4.rb
@@ -1,0 +1,6 @@
+# typed: true
+class S
+  extend T::Sig
+  sig { void }
+  def each; end
+end

--- a/test/cli/rbi-overrides/t4.rbi
+++ b/test/cli/rbi-overrides/t4.rbi
@@ -1,0 +1,6 @@
+# typed: true
+class S
+  include Enumerable
+  sig { void }
+  def each; end
+end

--- a/test/cli/sigil-rbi/overrides.rbi
+++ b/test/cli/sigil-rbi/overrides.rbi
@@ -1,0 +1,7 @@
+# typed: true
+
+class S
+  include Enumerable
+  sig { void }
+  def each; end
+end

--- a/test/cli/sigil-rbi/sigil-rbi.sh
+++ b/test/cli/sigil-rbi/sigil-rbi.sh
@@ -5,4 +5,5 @@ main/sorbet --silence-dev-message \
     test/cli/sigil-rbi/strict.rbi \
     test/cli/sigil-rbi/abstract.rbi \
     test/cli/sigil-rbi/multiple_definition.rbi \
+    test/cli/sigil-rbi/overrides.rbi \
     2>&1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This fixes #1170 as well as others, by restricting these specific checks to only happen in non-generated files.

### Test plan

See included automated tests.
