### PR TITLE
Fix default_checked_level

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -18,7 +18,7 @@ class T::Props::Decorator
 
   class NoRulesError < StandardError; end
 
-  sig {params(klass: DecoratedClass).void}
+  sig {params(klass: DecoratedClass).void.checked(:never)}
   def initialize(klass)
     @class = klass
     klass.plugins.each do |mod|
@@ -780,7 +780,7 @@ class T::Props::Decorator
   #
   # This gets called when a module or class that extends T::Props gets included, extended,
   # prepended, or inherited.
-  sig {params(child: DecoratedClass).void}
+  sig {params(child: DecoratedClass).void.checked(:never)}
   def model_inherited(child)
     child.extend(T::Props::ClassMethods)
     child.plugins.concat(decorated_class.plugins)
@@ -801,7 +801,7 @@ class T::Props::Decorator
     end
   end
 
-  sig {params(mod: Module).void}
+  sig {params(mod: Module).void.checked(:never)}
   def plugin(mod)
     decorated_class.plugins << mod
     Private.apply_class_methods(mod, decorated_class)

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -18,7 +18,7 @@ class T::Props::Decorator
 
   class NoRulesError < StandardError; end
 
-  sig {params(klass: DecoratedClass).void.checked(:never)}
+  T::Sig::WithoutRuntime.sig {params(klass: DecoratedClass).void}
   def initialize(klass)
     @class = klass
     klass.plugins.each do |mod|
@@ -780,7 +780,7 @@ class T::Props::Decorator
   #
   # This gets called when a module or class that extends T::Props gets included, extended,
   # prepended, or inherited.
-  sig {params(child: DecoratedClass).void.checked(:never)}
+  T::Sig::WithoutRuntime.sig {params(child: DecoratedClass).void}
   def model_inherited(child)
     child.extend(T::Props::ClassMethods)
     child.plugins.concat(decorated_class.plugins)
@@ -801,7 +801,7 @@ class T::Props::Decorator
     end
   end
 
-  sig {params(mod: Module).void.checked(:never)}
+  T::Sig::WithoutRuntime.sig {params(mod: Module).void}
   def plugin(mod)
     decorated_class.plugins << mod
     Private.apply_class_methods(mod, decorated_class)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

#1135 introduced `T::Configuration.default_checked_level=`, but if I do the following:
```ruby
require "bundler/inline"

gemfile do
  source "https://rubygems.org"

  gem "sorbet-runtime"
end

require "sorbet-runtime"
T::Configuration.default_checked_level = :never
```

I get the error:
```
Traceback (most recent call last):
        2: from temp.rb:13:in `<main>'
        1: from /Users/peterzhu/.gem/ruby/2.5.5/gems/sorbet-runtime-0.4.4366/lib/types/configuration.rb:30:in `default_checked_level='
/Users/peterzhu/.gem/ruby/2.5.5/gems/sorbet-runtime-0.4.4366/lib/types/private/runtime_levels.rb:48:in `default_checked_level=': Set the default checked level earlier. There are already some methods whose sig blocks have evaluated which would not be affected by the new default. (RuntimeError)
```

This is caused by some typed methods in `decorator.rb` that is ran when the gem is required but doesn't have an explicit `checked` value so it calls `T::Private::RuntimeLevels.default_checked_level` before the line `T::Configuration.default_checked_level = :never` is ran which causes `@has_read_default_checked_level` to be set to `true` which causes the error (see code [here](https://github.com/sorbet/sorbet/blob/8d12e2eb5fbc2b8da0161337d52ef9a73bcd8c61/gems/sorbet-runtime/lib/types/private/runtime_levels.rb#L42)).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

None
