### PR TITLE
Docs: Add Plug-Ins page

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -133,3 +133,10 @@ from YARD docs.
 Also see the [Community] page for more community-maintained projects!
 
 [sord]: https://github.com/AaronC81/sord
+
+## Can Sorbet produce statistics?
+
+Yes, you can use options like `--metrics-file` to produce statistics. For
+example, check out
+[sorbet-progress](https://github.com/jaredbeck/sorbet-progress) which uses those
+statistics to keep track of your progress adopting sorbet in big codebases.

--- a/website/pages/en/community.js
+++ b/website/pages/en/community.js
@@ -109,12 +109,6 @@ class Index extends React.Component {
             <ProjectList
               content={[
                 {
-                  title: 'sorbet-progress',
-                  link: 'https://github.com/jaredbeck/sorbet-progress',
-                  description:
-                    'Measure your progress as you adopt Sorbet, stay motivated!',
-                },
-                {
                   title: 'sorbet-typed',
                   link: 'https://github.com/sorbet/sorbet-typed',
                   description:
@@ -131,6 +125,12 @@ class Index extends React.Component {
                   link: 'https://github.com/AaronC81/sord',
                   description:
                     'A tool to generate RBIs from YARD documentation',
+                },
+                {
+                  title: 'sorbet-progress',
+                  link: 'https://github.com/jaredbeck/sorbet-progress',
+                  description:
+                    'Measure your progress as you adopt Sorbet, stay motivated!',
                 },
               ]}
             />

--- a/website/pages/en/community.js
+++ b/website/pages/en/community.js
@@ -109,6 +109,12 @@ class Index extends React.Component {
             <ProjectList
               content={[
                 {
+                  title: 'sorbet-progress',
+                  link: 'https://github.com/jaredbeck/sorbet-progress',
+                  description:
+                    'Measure your progress as you adopt Sorbet, stay motivated!',
+                },
+                {
                   title: 'sorbet-typed',
                   link: 'https://github.com/sorbet/sorbet-typed',
                   description:


### PR DESCRIPTION
I put this new page in "Static & Runtime", but it's not clear
to me that is the correct category. Please advise.

### Motivation

So people can browse a list of plug-ins.

### Test plan

Whatever is normal for docs.