### PR TITLE
Add final method runtime

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -372,7 +372,7 @@ bool extendsTHelpers(core::Context ctx, core::SymbolRef enclosingClass) {
 }
 
 /**
- * Make an autocorrection for adding `extends T::Helpers`, when needed.
+ * Make an autocorrection for adding `extend T::Helpers`, when needed.
  */
 optional<core::AutocorrectSuggestion> maybeSuggestExtendTHelpers(core::Context ctx, const Type *thisType,
                                                                  const Loc &call) {

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -17,10 +17,21 @@ module T::Configuration
     T::Private::RuntimeLevels.enable_checking_in_tests
   end
 
-  # Announce to Sorbet that we would like the final checks to be done when including and extending modules. If this is
-  # not called, then, for example, if you have a module A which defines a final method named M, and then A includes a
-  # module B which also defines a method named M, then the runtime will not issue an error about redefining a final
-  # method.
+  # Announce to Sorbet that we would like the final checks to be done when
+  # including and extending modules. Iff this is not called, then the following
+  # example will not raise an error.
+  #
+  # ```ruby
+  # module M
+  #   extend T::Sig
+  #   sig(:final) {void}
+  #   def foo; end
+  # end
+  # class C
+  #   include M
+  #   def foo; end
+  # end
+  # ```
   def self.enable_final_checks_for_include_extend
     T::Private::Methods.enable_final_checks_for_include_extend
   end

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -17,6 +17,14 @@ module T::Configuration
     T::Private::RuntimeLevels.enable_checking_in_tests
   end
 
+  # Announce to Sorbet that we would like the final checks to be done when including and extending modules. If this is
+  # not called, then, for example, if you have a module A which defines a final method named M, and then A includes a
+  # module B which also defines a method named M, then the runtime will not issue an error about redefining a final
+  # method.
+  def self.enable_final_checks_for_include_extend
+    T::Private::Methods.enable_final_checks_for_include_extend
+  end
+
   # Configure the default checked level for a sig with no explicit `.checked`
   # builder. When unset, the default checked level is `:always`.
   #

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -17,7 +17,7 @@ module T::Configuration
     T::Private::RuntimeLevels.enable_checking_in_tests
   end
 
-  # Announce to Sorbet that we would like the final checks to be done when
+  # Announce to Sorbet that we would like the final checks to be enabled when
   # including and extending modules. Iff this is not called, then the following
   # example will not raise an error.
   #
@@ -33,7 +33,13 @@ module T::Configuration
   # end
   # ```
   def self.enable_final_checks_for_include_extend
-    T::Private::Methods.enable_final_checks_for_include_extend
+    T::Private::Methods.set_final_checks_for_include_extend(true)
+  end
+
+  # Undo the effects of a previous call to
+  # `enable_final_checks_for_include_extend`.
+  def self.reset_final_checks_for_include_extend
+    T::Private::Methods.set_final_checks_for_include_extend(false)
   end
 
   # Configure the default checked level for a sig with no explicit `.checked`

--- a/gems/sorbet-runtime/lib/types/private/decl_state.rb
+++ b/gems/sorbet-runtime/lib/types/private/decl_state.rb
@@ -11,6 +11,7 @@ class T::Private::DeclState
   end
 
   attr_accessor :active_declaration
+  attr_accessor :skip_next_on_method_added
 
   def reset!
     self.active_declaration = nil

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -165,11 +165,7 @@ module T::Private::Methods
   end
 
   def self.sig_error(loc, message)
-    raise(
-      ArgumentError.new(
-        "#{loc.path}:#{loc.lineno}: Error interpreting `sig`:\n  #{message}\n\n"
-      )
-    )
+    raise(ArgumentError.new("#{loc.path}:#{loc.lineno}: Error interpreting `sig`:\n  #{message}\n\n"))
   end
 
   # Executes the `sig` block, and converts the resulting Declaration

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -109,7 +109,7 @@ module T::Private::Methods
   # Only public because it needs to get called below inside the replace_method blocks below.
   def self._on_method_added(hook_mod, method_name, is_singleton_method: false)
     current_declaration = T::Private::DeclState.current.active_declaration
-    return if !current_declaration
+    return if current_declaration.nil?
     T::Private::DeclState.current.reset!
 
     mod = is_singleton_method ? hook_mod.singleton_class : hook_mod

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -16,7 +16,7 @@ module T::Private::Methods
     install_hooks(mod)
 
     if T::Private::DeclState.current.active_declaration
-      T::Private::DeclState.current.active_declaration = nil
+      T::Private::DeclState.current.reset!
       raise "You called sig twice without declaring a method inbetween"
     end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -119,9 +119,9 @@ module T::Private::Methods
     @signatures_by_method[key]
   end
 
-  # when `mod` includes a module with instance methods `method_names`, ensure there is zero intersection between the
-  # final instance methods of `mod` and `method_names`. so, for every m in `method_names`, check if there is already a
-  # method defined on one of `mod`'s `ancestors` with the same name that is final.
+  # when mod includes a module with instance methods method_names, ensure there is zero intersection between the final
+  # instance methods of mod and method_names. so, for every m in method_names, check if there is already a method
+  # defined on one of mod's ancestors with the same name that is final.
   def self._check_final_ancestors(mod, ancestors, method_names)
     # use reverse_each to check farther-up ancestors first, for better error messages. we could avoid this if we were on
     # the version of ruby that adds the optional argument to method_defined? that allows you to exclude ancestors.

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -121,7 +121,7 @@ module T::Private::Methods
 
   # when mod includes a module with instance methods method_names, ensure there is zero intersection between the final
   # instance methods of mod and method_names. so, for every m in method_names, check if there is already a method
-  # defined on one of mod's ancestors with the same name that is final.
+  # defined on one of ancestors with the same name that is final.
   def self._check_final_ancestors(mod, ancestors, method_names)
     # use reverse_each to check farther-up ancestors first, for better error messages. we could avoid this if we were on
     # the version of ruby that adds the optional argument to method_defined? that allows you to exclude ancestors.

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -326,8 +326,13 @@ module T::Private::Methods
     original_singleton_method.bind(attached).call(:singleton_method_added)
   end
 
+  # use this directly if you don't want/need to box up the method into an object to pass to method_to_key.
+  private_class_method def self.method_owner_and_name_to_key(owner, name)
+    "#{owner.object_id}##{name}"
+  end
+
   private_class_method def self.method_to_key(method)
-    "#{method.owner.object_id}##{method.name}"
+    method_owner_and_name_to_key(method.owner, method.name)
   end
 
   private_class_method def self.key_to_method(key)

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -108,6 +108,11 @@ module T::Private::Methods
 
   # Only public because it needs to get called below inside the replace_method blocks below.
   def self._on_method_added(hook_mod, method_name, is_singleton_method: false)
+    if T::Private::DeclState.current.skip_next_on_method_added
+      T::Private::DeclState.current.skip_next_on_method_added = false
+      return
+    end
+
     current_declaration = T::Private::DeclState.current.active_declaration
     return if current_declaration.nil?
     T::Private::DeclState.current.reset!

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -163,6 +163,7 @@ module T::Private::Methods::CallValidation
   end
 
   def self.create_validator_method(mod, original_method, method_sig, original_visibility)
+    T::Private::DeclState.current.skip_next_on_method_added = true
     has_fixed_arity = method_sig.kwarg_types.empty? && !method_sig.has_rest && !method_sig.has_keyrest &&
       original_method.parameters.all? {|(kind, _name)| kind == :req}
     all_args_are_simple = method_sig.arg_types.all? {|_name, type| type.is_a?(T::Types::Simple)}

--- a/gems/sorbet-runtime/lib/types/sig.rb
+++ b/gems/sorbet-runtime/lib/types/sig.rb
@@ -7,15 +7,15 @@ module T::Sig
   module WithoutRuntime
     # At runtime, does nothing, but statically it is treated exactly the same
     # as T::Sig#sig. Only use it in cases where you can't use T::Sig#sig.
-    def self.sig(&blk); end # rubocop:disable PrisonGuard/BanBuiltinMethodOverride
+    def self.sig(arg=nil, &blk); end # rubocop:disable PrisonGuard/BanBuiltinMethodOverride
 
     original_verbose = $VERBOSE
     $VERBOSE = false
 
     # At runtime, does nothing, but statically it is treated exactly the same
     # as T::Sig#sig. Only use it in cases where you can't use T::Sig#sig.
-    T::Sig::WithoutRuntime.sig {params(blk: T.proc.bind(T::Private::Methods::DeclBuilder).void).void}
-    def self.sig(&blk); end # rubocop:disable PrisonGuard/BanBuiltinMethodOverride, Lint/DuplicateMethods
+    T::Sig::WithoutRuntime.sig {params(arg: T.nilable(Symbol), blk: T.proc.bind(T::Private::Methods::DeclBuilder).void).void}
+    def self.sig(arg=nil, &blk); end # rubocop:disable PrisonGuard/BanBuiltinMethodOverride, Lint/DuplicateMethods
 
     $VERBOSE = original_verbose
   end
@@ -23,8 +23,8 @@ module T::Sig
   # Declares a method with type signatures and/or
   # abstract/override/... helpers. See the documentation URL on
   # {T::Helpers}
-  T::Sig::WithoutRuntime.sig {params(blk: T.proc.bind(T::Private::Methods::DeclBuilder).void).void}
-  def sig(&blk) # rubocop:disable PrisonGuard/BanBuiltinMethodOverride
-    T::Private::Methods.declare_sig(self, &blk)
+  T::Sig::WithoutRuntime.sig {params(arg: T.nilable(Symbol), blk: T.proc.bind(T::Private::Methods::DeclBuilder).void).void}
+  def sig(arg=nil, &blk) # rubocop:disable PrisonGuard/BanBuiltinMethodOverride
+    T::Private::Methods.declare_sig(self, arg, &blk)
   end
 end

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -275,6 +275,25 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
     assert_equal(2, m.calls)
   end
 
+  it "calls an exotic user-defined included" do
+    m2 = Module.new do
+      def self.included(arg)
+        arg.include(Module.new do
+          extend T::Sig
+          sig(:final) {void}
+          def foo; end
+        end)
+      end
+    end
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        include m2
+        def foo; end
+      end
+    end
+    assert_includes(err.message, "was declared as final and cannot be overridden")
+  end
+
   it "forbids overriding through many levels of include" do
     m1 = Module.new do
       extend T::Sig

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -8,6 +8,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
 
   after do
     T::Private::DeclState.current.reset!
+    T::Configuration.reset_final_checks_for_include_extend
   end
 
   it "allows declaring an instance method as final" do

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -1,0 +1,319 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
+  before do
+    T::Configuration.enable_final_checks_for_include_extend
+  end
+
+  after do
+    T::Private::DeclState.current.reset!
+  end
+
+  it "allows declaring an instance method as final" do
+    Class.new do
+      extend T::Sig
+      sig(:final) {void}
+      def foo; end
+    end
+  end
+
+  it "allows declaring a class method as final" do
+    Class.new do
+      extend T::Sig
+      sig(:final) {void}
+      def self.foo; end
+    end
+  end
+
+  it "forbids redefining a final instance method with a final sig" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Sig
+        sig(:final) {void}
+        def foo; end
+        sig(:final) {void}
+        def foo; end
+      end
+    end
+    assert_includes(err.message, "was declared as final and cannot be redefined")
+  end
+
+  it "forbids redefining a final class method with a final sig" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Sig
+        sig(:final) {void}
+        def self.foo; end
+        sig(:final) {void}
+        def self.foo; end
+      end
+    end
+    assert_includes(err.message, "was declared as final and cannot be redefined")
+  end
+
+  it "forbids redefining a final instance method with a regular sig" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Sig
+        sig(:final) {void}
+        def foo; end
+        sig {void}
+        def foo; end
+      end
+    end
+    assert_includes(err.message, "was declared as final and cannot be redefined")
+  end
+
+  it "forbids redefining a final class method with a regular sig" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Sig
+        sig(:final) {void}
+        def self.foo; end
+        sig {void}
+        def self.foo; end
+      end
+    end
+    assert_includes(err.message, "was declared as final and cannot be redefined")
+  end
+
+  it "forbids redefining a final instance method with no sig" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Sig
+        sig(:final) {void}
+        def foo; end
+        def foo; end
+      end
+    end
+    assert_includes(err.message, "was declared as final and cannot be redefined")
+  end
+
+  it "forbids redefining a final class method with no sig" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Sig
+        sig(:final) {void}
+        def self.foo; end
+        def self.foo; end
+      end
+    end
+    assert_includes(err.message, "was declared as final and cannot be redefined")
+  end
+
+  it "allows redefining a regular instance method to be final" do
+    Class.new do
+      extend T::Sig
+      def foo; end
+      sig(:final) {void}
+      def foo; end
+    end
+  end
+
+  it "allows redefining a regular class method to be final" do
+    Class.new do
+      extend T::Sig
+      def self.foo; end
+      sig(:final) {void}
+      def self.foo; end
+    end
+  end
+
+  it "forbids overriding a final instance method" do
+    c = Class.new do
+      extend T::Sig
+      sig(:final) {void}
+      def foo; end
+    end
+    err = assert_raises(RuntimeError) do
+      Class.new(c) do
+        def foo; end
+      end
+    end
+    assert_includes(err.message, "was declared as final and cannot be overridden")
+  end
+
+  it "forbids overriding a final class method" do
+    c = Class.new do
+      extend T::Sig
+      sig(:final) {void}
+      def self.foo; end
+    end
+    err = assert_raises(RuntimeError) do
+      Class.new(c) do
+        def self.foo; end
+      end
+    end
+    assert_includes(err.message, "was declared as final and cannot be overridden")
+  end
+
+  it "forbids overriding a final method from an included module" do
+    m = Module.new do
+      extend T::Sig
+      sig(:final) {void}
+      def foo; end
+    end
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        include m
+        def foo; end
+      end
+    end
+    assert_includes(err.message, "was declared as final and cannot be overridden")
+  end
+
+  it "forbids overriding a final method from an extended module" do
+    m = Module.new do
+      extend T::Sig
+      sig(:final) {void}
+      def foo; end
+    end
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend m
+        def self.foo; end
+      end
+    end
+    assert_includes(err.message, "was declared as final and cannot be overridden")
+  end
+
+  it "forbids overriding a final method by including two modules" do
+    m1 = Module.new do
+      extend T::Sig
+      sig(:final) {void}
+      def foo; end
+    end
+    m2 = Module.new do
+      def foo; end
+    end
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        include m2, m1
+      end
+    end
+    assert_includes(err.message, "was declared as final and cannot be overridden")
+  end
+
+  it "forbids overriding a final method by extending two modules" do
+    m1 = Module.new do
+      extend T::Sig
+      sig(:final) {void}
+      def foo; end
+    end
+    m2 = Module.new do
+      def foo; end
+    end
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend m2, m1
+      end
+    end
+    assert_includes(err.message, "was declared as final and cannot be overridden")
+  end
+
+  it "allows calling final methods" do
+    m = Module.new do
+      extend T::Sig
+      sig(:final) {void}
+      def self.n0; end
+      sig(:final) {params(x: Integer).void}
+      def self.n1(x); end
+      sig(:final) {params(x: Integer, y: Integer).void}
+      def self.n2(x, y); end
+      sig(:final) {params(x: Integer, y: Integer, z: Integer).void}
+      def self.n3(x, y, z); end
+    end
+    m.n0
+    m.n1 1
+    m.n2 1, 2
+    m.n3 1, 2, 3
+  end
+
+  it "calls a user-defined included" do
+    m = Module.new do
+      @calls = 0
+      extend T::Sig
+      sig(:final) {returns(Integer)}
+      def self.calls
+        @calls
+      end
+      def self.included(x)
+        @calls += 1
+      end
+    end
+    Class.new do
+      include m
+    end
+    assert_equal(1, m.calls)
+    Class.new do
+      include m
+    end
+    assert_equal(2, m.calls)
+  end
+
+  it "calls a user-defined extended" do
+    m = Module.new do
+      @calls = 0
+      extend T::Sig
+      sig(:final) {returns(Integer)}
+      def self.calls
+        @calls
+      end
+      def self.extended(x)
+        @calls += 1
+      end
+    end
+    Class.new do
+      extend m
+    end
+    assert_equal(1, m.calls)
+    Class.new do
+      extend m
+    end
+    assert_equal(2, m.calls)
+  end
+
+  it "forbids overriding through many levels of include" do
+    m1 = Module.new do
+      extend T::Sig
+      sig(:final) {void}
+      def foo; end
+    end
+    m2 = Module.new do
+      include m1
+    end
+    m3 = Module.new do
+      include m2
+    end
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        include m3
+        def foo; end
+      end
+    end
+    assert_includes(err.message, "was declared as final and cannot be overridden")
+  end
+
+  it "allows including modules again" do
+    m1 = Module.new do
+      extend T::Sig
+      sig(:final) {void}
+      def foo; end
+    end
+    m2 = Module.new do
+      include m1, m1
+    end
+  end
+
+  it "allows extending modules again" do
+    m1 = Module.new do
+      extend T::Sig
+      sig(:final) {void}
+      def foo; end
+    end
+    m2 = Module.new do
+      extend m1, m1
+    end
+  end
+end

--- a/gems/sorbet/lib/t.rb
+++ b/gems/sorbet/lib/t.rb
@@ -12,7 +12,7 @@
 module T
   module Sig
     module WithoutRuntime
-      def self.sig(&blk); end
+      def self.sig(arg=nil, &blk); end
     end
   end
 

--- a/gems/sorbet/lib/t.rb
+++ b/gems/sorbet/lib/t.rb
@@ -55,4 +55,3 @@ module T
     def self.[](type); end
   end
 end
-

--- a/rbi/sorbet/sig.rbi
+++ b/rbi/sorbet/sig.rbi
@@ -3,7 +3,7 @@ class Sorbet
   # Identical to `T::Sig`'s `sig` in semantics, but couldn't work at
   # runtime since it doesn't know `self`. Used in `rbi`s that don't `extend
   # T::Sig`.
-  sig {params(blk: T.proc.bind(T::Private::Methods::DeclBuilder).void).void}
-  def self.sig(&blk)
+  sig {params(arg: T.nilable(Symbol), blk: T.proc.bind(T::Private::Methods::DeclBuilder).void).void}
+  def self.sig(arg=nil, &blk)
   end
 end

--- a/rbi/sorbet/sig.rbi
+++ b/rbi/sorbet/sig.rbi
@@ -7,4 +7,3 @@ class Sorbet
   def self.sig(&blk)
   end
 end
-

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -3,14 +3,14 @@ module T::Sig
   # We could provide a more-complete signature, but these are already
   # parsed in C++, so there's no need to emit errors twice.
 
-  sig {params(blk: T.proc.bind(T::Private::Methods::DeclBuilder).void).void}
-  def sig(&blk); end
+  sig {params(arg: T.nilable(Symbol), blk: T.proc.bind(T::Private::Methods::DeclBuilder).void).void}
+  def sig(arg=nil, &blk); end
 end
 module T::Sig::WithoutRuntime
   # At runtime, does nothing, but statically it is treated exactly the same
   # as T::Sig#sig. Only use it in cases where you can't use T::Sig#sig.
-  sig {params(blk: T.proc.bind(T::Private::Methods::DeclBuilder).void).void}
-  def self.sig(&blk); end
+  sig {params(arg: T.nilable(Symbol), blk: T.proc.bind(T::Private::Methods::DeclBuilder).void).void}
+  def self.sig(arg=nil, &blk); end
 end
 
 module T


### PR DESCRIPTION
This is the impl for final methods in the runtime.

I would recommend reviewing by commit. There are:
- a few commits that make minor pre-work-y changes
- a big commit that "does everything"
- a commit to re-generate test files

Some more things to note:

I wasn't sure exactly where to store the information about what methods are final. Because `DeclBuilder` and `Signature` deal with the block to `sig`, and we explicitly don't want to put the marker for final inside the block because that makes it lazy, I added a `Set` of methods marked final.

Related: We want to do the final checks eagerly for _every_ method definition, not just every method definition with a `sig`. So I did those checks directly in `_on_method_added`.

Although we initially said that we want the syntax for final methods to be

```rb
class A
  extend T::Sig
  sig.final {void}
  def foo; end
end
```

this implements it with the syntax

```rb
class A
  extend T::Sig
  sig(:final) {void}
  def foo; end
end
```

This is because in order to write the `sig` for `sig` in the first example, I would like to write

```rb
class Foo
  sig {params(blk: T.proc.bind(T::Private::Methods::DeclBuilder).void).void}
  def final; end
end
sig {params(blk: T.proc.bind(T::Private::Methods::DeclBuilder).void).void}
sig {returns(Foo)}
def sig; end
```

but this would require us to have access to sig overloads, which only works in rbi files, and there are some places where `sig` is defined in actual Ruby.

An alternative strategy would be to write 
```rb
class Foo
  sig {params(blk: T.proc.bind(T::Private::Methods::DeclBuilder).void).void}
  def final; end
end
sig {params(blk: T.nilable(T.proc.bind(T::Private::Methods::DeclBuilder)).returns(Foo)}
def sig; end
```
but this doesn't work because you can't combine `T.proc.bind` with `T.nilable`, it seems.

### Motivation
To finalize.

### Test plan

Updated the tests.