### PR TITLE
(LSP) Report errors in files that lack a typed sigil.

### DIFF
--- a/main/lsp/updates.cc
+++ b/main/lsp/updates.cc
@@ -54,6 +54,7 @@ core::FileRef LSPLoop::updateFile(const shared_ptr<core::File> &file) {
     }
 
     vector<string> emptyInputNames;
+    fref.data(*initialGS).strictLevel = pipeline::decideStrictLevel(*initialGS, fref, opts);
     auto t = pipeline::indexOne(opts, *initialGS, fref, kvstore);
     int id = t.file.id();
     if (id >= indexed.size()) {

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -167,6 +167,7 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
                          unique_ptr<KeyValueStore> &kvstore) {
     auto &print = opts.print;
     ast::ParsedFile dslsInlined{nullptr, file};
+    ENFORCE(file.data(lgs).strictLevel == decideStrictLevel(lgs, file, opts));
 
     Timer timeit(lgs.tracer(), "indexOne");
     try {
@@ -1045,6 +1046,7 @@ core::FileHash computeFileHash(shared_ptr<core::File> forWhat, spdlog::logger &l
     {
         core::UnfreezeFileTable fileTableAccess(*lgs);
         fref = lgs->enterFile(forWhat);
+        fref.data(*lgs).strictLevel = pipeline::decideStrictLevel(*lgs, fref, emptyOpts);
     }
     vector<ast::ParsedFile> single;
     unique_ptr<KeyValueStore> kvstore;

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -38,5 +38,8 @@ ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const 
 
 core::FileHash computeFileHash(std::shared_ptr<core::File> forWhat, spdlog::logger &logger);
 
+core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::FileRef file,
+                                    const options::Options &opts);
+
 } // namespace sorbet::realmain::pipeline
 #endif // RUBY_TYPER_PIPELINE_H

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -85,10 +85,8 @@ TEST_F(ProtocolTest, Cancellation) {
 // Asserts that Sorbet returns an empty result when requesting definitions in untyped Ruby files.
 TEST_F(ProtocolTest, DefinitionError) {
     assertDiagnostics(initializeLSP(), {});
-    assertDiagnostics(
-        send(*openFile("foobar.rb", "class Foobar\n  sig {returns(Integer)}\n  def bar\n    1\n  end\nend\n\nbar\n")),
-        {});
-    auto defResponses = send(*getDefinition("foobar.rb", 7, 1));
+    assertDiagnostics(send(*openFile("foobar.rb", "class Foobar\n  def bar\n    1\n  end\nend\n\nbar\n")), {});
+    auto defResponses = send(*getDefinition("foobar.rb", 6, 1));
     ASSERT_EQ(defResponses.size(), 1) << "Expected a single response to a definition request to an untyped document.";
 
     assertResponseMessage(nextId - 1, *defResponses.at(0));

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -152,11 +152,16 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
     core::MutableContext ctx(gs, core::Symbols::root());
     // Parser
     vector<core::FileRef> files;
+    constexpr string_view whitelistedTypedNoneTest = "missing_typed_sigil.rb"sv;
     {
         core::UnfreezeFileTable fileTableAccess(gs);
 
         for (auto &sourceFile : test.sourceFiles) {
-            files.emplace_back(gs.enterFile(test.sourceFileContents[test.folder + sourceFile]));
+            auto fref = gs.enterFile(test.sourceFileContents[test.folder + sourceFile]);
+            if (FileOps::getFileName(sourceFile) == whitelistedTypedNoneTest) {
+                fref.data(gs).strictLevel = core::StrictLevel::False;
+            }
+            files.emplace_back(fref);
         }
     }
     vector<ast::ParsedFile> trees;
@@ -165,6 +170,11 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
     vector<core::ErrorRegion> errs;
     for (auto file : files) {
         errs.emplace_back(gs, file);
+
+        if (FileOps::getFileName(file.data(ctx).path()) != whitelistedTypedNoneTest &&
+            file.data(ctx).source().find("# typed:") == string::npos) {
+            ADD_FAILURE_AT(file.data(gs).path().data(), 1) << "Add a `# typed: strict` line to the top of this file";
+        }
         unique_ptr<parser::Node> nodes;
         {
             core::UnfreezeNameTable nameTableAccess(gs); // enters original strings
@@ -453,7 +463,7 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
     errorQueue->drainAllErrors();
 
     TEST_COUT << "errors OK" << '\n';
-}
+} // namespace sorbet::test
 
 bool isTestMessage(const LSPMessage &msg) {
     return msg.isNotification() && msg.method() == LSPMethod::SorbetTypecheckRunInfo;

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -165,10 +165,6 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
     vector<core::ErrorRegion> errs;
     for (auto file : files) {
         errs.emplace_back(gs, file);
-        if (file.data(ctx).source().find("# typed:") == string::npos) {
-            ADD_FAILURE_AT(file.data(gs).path().data(), 1) << "Add a `# typed: strict` line to the top of this file";
-        }
-
         unique_ptr<parser::Node> nodes;
         {
             core::UnfreezeNameTable nameTableAccess(gs); // enters original strings

--- a/test/testdata/lsp/missing_typed_sigil.rb
+++ b/test/testdata/lsp/missing_typed_sigil.rb
@@ -1,0 +1,9 @@
+class Hello
+  def something(x)
+
+  end
+end
+
+def main
+  puts Helo.new # error: Unable to resolve constant `Helo`
+end

--- a/test/testdata/lsp/missing_typed_sigil.rb
+++ b/test/testdata/lsp/missing_typed_sigil.rb
@@ -1,3 +1,10 @@
+# !!!!
+# THIS IS THE ONLY TEST FILE WITHOUT A TYPED SIGIL.
+# Normally, we ban the use of test files lacking a sigil to ensure that all tests are intentionally typed at the
+# expected level. However, this file tests a codepath that only triggers in files without a sigil, so it has been
+# specially whitelisted.
+# !!!!
+
 class Hello
   def something(x)
 


### PR DESCRIPTION
In the editor setting, report errors in files that lack a typed sigil.

The second commit adds an ENFORCE that tries to ensure that we don't repeat this mistake again.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes https://github.com/sorbet/sorbet/issues/1187

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
