### PR TITLE
Publish sorbet-static-* before anything else

### DIFF
--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -90,7 +90,19 @@ printf -- $'---\n:rubygems_api_key: %s\n' "$RUBY_GEMS_API_KEY" > "$HOME/.gem/cre
 chmod 600 "$HOME/.gem/credentials"
 
 if [ "$dryrun" = "" ]; then
+  # push the sorbet-static gems first, in case they fail. We don't want to end
+  # up in a weird state where 'sorbet' is an requires a pinned version of
+  # sorbet-static, but the sorbet-static gem push failed.
+  #
+  # (By failure here, we mean that RubyGems.org 502'd for some reason.)
+  for gem_archive in _out_/gems/sorbet-static*.gem; do
+    gem push "$gem_archive"
+  done
+
   for gem_archive in _out_/gems/*.gem; do
+    if [[ "$gem_archive" == *sorbet-static* ]]; then
+      continue
+    fi
     gem push "$gem_archive"
   done
 fi

--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -91,7 +91,7 @@ chmod 600 "$HOME/.gem/credentials"
 
 if [ "$dryrun" = "" ]; then
   # push the sorbet-static gems first, in case they fail. We don't want to end
-  # up in a weird state where 'sorbet' is an requires a pinned version of
+  # up in a weird state where 'sorbet' requires a pinned version of
   # sorbet-static, but the sorbet-static gem push failed.
   #
   # (By failure here, we mean that RubyGems.org 502'd for some reason.)

--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -95,16 +95,12 @@ if [ "$dryrun" = "" ]; then
   # sorbet-static, but the sorbet-static gem push failed.
   #
   # (By failure here, we mean that RubyGems.org 502'd for some reason.)
-  for gem_archive in _out_/gems/sorbet-static*.gem; do
+  for gem_archive in "_out_/gems/sorbet-static-$release_version"-*.gem; do
     gem push "$gem_archive"
   done
 
-  for gem_archive in _out_/gems/*.gem; do
-    if [[ "$gem_archive" == *sorbet-static* ]]; then
-      continue
-    fi
-    gem push "$gem_archive"
-  done
+  gem push "_out_/gems/sorbet-runtime-$release_version.gem"
+  gem push "_out_/gems/sorbet-$release_version.gem"
 fi
 
 echo "--- making a github release"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

push the sorbet-static gems first, in case they fail. We don't want to end
up in a weird state where 'sorbet' is an requires a pinned version of
sorbet-static, but the sorbet-static gem push failed.

(By failure here, we mean that RubyGems.org 502'd for some reason.)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.