### PR TITLE
Add blocks to methods generated by `delegate` DSL

### DIFF
--- a/dsl/Delegate.cc
+++ b/dsl/Delegate.cc
@@ -108,12 +108,15 @@ vector<unique_ptr<ast::Expression>> Delegate::replaceDSL(core::MutableContext ct
             methodName = lit->asSymbol(ctx);
         }
         // sig {params(arg0: T.untyped).returns(T.untyped)}
-        // def $methodName(*arg0); end
+        // def $methodName(*arg0, &blk); end
+        ast::MethodDef::ARGS_store args;
+        args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
+        args.emplace_back(std::make_unique<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
+
         methodStubs.push_back(ast::MK::Sig1(loc, ast::MK::Symbol(loc, core::Names::arg0()), ast::MK::Untyped(loc),
                                             ast::MK::Untyped(loc)));
-        methodStubs.push_back(ast::MK::Method1(loc, loc, methodName,
-                                               ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())),
-                                               ast::MK::EmptyTree(), ast::MethodDef::DSLSynthesized));
+        methodStubs.push_back(ast::MK::Method(loc, loc, methodName, std::move(args), ast::MK::EmptyTree(),
+                                              ast::MethodDef::DSLSynthesized));
     }
 
     return methodStubs;

--- a/dsl/Delegate.cc
+++ b/dsl/Delegate.cc
@@ -107,14 +107,23 @@ vector<unique_ptr<ast::Expression>> Delegate::replaceDSL(core::MutableContext ct
         } else {
             methodName = lit->asSymbol(ctx);
         }
-        // sig {params(arg0: T.untyped).returns(T.untyped)}
+        // sig {params(arg0: T.untyped, blk: Proc).returns(T.untyped)}
+        ast::Hash::ENTRY_store paramsKeys;
+        paramsKeys.emplace_back(ast::MK::Symbol(loc, core::Names::arg0()));
+        paramsKeys.emplace_back(ast::MK::Symbol(loc, core::Names::blkArg()));
+
+        ast::Hash::ENTRY_store paramsValues;
+        paramsValues.emplace_back(ast::MK::Untyped(loc));
+        paramsValues.emplace_back(ast::MK::Nilable(loc, ast::MK::Constant(loc, core::Symbols::Proc())));
+
+        methodStubs.push_back(ast::MK::Sig(loc, ast::MK::Hash(loc, std::move(paramsKeys), std::move(paramsValues)),
+                                           ast::MK::Untyped(loc)));
+
         // def $methodName(*arg0, &blk); end
         ast::MethodDef::ARGS_store args;
         args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
         args.emplace_back(std::make_unique<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
 
-        methodStubs.push_back(ast::MK::Sig1(loc, ast::MK::Symbol(loc, core::Names::arg0()), ast::MK::Untyped(loc),
-                                            ast::MK::Untyped(loc)));
         methodStubs.push_back(ast::MK::Method(loc, loc, methodName, std::move(args), ast::MK::EmptyTree(),
                                               ast::MethodDef::DSLSynthesized));
     }

--- a/test/testdata/dsl/rails/delegate.rb
+++ b/test/testdata/dsl/rails/delegate.rb
@@ -45,3 +45,11 @@ class IgnoredUsages
   delegate :foo, :bar, to: :@hi, prefix: true # error: Method `delegate` does not exist
   delegate :foo, :bar, to: '', prefix: true # error: Method `delegate` does not exist
 end
+
+class EnumerableUsage
+  include Enumerable
+
+  Elem = type_member
+
+  delegate :each, to: :foo
+end

--- a/test/testdata/dsl/rails/delegate.rb.dsl-tree.exp
+++ b/test/testdata/dsl/rails/delegate.rb.dsl-tree.exp
@@ -1,0 +1,170 @@
+class <emptyTree><<C <root>>> < ()
+  class <emptyTree>::<C GoodUsages><<C <todo sym>>> < (::<todo sym>)
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({:"arg0" => ::T.untyped(), :"<blk>" => ::T.nilable(::Proc)}).returns(::T.untyped())
+    end
+
+    def foo<<C <todo sym>>>(*arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({:"arg0" => ::T.untyped(), :"<blk>" => ::T.nilable(::Proc)}).returns(::T.untyped())
+    end
+
+    def bar<<C <todo sym>>>(*arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({:"arg0" => ::T.untyped(), :"<blk>" => ::T.nilable(::Proc)}).returns(::T.untyped())
+    end
+
+    def baz<<C <todo sym>>>(*arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({:"arg0" => ::T.untyped(), :"<blk>" => ::T.nilable(::Proc)}).returns(::T.untyped())
+    end
+
+    def ball<<C <todo sym>>>(*arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({:"arg0" => ::T.untyped(), :"<blk>" => ::T.nilable(::Proc)}).returns(::T.untyped())
+    end
+
+    def string_foo<<C <todo sym>>>(*arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({:"arg0" => ::T.untyped(), :"<blk>" => ::T.nilable(::Proc)}).returns(::T.untyped())
+    end
+
+    def string_bar<<C <todo sym>>>(*arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({:"arg0" => ::T.untyped(), :"<blk>" => ::T.nilable(::Proc)}).returns(::T.untyped())
+    end
+
+    def symbol_foo<<C <todo sym>>>(*arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({:"arg0" => ::T.untyped(), :"<blk>" => ::T.nilable(::Proc)}).returns(::T.untyped())
+    end
+
+    def symbol_bar<<C <todo sym>>>(*arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({:"arg0" => ::T.untyped(), :"<blk>" => ::T.nilable(::Proc)}).returns(::T.untyped())
+    end
+
+    def true_foo<<C <todo sym>>>(*arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({:"arg0" => ::T.untyped(), :"<blk>" => ::T.nilable(::Proc)}).returns(::T.untyped())
+    end
+
+    def true_bar<<C <todo sym>>>(*arg0, &<blk>)
+      <emptyTree>
+    end
+
+    <self>.sig() do ||
+      <self>.void()
+    end
+
+    def usages<<C <todo sym>>>(&<blk>)
+      begin
+        <self>.foo() do ||
+          <emptyTree>
+        end
+        <self>.bar(1, 3, 4, 5)
+        <self>.baz()
+        <self>.ball({:"thing" => 0}) do ||
+          <emptyTree>
+        end
+        <self>.string_foo()
+        <self>.string_bar()
+        <self>.symbol_foo() do ||
+          <emptyTree>
+        end
+        <self>.symbol_bar(1, 2) do ||
+          <emptyTree>
+        end
+        <self>.true_foo()
+        <self>.true_bar()
+      end
+    end
+  end
+
+  class <emptyTree>::<C WorksWithoutExtendingTSig><<C <todo sym>>> < (::<todo sym>)
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({:"arg0" => ::T.untyped(), :"<blk>" => ::T.nilable(::Proc)}).returns(::T.untyped())
+    end
+
+    def foo<<C <todo sym>>>(*arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({:"arg0" => ::T.untyped(), :"<blk>" => ::T.nilable(::Proc)}).returns(::T.untyped())
+    end
+
+    def bar<<C <todo sym>>>(*arg0, &<blk>)
+      <emptyTree>
+    end
+  end
+
+  class <emptyTree>::<C IgnoredUsages><<C <todo sym>>> < (::<todo sym>)
+    local = 0
+
+    <self>.not_delegate(:"thing", {:"to" => :"nop"})
+
+    <self>.delegate()
+
+    <self>.delegate(:"thing")
+
+    <self>.delegate({:"to" => :"thing"})
+
+    <self>.delegate(:"thing", {:"prefix" => :"thing"})
+
+    <self>.delegate(:"foo", {:"to" => :"thing", :"prefix" => local})
+
+    <self>.delegate(:"foo", {local => :"thing"})
+
+    <self>.delegate(234, {:"to" => :"good"})
+
+    <self>.delegate({:"thing" => :"thing"})
+
+    <self>.delegate(:"foo", :"bar", {:"to" => :"@hi", :"prefix" => true})
+
+    <self>.delegate(:"foo", :"bar", {:"to" => "", :"prefix" => true})
+  end
+
+  class <emptyTree>::<C EnumerableUsage><<C <todo sym>>> < (::<todo sym>)
+    <self>.include(<emptyTree>::<C Enumerable>)
+
+    <emptyTree>::<C Elem> = <self>.type_member()
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({:"arg0" => ::T.untyped(), :"<blk>" => ::T.nilable(::Proc)}).returns(::T.untyped())
+    end
+
+    def each<<C <todo sym>>>(*arg0, &<blk>)
+      <emptyTree>
+    end
+  end
+end


### PR DESCRIPTION
The PR adds an extra block argument to the (synthetic) methods generated by the `delegate` DSL, so that `delegate :foo, to: :bar` generates `def foo(*args, &blk); end` instead of, what is now, `def foo(*args); end`.

### Motivation

The reason this is needed is because it is common for types that are `Enumerable` to `delegate` the `each` method to something else. However, a recent change in Sorbet made the block argument in `Enumerable#each` mandatory.

Currently, running `sorbet -e "class A; include Enumerable; delegate :each, to: :foo; end"` would give:
```
-e:1: Implementation of abstract method Enumerable#each must explicitly name a block argument https://srb.help/5035
     1 |class A; include Enumerable; delegate :each, to: :foo; end
                                     ^^^^^^^^^^^^^^^^^^^^^^^^
    https://github.com/sorbet/sorbet/tree/a4a1e7eb5e9aefa178711b77c857857b7793b315/rbi/core/enumerable.rbi#L17: Base method defined here
    17 |  def each(&blk); end
          ^^^^^^^^^^^^^^
Errors: 1
```

After this PR, the output is:
```
No errors! Great job.
```
### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
