### PR TITLE
Make thread IDs in htop match numbers in idle thread names

### DIFF
--- a/common/concurrency/WorkerPoolImpl.cc
+++ b/common/concurrency/WorkerPoolImpl.cc
@@ -23,7 +23,7 @@ WorkerPoolImpl::WorkerPoolImpl(int size, spd::logger &logger) : size(size), logg
         for (int i = 0; i < size; i++) {
             auto &last = threadQueues.emplace_back(make_unique<Queue>());
             auto *ptr = last.get();
-            auto threadIdleName = absl::StrCat("idle", i);
+            auto threadIdleName = absl::StrCat("idle", i + 1);
             optional<int> pinToCore;
             if (pinThreads) {
                 pinToCore = i;


### PR DESCRIPTION
Convenience thing

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
