### PR TITLE
Avoid generating invalid symbols due to constant redefinition

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -235,6 +235,7 @@ public:
                 auto origName = klass->symbol.data(ctx)->name;
                 ctx.state.mangleRenameSymbol(klass->symbol, klass->symbol.data(ctx)->name);
                 klass->symbol = ctx.state.enterClassSymbol(klass->declLoc, klass->symbol.data(ctx)->owner, origName);
+                klass->symbol.data(ctx)->setIsModule(isModule);
 
                 auto oldSymCount = ctx.state.symbolsUsed();
                 auto newSignleton =

--- a/test/cli/incremental-resolver/expect-failures/constant_override.rb
+++ b/test/cli/incremental-resolver/expect-failures/constant_override.rb
@@ -1,0 +1,7 @@
+#typed:true
+B = e
+module B
+  extend T::Sig
+  sig { returns(T.all(B,T)) }
+  def foo; T.unsafe(nil); end
+end

--- a/test/cli/incremental-resolver/incremental-resolver.out
+++ b/test/cli/incremental-resolver/incremental-resolver.out
@@ -17,3 +17,42 @@ test/cli/incremental-resolver/expect-failures/abstract_impl.rb:126: Implementati
      123 |  def foo(*foo)end
             ^^^^^^^^^^^^^
 Errors: 2
+----- test/cli/incremental-resolver/expect-failures/constant_override.rb ---------------------
+test/cli/incremental-resolver/expect-failures/constant_override.rb:3: Redefining constant `B` https://srb.help/4012
+     3 |module B
+     4 |  extend T::Sig
+     5 |  sig { returns(T.all(B,T)) }
+     6 |  def foo; T.unsafe(nil); end
+     7 |end
+    test/cli/incremental-resolver/expect-failures/constant_override.rb:2: Previous definition
+     2 |B = e
+        ^
+
+test/cli/incremental-resolver/expect-failures/constant_override.rb:110: Redefining constant `B` https://srb.help/4012
+     110 |B = e
+          ^^^^^
+    test/cli/incremental-resolver/expect-failures/constant_override.rb:19: Previous definition
+    19 |
+    20 |
+    21 |
+    22 |
+    23 |
+    24 |
+    25 |
+    26 |
+    27 |
+
+test/cli/incremental-resolver/expect-failures/constant_override.rb:111: Redefining constant `B` https://srb.help/4012
+     111 |module B
+     112 |  extend T::Sig
+     113 |  sig { returns(T.all(B,T)) }
+     114 |  def foo; T.unsafe(nil); end
+     115 |end
+    test/cli/incremental-resolver/expect-failures/constant_override.rb:110: Previous definition
+     110 |B = e
+          ^
+
+test/cli/incremental-resolver/expect-failures/constant_override.rb:110: Method `e` does not exist on `T.class_of(<root>)` https://srb.help/7003
+     110 |B = e
+              ^
+Errors: 4

--- a/test/testdata/namer/class_and_alias.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/class_and_alias.rb.symbol-table-raw.exp
@@ -2,9 +2,9 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
   class <S <C <U <root>>> $1> < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $108> (<blk>) @ Loc {file=test/testdata/namer/class_and_alias.rb start=3:1 end=9:7}
       argument <blk><block> @ Loc {file=test/testdata/namer/class_and_alias.rb start=??? end=???}
-  class <C <U A>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/namer/class_and_alias.rb start=4:1 end=4:8}
+  class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/namer/class_and_alias.rb start=4:1 end=4:8}
   static-field <M <C <U A>> $1> -> Integer(91) @ Loc {file=test/testdata/namer/class_and_alias.rb start=3:1 end=3:2}
-  class <S <C <U A>> $1> < <C <U Module>> () @ Loc {file=test/testdata/namer/class_and_alias.rb start=4:1 end=4:8}
+  class <S <C <U A>> $1> < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/class_and_alias.rb start=4:1 end=4:8}
     method <S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/class_and_alias.rb start=4:1 end=5:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/class_and_alias.rb start=??? end=???}
   static-field <C <U B>> -> Integer(91) @ Loc {file=test/testdata/namer/class_and_alias.rb start=9:1 end=9:2}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes #1197; in some cases we would generate new symbols because of constant redefinition, and those symbols would have their `isClass` bit set but neither `isClassClass` nor `isClassModule` would get set, resulting in exceptions later on in the pipeline. This ensures that one of those bits is always set.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests, including a cleaned-up version of the fuzzer-generated program.
