### PR TITLE
Rework: DispatchResult, DispatchComponent and SendBlockAndLink

### DIFF
--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -27,7 +27,7 @@ class SerializerImpl;
 }
 class IntrinsicMethod {
 public:
-    virtual TypePtr apply(Context ctx, DispatchArgs args, const Type *thisType) const = 0;
+    virtual void apply(Context ctx, DispatchArgs args, const Type *thisType, DispatchResult &res) const = 0;
 };
 
 enum class Variance { CoVariant = 1, ContraVariant = -1, Invariant = 0 };

--- a/core/TypeConstraint.cc
+++ b/core/TypeConstraint.cc
@@ -138,9 +138,9 @@ TypePtr TypeConstraint::getInstantiation(SymbolRef sym) const {
     return findSolution(sym);
 }
 
-shared_ptr<TypeConstraint> TypeConstraint::deepCopy() const {
+unique_ptr<TypeConstraint> TypeConstraint::deepCopy() const {
     ENFORCE(!wasSolved);
-    auto res = make_shared<TypeConstraint>();
+    auto res = make_unique<TypeConstraint>();
     res->lowerBounds = this->lowerBounds;
     res->upperBounds = this->upperBounds;
     return res;

--- a/core/TypeConstraint.h
+++ b/core/TypeConstraint.h
@@ -1,7 +1,9 @@
 #ifndef SORBET_TYPECONSTRAINT_H
 #define SORBET_TYPECONSTRAINT_H
 
-#include "Types.h"
+#include "core/Context.h"
+#include "core/SymbolRef.h"
+#include "core/TypePtr.h"
 namespace sorbet::core {
 
 class TypeConstraint {

--- a/core/TypeConstraint.h
+++ b/core/TypeConstraint.h
@@ -41,7 +41,7 @@ public:
     // returns true if was successfully solved
     bool solve(Context ctx);
     TypePtr getInstantiation(SymbolRef) const;
-    std::shared_ptr<TypeConstraint> deepCopy() const;
+    std::unique_ptr<TypeConstraint> deepCopy() const;
     InlinedVector<SymbolRef, 4> getDomain() const;
     static TypeConstraint EmptyFrozenConstraint;
     std::string toString(Context ctx) const;

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -1,0 +1,52 @@
+#ifndef SORBET_TYPEPTR_H
+#define SORBET_TYPEPTR_H
+#include "common/common.h"
+#include <memory>
+
+namespace sorbet::core {
+// using TypePtr = std::shared_ptr<Type>;
+class Type;
+class TypePtr {
+    std::shared_ptr<Type> store;
+    TypePtr(std::shared_ptr<Type> &&store);
+
+public:
+    TypePtr() = default;
+    TypePtr(TypePtr &&other) = default;
+    TypePtr(const TypePtr &other) = default;
+    TypePtr &operator=(TypePtr &&other) = default;
+    TypePtr &operator=(const TypePtr &other) = default;
+    explicit TypePtr(Type *ptr) : store(ptr) {}
+    TypePtr(std::nullptr_t n) : store(nullptr) {}
+    operator bool() const {
+        return (bool)store;
+    }
+    Type *get() const {
+        return store.get();
+    }
+    Type *operator->() const {
+        return get();
+    }
+    Type &operator*() const {
+        return *get();
+    }
+    bool operator!=(const TypePtr &other) const {
+        return store != other.store;
+    }
+    bool operator==(const TypePtr &other) const {
+        return store == other.store;
+    }
+    bool operator!=(std::nullptr_t n) const {
+        return store != nullptr;
+    }
+    bool operator==(std::nullptr_t n) const {
+        return store == nullptr;
+    }
+    friend class Symbol;
+
+    template <class T, class... Args> friend TypePtr make_type(Args &&... args);
+};
+CheckSize(TypePtr, 16, 8);
+} // namespace sorbet::core
+
+#endif

--- a/core/Types.h
+++ b/core/Types.h
@@ -130,7 +130,7 @@ public:
      * tc.solve(). If the constraint has already been solved, use `instantiate` instead.
      */
     static TypePtr approximate(Context ctx, const TypePtr &what, const TypeConstraint &tc);
-
+    static TypePtr dispatchCallWithoutBlock(Context ctx, const TypePtr &recv, DispatchArgs args);
     static TypePtr dropLiteral(const TypePtr &tp);
 
     /** Internal implementation. You should probably use all(). */

--- a/core/Types.h
+++ b/core/Types.h
@@ -5,10 +5,10 @@
 #include "core/Context.h"
 #include "core/Error.h"
 #include "core/SymbolRef.h"
+#include "core/TypeConstraint.h"
 #include <memory>
 #include <optional>
 #include <string>
-
 namespace sorbet::core {
 /** Dmitry: unlike in Dotty, those types are always dealiased. For now */
 class Type;
@@ -23,49 +23,6 @@ class Symbol;
 class TypeVar;
 class SendAndBlockLink;
 class TypeAndOrigins;
-// using TypePtr = std::shared_ptr<Type>;
-
-class TypePtr {
-    std::shared_ptr<Type> store;
-    TypePtr(std::shared_ptr<Type> &&store);
-
-public:
-    TypePtr() = default;
-    TypePtr(TypePtr &&other) = default;
-    TypePtr(const TypePtr &other) = default;
-    TypePtr &operator=(TypePtr &&other) = default;
-    TypePtr &operator=(const TypePtr &other) = default;
-    explicit TypePtr(Type *ptr) : store(ptr) {}
-    TypePtr(std::nullptr_t n) : store(nullptr) {}
-    operator bool() const {
-        return (bool)store;
-    }
-    Type *get() const {
-        return store.get();
-    }
-    Type *operator->() const {
-        return get();
-    }
-    Type &operator*() const {
-        return *get();
-    }
-    bool operator!=(const TypePtr &other) const {
-        return store != other.store;
-    }
-    bool operator==(const TypePtr &other) const {
-        return store == other.store;
-    }
-    bool operator!=(std::nullptr_t n) const {
-        return store != nullptr;
-    }
-    bool operator==(std::nullptr_t n) const {
-        return store == nullptr;
-    }
-    friend class Symbol;
-
-    template <class T, class... Args> friend TypePtr make_type(Args &&... args);
-};
-CheckSize(TypePtr, 16, 8);
 
 class ArgInfo {
 public:

--- a/core/lsp/QueryResponse.cc
+++ b/core/lsp/QueryResponse.cc
@@ -5,29 +5,6 @@ template class std::unique_ptr<sorbet::core::lsp::QueryResponse>;
 using namespace std;
 namespace sorbet::core::lsp {
 
-SendResponse::SendResponse(core::DispatchResult::ComponentVec dispatchComponents,
-                           std::shared_ptr<core::TypeConstraint> constraint, core::Loc termLoc, core::NameRef name,
-                           core::TypeAndOrigins receiver, core::TypeAndOrigins retType)
-    : dispatchComponents(std::move(dispatchComponents)), constraint(std::move(constraint)), termLoc(termLoc),
-      name(name), receiver(std::move(receiver)), retType(std::move(retType)) {}
-
-IdentResponse::IdentResponse(core::SymbolRef owner, core::Loc termLoc, core::LocalVariable variable,
-                             core::TypeAndOrigins retType)
-    : owner(owner), termLoc(termLoc), variable(variable), retType(std::move(retType)) {}
-
-LiteralResponse::LiteralResponse(core::SymbolRef owner, core::Loc termLoc, core::TypeAndOrigins retType)
-    : owner(owner), termLoc(termLoc), retType(std::move(retType)) {}
-
-ConstantResponse::ConstantResponse(core::SymbolRef owner, core::DispatchResult::ComponentVec dispatchComponents,
-                                   core::Loc termLoc, core::NameRef name, core::TypeAndOrigins receiver,
-                                   core::TypeAndOrigins retType)
-    : owner(owner), dispatchComponents(std::move(dispatchComponents)), termLoc(termLoc), name(name),
-      receiver(std::move(receiver)), retType(std::move(retType)) {}
-
-DefinitionResponse::DefinitionResponse(core::DispatchResult::ComponentVec dispatchComponents, core::Loc termLoc,
-                                       core::NameRef name, core::TypeAndOrigins retType)
-    : dispatchComponents(std::move(dispatchComponents)), termLoc(termLoc), name(name), retType(std::move(retType)) {}
-
 void QueryResponse::pushQueryResponse(core::Context ctx, QueryResponseVariant response) {
     ctx.state.errorQueue->pushQueryResponse(make_unique<QueryResponse>(std::move(response)));
 }
@@ -74,7 +51,7 @@ core::TypePtr QueryResponse::getRetType() const {
     if (auto ident = isIdent()) {
         return ident->retType.type;
     } else if (auto send = isSend()) {
-        return send->retType.type;
+        return send->dispatchResult->returnType;
     } else if (auto literal = isLiteral()) {
         return literal->retType.type;
     } else if (auto constant = isConstant()) {
@@ -86,17 +63,17 @@ core::TypePtr QueryResponse::getRetType() const {
     }
 }
 
-const core::DispatchResult::ComponentVec emptyDispatchComponents;
-
-const core::DispatchResult::ComponentVec &QueryResponse::getDispatchComponents() const {
-    if (auto send = get_if<SendResponse>(&response)) {
-        return send->dispatchComponents;
-    } else if (auto constant = get_if<ConstantResponse>(&response)) {
-        return constant->dispatchComponents;
-    } else if (auto def = get_if<DefinitionResponse>(&response)) {
-        return def->dispatchComponents;
+const core::TypeAndOrigins &QueryResponse::getTypeAndOrigins() const {
+    if (auto ident = isIdent()) {
+        return ident->retType;
+    } else if (auto literal = isLiteral()) {
+        return literal->retType;
+    } else if (auto constant = isConstant()) {
+        return constant->retType;
+    } else if (auto def = isDefinition()) {
+        return def->retType;
     } else {
-        return emptyDispatchComponents;
+        Exception::raise("QueryResponse is of type that does not have TypeAndOrigins.");
     }
 }
 

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -10,20 +10,17 @@ class TypeConstraint;
 
 class SendResponse final {
 public:
-    SendResponse(core::DispatchResult::ComponentVec dispatchComponents,
-                 std::shared_ptr<core::TypeConstraint> constraint, core::Loc termLoc, core::NameRef name,
-                 core::TypeAndOrigins receiver, core::TypeAndOrigins retType);
-    core::DispatchResult::ComponentVec dispatchComponents;
-    const std::shared_ptr<core::TypeConstraint> constraint;
+    SendResponse(core::Loc termLoc, std::shared_ptr<core::DispatchResult> dispatchResult, core::NameRef callerSideName)
+        : dispatchResult(std::move(dispatchResult)), callerSideName(callerSideName), termLoc(termLoc){};
+    const std::shared_ptr<core::DispatchResult> dispatchResult;
+    const core::NameRef callerSideName;
     const core::Loc termLoc;
-    const core::NameRef name;
-    const core::TypeAndOrigins receiver;
-    const core::TypeAndOrigins retType;
 };
 
 class IdentResponse final {
 public:
-    IdentResponse(core::SymbolRef owner, core::Loc termLoc, core::LocalVariable variable, core::TypeAndOrigins retType);
+    IdentResponse(core::SymbolRef owner, core::Loc termLoc, core::LocalVariable variable, core::TypeAndOrigins retType)
+        : owner(owner), termLoc(termLoc), variable(variable), retType(std::move(retType)){};
     const core::SymbolRef owner;
     const core::Loc termLoc;
     const core::LocalVariable variable;
@@ -32,7 +29,8 @@ public:
 
 class LiteralResponse final {
 public:
-    LiteralResponse(core::SymbolRef owner, core::Loc termLoc, core::TypeAndOrigins retType);
+    LiteralResponse(core::SymbolRef owner, core::Loc termLoc, core::TypeAndOrigins retType)
+        : owner(owner), termLoc(termLoc), retType(std::move(retType)){};
     const core::SymbolRef owner;
     const core::Loc termLoc;
     const core::TypeAndOrigins retType;
@@ -40,21 +38,21 @@ public:
 
 class ConstantResponse final {
 public:
-    ConstantResponse(core::SymbolRef owner, core::DispatchResult::ComponentVec dispatchComponents, core::Loc termLoc,
-                     core::NameRef name, core::TypeAndOrigins receiver, core::TypeAndOrigins retType);
+    ConstantResponse(core::SymbolRef owner, core::SymbolRef symbol, core::Loc termLoc, core::NameRef name,
+                     core::TypeAndOrigins receiver, core::TypeAndOrigins retType)
+        : owner(owner), symbol(symbol), termLoc(termLoc), name(name), retType(std::move(retType)){};
     const core::SymbolRef owner;
-    core::DispatchResult::ComponentVec dispatchComponents;
+    const core::SymbolRef symbol;
     const core::Loc termLoc;
     const core::NameRef name;
-    const core::TypeAndOrigins receiver;
     const core::TypeAndOrigins retType;
 };
 
 class DefinitionResponse final {
 public:
-    DefinitionResponse(core::DispatchResult::ComponentVec dispatchComponents, core::Loc termLoc, core::NameRef name,
-                       core::TypeAndOrigins retType);
-    core::DispatchResult::ComponentVec dispatchComponents;
+    DefinitionResponse(core::SymbolRef symbol, core::Loc termLoc, core::NameRef name, core::TypeAndOrigins retType)
+        : symbol(symbol), termLoc(termLoc), name(name), retType(std::move(retType)){};
+    const core::SymbolRef symbol;
     const core::Loc termLoc;
     const core::NameRef name;
     const core::TypeAndOrigins retType;
@@ -115,10 +113,10 @@ public:
     core::TypePtr getRetType() const;
 
     /**
-     * Returns dispatch components associated with this response, if any.
-     * If none, returns an empty vector.
+     * Returns a reference to this response's TypeAndOrigins, if it has any.
+     * If response is of a type without TypeAndOrigins, it throws an exception.
      */
-    const core::DispatchResult::ComponentVec &getDispatchComponents() const;
+    const core::TypeAndOrigins &getTypeAndOrigins() const;
 };
 
 } // namespace sorbet::core::lsp

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -29,13 +29,8 @@ DispatchResult OrType::dispatchCall(Context ctx, DispatchArgs args) {
     categoryCounterInc("dispatch_call", "ortype");
     auto leftRet = left->dispatchCall(ctx, args.withSelfRef(left));
     auto rightRet = right->dispatchCall(ctx, args.withSelfRef(right));
-    DispatchResult::ComponentVec components = std::move(leftRet.components);
-    components.insert(components.end(), make_move_iterator(rightRet.components.begin()),
-                      make_move_iterator(rightRet.components.end()));
-    DispatchResult ret{
-        Types::any(ctx, leftRet.returnType, rightRet.returnType),
-        std::move(components),
-    };
+    DispatchResult ret{Types::any(ctx, leftRet.returnType, rightRet.returnType), move(leftRet.main),
+                       make_unique<DispatchResult>(move(rightRet)), DispatchResult::Combinator::OR};
     return ret;
 }
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -35,7 +35,15 @@ DispatchResult OrType::dispatchCall(Context ctx, DispatchArgs args) {
 }
 
 TypePtr OrType::getCallArguments(Context ctx, NameRef name) {
-    return left->getCallArguments(ctx, name); // TODO: should glb with right
+    auto largs = left->getCallArguments(ctx, name);
+    auto rargs = right->getCallArguments(ctx, name);
+    if (!largs) {
+        largs = Types::untypedUntracked();
+    }
+    if (!rargs) {
+        rargs = Types::untypedUntracked();
+    }
+    return Types::glb(ctx, largs, rargs);
 }
 
 DispatchResult TypeVar::dispatchCall(Context ctx, DispatchArgs args) {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -740,11 +740,7 @@ bool ShapeType::hasUntyped() {
     }
     return false;
 };
-SendAndBlockLink::SendAndBlockLink(NameRef fun, vector<ArgInfo::ArgFlags> &&argFlags)
-    : fun(fun), argFlags(argFlags), constr(make_shared<TypeConstraint>()) {}
-SendAndBlockLink::SendAndBlockLink(const SendAndBlockLink &orig)
-    : receiver(orig.receiver), fun(orig.fun), argFlags(orig.argFlags), constr(orig.constr), returnTp(orig.returnTp),
-      blockPreType(orig.blockPreType), blockSpec(orig.blockSpec.deepCopy()), sendTp(orig.sendTp) {}
+SendAndBlockLink::SendAndBlockLink(NameRef fun, vector<ArgInfo::ArgFlags> &&argFlags) : argFlags(argFlags), fun(fun) {}
 
 shared_ptr<SendAndBlockLink> SendAndBlockLink::duplicate() {
     auto copy = *this;
@@ -849,12 +845,4 @@ core::SymbolRef Types::getRepresentedClass(core::Context ctx, const core::Type *
 DispatchArgs DispatchArgs::withSelfRef(const TypePtr &newSelfRef) {
     return DispatchArgs{name, locs, args, newSelfRef, fullType, block};
 }
-
-core::TypeConstraint &DispatchArgs::constraint() {
-    if (!block || !block->constr) {
-        return core::TypeConstraint::EmptyFrozenConstraint;
-    }
-    return *block->constr;
-}
-
 } // namespace sorbet::core

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -38,14 +38,10 @@ unique_ptr<ast::MethodDef> DefLocSaver::postTransformMethodDef(core::Context ctx
             }
         }
 
-        core::DispatchComponent dispatchComponent;
-        core::DispatchResult::ComponentVec dispatchComponents;
-        dispatchComponent.method = methodDef->symbol;
-        dispatchComponents.emplace_back(std::move(dispatchComponent));
         tp.type = symbolData->resultType;
         tp.origins.emplace_back(methodDef->declLoc);
         core::lsp::QueryResponse::pushQueryResponse(
-            ctx, core::lsp::DefinitionResponse(std::move(dispatchComponents), methodDef->declLoc, methodDef->name, tp));
+            ctx, core::lsp::DefinitionResponse(methodDef->symbol, methodDef->declLoc, methodDef->name, tp));
     }
 
     return methodDef;

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -205,7 +205,7 @@ class LSPLoop {
                                            const CompletionParams &params);
     std::unique_ptr<CompletionItem> getCompletionItem(const core::GlobalState &gs, core::SymbolRef what,
                                                       core::TypePtr receiverType,
-                                                      const std::shared_ptr<core::TypeConstraint> &constraint);
+                                                      const std::unique_ptr<core::TypeConstraint> &constraint);
     void findSimilarConstantOrIdent(const core::GlobalState &gs, const core::TypePtr receiverType,
                                     std::vector<std::unique_ptr<CompletionItem>> &items);
     void sendShowMessageNotification(MessageType messageType, std::string_view message);
@@ -264,9 +264,9 @@ std::optional<std::string> findDocumentation(std::string_view sourceCode, int be
 bool hasSimilarName(const core::GlobalState &gs, core::NameRef name, std::string_view pattern);
 bool hideSymbol(const core::GlobalState &gs, core::SymbolRef sym);
 std::string methodDetail(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver,
-                         core::TypePtr retType, const std::shared_ptr<core::TypeConstraint> &constraint);
+                         core::TypePtr retType, const std::unique_ptr<core::TypeConstraint> &constraint);
 core::TypePtr getResultType(const core::GlobalState &gs, core::TypePtr type, core::SymbolRef inWhat,
-                            core::TypePtr receiver, const std::shared_ptr<core::TypeConstraint> &constr);
+                            core::TypePtr receiver, const std::unique_ptr<core::TypeConstraint> &constr);
 SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef);
 std::unique_ptr<Range> loc2Range(const core::GlobalState &gs, core::Loc loc);
 

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -121,7 +121,7 @@ bool hasSimilarName(const core::GlobalState &gs, core::NameRef name, string_view
 }
 
 string methodDetail(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver, core::TypePtr retType,
-                    const shared_ptr<core::TypeConstraint> &constraint) {
+                    const unique_ptr<core::TypeConstraint> &constraint) {
     ENFORCE(method.exists());
     // handle this case anyways so that we don't crash in prod when this method is mis-used
     if (!method.exists()) {
@@ -182,7 +182,7 @@ string methodDetail(const core::GlobalState &gs, core::SymbolRef method, core::T
 }
 
 core::TypePtr getResultType(const core::GlobalState &gs, core::TypePtr type, core::SymbolRef inWhat,
-                            core::TypePtr receiver, const shared_ptr<core::TypeConstraint> &constr) {
+                            core::TypePtr receiver, const unique_ptr<core::TypeConstraint> &constr) {
     core::Context ctx(gs, inWhat);
     auto resultType = type;
     if (auto *proxy = core::cast_type<core::ProxyType>(receiver.get())) {

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -196,8 +196,9 @@ core::TypePtr getResultType(const core::GlobalState &gs, core::TypePtr type, cor
     if (!resultType) {
         resultType = core::Types::untypedUntracked();
     }
-
-    resultType = core::Types::replaceSelfType(ctx, resultType, receiver); // instantiate self types
+    if (receiver) {
+        resultType = core::Types::replaceSelfType(ctx, resultType, receiver); // instantiate self types
+    }
     if (constr) {
         resultType = core::Types::instantiate(ctx, resultType, *constr); // instantiate generic methods
     }

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -126,7 +126,7 @@ optional<string> findDocumentation(string_view sourceCode, int beginIndex) {
 
 unique_ptr<CompletionItem> LSPLoop::getCompletionItem(const core::GlobalState &gs, core::SymbolRef what,
                                                       core::TypePtr receiverType,
-                                                      const shared_ptr<core::TypeConstraint> &constraint) {
+                                                      const unique_ptr<core::TypeConstraint> &constraint) {
     ENFORCE(what.exists());
     auto item = make_unique<CompletionItem>(string(what.data(gs)->name.data(gs)->shortName(gs)));
     auto resultType = what.data(gs)->resultType;

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -210,8 +210,8 @@ LSPResult LSPLoop::handleTextDocumentCompletion(unique_ptr<core::GlobalState> gs
             auto resp = move(queryResponses[0]);
 
             if (auto sendResp = resp->isSend()) {
-                auto pattern = sendResp->name.data(*gs)->shortName(*gs);
-                auto receiverType = sendResp->receiver.type;
+                auto pattern = sendResp->callerSideName.data(*gs)->shortName(*gs);
+                auto receiverType = sendResp->dispatchResult->main.receiver;
                 logger->debug("Looking for method similar to {}", pattern);
                 UnorderedMap<core::NameRef, vector<core::SymbolRef>> methods =
                     findSimilarMethodsIn(*gs, receiverType, pattern);
@@ -229,8 +229,8 @@ LSPResult LSPLoop::handleTextDocumentCompletion(unique_ptr<core::GlobalState> gs
                 for (auto &entry : methodsSorted) {
                     if (entry.second[0].exists()) {
                         fast_sort(entry.second, [&](auto lhs, auto rhs) -> bool { return lhs._id < rhs._id; });
-                        items.push_back(
-                            getCompletionItem(*gs, entry.second[0], sendResp->receiver.type, sendResp->constraint));
+                        items.push_back(getCompletionItem(*gs, entry.second[0], receiverType,
+                                                          sendResp->dispatchResult->main.constr));
                     }
                 }
             } else if (auto identResp = resp->isIdent()) {

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -7,7 +7,7 @@ namespace sorbet::realmain::lsp {
 
 string methodSignatureString(const core::GlobalState &gs, const core::TypePtr &retType,
                              const core::DispatchResult::ComponentVec &dispatchComponents,
-                             const shared_ptr<core::TypeConstraint> &constraint) {
+                             const unique_ptr<core::TypeConstraint> &constraint) {
     string contents = "";
     for (auto &dispatchComponent : dispatchComponents) {
         if (dispatchComponent.method.exists()) {

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -28,8 +28,8 @@ LSPResult LSPLoop::handleTextDocumentReferences(unique_ptr<core::GlobalState> gs
             auto resp = move(queryResponses[0]);
 
             if (auto constResp = resp->isConstant()) {
-                if (!constResp->dispatchComponents.empty()) {
-                    auto symRef = constResp->dispatchComponents[0].method;
+                if (constResp->symbol.exists()) {
+                    auto symRef = constResp->symbol;
                     auto run2 = setupLSPQueryBySymbol(move(gs), symRef);
                     gs = move(run2.gs);
                     vector<unique_ptr<Location>> result;

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -33,7 +33,9 @@ void addSignatureHelpItem(const core::GlobalState &gs, core::SymbolRef method,
         if (i != args.size() - 1) {
             methodDocumentation += ", ";
         }
-        parameter->documentation = getResultType(gs, arg.type, method, resp.receiver.type, resp.constraint)->show(gs);
+        parameter->documentation =
+            getResultType(gs, arg.type, method, resp.dispatchResult->main.receiver, resp.dispatchResult->main.constr)
+                ->show(gs);
         parameters.push_back(move(parameter));
         i += 1;
     }
@@ -85,7 +87,7 @@ LSPResult LSPLoop::handleTextSignatureHelp(unique_ptr<core::GlobalState> gs, con
                 // 2nd arg)
                 activeParameter = numberCommas;
 
-                auto firstDispatchComponentMethod = sendResp->dispatchComponents.front().method;
+                auto firstDispatchComponentMethod = sendResp->dispatchResult->main.method;
 
                 addSignatureHelpItem(*gs, firstDispatchComponentMethod, signatures, *sendResp, numberCommas);
             }

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -769,13 +769,7 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
                 argLocs,
             };
             core::DispatchArgs dispatchArgs{core::Names::squareBrackets(), locs, targs, ctype, ctype, nullptr};
-            auto dispatched = ctype->dispatchCall(ctx, dispatchArgs);
-            for (auto &comp : dispatched.components) {
-                for (auto &err : comp.errors) {
-                    ctx.state._error(move(err));
-                }
-            }
-            auto out = dispatched.returnType;
+            auto out = core::Types::dispatchCallWithoutBlock(ctx, ctype, dispatchArgs);
 
             if (out->isUntyped()) {
                 result.type = out;
@@ -810,7 +804,7 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
     ENFORCE(result.type.get() != nullptr);
     result.type->sanityCheck(ctx);
     return result;
-}
+} // namespace sorbet::resolver
 
 ParsedSig::TypeArgSpec &ParsedSig::enterTypeArgByName(core::NameRef name) {
     for (auto &current : typeArgs) {

--- a/test/cli/print_generics/print_generics.out
+++ b/test/cli/print_generics/print_generics.out
@@ -47,7 +47,7 @@ test/cli/print_generics/print_generics.rb:25: This function does not have a `sig
     25 |def gaz(x)
         ^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/print_generics/print_generics.rb:25: Insert `sig {params(x: T.untyped).void}
+    test/cli/print_generics/print_generics.rb:25: Insert `sig {params(x: T.untyped).returns(T::Enumerator[Integer])}
 `
     25 |def gaz(x)
         ^

--- a/test/cli/suggest-sig-literal/suggest-sig-literal.out
+++ b/test/cli/suggest-sig-literal/suggest-sig-literal.out
@@ -2,7 +2,7 @@ suggest-sig-literal.rb:2: This function does not have a `sig` https://srb.help/7
      2 |def index_for_live(fields)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig-literal.rb:2: Inserted `sig {params(fields: T::Enumerable[T::Array[T.any(Symbol, Integer)]]).returns(T::Array[T::Array[T.any(Symbol, Integer)]])}
+    suggest-sig-literal.rb:2: Inserted `sig {params(fields: T.untyped).returns(T::Array[T::Array[T.any(Symbol, Integer)]])}
 `
      2 |def index_for_live(fields)
         ^
@@ -11,7 +11,7 @@ Errors: 1
 --------------------------------------------------------------------------
 
 # typed: strict
-sig {params(fields: T::Enumerable[T::Array[T.any(Symbol, Integer)]]).returns(T::Array[T::Array[T.any(Symbol, Integer)]])}
+sig {params(fields: T.untyped).returns(T::Array[T::Array[T.any(Symbol, Integer)]])}
 def index_for_live(fields)
   [[:deleted_at, 1]] + fields
 end

--- a/test/testdata/call_with_block_strict.rb
+++ b/test/testdata/call_with_block_strict.rb
@@ -20,9 +20,7 @@ class B < A
 end
 
 def no_sig(&blk) # error: This function does not have a `sig`
-  # this error only happens in strict mode, since SigSuggestion only runs in strict mode,
-  # which then passes in generics to try to guess argument types
-  foo(1, &blk) # error: Passing generics as block arguments is not supported
+  foo(1, &blk)
 end
 
 sig {params(a: Integer, blk: T.nilable(T.proc.returns(String))).void}

--- a/test/testdata/call_with_splat_and_block_strict.rb
+++ b/test/testdata/call_with_splat_and_block_strict.rb
@@ -20,9 +20,7 @@ class B < A
 end
 
 def no_sig(&blk) # error: This function does not have a `sig`
-  # this error only happens in strict mode, since SigSuggestion only runs in strict mode,
-  # which then passes in generics to try to guess argument types
-  foo(*[1], &blk) # error: Passing generics as block arguments is not supported
+  foo(*[1], &blk)
 end
 
 sig {params(a: Integer, blk: T.nilable(T.proc.returns(String))).void}

--- a/test/testdata/cfg/block_in_deadcode.rb.cfg.exp
+++ b/test/testdata/cfg/block_in_deadcode.rb.cfg.exp
@@ -6,7 +6,7 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_1" [shape = parallelogram];
 
     "bb::Object#foo_0" [
-        label = "block[id=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<block-pre-call-temp>$4: T.untyped = <self>: Object.outer()\l<selfRestore>$5: Object = <self>\l<unconditional>\l"
+        label = "block[id=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<block-pre-call-temp>$4: Sorbet::Private::Static::Void = <self>: Object.outer()\l<selfRestore>$5: Object = <self>\l<unconditional>\l"
     ];
 
     "bb::Object#foo_0" -> "bb::Object#foo_2" [style="bold"];

--- a/test/testdata/cfg/blocks.rb.cfg.exp
+++ b/test/testdata/cfg/blocks.rb.cfg.exp
@@ -6,7 +6,7 @@ subgraph "cluster_::BlockTest#blockPass" {
     "bb::BlockTest#blockPass_1" [shape = parallelogram];
 
     "bb::BlockTest#blockPass_0" [
-        label = "block[id=0]()\l<self>: BlockTest = cast(<self>: NilClass, BlockTest);\l<statTemp>$4: Integer(1) = 1\l<statTemp>$5: Integer(2) = 2\l<statTemp>$6: Integer(3) = 3\l<block-pre-call-temp>$7: T.untyped = <self>: BlockTest.foo(<statTemp>$4: Integer(1), <statTemp>$5: Integer(2), <statTemp>$6: Integer(3))\l<selfRestore>$8: BlockTest = <self>\l<unconditional>\l"
+        label = "block[id=0]()\l<self>: BlockTest = cast(<self>: NilClass, BlockTest);\l<statTemp>$4: Integer(1) = 1\l<statTemp>$5: Integer(2) = 2\l<statTemp>$6: Integer(3) = 3\l<block-pre-call-temp>$7: Sorbet::Private::Static::Void = <self>: BlockTest.foo(<statTemp>$4: Integer(1), <statTemp>$5: Integer(2), <statTemp>$6: Integer(3))\l<selfRestore>$8: BlockTest = <self>\l<unconditional>\l"
     ];
 
     "bb::BlockTest#blockPass_0" -> "bb::BlockTest#blockPass_2" [style="bold"];

--- a/test/testdata/cfg/break.rb.cfg.exp
+++ b/test/testdata/cfg/break.rb.cfg.exp
@@ -6,7 +6,7 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_1" [shape = parallelogram];
 
     "bb::Object#foo_0" [
-        label = "block[id=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<arrayTemp>$5: Integer(1) = 1\l<arrayTemp>$6: Integer(2) = 2\l<magic>$7: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$4: [Integer(1), Integer(2)] = <magic>$7: T.class_of(<Magic>).<build-array>(<arrayTemp>$5: Integer(1), <arrayTemp>$6: Integer(2))\l<block-pre-call-temp>$8: T::Array[U] = <statTemp>$4: [Integer(1), Integer(2)].map()\l<selfRestore>$9: Object = <self>\l<unconditional>\l"
+        label = "block[id=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<arrayTemp>$5: Integer(1) = 1\l<arrayTemp>$6: Integer(2) = 2\l<magic>$7: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$4: [Integer(1), Integer(2)] = <magic>$7: T.class_of(<Magic>).<build-array>(<arrayTemp>$5: Integer(1), <arrayTemp>$6: Integer(2))\l<block-pre-call-temp>$8: Sorbet::Private::Static::Void = <statTemp>$4: [Integer(1), Integer(2)].map()\l<selfRestore>$9: Object = <self>\l<unconditional>\l"
     ];
 
     "bb::Object#foo_0" -> "bb::Object#foo_2" [style="bold"];
@@ -81,7 +81,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_2" -> "bb::<Class:<root>>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_3" [
-        label = "block[id=3](<selfRestore>$10: T.class_of(<root>))\l<statTemp>$7: Sorbet::Private::Static::Void = Solve<sig>\l<self>: T.class_of(<root>) = <selfRestore>$10\l<block-pre-call-temp>$32: String = <self>: T.class_of(<root>).bar()\l<selfRestore>$33: T.class_of(<root>) = <self>\l<unconditional>\l"
+        label = "block[id=3](<selfRestore>$10: T.class_of(<root>))\l<statTemp>$7: Sorbet::Private::Static::Void = Solve<sig>\l<self>: T.class_of(<root>) = <selfRestore>$10\l<block-pre-call-temp>$32: Sorbet::Private::Static::Void = <self>: T.class_of(<root>).bar()\l<selfRestore>$33: T.class_of(<root>) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_3" -> "bb::<Class:<root>>#<static-init>_6" [style="bold"];
@@ -103,7 +103,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 
     "bb::<Class:<root>>#<static-init>_7" -> "bb::<Class:<root>>#<static-init>_8" [style="bold"];
     "bb::<Class:<root>>#<static-init>_8" [
-        label = "block[id=8](<selfRestore>$33: T.class_of(<root>), a: T.any(String, Integer))\l<self>: T.class_of(<root>) = <selfRestore>$33\l<statTemp>$45: T.class_of(T) = alias <C T>\l<statTemp>$44: T.any(String, Integer) = <statTemp>$45: T.class_of(T).reveal_type(a: T.any(String, Integer))\l<block-pre-call-temp>$49: String = <self>: T.class_of(<root>).bar()\l<selfRestore>$50: T.class_of(<root>) = <self>\l<unconditional>\l"
+        label = "block[id=8](<selfRestore>$33: T.class_of(<root>), a: T.any(String, Integer))\l<self>: T.class_of(<root>) = <selfRestore>$33\l<statTemp>$45: T.class_of(T) = alias <C T>\l<statTemp>$44: T.any(String, Integer) = <statTemp>$45: T.class_of(T).reveal_type(a: T.any(String, Integer))\l<block-pre-call-temp>$49: Sorbet::Private::Static::Void = <self>: T.class_of(<root>).bar()\l<selfRestore>$50: T.class_of(<root>) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_8" -> "bb::<Class:<root>>#<static-init>_12" [style="bold"];

--- a/test/testdata/cfg/export.rb.cfg-json.exp
+++ b/test/testdata/cfg/export.rb.cfg-json.exp
@@ -1385,7 +1385,7 @@
       "unique_name": "\u003cblock-pre-call-temp\u003e$16",
       "type": {
        "kind": "CLASS",
-       "class_full_name": "Integer"
+       "class_full_name": "Sorbet::Private::Static::Void"
       }
      },
      "instruction": {

--- a/test/testdata/cfg/next.rb.cfg.exp
+++ b/test/testdata/cfg/next.rb.cfg.exp
@@ -6,7 +6,7 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_1" [shape = parallelogram];
 
     "bb::Object#foo_0" [
-        label = "block[id=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<arrayTemp>$4: Integer(1) = 1\l<magic>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$3: [Integer(1)] = <magic>$5: T.class_of(<Magic>).<build-array>(<arrayTemp>$4: Integer(1))\l<block-pre-call-temp>$6: T::Array[U] = <statTemp>$3: [Integer(1)].map()\l<selfRestore>$7: Object = <self>\l<unconditional>\l"
+        label = "block[id=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<arrayTemp>$4: Integer(1) = 1\l<magic>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$3: [Integer(1)] = <magic>$5: T.class_of(<Magic>).<build-array>(<arrayTemp>$4: Integer(1))\l<block-pre-call-temp>$6: Sorbet::Private::Static::Void = <statTemp>$3: [Integer(1)].map()\l<selfRestore>$7: Object = <self>\l<unconditional>\l"
     ];
 
     "bb::Object#foo_0" -> "bb::Object#foo_2" [style="bold"];

--- a/test/testdata/cfg/uaf1.rb.cfg.exp
+++ b/test/testdata/cfg/uaf1.rb.cfg.exp
@@ -6,7 +6,7 @@ subgraph "cluster_::A#initialize" {
     "bb::A#initialize_1" [shape = parallelogram];
 
     "bb::A#initialize_0" [
-        label = "block[id=0]()\l<self>: A = cast(<self>: NilClass, A);\l<statTemp>$3: T.untyped = <self>: A.spec_list()\l<block-pre-call-temp>$5: T.untyped = <statTemp>$3: T.untyped.map()\l<selfRestore>$6: A = <self>\l<unconditional>\l"
+        label = "block[id=0]()\l<self>: A = cast(<self>: NilClass, A);\l<statTemp>$3: T.untyped = <self>: A.spec_list()\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$3: T.untyped.map()\l<selfRestore>$6: A = <self>\l<unconditional>\l"
     ];
 
     "bb::A#initialize_0" -> "bb::A#initialize_2" [style="bold"];

--- a/test/testdata/desugar/for.rb.cfg.exp
+++ b/test/testdata/desugar/for.rb.cfg.exp
@@ -78,7 +78,7 @@ subgraph "cluster_::<Class:Main>#main" {
     "bb::<Class:Main>#main_1" [shape = parallelogram];
 
     "bb::<Class:Main>#main_0" [
-        label = "block[id=0]()\l@a$121: T.untyped = alias <C <undeclared-field-stub>>\l@@b$125: T.untyped = alias <C <undeclared-field-stub>>\l$c$129: T.untyped = alias $c\l<self>: T.class_of(Main) = cast(<self>: NilClass, T.class_of(Main));\l<statTemp>$4: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$5: T.untyped = <statTemp>$4: T.class_of(A).each()\l<selfRestore>$6: T.class_of(Main) = <self>\l<unconditional>\l"
+        label = "block[id=0]()\l@a$121: T.untyped = alias <C <undeclared-field-stub>>\l@@b$125: T.untyped = alias <C <undeclared-field-stub>>\l$c$129: T.untyped = alias $c\l<self>: T.class_of(Main) = cast(<self>: NilClass, T.class_of(Main));\l<statTemp>$4: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$4: T.class_of(A).each()\l<selfRestore>$6: T.class_of(Main) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#main_0" -> "bb::<Class:Main>#main_2" [style="bold"];
@@ -95,7 +95,7 @@ subgraph "cluster_::<Class:Main>#main" {
     "bb::<Class:Main>#main_2" -> "bb::<Class:Main>#main_3" [style="tapered"];
 
     "bb::<Class:Main>#main_3" [
-        label = "block[id=3](<selfRestore>$6: T.class_of(Main), @a$121: T.untyped, @@b$125: T.untyped, $c$129: T.untyped)\l<statTemp>$3: T.untyped = Solve<each>\l<self>: T.class_of(Main) = <selfRestore>$6\l<statTemp>$25: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$26: T.untyped = <statTemp>$25: T.class_of(A).each()\l<selfRestore>$27: T.class_of(Main) = <self>\l<unconditional>\l"
+        label = "block[id=3](<selfRestore>$6: T.class_of(Main), @a$121: T.untyped, @@b$125: T.untyped, $c$129: T.untyped)\l<statTemp>$3: T.untyped = Solve<each>\l<self>: T.class_of(Main) = <selfRestore>$6\l<statTemp>$25: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$26: Sorbet::Private::Static::Void = <statTemp>$25: T.class_of(A).each()\l<selfRestore>$27: T.class_of(Main) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#main_3" -> "bb::<Class:Main>#main_6" [style="bold"];
@@ -112,7 +112,7 @@ subgraph "cluster_::<Class:Main>#main" {
     "bb::<Class:Main>#main_6" -> "bb::<Class:Main>#main_7" [style="tapered"];
 
     "bb::<Class:Main>#main_7" [
-        label = "block[id=7](<selfRestore>$27: T.class_of(Main), @a$121: T.untyped, @@b$125: T.untyped, $c$129: T.untyped)\l<statTemp>$24: T.untyped = Solve<each>\l<self>: T.class_of(Main) = <selfRestore>$27\l<statTemp>$47: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$48: T.untyped = <statTemp>$47: T.class_of(A).each()\l<selfRestore>$49: T.class_of(Main) = <self>\l<unconditional>\l"
+        label = "block[id=7](<selfRestore>$27: T.class_of(Main), @a$121: T.untyped, @@b$125: T.untyped, $c$129: T.untyped)\l<statTemp>$24: T.untyped = Solve<each>\l<self>: T.class_of(Main) = <selfRestore>$27\l<statTemp>$47: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$48: Sorbet::Private::Static::Void = <statTemp>$47: T.class_of(A).each()\l<selfRestore>$49: T.class_of(Main) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#main_7" -> "bb::<Class:Main>#main_10" [style="bold"];
@@ -129,7 +129,7 @@ subgraph "cluster_::<Class:Main>#main" {
     "bb::<Class:Main>#main_10" -> "bb::<Class:Main>#main_11" [style="tapered"];
 
     "bb::<Class:Main>#main_11" [
-        label = "block[id=11](<selfRestore>$49: T.class_of(Main), @a$121: T.untyped, @@b$125: T.untyped, $c$129: T.untyped)\l<statTemp>$46: T.untyped = Solve<each>\l<self>: T.class_of(Main) = <selfRestore>$49\l<statTemp>$75: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$76: T.untyped = <statTemp>$75: T.class_of(A).each()\l<selfRestore>$77: T.class_of(Main) = <self>\l<unconditional>\l"
+        label = "block[id=11](<selfRestore>$49: T.class_of(Main), @a$121: T.untyped, @@b$125: T.untyped, $c$129: T.untyped)\l<statTemp>$46: T.untyped = Solve<each>\l<self>: T.class_of(Main) = <selfRestore>$49\l<statTemp>$75: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$76: Sorbet::Private::Static::Void = <statTemp>$75: T.class_of(A).each()\l<selfRestore>$77: T.class_of(Main) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#main_11" -> "bb::<Class:Main>#main_14" [style="bold"];
@@ -146,7 +146,7 @@ subgraph "cluster_::<Class:Main>#main" {
     "bb::<Class:Main>#main_14" -> "bb::<Class:Main>#main_15" [style="tapered"];
 
     "bb::<Class:Main>#main_15" [
-        label = "block[id=15](<selfRestore>$77: T.class_of(Main), @a$121: T.untyped, @@b$125: T.untyped, $c$129: T.untyped)\l<statTemp>$74: T.untyped = Solve<each>\l<self>: T.class_of(Main) = <selfRestore>$77\l<statTemp>$105: String(\"main\") = \"main\"\l<statTemp>$103: NilClass = <self>: T.class_of(Main).puts(<statTemp>$105: String(\"main\"))\l<statTemp>$107: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$108: T.untyped = <statTemp>$107: T.class_of(A).each()\l<selfRestore>$109: T.class_of(Main) = <self>\l<unconditional>\l"
+        label = "block[id=15](<selfRestore>$77: T.class_of(Main), @a$121: T.untyped, @@b$125: T.untyped, $c$129: T.untyped)\l<statTemp>$74: T.untyped = Solve<each>\l<self>: T.class_of(Main) = <selfRestore>$77\l<statTemp>$105: String(\"main\") = \"main\"\l<statTemp>$103: NilClass = <self>: T.class_of(Main).puts(<statTemp>$105: String(\"main\"))\l<statTemp>$107: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$108: Sorbet::Private::Static::Void = <statTemp>$107: T.class_of(A).each()\l<selfRestore>$109: T.class_of(Main) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#main_15" -> "bb::<Class:Main>#main_18" [style="bold"];
@@ -163,7 +163,7 @@ subgraph "cluster_::<Class:Main>#main" {
     "bb::<Class:Main>#main_18" -> "bb::<Class:Main>#main_19" [style="tapered"];
 
     "bb::<Class:Main>#main_19" [
-        label = "block[id=19](<selfRestore>$109: T.class_of(Main), @a$121: T.untyped, @@b$125: T.untyped, $c$129: T.untyped)\l<statTemp>$106: T.untyped = Solve<each>\l<self>: T.class_of(Main) = <selfRestore>$109\l<statTemp>$161: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$162: T.untyped = <statTemp>$161: T.class_of(A).each()\l<selfRestore>$163: T.class_of(Main) = <self>\l<unconditional>\l"
+        label = "block[id=19](<selfRestore>$109: T.class_of(Main), @a$121: T.untyped, @@b$125: T.untyped, $c$129: T.untyped)\l<statTemp>$106: T.untyped = Solve<each>\l<self>: T.class_of(Main) = <selfRestore>$109\l<statTemp>$161: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$162: Sorbet::Private::Static::Void = <statTemp>$161: T.class_of(A).each()\l<selfRestore>$163: T.class_of(Main) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#main_19" -> "bb::<Class:Main>#main_22" [style="bold"];

--- a/test/testdata/infer/blocks2.rb.cfg.exp
+++ b/test/testdata/infer/blocks2.rb.cfg.exp
@@ -24,7 +24,7 @@ subgraph "cluster_::Foo#baz" {
     "bb::Foo#baz_1" [shape = parallelogram];
 
     "bb::Foo#baz_0" [
-        label = "block[id=0]()\l<self>: Foo = cast(<self>: NilClass, Foo);\l<block-pre-call-temp>$4: T.untyped = <self>: Foo.bar()\l<selfRestore>$5: Foo = <self>\l<unconditional>\l"
+        label = "block[id=0]()\l<self>: Foo = cast(<self>: NilClass, Foo);\l<block-pre-call-temp>$4: Sorbet::Private::Static::Void = <self>: Foo.bar()\l<selfRestore>$5: Foo = <self>\l<unconditional>\l"
     ];
 
     "bb::Foo#baz_0" -> "bb::Foo#baz_2" [style="bold"];

--- a/test/testdata/infer/control_flow/normalize_params.rb.cfg.exp
+++ b/test/testdata/infer/control_flow/normalize_params.rb.cfg.exp
@@ -30,7 +30,7 @@ subgraph "cluster_::Test#normalize_params" {
     "bb::Test#normalize_params_3" -> "bb::Test#normalize_params_5" [style="tapered"];
 
     "bb::Test#normalize_params_4" [
-        label = "block[id=4](<self>: Test, v: T::Array[T.untyped])\l<block-pre-call-temp>$14: T::Array[U] = v: T::Array[T.untyped].map()\l<selfRestore>$15: Test = <self>\l<unconditional>\l"
+        label = "block[id=4](<self>: Test, v: T::Array[T.untyped])\l<block-pre-call-temp>$14: Sorbet::Private::Static::Void = v: T::Array[T.untyped].map()\l<selfRestore>$15: Test = <self>\l<unconditional>\l"
     ];
 
     "bb::Test#normalize_params_4" -> "bb::Test#normalize_params_6" [style="bold"];

--- a/test/testdata/infer/rebind.rb.cfg.exp
+++ b/test/testdata/infer/rebind.rb.cfg.exp
@@ -166,7 +166,7 @@ subgraph "cluster_::Use#shouldRemoveSelfTemp" {
     "bb::Use#shouldRemoveSelfTemp_1" [shape = parallelogram];
 
     "bb::Use#shouldRemoveSelfTemp_0" [
-        label = "block[id=0]()\l<self>: Use = cast(<self>: NilClass, Use);\l<block-pre-call-temp>$4: T.untyped = <self>: Use.only_on_Use()\l<selfRestore>$5: Use = <self>\l<unconditional>\l"
+        label = "block[id=0]()\l<self>: Use = cast(<self>: NilClass, Use);\l<block-pre-call-temp>$4: Sorbet::Private::Static::Void = <self>: Use.only_on_Use()\l<selfRestore>$5: Use = <self>\l<unconditional>\l"
     ];
 
     "bb::Use#shouldRemoveSelfTemp_0" -> "bb::Use#shouldRemoveSelfTemp_2" [style="bold"];

--- a/test/testdata/infer/zsuper.rb.cfg.exp
+++ b/test/testdata/infer/zsuper.rb.cfg.exp
@@ -42,7 +42,7 @@ subgraph "cluster_::Bar#baz" {
     "bb::Bar#baz_1" [shape = parallelogram];
 
     "bb::Bar#baz_0" [
-        label = "block[id=0]()\l<self>: Bar = cast(<self>: NilClass, Bar);\lb: T.untyped = load_arg(b)\l<blk>: T.untyped = load_arg(<blk>)\l<block-pre-call-temp>$6: T.untyped = <self>: Bar.super(b: T.untyped, <blk>: T.untyped)\l<selfRestore>$7: Bar = <self>\l<unconditional>\l"
+        label = "block[id=0]()\l<self>: Bar = cast(<self>: NilClass, Bar);\lb: T.untyped = load_arg(b)\l<blk>: T.untyped = load_arg(<blk>)\l<block-pre-call-temp>$6: Sorbet::Private::Static::Void = <self>: Bar.super(b: T.untyped, <blk>: T.untyped)\l<selfRestore>$7: Bar = <self>\l<unconditional>\l"
     ];
 
     "bb::Bar#baz_0" -> "bb::Bar#baz_2" [style="bold"];

--- a/test/testdata/namer/yield.rb.cfg.exp
+++ b/test/testdata/namer/yield.rb.cfg.exp
@@ -78,7 +78,7 @@ subgraph "cluster_::Main#blockyield" {
     "bb::Main#blockyield_1" [shape = parallelogram];
 
     "bb::Main#blockyield_0" [
-        label = "block[id=0]()\l<self>: Main = cast(<self>: NilClass, Main);\l<blk>: T.untyped = load_arg(<blk>)\l<block-pre-call-temp>$4: T.untyped = <self>: Main.yielder()\l<selfRestore>$5: Main = <self>\l<unconditional>\l"
+        label = "block[id=0]()\l<self>: Main = cast(<self>: NilClass, Main);\l<blk>: T.untyped = load_arg(<blk>)\l<block-pre-call-temp>$4: Sorbet::Private::Static::Void = <self>: Main.yielder()\l<selfRestore>$5: Main = <self>\l<unconditional>\l"
     ];
 
     "bb::Main#blockyield_0" -> "bb::Main#blockyield_2" [style="bold"];
@@ -113,7 +113,7 @@ subgraph "cluster_::Main#main" {
     "bb::Main#main_1" [shape = parallelogram];
 
     "bb::Main#main_0" [
-        label = "block[id=0]()\l<self>: Main = cast(<self>: NilClass, Main);\l<block-pre-call-temp>$5: T.proc.params(arg0: T.untyped).returns(T.untyped) = <self>: Main.lambda()\l<selfRestore>$6: Main = <self>\l<unconditional>\l"
+        label = "block[id=0]()\l<self>: Main = cast(<self>: NilClass, Main);\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: Main.lambda()\l<selfRestore>$6: Main = <self>\l<unconditional>\l"
     ];
 
     "bb::Main#main_0" -> "bb::Main#main_2" [style="bold"];

--- a/test/testdata/parser/whitequark/parse_ruby_bug_10653_1.rb
+++ b/test/testdata/parser/whitequark/parse_ruby_bug_10653_1.rb
@@ -1,4 +1,4 @@
 # typed: true
 def cond; end;
 def tap; end;
-cond ? raise {} : tap {} # error: This code is unreachable
+cond ? raise {} : tap {}

--- a/test/testdata/parser/whitequark/parse_ruby_bug_10653_2.rb
+++ b/test/testdata/parser/whitequark/parse_ruby_bug_10653_2.rb
@@ -1,4 +1,4 @@
 # typed: true
 def cond; end;
 def tap; end;
-cond ? raise do end : tap do end # error: This code is unreachable
+cond ? raise do end : tap do end


### PR DESCRIPTION
### Motivation
Be able to have https://github.com/sorbet/sorbet/commit/4f60626cdc58332d06a7f06ac2dbad029c0cb252 without other code stepping on each other toes. 
Before this refactor, it was unsafe as all other things used to cross talk via SendBlockAndLink and used to break each other.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
