### PR TITLE
Skip dangerous JRuby constants in ConstantLookupCache

### DIFF
--- a/gems/sorbet/lib/constant_cache.rb
+++ b/gems/sorbet/lib/constant_cache.rb
@@ -51,6 +51,18 @@ class Sorbet::Private::ConstantLookupCache
     'Sequel::UnbindDuplicate',
     'Sequel::Unbinder',
     'YARD::Parser::Ruby::Legacy::RipperParser',
+    'Java::ComHeadiusRacc::Cparse::CparseParams::NEVER',
+    'Java::ComHeadiusRacc::Cparse::CparseParams::UNDEF',
+    'Java::ComHeadiusRacc::Cparse::Parser::NEVER',
+    'Java::ComHeadiusRacc::Cparse::Parser::UNDEF',
+    'Java::OrgJruby::RubyBasicObject::NEVER',
+    'Java::OrgJruby::RubyBasicObject::UNDEF',
+    'Java::OrgJruby::RubyClass::NEVER',
+    'Java::OrgJruby::RubyClass::UNDEF',
+    'Java::OrgJruby::RubyModule::NEVER',
+    'Java::OrgJruby::RubyModule::UNDEF',
+    'Java::OrgJruby::RubyObject::NEVER',
+    'Java::OrgJruby::RubyObject::UNDEF',
   ].freeze
 
   def initialize


### PR DESCRIPTION
Calling constants on Java proxy objects generated by JRuby sometimes
returns objects that crash JRuby when any method is called on them.

### Motivation

Some objects generate by JRuby return constants that lead to a NullPointerException in JRuby's implementation. See #1216.

### Test plan

I've tested this change using a large-ish JRuby project. I am not sure whether or how to add automated JRuby tests to the project.