### PR TITLE
Add respond_to? guards for instance_methods and ancestors

### DIFF
--- a/gems/sorbet/lib/gem-generator-tracepoint/tracer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracer.rb
@@ -101,7 +101,7 @@ module Sorbet::Private
       def self.pre_cache_module_methods
         ObjectSpace.each_object(Module) do |mod_|
           mod = T.cast(mod_, Module)
-          @modules[Sorbet::Private::RealStdlib.real_object_id(mod)] = (mod.instance_methods(false) + mod.private_instance_methods(false)).to_set
+          @modules[Sorbet::Private::RealStdlib.real_object_id(mod)] = (Sorbet::Private::RealStdlib.real_instance_methods(mod, false) + Sorbet::Private::RealStdlib.real_private_instance_methods(mod, false)).to_set
         end
       end
 

--- a/gems/sorbet/lib/serialize.rb
+++ b/gems/sorbet/lib/serialize.rb
@@ -76,7 +76,8 @@ class Sorbet::Private::Serialize
       end
       ret << "  include ::#{ancestor_name}\n"
     end
-    Sorbet::Private::RealStdlib.real_singleton_class(klass).ancestors.each do |ancestor|
+    singleton_class = Sorbet::Private::RealStdlib.real_singleton_class(klass)
+    Sorbet::Private::RealStdlib.real_ancestors(singleton_class).each do |ancestor|
       next if ancestor == Sorbet::Private::RealStdlib.real_singleton_class(klass)
       break if superclass && ancestor == Sorbet::Private::RealStdlib.real_singleton_class(superclass)
       break if ancestor == Module

--- a/gems/sorbet/test/snapshot/partial/explosive-object/src/src.rb
+++ b/gems/sorbet/test/snapshot/partial/explosive-object/src/src.rb
@@ -15,6 +15,13 @@ class Boom
   EXPOSION = 1
 end
 
+module MethodsForSingletonClass
+  def ancestors
+    raise "You need to use Sorbet::Private::RealStdlib here"
+  end
+end
+Sorbet::Private::RealStdlib.real_singleton_class(Boom).extend(MethodsForSingletonClass)
+
 class A < Boom
 end
 class B

--- a/gems/sorbet/test/snapshot/partial/missing-instance-methods/src/Gemfile
+++ b/gems/sorbet/test/snapshot/partial/missing-instance-methods/src/Gemfile
@@ -1,0 +1,14 @@
+# We define MissesInstanceMethods here, since this test case specifically 
+# targets pre_cache_modules in GemGeneratorTracepoint::Tracer, which enumerates
+# ObjectSpace before any gems or user code are loaded, but *after* the Gemfile 
+# has been evaluated for the first time (via FetchRBIs).
+
+class MissesInstanceMethods
+  def self.instance_methods(*args)
+    raise "You need to use Sorbet::Private::RealStdlib here"
+  end
+  
+  def self.private_instance_methods(*args)
+    raise "You need to use Sorbet::Private::RealStdlib here"
+  end
+end

--- a/gems/sorbet/test/snapshot/partial/missing-instance-methods/src/Gemfile.lock
+++ b/gems/sorbet/test/snapshot/partial/missing-instance-methods/src/Gemfile.lock
@@ -1,0 +1,10 @@
+GEM
+  specs:
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+
+BUNDLED WITH
+   2.0.1

--- a/gems/sorbet/test/snapshot/partial/missing-instance-methods/src/src.rb
+++ b/gems/sorbet/test/snapshot/partial/missing-instance-methods/src/src.rb
@@ -1,0 +1,1 @@
+# See Gemfile


### PR DESCRIPTION
Some Java proxy objects generated by JRuby are Ruby modules, but do not
respond to some instance methods of Ruby's Module.

### Motivation

This works around an issue in JRuby with generated Java proxy classes. See #1216.

### Test plan

I've tested this change using a large-ish JRuby project. I am not sure whether or how to add automated JRuby tests to the project.
