### PR TITLE
#1201 Fix: Changed "sorbet" to "srb" in Usage output

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -256,7 +256,7 @@ cxxopts::Options buildOptions() {
     // Used to populate default options.
     Options empty;
 
-    cxxopts::Options options("sorbet", "Typechecker for Ruby");
+    cxxopts::Options options("srb", "Typechecker for Ruby");
 
     // Common user options in order of use
     options.add_options()("e", "Parse an inline ruby string",

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -4,7 +4,7 @@ You must pass either `-e` or at least one folder or ruby file.
 
 Typechecker for Ruby
 Usage:
-  sorbet [OPTION...] <path 1> <path 2> ...
+  srb [OPTION...] <path 1> <path 2> ...
 
   -e, string     Parse an inline ruby string (default: )
   -q, --quiet    Silence all non-critical errors
@@ -20,7 +20,7 @@ You must pass either `-e` or at least one folder or ruby file.
 
 Typechecker for Ruby
 Usage:
-  sorbet [OPTION...] <path 1> <path 2> ...
+  srb [OPTION...] <path 1> <path 2> ...
 
   -e, string     Parse an inline ruby string (default: )
   -q, --quiet    Silence all non-critical errors
@@ -34,7 +34,7 @@ Usage:
 
 Typechecker for Ruby
 Usage:
-  sorbet [OPTION...] <path 1> <path 2> ...
+  srb [OPTION...] <path 1> <path 2> ...
 
   -e, string     Parse an inline ruby string (default: )
   -q, --quiet    Silence all non-critical errors


### PR DESCRIPTION
#1201 Fix: Changed "sorbet" to "srb" in Usage output

### Motivation

To mirror what you must type in the Usage output.

### Test plan

Modified the test case.

Will watch build to check completeness.