### PR TITLE
Ensure consistency after constant resolution

### DIFF
--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -47,6 +47,7 @@ constexpr ErrorClass RevealTypeInUntypedFile{5039, StrictLevel::False};
 constexpr ErrorClass OverloadNotAllowed{5040, StrictLevel::False};
 constexpr ErrorClass SubclassingNotAllowed{5041, StrictLevel::False};
 constexpr ErrorClass NonPublicAbstract{5042, StrictLevel::True};
+constexpr ErrorClass InvalidTypeAlias{5043, StrictLevel::False};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/test/testdata/resolver/fuzz_empty_type_alias.rb
+++ b/test/testdata/resolver/fuzz_empty_type_alias.rb
@@ -1,0 +1,2 @@
+# typed: false
+B = T.type_alias # error: No argument given to `T.type_alias`

--- a/test/testdata/resolver/fuzz_include_infinite_typealias.rb
+++ b/test/testdata/resolver/fuzz_include_infinite_typealias.rb
@@ -1,6 +1,6 @@
 # typed: false
 # disable-fast-path: true
 class A
-  B = T.type_alias # error: Unable to resolve right hand side of type alias `A::B`
+  B = T.type_alias # error: No argument given to `T.type_alias`
   include B
 end

--- a/test/testdata/resolver/fuzz_infinite_type.rb
+++ b/test/testdata/resolver/fuzz_infinite_type.rb
@@ -1,5 +1,5 @@
 # typed: false
 # disable-fast-path: true
   T = T.type_alias
-# ^ error: Unable to resolve right hand side of type alias `T`
 # ^^^^^^^^^^^^^^^^ error: Redefining constant `T`
+    # ^^^^^^^^^^^^ error: No argument given to `T.type_alias`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes #1081; treats a no-argument `type_alias` differently by synthesizing a fake `T.untyped` as argument and reporting the invalid use of `type_alias` immediately, which avoids issues we had before where our sanity checks would fail post-constant-resolution. This changes some error messages slightly, but in what I think is a clearer way.

### Test plan
See included automated tests. Fuzzed test from #1081 was added, as well.
