### PR TITLE
Build a test_suite of disabled tests

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -148,7 +148,8 @@ cc_binary(
 
 load(":pipeline_test.bzl", "pipeline_tests")
 
-test_corpus_tests = pipeline_tests(
+pipeline_tests(
+    "test_corpus",
     glob([
         "testdata/**/*.rb",
         "testdata/**/*.exp",
@@ -158,7 +159,8 @@ test_corpus_tests = pipeline_tests(
     filter = "PosTests",
 )
 
-test_corpus_lsp_tests = pipeline_tests(
+pipeline_tests(
+    "test_corpus_lsp",
     glob([
         "testdata/**/*.rb",
         "testdata/**/*.exp",
@@ -166,16 +168,6 @@ test_corpus_lsp_tests = pipeline_tests(
     ]),
     "LSPTests",
     filter = "LSPTests",
-)
-
-test_suite(
-    name = "test_corpus",
-    tests = test_corpus_tests,
-)
-
-test_suite(
-    name = "test_corpus_lsp",
-    tests = test_corpus_lsp_tests,
 )
 
 test_suite(

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -58,15 +58,13 @@ def pipeline_tests(suite_name, all_paths, test_name_prefix, filter = "*", extra_
             tags = tags + extra_tags,
         )
 
-    if enabled_tests:
-        native.test_suite(
-            name = suite_name,
-            tests = enabled_tests,
-        )
+    native.test_suite(
+        name = suite_name,
+        tests = enabled_tests,
+    )
 
-    if disabled_tests:
-        native.test_suite(
-            name = "{}_disabled".format(suite_name),
-            tests = disabled_tests,
-            tags = ["manual"],
-        )
+    native.test_suite(
+        name = "{}_disabled".format(suite_name),
+        tests = disabled_tests,
+        tags = ["manual"],
+    )


### PR DESCRIPTION
Tests that are disabled are still registered, but are marked as "manual", and added to a test suite of the same name with "_disabled" appended.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Allow disabled pipeline tests to still be run in bazel, but not be run automatically with `bazel test //...`. Additionally there is another test suite added with the "_disabled" suffix when disabled tests are present.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
