### PR TITLE
Support Array[Comparable] as return of blocks for Enumerable#*_by

### DIFF
--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -273,9 +273,12 @@ module Enumerable
   def max(arg0=T.unsafe(nil), &blk); end
 
   sig {returns(T::Enumerator[Elem])}
+  # The block returning T::Array[BasicObject] is just a stopgap solution to get better
+  # signatures. In reality, it should be recursively defined as an Array of elements of
+  # the same T.any
   sig do
     params(
-        blk: T.proc.params(arg0: Elem).returns(Comparable),
+        blk: T.proc.params(arg0: Elem).returns(T.any(Comparable, T::Array[BasicObject])),
     )
     .returns(T.nilable(Elem))
   end
@@ -285,10 +288,13 @@ module Enumerable
     )
     .returns(T::Enumerator[Elem])
   end
+  # The block returning T::Array[BasicObject] is just a stopgap solution to get better
+  # signatures. In reality, it should be recursively defined as an Array of elements of
+  # the same T.any
   sig do
     params(
         arg0: Integer,
-        blk: T.proc.params(arg0: Elem).returns(Comparable),
+        blk: T.proc.params(arg0: Elem).returns(T.any(Comparable, T::Array[BasicObject])),
     )
     .returns(T::Array[Elem])
   end
@@ -317,9 +323,12 @@ module Enumerable
   def min(arg0=T.unsafe(nil), &blk); end
 
   sig {returns(T::Enumerator[Elem])}
+  # The block returning T::Array[BasicObject] is just a stopgap solution to get better
+  # signatures. In reality, it should be recursively defined as an Array of elements of
+  # the same T.any
   sig do
     params(
-        blk: T.proc.params(arg0: Elem).returns(Comparable),
+        blk: T.proc.params(arg0: Elem).returns(T.any(Comparable, T::Array[BasicObject])),
     )
     .returns(T.nilable(Elem))
   end
@@ -329,10 +338,13 @@ module Enumerable
     )
     .returns(T::Enumerator[Elem])
   end
+  # The block returning T::Array[BasicObject] is just a stopgap solution to get better
+  # signatures. In reality, it should be recursively defined as an Array of elements of
+  # the same T.any
   sig do
     params(
         arg0: Integer,
-        blk: T.proc.params(arg0: Elem).returns(Comparable),
+        blk: T.proc.params(arg0: Elem).returns(T.any(Comparable, T::Array[BasicObject])),
     )
     .returns(T::Array[Elem])
   end
@@ -348,9 +360,12 @@ module Enumerable
   def minmax(&blk); end
 
   sig {returns([T.nilable(Elem), T.nilable(Elem)])}
+  # The block returning T::Array[BasicObject] is just a stopgap solution to get better
+  # signatures. In reality, it should be recursively defined as an Array of elements of
+  # the same T.any
   sig do
     params(
-        blk: T.proc.params(arg0: Elem).returns(Comparable),
+        blk: T.proc.params(arg0: Elem).returns(T.any(Comparable, T::Array[BasicObject])),
     )
     .returns(T::Enumerator[Elem])
   end
@@ -409,10 +424,12 @@ module Enumerable
     .returns(T::Array[Elem])
   end
   def sort(&blk); end
-
+  # The block returning T::Array[BasicObject] is just a stopgap solution to get better
+  # signatures. In reality, it should be recursively defined as an Array of elements of
+  # the same T.any
   sig do
     params(
-        blk: T.proc.params(arg0: Elem).returns(BasicObject),
+        blk: T.proc.params(arg0: Elem).returns(T.any(Comparable, T::Array[BasicObject])),
     )
     .returns(T::Array[Elem])
   end

--- a/test/testdata/rbi/enumerable.rb
+++ b/test/testdata/rbi/enumerable.rb
@@ -1,6 +1,19 @@
 # typed: true
 
-# You can return any Comparable in the block for max_by (and String is one)
+# You can return any Comparable in the block *_by (and String is one)
 [1, 3, 20].min_by {|n| n.to_s}
 [1, 3, 20].max_by {|n| n.to_s}
 [1, 3, 20].minmax_by {|n| n.to_s}
+[1, 3, 20].sort_by {|n| n.to_s}
+
+# You can return an Array of Comparables in the block for *_by
+[1, 3, 20].min_by {|n| [n.to_s, 1]}
+[1, 3, 20].max_by {|n| [n.to_s, 1]}
+[1, 3, 20].minmax_by {|n| [n.to_s, 1]}
+[1, 3, 20].sort_by {|n| [n.to_s, 1]}
+
+# You can return an Array with an Array of Comparables in the block for *_by
+[1, 3, 20].min_by {|n| [n.to_s, [1, 2]]}
+[1, 3, 20].max_by {|n| [n.to_s, [1, 2]]}
+[1, 3, 20].minmax_by {|n| [n.to_s, [1, 2]]}
+[1, 3, 20].sort_by {|n| [n.to_s, [1, 2]]}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Given that Ruby supports sorting/selecting via an `Array` (for multiple criteria), the signatures for `min_by`, `max_by`, `minmax_by` and `sort_by` should accept not only `Comparable`, but also an `Array[Comparable]`.

The main problem is that `Array` is not `Comparable` (and, most likely, won't be, see [here](https://bugs.ruby-lang.org/issues/5574))

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
#1231 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
