### PR TITLE
Fix error count reporting in metrics

### DIFF
--- a/core/ErrorFlusher.cc
+++ b/core/ErrorFlusher.cc
@@ -13,6 +13,9 @@ void ErrorFlusher::flushErrors(spdlog::logger &logger, vector<unique_ptr<ErrorQu
             if (error->error->isSilenced) {
                 continue;
             }
+
+            prodHistogramAdd("error", error->error->what.code, 1);
+
             auto &out = error->error->isCritical() ? critical : nonCritical;
             if (out.size() != 0) {
                 fmt::format_to(out, "\n\n");

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1211,9 +1211,6 @@ void GlobalState::_error(unique_ptr<Error> error) const {
         loc.file().data(*this).minErrorLevel_ = min(loc.file().data(*this).minErrorLevel_, error->what.minLevel);
     }
 
-    if (shouldReportErrorOn(loc, error->what)) {
-        prodHistogramAdd("error", error->what.code, 1);
-    }
     errorQueue->pushError(*this, move(error));
 }
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1226,7 +1226,7 @@ ErrorBuilder GlobalState::beginError(Loc loc, ErrorClass what) const {
         Exception::failInFuzzer();
     }
     bool report = (what == errors::Internal::InternalError) || (what == errors::Internal::FileNotFound) ||
-        (shouldReportErrorOn(loc, what) && !this->silenceErrors);
+                  (shouldReportErrorOn(loc, what) && !this->silenceErrors);
     return ErrorBuilder(*this, report, loc, what);
 }
 

--- a/test/cli/metrics-file/metrics-file.out
+++ b/test/cli/metrics-file/metrics-file.out
@@ -14,5 +14,4 @@ No errors! Great job.
    "value": 1
 ------------------------------
 No errors! Great job.
-   "name": "ruby_typer.unknown..infer.methods_typechecked.no_errors",
-   "value": 2
+No error metrics reported.

--- a/test/cli/metrics-file/metrics-file.out
+++ b/test/cli/metrics-file/metrics-file.out
@@ -12,3 +12,7 @@ No errors! Great job.
    "value": 1
    "name": "ruby_typer.unknown..types.input.files.sigil.true",
    "value": 1
+------------------------------
+No errors! Great job.
+   "name": "ruby_typer.unknown..infer.methods_typechecked.no_errors",
+   "value": 2

--- a/test/cli/metrics-file/metrics-file.sh
+++ b/test/cli/metrics-file/metrics-file.sh
@@ -25,3 +25,14 @@ main/sorbet --silence-dev-message \
 grep -A1 "\"ruby_typer.unknown..types.input.files\"" metrics4.json
 grep -A1 "\"ruby_typer.unknown..types.input.files.sigil.false\"" metrics4.json
 grep -A1 "\"ruby_typer.unknown..types.input.files.sigil.true\"" metrics4.json
+
+echo ------------------------------
+
+# Sorbet will not count errors that are created but end up being
+# ignored by other branches, e.g. when a type error is found in one
+# branch of a T.all but ends up being made irrelevant by the other
+main/sorbet --silence-dev-message \
+            --metrics-file=metrics5.json \
+            test/cli/metrics-file/with-error-branching.rb 2>&1
+
+grep -A1 "\"ruby_typer.unknown..infer.methods_typechecked.no_errors\"" metrics5.json

--- a/test/cli/metrics-file/metrics-file.sh
+++ b/test/cli/metrics-file/metrics-file.sh
@@ -35,4 +35,4 @@ main/sorbet --silence-dev-message \
             --metrics-file=metrics5.json \
             test/cli/metrics-file/with-error-branching.rb 2>&1
 
-grep -A1 "\"ruby_typer.unknown..infer.methods_typechecked.no_errors\"" metrics5.json
+grep -A1 "\"ruby_typer.unknown..error.total\"" metrics5.json || echo "No error metrics reported."

--- a/test/cli/metrics-file/with-error-branching.rb
+++ b/test/cli/metrics-file/with-error-branching.rb
@@ -1,0 +1,5 @@
+# typed: true
+extend T::Sig
+class C; end
+sig { params(x: T.all(T::Enumerable[Integer], C)).void }
+def foo(x); x.each { |i| puts i }; end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes #1211: certain parts of our code will start to produce `Error` values that turn out to not be relevant, especially in type-checking: e.g. when we're dispatching a method `#m` on a value of type `T.all(X, Y)`, there will be situations where the method is not present on `X`, which will lead us to produce an `UnknownMethod` error, but we'll then find the method on `Y`, at which point we'll get rid of the error without adding it to the error queue. However, we were previously adding information to the metrics as soon as we _created_ an `Error` value, and not when we added it to the queue, which meant that these thrown-away errors would appear in the metrics output despite not appearing in the final output. This simply moves the logic so that we don't report an error to the metrics until we're sure it's going to show up in the output as well.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
