### PR TITLE
Def sorting rules, only store one non-behavior def

### DIFF
--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -128,7 +128,7 @@ core::FileRef DefTree::file() const {
     if (!namedDefs.empty()) {
         // TODO what if there are more than one?
         ref = namedDefs[0].fileRef;
-    } else if (nonBehaviorDef) {
+    } else if (nonBehaviorDef == nullptr) {
         ref = nonBehaviorDef->fileRef;
     }
     return ref;
@@ -247,7 +247,7 @@ Definition::Type DefTree::definitionType(core::Context ctx) const {
 }
 
 bool DefTree::hasDef() const {
-    return nonBehaviorDef || !namedDefs.empty();
+    return (nonBehaviorDef != nullptr) || !namedDefs.empty();
 }
 
 const NamedDefinition &DefTree::definition(core::Context ctx) const {
@@ -256,7 +256,7 @@ const NamedDefinition &DefTree::definition(core::Context ctx) const {
                 namedDefs.size());
         return namedDefs[0];
     } else {
-        ENFORCE(nonBehaviorDef, "Could not find any definitions for '{}'", fullName(ctx));
+        ENFORCE(nonBehaviorDef != nullptr, "Could not find any definitions for '{}'", fullName(ctx));
         return *nonBehaviorDef;
     }
 }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -229,7 +229,7 @@ void runAutogen(core::Context ctx, options::Options &opts, const autogen::Autolo
         merged.insert(merged.end(), make_move_iterator(out.prints.begin()), make_move_iterator(out.prints.end()));
         if (opts.print.AutogenAutoloader.enabled) {
             Timer timeit(logger, "autogenAutoloaderDefTreeMerge");
-            root = autogen::DefTreeBuilder::merge(move(root), move(*out.defTree));
+            root = autogen::DefTreeBuilder::merge(ctx, move(root), move(*out.defTree));
         }
     }
     fast_sort(merged, [](const auto &lhs, const auto &rhs) -> bool { return lhs.first < rhs.first; });


### PR DESCRIPTION
Based on https://github.com/sorbet/sorbet/pull/1102


### Motivation
For autoloader output where a DefTree node has no "behavior defining" definitions but is referenced in multiple places, deterministically select which location to use. This selects class defs over module usage, shorter paths over longer, and finally by name.


### Test plan
Automated autoloader tests.

cc @gw 