### PR TITLE
Make install hooks viral

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -372,7 +372,7 @@ bool extendsTHelpers(core::Context ctx, core::SymbolRef enclosingClass) {
 }
 
 /**
- * Make an autocorrection for adding `extends T::Helpers`, when needed.
+ * Make an autocorrection for adding `extend T::Helpers`, when needed.
  */
 optional<core::AutocorrectSuggestion> maybeSuggestExtendTHelpers(core::Context ctx, const Type *thisType,
                                                                  const Loc &call) {

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -165,11 +165,7 @@ module T::Private::Methods
   end
 
   def self.sig_error(loc, message)
-    raise(
-      ArgumentError.new(
-        "#{loc.path}:#{loc.lineno}: Error interpreting `sig`:\n  #{message}\n\n"
-      )
-    )
+    raise(ArgumentError.new("#{loc.path}:#{loc.lineno}: Error interpreting `sig`:\n  #{message}\n\n"))
   end
 
   # Executes the `sig` block, and converts the resulting Declaration

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -109,7 +109,7 @@ module T::Private::Methods
   # Only public because it needs to get called below inside the replace_method blocks below.
   def self._on_method_added(hook_mod, method_name, is_singleton_method: false)
     current_declaration = T::Private::DeclState.current.active_declaration
-    return if !current_declaration
+    return if current_declaration.nil?
     T::Private::DeclState.current.reset!
 
     mod = is_singleton_method ? hook_mod.singleton_class : hook_mod

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -16,7 +16,7 @@ module T::Private::Methods
     install_hooks(mod)
 
     if T::Private::DeclState.current.active_declaration
-      T::Private::DeclState.current.active_declaration = nil
+      T::Private::DeclState.current.reset!
       raise "You called sig twice without declaring a method inbetween"
     end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -106,6 +106,26 @@ module T::Private::Methods
     @signatures_by_method[key]
   end
 
+  # a module A such that:
+  #   if A is included or extended by a module B,
+  #   then we want B to have the hooks installed on itself
+  # should extend this module.
+  module VirallyInstallHooks
+    def included(arg)
+      super(arg)
+      if arg.is_a?(Module)
+        ::T::Private::Methods.install_hooks(arg)
+      end
+    end
+
+    def extended(arg)
+      super(arg)
+      if arg.is_a?(Module)
+        ::T::Private::Methods.install_hooks(arg)
+      end
+    end
+  end
+
   # Only public because it needs to get called below inside the replace_method blocks below.
   def self._on_method_added(hook_mod, method_name, is_singleton_method: false)
     current_declaration = T::Private::DeclState.current.active_declaration


### PR DESCRIPTION
## Motivation

This PR is pre-work for the final runtime checks. It also contains some other
assorted minor fixes.

When final things (methods and modules) are implemented in the runtime, we would
like for all consumers of final things to have all of the final checks be run
for them, at all times. This means that even if a consumer of a final thing
isn't using other features of the Sorbet runtime like `sig`s in their own code,
we would still like to make sure they are respecting the final checks.

This means that, for instance, if a module `Consumer` includes a module
`HasFinal`, where `HasFinal` defines some final methods, we would like all
further method definitions in `Consumer` to make sure that they are not
overriding a final method definition in `HasFinal`.

The way that we listen in for and do things with method definitions is the
runtime hooks. Whenever a module utters `extend T::Sig` followed by a call to
`sig`, that module has the hooks installed on itself. These hooks then listen in
for new method definitions on that module, and wrap those method definitions
with the preceding `sig` logic, if there was any.

Before this PR, the only way the hooks could be installed on a module (other
than explicitly calling `T::Private::Methods::install_hooks(mod)`) was by
uttering `sig`. However, as previously mentioned, we would like for the final
checks to be run for consumers of final methods, even if a consumer doesn't use
`sig`.

Because I plan to implement the final checks using the existing hooks machinery
(i.e. by adding to `T::Private::Methods._on_method_added`), this means that we
would like to install the hooks on any module `Consumer` that includes or
extends a module `HasFinal`, where `HasFinal` contains some final methods.

This PR implements approximately that, in that, we now install the hooks on any
module `Consumer` that includes or extends a module `HasHooks`, where `HasHooks`
is a module that has the hooks installed on it. This works because the only way
to mark a method as final is to say so in its `sig`, and once you have put a
`sig` on a method, you have the hooks installed on yourself.

This means that when final modules are added, we will probably want to install
the hooks on any module that utters `final!` in its body.

The way we implement the above logic is by tapping into the `included` and
`extended` methods in Ruby, which are called when a module is included or
extended. When a module has the hooks installed on itself, we add a bit of logic
to its `included` and `extended` that make it such that the includer or extender
also gets the hooks.

## Pitfalls (OUTDATED)

Reviewers of this PR who review by commit will notice that the first pass at the
implementation looked like this:

```rb
orig_included = T::Private::ClassUtils.replace_method(mod.singleton_class, :included) do |arg|
  # ... our logic to apply the hooks to arg ...
  orig_included.bind(self).call(arg)
end
```

Here, `orig_included` is the `included` that was defined on
`mod.singleton_class` at the time that the call to
`T::Private::ClassUtils.replace_method` was made. The problem with this is that,
if, after this call to `replace_method`, we define a different `included` on
`mod.singleton_class`, that `orig_included` does not refer to it.

This was exemplified by modules that `include T::Props::Plugin` not behaving
correctly.

The fix for this bug is to change the implementation to this:

```rb
T::Private::ClassUtils.replace_method(mod.singleton_class, :included) do |arg|
  # ... our logic to apply the hooks to arg ...
  super(arg)
end
```

Where `super` (appears to) simply refer to "the included before us". (I'm not
100% on the semantics here, but all tests pass so I think this is right.)

The reason why I'm specifically calling this out here is because there seems to
be lots of places in the sorbet runtime where we use the general pattern shown
in the first example, and I wonder if any of them are subtly incorrect the way
my first implementation was.

## A third pass

The above section has been marked outdated, but has been kept for posterity.

A third pass at the implementation avoids `replace_method` altogether. We
instead defines a `module VirallyInstallHooks` which defines the `included` and
`extended` we want, together with the appropriate `super` to make sure we still
run the other `included` and `extended`. We then have modules extend this
`VirallyInstallHooks`.

## Test plan

Existing tests pass. New tests added.
