### PR TITLE
Fix segfault in `calls.cc`

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1046,6 +1046,7 @@ public:
         for (auto &err : res.main.errors) {
             dispatched.main.errors.emplace_back(std::move(err));
         }
+        res.main.errors.clear();
         res.returnType = instanceTy;
         res.main = move(dispatched.main);
         res.main.sendTp = instanceTy;
@@ -1277,6 +1278,7 @@ public:
         for (auto &err : dispatched.main.errors) {
             res.main.errors.emplace_back(std::move(err));
         }
+        dispatched.main.errors.clear();
 
         // TODO: this should merge constrains from `res` and `dispatched` instead
         if ((dispatched.main.constr == nullptr) || dispatched.main.constr->isEmpty()) {
@@ -1369,6 +1371,7 @@ private:
         for (auto &err : dispatched.main.errors) {
             res.main.errors.emplace_back(std::move(err));
         }
+        dispatched.main.errors.clear();
         // We use isSubTypeUnderConstraint here with a TypeConstraint, so that we discover the correct generic bounds
         // as we do the subtyping check.
         auto &constr = dispatched.main.constr;
@@ -1865,6 +1868,7 @@ public:
         for (auto &err : dispatched.main.errors) {
             res.main.errors.emplace_back(std::move(err));
         }
+        dispatched.main.errors.clear();
         res.returnType = move(dispatched.returnType);
     }
 } enumerable_to_h;

--- a/test/testdata/core/fuzz_unparseable.rb
+++ b/test/testdata/core/fuzz_unparseable.rb
@@ -1,0 +1,4 @@
+# typed: strict
+r *[1]g#typed:true
+    # ^ error: Parse Error: unexpected token: syntax error
+m do # error: Parse Error: unexpected token: syntax error


### PR DESCRIPTION


### Motivation

Fixes #1242; makes sure we clear out arrays after we've `move`d data from them.

### Test plan

See included automated tests.
