### PR TITLE
Make error assertions that match duplicate errors explicit.

### DIFF
--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -570,7 +570,9 @@ void reportMissingError(const string &filename, const ErrorAssertion &assertion,
 void reportUnexpectedError(const string &filename, const Diagnostic &diagnostic, string_view sourceLine,
                            string_view errorPrefix) {
     ADD_FAILURE_AT(filename.c_str(), diagnostic.range->start->line + 1) << fmt::format(
-        "{}Found unexpected error:\n{}", errorPrefix,
+        "{}Found unexpected error:\n{}\nNote: If there is already an assertion for this error, then this is a "
+        "duplicate error. Change the assertion to `# error-with-dupes: <error message>` if the duplicate is expected.",
+        errorPrefix,
         prettyPrintRangeComment(sourceLine, *diagnostic.range, fmt::format("error: {}", diagnostic.message)));
 }
 

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -20,6 +20,7 @@ const UnorderedMap<
     string, function<shared_ptr<RangeAssertion>(string_view, unique_ptr<Range> &, int, string_view, string_view)>>
     assertionConstructors = {
         {"error", ErrorAssertion::make},
+        {"error-with-dupes", ErrorAssertion::make},
         {"usage", UsageAssertion::make},
         {"def", DefAssertion::make},
         {"disable-fast-path", BooleanPropertyAssertion::make},
@@ -155,16 +156,19 @@ int RangeAssertion::compare(string_view otherFilename, const Range &otherRange) 
     return rangeComparison(*range, otherRange);
 }
 
-ErrorAssertion::ErrorAssertion(string_view filename, unique_ptr<Range> &range, int assertionLine, string_view message)
-    : RangeAssertion(filename, range, assertionLine), message(message) {}
+ErrorAssertion::ErrorAssertion(string_view filename, unique_ptr<Range> &range, int assertionLine, string_view message,
+                               bool matchesDuplicateErrors)
+    : RangeAssertion(filename, range, assertionLine), message(message), matchesDuplicateErrors(matchesDuplicateErrors) {
+}
 
 shared_ptr<ErrorAssertion> ErrorAssertion::make(string_view filename, unique_ptr<Range> &range, int assertionLine,
                                                 string_view assertionContents, string_view assertionType) {
-    return make_shared<ErrorAssertion>(filename, range, assertionLine, assertionContents);
+    return make_shared<ErrorAssertion>(filename, range, assertionLine, assertionContents,
+                                       assertionType == "error-with-dupes");
 }
 
 string ErrorAssertion::toString() const {
-    return fmt::format("error: {}", message);
+    return fmt::format("{}: {}", (matchesDuplicateErrors ? "error-with-dupes" : "error"), message);
 }
 
 bool ErrorAssertion::check(const Diagnostic &diagnostic, string_view sourceLine, string_view errorPrefix) {
@@ -570,11 +574,6 @@ void reportUnexpectedError(const string &filename, const Diagnostic &diagnostic,
         prettyPrintRangeComment(sourceLine, *diagnostic.range, fmt::format("error: {}", diagnostic.message)));
 }
 
-/** Returns true if a and b are different Diagnostic objects but have the same range and message. */
-bool isDuplicateDiagnostic(const Diagnostic *a, const Diagnostic *b) {
-    return a != b && rangeComparison(*a->range, *b->range) == 0 && a->message == b->message;
-}
-
 string getSourceLine(const UnorderedMap<string, shared_ptr<core::File>> &sourceFileContents, const string &filename,
                      int line) {
     auto it = sourceFileContents.find(filename);
@@ -592,6 +591,11 @@ string getSourceLine(const UnorderedMap<string, shared_ptr<core::File>> &sourceF
         auto lineView = file->getLine(line + 1);
         return string(lineView.begin(), lineView.end());
     }
+}
+
+bool isDuplicateDiagnostic(string_view filename, ErrorAssertion *assertion, const Diagnostic &d) {
+    return assertion && assertion->matchesDuplicateErrors && assertion->compare(filename, *d.range) == 0 &&
+           d.message.find(assertion->message) != string::npos;
 }
 
 bool ErrorAssertion::checkAll(const UnorderedMap<string, shared_ptr<core::File>> &files,
@@ -620,20 +624,19 @@ bool ErrorAssertion::checkAll(const UnorderedMap<string, shared_ptr<core::File>>
         });
 
         auto diagnosticsIt = diagnostics.begin();
-        auto *lastDiagnostic = diagnosticsIt == diagnostics.end() ? nullptr : (*diagnosticsIt).get();
+        ErrorAssertion *lastAssertion = nullptr;
 
         while (diagnosticsIt != diagnostics.end() && assertionsIt != errorAssertions.end()) {
             // See if the ranges match.
             auto &diagnostic = *diagnosticsIt;
             auto &assertion = *assertionsIt;
 
-            // TODO: Remove duplicate diagnostics for parity with old runner.
-            // Remove this check when ruby types team fixes duplicate diagnostics.
-            if (isDuplicateDiagnostic(lastDiagnostic, diagnostic.get())) {
+            if (isDuplicateDiagnostic(filename, lastAssertion, *diagnostic)) {
                 diagnosticsIt++;
                 continue;
+            } else {
+                lastAssertion = nullptr;
             }
-            lastDiagnostic = diagnostic.get();
 
             switch (assertion->compare(filename, *diagnostic->range)) {
                 case 1: {
@@ -664,6 +667,8 @@ bool ErrorAssertion::checkAll(const UnorderedMap<string, shared_ptr<core::File>>
                                                errorPrefix) &&
                               success;
                     // We've 'consumed' the diagnostic and assertion.
+                    // Save assertion in case it matches multiple diagnostics.
+                    lastAssertion = assertion.get();
                     diagnosticsIt++;
                     assertionsIt++;
                     break;
@@ -673,15 +678,13 @@ bool ErrorAssertion::checkAll(const UnorderedMap<string, shared_ptr<core::File>>
 
         while (diagnosticsIt != diagnostics.end()) {
             // We had more diagnostics than error assertions.
-            // Drain dupes.
-            // TODO: Remove when ruby types team fixes duplicate diagnostics; see note above.
-            if (!isDuplicateDiagnostic(lastDiagnostic, (*diagnosticsIt).get())) {
-                auto &diagnostic = *diagnosticsIt;
+            auto &diagnostic = *diagnosticsIt;
+            if (!isDuplicateDiagnostic(filename, lastAssertion, *diagnostic)) {
                 reportUnexpectedError(filename, *diagnostic,
                                       getSourceLine(files, filename, diagnostic->range->start->line), errorPrefix);
                 success = false;
+                lastAssertion = nullptr;
             }
-            lastDiagnostic = (*diagnosticsIt).get();
             diagnosticsIt++;
         }
     }

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -95,9 +95,10 @@ public:
                          std::string errorPrefix = "");
 
     const std::string message;
+    const bool matchesDuplicateErrors;
 
     ErrorAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
-                   std::string_view message);
+                   std::string_view message, bool matchesDuplicateErrors);
 
     std::string toString() const override;
 

--- a/test/testdata/core/fuzz_unparseable.rb
+++ b/test/testdata/core/fuzz_unparseable.rb
@@ -1,4 +1,4 @@
 # typed: strict
 r *[1]g#typed:true
     # ^ error: Parse Error: unexpected token: syntax error
-m do # error: Parse Error: unexpected token: syntax error
+m do # error-with-dupes: Parse Error: unexpected token: syntax error

--- a/test/testdata/core/fuzz_unparseable.rb
+++ b/test/testdata/core/fuzz_unparseable.rb
@@ -1,4 +1,4 @@
 # typed: strict
 r *[1]g#typed:true
-    # ^ error: Parse Error: unexpected token: syntax error
+    # ^ error-with-dupes: Parse Error: unexpected token: syntax error
 m do # error-with-dupes: Parse Error: unexpected token: syntax error

--- a/test/testdata/desugar/constant_reassignment.rb
+++ b/test/testdata/desugar/constant_reassignment.rb
@@ -1,10 +1,10 @@
 # typed: true
 
 A = 1
-A ||= 2 # error: Constant reassignment is not supported
+A ||= 2 # error-with-dupes: Constant reassignment is not supported
 
 B = 1
-B &&= 2 # error: Constant reassignment is not supported
+B &&= 2 # error-with-dupes: Constant reassignment is not supported
 
 C = 1
-C += 2 # error: Constant reassignment is not supported
+C += 2 # error-with-dupes: Constant reassignment is not supported

--- a/test/testdata/desugar/defs_not_self.rb
+++ b/test/testdata/desugar/defs_not_self.rb
@@ -1,3 +1,3 @@
 # typed: true
-def x.method # error: `def EXPRESSION.method` is only supported for `def self.method`
+def x.method # error-with-dupes: `def EXPRESSION.method` is only supported for `def self.method`
 end

--- a/test/testdata/desugar/for.rb
+++ b/test/testdata/desugar/for.rb
@@ -2,8 +2,8 @@
 
 class A
     def self.each
+  # ^^^^^^^^^^^^^ error-with-dupes: Method `each` uses `yield` but does not mention a block parameter
   # ^^^^^^^^^^^^^ error: This function does not have a `sig`
-  # ^^^^^^^^^^^^^ error: Method `each` uses `yield` but does not mention a block parameter
         yield 1,2,3,4,5
         yield 6,7,8,9,0
     end

--- a/test/testdata/desugar/fuzz_block_pass.rb
+++ b/test/testdata/desugar/fuzz_block_pass.rb
@@ -1,7 +1,7 @@
 # typed: false
-next &a # error: Block argument should not be given
-next a, &b # error: Block argument should not be given
-break &a # error: Block argument should not be given
-break a, &b # error: Block argument should not be given
-return &a # error: Block argument should not be given
-return a, &b # error: Block argument should not be given
+next &a # error-with-dupes: Block argument should not be given
+next a, &b # error-with-dupes: Block argument should not be given
+break &a # error-with-dupes: Block argument should not be given
+break a, &b # error-with-dupes: Block argument should not be given
+return &a # error-with-dupes: Block argument should not be given
+return a, &b # error-with-dupes: Block argument should not be given

--- a/test/testdata/desugar/fuzz_break_do_end.rb
+++ b/test/testdata/desugar/fuzz_break_do_end.rb
@@ -1,3 +1,3 @@
 # typed: false
-break 1 do # error: No body in block
+break 1 do # error-with-dupes: No body in block
 end

--- a/test/testdata/desugar/integers.rb
+++ b/test/testdata/desugar/integers.rb
@@ -1,14 +1,14 @@
 # typed: true
 def test_large_int
   [
-    0B, # error: numeric literal without digits
-    0X, # error: numeric literal without digits
+    0B, # error-with-dupes: numeric literal without digits
+    0X, # error-with-dupes: numeric literal without digits
     00,
     9223372036854775807,
     -9223372036854775808,
-    18446744073709551616,   # error: Unsupported integer
+    18446744073709551616,   # error-with-dupes: Unsupported integer
     0xcafe,
     0_0,
-    1_, # error: trailing `_`
+    1_, # error-with-dupes: trailing `_`
   ]
 end

--- a/test/testdata/desugar/regexp.rb
+++ b/test/testdata/desugar/regexp.rb
@@ -14,5 +14,5 @@ def foo
     /#{a}b#{c}/
     Regexp.new(a + 'b' + c)
 
-    /abc/a # error: Parse Error: unknown regexp options: a
+    /abc/a # error-with-dupes: Parse Error: unknown regexp options: a
 end

--- a/test/testdata/desugar/sclass.rb
+++ b/test/testdata/desugar/sclass.rb
@@ -2,7 +2,7 @@
 class A
 end
 
-class << A # error: `class << EXPRESSION` is only supported for `class << self`
+class << A # error-with-dupes: `class << EXPRESSION` is only supported for `class << self`
     def a
         'a'
     end
@@ -17,7 +17,7 @@ class B
 end
 
 $c = Object.new
-class << $c # error: `class << EXPRESSION` is only supported for `class << self`
+class << $c # error-with-dupes: `class << EXPRESSION` is only supported for `class << self`
     def c
         "c"
     end

--- a/test/testdata/desugar/star_in_block_arg.rb
+++ b/test/testdata/desugar/star_in_block_arg.rb
@@ -5,6 +5,6 @@ sig {params(blk: T.proc.params(args: Integer).void).void}
 def foo(&blk)
 end
 
-foo do |(*args)| # error: Unsupported rest args in destructure
+foo do |(*args)| # error-with-dupes: Unsupported rest args in destructure
   T.reveal_type(args) # error: Revealed type: `Integer`
 end

--- a/test/testdata/desugar/undef_strict.rb
+++ b/test/testdata/desugar/undef_strict.rb
@@ -11,4 +11,4 @@ def undef(*arg); end
 sig {void}
 def foo
 end
-undef foo # error: Unsuppored method: undef
+undef foo # error-with-dupes: Unsuppored method: undef

--- a/test/testdata/dsl/attr.rb
+++ b/test/testdata/dsl/attr.rb
@@ -20,7 +20,7 @@ class TestAttr
   sig {returns(String)}
   attr_reader :v3 # error: Use of undeclared variable
 
-  attr_writer :v4, :v5 # error: This function does not have a `sig`
+  attr_writer :v4, :v5 # error-with-dupes: This function does not have a `sig`
 #              ^^        error: Use of undeclared variable `@v4`
 #                   ^^   error: Use of undeclared variable `@v5`
 end

--- a/test/testdata/dsl/command.rb
+++ b/test/testdata/dsl/command.rb
@@ -21,7 +21,7 @@ end
 
 T.assert_type!(OtherCommand.call("8"), Integer)
 
-class NotACommand < Llamas::Opus::Command # error: Unable to resolve constant
+class NotACommand < Llamas::Opus::Command # error-with-dupes: Unable to resolve constant
   extend T::Sig
 
   sig {params(x: String).returns(Integer)}

--- a/test/testdata/dsl/interface_wrapper.rb
+++ b/test/testdata/dsl/interface_wrapper.rb
@@ -26,7 +26,7 @@ def testit
   wrap.other_method # error: does not exist
   wrap.some_method
 
-  Other.wrap_instance("hi", "there") # error: Wrong number of arguments
+  Other.wrap_instance("hi", "there") # error-with-dupes: Wrong number of arguments
   o = Other
-  o.wrap_instance("hi") # error: Unsupported wrap_instance() on a non-constant-literal
+  o.wrap_instance("hi") # error-with-dupes: Unsupported wrap_instance() on a non-constant-literal
 end

--- a/test/testdata/infer/crash_after_parse_errors.rb
+++ b/test/testdata/infer/crash_after_parse_errors.rb
@@ -1,5 +1,5 @@
 # typed: true
-->e # error: syntax error
+->e # error-with-dupes: syntax error
 r=e
 r=e
 r&&o # error: This code is unreachable

--- a/test/testdata/infer/fuzz_uninitialized_vars.rb
+++ b/test/testdata/infer/fuzz_uninitialized_vars.rb
@@ -1,6 +1,6 @@
 # typed: true
 foo = a(b
-if @c && foo # error: Parse Error: unexpected token: syntax error
+if @c && foo # error-with-dupes: Parse Error: unexpected token: syntax error
   d # error: This code is unreachable
 end
 

--- a/test/testdata/lsp/fast_path/method_signature_update.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_signature_update.1.rbupdate
@@ -1,0 +1,12 @@
+# typed: true
+class A
+  extend T::Sig
+
+  # Change 'String' to 'Integer'
+  sig {params(x: Integer).returns(Integer)}
+  def bar(x)
+    x.to_s # error: Returning value that does not conform to method result type
+  end
+end
+
+j = T.let(A.new.bar(10), String) # error: Argument does not have asserted type `String`

--- a/test/testdata/lsp/fast_path/method_signature_update.rb
+++ b/test/testdata/lsp/fast_path/method_signature_update.rb
@@ -1,0 +1,12 @@
+# typed: true
+class A
+  extend T::Sig
+
+  # Change 'String' to 'Integer'
+  sig {params(x: Integer).returns(String)}
+  def bar(x)
+    x.to_s
+  end
+end
+
+j = T.let(A.new.bar(10), String)

--- a/test/testdata/namer/super.rb
+++ b/test/testdata/namer/super.rb
@@ -1,2 +1,2 @@
 # typed: true
-super # error: `super` outside of method
+super # error-with-dupes: `super` outside of method

--- a/test/testdata/parser/begin_block_nullderef.rb
+++ b/test/testdata/parser/begin_block_nullderef.rb
@@ -1,3 +1,3 @@
 # typed: true
 def s()else
-n # error: syntax error
+n # error-with-dupes: syntax error

--- a/test/testdata/parser/compare_overload_parse_error.rb
+++ b/test/testdata/parser/compare_overload_parse_error.rb
@@ -1,15 +1,15 @@
 # typed: false
-class A # error: Parse Error: class definition in method body
-  def greater_eqaul>=(foo) # error: Parse Error: unexpected token: syntax error
+class A # error-with-dupes: Parse Error: class definition in method body
+  def greater_eqaul>=(foo) # error-with-dupes: Parse Error: unexpected token: syntax error
   end
 end
 
-class B # error: Parse Error: class definition in method body
-  def less_equal<=(foo) # error: Parse Error: unexpected token: syntax error
+class B # error-with-dupes: Parse Error: class definition in method body
+  def less_equal<=(foo) # error-with-dupes: Parse Error: unexpected token: syntax error
   end
 end
 
-class C # error: Parse Error: class definition in method body
-  def not_equal!=(foo) # error: Parse Error: unexpected token: syntax error
+class C # error-with-dupes: Parse Error: class definition in method body
+  def not_equal!=(foo) # error-with-dupes: Parse Error: unexpected token: syntax error
   end
 end

--- a/test/testdata/parser/encoding.rb
+++ b/test/testdata/parser/encoding.rb
@@ -1,2 +1,2 @@
 # typed: false
-__ENCODING__ # error: Unsupported node type `EncodingLiteral`
+__ENCODING__ # error-with-dupes: Unsupported node type `EncodingLiteral`

--- a/test/testdata/parser/fuzz_def_begin.rb
+++ b/test/testdata/parser/fuzz_def_begin.rb
@@ -1,2 +1,2 @@
 # typed: false
-def BEGIN # error: Parse Error: unexpected token: syntax error
+def BEGIN # error-with-dupes: Parse Error: unexpected token: syntax error

--- a/test/testdata/parser/fuzz_ivar.rb
+++ b/test/testdata/parser/fuzz_ivar.rb
@@ -1,3 +1,3 @@
 # typed: false
-@1 # error: Parse Error: `@1` is not allowed as an instance variable name
-@@2 # error: Parse Error: `@@2` is not allowed as a class variable name
+@1 # error-with-dupes: Parse Error: `@1` is not allowed as an instance variable name
+@@2 # error-with-dupes: Parse Error: `@@2` is not allowed as a class variable name

--- a/test/testdata/parser/invalid_fatal.rb
+++ b/test/testdata/parser/invalid_fatal.rb
@@ -1,2 +1,2 @@
 # typed: true
-"\xg3" # error: Parse Fatal: invalid hex escape
+"\xg3" # error-with-dupes: Parse Fatal: invalid hex escape

--- a/test/testdata/parser/invalid_syntax_error.rb
+++ b/test/testdata/parser/invalid_syntax_error.rb
@@ -1,2 +1,2 @@
 # typed: false
-1j # error: Parse Error: unexpected token: syntax error
+1j # error-with-dupes: Parse Error: unexpected token: syntax error

--- a/test/testdata/parser/invalid_trailing_in_number.rb
+++ b/test/testdata/parser/invalid_trailing_in_number.rb
@@ -1,2 +1,2 @@
 # typed: true
-0_ # error: Parse Error: trailing `_` in number
+0_ # error-with-dupes: Parse Error: trailing `_` in number

--- a/test/testdata/parser/misc.rb
+++ b/test/testdata/parser/misc.rb
@@ -109,8 +109,8 @@ def optfoo(x=1, *y); end
 # pair and pair_quoted
 {x => y, "foo": 1}
 
-BEGIN{foo} # error: Unsupported node type `Preexe`
-END{bar} # error: Unsupported node type `Postexe`
+BEGIN{foo} # error-with-dupes: Unsupported node type `Preexe`
+END{bar} # error-with-dupes: Unsupported node type `Postexe`
 
 # rationals
 4r

--- a/test/testdata/parser/offset0.rb
+++ b/test/testdata/parser/offset0.rb
@@ -1,4 +1,4 @@
 # typed: true
-module Model # error: module definition in method body
-  def a-b; end # error: unexpected token
+module Model # error-with-dupes: module definition in method body
+  def a-b; end # error-with-dupes: unexpected token
 end

--- a/test/testdata/parser/whitequark/assert_parses_args_2.rb
+++ b/test/testdata/parser/whitequark/assert_parses_args_2.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def f ((a, *r)); end # error: Unsupported rest args in destructure
+def f ((a, *r)); end # error-with-dupes: Unsupported rest args in destructure

--- a/test/testdata/parser/whitequark/assert_parses_args_3.rb
+++ b/test/testdata/parser/whitequark/assert_parses_args_3.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def f ((a, *r, p)); end # error: Unsupported rest args in destructure
+def f ((a, *r, p)); end # error-with-dupes: Unsupported rest args in destructure

--- a/test/testdata/parser/whitequark/assert_parses_args_4.rb
+++ b/test/testdata/parser/whitequark/assert_parses_args_4.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def f ((a, *)); end # error: Unsupported rest args in destructure
+def f ((a, *)); end # error-with-dupes: Unsupported rest args in destructure

--- a/test/testdata/parser/whitequark/assert_parses_args_5.rb
+++ b/test/testdata/parser/whitequark/assert_parses_args_5.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def f ((a, *, p)); end # error: Unsupported rest args in destructure
+def f ((a, *, p)); end # error-with-dupes: Unsupported rest args in destructure

--- a/test/testdata/parser/whitequark/assert_parses_args_6.rb
+++ b/test/testdata/parser/whitequark/assert_parses_args_6.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def f ((*r)); end # error: Unsupported rest args in destructure
+def f ((*r)); end # error-with-dupes: Unsupported rest args in destructure

--- a/test/testdata/parser/whitequark/assert_parses_args_7.rb
+++ b/test/testdata/parser/whitequark/assert_parses_args_7.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def f ((*r, p)); end # error: Unsupported rest args in destructure
+def f ((*r, p)); end # error-with-dupes: Unsupported rest args in destructure

--- a/test/testdata/parser/whitequark/assert_parses_args_8.rb
+++ b/test/testdata/parser/whitequark/assert_parses_args_8.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def f ((*)); end # error: Unsupported rest args in destructure
+def f ((*)); end # error-with-dupes: Unsupported rest args in destructure

--- a/test/testdata/parser/whitequark/assert_parses_args_9.rb
+++ b/test/testdata/parser/whitequark/assert_parses_args_9.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def f ((*, p)); end # error: Unsupported rest args in destructure
+def f ((*, p)); end # error-with-dupes: Unsupported rest args in destructure

--- a/test/testdata/parser/whitequark/parse_alias_gvar_1.rb
+++ b/test/testdata/parser/whitequark/parse_alias_gvar_1.rb
@@ -1,3 +1,3 @@
 # typed: false
 
-alias $a $+ # error: Unsupported node type
+alias $a $+ # error-with-dupes: Unsupported node type

--- a/test/testdata/parser/whitequark/parse_back_ref.rb
+++ b/test/testdata/parser/whitequark/parse_back_ref.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-$+ # error: Unsupported node type
+$+ # error-with-dupes: Unsupported node type

--- a/test/testdata/parser/whitequark/parse_cond_eflipflop.rb
+++ b/test/testdata/parser/whitequark/parse_cond_eflipflop.rb
@@ -1,4 +1,4 @@
 # typed: true
 def foo; end;
 def bar; end;
-if foo...bar; end # error: Unsupported node type `EFlipflop`
+if foo...bar; end # error-with-dupes: Unsupported node type `EFlipflop`

--- a/test/testdata/parser/whitequark/parse_cond_iflipflop.rb
+++ b/test/testdata/parser/whitequark/parse_cond_iflipflop.rb
@@ -1,4 +1,4 @@
 # typed: true
 def foo; end;
 def bar; end;
-if foo..bar; end # error: Unsupported node type `IFlipflop`
+if foo..bar; end # error-with-dupes: Unsupported node type `IFlipflop`

--- a/test/testdata/parser/whitequark/parse_cond_match_current_line.rb
+++ b/test/testdata/parser/whitequark/parse_cond_match_current_line.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-if /wat/; end # error: Unsupported node type
+if /wat/; end # error-with-dupes: Unsupported node type

--- a/test/testdata/parser/whitequark/parse_const_op_asgn.rb
+++ b/test/testdata/parser/whitequark/parse_const_op_asgn.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-A += 1 # error: Constant reassignment is not supported
+A += 1 # error-with-dupes: Constant reassignment is not supported

--- a/test/testdata/parser/whitequark/parse_const_op_asgn_1.rb
+++ b/test/testdata/parser/whitequark/parse_const_op_asgn_1.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-::A += 1 # error: Constant reassignment is not supported
+::A += 1 # error-with-dupes: Constant reassignment is not supported

--- a/test/testdata/parser/whitequark/parse_const_op_asgn_2.rb
+++ b/test/testdata/parser/whitequark/parse_const_op_asgn_2.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-B::A += 1 # error: Constant reassignment is not supported
+B::A += 1 # error-with-dupes: Constant reassignment is not supported

--- a/test/testdata/parser/whitequark/parse_const_op_asgn_3.rb
+++ b/test/testdata/parser/whitequark/parse_const_op_asgn_3.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def x; self::A ||= 1; end # error: Constant reassignment is not supported
+def x; self::A ||= 1; end # error-with-dupes: Constant reassignment is not supported

--- a/test/testdata/parser/whitequark/parse_const_op_asgn_4.rb
+++ b/test/testdata/parser/whitequark/parse_const_op_asgn_4.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def x; ::A ||= 1; end # error: Constant reassignment is not supported
+def x; ::A ||= 1; end # error-with-dupes: Constant reassignment is not supported

--- a/test/testdata/parser/whitequark/parse_defs_2.rb
+++ b/test/testdata/parser/whitequark/parse_defs_2.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def (foo).foo; end # error: `def EXPRESSION.method` is only supported for `def self.method`
+def (foo).foo; end # error-with-dupes: `def EXPRESSION.method` is only supported for `def self.method`

--- a/test/testdata/parser/whitequark/parse_defs_3.rb
+++ b/test/testdata/parser/whitequark/parse_defs_3.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def String.foo; end # error: `def EXPRESSION.method` is only supported for `def self.method`
+def String.foo; end # error-with-dupes: `def EXPRESSION.method` is only supported for `def self.method`

--- a/test/testdata/parser/whitequark/parse_defs_4.rb
+++ b/test/testdata/parser/whitequark/parse_defs_4.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def String::foo; end # error: `def EXPRESSION.method` is only supported for `def self.method`
+def String::foo; end # error-with-dupes: `def EXPRESSION.method` is only supported for `def self.method`

--- a/test/testdata/parser/whitequark/parse_op_asgn_cmd_3.rb
+++ b/test/testdata/parser/whitequark/parse_op_asgn_cmd_3.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-foo::A += m foo # error: Constant reassignment is not supported
+foo::A += m foo # error-with-dupes: Constant reassignment is not supported

--- a/test/testdata/parser/whitequark/parse_postexe.rb
+++ b/test/testdata/parser/whitequark/parse_postexe.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-END { 1 }# error: Unsupported node type
+END { 1 }# error-with-dupes: Unsupported node type

--- a/test/testdata/parser/whitequark/parse_preexe.rb
+++ b/test/testdata/parser/whitequark/parse_preexe.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-BEGIN { 1 } # error: Unsupported node type `Preexe`
+BEGIN { 1 } # error-with-dupes: Unsupported node type `Preexe`

--- a/test/testdata/parser/whitequark/parse_redo.rb
+++ b/test/testdata/parser/whitequark/parse_redo.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-redo # error: Unsupported node type `Redo`
+redo # error-with-dupes: Unsupported node type `Redo`

--- a/test/testdata/parser/whitequark/parse_ruby_bug_12402_13.rb
+++ b/test/testdata/parser/whitequark/parse_ruby_bug_12402_13.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-foo::C ||= raise bar rescue nil # error: Constant reassignment is not supported
+foo::C ||= raise bar rescue nil # error-with-dupes: Constant reassignment is not supported

--- a/test/testdata/parser/whitequark/parse_ruby_bug_12402_6.rb
+++ b/test/testdata/parser/whitequark/parse_ruby_bug_12402_6.rb
@@ -1,4 +1,4 @@
 # typed: true
 def foo; end;
 def bar; end;
-foo::C ||= raise(bar) rescue nil # error: Constant reassignment is not supported
+foo::C ||= raise(bar) rescue nil # error-with-dupes: Constant reassignment is not supported

--- a/test/testdata/parser/whitequark/parse_sclass.rb
+++ b/test/testdata/parser/whitequark/parse_sclass.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-class << foo; nil; end # error: `class << EXPRESSION` is only supported for `class << self`
+class << foo; nil; end # error-with-dupes: `class << EXPRESSION` is only supported for `class << self`

--- a/test/testdata/parser/whitequark/parse_super_block_1.rb
+++ b/test/testdata/parser/whitequark/parse_super_block_1.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-super do end # error: `super` outside of method
+super do end # error-with-dupes: `super` outside of method

--- a/test/testdata/parser/whitequark/parse_zsuper.rb
+++ b/test/testdata/parser/whitequark/parse_zsuper.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-super # error: `super` outside of method
+super # error-with-dupes: `super` outside of method

--- a/test/testdata/resolver/abstract_override.rb
+++ b/test/testdata/resolver/abstract_override.rb
@@ -36,7 +36,7 @@ class Abstract
   include InterfaceChild
 end
 
-class AbstractBadChild < Abstract # error: Missing definition for abstract method `Interface#a_method`
+class AbstractBadChild < Abstract # error-with-dupes: Missing definition for abstract method `Interface#a_method`
 end
 
 class AbstractChild < Abstract
@@ -69,7 +69,7 @@ class AbstractSingleton
   def self.abstract_method; end
 end
 
-class AbstractSingletonBadChild < AbstractSingleton # error: Missing definition for abstract method
+class AbstractSingletonBadChild < AbstractSingleton # error-with-dupes: Missing definition for abstract method
 end
 
 class AbstractSingletonGoodChild < AbstractSingleton

--- a/test/testdata/resolver/abstract_validation.rb
+++ b/test/testdata/resolver/abstract_validation.rb
@@ -51,8 +51,8 @@ end
 
 # it fails if a concrete module doesn't implement abstract methods
   module M2
-# ^^^^^^^^^ error: Missing definition for abstract method `AbstractMixin#bar`
-# ^^^^^^^^^ error: Missing definition for abstract method `AbstractMixin#foo`
+# ^^^^^^^^^ error-with-dupes: Missing definition for abstract method `AbstractMixin#bar`
+# ^^^^^^^^^ error-with-dupes: Missing definition for abstract method `AbstractMixin#foo`
   extend T::Helpers
   include AbstractMixin
 end

--- a/test/testdata/resolver/fuzz_type_member_forget.rb
+++ b/test/testdata/resolver/fuzz_type_member_forget.rb
@@ -9,4 +9,4 @@ class DifferentArityChild < Parent # error: Type `TParent` declared by parent `P
   TChild = type_member(fixed: String)
 end
 
-T.cast(1, DifferentArityChild[Integer, String, Symbol]) # error: Wrong number of type parameters for `DifferentArityChild`. Expected: `0`, got: `3`
+T.cast(1, DifferentArityChild[Integer, String, Symbol]) # error-with-dupes: Wrong number of type parameters for `DifferentArityChild`. Expected: `0`, got: `3`

--- a/test/testdata/resolver/infinite.rb
+++ b/test/testdata/resolver/infinite.rb
@@ -8,25 +8,25 @@ def f(s); end
 sig {params(s: U60).void} # current resolution limit is 30, but because we're iterative we sometimes can resolve past it.
 def f_long(s); end
 
-U0 = Integer # error: Too many alias expansions
-U1 = U0 # error: Too many alias expansions
-U2 = U1 # error: Too many alias expansions
-U3 = U2 # error: Too many alias expansions
-U4 = U3 # error: Too many alias expansions
-U5 = U4 # error: Too many alias expansions
-U6 = U5 # error: Too many alias expansions
-U7 = U6 # error: Too many alias expansions
-U8 = U7 # error: Too many alias expansions
-U9 = U8 # error: Too many alias expansions
-U10 = U9 # error: Too many alias expansions
-U11 = U10 # error: Too many alias expansions
-U12 = U11 # error: Too many alias expansions
-U13 = U12 # error: Too many alias expansions
-U14 = U13 # error: Too many alias expansions
-U15 = U14 # error: Too many alias expansions
-U16 = U15 # error: Too many alias expansions
-U17 = U16 # error: Too many alias expansions
-U18 = U17 # error: Too many alias expansions
+U0 = Integer # error-with-dupes: Too many alias expansions
+U1 = U0 # error-with-dupes: Too many alias expansions
+U2 = U1 # error-with-dupes: Too many alias expansions
+U3 = U2 # error-with-dupes: Too many alias expansions
+U4 = U3 # error-with-dupes: Too many alias expansions
+U5 = U4 # error-with-dupes: Too many alias expansions
+U6 = U5 # error-with-dupes: Too many alias expansions
+U7 = U6 # error-with-dupes: Too many alias expansions
+U8 = U7 # error-with-dupes: Too many alias expansions
+U9 = U8 # error-with-dupes: Too many alias expansions
+U10 = U9 # error-with-dupes: Too many alias expansions
+U11 = U10 # error-with-dupes: Too many alias expansions
+U12 = U11 # error-with-dupes: Too many alias expansions
+U13 = U12 # error-with-dupes: Too many alias expansions
+U14 = U13 # error-with-dupes: Too many alias expansions
+U15 = U14 # error-with-dupes: Too many alias expansions
+U16 = U15 # error-with-dupes: Too many alias expansions
+U17 = U16 # error-with-dupes: Too many alias expansions
+U18 = U17 # error-with-dupes: Too many alias expansions
 U19 = U18
 U20 = U19
 U21 = U20

--- a/test/testdata/resolver/object_include_stub.rb
+++ b/test/testdata/resolver/object_include_stub.rb
@@ -1,4 +1,4 @@
 # typed: true
 class Object
-  include(E) # error: Unable to resolve constant `E`
+  include(E) # error-with-dupes: Unable to resolve constant `E`
 end

--- a/test/testdata/resolver/resolution_order.rb
+++ b/test/testdata/resolver/resolution_order.rb
@@ -8,7 +8,7 @@
 A::AB::BC
 
 class HasError
-  include D::DA::DOES_NOT_EXIST # error: Unable to resolve constant
+  include D::DA::DOES_NOT_EXIST # error-with-dupes: Unable to resolve constant
 end
 
 class IsGood

--- a/test/testdata/resolver/resolution_scoping.rb
+++ b/test/testdata/resolver/resolution_scoping.rb
@@ -1,5 +1,5 @@
 # typed: true
-class A < B # error: Unable to resolve constant `B`
+class A < B # error-with-dupes: Unable to resolve constant `B`
   module C
   end
   module B


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Make error assertions that match duplicate errors explicit.

Introduces a new assertion, `error-with-dupes`, which has the same semantics as `error` except that it can match multiple diagnostics.

Note: It is not an error to have an `error-with-dupes` assertion that does not match duplicate errors. Some errors only duplicate in LSP mode, some only on CLI mode, and some only on the fast path. :(

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Previously, `test_corpus` ignored duplicate error messages.

While working on another pull request, I realized that the IDE would report duplicate errors in certain scenarios. I included a fix:
https://github.com/sorbet/sorbet/pull/1202#discussion_r301725278

However, without this change, I had no way to add a test corresponding to the fix. It's also likely that, with this change, I would have spotted and fixed that bug earlier.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
