### PR TITLE
Add default second arg to BigDecimal.mode

### DIFF
--- a/rbi/stdlib/bigdecimal.rbi
+++ b/rbi/stdlib/bigdecimal.rbi
@@ -50,7 +50,7 @@ class BigDecimal < Numeric
     )
     .returns(Integer)
   end
-  def self.mode(mode, value); end
+  def self.mode(mode, value=T.unsafe(nil)); end
 
   sig do
     type_parameters(:U)


### PR DESCRIPTION
e.g. `BigDecimal.mode(BigDecimal::ROUND_MODE)` is valid

cc @gw