### PR TITLE
Stop stretching logos that are non-square

### DIFF
--- a/website/static/css/overrides.css
+++ b/website/static/css/overrides.css
@@ -107,6 +107,21 @@ sup {
 }
 
 /*
+ * To avoid squashing non-square logos
+ */
+.productShowcaseSection .logos img {
+  height: 110px;
+  width: auto;
+}
+
+@media only screen and (max-width: 735px) {
+  .productShowcaseSection .logos img {
+    height: 64px;
+    width: auto;
+  }
+}
+
+/*
  * Lets us stack the images + captions in a column.
  */
 .productShowcaseSection .link {


### PR DESCRIPTION
# Before 👇😞 

<img width="731" alt="logos_before2" src="https://user-images.githubusercontent.com/319655/61010249-799d5080-a343-11e9-98e8-12d8d6e20f1c.png">


# After 👇😎 

<img width="732" alt="logos_after2" src="https://user-images.githubusercontent.com/319655/61010250-7c984100-a343-11e9-9519-40637d85f54b.png">

