### PR TITLE
"Find all references" support for ivars and cvars.

### DIFF
--- a/main/lsp/DefLocSaver.h
+++ b/main/lsp/DefLocSaver.h
@@ -6,7 +6,11 @@ namespace sorbet::realmain::lsp {
 
 class DefLocSaver {
 public:
+    // Handles loc and symbol requests for method definitions.
     std::unique_ptr<ast::MethodDef> postTransformMethodDef(core::Context ctx,
                                                            std::unique_ptr<ast::MethodDef> methodDef);
+    // Handles loc and symbol requests for instance variables.
+    std::unique_ptr<ast::UnresolvedIdent> postTransformUnresolvedIdent(core::Context ctx,
+                                                                       std::unique_ptr<ast::UnresolvedIdent> id);
 };
 }; // namespace sorbet::realmain::lsp

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -202,6 +202,9 @@ class LSPLoop {
                                                const DocumentSymbolParams &params);
     LSPResult handleWorkspaceSymbols(std::unique_ptr<core::GlobalState> gs, const MessageId &id,
                                      const WorkspaceSymbolParams &params);
+    std::pair<std::unique_ptr<core::GlobalState>, std::vector<std::unique_ptr<Location>>>
+    getReferencesToSymbol(std::unique_ptr<core::GlobalState> gs, core::SymbolRef symbol,
+                          std::vector<std::unique_ptr<Location>> locations = {});
     LSPResult handleTextDocumentReferences(std::unique_ptr<core::GlobalState> gs, const MessageId &id,
                                            const ReferenceParams &params);
     LSPResult handleTextDocumentDefinition(std::unique_ptr<core::GlobalState> gs, const MessageId &id,

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1061,6 +1061,14 @@ public:
         handleUnresolvedConstantLit(ctx, original.get());
         return original;
     }
+
+    unique_ptr<ast::UnresolvedIdent> postTransformUnresolvedIdent(core::Context ctx,
+                                                                  unique_ptr<ast::UnresolvedIdent> id) {
+        if (id->kind != ast::UnresolvedIdent::Local) {
+            acc.constants.emplace_back(ctx.state, id->name.data(ctx));
+        }
+        return id;
+    }
 };
 
 core::UsageHash getAllNames(const core::GlobalState &gs, unique_ptr<ast::Expression> &tree) {

--- a/test/testdata/lsp/cvar__definition.rb
+++ b/test/testdata/lsp/cvar__definition.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+class WithCVars
+  @@some_c_var = T.let("Foobar", String)
+  # ^ def: some_c_var
+  # ^ hover: String
+end
+

--- a/test/testdata/lsp/cvar__usage.rb
+++ b/test/testdata/lsp/cvar__usage.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+class InheritsCVar < WithCVars
+  def get_c_var
+    @@some_c_var
+    # ^ usage: some_c_var
+    # ^ hover: String
+  end
+end

--- a/test/testdata/lsp/ivars.rb
+++ b/test/testdata/lsp/ivars.rb
@@ -1,0 +1,26 @@
+# typed: strict
+
+class Foo
+  extend T::Sig
+
+  sig {void}
+  def initialize
+    @boo = T.let(3, Integer)
+   # ^ def: boo
+   # ^ hover: Integer
+  end
+
+  sig {returns(Integer)}
+  def boo
+    @boo
+   # ^ usage: boo
+   # ^ hover: Integer
+    @boo += 1
+   # ^ usage: boo
+   # ^ hover: Integer
+    @boo + 10
+   # ^ usage: boo
+   # ^ hover: Integer
+  end
+end
+

--- a/test/testdata/lsp/symbol_query_filter__helper.rb
+++ b/test/testdata/lsp/symbol_query_filter__helper.rb
@@ -61,3 +61,12 @@ class WillGetAliased
     a
   end
 end
+
+class DefinesInstanceAndClassVars
+  @@some_class_var = T.let("h", String)
+  # ^ def: some_class_var
+  def initialize
+    @some_ivar = T.let(10, Integer)
+   # ^ def: some_ivar
+  end
+end

--- a/test/testdata/lsp/symbol_query_filter__main.rb
+++ b/test/testdata/lsp/symbol_query_filter__main.rb
@@ -47,3 +47,15 @@ end
 AliasForClass = T.type_alias(WillGetAliased)
 # ^ def: AliasForClass
                            # ^ usage: WillGetAliased
+
+class InheritsClassAndIvars < DefinesInstanceAndClassVars
+  def references_vars
+    if @some_ivar < 3
+      # ^ usage: some_ivar
+      @@some_class_var
+      # ^ usage: some_class_var
+    else
+      ""
+    end
+  end
+end


### PR DESCRIPTION
"Find all references" support for ivars and cvars.

Adds logic to `DefLocSaver` that saves references to instance and class variables.

Also contains logic to dedupe locations, as certain queries may return multiple identical results.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Improving find all references and go-to-def.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
