### PR TITLE
Don't get arg info for non-existent method symbols

### DIFF
--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -100,6 +100,9 @@ optional<core::AutocorrectSuggestion> maybeSuggestExtendTSig(core::Context ctx, 
 }
 
 core::TypePtr extractArgType(core::Context ctx, cfg::Send &send, core::DispatchComponent &component, int argId) {
+    if (!component.method.exists()) {
+        return nullptr;
+    }
     const auto &args = component.method.data(ctx)->arguments();
     if (argId >= args.size()) {
         return nullptr;

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -146,14 +146,16 @@ void extractSendArgumentKnowledge(core::Context ctx, core::Loc bindLoc, cfg::Sen
         }
         core::TypePtr thisType;
         auto iter = &dispatchInfo;
-        while (iter != nullptr && iter->main.method.exists()) {
-            auto argType = extractArgType(ctx, *snd, iter->main, i);
-            if (argType && !argType->isUntyped()) {
-                if (!thisType) {
-                    thisType = argType;
-                } else {
-                    // 'or' together every dispatch component for _this_ usage site
-                    thisType = core::Types::lub(ctx, thisType, argType);
+        while (iter != nullptr) {
+            if (iter->main.method.exists()) {
+                auto argType = extractArgType(ctx, *snd, iter->main, i);
+                if (argType && !argType->isUntyped()) {
+                    if (!thisType) {
+                        thisType = argType;
+                    } else {
+                        // 'or' together every dispatch component for _this_ usage site
+                        thisType = core::Types::lub(ctx, thisType, argType);
+                    }
                 }
             }
 

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -100,9 +100,7 @@ optional<core::AutocorrectSuggestion> maybeSuggestExtendTSig(core::Context ctx, 
 }
 
 core::TypePtr extractArgType(core::Context ctx, cfg::Send &send, core::DispatchComponent &component, int argId) {
-    if (!component.method.exists()) {
-        return nullptr;
-    }
+    ENFORCE(component.method.exists());
     const auto &args = component.method.data(ctx)->arguments();
     if (argId >= args.size()) {
         return nullptr;
@@ -148,7 +146,7 @@ void extractSendArgumentKnowledge(core::Context ctx, core::Loc bindLoc, cfg::Sen
         }
         core::TypePtr thisType;
         auto iter = &dispatchInfo;
-        while (iter != nullptr) {
+        while (iter != nullptr && iter->main.method.exists()) {
             auto argType = extractArgType(ctx, *snd, iter->main, i);
             if (argType && !argType->isUntyped()) {
                 if (!thisType) {

--- a/test/testdata/infer/fuzz_nonexistant_method.rb
+++ b/test/testdata/infer/fuzz_nonexistant_method.rb
@@ -1,0 +1,5 @@
+# typed: strict
+# Found by fuzzer: https://github.com/sorbet/sorbet/issues/1258
+def c(x)b(x)end # error: This function does not have a `sig`
+      # ^^^^ error: Method `b` does not exist on `Object`
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes #1258; adds an extra check to make sure we don't run afoul of an `ENFORCE`.

It's possible this isn't the right place for this check, and that maybe we should avoid generating `DispatchComponent`s with non-existent methods instead of checking against them when using them, but based on other places in the codebase (e.g. the `allComponentsPresent` method in `calls.cc`) I surmised that we do expect to sometimes have non-existent methods in our `DispatchComponent`s, hence my choice of placement for this check.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Added the fuzzed test from #1258 as well.
