### PR TITLE
Add optparser.rbi to stdlib

### DIFF
--- a/rbi/stdlib/optparser.rbi
+++ b/rbi/stdlib/optparser.rbi
@@ -1,0 +1,959 @@
+# typed: __STDLIB_INTERNAL
+class OptionParser
+  sig { params(to: T.untyped, name: T.untyped).returns(T.untyped) }
+  def compsys(to, name = File.basename($0)); end
+
+  sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+  def self.with(*args, &block); end
+
+  sig { params(arg: T.untyped, default: T.untyped).returns(T.untyped) }
+  def self.inc(arg, default = nil); end
+
+  sig { params(args: T.untyped).returns(T.untyped) }
+  def inc(*args); end
+
+  sig { params(banner: T.untyped, width: T.untyped, indent: T.untyped).void }
+  def initialize(banner = nil, width = 32, indent = ' ' * 4); end
+
+  sig { returns(T.untyped) }
+  def add_officious(); end
+
+  sig { params(arg: T.untyped).returns(T.untyped) }
+  def terminate(arg = nil); end
+
+  sig { params(arg: T.untyped).returns(T.untyped) }
+  def self.terminate(arg = nil); end
+
+  sig { returns(T.untyped) }
+  def self.top(); end
+
+  sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+  def accept(*args, &blk); end
+
+  sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+  def self.accept(*args, &blk); end
+
+  sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+  def reject(*args, &blk); end
+
+  sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+  def self.reject(*args, &blk); end
+
+  sig { params(value: T.untyped).returns(T.untyped) }
+  def banner=(value); end
+
+  sig { params(value: T.untyped).returns(T.untyped) }
+  def program_name=(value); end
+
+  sig { returns(T.untyped) }
+  def summary_width(); end
+
+  sig { params(value: T.untyped).returns(T.untyped) }
+  def summary_width=(value); end
+
+  sig { returns(T.untyped) }
+  def summary_indent(); end
+
+  sig { params(value: T.untyped).returns(T.untyped) }
+  def summary_indent=(value); end
+
+  sig { returns(T.untyped) }
+  def default_argv(); end
+
+  sig { params(value: T.untyped).returns(T.untyped) }
+  def default_argv=(value); end
+
+  sig { returns(T.untyped) }
+  def banner(); end
+
+  sig { returns(T.untyped) }
+  def program_name(); end
+
+  sig { params(value: T.untyped).returns(T.untyped) }
+  def version=(value); end
+
+  sig { params(value: T.untyped).returns(T.untyped) }
+  def release=(value); end
+
+  sig { returns(T.untyped) }
+  def version(); end
+
+  sig { returns(T.untyped) }
+  def release(); end
+
+  sig { returns(T.untyped) }
+  def ver(); end
+
+  sig { params(mesg: T.untyped).returns(T.untyped) }
+  def warn(mesg = $!); end
+
+  sig { params(mesg: T.untyped).returns(T.untyped) }
+  def abort(mesg = $!); end
+
+  sig { returns(T.untyped) }
+  def top(); end
+
+  sig { returns(T.untyped) }
+  def base(); end
+
+  sig { returns(T.untyped) }
+  def new(); end
+
+  sig { returns(T.untyped) }
+  def remove(); end
+
+  sig do
+    params(
+      to: T.untyped,
+      width: T.untyped,
+      max: T.untyped,
+      indent: T.untyped,
+      blk: T.untyped
+    ).returns(T.untyped)
+  end
+  def summarize(to = [], width = @summary_width, max = width - 1, indent = @summary_indent, &blk); end
+
+  sig { returns(T.untyped) }
+  def help(); end
+
+  sig { returns(T.untyped) }
+  def to_a(); end
+
+  sig { params(obj: T.untyped, prv: T.untyped, msg: T.untyped).returns(T.untyped) }
+  def notwice(obj, prv, msg); end
+
+  sig { params(opts: T.untyped, block: T.untyped).returns(T.untyped) }
+  def make_switch(opts, block = nil); end
+
+  sig { params(opts: T.untyped, block: T.untyped).returns(T.untyped) }
+  def define(*opts, &block); end
+
+  sig { params(opts: T.untyped, block: T.untyped).returns(T.untyped) }
+  def on(*opts, &block); end
+
+  sig { params(opts: T.untyped, block: T.untyped).returns(T.untyped) }
+  def define_head(*opts, &block); end
+
+  sig { params(opts: T.untyped, block: T.untyped).returns(T.untyped) }
+  def on_head(*opts, &block); end
+
+  sig { params(opts: T.untyped, block: T.untyped).returns(T.untyped) }
+  def define_tail(*opts, &block); end
+
+  sig { params(opts: T.untyped, block: T.untyped).returns(T.untyped) }
+  def on_tail(*opts, &block); end
+
+  sig { params(string: T.untyped).returns(T.untyped) }
+  def separator(string); end
+
+  sig { params(argv: T.untyped, into: T.untyped, nonopt: T.untyped).returns(T.untyped) }
+  def order(*argv, into: nil, &nonopt); end
+
+  sig { params(argv: T.untyped, into: T.untyped, nonopt: T.untyped).returns(T.untyped) }
+  def order!(argv = default_argv, into: nil, &nonopt); end
+
+  sig { params(argv: T.untyped, setter: T.untyped, nonopt: T.untyped).returns(T.untyped) }
+  def parse_in_order(argv = default_argv, setter = nil, &nonopt); end
+
+  sig { params(argv: T.untyped, into: T.untyped).returns(T.untyped) }
+  def permute(*argv, into: nil); end
+
+  sig { params(argv: T.untyped, into: T.untyped).returns(T.untyped) }
+  def permute!(argv = default_argv, into: nil); end
+
+  sig { params(argv: T.untyped, into: T.untyped).returns(T.untyped) }
+  def parse(*argv, into: nil); end
+
+  sig { params(argv: T.untyped, into: T.untyped).returns(T.untyped) }
+  def parse!(argv = default_argv, into: nil); end
+
+  sig { params(args: T.untyped).returns(T.untyped) }
+  def getopts(*args); end
+
+  sig { params(args: T.untyped).returns(T.untyped) }
+  def self.getopts(*args); end
+
+  sig { params(id: T.untyped, args: T.untyped, block: T.untyped).returns(T.untyped) }
+  def visit(id, *args, &block); end
+
+  sig { params(id: T.untyped, key: T.untyped).returns(T.untyped) }
+  def search(id, key); end
+
+  sig do
+    params(
+      typ: T.untyped,
+      opt: T.untyped,
+      icase: T.untyped,
+      pat: T.untyped
+    ).returns(T.untyped)
+  end
+  def complete(typ, opt, icase = false, *pat); end
+
+  sig { params(word: T.untyped).returns(T.untyped) }
+  def candidate(word); end
+
+  sig { params(filename: T.untyped).returns(T.untyped) }
+  def load(filename = nil); end
+
+  sig { params(env: T.untyped).returns(T.untyped) }
+  def environment(env = File.basename($0, '.*')); end
+
+  module Completion
+    sig { params(key: T.untyped, icase: T.untyped).returns(T.untyped) }
+    def self.regexp(key, icase); end
+
+    sig do
+      params(
+        key: T.untyped,
+        icase: T.untyped,
+        pat: T.untyped,
+        block: T.untyped
+      ).returns(T.untyped)
+    end
+    def self.candidate(key, icase = false, pat = nil, &block); end
+
+    sig { params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped) }
+    def candidate(key, icase = false, pat = nil); end
+
+    sig { params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped) }
+    def complete(key, icase = false, pat = nil); end
+
+    sig { params(opt: T.untyped, val: T.untyped).returns(T.untyped) }
+    def convert(opt = nil, val = nil); end
+  end
+
+  class OptionMap < Hash
+    include OptionParser::Completion
+
+    sig { params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped) }
+    def candidate(key, icase = false, pat = nil); end
+
+    sig { params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped) }
+    def complete(key, icase = false, pat = nil); end
+
+    sig { params(opt: T.untyped, val: T.untyped).returns(T.untyped) }
+    def convert(opt = nil, val = nil); end
+  end
+
+  class Switch
+    sig { returns(T.untyped) }
+    def pattern(); end
+
+    sig { returns(T.untyped) }
+    def conv(); end
+
+    sig { returns(T.untyped) }
+    def short(); end
+
+    sig { returns(T.untyped) }
+    def long(); end
+
+    sig { returns(T.untyped) }
+    def arg(); end
+
+    sig { returns(T.untyped) }
+    def desc(); end
+
+    sig { returns(T.untyped) }
+    def block(); end
+
+    sig { params(arg: T.untyped).returns(T.untyped) }
+    def self.guess(arg); end
+
+    sig { params(arg: T.untyped, t: T.untyped).returns(T.untyped) }
+    def self.incompatible_argument_styles(arg, t); end
+
+    sig { returns(T.untyped) }
+    def self.pattern(); end
+
+    sig do
+      params(
+        pattern: T.untyped,
+        conv: T.untyped,
+        short: T.untyped,
+        long: T.untyped,
+        arg: T.untyped,
+        desc: T.untyped,
+        block: T.untyped,
+        _block: T.untyped
+      ).void
+    end
+    def initialize(pattern = nil, conv = nil, short = nil, long = nil, arg = nil, desc = ([] if short or long), block = nil, &_block); end
+
+    sig { params(arg: T.untyped).returns(T.untyped) }
+    def parse_arg(arg); end
+
+    sig { params(arg: T.untyped, val: T.untyped).returns(T.untyped) }
+    def conv_arg(arg, val = []); end
+
+    sig do
+      params(
+        sdone: T.untyped,
+        ldone: T.untyped,
+        width: T.untyped,
+        max: T.untyped,
+        indent: T.untyped
+      ).returns(T.untyped)
+    end
+    def summarize(sdone = [], ldone = [], width = 1, max = width - 1, indent = ""); end
+
+    sig { params(to: T.untyped).returns(T.untyped) }
+    def add_banner(to); end
+
+    sig { params(str: T.untyped).returns(T::Boolean) }
+    def match_nonswitch?(str); end
+
+    sig { returns(T.untyped) }
+    def switch_name(); end
+
+    sig { params(sdone: T.untyped, ldone: T.untyped).returns(T.untyped) }
+    def compsys(sdone, ldone); end
+
+    class NoArgument < OptionParser::Switch
+      sig { params(arg: T.untyped, argv: T.untyped).returns(T.untyped) }
+      def parse(arg, argv); end
+
+      sig { returns(T.untyped) }
+      def self.incompatible_argument_styles(); end
+
+      sig { returns(T.untyped) }
+      def self.pattern(); end
+
+      sig { returns(T.untyped) }
+      def pattern(); end
+
+      sig { returns(T.untyped) }
+      def conv(); end
+
+      sig { returns(T.untyped) }
+      def short(); end
+
+      sig { returns(T.untyped) }
+      def long(); end
+
+      sig { returns(T.untyped) }
+      def arg(); end
+
+      sig { returns(T.untyped) }
+      def desc(); end
+
+      sig { returns(T.untyped) }
+      def block(); end
+
+      sig { params(arg: T.untyped).returns(T.untyped) }
+      def self.guess(arg); end
+
+      sig do
+        params(
+          pattern: T.untyped,
+          conv: T.untyped,
+          short: T.untyped,
+          long: T.untyped,
+          arg: T.untyped,
+          desc: T.untyped,
+          block: T.untyped,
+          _block: T.untyped
+        ).void
+      end
+      def initialize(pattern = nil, conv = nil, short = nil, long = nil, arg = nil, desc = ([] if short or long), block = nil, &_block); end
+
+      sig { params(arg: T.untyped).returns(T.untyped) }
+      def parse_arg(arg); end
+
+      sig { params(arg: T.untyped, val: T.untyped).returns(T.untyped) }
+      def conv_arg(arg, val = []); end
+
+      sig do
+        params(
+          sdone: T.untyped,
+          ldone: T.untyped,
+          width: T.untyped,
+          max: T.untyped,
+          indent: T.untyped
+        ).returns(T.untyped)
+      end
+      def summarize(sdone = [], ldone = [], width = 1, max = width - 1, indent = ""); end
+
+      sig { params(to: T.untyped).returns(T.untyped) }
+      def add_banner(to); end
+
+      sig { params(str: T.untyped).returns(T::Boolean) }
+      def match_nonswitch?(str); end
+
+      sig { returns(T.untyped) }
+      def switch_name(); end
+
+      sig { params(sdone: T.untyped, ldone: T.untyped).returns(T.untyped) }
+      def compsys(sdone, ldone); end
+    end
+
+    class RequiredArgument < OptionParser::Switch
+      sig { params(arg: T.untyped, argv: T.untyped).returns(T.untyped) }
+      def parse(arg, argv); end
+
+      sig { returns(T.untyped) }
+      def pattern(); end
+
+      sig { returns(T.untyped) }
+      def conv(); end
+
+      sig { returns(T.untyped) }
+      def short(); end
+
+      sig { returns(T.untyped) }
+      def long(); end
+
+      sig { returns(T.untyped) }
+      def arg(); end
+
+      sig { returns(T.untyped) }
+      def desc(); end
+
+      sig { returns(T.untyped) }
+      def block(); end
+
+      sig { params(arg: T.untyped).returns(T.untyped) }
+      def self.guess(arg); end
+
+      sig { params(arg: T.untyped, t: T.untyped).returns(T.untyped) }
+      def self.incompatible_argument_styles(arg, t); end
+
+      sig { returns(T.untyped) }
+      def self.pattern(); end
+
+      sig do
+        params(
+          pattern: T.untyped,
+          conv: T.untyped,
+          short: T.untyped,
+          long: T.untyped,
+          arg: T.untyped,
+          desc: T.untyped,
+          block: T.untyped,
+          _block: T.untyped
+        ).void
+      end
+      def initialize(pattern = nil, conv = nil, short = nil, long = nil, arg = nil, desc = ([] if short or long), block = nil, &_block); end
+
+      sig { params(arg: T.untyped).returns(T.untyped) }
+      def parse_arg(arg); end
+
+      sig { params(arg: T.untyped, val: T.untyped).returns(T.untyped) }
+      def conv_arg(arg, val = []); end
+
+      sig do
+        params(
+          sdone: T.untyped,
+          ldone: T.untyped,
+          width: T.untyped,
+          max: T.untyped,
+          indent: T.untyped
+        ).returns(T.untyped)
+      end
+      def summarize(sdone = [], ldone = [], width = 1, max = width - 1, indent = ""); end
+
+      sig { params(to: T.untyped).returns(T.untyped) }
+      def add_banner(to); end
+
+      sig { params(str: T.untyped).returns(T::Boolean) }
+      def match_nonswitch?(str); end
+
+      sig { returns(T.untyped) }
+      def switch_name(); end
+
+      sig { params(sdone: T.untyped, ldone: T.untyped).returns(T.untyped) }
+      def compsys(sdone, ldone); end
+    end
+
+    class OptionalArgument < OptionParser::Switch
+      sig { params(arg: T.untyped, argv: T.untyped, error: T.untyped).returns(T.untyped) }
+      def parse(arg, argv, &error); end
+
+      sig { returns(T.untyped) }
+      def pattern(); end
+
+      sig { returns(T.untyped) }
+      def conv(); end
+
+      sig { returns(T.untyped) }
+      def short(); end
+
+      sig { returns(T.untyped) }
+      def long(); end
+
+      sig { returns(T.untyped) }
+      def arg(); end
+
+      sig { returns(T.untyped) }
+      def desc(); end
+
+      sig { returns(T.untyped) }
+      def block(); end
+
+      sig { params(arg: T.untyped).returns(T.untyped) }
+      def self.guess(arg); end
+
+      sig { params(arg: T.untyped, t: T.untyped).returns(T.untyped) }
+      def self.incompatible_argument_styles(arg, t); end
+
+      sig { returns(T.untyped) }
+      def self.pattern(); end
+
+      sig do
+        params(
+          pattern: T.untyped,
+          conv: T.untyped,
+          short: T.untyped,
+          long: T.untyped,
+          arg: T.untyped,
+          desc: T.untyped,
+          block: T.untyped,
+          _block: T.untyped
+        ).void
+      end
+      def initialize(pattern = nil, conv = nil, short = nil, long = nil, arg = nil, desc = ([] if short or long), block = nil, &_block); end
+
+      sig { params(arg: T.untyped).returns(T.untyped) }
+      def parse_arg(arg); end
+
+      sig { params(arg: T.untyped, val: T.untyped).returns(T.untyped) }
+      def conv_arg(arg, val = []); end
+
+      sig do
+        params(
+          sdone: T.untyped,
+          ldone: T.untyped,
+          width: T.untyped,
+          max: T.untyped,
+          indent: T.untyped
+        ).returns(T.untyped)
+      end
+      def summarize(sdone = [], ldone = [], width = 1, max = width - 1, indent = ""); end
+
+      sig { params(to: T.untyped).returns(T.untyped) }
+      def add_banner(to); end
+
+      sig { params(str: T.untyped).returns(T::Boolean) }
+      def match_nonswitch?(str); end
+
+      sig { returns(T.untyped) }
+      def switch_name(); end
+
+      sig { params(sdone: T.untyped, ldone: T.untyped).returns(T.untyped) }
+      def compsys(sdone, ldone); end
+    end
+
+    class PlacedArgument < OptionParser::Switch
+      sig { params(arg: T.untyped, argv: T.untyped, error: T.untyped).returns(T.untyped) }
+      def parse(arg, argv, &error); end
+
+      sig { returns(T.untyped) }
+      def pattern(); end
+
+      sig { returns(T.untyped) }
+      def conv(); end
+
+      sig { returns(T.untyped) }
+      def short(); end
+
+      sig { returns(T.untyped) }
+      def long(); end
+
+      sig { returns(T.untyped) }
+      def arg(); end
+
+      sig { returns(T.untyped) }
+      def desc(); end
+
+      sig { returns(T.untyped) }
+      def block(); end
+
+      sig { params(arg: T.untyped).returns(T.untyped) }
+      def self.guess(arg); end
+
+      sig { params(arg: T.untyped, t: T.untyped).returns(T.untyped) }
+      def self.incompatible_argument_styles(arg, t); end
+
+      sig { returns(T.untyped) }
+      def self.pattern(); end
+
+      sig do
+        params(
+          pattern: T.untyped,
+          conv: T.untyped,
+          short: T.untyped,
+          long: T.untyped,
+          arg: T.untyped,
+          desc: T.untyped,
+          block: T.untyped,
+          _block: T.untyped
+        ).void
+      end
+      def initialize(pattern = nil, conv = nil, short = nil, long = nil, arg = nil, desc = ([] if short or long), block = nil, &_block); end
+
+      sig { params(arg: T.untyped).returns(T.untyped) }
+      def parse_arg(arg); end
+
+      sig { params(arg: T.untyped, val: T.untyped).returns(T.untyped) }
+      def conv_arg(arg, val = []); end
+
+      sig do
+        params(
+          sdone: T.untyped,
+          ldone: T.untyped,
+          width: T.untyped,
+          max: T.untyped,
+          indent: T.untyped
+        ).returns(T.untyped)
+      end
+      def summarize(sdone = [], ldone = [], width = 1, max = width - 1, indent = ""); end
+
+      sig { params(to: T.untyped).returns(T.untyped) }
+      def add_banner(to); end
+
+      sig { params(str: T.untyped).returns(T::Boolean) }
+      def match_nonswitch?(str); end
+
+      sig { returns(T.untyped) }
+      def switch_name(); end
+
+      sig { params(sdone: T.untyped, ldone: T.untyped).returns(T.untyped) }
+      def compsys(sdone, ldone); end
+    end
+  end
+
+  class List
+    sig { returns(T.untyped) }
+    def atype(); end
+
+    sig { returns(T.untyped) }
+    def short(); end
+
+    sig { returns(T.untyped) }
+    def long(); end
+
+    sig { returns(T.untyped) }
+    def list(); end
+
+    sig { void }
+    def initialize(); end
+
+    sig { params(t: T.untyped, pat: T.untyped, block: T.untyped).returns(T.untyped) }
+    def accept(t, pat = /.*/m, &block); end
+
+    sig { params(t: T.untyped).returns(T.untyped) }
+    def reject(t); end
+
+    sig do
+      params(
+        sw: T.untyped,
+        sopts: T.untyped,
+        lopts: T.untyped,
+        nsw: T.untyped,
+        nlopts: T.untyped
+      ).returns(T.untyped)
+    end
+    def update(sw, sopts, lopts, nsw = nil, nlopts = nil); end
+
+    sig { params(args: T.untyped).returns(T.untyped) }
+    def prepend(*args); end
+
+    sig { params(args: T.untyped).returns(T.untyped) }
+    def append(*args); end
+
+    sig { params(id: T.untyped, key: T.untyped).returns(T.untyped) }
+    def search(id, key); end
+
+    sig do
+      params(
+        id: T.untyped,
+        opt: T.untyped,
+        icase: T.untyped,
+        pat: T.untyped,
+        block: T.untyped
+      ).returns(T.untyped)
+    end
+    def complete(id, opt, icase = false, *pat, &block); end
+
+    sig { params(block: T.untyped).returns(T.untyped) }
+    def each_option(&block); end
+
+    sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+    def summarize(*args, &block); end
+
+    sig { params(to: T.untyped).returns(T.untyped) }
+    def add_banner(to); end
+
+    sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+    def compsys(*args, &block); end
+  end
+
+  class CompletingHash < Hash
+    include OptionParser::Completion
+
+    sig { params(key: T.untyped).returns(T.untyped) }
+    def match(key); end
+
+    sig { params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped) }
+    def candidate(key, icase = false, pat = nil); end
+
+    sig { params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped) }
+    def complete(key, icase = false, pat = nil); end
+
+    sig { params(opt: T.untyped, val: T.untyped).returns(T.untyped) }
+    def convert(opt = nil, val = nil); end
+  end
+
+  class ParseError < RuntimeError
+    sig { params(args: T.untyped).void }
+    def initialize(*args); end
+
+    sig { returns(T.untyped) }
+    def args(); end
+
+    sig { params(value: T.untyped).returns(T.untyped) }
+    def reason=(value); end
+
+    sig { params(argv: T.untyped).returns(T.untyped) }
+    def recover(argv); end
+
+    sig { params(array: T.untyped).returns(T.untyped) }
+    def self.filter_backtrace(array); end
+
+    sig { params(array: T.untyped).returns(T.untyped) }
+    def set_backtrace(array); end
+
+    sig { params(opt: T.untyped, eq: T.untyped).returns(T.untyped) }
+    def set_option(opt, eq); end
+
+    sig { returns(T.untyped) }
+    def reason(); end
+
+    sig { returns(T.untyped) }
+    def inspect(); end
+
+    sig { returns(T.untyped) }
+    def message(); end
+  end
+
+  class AmbiguousOption < OptionParser::ParseError
+    sig { params(args: T.untyped).void }
+    def initialize(*args); end
+
+    sig { returns(T.untyped) }
+    def args(); end
+
+    sig { params(value: T.untyped).returns(T.untyped) }
+    def reason=(value); end
+
+    sig { params(argv: T.untyped).returns(T.untyped) }
+    def recover(argv); end
+
+    sig { params(array: T.untyped).returns(T.untyped) }
+    def self.filter_backtrace(array); end
+
+    sig { params(array: T.untyped).returns(T.untyped) }
+    def set_backtrace(array); end
+
+    sig { params(opt: T.untyped, eq: T.untyped).returns(T.untyped) }
+    def set_option(opt, eq); end
+
+    sig { returns(T.untyped) }
+    def reason(); end
+
+    sig { returns(T.untyped) }
+    def inspect(); end
+
+    sig { returns(T.untyped) }
+    def message(); end
+  end
+
+  class NeedlessArgument < OptionParser::ParseError
+    sig { params(args: T.untyped).void }
+    def initialize(*args); end
+
+    sig { returns(T.untyped) }
+    def args(); end
+
+    sig { params(value: T.untyped).returns(T.untyped) }
+    def reason=(value); end
+
+    sig { params(argv: T.untyped).returns(T.untyped) }
+    def recover(argv); end
+
+    sig { params(array: T.untyped).returns(T.untyped) }
+    def self.filter_backtrace(array); end
+
+    sig { params(array: T.untyped).returns(T.untyped) }
+    def set_backtrace(array); end
+
+    sig { params(opt: T.untyped, eq: T.untyped).returns(T.untyped) }
+    def set_option(opt, eq); end
+
+    sig { returns(T.untyped) }
+    def reason(); end
+
+    sig { returns(T.untyped) }
+    def inspect(); end
+
+    sig { returns(T.untyped) }
+    def message(); end
+  end
+
+  class MissingArgument < OptionParser::ParseError
+    sig { params(args: T.untyped).void }
+    def initialize(*args); end
+
+    sig { returns(T.untyped) }
+    def args(); end
+
+    sig { params(value: T.untyped).returns(T.untyped) }
+    def reason=(value); end
+
+    sig { params(argv: T.untyped).returns(T.untyped) }
+    def recover(argv); end
+
+    sig { params(array: T.untyped).returns(T.untyped) }
+    def self.filter_backtrace(array); end
+
+    sig { params(array: T.untyped).returns(T.untyped) }
+    def set_backtrace(array); end
+
+    sig { params(opt: T.untyped, eq: T.untyped).returns(T.untyped) }
+    def set_option(opt, eq); end
+
+    sig { returns(T.untyped) }
+    def reason(); end
+
+    sig { returns(T.untyped) }
+    def inspect(); end
+
+    sig { returns(T.untyped) }
+    def message(); end
+  end
+
+  class InvalidOption < OptionParser::ParseError
+    sig { params(args: T.untyped).void }
+    def initialize(*args); end
+
+    sig { returns(T.untyped) }
+    def args(); end
+
+    sig { params(value: T.untyped).returns(T.untyped) }
+    def reason=(value); end
+
+    sig { params(argv: T.untyped).returns(T.untyped) }
+    def recover(argv); end
+
+    sig { params(array: T.untyped).returns(T.untyped) }
+    def self.filter_backtrace(array); end
+
+    sig { params(array: T.untyped).returns(T.untyped) }
+    def set_backtrace(array); end
+
+    sig { params(opt: T.untyped, eq: T.untyped).returns(T.untyped) }
+    def set_option(opt, eq); end
+
+    sig { returns(T.untyped) }
+    def reason(); end
+
+    sig { returns(T.untyped) }
+    def inspect(); end
+
+    sig { returns(T.untyped) }
+    def message(); end
+  end
+
+  class InvalidArgument < OptionParser::ParseError
+    sig { params(args: T.untyped).void }
+    def initialize(*args); end
+
+    sig { returns(T.untyped) }
+    def args(); end
+
+    sig { params(value: T.untyped).returns(T.untyped) }
+    def reason=(value); end
+
+    sig { params(argv: T.untyped).returns(T.untyped) }
+    def recover(argv); end
+
+    sig { params(array: T.untyped).returns(T.untyped) }
+    def self.filter_backtrace(array); end
+
+    sig { params(array: T.untyped).returns(T.untyped) }
+    def set_backtrace(array); end
+
+    sig { params(opt: T.untyped, eq: T.untyped).returns(T.untyped) }
+    def set_option(opt, eq); end
+
+    sig { returns(T.untyped) }
+    def reason(); end
+
+    sig { returns(T.untyped) }
+    def inspect(); end
+
+    sig { returns(T.untyped) }
+    def message(); end
+  end
+
+  class AmbiguousArgument < OptionParser::InvalidArgument
+    sig { params(args: T.untyped).void }
+    def initialize(*args); end
+
+    sig { returns(T.untyped) }
+    def args(); end
+
+    sig { params(value: T.untyped).returns(T.untyped) }
+    def reason=(value); end
+
+    sig { params(argv: T.untyped).returns(T.untyped) }
+    def recover(argv); end
+
+    sig { params(array: T.untyped).returns(T.untyped) }
+    def self.filter_backtrace(array); end
+
+    sig { params(array: T.untyped).returns(T.untyped) }
+    def set_backtrace(array); end
+
+    sig { params(opt: T.untyped, eq: T.untyped).returns(T.untyped) }
+    def set_option(opt, eq); end
+
+    sig { returns(T.untyped) }
+    def reason(); end
+
+    sig { returns(T.untyped) }
+    def inspect(); end
+
+    sig { returns(T.untyped) }
+    def message(); end
+  end
+
+  module Arguable
+    sig { params(opt: T.untyped).returns(T.untyped) }
+    def options=(opt); end
+
+    sig { returns(T.untyped) }
+    def options(); end
+
+    sig { params(blk: T.untyped).returns(T.untyped) }
+    def order!(&blk); end
+
+    sig { returns(T.untyped) }
+    def permute!(); end
+
+    sig { returns(T.untyped) }
+    def parse!(); end
+
+    sig { params(args: T.untyped).returns(T.untyped) }
+    def getopts(*args); end
+
+    sig { params(obj: T.untyped).returns(T.untyped) }
+    def self.extend_object(obj); end
+
+    sig { params(args: T.untyped).void }
+    def initialize(*args); end
+  end
+
+  module Acceptables
+  end
+end

--- a/rbi/stdlib/optparser.rbi
+++ b/rbi/stdlib/optparser.rbi
@@ -1,105 +1,105 @@
 # typed: __STDLIB_INTERNAL
 class OptionParser
-  sig { params(to: T.untyped, name: T.untyped).returns(T.untyped) }
+  sig {params(to: T.untyped, name: T.untyped).returns(T.untyped)}
   def compsys(to, name = File.basename($0)); end
 
-  sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+  sig {params(args: T.untyped, block: T.untyped).returns(T.untyped)}
   def self.with(*args, &block); end
 
-  sig { params(arg: T.untyped, default: T.untyped).returns(T.untyped) }
+  sig {params(arg: T.untyped, default: T.untyped).returns(T.untyped)}
   def self.inc(arg, default = nil); end
 
-  sig { params(args: T.untyped).returns(T.untyped) }
+  sig {params(args: T.untyped).returns(T.untyped)}
   def inc(*args); end
 
-  sig { params(banner: T.untyped, width: T.untyped, indent: T.untyped).void }
+  sig {params(banner: T.untyped, width: T.untyped, indent: T.untyped).void}
   def initialize(banner = nil, width = 32, indent = ' ' * 4); end
 
-  sig { returns(T.untyped) }
+  sig {returns(T.untyped)}
   def add_officious(); end
 
-  sig { params(arg: T.untyped).returns(T.untyped) }
+  sig {params(arg: T.untyped).returns(T.untyped)}
   def terminate(arg = nil); end
 
-  sig { params(arg: T.untyped).returns(T.untyped) }
+  sig {params(arg: T.untyped).returns(T.untyped)}
   def self.terminate(arg = nil); end
 
-  sig { returns(T.untyped) }
+  sig {returns(T.untyped)}
   def self.top(); end
 
-  sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+  sig {params(args: T.untyped, blk: T.untyped).returns(T.untyped)}
   def accept(*args, &blk); end
 
-  sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+  sig {params(args: T.untyped, blk: T.untyped).returns(T.untyped)}
   def self.accept(*args, &blk); end
 
-  sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+  sig {params(args: T.untyped, blk: T.untyped).returns(T.untyped)}
   def reject(*args, &blk); end
 
-  sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+  sig {params(args: T.untyped, blk: T.untyped).returns(T.untyped)}
   def self.reject(*args, &blk); end
 
-  sig { params(value: T.untyped).returns(T.untyped) }
+  sig {params(value: T.untyped).returns(T.untyped)}
   def banner=(value); end
 
-  sig { params(value: T.untyped).returns(T.untyped) }
+  sig {params(value: T.untyped).returns(T.untyped)}
   def program_name=(value); end
 
-  sig { returns(T.untyped) }
+  sig {returns(T.untyped)}
   def summary_width(); end
 
-  sig { params(value: T.untyped).returns(T.untyped) }
+  sig {params(value: T.untyped).returns(T.untyped)}
   def summary_width=(value); end
 
-  sig { returns(T.untyped) }
+  sig {returns(T.untyped)}
   def summary_indent(); end
 
-  sig { params(value: T.untyped).returns(T.untyped) }
+  sig {params(value: T.untyped).returns(T.untyped)}
   def summary_indent=(value); end
 
-  sig { returns(T.untyped) }
+  sig {returns(T.untyped)}
   def default_argv(); end
 
-  sig { params(value: T.untyped).returns(T.untyped) }
+  sig {params(value: T.untyped).returns(T.untyped)}
   def default_argv=(value); end
 
-  sig { returns(T.untyped) }
+  sig {returns(T.untyped)}
   def banner(); end
 
-  sig { returns(T.untyped) }
+  sig {returns(T.untyped)}
   def program_name(); end
 
-  sig { params(value: T.untyped).returns(T.untyped) }
+  sig {params(value: T.untyped).returns(T.untyped)}
   def version=(value); end
 
-  sig { params(value: T.untyped).returns(T.untyped) }
+  sig {params(value: T.untyped).returns(T.untyped)}
   def release=(value); end
 
-  sig { returns(T.untyped) }
+  sig {returns(T.untyped)}
   def version(); end
 
-  sig { returns(T.untyped) }
+  sig {returns(T.untyped)}
   def release(); end
 
-  sig { returns(T.untyped) }
+  sig {returns(T.untyped)}
   def ver(); end
 
-  sig { params(mesg: T.untyped).returns(T.untyped) }
+  sig {params(mesg: T.untyped).returns(T.untyped)}
   def warn(mesg = $!); end
 
-  sig { params(mesg: T.untyped).returns(T.untyped) }
+  sig {params(mesg: T.untyped).returns(T.untyped)}
   def abort(mesg = $!); end
 
-  sig { returns(T.untyped) }
+  sig {returns(T.untyped)}
   def top(); end
 
-  sig { returns(T.untyped) }
+  sig {returns(T.untyped)}
   def base(); end
 
-  sig { returns(T.untyped) }
+  sig {returns(T.untyped)}
   def new(); end
 
-  sig { returns(T.untyped) }
+  sig {returns(T.untyped)}
   def remove(); end
 
   sig do
@@ -113,70 +113,70 @@ class OptionParser
   end
   def summarize(to = [], width = @summary_width, max = width - 1, indent = @summary_indent, &blk); end
 
-  sig { returns(T.untyped) }
+  sig {returns(T.untyped)}
   def help(); end
 
-  sig { returns(T.untyped) }
+  sig {returns(T.untyped)}
   def to_a(); end
 
-  sig { params(obj: T.untyped, prv: T.untyped, msg: T.untyped).returns(T.untyped) }
+  sig {params(obj: T.untyped, prv: T.untyped, msg: T.untyped).returns(T.untyped)}
   def notwice(obj, prv, msg); end
 
-  sig { params(opts: T.untyped, block: T.untyped).returns(T.untyped) }
+  sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
   def make_switch(opts, block = nil); end
 
-  sig { params(opts: T.untyped, block: T.untyped).returns(T.untyped) }
+  sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
   def define(*opts, &block); end
 
-  sig { params(opts: T.untyped, block: T.untyped).returns(T.untyped) }
+  sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
   def on(*opts, &block); end
 
-  sig { params(opts: T.untyped, block: T.untyped).returns(T.untyped) }
+  sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
   def define_head(*opts, &block); end
 
-  sig { params(opts: T.untyped, block: T.untyped).returns(T.untyped) }
+  sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
   def on_head(*opts, &block); end
 
-  sig { params(opts: T.untyped, block: T.untyped).returns(T.untyped) }
+  sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
   def define_tail(*opts, &block); end
 
-  sig { params(opts: T.untyped, block: T.untyped).returns(T.untyped) }
+  sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
   def on_tail(*opts, &block); end
 
-  sig { params(string: T.untyped).returns(T.untyped) }
+  sig {params(string: T.untyped).returns(T.untyped)}
   def separator(string); end
 
-  sig { params(argv: T.untyped, into: T.untyped, nonopt: T.untyped).returns(T.untyped) }
+  sig {params(argv: T.untyped, into: T.untyped, nonopt: T.untyped).returns(T.untyped)}
   def order(*argv, into: nil, &nonopt); end
 
-  sig { params(argv: T.untyped, into: T.untyped, nonopt: T.untyped).returns(T.untyped) }
+  sig {params(argv: T.untyped, into: T.untyped, nonopt: T.untyped).returns(T.untyped)}
   def order!(argv = default_argv, into: nil, &nonopt); end
 
-  sig { params(argv: T.untyped, setter: T.untyped, nonopt: T.untyped).returns(T.untyped) }
+  sig {params(argv: T.untyped, setter: T.untyped, nonopt: T.untyped).returns(T.untyped)}
   def parse_in_order(argv = default_argv, setter = nil, &nonopt); end
 
-  sig { params(argv: T.untyped, into: T.untyped).returns(T.untyped) }
+  sig {params(argv: T.untyped, into: T.untyped).returns(T.untyped)}
   def permute(*argv, into: nil); end
 
-  sig { params(argv: T.untyped, into: T.untyped).returns(T.untyped) }
+  sig {params(argv: T.untyped, into: T.untyped).returns(T.untyped)}
   def permute!(argv = default_argv, into: nil); end
 
-  sig { params(argv: T.untyped, into: T.untyped).returns(T.untyped) }
+  sig {params(argv: T.untyped, into: T.untyped).returns(T.untyped)}
   def parse(*argv, into: nil); end
 
-  sig { params(argv: T.untyped, into: T.untyped).returns(T.untyped) }
+  sig {params(argv: T.untyped, into: T.untyped).returns(T.untyped)}
   def parse!(argv = default_argv, into: nil); end
 
-  sig { params(args: T.untyped).returns(T.untyped) }
+  sig {params(args: T.untyped).returns(T.untyped)}
   def getopts(*args); end
 
-  sig { params(args: T.untyped).returns(T.untyped) }
+  sig {params(args: T.untyped).returns(T.untyped)}
   def self.getopts(*args); end
 
-  sig { params(id: T.untyped, args: T.untyped, block: T.untyped).returns(T.untyped) }
+  sig {params(id: T.untyped, args: T.untyped, block: T.untyped).returns(T.untyped)}
   def visit(id, *args, &block); end
 
-  sig { params(id: T.untyped, key: T.untyped).returns(T.untyped) }
+  sig {params(id: T.untyped, key: T.untyped).returns(T.untyped)}
   def search(id, key); end
 
   sig do
@@ -189,17 +189,17 @@ class OptionParser
   end
   def complete(typ, opt, icase = false, *pat); end
 
-  sig { params(word: T.untyped).returns(T.untyped) }
+  sig {params(word: T.untyped).returns(T.untyped)}
   def candidate(word); end
 
-  sig { params(filename: T.untyped).returns(T.untyped) }
+  sig {params(filename: T.untyped).returns(T.untyped)}
   def load(filename = nil); end
 
-  sig { params(env: T.untyped).returns(T.untyped) }
+  sig {params(env: T.untyped).returns(T.untyped)}
   def environment(env = File.basename($0, '.*')); end
 
   module Completion
-    sig { params(key: T.untyped, icase: T.untyped).returns(T.untyped) }
+    sig {params(key: T.untyped, icase: T.untyped).returns(T.untyped)}
     def self.regexp(key, icase); end
 
     sig do
@@ -212,58 +212,58 @@ class OptionParser
     end
     def self.candidate(key, icase = false, pat = nil, &block); end
 
-    sig { params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped) }
+    sig {params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped)}
     def candidate(key, icase = false, pat = nil); end
 
-    sig { params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped) }
+    sig {params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped)}
     def complete(key, icase = false, pat = nil); end
 
-    sig { params(opt: T.untyped, val: T.untyped).returns(T.untyped) }
+    sig {params(opt: T.untyped, val: T.untyped).returns(T.untyped)}
     def convert(opt = nil, val = nil); end
   end
 
   class OptionMap < Hash
     include OptionParser::Completion
 
-    sig { params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped) }
+    sig {params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped)}
     def candidate(key, icase = false, pat = nil); end
 
-    sig { params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped) }
+    sig {params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped)}
     def complete(key, icase = false, pat = nil); end
 
-    sig { params(opt: T.untyped, val: T.untyped).returns(T.untyped) }
+    sig {params(opt: T.untyped, val: T.untyped).returns(T.untyped)}
     def convert(opt = nil, val = nil); end
   end
 
   class Switch
-    sig { returns(T.untyped) }
+    sig {returns(T.untyped)}
     def pattern(); end
 
-    sig { returns(T.untyped) }
+    sig {returns(T.untyped)}
     def conv(); end
 
-    sig { returns(T.untyped) }
+    sig {returns(T.untyped)}
     def short(); end
 
-    sig { returns(T.untyped) }
+    sig {returns(T.untyped)}
     def long(); end
 
-    sig { returns(T.untyped) }
+    sig {returns(T.untyped)}
     def arg(); end
 
-    sig { returns(T.untyped) }
+    sig {returns(T.untyped)}
     def desc(); end
 
-    sig { returns(T.untyped) }
+    sig {returns(T.untyped)}
     def block(); end
 
-    sig { params(arg: T.untyped).returns(T.untyped) }
+    sig {params(arg: T.untyped).returns(T.untyped)}
     def self.guess(arg); end
 
-    sig { params(arg: T.untyped, t: T.untyped).returns(T.untyped) }
+    sig {params(arg: T.untyped, t: T.untyped).returns(T.untyped)}
     def self.incompatible_argument_styles(arg, t); end
 
-    sig { returns(T.untyped) }
+    sig {returns(T.untyped)}
     def self.pattern(); end
 
     sig do
@@ -280,10 +280,10 @@ class OptionParser
     end
     def initialize(pattern = nil, conv = nil, short = nil, long = nil, arg = nil, desc = ([] if short or long), block = nil, &_block); end
 
-    sig { params(arg: T.untyped).returns(T.untyped) }
+    sig {params(arg: T.untyped).returns(T.untyped)}
     def parse_arg(arg); end
 
-    sig { params(arg: T.untyped, val: T.untyped).returns(T.untyped) }
+    sig {params(arg: T.untyped, val: T.untyped).returns(T.untyped)}
     def conv_arg(arg, val = []); end
 
     sig do
@@ -297,50 +297,50 @@ class OptionParser
     end
     def summarize(sdone = [], ldone = [], width = 1, max = width - 1, indent = ""); end
 
-    sig { params(to: T.untyped).returns(T.untyped) }
+    sig {params(to: T.untyped).returns(T.untyped)}
     def add_banner(to); end
 
-    sig { params(str: T.untyped).returns(T::Boolean) }
+    sig {params(str: T.untyped).returns(T::Boolean)}
     def match_nonswitch?(str); end
 
-    sig { returns(T.untyped) }
+    sig {returns(T.untyped)}
     def switch_name(); end
 
-    sig { params(sdone: T.untyped, ldone: T.untyped).returns(T.untyped) }
+    sig {params(sdone: T.untyped, ldone: T.untyped).returns(T.untyped)}
     def compsys(sdone, ldone); end
 
     class NoArgument < OptionParser::Switch
-      sig { params(arg: T.untyped, argv: T.untyped).returns(T.untyped) }
+      sig {params(arg: T.untyped, argv: T.untyped).returns(T.untyped)}
       def parse(arg, argv); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def self.incompatible_argument_styles(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def self.pattern(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def pattern(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def conv(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def short(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def long(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def arg(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def desc(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def block(); end
 
-      sig { params(arg: T.untyped).returns(T.untyped) }
+      sig {params(arg: T.untyped).returns(T.untyped)}
       def self.guess(arg); end
 
       sig do
@@ -357,10 +357,10 @@ class OptionParser
       end
       def initialize(pattern = nil, conv = nil, short = nil, long = nil, arg = nil, desc = ([] if short or long), block = nil, &_block); end
 
-      sig { params(arg: T.untyped).returns(T.untyped) }
+      sig {params(arg: T.untyped).returns(T.untyped)}
       def parse_arg(arg); end
 
-      sig { params(arg: T.untyped, val: T.untyped).returns(T.untyped) }
+      sig {params(arg: T.untyped, val: T.untyped).returns(T.untyped)}
       def conv_arg(arg, val = []); end
 
       sig do
@@ -374,51 +374,51 @@ class OptionParser
       end
       def summarize(sdone = [], ldone = [], width = 1, max = width - 1, indent = ""); end
 
-      sig { params(to: T.untyped).returns(T.untyped) }
+      sig {params(to: T.untyped).returns(T.untyped)}
       def add_banner(to); end
 
-      sig { params(str: T.untyped).returns(T::Boolean) }
+      sig {params(str: T.untyped).returns(T::Boolean)}
       def match_nonswitch?(str); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def switch_name(); end
 
-      sig { params(sdone: T.untyped, ldone: T.untyped).returns(T.untyped) }
+      sig {params(sdone: T.untyped, ldone: T.untyped).returns(T.untyped)}
       def compsys(sdone, ldone); end
     end
 
     class RequiredArgument < OptionParser::Switch
-      sig { params(arg: T.untyped, argv: T.untyped).returns(T.untyped) }
+      sig {params(arg: T.untyped, argv: T.untyped).returns(T.untyped)}
       def parse(arg, argv); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def pattern(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def conv(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def short(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def long(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def arg(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def desc(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def block(); end
 
-      sig { params(arg: T.untyped).returns(T.untyped) }
+      sig {params(arg: T.untyped).returns(T.untyped)}
       def self.guess(arg); end
 
-      sig { params(arg: T.untyped, t: T.untyped).returns(T.untyped) }
+      sig {params(arg: T.untyped, t: T.untyped).returns(T.untyped)}
       def self.incompatible_argument_styles(arg, t); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def self.pattern(); end
 
       sig do
@@ -435,10 +435,10 @@ class OptionParser
       end
       def initialize(pattern = nil, conv = nil, short = nil, long = nil, arg = nil, desc = ([] if short or long), block = nil, &_block); end
 
-      sig { params(arg: T.untyped).returns(T.untyped) }
+      sig {params(arg: T.untyped).returns(T.untyped)}
       def parse_arg(arg); end
 
-      sig { params(arg: T.untyped, val: T.untyped).returns(T.untyped) }
+      sig {params(arg: T.untyped, val: T.untyped).returns(T.untyped)}
       def conv_arg(arg, val = []); end
 
       sig do
@@ -452,51 +452,51 @@ class OptionParser
       end
       def summarize(sdone = [], ldone = [], width = 1, max = width - 1, indent = ""); end
 
-      sig { params(to: T.untyped).returns(T.untyped) }
+      sig {params(to: T.untyped).returns(T.untyped)}
       def add_banner(to); end
 
-      sig { params(str: T.untyped).returns(T::Boolean) }
+      sig {params(str: T.untyped).returns(T::Boolean)}
       def match_nonswitch?(str); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def switch_name(); end
 
-      sig { params(sdone: T.untyped, ldone: T.untyped).returns(T.untyped) }
+      sig {params(sdone: T.untyped, ldone: T.untyped).returns(T.untyped)}
       def compsys(sdone, ldone); end
     end
 
     class OptionalArgument < OptionParser::Switch
-      sig { params(arg: T.untyped, argv: T.untyped, error: T.untyped).returns(T.untyped) }
+      sig {params(arg: T.untyped, argv: T.untyped, error: T.untyped).returns(T.untyped)}
       def parse(arg, argv, &error); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def pattern(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def conv(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def short(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def long(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def arg(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def desc(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def block(); end
 
-      sig { params(arg: T.untyped).returns(T.untyped) }
+      sig {params(arg: T.untyped).returns(T.untyped)}
       def self.guess(arg); end
 
-      sig { params(arg: T.untyped, t: T.untyped).returns(T.untyped) }
+      sig {params(arg: T.untyped, t: T.untyped).returns(T.untyped)}
       def self.incompatible_argument_styles(arg, t); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def self.pattern(); end
 
       sig do
@@ -513,10 +513,10 @@ class OptionParser
       end
       def initialize(pattern = nil, conv = nil, short = nil, long = nil, arg = nil, desc = ([] if short or long), block = nil, &_block); end
 
-      sig { params(arg: T.untyped).returns(T.untyped) }
+      sig {params(arg: T.untyped).returns(T.untyped)}
       def parse_arg(arg); end
 
-      sig { params(arg: T.untyped, val: T.untyped).returns(T.untyped) }
+      sig {params(arg: T.untyped, val: T.untyped).returns(T.untyped)}
       def conv_arg(arg, val = []); end
 
       sig do
@@ -530,51 +530,51 @@ class OptionParser
       end
       def summarize(sdone = [], ldone = [], width = 1, max = width - 1, indent = ""); end
 
-      sig { params(to: T.untyped).returns(T.untyped) }
+      sig {params(to: T.untyped).returns(T.untyped)}
       def add_banner(to); end
 
-      sig { params(str: T.untyped).returns(T::Boolean) }
+      sig {params(str: T.untyped).returns(T::Boolean)}
       def match_nonswitch?(str); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def switch_name(); end
 
-      sig { params(sdone: T.untyped, ldone: T.untyped).returns(T.untyped) }
+      sig {params(sdone: T.untyped, ldone: T.untyped).returns(T.untyped)}
       def compsys(sdone, ldone); end
     end
 
     class PlacedArgument < OptionParser::Switch
-      sig { params(arg: T.untyped, argv: T.untyped, error: T.untyped).returns(T.untyped) }
+      sig {params(arg: T.untyped, argv: T.untyped, error: T.untyped).returns(T.untyped)}
       def parse(arg, argv, &error); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def pattern(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def conv(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def short(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def long(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def arg(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def desc(); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def block(); end
 
-      sig { params(arg: T.untyped).returns(T.untyped) }
+      sig {params(arg: T.untyped).returns(T.untyped)}
       def self.guess(arg); end
 
-      sig { params(arg: T.untyped, t: T.untyped).returns(T.untyped) }
+      sig {params(arg: T.untyped, t: T.untyped).returns(T.untyped)}
       def self.incompatible_argument_styles(arg, t); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def self.pattern(); end
 
       sig do
@@ -591,10 +591,10 @@ class OptionParser
       end
       def initialize(pattern = nil, conv = nil, short = nil, long = nil, arg = nil, desc = ([] if short or long), block = nil, &_block); end
 
-      sig { params(arg: T.untyped).returns(T.untyped) }
+      sig {params(arg: T.untyped).returns(T.untyped)}
       def parse_arg(arg); end
 
-      sig { params(arg: T.untyped, val: T.untyped).returns(T.untyped) }
+      sig {params(arg: T.untyped, val: T.untyped).returns(T.untyped)}
       def conv_arg(arg, val = []); end
 
       sig do
@@ -608,40 +608,40 @@ class OptionParser
       end
       def summarize(sdone = [], ldone = [], width = 1, max = width - 1, indent = ""); end
 
-      sig { params(to: T.untyped).returns(T.untyped) }
+      sig {params(to: T.untyped).returns(T.untyped)}
       def add_banner(to); end
 
-      sig { params(str: T.untyped).returns(T::Boolean) }
+      sig {params(str: T.untyped).returns(T::Boolean)}
       def match_nonswitch?(str); end
 
-      sig { returns(T.untyped) }
+      sig {returns(T.untyped)}
       def switch_name(); end
 
-      sig { params(sdone: T.untyped, ldone: T.untyped).returns(T.untyped) }
+      sig {params(sdone: T.untyped, ldone: T.untyped).returns(T.untyped)}
       def compsys(sdone, ldone); end
     end
   end
 
   class List
-    sig { returns(T.untyped) }
+    sig {returns(T.untyped)}
     def atype(); end
 
-    sig { returns(T.untyped) }
+    sig {returns(T.untyped)}
     def short(); end
 
-    sig { returns(T.untyped) }
+    sig {returns(T.untyped)}
     def long(); end
 
-    sig { returns(T.untyped) }
+    sig {returns(T.untyped)}
     def list(); end
 
-    sig { void }
+    sig {void}
     def initialize(); end
 
-    sig { params(t: T.untyped, pat: T.untyped, block: T.untyped).returns(T.untyped) }
+    sig {params(t: T.untyped, pat: T.untyped, block: T.untyped).returns(T.untyped)}
     def accept(t, pat = /.*/m, &block); end
 
-    sig { params(t: T.untyped).returns(T.untyped) }
+    sig {params(t: T.untyped).returns(T.untyped)}
     def reject(t); end
 
     sig do
@@ -655,13 +655,13 @@ class OptionParser
     end
     def update(sw, sopts, lopts, nsw = nil, nlopts = nil); end
 
-    sig { params(args: T.untyped).returns(T.untyped) }
+    sig {params(args: T.untyped).returns(T.untyped)}
     def prepend(*args); end
 
-    sig { params(args: T.untyped).returns(T.untyped) }
+    sig {params(args: T.untyped).returns(T.untyped)}
     def append(*args); end
 
-    sig { params(id: T.untyped, key: T.untyped).returns(T.untyped) }
+    sig {params(id: T.untyped, key: T.untyped).returns(T.untyped)}
     def search(id, key); end
 
     sig do
@@ -675,64 +675,64 @@ class OptionParser
     end
     def complete(id, opt, icase = false, *pat, &block); end
 
-    sig { params(block: T.untyped).returns(T.untyped) }
+    sig {params(block: T.untyped).returns(T.untyped)}
     def each_option(&block); end
 
-    sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+    sig {params(args: T.untyped, block: T.untyped).returns(T.untyped)}
     def summarize(*args, &block); end
 
-    sig { params(to: T.untyped).returns(T.untyped) }
+    sig {params(to: T.untyped).returns(T.untyped)}
     def add_banner(to); end
 
-    sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+    sig {params(args: T.untyped, block: T.untyped).returns(T.untyped)}
     def compsys(*args, &block); end
   end
 
   class CompletingHash < Hash
     include OptionParser::Completion
 
-    sig { params(key: T.untyped).returns(T.untyped) }
+    sig {params(key: T.untyped).returns(T.untyped)}
     def match(key); end
 
-    sig { params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped) }
+    sig {params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped)}
     def candidate(key, icase = false, pat = nil); end
 
-    sig { params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped) }
+    sig {params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped)}
     def complete(key, icase = false, pat = nil); end
 
-    sig { params(opt: T.untyped, val: T.untyped).returns(T.untyped) }
+    sig {params(opt: T.untyped, val: T.untyped).returns(T.untyped)}
     def convert(opt = nil, val = nil); end
   end
 
   class ParseError < RuntimeError
-    sig { params(args: T.untyped).void }
+    sig {params(args: T.untyped).void}
     def initialize(*args); end
 
-    sig { returns(T.untyped) }
+    sig {returns(T.untyped)}
     def args(); end
 
-    sig { params(value: T.untyped).returns(T.untyped) }
+    sig {params(value: T.untyped).returns(T.untyped)}
     def reason=(value); end
 
-    sig { params(argv: T.untyped).returns(T.untyped) }
+    sig {params(argv: T.untyped).returns(T.untyped)}
     def recover(argv); end
 
-    sig { params(array: T.untyped).returns(T.untyped) }
+    sig {params(array: T.untyped).returns(T.untyped)}
     def self.filter_backtrace(array); end
 
-    sig { params(array: T.untyped).returns(T.untyped) }
+    sig {params(array: T.untyped).returns(T.untyped)}
     def set_backtrace(array); end
 
-    sig { params(opt: T.untyped, eq: T.untyped).returns(T.untyped) }
+    sig {params(opt: T.untyped, eq: T.untyped).returns(T.untyped)}
     def set_option(opt, eq); end
 
-    sig { returns(T.untyped) }
+    sig {returns(T.untyped)}
     def reason(); end
 
-    sig { returns(T.untyped) }
+    sig {returns(T.untyped)}
     def inspect(); end
 
-    sig { returns(T.untyped) }
+    sig {returns(T.untyped)}
     def message(); end
   end
 
@@ -749,28 +749,28 @@ class OptionParser
   class AmbiguousArgument < OptionParser::InvalidArgument; end
 
   module Arguable
-    sig { params(opt: T.untyped).returns(T.untyped) }
+    sig {params(opt: T.untyped).returns(T.untyped)}
     def options=(opt); end
 
-    sig { returns(T.untyped) }
+    sig {returns(T.untyped)}
     def options(); end
 
-    sig { params(blk: T.untyped).returns(T.untyped) }
+    sig {params(blk: T.untyped).returns(T.untyped)}
     def order!(&blk); end
 
-    sig { returns(T.untyped) }
+    sig {returns(T.untyped)}
     def permute!(); end
 
-    sig { returns(T.untyped) }
+    sig {returns(T.untyped)}
     def parse!(); end
 
-    sig { params(args: T.untyped).returns(T.untyped) }
+    sig {params(args: T.untyped).returns(T.untyped)}
     def getopts(*args); end
 
-    sig { params(obj: T.untyped).returns(T.untyped) }
+    sig {params(obj: T.untyped).returns(T.untyped)}
     def self.extend_object(obj); end
 
-    sig { params(args: T.untyped).void }
+    sig {params(args: T.untyped).void}
     def initialize(*args); end
   end
 

--- a/rbi/stdlib/optparser.rbi
+++ b/rbi/stdlib/optparser.rbi
@@ -736,197 +736,17 @@ class OptionParser
     def message(); end
   end
 
-  class AmbiguousOption < OptionParser::ParseError
-    sig { params(args: T.untyped).void }
-    def initialize(*args); end
+  class AmbiguousOption < OptionParser::ParseError; end
 
-    sig { returns(T.untyped) }
-    def args(); end
+  class NeedlessArgument < OptionParser::ParseError; end
 
-    sig { params(value: T.untyped).returns(T.untyped) }
-    def reason=(value); end
+  class MissingArgument < OptionParser::ParseError; end
 
-    sig { params(argv: T.untyped).returns(T.untyped) }
-    def recover(argv); end
+  class InvalidOption < OptionParser::ParseError; end
 
-    sig { params(array: T.untyped).returns(T.untyped) }
-    def self.filter_backtrace(array); end
+  class InvalidArgument < OptionParser::ParseError; end
 
-    sig { params(array: T.untyped).returns(T.untyped) }
-    def set_backtrace(array); end
-
-    sig { params(opt: T.untyped, eq: T.untyped).returns(T.untyped) }
-    def set_option(opt, eq); end
-
-    sig { returns(T.untyped) }
-    def reason(); end
-
-    sig { returns(T.untyped) }
-    def inspect(); end
-
-    sig { returns(T.untyped) }
-    def message(); end
-  end
-
-  class NeedlessArgument < OptionParser::ParseError
-    sig { params(args: T.untyped).void }
-    def initialize(*args); end
-
-    sig { returns(T.untyped) }
-    def args(); end
-
-    sig { params(value: T.untyped).returns(T.untyped) }
-    def reason=(value); end
-
-    sig { params(argv: T.untyped).returns(T.untyped) }
-    def recover(argv); end
-
-    sig { params(array: T.untyped).returns(T.untyped) }
-    def self.filter_backtrace(array); end
-
-    sig { params(array: T.untyped).returns(T.untyped) }
-    def set_backtrace(array); end
-
-    sig { params(opt: T.untyped, eq: T.untyped).returns(T.untyped) }
-    def set_option(opt, eq); end
-
-    sig { returns(T.untyped) }
-    def reason(); end
-
-    sig { returns(T.untyped) }
-    def inspect(); end
-
-    sig { returns(T.untyped) }
-    def message(); end
-  end
-
-  class MissingArgument < OptionParser::ParseError
-    sig { params(args: T.untyped).void }
-    def initialize(*args); end
-
-    sig { returns(T.untyped) }
-    def args(); end
-
-    sig { params(value: T.untyped).returns(T.untyped) }
-    def reason=(value); end
-
-    sig { params(argv: T.untyped).returns(T.untyped) }
-    def recover(argv); end
-
-    sig { params(array: T.untyped).returns(T.untyped) }
-    def self.filter_backtrace(array); end
-
-    sig { params(array: T.untyped).returns(T.untyped) }
-    def set_backtrace(array); end
-
-    sig { params(opt: T.untyped, eq: T.untyped).returns(T.untyped) }
-    def set_option(opt, eq); end
-
-    sig { returns(T.untyped) }
-    def reason(); end
-
-    sig { returns(T.untyped) }
-    def inspect(); end
-
-    sig { returns(T.untyped) }
-    def message(); end
-  end
-
-  class InvalidOption < OptionParser::ParseError
-    sig { params(args: T.untyped).void }
-    def initialize(*args); end
-
-    sig { returns(T.untyped) }
-    def args(); end
-
-    sig { params(value: T.untyped).returns(T.untyped) }
-    def reason=(value); end
-
-    sig { params(argv: T.untyped).returns(T.untyped) }
-    def recover(argv); end
-
-    sig { params(array: T.untyped).returns(T.untyped) }
-    def self.filter_backtrace(array); end
-
-    sig { params(array: T.untyped).returns(T.untyped) }
-    def set_backtrace(array); end
-
-    sig { params(opt: T.untyped, eq: T.untyped).returns(T.untyped) }
-    def set_option(opt, eq); end
-
-    sig { returns(T.untyped) }
-    def reason(); end
-
-    sig { returns(T.untyped) }
-    def inspect(); end
-
-    sig { returns(T.untyped) }
-    def message(); end
-  end
-
-  class InvalidArgument < OptionParser::ParseError
-    sig { params(args: T.untyped).void }
-    def initialize(*args); end
-
-    sig { returns(T.untyped) }
-    def args(); end
-
-    sig { params(value: T.untyped).returns(T.untyped) }
-    def reason=(value); end
-
-    sig { params(argv: T.untyped).returns(T.untyped) }
-    def recover(argv); end
-
-    sig { params(array: T.untyped).returns(T.untyped) }
-    def self.filter_backtrace(array); end
-
-    sig { params(array: T.untyped).returns(T.untyped) }
-    def set_backtrace(array); end
-
-    sig { params(opt: T.untyped, eq: T.untyped).returns(T.untyped) }
-    def set_option(opt, eq); end
-
-    sig { returns(T.untyped) }
-    def reason(); end
-
-    sig { returns(T.untyped) }
-    def inspect(); end
-
-    sig { returns(T.untyped) }
-    def message(); end
-  end
-
-  class AmbiguousArgument < OptionParser::InvalidArgument
-    sig { params(args: T.untyped).void }
-    def initialize(*args); end
-
-    sig { returns(T.untyped) }
-    def args(); end
-
-    sig { params(value: T.untyped).returns(T.untyped) }
-    def reason=(value); end
-
-    sig { params(argv: T.untyped).returns(T.untyped) }
-    def recover(argv); end
-
-    sig { params(array: T.untyped).returns(T.untyped) }
-    def self.filter_backtrace(array); end
-
-    sig { params(array: T.untyped).returns(T.untyped) }
-    def set_backtrace(array); end
-
-    sig { params(opt: T.untyped, eq: T.untyped).returns(T.untyped) }
-    def set_option(opt, eq); end
-
-    sig { returns(T.untyped) }
-    def reason(); end
-
-    sig { returns(T.untyped) }
-    def inspect(); end
-
-    sig { returns(T.untyped) }
-    def message(); end
-  end
+  class AmbiguousArgument < OptionParser::InvalidArgument; end
 
   module Arguable
     sig { params(opt: T.untyped).returns(T.untyped) }
@@ -954,6 +774,5 @@ class OptionParser
     def initialize(*args); end
   end
 
-  module Acceptables
-  end
+  module Acceptables; end
 end

--- a/test/cli/error-url/error-url.out
+++ b/test/cli/error-url/error-url.out
@@ -1,12 +1,21 @@
 test/cli/error-url/error-url.rb:4: Unable to resolve constant `MissingConstant` https://example.com/errors/?error=5002
      4 |    MissingConstant
             ^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparser.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
+     743 |  class MissingArgument < OptionParser::ParseError; end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 1
 test/cli/error-url/error-url.rb:4: Unable to resolve constant `MissingConstant` https://example.com/error/5002
      4 |    MissingConstant
             ^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparser.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
+     743 |  class MissingArgument < OptionParser::ParseError; end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 1
 test/cli/error-url/error-url.rb:4: Unable to resolve constant `MissingConstant` https://example.com/error#5002
      4 |    MissingConstant
             ^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparser.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
+     743 |  class MissingArgument < OptionParser::ParseError; end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 1

--- a/test/cli/errors/errors.out
+++ b/test/cli/errors/errors.out
@@ -1,6 +1,9 @@
 test/cli/errors/errors.rb:4: Unable to resolve constant `MissingConstant` https://srb.help/5002
      4 |    MissingConstant
             ^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparser.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
+     743 |  class MissingArgument < OptionParser::ParseError; end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 test/cli/errors/errors.rb:14: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
     14 |    raise arg # raise is defined by stdlib
@@ -48,6 +51,9 @@ Errors: 4
 test/cli/errors/errors.rb:4: Unable to resolve constant `MissingConstant` https://srb.help/5002
      4 |    MissingConstant
             ^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparser.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
+     743 |  class MissingArgument < OptionParser::ParseError; end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 test/cli/errors/errors.rb:14: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
     14 |    raise arg # raise is defined by stdlib
@@ -95,6 +101,9 @@ Errors: 4
 test/cli/errors/errors.rb:4: Unable to resolve constant `MissingConstant` https://srb.help/5002
      4 |    MissingConstant
             ^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparser.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
+     743 |  class MissingArgument < OptionParser::ParseError; end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 test/cli/errors/errors.rb:14: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
     14 |    raise arg # raise is defined by stdlib


### PR DESCRIPTION
This fixes #1263. Based on the `optparse.rb` file in Ruby itself: https://github.com/ruby/ruby/blob/v2_6_3/lib/optparse.rb

I used [Sord](https://github.com/AaronC81/sord) to create this skeleton, and it seems to have worked relatively well even without any YARD docs (though, everything is untyped obviously). I replaced a few `returns` with `void` for some `initialize` methods, but other than that I didn't mess with it much. Another concern is that Sord replaced the attr_readers/writers with the methods that Ruby actually generates, even though Sorbet can handle that itself. I'm not sure if that's a huge problem, but I figured I'd mention it.

I'm not sure if `private` methods should be excluded from this `rbi`?

My only other question is how I should handle the last line of `optparser.rb`, where the `OptParser` is made an alias of `OptionParser`: https://github.com/ruby/ruby/blob/v2_6_3/lib/optparse.rb#L2191

### Motivation

I wanted to have OptionParser not throw Sorbet errors when it's used.

### Test plan
I didn't see any tests for other stdlib libraries, so I didn't include any here.