### PR TITLE
Silence warnings caused by redefining methods in sorbet-runtime.

### DIFF
--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -333,6 +333,26 @@ module T::Configuration
     @scalar_types || @default_scalar_types
   end
 
+  # Temporarily disable ruby warnings while executing the given block. This is
+  # useful when doing something that would normally cause a warning to be
+  # emitted in Ruby verbose mode ($VERBOSE = true).
+  #
+  # @yield
+  #
+  def self.without_ruby_warnings
+    if $VERBOSE
+      begin
+        original_verbose = $VERBOSE
+        $VERBOSE = false
+        yield
+      ensure
+        $VERBOSE = original_verbose
+      end
+    else
+      yield
+    end
+  end
+
 
   private_class_method def self.validate_lambda_given!(value)
     if !value.nil? && !value.respond_to?(:call)

--- a/gems/sorbet-runtime/lib/types/private/abstract/declare.rb
+++ b/gems/sorbet-runtime/lib/types/private/abstract/declare.rb
@@ -28,6 +28,9 @@ module T::Private::Abstract::Declare
         raise "You must call `abstract!` *before* defining an initialize method"
       end
 
+      # Don't need to silence warnings via without_ruby_warnings when calling
+      # define_method because of the guard above
+
       mod.send(:define_method, :initialize) do |*args, &blk|
         if self.class == mod
           raise "#{mod} is declared as abstract; it cannot be instantiated"

--- a/gems/sorbet-runtime/lib/types/private/class_utils.rb
+++ b/gems/sorbet-runtime/lib/types/private/class_utils.rb
@@ -32,7 +32,9 @@ module T::Private::ClassUtils
 
       if @overwritten
         # The original method was overwritten. Overwrite again to restore it.
-        @mod.send(:define_method, @old_method.name, @old_method) # rubocop:disable PrisonGuard/UsePublicSend
+        T::Configuration.without_ruby_warnings do
+          @mod.send(:define_method, @old_method.name, @old_method) # rubocop:disable PrisonGuard/UsePublicSend
+        end
       else
         # The original method was in an ancestor. Restore it by removing the overriding method.
         @mod.send(:remove_method, @old_method.name) # rubocop:disable PrisonGuard/UsePublicSend
@@ -93,8 +95,10 @@ module T::Private::ClassUtils
     end
 
     overwritten = original_owner == mod
-    mod.send(:define_method, name, &blk) # rubocop:disable PrisonGuard/UsePublicSend
-    mod.send(original_visibility, name) # rubocop:disable PrisonGuard/UsePublicSend
+    T::Configuration.without_ruby_warnings do
+      mod.send(:define_method, name, &blk) # rubocop:disable PrisonGuard/UsePublicSend
+      mod.send(original_visibility, name) # rubocop:disable PrisonGuard/UsePublicSend
+    end
     new_method = mod.instance_method(name)
 
     ReplacedMethod.new(mod, original_method, new_method, overwritten, original_visibility)

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -485,18 +485,20 @@ class T::Props::Decorator
 
   sig {params(name: Symbol, rules: Rules).void}
   private def define_getter_and_setter(name, rules)
-    if rules[:immutable]
-      @class.send(:define_method, "#{name}=") do |_x|
-        raise T::Props::ImmutableProp.new("#{self.class}##{name} cannot be modified after creation.")
+    T::Configuration.without_ruby_warnings do
+      if rules[:immutable]
+        @class.send(:define_method, "#{name}=") do |_x|
+          raise T::Props::ImmutableProp.new("#{self.class}##{name} cannot be modified after creation.")
+        end
+      else
+        @class.send(:define_method, "#{name}=") do |x|
+          self.class.decorator.prop_set(self, name, x, rules)
+        end
       end
-    else
-      @class.send(:define_method, "#{name}=") do |x|
-        self.class.decorator.prop_set(self, name, x, rules)
-      end
-    end
 
-    @class.send(:define_method, name) do
-      self.class.decorator.prop_get(self, name, rules)
+      @class.send(:define_method, name) do
+        self.class.decorator.prop_get(self, name, rules)
+      end
     end
   end
 

--- a/gems/sorbet-runtime/lib/types/sig.rb
+++ b/gems/sorbet-runtime/lib/types/sig.rb
@@ -9,10 +9,15 @@ module T::Sig
     # as T::Sig#sig. Only use it in cases where you can't use T::Sig#sig.
     def self.sig(&blk); end # rubocop:disable PrisonGuard/BanBuiltinMethodOverride
 
+    original_verbose = $VERBOSE
+    $VERBOSE = false
+
     # At runtime, does nothing, but statically it is treated exactly the same
     # as T::Sig#sig. Only use it in cases where you can't use T::Sig#sig.
     T::Sig::WithoutRuntime.sig {params(blk: T.proc.bind(T::Private::Methods::DeclBuilder).void).void}
     def self.sig(&blk); end # rubocop:disable PrisonGuard/BanBuiltinMethodOverride, Lint/DuplicateMethods
+
+    $VERBOSE = original_verbose
   end
 
   # Declares a method with type signatures and/or

--- a/gems/sorbet-runtime/test/test_helper.rb
+++ b/gems/sorbet-runtime/test/test_helper.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# Ideally we might run tests with warnings enabled, but currently this triggers
+# a number of uninitialized instance variable warnings.
+# $VERBOSE = true
+
 require 'minitest/autorun'
 require 'minitest/spec'
 require 'mocha/minitest'

--- a/gems/sorbet-runtime/test/types/props/_props.rb
+++ b/gems/sorbet-runtime/test/types/props/_props.rb
@@ -33,9 +33,14 @@ class Opus::Types::Test::Props::PropsTest < Critic::Unit::UnitTest
     prop :prop2, Integer, ifunset: 42
     prop :shadowed, String
 
+    orig_verbose = $VERBOSE
+    $VERBOSE = false
+
     def shadowed
       "I can't let you see that"
     end
+
+    $VERBOSE = orig_verbose
   end
 
   class SubProps

--- a/gems/sorbet-runtime/test/types/sig.rb
+++ b/gems/sorbet-runtime/test/types/sig.rb
@@ -36,4 +36,30 @@ class Opus::Types::Test::SigTest < Critic::Unit::UnitTest
     end
     assert_match(/undefined method `sig' for/, e.message)
   end
+
+  # Enable $VERBOSE and redirect stderr to a string for the duration of the
+  # passed block.
+  def fake_stderr_with_warnings
+    original_stderr = $stderr
+    original_verbose = $VERBOSE
+    $stderr = StringIO.new
+    $VERBOSE = true
+    yield
+    $stderr.string
+  ensure
+    $stderr = original_stderr
+    $VERBOSE = original_verbose
+  end
+
+  it 'does not emit warnings when overriding methods' do
+    output = fake_stderr_with_warnings do
+      Class.new do
+        extend T::Sig
+        sig {void}
+        def foo; end
+      end
+    end
+
+    assert_equal(output, '')
+  end
 end


### PR DESCRIPTION
Add a new method, `T::Configuration.without_ruby_warnings`, which runs a block with `$VERBOSE` disabled (if it was originally enabled) and then restores the original value. This is useful for running code that is expected to trigger warnings in Ruby's verbose mode. The method is similar to ActiveSupport's `Kernel.silence_warnings`.

Putting the method in `T::Configuration` was entirely arbitrary. It just needs to be somewhere that is loaded relatively early in the `require` list.

Use the `without_ruby_warnings` method to wrap locations in sorbet-runtime that call `define_method` in case this overrides an existing method. There are several occurrences, and I added the wrappers pretty close to define_method, since I wasn't sure if there was some higher level sorbet entrypoint that would cover everything.

The PR diff will be most readable when ignoring whitespace / with `?w=1`.

There shouldn't be any user-visible changes to this except for the warnings no longer appearing.

### Motivation

Fixes: https://github.com/sorbet/sorbet/issues/1150

Currently sorbet-runtime emits lots of warnings like this:
```
$ ruby -w -r sorbet-runtime -e 'puts "hi"'
~/.rbenv/gems/2.6.0/gems/sorbet-runtime-0.4.4358/lib/types/sig.rb:15: warning: method redefined; discarding old sig
~/.rbenv/gems/2.6.0/gems/sorbet-runtime-0.4.4358/lib/types/sig.rb:10: warning: previous definition of sig was here
```

### Test plan

I added a single test that no warnings are emitted to STDERR when creating a simple method sig. It failed prior to the changes but now passes.

I also manually ran sorbet-runtime against a small library of mine that was previously triggering warnings and found that all of them were resolved.

A more robust test would be to run the whole test suite with `$VERBOSE = true` and check for method redefined warnings. This seemed challenging, so I only did this manually. I added a comment in test_helper.rb for where we could enable verbose mode, but doing so also surfaced a number of noisy warnings about using instance variables without initialization, so I left it commented out.

I also made no effort to evaluate the performance impact of this change. It adds some logic to some places that look like relatively hot paths, so that may be a concern.
