### PR TITLE
Fix --autogen-autoloader-root option

### DIFF
--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -199,7 +199,8 @@ string DefTree::renderAutoloadSrc(core::Context ctx, const AutoloaderConfig &alC
                            [ctx](const auto &pair) { return make_pair(pair.first, pair.first.show(ctx)); });
             fast_sort(childNames, [](const auto &lhs, const auto &rhs) -> bool { return lhs.second < rhs.second; });
             for (const auto &pair : childNames) {
-                fmt::format_to(buf, "  {}: \"autoloader/{}\",\n", pair.second, children.at(pair.first)->path(ctx));
+                fmt::format_to(buf, "  {}: \"{}/{}\",\n", pair.second, alCfg.rootDir,
+                               children.at(pair.first)->path(ctx));
             }
             fmt::format_to(buf, "}})\n", fullName);
         }

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -564,7 +564,7 @@ bool extractAutoloaderConfig(cxxopts::ParseResult &raw, Options &opts, shared_pt
         }
     }
     cfg.preamble = raw["autogen-autoloader-preamble"].as<string>();
-    cfg.rootDir = raw["autogen-autoloader-root"].as<string>();
+    cfg.rootDir = stripTrailingSlashes(raw["autogen-autoloader-root"].as<string>());
     return true;
 }
 

--- a/test/cli/autogen-autoloader/autogen-autoloader.out
+++ b/test/cli/autogen-autoloader/autogen-autoloader.out
@@ -208,7 +208,12 @@ inplace-output
 inplace-output/Foo.rb
 inplace-output/root.rb
 
---- strip-prefixes
+--- strip-prefixes and root rename
+
+
+Opus::Require.autoload_map(Object, {
+  Foo: "my-autoloader/Foo.rb",
+})
 
 Opus::Require.on_autoload('Foo')
 

--- a/test/cli/autogen-autoloader/autogen-autoloader.sh
+++ b/test/cli/autogen-autoloader/autogen-autoloader.sh
@@ -44,13 +44,15 @@ main/sorbet --silence-dev-message --stop-after=namer \
 find inplace-output | sort
 
 echo
-echo "--- strip-prefixes"
+echo "--- strip-prefixes and root rename"
 rm -rf strip-output
 mkdir -p strip-output
 main/sorbet --silence-dev-message --stop-after=namer \
   -p autogen-autoloader:strip-output \
   --autogen-autoloader-modules=Foo \
+  --autogen-autoloader-root my-autoloader/ \
   --autogen-autoloader-strip-prefix test/cli/ \
   test/cli/autogen-autoloader/inplace.rb
 
+cat strip-output/root.rb
 cat strip-output/Foo.rb


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
`--autogen-autoloader-root` was present as an option but I missed that I hadn't wired it up to the rendering code because the default was the same.


### Test plan
Se added test.