### PR TITLE
Variance Checking

### DIFF
--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -48,6 +48,7 @@ constexpr ErrorClass OverloadNotAllowed{5040, StrictLevel::False};
 constexpr ErrorClass SubclassingNotAllowed{5041, StrictLevel::False};
 constexpr ErrorClass NonPublicAbstract{5042, StrictLevel::True};
 constexpr ErrorClass InvalidTypeAlias{5043, StrictLevel::False};
+constexpr ErrorClass InvalidVariance{5044, StrictLevel::True};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -286,8 +286,10 @@ public:
     }
 
     unique_ptr<ast::MethodDef> preTransformMethodDef(core::Context ctx, unique_ptr<ast::MethodDef> methodDef) {
-        // only perform this check if there are type members in the
-        if (!methodDef->symbol.data(ctx)->owner.data(ctx)->typeMembers().empty()) {
+        // Only perform this check if this isn't a module from the stdlib, and
+        // if there are type members in the owning context.
+        auto methodData = methodDef->symbol.data(ctx);
+        if (!methodData->loc().file().data(ctx).isStdlib() && !methodData->owner.data(ctx)->typeMembers().empty()) {
             variance::validateMethodVariance(ctx, methodDef->symbol);
         }
 

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -192,6 +192,27 @@ class ValidateWalk {
 private:
     UnorderedMap<core::SymbolRef, vector<core::SymbolRef>> abstractCache;
 
+    struct GenericFrame {
+        bool isStdlib = false;
+        bool hasTypeTemplates = false;
+        bool hasTypeMembers = false;
+    };
+
+    vector<GenericFrame> genericContext;
+
+    void pushGenericContext(const core::GlobalState &gs, const core::SymbolRef sym, const core::SymbolRef singleton) {
+        auto symData = sym.data(gs);
+
+        GenericFrame &frame = genericContext.emplace_back();
+        frame.isStdlib = symData->loc().file().data(gs).isStdlib();
+        frame.hasTypeTemplates = singleton != core::Symbols::noSymbol() && !singleton.data(gs)->typeMembers().empty();
+        frame.hasTypeMembers = !symData->typeMembers().empty();
+    }
+
+    void popGenericContext() {
+        genericContext.pop_back();
+    }
+
     const vector<core::SymbolRef> &getAbstractMethods(const core::GlobalState &gs, core::SymbolRef klass) {
         vector<core::SymbolRef> abstract;
         auto ent = abstractCache.find(klass);
@@ -282,6 +303,12 @@ public:
         validateTStructNotGrandparent(ctx.state, sym);
         auto singleton = sym.data(ctx)->lookupSingletonClass(ctx);
         validateAbstract(ctx.state, singleton);
+        pushGenericContext(ctx, sym, singleton);
+        return classDef;
+    }
+
+    unique_ptr<ast::ClassDef> postTransformClassDef(core::Context ctx, unique_ptr<ast::ClassDef> classDef) {
+        popGenericContext();
         return classDef;
     }
 
@@ -289,7 +316,9 @@ public:
         // Only perform this check if this isn't a module from the stdlib, and
         // if there are type members in the owning context.
         auto methodData = methodDef->symbol.data(ctx);
-        if (!methodData->loc().file().data(ctx).isStdlib() && !methodData->owner.data(ctx)->typeMembers().empty()) {
+        auto isSelfMethod = methodData->owner.data(ctx)->isSingletonClass(ctx);
+        auto &frame = genericContext.back();
+        if (!frame.isStdlib && ((!isSelfMethod && frame.hasTypeMembers) || (isSelfMethod && frame.hasTypeTemplates))) {
             variance::validateMethodVariance(ctx, methodDef->symbol);
         }
 

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -286,7 +286,12 @@ public:
     }
 
     unique_ptr<ast::MethodDef> preTransformMethodDef(core::Context ctx, unique_ptr<ast::MethodDef> methodDef) {
-        variance::validateMethodVariance(ctx, methodDef->symbol);
+
+        // only perform this check if there are type members in the 
+        if (!methodDef->symbol.data(ctx)->owner.data(ctx)->typeMembers().empty()) {
+            variance::validateMethodVariance(ctx, methodDef->symbol);
+        }
+
         validateOverriding(ctx.state, methodDef->symbol);
         return methodDef;
     }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -5,6 +5,8 @@
 
 #include "absl/algorithm/container.h"
 
+#include "variance.h"
+
 using namespace std;
 
 namespace sorbet::definition_validator {
@@ -284,6 +286,7 @@ public:
     }
 
     unique_ptr<ast::MethodDef> preTransformMethodDef(core::Context ctx, unique_ptr<ast::MethodDef> methodDef) {
+        variance::validateMethodVariance(ctx, methodDef->symbol);
         validateOverriding(ctx.state, methodDef->symbol);
         return methodDef;
     }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -286,8 +286,7 @@ public:
     }
 
     unique_ptr<ast::MethodDef> preTransformMethodDef(core::Context ctx, unique_ptr<ast::MethodDef> methodDef) {
-
-        // only perform this check if there are type members in the 
+        // only perform this check if there are type members in the
         if (!methodDef->symbol.data(ctx)->owner.data(ctx)->typeMembers().empty()) {
             variance::validateMethodVariance(ctx, methodDef->symbol);
         }

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -40,17 +40,6 @@ private:
 
     VarianceValidator(const core::Loc loc) : loc(loc) {}
 
-    core::Variance invertVariance(const core::Variance variance) {
-        switch (variance) {
-            case core::Variance::CoVariant:
-                return core::Variance::ContraVariant;
-            case core::Variance::Invariant:
-                return core::Variance::Invariant;
-            case core::Variance::ContraVariant:
-                return core::Variance::CoVariant;
-        }
-    }
-
     string showVariance(const core::Variance variance) {
         switch (variance) {
             case core::Variance::CoVariant:

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -34,31 +34,31 @@ const Polarity negatePolarity(const Polarity polarity) {
     }
 }
 
+string showVariance(const core::Variance variance) {
+    switch (variance) {
+        case core::Variance::CoVariant:
+            return ":out";
+        case core::Variance::Invariant:
+            return ":invariant";
+        case core::Variance::ContraVariant:
+            return ":in";
+    }
+}
+
+bool hasCompatibleVariance(const Polarity polarity, const core::Variance argVariance) {
+    switch (polarity) {
+        case Polarity::Positive:
+            return argVariance != core::Variance::ContraVariant;
+        case Polarity::Negative:
+            return argVariance != core::Variance::CoVariant;
+    }
+}
+
 class VarianceValidator {
 private:
     const core::Loc loc;
 
     VarianceValidator(const core::Loc loc) : loc(loc) {}
-
-    string showVariance(const core::Variance variance) {
-        switch (variance) {
-            case core::Variance::CoVariant:
-                return ":out";
-            case core::Variance::Invariant:
-                return ":invariant";
-            case core::Variance::ContraVariant:
-                return ":in";
-        }
-    }
-
-    bool hasCompatibleVariance(const Polarity polarity, const core::Variance argVariance) {
-        switch (polarity) {
-            case Polarity::Positive:
-                return argVariance != core::Variance::ContraVariant;
-            case Polarity::Negative:
-                return argVariance != core::Variance::CoVariant;
-        }
-    }
 
     void validate(const core::Context ctx, const Polarity polarity, const core::TypePtr type) {
         typecase(

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -169,14 +169,10 @@ private:
     }
 
 public:
-    static void validateCoVariant(const core::Loc loc, const core::Context ctx, const core::TypePtr type) {
+    static void validatePolarity(const core::Loc loc, const core::Context ctx, const Polarity polarity,
+                                 const core::TypePtr type) {
         VarianceValidator validator(loc);
-        return validator.validate(ctx, Polarity::Positive, type);
-    }
-
-    static void validateContraVariant(const core::Loc loc, const core::Context ctx, const core::TypePtr type) {
-        VarianceValidator validator(loc);
-        return validator.validate(ctx, Polarity::Negative, type);
+        return validator.validate(ctx, polarity, type);
     }
 };
 
@@ -186,12 +182,12 @@ void validateMethodVariance(const core::Context ctx, const core::SymbolRef metho
 
     for (auto &arg : methodData->arguments()) {
         if (arg.type != nullptr) {
-            VarianceValidator::validateContraVariant(arg.loc, ctx, arg.type);
+            VarianceValidator::validatePolarity(arg.loc, ctx, Polarity::Negative, arg.type);
         }
     }
 
     if (methodData->resultType != nullptr) {
-        VarianceValidator::validateCoVariant(methodData->loc(), ctx, methodData->resultType);
+        VarianceValidator::validatePolarity(methodData->loc(), ctx, Polarity::Positive, methodData->resultType);
     }
 }
 

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -51,9 +51,15 @@ private:
 
     void validate(const core::Context ctx, const core::Variance variance, const core::TypePtr type) {
         typecase(
-            type.get(), [&](core::LiteralType *lit) {},
+            type.get(), [&](core::ClassType *klass) {},
 
-            [&](core::ClassType *klass) {},
+            [&](core::LiteralType *lit) {},
+
+            [&](core::SelfType *self) {},
+
+            [&](core::SelfTypeParam *sp) {},
+
+            [&](core::TypeVar *tvar) {},
 
             [&](core::OrType *any) {
                 validate(ctx, variance, any->left);
@@ -64,12 +70,6 @@ private:
                 validate(ctx, variance, all->left);
                 validate(ctx, variance, all->right);
             },
-
-            [&](core::TypeVar *tvar) {},
-
-            [&](core::SelfType *self) {},
-
-            [&](core::SelfTypeParam *sp) {},
 
             [&](core::AliasType *alias) {
                 auto aliasData = alias->symbol.data(ctx);
@@ -149,7 +149,9 @@ private:
 
             [&](core::MetaType *mt) { validate(ctx, variance, mt->wrapped); },
 
-            [&](core::Type *skipped) { Exception::raise("skipped type {}", skipped->toString(ctx)); });
+            [&](core::Type *skipped) {
+                Exception::raise("Unhandled type during variance checking: {}", skipped->toString(ctx));
+            });
     }
 
 public:

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -142,7 +142,7 @@ private:
             },
 
             [&](core::AliasType *alias) {
-                auto aliasSym = alias->symbol.data(ctx)->dealias();
+                auto aliasSym = alias->symbol.data(ctx)->dealias(ctx);
 
                 // This can be introduced by `module_function`, which in its
                 // current implementation will alias an instance method as a

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -82,19 +82,6 @@ private:
                 validate(ctx, polarity, all->right);
             },
 
-            [&](core::AliasType *alias) {
-                auto aliasSym = alias->symbol;
-
-                // This can be introduced by `module_function`, which in its
-                // current implementation will alias an instance method as a
-                // class method.
-                if (aliasSym.data(ctx)->isMethod()) {
-                    validateMethod(ctx, polarity, aliasSym);
-                } else {
-                    Exception::raise("Unexpected type alias: {}", alias->toString(ctx));
-                }
-            },
-
             [&](core::ShapeType *shape) {
                 for (auto value : shape->values) {
                     validate(ctx, polarity, value);
@@ -151,6 +138,19 @@ private:
                         e.addErrorLine(paramData->loc(), "`{}` `{}` defined here as `{}`", flavor, paramName,
                                        showVariance(paramVariance));
                     }
+                }
+            },
+
+            [&](core::AliasType *alias) {
+                auto aliasSym = alias->symbol.data(ctx)->dealias();
+
+                // This can be introduced by `module_function`, which in its
+                // current implementation will alias an instance method as a
+                // class method.
+                if (aliasSym.data(ctx)->isMethod()) {
+                    validateMethod(ctx, polarity, aliasSym);
+                } else {
+                    Exception::raise("Unexpected type alias: {}", alias->toString(ctx));
                 }
             },
 

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -1,0 +1,145 @@
+
+#include "common/typecase.h"
+#include "core/Symbols.h"
+#include "core/core.h"
+#include "core/errors/resolver.h"
+
+#include "variance.h"
+
+using namespace std;
+
+namespace sorbet::definition_validator::variance {
+
+class VarianceValidator {
+private:
+    const core::Loc loc;
+
+    VarianceValidator(const core::Loc loc) : loc(loc) {}
+
+    core::Variance invertVariance(const core::Variance variance) {
+        switch (variance) {
+            case core::Variance::CoVariant:
+                return core::Variance::ContraVariant;
+            case core::Variance::Invariant:
+                return core::Variance::Invariant;
+            case core::Variance::ContraVariant:
+                return core::Variance::CoVariant;
+        }
+    }
+
+    string showVariance(const core::Variance variance) {
+        switch (variance) {
+            case core::Variance::CoVariant:
+                return ":out";
+            case core::Variance::Invariant:
+                return ":invariant";
+            case core::Variance::ContraVariant:
+                return ":in";
+        }
+    }
+
+    void validate(const core::Context ctx, const core::Variance variance, const core::TypePtr type) {
+        typecase(
+            type.get(), [&](core::LiteralType *lit) {},
+
+            [&](core::ClassType *klass) {},
+
+            [&](core::OrType *any) {
+                validate(ctx, variance, any->left);
+                validate(ctx, variance, any->right);
+            },
+
+            [&](core::AndType *all) {
+                validate(ctx, variance, all->left);
+                validate(ctx, variance, all->right);
+            },
+
+            [&](core::ShapeType *shape) {
+                for (auto value : shape->values) {
+                    validate(ctx, variance, value);
+                }
+            },
+
+            [&](core::TupleType *tuple) {
+                for (auto value : tuple->elems) {
+                    validate(ctx, variance, value);
+                }
+            },
+
+            [&](core::AppliedType *app) {
+                auto members = app->klass.data(ctx)->typeMembers();
+                auto params = app->targs;
+
+                // We expect that types are fully saturated.
+                ENFORCE(members.size() == params.size());
+
+                for (int i = 0; i < members.size(); ++i) {
+                    auto memberVariance = members[i].data(ctx)->variance();
+                    auto typeArg = params[i];
+
+                    // Invert the variance when the type_member was defined as
+                    // contravariant (:in).
+                    const core::Variance checkedVariance =
+                        (variance == core::Variance::ContraVariant) ? invertVariance(memberVariance) : memberVariance;
+
+                    validate(ctx, checkedVariance, typeArg);
+                }
+            },
+
+            // This is where the actual variance checks are done.
+            [&](core::LambdaParam *param) {
+                auto paramData = param->definition.data(ctx);
+
+                ENFORCE(paramData->isTypeMember());
+
+                auto paramVariance = paramData->variance();
+
+                if (paramVariance != variance) {
+                    if (auto e = ctx.state.beginError(this->loc, core::errors::Resolver::InvalidVariance)) {
+                        auto flavor =
+                            paramData->owner.data(ctx)->isSingletonClass(ctx) ? "type_template" : "type_member";
+
+                        auto paramName = paramData->name.data(ctx)->show(ctx);
+
+                        e.setHeader("`{}` `{}` was defined as `{}` but is used in an `{}` context", flavor, paramName,
+                                    showVariance(paramVariance), showVariance(variance));
+
+                        e.addErrorLine(paramData->loc(), "`{}` `{}` defined here as `{}`", flavor, paramName,
+                                       showVariance(paramVariance));
+                    }
+                }
+            },
+
+            [&](core::MetaType *mt) { validate(ctx, variance, mt->wrapped); },
+
+            [&](core::Type *skipped) { Exception::raise("skipped type {}", skipped->toString(ctx)); });
+    }
+
+public:
+    static void validateCoVariant(const core::Loc loc, const core::Context ctx, const core::TypePtr type) {
+        VarianceValidator validator(loc);
+        return validator.validate(ctx, core::Variance::CoVariant, type);
+    }
+
+    static void validateContraVariant(const core::Loc loc, const core::Context ctx, const core::TypePtr type) {
+        VarianceValidator validator(loc);
+        return validator.validate(ctx, core::Variance::ContraVariant, type);
+    }
+};
+
+// Validates uses of type members according to their variance.
+void validateMethodVariance(const core::Context ctx, const core::SymbolRef method) {
+    auto methodData = method.data(ctx);
+
+    for (auto &arg : methodData->arguments()) {
+        if (arg.type != nullptr) {
+            VarianceValidator::validateContraVariant(arg.loc, ctx, arg.type);
+        }
+    }
+
+    if (methodData->resultType != nullptr) {
+        VarianceValidator::validateCoVariant(methodData->loc(), ctx, methodData->resultType);
+    }
+}
+
+} // namespace sorbet::definition_validator::variance

--- a/definition_validator/variance.h
+++ b/definition_validator/variance.h
@@ -1,0 +1,12 @@
+#ifndef SORBET_VARIANCE_CHECKS_H
+#define SORBET_VARIANCE_CHECKS_H
+
+#include "core/core.h"
+
+namespace sorbet::definition_validator::variance {
+
+void validateMethodVariance(const core::Context ctx, const core::SymbolRef method);
+
+};
+
+#endif

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -132,23 +132,6 @@ void resolveTypeMembers(core::GlobalState &gs, core::SymbolRef sym,
             resolveTypeMember(gs, mixin, tp, sym, typeAliases);
         }
     }
-
-    if (sym.data(gs)->isClassClass()) {
-        for (core::SymbolRef tp : sym.data(gs)->typeMembers()) {
-            auto myVariance = tp.data(gs)->variance();
-            if (myVariance != core::Variance::Invariant) {
-                auto loc = tp.data(gs)->loc();
-                if (!loc.file().data(gs).isPayload()) {
-                    if (auto e = gs.beginError(loc, core::errors::Resolver::VariantTypeMemberInClass)) {
-                        e.setHeader("Classes can only have invariant type members");
-                    }
-                    return;
-                }
-            }
-        }
-    }
-
-    // TODO: this will be the right moment to implement checks for correct locations of co&contra variant types.
 }
 
 }; // namespace

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -132,6 +132,23 @@ void resolveTypeMembers(core::GlobalState &gs, core::SymbolRef sym,
             resolveTypeMember(gs, mixin, tp, sym, typeAliases);
         }
     }
+
+    if (sym.data(gs)->isClassClass()) {
+        for (core::SymbolRef tp : sym.data(gs)->typeMembers()) {
+            auto myVariance = tp.data(gs)->variance();
+            if (myVariance != core::Variance::Invariant) {
+                auto loc = tp.data(gs)->loc();
+                if (!loc.file().data(gs).isPayload()) {
+                    if (auto e = gs.beginError(loc, core::errors::Resolver::VariantTypeMemberInClass)) {
+                        e.setHeader("Classes can only have invariant type members");
+                    }
+                    return;
+                }
+            }
+        }
+    }
+
+    // TODO: this will be the right moment to implement checks for correct locations of co&contra variant types.
 }
 
 }; // namespace

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -147,8 +147,6 @@ void resolveTypeMembers(core::GlobalState &gs, core::SymbolRef sym,
             }
         }
     }
-
-    // TODO: this will be the right moment to implement checks for correct locations of co&contra variant types.
 }
 
 }; // namespace

--- a/test/testdata/infer/generics/variance_methods.rb
+++ b/test/testdata/infer/generics/variance_methods.rb
@@ -22,24 +22,30 @@ module A
   # should fail: the contravariant type key is returned
   sig {abstract.returns(In)}
   def returns_contravariant; end
+# ^^^^^^^^^^^^^^^^^^^^^^^^^ error: `type_member` `In` was defined as `:in` but is used in an `:out` context
 
   # should fail: the contravariant type key is returned
   sig {abstract.returns(T.nilable(In))}
   def returns_nilable_contravariant; end
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `type_member` `In` was defined as `:in` but is used in an `:out` context
 
   # should fail: the contravariant type key is given to the block as an argument
   sig {abstract.params(blk: T.proc.params(arg: In).void).void}
+                     # ^^^ error: `type_member` `In` was defined as `:in` but is used in an `:out` context
   def block_arg_contravariant(&blk); end
 
   # should fail: the covariant type key is taken as an argument
   sig {abstract.params(val: Out).void}
+                     # ^^^ error: `type_member` `Out` was defined as `:out` but is used in an `:in` context
   def accepts_covariant(val); end
 
   # should fail: the covariant type key is taken as an argument
   sig {abstract.params(val: T.nilable(Out)).void}
+                     # ^^^ error: `type_member` `Out` was defined as `:out` but is used in an `:in` context
   def accepts_nilable_covariant(val); end
 
   # should fail: the covariant type Out is returned from the block
   sig {abstract.params(blk: T.proc.returns(Out)).void}
+                     # ^^^ error: `type_member` `Out` was defined as `:out` but is used in an `:in` context
   def block_returns_covariant(&blk); end
 end

--- a/test/testdata/infer/generics/variance_neutral.rb
+++ b/test/testdata/infer/generics/variance_neutral.rb
@@ -1,0 +1,30 @@
+# typed: true
+
+class A
+  extend T::Generic
+
+  S = type_member
+end
+
+module I
+  extend T::Sig
+  extend T::Helpers
+  extend T::Generic
+
+  interface!
+
+  In = type_member(:in)
+  Out = type_member(:out)
+
+  # should pass: Out and In are used in invariant position
+  sig {abstract.params(arg: A[Out]).returns(A[In])}
+  def invariant_arg_and_return(arg); end
+
+  # should pass: Out is used in an array used in invariant context
+  sig {abstract.params(arg: A[T::Array[Out]]).void}
+  def invariant_arg_array(arg); end
+
+  # should pass: In is used in an array used in invariant context
+  sig {abstract.returns(A[T::Array[In]])}
+  def return_invariant_array; end
+end

--- a/test/testdata/infer/generics/variance_user.rb
+++ b/test/testdata/infer/generics/variance_user.rb
@@ -38,6 +38,7 @@ module OnlyIn
   # should fail: `In` occurs in the contravariant position of Arrow, which is in
   # contravariant position.
   sig {abstract.params(arr: Arrow[In, Unit]).void}
+                     # ^^^ error: `type_member` `In` was defined as `:in` but is used in an `:out` context
   def arrow_fail(arr); end
 
   # should pass: `In` occurs in the contravariant position of Arrow, which is in
@@ -49,6 +50,7 @@ module OnlyIn
   # covariant position.
   sig {abstract.returns(Arrow[Unit,In])}
   def ret_arrow_fail; end
+# ^^^^^^^^^^^^^^^^^^ error: `type_member` `In` was defined as `:in` but is used in an `:out` context
 end
 
 module OnlyOut
@@ -63,6 +65,7 @@ module OnlyOut
   # should fail: `Out` occurs in the covariant position of Arrow, which is in
   # contravariant position.
   sig {abstract.params(arr: Arrow[Unit, Out]).void}
+                     # ^^^ error: `type_member` `Out` was defined as `:out` but is used in an `:in` context
   def arrow_fail(arr); end
 
   # should pass: `Out` occurs in the contravariant position of Arrow, which is
@@ -73,7 +76,8 @@ module OnlyOut
   # should fail: `Out` occurs in the contravariant position of Arrow, which is
   # in covariant position.
   sig {abstract.returns(Arrow[Out,Unit])}
-  def ret_arrow_pass; end
+  def ret_arrow_fail; end
+# ^^^^^^^^^^^^^^^^^^ error: `type_member` `Out` was defined as `:out` but is used in an `:in` context
 
   # should pass: `Out` occurs in the covariant position of Arrow, which is in
   # covariant position.

--- a/test/testdata/resolver/type_members.rb
+++ b/test/testdata/resolver/type_members.rb
@@ -1,5 +1,9 @@
 # typed: true
 # disable-fast-path: true
+class CovariantNotAllowed
+  Elem = type_member(:in) # error: can only have invariant type members
+end
+
 class Invalids
   Exp = type_member(1+1) # error: Invalid param, must be a :symbol
   Baz = type_member(:baz) # error: Invalid variance kind, only `:out` and `:in` are supported

--- a/test/testdata/resolver/type_members.rb
+++ b/test/testdata/resolver/type_members.rb
@@ -1,9 +1,5 @@
 # typed: true
 # disable-fast-path: true
-class CovariantNotAllowed
-  Elem = type_member(:in) # error: can only have invariant type members
-end
-
 class Invalids
   Exp = type_member(1+1) # error: Invalid param, must be a :symbol
   Baz = type_member(:baz) # error: Invalid variance kind, only `:out` and `:in` are supported


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This change allows the `type_member` parameters of generics to be annotated with their variance, and adds checks to their methods enforcing correct usage of those parameters.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
This change now enforces the errors defined in #1232.
