### PR TITLE
Avoid out-of-bounds error in subtype checks

### DIFF
--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -1,5 +1,6 @@
 #include "common/common.h"
 #include "common/typecase.h"
+#include "core/GlobalState.h"
 #include "core/Symbols.h"
 #include "core/TypeConstraint.h"
 #include "core/Types.h"
@@ -1032,6 +1033,9 @@ bool isSubTypeUnderConstraintSingle(Context ctx, TypeConstraint &constr, const T
                 int i = 0;
                 while (indexes[j] != a1->klass.data(ctx)->typeMembers()[i]) {
                     i++;
+                    if (i >= a1->klass.data(ctx)->typeMembers().size()) {
+                        return result;
+                    }
                 }
 
                 ENFORCE(i < a1->klass.data(ctx)->typeMembers().size());

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -1,6 +1,5 @@
 #include "common/common.h"
 #include "common/typecase.h"
-#include "core/GlobalState.h"
 #include "core/Symbols.h"
 #include "core/TypeConstraint.h"
 #include "core/Types.h"

--- a/test/testdata/core/fuzz_bad_subtyping.rb
+++ b/test/testdata/core/fuzz_bad_subtyping.rb
@@ -1,4 +1,5 @@
 # typed: true
+# disable-fast-path: true
 # Found by fuzzer: https://github.com/sorbet/sorbet/issues/1132
 module MyEnumerable
 extend T::Generic

--- a/test/testdata/core/fuzz_bad_subtyping.rb
+++ b/test/testdata/core/fuzz_bad_subtyping.rb
@@ -1,0 +1,15 @@
+# typed: true
+# Found by fuzzer: https://github.com/sorbet/sorbet/issues/1132
+module MyEnumerable
+extend T::Generic
+A = type_member
+  sig {params(a: MyEnumerable[])} # error: Malformed `sig`: No return type specified. Specify one with .returns()
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Method `sig` does not exist on `T.class_of(MyEnumerable)`
+     # ^^^^^^^^^^^^^^^^^^^^^^^^^ error: Method `params` does not exist on `T.class_of(MyEnumerable)`
+               # ^^^^^^^^^^^^^^ error-with-dupes: Wrong number of type parameters for `MyEnumerable`.
+  def-(a) end
+ class MySet
+include MyEnumerable
+ A = # error: Type variable `A` needs to be declared as `= type_member(SOMETHING)`
+new-MySet.new()  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes #1132 and fixes #1168 by checking for an out-of-bounds index in subtyping checks.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Added fuzzed test case.
