### PR TITLE
[wip] Avoid adding redundant type members in incremental mode

### DIFF
--- a/core/NameRef.h
+++ b/core/NameRef.h
@@ -97,6 +97,8 @@ public:
     std::string toString(const GlobalState &gs) const;
     std::string show(const GlobalState &gs) const;
 
+    NameRef originalName(const GlobalState &gs) const;
+
     void enforceCorrectGlobalState(const GlobalState &gs) const;
     void sanityCheckSubstitution(const GlobalSubstitution &subst) const;
 

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -243,6 +243,14 @@ string NameRef::show(const GlobalState &gs) const {
     return data(gs)->show(gs);
 }
 
+NameRef NameRef::originalName(const GlobalState &gs) const {
+    auto name = *this;
+    while (name.data(gs)->kind == UNIQUE) {
+        name = name.data(gs)->unique.original;
+    }
+    return name;
+}
+
 NameRef NameRef::addEq(GlobalState &gs) const {
     auto name = this->data(gs);
     ENFORCE(name->kind == UTF8, "addEq over non-utf8 name");

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -703,7 +703,7 @@ public:
         }
 
         auto members = onSymbol.data(ctx)->typeMembers();
-        auto it = absl::c_find_if(members, [&](auto mem) { return mem.data(ctx)->name == typeName->cnst; });
+        auto it = absl::c_find_if(members, [&](auto mem) { return mem.data(ctx)->name.originalName(ctx) == typeName->cnst.originalName(ctx); });
         if (it != members.end() && !(it->data(ctx)->loc() == asgn->loc || it->data(ctx)->loc().isTombStoned(ctx))) {
             if (auto e = ctx.state.beginError(typeName->loc, core::errors::Namer::InvalidTypeDefinition)) {
                 e.setHeader("Duplicate type member `{}`", typeName->cnst.data(ctx)->show(ctx));

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -703,7 +703,9 @@ public:
         }
 
         auto members = onSymbol.data(ctx)->typeMembers();
-        auto it = absl::c_find_if(members, [&](auto mem) { return mem.data(ctx)->name.originalName(ctx) == typeName->cnst.originalName(ctx); });
+        auto it = absl::c_find_if(members, [&](auto mem) {
+            return mem.data(ctx)->name.originalName(ctx) == typeName->cnst.originalName(ctx);
+        });
         if (it != members.end() && !(it->data(ctx)->loc() == asgn->loc || it->data(ctx)->loc().isTombStoned(ctx))) {
             if (auto e = ctx.state.beginError(typeName->loc, core::errors::Namer::InvalidTypeDefinition)) {
                 e.setHeader("Duplicate type member `{}`", typeName->cnst.data(ctx)->show(ctx));

--- a/test/cli/incremental-resolver/expect-failures/redefined_member.rb
+++ b/test/cli/incremental-resolver/expect-failures/redefined_member.rb
@@ -1,0 +1,6 @@
+class FullChild
+  V=type_member
+  V=y
+  sig{params(f:FullChild).void}
+  def foo(f); end
+end

--- a/test/cli/incremental-resolver/incremental-resolver.out
+++ b/test/cli/incremental-resolver/incremental-resolver.out
@@ -56,3 +56,27 @@ test/cli/incremental-resolver/expect-failures/constant_override.rb:110: Method `
      110 |B = e
               ^
 Errors: 4
+----- test/cli/incremental-resolver/expect-failures/redefined_member.rb ---------------------
+test/cli/incremental-resolver/expect-failures/redefined_member.rb:3: Redefining constant `V` https://srb.help/4012
+     3 |  V=y
+          ^^^
+    test/cli/incremental-resolver/expect-failures/redefined_member.rb:2: Previous definition
+     2 |  V=type_member
+          ^^^^^^^^^^^^^
+
+test/cli/incremental-resolver/expect-failures/redefined_member.rb:4: To use `sig`, this file must declare an explicit `# typed:` sigil (found: none). If you're not sure which one to use, start with `# typed: false` https://srb.help/5038
+     4 |  sig{params(f:FullChild).void}
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/cli/incremental-resolver/expect-failures/redefined_member.rb:4: Malformed type declaration. Generic class without type arguments `FullChild` https://srb.help/5004
+     4 |  sig{params(f:FullChild).void}
+                       ^^^^^^^^^
+
+test/cli/incremental-resolver/expect-failures/redefined_member.rb:97: To use `sig`, this file must declare an explicit `# typed:` sigil (found: none). If you're not sure which one to use, start with `# typed: false` https://srb.help/5038
+    97 |  sig{params(f:FullChild).void}
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/cli/incremental-resolver/expect-failures/redefined_member.rb:97: Malformed type declaration. Generic class without type arguments `FullChild` https://srb.help/5004
+    97 |  sig{params(f:FullChild).void}
+                       ^^^^^^^^^
+Errors: 5


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes #1164: when we had a situation in which if we redefined type members, we would later on add "new" type members when we re-ran the namer (in incremental mode) because the existing type member array contained only the redefined constant, which in turn was given a unique name: because the uniquified name `T$1` is not `==` to `T`, we would believe that we were seeing a "new" type variable and re-add it.

This fixes it with a kind of broad hammer: when looking to see if we've already defined a type member, we look not at the unique name, but rather at the original `NameRef` if it exists. This does mean looking through the `data` for the name, and my feeling is that this will be rare enough (only happening on type member definitions and only looking through a small set of names) that it's probably alright, but I still have some minor FUD about whether this is the best way of solving this problem.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Added the fuzzed test case.
