### PR TITLE
fix `--typed-override` paths

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -174,7 +174,7 @@ UnorderedMap<string, core::StrictLevel> extractStricnessOverrides(string fileNam
                             for (const auto &file : child.second) {
                                 if (file.IsScalar()) {
                                     string key = file.as<string>();
-                                    if (key.size() > 2 && !(key[0] == '/' || (key[0] == '.' && key[1] == '/'))) {
+                                    if (!absl::StartsWith(key, "/") && !absl::StartsWith(key, "./")) {
                                         logger->error("All relative file names in \"{}\" should start with ./",
                                                       fileName);
                                         throw EarlyReturnWithCode(1);

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -174,8 +174,9 @@ UnorderedMap<string, core::StrictLevel> extractStricnessOverrides(string fileNam
                             for (const auto &file : child.second) {
                                 if (file.IsScalar()) {
                                     string key = file.as<string>();
-                                    if (key.find("/") != 0 && key.find("./") != 0) {
-                                        key.insert(0, "./");
+                                    if (key.size() > 2 && !(key[0] == '/' || (key[0] == '.' && key[1] == '/'))) {
+                                        logger->error("All relative file names in \"{}\" should start with ./", fileName);
+                                        throw EarlyReturnWithCode(1);
                                     }
                                     result[key] = level;
                                 } else {

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -175,7 +175,8 @@ UnorderedMap<string, core::StrictLevel> extractStricnessOverrides(string fileNam
                                 if (file.IsScalar()) {
                                     string key = file.as<string>();
                                     if (key.size() > 2 && !(key[0] == '/' || (key[0] == '.' && key[1] == '/'))) {
-                                        logger->error("All relative file names in \"{}\" should start with ./", fileName);
+                                        logger->error("All relative file names in \"{}\" should start with ./",
+                                                      fileName);
                                         throw EarlyReturnWithCode(1);
                                     }
                                     result[key] = level;

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -173,7 +173,11 @@ UnorderedMap<string, core::StrictLevel> extractStricnessOverrides(string fileNam
                         case YAML::NodeType::Sequence:
                             for (const auto &file : child.second) {
                                 if (file.IsScalar()) {
-                                    result[file.as<string>()] = level;
+                                    string key = file.as<string>();
+                                    if (key.find("/") != 0 && key.find("./") != 0) {
+                                        key.insert(0, "./");
+                                    }
+                                    result[key] = level;
                                 } else {
                                     logger->error("Cannot parse strictness override format. Invalid file name.");
                                     throw EarlyReturnWithCode(1);

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -4,6 +4,7 @@
 
 #include "ProgressIndicator.h"
 #include "absl/strings/escaping.h" // BytesToHexString
+#include "absl/strings/match.h"
 #include "ast/desugar/Desugar.h"
 #include "ast/substitute/substitute.h"
 #include "ast/treemap/treemap.h"
@@ -354,7 +355,7 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
     core::StrictLevel level;
     string filePath = string(fileData.path());
     // make sure all relative file paths start with ./
-    if (filePath.size() > 2 && !(filePath[0] == '/' || (filePath[0] == '.' && filePath[1] == '/'))) {
+    if (!absl::StartsWith(filePath, "/") && !absl::StartsWith(filePath, "./")) {
         filePath.insert(0, "./");
     }
     auto fnd = opts.strictnessOverrides.find(filePath);

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -353,7 +353,8 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
 
     core::StrictLevel level;
     string filePath = string(fileData.path());
-    if (filePath.find("/") != 0 && filePath.find("./") != 0) {
+    // make sure all relative file paths start with ./
+    if (filePath.size() > 2 && !(filePath[0] == '/' || (filePath[0] == '.' && filePath[1] == '/'))) {
         filePath.insert(0, "./");
     }
     auto fnd = opts.strictnessOverrides.find(filePath);

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -352,7 +352,11 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
     auto &fileData = file.data(gs);
 
     core::StrictLevel level;
-    auto fnd = opts.strictnessOverrides.find(string(fileData.path()));
+    string filePath = string(fileData.path());
+    if (filePath.find("/") != 0 && filePath.find("./") != 0) {
+        filePath.insert(0, "./");
+    }
+    auto fnd = opts.strictnessOverrides.find(filePath);
     if (fnd != opts.strictnessOverrides.end()) {
         if (fnd->second == fileData.originalSigil) {
             core::ErrorRegion errs(gs, file);

--- a/test/cli/override-typed-bad/bad-filename.yaml
+++ b/test/cli/override-typed-bad/bad-filename.yaml
@@ -1,2 +1,2 @@
 true:
-  - not a: string
+  - ./not a: string

--- a/test/cli/override-typed-bad/override-typed-bad.yaml
+++ b/test/cli/override-typed-bad/override-typed-bad.yaml
@@ -1,2 +1,2 @@
 true:
- - 'test/cli/override-typed-bad/override-typed-bad.rb'
+ - './test/cli/override-typed-bad/override-typed-bad.rb'

--- a/test/cli/override-typed/override-typed.out
+++ b/test/cli/override-typed/override-typed.out
@@ -9,3 +9,25 @@ test/cli/override-typed/override-typed.rb:1: Expected `Integer` but found `Strin
      1 |1 + "s"
             ^^^
 Errors: 1
+./test/cli/override-typed/override-typed.rb:1: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
+     1 |1 + "s"
+        ^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L104: Method `Integer#+` has specified `arg0` as `Integer`
+     104 |        arg0: Integer,
+                  ^^^^
+  Got String("s") originating from:
+    ./test/cli/override-typed/override-typed.rb:1:
+     1 |1 + "s"
+            ^^^
+Errors: 1
+test/cli/override-typed/override-typed.rb:1: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
+     1 |1 + "s"
+        ^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L104: Method `Integer#+` has specified `arg0` as `Integer`
+     104 |        arg0: Integer,
+                  ^^^^
+  Got String("s") originating from:
+    test/cli/override-typed/override-typed.rb:1:
+     1 |1 + "s"
+            ^^^
+Errors: 1

--- a/test/cli/override-typed/override-typed.sh
+++ b/test/cli/override-typed/override-typed.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
 main/sorbet --silence-dev-message --typed-override=test/cli/override-typed/override-typed.yaml test/cli/override-typed/override-typed.rb 2>&1
+main/sorbet --silence-dev-message --typed-override=test/cli/override-typed/override-typed.yaml ./test/cli/override-typed/override-typed.rb 2>&1
+main/sorbet --silence-dev-message --typed-override=test/cli/override-typed/override-typed.yaml . 2>&1

--- a/test/cli/override-typed/override-typed.yaml
+++ b/test/cli/override-typed/override-typed.yaml
@@ -1,2 +1,2 @@
 true:
- - 'test/cli/override-typed/override-typed.rb'
+ - './test/cli/override-typed/override-typed.rb'


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
We were handling `--typed-override` by doing naive path matching, which meant it was very easy for it to fail to work, and in fact rarely works in a project context unless your override `.yaml` file included a prefixed `./` on every path. This PR adds `./` to non-absolute paths, which bypasses this problem. (It does not fully solve the problem of path-matching: e.g. `foo/./bar` and `foo/bar` are still understood to be different, but that's a big can of worms.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. This expands a test of `--typed-override` to avoid regressions, as well.
