### PR TITLE
Start cleaning up manual patch of child map

### DIFF
--- a/main/autogen/subclasses.cc
+++ b/main/autogen/subclasses.cc
@@ -92,10 +92,6 @@ optional<Subclasses::Entries> Subclasses::descendantsOf(const Subclasses::Map &c
 void Subclasses::patchChildMap(Subclasses::Map &childMap) {
     childMap["Opus::SafeMachine"].insert(childMap["Opus::Risk::Model::Mixins::RiskSafeMachine"].begin(),
                                          childMap["Opus::Risk::Model::Mixins::RiskSafeMachine"].end());
-
-    childMap["Chalk::SafeMachine"].insert(childMap["Opus::SafeMachine"].begin(), childMap["Opus::SafeMachine"].end());
-
-    childMap["Chalk::ODM::Model"].insert(make_pair("Chalk::ODM::Private::Lock", autogen::Definition::Type::Class));
 }
 
 vector<string> Subclasses::serializeSubclassMap(const Subclasses::Map &descendantsMap,

--- a/test/cli/autogen-subclasses/autogen-subclasses.out
+++ b/test/cli/autogen-subclasses/autogen-subclasses.out
@@ -1,11 +1,7 @@
 --- autogen-subclasses ---
-Chalk::ODM::Model
- Chalk::ODM::Private::Lock
 Opus::Mixin
  Opus::Mixed
  Opus::MixedDescendant
 Opus::Parent
  Opus::Child
  Opus::DupChild
-Opus::SafeMachine
- FooSafeMachine

--- a/test/cli/autogen-subclasses/autogen-subclasses.sh
+++ b/test/cli/autogen-subclasses/autogen-subclasses.sh
@@ -5,8 +5,6 @@ echo "--- autogen-subclasses ---"
 main/sorbet --silence-dev-message --stop-after=namer -p autogen-subclasses \
   --autogen-subclasses-parent=Opus::Mixin \
   --autogen-subclasses-parent=Opus::Parent \
-  --autogen-subclasses-parent=Opus::SafeMachine \
-  --autogen-subclasses-parent=Chalk::ODM::Model \
   --autogen-subclasses-parent=Opus::IDontExist \
   --autogen-subclasses-parent=Opus::NeverSubclassed \
   test/cli/autogen-subclasses/a.rb


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Starting to remove a legacy hack.

`Chalk::SafeMachine` isn't referenced anywhere in pay-server.
`Private::Lock` inheriting from `Chalk::ODM::Model` can already be determined statically.
`Opus::SafeMachine` is going to be a little more work to remove.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Cleanliness is next to cleanly in the dictionary

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
Updated automated tests, and also confirmed that the md5 of `build/subclasses` didn't change.

