### PR TITLE
Update T::InexactStruct sig

### DIFF
--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -104,8 +104,8 @@ end
 
 class T::InexactStruct
   def initialize(rules={}); end
-  def prop(name, type, rules={}); end
-  def const(name, type, rules={}); end
+  def self.prop(name, type, rules={}); end
+  def self.const(name, type, rules={}); end
 end
 class T::Struct < T::InexactStruct; end
 


### PR DESCRIPTION
`prop` and `const` are class methods not instance methods of T::InexactStruct

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
