### PR TITLE
Decrease suggest-typed attempts from 100 to 50.

### DIFF
--- a/gems/sorbet/lib/suggest-typed.rb
+++ b/gems/sorbet/lib/suggest-typed.rb
@@ -10,13 +10,13 @@ class Sorbet::Private::SuggestTyped
 
   def self.main
     count = 0
-    while count < 100
+    while count < 50
       count += 1
       if suggest_typed
         return true
       end
     end
-    puts "Adding `typed:` sigils did not converge after 100 tries."
+    puts "Adding `typed:` sigils did not converge after 50 tries."
     false
   end
 

--- a/gems/sorbet/lib/suggest-typed.rb
+++ b/gems/sorbet/lib/suggest-typed.rb
@@ -10,13 +10,31 @@ class Sorbet::Private::SuggestTyped
 
   def self.main
     count = 0
-    while count < 50
+    while count < 100
       count += 1
       if suggest_typed
         return true
       end
+
+      if count == 50
+        puts "Adding `typed:` sigils did not converge after 50 tries."
+        STDOUT.write("Would you like to continue anyway? [Y/n] ")
+        if STDIN.isatty && STDOUT.isatty
+          begin
+            input = STDIN.gets&.strip
+            if input.nil? || (input != '' && input != 'y' && input != 'Y')
+              return false
+            end
+          rescue Interrupt
+            return false
+          end
+        else
+          puts "Not running interactively, continuing."
+        end
+      end
     end
-    puts "Adding `typed:` sigils did not converge after 50 tries."
+
+    puts "Adding `typed:` sigils did not converge after 100 tries."
     false
   end
 


### PR DESCRIPTION
The 100 attempts was originally set in https://github.com/sorbet/sorbet/commit/385ccb7be8c8fbb281670b9eedc4c890785d349d.

### Motivation
It's probably pretty unlikely that the sigils will converge after 100 attempts if they haven't after 50. This reaches the failure state a bit faster so the user isn't stuck waiting for as long. It takes around 10 minutes (for me, at least) to hit the 100 attempts mark. The length of my wait might have been because of the library that was causing the problem, or something else. I'm not entirely sure.