### PR TITLE
Support Object#yield_self and Object#then

### DIFF
--- a/rbi/core/object.rbi
+++ b/rbi/core/object.rbi
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: __STDLIB_INTERNAL
 
 class Object < BasicObject
   include Kernel

--- a/rbi/core/object.rbi
+++ b/rbi/core/object.rbi
@@ -9,5 +9,7 @@ class Object < BasicObject
   sig {params(blk: T.proc.params(arg: T.untyped).returns(T.untyped)).returns(T.untyped)}
   def yield_self(&blk); end
 
-  alias_method :then, :yield_self
+  # `then` is just an alias of `yield_self`. Separately def'd here for easier IDE integration
+  sig {params(blk: T.proc.params(arg: T.untyped).returns(T.untyped)).returns(T.untyped)}
+  def then(&blk); end
 end

--- a/rbi/core/object.rbi
+++ b/rbi/core/object.rbi
@@ -6,7 +6,7 @@ class Object < BasicObject
   sig {returns(Integer)}
   def object_id(); end
 
-  sig { params(blk: T.proc.params(arg: T.untyped).returns(T.untyped)).returns(T.untyped) }
+  sig {params(blk: T.proc.params(arg: T.untyped).returns(T.untyped)).returns(T.untyped)}
   def yield_self(&blk); end
 
   alias_method :then, :yield_self

--- a/rbi/core/object.rbi
+++ b/rbi/core/object.rbi
@@ -1,8 +1,13 @@
-# typed: __STDLIB_INTERNAL
+# typed: strong
 
 class Object < BasicObject
   include Kernel
 
   sig {returns(Integer)}
   def object_id(); end
+
+  sig { params(blk: T.proc.params(arg: T.untyped).returns(T.untyped)).returns(T.untyped) }
+  def yield_self(&blk); end
+
+  alias_method :then, :yield_self
 end

--- a/test/testdata/rbi/object.rb
+++ b/test/testdata/rbi/object.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+obj = T.let("foo", String)
+
+# Object#then, with a block
+T.reveal_type(obj.then(&:to_i)) # error: Revealed type: `T.untyped`


### PR DESCRIPTION
This changeset adds support for [`Object#yield_self`](https://ruby-doc.org/core-2.6.3/Object.html#method-i-yield_self) and its alias, [`Object#then`](https://ruby-doc.org/core-2.6.3/Object.html#method-i-then), which were added to Ruby 2.5 and 2.6, respectively.

### Test plan

See included automated test.

### Caveats

`Object#yield_self` actually returns an `Enumerator` instance if it's not provided a block, but I couldn't get those semantics encoded in the type signatures using overloading. :\ In lieu of signature overloading, I chose _not_ to return a `T.any(Enumerator, T.untyped)` because the block-less form of `yield_self` is far less commonly used.

