### PR TITLE
Fix crash with --symbol-table-full

### DIFF
--- a/core/Files.cc
+++ b/core/Files.cc
@@ -116,12 +116,14 @@ FileRef::FileRef(unsigned int id) : _id(id) {
 }
 
 const File &FileRef::data(const GlobalState &gs) const {
+    ENFORCE(gs.files[_id]);
     ENFORCE(gs.files[_id]->sourceType != File::TombStone);
     ENFORCE(gs.files[_id]->sourceType != File::NotYetRead);
     return dataAllowingUnsafe(gs);
 }
 
 File &FileRef::data(GlobalState &gs) const {
+    ENFORCE(gs.files[_id]);
     ENFORCE(gs.files[_id]->sourceType != File::TombStone);
     ENFORCE(gs.files[_id]->sourceType != File::NotYetRead);
     return dataAllowingUnsafe(gs);

--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -149,7 +149,12 @@ string Loc::toStringWithTabs(const GlobalState &gs, int tabs) const {
 }
 
 string Loc::showRaw(const GlobalState &gs) const {
-    auto path = file().data(gs).path();
+    string_view path;
+    if (file().exists()) {
+        path = file().data(gs).path();
+    } else {
+        path = "???"sv;
+    }
     if (!exists()) {
         return fmt::format("Loc {{file={} start=??? end=???}}", path);
     }

--- a/test/cli/phases/phases.out
+++ b/test/cli/phases/phases.out
@@ -776,3 +776,5 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 --- cfg-json start ---
 --- cfg-json end ---
 --- checking diff ---
+--- checking crashes ---
+--- checking crashes end ---

--- a/test/cli/phases/phases.sh
+++ b/test/cli/phases/phases.sh
@@ -16,6 +16,7 @@ done
 echo "--- checking diff ---"
 diff -r out fileout | sort
 
+echo "--- checking crashes ---"
 # Makes sure all these options don't crash us
 for p in symbol-table-json symbol-table-full symbol-table-full-raw symbol-table-full-json cfg-proto; do
     main/sorbet --silence-dev-message -p "$p" -e '1' > /dev/null
@@ -24,3 +25,4 @@ done
 for p in init parser desugarer dsl namer resolver cfg inferencer; do
     main/sorbet --silence-dev-message --stop-after $p -e '1'
 done
+echo "--- checking crashes end ---"


### PR DESCRIPTION
Fix #1069.

Synethesized methods like the ones in the sig builder have file id = 0
as their file (through Loc::none). File 0 is a null pointer in the file
table so it's not safe to dereference it.

In debug mode, we were dereferencing it in our FileData ENFORCE, in
release mode, we were crashing later.

The cli phases test that was supposed to catch this crash wasn't doing
its job since the exit status for the test script is not checked. Only
the diff is checked, which crashing did not affect.

### Motivation
Don't crash.

### Test plan

See included automated tests.
