### PR TITLE
Raise an error when omitting `override` for `overridable` methods

### DIFF
--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -583,6 +583,11 @@ public:
     NameRef name;         // todo: move out? it should not matter but it's important for name resolution
     TypePtr resultType;
 
+    bool hasSig() const {
+        ENFORCE(isMethod());
+        return resultType != nullptr;
+    }
+
     UnorderedMap<NameRef, SymbolRef> members_;
     std::vector<ArgInfo> arguments_;
 

--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -55,6 +55,7 @@ constexpr ErrorClass FinalAncestor{5047, StrictLevel::False};
 constexpr ErrorClass FinalModuleNonFinalMethod{5048, StrictLevel::False};
 constexpr ErrorClass BadParameterOrdering{5049, StrictLevel::False};
 constexpr ErrorClass SealedAncestor{5050, StrictLevel::False};
+constexpr ErrorClass UndeclaredOverride{5051, StrictLevel::True};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -181,15 +181,15 @@ void validateOverriding(const core::GlobalState &gs, core::SymbolRef method) {
                 e.addErrorLine(overridenMethod.data(gs)->loc(), "original method defined here");
             }
         }
-        auto isRBI = absl::c_any_of(method.data(gs)->locs(), [&](auto &loc) { return loc.file().data(gs).isRBI(); });
         if (!method.data(gs)->isOverride() && method.data(gs)->hasSig() && overridenMethod.data(gs)->isOverridable() &&
-            overridenMethod.data(gs)->hasSig() && !isRBI) {
+            overridenMethod.data(gs)->hasSig()) {
             if (auto e = gs.beginError(method.data(gs)->loc(), core::errors::Resolver::UndeclaredOverride)) {
                 e.setHeader("Method `{}` overrides `{}` but is not declared with `{}`", method.data(gs)->show(gs),
                             overridenMethod.data(gs)->show(gs), ".override");
                 e.addErrorLine(overridenMethod.data(gs)->loc(), "defined here");
             }
         }
+        auto isRBI = absl::c_any_of(method.data(gs)->locs(), [&](auto &loc) { return loc.file().data(gs).isRBI(); });
         if ((overridenMethod.data(gs)->isAbstract() || overridenMethod.data(gs)->isOverridable()) &&
             !method.data(gs)->isIncompatibleOverride() && !isRBI) {
             validateCompatibleOverride(gs, overridenMethod, method);

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -184,8 +184,8 @@ void validateOverriding(const core::GlobalState &gs, core::SymbolRef method) {
         if (!method.data(gs)->isOverride() && method.data(gs)->hasSig() && overridenMethod.data(gs)->isOverridable() &&
             overridenMethod.data(gs)->hasSig()) {
             if (auto e = gs.beginError(method.data(gs)->loc(), core::errors::Resolver::UndeclaredOverride)) {
-                e.setHeader("Method `{}` overrides an overridable method `{}` but is not declared with `{}`", method.data(gs)->show(gs),
-                            overridenMethod.data(gs)->show(gs), ".override");
+                e.setHeader("Method `{}` overrides an overridable method `{}` but is not declared with `{}`",
+                            method.data(gs)->show(gs), overridenMethod.data(gs)->show(gs), ".override");
                 e.addErrorLine(overridenMethod.data(gs)->loc(), "defined here");
             }
         }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -182,9 +182,11 @@ void validateOverriding(const core::GlobalState &gs, core::SymbolRef method) {
             }
         }
         auto isRBI = absl::c_any_of(method.data(gs)->locs(), [&](auto &loc) { return loc.file().data(gs).isRBI(); });
-        if (!method.data(gs)->isOverride() && method.data(gs)->hasSig() && overridenMethod.data(gs)->isOverridable() && overridenMethod.data(gs)->hasSig() && !isRBI) {
+        if (!method.data(gs)->isOverride() && method.data(gs)->hasSig() && overridenMethod.data(gs)->isOverridable() &&
+            overridenMethod.data(gs)->hasSig() && !isRBI) {
             if (auto e = gs.beginError(method.data(gs)->loc(), core::errors::Resolver::UndeclaredOverride)) {
-                e.setHeader("Method `{}` overrides `{}` but is not declared with `{}`", method.data(gs)->show(gs), overridenMethod.data(gs)->show(gs), ".override");
+                e.setHeader("Method `{}` overrides `{}` but is not declared with `{}`", method.data(gs)->show(gs),
+                            overridenMethod.data(gs)->show(gs), ".override");
                 e.addErrorLine(overridenMethod.data(gs)->loc(), "defined here");
             }
         }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -182,6 +182,12 @@ void validateOverriding(const core::GlobalState &gs, core::SymbolRef method) {
             }
         }
         auto isRBI = absl::c_any_of(method.data(gs)->locs(), [&](auto &loc) { return loc.file().data(gs).isRBI(); });
+        if (!method.data(gs)->isOverride() && method.data(gs)->hasSig() && overridenMethod.data(gs)->isOverridable() && overridenMethod.data(gs)->hasSig() && !isRBI) {
+            if (auto e = gs.beginError(method.data(gs)->loc(), core::errors::Resolver::UndeclaredOverride)) {
+                e.setHeader("Method `{}` overrides `{}` but is not declared with `{}`", method.data(gs)->show(gs), overridenMethod.data(gs)->show(gs), ".override");
+                e.addErrorLine(overridenMethod.data(gs)->loc(), "defined here");
+            }
+        }
         if ((overridenMethod.data(gs)->isAbstract() || overridenMethod.data(gs)->isOverridable()) &&
             !method.data(gs)->isIncompatibleOverride() && !isRBI) {
             validateCompatibleOverride(gs, overridenMethod, method);

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -184,7 +184,7 @@ void validateOverriding(const core::GlobalState &gs, core::SymbolRef method) {
         if (!method.data(gs)->isOverride() && method.data(gs)->hasSig() && overridenMethod.data(gs)->isOverridable() &&
             overridenMethod.data(gs)->hasSig()) {
             if (auto e = gs.beginError(method.data(gs)->loc(), core::errors::Resolver::UndeclaredOverride)) {
-                e.setHeader("Method `{}` overrides `{}` but is not declared with `{}`", method.data(gs)->show(gs),
+                e.setHeader("Method `{}` overrides an overridable method `{}` but is not declared with `{}`", method.data(gs)->show(gs),
                             overridenMethod.data(gs)->show(gs), ".override");
                 e.addErrorLine(overridenMethod.data(gs)->loc(), "defined here");
             }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -190,8 +190,9 @@ void validateOverriding(const core::GlobalState &gs, core::SymbolRef method) {
                 e.addErrorLine(overridenMethod.data(gs)->loc(), "defined here");
             }
         }
-        if (!method.data(gs)->isImplementation() && !method.data(gs)->isOverride() && method.data(gs)->hasSig() && overridenMethod.data(gs)->isAbstract() &&
-            overridenMethod.data(gs)->hasSig() && !method.data(gs)->isDSLSynthesized() && !isRBI) {
+        if (!method.data(gs)->isImplementation() && !method.data(gs)->isOverride() && method.data(gs)->hasSig() &&
+            overridenMethod.data(gs)->isAbstract() && overridenMethod.data(gs)->hasSig() &&
+            !method.data(gs)->isDSLSynthesized() && !isRBI) {
             if (auto e = gs.beginError(method.data(gs)->loc(), core::errors::Resolver::UndeclaredOverride)) {
                 e.setHeader("Method `{}` implements an abstract method `{}` but is not declared with `{}`",
                             method.data(gs)->show(gs), overridenMethod.data(gs)->show(gs), ".implementation");

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -182,7 +182,7 @@ void validateOverriding(const core::GlobalState &gs, core::SymbolRef method) {
             }
         }
         if (!method.data(gs)->isOverride() && method.data(gs)->hasSig() && overridenMethod.data(gs)->isOverridable() &&
-            overridenMethod.data(gs)->hasSig()) {
+            overridenMethod.data(gs)->hasSig() && !method.data(gs)->isDSLSynthesized()) {
             if (auto e = gs.beginError(method.data(gs)->loc(), core::errors::Resolver::UndeclaredOverride)) {
                 e.setHeader("Method `{}` overrides an overridable method `{}` but is not declared with `{}`",
                             method.data(gs)->show(gs), overridenMethod.data(gs)->show(gs), ".override");
@@ -191,7 +191,7 @@ void validateOverriding(const core::GlobalState &gs, core::SymbolRef method) {
         }
         auto isRBI = absl::c_any_of(method.data(gs)->locs(), [&](auto &loc) { return loc.file().data(gs).isRBI(); });
         if ((overridenMethod.data(gs)->isAbstract() || overridenMethod.data(gs)->isOverridable()) &&
-            !method.data(gs)->isIncompatibleOverride() && !isRBI) {
+            !method.data(gs)->isIncompatibleOverride() && !isRBI && !method.data(gs)->isDSLSynthesized()) {
             validateCompatibleOverride(gs, overridenMethod, method);
         }
     }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -181,15 +181,23 @@ void validateOverriding(const core::GlobalState &gs, core::SymbolRef method) {
                 e.addErrorLine(overridenMethod.data(gs)->loc(), "original method defined here");
             }
         }
+        auto isRBI = absl::c_any_of(method.data(gs)->locs(), [&](auto &loc) { return loc.file().data(gs).isRBI(); });
         if (!method.data(gs)->isOverride() && method.data(gs)->hasSig() && overridenMethod.data(gs)->isOverridable() &&
-            overridenMethod.data(gs)->hasSig() && !method.data(gs)->isDSLSynthesized()) {
+            overridenMethod.data(gs)->hasSig() && !method.data(gs)->isDSLSynthesized() && !isRBI) {
             if (auto e = gs.beginError(method.data(gs)->loc(), core::errors::Resolver::UndeclaredOverride)) {
                 e.setHeader("Method `{}` overrides an overridable method `{}` but is not declared with `{}`",
                             method.data(gs)->show(gs), overridenMethod.data(gs)->show(gs), ".override");
                 e.addErrorLine(overridenMethod.data(gs)->loc(), "defined here");
             }
         }
-        auto isRBI = absl::c_any_of(method.data(gs)->locs(), [&](auto &loc) { return loc.file().data(gs).isRBI(); });
+        if (!method.data(gs)->isImplementation() && !method.data(gs)->isOverride() && method.data(gs)->hasSig() && overridenMethod.data(gs)->isAbstract() &&
+            overridenMethod.data(gs)->hasSig() && !method.data(gs)->isDSLSynthesized() && !isRBI) {
+            if (auto e = gs.beginError(method.data(gs)->loc(), core::errors::Resolver::UndeclaredOverride)) {
+                e.setHeader("Method `{}` implements an abstract method `{}` but is not declared with `{}`",
+                            method.data(gs)->show(gs), overridenMethod.data(gs)->show(gs), ".implementation");
+                e.addErrorLine(overridenMethod.data(gs)->loc(), "defined here");
+            }
+        }
         if ((overridenMethod.data(gs)->isAbstract() || overridenMethod.data(gs)->isOverridable()) &&
             !method.data(gs)->isIncompatibleOverride() && !isRBI && !method.data(gs)->isDSLSynthesized()) {
             validateCompatibleOverride(gs, overridenMethod, method);

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -173,6 +173,9 @@ void validateOverriding(const core::GlobalState &gs, core::SymbolRef method) {
         }
     }
 
+    // we don't raise override errors if the method implements an abstract method, which means we need to know ahead of
+    // time whether any parent methods are abstract
+    auto anyIsInterface = absl::c_any_of(overridenMethods, [&](auto &m) { return m.data(gs)->isAbstract(); });
     for (const auto &overridenMethod : overridenMethods) {
         if (overridenMethod.data(gs)->isFinalMethod()) {
             if (auto e = gs.beginError(method.data(gs)->loc(), core::errors::Resolver::OverridesFinal)) {
@@ -183,7 +186,7 @@ void validateOverriding(const core::GlobalState &gs, core::SymbolRef method) {
         }
         auto isRBI = absl::c_any_of(method.data(gs)->locs(), [&](auto &loc) { return loc.file().data(gs).isRBI(); });
         if (!method.data(gs)->isOverride() && method.data(gs)->hasSig() && overridenMethod.data(gs)->isOverridable() &&
-            overridenMethod.data(gs)->hasSig() && !method.data(gs)->isDSLSynthesized() && !isRBI) {
+            !anyIsInterface && overridenMethod.data(gs)->hasSig() && !method.data(gs)->isDSLSynthesized() && !isRBI) {
             if (auto e = gs.beginError(method.data(gs)->loc(), core::errors::Resolver::UndeclaredOverride)) {
                 e.setHeader("Method `{}` overrides an overridable method `{}` but is not declared with `{}`",
                             method.data(gs)->show(gs), overridenMethod.data(gs)->show(gs), ".override");

--- a/test/testdata/resolver/enumerable_strict.rb
+++ b/test/testdata/resolver/enumerable_strict.rb
@@ -6,5 +6,6 @@ class A # error: Type `Elem` declared by parent `Enumerable` must be re-declared
 
   sig {void}
   def each # error: Implementation of abstract method `Enumerable#each` must explicitly name a block argument
+# ^^^^^^^^ error: Method `A#each` implements an abstract method `Enumerable#each` but is not declared with `.implementation`
   end
 end

--- a/test/testdata/resolver/implementations.rb
+++ b/test/testdata/resolver/implementations.rb
@@ -1,0 +1,41 @@
+# typed: true
+
+# implementing an abstract method but not using a sig on the child is temporarily okay
+class A1
+  extend T::Sig
+  extend T::Helpers
+  abstract!
+  sig { abstract.void }
+  def foo; end
+end
+class B1 < A1
+  def foo; end
+end
+
+# implementing an abstract method without implementation sig on the child should be an error
+class A2
+  extend T::Sig
+  extend T::Helpers
+  abstract!
+  sig { abstract.void }
+  def foo; end
+end
+class B2 < A2
+  extend T::Sig
+  sig { void }
+  def foo; end # error: Method `B2#foo` implements an abstract method `A2#foo` but is not declared with `.implementation`
+end
+
+# implementing an abstract method with an implementation sig on the child should be okay
+class A3
+  extend T::Sig
+  extend T::Helpers
+  abstract!
+  sig { abstract.void }
+  def foo; end
+end
+class B3 < A3
+  extend T::Sig
+  sig { implementation.void }
+  def foo; end
+end

--- a/test/testdata/resolver/override_shapes.rb
+++ b/test/testdata/resolver/override_shapes.rb
@@ -153,5 +153,5 @@ class NoOverride < Base
       params(req: Object, opt: Object, kwreq: Object, kwopt: Object, blk: Proc)
       .returns(Object)
   end
-  def foo(req, opt=nil, kwreq:, kwopt: nil, &blk); end # error: Method `NoOverride#foo` overrides `Base#foo` but is not declared with `.override`
+  def foo(req, opt=nil, kwreq:, kwopt: nil, &blk); end # error: Method `NoOverride#foo` overrides an overridable method `Base#foo` but is not declared with `.override`
 end

--- a/test/testdata/resolver/override_shapes.rb
+++ b/test/testdata/resolver/override_shapes.rb
@@ -146,3 +146,12 @@ class Bad_NoKwrest < Base_Repeated
   def foo(*rest) # error: must accept **`kwrest`
   end
 end
+
+
+class NoOverride < Base
+  sig do
+      params(req: Object, opt: Object, kwreq: Object, kwopt: Object, blk: Proc)
+      .returns(Object)
+  end
+  def foo(req, opt=nil, kwreq:, kwopt: nil, &blk); end # error: Method `NoOverride#foo` overrides `Base#foo` but is not declared with `.override`
+end

--- a/test/testdata/resolver/overrides.rb
+++ b/test/testdata/resolver/overrides.rb
@@ -1,0 +1,57 @@
+# typed: true
+
+# overriding a method not marked overridable without a sig should be okay
+class A1
+  def foo; end
+end
+class B1 < A1
+  extend T::Sig
+  sig { override.void }
+  def foo; end
+end
+
+# overriding a method not marked overridable with a sig should be okay
+class A2
+  extend T::Sig
+  sig { void }
+  def foo; end
+end
+class B2 < A2
+  extend T::Sig
+  sig { override.void }
+  def foo; end
+end
+
+# overriding an overridable method but not using a sig on the child should be okay
+class A3
+  extend T::Sig
+  sig { overridable.void }
+  def foo; end
+end
+class B3 < A3
+  def foo; end
+end
+
+# overriding an overridable method with a non-override sig on the child should be an error
+class A4
+  extend T::Sig
+  sig { overridable.void }
+  def foo; end
+end
+class B4 < A4
+  extend T::Sig
+  sig { void }
+  def foo; end # error: Method `B4#foo` overrides an overridable method `A4#foo` but is not declared with `.override`
+end
+
+# overriding an overridable method with an override sig on the child should be okay
+class A5
+  extend T::Sig
+  sig { overridable.void }
+  def foo; end
+end
+class B5 < A5
+  extend T::Sig
+  sig { override.void }
+  def foo; end
+end


### PR DESCRIPTION
Produce an error when a method overrides another method, and the parent method is marked `overridable`, and the child method does not explicitly say `override` in its `sig`.

### Motivation
This statically checks something our runtime also checks, so this helps prevent errors ahead-of-time.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
