### PR TITLE
Fix failing `ENFORCE` in struct dsl pass

### DIFF
--- a/dsl/Struct.cc
+++ b/dsl/Struct.cc
@@ -20,11 +20,15 @@ unique_ptr<ast::Expression> dupName(ast::Expression *node) {
     if (node->isSelfReference()) {
         return ast::MK::EmptyTree();
     }
-    auto cnst = ast::cast_tree<ast::UnresolvedConstantLit>(node);
-    ENFORCE(cnst);
-    auto newScope = dupName(cnst->scope.get());
-    ENFORCE(newScope);
-    return ast::MK::UnresolvedConstant(node->loc, std::move(newScope), cnst->cnst);
+    if (auto cnst = ast::cast_tree<ast::UnresolvedConstantLit>(node)) {
+        auto newScope = dupName(cnst->scope.get());
+        ENFORCE(newScope);
+        return ast::MK::UnresolvedConstant(node->loc, std::move(newScope), cnst->cnst);
+    } else if (auto cnst = ast::cast_tree<ast::ConstantLit>(node)) {
+        return ast::MK::Constant(node->loc, cnst->symbol);
+    } else {
+        Exception::raise("dupName called on a node that is neither an UnresolvedConstant nor a Constant");
+    }
 }
 
 static bool isKeywordInitKey(const core::GlobalState &gs, ast::Expression *node) {

--- a/test/testdata/dsl/fuzz_qualified_lhs.rb
+++ b/test/testdata/dsl/fuzz_qualified_lhs.rb
@@ -1,0 +1,2 @@
+# typed: true
+::B=Struct.new:x


### PR DESCRIPTION


### Motivation
Fixes #1079; if a struct was assigned to a fully qualified constant, our `dupName` helper function would fail; this just adds another case to handle the fully qualified names.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Fuzzed test from #1079 was also added.
