### PR TITLE
Add syntax for type bounds

### DIFF
--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -94,6 +94,7 @@ public:
         static constexpr u4 TYPE_INVARIANT = 0x0000'0020;
         static constexpr u4 TYPE_CONTRAVARIANT = 0x0000'0040;
         static constexpr u4 TYPE_FIXED = 0x0000'0080;
+        static constexpr u4 TYPE_BOUNDED = 0x0000'0100;
 
         // Static Field flags
         static constexpr u4 STATIC_FIELD_TYPE_ALIAS = 0x0000'0010;
@@ -240,6 +241,11 @@ public:
         return (flags & Symbol::Flags::TYPE_FIXED) != 0;
     }
 
+    inline bool isBounded() const {
+        ENFORCE(isTypeArgument() || isTypeMember());
+        return (flags & Symbol::Flags::TYPE_BOUNDED) != 0;
+    }
+
     Variance variance() const {
         if (isInvariant())
             return Variance::Invariant;
@@ -360,6 +366,11 @@ public:
     inline void setFixed() {
         ENFORCE(isTypeArgument() || isTypeMember());
         flags |= Symbol::Flags::TYPE_FIXED;
+    }
+
+    inline void setBounded() {
+        ENFORCE(isTypeArgument() || isTypeMember());
+        flags |= Symbol::Flags::TYPE_BOUNDED;
     }
 
     inline void setOverloaded() {

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -148,6 +148,8 @@ NameDef names[] = {
     {"contravariant", "in"},
     {"invariant", "<invariant>"},
     {"fixed"},
+    {"lower"},
+    {"upper"},
 
     {"prop"},
     {"token_prop"},

--- a/gems/sorbet-runtime/lib/types/generic.rb
+++ b/gems/sorbet-runtime/lib/types/generic.rb
@@ -13,11 +13,11 @@ module T::Generic
     self
   end
 
-  def type_member(variance=:invariant, fixed: nil)
+  def type_member(variance=:invariant, fixed: nil, lower: T.untyped, upper: BasicObject)
     T::Types::TypeMember.new(variance) # rubocop:disable PrisonGuard/UseOpusTypesShortcut
   end
 
-  def type_template(variance=:invariant, fixed: nil)
+  def type_template(variance=:invariant, fixed: nil, lower: T.untyped, upper: BasicObject)
     T::Types::TypeTemplate.new(variance) # rubocop:disable PrisonGuard/UseOpusTypesShortcut
   end
 end

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -766,6 +766,14 @@ public:
 
                 const bool fixed = sym.data(ctx)->isFixed();
                 const bool bounded = sym.data(ctx)->isBounded();
+
+                // For now, bounded type members are not supported
+                if (bounded) {
+                    if (auto e = ctx.state.beginError(send->loc, core::errors::Namer::InvalidTypeDefinition)) {
+                        e.setHeader("Only `{}` type members are supported", ":fixed");
+                    }
+                }
+
                 // one of :fixed or bounds were provided
                 if (fixed != bounded) {
                     return asgn;

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -69,8 +69,8 @@ module T::Generic
   sig {params(params: T.untyped).returns(T::Private::Methods::DeclBuilder)}
   def type_parameters(*params); end
 
-  def type_member(variance=:invariant, fixed: nil); end
-  def type_template(variance=:invariant, fixed: nil); end
+  def type_member(variance=:invariant, fixed: nil, lower: T.untyped, upper: BasicObject); end
+  def type_template(variance=:invariant, fixed: nil, lower: T.untyped, upper: BasicObject); end
   def [](*types); end
 end
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1305,7 +1305,7 @@ public:
         }
 
         if (data->isTypeMember()) {
-            ENFORCE(data->isFixed());
+            ENFORCE(data->isFixed() || data->isBounded());
             auto send = ast::cast_tree<ast::Send>(asgn->rhs.get());
             ENFORCE(send->recv->isSelfReference());
             ENFORCE(send->fun == core::Names::typeMember() || send->fun == core::Names::typeTemplate());

--- a/test/testdata/infer/generics/bounds.rb
+++ b/test/testdata/infer/generics/bounds.rb
@@ -1,0 +1,35 @@
+# typed: true
+
+class Animal; end
+class Cat < Animal; end
+class Persian < Cat; end
+
+class A1
+  extend T::Sig
+  extend T::Generic
+
+  X = type_member(fixed: Cat, lower: Persian, upper: Animal)
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Type member is defined with bounds and `:fixed`
+end
+
+class A2
+  extend T::Sig
+  extend T::Generic
+
+  # This should allow instantiations of this variable as any of Animal, Cat, or
+  # Persian.
+  X = type_member(lower: Persian, upper: Animal)
+end
+
+class Test
+  extend T::Sig
+
+  # should pass: the type given is valid in the context of the Animal/Persian
+  # bounds
+  sig {params(arg1: A2[Animal], arg2: A2[Cat], arg3: A2[Persian]).void}
+  def test1(arg1, arg2, arg3); end
+
+  # should fail: Integer is not within the Animal/Persian bounds.
+  sig {params(arg1: A2[Integer], arg2: A2[BasicObject]).void}
+  def test2(arg1, arg2); end
+end

--- a/test/testdata/infer/generics/bounds.rb
+++ b/test/testdata/infer/generics/bounds.rb
@@ -10,6 +10,7 @@ class A1
 
   X = type_member(fixed: Cat, lower: Persian, upper: Animal)
     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Type member is defined with bounds and `:fixed`
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Only `:fixed` type members are supported
 end
 
 class A2
@@ -19,6 +20,15 @@ class A2
   # This should allow instantiations of this variable as any of Animal, Cat, or
   # Persian.
   X = type_member(lower: Persian, upper: Animal)
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Only `:fixed` type members are supported
+end
+
+module M
+  extend T::Sig
+  extend T::Generic
+
+  X = type_member(lower: Persian, upper: Animal)
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Only `:fixed` type members are supported
 end
 
 class Test

--- a/test/testdata/infer/generics/bounds.rb
+++ b/test/testdata/infer/generics/bounds.rb
@@ -8,9 +8,60 @@ class A1
   extend T::Sig
   extend T::Generic
 
-  X = type_member(fixed: Cat, lower: Persian, upper: Animal)
-    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Type member is defined with bounds and `:fixed`
-    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Only `:fixed` type members are supported
+  T1 = type_member
+
+  # should fail: T2 mentions another type member
+  T2 = type_member(lower: T1)
+     # ^^^^^^^^^^^^^^^^^^^^^^ error: Only `:fixed` type members are supported
+
+  # should fail: T3 mentions another type member
+  T3 = type_member(lower: T2, upper: T1)
+     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Only `:fixed` type members are supported
+
+  # should fail: T4 mentions another type member (this message could be better)
+  T4 = type_member(fixed: T1)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expression does not have a fully-defined type
+
+  # should fail: the bounds are invalid
+  T5 = type_member(lower: Animal, upper: Persian)
+     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Only `:fixed` type members are supported
+
+  # should fail: type member used as an argument to another type (this message
+  # could be better)
+  T6 = type_member(fixed: T::Array[T1])
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expression does not have a fully-defined type
+
+  # should fail: type member used as an argument to another type
+  T7 = type_member(lower: T::Array[T1])
+     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Only `:fixed` type members are supported
+
+  # should fail: both bounds and a fixed type are specified
+  T8 = type_member(fixed: Cat, lower: Persian, upper: Animal)
+     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Type member is defined with bounds and `:fixed`
+     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Only `:fixed` type members are supported
+
+  # should pass: just an alias to a type member
+  T9 = T1
+
+  # should fail: still using a type member in the definition of another
+  T10 = type_member(fixed: T9)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expression does not have
+
+  # should fail: using a type alias in bounds
+  T11 = type_member(upper: T9)
+      # ^^^^^^^^^^^^^^^^^^^^^^ error: Only `:fixed` type members are supported
+
+  # should fail: multiple upper and lower bounds specified
+  T12 = type_member(lower: Integer, lower: String, upper: BasicObject, upper: TrueClass)
+      # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Only `:fixed`
+end
+
+module M
+  extend T::Sig
+  extend T::Generic
+
+  X = type_member(lower: Persian, upper: Animal)
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Only `:fixed` type members are supported
 end
 
 class A2
@@ -19,14 +70,6 @@ class A2
 
   # This should allow instantiations of this variable as any of Animal, Cat, or
   # Persian.
-  X = type_member(lower: Persian, upper: Animal)
-    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Only `:fixed` type members are supported
-end
-
-module M
-  extend T::Sig
-  extend T::Generic
-
   X = type_member(lower: Persian, upper: Animal)
     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Only `:fixed` type members are supported
 end


### PR DESCRIPTION
Add syntax for upper and lower type bounds on `type_member` and `type_template`, as well as a test of the new syntax.

### Motivation
This PR sets up tests and syntax to support the addition of type bounds.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
