### PR TITLE
Replace use of the word 'predication'  with 'prediction'

### DIFF
--- a/website/docs/runtime.md
+++ b/website/docs/runtime.md
@@ -4,8 +4,8 @@ title: Enabling Runtime Checks
 ---
 
 As we've mentioned before, Sorbet is a [gradual](gradual.md) system: it can be
-turned on and off at will. This means the predictions `srb` makes statically
-can be wrong.
+turned on and off at will. This means the predictions `srb` makes statically can
+be wrong.
 
 That's why Sorbet also uses **runtime checks**: even if a static prediction was
 wrong, it will get checked during runtime, making things fail loudly and

--- a/website/docs/runtime.md
+++ b/website/docs/runtime.md
@@ -4,7 +4,7 @@ title: Enabling Runtime Checks
 ---
 
 As we've mentioned before, Sorbet is a [gradual](gradual.md) system: it can be
-turned on and off at will. This means the predications `srb` makes statically
+turned on and off at will. This means the predictions `srb` makes statically
 can be wrong.
 
 That's why Sorbet also uses **runtime checks**: even if a static prediction was


### PR DESCRIPTION

### Motivation
Apple Dictionary doesn't know about the word "predication". I did find a definition online:

https://www.merriam-webster.com/dictionary/predication

But this word seems slightly archaic. The word "prediction" is used in the next paragraph, so switch to that instead.

### Test plan
none

See included automated tests.
