### PR TITLE
Prevent top-level use of type_member

### DIFF
--- a/core/errors/namer.h
+++ b/core/errors/namer.h
@@ -18,6 +18,7 @@ constexpr ErrorClass ModuleKindRedefinition{4012, StrictLevel::False};
 constexpr ErrorClass InterfaceClass{4013, StrictLevel::False};
 constexpr ErrorClass DynamicConstant{4014, StrictLevel::False};
 constexpr ErrorClass InvalidClassOwner{4015, StrictLevel::False};
+constexpr ErrorClass RootTypeMember{4016, StrictLevel::False};
 } // namespace sorbet::core::errors::Namer
 
 #endif

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -663,11 +663,8 @@ SelfTypeParam::SelfTypeParam(const SymbolRef definition) : definition(definition
 }
 
 bool LambdaParam::derivesFrom(const GlobalState &gs, SymbolRef klass) const {
-    // This only ever gets called in bad situations when we haven't instantiated a LambdaParam as either a SelfTypeParam
-    // (within the body of a generic class) or a specific type (after having instantiated the class with specific
-    // parameters and/or T.untyped.) However, those errors are captured elsewhere, so here we can follow the same
-    // behavior as SelfTypeParam and return 'false'.
-    return false;
+    Exception::raise(
+        "LambdaParam::derivesFrom not implemented, not clear what it should do. Let's see this fire first.");
 }
 
 bool SelfTypeParam::derivesFrom(const GlobalState &gs, SymbolRef klass) const {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -663,8 +663,11 @@ SelfTypeParam::SelfTypeParam(const SymbolRef definition) : definition(definition
 }
 
 bool LambdaParam::derivesFrom(const GlobalState &gs, SymbolRef klass) const {
-    Exception::raise(
-        "LambdaParam::derivesFrom not implemented, not clear what it should do. Let's see this fire first.");
+    // This only ever gets called in bad situations when we haven't instantiated a LambdaParam as either a SelfTypeParam
+    // (within the body of a generic class) or a specific type (after having instantiated the class with specific
+    // parameters and/or T.untyped.) However, those errors are captured elsewhere, so here we can follow the same
+    // behavior as SelfTypeParam and return 'false'.
+    return false;
 }
 
 bool SelfTypeParam::derivesFrom(const GlobalState &gs, SymbolRef klass) const {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -666,6 +666,12 @@ public:
             }
             return make_unique<ast::EmptyTree>();
         }
+        if (ctx.owner == core::Symbols::root()) {
+            if (auto e = ctx.state.beginError(send->loc, core::errors::Namer::RootTypeMember)) {
+                e.setHeader("`{}` cannot be used outside of a class declaration", "type_member");
+            }
+            return make_unique<ast::EmptyTree>();
+        }
 
         auto onSymbol = isTypeTemplate ? ctx.owner.data(ctx)->singletonClass(ctx) : ctx.owner;
         if (!send->args.empty()) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -670,7 +670,8 @@ public:
             if (auto e = ctx.state.beginError(send->loc, core::errors::Namer::RootTypeMember)) {
                 e.setHeader("`{}` cannot be used at the top-level", "type_member");
             }
-            auto send = ast::MK::Send1(asgn->loc, ast::MK::T(asgn->loc), core::Names::typeAlias(), ast::MK::Untyped(asgn->loc));
+            auto send =
+                ast::MK::Send1(asgn->loc, ast::MK::T(asgn->loc), core::Names::typeAlias(), ast::MK::Untyped(asgn->loc));
             return handleAssignment(ctx, make_unique<ast::Assign>(asgn->loc, std::move(asgn->lhs), std::move(send)));
         }
 
@@ -680,8 +681,10 @@ public:
                 if (auto e = ctx.state.beginError(send->loc, core::errors::Namer::InvalidTypeDefinition)) {
                     e.setHeader("Too many args in type definition");
                 }
-                auto send = ast::MK::Send1(asgn->loc, ast::MK::T(asgn->loc), core::Names::typeAlias(), ast::MK::Untyped(asgn->loc));
-                return handleAssignment(ctx, make_unique<ast::Assign>(asgn->loc, std::move(asgn->lhs), std::move(send)));
+                auto send = ast::MK::Send1(asgn->loc, ast::MK::T(asgn->loc), core::Names::typeAlias(),
+                                           ast::MK::Untyped(asgn->loc));
+                return handleAssignment(ctx,
+                                        make_unique<ast::Assign>(asgn->loc, std::move(asgn->lhs), std::move(send)));
             }
 
             auto lit = ast::cast_tree<ast::Literal>(send->args[0].get());

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -668,9 +668,10 @@ public:
         }
         if (ctx.owner == core::Symbols::root()) {
             if (auto e = ctx.state.beginError(send->loc, core::errors::Namer::RootTypeMember)) {
-                e.setHeader("`{}` cannot be used outside of a class declaration", "type_member");
+                e.setHeader("`{}` cannot be used at the top-level", "type_member");
             }
-            return make_unique<ast::EmptyTree>();
+            auto send = ast::MK::Send1(asgn->loc, ast::MK::T(asgn->loc), core::Names::typeAlias(), ast::MK::Untyped(asgn->loc));
+            return handleAssignment(ctx, make_unique<ast::Assign>(asgn->loc, std::move(asgn->lhs), std::move(send)));
         }
 
         auto onSymbol = isTypeTemplate ? ctx.owner.data(ctx)->singletonClass(ctx) : ctx.owner;
@@ -679,7 +680,8 @@ public:
                 if (auto e = ctx.state.beginError(send->loc, core::errors::Namer::InvalidTypeDefinition)) {
                     e.setHeader("Too many args in type definition");
                 }
-                return make_unique<ast::EmptyTree>();
+                auto send = ast::MK::Send1(asgn->loc, ast::MK::T(asgn->loc), core::Names::typeAlias(), ast::MK::Untyped(asgn->loc));
+                return handleAssignment(ctx, make_unique<ast::Assign>(asgn->loc, std::move(asgn->lhs), std::move(send)));
             }
 
             auto lit = ast::cast_tree<ast::Literal>(send->args[0].get());
@@ -798,6 +800,23 @@ public:
         return make_unique<ast::EmptyTree>();
     }
 
+    unique_ptr<ast::Expression> handleAssignment(core::MutableContext ctx, unique_ptr<ast::Assign> asgn) {
+        auto *send = ast::cast_tree<ast::Send>(asgn->rhs.get());
+        auto ret = fillAssign(ctx, std::move(asgn));
+        if (send->fun == core::Names::typeAlias()) {
+            auto id = ast::cast_tree<ast::ConstantLit>(ret->lhs.get());
+            ENFORCE(id != nullptr, "fillAssign did not make lhs into a ConstantLit");
+
+            auto sym = id->symbol;
+            ENFORCE(sym.exists(), "fillAssign did not make symbol for ConstantLit");
+
+            if (sym.data(ctx)->isStaticField()) {
+                sym.data(ctx)->setTypeAlias();
+            }
+        }
+        return ret;
+    }
+
     unique_ptr<ast::Expression> postTransformAssign(core::MutableContext ctx, unique_ptr<ast::Assign> asgn) {
         auto *lhs = ast::cast_tree<ast::UnresolvedConstantLit>(asgn->lhs.get());
         if (lhs == nullptr) {
@@ -810,19 +829,7 @@ public:
         }
 
         if (!send->recv->isSelfReference()) {
-            auto ret = fillAssign(ctx, std::move(asgn));
-            if (send->fun == core::Names::typeAlias()) {
-                auto id = ast::cast_tree<ast::ConstantLit>(ret->lhs.get());
-                ENFORCE(id != nullptr, "fillAssign did not make lhs into a ConstantLit");
-
-                auto sym = id->symbol;
-                ENFORCE(sym.exists(), "fillAssign did not make symbol for ConstantLit");
-
-                if (sym.data(ctx)->isStaticField()) {
-                    sym.data(ctx)->setTypeAlias();
-                }
-            }
-            return ret;
+            return handleAssignment(ctx, std::move(asgn));
         }
 
         auto *typeName = ast::cast_tree<ast::UnresolvedConstantLit>(asgn->lhs.get());

--- a/test/testdata/infer/fuzz_toplevel_type_member.rb
+++ b/test/testdata/infer/fuzz_toplevel_type_member.rb
@@ -1,9 +1,9 @@
 # typed: true
 # Adapted from fuzzed test case: https://github.com/sorbet/sorbet/issues/1087
 extend T::Sig
-Elem = type_member
+Elem = type_member # error: `type_member` cannot be used at the top-level
 sig {params(block: T.proc.params(ar0: Elem).void).void}
 def yield_type_member(&block)
-  yield_type_member { |y, z| } # error: Expression does not have a fully-defined type
+  yield_type_member { |y, z| }
 end
 

--- a/test/testdata/infer/fuzz_toplevel_type_member.rb
+++ b/test/testdata/infer/fuzz_toplevel_type_member.rb
@@ -1,4 +1,5 @@
 # typed: true
+# Adapted from fuzzed test case: https://github.com/sorbet/sorbet/issues/1087
 extend T::Sig
 Elem = type_member
 sig {params(block: T.proc.params(ar0: Elem).void).void}

--- a/test/testdata/infer/fuzz_toplevel_type_member.rb
+++ b/test/testdata/infer/fuzz_toplevel_type_member.rb
@@ -1,0 +1,8 @@
+# typed: true
+extend T::Sig
+Elem = type_member
+sig {params(block: T.proc.params(ar0: Elem).void).void}
+def yield_type_member(&block)
+  yield_type_member { |y, z| } # error: Expression does not have a fully-defined type
+end
+

--- a/test/testdata/namer/fuzz_type_member.rb
+++ b/test/testdata/namer/fuzz_type_member.rb
@@ -1,4 +1,4 @@
 # typed: true
 # disable-fast-path: true
-A=3
-A=type_member # error: Redefining constant `A`
+A=3 # error: Reassigning field with a value of wrong type
+A=type_member # error: `type_member` cannot be used at the top-level

--- a/test/testdata/resolver/fuzz_type_member_scope.rb
+++ b/test/testdata/resolver/fuzz_type_member_scope.rb
@@ -1,3 +1,3 @@
 # typed: false
-A::B # error: Unable to resolve constant `B`
-A=type_member
+A::B # error: Resolving constants through type aliases is not supported
+A=type_member # error: `type_member` cannot be used at the top-level

--- a/test/testdata/resolver/fuzz_type_member_scope.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/fuzz_type_member_scope.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
-class <C <U <root>>>[<C <U A>>] < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/fuzz_type_member_scope.rb start=2:1 end=3:14}, Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4})
+class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/fuzz_type_member_scope.rb start=2:1 end=3:14}, Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4})
   class <S <C <U <root>>> $1> < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $108> (<blk>) @ Loc {file=test/testdata/resolver/fuzz_type_member_scope.rb start=2:1 end=3:14}
       argument <blk><block> @ Loc {file=test/testdata/resolver/fuzz_type_member_scope.rb start=??? end=???}
-  type-member(=) <C <U A>> @ Loc {file=test/testdata/resolver/fuzz_type_member_scope.rb start=3:1 end=3:14}
+  static-field-type-alias <C <U A>> -> T.untyped @ Loc {file=test/testdata/resolver/fuzz_type_member_scope.rb start=3:1 end=3:2}
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes #1087: this is a situation that can only ever happen in an error, and I went back and forth on whether to try to implement this check elsewhere, but after some digging and reflection, I think this implementation is both correct and sufficient here.

Most of our type-checking code doesn't care about `LambdaParam` types. If we're in the context of a class that uses a `LambdaParam`, then we convert it to a `SelfTypeParam` instead (e.g. if we wrapped the relevant fuzzed test case in `class A; ...; end`, then we don't see the same error because the type surfaces as a `SelfTypeParam` instead of a `LambdaParam`.) We might also instantiate them with known type variables or with `T.untyped` if we're working in a different context.

This hits into an edge-case where if you use a `type_member` at the top level, then we don't instantiate it into a `SelfTypeParam` and keep using it as a `LambdaParam` directly, and then (in this case) try to check and see if it's a kind of `Array` so that maybe we can splat it into a proc. If we _had_ instantiated it into a `SelfTypeParam`, then we'd just return `false` for that same check, so this copies that behavior into `LambdaParam::derivesFrom`, along with a comment about why.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Added relevant fuzzed test.
