### PR TITLE
Adds the method String#match? to the type repository

### DIFF
--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -468,6 +468,21 @@ class String < Object
   end
   def match(arg0, arg1=T.unsafe(nil)); end
 
+  sig do
+    params(
+        arg0: T.any(Regexp, String),
+    )
+    .returns(T::Boolean)
+  end
+  sig do
+    params(
+        arg0: T.any(Regexp, String),
+        arg1: Integer,
+    )
+    .returns(T::Boolean)
+  end
+  def match?(arg0, arg1=T.unsafe(nil)); end
+
   sig {returns(String)}
   def next(); end
 


### PR DESCRIPTION
### Motivation
To have more complete bindings for the `String` class https://github.com/sorbet/sorbet/issues/1249

https://ruby-doc.org/core-2.4.0/String.html#method-i-match-3F

### Test plan
I couldn't find any tests for the rbi files with the signatures. I wouldn't mind adding a test if I pointed to the right direction. Though I don't know how useful it would be.
