### PR TITLE
Pay attention to sorbet-typed.rev in run_one_bazel.sh

### DIFF
--- a/gems/sorbet/test/snapshot/BUILD
+++ b/gems/sorbet/test/snapshot/BUILD
@@ -9,6 +9,7 @@ sh_binary(
     name = "run_one_bazel",
     srcs = ["run_one_bazel.sh"],
     data = [
+        "sorbet-typed.rev",
         "//main:sorbet",
         "@gems//bundler",
         "@gems//bundler:bundle",

--- a/gems/sorbet/test/snapshot/run_one_bazel.sh
+++ b/gems/sorbet/test/snapshot/run_one_bazel.sh
@@ -97,7 +97,7 @@ SORBET_TYPED_REV="$(rlocation com_stripe_ruby_typer/gems/sorbet/test/snapshot/so
 SRB_SORBET_TYPED_REVISION="$(<"$SORBET_TYPED_REV")"
 export SRB_SORBET_TYPED_REVISION
 
-if [ -z "$SRB_SORBET_TYPED_REVISION" ]; then
+if [ "$SRB_SORBET_TYPED_REVISION" = "" ]; then
   error "└─ empty sorbet-typed revision from: ${SORBET_TYPED_REV}"
   exit 1
 else

--- a/gems/sorbet/test/snapshot/run_one_bazel.sh
+++ b/gems/sorbet/test/snapshot/run_one_bazel.sh
@@ -93,6 +93,17 @@ srb="${repo_root}/gems/sorbet/bin/srb"
 info "├─ sorbet:           $SRB_SORBET_EXE"
 info "├─ sorbet --version: $("$SRB_SORBET_EXE" --version)"
 
+SORBET_TYPED_REV="$(rlocation com_stripe_ruby_typer/gems/sorbet/test/snapshot/sorbet-typed.rev)"
+SRB_SORBET_TYPED_REVISION="$(<"$SORBET_TYPED_REV")"
+export SRB_SORBET_TYPED_REVISION
+
+if [ -z "$SRB_SORBET_TYPED_REVISION" ]; then
+  error "└─ empty sorbet-typed revision from: ${SORBET_TYPED_REV}"
+  exit 1
+else
+  info "├─ sorbet-typed:     $SRB_SORBET_TYPED_REVISION"
+fi
+
 
 # ----- Build the test sandbox -----
 


### PR DESCRIPTION
Update `run_one_bazel.sh` to respect `sorbet-typed.rev`

### Motivation
The bazel version of the snapshot tests wasn't pinning the revision of sorbet-typed, which caused a failure on master when an RBI update happened.

### Test plan
See included automated tests.
