### PR TITLE
Fix Numeric#step sigs

### DIFF
--- a/rbi/core/numeric.rbi
+++ b/rbi/core/numeric.rbi
@@ -249,33 +249,20 @@ class Numeric < Object
 
   sig do
     params(
-        arg0: Numeric,
+        limit: T.nilable(Numeric),
+        step: Numeric,
         blk: T.proc.params(arg0: Numeric).returns(BasicObject),
     )
     .returns(Numeric)
   end
   sig do
     params(
-        arg0: Numeric,
+        limit: T.nilable(Numeric),
+        step: Numeric,
     )
     .returns(T::Enumerator[Numeric])
   end
-  sig do
-    params(
-        arg0: Numeric,
-        arg1: Numeric,
-        blk: T.proc.params(arg0: Numeric).returns(BasicObject),
-    )
-    .returns(Numeric)
-  end
-  sig do
-    params(
-        arg0: Numeric,
-        arg1: Numeric,
-    )
-    .returns(T::Enumerator[Numeric])
-  end
-  def step(arg0, arg1=T.unsafe(nil), &blk); end
+  def step(limit=nil, step=1, &blk); end
 
   sig {returns(Complex)}
   def to_c(); end

--- a/test/cli/symbol-table-json/symbol-table-json.out
+++ b/test/cli/symbol-table-json/symbol-table-json.out
@@ -80,7 +80,7 @@ No errors! Great job.
     "name": "B"
    },
    "kind": "STATIC_FIELD",
-   "aliasTo": 10941
+   "aliasTo": 10939
   }
  ]
 }


### PR DESCRIPTION
- Use the defaults indicated in the official docs https://ruby-doc.org/core-2.6.3/Numeric.html#method-i-step
  - This means we can reduce the `sig` overloads from 4 to 2
- Also allow `nil` as a first argument

resolves https://github.com/sorbet/sorbet/issues/1299

Test plan:
```
[1] pry(main)> 0.step(nil, 1.5) {|i| puts i; break if i > 5}
0.0
1.5
3.0
4.5
6.0
=> nil
[2] pry(main)> 0.step {|i| puts i; break if i > 5}
0
1
2
3
4
5
6
=> nil
[3] pry(main)> 0.step(nil) {|i| puts i; break if i > 5}
0
1
2
3
4
5
6
=> nil
```