### PR TITLE
Use `T.untyped` as the default type argument for all built-in enumerable types

### DIFF
--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -552,9 +552,11 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
                 result.type = maybeAliased.data(ctx)->resultType;
                 return;
             }
-            bool silenceGenericError = maybeAliased == core::Symbols::Hash() ||
-                                       maybeAliased == core::Symbols::Array() || maybeAliased == core::Symbols::Set() ||
-                                       maybeAliased == core::Symbols::Struct() || maybeAliased == core::Symbols::File();
+            bool silenceGenericError =
+                maybeAliased == core::Symbols::Hash() || maybeAliased == core::Symbols::Array() ||
+                maybeAliased == core::Symbols::Set() || maybeAliased == core::Symbols::Range() ||
+                maybeAliased == core::Symbols::Enumerable() || maybeAliased == core::Symbols::Enumerator() ||
+                maybeAliased == core::Symbols::Struct() || maybeAliased == core::Symbols::File();
             // TODO: reduce this^^^ set.
             auto sym = maybeAliased.data(ctx)->dealias(ctx);
             if (sym.data(ctx)->isClass()) {

--- a/test/testdata/resolver/untyped_generics.rb
+++ b/test/testdata/resolver/untyped_generics.rb
@@ -1,0 +1,71 @@
+# typed: true
+class Foo
+  extend(T::Sig)
+  
+  sig { returns(Array) }
+  def array_method
+    [1, "2", :foo]
+  end
+
+  sig { returns(Hash) }
+  def hash_method
+    { a: 1, b: "2", "c" => :foo }
+  end
+
+  sig { returns(Set) }
+  def set_method
+    Set.new([1, "2", :foo])
+  end
+
+  sig { returns(Range) }
+  def range_method
+    'a'..'b'
+  end
+
+  sig { returns(Enumerable) }
+  def enumerable_method
+    [1, "2", :foo].to_enum
+  end
+
+  sig { returns(Enumerator) }
+  def enumerator_method
+    [1, "2", :foo].to_enum
+  end
+
+  sig { returns(Array) }
+  def bad_array_method
+    1 # error: Returning value that does not conform to method result type
+  end
+
+  sig { returns(Hash) }
+  def bad_hash_method
+    1 # error: Returning value that does not conform to method result type
+  end
+
+  sig { returns(Set) }
+  def bad_set_method
+    1 # error: Returning value that does not conform to method result type
+  end
+
+  sig { returns(Range) }
+  def bad_range_method
+    1 # error: Returning value that does not conform to method result type
+  end
+
+  sig { returns(Enumerable) }
+  def bad_enumerable_method
+    1 # error: Returning value that does not conform to method result type
+  end
+
+  sig { returns(Enumerator) }
+  def bad_enumerator_method
+    1 # error: Returning value that does not conform to method result type
+  end
+end
+
+T.reveal_type(Foo.new.array_method) # error: Revealed type: `T::Array[T.untyped]`
+T.reveal_type(Foo.new.hash_method) # error: Revealed type: `T::Hash[T.untyped, T.untyped]`
+T.reveal_type(Foo.new.set_method) # error: Revealed type: `T::Set[T.untyped]`
+T.reveal_type(Foo.new.range_method) # error: Revealed type: `T::Range[T.untyped]`
+T.reveal_type(Foo.new.enumerable_method) # error: Revealed type: `T::Enumerable[T.untyped]`
+T.reveal_type(Foo.new.enumerator_method) # error: Revealed type: `T::Enumerator[T.untyped]`


### PR DESCRIPTION
This change allows people to use `Range`, `Enumerable` and `Enumerator` in type signatures.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Currently, only `Array`, `Hash` and `Set` can be used to mean `T::Array[T.untyped]`, `T::Hash[T.untyped, T.untyped]` and `T::Set[T.untyped]`, respectively. However, people expect to use `Range`, `Enumerable` and `Enumerator` in type signatures to mean their untyped variants, too.

Fixes: #1220 
Fixes: #1074 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
