### PR TITLE
Add `JSON::Ext` declarations and signatures

### DIFF
--- a/rbi/stdlib/json.rbi
+++ b/rbi/stdlib/json.rbi
@@ -378,6 +378,329 @@ class JSON::GenericObject < OpenStruct
   def self.load(source, proc=T.unsafe(nil), opts=T.unsafe(nil)); end
 end
 
+module JSON::Ext
+end
+
+module JSON::Ext::Generator
+end
+
+module JSON::Ext::Generator::GeneratorMethods
+end
+
+module JSON::Ext::Generator::GeneratorMethods::Array
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::String)
+  end
+  def to_json(*_); end
+end
+
+module JSON::Ext::Generator::GeneratorMethods::FalseClass
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::String)
+  end
+  def to_json(*_); end
+end
+
+module JSON::Ext::Generator::GeneratorMethods::Float
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::String)
+  end
+  def to_json(*_); end
+end
+
+module JSON::Ext::Generator::GeneratorMethods::Hash
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::String)
+  end
+  def to_json(*_); end
+end
+
+module JSON::Ext::Generator::GeneratorMethods::Integer
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::String)
+  end
+  def to_json(*_); end
+end
+
+module JSON::Ext::Generator::GeneratorMethods::NilClass
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::String)
+  end
+  def to_json(*_); end
+end
+
+module JSON::Ext::Generator::GeneratorMethods::Object
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::String)
+  end
+  def to_json(*_); end
+end
+
+module JSON::Ext::Generator::GeneratorMethods::String
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::String)
+  end
+  def to_json(*_); end
+
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::String)
+  end
+  def to_json_raw(*_); end
+
+  sig do
+    returns(::Hash)
+  end
+  def to_json_raw_object; end
+
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .void
+  end
+  def self.included(_); end
+end
+
+module JSON::Ext::Generator::GeneratorMethods::String::Extend
+  sig do
+    params(
+      _: ::Hash
+    )
+    .returns(::String)
+  end
+  def json_create(_); end
+end
+
+module JSON::Ext::Generator::GeneratorMethods::TrueClass
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::String)
+  end
+  def to_json(*_); end
+end
+
+class JSON::Ext::Generator::State
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .void
+  end
+  def initialize(*_); end
+
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::T.untyped)
+  end
+  def [](_); end
+
+  sig do
+    params(
+      _: ::T.untyped,
+      _: ::T.untyped,
+    )
+    .returns(::T.untyped)
+  end
+  def []=(_, _); end
+
+  sig do
+    returns(::T.untyped)
+  end
+  def allow_nan?; end
+
+  sig do
+    returns(::T.untyped)
+  end
+  def array_nl; end
+
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::T.untyped)
+  end
+  def array_nl=(_); end
+
+  sig do
+    returns(::T.untyped)
+  end
+  def ascii_only?; end
+
+  sig do
+    returns(::T.untyped)
+  end
+  def buffer_initial_length; end
+
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::T.untyped)
+  end
+  def buffer_initial_length=(_); end
+
+  sig do
+    returns(::T.untyped)
+  end
+  def check_circular?; end
+
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::T.untyped)
+  end
+  def configure(_); end
+
+  sig do
+    returns(::T.untyped)
+  end
+  def depth; end
+
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::T.untyped)
+  end
+  def depth=(_); end
+
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::T.untyped)
+  end
+  def generate(_); end
+
+  sig do
+    returns(::T.untyped)
+  end
+  def indent; end
+
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::T.untyped)
+  end
+  def indent=(_); end
+
+  sig do
+    returns(::T.untyped)
+  end
+  def max_nesting; end
+
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::T.untyped)
+  end
+  def max_nesting=(_); end
+
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::T.untyped)
+  end
+  def merge(_); end
+
+  sig do
+    returns(::T.untyped)
+  end
+  def object_nl; end
+
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::T.untyped)
+  end
+  def object_nl=(_); end
+
+  sig do
+    returns(::T.untyped)
+  end
+  def space; end
+
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::T.untyped)
+  end
+  def space=(_); end
+
+  sig do
+    returns(::T.untyped)
+  end
+  def space_before; end
+
+  sig do
+    params(
+      _: ::T.untyped
+    )
+    .returns(::T.untyped)
+  end
+  def space_before=(_); end
+
+  sig do
+    returns(::T.untyped)
+  end
+  def to_h; end
+
+  sig do
+    returns(::T.untyped)
+  end
+  def to_hash; end
+end
+
+class JSON::Ext::Parser
+  sig do
+    returns(::T.untyped)
+  end
+  def parse; end
+
+  sig do
+    returns(::String)
+  end
+  def source; end
+end
+
+
 class JSON::JSONError < StandardError
   sig do
     params(

--- a/test/testdata/rbi/json.rb
+++ b/test/testdata/rbi/json.rb
@@ -1,0 +1,47 @@
+# typed: true
+
+class Array
+  include JSON::Ext::Generator::GeneratorMethods::Array
+end
+
+class FalseClass
+  include JSON::Ext::Generator::GeneratorMethods::FalseClass
+end
+
+class Float
+  include JSON::Ext::Generator::GeneratorMethods::Float
+end
+
+class Hash
+  include JSON::Ext::Generator::GeneratorMethods::Hash
+end
+
+class Integer
+  include JSON::Ext::Generator::GeneratorMethods::Integer
+end
+
+class NilClass
+  include JSON::Ext::Generator::GeneratorMethods::NilClass
+end
+
+class Object
+  include JSON::Ext::Generator::GeneratorMethods::Object
+end
+
+class String
+  include JSON::Ext::Generator::GeneratorMethods::String
+end
+
+class TrueClass
+  include JSON::Ext::Generator::GeneratorMethods::TrueClass
+end
+
+T.reveal_type([1, "2", :foo].to_json) # error: Revealed type: `String`
+T.reveal_type(false.to_json) # error: Revealed type: `String`
+T.reveal_type(1.23.to_json) # error: Revealed type: `String`
+T.reveal_type({ a: 1, b: "2", "c" => :foo }.to_json) # error: Revealed type: `String`
+T.reveal_type(1.to_json) # error: Revealed type: `String`
+T.reveal_type(nil.to_json) # error: Revealed type: `String`
+T.reveal_type(Object.new.to_json) # error: Revealed type: `String`
+T.reveal_type("123".to_json) # error: Revealed type: `String`
+T.reveal_type(true.to_json) # error: Revealed type: `String`


### PR DESCRIPTION
I've added the proper parameter/return types for methods that I am sure of. Let me know if you'd prefer all methods to have untyped params/returns, though.

### Motivation

When the `json` library is required, it mixes in subtypes of `JSON::Ext` into various stdlib types to inject `to_json` method into them. 

During RBI generation, these mixins are usually present in generated types, and they unnecessarily end up in `hidden-definitions/hidden.rbi` .

<details>
  <summary>Excerpt from a real <code>hidden.rbi</code> file</summary>

```ruby
class NilClass
  include ::JSON::Ext::Generator::GeneratorMethods::NilClass
  def to_i(); end
end

...

class TrueClass
  include ::JSON::Ext::Generator::GeneratorMethods::TrueClass
end

...

class Integer
  include ::JSON::Ext::Generator::GeneratorMethods::Integer
  def allbits?(_); end

  def anybits?(_); end

  def digits(*_); end

  def nobits?(_); end

  def pow(*_); end

  def to_bn(); end

end

...

module JSON::Ext::Generator::GeneratorMethods::Array
  extend ::T::Sig
end

module JSON::Ext::Generator::GeneratorMethods::FalseClass
  extend ::T::Sig
end

module JSON::Ext::Generator::GeneratorMethods::Float
  extend ::T::Sig
end

module JSON::Ext::Generator::GeneratorMethods::Hash
  extend ::T::Sig
end

module JSON::Ext::Generator::GeneratorMethods::Integer
  extend ::T::Sig
end

module JSON::Ext::Generator::GeneratorMethods::NilClass
  extend ::T::Sig
end

module JSON::Ext::Generator::GeneratorMethods::Object
  extend ::T::Sig
end

module JSON::Ext::Generator::GeneratorMethods::String::Extend
  extend ::T::Sig
end

module JSON::Ext::Generator::GeneratorMethods::String
  extend ::T::Sig
end

module JSON::Ext::Generator::GeneratorMethods::TrueClass
  extend ::T::Sig
end

module JSON::Ext::Generator::GeneratorMethods
  extend ::T::Sig
end

module JSON::Ext::Generator
  extend ::T::Sig
end

module JSON::Ext
  extend ::T::Sig
end
```
</details>

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
