### PR TITLE
Fix handling of duplicated error lists options

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -780,14 +780,16 @@ void readOptions(Options &opts, int argc, char *argv[],
         extractAutoloaderConfig(raw, opts, logger);
         opts.errorUrlBase = raw["error-url-base"].as<string>();
         if (raw.count("error-white-list") > 0) {
-            opts.errorCodeWhiteList = raw["error-white-list"].as<vector<int>>();
+            auto rawList = raw["error-white-list"].as<vector<int>>();
+            opts.errorCodeWhiteList = set<int>(rawList.begin(), rawList.end());
         }
         if (raw.count("error-black-list") > 0) {
             if (raw.count("error-white-list") > 0) {
                 logger->error("You can't pass both `{}` and `{}`", "--error-black-list", "--error-white-list");
                 throw EarlyReturnWithCode(1);
             }
-            opts.errorCodeBlackList = raw["error-black-list"].as<vector<int>>();
+            auto rawList = raw["error-black-list"].as<vector<int>>();
+            opts.errorCodeBlackList = set<int>(rawList.begin(), rawList.end());
         }
         if (sorbet::debug_mode) {
             opts.suggestSig = raw["suggest-sig"].as<bool>();
@@ -810,14 +812,14 @@ void readOptions(Options &opts, int argc, char *argv[],
         }
 
         if (opts.suggestTyped) {
-            if (opts.errorCodeWhiteList != vector<int>{core::errors::Infer::SuggestTyped.code} &&
+            if (opts.errorCodeWhiteList != set<int>{core::errors::Infer::SuggestTyped.code} &&
                 raw["typed"].as<string>() != "strict") {
                 logger->error(
                     "--suggest-typed must also include `{}`",
                     fmt::format("{}{}", "--typed=strict --error-white-list=", core::errors::Infer::SuggestTyped.code));
                 throw EarlyReturnWithCode(1);
             }
-            if (opts.errorCodeWhiteList != vector<int>{core::errors::Infer::SuggestTyped.code}) {
+            if (opts.errorCodeWhiteList != set<int>{core::errors::Infer::SuggestTyped.code}) {
                 logger->error("--suggest-typed must also include `{}`",
                               fmt::format("{}{}", "--error-white-list=", core::errors::Infer::SuggestTyped.code));
                 throw EarlyReturnWithCode(1);

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -152,8 +152,8 @@ struct Options {
     bool enableCounters = false;
     std::vector<std::string> someCounters;
     std::string errorUrlBase = "https://srb.help/";
-    std::vector<int> errorCodeWhiteList;
-    std::vector<int> errorCodeBlackList;
+    std::set<int> errorCodeWhiteList;
+    std::set<int> errorCodeBlackList;
     /** Prefix to remove from all printed paths. */
     std::string pathPrefix;
 

--- a/test/cli/suggest-typed-true/suggest-typed-true.out
+++ b/test/cli/suggest-typed-true/suggest-typed-true.out
@@ -15,6 +15,16 @@ suggest-typed-true.rb:1: You could add `# typed: true` https://srb.help/7022
         ^
 Errors: 1
 -------------------------
+suggest-typed-true.rb:1: You could add `# typed: true` https://srb.help/7022
+     1 |def true_func
+        ^
+  Autocorrect: Use `-a` to autocorrect
+    suggest-typed-true.rb:1: Insert `# typed: true
+`
+     1 |def true_func
+        ^
+Errors: 1
+-------------------------
 suggest-typed-ignore.rb:1: You could add `# typed: ignore` https://srb.help/7022
      1 |Foo
         ^

--- a/test/cli/suggest-typed-true/suggest-typed-true.sh
+++ b/test/cli/suggest-typed-true/suggest-typed-true.sh
@@ -22,6 +22,10 @@ separator
 "$cwd/main/sorbet" --silence-dev-message --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-true.rb 2>&1
 separator
 
+# Avoid error when repeating options
+"$cwd/main/sorbet" --silence-dev-message --suggest-typed --error-white-list=7022 --typed=strict --error-white-list=7022 suggest-typed-true.rb 2>&1
+separator
+
 "$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-ignore.rb 2>&1
 cat suggest-typed-ignore.rb
 "$cwd/main/sorbet" --silence-dev-message --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-ignore.rb 2>&1


### PR DESCRIPTION
Use `set` instead of `vector` for `Options::errorWhiteList` and `Options::errorBlackList` so the client can pass the same options multiple times.

### Motivation

Before this PR:

```
$ sorbet --suggest-typed --typed=strict --error-white-list=7022 --error-white-list=7022 .
--suggest-typed must also include `--error-white-list=7022`
```

After this PR:

```
$ sorbet --suggest-typed --typed=strict --error-white-list=7022 --error-white-list=7022 .
No errors! Great job.
```

While I don't want to encourage people doing weird things with options, this new behaviour makes it easier to work with projects having a config file.

### Test plan

See included automated tests.