### PR TITLE
Disallow multiple sigs in non-stdlib Object contexts

### DIFF
--- a/core/Context.cc
+++ b/core/Context.cc
@@ -25,14 +25,15 @@ SymbolRef MutableContext::selfClass() {
     return data->enclosingClass(this->state);
 }
 
-bool Context::permitOverloadDefinitions() const {
+bool Context::permitOverloadDefinitions(FileRef sigLoc) const {
     if (!owner.exists()) {
         return false;
     }
     for (auto loc : owner.data(*this)->locs()) {
         auto &file = loc.file().data(*this);
         constexpr string_view whitelistedTest = "overloads_test.rb"sv;
-        if (((file.isPayload() || file.isStdlib()) && owner != Symbols::root()) ||
+        if (((file.isPayload() || file.isStdlib()) && owner != Symbols::root() &&
+             (owner != Symbols::Object() || sigLoc.data(*this).isStdlib())) ||
             FileOps::getFileName(file.path()) == whitelistedTest) {
             return true;
         }
@@ -40,9 +41,9 @@ bool Context::permitOverloadDefinitions() const {
     return false;
 }
 
-bool MutableContext::permitOverloadDefinitions() const {
+bool MutableContext::permitOverloadDefinitions(FileRef sigLoc) const {
     Context self(*this);
-    return self.permitOverloadDefinitions();
+    return self.permitOverloadDefinitions(sigLoc);
 }
 
 Context::Context(const MutableContext &other) noexcept : state(other.state), owner(other.owner) {}

--- a/core/Context.h
+++ b/core/Context.h
@@ -7,6 +7,7 @@
 
 namespace sorbet::core {
 class GlobalState;
+class FileRef;
 class MutableContext;
 
 class Context {
@@ -22,7 +23,7 @@ public:
     Context(const Context &other) noexcept : state(other.state), owner(other.owner) {}
     Context(const MutableContext &other) noexcept;
 
-    bool permitOverloadDefinitions() const;
+    bool permitOverloadDefinitions(FileRef sigLoc) const;
 
     Context withOwner(SymbolRef sym) const;
 
@@ -52,7 +53,7 @@ public:
     // their singleton classes for most purposes)
     SymbolRef selfClass();
 
-    bool permitOverloadDefinitions() const;
+    bool permitOverloadDefinitions(FileRef sigLoc) const;
 
     MutableContext withOwner(SymbolRef sym) const {
         return MutableContext(state, sym);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -200,7 +200,7 @@ SymbolRef guessOverload(Context ctx, SymbolRef inClass, SymbolRef primary,
                         InlinedVector<const TypeAndOrigins *, 2> &args, const TypePtr &fullType, vector<TypePtr> &targs,
                         bool hasBlock) {
     counterInc("calls.overloaded_invocations");
-    ENFORCE(ctx.permitOverloadDefinitions(), "overload not permitted here");
+    ENFORCE(ctx.permitOverloadDefinitions(primary.data(ctx)->loc().file()), "overload not permitted here");
     SymbolRef fallback = primary;
     vector<SymbolRef> allCandidates;
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1026,7 +1026,7 @@ private:
             [&](ast::Send *send) {
                 if (TypeSyntax::isSig(ctx, send)) {
                     if (!lastSigs.empty()) {
-                        if (!ctx.permitOverloadDefinitions()) {
+                        if (!ctx.permitOverloadDefinitions(send->loc.file())) {
                             if (auto e = ctx.state.beginError(lastSigs[0]->loc,
                                                               core::errors::Resolver::OverloadNotAllowed)) {
                                 e.setHeader("Unused type annotation. No method def before next annotation");
@@ -1077,7 +1077,7 @@ private:
                         }
                     }
 
-                    bool isOverloaded = lastSigs.size() > 1 && ctx.permitOverloadDefinitions();
+                    bool isOverloaded = lastSigs.size() > 1 && ctx.permitOverloadDefinitions(loc.file());
                     auto originalName = mdef->symbol.data(ctx)->name;
                     if (isOverloaded) {
                         ctx.state.mangleRenameSymbol(mdef->symbol, originalName);

--- a/test/cli/incremental-resolver/expect-failures/multiple_sigs.rb
+++ b/test/cli/incremental-resolver/expect-failures/multiple_sigs.rb
@@ -1,6 +1,7 @@
+# typed: true
 def z
-2sig {}
-sig{}
-def-f
-end
+  sig {void}
+  sig {void}
+  def-f
+  end
 end

--- a/test/cli/incremental-resolver/expect-failures/multiple_sigs.rb
+++ b/test/cli/incremental-resolver/expect-failures/multiple_sigs.rb
@@ -1,0 +1,6 @@
+def z
+2sig {}
+sig{}
+def-f
+end
+end

--- a/test/cli/incremental-resolver/incremental-resolver.out
+++ b/test/cli/incremental-resolver/incremental-resolver.out
@@ -56,3 +56,50 @@ test/cli/incremental-resolver/expect-failures/constant_override.rb:110: Method `
      110 |B = e
               ^
 Errors: 4
+----- test/cli/incremental-resolver/expect-failures/multiple_sigs.rb ---------------------
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:2: Parse Error: unexpected token: syntax error https://srb.help/2001
+     2 |2sig {}
+         ^^^
+
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:2: Unused type annotation. No method def before next annotation https://srb.help/5040
+     2 |2sig {}
+         ^^^^^^
+    test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:3: Type annotation that will be used instead
+     3 |sig{}
+        ^^^^^
+
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:2: To use `sig`, this file must declare an explicit `# typed:` sigil (found: none). If you're not sure which one to use, start with `# typed: false` https://srb.help/5038
+     2 |2sig {}
+         ^^^^^^
+
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:2: Malformed `sig`: No return type specified. Specify one with .returns() https://srb.help/5003
+     2 |2sig {}
+         ^^^^^^
+
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:3: Malformed `sig`: No return type specified. Specify one with .returns() https://srb.help/5003
+     3 |sig{}
+        ^^^^^
+
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:37: Parse Error: unexpected token: syntax error https://srb.help/2001
+    37 |2sig {}
+         ^^^
+
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:37: Unused type annotation. No method def before next annotation https://srb.help/5040
+    37 |2sig {}
+         ^^^^^^
+    test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:38: Type annotation that will be used instead
+    38 |sig{}
+        ^^^^^
+
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:37: To use `sig`, this file must declare an explicit `# typed:` sigil (found: none). If you're not sure which one to use, start with `# typed: false` https://srb.help/5038
+    37 |2sig {}
+         ^^^^^^
+
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:37: Malformed `sig`: No return type specified. Specify one with .returns() https://srb.help/5003
+    37 |2sig {}
+         ^^^^^^
+
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:38: Malformed `sig`: No return type specified. Specify one with .returns() https://srb.help/5003
+    38 |sig{}
+        ^^^^^
+Errors: 10

--- a/test/cli/incremental-resolver/incremental-resolver.out
+++ b/test/cli/incremental-resolver/incremental-resolver.out
@@ -57,49 +57,46 @@ test/cli/incremental-resolver/expect-failures/constant_override.rb:110: Method `
               ^
 Errors: 4
 ----- test/cli/incremental-resolver/expect-failures/multiple_sigs.rb ---------------------
-test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:2: Parse Error: unexpected token: syntax error https://srb.help/2001
-     2 |2sig {}
-         ^^^
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:3: Unused type annotation. No method def before next annotation https://srb.help/5040
+     3 |  sig {void}
+          ^^^^^^^^^^
+    test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:4: Type annotation that will be used instead
+     4 |  sig {void}
+          ^^^^^^^^^^
 
-test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:2: Unused type annotation. No method def before next annotation https://srb.help/5040
-     2 |2sig {}
-         ^^^^^^
-    test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:3: Type annotation that will be used instead
-     3 |sig{}
-        ^^^^^
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:5: Malformed `sig`. Type not specified for argument `f` https://srb.help/5003
+     5 |  def-f
+              ^
+    test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:3: Signature
+     3 |  sig {void}
+          ^^^^^^^^^^
 
-test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:2: To use `sig`, this file must declare an explicit `# typed:` sigil (found: none). If you're not sure which one to use, start with `# typed: false` https://srb.help/5038
-     2 |2sig {}
-         ^^^^^^
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:68: Unused type annotation. No method def before next annotation https://srb.help/5040
+    68 |  sig {void}
+          ^^^^^^^^^^
+    test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:69: Type annotation that will be used instead
+    69 |  sig {void}
+          ^^^^^^^^^^
 
-test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:2: Malformed `sig`: No return type specified. Specify one with .returns() https://srb.help/5003
-     2 |2sig {}
-         ^^^^^^
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:68: Method `sig` does not exist on `Object` https://srb.help/7003
+    68 |  sig {void}
+          ^^^^^^^^^^
 
-test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:3: Malformed `sig`: No return type specified. Specify one with .returns() https://srb.help/5003
-     3 |sig{}
-        ^^^^^
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:68: Method `void` does not exist on `Object` https://srb.help/7003
+    68 |  sig {void}
+               ^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L647: Did you mean: `Kernel#load`?
+     647 |  def load(filename, arg0=T.unsafe(nil)); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:37: Parse Error: unexpected token: syntax error https://srb.help/2001
-    37 |2sig {}
-         ^^^
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:69: Method `sig` does not exist on `Object` https://srb.help/7003
+    69 |  sig {void}
+          ^^^^^^^^^^
 
-test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:37: Unused type annotation. No method def before next annotation https://srb.help/5040
-    37 |2sig {}
-         ^^^^^^
-    test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:38: Type annotation that will be used instead
-    38 |sig{}
-        ^^^^^
-
-test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:37: To use `sig`, this file must declare an explicit `# typed:` sigil (found: none). If you're not sure which one to use, start with `# typed: false` https://srb.help/5038
-    37 |2sig {}
-         ^^^^^^
-
-test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:37: Malformed `sig`: No return type specified. Specify one with .returns() https://srb.help/5003
-    37 |2sig {}
-         ^^^^^^
-
-test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:38: Malformed `sig`: No return type specified. Specify one with .returns() https://srb.help/5003
-    38 |sig{}
-        ^^^^^
-Errors: 10
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:69: Method `void` does not exist on `Object` https://srb.help/7003
+    69 |  sig {void}
+               ^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L647: Did you mean: `Kernel#load`?
+     647 |  def load(filename, arg0=T.unsafe(nil)); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Errors: 7

--- a/test/testdata/resolver/fuzz_multiple_sigs.rb
+++ b/test/testdata/resolver/fuzz_multiple_sigs.rb
@@ -1,0 +1,11 @@
+# typed: true
+# fuzzed test from https://github.com/sorbet/sorbet/issues/1166
+def r
+  sig{} # error: Malformed `sig`: No return type specified. Specify one with .returns()
+# ^^^^^ error: Method `sig` does not exist on `Object`
+# ^^^^^ error: Unused type annotation. No method def before next annotation
+  sig{} # error: Malformed `sig`: No return type specified. Specify one with .returns()
+# ^^^^^ error: Method `sig` does not exist on `Object`
+  def f; end
+end
+f


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes #1085 and fixes #1166. We had a loophole where, because the owner of methods defined on `<root>` was `Object`, we would allow multiple overloaded `sig`s on nested method definitions. Sometimes this would result in anomalous broken invariants (as in #1085) and sometimes we would fail later on when realizing that those methods (given that they do end up on `<root>` eventually) should not have allowed overloads in the first place.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. This added fuzzed tests from two sources, as well.
