### PR TITLE
Add proper RBI definitions for sorbet-runtime

### DIFF
--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -103,11 +103,73 @@ end
 module T::CFGExport
 end
 
-class T::InexactStruct
-  def initialize(rules={}); end
-  def self.prop(name, type, rules={}); end
-  def self.const(name, type, rules={}); end
-end
-class T::Struct < T::InexactStruct; end
-
 T::Boolean = T.type_alias(T.any(TrueClass, FalseClass))
+
+module T::Configuration
+  def self.call_validation_error_handler(signature, opts); end
+  def self.call_validation_error_handler=(value); end
+  def self.default_checked_level=(default_checked_level); end
+  def self.enable_checking_for_sigs_marked_checked_tests; end
+  def self.enable_final_checks_for_include_extend; end
+  def self.reset_final_checks_for_include_extend; end
+  def self.hard_assert_handler(str, extra); end
+  def self.hard_assert_handler=(value); end
+  def self.inline_type_error_handler(error); end
+  def self.inline_type_error_handler=(value); end
+  def self.log_info_handler(str, extra); end
+  def self.log_info_handler=(value); end
+  def self.scalar_types; end
+  def self.scalar_types=(values); end
+  def self.sig_builder_error_handler(error, location); end
+  def self.sig_builder_error_handler=(value); end
+  def self.sig_validation_error_handler(error, opts); end
+  def self.sig_validation_error_handler=(value); end
+  def self.soft_assert_handler(str, extra); end
+  def self.soft_assert_handler=(value); end
+end
+
+module T::Profile
+  def self.reset; end
+  def self.typecheck_count_estimate; end
+  def self.typecheck_duration; end
+  def self.typecheck_duration=(arg0); end
+  def self.typecheck_duration_estimate; end
+  def self.typecheck_sample_attempts; end
+  def self.typecheck_sample_attempts=(arg0); end
+  def self.typecheck_samples; end
+  def self.typecheck_samples=(arg0); end
+end
+
+module T::Utils
+  def self.arity(method); end
+  def self.coerce(val); end
+  def self.run_all_sig_blocks; end
+  def self.signature_for_instance_method(mod, method_name); end
+  def self.unwrap_nilable(type); end
+  def self.wrap_method_with_call_validation_if_needed(mod, method_sig, original_method); end
+
+  # only one caller; delete
+  def self.methods_excluding_object(mod); end
+  # only one caller; delete
+  def self.register_forwarder(from_method, to_method, remove_first_param: nil); end
+end
+
+class T::Utils::RuntimeProfiled
+end
+
+module T::AbstractUtils
+  def self.abstract_method?(method); end
+  def self.abstract_methods_for(mod); end
+  def self.abstract_module?(mod); end
+  def self.declared_abstract_methods_for(mod); end
+end
+
+class T::InterfaceWrapper
+  def self.dynamic_cast(obj, mod); end
+end
+
+module T::Utils::Nilable
+  def self.get_type_info(prop_type); end
+  def self.get_underlying_type(prop_type); end
+  def self.get_underlying_type_object(prop_type); end
+end

--- a/rbi/sorbet/tprivate.rbi
+++ b/rbi/sorbet/tprivate.rbi
@@ -1,0 +1,23 @@
+# typed: strict
+
+# These things are things that Sorbet considers unstable internal APIs that
+# could (and do) change at any moment without notice.
+#
+# Use them at your own risk.
+
+module T::Private
+end
+
+module T::Private::Types
+end
+
+class T::Private::Types::Void < T::Types::Base
+end
+
+module T::Private::Methods
+  def self.signature_for_method(method); end
+end
+
+module T::Private::Methods::CallValidation
+  def self.disable_fast_path; end
+end

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -1,0 +1,207 @@
+# typed: strict
+
+# The vast majority Most of the methods defined below are arguably private
+# APIs, but are actually not private because they're used by Chalk::ODM.
+
+class T::InexactStruct
+  include T::Props
+  include T::Props::Constructor
+  include T::Props::Serializable
+end
+
+class T::Struct < T::InexactStruct
+end
+
+module T::Props
+  extend T::Helpers
+  mixes_in_class_methods(T::Props::ClassMethods)
+end
+
+module T::Props::ClassMethods
+  sig {params(name: T.any(Symbol, String), cls_or_args: T.untyped, args: T::Hash[Symbol, T.untyped]).void}
+  def const(name, cls_or_args, args={}, &blk); end
+  def prop(name, cls, rules = nil); end
+  def decorator; end
+  def decorator_class; end
+  def plugin(mod); end
+  def plugins; end
+  def props; end
+  def reload_decorator!; end
+  def validate_prop_value(prop, val); end
+end
+
+module T::Props::CustomType
+  def deserialize(_mongo_scalar); end
+  def instance?(_value); end
+  def self.scalar_type?(val); end
+  def self.valid_serialization?(val, type = nil); end
+  def serialize(_instance); end
+  def valid?(value); end
+  include Kernel
+end
+
+class T::Props::Decorator
+  Rules = T.type_alias(T::Hash[Symbol, T.untyped])
+  DecoratedClass = T.type_alias(T.untyped) # T.class_of(T::Props), but that produces circular reference errors in some circumstances
+  DecoratedInstance = T.type_alias(T.untyped) # Would be T::Props, but that produces circular reference errors in some circumstances
+  PropType = T.type_alias(T.any(T::Types::Base, T::Props::CustomType))
+  PropTypeOrClass = T.type_alias(T.any(PropType, Module))
+end
+
+class T::Props::Decorator
+  def add_prop_definition(*args, &blk); end
+  def all_props(*args, &blk); end
+  def array_subdoc_type(*args, &blk); end
+  def check_prop_type(*args, &blk); end
+  def convert_type_to_class(*args, &blk); end
+  def decorated_class; end
+  def define_foreign_method(*args, &blk); end
+  def define_getter_and_setter(*args, &blk); end
+  def foreign_prop_get(*args, &blk); end
+  def get(*args, &blk); end
+  def handle_foreign_hint_only_option(*args, &blk); end
+  def handle_foreign_option(*args, &blk); end
+  def handle_redaction_option(*args, &blk); end
+  def hash_key_custom_type(*args, &blk); end
+  def hash_value_subdoc_type(*args, &blk); end
+  def initialize(klass); end
+  def is_nilable?(*args, &blk); end
+  def model_inherited(child); end
+  def mutate_prop_backdoor!(*args, &blk); end
+  def plugin(mod); end
+  def prop_defined(*args, &blk); end
+  def prop_get(*args, &blk); end
+  def prop_rules(*args, &blk); end
+  def prop_set(*args, &blk); end
+  def prop_validate_definition!(*args, &blk); end
+  def props; end
+  def self.method_added(name); end
+  def self.singleton_method_added(name); end
+  def set(*args, &blk); end
+  def shallow_clone_ok(*args, &blk); end
+  def smart_coerce(*args, &blk); end
+  def valid_props(*args, &blk); end
+  def validate_foreign_option(*args, &blk); end
+  def validate_not_missing_sensitivity(*args, &blk); end
+  def validate_prop_name(name); end
+  def validate_prop_value(*args, &blk); end
+  extend T::Sig
+end
+
+class T::Props::Decorator::NoRulesError < StandardError
+end
+class T::Props::Error < StandardError
+end
+class T::Props::InvalidValueError < T::Props::Error
+end
+class T::Props::ImmutableProp < T::Props::Error
+end
+
+module T::Props::Plugin
+  extend T::Helpers
+  include T::Props
+end
+
+module T::Props::Utils
+  def self.deep_clone_object(what, freeze: nil); end
+  def self.merge_serialized_optional_rule(prop_rules); end
+  def self.need_nil_write_check?(prop_rules); end
+  def self.optional_prop?(prop_rules); end
+  def self.required_prop?(prop_rules); end
+end
+
+module T::Props::Optional
+  include T::Props::Plugin
+end
+
+module T::Props::Optional::DecoratorMethods
+  def add_prop_definition(prop, rules); end
+  def compute_derived_rules(rules); end
+  def get_default(rules, instance_class); end
+  def has_default?(rules); end
+  def mutate_prop_backdoor!(prop, key, value); end
+  def prop_optional?(prop); end
+  def prop_validate_definition!(name, cls, rules, type); end
+  def valid_props; end
+end
+
+module T::Props::WeakConstructor
+  def initialize(hash = nil); end
+  include T::Props::Optional
+end
+
+module T::Props::Constructor
+  def initialize(hash = nil); end
+  include T::Props::WeakConstructor
+end
+
+module T::Props::PrettyPrintable
+  def inspect; end
+  def pretty_inspect; end
+  include T::Props::Plugin
+end
+
+module T::Props::PrettyPrintable::DecoratorMethods
+  def inspect_instance(instance, multiline: false, indent: '  ', &blk); end
+  def inspect_instance_components(instance, multiline:, indent:, &blk); end
+  def inspect_prop_value(instance, prop, multiline:, indent:, &blk); end
+  def join_props_with_pretty_values(pretty_kvs, multiline:, indent: '  ', &blk); end
+  def self.method_added(name); end
+  def self.singleton_method_added(name); end
+  def valid_props(&blk); end
+  extend T::Sig
+end
+
+module T::Props::Serializable
+  def deserialize(hash, strict = nil); end
+  def recursive_stringify_keys(obj); end
+  def required_prop_missing_from_deserialize(prop); end
+  def required_prop_missing_from_deserialize?(prop); end
+  def serialize(strict = nil); end
+  def with(changed_props); end
+  def with_existing_hash(changed_props, existing_hash:); end
+  include T::Props::Optional
+  include T::Props::Plugin
+  include T::Props::PrettyPrintable
+  mixes_in_class_methods(T::Props::Serializable::ClassMethods)
+end
+
+module T::Props::Serializable::DecoratorMethods
+  def add_prop_definition(prop, rules); end
+  def extra_props(instance); end
+  def from_hash(hash, strict = nil); end
+  def get_id(instance); end
+  def inspect_instance_components(instance, multiline:, indent:); end
+  def prop_by_serialized_forms; end
+  def prop_dont_store?(prop); end
+  def prop_serialized_form(prop); end
+  def prop_validate_definition!(name, cls, rules, type); end
+  def required_props; end
+  def serialized_form_prop(serialized_form); end
+  def valid_props; end
+end
+
+module T::Props::Serializable::ClassMethods
+  def from_hash!(hash); end
+  def from_hash(hash, strict = nil); end
+  def prop_by_serialized_forms; end
+end
+
+module T::Props::TypeValidation
+  include T::Props::Plugin
+end
+
+class T::Props::TypeValidation::UnderspecifiedType < ArgumentError
+end
+
+module T::Props::TypeValidation::DecoratorMethods
+  def find_invalid_subtype(*args, &blk); end
+  def prop_validate_definition!(*args, &blk); end
+  def self.method_added(name); end
+  def self.singleton_method_added(name); end
+  def type_error_message(*args, &blk); end
+  def valid_props(*args, &blk); end
+  def validate_type(*args, &blk); end
+  extend T::Sig
+end
+

--- a/rbi/sorbet/ttypes.rbi
+++ b/rbi/sorbet/ttypes.rbi
@@ -1,0 +1,169 @@
+# typed: strict
+
+# These model the runtime representations of Sorbet's type syntax.  This is
+# considered a private API and might be changed at any time without notice.
+
+module T::Types
+end
+
+class T::Types::Base
+  def self.method_added(method_name); end
+  def valid?(obj); end
+  def name; end
+  def subtype_of?(t2); end
+  def to_s; end
+  def describe_obj(obj); end
+  def error_message_for_obj(obj); end
+  def validate!(obj); end
+  def hash; end
+  def ==(other); end
+end
+
+class T::Types::Simple < T::Types::Base
+  def initialize(raw_type); end
+  def name; end
+  def valid?(obj); end
+  def raw_type; end
+end
+
+class T::Types::Union < T::Types::Base
+  def initialize(types); end
+  def name; end
+  def valid?(obj); end
+  def types; end
+end
+
+class T::Types::Intersection < T::Types::Base
+  def initialize(types); end
+  def name; end
+  def valid?(obj); end
+  def types; end
+end
+
+class T::Types::ClassOf < T::Types::Base
+  def initialize(type); end
+  def name; end
+  def valid?(obj); end
+  def subtype_of_single?(other); end
+  def describe_obj(obj); end
+  def type; end
+end
+
+class T::Types::FixedArray < T::Types::Base
+  def initialize(types); end
+  def name; end
+  def valid?(obj); end
+  def describe_obj(obj); end
+  def types; end
+end
+
+class T::Types::FixedHash < T::Types::Base
+  def initialize(types); end
+  def name; end
+  def valid?(obj); end
+  def describe_obj(obj); end
+  def types; end
+end
+
+class T::Types::Untyped < T::Types::Base
+  def initialize; end
+  def name; end
+  def valid?(obj); end
+end
+
+class T::Types::Proc < T::Types::Base
+  def initialize(arg_types, returns); end
+  def name; end
+  def valid?(obj); end
+  def arg_types; end
+  def returns; end
+end
+
+class T::Types::NoReturn < T::Types::Base
+  def initialize; end
+  def name; end
+  def valid?(obj); end
+end
+
+class T::Types::Enum < T::Types::Base
+  def initialize(values); end
+  def valid?(obj); end
+  def name; end
+  def describe_obj(obj); end
+  def values; end
+end
+
+class T::Types::SelfType < T::Types::Base
+  def initialize(); end
+  def name; end
+  def valid?(obj); end
+end
+
+# --- user-defined generics ---
+
+class T::Types::TypeVariable < T::Types::Base
+  def initialize(variance); end
+  def name; end
+  def subtype_of_single?(type); end
+  def valid?(obj); end
+  def variance; end
+end
+
+class T::Types::TypeMember < T::Types::TypeVariable
+end
+
+class T::Types::TypeTemplate < T::Types::TypeVariable
+end
+
+class T::Types::TypeParameter < T::Types::Base
+  def initialize(name); end
+  def valid?(obj); end
+  def subtype_of_single?(type); end
+  def name; end
+end
+
+# --- stdlib generics ---
+
+class T::Types::TypedArray < T::Types::TypedEnumerable
+  def name; end
+  def valid?(obj); end
+  def new(*args); end
+end
+
+class T::Types::TypedHash < T::Types::TypedEnumerable
+  def initialize(keys:, values:); end
+  def name; end
+  def valid?(obj); end
+  def keys; end
+  def values; end
+end
+
+class T::Types::TypedEnumerable < T::Types::Base
+  def initialize(type); end
+  def name; end
+  def valid?(obj); end
+  def describe_obj(obj); end
+  def type; end
+end
+
+class T::Types::TypedSet < T::Types::TypedEnumerable
+  def name; end
+  def valid?(obj); end
+  def new(*args); end
+  def type; end
+end
+
+class T::Types::TypedRange < T::Types::TypedEnumerable
+  def name; end
+  def valid?(obj); end
+  def new(*args); end
+  def type; end
+end
+
+class T::Types::TypedEnumerator < T::Types::TypedEnumerable
+  def name; end
+  def valid?(obj); end
+  def new(*args); end
+  def type; end
+end
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

After we removed extn/types/ from pay-server, we created an RBI file for all
the things that Sorbet used to see via the sources directly.

Instead of living in pay-server, those RBI definition should live in Sorbet
itself so that everyone can benefit from them.

One thing we might want to do in the future is typecheck the source code, which
would cause method redefinition errors in CI if we updated the source in a way
that was no longer compatible with our RBIs.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I built a release build of Sorbet and tested against pay-server.
It even passes when I delete the RBI file in pay-server.