### PR TITLE
runtime: Give type memebers a free pass for override checks

### DIFF
--- a/gems/sorbet-runtime/test/types/validate_override_types.rb
+++ b/gems/sorbet-runtime/test/types/validate_override_types.rb
@@ -95,6 +95,21 @@ module Opus::Types::Test
 
         GenericReturnSub[NilClass].new.foo(SubFoo1.new, kw: SubFoo2.new)
       end
+
+      it "fails when the return type is Array[Elem]" do
+        class GenericReturnArrayElemSub < SuccessBase
+          extend T::Generic
+          Elem = type_member
+          sig {override.params(pos: SubFoo1, kw: SubFoo2).returns(Array[Elem])}
+          def foo(pos, kw:); end
+        end
+
+        err = assert_raises(RuntimeError) do
+          GenericReturnArrayElemSub[NilClass].new.foo(SubFoo1.new, kw: SubFoo2.new)
+        end
+
+        assert_includes(err.message, "Incompatible return type in override of method `foo`")
+      end
     end
 
     describe "overriding when a type member is in the base class method signature" do

--- a/gems/sorbet-runtime/test/types/validate_override_types.rb
+++ b/gems/sorbet-runtime/test/types/validate_override_types.rb
@@ -58,6 +58,103 @@ module Opus::Types::Test
       klass.new.foo(SubFoo1.new, kw: SubFoo2.new)
     end
 
+    describe "overriding with a type member in the subclass" do
+      it "succeeds when a positional param is a type member in the subclass" do
+        class GenericPositionalSub < SuccessBase
+          extend T::Generic
+          Elem = type_member
+          sig {override.params(pos: Elem, kw: SubFoo2).returns(BaseFoo3)}
+          def foo(pos, kw:)
+            BaseFoo3.new
+          end
+        end
+
+        GenericPositionalSub[NilClass].new.foo(nil, kw: SubFoo2.new)
+      end
+
+      it "succeeds when a keyword param is a type member in the subclass" do
+        class GenericKeywordSub < SuccessBase
+          extend T::Generic
+          Elem = type_member
+          sig {override.params(pos: SubFoo1, kw: Elem).returns(BaseFoo3)}
+          def foo(pos, kw:)
+            BaseFoo3.new
+          end
+        end
+
+        GenericKeywordSub[NilClass].new.foo(SubFoo1.new, kw: nil)
+      end
+
+      it "succeeds when the return type is a type member in the subclass" do
+        class GenericReturnSub < SuccessBase
+          extend T::Generic
+          Elem = type_member
+          sig {override.params(pos: SubFoo1, kw: SubFoo2).returns(Elem)}
+          def foo(pos, kw:); end
+        end
+
+        GenericReturnSub[NilClass].new.foo(SubFoo1.new, kw: SubFoo2.new)
+      end
+    end
+
+    describe "overriding when a type member is in the base class method signature" do
+      it "succeeds when a positional param is a type member in the base class" do
+        class GenericPositionalBase
+          extend T::Generic
+          extend T::Sig
+          Elem = type_member
+          sig {overridable.params(pos: Elem).void}
+          def foo(pos); end
+        end
+
+        class GenericPositionalSub2 < GenericPositionalBase
+          Elem = type_member(fixed: T::Array[String])
+          sig {override.params(pos: T::Array[String]).void}
+          def foo(pos); end
+        end
+
+        GenericPositionalSub2.new.foo(["hi"])
+      end
+
+      it "succeeds when a keyword param is a type member in the base class" do
+        class GenericKeywordBase
+          extend T::Generic
+          extend T::Sig
+          Elem = type_member
+          sig {overridable.params(key: Elem).void}
+          def foo(key:); end
+        end
+
+        class GenericKeywordSub2 < GenericKeywordBase
+          Elem = type_member(fixed: T::Array[String])
+          sig {override.params(key: T::Array[String]).void}
+          def foo(key:); end
+        end
+
+        GenericKeywordSub2.new.foo(key: ["hello"])
+      end
+
+      it "succeeds when the return type in the base class is a type member" do
+        class GenericReturnBase
+          extend T::Generic
+          extend T::Sig
+          Elem = type_member
+          sig {overridable.returns(Elem)}
+          def foo; end
+        end
+
+        class GenericReturnSub2 < GenericReturnBase
+          Elem = type_member(fixed: T::Array[String])
+          sig {override.returns(T::Array[String])}
+          def foo
+            ["greetings"]
+          end
+        end
+
+        GenericReturnSub2.new.foo
+      end
+    end
+
     it "raises if a positional param type is covariant" do
       klass = Class.new(FailureBase) do
         extend T::Sig

--- a/gems/sorbet-runtime/test/types/validate_override_types.rb
+++ b/gems/sorbet-runtime/test/types/validate_override_types.rb
@@ -96,11 +96,11 @@ module Opus::Types::Test
         GenericReturnSub[NilClass].new.foo(SubFoo1.new, kw: SubFoo2.new)
       end
 
-      it "fails when the return type is Array[Elem]" do
+      it "fails when the return type is T::Array[Elem]" do
         class GenericReturnArrayElemSub < SuccessBase
           extend T::Generic
           Elem = type_member
-          sig {override.params(pos: SubFoo1, kw: SubFoo2).returns(Array[Elem])}
+          sig {override.params(pos: SubFoo1, kw: SubFoo2).returns(T::Array[Elem])}
           def foo(pos, kw:); end
         end
 


### PR DESCRIPTION
I get a confusing sig validation failure with the following
```ruby
require 'sorbet-runtime'

module AbstractGenericModule
  extend T::Generic
  extend T::Sig
  interface!

  C = type_member
  sig {abstract.returns(C)}
  def hi; end
end

class Foo
  extend T::Generic
  extend T::Sig
  include AbstractGenericModule

  C = type_member(fixed: String)

  sig {implementation.returns(String)}
  def hi
    "hi"
  end
end

Foo.new.hi
```

```
* Base: `T.untyped` (in AbstractGenericModule at repro.rb:10)
* Implementation: `String` (in Foo at repro.rb:21)
(The types must be covariant.)
```

If the base were actually `T.untyped` this error doesn't happen.
Type members show up as untyped in the error but were not actually
treated like untyped during subtype checking.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Be more permissive with generic interfaces. Also fix a confusing error message (String is in fact covariant with T.untyped).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
