### PR TITLE
Make Hash#merge variadic

### DIFF
--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -235,13 +235,13 @@ class Hash < Object
   def member?(arg0); end
 
   sig do
-    type_parameters(:A, :B).params(
+    type_parameters(:A ,:B).params(
         arg0: T::Hash[T.type_parameter(:A), T.type_parameter(:B)],
     )
     .returns(T::Hash[T.any(T.type_parameter(:A), K), T.any(T.type_parameter(:B), V)])
   end
   sig do
-    type_parameters(:A, :B).params(
+    type_parameters(:A ,:B).params(
         arg0: T::Hash[T.type_parameter(:A), T.type_parameter(:B)],
         blk: T.proc.params(arg0: K, arg1: V, arg2: T.type_parameter(:B)).returns(T.any(V, T.type_parameter(:B))),
     )

--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -235,19 +235,19 @@ class Hash < Object
   def member?(arg0); end
 
   sig do
-    type_parameters(:A ,:B).params(
+    type_parameters(:A, :B).params(
         arg0: T::Hash[T.type_parameter(:A), T.type_parameter(:B)],
     )
     .returns(T::Hash[T.any(T.type_parameter(:A), K), T.any(T.type_parameter(:B), V)])
   end
   sig do
-    type_parameters(:A ,:B).params(
+    type_parameters(:A, :B).params(
         arg0: T::Hash[T.type_parameter(:A), T.type_parameter(:B)],
         blk: T.proc.params(arg0: K, arg1: V, arg2: T.type_parameter(:B)).returns(T.any(V, T.type_parameter(:B))),
     )
     .returns(T::Hash[T.any(T.type_parameter(:A), K), T.any(T.type_parameter(:B), V)])
   end
-  def merge(arg0, &blk); end
+  def merge(*arg0, &blk); end
 
   sig do
     params(

--- a/test/testdata/rbi/hash.rb
+++ b/test/testdata/rbi/hash.rb
@@ -24,3 +24,5 @@ T.assert_type!(
   my_hash.fetch("doesnt_exist", "foo"),
   String
 )
+
+{a: 1}.merge({b: 2}, {c: 3})


### PR DESCRIPTION
`Hash#merge` became [variadic](https://ruby-doc.org/core-2.6.3/Hash.html#method-i-merge) in Ruby 2.6.