### PR TITLE
Update a comment

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/final.rb
+++ b/gems/sorbet-runtime/lib/types/private/final.rb
@@ -34,6 +34,7 @@ module T::Private::Final
     mod.extend(mod.is_a?(Class) ? NoInherit : NoIncludeExtend)
     mark_as_final_module(mod)
     mark_as_final_module(mod.singleton_class)
+    T::Private::Methods.add_module_with_final(mod)
     T::Private::Methods.install_hooks(mod)
   end
 
@@ -43,6 +44,5 @@ module T::Private::Final
 
   private_class_method def self.mark_as_final_module(mod)
     mod.instance_variable_set(:@sorbet_final_module, true)
-    T::Private::Methods.add_module_with_final(mod)
   end
 end

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -11,8 +11,11 @@ module T::Private::Methods
   # - they are done possibly before any sig block has run.
   # - they are done even if the method being defined doesn't have a sig.
   @final_methods = Set.new
-  # if a module directly defines a final method, or includes, extends, or inherits from a module which does so, then it
-  # should be in this set.
+  # a module-with-final is a module for which at least one of the following is true:
+  # - is declared final
+  # - defines a method that is declared final
+  # - includes an module-with-final
+  # - extends an module-with-final
   @modules_with_final = Set.new
   @old_included_extended = nil
 


### PR DESCRIPTION
When investigating the performance of the final checks, a thought I had was that we could add the following diff:

```diff
diff --git a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
index 8e51c93e..b49cf707 100644
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -126,6 +126,9 @@ module T::Private::Methods
   # the final instance methods of target and source_method_names. so, for every m in source_method_names, check if there
   # is already a method defined on one of target_ancestors with the same name that is final.
   def self._check_final_ancestors(target, target_ancestors, source_method_names)
+    if !module_with_final?(target)
+      return
+    end
     # use reverse_each to check farther-up ancestors first, for better error messages. we could avoid this if we were on
     # the version of ruby that adds the optional argument to method_defined? that allows you to exclude ancestors.
     target_ancestors.reverse_each do |ancestor|
```
which would allow us change `_check_final_ancestors` to be just a hash lookup in many cases. This would save us from having to calculate the ancestors of every module every time we say "def".

When testing to see if this diff would make the checks faster or not, I noticed that applying this diff actually causes us to lose correctness in some situations. This led me to notice that the comment about what modules `@modules_with_final` contains is not accurate. Specifically:

- It does not mention anything about the `singleton_class`es of modules being in the set, when they were in certain cases.
- It says that if class A inherits from class B and B is in the set, then A is in the set. This is currently false.

Because I'm not actually sure whether adding the diff shown above would make the checks faster or slower, this PR only does two things:

- Stop adding the `singleton_class`es when we don't need to. (But see below).
- Update the comment to be accurate.

Note that if we do want to add that diff, we will probably have to do the following two things:

- Do add the singleton_classes to the set in certain cases.
- Listen in on `Class`'s `inherited` and do something similar to what we're doing on `Module`'s `included` and `extended`.

### Motivation
To make a comment more accurate.

### Test plan
No test changes.