### PR TITLE
Remove Struct and File from silenced type arity errors

### DIFF
--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -560,8 +560,7 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
             bool silenceGenericError =
                 maybeAliased == core::Symbols::Hash() || maybeAliased == core::Symbols::Array() ||
                 maybeAliased == core::Symbols::Set() || maybeAliased == core::Symbols::Range() ||
-                maybeAliased == core::Symbols::Enumerable() || maybeAliased == core::Symbols::Enumerator() ||
-                maybeAliased == core::Symbols::File();
+                maybeAliased == core::Symbols::Enumerable() || maybeAliased == core::Symbols::Enumerator();
             // TODO: reduce this^^^ set.
             auto sym = maybeAliased.data(ctx)->dealias(ctx);
             if (sym.data(ctx)->isClass()) {

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -561,7 +561,7 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
                 maybeAliased == core::Symbols::Hash() || maybeAliased == core::Symbols::Array() ||
                 maybeAliased == core::Symbols::Set() || maybeAliased == core::Symbols::Range() ||
                 maybeAliased == core::Symbols::Enumerable() || maybeAliased == core::Symbols::Enumerator() ||
-                maybeAliased == core::Symbols::Struct() || maybeAliased == core::Symbols::File();
+                maybeAliased == core::Symbols::File();
             // TODO: reduce this^^^ set.
             auto sym = maybeAliased.data(ctx)->dealias(ctx);
             if (sym.data(ctx)->isClass()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

<https://github.com/sorbet/sorbet/blob/9c0a72ea11ba3f20d73dc75b019e4420d52dcdb6/core/Symbols.cc#L900-L909>

^ This function makes mentioning `Struct` and `File` here unnecessary because:


https://github.com/sorbet/sorbet/blob/9c0a72ea11ba3f20d73dc75b019e4420d52dcdb6/rbi/core/struct.rbi#L7

and

https://github.com/sorbet/sorbet/blob/fd8d6c63a2a2df17864e38dc16ddb38690f1e5be/rbi/core/file.rbi#L44


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested on pay-server locally.