### PR TITLE
Add a new error for dynamic constant assignment

### DIFF
--- a/core/errors/namer.h
+++ b/core/errors/namer.h
@@ -19,6 +19,7 @@ constexpr ErrorClass InterfaceClass{4013, StrictLevel::False};
 constexpr ErrorClass DynamicConstant{4014, StrictLevel::False};
 constexpr ErrorClass InvalidClassOwner{4015, StrictLevel::False};
 constexpr ErrorClass RootTypeMember{4016, StrictLevel::False};
+constexpr ErrorClass DynamicConstantAssignment{4017, StrictLevel::False};
 } // namespace sorbet::core::errors::Namer
 
 #endif

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -618,7 +618,14 @@ public:
     }
 
     unique_ptr<ast::Assign> fillAssign(core::MutableContext ctx, unique_ptr<ast::Assign> asgn) {
-        // TODO(nelhage): forbid dynamic constant definition
+
+        // forbid dynamic constant definition
+        if (!ctx.owner.data(ctx)->isClass()) {
+            if (auto e = ctx.state.beginError(asgn->loc, core::errors::Namer::DynamicConstant)) {
+                e.setHeader("Dynamic constant assignment");
+            }
+        }
+
         auto lhs = ast::cast_tree<ast::UnresolvedConstantLit>(asgn->lhs.get());
         ENFORCE(lhs);
         core::SymbolRef scope = squashNames(ctx, contextClass(ctx, ctx.owner), lhs->scope);

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -620,7 +620,7 @@ public:
     unique_ptr<ast::Assign> fillAssign(core::MutableContext ctx, unique_ptr<ast::Assign> asgn) {
         // forbid dynamic constant definition
         if (!ctx.owner.data(ctx)->isClass()) {
-            if (auto e = ctx.state.beginError(asgn->loc, core::errors::Namer::DynamicConstant)) {
+            if (auto e = ctx.state.beginError(asgn->loc, core::errors::Namer::DynamicConstantAssignment)) {
                 e.setHeader("Dynamic constant assignment");
             }
         }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -618,7 +618,6 @@ public:
     }
 
     unique_ptr<ast::Assign> fillAssign(core::MutableContext ctx, unique_ptr<ast::Assign> asgn) {
-
         // forbid dynamic constant definition
         if (!ctx.owner.data(ctx)->isClass()) {
             if (auto e = ctx.state.beginError(asgn->loc, core::errors::Namer::DynamicConstant)) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -619,7 +619,8 @@ public:
 
     unique_ptr<ast::Assign> fillAssign(core::MutableContext ctx, unique_ptr<ast::Assign> asgn) {
         // forbid dynamic constant definition
-        if (!ctx.owner.data(ctx)->isClass()) {
+        auto ownerData = ctx.owner.data(ctx);
+        if (!ownerData->isClass() && !ownerData->isDSLSynthesized()) {
             if (auto e = ctx.state.beginError(asgn->loc, core::errors::Namer::DynamicConstantAssignment)) {
                 e.setHeader("Dynamic constant assignment");
             }

--- a/test/testdata/dsl/minitest.rb
+++ b/test/testdata/dsl/minitest.rb
@@ -7,6 +7,10 @@ class MyTest
         outside_method
     end
 
+    it "allows constants inside of IT" do
+      CONST = 10
+    end
+
     describe "some inner tests" do
         def inside_method
         end

--- a/test/testdata/dsl/minitest.rb.dsl-tree.exp
+++ b/test/testdata/dsl/minitest.rb.dsl-tree.exp
@@ -8,6 +8,10 @@ class <emptyTree><<C <root>>> < ()
       <self>.outside_method()
     end
 
+    def <test_allows constants inside of IT><<C <todo sym>>>(&<blk>)
+      <emptyTree>::<C CONST> = 10
+    end
+
     class <emptyTree>::<C <class_some inner tests>><<C <todo sym>>> < (<self>)
       begin
         def inside_method<<C <todo sym>>>(&<blk>)

--- a/test/testdata/namer/constant_in_block.rb
+++ b/test/testdata/namer/constant_in_block.rb
@@ -1,15 +1,17 @@
 # typed: true
 class A
-  
+
   def self.foo
     foo do
     C = 1 # this is parse error in Ruby, but not in Sorbet
+  # ^^^^^ error: Dynamic constant assignment
     C # error: Unable to resolve constant
     end
   end
-  
+
   [].each do
     B = 1
+  # ^^^^^ error: Dynamic constant assignment
     B
   end
 end

--- a/test/testdata/namer/constant_in_block.rb
+++ b/test/testdata/namer/constant_in_block.rb
@@ -11,7 +11,6 @@ class A
 
   [].each do
     B = 1
-  # ^^^^^ error: Dynamic constant assignment
     B
   end
 end

--- a/test/testdata/namer/constant_in_block.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/constant_in_block.rb.symbol-table-raw.exp
@@ -1,8 +1,8 @@
 class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4})
   class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/namer/constant_in_block.rb start=2:1 end=2:8}
-    static-field <C <U A>><C <U B>> -> Integer(1) @ Loc {file=test/testdata/namer/constant_in_block.rb start=12:5 end=12:6}
+    static-field <C <U A>><C <U B>> -> Integer(1) @ Loc {file=test/testdata/namer/constant_in_block.rb start=13:5 end=13:6}
   class <S <C <U A>> $1> < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/constant_in_block.rb start=2:7 end=2:8}
-    method <S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/constant_in_block.rb start=2:1 end=15:4}
+    method <S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/constant_in_block.rb start=2:1 end=17:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/constant_in_block.rb start=??? end=???}
     static-field <S <C <U A>> $1><C <U C>> -> Integer(1) @ Loc {file=test/testdata/namer/constant_in_block.rb start=6:5 end=6:6}
     method <S <C <U A>> $1><U foo> (<blk>) @ Loc {file=test/testdata/namer/constant_in_block.rb start=4:3 end=4:15}

--- a/test/testdata/namer/constant_in_block.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/constant_in_block.rb.symbol-table-raw.exp
@@ -1,10 +1,10 @@
 class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4})
-  class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/namer/constant_in_block.rb start=2:1 end=2:8}
-    static-field <C <U A>><C <U B>> -> Integer(1) @ Loc {file=test/testdata/namer/constant_in_block.rb start=13:5 end=13:6}
-  class <S <C <U A>> $1> < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/constant_in_block.rb start=2:7 end=2:8}
-    method <S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/constant_in_block.rb start=2:1 end=17:4}
+  class <C <U A>> < <C <U <todo sym>>> () @ Loc {file=test/testdata/namer/constant_in_block.rb start=2:1 end=2:8}
+    static-field <C <U A>><C <U B>> @ Loc {file=test/testdata/namer/constant_in_block.rb start=13:5 end=13:6}
+  class <S <C <U A>> $1> < <C <U <todo sym>>> () @ Loc {file=test/testdata/namer/constant_in_block.rb start=2:7 end=2:8}
+    method <S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/constant_in_block.rb start=2:1 end=16:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/constant_in_block.rb start=??? end=???}
-    static-field <S <C <U A>> $1><C <U C>> -> Integer(1) @ Loc {file=test/testdata/namer/constant_in_block.rb start=6:5 end=6:6}
+    static-field <S <C <U A>> $1><C <U C>> @ Loc {file=test/testdata/namer/constant_in_block.rb start=6:5 end=6:6}
     method <S <C <U A>> $1><U foo> (<blk>) @ Loc {file=test/testdata/namer/constant_in_block.rb start=4:3 end=4:15}
       argument <blk><block> @ Loc {file=test/testdata/namer/constant_in_block.rb start=??? end=???}
 

--- a/test/testdata/namer/constant_in_block.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/constant_in_block.rb.symbol-table-raw.exp
@@ -1,10 +1,10 @@
 class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4})
-  class <C <U A>> < <C <U <todo sym>>> () @ Loc {file=test/testdata/namer/constant_in_block.rb start=2:1 end=2:8}
-    static-field <C <U A>><C <U B>> @ Loc {file=test/testdata/namer/constant_in_block.rb start=13:5 end=13:6}
-  class <S <C <U A>> $1> < <C <U <todo sym>>> () @ Loc {file=test/testdata/namer/constant_in_block.rb start=2:7 end=2:8}
+  class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/namer/constant_in_block.rb start=2:1 end=2:8}
+    static-field <C <U A>><C <U B>> -> Integer(1) @ Loc {file=test/testdata/namer/constant_in_block.rb start=13:5 end=13:6}
+  class <S <C <U A>> $1> < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/constant_in_block.rb start=2:7 end=2:8}
     method <S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/constant_in_block.rb start=2:1 end=16:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/constant_in_block.rb start=??? end=???}
-    static-field <S <C <U A>> $1><C <U C>> @ Loc {file=test/testdata/namer/constant_in_block.rb start=6:5 end=6:6}
+    static-field <S <C <U A>> $1><C <U C>> -> Integer(1) @ Loc {file=test/testdata/namer/constant_in_block.rb start=6:5 end=6:6}
     method <S <C <U A>> $1><U foo> (<blk>) @ Loc {file=test/testdata/namer/constant_in_block.rb start=4:3 end=4:15}
       argument <blk><block> @ Loc {file=test/testdata/namer/constant_in_block.rb start=??? end=???}
 

--- a/test/testdata/namer/dynamic_constant.rb
+++ b/test/testdata/namer/dynamic_constant.rb
@@ -1,0 +1,8 @@
+# typed: false
+
+class A
+  def self.foo
+    X = 10
+  # ^^^^^^ error: Dynamic constant assignment
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Dynamic constant assignment is a runtime error in ruby, and we currently have partial support for ruling them out. This change forbids them in the context of a method definition.

Fixes #105

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
