### PR TITLE
Rename

### DIFF
--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -32,14 +32,14 @@ module T::Configuration
   #   def foo; end
   # end
   # ```
-  def self.enable_final_checks_for_include_extend
-    T::Private::Methods.set_final_checks_for_include_extend(true)
+  def self.enable_final_checks_on_hooks
+    T::Private::Methods.set_final_checks_on_hooks(true)
   end
 
   # Undo the effects of a previous call to
-  # `enable_final_checks_for_include_extend`.
-  def self.reset_final_checks_for_include_extend
-    T::Private::Methods.set_final_checks_for_include_extend(false)
+  # `enable_final_checks_on_hooks`.
+  def self.reset_final_checks_on_hooks
+    T::Private::Methods.set_final_checks_on_hooks(false)
   end
 
   # Configure the default checked level for a sig with no explicit `.checked`

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -3,12 +3,12 @@ require_relative '../test_helper'
 
 class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   before do
-    T::Configuration.enable_final_checks_for_include_extend
+    T::Configuration.enable_final_checks_on_hooks
   end
 
   after do
     T::Private::DeclState.current.reset!
-    T::Configuration.reset_final_checks_for_include_extend
+    T::Configuration.reset_final_checks_on_hooks
   end
 
   it "allows declaring an instance method as final" do

--- a/gems/sorbet-runtime/test/types/final_module.rb
+++ b/gems/sorbet-runtime/test/types/final_module.rb
@@ -3,12 +3,12 @@ require_relative '../test_helper'
 
 class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
   before do
-    T::Configuration.enable_final_checks_for_include_extend
+    T::Configuration.enable_final_checks_on_hooks
   end
 
   after do
     T::Private::DeclState.current.reset!
-    T::Configuration.reset_final_checks_for_include_extend
+    T::Configuration.reset_final_checks_on_hooks
   end
 
   it "allows declaring a class as final" do


### PR DESCRIPTION
### Motivation
This renames some methods to be shorter. The methods now also don't mention include and extend, which is good because if we want to use this method in the future to attach a hook to `Class#inherited` (see #1327), we don't have to rename this method again.

### Test plan
Tests updated.