### PR TITLE
Make bare stdlib generics an error in strict mode

### DIFF
--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -49,6 +49,8 @@ constexpr ErrorClass SubclassingNotAllowed{5041, StrictLevel::False};
 constexpr ErrorClass NonPublicAbstract{5042, StrictLevel::True};
 constexpr ErrorClass InvalidTypeAlias{5043, StrictLevel::False};
 constexpr ErrorClass InvalidVariance{5044, StrictLevel::True};
+constexpr ErrorClass GenericClassWithoutTypeArgs{5045, StrictLevel::False};
+constexpr ErrorClass GenericClassWithoutTypeArgsStdlib{5046, StrictLevel::Strict};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -557,13 +557,12 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
                 result.type = maybeAliased.data(ctx)->resultType;
                 return;
             }
-            bool silenceGenericError =
-                maybeAliased == core::Symbols::Hash() || maybeAliased == core::Symbols::Array() ||
-                maybeAliased == core::Symbols::Set() || maybeAliased == core::Symbols::Range() ||
-                maybeAliased == core::Symbols::Enumerable() || maybeAliased == core::Symbols::Enumerator();
             // TODO: reduce this^^^ set.
             auto sym = maybeAliased.data(ctx)->dealias(ctx);
             if (sym.data(ctx)->isClass()) {
+                bool silenceGenericError = sym == core::Symbols::Hash() || sym == core::Symbols::Array() ||
+                                           sym == core::Symbols::Set() || sym == core::Symbols::Range() ||
+                                           sym == core::Symbols::Enumerable() || sym == core::Symbols::Enumerator();
                 if (sym.data(ctx)->typeArity(ctx) > 0 && !silenceGenericError) {
                     if (auto e = ctx.state.beginError(i->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                         e.setHeader("Malformed type declaration. Generic class without type arguments `{}`",

--- a/test/cli/autocorrect-private/autocorrect-private.sh
+++ b/test/cli/autocorrect-private/autocorrect-private.sh
@@ -17,4 +17,4 @@ echo
 cat autocorrect-private.rb
 
 rm autocorrect-private.rb
-rm "$tmp"
+rm -rf "$tmp"

--- a/test/cli/correct-bare-stdlib-generics/correct-bare-stdlib-generics.out
+++ b/test/cli/correct-bare-stdlib-generics/correct-bare-stdlib-generics.out
@@ -1,0 +1,68 @@
+correct-bare-stdlib-generics.rb:8: Malformed type declaration. Generic class without type arguments `Array` https://srb.help/5046
+     8 |      a: Array,
+                 ^^^^^
+  Autocorrect: Done
+    correct-bare-stdlib-generics.rb:8: Replaced with `T::Array[T.untyped]`
+     8 |      a: Array,
+                 ^^^^^
+
+correct-bare-stdlib-generics.rb:9: Malformed type declaration. Generic class without type arguments `Hash` https://srb.help/5046
+     9 |      b: Hash,
+                 ^^^^
+  Autocorrect: Done
+    correct-bare-stdlib-generics.rb:9: Replaced with `T::Hash[T.untyped, T.untyped]`
+     9 |      b: Hash,
+                 ^^^^
+
+correct-bare-stdlib-generics.rb:10: Malformed type declaration. Generic class without type arguments `Set` https://srb.help/5046
+    10 |      c: Set,
+                 ^^^
+  Autocorrect: Done
+    correct-bare-stdlib-generics.rb:10: Replaced with `T::Set[T.untyped]`
+    10 |      c: Set,
+                 ^^^
+
+correct-bare-stdlib-generics.rb:11: Malformed type declaration. Generic class without type arguments `Range` https://srb.help/5046
+    11 |      d: Range,
+                 ^^^^^
+  Autocorrect: Done
+    correct-bare-stdlib-generics.rb:11: Replaced with `T::Range[T.untyped]`
+    11 |      d: Range,
+                 ^^^^^
+
+correct-bare-stdlib-generics.rb:12: Malformed type declaration. Generic class without type arguments `Enumerable` https://srb.help/5046
+    12 |      e: Enumerable,
+                 ^^^^^^^^^^
+  Autocorrect: Done
+    correct-bare-stdlib-generics.rb:12: Replaced with `T::Enumerable[T.untyped]`
+    12 |      e: Enumerable,
+                 ^^^^^^^^^^
+
+correct-bare-stdlib-generics.rb:13: Malformed type declaration. Generic class without type arguments `Enumerator` https://srb.help/5046
+    13 |      f: Enumerator,
+                 ^^^^^^^^^^
+  Autocorrect: Done
+    correct-bare-stdlib-generics.rb:13: Replaced with `T::Enumerator[T.untyped]`
+    13 |      f: Enumerator,
+                 ^^^^^^^^^^
+Errors: 6
+
+--------------------------------------------------------------------------
+
+# typed: strict
+
+module StdlibTest
+  extend T::Sig
+
+  sig do
+    params(
+      a: T::Array[T.untyped],
+      b: T::Hash[T.untyped, T.untyped],
+      c: T::Set[T.untyped],
+      d: T::Range[T.untyped],
+      e: T::Enumerable[T.untyped],
+      f: T::Enumerator[T.untyped],
+    )
+    .void
+  end
+end

--- a/test/cli/correct-bare-stdlib-generics/correct-bare-stdlib-generics.out
+++ b/test/cli/correct-bare-stdlib-generics/correct-bare-stdlib-generics.out
@@ -65,4 +65,5 @@ module StdlibTest
     )
     .void
   end
+  def foo(a, b, c, d, e, f); end
 end

--- a/test/cli/correct-bare-stdlib-generics/correct-bare-stdlib-generics.rb
+++ b/test/cli/correct-bare-stdlib-generics/correct-bare-stdlib-generics.rb
@@ -1,0 +1,18 @@
+# typed: strict
+
+module StdlibTest
+  extend T::Sig
+
+  sig do
+    params(
+      a: Array,
+      b: Hash,
+      c: Set,
+      d: Range,
+      e: Enumerable,
+      f: Enumerator,
+    )
+    .void
+  end
+  def foo(a, b, c, d, e, f); end
+end

--- a/test/cli/correct-bare-stdlib-generics/correct-bare-stdlib-generics.sh
+++ b/test/cli/correct-bare-stdlib-generics/correct-bare-stdlib-generics.sh
@@ -16,4 +16,4 @@ echo
 cat correct-bare-stdlib-generics.rb
 
 rm correct-bare-stdlib-generics.rb
-rm "$tmp"
+rm -r "$tmp"

--- a/test/cli/correct-bare-stdlib-generics/correct-bare-stdlib-generics.sh
+++ b/test/cli/correct-bare-stdlib-generics/correct-bare-stdlib-generics.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+tmp="$(mktemp -d)"
+infile="test/cli/correct-bare-stdlib-generics/correct-bare-stdlib-generics.rb"
+cp "$infile" "$tmp"
+
+cwd="$(pwd)"
+cd "$tmp" || exit 1
+
+"$cwd/main/sorbet" --silence-dev-message -a correct-bare-stdlib-generics.rb 2>&1
+
+echo
+echo --------------------------------------------------------------------------
+echo
+
+cat correct-bare-stdlib-generics.rb
+
+rm correct-bare-stdlib-generics.rb
+rm "$tmp"

--- a/test/cli/suggest-sig-garbage/suggest-sig-garbage.sh
+++ b/test/cli/suggest-sig-garbage/suggest-sig-garbage.sh
@@ -17,4 +17,4 @@ echo
 cat suggest-sig-garbage.rb
 
 rm suggest-sig-garbage.rb
-rm "$tmp"
+rm -r "$tmp"

--- a/test/cli/suggest-sig-literal/suggest-sig-literal.sh
+++ b/test/cli/suggest-sig-literal/suggest-sig-literal.sh
@@ -17,4 +17,4 @@ echo
 cat suggest-sig-literal.rb
 
 rm suggest-sig-literal.rb
-rm "$tmp"
+rm -r "$tmp"

--- a/test/cli/suggest-t-let/suggest-t-let.sh
+++ b/test/cli/suggest-t-let/suggest-t-let.sh
@@ -17,4 +17,4 @@ echo
 cat suggest-t-let.rb
 
 rm suggest-t-let.rb
-rm "$tmp"
+rm -r "$tmp"

--- a/test/cli/suggest-type-alias/suggest-type-alias.sh
+++ b/test/cli/suggest-type-alias/suggest-type-alias.sh
@@ -16,4 +16,4 @@ echo
 cat suggest-type-alias.rb
 
 rm suggest-type-alias.rb
-rm "$tmp"
+rm -r "$tmp"

--- a/test/testdata/resolver/bare_generics.rb
+++ b/test/testdata/resolver/bare_generics.rb
@@ -5,18 +5,36 @@ class Foo
 end
 
 module Test
-    extend T::Sig
+  extend T::Sig
 
-    sig do
-      params(a: Foo) # error: Generic class without type arguments
-      .returns(Foo) # error: Generic class without type arguments
-    end
-    def run(a)
-	spec = {
-          api_method: api_method.short_name, # error: does not exist on `Test`
-        }
-	cspec = spec.clone
-	cspec[:params] = 1
-	a
-    end
+  sig do
+    params(a: Foo) # error: Generic class without type arguments
+    .returns(Foo) # error: Generic class without type arguments
+  end
+  def run(a)
+    spec = {
+      api_method: api_method.short_name, # error: does not exist on `Test`
+    }
+    cspec = spec.clone
+    cspec[:params] = 1
+    a
+  end
+end
+
+module StdlibTest
+  extend T::Sig
+
+  # These are not errors at typed: true, but they are at typed: strict
+  sig do
+    params(
+      a: Array,
+      b: Hash,
+      c: Set,
+      d: Range,
+      e: Enumerable,
+      f: Enumerator,
+    )
+    .void
+  end
+  def foo(a, b, c, d, e, f); end
 end

--- a/test/testdata/resolver/bare_generics_strict.rb
+++ b/test/testdata/resolver/bare_generics_strict.rb
@@ -1,0 +1,19 @@
+# typed: strict
+
+module StdlibTest
+  extend T::Sig
+
+  # These are not errors at typed: true, but they are at typed: strict
+  sig do
+    params(
+      a: Array, # error: Generic class without type arguments
+      b: Hash, # error: Generic class without type arguments
+      c: Set, # error: Generic class without type arguments
+      d: Range, # error: Generic class without type arguments
+      e: Enumerable, # error: Generic class without type arguments
+      f: Enumerator, # error: Generic class without type arguments
+    )
+    .void
+  end
+  def foo(a, b, c, d, e, f); end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We discussed on Slack that they should either all be allowed, or all
disallowed from omitting the type argument. This was implemented in #1309.

But we don't want to encourage this behavior, so we want to introduce an error
that makes these things explicit. This only affects strict mode. I've also
added an autocorrect to ease the migration (and I tested the autocorrect on
pay-server).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.