### PR TITLE
RBI commands should respect ignores in configuration

### DIFF
--- a/gems/sorbet/lib/require_everything.rb
+++ b/gems/sorbet/lib/require_everything.rb
@@ -40,11 +40,12 @@ class Sorbet::Private::RequireEverything
   end
 
   def self.ignore_paths
-    sorbet_config=File.open('sorbet/config').read
-    sorbet_config.gsub!(/\r\n?/, "\n")
-    ignore_matcher = %r{^--ignore=(.*)$}
     ignore_paths = Set.new
-    sorbet_config.each_line do |line|
+    return ignore_paths unless File.exist?('sorbet/config')
+    config = File.open('sorbet/config').read
+    config.gsub!(/\r\n?/, "\n")
+    ignore_matcher = %r{^--ignore=(.*)$}
+    config.each_line do |line|
       match = ignore_matcher.match(line)
       if match
         ignore_paths << match[1]

--- a/gems/sorbet/lib/require_everything.rb
+++ b/gems/sorbet/lib/require_everything.rb
@@ -48,7 +48,7 @@ class Sorbet::Private::RequireEverything
     config.each_line do |line|
       match = ignore_matcher.match(line)
       if match
-        ignore_paths << match[1]
+        ignore_paths << Regexp.new(match[1])
       end
     end
     ignore_paths
@@ -56,7 +56,7 @@ class Sorbet::Private::RequireEverything
 
   def self.abs_paths
     abs_paths = Dir.glob("#{Dir.pwd}/**/*.rb")
-    abs_paths.reject{|ap| ignore_paths.detect{|ip| File.fnmatch(ip, ap)}}
+    abs_paths.reject{|ap| ignore_paths.detect{|ip| ip.match(ap)}}
   end
 
   def self.require_all_files


### PR DESCRIPTION
### Motivation
`srb rbi gems` and `srb rbi hidden-definitions` currently do not respect files ignored in `sorbet/config` as `srb tc` does. This can cause major problems when these steps require all files. For example, requiring [`db/schema.rb`](https://edgeguides.rubyonrails.org/active_record_migrations.html) will wipe out the entire database. This file is auto-generated so adding `typed: ignore` to the top is not possible.

### Test plan
I did not add a test for this because I couldn't find any existing `rspec` tests to model off of/add to and am not in a position to set this up. I ran both commands across our code base. 

See included automated tests.
