### PR TITLE
Return early

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -240,8 +240,8 @@ module T::Private::Methods
     @sig_wrappers[key] = sig_block
     if current_declaration.final
       add_final_method(key)
-      # use hook_mod, not mod, because for example, we want class C to be marked as having final if we define def C.foo
-      # as final. change this to mod to see >1 final_method tests fail.
+      # use hook_mod, not mod, because for example, we want class C to be marked as having final if we def C.foo as
+      # final. change this to mod to see some final_method tests fail.
       add_module_with_final(hook_mod)
     end
   end

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -128,6 +128,9 @@ module T::Private::Methods
   # the final instance methods of target and source_method_names. so, for every m in source_method_names, check if there
   # is already a method defined on one of target_ancestors with the same name that is final.
   def self._check_final_ancestors(target, target_ancestors, source_method_names)
+    if !module_with_final?(target)
+      return
+    end
     # use reverse_each to check farther-up ancestors first, for better error messages. we could avoid this if we were on
     # the version of ruby that adds the optional argument to method_defined? that allows you to exclude ancestors.
     target_ancestors.reverse_each do |ancestor|

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -400,7 +400,11 @@ module T::Private::Methods
         old_extended.bind(self).call(arg)
         ::T::Private::Methods._hook_impl(arg, arg.singleton_class.ancestors, self)
       end
-      @old_hooks = [old_included, old_extended]
+      old_inherited = T::Private::ClassUtils.replace_method(Class, :inherited) do |arg|
+        old_inherited.bind(self).call(arg)
+        ::T::Private::Methods._hook_impl(arg, arg.ancestors, self)
+      end
+      @old_hooks = [old_included, old_extended, old_inherited]
     end
   end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -19,6 +19,9 @@ module T::Private::Methods
   # a singleton is the singleton_class of a non-singleton.
   # modules_with_final is the set of singletons and non-singletons.
   @modules_with_final = Set.new
+  # this stores the old [included, extended] hooks for Module and inherited hook for Class that we override when
+  # enabling final checks for when those hooks are called. the 'hooks' here don't have anything to do with the 'hooks'
+  # in installed_hooks.
   @old_hooks = nil
 
   ARG_NOT_PROVIDED = Object.new

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -11,11 +11,13 @@ module T::Private::Methods
   # - they are done possibly before any sig block has run.
   # - they are done even if the method being defined doesn't have a sig.
   @final_methods = Set.new
-  # a module-with-final is a module for which at least one of the following is true:
+  # a non-singleton is a module for which at least one of the following is true:
   # - is declared final
   # - defines a method that is declared final
-  # - includes an module-with-final
-  # - extends an module-with-final
+  # - includes an non-singleton
+  # - extends an non-singleton
+  # a singleton is the singleton_class of a non-singleton.
+  # modules_with_final is the set of singletons and non-singletons.
   @modules_with_final = Set.new
   @old_hooks = nil
 
@@ -154,6 +156,7 @@ module T::Private::Methods
 
   def self.add_module_with_final(mod)
     @modules_with_final.add(mod)
+    @modules_with_final.add(mod.singleton_class)
   end
 
   private_class_method def self.module_with_final?(mod)

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -234,7 +234,9 @@ module T::Private::Methods
     @sig_wrappers[key] = sig_block
     if current_declaration.final
       add_final_method(key)
-      add_module_with_final(mod)
+      # use hook_mod, not mod, because for example, we want class C to be marked as having final if we define def C.foo
+      # as final. change this to mod to see >1 final_method tests fail.
+      add_module_with_final(hook_mod)
     end
   end
 


### PR DESCRIPTION
This does 4 small things:
1. Add an early return in `_check_final_ancestors` if we know we can, to speed it up.
2. Add more things to `@modules_with_final ` to allow us to do 1 while preserving correctness.
3. Update the comments to explain 2.
4. Explain a naming decision.

### Motivation
This makes require_everything on pay-server take about 5-10 seconds fewer, on my machine.

However, it should be noted that it does this at the cost of doubling the size of `@modules_with_final`. This may, once we start actually using modules with final in pay-server, cause this to be slower overall. (`@modules_with_final` is currently size 0 on pay-server, and it turns out 0 * 2 = 0, so we don't notice the effects of this doubling yet.)

### Test plan
No changes to tests.
