### PR TITLE
Fix failing enforce in `constantResolutionFailed`

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -230,6 +230,13 @@ private:
             }
             job.out->symbol = resolved;
             return;
+        } else if (resolved.exists() && resolved.data(ctx)->isClassClass()) {
+            // this can happen when we try to resolve a constant through a type alias which was itself not
+            // well-formed. If we've gotten here, we already have shown reasonable error messages to the user, so just
+            // make sure we can continue gracefully by stubbing in an untyped
+            resolved.data(ctx)->resultType = core::Types::untyped(ctx, resolved);
+            job.out->symbol = resolved;
+            return;
         }
         ENFORCE(!resolved.exists());
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -193,7 +193,7 @@ private:
         ast::Expression *resolvedScope = c->scope.get();
         if (auto *id = ast::cast_tree<ast::ConstantLit>(resolvedScope)) {
             if (!id->symbol.exists()) {
-                id->symbol =resolveConstant(ctx, nesting, id->original);
+                id->symbol = resolveConstant(ctx, nesting, id->original);
                 if (!id->symbol.exists()) {
                     return core::Symbols::noSymbol();
                 }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -101,7 +101,7 @@ private:
     struct ResolutionItem {
         shared_ptr<Nesting> scope;
         ast::ConstantLit *out;
-        bool resolution_failed = false;
+        bool resolutionFailed = false;
 
         ResolutionItem() = default;
         ResolutionItem(ResolutionItem &&rhs) noexcept = default;
@@ -199,7 +199,7 @@ private:
     }
 
     static core::SymbolRef resolveConstant(core::Context ctx, shared_ptr<Nesting> nesting,
-                                           const unique_ptr<ast::UnresolvedConstantLit> &c, bool &resolution_failed) {
+                                           const unique_ptr<ast::UnresolvedConstantLit> &c, bool &resolutionFailed) {
         if (ast::isa_tree<ast::EmptyTree>(c->scope.get())) {
             core::SymbolRef result = resolveLhs(ctx, nesting, c->cnst);
             return result;
@@ -207,11 +207,11 @@ private:
         ast::Expression *resolvedScope = c->scope.get();
         if (auto *id = ast::cast_tree<ast::ConstantLit>(resolvedScope)) {
             auto sym = id->symbol;
-            if (sym.exists() && sym.data(ctx)->isTypeAlias() && !resolution_failed) {
+            if (sym.exists() && sym.data(ctx)->isTypeAlias() && !resolutionFailed) {
                 if (auto e = ctx.state.beginError(c->loc, core::errors::Resolver::ConstantInTypeAlias)) {
                     e.setHeader("Resolving constants through type aliases is not supported");
                 }
-                resolution_failed = true;
+                resolutionFailed = true;
                 return core::Symbols::noSymbol();
             }
             if (!sym.exists()) {
@@ -221,12 +221,12 @@ private:
             core::SymbolRef result = resolved.data(ctx)->findMember(ctx, c->cnst);
             return result;
         } else {
-            if (!resolution_failed) {
+            if (!resolutionFailed) {
                 if (auto e = ctx.state.beginError(c->loc, core::errors::Resolver::DynamicConstant)) {
                     e.setHeader("Dynamic constant references are unsupported");
                 }
             }
-            resolution_failed = true;
+            resolutionFailed = true;
             return core::Symbols::noSymbol();
         }
     }
@@ -234,7 +234,7 @@ private:
     // We have failed to resolve the constant. We'll need to report the error and stub it so that we can proceed
     static void constantResolutionFailed(core::MutableContext ctx, ResolutionItem &job) {
         auto resolved =
-            resolveConstant(ctx.withOwner(job.scope->scope), job.scope, job.out->original, job.resolution_failed);
+            resolveConstant(ctx.withOwner(job.scope->scope), job.scope, job.out->original, job.resolutionFailed);
         if (resolved.exists() && resolved.data(ctx)->isTypeAlias()) {
             if (resolved.data(ctx)->resultType == nullptr) {
                 // This is actually a use-site error, but we limit ourselves to emitting it once by checking resultType
@@ -249,7 +249,7 @@ private:
             job.out->symbol = resolved;
             return;
         }
-        if (job.resolution_failed) {
+        if (job.resolutionFailed) {
             // we only set this when a job has failed for other reasons and we've already reported an error, and
             // continuining on will only redundantly report that we can't resolve the constant, so bail early here
             job.out->symbol = core::Symbols::untyped();
@@ -309,7 +309,7 @@ private:
             return true;
         }
         auto resolved =
-            resolveConstant(ctx.withOwner(job.scope->scope), job.scope, job.out->original, job.resolution_failed);
+            resolveConstant(ctx.withOwner(job.scope->scope), job.scope, job.out->original, job.resolutionFailed);
         if (!resolved.exists()) {
             return false;
         }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -61,7 +61,20 @@ namespace {
  *    resolvable, and so if any resolution succeeds, we need to keep looping in
  *    the outer loop.
  *
- * After this pass:
+ * We also track failure in the item, in order to distinguish a thing left in the
+ * list because we simply haven't succeeded yet and a thing left in the list
+ * because we have actively found a failure. For example, we might know that a
+ * given constant is unresolvable by Sorbet because it was qualified under
+ * not-a-constant: we mark this kind of job `resolution_failed`. The reason for
+ * this is unresolved constants are set to noSymbol, and once constant resolution
+ * has truly finished, we want to know which remaining failed jobs we need to set
+ * to a sensible default value. (Setting a conceptually failed job to untyped()
+ * before we've completed this loop can occasionally cause other jobs to
+ * non-deterministically half-resolve in the presence of multiple errors---c.f.
+ * issue #1126 on Github---so we mark jobs as failed rather than reporting an
+ * error and "resolving" them as untyped during the loop.)
+ *
+ * After the above passes:
  *
  * - ast::UnresolvedConstantLit nodes (constants that have a NameRef) are
  *   replaced with ast::ConstantLit nodes (constants that have a SymbolRef).

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -197,7 +197,7 @@ private:
                 if (auto e = ctx.state.beginError(c->loc, core::errors::Resolver::ConstantInTypeAlias)) {
                     e.setHeader("Resolving constants through type aliases is not supported");
                 }
-                return core::Symbols::untyped();
+                return core::Symbols::noSymbol();
             }
             if (!sym.exists()) {
                 return core::Symbols::noSymbol();
@@ -209,7 +209,7 @@ private:
             if (auto e = ctx.state.beginError(c->loc, core::errors::Resolver::DynamicConstant)) {
                 e.setHeader("Dynamic constant references are unsupported");
             }
-            return core::Symbols::untyped();
+            return core::Symbols::noSymbol();
         }
     }
 
@@ -288,12 +288,8 @@ private:
             return false;
         }
         if (resolved.data(ctx)->isTypeAlias()) {
-            // even if we haven't completed resolution, we might want to report this intermediate symbol to help resolve
-            // other constants via its metadata. This in particular happens when we have a type alias that's unresolved
-            // but we still incorrectly refer to a constant underneath a type alias: updating the job to be closer to
-            // the truth while still not having "finished" is going to let us determine that the constant is incorrect
-            job.out->symbol = resolved;
             if (resolved.data(ctx)->resultType != nullptr) {
+                job.out->symbol = resolved;
                 return true;
             }
             return false;

--- a/test/testdata/resolver/fuzz_alias_to_type_alias.rb
+++ b/test/testdata/resolver/fuzz_alias_to_type_alias.rb
@@ -1,0 +1,4 @@
+# typed: true
+# from fuzzer: https://github.com/sorbet/sorbet/issues/1126
+A = T.type_alias(A) # error: Unable to resolve right hand side of type alias `A`
+C = A::B # error: Resolving constants through type aliases is not supported

--- a/test/testdata/resolver/fuzz_alias_to_type_alias.rb
+++ b/test/testdata/resolver/fuzz_alias_to_type_alias.rb
@@ -1,4 +1,5 @@
 # typed: true
+# disable-fast-path: true
 # from fuzzer: https://github.com/sorbet/sorbet/issues/1126
 A = T.type_alias(A) # error: Unable to resolve right hand side of type alias `A`
 C = A::B # error: Resolving constants through type aliases is not supported

--- a/test/testdata/resolver/recover_from_bad_superclass.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/recover_from_bad_superclass.rb.symbol-table-raw.exp
@@ -11,8 +11,8 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
   class <S <C <U B>> $1> < <C <U Sorbet>><C <U Private>><C <U Static>><S <C <U StubSuperClass>> $1> () @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=12:7 end=12:8}
     method <S <C <U B>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=12:1 end=13:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=??? end=???}
-  class <C <U C>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U StubSuperClass>> () @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=17:1 end=17:16}
-  class <S <C <U C>> $1> < <C <U Sorbet>><C <U Private>><C <U Static>><S <C <U StubSuperClass>> $1> () @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=17:7 end=17:8}
+  class <C <U C>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=17:1 end=17:16}
+  class <S <C <U C>> $1> < <S <C <U Object>> $1> () @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=17:7 end=17:8}
     method <S <C <U C>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=17:1 end=18:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=??? end=???}
   class <C <U D>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U StubSuperClass>> () @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=21:1 end=21:12}

--- a/test/testdata/resolver/recover_from_bad_superclass.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/recover_from_bad_superclass.rb.symbol-table-raw.exp
@@ -11,8 +11,8 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
   class <S <C <U B>> $1> < <C <U Sorbet>><C <U Private>><C <U Static>><S <C <U StubSuperClass>> $1> () @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=12:7 end=12:8}
     method <S <C <U B>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=12:1 end=13:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=??? end=???}
-  class <C <U C>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=17:1 end=17:16}
-  class <S <C <U C>> $1> < <S <C <U Object>> $1> () @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=17:7 end=17:8}
+  class <C <U C>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U StubSuperClass>> () @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=17:1 end=17:16}
+  class <S <C <U C>> $1> < <C <U Sorbet>><C <U Private>><C <U Static>><S <C <U StubSuperClass>> $1> () @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=17:7 end=17:8}
     method <S <C <U C>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=17:1 end=18:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=??? end=???}
   class <C <U D>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U StubSuperClass>> () @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=21:1 end=21:12}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes #1126: the previous code assumed that failed constant resolutions that still produced symbols that existed must be because of bad type aliases, but if you tried writing a constant alias that in turn referenced an ill-formed type alias (e.g. `A = T.type_alias(x); B = A::X`) then we'd run `constantResolutionFailed` on an existing class symbol and run into a failed enforce. As far as I can tell, this only happens when several other errors have already been raised, and those produce useful error messages in this case as well, so this just adds stub code to handle this esoteric case.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Included cleaned-up fuzzed test.