### PR TITLE
Fix `Array#flatten` argument handling ENFORCE

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1804,6 +1804,8 @@ public:
                 depth = INT64_MAX;
             }
         } else {
+            // If our arity is off, then calls.cc will report an error due to mismatch with the RBI elsewhere, so we
+            // don't need to do anything special here
             return;
         }
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1804,7 +1804,7 @@ public:
                 depth = INT64_MAX;
             }
         } else {
-            ENFORCE(args.args.empty(), "Array#flatten passed too many args: {}", args.args.size());
+            return;
         }
 
         res.returnType = Types::arrayOf(ctx, recursivelyFlattenArrays(ctx, element, depth));

--- a/test/testdata/infer/flatten.rb
+++ b/test/testdata/infer/flatten.rb
@@ -41,3 +41,5 @@ xs.flatten(1 + 1) # error: You must pass an Integer literal to specify a depth
 
 xs.flatten(true) # error: Expected `Integer` but found `TrueClass` for argument `depth`
          # ^^^^ error: You must pass an Integer literal to specify a depth with Array#flatten
+
+xs.flatten(1, 1) # error: Too many arguments provided for method `Array#flatten`. Expected: `0..1`, got: `2`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes #1128: we tried to `ENFORCE` something that wasn't an invariant. Specifically, it's totally possible for `IntrinsicMethod::apply` implementations to be passed arguments of an arity and/or type that they don't expect, and they should deal with that gracefully (e.g. [this example from `revealType`](https://github.com/sorbet/sorbet/blob/master/core/types/calls.cc#L982-L984).) The fix is simple—just remove the enforce and exit early; we already have a sig for `Array#flatten` that we can use to raise an error about its arity.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Added a test case that exercises this.
