### PR TITLE
Add final module statics

### DIFF
--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -75,6 +75,7 @@ public:
         static constexpr u4 CLASS_ABSTRACT = 0x0000'0040;
         static constexpr u4 CLASS_INTERFACE = 0x0000'0080;
         static constexpr u4 CLASS_LINEARIZATION_COMPUTED = 0x0000'0100;
+        static constexpr u4 CLASS_FINAL = 0x0000'0200;
 
         // Method flags
         static constexpr u4 METHOD_PROTECTED = 0x0000'0010;
@@ -304,6 +305,11 @@ public:
         return (flags & Symbol::Flags::CLASS_LINEARIZATION_COMPUTED) != 0;
     }
 
+    inline bool isClassFinal() const {
+        ENFORCE(isClass());
+        return (flags & Symbol::Flags::CLASS_FINAL) != 0;
+    }
+
     inline void setClass() {
         ENFORCE(!isStaticField() && !isField() && !isMethod() && !isTypeArgument() && !isTypeMember());
         flags = flags | Symbol::Flags::CLASS;
@@ -457,6 +463,11 @@ public:
     inline void setClassLinearizationComputed() {
         ENFORCE(isClass());
         flags |= Symbol::Flags::CLASS_LINEARIZATION_COMPUTED;
+    }
+
+    inline void setClassFinal() {
+        ENFORCE(isClass());
+        flags |= Symbol::Flags::CLASS_FINAL;
     }
 
     inline void setTypeAlias() {

--- a/core/errors/namer.h
+++ b/core/errors/namer.h
@@ -20,7 +20,6 @@ constexpr ErrorClass DynamicConstant{4014, StrictLevel::False};
 constexpr ErrorClass InvalidClassOwner{4015, StrictLevel::False};
 constexpr ErrorClass RootTypeMember{4016, StrictLevel::False};
 constexpr ErrorClass DynamicConstantAssignment{4017, StrictLevel::False};
-constexpr ErrorClass AbstractFinal{4018, StrictLevel::True};
 } // namespace sorbet::core::errors::Namer
 
 #endif

--- a/core/errors/namer.h
+++ b/core/errors/namer.h
@@ -20,6 +20,7 @@ constexpr ErrorClass DynamicConstant{4014, StrictLevel::False};
 constexpr ErrorClass InvalidClassOwner{4015, StrictLevel::False};
 constexpr ErrorClass RootTypeMember{4016, StrictLevel::False};
 constexpr ErrorClass DynamicConstantAssignment{4017, StrictLevel::False};
+constexpr ErrorClass AbstractFinal{4018, StrictLevel::True};
 } // namespace sorbet::core::errors::Namer
 
 #endif

--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -52,6 +52,7 @@ constexpr ErrorClass InvalidVariance{5044, StrictLevel::True};
 constexpr ErrorClass GenericClassWithoutTypeArgs{5045, StrictLevel::False};
 constexpr ErrorClass GenericClassWithoutTypeArgsStdlib{5046, StrictLevel::Strict};
 constexpr ErrorClass FinalAncestor{5047, StrictLevel::True};
+constexpr ErrorClass FinalModuleNonFinalMethod{5048, StrictLevel::True};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -51,6 +51,7 @@ constexpr ErrorClass InvalidTypeAlias{5043, StrictLevel::False};
 constexpr ErrorClass InvalidVariance{5044, StrictLevel::True};
 constexpr ErrorClass GenericClassWithoutTypeArgs{5045, StrictLevel::False};
 constexpr ErrorClass GenericClassWithoutTypeArgsStdlib{5046, StrictLevel::Strict};
+constexpr ErrorClass FinalAncestor{5047, StrictLevel::True};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -127,6 +127,7 @@ NameDef names[] = {
     {"must"},
     {"declareInterface", "interface!"},
     {"declareAbstract", "abstract!"},
+    {"declareFinal", "final!"},
     {"revealType", "reveal_type"},
     // end T keywords
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -462,9 +462,10 @@ DispatchResult dispatchCallSymbol(Context ctx, DispatchArgs args,
             } else {
                 e.setHeader("Method `{}` does not exist on `{}`", args.name.data(ctx)->show(ctx), thisStr);
 
-                // catch the special case of `interface!` or `abstract!` and
+                // catch the special case of `interface!` or `abstract!` or `final!` and
                 // suggest adding `extend T::Helpers`.
-                if (args.name == core::Names::declareInterface() || args.name == core::Names::declareAbstract()) {
+                if (args.name == core::Names::declareInterface() || args.name == core::Names::declareAbstract() ||
+                    args.name == core::Names::declareFinal()) {
                     if (auto suggestion = maybeSuggestExtendTHelpers(ctx, thisType, args.locs.call)) {
                         e.addAutocorrect(std::move(*suggestion));
                     }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -215,7 +215,7 @@ core::Loc getAncestorLoc(const core::GlobalState &gs, const unique_ptr<ast::Clas
 
 void validateFinalAncestorHelper(const core::GlobalState &gs, const core::SymbolRef klass,
                                  const unique_ptr<ast::ClassDef> &classDef, const core::SymbolRef errMsgClass,
-                                 const std::string verb) {
+                                 const string_view verb) {
     for (const auto &mixin : klass.data(gs)->mixins()) {
         if (!mixin.data(gs)->isClassFinal()) {
             continue;

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -221,7 +221,7 @@ void validateFinalAncestorHelper(const core::GlobalState &gs, const core::Symbol
             continue;
         }
         if (auto e = gs.beginError(getAncestorLoc(gs, classDef, mixin), core::errors::Resolver::FinalAncestor)) {
-            e.setHeader("`{}` was declared as final and cannot be {} by `{}`", mixin.data(gs)->show(gs), verb,
+            e.setHeader("`{}` was declared as final and cannot be {} in `{}`", mixin.data(gs)->show(gs), verb,
                         errMsgClassData->show(gs));
             e.addErrorLine(mixin.data(gs)->loc(), "`{}` defined here", mixin.data(gs)->show(gs));
         }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -189,7 +189,7 @@ void validateOverriding(const core::GlobalState &gs, core::SymbolRef method) {
     }
 }
 
-core::Loc getAncestorLoc(const core::GlobalState &gs, const ast::ClassDef *const classDef,
+core::Loc getAncestorLoc(const core::GlobalState &gs, const unique_ptr<ast::ClassDef> &classDef,
                          const core::SymbolRef ancestor) {
     for (const auto &anc : classDef->ancestors) {
         const auto ancConst = ast::cast_tree<ast::ConstantLit>(anc.get());
@@ -214,7 +214,7 @@ core::Loc getAncestorLoc(const core::GlobalState &gs, const ast::ClassDef *const
 }
 
 void validateFinalAncestorHelper(const core::GlobalState &gs, const core::SymbolRef klass,
-                                 const ast::ClassDef *const classDef, const core::SymbolRef errMsgClass,
+                                 const unique_ptr<ast::ClassDef> &classDef, const core::SymbolRef errMsgClass,
                                  const std::string verb) {
     for (const auto &mixin : klass.data(gs)->mixins()) {
         if (!mixin.data(gs)->isClassFinal()) {
@@ -245,7 +245,8 @@ void validateFinalMethodHelper(const core::GlobalState &gs, const core::SymbolRe
     }
 }
 
-void validateFinal(const core::GlobalState &gs, const core::SymbolRef klass, const ast::ClassDef *const classDef) {
+void validateFinal(const core::GlobalState &gs, const core::SymbolRef klass,
+                   const unique_ptr<ast::ClassDef> &classDef) {
     const auto superClass = klass.data(gs)->superClass();
     if (superClass.exists() && superClass.data(gs)->isClassFinal()) {
         if (auto e = gs.beginError(getAncestorLoc(gs, classDef, superClass), core::errors::Resolver::FinalAncestor)) {
@@ -355,7 +356,7 @@ public:
         validateTStructNotGrandparent(ctx.state, sym);
         validateAbstract(ctx.state, sym);
         validateAbstract(ctx.state, singleton);
-        validateFinal(ctx.state, sym, classDef.get());
+        validateFinal(ctx.state, sym, classDef);
         return classDef;
     }
 

--- a/gems/sorbet-runtime/lib/types/private/final.rb
+++ b/gems/sorbet-runtime/lib/types/private/final.rb
@@ -23,7 +23,7 @@ module T::Private::Final
 
   def self.declare(mod)
     if !mod.is_a?(Module)
-      raise "#{mod.name} is not a class or module and cannot be declared as final with `final!`"
+      raise "#{mod.inspect} is not a class or module and cannot be declared as final with `final!`"
     end
     if final_module?(mod)
       raise "#{mod.name} was already declared as final and cannot be re-declared as final"

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -238,9 +238,9 @@ public:
                 klass->symbol.data(ctx)->setIsModule(isModule);
 
                 auto oldSymCount = ctx.state.symbolsUsed();
-                auto newSignleton =
+                auto newSingleton =
                     klass->symbol.data(ctx)->singletonClass(ctx); // force singleton class into existence
-                ENFORCE(newSignleton._id >= oldSymCount,
+                ENFORCE(newSingleton._id >= oldSymCount,
                         "should be a fresh symbol. Otherwise we could be reusing an existing singletonClass");
             } else if (klass->symbol.data(ctx)->isClassModuleSet() &&
                        isModule != klass->symbol.data(ctx)->isClassModule()) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -268,22 +268,10 @@ public:
         if (send->fun == core::Names::declareFinal()) {
             klass->symbol.data(ctx)->setClassFinal();
             klass->symbol.data(ctx)->singletonClass(ctx).data(ctx)->setClassFinal();
-            if (klass->symbol.data(ctx)->isClassAbstract()) {
-                if (auto e = ctx.state.beginError(send->loc, core::errors::Namer::AbstractFinal)) {
-                    e.setHeader("`{}` was already declared as abstract and cannot be declared as final",
-                                klass->symbol.data(ctx)->show(ctx));
-                }
-            }
         }
         if (send->fun == core::Names::declareInterface() || send->fun == core::Names::declareAbstract()) {
             klass->symbol.data(ctx)->setClassAbstract();
             klass->symbol.data(ctx)->singletonClass(ctx).data(ctx)->setClassAbstract();
-            if (klass->symbol.data(ctx)->isClassFinal()) {
-                if (auto e = ctx.state.beginError(send->loc, core::errors::Namer::AbstractFinal)) {
-                    e.setHeader("`{}` was already declared as final and cannot be declared as abstract",
-                                klass->symbol.data(ctx)->show(ctx));
-                }
-            }
         }
         if (send->fun == core::Names::declareInterface()) {
             klass->symbol.data(ctx)->setClassInterface();

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -265,6 +265,10 @@ public:
         if (send == nullptr) {
             return false;
         }
+        if (send->fun == core::Names::declareFinal()) {
+            klass->symbol.data(ctx)->setClassFinal();
+            klass->symbol.data(ctx)->singletonClass(ctx).data(ctx)->setClassFinal();
+        }
         if (send->fun == core::Names::declareInterface() || send->fun == core::Names::declareAbstract()) {
             klass->symbol.data(ctx)->setClassAbstract();
             klass->symbol.data(ctx)->singletonClass(ctx).data(ctx)->setClassAbstract();

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -265,13 +265,10 @@ public:
         if (send == nullptr) {
             return false;
         }
-        if (send->fun != core::Names::declareInterface() && send->fun != core::Names::declareAbstract()) {
-            return false;
+        if (send->fun == core::Names::declareInterface() || send->fun == core::Names::declareAbstract()) {
+            klass->symbol.data(ctx)->setClassAbstract();
+            klass->symbol.data(ctx)->singletonClass(ctx).data(ctx)->setClassAbstract();
         }
-
-        klass->symbol.data(ctx)->setClassAbstract();
-        klass->symbol.data(ctx)->singletonClass(ctx).data(ctx)->setClassAbstract();
-
         if (send->fun == core::Names::declareInterface()) {
             klass->symbol.data(ctx)->setClassInterface();
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -271,7 +271,6 @@ public:
         }
         if (send->fun == core::Names::declareInterface()) {
             klass->symbol.data(ctx)->setClassInterface();
-
             if (klass->kind == ast::Class) {
                 if (auto e = ctx.state.beginError(send->loc, core::errors::Namer::InterfaceClass)) {
                     e.setHeader("Classes can't be interfaces. Use `abstract!` instead of `interface!`");

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -268,10 +268,22 @@ public:
         if (send->fun == core::Names::declareFinal()) {
             klass->symbol.data(ctx)->setClassFinal();
             klass->symbol.data(ctx)->singletonClass(ctx).data(ctx)->setClassFinal();
+            if (klass->symbol.data(ctx)->isClassAbstract()) {
+                if (auto e = ctx.state.beginError(send->loc, core::errors::Namer::AbstractFinal)) {
+                    e.setHeader("`{}` was already declared as abstract and cannot be declared as final",
+                                klass->symbol.data(ctx)->show(ctx));
+                }
+            }
         }
         if (send->fun == core::Names::declareInterface() || send->fun == core::Names::declareAbstract()) {
             klass->symbol.data(ctx)->setClassAbstract();
             klass->symbol.data(ctx)->singletonClass(ctx).data(ctx)->setClassAbstract();
+            if (klass->symbol.data(ctx)->isClassFinal()) {
+                if (auto e = ctx.state.beginError(send->loc, core::errors::Namer::AbstractFinal)) {
+                    e.setHeader("`{}` was already declared as final and cannot be declared as abstract",
+                                klass->symbol.data(ctx)->show(ctx));
+                }
+            }
         }
         if (send->fun == core::Names::declareInterface()) {
             klass->symbol.data(ctx)->setClassInterface();

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -110,8 +110,8 @@ module T::Configuration
   def self.call_validation_error_handler=(value); end
   def self.default_checked_level=(default_checked_level); end
   def self.enable_checking_for_sigs_marked_checked_tests; end
-  def self.enable_final_checks_for_include_extend; end
-  def self.reset_final_checks_for_include_extend; end
+  def self.enable_final_checks_on_hooks; end
+  def self.reset_final_checks_on_hooks; end
   def self.hard_assert_handler(str, extra); end
   def self.hard_assert_handler=(value); end
   def self.inline_type_error_handler(error); end

--- a/test/testdata/resolver/final_module.rb
+++ b/test/testdata/resolver/final_module.rb
@@ -1,5 +1,4 @@
 # typed: true
-# disable-fast-path: true
 
 class FinalClass
   extend T::Helpers

--- a/test/testdata/resolver/final_module.rb
+++ b/test/testdata/resolver/final_module.rb
@@ -18,19 +18,19 @@ end
 module BadInclude
   include NonFinalModule
   extend NonFinalModule
-  include FinalModule # error: `FinalModule` was declared as final and cannot be included by `BadInclude`
+  include FinalModule # error: `FinalModule` was declared as final and cannot be included in `BadInclude`
 end
 
 module BadExtend
   include NonFinalModule
   extend NonFinalModule
-  extend FinalModule # error: `FinalModule` was declared as final and cannot be extended by `BadExtend`
+  extend FinalModule # error: `FinalModule` was declared as final and cannot be extended in `BadExtend`
 end
 
 AliasFinalModule = FinalModule
 
 module BadAliasInclude
-  include AliasFinalModule # error: `FinalModule` was declared as final and cannot be included by `BadAliasInclude`
+  include AliasFinalModule # error: `FinalModule` was declared as final and cannot be included in `BadAliasInclude`
 end
 
 module FinalModuleWithFinalMethods

--- a/test/testdata/resolver/final_module.rb
+++ b/test/testdata/resolver/final_module.rb
@@ -1,0 +1,64 @@
+# typed: true
+# disable-fast-path: true
+
+class FinalClass
+  extend T::Helpers
+  final!
+end
+
+module FinalModule
+  extend T::Helpers
+  final!
+end
+
+module NonFinalModule; end
+
+class BadInherit < FinalClass # error: `FinalClass` was declared as final and cannot be inherited by `BadInherit`
+end
+
+module BadInclude
+  include NonFinalModule
+  extend NonFinalModule
+  include FinalModule # error: `FinalModule` was declared as final and cannot be included by `BadInclude`
+end
+
+module BadExtend
+  include NonFinalModule
+  extend NonFinalModule
+  extend FinalModule # error: `FinalModule` was declared as final and cannot be extended by `BadExtend`
+end
+
+AliasFinalModule = FinalModule
+
+module BadAliasInclude
+  include AliasFinalModule # error: `FinalModule` was declared as final and cannot be included by `BadAliasInclude`
+end
+
+module FinalModuleWithFinalMethods
+  extend T::Helpers
+  final!
+  extend T::Sig
+  sig(:final) {void}
+  def foo; end
+  sig(:final) {void}
+  def self.bar; end
+end
+
+module FinalModuleWithNoFinalMethods
+  extend T::Helpers
+  final!
+  def foo; end # error: `FinalModuleWithNoFinalMethods` was declared as final but its method `foo` was not declared as final
+  def self.bar; end # error: `FinalModuleWithNoFinalMethods` was declared as final but its method `bar` was not declared as final
+end
+
+class AbstractFinal
+  extend T::Helpers
+  abstract!
+  final! # error: `AbstractFinal` was already declared as abstract and cannot be declared as final
+end
+
+class FinalAbstract
+  extend T::Helpers
+  final!
+  abstract! # error: `FinalAbstract` was already declared as final and cannot be declared as abstract
+end

--- a/test/testdata/resolver/final_module.rb
+++ b/test/testdata/resolver/final_module.rb
@@ -18,19 +18,19 @@ end
 module BadInclude
   include NonFinalModule
   extend NonFinalModule
-  include FinalModule # error: `FinalModule` was declared as final and cannot be included in `BadInclude`
+  include FinalModule # error-with-dupes: `FinalModule` was declared as final and cannot be included in `BadInclude`
 end
 
 module BadExtend
   include NonFinalModule
   extend NonFinalModule
-  extend FinalModule # error: `FinalModule` was declared as final and cannot be extended in `BadExtend`
+  extend FinalModule # error-with-dupes: `FinalModule` was declared as final and cannot be extended in `BadExtend`
 end
 
 AliasFinalModule = FinalModule
 
 module BadAliasInclude
-  include AliasFinalModule # error: `FinalModule` was declared as final and cannot be included in `BadAliasInclude`
+  include AliasFinalModule # error-with-dupes: `FinalModule` was declared as final and cannot be included in `BadAliasInclude`
 end
 
 module FinalModuleWithFinalMethods

--- a/test/testdata/resolver/final_module.rb
+++ b/test/testdata/resolver/final_module.rb
@@ -49,15 +49,3 @@ module FinalModuleWithNoFinalMethods
   def foo; end # error: `FinalModuleWithNoFinalMethods` was declared as final but its method `foo` was not declared as final
   def self.bar; end # error: `FinalModuleWithNoFinalMethods` was declared as final but its method `bar` was not declared as final
 end
-
-class AbstractFinal
-  extend T::Helpers
-  abstract!
-  final! # error: `AbstractFinal` was already declared as abstract and cannot be declared as final
-end
-
-class FinalAbstract
-  extend T::Helpers
-  final!
-  abstract! # error: `FinalAbstract` was already declared as final and cannot be declared as abstract
-end


### PR DESCRIPTION
This is the impl of final modules in the statics. It also fixes some unrelated minor things, like updating some RBIs with some renamed names and using `inspect` instead of `name` in an error message.

I'd like to follow this up with documenting the new error codes and also documenting final itself, once we decide we're ready to ship.

### Motivation
To catch errors statically.

### Test plan

See included automated tests.