### PR TITLE
Improve final syntax error

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -99,7 +99,7 @@ NameDef names[] = {
     // Sig builders
     {"bind"},
     {"params"},
-    {"final"},
+    {"final_", "final"},
     {"returns"},
     {"void_", "void"},
     {"checked"},

--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -154,7 +154,7 @@ module T::Private::Methods
 
     def final
       check_live!
-      raise BuilderError.new("The syntax for declaring a method final is `sig(:final) {[...]}`, not `sig {final.[...]}`")
+      raise BuilderError.new("The syntax for declaring a method final is `sig(:final) {...}`, not `sig {final. ...}`")
     end
 
     def override(allow_incompatible: false)

--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -152,6 +152,11 @@ module T::Private::Methods
       self
     end
 
+    def final
+      check_live!
+      raise BuilderError.new("The syntax for declaring a method final is `sig(:final) {[...]}`, not `sig {final.[...]}`")
+    end
+
     def override(allow_incompatible: false)
       check_live!
 

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -336,4 +336,16 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
       extend m1, m1
     end
   end
+
+  it "has a good error if you use the wrong syntax" do
+    err = assert_raises(ArgumentError) do
+      m = Module.new do
+        extend T::Sig
+        sig {final.void}
+        def self.foo; end
+      end
+      m.foo
+    end
+    assert_includes(err.message, "The syntax for declaring a method final is `sig(:final) {[...]}`, not `sig {final.[...]}`")
+  end
 end

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -346,6 +346,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
       end
       m.foo
     end
-    assert_includes(err.message, "The syntax for declaring a method final is `sig(:final) {[...]}`, not `sig {final.[...]}`")
+    assert_includes(err.message, "The syntax for declaring a method final is `sig(:final) {...}`, not `sig {final. ...}`")
   end
 end

--- a/rbi/sorbet/builder.rbi
+++ b/rbi/sorbet/builder.rbi
@@ -10,6 +10,9 @@ class T::Private::Methods::DeclBuilder
   def abstract; end
 
   sig {returns(T::Private::Methods::DeclBuilder)}
+  def final; end
+
+  sig {returns(T::Private::Methods::DeclBuilder)}
   def implementation; end
 
   sig {params(allow_incompatible: T::Boolean).returns(T::Private::Methods::DeclBuilder)}

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -324,6 +324,13 @@ ParsedSig TypeSyntax::parseSig(core::MutableContext ctx, ast::Send *sigSend, con
                 case core::Names::generated()._id:
                     sig.seen.generated = true;
                     break;
+                case core::Names::final_()._id:
+                    if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                        reportedInvalidMethod = true;
+                        e.setHeader("The syntax for declaring a method final is `sig(:final) {{[...]}}`, not `sig "
+                                    "{{final.[...]}}`");
+                    }
+                    break;
                 default:
                     if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
                         reportedInvalidMethod = true;

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -327,8 +327,8 @@ ParsedSig TypeSyntax::parseSig(core::MutableContext ctx, ast::Send *sigSend, con
                 case core::Names::final_()._id:
                     if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
                         reportedInvalidMethod = true;
-                        e.setHeader("The syntax for declaring a method final is `sig(:final) {{[...]}}`, not `sig "
-                                    "{{final.[...]}}`");
+                        e.setHeader("The syntax for declaring a method final is `sig(:final) {{...}}`, not `sig "
+                                    "{{final. ...}}`");
                     }
                     break;
                 default:

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -104,7 +104,7 @@ ParsedSig TypeSyntax::parseSig(core::MutableContext ctx, ast::Send *sigSend, con
 
     for (auto &arg : sigSend->args) {
         auto lit = ast::cast_tree<ast::Literal>(arg.get());
-        if (lit != nullptr && lit->isSymbol(ctx) && lit->asSymbol(ctx) == core::Names::final()) {
+        if (lit != nullptr && lit->isSymbol(ctx) && lit->asSymbol(ctx) == core::Names::final_()) {
             sig.seen.final = true;
         }
     }

--- a/test/testdata/resolver/bad_final_sig.rb
+++ b/test/testdata/resolver/bad_final_sig.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+class C
+  extend T::Sig
+  sig {final.void} # error: The syntax for declaring a method final is `sig(:final) {[...]}`, not `sig {final.[...]}`
+  def foo; end
+end

--- a/test/testdata/resolver/bad_final_sig.rb
+++ b/test/testdata/resolver/bad_final_sig.rb
@@ -2,6 +2,6 @@
 
 class C
   extend T::Sig
-  sig {final.void} # error: The syntax for declaring a method final is `sig(:final) {[...]}`, not `sig {final.[...]}`
+  sig {final.void} # error: The syntax for declaring a method final is `sig(:final) {...}`, not `sig {final. ...}`
   def foo; end
 end


### PR DESCRIPTION
The syntax for declaring final methods is a bit different from the usual sig builder syntax. This educates users on that difference with some errors, both statically and in the runtime.

cc @ptarjan 

### Motivation
To help users.

### Test plan
See included automated tests.