### PR TITLE
Add final rbi test

### DIFF
--- a/test/testdata/resolver/rbi_final_no_sig__1.rb
+++ b/test/testdata/resolver/rbi_final_no_sig__1.rb
@@ -1,0 +1,6 @@
+# typed: true
+class C
+  extend T::Sig
+  sig(:final) {void}
+  def foo; end
+end

--- a/test/testdata/resolver/rbi_final_no_sig__2.rb
+++ b/test/testdata/resolver/rbi_final_no_sig__2.rb
@@ -1,0 +1,4 @@
+# typed: true
+class C
+  def foo; end
+end

--- a/test/testdata/resolver/rbi_final_re_sig__1.rb
+++ b/test/testdata/resolver/rbi_final_re_sig__1.rb
@@ -1,0 +1,6 @@
+# typed: true
+class C
+  extend T::Sig
+  sig(:final) {void}
+  def foo; end
+end

--- a/test/testdata/resolver/rbi_final_re_sig__2.rb
+++ b/test/testdata/resolver/rbi_final_re_sig__2.rb
@@ -1,0 +1,5 @@
+# typed: true
+class C
+  sig(:final) {void}
+  def foo; end
+end


### PR DESCRIPTION
I realized that we don't ever test rbis with final. I thought there might be some issues with redeclaring things marked as final. Although the tests in here pass as I think they should, I think the following test (not included in this PR) should fail:

In `r.rbi`:

```rb
# typed: true
class C
  sig(:final) {void}
  def foo; end
end
```

In `r.rb`:

```rb
# typed: true
class C
  sig {void}
  def foo; end
end
```

On command line: 

```
sorbet r.rbi r.rb
```

Expected output: some error about sigs not matching up.

Actual current output: no errors.

I'm not actually sure if this example should give an error or not, but in any case the tests in this PR do pass as I expect they should.

### Motivation
To test more.

### Test plan

See included automated tests.