### PR TITLE
Allow user-defined hooks

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -188,6 +188,13 @@ module T::Private::Methods
     end
     T::Private::DeclState.current.reset!
 
+    if method_name == :method_added || method_name == :singleton_method_added
+      raise(
+        "Putting a `sig` on `#{method_name}` is not supported" +
+        " (sorbet-runtime uses this method internally to perform `sig` validation logic)"
+      )
+    end
+
     original_method = mod.instance_method(method_name)
     sig_block = lambda do
       T::Private::Methods.run_sig(hook_mod, method_name, original_method, current_declaration)

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -37,7 +37,9 @@ module T::Private::Methods::CallValidation
     else
       T::Configuration.without_ruby_warnings do
         # get all the shims out of the way and put back the original method
+        T::Private::DeclState.current.skip_on_method_added = true
         mod.send(:define_method, method_sig.method_name, original_method)
+        T::Private::DeclState.current.skip_on_method_added = false
         mod.send(original_visibility, method_sig.method_name)
       end
     end

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -229,7 +229,6 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
   it "allows custom hooks" do
     parent = Class.new do
       extend T::Sig
-      sig {params(method: Symbol).void}
       def self.method_added(method)
         super(method)
       end

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -248,6 +248,24 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     end
   end
 
+  it "still calls our hooks if the user supers up" do
+    c1 = Class.new do
+      extend T::Sig
+      sig {returns(Integer)}
+      def foo; 1; end
+      def self.method_added(method)
+        super(method)
+      end
+      def self.singleton_method_added(method)
+        super(method)
+      end
+      sig {returns(Integer)}
+      def bar; "bad"; end
+    end
+    assert_equal(1, c1.new.foo)
+    assert_raises(TypeError) { c1.new.bar }
+  end
+
   it "does not make sig available to attached class" do
     assert_raises(NoMethodError) do
       Class.new do

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -216,10 +216,6 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     assert_equal(
       [
         :singleton_method_added,
-        :method_added,
-        # hook registration overwrites this method but it should
-        # still call the original defined above
-        :singleton_method_added,
         :post_hook,
       ],
       klass.instance_variable_get(:@called)

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -261,6 +261,32 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     assert_raises(TypeError) { c1.new.bar }
   end
 
+  it "forbids adding a sig to method_added" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Sig
+        sig {params(method: Symbol).void}
+        def self.method_added(method)
+          super(method)
+        end
+      end
+    end
+    assert_includes(err.message, "Putting a `sig` on `method_added` is not supported")
+  end
+
+  it "forbids adding a sig to singleton_method_added" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Sig
+        sig {params(method: Symbol).void}
+        def self.singleton_method_added(method)
+          super(method)
+        end
+      end
+    end
+    assert_includes(err.message, "Putting a `sig` on `singleton_method_added` is not supported")
+  end
+
   it "does not make sig available to attached class" do
     assert_raises(NoMethodError) do
       Class.new do

--- a/gems/sorbet-runtime/test/types/final_module.rb
+++ b/gems/sorbet-runtime/test/types/final_module.rb
@@ -196,4 +196,16 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
     err = assert_raises(RuntimeError) { Class.new.include(outer) }
     assert_match(/^#<Module:0x[0-9a-f]+> was declared as final and cannot be included$/, err.message)
   end
+
+  it "allows inheriting a class with hooks" do
+    parent = Class.new do
+      extend T::Sig
+      sig {void}
+      def foo; end
+    end
+    Class.new(parent) do
+      extend T::Helpers
+      final!
+    end
+  end
 end


### PR DESCRIPTION
Close #1348.

In the above-referenced issue, it was noted that if a user has a module that defines its own `method_added` and/or `singleton_method_added` hooks at certain times relative to when we `extend T::Sig`, that interfered with our logic to intercept those hooks to wrap method defs with sig logic.

The root cause of this issue was that, when you stay `extend T::Sig`, we install the hooks on the module that did the `extend`, and installing the hooks amounts to *replacing* the current `method_added` and `singleton_method_added` with our stuff.

Although when we do this replacing, we keep the old method around and call it, if the user then later defines their own hooks, the user cannot super up to call our hook because we registered our hook directly on the module.

What this PR does is allow users to define their own hooks whenever they want (before or after `extend T::Sig`), *with the restriction* that they *must* super up in those hooks.

That means that the examples shown in the linked issue continue to fail even after this PR. However, if we change the examples in the issue to simply have the user-defined hooks super up, then those changed examples fail before this PR but succeed after this PR.

Those modified examples are contained as passing tests in this PR.

### Motivation
To fix bugs. To allow us to bump sorbet-runtime on pay-server to get final checks.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
