### PR TITLE
Forbid `return <expr>` when returning `void`

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -170,6 +170,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::Expression *what, BasicBlock 
             },
             [&](ast::Return *a) {
                 if (!ast::isa_tree<ast::EmptyTree>(a->expr.get()) &&
+                    cctx.inWhat.symbol.data(cctx.ctx)->resultType != nullptr &&
                     core::Types::isSubType(cctx.ctx, cctx.inWhat.symbol.data(cctx.ctx)->resultType,
                                            core::Types::void_())) {
                     if (auto e = cctx.ctx.state.beginError(a->loc, core::errors::CFG::ReturnExprVoid)) {

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -173,8 +173,8 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::Expression *what, BasicBlock 
                     core::Types::isSubType(cctx.ctx, cctx.inWhat.symbol.data(cctx.ctx)->resultType,
                                            core::Types::void_())) {
                     if (auto e = cctx.ctx.state.beginError(a->loc, core::errors::CFG::ReturnExprVoid)) {
-                        e.setHeader("`{}` returns `void` but contains an explicit `return <expression>`",
-                                    cctx.inWhat.symbol.data(cctx.ctx)->show(cctx.ctx));
+                        e.setHeader("`{}` has return type `{}` but explicitly returns an expression",
+                                    cctx.inWhat.symbol.data(cctx.ctx)->show(cctx.ctx), "void");
                     }
                 }
                 core::LocalVariable retSym = cctx.newTemporary(core::Names::returnTemp());

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -171,6 +171,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::Expression *what, BasicBlock 
             [&](ast::Return *a) {
                 if (!ast::isa_tree<ast::EmptyTree>(a->expr.get()) &&
                     cctx.inWhat.symbol.data(cctx.ctx)->resultType != nullptr &&
+                    !cctx.inWhat.symbol.data(cctx.ctx)->resultType->isUntyped() &&
                     core::Types::isSubType(cctx.ctx, cctx.inWhat.symbol.data(cctx.ctx)->resultType,
                                            core::Types::void_())) {
                     if (auto e = cctx.ctx.state.beginError(a->loc, core::errors::CFG::ReturnExprVoid)) {

--- a/core/errors/cfg.h
+++ b/core/errors/cfg.h
@@ -5,5 +5,6 @@
 namespace sorbet::core::errors::CFG {
 constexpr ErrorClass NoNextScope{6001, StrictLevel::False};
 constexpr ErrorClass UndeclaredVariable{6002, StrictLevel::Strict};
+constexpr ErrorClass ReturnExprVoid{6003, StrictLevel::True};
 } // namespace sorbet::core::errors::CFG
 #endif

--- a/test/testdata/cfg/return_expr_void.rb
+++ b/test/testdata/cfg/return_expr_void.rb
@@ -1,0 +1,8 @@
+# typed: true
+class C
+  extend T::Sig
+  sig {void}
+  def foo
+    return 3 # error: `C#foo` returns `void` but contains an explicit `return <expression>`
+  end
+end

--- a/test/testdata/cfg/return_expr_void.rb
+++ b/test/testdata/cfg/return_expr_void.rb
@@ -16,4 +16,8 @@ class C
   def explicit_return_nothing
     return
   end
+
+  def explicit_return_expr_no_sig
+    return 3
+  end
 end

--- a/test/testdata/cfg/return_expr_void.rb
+++ b/test/testdata/cfg/return_expr_void.rb
@@ -1,8 +1,19 @@
 # typed: true
 class C
   extend T::Sig
+
   sig {void}
-  def foo
-    return 3 # error: `C#foo` has return type `void` but explicitly returns an expression
+  def explicit_return_expr
+    return 3 # error: `C#explicit_return_expr` has return type `void` but explicitly returns an expression
+  end
+
+  sig {void}
+  def implicit_return_at_end
+    3
+  end
+
+  sig {void}
+  def explicit_return_nothing
+    return
   end
 end

--- a/test/testdata/cfg/return_expr_void.rb
+++ b/test/testdata/cfg/return_expr_void.rb
@@ -3,11 +3,6 @@ class C
   extend T::Sig
 
   sig {void}
-  def explicit_return_expr
-    return 3 # error: `C#explicit_return_expr` has return type `void` but explicitly returns an expression
-  end
-
-  sig {void}
   def implicit_return_at_end
     3
   end
@@ -24,5 +19,10 @@ class C
   sig {returns(T.untyped)}
   def explicit_return_expr_t_untyped
     return 3
+  end
+
+  sig {void}
+  def explicit_return_expr
+    return 3 # error: `C#explicit_return_expr` has return type `void` but explicitly returns an expression
   end
 end

--- a/test/testdata/cfg/return_expr_void.rb
+++ b/test/testdata/cfg/return_expr_void.rb
@@ -3,6 +3,6 @@ class C
   extend T::Sig
   sig {void}
   def foo
-    return 3 # error: `C#foo` returns `void` but contains an explicit `return <expression>`
+    return 3 # error: `C#foo` has return type `void` but explicitly returns an expression
   end
 end

--- a/test/testdata/cfg/return_expr_void.rb
+++ b/test/testdata/cfg/return_expr_void.rb
@@ -20,4 +20,9 @@ class C
   def explicit_return_expr_no_sig
     return 3
   end
+
+  sig {returns(T.untyped)}
+  def explicit_return_expr_t_untyped
+    return 3
+  end
 end

--- a/test/testdata/infer/loop_in_self_reassignments.rb
+++ b/test/testdata/infer/loop_in_self_reassignments.rb
@@ -4,7 +4,7 @@ class Repro
   def api_sections
   end
 
-  sig {void}
+  sig {returns(T.untyped)}
   def get_repro()
     api_sections.each do
       return api_sections.map {1}

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -395,6 +395,18 @@ For how to fix, see [Type Annotations](type-annotations.md).
 
 See also: [5028](#5028), [7017](#7017).
 
+## 6003
+
+A method was marked as returning `void`, but its body contained an explicit
+`return <expression>`.
+
+```rb
+sig {void}
+def foo
+  return 3 # error
+end
+```
+
 ## 7001
 
 Sorbet does not allow reassigning a variable to a different type within a loop


### PR DESCRIPTION
This forbids writing `return <expression>` when the method returns `void`.

### Motivation
To forbid things that don't make sense.

### Test plan

See included automated tests.