### PR TITLE
Remove `extend ::T::Sig` from BasicObject and Object

### DIFF
--- a/gems/sorbet/lib/serialize.rb
+++ b/gems/sorbet/lib/serialize.rb
@@ -55,7 +55,6 @@ class Sorbet::Private::Serialize
     end
     superclass_str = !superclass_str || superclass_str.empty? ? '' : " < #{superclass_str}"
     ret << (Sorbet::Private::RealStdlib.real_is_a?(klass, Class) ? "class #{class_name}#{superclass_str}\n" : "module #{class_name}\n")
-    ret << "  extend ::T::Sig\n"
 
     # We don't use .included_modules since that also has all the aweful things
     # that are mixed into Object. This way we at least have a delimiter before


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This fixes hidden-definition generation by stopping it from adding `extend ::T::Sig` to `Object` and `BasicObject` in hidden.rbi.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
