### PR TITLE
Turn off some final runtime

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/decl_state.rb
+++ b/gems/sorbet-runtime/lib/types/private/decl_state.rb
@@ -11,7 +11,6 @@ class T::Private::DeclState
   end
 
   attr_accessor :active_declaration
-  attr_accessor :skip_next_on_method_added
 
   def reset!
     self.active_declaration = nil

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -163,7 +163,6 @@ module T::Private::Methods::CallValidation
   end
 
   def self.create_validator_method(mod, original_method, method_sig, original_visibility)
-    T::Private::DeclState.current.skip_next_on_method_added = true
     has_fixed_arity = method_sig.kwarg_types.empty? && !method_sig.has_rest && !method_sig.has_keyrest &&
       original_method.parameters.all? {|(kind, _name)| kind == :req}
     all_args_are_simple = method_sig.arg_types.all? {|_name, type| type.is_a?(T::Types::Simple)}

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -12,6 +12,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "allows declaring an instance method as final" do
+    skip
     Class.new do
       extend T::Sig
       sig(:final) {void}
@@ -20,6 +21,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "allows declaring a class method as final" do
+    skip
     Class.new do
       extend T::Sig
       sig(:final) {void}
@@ -28,6 +30,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids redefining a final instance method with a final sig" do
+    skip
     err = assert_raises(RuntimeError) do
       Class.new do
         extend T::Sig
@@ -41,6 +44,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids redefining a final class method with a final sig" do
+    skip
     err = assert_raises(RuntimeError) do
       Class.new do
         extend T::Sig
@@ -54,6 +58,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids redefining a final instance method with a regular sig" do
+    skip
     err = assert_raises(RuntimeError) do
       Class.new do
         extend T::Sig
@@ -67,6 +72,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids redefining a final class method with a regular sig" do
+    skip
     err = assert_raises(RuntimeError) do
       Class.new do
         extend T::Sig
@@ -80,6 +86,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids redefining a final instance method with no sig" do
+    skip
     err = assert_raises(RuntimeError) do
       Class.new do
         extend T::Sig
@@ -92,6 +99,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids redefining a final class method with no sig" do
+    skip
     err = assert_raises(RuntimeError) do
       Class.new do
         extend T::Sig
@@ -104,6 +112,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "allows redefining a regular instance method to be final" do
+    skip
     Class.new do
       extend T::Sig
       def foo; end
@@ -113,6 +122,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "allows redefining a regular class method to be final" do
+    skip
     Class.new do
       extend T::Sig
       def self.foo; end
@@ -122,6 +132,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding a final instance method" do
+    skip
     c = Class.new do
       extend T::Sig
       sig(:final) {void}
@@ -136,6 +147,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding a final class method" do
+    skip
     c = Class.new do
       extend T::Sig
       sig(:final) {void}
@@ -150,6 +162,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding a final method from an included module" do
+    skip
     m = Module.new do
       extend T::Sig
       sig(:final) {void}
@@ -165,6 +178,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding a final method from an extended module" do
+    skip
     m = Module.new do
       extend T::Sig
       sig(:final) {void}
@@ -180,6 +194,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding a final method by including two modules" do
+    skip
     m1 = Module.new do
       extend T::Sig
       sig(:final) {void}
@@ -197,6 +212,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding a final method by extending two modules" do
+    skip
     m1 = Module.new do
       extend T::Sig
       sig(:final) {void}
@@ -214,6 +230,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "allows calling final methods" do
+    skip
     m = Module.new do
       extend T::Sig
       sig(:final) {void}
@@ -232,6 +249,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "calls a user-defined included" do
+    skip
     m = Module.new do
       @calls = 0
       extend T::Sig
@@ -254,6 +272,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "calls a user-defined extended" do
+    skip
     m = Module.new do
       @calls = 0
       extend T::Sig
@@ -276,6 +295,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "calls an exotic user-defined included" do
+    skip
     m2 = Module.new do
       def self.included(arg)
         arg.include(Module.new do
@@ -295,6 +315,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding through many levels of include" do
+    skip
     m1 = Module.new do
       extend T::Sig
       sig(:final) {void}
@@ -316,6 +337,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "allows including modules again" do
+    skip
     m1 = Module.new do
       extend T::Sig
       sig(:final) {void}
@@ -327,6 +349,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "allows extending modules again" do
+    skip
     m1 = Module.new do
       extend T::Sig
       sig(:final) {void}
@@ -338,6 +361,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "has a good error if you use the wrong syntax" do
+    skip
     err = assert_raises(ArgumentError) do
       m = Module.new do
         extend T::Sig

--- a/gems/sorbet-runtime/test/types/final_module.rb
+++ b/gems/sorbet-runtime/test/types/final_module.rb
@@ -63,6 +63,7 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
   end
 
   it "allows declaring a module as final and its instance method as final" do
+    skip
     Module.new do
       extend T::Helpers
       final!
@@ -73,6 +74,7 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
   end
 
   it "allows declaring a module as final and its class method as final" do
+    skip
     Module.new do
       extend T::Helpers
       final!
@@ -83,6 +85,7 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
   end
 
   it "forbids declaring a module as final but not its instance method as final" do
+    skip
     err = assert_raises(RuntimeError) do
       Module.new do
         extend T::Helpers
@@ -96,6 +99,7 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
   end
 
   it "forbids declaring a module as final but not its class method as final" do
+    skip
     err = assert_raises(RuntimeError) do
       Module.new do
         extend T::Helpers


### PR DESCRIPTION
This turns off some of the final runtime.

Final modules still work. Of course, no one should be using any of this yet anyway.

### Motivation
pay-server is unbumpable. 

Introducing `skip_next_on_method_added` surfaced some latent bugs.

### Test plan
See included automated tests.

Some tests were disabled
