### PR TITLE
Turn on final checks

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/class_utils.rb
+++ b/gems/sorbet-runtime/lib/types/private/class_utils.rb
@@ -97,8 +97,8 @@ module T::Private::ClassUtils
     overwritten = original_owner == mod
     T::Configuration.without_ruby_warnings do
       mod.send(:define_method, name, &blk) # rubocop:disable PrisonGuard/UsePublicSend
-      mod.send(original_visibility, name) # rubocop:disable PrisonGuard/UsePublicSend
     end
+    mod.send(original_visibility, name) # rubocop:disable PrisonGuard/UsePublicSend
     new_method = mod.instance_method(name)
 
     ReplacedMethod.new(mod, original_method, new_method, overwritten, original_visibility)

--- a/gems/sorbet-runtime/lib/types/private/class_utils.rb
+++ b/gems/sorbet-runtime/lib/types/private/class_utils.rb
@@ -96,7 +96,9 @@ module T::Private::ClassUtils
 
     overwritten = original_owner == mod
     T::Configuration.without_ruby_warnings do
+      T::Private::DeclState.current.skip_on_method_added = true
       mod.send(:define_method, name, &blk) # rubocop:disable PrisonGuard/UsePublicSend
+      T::Private::DeclState.current.skip_on_method_added = false
     end
     mod.send(original_visibility, name) # rubocop:disable PrisonGuard/UsePublicSend
     new_method = mod.instance_method(name)

--- a/gems/sorbet-runtime/lib/types/private/decl_state.rb
+++ b/gems/sorbet-runtime/lib/types/private/decl_state.rb
@@ -11,6 +11,7 @@ class T::Private::DeclState
   end
 
   attr_accessor :active_declaration
+  attr_accessor :skip_on_method_added
 
   def reset!
     self.active_declaration = nil

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -187,7 +187,6 @@ module T::Private::Methods
     # This wrapper is very slow, so it will subsequently re-wrap with a much faster wrapper
     # (or unwrap back to the original method).
     new_method = nil
-    # this prevents us from running the final checks twice for every method def.
     T::Private::ClassUtils.replace_method(mod, method_name) do |*args, &blk|
       if !T::Private::Methods.has_sig_block_for_method(new_method)
         # This should only happen if the user used alias_method to grab a handle
@@ -420,8 +419,6 @@ module T::Private::Methods
 
   private_class_method def self.install_singleton_method_added_hook(singleton_klass)
     attached = nil
-    # this prevents the final checks from triggering about singleton_method_added not being a final method even if the
-    # module is final.
     original_singleton_method = T::Private::ClassUtils.replace_method(singleton_klass, :singleton_method_added) do |name|
       attached = self
       T::Private::Methods._on_method_added(self, name, is_singleton_method: true)

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -173,11 +173,11 @@ module T::Private::Methods
   def self._on_method_added(hook_mod, method_name, is_singleton_method: false)
     current_declaration = T::Private::DeclState.current.active_declaration
     mod = is_singleton_method ? hook_mod.singleton_class : hook_mod
-    original_method = mod.instance_method(method_name)
 
     return if current_declaration.nil?
     T::Private::DeclState.current.reset!
 
+    original_method = mod.instance_method(method_name)
     sig_block = lambda do
       T::Private::Methods.run_sig(hook_mod, method_name, original_method, current_declaration)
     end

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -174,7 +174,9 @@ module T::Private::Methods
     current_declaration = T::Private::DeclState.current.active_declaration
     mod = is_singleton_method ? hook_mod.singleton_class : hook_mod
 
-    return if current_declaration.nil?
+    if current_declaration.nil?
+      return
+    end
     T::Private::DeclState.current.reset!
 
     original_method = mod.instance_method(method_name)

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -178,6 +178,11 @@ module T::Private::Methods
     current_declaration = T::Private::DeclState.current.active_declaration
     mod = is_singleton_method ? hook_mod.singleton_class : hook_mod
 
+    if T::Private::Final.final_module?(mod) && (current_declaration.nil? || !current_declaration.final)
+      raise "`#{mod.name}` was declared as final but its method `#{method_name}` was not declared as final"
+    end
+    _check_final_ancestors(mod, mod.ancestors, [method_name])
+
     if current_declaration.nil?
       return
     end

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -171,6 +171,10 @@ module T::Private::Methods
 
   # Only public because it needs to get called below inside the replace_method blocks below.
   def self._on_method_added(hook_mod, method_name, is_singleton_method: false)
+    if T::Private::DeclState.current.skip_on_method_added
+      return
+    end
+
     current_declaration = T::Private::DeclState.current.active_declaration
     mod = is_singleton_method ? hook_mod.singleton_class : hook_mod
 

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -170,6 +170,7 @@ module T::Private::Methods::CallValidation
     has_simple_procedure_types = all_args_are_simple && method_sig.return_type.is_a?(T::Private::Types::Void)
 
     T::Configuration.without_ruby_warnings do
+      T::Private::DeclState.current.skip_on_method_added = true
       if has_fixed_arity && has_simple_method_types && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path
         create_validator_method_fast(mod, original_method, method_sig)
       elsif has_fixed_arity && has_simple_procedure_types && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path
@@ -177,6 +178,7 @@ module T::Private::Methods::CallValidation
       else
         create_validator_slow(mod, original_method, method_sig)
       end
+      T::Private::DeclState.current.skip_on_method_added = false
     end
     mod.send(original_visibility, method_sig.method_name)
   end

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -196,7 +196,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     end
   end
 
-  it 'calls original singleton_method_added when registering hooks' do
+  it "calls a user-defined singleton_method_added when registering hooks" do
     klass = Class.new do
       class << self
         def singleton_method_added(name)

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -225,6 +225,28 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     )
   end
 
+  it "allows custom hooks" do
+    parent = Class.new do
+      extend T::Sig
+      sig {params(method: Symbol).void}
+      def self.method_added(method)
+        super(method)
+      end
+      def self.singleton_method_added(method)
+        super(method)
+      end
+    end
+    Class.new(parent) do
+      extend T::Sig
+      sig {void}
+      def a; end
+      sig {void}
+      def b; end
+      sig {void}
+      def c; end
+    end
+  end
+
   it "does not make sig available to attached class" do
     assert_raises(NoMethodError) do
       Class.new do

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -12,7 +12,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "allows declaring an instance method as final" do
-    skip
     Class.new do
       extend T::Sig
       sig(:final) {void}
@@ -21,7 +20,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "allows declaring a class method as final" do
-    skip
     Class.new do
       extend T::Sig
       sig(:final) {void}
@@ -30,7 +28,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids redefining a final instance method with a final sig" do
-    skip
     err = assert_raises(RuntimeError) do
       Class.new do
         extend T::Sig
@@ -44,7 +41,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids redefining a final class method with a final sig" do
-    skip
     err = assert_raises(RuntimeError) do
       Class.new do
         extend T::Sig
@@ -58,7 +54,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids redefining a final instance method with a regular sig" do
-    skip
     err = assert_raises(RuntimeError) do
       Class.new do
         extend T::Sig
@@ -72,7 +67,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids redefining a final class method with a regular sig" do
-    skip
     err = assert_raises(RuntimeError) do
       Class.new do
         extend T::Sig
@@ -86,7 +80,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids redefining a final instance method with no sig" do
-    skip
     err = assert_raises(RuntimeError) do
       Class.new do
         extend T::Sig
@@ -99,7 +92,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids redefining a final class method with no sig" do
-    skip
     err = assert_raises(RuntimeError) do
       Class.new do
         extend T::Sig
@@ -112,7 +104,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "allows redefining a regular instance method to be final" do
-    skip
     Class.new do
       extend T::Sig
       def foo; end
@@ -122,7 +113,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "allows redefining a regular class method to be final" do
-    skip
     Class.new do
       extend T::Sig
       def self.foo; end
@@ -132,7 +122,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding a final instance method" do
-    skip
     c = Class.new do
       extend T::Sig
       sig(:final) {void}
@@ -147,7 +136,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding a final class method" do
-    skip
     c = Class.new do
       extend T::Sig
       sig(:final) {void}
@@ -162,7 +150,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding a final method from an included module" do
-    skip
     m = Module.new do
       extend T::Sig
       sig(:final) {void}
@@ -178,7 +165,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding a final method from an extended module" do
-    skip
     m = Module.new do
       extend T::Sig
       sig(:final) {void}
@@ -194,7 +180,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding a final method by including two modules" do
-    skip
     m1 = Module.new do
       extend T::Sig
       sig(:final) {void}
@@ -212,7 +197,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding a final method by extending two modules" do
-    skip
     m1 = Module.new do
       extend T::Sig
       sig(:final) {void}
@@ -230,7 +214,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "allows calling final methods" do
-    skip
     m = Module.new do
       extend T::Sig
       sig(:final) {void}
@@ -249,7 +232,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "calls a user-defined included" do
-    skip
     m = Module.new do
       @calls = 0
       extend T::Sig
@@ -272,7 +254,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "calls a user-defined extended" do
-    skip
     m = Module.new do
       @calls = 0
       extend T::Sig
@@ -295,7 +276,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "calls an exotic user-defined included" do
-    skip
     m2 = Module.new do
       def self.included(arg)
         arg.include(Module.new do
@@ -315,7 +295,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding through many levels of include" do
-    skip
     m1 = Module.new do
       extend T::Sig
       sig(:final) {void}
@@ -337,7 +316,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "allows including modules again" do
-    skip
     m1 = Module.new do
       extend T::Sig
       sig(:final) {void}
@@ -349,7 +327,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "allows extending modules again" do
-    skip
     m1 = Module.new do
       extend T::Sig
       sig(:final) {void}
@@ -361,7 +338,6 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "has a good error if you use the wrong syntax" do
-    skip
     err = assert_raises(ArgumentError) do
       m = Module.new do
         extend T::Sig

--- a/gems/sorbet-runtime/test/types/final_module.rb
+++ b/gems/sorbet-runtime/test/types/final_module.rb
@@ -63,7 +63,6 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
   end
 
   it "allows declaring a module as final and its instance method as final" do
-    skip
     Module.new do
       extend T::Helpers
       final!
@@ -74,7 +73,6 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
   end
 
   it "allows declaring a module as final and its class method as final" do
-    skip
     Module.new do
       extend T::Helpers
       final!
@@ -85,7 +83,6 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
   end
 
   it "forbids declaring a module as final but not its instance method as final" do
-    skip
     err = assert_raises(RuntimeError) do
       Module.new do
         extend T::Helpers
@@ -99,7 +96,6 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
   end
 
   it "forbids declaring a module as final but not its class method as final" do
-    skip
     err = assert_raises(RuntimeError) do
       Module.new do
         extend T::Helpers


### PR DESCRIPTION
Related to #1348.

#1348 noted a latent issue that was brought to light because of the way the final checks were implemented. This PR doesn't fix the underlying issue, but it does implement the final checks in such a way that the latent issue remains latent.

It is for that reason that although you could say that this PR fixes that issue, in the sense that the given failing example no longer fails, I'm opting to leave the issue open. This is because the actual underlying issue noted in #1348 is not fixed by this PR, but will ultimately be fixed by #1353, which we are temporarily holding off on merging.

The difference between the way final checks used to be implemented, and now, is the way we communicate that we want to skip a call to `_on_method_added` that would have been triggered by `method_added` or `singleton_method_added`.

We used to set a global flag to true to skip the next `_on_method_added`. Then, when `_on_method_added` was called, if that flag was true, we would set it to false and then return.

This broke things when `_on_method_added` wasn't called, such as in the edge-case example brought to light in #1348. In this example, the code overrides sorbet-runtime's custom `method_added` and `singleton_method_added`, which sorbet-runtime had set up to call `_on_method_added`.

Now, in this PR, we still have a global flag which we set to true, but instead the setter of the flag is responsible for re-setting the flag back to false once the `_on_method_added` call is known to have been resolved, if it was going to be resolved.

If `_on_method_added` is called in between setting the flag to true, and setting the flag to false, then it immediately returns because it reads the flag as true. But if it isn't called, then we still ensure the flag is set to false, because it is now the flag-setter's responsibility.

This is a bit of a hacky solution, but given the fact that we implement lazy sig-wrapping logic with an extra call (or two!) to `define_method` for every `def` from the user, and given also that we do want to allow redefinitions of methods if they're not marked final, I couldn't think of anything more encapsulated.

### Motivation
To allow the final checks to be turned on.

### Test plan

See included automated tests.
