### PR TITLE
Fix incompatible overrides in pay-server

### DIFF
--- a/rbi/stdlib/optparse.rbi
+++ b/rbi/stdlib/optparse.rbi
@@ -218,8 +218,8 @@ class OptionParser
     sig {params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped)}
     def complete(key, icase = false, pat = nil); end
 
-    sig {params(opt: T.untyped, val: T.untyped).returns(T.untyped)}
-    def convert(opt = nil, val = nil); end
+    sig {params(opt: T.untyped, val: T.untyped, _: T.untyped).returns(T.untyped)}
+    def convert(opt = nil, val = nil, *_); end
   end
 
   class OptionMap < Hash
@@ -313,8 +313,8 @@ class OptionParser
       sig {params(arg: T.untyped, argv: T.untyped).returns(T.untyped)}
       def parse(arg, argv); end
 
-      sig {returns(T.untyped)}
-      def self.incompatible_argument_styles(); end
+      sig {params(_: T.untyped).returns(T.untyped)}
+      def self.incompatible_argument_styles(*_); end
 
       sig {returns(T.untyped)}
       def self.pattern(); end

--- a/test/cli/error-url/error-url.out
+++ b/test/cli/error-url/error-url.out
@@ -1,21 +1,21 @@
 test/cli/error-url/error-url.rb:4: Unable to resolve constant `MissingConstant` https://example.com/errors/?error=5002
      4 |    MissingConstant
             ^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparser.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparse.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
      743 |  class MissingArgument < OptionParser::ParseError; end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 1
 test/cli/error-url/error-url.rb:4: Unable to resolve constant `MissingConstant` https://example.com/error/5002
      4 |    MissingConstant
             ^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparser.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparse.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
      743 |  class MissingArgument < OptionParser::ParseError; end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 1
 test/cli/error-url/error-url.rb:4: Unable to resolve constant `MissingConstant` https://example.com/error#5002
      4 |    MissingConstant
             ^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparser.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparse.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
      743 |  class MissingArgument < OptionParser::ParseError; end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 1

--- a/test/cli/errors/errors.out
+++ b/test/cli/errors/errors.out
@@ -1,7 +1,7 @@
 test/cli/errors/errors.rb:4: Unable to resolve constant `MissingConstant` https://srb.help/5002
      4 |    MissingConstant
             ^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparser.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparse.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
      743 |  class MissingArgument < OptionParser::ParseError; end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -51,7 +51,7 @@ Errors: 4
 test/cli/errors/errors.rb:4: Unable to resolve constant `MissingConstant` https://srb.help/5002
      4 |    MissingConstant
             ^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparser.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparse.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
      743 |  class MissingArgument < OptionParser::ParseError; end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -101,7 +101,7 @@ Errors: 4
 test/cli/errors/errors.rb:4: Unable to resolve constant `MissingConstant` https://srb.help/5002
      4 |    MissingConstant
             ^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparser.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparse.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
      743 |  class MissingArgument < OptionParser::ParseError; end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
These are also more correct w.r.t. the official docs:

<https://ruby-doc.org/stdlib-2.5.1/libdoc/optparse/rdoc/OptionParser/Switch/NoArgument.html#method-c-incompatible_argument_styles>
<https://ruby-doc.org/stdlib-2.6.1/libdoc/optparse/rdoc/OptionParser/Completion.html#method-i-convert>

It's also `require 'optparse'`, so I've changed the filename (this also
matches what was in pay-server).


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Unbreak pay-server. This regressed in #1265.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Verified that typecheck_devel passes and that the total/empty test still inits
+ typechecks.