### PR TITLE
Make two tests not depend on the stdlib

### DIFF
--- a/test/cli/error-url/error-url.out
+++ b/test/cli/error-url/error-url.out
@@ -1,21 +1,24 @@
-test/cli/error-url/error-url.rb:4: Unable to resolve constant `MissingConstant` https://example.com/errors/?error=5002
-     4 |    MissingConstant
-            ^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparse.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
-     743 |  class MissingArgument < OptionParser::ParseError; end
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+test/cli/error-url/error-url.rb:5: Revealed type: `TrueClass` https://example.com/errors/?error=7014
+     5 |T.reveal_type(true)
+        ^^^^^^^^^^^^^^^^^^^
+  From:
+    test/cli/error-url/error-url.rb:5:
+     5 |T.reveal_type(true)
+                      ^^^^
 Errors: 1
-test/cli/error-url/error-url.rb:4: Unable to resolve constant `MissingConstant` https://example.com/error/5002
-     4 |    MissingConstant
-            ^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparse.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
-     743 |  class MissingArgument < OptionParser::ParseError; end
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+test/cli/error-url/error-url.rb:5: Revealed type: `TrueClass` https://example.com/error/7014
+     5 |T.reveal_type(true)
+        ^^^^^^^^^^^^^^^^^^^
+  From:
+    test/cli/error-url/error-url.rb:5:
+     5 |T.reveal_type(true)
+                      ^^^^
 Errors: 1
-test/cli/error-url/error-url.rb:4: Unable to resolve constant `MissingConstant` https://example.com/error#5002
-     4 |    MissingConstant
-            ^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparse.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
-     743 |  class MissingArgument < OptionParser::ParseError; end
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+test/cli/error-url/error-url.rb:5: Revealed type: `TrueClass` https://example.com/error#7014
+     5 |T.reveal_type(true)
+        ^^^^^^^^^^^^^^^^^^^
+  From:
+    test/cli/error-url/error-url.rb:5:
+     5 |T.reveal_type(true)
+                      ^^^^
 Errors: 1

--- a/test/cli/error-url/error-url.rb
+++ b/test/cli/error-url/error-url.rb
@@ -1,6 +1,5 @@
 # typed: true
-class BasicError
-  def basicError
-    MissingConstant
-  end
-end
+
+# Make this test not depend on anything in the stdlib so that snapshot output
+# never can change in response to things external to this test.
+T.reveal_type(true)

--- a/test/cli/errors/errors.out
+++ b/test/cli/errors/errors.out
@@ -1,150 +1,150 @@
-test/cli/errors/errors.rb:4: Unable to resolve constant `MissingConstant` https://srb.help/5002
-     4 |    MissingConstant
-            ^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparse.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
-     743 |  class MissingArgument < OptionParser::ParseError; end
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+test/cli/errors/errors.rb:5: Unable to resolve constant `MyConstantWithTypo` https://srb.help/5002
+     5 |    MyConstantWithTypo
+            ^^^^^^^^^^^^^^^^^^
+    test/cli/errors/errors.rb:3: Did you mean: `BasicError::MyConstantWithNoTypo`?
+     3 |  MyConstantWithNoTypo = nil
+          ^^^^^^^^^^^^^^^^^^^^
 
-test/cli/errors/errors.rb:14: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
-    14 |    raise arg # raise is defined by stdlib
+test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
+    15 |    raise arg # raise is defined by stdlib
             ^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L850: Method `Kernel#raise (overload.1)` has specified `arg0` as `String`
      850 |        arg0: String,
                   ^^^^
   Got Integer originating from:
-    test/cli/errors/errors.rb:12:
-    12 |  def foo(arg)
+    test/cli/errors/errors.rb:13:
+    13 |  def foo(arg)
                   ^^^
 
-test/cli/errors/errors.rb:18: Expected `Integer` but found `String("foo")` for argument `arg` https://srb.help/7002
-    18 |    foo("foo")
+test/cli/errors/errors.rb:19: Expected `Integer` but found `String("foo")` for argument `arg` https://srb.help/7002
+    19 |    foo("foo")
             ^^^^^^^^^^
-    test/cli/errors/errors.rb:11: Method `ComplexError#foo` has specified `arg` as `Integer`
-    11 |  sig {params(arg: Integer).returns(NilClass)}
+    test/cli/errors/errors.rb:12: Method `ComplexError#foo` has specified `arg` as `Integer`
+    12 |  sig {params(arg: Integer).returns(NilClass)}
                       ^^^
   Got String("foo") originating from:
-    test/cli/errors/errors.rb:18:
-    18 |    foo("foo")
+    test/cli/errors/errors.rb:19:
+    19 |    foo("foo")
                 ^^^^^
 
-test/cli/errors/errors.rb:32: Expected `Integer` but found `T.nilable(Integer)` for argument `a` https://srb.help/7002
-    32 |    bar(a)
+test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` for argument `a` https://srb.help/7002
+    33 |    bar(a)
             ^^^^^^
-    test/cli/errors/errors.rb:35: Method `ErrorLines#bar` has specified `a` as `Integer`
-    35 |  sig {params(a: Integer).returns(Integer)}
+    test/cli/errors/errors.rb:36: Method `ErrorLines#bar` has specified `a` as `Integer`
+    36 |  sig {params(a: Integer).returns(Integer)}
                       ^
   Got T.nilable(Integer) originating from:
-    test/cli/errors/errors.rb:25:
-    25 |  def main(foo)
+    test/cli/errors/errors.rb:26:
+    26 |  def main(foo)
           ^^^^^^^^^^^^^
-    test/cli/errors/errors.rb:28:
-    28 |          nil
+    test/cli/errors/errors.rb:29:
+    29 |          nil
                   ^^^
-    test/cli/errors/errors.rb:30:
-    30 |          2
+    test/cli/errors/errors.rb:31:
+    31 |          2
                   ^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/errors/errors.rb:32: Replace with `T.must(a)`
-    32 |    bar(a)
+    test/cli/errors/errors.rb:33: Replace with `T.must(a)`
+    33 |    bar(a)
                 ^
 Errors: 4
-test/cli/errors/errors.rb:4: Unable to resolve constant `MissingConstant` https://srb.help/5002
-     4 |    MissingConstant
-            ^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparse.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
-     743 |  class MissingArgument < OptionParser::ParseError; end
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+test/cli/errors/errors.rb:5: Unable to resolve constant `MyConstantWithTypo` https://srb.help/5002
+     5 |    MyConstantWithTypo
+            ^^^^^^^^^^^^^^^^^^
+    test/cli/errors/errors.rb:3: Did you mean: `BasicError::MyConstantWithNoTypo`?
+     3 |  MyConstantWithNoTypo = nil
+          ^^^^^^^^^^^^^^^^^^^^
 
-test/cli/errors/errors.rb:14: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
-    14 |    raise arg # raise is defined by stdlib
+test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
+    15 |    raise arg # raise is defined by stdlib
             ^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L850: Method `Kernel#raise (overload.1)` has specified `arg0` as `String`
      850 |        arg0: String,
                   ^^^^
   Got Integer originating from:
-    test/cli/errors/errors.rb:12:
-    12 |  def foo(arg)
+    test/cli/errors/errors.rb:13:
+    13 |  def foo(arg)
                   ^^^
 
-test/cli/errors/errors.rb:18: Expected `Integer` but found `String("foo")` for argument `arg` https://srb.help/7002
-    18 |    foo("foo")
+test/cli/errors/errors.rb:19: Expected `Integer` but found `String("foo")` for argument `arg` https://srb.help/7002
+    19 |    foo("foo")
             ^^^^^^^^^^
-    test/cli/errors/errors.rb:11: Method `ComplexError#foo` has specified `arg` as `Integer`
-    11 |  sig {params(arg: Integer).returns(NilClass)}
+    test/cli/errors/errors.rb:12: Method `ComplexError#foo` has specified `arg` as `Integer`
+    12 |  sig {params(arg: Integer).returns(NilClass)}
                       ^^^
   Got String("foo") originating from:
-    test/cli/errors/errors.rb:18:
-    18 |    foo("foo")
+    test/cli/errors/errors.rb:19:
+    19 |    foo("foo")
                 ^^^^^
 
-test/cli/errors/errors.rb:32: Expected `Integer` but found `T.nilable(Integer)` for argument `a` https://srb.help/7002
-    32 |    bar(a)
+test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` for argument `a` https://srb.help/7002
+    33 |    bar(a)
             ^^^^^^
-    test/cli/errors/errors.rb:35: Method `ErrorLines#bar` has specified `a` as `Integer`
-    35 |  sig {params(a: Integer).returns(Integer)}
+    test/cli/errors/errors.rb:36: Method `ErrorLines#bar` has specified `a` as `Integer`
+    36 |  sig {params(a: Integer).returns(Integer)}
                       ^
   Got T.nilable(Integer) originating from:
-    test/cli/errors/errors.rb:25:
-    25 |  def main(foo)
+    test/cli/errors/errors.rb:26:
+    26 |  def main(foo)
           ^^^^^^^^^^^^^
-    test/cli/errors/errors.rb:28:
-    28 |          nil
+    test/cli/errors/errors.rb:29:
+    29 |          nil
                   ^^^
-    test/cli/errors/errors.rb:30:
-    30 |          2
+    test/cli/errors/errors.rb:31:
+    31 |          2
                   ^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/errors/errors.rb:32: Replace with `T.must(a)`
-    32 |    bar(a)
+    test/cli/errors/errors.rb:33: Replace with `T.must(a)`
+    33 |    bar(a)
                 ^
 Errors: 4
-test/cli/errors/errors.rb:4: Unable to resolve constant `MissingConstant` https://srb.help/5002
-     4 |    MissingConstant
-            ^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/optparse.rbi#L743: Did you mean: `OptionParser::MissingArgument`?
-     743 |  class MissingArgument < OptionParser::ParseError; end
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+test/cli/errors/errors.rb:5: Unable to resolve constant `MyConstantWithTypo` https://srb.help/5002
+     5 |    MyConstantWithTypo
+            ^^^^^^^^^^^^^^^^^^
+    test/cli/errors/errors.rb:3: Did you mean: `BasicError::MyConstantWithNoTypo`?
+     3 |  MyConstantWithNoTypo = nil
+          ^^^^^^^^^^^^^^^^^^^^
 
-test/cli/errors/errors.rb:14: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
-    14 |    raise arg # raise is defined by stdlib
+test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
+    15 |    raise arg # raise is defined by stdlib
             ^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L850: Method `Kernel#raise (overload.1)` has specified `arg0` as `String`
      850 |        arg0: String,
                   ^^^^
   Got Integer originating from:
-    test/cli/errors/errors.rb:12:
-    12 |  def foo(arg)
+    test/cli/errors/errors.rb:13:
+    13 |  def foo(arg)
                   ^^^
 
-test/cli/errors/errors.rb:18: Expected `Integer` but found `String("foo")` for argument `arg` https://srb.help/7002
-    18 |    foo("foo")
+test/cli/errors/errors.rb:19: Expected `Integer` but found `String("foo")` for argument `arg` https://srb.help/7002
+    19 |    foo("foo")
             ^^^^^^^^^^
-    test/cli/errors/errors.rb:11: Method `ComplexError#foo` has specified `arg` as `Integer`
-    11 |  sig {params(arg: Integer).returns(NilClass)}
+    test/cli/errors/errors.rb:12: Method `ComplexError#foo` has specified `arg` as `Integer`
+    12 |  sig {params(arg: Integer).returns(NilClass)}
                       ^^^
   Got String("foo") originating from:
-    test/cli/errors/errors.rb:18:
-    18 |    foo("foo")
+    test/cli/errors/errors.rb:19:
+    19 |    foo("foo")
                 ^^^^^
 
-test/cli/errors/errors.rb:32: Expected `Integer` but found `T.nilable(Integer)` for argument `a` https://srb.help/7002
-    32 |    bar(a)
+test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` for argument `a` https://srb.help/7002
+    33 |    bar(a)
             ^^^^^^
-    test/cli/errors/errors.rb:35: Method `ErrorLines#bar` has specified `a` as `Integer`
-    35 |  sig {params(a: Integer).returns(Integer)}
+    test/cli/errors/errors.rb:36: Method `ErrorLines#bar` has specified `a` as `Integer`
+    36 |  sig {params(a: Integer).returns(Integer)}
                       ^
   Got T.nilable(Integer) originating from:
-    test/cli/errors/errors.rb:25:
-    25 |  def main(foo)
+    test/cli/errors/errors.rb:26:
+    26 |  def main(foo)
           ^^^^^^^^^^^^^
-    test/cli/errors/errors.rb:28:
-    28 |          nil
+    test/cli/errors/errors.rb:29:
+    29 |          nil
                   ^^^
-    test/cli/errors/errors.rb:30:
-    30 |          2
+    test/cli/errors/errors.rb:31:
+    31 |          2
                   ^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/errors/errors.rb:32: Replace with `T.must(a)`
-    32 |    bar(a)
+    test/cli/errors/errors.rb:33: Replace with `T.must(a)`
+    33 |    bar(a)
                 ^
 Errors: 4

--- a/test/cli/errors/errors.rb
+++ b/test/cli/errors/errors.rb
@@ -1,7 +1,8 @@
 # typed: true
 class BasicError
+  MyConstantWithNoTypo = nil
   def basicError
-    MissingConstant
+    MyConstantWithTypo
   end
 end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These caused me to update_exp_files for an RBI-only change.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.