### PR TITLE
Don't need minitest nor mocha to test srb init

### DIFF
--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -80,6 +80,8 @@ smoke_test_dir="$(mktemp -d)"
 # shellcheck disable=SC2064
 trap "rm -rf '$smoke_test_dir'" EXIT
 
+cp ../../.ruby-version "$smoke_test_dir"
+
 (
   # Make sure we're in a totally separate tree, otherwise a Gemfile from a
   # parent folder will affect this test.

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -50,7 +50,8 @@ steps:
 
   - label: ":mac: build-static-release.sh (master only)"
     command: .buildkite/build-static-release.sh
-    branches: master
+    # TODO(jez) TESTING DONT COMMIT
+    # branches: master
     artifact_paths: _out_/**/*
     agents:
       os: mac


### PR DESCRIPTION
Turns out that `srb init` explicitly doesn't work in projects without Gemfiles,
so I deleted the part of this test where I thought that was supposed to work
but in fact it was only working because it was using the `Gemfile` from the
parent directory.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Improves #1369.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.