### PR TITLE
Hide suggestion in error-reference

### DIFF
--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -149,7 +149,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                     }
                     if (auto e = ctx.state.beginError(expr.loc, core::errors::Infer::DeadBranchInferencer)) {
                         e.setHeader("This code is unreachable");
-                        e.addErrorLine(expr.loc, "To assert that a branch can never happen, use `{}`", "T.absurd(...)");
+                        e.addErrorLine(expr.loc, "If you meant this to be unreachable use `{}`", "T.absurd(...)");
                     }
                     break;
                 }

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -149,7 +149,6 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                     }
                     if (auto e = ctx.state.beginError(expr.loc, core::errors::Infer::DeadBranchInferencer)) {
                         e.setHeader("This code is unreachable");
-                        e.addErrorLine(expr.loc, "If you meant this to be unreachable use `{}`", "T.absurd(...)");
                     }
                     break;
                 }

--- a/test/cli/configatron/configatron.out
+++ b/test/cli/configatron/configatron.out
@@ -1,7 +1,4 @@
 test/cli/configatron/configatron.rb:24: This code is unreachable https://srb.help/7006
     24 |    if config && 4
                ^^^^^^
-    test/cli/configatron/configatron.rb:24: To assert that a branch can never happen, use `T.absurd(...)`
-    24 |    if config && 4
-               ^^^^^^
 Errors: 1

--- a/test/cli/suggest-sig-garbage/suggest-sig-garbage.out
+++ b/test/cli/suggest-sig-garbage/suggest-sig-garbage.out
@@ -149,21 +149,12 @@ suggest-sig-garbage.rb:79: This function does not have a `sig` https://srb.help/
 suggest-sig-garbage.rb:85: This code is unreachable https://srb.help/7006
     85 |  if true || qux || blah
                      ^^^
-    suggest-sig-garbage.rb:85: To assert that a branch can never happen, use `T.absurd(...)`
-    85 |  if true || qux || blah
-                     ^^^
 
 suggest-sig-garbage.rb:85: This code is unreachable https://srb.help/7006
     85 |  if true || qux || blah
                             ^^^^
-    suggest-sig-garbage.rb:85: To assert that a branch can never happen, use `T.absurd(...)`
-    85 |  if true || qux || blah
-                            ^^^^
 
 suggest-sig-garbage.rb:88: This code is unreachable https://srb.help/7006
-    88 |    takesString(x)
-            ^^^^^^^^^^^^^^
-    suggest-sig-garbage.rb:88: To assert that a branch can never happen, use `T.absurd(...)`
     88 |    takesString(x)
             ^^^^^^^^^^^^^^
 

--- a/test/cli/suggest-sig/suggest-sig.out
+++ b/test/cli/suggest-sig/suggest-sig.out
@@ -144,21 +144,12 @@ suggest-sig.rb:79: This function does not have a `sig` https://srb.help/7017
 suggest-sig.rb:85: This code is unreachable https://srb.help/7006
     85 |  if true || qux || blah
                      ^^^
-    suggest-sig.rb:85: To assert that a branch can never happen, use `T.absurd(...)`
-    85 |  if true || qux || blah
-                     ^^^
 
 suggest-sig.rb:85: This code is unreachable https://srb.help/7006
     85 |  if true || qux || blah
                             ^^^^
-    suggest-sig.rb:85: To assert that a branch can never happen, use `T.absurd(...)`
-    85 |  if true || qux || blah
-                            ^^^^
 
 suggest-sig.rb:88: This code is unreachable https://srb.help/7006
-    88 |    takesString(x)
-            ^^^^^^^^^^^^^^
-    suggest-sig.rb:88: To assert that a branch can never happen, use `T.absurd(...)`
     88 |    takesString(x)
             ^^^^^^^^^^^^^^
 

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -594,6 +594,11 @@ don't usually expect that some branch of code is never taken; usually dead code
 errors come from simple typos or misunderstandings about how Ruby works. In
 particular: the only two "falsy" values in Ruby are `nil` and `false`.
 
+Note if you intend for code to be dead because you've exhausted all the cases
+and are trying to raise in the default case, use `T.absurd` to assert that a
+case analysis is exhaustive. See [Exhaustiveness Checking](exhaustiveness.md)
+for more information.
+
 Sometimes, dead code errors can be hard to track down. The best way to pinpoint
 the cause of a dead code error is to wrap variables or expressions in
 `T.reveal_type(...)` to validate the assumptions that a piece of code is making.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->





### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Carl pointed out that we can suggest this in places where `T.absurd` is
not the answer, so I'd rather put this help in the error-reference
rather than in every error message.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
