### PR TITLE
Add constants and aliases to optparse.rbi

### DIFF
--- a/rbi/stdlib/optparse.rbi
+++ b/rbi/stdlib/optparse.rbi
@@ -1,5 +1,20 @@
 # typed: __STDLIB_INTERNAL
 class OptionParser
+  ArgumentStyle = T.let(nil, T.untyped)
+  COMPSYS_HEADER = T.let(nil, T.untyped)
+  DecimalInteger = T.let(nil, T.untyped)
+  DecimalNumeric = T.let(nil, T.untyped)
+  DefaultList = T.let(nil, T.untyped)
+  NO_ARGUMENT = T.let(nil, T.untyped)
+  NoArgument = T.let(nil, T.untyped)
+  OPTIONAL_ARGUMENT = T.let(nil, T.untyped)
+  OctalInteger = T.let(nil, T.untyped)
+  Officious = T.let(nil, T.untyped)
+  OptionalArgument = T.let(nil, T.untyped)
+  REQUIRED_ARGUMENT = T.let(nil, T.untyped)
+  RequiredArgument = T.let(nil, T.untyped)
+  SPLAT_PROC = T.let(nil, T.untyped)
+
   sig {params(to: T.untyped, name: T.untyped).returns(T.untyped)}
   def compsys(to, name = File.basename($0)); end
 
@@ -69,6 +84,11 @@ class OptionParser
   sig {returns(T.untyped)}
   def program_name(); end
 
+  alias set_banner banner=
+  alias set_program_name program_name=
+  alias set_summary_width summary_width=
+  alias set_summary_indent summary_indent=
+
   sig {params(value: T.untyped).returns(T.untyped)}
   def version=(value); end
 
@@ -128,17 +148,23 @@ class OptionParser
   sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
   def define(*opts, &block); end
 
+  alias def_option define
+
   sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
   def on(*opts, &block); end
 
   sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
   def define_head(*opts, &block); end
+  
+  alias def_head_option define_head
 
   sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
   def on_head(*opts, &block); end
 
   sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
   def define_tail(*opts, &block); end
+  
+  alias def_tail_option define_tail
 
   sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
   def on_tail(*opts, &block); end
@@ -705,6 +731,8 @@ class OptionParser
   end
 
   class ParseError < RuntimeError
+    Reason = T.let(nil, T.untyped)
+
     sig {params(args: T.untyped).void}
     def initialize(*args); end
 
@@ -736,17 +764,29 @@ class OptionParser
     def message(); end
   end
 
-  class AmbiguousOption < OptionParser::ParseError; end
+  class AmbiguousOption < OptionParser::ParseError
+    Reason = T.let(nil, T.untyped)
+  end
 
-  class NeedlessArgument < OptionParser::ParseError; end
+  class NeedlessArgument < OptionParser::ParseError
+    Reason = T.let(nil, T.untyped)
+  end
 
-  class MissingArgument < OptionParser::ParseError; end
+  class MissingArgument < OptionParser::ParseError
+    Reason = T.let(nil, T.untyped)
+  end
 
-  class InvalidOption < OptionParser::ParseError; end
+  class InvalidOption < OptionParser::ParseError
+    Reason = T.let(nil, T.untyped)
+  end
 
-  class InvalidArgument < OptionParser::ParseError; end
+  class InvalidArgument < OptionParser::ParseError
+    Reason = T.let(nil, T.untyped)
+  end
 
-  class AmbiguousArgument < OptionParser::InvalidArgument; end
+  class AmbiguousArgument < OptionParser::InvalidArgument
+    Reason = T.let(nil, T.untyped)
+  end
 
   module Arguable
     sig {params(opt: T.untyped).returns(T.untyped)}
@@ -774,5 +814,11 @@ class OptionParser
     def initialize(*args); end
   end
 
-  module Acceptables; end
+  module Acceptables
+    DecimalInteger = T.let(nil, T.untyped)
+    DecimalNumeric = T.let(nil, T.untyped)
+    OctalInteger = T.let(nil, T.untyped)
+  end
 end
+
+OptParse = OptionParser

--- a/rbi/stdlib/optparse.rbi
+++ b/rbi/stdlib/optparse.rbi
@@ -58,7 +58,13 @@ class OptionParser
   def banner=(value); end
 
   sig {params(value: T.untyped).returns(T.untyped)}
+  def set_banner(value); end
+
+  sig {params(value: T.untyped).returns(T.untyped)}
   def program_name=(value); end
+
+  sig {params(value: T.untyped).returns(T.untyped)}
+  def set_program_name(value); end
 
   sig {returns(T.untyped)}
   def summary_width(); end
@@ -66,11 +72,17 @@ class OptionParser
   sig {params(value: T.untyped).returns(T.untyped)}
   def summary_width=(value); end
 
+  sig {params(value: T.untyped).returns(T.untyped)}
+  def set_summary_width(value); end
+
   sig {returns(T.untyped)}
   def summary_indent(); end
 
   sig {params(value: T.untyped).returns(T.untyped)}
   def summary_indent=(value); end
+
+  sig {params(value: T.untyped).returns(T.untyped)}
+  def set_summary_indent(value); end
 
   sig {returns(T.untyped)}
   def default_argv(); end
@@ -83,11 +95,6 @@ class OptionParser
 
   sig {returns(T.untyped)}
   def program_name(); end
-
-  alias set_banner banner=
-  alias set_program_name program_name=
-  alias set_summary_width summary_width=
-  alias set_summary_indent summary_indent=
 
   sig {params(value: T.untyped).returns(T.untyped)}
   def version=(value); end
@@ -148,23 +155,26 @@ class OptionParser
   sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
   def define(*opts, &block); end
 
-  alias def_option define
+  sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
+  def def_option(*opts, &block); end
 
   sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
   def on(*opts, &block); end
 
   sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
   def define_head(*opts, &block); end
-  
-  alias def_head_option define_head
+
+  sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
+  def def_head_option(*opts, &block); end
 
   sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
   def on_head(*opts, &block); end
 
   sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
   def define_tail(*opts, &block); end
-  
-  alias def_tail_option define_tail
+
+  sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
+  def def_tail_option(*opts, &block); end
 
   sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
   def on_tail(*opts, &block); end


### PR DESCRIPTION
Just handling a few things I missed in the original creation of `optparse.rbi`. Hopefully this time nothing will break 🙇 

I'm not sure if `alias` will work in a Sorbet stdlib RBI, none of the others seem to use it? I'm just using what's in the optparse.rb file in Ruby itself.

### Motivation
There were still some methods and constants from OptionParser that , and the original RBI also missed the [`OptParse` alias for `OptionParser`](https://github.com/ruby/ruby/blob/v2_6_3/lib/optparse.rb#L2191).

### Test plan
See included automated tests.
