### PR TITLE
Make publish script fail when `file` is missing

### DIFF
--- a/.buildkite/tools/gh-release.sh
+++ b/.buildkite/tools/gh-release.sh
@@ -45,6 +45,7 @@ fi
 
 if ! command file &> /dev/null; then
   echo "This script requires the 'file' command, but it was not in PATH"
+  exit 1
 fi
 
 REPO="$1"

--- a/.buildkite/tools/gh-release.sh
+++ b/.buildkite/tools/gh-release.sh
@@ -43,6 +43,10 @@ fi
 
 [ "$2" != "" ] || (usage; exit 1);
 
+if ! command file &> /dev/null; then
+  echo "This script requires the 'file' command, but it was not in PATH"
+fi
+
 REPO="$1"
 shift
 

--- a/.buildkite/tools/gh-release.sh
+++ b/.buildkite/tools/gh-release.sh
@@ -82,9 +82,10 @@ response=$(
 
 upload_url="$(echo "$response" | jq -r .upload_url | sed -e "s/{?name,label}//")"
 
+content_type="Content-Type:$(file --mime-type -b "${asset}")"
 for asset in $ASSETS; do
   curl --netrc \
-       --header "Content-Type:$(file --mime-type -b "${asset}")" \
+       --header "$content_type" \
        --data-binary "@$asset" \
        "$upload_url?name=$asset"
 done


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This will make publish.sh fail fast when the `file` command isn't
available. As far as I can tell, there's no way to make the bash
pattern:

    some_good_cmd "$(some_bad_command)"

fail fast by enabling a flag. In every case it will need to be
refactored to

    x="$(some_bad_command)"
    some_good_cmd "$x"

which as a Bash enthusiast is deeply saddening. shellcheck doesn't warn
for this, no future version of bash solves this, etc. I don't think it's
worth patently avoiding this, because it can make things more verbose
and coming up with names can be hard, but it's something to be aware of.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This will fail if we merge to master, because this change is hidden on branch
builds behind a `$dryrun` check.

The only machine affected right now is the non-elastic Linux build machine.
We'll need to make sure that `file` is installed there before proceeding.