### PR TITLE
LSP - Initialize - Trim trailing slash from rootUri

### DIFF
--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -1,6 +1,8 @@
 #include "common/Timer.h"
 #include "lsp.h"
 
+#include "absl/strings/match.h"
+
 using namespace std;
 
 namespace sorbet::realmain::lsp {
@@ -130,7 +132,11 @@ LSPResult LSPLoop::processRequestInternal(unique_ptr<core::GlobalState> gs, cons
             prodCategoryCounterInc("lsp.messages.processed", "initialize");
             auto &params = get<unique_ptr<InitializeParams>>(rawParams);
             if (auto rootUriString = get_if<string>(&params->rootUri)) {
-                rootUri = *rootUriString;
+                if (absl::EndsWith(*rootUriString, "/")) {
+                    rootUri = rootUriString->substr(0, rootUriString->length() - 1);
+                } else {
+                    rootUri = *rootUriString;
+                }
             }
             clientCompletionItemSnippetSupport = false;
             clientHoverMarkupKind = MarkupKind::Plaintext;


### PR DESCRIPTION
### Motivation
Atom reports the rootUri with a trailing slash. This causes uris of filter paths to have double slashes in them.

### Test plan
It's been many years since I wrote C++, and I was uncertain of how to test this - LSP tests seem to all be recordings? Happy to add a test if it's necessary and I'm pointed in the right direction :)
