### PR TITLE
runtime: Fix sig block deletion race

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -352,7 +352,13 @@ module T::Private::Methods
   private_class_method def self.run_sig_block_for_key(key)
     blk = @sig_wrappers[key]
     if !blk
-      raise "No `sig` wrapper for #{key_to_method(key)}"
+      sig = @signatures_by_method[key]
+      if sig
+        # We already ran the sig block, perhaps in another thread.
+        return sig
+      else
+        raise "No `sig` wrapper for #{key_to_method(key)}"
+      end
     end
 
     begin

--- a/gems/sorbet-runtime/sorbet-runtime.gemspec
+++ b/gems/sorbet-runtime/sorbet-runtime.gemspec
@@ -13,4 +13,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest', '~> 5.11'
   s.add_development_dependency 'mocha', '~> 1.7'
   s.add_development_dependency 'rake'
+  # for reproducing race conditions in tests
+  s.add_development_dependency 'concurrent-ruby', '~> 1.1.5'
 end


### PR DESCRIPTION
When two threads commit to calling the the same wrapper and
one thread deletes the sig block from the `sig_wrappers` hash
before the other one does the look up, sorbet-runtime raises.

Fix this issue by checking whether the sig block was already
evaluated when it is missing from the sig_wrappers hash.

Fixes #1386

### Motivation
This is making CI flaky for us.


### Test plan

See included automated tests.
