### PR TITLE
Do not print full option manual on mistyping options.

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -844,7 +844,7 @@ void readOptions(Options &opts, int argc, char *argv[],
             opts.dslRubyExtraArgs = std::move(dslConfig.rubyExtraArgs);
         }
     } catch (cxxopts::OptionParseException &e) {
-        logger->info("{}\n\n{}", e.what(), options.help({"", "advanced", "dev"}));
+        logger->info("{}. To see all available options pass `--help`.", e.what());
         throw EarlyReturnWithCode(1);
     }
 }

--- a/test/cli/non-existing-option/non-existing-option.out
+++ b/test/cli/non-existing-option/non-existing-option.out
@@ -1,0 +1,2 @@
+Option ‘long-option’ does not exist. To see all available options pass `--help`.
+Argument ‘-short-option’ starts with a - but has incorrect syntax. To see all available options pass `--help`.

--- a/test/cli/non-existing-option/non-existing-option.sh
+++ b/test/cli/non-existing-option/non-existing-option.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+main/sorbet --long-option 2>&1
+main/sorbet -short-option 2>&1


### PR DESCRIPTION
Option manual is huge and folks do not see the error above it.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
