### PR TITLE
Substantially (~2x) speedup iteration time for folks working on LSP.

### DIFF
--- a/main/BUILD
+++ b/main/BUILD
@@ -45,7 +45,7 @@ cc_binary(
     }),
     visibility = ["//visibility:public"],
     deps = [
-        "realmain",
+        "realmain-orig",
         "//payload:text",
     ],
 )
@@ -68,6 +68,27 @@ cc_library(
         "//core/proto",
         "//main/autogen",
         "//main/lsp",
+        "//main/options",
+        "//main/pipeline",
+        "//payload:interface",
+    ],
+)
+
+cc_library(
+    name = "realmain-orig",
+    srcs = [
+        "realmain.cc",
+        "realmain.h",
+    ],
+    defines = ["SORBET_REALMAIN_MIN"],
+    linkstatic = select({
+        "//tools/config:linkshared": 0,
+        "//conditions:default": 1,
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//ast",
+        "//core",
         "//main/options",
         "//main/pipeline",
         "//payload:interface",

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -1,6 +1,5 @@
 #ifdef SORBET_REALMAIN_MIN
 // minimal build to speedup compilation. Remove extra features
-#define FULL_BUILD_ONLY(X) false; // do nothing
 #else
 #define FULL_BUILD_ONLY(X) X;
 #include "core/proto/proto.h" // has to be included first as it violates our poisons

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -40,6 +40,7 @@ compilation_database(
         "//payload/binary:empty",
         "//main:sorbet",
         "//payload:payload",
+        "//main:realmain-orig",
         "//infer:infer_test",
         "//emscripten:main",
         "//payload/text:empty",


### PR DESCRIPTION
Do not link against LSP, Autogen, Proto & metrics in sorbet-orig.

### Motivation
Faster iteration time.
I've tried to do it using smart macros similar to `DEBUG_ONLY` that we already have, but IMHO it looked worse.

While I hate the implementation of this PR, I think it's worth it as it speeds up folks who work outside of Sorbet core.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
