### PR TITLE
Add missing methods for the Method class.

### DIFF
--- a/rbi/core/method.rbi
+++ b/rbi/core/method.rbi
@@ -7,17 +7,17 @@ class Method < Object
   sig {params(args: T.untyped).returns(T.untyped)}
   def call(*args);end
 
-  sig {params(_: T.untyped).returns(T.untyped)}
-  def <<(_); end
+  sig {params(g: T.untyped).returns(T.untyped)}
+  def <<(g); end
 
-  sig {params(_: T.untyped).returns(T.untyped)}
-  def ===(*_); end
+  sig {params(obj: T.untyped).returns(T.untyped)}
+  def ===(*obj); end
 
-  sig {params(_: T.untyped).returns(T.untyped)}
-  def >>(_); end
+  sig {params(g: T.untyped).returns(T.untyped)}
+  def >>(g); end
 
-  sig {params(_: T.untyped).returns(T.untyped)}
-  def [](*_); end
+  sig {params(args: T.untyped).returns(T.untyped)}
+  def [](*args); end
 
   sig {returns(Integer)}
   def arity; end
@@ -25,8 +25,8 @@ class Method < Object
   sig {returns(Method)}
   def clone; end
 
-  sig {params(_: T.untyped).returns(T.untyped)}
-  def curry(*_); end
+  sig {params(args: T.untyped).returns(T.untyped)}
+  def curry(*args); end
 
   sig {returns(Symbol)}
   def name; end

--- a/rbi/core/method.rbi
+++ b/rbi/core/method.rbi
@@ -6,4 +6,49 @@ class Method < Object
 
   sig {params(args: T.untyped).returns(T.untyped)}
   def call(*args);end
+
+  sig {params(_: T.untyped).returns(T.untyped)}
+  def <<(_); end
+
+  sig {params(_: T.untyped).returns(T.untyped)}
+  def ===(*_); end
+
+  sig {params(_: T.untyped).returns(T.untyped)}
+  def >>(_); end
+
+  sig {params(_: T.untyped).returns(T.untyped)}
+  def [](*_); end
+
+  sig {returns(Integer)}
+  def arity; end
+
+  sig {returns(Method)}
+  def clone; end
+
+  sig {params(_: T.untyped).returns(T.untyped)}
+  def curry(*_); end
+
+  sig {returns(Symbol)}
+  def name; end
+
+  sig {returns(Symbol)}
+  def original_name; end
+
+  sig {returns(T.any(Class, Module))}
+  def owner; end
+
+  sig {returns(T::Array[T.untyped])}
+  def parameters; end
+
+  sig {returns(T.untyped)}
+  def receiver; end
+
+  sig {returns(T.untyped)}
+  def source_location; end
+
+  sig {returns(T.nilable(Method))}
+  def super_method; end
+
+  sig {returns(T.untyped)}
+  def unbind; end
 end


### PR DESCRIPTION
https://ruby-doc.org/core-2.6.3/Method.html#method-i-source_location

### Motivation
I wanted to add some missing methods that exist on the Method class to make `hidden.rbi` a bit smaller.

### Test plan
Existing test coverage should cover this. Also compare the signatures to the ruby documentation.