### PR TITLE
Add missing methods for the Symbol class

### DIFF
--- a/rbi/core/symbol.rbi
+++ b/rbi/core/symbol.rbi
@@ -102,7 +102,7 @@ class Symbol < Object
   sig do
     params(
         args: T.untyped
-    ).return(T.untyped)
+    ).returns(T.untyped)
   end
   def match?(*args); end
 

--- a/rbi/core/symbol.rbi
+++ b/rbi/core/symbol.rbi
@@ -62,6 +62,14 @@ class Symbol < Object
   end
   def casecmp(other); end
 
+  sig do
+    params(
+        other: Symbol,
+    )
+    .returns(T.nilable(T::Boolean))
+  end
+  def casecmp?(other); end
+
   sig {returns(Symbol)}
   def downcase(); end
 
@@ -90,6 +98,16 @@ class Symbol < Object
     .returns(T.nilable(Integer))
   end
   def match(obj); end
+
+  sig do
+    params(
+        args: T.untyped
+    ).return(T.untyped)
+  end
+  def match?(*args); end
+
+  sig {returns(Symbol)}
+  def next(); end
 
   sig {returns(Symbol)}
   def succ(); end


### PR DESCRIPTION
https://ruby-doc.org/core-2.6.3/Symbol.html

### Motivation
Symbol was missing `casecmp?`, `match?`, and `next`. `next` doesn't actually have any documentation somehow, but it seems to be an alias for `succ` as far as I can tell.

### Test plan
Compare the signatures to the ruby documentation.