### PR TITLE
Refactor type_syntax args as a struct

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1144,7 +1144,7 @@ private:
 
                     while (i < lastSigs.size()) {
                         auto allowSelfType = true;
-                        auto allowRebind = true;
+                        auto allowRebind = false;
                         auto sig =
                             TypeSyntax::parseSig(ctx.withOwner(sigOwner), ast::cast_tree<ast::Send>(lastSigs[i]),
                                                  nullptr, TypeSyntaxArgs{allowSelfType, allowRebind, mdef->symbol});

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -320,7 +320,8 @@ private:
             return true;
         }
         if (isFullyResolved(ctx, job.rhs)) {
-            job.lhs.data(ctx)->resultType = TypeSyntax::getResultType(ctx, *(job.rhs), ParsedSig{}, true, job.lhs);
+            job.lhs.data(ctx)->resultType =
+                TypeSyntax::getResultType(ctx, *(job.rhs), ParsedSig{}, TypeSyntaxArgs::forGetResultType(job.lhs));
             return true;
         }
 
@@ -1016,7 +1017,7 @@ private:
             // These sigs won't have been parsed, as there was no methods to
             // attach them to -- parse them here manually to force any errors.
             for (auto sig : lastSigs) {
-                TypeSyntax::parseSig(ctx, sig, nullptr, true, core::Symbols::untyped());
+                TypeSyntax::parseSig(ctx, sig, nullptr, TypeSyntaxArgs::forParseSig(core::Symbols::untyped()));
             }
 
             if (auto e = ctx.state.beginError(lastSigs[0]->loc, core::errors::Resolver::InvalidMethodSignature)) {
@@ -1138,7 +1139,7 @@ private:
 
                     while (i < lastSigs.size()) {
                         auto sig = TypeSyntax::parseSig(ctx.withOwner(sigOwner), ast::cast_tree<ast::Send>(lastSigs[i]),
-                                                        nullptr, true, mdef->symbol);
+                                                        nullptr, TypeSyntaxArgs::forParseSig(mdef->symbol));
                         core::SymbolRef overloadSym;
                         if (isOverloaded) {
                             vector<int> argsToKeep;
@@ -1368,7 +1369,8 @@ public:
                     auto lit = ast::cast_tree<ast::Literal>(keyExpr.get());
                     if (lit && lit->isSymbol(ctx) && lit->asSymbol(ctx) == core::Names::fixed()) {
                         ParsedSig emptySig;
-                        data->resultType = TypeSyntax::getResultType(ctx, *(hash->values[i]), emptySig, false, sym);
+                        data->resultType = TypeSyntax::getResultType(ctx, *(hash->values[i]), emptySig,
+                                                                     TypeSyntaxArgs::forGetResultType(sym));
                     }
                 }
             }
@@ -1434,8 +1436,8 @@ public:
 
                     auto expr = std::move(send->args[0]);
                     ParsedSig emptySig;
-                    auto type = TypeSyntax::getResultType(ctx.withOwner(ownerClass), *(send->args[1]), emptySig, false,
-                                                          core::Symbols::noSymbol());
+                    auto type = TypeSyntax::getResultType(ctx.withOwner(ownerClass), *(send->args[1]), emptySig,
+                                                          TypeSyntaxArgs::forGetResultType(core::Symbols::noSymbol()));
                     return ast::MK::InsSeq1(send->loc, ast::MK::KeepForTypechecking(std::move(send->args[1])),
                                             make_unique<ast::Cast>(send->loc, type, std::move(expr), send->fun));
                 }

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -65,7 +65,7 @@ bool TypeSyntax::isSig(core::Context ctx, ast::Send *send) {
 }
 
 ParsedSig TypeSyntax::parseSig(core::MutableContext ctx, ast::Send *sigSend, const ParsedSig *parent,
-                               bool allowSelfType, core::SymbolRef untypedBlame) {
+                               const TypeSyntaxArgs &args) {
     ParsedSig sig;
 
     vector<ast::Send *> sends;
@@ -179,7 +179,7 @@ ParsedSig TypeSyntax::parseSig(core::MutableContext ctx, ast::Send *sigSend, con
                         break;
                     }
 
-                    auto bind = getResultType(ctx, *(send->args.front()), *parent, allowSelfType, untypedBlame);
+                    auto bind = getResultType(ctx, *(send->args.front()), *parent, args);
                     auto classType = core::cast_type<core::ClassType>(bind.get());
                     if (!classType) {
                         if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
@@ -228,8 +228,7 @@ ParsedSig TypeSyntax::parseSig(core::MutableContext ctx, ast::Send *sigSend, con
                         auto lit = ast::cast_tree<ast::Literal>(key.get());
                         if (lit && lit->isSymbol(ctx)) {
                             core::NameRef name = lit->asSymbol(ctx);
-                            auto resultAndBind =
-                                getResultTypeAndBind(ctx, *value, *parent, allowSelfType, true, untypedBlame);
+                            auto resultAndBind = getResultTypeAndBind(ctx, *value, *parent, args.withRebind());
                             sig.argTypes.emplace_back(
                                 ParsedSig::ArgSpec{key->loc, name, resultAndBind.type, resultAndBind.rebind});
                         }
@@ -306,7 +305,7 @@ ParsedSig TypeSyntax::parseSig(core::MutableContext ctx, ast::Send *sigSend, con
                         break;
                     }
 
-                    sig.returns = getResultType(ctx, *(send->args.front()), *parent, allowSelfType, untypedBlame);
+                    sig.returns = getResultType(ctx, *(send->args.front()), *parent, args);
 
                     break;
                 }
@@ -361,26 +360,24 @@ ParsedSig TypeSyntax::parseSig(core::MutableContext ctx, ast::Send *sigSend, con
     return sig;
 }
 
-core::TypePtr interpretTCombinator(core::MutableContext ctx, ast::Send *send, const ParsedSig &sig, bool allowSelfType,
-                                   core::SymbolRef untypedBlame) {
+core::TypePtr interpretTCombinator(core::MutableContext ctx, ast::Send *send, const ParsedSig &sig,
+                                   const TypeSyntaxArgs &args) {
     switch (send->fun._id) {
         case core::Names::nilable()._id:
             if (send->args.size() != 1) {
                 return core::Types::untypedUntracked(); // error will be reported in infer.
             }
-            return core::Types::any(ctx,
-                                    TypeSyntax::getResultType(ctx, *(send->args[0]), sig, allowSelfType, untypedBlame),
+            return core::Types::any(ctx, TypeSyntax::getResultType(ctx, *(send->args[0]), sig, args),
                                     core::Types::nilClass());
         case core::Names::all()._id: {
             if (send->args.empty()) {
                 // Error will be reported in infer
                 return core::Types::untypedUntracked();
             }
-            auto result = TypeSyntax::getResultType(ctx, *(send->args[0]), sig, allowSelfType, untypedBlame);
+            auto result = TypeSyntax::getResultType(ctx, *(send->args[0]), sig, args);
             int i = 1;
             while (i < send->args.size()) {
-                result = core::Types::all(
-                    ctx, result, TypeSyntax::getResultType(ctx, *(send->args[i]), sig, allowSelfType, untypedBlame));
+                result = core::Types::all(ctx, result, TypeSyntax::getResultType(ctx, *(send->args[i]), sig, args));
                 i++;
             }
             return result;
@@ -390,11 +387,10 @@ core::TypePtr interpretTCombinator(core::MutableContext ctx, ast::Send *send, co
                 // Error will be reported in infer
                 return core::Types::untypedUntracked();
             }
-            auto result = TypeSyntax::getResultType(ctx, *(send->args[0]), sig, allowSelfType, untypedBlame);
+            auto result = TypeSyntax::getResultType(ctx, *(send->args[0]), sig, args);
             int i = 1;
             while (i < send->args.size()) {
-                result = core::Types::any(
-                    ctx, result, TypeSyntax::getResultType(ctx, *(send->args[i]), sig, allowSelfType, untypedBlame));
+                result = core::Types::any(ctx, result, TypeSyntax::getResultType(ctx, *(send->args[i]), sig, args));
                 i++;
             }
             return result;
@@ -494,9 +490,9 @@ core::TypePtr interpretTCombinator(core::MutableContext ctx, ast::Send *send, co
             return core::make_type<core::ClassType>(singleton);
         }
         case core::Names::untyped()._id:
-            return core::Types::untyped(ctx, untypedBlame);
+            return core::Types::untyped(ctx, args.untypedBlame);
         case core::Names::selfType()._id:
-            if (allowSelfType) {
+            if (args.allowSelfType) {
                 return core::make_type<core::SelfType>();
             }
             if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
@@ -515,14 +511,12 @@ core::TypePtr interpretTCombinator(core::MutableContext ctx, ast::Send *send, co
 }
 
 core::TypePtr TypeSyntax::getResultType(core::MutableContext ctx, ast::Expression &expr,
-                                        const ParsedSig &sigBeingParsed, bool allowSelfType,
-                                        core::SymbolRef untypedBlame) {
-    return getResultTypeAndBind(ctx, expr, sigBeingParsed, allowSelfType, false, untypedBlame).type;
+                                        const ParsedSig &sigBeingParsed, const TypeSyntaxArgs &args) {
+    return getResultTypeAndBind(ctx, expr, sigBeingParsed, args.noRebind()).type;
 }
 
 TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx, ast::Expression &expr,
-                                                        const ParsedSig &sigBeingParsed, bool allowSelfType,
-                                                        bool allowRebind, core::SymbolRef untypedBlame) {
+                                                        const ParsedSig &sigBeingParsed, const TypeSyntaxArgs &args) {
     // Ensure that we only check types from a class context
     auto ctxOwnerData = ctx.owner.data(ctx);
     ENFORCE(ctxOwnerData->isClass(), "getResultTypeAndBind wasn't called with a class owner");
@@ -533,7 +527,7 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
         [&](ast::Array *arr) {
             vector<core::TypePtr> elems;
             for (auto &el : arr->elems) {
-                elems.emplace_back(getResultType(ctx, *el, sigBeingParsed, false, untypedBlame));
+                elems.emplace_back(getResultType(ctx, *el, sigBeingParsed, args.noSelfType()));
             }
             result.type = core::TupleType::build(ctx, elems);
         },
@@ -543,7 +537,7 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
 
             for (auto &ktree : hash->keys) {
                 auto &vtree = hash->values[&ktree - &hash->keys.front()];
-                auto val = getResultType(ctx, *vtree, sigBeingParsed, false, untypedBlame);
+                auto val = getResultType(ctx, *vtree, sigBeingParsed, args.noSelfType());
                 auto lit = ast::cast_tree<ast::Literal>(ktree.get());
                 if (lit && (lit->isSymbol(ctx) || lit->isString(ctx))) {
                     ENFORCE(core::cast_type<core::LiteralType>(lit->value.get()));
@@ -665,9 +659,9 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
         },
         [&](ast::Send *s) {
             if (isTProc(ctx, s)) {
-                auto sig = parseSig(ctx, s, &sigBeingParsed, false, untypedBlame);
+                auto sig = parseSig(ctx, s, &sigBeingParsed, args.noSelfType());
                 if (sig.bind.exists()) {
-                    if (!allowRebind) {
+                    if (!args.allowRebind) {
                         if (auto e = ctx.state.beginError(s->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                             e.setHeader("Using `bind` is not permitted here");
                         }
@@ -715,7 +709,7 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
                 return;
             }
             if (recvi->symbol == core::Symbols::T()) {
-                result.type = interpretTCombinator(ctx, s, sigBeingParsed, allowSelfType, untypedBlame);
+                result.type = interpretTCombinator(ctx, s, sigBeingParsed, args);
                 return;
             }
 
@@ -746,7 +740,7 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
                 core::TypeAndOrigins ty;
                 ty.origins.emplace_back(arg->loc);
                 ty.type = core::make_type<core::MetaType>(
-                    TypeSyntax::getResultType(ctx, *arg, sigBeingParsed, false, untypedBlame));
+                    TypeSyntax::getResultType(ctx, *arg, sigBeingParsed, args.noSelfType()));
                 holders.emplace_back(make_unique<core::TypeAndOrigins>(move(ty)));
                 targs.emplace_back(holders.back().get());
                 argLocs.emplace_back(arg->loc);

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -512,7 +512,7 @@ core::TypePtr interpretTCombinator(core::MutableContext ctx, ast::Send *send, co
 
 core::TypePtr TypeSyntax::getResultType(core::MutableContext ctx, ast::Expression &expr,
                                         const ParsedSig &sigBeingParsed, const TypeSyntaxArgs &args) {
-    return getResultTypeAndBind(ctx, expr, sigBeingParsed, args.noRebind()).type;
+    return getResultTypeAndBind(ctx, expr, sigBeingParsed, args.withoutRebind()).type;
 }
 
 TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx, ast::Expression &expr,
@@ -527,7 +527,7 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
         [&](ast::Array *arr) {
             vector<core::TypePtr> elems;
             for (auto &el : arr->elems) {
-                elems.emplace_back(getResultType(ctx, *el, sigBeingParsed, args.noSelfType()));
+                elems.emplace_back(getResultType(ctx, *el, sigBeingParsed, args.withoutSelfType()));
             }
             result.type = core::TupleType::build(ctx, elems);
         },
@@ -537,7 +537,7 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
 
             for (auto &ktree : hash->keys) {
                 auto &vtree = hash->values[&ktree - &hash->keys.front()];
-                auto val = getResultType(ctx, *vtree, sigBeingParsed, args.noSelfType());
+                auto val = getResultType(ctx, *vtree, sigBeingParsed, args.withoutSelfType());
                 auto lit = ast::cast_tree<ast::Literal>(ktree.get());
                 if (lit && (lit->isSymbol(ctx) || lit->isString(ctx))) {
                     ENFORCE(core::cast_type<core::LiteralType>(lit->value.get()));
@@ -659,7 +659,7 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
         },
         [&](ast::Send *s) {
             if (isTProc(ctx, s)) {
-                auto sig = parseSig(ctx, s, &sigBeingParsed, args.noSelfType());
+                auto sig = parseSig(ctx, s, &sigBeingParsed, args.withoutSelfType());
                 if (sig.bind.exists()) {
                     if (!args.allowRebind) {
                         if (auto e = ctx.state.beginError(s->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
@@ -740,7 +740,7 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
                 core::TypeAndOrigins ty;
                 ty.origins.emplace_back(arg->loc);
                 ty.type = core::make_type<core::MetaType>(
-                    TypeSyntax::getResultType(ctx, *arg, sigBeingParsed, args.noSelfType()));
+                    TypeSyntax::getResultType(ctx, *arg, sigBeingParsed, args.withoutSelfType()));
                 holders.emplace_back(make_unique<core::TypeAndOrigins>(move(ty)));
                 targs.emplace_back(holders.back().get());
                 argLocs.emplace_back(arg->loc);

--- a/resolver/type_syntax.h
+++ b/resolver/type_syntax.h
@@ -52,27 +52,16 @@ struct TypeSyntaxArgs {
     bool allowRebind = false;
     core::SymbolRef untypedBlame;
 
-    TypeSyntaxArgs(const bool allowSelfType, const bool allowRebind, core::SymbolRef untypedBlame)
-        : allowSelfType(allowSelfType), allowRebind(allowRebind), untypedBlame(untypedBlame) {}
-
-    static TypeSyntaxArgs forGetResultType(core::SymbolRef untypedBlame) {
-        return TypeSyntaxArgs(true, false, untypedBlame);
-    }
-
-    static TypeSyntaxArgs forParseSig(core::SymbolRef untypedBlame) {
-        return TypeSyntaxArgs(true, false, untypedBlame);
-    }
-
-    TypeSyntaxArgs noRebind() const {
-        return TypeSyntaxArgs(allowSelfType, false, untypedBlame);
+    TypeSyntaxArgs withoutRebind() const {
+        return TypeSyntaxArgs{allowSelfType, false, untypedBlame};
     }
 
     TypeSyntaxArgs withRebind() const {
-        return TypeSyntaxArgs(allowSelfType, true, untypedBlame);
+        return TypeSyntaxArgs{allowSelfType, true, untypedBlame};
     }
 
-    TypeSyntaxArgs noSelfType() const {
-        return TypeSyntaxArgs(false, allowRebind, untypedBlame);
+    TypeSyntaxArgs withoutSelfType() const {
+        return TypeSyntaxArgs{false, allowRebind, untypedBlame};
     }
 };
 

--- a/resolver/type_syntax.h
+++ b/resolver/type_syntax.h
@@ -47,20 +47,49 @@ struct ParsedSig {
     const TypeArgSpec &findTypeArgByName(core::NameRef name) const;
 };
 
+struct TypeSyntaxArgs {
+    bool allowSelfType = false;
+    bool allowRebind = false;
+    core::SymbolRef untypedBlame;
+
+    TypeSyntaxArgs(const bool allowSelfType, const bool allowRebind, core::SymbolRef untypedBlame)
+        : allowSelfType(allowSelfType), allowRebind(allowRebind), untypedBlame(untypedBlame) {}
+
+    static TypeSyntaxArgs forGetResultType(core::SymbolRef untypedBlame) {
+        return TypeSyntaxArgs(true, false, untypedBlame);
+    }
+
+    static TypeSyntaxArgs forParseSig(core::SymbolRef untypedBlame) {
+        return TypeSyntaxArgs(true, false, untypedBlame);
+    }
+
+    TypeSyntaxArgs noRebind() const {
+        return TypeSyntaxArgs(allowSelfType, false, untypedBlame);
+    }
+
+    TypeSyntaxArgs withRebind() const {
+        return TypeSyntaxArgs(allowSelfType, true, untypedBlame);
+    }
+
+    TypeSyntaxArgs noSelfType() const {
+        return TypeSyntaxArgs(false, allowRebind, untypedBlame);
+    }
+};
+
 class TypeSyntax {
 public:
     static bool isSig(core::Context ctx, ast::Send *send);
-    static ParsedSig parseSig(core::MutableContext ctx, ast::Send *send, const ParsedSig *parent, bool allowSelfType,
-                              core::SymbolRef untypedBlame);
+    static ParsedSig parseSig(core::MutableContext ctx, ast::Send *send, const ParsedSig *parent,
+                              const TypeSyntaxArgs &args);
 
     struct ResultType {
         core::TypePtr type;
         core::SymbolRef rebind;
     };
     static ResultType getResultTypeAndBind(core::MutableContext ctx, ast::Expression &expr, const ParsedSig &,
-                                           bool allowSelfType, bool allowRebind, core::SymbolRef untypedBlame);
+                                           const TypeSyntaxArgs &args);
     static core::TypePtr getResultType(core::MutableContext ctx, ast::Expression &expr, const ParsedSig &,
-                                       bool allowSelfType, core::SymbolRef untypedBlame);
+                                       const TypeSyntaxArgs &args);
 
     TypeSyntax() = delete;
 };


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This helps with plumbing new arguments through the `type_syntax` module on the type bounds branch. New flags can be plumbed through without complicating existing call sites, and there are new constructor functions that deal with specific flags.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
