### PR TITLE
Fix param order

### DIFF
--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -51,9 +51,9 @@ constexpr ErrorClass InvalidTypeAlias{5043, StrictLevel::False};
 constexpr ErrorClass InvalidVariance{5044, StrictLevel::True};
 constexpr ErrorClass GenericClassWithoutTypeArgs{5045, StrictLevel::False};
 constexpr ErrorClass GenericClassWithoutTypeArgsStdlib{5046, StrictLevel::Strict};
-constexpr ErrorClass BadParameterOrdering{5047, StrictLevel::False};
-constexpr ErrorClass FinalAncestor{5048, StrictLevel::True};
-constexpr ErrorClass FinalModuleNonFinalMethod{5049, StrictLevel::True};
+constexpr ErrorClass FinalAncestor{5047, StrictLevel::True};
+constexpr ErrorClass FinalModuleNonFinalMethod{5048, StrictLevel::True};
+constexpr ErrorClass BadParameterOrdering{5049, StrictLevel::False};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/dsl/Prop.cc
+++ b/dsl/Prop.cc
@@ -391,12 +391,25 @@ void Prop::patchDSL(core::MutableContext ctx, ast::ClassDef *klass) {
         args.reserve(props.size());
         sigKeys.reserve(props.size());
         sigVals.reserve(props.size());
+        // add all the required props first.
         for (auto &prop : props) {
+            if (prop.default_.has_value()) {
+                continue;
+            }
             auto loc = prop.loc;
             auto arg = ast::MK::KeywordArg(loc, ast::MK::Local(loc, prop.name));
-            if (prop.default_.has_value()) {
-                arg = ast::MK::OptionalArg(loc, std::move(arg), std::move(*(prop.default_)));
+            args.emplace_back(std::move(arg));
+            sigKeys.emplace_back(ast::MK::Symbol(loc, prop.name));
+            sigVals.emplace_back(std::move(prop.type));
+        }
+        // then, add all the optional props.
+        for (auto &prop : props) {
+            if (!prop.default_.has_value()) {
+                continue;
             }
+            auto loc = prop.loc;
+            auto arg = ast::MK::OptionalArg(loc, ast::MK::KeywordArg(loc, ast::MK::Local(loc, prop.name)),
+                                            std::move(*(prop.default_)));
             args.emplace_back(std::move(arg));
             sigKeys.emplace_back(ast::MK::Symbol(loc, prop.name));
             sigVals.emplace_back(std::move(prop.type));

--- a/dsl/Prop.cc
+++ b/dsl/Prop.cc
@@ -397,8 +397,7 @@ void Prop::patchDSL(core::MutableContext ctx, ast::ClassDef *klass) {
                 continue;
             }
             auto loc = prop.loc;
-            auto arg = ast::MK::KeywordArg(loc, ast::MK::Local(loc, prop.name));
-            args.emplace_back(std::move(arg));
+            args.emplace_back(ast::MK::KeywordArg(loc, ast::MK::Local(loc, prop.name)));
             sigKeys.emplace_back(ast::MK::Symbol(loc, prop.name));
             sigVals.emplace_back(std::move(prop.type));
         }
@@ -408,9 +407,8 @@ void Prop::patchDSL(core::MutableContext ctx, ast::ClassDef *klass) {
                 continue;
             }
             auto loc = prop.loc;
-            auto arg = ast::MK::OptionalArg(loc, ast::MK::KeywordArg(loc, ast::MK::Local(loc, prop.name)),
-                                            std::move(*(prop.default_)));
-            args.emplace_back(std::move(arg));
+            args.emplace_back(ast::MK::OptionalArg(loc, ast::MK::KeywordArg(loc, ast::MK::Local(loc, prop.name)),
+                                                   std::move(*(prop.default_))));
             sigKeys.emplace_back(ast::MK::Symbol(loc, prop.name));
             sigVals.emplace_back(std::move(prop.type));
         }

--- a/test/testdata/dsl/t_struct/param_order.rb
+++ b/test/testdata/dsl/t_struct/param_order.rb
@@ -1,5 +1,8 @@
 # typed: true
 
+# We run checks to ensure that all optional arguments to a method appear after all required arguments. This means that
+# when we synthesize the initalize method for this struct, the optional foo parameter must by synthesized to come after
+# the required bar parameter, even though the order we wrote in the code was the opposite.
 class ParamOrder < T::Struct
   prop :foo, Integer, default: 3
   prop :bar, Integer

--- a/test/testdata/dsl/t_struct/param_order.rb
+++ b/test/testdata/dsl/t_struct/param_order.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+class ParamOrder < T::Struct
+  prop :foo, Integer, default: 3
+  prop :bar, Integer
+end

--- a/test/testdata/dsl/t_struct/param_order.rb.dsl-tree.exp
+++ b/test/testdata/dsl/t_struct/param_order.rb.dsl-tree.exp
@@ -1,0 +1,41 @@
+class <emptyTree>::<C ParamOrder><<C <todo sym>>> < (<emptyTree>::<C T>::<C Struct>)
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.params({:"bar" => <emptyTree>::<C Integer>, :"foo" => <emptyTree>::<C Integer>}).void()
+  end
+
+  def initialize<<C <todo sym>>>(bar:, foo: = 3, &<blk>)
+    <emptyTree>
+  end
+
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.params({}).returns(<emptyTree>::<C Integer>)
+  end
+
+  def foo<<C <todo sym>>>(&<blk>)
+    ::T.cast(::T.unsafe(nil), <emptyTree>::<C Integer>)
+  end
+
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.params({:"arg0" => <emptyTree>::<C Integer>}).returns(<emptyTree>::<C Integer>)
+  end
+
+  def foo=<<C <todo sym>>>(arg0, &<blk>)
+    ::T.cast(::T.unsafe(nil), <emptyTree>::<C Integer>)
+  end
+
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.params({}).returns(<emptyTree>::<C Integer>)
+  end
+
+  def bar<<C <todo sym>>>(&<blk>)
+    ::T.cast(::T.unsafe(nil), <emptyTree>::<C Integer>)
+  end
+
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.params({:"arg0" => <emptyTree>::<C Integer>}).returns(<emptyTree>::<C Integer>)
+  end
+
+  def bar=<<C <todo sym>>>(arg0, &<blk>)
+    ::T.cast(::T.unsafe(nil), <emptyTree>::<C Integer>)
+  end
+end


### PR DESCRIPTION
This makes the logic to synthesize initialize for `T::Struct` add all the required parameters first, and then after that add all the optional parameters.

It also switches around some error numbers to be consistent with the docs.

### Motivation
To fix a bug.

### Test plan
See included automated tests.
