### PR TITLE
Use replaceWith in more places

### DIFF
--- a/dsl/Private.cc
+++ b/dsl/Private.cc
@@ -28,14 +28,14 @@ vector<unique_ptr<ast::Expression>> Private::replaceDSL(core::MutableContext ctx
             e.setHeader("Use `{}` to define private class methods", "private_class_method");
             auto beginPos = send->loc.beginPos();
             auto replacementLoc = core::Loc{send->loc.file(), beginPos, beginPos + 7};
-            e.addAutocorrect(core::AutocorrectSuggestion(replacementLoc, "private_class_method"));
+            e.replaceWith(replacementLoc, "private_class_method");
         }
     } else if (send->fun == core::Names::privateClassMethod() && !mdef->isSelf()) {
         if (auto e = ctx.state.beginError(send->loc, core::errors::DSL::PrivateMethodMismatch)) {
             e.setHeader("Use `{}` to define private instance methods", "private");
             auto beginPos = send->loc.beginPos();
             auto replacementLoc = core::Loc{send->loc.file(), beginPos, beginPos + 20};
-            e.addAutocorrect(core::AutocorrectSuggestion(replacementLoc, "private"));
+            e.replaceWith(replacementLoc, "private");
         }
     }
 

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -517,16 +517,16 @@ bool SigSuggestion::maybeSuggestSig(core::Context ctx, core::ErrorBuilder &e, un
         }
     }
 
-    e.addAutocorrect(core::AutocorrectSuggestion(replacementLoc, fmt::format("{}\n{}", to_string(ss), spaces)));
+    e.replaceWith(replacementLoc, "{}\n{}", to_string(ss), spaces);
 
     if (parentNeedsOverridable(ctx, methodSymbol, closestMethod)) {
         if (auto maybeOffset = startOfExistingReturn(ctx, closestMethod.data(ctx)->loc())) {
             auto offset = *maybeOffset;
             core::Loc overridableReturnLoc(closestMethod.data(ctx)->loc().file(), offset, offset);
             if (closestMethod.data(ctx)->hasGeneratedSig()) {
-                e.addAutocorrect(core::AutocorrectSuggestion(overridableReturnLoc, "overridable."));
+                e.replaceWith(overridableReturnLoc, "overridable.");
             } else {
-                e.addAutocorrect(core::AutocorrectSuggestion(overridableReturnLoc, "generated.overridable."));
+                e.replaceWith(overridableReturnLoc, "generated.overridable.");
             }
         }
     }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -521,7 +521,7 @@ int realmain(int argc, char *argv[]) {
                 if (auto e = gs->beginError(loc, core::errors::Infer::SuggestTyped)) {
                     auto sigil = levelToSigil(minErrorLevel);
                     e.setHeader("You could add `# typed: {}`", sigil);
-                    e.addAutocorrect(core::AutocorrectSuggestion(loc, fmt::format("# typed: {}\n", sigil)));
+                    e.replaceWith(loc, "# typed: {}\n", sigil);
                 }
             }
         }

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -579,15 +579,13 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
                                     sym.show(ctx));
                         if (sym == core::Symbols::Hash()) {
                             // Hash is special because it has arity 3 but you're only supposed to write the first 2
-                            e.addAutocorrect(core::AutocorrectSuggestion(
-                                i->loc, fmt::format("T::{}[T.untyped, T.untyped]", i->loc.source(ctx))));
+                            e.replaceWith(i->loc, "T::{}[T.untyped, T.untyped]", i->loc.source(ctx));
                         } else if (isStdlibWhitelisted) {
                             vector<string> untypeds;
                             for (int i = 0; i < sym.data(ctx)->typeArity(ctx); i++) {
                                 untypeds.emplace_back("T.untyped");
                             }
-                            e.addAutocorrect(core::AutocorrectSuggestion(
-                                i->loc, fmt::format("T::{}[{}]", i->loc.source(ctx), absl::StrJoin(untypeds, ", "))));
+                            e.replaceWith(i->loc, "T::{}[{}]", i->loc.source(ctx), absl::StrJoin(untypeds, ", "));
                         }
                     }
                 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

replaceWith is defined like this:

    template <typename... Args> void replaceWith(Loc loc, const std::string &msg, const Args &... args) {
        std::string formatted = fmt::format(msg, args...);
        addAutocorrect(AutocorrectSuggestion(loc, move(formatted)));
    }

We were duplicating a lot of this into the call sites.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.