### PR TITLE
Add red blockquote for errors

### DIFF
--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -12,6 +12,8 @@ sidebar_label: Error Reference
 
 <div class="is-hidden red" id="missing-doc-for-error-code-box">
 
+<a class="anchor" aria-hidden="true" id="missing-doc-for-error-code-scroll"></a>
+
 > **Heads up**: There aren't any docs yet for <span id="missing-error-code">this
 > error code</span>. If you have suggestions for what would have helped you
 > solve this problem, click the "Edit" button above to contribute! Otherwise,

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -10,7 +10,7 @@ sidebar_label: Error Reference
 }
 </style>
 
-<div class="is-hidden" id="missing-doc-for-error-code-box">
+<div class="is-hidden red" id="missing-doc-for-error-code-box">
 
 > **Heads up**: There aren't any docs yet for <span id="missing-error-code">this
 > error code</span>. If you have suggestions for what would have helped you

--- a/website/static/css/overrides.css
+++ b/website/static/css/overrides.css
@@ -16,6 +16,16 @@ blockquote.monotone {
 }
 
 /*
+ * Docusaurus uses blockquote to show warnings / yellow callouts.
+ * Sometimes, we want it to stand out even more.
+ */
+blockquote.red,
+.red blockquote {
+  background-color: rgba(255, 109, 84, 0.3);
+  border-color: rgb(255, 132, 132);
+}
+
+/*
  * By default, the link color is the same as the primaryColor.
  * For us, this color is too dark, and links don't pop enough.
  * Thus, we override the link color to be more vibrant.

--- a/website/static/js/error-reference.js
+++ b/website/static/js/error-reference.js
@@ -14,4 +14,6 @@
 
   const box = document.getElementById('missing-doc-for-error-code-box');
   box.classList.toggle('is-hidden');
+
+  document.getElementById('missing-doc-for-error-code-scroll').scrollIntoView();
 })();


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This makes the error message that we unhide when an error code is
undocumented a little more apparent, vs looking like something that
was always on the page.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

**Before**

<img width="811" alt="Screen Shot 2019-07-29 at 1 52 59 PM" src="https://user-images.githubusercontent.com/5544532/62081878-6b3aaa00-b208-11e9-9768-38c06ef019fd.png">


**After**


<img width="818" alt="Screen Shot 2019-07-29 at 1 52 43 PM" src="https://user-images.githubusercontent.com/5544532/62081879-6b3aaa00-b208-11e9-83e4-9394e9af063a.png">
