### PR TITLE
Move MockFileSystem

### DIFF
--- a/test/helpers/MockFileSystem.cc
+++ b/test/helpers/MockFileSystem.cc
@@ -1,0 +1,48 @@
+#include "test/helpers/MockFileSystem.h"
+
+using namespace sorbet::test;
+
+MockFileSystem::MockFileSystem(std::string_view rootPath) : rootPath(std::string(rootPath)) {}
+
+std::string makeAbsolute(std::string_view rootPath, std::string_view path) {
+    if (path[0] == '/') {
+        return std::string(path);
+    } else {
+        return fmt::format("{}/{}", rootPath, path);
+    }
+}
+
+void MockFileSystem::writeFiles(const std::vector<std::pair<std::string, std::string>> &initialFiles) {
+    for (auto &pair : initialFiles) {
+        writeFile(pair.first, pair.second);
+    }
+}
+
+std::string MockFileSystem::readFile(std::string_view path) const {
+    auto file = contents.find(makeAbsolute(rootPath, path));
+    if (file == contents.end()) {
+        throw sorbet::FileNotFoundException();
+    } else {
+        return file->second;
+    }
+}
+
+void MockFileSystem::writeFile(std::string_view filename, std::string_view text) {
+    contents[makeAbsolute(rootPath, filename)] = text;
+}
+
+void MockFileSystem::deleteFile(std::string_view filename) {
+    auto file = contents.find(makeAbsolute(rootPath, filename));
+    if (file == contents.end()) {
+        throw sorbet::FileNotFoundException();
+    } else {
+        contents.erase(file);
+    }
+}
+
+std::vector<std::string> MockFileSystem::listFilesInDir(std::string_view path,
+                                                        const UnorderedSet<std::string> &extensions, bool recursive,
+                                                        const std::vector<std::string> &absoluteIgnorePatterns,
+                                                        const std::vector<std::string> &relativeIgnorePatterns) const {
+    Exception::raise("Not implemented.");
+}

--- a/test/helpers/MockFileSystem.h
+++ b/test/helpers/MockFileSystem.h
@@ -1,0 +1,27 @@
+#ifndef TEST_HELPERS_MOCKFILESYSTEM_H
+#define TEST_HELPERS_MOCKFILESYSTEM_H
+
+#include "common/FileSystem.h"
+
+namespace sorbet::test {
+using namespace sorbet;
+
+class MockFileSystem final : public FileSystem {
+private:
+    UnorderedMap<std::string, std::string> contents;
+    std::string rootPath;
+
+public:
+    MockFileSystem(std::string_view rootPath);
+    void writeFiles(const std::vector<std::pair<std::string, std::string>> &files);
+    std::string readFile(std::string_view path) const override;
+    void writeFile(std::string_view filename, std::string_view text) override;
+    void deleteFile(std::string_view filename);
+    std::vector<std::string> listFilesInDir(std::string_view path, const UnorderedSet<std::string> &extensions,
+                                            bool recursive, const std::vector<std::string> &absoluteIgnorePatterns,
+                                            const std::vector<std::string> &relativeIgnorePatterns) const override;
+};
+
+} // namespace sorbet::test
+
+#endif // TEST_HELPERS_MOCKFILESYSTEM_H

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -1,53 +1,10 @@
 #include "test/lsp/ProtocolTest.h"
+#include "test/helpers/MockFileSystem.h"
 #include "test/helpers/lsp.h"
 #include "test/helpers/position_assertions.h"
 
 namespace sorbet::test::lsp {
 using namespace std;
-
-MockFileSystem::MockFileSystem(std::string_view rootPath) : rootPath(string(rootPath)) {}
-
-string makeAbsolute(string_view rootPath, string_view path) {
-    if (path[0] == '/') {
-        return string(path);
-    } else {
-        return fmt::format("{}/{}", rootPath, path);
-    }
-}
-
-void MockFileSystem::writeFiles(const vector<pair<string, string>> &initialFiles) {
-    for (auto &pair : initialFiles) {
-        writeFile(pair.first, pair.second);
-    }
-}
-
-string MockFileSystem::readFile(string_view path) const {
-    auto file = contents.find(makeAbsolute(rootPath, path));
-    if (file == contents.end()) {
-        throw FileNotFoundException();
-    } else {
-        return file->second;
-    }
-}
-
-void MockFileSystem::writeFile(string_view filename, string_view text) {
-    contents[makeAbsolute(rootPath, filename)] = text;
-}
-
-void MockFileSystem::deleteFile(string_view filename) {
-    auto file = contents.find(makeAbsolute(rootPath, filename));
-    if (file == contents.end()) {
-        throw FileNotFoundException();
-    } else {
-        contents.erase(file);
-    }
-}
-
-vector<string> MockFileSystem::listFilesInDir(string_view path, const UnorderedSet<string> &extensions, bool recursive,
-                                              const std::vector<std::string> &absoluteIgnorePatterns,
-                                              const std::vector<std::string> &relativeIgnorePatterns) const {
-    Exception::raise("Not implemented.");
-}
 
 void ProtocolTest::SetUp() {
     rootPath = "/Users/jvilk/stripe/pay-server";

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -3,8 +3,8 @@
 
 #include "gtest/gtest.h"
 // ^ Violates linting rules, so include first.
-#include "common/FileSystem.h"
 #include "main/lsp/wrapper.h"
+#include "test/helpers/MockFileSystem.h"
 
 namespace sorbet::test::lsp {
 using namespace sorbet::realmain::lsp;
@@ -13,22 +13,6 @@ struct ExpectedDiagnostic {
     std::string path;
     int line;
     std::string message;
-};
-
-class MockFileSystem final : public FileSystem {
-private:
-    UnorderedMap<std::string, std::string> contents;
-    std::string rootPath;
-
-public:
-    MockFileSystem(std::string_view rootPath);
-    void writeFiles(const std::vector<std::pair<std::string, std::string>> &files);
-    std::string readFile(std::string_view path) const override;
-    void writeFile(std::string_view filename, std::string_view text) override;
-    void deleteFile(std::string_view filename);
-    std::vector<std::string> listFilesInDir(std::string_view path, const UnorderedSet<std::string> &extensions,
-                                            bool recursive, const std::vector<std::string> &absoluteIgnorePatterns,
-                                            const std::vector<std::string> &relativeIgnorePatterns) const override;
 };
 
 class ProtocolTest : public testing::Test {
@@ -44,7 +28,7 @@ protected:
     // Currently active diagnostics, specifically using map to enforce sort order on filename.
     std::map<std::string, std::vector<std::unique_ptr<Diagnostic>>> diagnostics;
     // Emulated file system.
-    std::shared_ptr<MockFileSystem> fs;
+    std::shared_ptr<sorbet::test::MockFileSystem> fs;
 
     /** The next ID to use when sending an LSP message. */
     int nextId = 0;

--- a/test/testdata/dsl/t_struct/param_order.rb
+++ b/test/testdata/dsl/t_struct/param_order.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 # We run checks to ensure that all optional arguments to a method appear after all required arguments. This means that
-# when we synthesize the initalize method for this struct, the optional foo parameter must by synthesized to come after
+# when we synthesize the initalize method for this struct, the optional foo parameter must be synthesized to come after
 # the required bar parameter, even though the order we wrote in the code was the opposite.
 class ParamOrder < T::Struct
   prop :foo, Integer, default: 3


### PR DESCRIPTION
cc @jvilk-stripe 

This moves `MockFileSystem` out to test/helpers.

It also fixes a typo.

### Motivation
To prepare to create more fuzzers.

### Test plan
Ran test_corpus locally, it compiled + passed.