### PR TITLE
Move final errors to `typed: false`

### DIFF
--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -51,8 +51,8 @@ constexpr ErrorClass InvalidTypeAlias{5043, StrictLevel::False};
 constexpr ErrorClass InvalidVariance{5044, StrictLevel::True};
 constexpr ErrorClass GenericClassWithoutTypeArgs{5045, StrictLevel::False};
 constexpr ErrorClass GenericClassWithoutTypeArgsStdlib{5046, StrictLevel::Strict};
-constexpr ErrorClass FinalAncestor{5047, StrictLevel::True};
-constexpr ErrorClass FinalModuleNonFinalMethod{5048, StrictLevel::True};
+constexpr ErrorClass FinalAncestor{5047, StrictLevel::False};
+constexpr ErrorClass FinalModuleNonFinalMethod{5048, StrictLevel::False};
 constexpr ErrorClass BadParameterOrdering{5049, StrictLevel::False};
 } // namespace sorbet::core::errors::Resolver
 

--- a/test/testdata/resolver/final_method.rb
+++ b/test/testdata/resolver/final_method.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: false
 # disable-fast-path: true
 
 class Redefine

--- a/test/testdata/resolver/final_module.rb
+++ b/test/testdata/resolver/final_module.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: false
 
 class FinalClass
   extend T::Helpers


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These errors should be in `typed: false`, because otherwise people can silence
the final module errors by just downgrading the strictness levels. It can also
lead to weird errors like this with RBI file generation:

**foo.rb**

```ruby
# typed: false

class Parent
  extend T::Helpers
  final!
end

class Child < Parent; end
```

**foo.rbi**

```ruby
# typed: strict

class Parent
end

class Child < Parent
end
```


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.