### PR TITLE
Optimize containers of untyped

### DIFF
--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -217,25 +217,41 @@ module T
 
   module Array
     def self.[](type)
-      T::Types::TypedArray.new(type)
+      if type.is_a?(T::Types::Untyped)
+        T::Types::TypedArray::Untyped.new
+      else
+        T::Types::TypedArray.new(type)
+      end
     end
   end
 
   module Hash
     def self.[](keys, values)
-      T::Types::TypedHash.new(keys: keys, values: values)
+      if keys.is_a?(T::Types::Untyped) && values.is_a?(T::Types::Untyped)
+        T::Types::TypedHash::Untyped.new
+      else
+        T::Types::TypedHash.new(keys: keys, values: values)
+      end
     end
   end
 
   module Enumerable
     def self.[](type)
-      T::Types::TypedEnumerable.new(type)
+      if type.is_a?(T::Types::Untyped)
+        T::Types::TypedEnumerable::Untyped.new
+      else
+        T::Types::TypedEnumerable.new(type)
+      end
     end
   end
 
   module Enumerator
     def self.[](type)
-      T::Types::TypedEnumerator.new(type)
+      if type.is_a?(T::Types::Untyped)
+        T::Types::TypedEnumerator::Untyped.new
+      else
+        T::Types::TypedEnumerator.new(type)
+      end
     end
   end
 
@@ -247,7 +263,11 @@ module T
 
   module Set
     def self.[](type)
-      T::Types::TypedSet.new(type)
+      if type.is_a?(T::Types::Untyped)
+        T::Types::TypedSet::Untyped.new
+      else
+        T::Types::TypedSet.new(type)
+      end
     end
   end
 

--- a/gems/sorbet-runtime/lib/types/types/typed_array.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_array.rb
@@ -8,6 +8,10 @@ module T::Types
       "T::Array[#{@type.name}]"
     end
 
+    def underlying_class
+      Array
+    end
+
     # @override Base
     def valid?(obj)
       obj.is_a?(Array) && super

--- a/gems/sorbet-runtime/lib/types/types/typed_array.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_array.rb
@@ -16,5 +16,15 @@ module T::Types
     def new(*args) # rubocop:disable PrisonGuard/BanBuiltinMethodOverride
       Array.new(*T.unsafe(args))
     end
+
+    class Untyped < TypedArray
+      def initialize
+        super(T.untyped)
+      end
+
+      def valid?(obj)
+        obj.is_a?(Array)
+      end
+    end
   end
 end

--- a/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
@@ -137,5 +137,15 @@ module T::Types
         self.class.new(type_from_instances(obj))
       end
     end
+
+    class Untyped < TypedEnumerable
+      def initialize
+        super(T.untyped)
+      end
+
+      def valid?(obj)
+        obj.is_a?(Enumerable)
+      end
+    end
   end
 end

--- a/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
@@ -12,6 +12,10 @@ module T::Types
       @type = T::Utils.coerce(type)
     end
 
+    def underlying_class
+      Enumerable
+    end
+
     # @override Base
     def name
       "T::Enumerable[#{@type.name}]"
@@ -68,7 +72,8 @@ module T::Types
 
     # @override Base
     private def subtype_of_single?(other)
-      if self.class <= other.class
+      if other.class <= TypedEnumerable &&
+         underlying_class <= other.underlying_class
         # Enumerables are covariant because they are read only
         #
         # Properly speaking, many Enumerable subtypes (e.g. Set)

--- a/gems/sorbet-runtime/lib/types/types/typed_enumerator.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerator.rb
@@ -18,5 +18,15 @@ module T::Types
     def new(*args, &blk) # rubocop:disable PrisonGuard/BanBuiltinMethodOverride
       T.unsafe(Enumerator).new(*args, &blk)
     end
+
+    class Untyped < TypedEnumerator
+      def initialize
+        super(T.untyped)
+      end
+
+      def valid?(obj)
+        obj.is_a?(Enumerator)
+      end
+    end
   end
 end

--- a/gems/sorbet-runtime/lib/types/types/typed_enumerator.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerator.rb
@@ -5,6 +5,10 @@ module T::Types
   class TypedEnumerator < TypedEnumerable
     attr_reader :type
 
+    def underlying_class
+      Enumerator
+    end
+
     # @override Base
     def name
       "T::Enumerator[#{@type.name}]"

--- a/gems/sorbet-runtime/lib/types/types/typed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_hash.rb
@@ -25,5 +25,15 @@ module T::Types
     def new(*args, &blk) # rubocop:disable PrisonGuard/BanBuiltinMethodOverride
       Hash.new(*T.unsafe(args), &blk) # rubocop:disable PrisonGuard/RestrictHashDefaults
     end
+
+    class Untyped < TypedHash
+      def initialize
+        super(keys: T.untyped, values: T.untyped)
+      end
+
+      def valid?(obj)
+        obj.is_a?(Hash)
+      end
+    end
   end
 end

--- a/gems/sorbet-runtime/lib/types/types/typed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_hash.rb
@@ -6,7 +6,11 @@ module T::Types
     # Technically we don't need these, but they are a nice api
     attr_reader :keys, :values
 
-    def initialize(keys:, values:)
+    def underlying_class
+      Hash
+    end
+
+      def initialize(keys:, values:)
       @keys = T::Utils.coerce(keys)
       @values = T::Utils.coerce(values)
       @type = T::Utils.coerce([keys, values])

--- a/gems/sorbet-runtime/lib/types/types/typed_range.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_range.rb
@@ -5,6 +5,10 @@ module T::Types
   class TypedRange < TypedEnumerable
     attr_reader :type
 
+    def underlying_class
+      Hash
+    end
+
     # @override Base
     def name
       "T::Range[#{@type.name}]"

--- a/gems/sorbet-runtime/lib/types/types/typed_set.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_set.rb
@@ -18,5 +18,15 @@ module T::Types
     def new(*args) # rubocop:disable PrisonGuard/BanBuiltinMethodOverride
       Set.new(*T.unsafe(args))
     end
+
+    class Untyped < TypedSet
+      def initialize
+        super(T.untyped)
+      end
+
+      def valid?(obj)
+        obj.is_a?(Set)
+      end
+    end
   end
 end

--- a/gems/sorbet-runtime/lib/types/types/typed_set.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_set.rb
@@ -5,6 +5,10 @@ module T::Types
   class TypedSet < TypedEnumerable
     attr_reader :type
 
+    def underlying_class
+      Hash
+    end
+
     # @override Base
     def name
       "T::Set[#{@type.name}]"

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -932,6 +932,26 @@ module Opus::Types::Test
           # rubocop:enable PrisonGuard/UseOpusTypesShortcut
         end
       end
+
+      describe 'untyped containers' do
+        it 'untyped containers are subtypes of typed containers' do
+          assert_subtype(T::Array[T.untyped], T::Array[Integer])
+          assert_subtype(T::Array[T.untyped], T::Enumerable[Integer])
+          assert_subtype(T::Set[T.untyped], T::Enumerable[Integer])
+          assert_subtype(T::Set[T.untyped], T::Set[Integer])
+          assert_subtype(T::Hash[T.untyped, T.untyped], T::Hash[Integer, String])
+          assert_subtype(T::Enumerator[T.untyped], T::Enumerator[Integer])
+        end
+
+        it 'typed containers are subtypes of untyped containers' do
+          assert_subtype(T::Array[Integer], T::Array[T.untyped])
+          assert_subtype(T::Array[Integer], T::Enumerable[T.untyped])
+          assert_subtype(T::Set[Integer], T::Enumerable[T.untyped])
+          assert_subtype(T::Set[Integer], T::Set[T.untyped])
+          assert_subtype(T::Hash[Integer, String], T::Hash[T.untyped, T.untyped])
+          assert_subtype(T::Enumerator[Integer], T::Enumerator[T.untyped])
+        end
+      end
     end
 
     module TestGeneric1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
If we have a container of T.untyped, there's no need to walk the
container when doing typechecking. Optimize by creating
special-purpose subclasses for T.untyped that do no checking.

We opt for special subclasses instead of a generic
`T::Types::UntypedEnumerable` or degrading to a raw `T::Types::Simple`
so that code that inspects types can still inspect the precise
declared type in a compatible way.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Relying on automated testing. I can write a test with (e.g.) an infinite Enumerable if we want to test that the short-circuiting is actually happening.
