### PR TITLE
Turn off final again

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -178,11 +178,6 @@ module T::Private::Methods
     current_declaration = T::Private::DeclState.current.active_declaration
     mod = is_singleton_method ? hook_mod.singleton_class : hook_mod
 
-    if T::Private::Final.final_module?(mod) && (current_declaration.nil? || !current_declaration.final)
-      raise "`#{mod.name}` was declared as final but its method `#{method_name}` was not declared as final"
-    end
-    _check_final_ancestors(mod, mod.ancestors, [method_name])
-
     if current_declaration.nil?
       return
     end

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -28,6 +28,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids redefining a final instance method with a final sig" do
+    skip
     err = assert_raises(RuntimeError) do
       Class.new do
         extend T::Sig
@@ -41,6 +42,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids redefining a final class method with a final sig" do
+    skip
     err = assert_raises(RuntimeError) do
       Class.new do
         extend T::Sig
@@ -54,6 +56,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids redefining a final instance method with a regular sig" do
+    skip
     err = assert_raises(RuntimeError) do
       Class.new do
         extend T::Sig
@@ -67,6 +70,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids redefining a final class method with a regular sig" do
+    skip
     err = assert_raises(RuntimeError) do
       Class.new do
         extend T::Sig
@@ -80,6 +84,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids redefining a final instance method with no sig" do
+    skip
     err = assert_raises(RuntimeError) do
       Class.new do
         extend T::Sig
@@ -92,6 +97,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids redefining a final class method with no sig" do
+    skip
     err = assert_raises(RuntimeError) do
       Class.new do
         extend T::Sig
@@ -122,6 +128,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding a final instance method" do
+    skip
     c = Class.new do
       extend T::Sig
       sig(:final) {void}
@@ -136,6 +143,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding a final class method" do
+    skip
     c = Class.new do
       extend T::Sig
       sig(:final) {void}
@@ -150,6 +158,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding a final method from an included module" do
+    skip
     m = Module.new do
       extend T::Sig
       sig(:final) {void}
@@ -165,6 +174,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding a final method from an extended module" do
+    skip
     m = Module.new do
       extend T::Sig
       sig(:final) {void}
@@ -180,6 +190,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding a final method by including two modules" do
+    skip
     m1 = Module.new do
       extend T::Sig
       sig(:final) {void}
@@ -197,6 +208,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding a final method by extending two modules" do
+    skip
     m1 = Module.new do
       extend T::Sig
       sig(:final) {void}
@@ -232,6 +244,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "calls a user-defined included" do
+    skip
     m = Module.new do
       @calls = 0
       extend T::Sig
@@ -254,6 +267,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "calls a user-defined extended" do
+    skip
     m = Module.new do
       @calls = 0
       extend T::Sig
@@ -276,6 +290,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "calls an exotic user-defined included" do
+    skip
     m2 = Module.new do
       def self.included(arg)
         arg.include(Module.new do
@@ -295,6 +310,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids overriding through many levels of include" do
+    skip
     m1 = Module.new do
       extend T::Sig
       sig(:final) {void}

--- a/gems/sorbet-runtime/test/types/final_module.rb
+++ b/gems/sorbet-runtime/test/types/final_module.rb
@@ -83,6 +83,7 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
   end
 
   it "forbids declaring a module as final but not its instance method as final" do
+    skip
     err = assert_raises(RuntimeError) do
       Module.new do
         extend T::Helpers
@@ -96,6 +97,7 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
   end
 
   it "forbids declaring a module as final but not its class method as final" do
+    skip
     err = assert_raises(RuntimeError) do
       Module.new do
         extend T::Helpers


### PR DESCRIPTION
### Motivation

The final checks were never actually running on pay-server because I bumped it incorrectly. When we tried to bump pay-server, we discovered the runtime final checks still don't work for reasons we don't understand.

### Test plan
Some tests disabled.
