### PR TITLE
Send payload files and files not present editor-side to supported clients with `sorbet:` URIs

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1370,7 +1370,7 @@ unique_ptr<GlobalStateHash> GlobalState::hash() const {
     return result;
 }
 
-vector<shared_ptr<File>> GlobalState::getFiles() const {
+const vector<shared_ptr<File>> &GlobalState::getFiles() const {
     return files;
 }
 

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -173,7 +173,7 @@ public:
     void trace(std::string_view msg) const;
 
     std::unique_ptr<GlobalStateHash> hash() const;
-    std::vector<std::shared_ptr<File>> getFiles() const;
+    const std::vector<std::shared_ptr<File>> &getFiles() const;
 
     // Contains a string to be used as the base of the error URL.
     // The error code is appended to this string.

--- a/main/lsp/LSPMessage.cc
+++ b/main/lsp/LSPMessage.cc
@@ -151,6 +151,8 @@ bool LSPMessage::isDelayable() const {
         case LSPMethod::TextDocumentDidClose:
         case LSPMethod::SorbetWorkspaceEdit:
         case LSPMethod::SorbetWatchmanFileChange:
+        // A file read. Should not be reordered with respect to file updates.
+        case LSPMethod::SorbetReadFile:
             return false;
         // VS Code requests document symbols automatically and in the background. It's OK to delay these requests.
         case LSPMethod::TextDocumentDocumentSymbol:

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -166,7 +166,7 @@ LSPResult LSPLoop::pushDiagnostics(TypecheckRun run) {
                 if (file.data(gs).sourceType == core::File::Type::Payload) {
                     uri = string(file.data(gs).path());
                 } else {
-                    uri = localName2Remote(file.data(gs).path());
+                    uri = fileRef2Uri(gs, file);
                 }
             }
 

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -147,7 +147,8 @@ class LSPLoop {
     /* Send the given message to client */
     void sendMessage(const LSPMessage &msg);
 
-    std::unique_ptr<Location> loc2Location(const core::GlobalState &gs, core::Loc loc);
+    std::unique_ptr<Location> loc2Location(const core::GlobalState &gs, core::Loc loc,
+                                           bool useDataLinksForPayload = false);
     void addLocIfExists(const core::GlobalState &gs, std::vector<std::unique_ptr<Location>> &locs, core::Loc loc);
     std::vector<std::unique_ptr<Location>>
     extractLocations(const core::GlobalState &gs,

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -136,7 +136,7 @@ class LSPLoop {
      */
     bool enableOperationNotifications = false;
     /**
-     * If true, then Sorbet will use sorbet:// URIs for files that are not stored on disk (e.g., payload files).
+     * If true, then Sorbet will use sorbet: URIs for files that are not stored on disk (e.g., payload files).
      */
     bool enableSorbetURIs = false;
     /** If true, then LSP sends metadata to the client every time it typechecks files. Used in tests. */

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -151,8 +151,7 @@ class LSPLoop {
     /* Send the given message to client */
     void sendMessage(const LSPMessage &msg);
 
-    std::unique_ptr<Location> loc2Location(const core::GlobalState &gs, core::Loc loc,
-                                           bool useDataLinksForPayload = false);
+    std::unique_ptr<Location> loc2Location(const core::GlobalState &gs, core::Loc loc);
     void addLocIfExists(const core::GlobalState &gs, std::vector<std::unique_ptr<Location>> &locs, core::Loc loc);
     std::vector<std::unique_ptr<Location>>
     extractLocations(const core::GlobalState &gs,

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -135,6 +135,10 @@ class LSPLoop {
      * `params.initializationOptions.supportsOperationNotifications` set to `true`.
      */
     bool enableOperationNotifications = false;
+    /**
+     * If true, then Sorbet will use sorbet:// URIs for files that are not stored on disk (e.g., payload files).
+     */
+    bool enableSorbetURIs = false;
     /** If true, then LSP sends metadata to the client every time it typechecks files. Used in tests. */
     bool enableTypecheckInfo = false;
     /**

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -190,7 +190,7 @@ class LSPLoop {
     core::FileRef uri2FileRef(std::string_view uri);
     std::string fileRef2Uri(const core::GlobalState &gs, core::FileRef);
     std::string remoteName2Local(std::string_view uri);
-    std::string localName2Remote(std::string_view uri);
+    std::string localName2Remote(std::string_view uri, bool useSorbetUri);
     std::unique_ptr<core::Loc> lspPos2Loc(core::FileRef fref, const Position &pos, const core::GlobalState &gs);
 
     /** Used to implement textDocument/documentSymbol

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -39,7 +39,10 @@ string LSPLoop::localName2Remote(string_view uri, bool useSorbetUri) {
         return string(relativeUri);
     }
 
-    return absl::StrCat((useSorbetUri ? sorbetUri : rootUri), "/", relativeUri);
+    if (useSorbetUri) {
+        return absl::StrCat(sorbetUri, relativeUri);
+    }
+    return absl::StrCat(rootUri, "/", relativeUri);
 }
 
 core::FileRef LSPLoop::uri2FileRef(string_view uri) {

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -95,7 +95,7 @@ unique_ptr<Range> loc2Range(const core::GlobalState &gs, core::Loc loc) {
 
 unique_ptr<Location> LSPLoop::loc2Location(const core::GlobalState &gs, core::Loc loc) {
     string uri = fileRef2Uri(gs, loc.file());
-    if (loc.file().data(gs).isPayload() && !enableSorbetURIs) {
+    if (loc.file().exists() && loc.file().data(gs).isPayload() && !enableSorbetURIs) {
         // This is hacky because VSCode appends #4,3 (or whatever the position is of the
         // error) to the uri before it shows it in the UI since this is the format that
         // VSCode uses to denote which location to jump to. However, if you append #L4

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -43,7 +43,7 @@ string LSPLoop::localName2Remote(string_view uri, bool useSorbetUri) {
 }
 
 core::FileRef LSPLoop::uri2FileRef(string_view uri) {
-    if (!absl::StartsWith(uri, rootUri) && !absl::StartsWith(sorbetUri, uri)) {
+    if (!absl::StartsWith(uri, rootUri) && !absl::StartsWith(uri, sorbetUri)) {
         return core::FileRef();
     }
     auto needle = remoteName2Local(uri);

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -11,7 +11,7 @@ namespace sorbet::realmain::lsp {
 constexpr string_view sorbetUri = "sorbet:";
 
 string LSPLoop::remoteName2Local(string_view uri) {
-    const bool isSorbetURI = absl::StartsWith(sorbetUri, uri);
+    const bool isSorbetURI = absl::StartsWith(uri, sorbetUri);
     ENFORCE(absl::StartsWith(uri, rootUri) || (enableSorbetURIs && isSorbetURI));
     const string_view root = isSorbetURI ? sorbetUri : rootUri;
     const char *start = uri.data() + root.length();

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -8,7 +8,7 @@ using namespace std;
 
 namespace sorbet::realmain::lsp {
 
-constexpr string_view sorbetUri = "sorbet://";
+constexpr string_view sorbetUri = "sorbet:";
 
 string LSPLoop::remoteName2Local(string_view uri) {
     const bool isSorbetURI = absl::StartsWith(sorbetUri, uri);
@@ -76,8 +76,8 @@ string LSPLoop::fileRef2Uri(const core::GlobalState &gs, core::FileRef file) {
                 uri = string(messageFile.path());
             }
         } else {
-            // Tell localName2Remote to use a sorbet:// URI if the file is not present on the client AND the client
-            // supports sorbet:// URIs
+            // Tell localName2Remote to use a sorbet: URI if the file is not present on the client AND the client
+            // supports sorbet: URIs
             uri = localName2Remote(
                 file.data(gs).path(),
                 enableSorbetURIs && FileOps::isFileIgnored(rootPath, messageFile.path(), opts.lspDirsNotOnClient, {}));

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -18,20 +18,12 @@ string LSPLoop::remoteName2Local(string_view uri) {
     if (*start == '/') {
         ++start;
     }
-    auto end = uri.end();
-    if (isSorbetURI) {
-        // Trim the data query parameter.
-        const auto idx = uri.find("?data=");
-        if (idx != string::npos) {
-            end = uri.data() + idx;
-        }
-    }
 
     // Special case: Folder is '' (current directory).
     if (rootPath.length() > 0) {
-        return absl::StrCat(rootPath, "/", string(start, end));
+        return absl::StrCat(rootPath, "/", string(start, uri.end()));
     } else {
-        return string(start, end);
+        return string(start, uri.end());
     }
 }
 
@@ -58,11 +50,11 @@ core::FileRef LSPLoop::uri2FileRef(string_view uri) {
     return initialGS->findFileByPath(needle);
 }
 
-// Embeds a file's information into a sorbet:// URI that encodes its path and full contents.
+// Embeds a file's information into a sorbet:// URI that encodes its path.
 // Used for files that are not available locally in the editor, like things in payload or directories available only on
 // the machine where Sorbet is running.
 string getSorbetURI(const core::File &file) {
-    return fmt::format("sorbet://{}?data={}", file.path(), absl::WebSafeBase64Escape(file.source()));
+    return fmt::format("sorbet://{}", file.path());
 }
 
 string LSPLoop::fileRef2Uri(const core::GlobalState &gs, core::FileRef file) {

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -9,6 +9,7 @@ using namespace std;
 namespace sorbet::realmain::lsp {
 
 constexpr string_view sorbetScheme = "sorbet:";
+constexpr string_view httpsScheme = "https:";
 
 string LSPLoop::remoteName2Local(string_view uri) {
     const bool isSorbetURI = absl::StartsWith(uri, sorbetScheme);
@@ -19,11 +20,12 @@ string LSPLoop::remoteName2Local(string_view uri) {
         ++start;
     }
 
-    // Special case: Folder is '' (current directory).
-    if (rootPath.length() > 0) {
-        return absl::StrCat(rootPath, "/", string(start, uri.end()));
+    string path = string(start, uri.end());
+    // Special case: Folder is '' (current directory) or file is `https://github.com/...` (payload RBIs)
+    if (rootPath.length() > 0 && !absl::StartsWith(path, httpsScheme)) {
+        return absl::StrCat(rootPath, "/", path);
     } else {
-        return string(start, uri.end());
+        return path;
     }
 }
 

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -65,19 +65,6 @@ string LSPLoop::fileRef2Uri(const core::GlobalState &gs, core::FileRef file) {
             if (enableSorbetURIs) {
                 uri = absl::StrCat(sorbetScheme, messageFile.path());
             } else {
-                // This is hacky because VSCode appends #4,3 (or whatever the position is of the
-                // error) to the uri before it shows it in the UI since this is the format that
-                // VSCode uses to denote which location to jump to. However, if you append #L4
-                // to the end of the uri, this will work on github (it will ignore the #4,3)
-                //
-                // As an example, in VSCode, on hover you might see
-                //
-                // string.rbi(18,7): Method `+` has specified type of argument `arg0` as `String`
-                //
-                // When you click on the link, in the browser it appears as
-                // https://git.corp.stripe.com/stripe-internal/ruby-typer/tree/master/rbi/core/string.rbi#L18%2318,7
-                // but shows you the same thing as
-                // https://git.corp.stripe.com/stripe-internal/ruby-typer/tree/master/rbi/core/string.rbi#L18
                 uri = string(messageFile.path());
             }
         } else {

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -8,8 +8,9 @@ using namespace std;
 
 namespace sorbet::realmain::lsp {
 
+constexpr string_view sorbetUri = "sorbet://";
+
 string LSPLoop::remoteName2Local(string_view uri) {
-    constexpr string_view sorbetUri = "sorbet://";
     const bool isSorbetURI = absl::StartsWith(sorbetUri, uri);
     ENFORCE(absl::StartsWith(uri, rootUri) || (enableSorbetURIs && isSorbetURI));
     const string_view root = isSorbetURI ? sorbetUri : rootUri;
@@ -50,7 +51,7 @@ string LSPLoop::localName2Remote(string_view uri) {
 }
 
 core::FileRef LSPLoop::uri2FileRef(string_view uri) {
-    if (!absl::StartsWith(uri, rootUri)) {
+    if (!absl::StartsWith(uri, rootUri) && !absl::StartsWith(sorbetUri, uri)) {
         return core::FileRef();
     }
     auto needle = remoteName2Local(uri);

--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -214,6 +214,15 @@ LSPResult LSPLoop::processRequestInternal(unique_ptr<core::GlobalState> gs, cons
         } else if (method == LSPMethod::TextDocumentReferences) {
             auto &params = get<unique_ptr<ReferenceParams>>(rawParams);
             return handleTextDocumentReferences(move(gs), id, *params);
+        } else if (method == LSPMethod::SorbetReadFile) {
+            auto &params = get<unique_ptr<TextDocumentIdentifier>>(rawParams);
+            auto fref = uri2FileRef(params->uri);
+            string_view contents = "";
+            if (fref.exists()) {
+                contents = fref.data(*gs).source();
+            }
+            response->result = make_unique<TextDocumentItem>(params->uri, "ruby", 0, string(contents));
+            return LSPResult::make(move(gs), move(response));
         } else if (method == LSPMethod::Shutdown) {
             prodCategoryCounterInc("lsp.messages.processed", "shutdown");
             response->result = JSONNullObject();

--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -159,6 +159,7 @@ LSPResult LSPLoop::processRequestInternal(unique_ptr<core::GlobalState> gs, cons
                 auto &initOptions = *params->initializationOptions;
                 enableOperationNotifications = initOptions->supportsOperationNotifications.value_or(false);
                 enableTypecheckInfo = initOptions->enableTypecheckInfo.value_or(false);
+                enableSorbetURIs = initOptions->supportsSorbetURIs.value_or(false);
             }
 
             auto serverCap = make_unique<ServerCapabilities>();

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -6,7 +6,7 @@ using namespace std;
 namespace sorbet::realmain::lsp {
 void LSPLoop::addLocIfExists(const core::GlobalState &gs, vector<unique_ptr<Location>> &locs, core::Loc loc) {
     if (loc.file().exists()) {
-        locs.push_back(loc2Location(gs, loc));
+        locs.push_back(loc2Location(gs, loc, true));
     }
 }
 
@@ -39,7 +39,7 @@ LSPResult LSPLoop::handleTextDocumentDefinition(unique_ptr<core::GlobalState> gs
                     addLocIfExists(*gs, result, originLoc);
                 }
             } else if (fileIsTyped && resp->isDefinition()) {
-                result.push_back(loc2Location(*gs, resp->isDefinition()->termLoc));
+                result.push_back(loc2Location(*gs, resp->isDefinition()->termLoc, true));
             } else if (fileIsTyped && resp->isSend()) {
                 auto sendResp = resp->isSend();
                 auto start = sendResp->dispatchResult.get();

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -6,7 +6,7 @@ using namespace std;
 namespace sorbet::realmain::lsp {
 void LSPLoop::addLocIfExists(const core::GlobalState &gs, vector<unique_ptr<Location>> &locs, core::Loc loc) {
     if (loc.file().exists()) {
-        locs.push_back(loc2Location(gs, loc, true));
+        locs.push_back(loc2Location(gs, loc));
     }
 }
 
@@ -39,7 +39,7 @@ LSPResult LSPLoop::handleTextDocumentDefinition(unique_ptr<core::GlobalState> gs
                     addLocIfExists(*gs, result, originLoc);
                 }
             } else if (fileIsTyped && resp->isDefinition()) {
-                result.push_back(loc2Location(*gs, resp->isDefinition()->termLoc, true));
+                result.push_back(loc2Location(*gs, resp->isDefinition()->termLoc));
             } else if (fileIsTyped && resp->isSend()) {
                 auto sendResp = resp->isSend();
                 auto start = sendResp->dispatchResult.get();

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -1207,6 +1207,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
         makeObject("SorbetInitializationOptions",
                    {
                        makeField("supportsOperationNotifications", makeOptional(JSONBool)),
+                       makeField("supportsSorbetURIs", makeOptional(JSONBool)),
                        makeField("enableTypecheckInfo", makeOptional(JSONBool)),
                    },
                    classTypes);

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -1307,6 +1307,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                      "initialized",
                                      "shutdown",
                                      "sorbet/error",
+                                     "sorbet/readFile",
                                      "sorbet/showOperation",
                                      "sorbet/typecheckRunInfo",
                                      "sorbet/watchmanFileChange",
@@ -1341,6 +1342,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                                 {"textDocument/codeAction", CodeActionParams},
                                                 {"workspace/symbol", WorkspaceSymbolParams},
                                                 {"sorbet/error", SorbetErrorParams},
+                                                {"sorbet/readFile", TextDocumentIdentifier},
                                             });
     auto RequestMessage =
         makeObject("RequestMessage",
@@ -1374,6 +1376,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
             // {"textDocument/codeAction", makeVariant({JSONNull, makeArray(CodeAction), makeArray(Command)})},
             {"workspace/symbol", makeVariant({JSONNull, makeArray(SymbolInformation)})},
             {"sorbet/error", SorbetErrorParams},
+            {"sorbet/readFile", TextDocumentItem},
         });
     // N.B.: ResponseMessage.params must be optional, as it is not present when an error occurs.
     // N.B.: We add a 'requestMethod' field to response messages to make the discriminated union work.

--- a/main/lsp/updates.cc
+++ b/main/lsp/updates.cc
@@ -164,6 +164,7 @@ LSPLoop::TypecheckRun LSPLoop::runSlowPath() {
 
     vector<ast::ParsedFile> indexedCopies;
     for (const auto &tree : indexed) {
+        // Note: indexed entries for payload files don't have any contents.
         if (tree.tree) {
             indexedCopies.emplace_back(ast::ParsedFile{tree.tree->deepCopy(), tree.file});
         }
@@ -302,7 +303,9 @@ LSPLoop::TypecheckRun LSPLoop::tryFastPath(unique_ptr<core::GlobalState> gs,
             const int id = f.id();
             const auto it = indexedFinalGS.find(id);
             const auto &parsedFile = it == indexedFinalGS.end() ? indexed[id] : it->second;
-            updatedIndexed.emplace_back(ast::ParsedFile{parsedFile.tree->deepCopy(), parsedFile.file});
+            if (parsedFile.tree) {
+                updatedIndexed.emplace_back(ast::ParsedFile{parsedFile.tree->deepCopy(), parsedFile.file});
+            }
         }
         subset.insert(subset.end(), filesForQuery.begin(), filesForQuery.end());
 

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -355,7 +355,7 @@ cxxopts::Options buildOptions() {
     options.add_options("advanced")(
         "lsp-dirs-not-on-client",
         "Directory prefixes that are not accessible editor-side. References to files in these directories will be sent "
-        "as sorbet:// URIs to clients that understand them.",
+        "as sorbet: URIs to clients that understand them.",
         cxxopts::value<vector<string>>(), "string");
     options.add_options("advanced")("no-error-count", "Do not print the error count summary line");
     options.add_options("advanced")("autogen-version", "Autogen version to output", cxxopts::value<int>());

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -353,7 +353,7 @@ cxxopts::Options buildOptions() {
         "`/bar/foo/baz.rb` but not `/foo.rb` or `/foo2/bar.rb`.",
         cxxopts::value<vector<string>>(), "string");
     options.add_options("advanced")(
-        "lsp-dirs-not-on-client",
+        "lsp-directories-missing-from-client",
         "Directory prefixes that are not accessible editor-side. References to files in these directories will be sent "
         "as sorbet: URIs to clients that understand them.",
         cxxopts::value<vector<string>>(), "string");
@@ -664,15 +664,15 @@ void readOptions(Options &opts, int argc, char *argv[],
             enableAllLSPFeatures || raw["enable-experimental-lsp-document-symbol"].as<bool>();
         opts.lspSignatureHelpEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-signature-help"].as<bool>();
 
-        if (raw.count("lsp-dirs-not-on-client") > 0) {
-            auto lspDirsNotOnClient = raw["lsp-dirs-not-on-client"].as<vector<string>>();
+        if (raw.count("lsp-directories-missing-from-client") > 0) {
+            auto lspDirsMissingFromClient = raw["lsp-directories-missing-from-client"].as<vector<string>>();
             // Convert all of these dirs into absolute ignore patterns that begin with '/'.
-            for (auto &dir : lspDirsNotOnClient) {
+            for (auto &dir : lspDirsMissingFromClient) {
                 string pNormalized = dir;
                 if (dir.at(0) != '/') {
                     pNormalized = '/' + dir;
                 }
-                opts.lspDirsNotOnClient.push_back(pNormalized);
+                opts.lspDirsMissingFromClient.push_back(pNormalized);
             }
         }
 

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -186,7 +186,7 @@ struct Options {
     // Ignore patterns that can occur anywhere in a file's path from an input folder.
     std::vector<std::string> autogenSubclassesRelativeIgnorePatterns;
     // List of directories not available editor-side. References to files in these directories should be sent via
-    // sorbet:// URIs to clients that support them.
+    // sorbet: URIs to clients that support them.
     std::vector<std::string> lspDirsNotOnClient;
     // Booleans enabling various experimental LSP features. Each will be removed once corresponding feature stabilizes.
     bool lspGoToDefinitionEnabled = false;

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -187,7 +187,7 @@ struct Options {
     std::vector<std::string> autogenSubclassesRelativeIgnorePatterns;
     // List of directories not available editor-side. References to files in these directories should be sent via
     // sorbet: URIs to clients that support them.
-    std::vector<std::string> lspDirsNotOnClient;
+    std::vector<std::string> lspDirsMissingFromClient;
     // Booleans enabling various experimental LSP features. Each will be removed once corresponding feature stabilizes.
     bool lspGoToDefinitionEnabled = false;
     bool lspFindReferencesEnabled = false;

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -185,6 +185,9 @@ struct Options {
     std::vector<std::string> autogenSubclassesAbsoluteIgnorePatterns;
     // Ignore patterns that can occur anywhere in a file's path from an input folder.
     std::vector<std::string> autogenSubclassesRelativeIgnorePatterns;
+    // List of directories not available editor-side. References to files in these directories should be sent via
+    // sorbet:// URIs to clients that support them.
+    std::vector<std::string> lspDirsNotOnClient;
     // Booleans enabling various experimental LSP features. Each will be removed once corresponding feature stabilizes.
     bool lspGoToDefinitionEnabled = false;
     bool lspFindReferencesEnabled = false;

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -103,7 +103,7 @@ Usage:
                                 be against whole folder and file names, so
                                 `foo` matches `/foo/bar.rb` and `/bar/foo/baz.rb`
                                 but not `/foo.rb` or `/foo2/bar.rb`.
-      --lsp-dirs-not-on-client string
+      --lsp-directories-missing-from-client string
                                 Directory prefixes that are not accessible
                                 editor-side. References to files in these
                                 directories will be sent as sorbet: URIs to clients

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -103,6 +103,11 @@ Usage:
                                 be against whole folder and file names, so
                                 `foo` matches `/foo/bar.rb` and `/bar/foo/baz.rb`
                                 but not `/foo.rb` or `/foo2/bar.rb`.
+      --lsp-dirs-not-on-client string
+                                Directory prefixes that are not accessible
+                                editor-side. References to files in these
+                                directories will be sent as sorbet: URIs to clients
+                                that understand them.
       --no-error-count          Do not print the error count summary line
       --autogen-version arg     Autogen version to output
       --autogen-autoloader-exclude-require arg

--- a/test/helpers/lsp.cc
+++ b/test/helpers/lsp.cc
@@ -267,7 +267,8 @@ optional<PublishDiagnosticsParams *> getPublishDiagnosticParams(NotificationMess
 }
 
 vector<unique_ptr<LSPMessage>> initializeLSP(string_view rootPath, string_view rootUri, LSPWrapper &lspWrapper,
-                                             int &nextId, bool enableTypecheckInfo, bool supportsMarkdown) {
+                                             int &nextId, bool enableTypecheckInfo, bool supportsMarkdown,
+                                             optional<unique_ptr<SorbetInitializationOptions>> initOptions) {
     // Reset next id.
     nextId = 0;
 
@@ -275,6 +276,7 @@ vector<unique_ptr<LSPMessage>> initializeLSP(string_view rootPath, string_view r
     {
         auto initializeParams =
             makeInitializeParams(string(rootPath), string(rootUri), enableTypecheckInfo, supportsMarkdown);
+        initializeParams->initializationOptions = move(initOptions);
         LSPMessage message(make_unique<RequestMessage>("2.0", nextId++, LSPMethod::Initialize, move(initializeParams)));
         auto responses = lspWrapper.getLSPResponsesFor(message);
 

--- a/test/helpers/lsp.h
+++ b/test/helpers/lsp.h
@@ -39,9 +39,10 @@ bool assertNotificationMessage(const LSPMethod expectedMethod, const LSPMessage 
 std::optional<PublishDiagnosticsParams *> getPublishDiagnosticParams(NotificationMessage &notifMsg);
 
 /** Sends boilerplate initialization / initialized messages to start a new LSP session. */
-std::vector<std::unique_ptr<LSPMessage>> initializeLSP(std::string_view rootPath, std::string_view rootUri,
-                                                       LSPWrapper &lspWrapper, int &nextId,
-                                                       bool enableTypecheckInfo = false, bool supportsMarkdown = true);
+std::vector<std::unique_ptr<LSPMessage>>
+initializeLSP(std::string_view rootPath, std::string_view rootUri, LSPWrapper &lspWrapper, int &nextId,
+              bool enableTypecheckInfo = false, bool supportsMarkdown = true,
+              std::optional<std::unique_ptr<SorbetInitializationOptions>> initOptions = std::nullopt);
 
 } // namespace sorbet::test
 #endif // TEST_HELPERS_LSP_H

--- a/test/helpers/lsp.h
+++ b/test/helpers/lsp.h
@@ -9,9 +9,10 @@ namespace sorbet::test {
 using namespace sorbet::realmain::lsp;
 
 /** Creates the parameters to the `initialize` message, which advertises the client's capabilities. */
-std::unique_ptr<InitializeParams> makeInitializeParams(std::variant<std::string, JSONNullObject> rootPath,
-                                                       std::variant<std::string, JSONNullObject> rootUri,
-                                                       bool enableTypecheckInfo, bool supportsMarkdown);
+std::unique_ptr<InitializeParams>
+makeInitializeParams(std::variant<std::string, JSONNullObject> rootPath,
+                     std::variant<std::string, JSONNullObject> rootUri, bool supportsMarkdown,
+                     std::optional<std::unique_ptr<SorbetInitializationOptions>> initOptions);
 
 /** Create an LSPMessage containing a textDocument/definition request. */
 std::unique_ptr<LSPMessage> makeDefinitionRequest(int id, std::string_view uri, int line, int character);

--- a/test/helpers/lsp.h
+++ b/test/helpers/lsp.h
@@ -41,7 +41,7 @@ std::optional<PublishDiagnosticsParams *> getPublishDiagnosticParams(Notificatio
 /** Sends boilerplate initialization / initialized messages to start a new LSP session. */
 std::vector<std::unique_ptr<LSPMessage>>
 initializeLSP(std::string_view rootPath, std::string_view rootUri, LSPWrapper &lspWrapper, int &nextId,
-              bool enableTypecheckInfo = false, bool supportsMarkdown = true,
+              bool supportsMarkdown = true,
               std::optional<std::unique_ptr<SorbetInitializationOptions>> initOptions = std::nullopt);
 
 } // namespace sorbet::test

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -72,6 +72,10 @@ protected:
 
     void assertDiagnostics(std::vector<std::unique_ptr<LSPMessage>> messages, std::vector<ExpectedDiagnostic> expected);
 
+    std::string readFile(std::string_view uri);
+
+    std::vector<std::unique_ptr<Location>> getDefinitions(std::string_view uri, int line, int character);
+
     /**
      * ProtocolTest maintains the latest diagnostics for files received over a session, as LSP is not required to
      * re-send diagnostics that have not changed. send() automatically updates diagnostics, but if a test manually

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -300,9 +300,9 @@ TEST_F(ProtocolTest, MonacoInitialization) {
     // Null is functionally equivalent to an empty rootUri. Manually reset rootUri before initializing.
     rootUri = "";
     const bool supportsMarkdown = true;
-    auto params =
-        make_unique<RequestMessage>("2.0", nextId++, LSPMethod::Initialize,
-                                    makeInitializeParams(JSONNullObject(), JSONNullObject(), supportsMarkdown));
+    auto params = make_unique<RequestMessage>(
+        "2.0", nextId++, LSPMethod::Initialize,
+        makeInitializeParams(JSONNullObject(), JSONNullObject(), supportsMarkdown, nullopt));
     auto responses = send(LSPMessage(move(params)));
     ASSERT_EQ(responses.size(), 1) << "Expected only a single response to the initialize request.";
     auto &respMsg = responses.at(0);

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -425,7 +425,7 @@ TEST_F(ProtocolTest, SorbetURIsWork) {
     const bool supportsMarkdown = false;
     auto initOptions = make_unique<SorbetInitializationOptions>();
     initOptions->supportsSorbetURIs = true;
-    lspWrapper->opts.lspDirsNotOnClient.push_back("/folder");
+    lspWrapper->opts.lspDirsMissingFromClient.push_back("/folder");
     auto initializeResponses =
         sorbet::test::initializeLSP(rootPath, rootUri, *lspWrapper, nextId, supportsMarkdown, move(initOptions));
     updateDiagnostics(initializeResponses);

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -299,11 +299,10 @@ TEST_F(ProtocolTest, EmptyRootUriInitialization) {
 TEST_F(ProtocolTest, MonacoInitialization) {
     // Null is functionally equivalent to an empty rootUri. Manually reset rootUri before initializing.
     rootUri = "";
-    const bool enableTypecheckInfo = false;
     const bool supportsMarkdown = true;
-    auto params = make_unique<RequestMessage>(
-        "2.0", nextId++, LSPMethod::Initialize,
-        makeInitializeParams(JSONNullObject(), JSONNullObject(), enableTypecheckInfo, supportsMarkdown));
+    auto params =
+        make_unique<RequestMessage>("2.0", nextId++, LSPMethod::Initialize,
+                                    makeInitializeParams(JSONNullObject(), JSONNullObject(), supportsMarkdown));
     auto responses = send(LSPMessage(move(params)));
     ASSERT_EQ(responses.size(), 1) << "Expected only a single response to the initialize request.";
     auto &respMsg = responses.at(0);
@@ -400,10 +399,8 @@ TEST_F(ProtocolTest, SilentlyIgnoresInvalidJSONMessages) {
 
 // If a client doesn't support markdown, send hover as plaintext.
 TEST_F(ProtocolTest, RespectsHoverTextLimitations) {
-    const bool enableTypecheckInfo = false;
     const bool supportsMarkdown = false;
-    auto initializeResponses =
-        sorbet::test::initializeLSP(rootPath, rootUri, *lspWrapper, nextId, enableTypecheckInfo, supportsMarkdown);
+    auto initializeResponses = sorbet::test::initializeLSP(rootPath, rootUri, *lspWrapper, nextId, supportsMarkdown);
     updateDiagnostics(initializeResponses);
     assertDiagnostics(move(initializeResponses), {});
 
@@ -425,13 +422,12 @@ TEST_F(ProtocolTest, RespectsHoverTextLimitations) {
 
 // Tests that Sorbet returns sorbet: URIs for payload references & files not on client, and that readFile works on them.
 TEST_F(ProtocolTest, SorbetURIsWork) {
-    const bool enableTypecheckInfo = false;
     const bool supportsMarkdown = false;
     auto initOptions = make_unique<SorbetInitializationOptions>();
     initOptions->supportsSorbetURIs = true;
     lspWrapper->opts.lspDirsNotOnClient.push_back("/folder");
-    auto initializeResponses = sorbet::test::initializeLSP(rootPath, rootUri, *lspWrapper, nextId, enableTypecheckInfo,
-                                                           supportsMarkdown, move(initOptions));
+    auto initializeResponses =
+        sorbet::test::initializeLSP(rootPath, rootUri, *lspWrapper, nextId, supportsMarkdown, move(initOptions));
     updateDiagnostics(initializeResponses);
     assertDiagnostics(move(initializeResponses), {});
 

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -524,7 +524,10 @@ TEST_P(LSPTest, All) {
 
     // Perform initialize / initialized handshake.
     {
-        auto initializedResponses = initializeLSP(rootPath, rootUri, *lspWrapper, nextId, true);
+        auto sorbetInitOptions = make_unique<SorbetInitializationOptions>();
+        sorbetInitOptions->enableTypecheckInfo = true;
+        auto initializedResponses =
+            initializeLSP(rootPath, rootUri, *lspWrapper, nextId, true, move(sorbetInitOptions));
         EXPECT_EQ(0, countNonTestMessages(initializedResponses))
             << "Should not receive any response to 'initialized' message.";
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call 
out user-visible changes. -->

Send payload files and files not present editor-side to supported clients with `sorbet:` URIs

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Internally, Sorbet uses `https://github.com/sorbet/sorbet/..." paths for payload RBIs. Requesting "go-to-definition" on a method described in a payload RBI (e.g., Array.select) results in Sorbet sending back one of these URLs as the URI for the file containing the definition. This works perfectly fine on sorbet.run, but fails in VS Code as VS Code does not support https:// URLs.

In a similar vein, VS Code errors when running "go to definition" on a method that is defined in a file not on the local file system. This is an issue at Stripe, as we have some codegenned files present on the computer running Sorbet that are not present on the laptop running VS Code.

This change causes Sorbet to use `sorbet:` URIs for the above two categories of files. It does so **only if the editor advertises that it understands the URI during initialization**.

This change also adds a `sorbet/readFile` request to Sorbet, which the VS Code extension uses to read the contents of `sorbet:` files. I initially encoded file data into the URIs, but VS Code froze up when dealing with 700+KB URIs.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Adds one protocol test that checks that:
* Payload files are sent as `sorbet:` URIs and that `readFile` works on them.
* Files specified as not available to the editor are sent as `sorbet:` URIs and that `readFile` works on them.
