### PR TITLE
Look up alias methods transitively

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1493,7 +1493,7 @@ public:
             auto toName = args[1];
 
             auto owner = methodOwner(ctx);
-            core::SymbolRef toMethod = owner.data(ctx)->findMember(ctx, toName);
+            core::SymbolRef toMethod = owner.data(ctx)->findMemberTransitive(ctx, toName);
             if (!toMethod.exists()) {
                 if (auto e = ctx.state.beginError(send->args[1]->loc, core::errors::Resolver::BadAliasMethod)) {
                     e.setHeader("Can't make method alias from `{}` to non existing method `{}`", fromName.show(ctx),

--- a/test/testdata/resolver/alias_transitive.rb
+++ b/test/testdata/resolver/alias_transitive.rb
@@ -1,0 +1,30 @@
+# typed: true
+
+class Parent
+  extend T::Sig
+
+  sig {returns(Integer)}
+  def parent_bar; 1; end
+end
+
+class Child < Parent
+  alias_method(:child_bar, :parent_bar)
+end
+
+T.reveal_type(Child.new.child_bar) # Revealed type: `Integer`
+
+# --- again, but in a different order ---
+
+class ChildFirst < ParentSecond
+  alias_method(:foo, :bar)
+end
+
+class ParentSecond
+  extend T::Sig
+
+  sig {returns(NilClass)}
+  def bar
+  end
+end
+
+T.reveal_type(ChildFirst.new.foo) # Revealed type: `NilClass`


### PR DESCRIPTION
Calling findMemberTransitive here is fine, because this is in
ResolveSignaturesWalk, which is run after GlobalPass::finalizeSymbols
which computes class linearization (i.e., it's using the fast
findMemberTransitive algorithm, not the exponential one).


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Reported at Stripe on Slack.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.