### PR TITLE
Remove duplicated indexing errors in LSP, and assert that errors-with-dupes are duplicated.

### DIFF
--- a/main/lsp/updates.cc
+++ b/main/lsp/updates.cc
@@ -267,6 +267,9 @@ LSPLoop::TypecheckRun LSPLoop::tryFastPath(unique_ptr<core::GlobalState> gs,
 
     if (takeFastPath) {
         Timer timeit(logger, "fast_path");
+        // Drop any indexing errors produced during `updateFile`, as we are going to run indexing a second time with
+        // finalGS. (Note: Flushing is disabled in LSP mode, so we have to drain.)
+        errorQueue->drainWithQueryResponses();
         int i = -1;
         for (auto &oldHash : globalStateHashes) {
             i++;

--- a/test/testdata/core/fuzz_unparseable.rb
+++ b/test/testdata/core/fuzz_unparseable.rb
@@ -1,4 +1,4 @@
 # typed: strict
 r *[1]g#typed:true
-    # ^ error-with-dupes: Parse Error: unexpected token: syntax error
-m do # error-with-dupes: Parse Error: unexpected token: syntax error
+    # ^ error: Parse Error: unexpected token: syntax error
+m do # error: Parse Error: unexpected token: syntax error

--- a/test/testdata/desugar/constant_reassignment.rb
+++ b/test/testdata/desugar/constant_reassignment.rb
@@ -1,10 +1,10 @@
 # typed: true
 
 A = 1
-A ||= 2 # error-with-dupes: Constant reassignment is not supported
+A ||= 2 # error: Constant reassignment is not supported
 
 B = 1
-B &&= 2 # error-with-dupes: Constant reassignment is not supported
+B &&= 2 # error: Constant reassignment is not supported
 
 C = 1
-C += 2 # error-with-dupes: Constant reassignment is not supported
+C += 2 # error: Constant reassignment is not supported

--- a/test/testdata/desugar/defs_not_self.rb
+++ b/test/testdata/desugar/defs_not_self.rb
@@ -1,3 +1,3 @@
 # typed: true
-def x.method # error-with-dupes: `def EXPRESSION.method` is only supported for `def self.method`
+def x.method # error: `def EXPRESSION.method` is only supported for `def self.method`
 end

--- a/test/testdata/desugar/fuzz_block_pass.rb
+++ b/test/testdata/desugar/fuzz_block_pass.rb
@@ -1,7 +1,7 @@
 # typed: false
-next &a # error-with-dupes: Block argument should not be given
-next a, &b # error-with-dupes: Block argument should not be given
-break &a # error-with-dupes: Block argument should not be given
-break a, &b # error-with-dupes: Block argument should not be given
-return &a # error-with-dupes: Block argument should not be given
-return a, &b # error-with-dupes: Block argument should not be given
+next &a # error: Block argument should not be given
+next a, &b # error: Block argument should not be given
+break &a # error: Block argument should not be given
+break a, &b # error: Block argument should not be given
+return &a # error: Block argument should not be given
+return a, &b # error: Block argument should not be given

--- a/test/testdata/desugar/fuzz_break_do_end.rb
+++ b/test/testdata/desugar/fuzz_break_do_end.rb
@@ -1,3 +1,3 @@
 # typed: false
-break 1 do # error-with-dupes: No body in block
+break 1 do # error: No body in block
 end

--- a/test/testdata/desugar/integers.rb
+++ b/test/testdata/desugar/integers.rb
@@ -1,14 +1,14 @@
 # typed: true
 def test_large_int
   [
-    0B, # error-with-dupes: numeric literal without digits
-    0X, # error-with-dupes: numeric literal without digits
+    0B, # error: numeric literal without digits
+    0X, # error: numeric literal without digits
     00,
     9223372036854775807,
     -9223372036854775808,
-    18446744073709551616,   # error-with-dupes: Unsupported integer
+    18446744073709551616,   # error: Unsupported integer
     0xcafe,
     0_0,
-    1_, # error-with-dupes: trailing `_`
+    1_, # error: trailing `_`
   ]
 end

--- a/test/testdata/desugar/regexp.rb
+++ b/test/testdata/desugar/regexp.rb
@@ -14,5 +14,5 @@ def foo
     /#{a}b#{c}/
     Regexp.new(a + 'b' + c)
 
-    /abc/a # error-with-dupes: Parse Error: unknown regexp options: a
+    /abc/a # error: Parse Error: unknown regexp options: a
 end

--- a/test/testdata/desugar/sclass.rb
+++ b/test/testdata/desugar/sclass.rb
@@ -2,7 +2,7 @@
 class A
 end
 
-class << A # error-with-dupes: `class << EXPRESSION` is only supported for `class << self`
+class << A # error: `class << EXPRESSION` is only supported for `class << self`
     def a
         'a'
     end
@@ -17,7 +17,7 @@ class B
 end
 
 $c = Object.new
-class << $c # error-with-dupes: `class << EXPRESSION` is only supported for `class << self`
+class << $c # error: `class << EXPRESSION` is only supported for `class << self`
     def c
         "c"
     end

--- a/test/testdata/desugar/star_in_block_arg.rb
+++ b/test/testdata/desugar/star_in_block_arg.rb
@@ -5,6 +5,6 @@ sig {params(blk: T.proc.params(args: Integer).void).void}
 def foo(&blk)
 end
 
-foo do |(*args)| # error-with-dupes: Unsupported rest args in destructure
+foo do |(*args)| # error: Unsupported rest args in destructure
   T.reveal_type(args) # error: Revealed type: `Integer`
 end

--- a/test/testdata/desugar/undef_strict.rb
+++ b/test/testdata/desugar/undef_strict.rb
@@ -11,4 +11,4 @@ def undef(*arg); end
 sig {void}
 def foo
 end
-undef foo # error-with-dupes: Unsuppored method: undef
+undef foo # error: Unsuppored method: undef

--- a/test/testdata/dsl/interface_wrapper.rb
+++ b/test/testdata/dsl/interface_wrapper.rb
@@ -26,7 +26,7 @@ def testit
   wrap.other_method # error: does not exist
   wrap.some_method
 
-  Other.wrap_instance("hi", "there") # error-with-dupes: Wrong number of arguments
+  Other.wrap_instance("hi", "there") # error: Wrong number of arguments
   o = Other
-  o.wrap_instance("hi") # error-with-dupes: Unsupported wrap_instance() on a non-constant-literal
+  o.wrap_instance("hi") # error: Unsupported wrap_instance() on a non-constant-literal
 end

--- a/test/testdata/infer/crash_after_parse_errors.rb
+++ b/test/testdata/infer/crash_after_parse_errors.rb
@@ -1,5 +1,5 @@
 # typed: true
-->e # error-with-dupes: syntax error
+->e # error: syntax error
 r=e
 r=e
 r&&o # error: This code is unreachable

--- a/test/testdata/infer/fuzz_uninitialized_vars.rb
+++ b/test/testdata/infer/fuzz_uninitialized_vars.rb
@@ -1,6 +1,6 @@
 # typed: true
 foo = a(b
-if @c && foo # error-with-dupes: Parse Error: unexpected token: syntax error
+if @c && foo # error: Parse Error: unexpected token: syntax error
   d # error: This code is unreachable
 end
 

--- a/test/testdata/namer/fuzz_repeated_kwarg.rb
+++ b/test/testdata/namer/fuzz_repeated_kwarg.rb
@@ -1,19 +1,19 @@
 # typed: false
 # from fuzzer: https://github.com/sorbet/sorbet/issues/1133
-def f1(x, x); end # error-with-dupes: Duplicated argument name `x`
-def f2(x, x=0); end # error-with-dupes: Duplicated argument name `x`
-def f3(x:, x:); end # error-with-dupes: Duplicated argument name `x`
-def f4(x:, x: nil); end # error-with-dupes: Duplicated argument name `x`
-def f5(x, x:); end # error-with-dupes: Duplicated argument name `x`
-def f6(x, x: nil); end # error-with-dupes: Duplicated argument name `x`
-def f7(x=0, x: nil); end # error-with-dupes: Duplicated argument name `x`
+def f1(x, x); end # error: Duplicated argument name `x`
+def f2(x, x=0); end # error: Duplicated argument name `x`
+def f3(x:, x:); end # error: Duplicated argument name `x`
+def f4(x:, x: nil); end # error: Duplicated argument name `x`
+def f5(x, x:); end # error: Duplicated argument name `x`
+def f6(x, x: nil); end # error: Duplicated argument name `x`
+def f7(x=0, x: nil); end # error: Duplicated argument name `x`
 
 def f8(
       this,
-      this: # error-with-dupes: Duplicated argument name `this`
+      this: # error: Duplicated argument name `this`
     )
 end
 
-def f9(x, y, z, x); end # error-with-dupes: Duplicated argument name `x`
+def f9(x, y, z, x); end # error: Duplicated argument name `x`
 
-l1 = lambda { |y, y| } # error-with-dupes: Duplicated argument name `y`
+l1 = lambda { |y, y| } # error: Duplicated argument name `y`

--- a/test/testdata/namer/super.rb
+++ b/test/testdata/namer/super.rb
@@ -1,2 +1,2 @@
 # typed: true
-super # error-with-dupes: `super` outside of method
+super # error: `super` outside of method

--- a/test/testdata/parser/begin_block_nullderef.rb
+++ b/test/testdata/parser/begin_block_nullderef.rb
@@ -1,3 +1,3 @@
 # typed: true
 def s()else
-n # error-with-dupes: syntax error
+n # error: syntax error

--- a/test/testdata/parser/compare_overload_parse_error.rb
+++ b/test/testdata/parser/compare_overload_parse_error.rb
@@ -1,15 +1,15 @@
 # typed: false
-class A # error-with-dupes: Parse Error: class definition in method body
-  def greater_eqaul>=(foo) # error-with-dupes: Parse Error: unexpected token: syntax error
+class A # error: Parse Error: class definition in method body
+  def greater_eqaul>=(foo) # error: Parse Error: unexpected token: syntax error
   end
 end
 
-class B # error-with-dupes: Parse Error: class definition in method body
-  def less_equal<=(foo) # error-with-dupes: Parse Error: unexpected token: syntax error
+class B # error: Parse Error: class definition in method body
+  def less_equal<=(foo) # error: Parse Error: unexpected token: syntax error
   end
 end
 
-class C # error-with-dupes: Parse Error: class definition in method body
-  def not_equal!=(foo) # error-with-dupes: Parse Error: unexpected token: syntax error
+class C # error: Parse Error: class definition in method body
+  def not_equal!=(foo) # error: Parse Error: unexpected token: syntax error
   end
 end

--- a/test/testdata/parser/encoding.rb
+++ b/test/testdata/parser/encoding.rb
@@ -1,2 +1,2 @@
 # typed: false
-__ENCODING__ # error-with-dupes: Unsupported node type `EncodingLiteral`
+__ENCODING__ # error: Unsupported node type `EncodingLiteral`

--- a/test/testdata/parser/fuzz_def_begin.rb
+++ b/test/testdata/parser/fuzz_def_begin.rb
@@ -1,2 +1,2 @@
 # typed: false
-def BEGIN # error-with-dupes: Parse Error: unexpected token: syntax error
+def BEGIN # error: Parse Error: unexpected token: syntax error

--- a/test/testdata/parser/fuzz_ivar.rb
+++ b/test/testdata/parser/fuzz_ivar.rb
@@ -1,3 +1,3 @@
 # typed: false
-@1 # error-with-dupes: Parse Error: `@1` is not allowed as an instance variable name
-@@2 # error-with-dupes: Parse Error: `@@2` is not allowed as a class variable name
+@1 # error: Parse Error: `@1` is not allowed as an instance variable name
+@@2 # error: Parse Error: `@@2` is not allowed as a class variable name

--- a/test/testdata/parser/invalid_fatal.rb
+++ b/test/testdata/parser/invalid_fatal.rb
@@ -1,2 +1,2 @@
 # typed: true
-"\xg3" # error-with-dupes: Parse Fatal: invalid hex escape
+"\xg3" # error: Parse Fatal: invalid hex escape

--- a/test/testdata/parser/invalid_syntax_error.rb
+++ b/test/testdata/parser/invalid_syntax_error.rb
@@ -1,2 +1,2 @@
 # typed: false
-1j # error-with-dupes: Parse Error: unexpected token: syntax error
+1j # error: Parse Error: unexpected token: syntax error

--- a/test/testdata/parser/invalid_trailing_in_number.rb
+++ b/test/testdata/parser/invalid_trailing_in_number.rb
@@ -1,2 +1,2 @@
 # typed: true
-0_ # error-with-dupes: Parse Error: trailing `_` in number
+0_ # error: Parse Error: trailing `_` in number

--- a/test/testdata/parser/misc.rb
+++ b/test/testdata/parser/misc.rb
@@ -109,8 +109,8 @@ def optfoo(x=1, *y); end
 # pair and pair_quoted
 {x => y, "foo": 1}
 
-BEGIN{foo} # error-with-dupes: Unsupported node type `Preexe`
-END{bar} # error-with-dupes: Unsupported node type `Postexe`
+BEGIN{foo} # error: Unsupported node type `Preexe`
+END{bar} # error: Unsupported node type `Postexe`
 
 # rationals
 4r

--- a/test/testdata/parser/offset0.rb
+++ b/test/testdata/parser/offset0.rb
@@ -1,4 +1,4 @@
 # typed: true
-module Model # error-with-dupes: module definition in method body
-  def a-b; end # error-with-dupes: unexpected token
+module Model # error: module definition in method body
+  def a-b; end # error: unexpected token
 end

--- a/test/testdata/parser/whitequark/assert_parses_args_2.rb
+++ b/test/testdata/parser/whitequark/assert_parses_args_2.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def f ((a, *r)); end # error-with-dupes: Unsupported rest args in destructure
+def f ((a, *r)); end # error: Unsupported rest args in destructure

--- a/test/testdata/parser/whitequark/assert_parses_args_3.rb
+++ b/test/testdata/parser/whitequark/assert_parses_args_3.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def f ((a, *r, p)); end # error-with-dupes: Unsupported rest args in destructure
+def f ((a, *r, p)); end # error: Unsupported rest args in destructure

--- a/test/testdata/parser/whitequark/assert_parses_args_4.rb
+++ b/test/testdata/parser/whitequark/assert_parses_args_4.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def f ((a, *)); end # error-with-dupes: Unsupported rest args in destructure
+def f ((a, *)); end # error: Unsupported rest args in destructure

--- a/test/testdata/parser/whitequark/assert_parses_args_5.rb
+++ b/test/testdata/parser/whitequark/assert_parses_args_5.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def f ((a, *, p)); end # error-with-dupes: Unsupported rest args in destructure
+def f ((a, *, p)); end # error: Unsupported rest args in destructure

--- a/test/testdata/parser/whitequark/assert_parses_args_6.rb
+++ b/test/testdata/parser/whitequark/assert_parses_args_6.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def f ((*r)); end # error-with-dupes: Unsupported rest args in destructure
+def f ((*r)); end # error: Unsupported rest args in destructure

--- a/test/testdata/parser/whitequark/assert_parses_args_7.rb
+++ b/test/testdata/parser/whitequark/assert_parses_args_7.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def f ((*r, p)); end # error-with-dupes: Unsupported rest args in destructure
+def f ((*r, p)); end # error: Unsupported rest args in destructure

--- a/test/testdata/parser/whitequark/assert_parses_args_8.rb
+++ b/test/testdata/parser/whitequark/assert_parses_args_8.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def f ((*)); end # error-with-dupes: Unsupported rest args in destructure
+def f ((*)); end # error: Unsupported rest args in destructure

--- a/test/testdata/parser/whitequark/assert_parses_args_9.rb
+++ b/test/testdata/parser/whitequark/assert_parses_args_9.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def f ((*, p)); end # error-with-dupes: Unsupported rest args in destructure
+def f ((*, p)); end # error: Unsupported rest args in destructure

--- a/test/testdata/parser/whitequark/parse_alias_gvar_1.rb
+++ b/test/testdata/parser/whitequark/parse_alias_gvar_1.rb
@@ -1,3 +1,3 @@
 # typed: false
 
-alias $a $+ # error-with-dupes: Unsupported node type
+alias $a $+ # error: Unsupported node type

--- a/test/testdata/parser/whitequark/parse_back_ref.rb
+++ b/test/testdata/parser/whitequark/parse_back_ref.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-$+ # error-with-dupes: Unsupported node type
+$+ # error: Unsupported node type

--- a/test/testdata/parser/whitequark/parse_cond_eflipflop.rb
+++ b/test/testdata/parser/whitequark/parse_cond_eflipflop.rb
@@ -1,4 +1,4 @@
 # typed: true
 def foo; end;
 def bar; end;
-if foo...bar; end # error-with-dupes: Unsupported node type `EFlipflop`
+if foo...bar; end # error: Unsupported node type `EFlipflop`

--- a/test/testdata/parser/whitequark/parse_cond_iflipflop.rb
+++ b/test/testdata/parser/whitequark/parse_cond_iflipflop.rb
@@ -1,4 +1,4 @@
 # typed: true
 def foo; end;
 def bar; end;
-if foo..bar; end # error-with-dupes: Unsupported node type `IFlipflop`
+if foo..bar; end # error: Unsupported node type `IFlipflop`

--- a/test/testdata/parser/whitequark/parse_cond_match_current_line.rb
+++ b/test/testdata/parser/whitequark/parse_cond_match_current_line.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-if /wat/; end # error-with-dupes: Unsupported node type
+if /wat/; end # error: Unsupported node type

--- a/test/testdata/parser/whitequark/parse_const_op_asgn.rb
+++ b/test/testdata/parser/whitequark/parse_const_op_asgn.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-A += 1 # error-with-dupes: Constant reassignment is not supported
+A += 1 # error: Constant reassignment is not supported

--- a/test/testdata/parser/whitequark/parse_const_op_asgn_1.rb
+++ b/test/testdata/parser/whitequark/parse_const_op_asgn_1.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-::A += 1 # error-with-dupes: Constant reassignment is not supported
+::A += 1 # error: Constant reassignment is not supported

--- a/test/testdata/parser/whitequark/parse_const_op_asgn_2.rb
+++ b/test/testdata/parser/whitequark/parse_const_op_asgn_2.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-B::A += 1 # error-with-dupes: Constant reassignment is not supported
+B::A += 1 # error: Constant reassignment is not supported

--- a/test/testdata/parser/whitequark/parse_const_op_asgn_3.rb
+++ b/test/testdata/parser/whitequark/parse_const_op_asgn_3.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def x; self::A ||= 1; end # error-with-dupes: Constant reassignment is not supported
+def x; self::A ||= 1; end # error: Constant reassignment is not supported

--- a/test/testdata/parser/whitequark/parse_const_op_asgn_4.rb
+++ b/test/testdata/parser/whitequark/parse_const_op_asgn_4.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def x; ::A ||= 1; end # error-with-dupes: Constant reassignment is not supported
+def x; ::A ||= 1; end # error: Constant reassignment is not supported

--- a/test/testdata/parser/whitequark/parse_defs_2.rb
+++ b/test/testdata/parser/whitequark/parse_defs_2.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def (foo).foo; end # error-with-dupes: `def EXPRESSION.method` is only supported for `def self.method`
+def (foo).foo; end # error: `def EXPRESSION.method` is only supported for `def self.method`

--- a/test/testdata/parser/whitequark/parse_defs_3.rb
+++ b/test/testdata/parser/whitequark/parse_defs_3.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def String.foo; end # error-with-dupes: `def EXPRESSION.method` is only supported for `def self.method`
+def String.foo; end # error: `def EXPRESSION.method` is only supported for `def self.method`

--- a/test/testdata/parser/whitequark/parse_defs_4.rb
+++ b/test/testdata/parser/whitequark/parse_defs_4.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def String::foo; end # error-with-dupes: `def EXPRESSION.method` is only supported for `def self.method`
+def String::foo; end # error: `def EXPRESSION.method` is only supported for `def self.method`

--- a/test/testdata/parser/whitequark/parse_op_asgn_cmd_3.rb
+++ b/test/testdata/parser/whitequark/parse_op_asgn_cmd_3.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-foo::A += m foo # error-with-dupes: Constant reassignment is not supported
+foo::A += m foo # error: Constant reassignment is not supported

--- a/test/testdata/parser/whitequark/parse_postexe.rb
+++ b/test/testdata/parser/whitequark/parse_postexe.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-END { 1 }# error-with-dupes: Unsupported node type
+END { 1 }# error: Unsupported node type

--- a/test/testdata/parser/whitequark/parse_preexe.rb
+++ b/test/testdata/parser/whitequark/parse_preexe.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-BEGIN { 1 } # error-with-dupes: Unsupported node type `Preexe`
+BEGIN { 1 } # error: Unsupported node type `Preexe`

--- a/test/testdata/parser/whitequark/parse_redo.rb
+++ b/test/testdata/parser/whitequark/parse_redo.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-redo # error-with-dupes: Unsupported node type `Redo`
+redo # error: Unsupported node type `Redo`

--- a/test/testdata/parser/whitequark/parse_ruby_bug_12402_13.rb
+++ b/test/testdata/parser/whitequark/parse_ruby_bug_12402_13.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-foo::C ||= raise bar rescue nil # error-with-dupes: Constant reassignment is not supported
+foo::C ||= raise bar rescue nil # error: Constant reassignment is not supported

--- a/test/testdata/parser/whitequark/parse_ruby_bug_12402_6.rb
+++ b/test/testdata/parser/whitequark/parse_ruby_bug_12402_6.rb
@@ -1,4 +1,4 @@
 # typed: true
 def foo; end;
 def bar; end;
-foo::C ||= raise(bar) rescue nil # error-with-dupes: Constant reassignment is not supported
+foo::C ||= raise(bar) rescue nil # error: Constant reassignment is not supported

--- a/test/testdata/parser/whitequark/parse_sclass.rb
+++ b/test/testdata/parser/whitequark/parse_sclass.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-class << foo; nil; end # error-with-dupes: `class << EXPRESSION` is only supported for `class << self`
+class << foo; nil; end # error: `class << EXPRESSION` is only supported for `class << self`

--- a/test/testdata/parser/whitequark/parse_super_block_1.rb
+++ b/test/testdata/parser/whitequark/parse_super_block_1.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-super do end # error-with-dupes: `super` outside of method
+super do end # error: `super` outside of method

--- a/test/testdata/parser/whitequark/parse_zsuper.rb
+++ b/test/testdata/parser/whitequark/parse_zsuper.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-super # error-with-dupes: `super` outside of method
+super # error: `super` outside of method

--- a/test/testdata/resolver/abstract_validation.rb
+++ b/test/testdata/resolver/abstract_validation.rb
@@ -1,4 +1,6 @@
 # typed: true
+# Fast path causes duplicate errors.
+# disable-fast-path: true
 
 module AbstractMixin
   extend T::Sig
@@ -51,8 +53,8 @@ end
 
 # it fails if a concrete module doesn't implement abstract methods
   module M2
-# ^^^^^^^^^ error-with-dupes: Missing definition for abstract method `AbstractMixin#bar`
-# ^^^^^^^^^ error-with-dupes: Missing definition for abstract method `AbstractMixin#foo`
+# ^^^^^^^^^ error: Missing definition for abstract method `AbstractMixin#bar`
+# ^^^^^^^^^ error: Missing definition for abstract method `AbstractMixin#foo`
   extend T::Helpers
   include AbstractMixin
 end

--- a/test/testdata/resolver/final_module.rb
+++ b/test/testdata/resolver/final_module.rb
@@ -1,4 +1,6 @@
 # typed: false
+# The fast path causes duplicate errors.
+# disable-fast-path: true
 
 class FinalClass
   extend T::Helpers
@@ -18,19 +20,19 @@ end
 module BadInclude
   include NonFinalModule
   extend NonFinalModule
-  include FinalModule # error-with-dupes: `FinalModule` was declared as final and cannot be included in `BadInclude`
+  include FinalModule # error: `FinalModule` was declared as final and cannot be included in `BadInclude`
 end
 
 module BadExtend
   include NonFinalModule
   extend NonFinalModule
-  extend FinalModule # error-with-dupes: `FinalModule` was declared as final and cannot be extended in `BadExtend`
+  extend FinalModule # error: `FinalModule` was declared as final and cannot be extended in `BadExtend`
 end
 
 AliasFinalModule = FinalModule
 
 module BadAliasInclude
-  include AliasFinalModule # error-with-dupes: `FinalModule` was declared as final and cannot be included in `BadAliasInclude`
+  include AliasFinalModule # error: `FinalModule` was declared as final and cannot be included in `BadAliasInclude`
 end
 
 module FinalModuleWithFinalMethods
@@ -75,7 +77,7 @@ module ModuleWithClass
 end
 
 class ModuleWithClassOkay < ModuleWithClass::C; end
-class ModuleWithClassBad; include ModuleWithClass; end # error-with-dupes: `ModuleWithClass` was declared as final and cannot be included in `ModuleWithClassBad`
+class ModuleWithClassBad; include ModuleWithClass; end # error: `ModuleWithClass` was declared as final and cannot be included in `ModuleWithClassBad`
 
 module ModuleWithModule
   extend T::Helpers
@@ -84,4 +86,4 @@ module ModuleWithModule
 end
 
 class ModuleWithModuleOkay; include ModuleWithModule::M; end
-class ModuleWithModuleBad; include ModuleWithModule; end # error-with-dupes: `ModuleWithModule` was declared as final and cannot be included in `ModuleWithModuleBad`
+class ModuleWithModuleBad; include ModuleWithModule; end # error: `ModuleWithModule` was declared as final and cannot be included in `ModuleWithModuleBad`

--- a/test/testdata/resolver/infinite.rb
+++ b/test/testdata/resolver/infinite.rb
@@ -1,4 +1,6 @@
 # typed: true
+# Fast path un-duplicates duplicated errors.
+# disable-fast-path: true
 extend T::Sig
 
 S = S # error: Class alias aliases to itself


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Remove duplicated indexing errors in LSP, and assert that errors-with-dupes are duplicated.

Removes/fixes many `error-with-dupes` assertions.

On some tests, the fast path introduces duplicate errors / removes duplicate errors. I've disabled the fast path on those tests as the root cause is the same redefinition issue.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Duplicate errors are bad UX.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
