### PR TITLE
Avoid name

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/abstract/declare.rb
+++ b/gems/sorbet-runtime/lib/types/private/abstract/declare.rb
@@ -7,10 +7,10 @@ module T::Private::Abstract::Declare
 
   def self.declare_abstract(mod, type:)
     if AbstractUtils.abstract_module?(mod)
-      raise "#{mod.name} is already declared as abstract"
+      raise "#{mod} is already declared as abstract"
     end
     if T::Private::Final.final_module?(mod)
-      raise "#{mod.name} was already declared as final and cannot be declared as abstract"
+      raise "#{mod} was already declared as final and cannot be declared as abstract"
     end
 
     Abstract::Data.set(mod, :can_have_abstract_methods, true)

--- a/gems/sorbet-runtime/lib/types/private/final.rb
+++ b/gems/sorbet-runtime/lib/types/private/final.rb
@@ -5,31 +5,31 @@ module T::Private::Final
   module NoInherit
     def inherited(arg)
       super(arg)
-      raise "#{self.name} was declared as final and cannot be inherited"
+      raise "#{self} was declared as final and cannot be inherited"
     end
   end
 
   module NoIncludeExtend
     def included(arg)
       super(arg)
-      raise "#{self.name} was declared as final and cannot be included"
+      raise "#{self} was declared as final and cannot be included"
     end
 
     def extended(arg)
       super(arg)
-      raise "#{self.name} was declared as final and cannot be extended"
+      raise "#{self} was declared as final and cannot be extended"
     end
   end
 
   def self.declare(mod)
     if !mod.is_a?(Module)
-      raise "#{mod.inspect} is not a class or module and cannot be declared as final with `final!`"
+      raise "#{mod} is not a class or module and cannot be declared as final with `final!`"
     end
     if final_module?(mod)
-      raise "#{mod.name} was already declared as final and cannot be re-declared as final"
+      raise "#{mod} was already declared as final and cannot be re-declared as final"
     end
     if T::AbstractUtils.abstract_module?(mod)
-      raise "#{mod.name} was already declared as abstract and cannot be declared as final"
+      raise "#{mod} was already declared as abstract and cannot be declared as final"
     end
     mod.extend(mod.is_a?(Class) ? NoInherit : NoIncludeExtend)
     mark_as_final_module(mod)

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -144,8 +144,8 @@ module T::Private::Methods
         # directly on ancestor but instead an ancestor of ancestor.
         if ancestor.method_defined?(method_name) && final_method?(method_owner_and_name_to_key(ancestor, method_name))
           raise(
-            "`#{ancestor.name}##{method_name}` was declared as final and cannot be " +
-            (target == ancestor ? "redefined" : "overridden in `#{target.name}`")
+            "The method `#{method_name}` on #{ancestor} was declared as final and cannot be " +
+            (target == ancestor ? "redefined" : "overridden in #{target}")
           )
         end
       end
@@ -179,7 +179,7 @@ module T::Private::Methods
     mod = is_singleton_method ? hook_mod.singleton_class : hook_mod
 
     if T::Private::Final.final_module?(mod) && (current_declaration.nil? || !current_declaration.final)
-      raise "`#{mod.name}` was declared as final but its method `#{method_name}` was not declared as final"
+      raise "#{mod} was declared as final but its method `#{method_name}` was not declared as final"
     end
     _check_final_ancestors(mod, mod.ancestors, [method_name])
 

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -37,7 +37,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def foo; end
       end
     end
-    assert_includes(err.message, "was declared as final and cannot be redefined")
+    assert_match(/^The method `foo` on #<Class:0x[0-9a-f]+> was declared as final and cannot be redefined$/, err.message)
   end
 
   it "forbids redefining a final class method with a final sig" do
@@ -50,7 +50,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def self.foo; end
       end
     end
-    assert_includes(err.message, "was declared as final and cannot be redefined")
+    assert_match(/^The method `foo` on #<Class:#<Class:0x[0-9a-f]+>> was declared as final and cannot be redefined$/, err.message)
   end
 
   it "forbids redefining a final instance method with a regular sig" do
@@ -63,7 +63,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def foo; end
       end
     end
-    assert_includes(err.message, "was declared as final and cannot be redefined")
+    assert_match(/^The method `foo` on #<Class:0x[0-9a-f]+> was declared as final and cannot be redefined$/, err.message)
   end
 
   it "forbids redefining a final class method with a regular sig" do
@@ -76,7 +76,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def self.foo; end
       end
     end
-    assert_includes(err.message, "was declared as final and cannot be redefined")
+    assert_match(/^The method `foo` on #<Class:#<Class:0x[0-9a-f]+>> was declared as final and cannot be redefined$/, err.message)
   end
 
   it "forbids redefining a final instance method with no sig" do
@@ -88,7 +88,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def foo; end
       end
     end
-    assert_includes(err.message, "was declared as final and cannot be redefined")
+    assert_match(/^The method `foo` on #<Class:0x[0-9a-f]+> was declared as final and cannot be redefined$/, err.message)
   end
 
   it "forbids redefining a final class method with no sig" do
@@ -100,7 +100,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def self.foo; end
       end
     end
-    assert_includes(err.message, "was declared as final and cannot be redefined")
+    assert_match(/^The method `foo` on #<Class:#<Class:0x[0-9a-f]+>> was declared as final and cannot be redefined$/, err.message)
   end
 
   it "allows redefining a regular instance method to be final" do
@@ -132,7 +132,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def foo; end
       end
     end
-    assert_includes(err.message, "was declared as final and cannot be overridden")
+    assert_match(/^The method `foo` on #<Class:0x[0-9a-f]+> was declared as final and cannot be overridden in #<Class:0x[0-9a-f]+>$/, err.message)
   end
 
   it "forbids overriding a final class method" do
@@ -146,7 +146,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def self.foo; end
       end
     end
-    assert_includes(err.message, "was declared as final and cannot be overridden")
+    assert_match(/^The method `foo` on #<Class:#<Class:0x[0-9a-f]+>> was declared as final and cannot be overridden in #<Class:#<Class:0x[0-9a-f]+>>$/, err.message)
   end
 
   it "forbids overriding a final method from an included module" do
@@ -161,7 +161,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def foo; end
       end
     end
-    assert_includes(err.message, "was declared as final and cannot be overridden")
+    assert_match(/^The method `foo` on #<Module:0x[0-9a-f]+> was declared as final and cannot be overridden in #<Class:0x[0-9a-f]+>$/, err.message)
   end
 
   it "forbids overriding a final method from an extended module" do
@@ -176,7 +176,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def self.foo; end
       end
     end
-    assert_includes(err.message, "was declared as final and cannot be overridden")
+    assert_match(/^The method `foo` on #<Module:0x[0-9a-f]+> was declared as final and cannot be overridden in #<Class:#<Class:0x[0-9a-f]+>>$/, err.message)
   end
 
   it "forbids overriding a final method by including two modules" do
@@ -193,7 +193,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         include m2, m1
       end
     end
-    assert_includes(err.message, "was declared as final and cannot be overridden")
+    assert_match(/^The method `foo` on #<Module:0x[0-9a-f]+> was declared as final and cannot be overridden in #<Class:0x[0-9a-f]+>$/, err.message)
   end
 
   it "forbids overriding a final method by extending two modules" do
@@ -210,7 +210,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend m2, m1
       end
     end
-    assert_includes(err.message, "was declared as final and cannot be overridden")
+    assert_match(/^The method `foo` on #<Module:0x[0-9a-f]+> was declared as final and cannot be overridden in #<Class:0x[0-9a-f]+>$/, err.message)
   end
 
   it "allows calling final methods" do
@@ -291,7 +291,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def foo; end
       end
     end
-    assert_includes(err.message, "was declared as final and cannot be overridden")
+    assert_match(/^The method `foo` on #<Module:0x[0-9a-f]+> was declared as final and cannot be overridden in #<Class:0x[0-9a-f]+>$/, err.message)
   end
 
   it "forbids overriding through many levels of include" do
@@ -312,7 +312,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def foo; end
       end
     end
-    assert_includes(err.message, "was declared as final and cannot be overridden")
+    assert_match(/^The method `foo` on #<Module:0x[0-9a-f]+> was declared as final and cannot be overridden in #<Class:0x[0-9a-f]+>$/, err.message)
   end
 
   it "allows including modules again" do

--- a/gems/sorbet-runtime/test/types/final_module.rb
+++ b/gems/sorbet-runtime/test/types/final_module.rb
@@ -33,7 +33,7 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
     err = assert_raises(RuntimeError) do
       Class.new(c)
     end
-    assert_includes(err.message, "was declared as final and cannot be inherited")
+    assert_match(/^#<Class:0x[0-9a-f]+> was declared as final and cannot be inherited$/, err.message)
   end
 
   it "forbids including a final module" do
@@ -46,7 +46,7 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
         include m
       end
     end
-    assert_includes(err.message, "was declared as final and cannot be included")
+    assert_match(/^#<Module:0x[0-9a-f]+> was declared as final and cannot be included$/, err.message)
   end
 
   it "forbids extending a final module" do
@@ -59,7 +59,7 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
         extend m
       end
     end
-    assert_includes(err.message, "was declared as final and cannot be extended")
+    assert_match(/^#<Module:0x[0-9a-f]+> was declared as final and cannot be extended$/, err.message)
   end
 
   it "allows declaring a module as final and its instance method as final" do
@@ -91,8 +91,7 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
         def foo; end
       end
     end
-    assert_includes(err.message, "was declared as final but its method")
-    assert_includes(err.message, "was not declared as final")
+    assert_match(/^#<Module:0x[0-9a-f]+> was declared as final but its method `foo` was not declared as final$/, err.message)
   end
 
   it "forbids declaring a module as final but not its class method as final" do
@@ -104,8 +103,7 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
         def self.foo; end
       end
     end
-    assert_includes(err.message, "was declared as final but its method")
-    assert_includes(err.message, "was not declared as final")
+    assert_match(/^#<Class:#<Module:0x[0-9a-f]+>> was declared as final but its method `foo` was not declared as final$/, err.message)
   end
 
   it "forbids declaring a class as final and then abstract" do
@@ -116,7 +114,7 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
         abstract!
       end
     end
-    assert_includes(err.message, "was already declared as final and cannot be declared as abstract")
+    assert_match(/^#<Class:0x[0-9a-f]+> was already declared as final and cannot be declared as abstract$/, err.message)
   end
 
   it "forbids declaring a class as abstract and then final" do
@@ -127,7 +125,7 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
         final!
       end
     end
-    assert_includes(err.message, "was already declared as abstract and cannot be declared as final")
+    assert_match(/^#<Class:0x[0-9a-f]+> was already declared as abstract and cannot be declared as final$/, err.message)
   end
 
   it "forbids re-declaring a class as final" do
@@ -138,7 +136,7 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
         final!
       end
     end
-    assert_includes(err.message, "was already declared as final and cannot be re-declared as final")
+    assert_match(/^#<Class:0x[0-9a-f]+> was already declared as final and cannot be re-declared as final$/, err.message)
   end
 
   it "forbids declaring a non-module, non-method as final" do
@@ -148,7 +146,7 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
         final!
       end
     end
-    assert_includes(err.message, "is not a class or module and cannot be declared as final with `final!`")
+    assert_match(/^#<Opus::Types::Test::FinalModuleTest:0x[0-9a-f]+> is not a class or module and cannot be declared as final with `final!`$/, err.message)
   end
 
   it "allows a non-final class in a final class" do
@@ -160,7 +158,7 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
     end
     Class.new(inner)
     err = assert_raises(RuntimeError) { Class.new(outer) }
-    assert_includes(err.message, "was declared as final")
+    assert_match(/^#<Class:0x[0-9a-f]+> was declared as final and cannot be inherited$/, err.message)
   end
 
   it "allows a non-final class in a final module" do
@@ -172,7 +170,7 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
     end
     Class.new(inner)
     err = assert_raises(RuntimeError) { Class.new.include(outer) }
-    assert_includes(err.message, "was declared as final")
+    assert_match(/^#<Module:0x[0-9a-f]+> was declared as final and cannot be included$/, err.message)
   end
 
   it "allows a non-final module in a final class" do
@@ -184,7 +182,7 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
     end
     Class.new.include(inner)
     err = assert_raises(RuntimeError) { Class.new(outer) }
-    assert_includes(err.message, "was declared as final")
+    assert_match(/^#<Class:0x[0-9a-f]+> was declared as final and cannot be inherited$/, err.message)
   end
 
   it "allows a non-final module in a final module" do
@@ -196,6 +194,6 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
     end
     Class.new.include(inner)
     err = assert_raises(RuntimeError) { Class.new.include(outer) }
-    assert_includes(err.message, "was declared as final")
+    assert_match(/^#<Module:0x[0-9a-f]+> was declared as final and cannot be included$/, err.message)
   end
 end


### PR DESCRIPTION
This avoids calling `name` so much.

### Motivation
When debugging, I discovered that `name` is actually worse most of the time because it doesn't seem to be defined by default for singleton classes.

### Test plan
Tests pass.