### PR TITLE
IO.select supports nil args

### DIFF
--- a/rbi/core/io.rbi
+++ b/rbi/core/io.rbi
@@ -539,14 +539,14 @@ class IO < Object
 
   sig do
     params(
-        read_array: T::Array[IO],
-        write_array: T::Array[IO],
-        error_array: T::Array[IO],
-        timeout: Integer,
+        read_array: T.nilable(T::Array[IO]),
+        write_array: T.nilable(T::Array[IO]),
+        error_array: T.nilable(T::Array[IO]),
+        timeout: T.nilable(Integer),
     )
     .returns(T.nilable(T::Array[T::Array[IO]]))
   end
-  def self.select(read_array, write_array=T.unsafe(nil), error_array=T.unsafe(nil), timeout=T.unsafe(nil)); end
+  def self.select(read_array, write_array=nil, error_array=nil, timeout=nil); end
 
   sig do
     params(


### PR DESCRIPTION
### Motivation
Per https://ruby-doc.org/core-2.6.3/IO.html#method-c-select, `IO.select` supports nil args, e.g.

```ruby
begin
  result = io_like.read_nonblock(maxlen)
rescue IO::WaitReadable
  IO.select([io_like])
  retry
rescue IO::WaitWritable
  IO.select(nil, [io_like])
  retry
end
```

### Test plan
I don't know how to write tests for this change