### PR TITLE
Emit "missing returns" from decl_builder

### DIFF
--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -120,7 +120,7 @@ module T::Configuration
   end
 
   private_class_method def self.sig_builder_error_handler_default(error, location)
-    T::Private::Methods.sig_error(location, error.message)
+    raise ArgumentError.new("#{loc.path}:#{loc.lineno}: Error interpreting `sig`:\n  #{message}\n\n")
   end
 
   def self.sig_builder_error_handler(error, location)

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -120,7 +120,7 @@ module T::Configuration
   end
 
   private_class_method def self.sig_builder_error_handler_default(error, location)
-    raise ArgumentError.new("#{loc.path}:#{loc.lineno}: Error interpreting `sig`:\n  #{message}\n\n")
+    raise ArgumentError.new("#{location.path}:#{location.lineno}: Error interpreting `sig`:\n  #{error.message}\n\n")
   end
 
   def self.sig_builder_error_handler(error, location)

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -289,10 +289,6 @@ module T::Private::Methods
               "class/module."
       end
 
-      if current_declaration.returns.equal?(ARG_NOT_PROVIDED)
-        sig_error(loc, "You must provide a return type; use the `.returns` or `.void` builder methods. Method: #{original_method}")
-      end
-
       signature = Signature.new(
         method: original_method,
         method_name: method_name,

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -245,10 +245,6 @@ module T::Private::Methods
     end
   end
 
-  def self.sig_error(loc, message)
-    raise(ArgumentError.new("#{loc.path}:#{loc.lineno}: Error interpreting `sig`:\n  #{message}\n\n"))
-  end
-
   # Executes the `sig` block, and converts the resulting Declaration
   # to a Signature.
   def self.run_sig(hook_mod, method_name, original_method, declaration_block)

--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -238,6 +238,10 @@ module T::Private::Methods
     def finalize!
       check_live!
 
+      if decl.returns.equal?(ARG_NOT_PROVIDED)
+        raise BuilderError.new("You must provide a return type; use the `.returns` or `.void` builder methods.")
+      end
+
       if decl.bind.equal?(ARG_NOT_PROVIDED)
         decl.bind = nil
       end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This solves a problem reported on Slack where a custom configuration
handler can't catch this particular error.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The tests don't change, because all BuilderError's are rescued and
handled with the sig_builder_error_handler. The
sig_builder_error_handler used to dispatch to sig_error and from there
raise an ArgumentError. The test was already asserting that there would
be an ArgumentError, so because BuilderError's already always become
ArgumentError from the default handler, the existing test doesn't need
to change.