### PR TITLE
Update knowledge when singleton used in x.===(y)

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -415,32 +415,32 @@ void Environment::updateKnowledge(core::Context ctx, core::LocalVariable local, 
             return;
         }
         auto &whoKnows = getKnowledge(local);
-        const auto &tp1 = send->args[0].type;
-        const auto &tp2 = send->recv.type;
+        const auto &argType = send->args[0].type;
+        const auto &recvType = send->recv.type;
 
         auto &truthy = send->fun == core::Names::eqeq() ? whoKnows.truthy : whoKnows.falsy;
         auto &falsy = send->fun == core::Names::eqeq() ? whoKnows.falsy : whoKnows.truthy;
 
-        ENFORCE(tp1.get() != nullptr);
-        ENFORCE(tp2.get() != nullptr);
-        if (!tp1->isUntyped()) {
-            truthy.mutate().yesTypeTests.emplace_back(send->recv.variable, tp1);
+        ENFORCE(argType.get() != nullptr);
+        ENFORCE(recvType.get() != nullptr);
+        if (!argType->isUntyped()) {
+            truthy.mutate().yesTypeTests.emplace_back(send->recv.variable, argType);
         }
-        if (!tp2->isUntyped()) {
-            truthy.mutate().yesTypeTests.emplace_back(send->args[0].variable, tp2);
+        if (!recvType->isUntyped()) {
+            truthy.mutate().yesTypeTests.emplace_back(send->args[0].variable, recvType);
         }
-        if (auto s = core::cast_type<core::ClassType>(tp1.get())) {
+        if (auto s = core::cast_type<core::ClassType>(argType.get())) {
             // check if s is a singleton. in this case we can learn that
             // a failed comparison means that type test would also fail
             if (isSingleton(ctx, s->symbol)) {
-                falsy.mutate().noTypeTests.emplace_back(send->recv.variable, tp1);
+                falsy.mutate().noTypeTests.emplace_back(send->recv.variable, argType);
             }
         }
-        if (auto s = core::cast_type<core::ClassType>(tp2.get())) {
+        if (auto s = core::cast_type<core::ClassType>(recvType.get())) {
             // check if s is a singleton. in this case we can learn that
             // a failed comparison means that type test would also fail
             if (isSingleton(ctx, s->symbol)) {
-                falsy.mutate().noTypeTests.emplace_back(send->args[0].variable, tp2);
+                falsy.mutate().noTypeTests.emplace_back(send->args[0].variable, recvType);
             }
         }
         whoKnows.sanityCheck();

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -450,12 +450,12 @@ void Environment::updateKnowledge(core::Context ctx, core::LocalVariable local, 
         }
         auto &whoKnows = getKnowledge(local);
         const auto &recvType = send->recv.type;
-        core::SymbolRef klass = core::Types::getRepresentedClass(ctx, recvType.get());
-        if (klass.exists()) {
-            auto ty = klass.data(ctx)->externalType(ctx);
-            if (!ty->isUntyped()) {
-                whoKnows.truthy.mutate().yesTypeTests.emplace_back(send->args[0].variable, ty);
-                whoKnows.falsy.mutate().noTypeTests.emplace_back(send->args[0].variable, ty);
+        core::SymbolRef representedClass = core::Types::getRepresentedClass(ctx, recvType.get());
+        if (representedClass.exists()) {
+            auto representedType = representedClass.data(ctx)->externalType(ctx);
+            if (!representedType->isUntyped()) {
+                whoKnows.truthy.mutate().yesTypeTests.emplace_back(send->args[0].variable, representedType);
+                whoKnows.falsy.mutate().noTypeTests.emplace_back(send->args[0].variable, representedType);
             }
         }
         whoKnows.sanityCheck();

--- a/test/testdata/infer/singleton_case_exhaustiveness.rb
+++ b/test/testdata/infer/singleton_case_exhaustiveness.rb
@@ -1,0 +1,47 @@
+# typed: strict
+extend T::Sig
+
+sig {params(x: T.nilable(T::Boolean)).void}
+def all_cases_handled(x)
+  case x
+  when true
+    T.reveal_type(x) # error: Revealed type: `TrueClass`
+  when false
+    T.reveal_type(x) # error: Revealed type: `FalseClass`
+  when nil
+    T.reveal_type(x) # error: Revealed type: `NilClass`
+  else
+    T.absurd(x)
+  end
+end
+
+sig {params(x: T.nilable(T::Boolean)).void}
+def unhandled_true(x)
+  case x
+  when false
+  when nil
+  else
+    T.absurd(x) # error: Control flow could reach `T.absurd` because the type `TrueClass` wasn't handled
+  end
+end
+
+sig {params(x: T.nilable(T::Boolean)).void}
+def unhandled_false(x)
+  case x
+  when true
+  when nil
+  else
+    T.absurd(x) # error: Control flow could reach `T.absurd` because the type `FalseClass` wasn't handled
+  end
+end
+
+sig {params(x: T.nilable(T::Boolean)).void}
+def unhandled_nil(x)
+  case x
+  when true
+  when false
+  else
+    T.absurd(x) # error: Control flow could reach `T.absurd` because the type `NilClass` wasn't handled
+  end
+end
+

--- a/test/testdata/infer/singleton_if_exhaustiveness.rb
+++ b/test/testdata/infer/singleton_if_exhaustiveness.rb
@@ -1,0 +1,41 @@
+# typed: strict
+extend T::Sig
+
+sig {params(x: T::Boolean).void}
+def all_cases_handled(x)
+  if x == true
+    T.reveal_type(x) # error: Revealed type: `TrueClass`
+  elsif x == false
+    T.reveal_type(x) # error: Revealed type: `FalseClass`
+  else
+    T.absurd(x)
+  end
+end
+
+sig {params(x: T::Boolean).void}
+def missing_false(x)
+  if x == true
+  else
+    T.absurd(x) # error: Control flow could reach `T.absurd` because the type `FalseClass` wasn't handled
+  end
+end
+
+sig {params(x: T::Boolean).void}
+def commutative_all_cases_handled(x)
+  if true == x
+    T.reveal_type(x) # error: Revealed type: `TrueClass`
+  elsif false == x
+    T.reveal_type(x) # error: Revealed type: `FalseClass`
+  else
+    T.absurd(x)
+  end
+end
+
+sig {params(x: T::Boolean).void}
+def commutative_missing_false(x)
+  if true == x
+  else
+    T.absurd(x) # error: Control flow could reach `T.absurd` because the type `FalseClass` wasn't handled
+  end
+end
+


### PR DESCRIPTION
### Commit summary

I suggest reviewing by commit.

- **tp1, tp2 -> argType, recvType** (54a1ae16d)

  This makes this case more consistent with the other cases in
  updateKnowledge.

- **klass -> representedClass** (fd560b3b6)

  There are actually two classes in play here. The recvType could be a
  ClassType because it's actually a `T.class_of(A)` for some A. But
  getRepresentedClass is designed to unwrap this type to get a SymbolRef
  corresponding to the class inside the `T.class_of` (this is how `===`
  works, because the constant literal `A` has type `T.class_of(A)`, so
  `A.===(x)` has `T.class_of(A)` for it's recvType).

  This is confusing, because I'm about to add a case to `===` when the
  recvType **doesn't** have a represented class, namely `false.===(x)`.

  Accordingly, I've renamed the variable.

- **Update knowledge when singleton used in x.===(y)** (478a37d0e)

  This PR adds two tests:

  - singleton_if_exhaustiveness.rb ALREADY passed on master
  - singleton_case_exhaustiveness did not pass on master

  I thought it was weird that these two cases diverged from each other, so
  I've updated the case for `===` to handle when the reciever is a
  singleton value.

  This is pre-work for supporting Opus::Enum as a singleton with
  exhaustiveness checks.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Prework for supporting singletons statically.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.