### PR TITLE
Add missing methods for ThreadGroup

### DIFF
--- a/rbi/core/thread_group.rbi
+++ b/rbi/core/thread_group.rbi
@@ -1,7 +1,7 @@
 # typed: __STDLIB_INTERNAL
 
 class ThreadGroup < Object
-  Default = T.let(nil, T.untyped)
+  Default = T.let(T.unsafe(nil), ThreadGroup)
 
   sig {params(thread: Thread).returns(ThreadGroup)}
   def add(thread); end

--- a/rbi/core/thread_group.rbi
+++ b/rbi/core/thread_group.rbi
@@ -1,4 +1,17 @@
 # typed: __STDLIB_INTERNAL
 
 class ThreadGroup < Object
+  Default = T.let(nil, T.untyped)
+
+  sig {params(thread: Thread).returns(ThreadGroup)}
+  def add(thread); end
+
+  sig {returns(ThreadGroup)}
+  def enclose; end
+
+  sig {returns(T::Boolean)}
+  def enclosed?; end
+
+  sig {returns(T::Array[Thread])}
+  def list; end
 end


### PR DESCRIPTION
Based on https://ruby-doc.org/core-2.6.3/ThreadGroup.html

### Motivation
I wanted to add some missing methods that exist on the ThreadGroup class to make hidden.rbi a bit smaller and improve the type coverage for the core Ruby classes.

### Test plan
See existing automated tests.