### PR TITLE
Add MatchData#named_captures method.

### DIFF
--- a/rbi/core/match_data.rbi
+++ b/rbi/core/match_data.rbi
@@ -72,6 +72,9 @@ class MatchData < Object
   sig {returns(Integer)}
   def length(); end
 
+  sig {returns(T::Hash[String, T.nilable(String)])}
+  def named_captures(); end
+
   sig {returns(T::Array[String])}
   def names(); end
 


### PR DESCRIPTION
This has existed since Ruby 2.4, I think?: https://ruby-doc.org/core-2.4.3/MatchData.html#method-i-named_captures

It can be used like so:

```ruby
m = /(?<a>.)(?<b>.)/.match("01")
m.named_captures #=> {"a" => "0", "b" => "1"}

m = /(?<a>.)(?<b>.)?/.match("0")
m.named_captures #=> {"a" => "0", "b" => nil}

m = /(?<a>.)(?<a>.)/.match("01")
m.named_captures #=> {"a" => "1"}

m = /(?<a>x)|(?<a>y)/.match("x")
m.named_captures #=> {"a" => "x"}
```

### Motivation
The method was missing from the `match_data.rbi`.

### Test plan
See automated tests.