### PR TITLE
Add Array#prepend, #append, #union, and #difference.

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -244,7 +244,7 @@ class Array < Object
     params(
         arrays: T::Array[T.untyped]
     )
-    .returns(T::Array[T.untyped])
+    .returns(T::Array[Elem])
   end
   def difference(*arrays); end
 

--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -111,6 +111,15 @@ class Array < Object
   end
   def []=(arg0, arg1, arg2=T.unsafe(nil)); end
 
+  # append is an alias of push
+  sig do
+    params(
+        arg0: Elem,
+    )
+    .returns(T::Array[Elem])
+  end
+  def append(*arg0); end
+
   sig do
     params(
         arg0: Elem,
@@ -230,6 +239,14 @@ class Array < Object
   end
   sig {returns(T::Enumerator[Elem])}
   def delete_if(&blk); end
+
+  sig do
+    params(
+        arrays: T::Array[T.untyped]
+    )
+    .returns(T::Array[T.untyped])
+  end
+  def difference(*arrays); end
 
   sig do
     params(
@@ -477,6 +494,15 @@ class Array < Object
   sig {returns(T.nilable(Elem))}
   def pop(arg0=T.unsafe(nil)); end
 
+  # prepend is an alias for unshift
+  sig do
+    params(
+        arg0: Elem,
+    )
+    .returns(T::Array[Elem])
+  end
+  def prepend(*arg0); end
+
   sig do
     type_parameters(:U).params(
         arg0: T::Array[T.type_parameter(:U)],
@@ -710,6 +736,14 @@ class Array < Object
 
   sig {returns(T::Array[Elem])}
   def transpose(); end
+
+  sig do
+    params(
+        arrays: T::Array[T.untyped]
+    )
+    .returns(T::Array[T.untyped])
+  end
+  def union(*arrays); end
 
   sig {returns(T::Array[Elem])}
   def uniq(); end


### PR DESCRIPTION
Add [`Array#append`](https://ruby-doc.org/core-2.6.3/Array.html#method-i-append), [`Array#prepend`](https://ruby-doc.org/core-2.6.3/Array.html#method-i-prepend), [`Array#union`](https://ruby-doc.org/core-2.6.3/Array.html#method-i-union), and [`Array#difference`](https://ruby-doc.org/core-2.6.3/Array.html#method-i-difference). All of these were missing from the `array.rbi`.

### Motivation
These weren't returning proper type information despite being methods for Array, so I wanted to add them. They were all four introduced in Ruby 2.6.

### Test plan
See automated tests.
