### PR TITLE
Change the way TypeSyntaxArgs are passed.

### DIFF
--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -65,7 +65,7 @@ bool TypeSyntax::isSig(core::Context ctx, ast::Send *send) {
 }
 
 ParsedSig TypeSyntax::parseSig(core::MutableContext ctx, ast::Send *sigSend, const ParsedSig *parent,
-                               const TypeSyntaxArgs &args) {
+                               TypeSyntaxArgs args) {
     ParsedSig sig;
 
     vector<ast::Send *> sends;
@@ -361,7 +361,7 @@ ParsedSig TypeSyntax::parseSig(core::MutableContext ctx, ast::Send *sigSend, con
 }
 
 core::TypePtr interpretTCombinator(core::MutableContext ctx, ast::Send *send, const ParsedSig &sig,
-                                   const TypeSyntaxArgs &args) {
+                                   TypeSyntaxArgs args) {
     switch (send->fun._id) {
         case core::Names::nilable()._id:
             if (send->args.size() != 1) {
@@ -511,12 +511,12 @@ core::TypePtr interpretTCombinator(core::MutableContext ctx, ast::Send *send, co
 }
 
 core::TypePtr TypeSyntax::getResultType(core::MutableContext ctx, ast::Expression &expr,
-                                        const ParsedSig &sigBeingParsed, const TypeSyntaxArgs &args) {
+                                        const ParsedSig &sigBeingParsed, TypeSyntaxArgs args) {
     return getResultTypeAndBind(ctx, expr, sigBeingParsed, args.withoutRebind()).type;
 }
 
 TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx, ast::Expression &expr,
-                                                        const ParsedSig &sigBeingParsed, const TypeSyntaxArgs &args) {
+                                                        const ParsedSig &sigBeingParsed, TypeSyntaxArgs args) {
     // Ensure that we only check types from a class context
     auto ctxOwnerData = ctx.owner.data(ctx);
     ENFORCE(ctxOwnerData->isClass(), "getResultTypeAndBind wasn't called with a class owner");

--- a/resolver/type_syntax.h
+++ b/resolver/type_syntax.h
@@ -48,9 +48,9 @@ struct ParsedSig {
 };
 
 struct TypeSyntaxArgs {
-    bool allowSelfType = false;
-    bool allowRebind = false;
-    core::SymbolRef untypedBlame;
+    const bool allowSelfType = false;
+    const bool allowRebind = false;
+    const core::SymbolRef untypedBlame;
 
     TypeSyntaxArgs withoutRebind() const {
         return TypeSyntaxArgs{allowSelfType, false, untypedBlame};
@@ -68,17 +68,16 @@ struct TypeSyntaxArgs {
 class TypeSyntax {
 public:
     static bool isSig(core::Context ctx, ast::Send *send);
-    static ParsedSig parseSig(core::MutableContext ctx, ast::Send *send, const ParsedSig *parent,
-                              const TypeSyntaxArgs &args);
+    static ParsedSig parseSig(core::MutableContext ctx, ast::Send *send, const ParsedSig *parent, TypeSyntaxArgs args);
 
     struct ResultType {
         core::TypePtr type;
         core::SymbolRef rebind;
     };
     static ResultType getResultTypeAndBind(core::MutableContext ctx, ast::Expression &expr, const ParsedSig &,
-                                           const TypeSyntaxArgs &args);
+                                           TypeSyntaxArgs args);
     static core::TypePtr getResultType(core::MutableContext ctx, ast::Expression &expr, const ParsedSig &,
-                                       const TypeSyntaxArgs &args);
+                                       TypeSyntaxArgs args);
 
     TypeSyntax() = delete;
 };


### PR DESCRIPTION
1. Do defintion side `const` as it makes a global invariant rather than local.
2. Pass by value so that it can be better understood by both people and compilers: including not needing to think if it's aliased do something and thus allowing it to be passed in registers.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
