### PR TITLE
Follow sorbet agreements for use of namespaces.

### DIFF
--- a/test/helpers/MockFileSystem.cc
+++ b/test/helpers/MockFileSystem.cc
@@ -1,24 +1,25 @@
 #include "test/helpers/MockFileSystem.h"
 
-using namespace sorbet::test;
+using namespace std;
 
-MockFileSystem::MockFileSystem(std::string_view rootPath) : rootPath(std::string(rootPath)) {}
+namespace sorbet::test {
+MockFileSystem::MockFileSystem(string_view rootPath) : rootPath(string(rootPath)) {}
 
-std::string makeAbsolute(std::string_view rootPath, std::string_view path) {
+string makeAbsolute(string_view rootPath, string_view path) {
     if (path[0] == '/') {
-        return std::string(path);
+        return string(path);
     } else {
         return fmt::format("{}/{}", rootPath, path);
     }
 }
 
-void MockFileSystem::writeFiles(const std::vector<std::pair<std::string, std::string>> &initialFiles) {
+void MockFileSystem::writeFiles(const vector<pair<string, string>> &initialFiles) {
     for (auto &pair : initialFiles) {
         writeFile(pair.first, pair.second);
     }
 }
 
-std::string MockFileSystem::readFile(std::string_view path) const {
+string MockFileSystem::readFile(string_view path) const {
     auto file = contents.find(makeAbsolute(rootPath, path));
     if (file == contents.end()) {
         throw sorbet::FileNotFoundException();
@@ -27,11 +28,11 @@ std::string MockFileSystem::readFile(std::string_view path) const {
     }
 }
 
-void MockFileSystem::writeFile(std::string_view filename, std::string_view text) {
+void MockFileSystem::writeFile(string_view filename, string_view text) {
     contents[makeAbsolute(rootPath, filename)] = text;
 }
 
-void MockFileSystem::deleteFile(std::string_view filename) {
+void MockFileSystem::deleteFile(string_view filename) {
     auto file = contents.find(makeAbsolute(rootPath, filename));
     if (file == contents.end()) {
         throw sorbet::FileNotFoundException();
@@ -40,9 +41,9 @@ void MockFileSystem::deleteFile(std::string_view filename) {
     }
 }
 
-std::vector<std::string> MockFileSystem::listFilesInDir(std::string_view path,
-                                                        const UnorderedSet<std::string> &extensions, bool recursive,
-                                                        const std::vector<std::string> &absoluteIgnorePatterns,
-                                                        const std::vector<std::string> &relativeIgnorePatterns) const {
+vector<string> MockFileSystem::listFilesInDir(string_view path, const UnorderedSet<string> &extensions, bool recursive,
+                                              const vector<string> &absoluteIgnorePatterns,
+                                              const vector<string> &relativeIgnorePatterns) const {
     Exception::raise("Not implemented.");
 }
+} // namespace sorbet::test


### PR DESCRIPTION
- cc files should always `using namespace std`
- they should never use any other namespace
- all code should be nested into namespace of the corresponding header

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
