### PR TITLE
Mark go-to-def and find-all-refs as stable

### DIFF
--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -170,11 +170,11 @@ LSPResult LSPLoop::processRequestInternal(unique_ptr<core::GlobalState> gs, cons
 
             auto serverCap = make_unique<ServerCapabilities>();
             serverCap->textDocumentSync = TextDocumentSyncKind::Full;
-            serverCap->definitionProvider = opts.lspGoToDefinitionEnabled;
+            serverCap->definitionProvider = true;
             serverCap->documentSymbolProvider = opts.lspDocumentSymbolEnabled;
             serverCap->workspaceSymbolProvider = opts.lspWorkspaceSymbolsEnabled;
             serverCap->hoverProvider = true;
-            serverCap->referencesProvider = opts.lspFindReferencesEnabled;
+            serverCap->referencesProvider = true;
 
             if (opts.lspQuickFixEnabled) {
                 auto codeActionProvider = make_unique<CodeActionOptions>();

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -13,13 +13,6 @@ void LSPLoop::addLocIfExists(const core::GlobalState &gs, vector<unique_ptr<Loca
 LSPResult LSPLoop::handleTextDocumentDefinition(unique_ptr<core::GlobalState> gs, const MessageId &id,
                                                 const TextDocumentPositionParams &params) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentDefinition);
-    if (!opts.lspGoToDefinitionEnabled) {
-        response->error =
-            make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest,
-                                       "The `Go To Definition` LSP feature is experimental and disabled by default.");
-        return LSPResult::make(move(gs), move(response));
-    }
-
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.definition");
     auto result = setupLSPQueryByLoc(move(gs), params.textDocument->uri, *params.position,
                                      LSPMethod::TextDocumentDefinition, false);

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -20,13 +20,6 @@ LSPLoop::getReferencesToSymbol(unique_ptr<core::GlobalState> gs, core::SymbolRef
 LSPResult LSPLoop::handleTextDocumentReferences(unique_ptr<core::GlobalState> gs, const MessageId &id,
                                                 const ReferenceParams &params) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentReferences);
-    if (!opts.lspFindReferencesEnabled) {
-        response->error =
-            make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest,
-                                       "The `Find References` LSP feature is experimental and disabled by default.");
-        return LSPResult::make(move(gs), move(response));
-    }
-
     ShowOperation op(*this, "References", "Finding all references...");
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.references");
 

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -92,8 +92,6 @@ int LSPWrapper::getTypecheckCount() const {
 }
 
 void LSPWrapper::enableAllExperimentalFeatures() {
-    enableExperimentalFeature(LSPExperimentalFeature::GoToDefinition);
-    enableExperimentalFeature(LSPExperimentalFeature::FindReferences);
     enableExperimentalFeature(LSPExperimentalFeature::Autocomplete);
     enableExperimentalFeature(LSPExperimentalFeature::WorkspaceSymbols);
     enableExperimentalFeature(LSPExperimentalFeature::DocumentSymbol);
@@ -103,12 +101,6 @@ void LSPWrapper::enableAllExperimentalFeatures() {
 
 void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
     switch (feature) {
-        case LSPExperimentalFeature::GoToDefinition:
-            opts.lspGoToDefinitionEnabled = true;
-            break;
-        case LSPExperimentalFeature::FindReferences:
-            opts.lspFindReferencesEnabled = true;
-            break;
         case LSPExperimentalFeature::Autocomplete:
             opts.lspAutocompleteEnabled = true;
             break;

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -39,8 +39,6 @@ private:
 
 public:
     enum class LSPExperimentalFeature {
-        GoToDefinition = 2,
-        FindReferences = 3,
         Autocomplete = 4,
         WorkspaceSymbols = 5,
         DocumentSymbol = 6,

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -331,10 +331,6 @@ cxxopts::Options buildOptions() {
     options.add_options("advanced")("watchman-path",
                                     "Path to watchman executable. Defaults to using `watchman` on your PATH.",
                                     cxxopts::value<string>()->default_value(empty.watchmanPath));
-    options.add_options("advanced")("enable-experimental-lsp-go-to-definition",
-                                    "Enable experimental LSP feature: Go-to-definition");
-    options.add_options("advanced")("enable-experimental-lsp-find-references",
-                                    "Enable experimental LSP feature: Find References");
     options.add_options("advanced")("enable-experimental-lsp-autocomplete",
                                     "Enable experimental LSP feature: Autocomplete");
     options.add_options("advanced")("enable-experimental-lsp-workspace-symbols",
@@ -654,10 +650,6 @@ void readOptions(Options &opts, int argc, char *argv[],
         bool enableAllLSPFeatures = raw["enable-all-experimental-lsp-features"].as<bool>();
         opts.lspAutocompleteEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-autocomplete"].as<bool>();
         opts.lspQuickFixEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-quick-fix"].as<bool>();
-        opts.lspGoToDefinitionEnabled =
-            enableAllLSPFeatures || raw["enable-experimental-lsp-go-to-definition"].as<bool>();
-        opts.lspFindReferencesEnabled =
-            enableAllLSPFeatures || raw["enable-experimental-lsp-find-references"].as<bool>();
         opts.lspWorkspaceSymbolsEnabled =
             enableAllLSPFeatures || raw["enable-experimental-lsp-workspace-symbols"].as<bool>();
         opts.lspDocumentSymbolEnabled =

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -189,8 +189,6 @@ struct Options {
     // sorbet: URIs to clients that support them.
     std::vector<std::string> lspDirsMissingFromClient;
     // Booleans enabling various experimental LSP features. Each will be removed once corresponding feature stabilizes.
-    bool lspGoToDefinitionEnabled = false;
-    bool lspFindReferencesEnabled = false;
     bool lspAutocompleteEnabled = false;
     bool lspQuickFixEnabled = false;
     bool lspWorkspaceSymbolsEnabled = false;

--- a/main/options/test/options_test.cc
+++ b/main/options/test/options_test.cc
@@ -65,8 +65,6 @@ TEST(OptionsTest, DefaultConstructorMatchesReadOptions) {
     EXPECT_EQ(empty.absoluteIgnorePatterns.size(), opts.absoluteIgnorePatterns.size());
     EXPECT_EQ(empty.relativeIgnorePatterns.size(), opts.relativeIgnorePatterns.size());
     EXPECT_EQ(empty.inputFileNames.size(), opts.inputFileNames.size());
-    EXPECT_EQ(empty.lspGoToDefinitionEnabled, opts.lspGoToDefinitionEnabled);
-    EXPECT_EQ(empty.lspFindReferencesEnabled, opts.lspFindReferencesEnabled);
     EXPECT_EQ(empty.lspAutocompleteEnabled, opts.lspAutocompleteEnabled);
     EXPECT_EQ(empty.lspQuickFixEnabled, opts.lspQuickFixEnabled);
     EXPECT_EQ(empty.lspWorkspaceSymbolsEnabled, opts.lspWorkspaceSymbolsEnabled);

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -74,12 +74,6 @@ Usage:
                                 disable file watching via Watchman
       --watchman-path arg       Path to watchman executable. Defaults to
                                 using `watchman` on your PATH. (default: watchman)
-      --enable-experimental-lsp-go-to-definition
-                                Enable experimental LSP feature:
-                                Go-to-definition
-      --enable-experimental-lsp-find-references
-                                Enable experimental LSP feature: Find
-                                References
       --enable-experimental-lsp-autocomplete
                                 Enable experimental LSP feature: Autocomplete
       --enable-experimental-lsp-workspace-symbols


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Mark go-to-def and find-all-refs as stable.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These features are now stable! 🎉 If they have any bugs, they are minor enough to warrant wide release.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
