### PR TITLE
Update docs to indicate enumerations of primitive or literal types is not supported

### DIFF
--- a/website/docs/union-types.md
+++ b/website/docs/union-types.md
@@ -127,6 +127,21 @@ end
 href="https://sorbet.run/#%23%20typed%3A%20true%0Aclass%20A%3B%20end%0Aclass%20B%3B%20end%0Aclass%20C%3B%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7Bvoid%7D%0A%20%20def%20bar%3B%20end%0Aend%0A%0Aclass%20D%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7Bparams(x%3A%20T.any(A%2C%20B%2C%20C)).void%7D%0A%20%20def%20foo(x)%0A%20%20%20%20x.bar%20%23%20error%3A%20method%20bar%20does%20not%20exist%20on%20A%20or%20B%0A%0A%20%20%20%20case%20x%0A%20%20%20%20when%20A%2C%20B%0A%20%20%20%20%20%20T.reveal_type(x)%20%23%20Revealed%20type%3A%20T.any(B%2C%20A)%0A%20%20%20%20else%0A%20%20%20%20%20%20T.reveal_type(x)%20%23%20Revealed%20type%3A%20C%0A%20%20%20%20%20%20x.bar%20%23%20OK%2C%20x%20is%20known%20to%20be%20an%20instance%20of%20C%0A%20%20%20%20end%0A%20%20end%0Aend">
 → View on sorbet.run </a>
 
+Note that enumerations using primitive or literal types is not currently supported.  For example, the following is *not* valid:
+```ruby
+class A
+  extend T::Sig
+
+  sig { params(input_param: T.any('foo', 'bar')).void }
+  def a(input_param)
+    puts input_param
+  end
+end
+```
+<a
+href="https://sorbet.run/#class%20A%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7B%20params(input_param%3A%20T.any('foo'%2C%20'bar')).void%20%7D%0A%20%20def%20a(input_param)%0A%20%20%20%20puts%20input_param%0A%20%20end%0Aend">
+→ View on sorbet.run </a>
+
 ## `T.nilable` and `T::Boolean`
 
 `T.nilable` and `T::Boolean` are both defined in terms of `T.any`:

--- a/website/docs/union-types.md
+++ b/website/docs/union-types.md
@@ -127,7 +127,9 @@ end
 href="https://sorbet.run/#%23%20typed%3A%20true%0Aclass%20A%3B%20end%0Aclass%20B%3B%20end%0Aclass%20C%3B%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7Bvoid%7D%0A%20%20def%20bar%3B%20end%0Aend%0A%0Aclass%20D%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7Bparams(x%3A%20T.any(A%2C%20B%2C%20C)).void%7D%0A%20%20def%20foo(x)%0A%20%20%20%20x.bar%20%23%20error%3A%20method%20bar%20does%20not%20exist%20on%20A%20or%20B%0A%0A%20%20%20%20case%20x%0A%20%20%20%20when%20A%2C%20B%0A%20%20%20%20%20%20T.reveal_type(x)%20%23%20Revealed%20type%3A%20T.any(B%2C%20A)%0A%20%20%20%20else%0A%20%20%20%20%20%20T.reveal_type(x)%20%23%20Revealed%20type%3A%20C%0A%20%20%20%20%20%20x.bar%20%23%20OK%2C%20x%20is%20known%20to%20be%20an%20instance%20of%20C%0A%20%20%20%20end%0A%20%20end%0Aend">
 → View on sorbet.run </a>
 
-Note that enumerations using primitive or literal types is not supported.  For example, the following is *not* valid:
+Note that enumerations using primitive or literal types is not supported. For
+example, the following is _not_ valid:
+
 ```ruby
 class A
   extend T::Sig
@@ -138,6 +140,7 @@ class A
   end
 end
 ```
+
 <a
 href="https://sorbet.run/#class%20A%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7B%20params(input_param%3A%20T.any('foo'%2C%20'bar')).void%20%7D%0A%20%20def%20a(input_param)%0A%20%20%20%20puts%20input_param%0A%20%20end%0Aend">
 → View on sorbet.run </a>

--- a/website/docs/union-types.md
+++ b/website/docs/union-types.md
@@ -127,7 +127,7 @@ end
 href="https://sorbet.run/#%23%20typed%3A%20true%0Aclass%20A%3B%20end%0Aclass%20B%3B%20end%0Aclass%20C%3B%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7Bvoid%7D%0A%20%20def%20bar%3B%20end%0Aend%0A%0Aclass%20D%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7Bparams(x%3A%20T.any(A%2C%20B%2C%20C)).void%7D%0A%20%20def%20foo(x)%0A%20%20%20%20x.bar%20%23%20error%3A%20method%20bar%20does%20not%20exist%20on%20A%20or%20B%0A%0A%20%20%20%20case%20x%0A%20%20%20%20when%20A%2C%20B%0A%20%20%20%20%20%20T.reveal_type(x)%20%23%20Revealed%20type%3A%20T.any(B%2C%20A)%0A%20%20%20%20else%0A%20%20%20%20%20%20T.reveal_type(x)%20%23%20Revealed%20type%3A%20C%0A%20%20%20%20%20%20x.bar%20%23%20OK%2C%20x%20is%20known%20to%20be%20an%20instance%20of%20C%0A%20%20%20%20end%0A%20%20end%0Aend">
 → View on sorbet.run </a>
 
-Note that enumerations using primitive or literal types is not currently supported.  For example, the following is *not* valid:
+Note that enumerations using primitive or literal types is not supported.  For example, the following is *not* valid:
 ```ruby
 class A
   extend T::Sig


### PR DESCRIPTION
### Motivation
This is not supported, and wanted to be more explicit about it in the docs.

### Test plan
No tests  -- doc change only.