### PR TITLE
Suggest types for constants that are untyped

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -386,6 +386,17 @@ void GlobalState::initEmpty() {
         auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
         arg.flags.isBlock = true;
     }
+    // Synthesize <Magic>#<suggest-type>(arg: *T.untyped) => T.untyped
+    method = enterMethodSymbol(Loc::none(), Symbols::MagicSingleton(), Names::suggestType());
+    {
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg0());
+        arg.type = Types::untyped(*this, method);
+    }
+    method.data(*this)->resultType = Types::untyped(*this, method);
+    {
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
+        arg.flags.isBlock = true;
+    }
     // Synthesize <DeclBuilderForProcs>#<params>(args: Hash) => DeclBuilderForProcs
     method = enterMethodSymbol(Loc::none(), Symbols::DeclBuilderForProcsSingleton(), Names::params());
     {

--- a/core/errors/infer.h
+++ b/core/errors/infer.h
@@ -31,5 +31,6 @@ constexpr ErrorClass ProcArityUnknown{7023, StrictLevel::Strict};
 constexpr ErrorClass GenericPassedAsBlock{7024, StrictLevel::True};
 constexpr ErrorClass AbstractClassInstantiated{7025, StrictLevel::True};
 constexpr ErrorClass NotExhaustive{7026, StrictLevel::True};
+constexpr ErrorClass UntypedConstantSuggestion{7027, StrictLevel::Strict};
 } // namespace sorbet::core::errors::Infer
 #endif

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -286,6 +286,7 @@ NameDef names[] = {
     {"buildArray", "<build-array>"},
     {"splat", "<splat>"},
     {"expandSplat", "<expand-splat>"},
+    {"suggestType", "<suggest-type>"},
     {"arg0"},
     {"arg1"},
     {"arg2"},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1576,8 +1576,7 @@ public:
         if (!ty->isUntyped()) {
             if (auto e = ctx.state.beginError(loc, core::errors::Infer::UntypedConstantSuggestion)) {
                 e.setHeader("Suggested type: `{}`", ty->show(ctx));
-                e.addAutocorrect(
-                    core::AutocorrectSuggestion{loc, fmt::format("T.let({}, {})", loc.source(ctx), ty->show(ctx))});
+                e.replaceWith(loc, "T.let({}, {})", loc.source(ctx), ty->show(ctx));
             }
         }
         res.returnType = move(ty);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1567,6 +1567,23 @@ public:
     }
 } Magic_callWithSplatAndBlock;
 
+class Magic_suggestUntypedConstantType : public IntrinsicMethod {
+public:
+    void apply(Context ctx, DispatchArgs args, const Type *thisType, DispatchResult &res) const override {
+        ENFORCE(args.args.size() == 1);
+        auto ty = args.args.front()->type;
+        auto loc = args.locs.args[0];
+        if (!ty->isUntyped()) {
+            if (auto e = ctx.state.beginError(loc, core::errors::Infer::UntypedConstantSuggestion)) {
+                e.setHeader("Suggested type: `{}`", ty->show(ctx));
+                e.addAutocorrect(
+                    core::AutocorrectSuggestion{loc, fmt::format("T.let({}, {})", loc.source(ctx), ty->show(ctx))});
+            }
+        }
+        res.returnType = move(ty);
+    }
+} Magic_suggestUntypedConstantType;
+
 class DeclBuilderForProcs_void : public IntrinsicMethod {
 public:
     void apply(Context ctx, DispatchArgs args, const Type *thisType, DispatchResult &res) const override {
@@ -1940,6 +1957,7 @@ const vector<Intrinsic> intrinsicMethods{
     {Symbols::MagicSingleton(), false, Names::callWithSplat(), &Magic_callWithSplat},
     {Symbols::MagicSingleton(), false, Names::callWithBlock(), &Magic_callWithBlock},
     {Symbols::MagicSingleton(), false, Names::callWithSplatAndBlock(), &Magic_callWithSplatAndBlock},
+    {Symbols::MagicSingleton(), false, Names::suggestType(), &Magic_suggestUntypedConstantType},
 
     {Symbols::DeclBuilderForProcsSingleton(), false, Names::void_(), &DeclBuilderForProcs_void},
     {Symbols::DeclBuilderForProcsSingleton(), false, Names::returns(), &DeclBuilderForProcs_returns},

--- a/test/cli/suggest-constant-type/suggest-constant-type.out
+++ b/test/cli/suggest-constant-type/suggest-constant-type.out
@@ -1,0 +1,55 @@
+suggest-constant-type.rb:3: Constants must have type annotations with `T.let` when specifying `# typed: strict` https://srb.help/5028
+     3 |A = 2 + 1 # works in simple cases
+            ^^^^^
+
+suggest-constant-type.rb:5: Constants must have type annotations with `T.let` when specifying `# typed: strict` https://srb.help/5028
+     5 |B1 = [1].sum # works with generics
+             ^^^^^^^
+
+suggest-constant-type.rb:6: Constants must have type annotations with `T.let` when specifying `# typed: strict` https://srb.help/5028
+     6 |B2 = [1].map{|x| x.to_s}
+             ^^^^^^^^^^^^^^^^^^^
+
+suggest-constant-type.rb:8: Constants must have type annotations with `T.let` when specifying `# typed: strict` https://srb.help/5028
+     8 |C = B1 + 1 # does only a single iteration at a time
+            ^^^^^^
+
+suggest-constant-type.rb:3: Suggested type: `Integer` https://srb.help/7027
+     3 |A = 2 + 1 # works in simple cases
+            ^^^^^
+  Autocorrect: Done
+    suggest-constant-type.rb:3: Replaced with `T.let(2 + 1, Integer)`
+     3 |A = 2 + 1 # works in simple cases
+            ^^^^^
+
+suggest-constant-type.rb:5: Suggested type: `Integer` https://srb.help/7027
+     5 |B1 = [1].sum # works with generics
+             ^^^^^^^
+  Autocorrect: Done
+    suggest-constant-type.rb:5: Replaced with `T.let([1].sum, Integer)`
+     5 |B1 = [1].sum # works with generics
+             ^^^^^^^
+
+suggest-constant-type.rb:6: Suggested type: `T::Array[String]` https://srb.help/7027
+     6 |B2 = [1].map{|x| x.to_s}
+             ^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    suggest-constant-type.rb:6: Replaced with `T.let([1].map{|x| x.to_s}, T::Array[String])`
+     6 |B2 = [1].map{|x| x.to_s}
+             ^^^^^^^^^^^^^^^^^^^
+Errors: 7
+
+--------------------------------------------------------------------------
+
+# typed: strict
+
+A = T.let(2 + 1, Integer) # works in simple cases
+
+B1 = T.let([1].sum, Integer) # works with generics
+B2 = T.let([1].map{|x| x.to_s}, T::Array[String])
+
+C = B1 + 1 # does only a single iteration at a time
+
+E = F # doesn't do forward references
+F = 0
+

--- a/test/cli/suggest-constant-type/suggest-constant-type.rb
+++ b/test/cli/suggest-constant-type/suggest-constant-type.rb
@@ -1,0 +1,12 @@
+# typed: strict
+
+A = 2 + 1 # works in simple cases
+
+B1 = [1].sum # works with generics
+B2 = [1].map{|x| x.to_s}
+
+C = B1 + 1 # does only a single iteration at a time
+
+E = F # doesn't do forward references
+F = 0
+

--- a/test/cli/suggest-constant-type/suggest-constant-type.sh
+++ b/test/cli/suggest-constant-type/suggest-constant-type.sh
@@ -13,7 +13,7 @@ echo
 echo --------------------------------------------------------------------------
 echo
 
-# Also cat the file, to make sure that 'extend' is only added once per class.
+# Also cat the file, to show how it looks in the end
 cat suggest-constant-type.rb
 
 rm suggest-constant-type.rb

--- a/test/cli/suggest-constant-type/suggest-constant-type.sh
+++ b/test/cli/suggest-constant-type/suggest-constant-type.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+tmp="$(mktemp -d)"
+infile="test/cli/suggest-constant-type/suggest-constant-type.rb"
+cp "$infile" "$tmp"
+
+cwd="$(pwd)"
+cd "$tmp" || exit 1
+
+"$cwd/main/sorbet" --silence-dev-message -a suggest-constant-type.rb 2>&1
+
+echo
+echo --------------------------------------------------------------------------
+echo
+
+# Also cat the file, to make sure that 'extend' is only added once per class.
+cat suggest-constant-type.rb
+
+rm suggest-constant-type.rb
+rm "$tmp"

--- a/test/cli/symbol-table-json/symbol-table-json.out
+++ b/test/cli/symbol-table-json/symbol-table-json.out
@@ -15,7 +15,7 @@ No errors! Great job.
     "name": "\u003cClass:\u003croot\u003e\u003e"
    },
    "kind": "CLASS",
-   "superClass": 96,
+   "superClass": 97,
    "children": [
     {
      "id": <redacted>,
@@ -52,7 +52,7 @@ No errors! Great job.
     "name": "\u003cClass:A\u003e"
    },
    "kind": "CLASS",
-   "superClass": 96,
+   "superClass": 97,
    "children": [
     {
      "id": <redacted>,

--- a/test/testdata/dsl/opus_enum.rb
+++ b/test/testdata/dsl/opus_enum.rb
@@ -22,6 +22,7 @@ T.reveal_type(MyEnum::Z) # error: Revealed type: `MyEnum`
 
 class NotAnEnum
   X = new # error: Constants must have type annotations
+    # ^^^ error: Suggested type: `NotAnEnum`
   Y = T.let(new, self)
 end
 

--- a/test/testdata/resolver/strict.rb
+++ b/test/testdata/resolver/strict.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # disable-fast-path: true
 A = String.new # error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
-
+  # ^^^^^^^^^^ error: Suggested type: `String`
 B = T.let(T.unsafe(nil), T.untyped)
 
 C = T.let(1, Integer)


### PR DESCRIPTION
### Motivation
As many people pointed out, sorbet _does_ know types for untyped constants at some point.
This builds build a way to burn those types into source code.
This is build on prior exploration that @nelhage did.
### Test plan

See included automated tests.

cc @sushain97 