### PR TITLE
Fix crash when file cannot be found.

### DIFF
--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -69,7 +69,7 @@ core::FileRef LSPLoop::uri2FileRef(string_view uri) {
 string LSPLoop::fileRef2Uri(const core::GlobalState &gs, core::FileRef file) {
     string uri;
     if (!file.exists()) {
-        uri = localName2Remote("???", false);
+        uri = "???";
     } else {
         auto &messageFile = file.data(gs);
         if (messageFile.isPayload()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Fix crash when file cannot be found.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

@azdavis's fuzzer ran down a path where Sorbet couldn't resolve the file and tried to convert the file to a URI, leading to a crash because "???" doesn't start with the workspace path:

https://github.com/sorbet/sorbet/blob/master/main/lsp/lsp_helpers.cc#L44

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No automated tests included. The specific input for the fuzzer doesn't trigger the crash in our tests, so the fuzzer might be passing paths incorrectly.
