### PR TITLE
Support Singletons in updateKnowledge

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -276,6 +276,9 @@ void GlobalState::initEmpty() {
     id = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Struct());
     ENFORCE(id == Symbols::T_Struct());
 
+    id = synthesizeClass(core::Names::Constants::Singleton(), 0, true);
+    ENFORCE(id == Symbols::Singleton());
+
     // Root members
     Symbols::root().dataAllowingNone(*this)->members()[core::Names::Constants::NoSymbol()] = Symbols::noSymbol();
     Symbols::root().dataAllowingNone(*this)->members()[core::Names::Constants::Top()] = Symbols::top();

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -384,6 +384,10 @@ public:
         return SymbolRef(nullptr, 77);
     }
 
+    static SymbolRef Singleton() {
+        return SymbolRef(nullptr, 78);
+    }
+
     static constexpr int MAX_PROC_ARITY = 10;
     static SymbolRef Proc0() {
         return SymbolRef(nullptr, MAX_SYNTHETIC_SYMBOLS - MAX_PROC_ARITY * 2 - 2);

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -398,6 +398,7 @@ NameDef names[] = {
     {"Protocol", "Protocol", true},
     {"CFGExport", "CFGExport", true},
     {"WithoutRuntime", "WithoutRuntime", true},
+    {"Singleton", "Singleton", true},
 };
 
 void emit_name_header(ostream &out, NameDef &name) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -332,8 +332,9 @@ void Environment::clearKnowledge(core::Context ctx, core::LocalVariable reassign
 }
 
 bool isSingleton(core::Context ctx, core::SymbolRef sym) {
-    // TODO: when we have support for enums, we should add them here.
-    return sym == core::Symbols::NilClass() || sym == core::Symbols::FalseClass() || sym == core::Symbols::TrueClass();
+    return sym == core::Symbols::NilClass() || sym == core::Symbols::FalseClass() ||
+           sym == core::Symbols::TrueClass() ||
+           (sym.data(ctx)->derivesFrom(ctx, core::Symbols::Singleton()) && sym.data(ctx)->isClassFinal());
 }
 
 void Environment::updateKnowledge(core::Context ctx, core::LocalVariable local, core::Loc loc, const cfg::Send *send,

--- a/test/cli/symbol-table-json/symbol-table-json.out
+++ b/test/cli/symbol-table-json/symbol-table-json.out
@@ -15,7 +15,7 @@ No errors! Great job.
     "name": "\u003cClass:\u003croot\u003e\u003e"
    },
    "kind": "CLASS",
-   "superClass": 96,
+   "superClass": 97,
    "children": [
     {
      "id": <redacted>,
@@ -52,7 +52,7 @@ No errors! Great job.
     "name": "\u003cClass:A\u003e"
    },
    "kind": "CLASS",
-   "superClass": 96,
+   "superClass": 97,
    "children": [
     {
      "id": <redacted>,

--- a/test/testdata/infer/singleton_enum_case.rb
+++ b/test/testdata/infer/singleton_enum_case.rb
@@ -1,0 +1,41 @@
+# typed: strict
+extend T::Sig
+
+class MyEnum
+  extend T::Helpers
+  sealed!
+  abstract!
+
+  class AType < MyEnum; include Singleton; final!; end
+  A = T.let(AType.instance, AType)
+
+  class BType < MyEnum; include Singleton; final!; end
+  B = T.let(BType.instance, BType)
+
+  class CType < MyEnum; include Singleton; final!; end
+  C = T.let(CType.instance, CType)
+end
+
+sig {params(x: MyEnum).void}
+def all_cases_handled(x)
+  case x
+  when MyEnum::A
+    T.reveal_type(x) # error: Revealed type: `MyEnum::AType`
+  when MyEnum::B
+    T.reveal_type(x) # error: Revealed type: `MyEnum::BType`
+  when MyEnum::C
+    T.reveal_type(x) # error: Revealed type: `MyEnum::CType`
+  else
+    T.absurd(x)
+  end
+end
+
+sig {params(x: MyEnum).void}
+def missing_case(x)
+  case x
+  when MyEnum::A
+  when MyEnum::B
+  else
+    T.absurd(x) # error: Control flow could reach `T.absurd` because the type `MyEnum::CType` wasn't handled
+  end
+end

--- a/test/testdata/infer/singleton_enum_eqeq.rb
+++ b/test/testdata/infer/singleton_enum_eqeq.rb
@@ -1,0 +1,54 @@
+# typed: strict
+extend T::Sig
+
+module MyEnum
+  extend T::Helpers
+  sealed!
+
+  class AType
+    extend T::Helpers
+    include Singleton
+    include MyEnum
+    final!
+  end
+  A = T.let(AType.instance, AType)
+
+  class BType
+    extend T::Helpers
+    include Singleton
+    include MyEnum
+    final!
+  end
+  B = T.let(BType.instance, BType)
+
+  class CType
+    extend T::Helpers
+    include Singleton
+    include MyEnum
+    final!
+  end
+  C = T.let(CType.instance, CType)
+end
+
+sig {params(x: MyEnum).void}
+def all_cases_handled(x)
+  if x == MyEnum::A
+    T.reveal_type(x) # error: Revealed type: `MyEnum::AType`
+  elsif x == MyEnum::B
+    T.reveal_type(x) # error: Revealed type: `MyEnum::BType`
+  elsif x == MyEnum::C
+    T.reveal_type(x) # error: Revealed type: `MyEnum::CType`
+  else
+    T.absurd(x)
+  end
+end
+
+sig {params(x: MyEnum).void}
+def missing_case(x)
+  if x == MyEnum::A
+  elsif x == MyEnum::B
+  else
+    T.absurd(x) # error: Control flow could reach `T.absurd` because the type `MyEnum::CType` wasn't handled
+  end
+end
+

--- a/test/testdata/infer/singleton_non_final_enum.rb
+++ b/test/testdata/infer/singleton_non_final_enum.rb
@@ -1,0 +1,47 @@
+# typed: strict
+extend T::Sig
+
+class MyEnum
+  extend T::Helpers
+  sealed!
+  abstract!
+
+  class AType < MyEnum; include Singleton; end
+  A = T.let(AType.instance, AType)
+
+  class BType < MyEnum; include Singleton; end
+  B = T.let(BType.instance, BType)
+
+  class CType < MyEnum; include Singleton; end
+  C = T.let(CType.instance, CType)
+end
+
+sig {params(x: MyEnum).void}
+def if_over_non_final_singletons(x)
+  if x == MyEnum::A
+    T.reveal_type(x) # error: Revealed type: `MyEnum::AType`
+  elsif x == MyEnum::B
+    T.reveal_type(x) # error: Revealed type: `MyEnum::BType`
+  elsif x == MyEnum::C
+    T.reveal_type(x) # error: Revealed type: `MyEnum::CType`
+  else
+    T.absurd(x) # error: Control flow could reach `T.absurd` because the type `MyEnum` wasn't handled
+  end
+end
+
+# This currently differs from the `==` behavior above for no real reason, and
+# could probably be changed.
+sig {params(x: MyEnum).void}
+def case_over_non_final_singletons(x)
+  case x
+  when MyEnum::A
+    T.reveal_type(x) # error: Revealed type: `MyEnum`
+  when MyEnum::B
+    T.reveal_type(x) # error: Revealed type: `MyEnum`
+  when MyEnum::C
+    T.reveal_type(x) # error: Revealed type: `MyEnum`
+  else
+    T.absurd(x) # error: Control flow could reach `T.absurd` because the type `MyEnum` wasn't handled
+  end
+end
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This change affects Sorbet's updateKnowledge function: if a class derives
from Singleton (a class in the Ruby standard library[1]) and is final, then
we can know that not being equal to an **instance** of this type is the
same as not being a subtype of that type at all.

[1] https://ruby-doc.org/stdlib-2.4.5/libdoc/singleton/rdoc/Singleton.html

As far as I can tell, support for this class was added in Ruby 2.1.

Much of the pre-work actually landed in a separate PR, to expand support
for updating knowledge of the existing singletons (true, false, nil) in
Ruby's === operator: #1451


Another neat thing about this change is that it's trivially implemented in the
runtime, because it re-uses Ruby standard library constructs.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.