### PR TITLE
Fix indent on line 13 of typed_hash.rb

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/typed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_hash.rb
@@ -10,7 +10,7 @@ module T::Types
       Hash
     end
 
-      def initialize(keys:, values:)
+    def initialize(keys:, values:)
       @keys = T::Utils.coerce(keys)
       @values = T::Utils.coerce(values)
       @type = T::Utils.coerce([keys, values])


### PR DESCRIPTION
Got this warning message this morning, so I decided to "fix" it: 
```
sorbet-runtime-0.4.4564/lib/types/types/typed_hash.rb:17:
warning: mismatched indentations at 'end' with 'def' at 13
```

### Motivation

To stop getting the above warning message.

### Test plan

No code was changed so no new/changed tests are needed.

