### PR TITLE
pipeline: Fix crash when using sealed

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -286,10 +286,9 @@ public:
             klass->symbol.data(ctx)->singletonClass(ctx).data(ctx)->setClassFinal();
         }
         if (send->fun == core::Names::declareSealed()) {
-            auto classOfKlass = klass->symbol.data(ctx)->singletonClass(ctx);
             klass->symbol.data(ctx)->setClassSealed();
-            classOfKlass.data(ctx)->setClassSealed();
 
+            auto classOfKlass = klass->symbol.data(ctx)->singletonClass(ctx);
             auto sealedClassesList =
                 ctx.state.enterMethodSymbol(send->loc, classOfKlass, core::Names::sealedClassesList());
             auto &blkArg =

--- a/test/testdata/infer/sealed_singleton_class.rb
+++ b/test/testdata/infer/sealed_singleton_class.rb
@@ -1,0 +1,13 @@
+# typed: strict
+extend T::Sig
+
+class MyEnum
+  extend T::Sig
+  extend T::Helpers
+  sealed!
+  abstract!
+
+  sig {params(x: MyEnum).void}
+  def self.foo(x)
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I cargo culted setting singletonClass as sealed from above, but thinking
about it, it doesn't make sense to do so. If a class MyClass is sealed,
it must be the case that on MyClass.singleton_class there is a method
called sealedClassesList.

So if MyClass.singleton_class is also marked sealed, then
MyClass.singleton_class.singleton_class should have a method
sealedClassesList, which there wasn't, and I don't think it ever makes
sense to.

This manifested as a crash in the program before becaise it hit one of
my ENFORCEs somewhere.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.