### PR TITLE
Fix fuzz bug with `exists()`

### DIFF
--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -211,7 +211,10 @@ pair<Loc, u4> Loc::findStartOfLine(const GlobalState &gs) const {
     u4 lineStart = Loc::pos2Offset(this->file().data(gs), {startDetail.line, 1});
     std::string_view lineView = this->file().data(gs).source().substr(lineStart);
 
-    u4 padding = lineView.find_first_not_of(" \t");
+    size_t padding = lineView.find_first_not_of(" \t");
+    if (padding == string::npos) {
+        padding = 0;
+    }
     u4 startOffset = lineStart + padding;
     return make_pair(Loc(this->file(), startOffset, startOffset), padding);
 }

--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -213,6 +213,7 @@ pair<Loc, u4> Loc::findStartOfLine(const GlobalState &gs) const {
 
     size_t padding = lineView.find_first_not_of(" \t");
     if (padding == string::npos) {
+        // if this line didn't have a whitespace prefix, then don't add any padding to it, so startOffset = lineStart.
         padding = 0;
     }
     u4 startOffset = lineStart + padding;

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -228,13 +228,13 @@ void validateFinalMethodHelper(const core::GlobalState &gs, const core::SymbolRe
         return;
     }
     for (const auto [name, sym] : klass.data(gs)->members()) {
-        const auto memData = sym.data(gs);
-        if (!memData->isMethod() || memData->name == core::Names::staticInit() || memData->isFinalMethod()) {
+        if (!sym.data(gs)->isMethod() || sym.data(gs)->name == core::Names::staticInit() ||
+            sym.data(gs)->isFinalMethod()) {
             continue;
         }
-        if (auto e = gs.beginError(memData->loc(), core::errors::Resolver::FinalModuleNonFinalMethod)) {
+        if (auto e = gs.beginError(sym.data(gs)->loc(), core::errors::Resolver::FinalModuleNonFinalMethod)) {
             e.setHeader("`{}` was declared as final but its method `{}` was not declared as final",
-                        errMsgClass.data(gs)->show(gs), memData->name.show(gs));
+                        errMsgClass.data(gs)->show(gs), sym.data(gs)->name.show(gs));
         }
     }
 }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -228,7 +228,7 @@ void validateFinalMethodHelper(const core::GlobalState &gs, const core::SymbolRe
         return;
     }
     for (const auto [name, sym] : klass.data(gs)->members()) {
-        if (!sym.data(gs)->isMethod() || sym.data(gs)->name == core::Names::staticInit() ||
+        if (!sym.exists() || !sym.data(gs)->isMethod() || sym.data(gs)->name == core::Names::staticInit() ||
             sym.data(gs)->isFinalMethod()) {
             continue;
         }
@@ -330,7 +330,7 @@ private:
         auto isAbstract = klass.data(gs)->isClassAbstract();
         if (isAbstract) {
             for (auto [name, sym] : klass.data(gs)->members()) {
-                if (sym.data(gs)->isMethod() && sym.data(gs)->isAbstract()) {
+                if (sym.exists() && sym.data(gs)->isMethod() && sym.data(gs)->isAbstract()) {
                     abstract.emplace_back(sym);
                 }
             }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -227,8 +227,8 @@ void validateFinalMethodHelper(const core::GlobalState &gs, const core::SymbolRe
     if (!klass.data(gs)->isClassFinal()) {
         return;
     }
-    for (const auto mem : klass.data(gs)->members()) {
-        const auto memData = mem.second.data(gs);
+    for (const auto [name, sym] : klass.data(gs)->members()) {
+        const auto memData = sym.data(gs);
         if (!memData->isMethod() || memData->name == core::Names::staticInit() || memData->isFinalMethod()) {
             continue;
         }
@@ -329,9 +329,9 @@ private:
 
         auto isAbstract = klass.data(gs)->isClassAbstract();
         if (isAbstract) {
-            for (auto mem : klass.data(gs)->members()) {
-                if (mem.second.data(gs)->isMethod() && mem.second.data(gs)->isAbstract()) {
-                    abstract.emplace_back(mem.second);
+            for (auto [name, sym] : klass.data(gs)->members()) {
+                if (sym.data(gs)->isMethod() && sym.data(gs)->isAbstract()) {
+                    abstract.emplace_back(sym);
                 }
             }
         }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -193,19 +193,13 @@ core::Loc getAncestorLoc(const core::GlobalState &gs, const unique_ptr<ast::Clas
                          const core::SymbolRef ancestor) {
     for (const auto &anc : classDef->ancestors) {
         const auto ancConst = ast::cast_tree<ast::ConstantLit>(anc.get());
-        if (ancConst == nullptr) {
-            continue;
-        }
-        if (ancConst->symbol.data(gs)->dealias(gs) == ancestor) {
+        if (ancConst != nullptr && ancConst->symbol.data(gs)->dealias(gs) == ancestor) {
             return anc->loc;
         }
     }
     for (const auto &anc : classDef->singletonAncestors) {
         const auto ancConst = ast::cast_tree<ast::ConstantLit>(anc.get());
-        if (ancConst == nullptr) {
-            continue;
-        }
-        if (ancConst->symbol.data(gs)->dealias(gs) == ancestor) {
+        if (ancConst != nullptr && ancConst->symbol.data(gs)->dealias(gs) == ancestor) {
             return anc->loc;
         }
     }

--- a/test/testdata/resolver/fuzz_top_level_abstract.rb
+++ b/test/testdata/resolver/fuzz_top_level_abstract.rb
@@ -1,0 +1,4 @@
+# typed: false
+abstract!
+describe e do
+end

--- a/test/testdata/resolver/top_level_abstract_typed_true.rb
+++ b/test/testdata/resolver/top_level_abstract_typed_true.rb
@@ -1,0 +1,2 @@
+# typed: true
+abstract! # error: Method `abstract!` does not exist on `T.class_of(<root>)`


### PR DESCRIPTION
Close #1389, cc @jvilk-stripe.

In this PR, we:
1. Clean up some misc things (save some lines, etc).
2. Fix a fuzzer bug where we weren't checking for `exists()`.
3. Fix a bug unearthed by fixing that bug where we weren't checking for `std::string::npos`.

For more context on 3:

When a user says `final!` (or other special methods in `T::Helpers`), but they haven't first said `extend T::Helpers`, we create an autocorrect suggestion to first `extend T::Helpers`. To do that, we have to calculate where to put that `extend`. 

It turns out in the edge case where `final!` is the last thing in the file, a call to `find_first_not_of` returns `std::string::npos`, which is `(size_t) -1`. This is a very large number. Because we weren't checking for `npos`, we tried to allocate a very large string of spaces on [this line][1].

[1]: https://github.com/sorbet/sorbet/blob/c298e55573985c42e85270c0be8255e518bb1a4c/core/types/calls.cc#L411

### Motivation
To fix bugs.

### Test plan
No tests yet, but we should be able to copy over the tests from the linked issue.

We also might like to get the `extend T::Helpers` suggestion working a bit better, and add a test to that effect. Right now, if you say `final!` at the top level as in the examples linked in the issue, the `extend T::Helpers` line is put after you and the indentation isn't good.