### PR TITLE
Let an ENFORCE give a message

### DIFF
--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -105,8 +105,7 @@ private:
                 auto members = app->klass.data(ctx)->typeMembers();
                 auto params = app->targs;
 
-                // We expect that types are fully saturated.
-                ENFORCE(members.size() == params.size());
+                ENFORCE(members.size() == params.size(), "We expect that types are fully saturated.");
 
                 for (int i = 0; i < members.size(); ++i) {
                     auto memberVariance = members[i].data(ctx)->variance();

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -105,7 +105,9 @@ private:
                 auto members = app->klass.data(ctx)->typeMembers();
                 auto params = app->targs;
 
-                ENFORCE(members.size() == params.size(), "We expect that types are fully saturated.");
+                ENFORCE(members.size() == params.size(),
+                        fmt::format("types should be fully saturated, but there are {} members and {} params",
+                                    members.size(), params.size()));
 
                 for (int i = 0; i < members.size(); ++i) {
                     auto memberVariance = members[i].data(ctx)->variance();


### PR DESCRIPTION
This moves a comment into an ENFORCE message.

### Motivation
To help Sorbet maintainers.

### Test plan
No tests. This came up when investigating 

```rb
# typed: true
module M
  extend T::Generic
  extend T::Sig
  A = type_member
  sig {params(blk: T.proc.void).void}
  def foo(&blk) end
end
```

which fails with this enforce iff `--no-stdlib` is passed. Though it is this enforce that fails, we believe the real culprit is the fact that `--no-stdlib` causes us to stop knowing what `T` is, so `members` is empty in the enforce.