### PR TITLE
Turn on stdlib in fuzzer

### DIFF
--- a/test/fuzz/BUILD
+++ b/test/fuzz/BUILD
@@ -48,8 +48,7 @@ cc_test(
     deps = [
         "//core",
         "//main/lsp",
-        "//payload/binary:empty",
-        "//payload/text:empty",
+        "//payload",
         "//test/helpers",
     ],
 )

--- a/test/fuzz/fuzz_doc_symbols.cc
+++ b/test/fuzz/fuzz_doc_symbols.cc
@@ -16,7 +16,6 @@ const auto rootUri = fmt::format("file://{}", rootPath);
 sorbet::realmain::options::Options mkOpts() {
     sorbet::realmain::options::Options opts;
     opts.fs = std::make_shared<sorbet::test::MockFileSystem>(rootPath);
-    opts.noStdlib = true;
     opts.lspDocumentSymbolEnabled = true;
     opts.rawInputDirNames.emplace_back(rootPath);
     return opts;


### PR DESCRIPTION
This makes the document symbols fuzzer use the stdlib.

### Motivation

The fuzzer is choking on #1505. Pending an actual fix for that, we want the fuzzer to give us other fuzzer bugs.

This makes the fuzzer not crash on that, but it also makes it fantastically slow (on the order of 0 execs/s.) We need to make it faster in order to find more bugs.

### Test plan
None.