### PR TITLE
Mark a bunch of methods on LSPLoop class `const`.

### DIFF
--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -97,7 +97,7 @@ LSPLoop::TypecheckRun LSPLoop::setupLSPQueryBySymbol(unique_ptr<core::GlobalStat
 }
 
 bool LSPLoop::ensureInitialized(LSPMethod forMethod, const LSPMessage &msg,
-                                const unique_ptr<core::GlobalState> &currentGs) {
+                                const unique_ptr<core::GlobalState> &currentGs) const {
     if (initialized || forMethod == LSPMethod::Initialize || forMethod == LSPMethod::Initialized ||
         forMethod == LSPMethod::Exit || forMethod == LSPMethod::Shutdown || forMethod == LSPMethod::SorbetError) {
         return true;
@@ -226,7 +226,7 @@ LSPResult LSPLoop::pushDiagnostics(TypecheckRun run) {
 
 constexpr chrono::minutes STATSD_INTERVAL = chrono::minutes(5);
 
-bool LSPLoop::shouldSendCountersToStatsd(chrono::time_point<chrono::steady_clock> currentTime) {
+bool LSPLoop::shouldSendCountersToStatsd(chrono::time_point<chrono::steady_clock> currentTime) const {
     return !opts.statsdHost.empty() && (currentTime - lastMetricUpdateTime) > STATSD_INTERVAL;
 }
 

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -149,15 +149,15 @@ class LSPLoop {
     std::thread::id mainThreadId;
 
     /* Send the given message to client */
-    void sendMessage(const LSPMessage &msg);
+    void sendMessage(const LSPMessage &msg) const;
 
     // returns nullptr if this loc doesn't exist
-    std::unique_ptr<Location> loc2Location(const core::GlobalState &gs, core::Loc loc);
-    void addLocIfExists(const core::GlobalState &gs, std::vector<std::unique_ptr<Location>> &locs, core::Loc loc);
+    std::unique_ptr<Location> loc2Location(const core::GlobalState &gs, core::Loc loc) const;
+    void addLocIfExists(const core::GlobalState &gs, std::vector<std::unique_ptr<Location>> &locs, core::Loc loc) const;
     std::vector<std::unique_ptr<Location>>
     extractLocations(const core::GlobalState &gs,
                      const std::vector<std::unique_ptr<core::lsp::QueryResponse>> &queryResponses,
-                     std::vector<std::unique_ptr<Location>> locations = {});
+                     std::vector<std::unique_ptr<Location>> locations = {}) const;
 
     core::FileRef updateFile(const std::shared_ptr<core::File> &file);
     /** Invalidate all currently cached trees and re-index them from file system.
@@ -183,20 +183,20 @@ class LSPLoop {
 
     LSPResult pushDiagnostics(TypecheckRun run);
 
-    std::vector<core::FileHash> computeStateHashes(const std::vector<std::shared_ptr<core::File>> &files);
+    std::vector<core::FileHash> computeStateHashes(const std::vector<std::shared_ptr<core::File>> &files) const;
     bool ensureInitialized(const LSPMethod forMethod, const LSPMessage &msg,
-                           const std::unique_ptr<core::GlobalState> &currentGs);
+                           const std::unique_ptr<core::GlobalState> &currentGs) const;
 
-    core::FileRef uri2FileRef(std::string_view uri);
-    std::string fileRef2Uri(const core::GlobalState &gs, core::FileRef);
-    std::string remoteName2Local(std::string_view uri);
-    std::string localName2Remote(std::string_view uri, bool useSorbetUri);
-    std::unique_ptr<core::Loc> lspPos2Loc(core::FileRef fref, const Position &pos, const core::GlobalState &gs);
+    core::FileRef uri2FileRef(std::string_view uri) const;
+    std::string fileRef2Uri(const core::GlobalState &gs, core::FileRef) const;
+    std::string remoteName2Local(std::string_view uri) const;
+    std::string localName2Remote(std::string_view uri, bool useSorbetUri) const;
+    std::unique_ptr<core::Loc> lspPos2Loc(core::FileRef fref, const Position &pos, const core::GlobalState &gs) const;
 
     /** Used to implement textDocument/documentSymbol
      * Returns `nullptr` if symbol kind is not supported by LSP
      * */
-    std::unique_ptr<SymbolInformation> symbolRef2SymbolInformation(const core::GlobalState &gs, core::SymbolRef);
+    std::unique_ptr<SymbolInformation> symbolRef2SymbolInformation(const core::GlobalState &gs, core::SymbolRef) const;
     TypecheckRun runLSPQuery(std::unique_ptr<core::GlobalState> gs, const core::lsp::Query &q,
                              const std::vector<core::FileRef> &filesToQuery);
     std::variant<LSPLoop::TypecheckRun, std::pair<std::unique_ptr<ResponseError>, std::unique_ptr<core::GlobalState>>>
@@ -222,10 +222,10 @@ class LSPLoop {
                                            const CodeActionParams &params);
     std::unique_ptr<CompletionItem> getCompletionItem(const core::GlobalState &gs, core::SymbolRef what,
                                                       core::TypePtr receiverType,
-                                                      const std::unique_ptr<core::TypeConstraint> &constraint);
+                                                      const std::unique_ptr<core::TypeConstraint> &constraint) const;
     void findSimilarConstantOrIdent(const core::GlobalState &gs, const core::TypePtr receiverType,
-                                    std::vector<std::unique_ptr<CompletionItem>> &items);
-    void sendShowMessageNotification(MessageType messageType, std::string_view message);
+                                    std::vector<std::unique_ptr<CompletionItem>> &items) const;
+    void sendShowMessageNotification(MessageType messageType, std::string_view message) const;
     LSPResult handleTextSignatureHelp(std::unique_ptr<core::GlobalState> gs, const MessageId &id,
                                       const TextDocumentPositionParams &params);
     /**
@@ -260,7 +260,7 @@ class LSPLoop {
                                          UnorderedMap<std::string, std::string> &updates);
 
     /** Returns `true` if 5 minutes have elapsed since LSP last sent counters to statsd. */
-    bool shouldSendCountersToStatsd(std::chrono::time_point<std::chrono::steady_clock> currentTime);
+    bool shouldSendCountersToStatsd(std::chrono::time_point<std::chrono::steady_clock> currentTime) const;
     /** Sends counters to statsd. */
     void sendCountersToStatsd(std::chrono::time_point<std::chrono::steady_clock> currentTime);
 

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -12,7 +12,7 @@ namespace sorbet::realmain::lsp {
 constexpr string_view sorbetScheme = "sorbet:";
 constexpr string_view httpsScheme = "https";
 
-string LSPLoop::remoteName2Local(string_view uri) {
+string LSPLoop::remoteName2Local(string_view uri) const {
     const bool isSorbetURI = absl::StartsWith(uri, sorbetScheme);
     if (!absl::StartsWith(uri, rootUri) && !enableSorbetURIs && !isSorbetURI) {
         logger->error("Unrecognized URI received from client: {}", uri);
@@ -40,7 +40,7 @@ string LSPLoop::remoteName2Local(string_view uri) {
     }
 }
 
-string LSPLoop::localName2Remote(string_view uri, bool useSorbetUri) {
+string LSPLoop::localName2Remote(string_view uri, bool useSorbetUri) const {
     ENFORCE(absl::StartsWith(uri, rootPath));
     string_view relativeUri = uri.substr(rootPath.length());
     if (relativeUri.at(0) == '/') {
@@ -58,7 +58,7 @@ string LSPLoop::localName2Remote(string_view uri, bool useSorbetUri) {
     return absl::StrCat(rootUri, "/", relativeUri);
 }
 
-core::FileRef LSPLoop::uri2FileRef(string_view uri) {
+core::FileRef LSPLoop::uri2FileRef(string_view uri) const {
     if (!absl::StartsWith(uri, rootUri) && !absl::StartsWith(uri, sorbetScheme)) {
         return core::FileRef();
     }
@@ -66,7 +66,7 @@ core::FileRef LSPLoop::uri2FileRef(string_view uri) {
     return initialGS->findFileByPath(needle);
 }
 
-string LSPLoop::fileRef2Uri(const core::GlobalState &gs, core::FileRef file) {
+string LSPLoop::fileRef2Uri(const core::GlobalState &gs, core::FileRef file) const {
     string uri;
     if (!file.exists()) {
         uri = "???";
@@ -114,7 +114,7 @@ unique_ptr<core::Loc> range2Loc(const core::GlobalState &gs, const Range &range,
     return make_unique<core::Loc>(file, start, end);
 }
 
-unique_ptr<Location> LSPLoop::loc2Location(const core::GlobalState &gs, core::Loc loc) {
+unique_ptr<Location> LSPLoop::loc2Location(const core::GlobalState &gs, core::Loc loc) const {
     auto range = loc2Range(gs, loc);
     if (range == nullptr) {
         return nullptr;
@@ -171,7 +171,7 @@ int cmpRanges(const Range &a, const Range &b) {
 vector<unique_ptr<Location>>
 LSPLoop::extractLocations(const core::GlobalState &gs,
                           const vector<unique_ptr<core::lsp::QueryResponse>> &queryResponses,
-                          vector<unique_ptr<Location>> locations) {
+                          vector<unique_ptr<Location>> locations) const {
     for (auto &q : queryResponses) {
         core::Loc loc = q->getLoc();
         if (loc.exists() && loc.file().exists()) {

--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -422,7 +422,7 @@ void LSPLoop::enqueueRequest(const shared_ptr<spd::logger> &logger, LSPLoop::Que
     }
 }
 
-void LSPLoop::sendShowMessageNotification(MessageType messageType, string_view message) {
+void LSPLoop::sendShowMessageNotification(MessageType messageType, string_view message) const {
     sendMessage(LSPMessage(make_unique<NotificationMessage>(
         "2.0", LSPMethod::WindowShowMessage, make_unique<ShowMessageParams>(messageType, string(message)))));
 }
@@ -441,7 +441,7 @@ bool isServerNotification(const LSPMethod method) {
     }
 }
 
-unique_ptr<core::Loc> LSPLoop::lspPos2Loc(core::FileRef fref, const Position &pos, const core::GlobalState &gs) {
+unique_ptr<core::Loc> LSPLoop::lspPos2Loc(core::FileRef fref, const Position &pos, const core::GlobalState &gs) const {
     core::Loc::Detail reqPos;
     reqPos.line = pos.line + 1;
     reqPos.column = pos.character + 1;
@@ -449,7 +449,7 @@ unique_ptr<core::Loc> LSPLoop::lspPos2Loc(core::FileRef fref, const Position &po
     return make_unique<core::Loc>(core::Loc(fref, offset, offset));
 }
 
-void LSPLoop::sendMessage(const LSPMessage &msg) {
+void LSPLoop::sendMessage(const LSPMessage &msg) const {
     if (msg.isResponse()) {
         ENFORCE(msg.asResponse().result || msg.asResponse().error,
                 "A valid ResponseMessage must have a result or an error.");

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -126,7 +126,7 @@ optional<string> findDocumentation(string_view sourceCode, int beginIndex) {
 
 unique_ptr<CompletionItem> LSPLoop::getCompletionItem(const core::GlobalState &gs, core::SymbolRef what,
                                                       core::TypePtr receiverType,
-                                                      const unique_ptr<core::TypeConstraint> &constraint) {
+                                                      const unique_ptr<core::TypeConstraint> &constraint) const {
     ENFORCE(what.exists());
     auto item = make_unique<CompletionItem>(string(what.data(gs)->name.data(gs)->shortName(gs)));
     auto resultType = what.data(gs)->resultType;
@@ -167,7 +167,7 @@ unique_ptr<CompletionItem> LSPLoop::getCompletionItem(const core::GlobalState &g
 }
 
 void LSPLoop::findSimilarConstantOrIdent(const core::GlobalState &gs, const core::TypePtr receiverType,
-                                         vector<unique_ptr<CompletionItem>> &items) {
+                                         vector<unique_ptr<CompletionItem>> &items) const {
     if (auto c = core::cast_type<core::ClassType>(receiverType.get())) {
         auto pattern = c->symbol.data(gs)->name.data(gs)->shortName(gs);
         logger->debug("Looking for constant similar to {}", pattern);

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -4,7 +4,7 @@
 using namespace std;
 
 namespace sorbet::realmain::lsp {
-void LSPLoop::addLocIfExists(const core::GlobalState &gs, vector<unique_ptr<Location>> &locs, core::Loc loc) {
+void LSPLoop::addLocIfExists(const core::GlobalState &gs, vector<unique_ptr<Location>> &locs, core::Loc loc) const {
     auto location = loc2Location(gs, loc);
     if (location != nullptr) {
         locs.push_back(std::move(location));

--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -6,7 +6,7 @@ using namespace std;
 namespace sorbet::realmain::lsp {
 
 unique_ptr<SymbolInformation> LSPLoop::symbolRef2SymbolInformation(const core::GlobalState &gs,
-                                                                   core::SymbolRef symRef) {
+                                                                   core::SymbolRef symRef) const {
     auto sym = symRef.data(gs);
     if (!sym->loc().file().exists() || hideSymbol(gs, symRef)) {
         return nullptr;

--- a/main/lsp/updates.cc
+++ b/main/lsp/updates.cc
@@ -63,7 +63,7 @@ core::FileRef LSPLoop::updateFile(const shared_ptr<core::File> &file) {
     return fref;
 }
 
-vector<core::FileHash> LSPLoop::computeStateHashes(const vector<shared_ptr<core::File>> &files) {
+vector<core::FileHash> LSPLoop::computeStateHashes(const vector<shared_ptr<core::File>> &files) const {
     Timer timeit(logger, "computeStateHashes");
     vector<core::FileHash> res(files.size());
     shared_ptr<ConcurrentBoundedQueue<int>> fileq = make_shared<ConcurrentBoundedQueue<int>>(files.size());


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Mark a bunch of methods on LSPLoop class `const`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Lock down which methods actually mutate `LSPLoop`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

It compiled!