### PR TITLE
Mark ~all LSP methods as `const`.

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1347,7 +1347,7 @@ unique_ptr<GlobalState> GlobalState::replaceFile(unique_ptr<GlobalState> inWhat,
     return inWhat;
 }
 
-FileRef GlobalState::findFileByPath(string_view path) {
+FileRef GlobalState::findFileByPath(string_view path) const {
     auto fnd = fileRefByPath.find(string(path));
     if (fnd != fileRefByPath.end()) {
         return fnd->second;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -91,7 +91,7 @@ public:
     static std::unique_ptr<GlobalState> replaceFile(std::unique_ptr<GlobalState> inWhat, FileRef whatFile,
                                                     const std::shared_ptr<File> &withWhat);
     static std::unique_ptr<GlobalState> markFileAsTombStone(std::unique_ptr<GlobalState>, FileRef fref);
-    FileRef findFileByPath(std::string_view path);
+    FileRef findFileByPath(std::string_view path) const;
 
     void mangleRenameSymbol(SymbolRef what, NameRef origName);
     spdlog::logger &tracer() const;

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -29,23 +29,9 @@ LSPLoop::LSPLoop(unique_ptr<core::GlobalState> gs, const options::Options &opts,
     rootPath = opts.rawInputDirNames.at(0);
 }
 
-LSPLoop::TypecheckRun LSPLoop::runLSPQuery(unique_ptr<core::GlobalState> gs, const core::lsp::Query &q,
-                                           const vector<core::FileRef> &filesToQuery) {
-    ENFORCE(gs->lspQuery.isEmpty());
-    ENFORCE(initialGS->lspQuery.isEmpty());
-    ENFORCE(!q.isEmpty());
-    initialGS->lspQuery = gs->lspQuery = q;
-
-    // TODO(jvilk): If this throws, then we'll want to reset `lspQuery` on `initialGS`.
-    // If throwing is common, then we need some way to *not* throw away `gs`.
-    auto rv = tryFastPath(move(gs), nullopt, filesToQuery);
-    rv.gs->lspQuery = initialGS->lspQuery = core::lsp::Query::noQuery();
-    return rv;
-}
-
 variant<LSPLoop::TypecheckRun, pair<unique_ptr<ResponseError>, unique_ptr<core::GlobalState>>>
 LSPLoop::setupLSPQueryByLoc(unique_ptr<core::GlobalState> gs, string_view uri, const Position &pos,
-                            const LSPMethod forMethod, bool errorIfFileIsUntyped) {
+                            const LSPMethod forMethod, bool errorIfFileIsUntyped) const {
     Timer timeit(logger, "setupLSPQueryByLoc");
     auto fref = uri2FileRef(uri);
     if (!fref.exists()) {
@@ -69,10 +55,10 @@ LSPLoop::setupLSPQueryByLoc(unique_ptr<core::GlobalState> gs, string_view uri, c
                          move(gs));
     }
 
-    return runLSPQuery(move(gs), core::lsp::Query::createLocQuery(*loc.get()), {fref});
+    return tryFastPath(move(gs), nullopt, {fref}, core::lsp::Query::createLocQuery(*loc.get()));
 }
 
-LSPLoop::TypecheckRun LSPLoop::setupLSPQueryBySymbol(unique_ptr<core::GlobalState> gs, core::SymbolRef sym) {
+LSPLoop::TypecheckRun LSPLoop::setupLSPQueryBySymbol(unique_ptr<core::GlobalState> gs, core::SymbolRef sym) const {
     Timer timeit(logger, "setupLSPQueryBySymbol");
     ENFORCE(sym.exists());
     vector<core::FileRef> frefs;
@@ -93,7 +79,7 @@ LSPLoop::TypecheckRun LSPLoop::setupLSPQueryBySymbol(unique_ptr<core::GlobalStat
         }
     }
 
-    return runLSPQuery(move(gs), core::lsp::Query::createSymbolQuery(sym), frefs);
+    return tryFastPath(move(gs), nullopt, frefs, core::lsp::Query::createSymbolQuery(sym));
 }
 
 bool LSPLoop::ensureInitialized(LSPMethod forMethod, const LSPMessage &msg,

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -38,7 +38,7 @@ LSPLoop::TypecheckRun LSPLoop::runLSPQuery(unique_ptr<core::GlobalState> gs, con
 
     // TODO(jvilk): If this throws, then we'll want to reset `lspQuery` on `initialGS`.
     // If throwing is common, then we need some way to *not* throw away `gs`.
-    auto rv = tryFastPath(move(gs), {}, filesToQuery);
+    auto rv = tryFastPath(move(gs), nullopt, filesToQuery);
     rv.gs->lspQuery = initialGS->lspQuery = core::lsp::Query::noQuery();
     return rv;
 }
@@ -58,7 +58,7 @@ LSPLoop::setupLSPQueryByLoc(unique_ptr<core::GlobalState> gs, string_view uri, c
     if (errorIfFileIsUntyped && fref.data(*gs).strictLevel < core::StrictLevel::True) {
         logger->info("Ignoring request on untyped file `{}`", uri);
         // Act as if the query returned no results.
-        return TypecheckRun{{}, {}, {}, move(gs), true};
+        return TypecheckRun{{}, {}, {}, move(gs), nullopt, true};
     }
 
     auto loc = lspPos2Loc(fref, pos, *gs);

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -44,7 +44,7 @@ LSPLoop::setupLSPQueryByLoc(unique_ptr<core::GlobalState> gs, string_view uri, c
     if (errorIfFileIsUntyped && fref.data(*gs).strictLevel < core::StrictLevel::True) {
         logger->info("Ignoring request on untyped file `{}`", uri);
         // Act as if the query returned no results.
-        return TypecheckRun{{}, {}, {}, move(gs), nullopt, true};
+        return TypecheckRun{{}, {}, {}, move(gs), {}, true};
     }
 
     auto loc = lspPos2Loc(fref, pos, *gs);
@@ -55,7 +55,7 @@ LSPLoop::setupLSPQueryByLoc(unique_ptr<core::GlobalState> gs, string_view uri, c
                          move(gs));
     }
 
-    return tryFastPath(move(gs), nullopt, {fref}, core::lsp::Query::createLocQuery(*loc.get()));
+    return tryFastPath(move(gs), {}, {fref}, core::lsp::Query::createLocQuery(*loc.get()));
 }
 
 LSPLoop::TypecheckRun LSPLoop::setupLSPQueryBySymbol(unique_ptr<core::GlobalState> gs, core::SymbolRef sym) const {
@@ -79,7 +79,7 @@ LSPLoop::TypecheckRun LSPLoop::setupLSPQueryBySymbol(unique_ptr<core::GlobalStat
         }
     }
 
-    return tryFastPath(move(gs), nullopt, frefs, core::lsp::Query::createSymbolQuery(sym));
+    return tryFastPath(move(gs), {}, frefs, core::lsp::Query::createSymbolQuery(sym));
 }
 
 bool LSPLoop::ensureInitialized(LSPMethod forMethod, const LSPMessage &msg,

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -68,9 +68,8 @@ class LSPLoop {
      */
     struct FileUpdates {
         std::vector<std::shared_ptr<core::File>> updatedFiles;
-        // Note: `string_view`s point to `string`s owned by `core::File`s in `updatedFiles`
-        std::vector<std::string_view> openedFiles;
-        std::vector<std::string_view> closedFiles;
+        std::vector<std::string> openedFiles;
+        std::vector<std::string> closedFiles;
         std::vector<ast::ParsedFile> updatedFileIndexes;
         std::vector<std::pair<std::string_view, core::FileHash>> updatedFileHashes;
     };
@@ -181,16 +180,15 @@ class LSPLoop {
         // The global state, post-typechecking.
         std::unique_ptr<core::GlobalState> gs;
         // The edit applied to `gs`.
-        std::optional<LSPLoop::FileUpdates> updates;
+        LSPLoop::FileUpdates updates;
         bool tookFastPath;
     };
     /** Conservatively rerun entire pipeline without caching any trees */
-    TypecheckRun runSlowPath(std::optional<FileUpdates> updates,
-                             const core::lsp::Query &q = core::lsp::Query::noQuery()) const;
+    TypecheckRun runSlowPath(FileUpdates updates, const core::lsp::Query &q = core::lsp::Query::noQuery()) const;
     /** Returns `true` if the given changes can run on the fast path. */
     bool canTakeFastPath(const FileUpdates &updates, const std::vector<core::FileHash> &hashes) const;
     /** Apply conservative heuristics to see if we can run a fast path, if not, bail out and run slowPath */
-    TypecheckRun tryFastPath(std::unique_ptr<core::GlobalState> gs, std::optional<FileUpdates> updates,
+    TypecheckRun tryFastPath(std::unique_ptr<core::GlobalState> gs, FileUpdates updates,
                              const std::vector<core::FileRef> &filesForQuery = {},
                              const core::lsp::Query &q = core::lsp::Query::noQuery()) const;
     /** Officially 'commits' the output of a `TypecheckRun` by updating the relevant state on LSPLoop and, if specified,

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -181,7 +181,7 @@ class LSPLoop {
         std::unique_ptr<core::GlobalState> gs;
         // The edit applied to `gs`.
         LSPLoop::FileUpdates updates;
-        bool tookFastPath;
+        bool tookFastPath = false;
     };
     /** Conservatively rerun entire pipeline without caching any trees */
     TypecheckRun runSlowPath(FileUpdates updates, const core::lsp::Query &q = core::lsp::Query::noQuery()) const;

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -55,10 +55,10 @@ class LSPLoop {
     /** Used to store the state of LSPLoop's internal request queue.  */
     struct QueueState {
         std::deque<std::unique_ptr<LSPMessage>> pendingRequests;
-        bool terminate;
-        bool paused;
-        int requestCounter;
-        int errorCode;
+        bool terminate = false;
+        bool paused = false;
+        int requestCounter = 0;
+        int errorCode = 0;
         // Counters collected from worker threads.
         CounterState counters;
     };
@@ -125,7 +125,7 @@ class LSPLoop {
     /** What hover markup should we send to the client? */
     MarkupKind clientHoverMarkupKind = MarkupKind::Plaintext;
     /** Input file descriptor; used by runLSP to receive LSP messages */
-    int inputFd;
+    int inputFd = 0;
     /** Output stream; used by LSP to output messages */
     std::ostream &outputStream;
     /** If true, LSPLoop will skip configatron during type checking */
@@ -251,9 +251,9 @@ class LSPLoop {
 
     // Distilled form of an update to a single file.
     struct SorbetWorkspaceFileUpdate {
-        std::string contents;
-        bool newlyOpened;
-        bool newlyClosed;
+        std::string contents = "";
+        bool newlyOpened = false;
+        bool newlyClosed = false;
     };
     void preprocessSorbetWorkspaceEdit(const DidChangeTextDocumentParams &changeParams,
                                        UnorderedMap<std::string, SorbetWorkspaceFileUpdate> &updates) const;

--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -95,7 +95,7 @@ LSPResult LSPLoop::processRequestInternal(unique_ptr<core::GlobalState> gs, cons
             prodCategoryCounterInc("lsp.messages.processed", "initialized");
             Timer timeit(logger, "initial_index");
             reIndexFromFileSystem();
-            LSPResult result = pushDiagnostics(runSlowPath(nullopt));
+            LSPResult result = pushDiagnostics(runSlowPath({}));
             ENFORCE(result.gs);
             if (!disableFastPath) {
                 ShowOperation stateHashOp(*this, "GlobalStateHash", "Finishing initialization...");

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -19,9 +19,9 @@ LSPResult LSPLoop::handleTextDocumentCodeAction(unique_ptr<core::GlobalState> gs
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.codeAction");
 
     core::FileRef file = uri2FileRef(params.textDocument->uri);
-    optional<FileUpdates> updates(FileUpdates{});
-    (*updates).updatedFiles.push_back(make_shared<core::File>(
-        string(file.data(*gs).path()), string(file.data(*gs).source()), core::File::Type::Normal));
+    FileUpdates updates;
+    updates.updatedFiles.push_back(make_shared<core::File>(string(file.data(*gs).path()),
+                                                           string(file.data(*gs).source()), core::File::Type::Normal));
     // Simply querying the file in question is insufficient since indexing errors would not be detected.
     auto run = tryFastPath(move(gs), move(updates));
 

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -19,11 +19,11 @@ LSPResult LSPLoop::handleTextDocumentCodeAction(unique_ptr<core::GlobalState> gs
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.codeAction");
 
     core::FileRef file = uri2FileRef(params.textDocument->uri);
-    vector<shared_ptr<core::File>> files;
-    files.push_back(make_shared<core::File>(string(file.data(*gs).path()), string(file.data(*gs).source()),
-                                            core::File::Type::Normal));
+    optional<FileUpdates> updates(FileUpdates{});
+    (*updates).updatedFiles.push_back(make_shared<core::File>(
+        string(file.data(*gs).path()), string(file.data(*gs).source()), core::File::Type::Normal));
     // Simply querying the file in question is insufficient since indexing errors would not be detected.
-    auto run = tryFastPath(move(gs), files);
+    auto run = tryFastPath(move(gs), move(updates));
 
     auto loc = range2Loc(*run.gs, *params.range.get(), file);
     for (auto &error : run.errors) {

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -5,7 +5,7 @@ using namespace std;
 
 namespace sorbet::realmain::lsp {
 LSPResult LSPLoop::handleTextDocumentCodeAction(unique_ptr<core::GlobalState> gs, const MessageId &id,
-                                                const CodeActionParams &params) {
+                                                const CodeActionParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentCodeAction);
 
     if (!opts.lspQuickFixEnabled) {

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -188,7 +188,7 @@ void LSPLoop::findSimilarConstantOrIdent(const core::GlobalState &gs, const core
 }
 
 LSPResult LSPLoop::handleTextDocumentCompletion(unique_ptr<core::GlobalState> gs, const MessageId &id,
-                                                const CompletionParams &params) {
+                                                const CompletionParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentCompletion);
     if (!opts.lspAutocompleteEnabled) {
         response->error =

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -12,7 +12,7 @@ void LSPLoop::addLocIfExists(const core::GlobalState &gs, vector<unique_ptr<Loca
 }
 
 LSPResult LSPLoop::handleTextDocumentDefinition(unique_ptr<core::GlobalState> gs, const MessageId &id,
-                                                const TextDocumentPositionParams &params) {
+                                                const TextDocumentPositionParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentDefinition);
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.definition");
     auto result = setupLSPQueryByLoc(move(gs), params.textDocument->uri, *params.position,

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -68,7 +68,7 @@ std::unique_ptr<DocumentSymbol> symbolRef2DocumentSymbol(const core::GlobalState
 }
 
 LSPResult LSPLoop::handleTextDocumentDocumentSymbol(unique_ptr<core::GlobalState> gs, const MessageId &id,
-                                                    const DocumentSymbolParams &params) {
+                                                    const DocumentSymbolParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentDocumentSymbol);
     if (!opts.lspDocumentSymbolEnabled) {
         response->error =

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -32,7 +32,7 @@ unique_ptr<MarkupContent> formatRubyCode(MarkupKind markupKind, string str) {
 }
 
 LSPResult LSPLoop::handleTextDocumentHover(unique_ptr<core::GlobalState> gs, const MessageId &id,
-                                           const TextDocumentPositionParams &params) {
+                                           const TextDocumentPositionParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentHover);
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.hover");
 

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -47,7 +47,7 @@ LSPResult LSPLoop::handleTextDocumentReferences(unique_ptr<core::GlobalState> gs
                 auto identResp = resp->isIdent();
                 auto loc = identResp->owner.data(*gs)->loc();
                 if (loc.exists()) {
-                    auto run2 = tryFastPath(move(gs), nullopt, {loc.file()},
+                    auto run2 = tryFastPath(move(gs), {}, {loc.file()},
                                             core::lsp::Query::createVarQuery(identResp->owner, identResp->variable));
                     gs = move(run2.gs);
                     response->result = extractLocations(*gs, run2.responses);

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -48,7 +48,7 @@ void addSignatureHelpItem(const core::GlobalState &gs, core::SymbolRef method,
 }
 
 LSPResult LSPLoop::handleTextSignatureHelp(unique_ptr<core::GlobalState> gs, const MessageId &id,
-                                           const TextDocumentPositionParams &params) {
+                                           const TextDocumentPositionParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentSignatureHelp);
     if (!opts.lspSignatureHelpEnabled) {
         response->error =

--- a/main/lsp/requests/sorbet_workspace_edit.cc
+++ b/main/lsp/requests/sorbet_workspace_edit.cc
@@ -128,9 +128,7 @@ LSPLoop::commitSorbetWorkspaceEdits(unique_ptr<core::GlobalState> gs,
         }
         return tryFastPath(move(gs), move(fileUpdates));
     } else {
-        TypecheckRun emptyRun;
-        emptyRun.gs = move(gs);
-        return emptyRun;
+        return TypecheckRun{{}, {}, {}, move(gs), {}, true};
     }
 }
 

--- a/main/lsp/requests/sorbet_workspace_edit.cc
+++ b/main/lsp/requests/sorbet_workspace_edit.cc
@@ -113,21 +113,20 @@ LSPLoop::TypecheckRun
 LSPLoop::commitSorbetWorkspaceEdits(unique_ptr<core::GlobalState> gs,
                                     UnorderedMap<string, LSPLoop::SorbetWorkspaceFileUpdate> &updates) const {
     if (!updates.empty()) {
-        optional<FileUpdates> maybeFileUpdates(FileUpdates{});
-        auto &fileUpdates = maybeFileUpdates.value();
+        FileUpdates fileUpdates;
         fileUpdates.updatedFiles.reserve(updates.size());
         for (auto &update : updates) {
             auto file =
                 make_shared<core::File>(string(update.first), move(update.second.contents), core::File::Type::Normal);
             if (update.second.newlyClosed) {
-                fileUpdates.closedFiles.push_back(file->path());
+                fileUpdates.closedFiles.push_back(string(file->path()));
             }
             if (update.second.newlyOpened) {
-                fileUpdates.openedFiles.push_back(file->path());
+                fileUpdates.openedFiles.push_back(string(file->path()));
             }
             fileUpdates.updatedFiles.push_back(move(file));
         }
-        return tryFastPath(move(gs), move(maybeFileUpdates));
+        return tryFastPath(move(gs), move(fileUpdates));
     } else {
         TypecheckRun emptyRun;
         emptyRun.gs = move(gs);

--- a/main/lsp/requests/sorbet_workspace_edit.cc
+++ b/main/lsp/requests/sorbet_workspace_edit.cc
@@ -19,29 +19,29 @@ string readFile(string_view path, const FileSystem &fs) {
     }
 }
 
-string getFileContents(UnorderedMap<string, string> &updates, unique_ptr<core::GlobalState> &initialGS,
-                       const string &path) {
+string_view LSPLoop::getFileContents(UnorderedMap<string, LSPLoop::SorbetWorkspaceFileUpdate> &updates,
+                                     const core::GlobalState &initialGS, string_view path) {
     if (updates.find(path) != updates.end()) {
-        return updates[path];
+        return updates[path].contents;
     }
 
-    auto currentFileRef = initialGS->findFileByPath(path);
+    auto currentFileRef = initialGS.findFileByPath(path);
     if (currentFileRef.exists()) {
-        return string(currentFileRef.data(*initialGS).source());
+        return currentFileRef.data(initialGS).source();
     } else {
         return "";
     }
 }
 
 void LSPLoop::preprocessSorbetWorkspaceEdit(const DidChangeTextDocumentParams &changeParams,
-                                            UnorderedMap<string, string> &updates) {
+                                            UnorderedMap<string, LSPLoop::SorbetWorkspaceFileUpdate> &updates) const {
     string_view uri = changeParams.textDocument->uri;
     if (absl::StartsWith(uri, rootUri)) {
         string localPath = remoteName2Local(uri);
         if (FileOps::isFileIgnored(rootPath, localPath, opts.absoluteIgnorePatterns, opts.relativeIgnorePatterns)) {
             return;
         }
-        string fileContents = getFileContents(updates, initialGS, localPath);
+        string fileContents = string(getFileContents(updates, *initialGS, localPath));
         for (auto &change : changeParams.contentChanges) {
             if (change->range) {
                 auto &range = *change->range;
@@ -60,95 +60,113 @@ void LSPLoop::preprocessSorbetWorkspaceEdit(const DidChangeTextDocumentParams &c
                 fileContents = change->text;
             }
         }
-        updates[localPath] = fileContents;
+        updates[localPath] = {fileContents, /* newlyOpened */ false, /* newlyClosed */ false};
     }
 }
 
 void LSPLoop::preprocessSorbetWorkspaceEdit(const DidOpenTextDocumentParams &openParams,
-                                            UnorderedMap<string, string> &updates) {
+                                            UnorderedMap<string, LSPLoop::SorbetWorkspaceFileUpdate> &updates) const {
     string_view uri = openParams.textDocument->uri;
     if (absl::StartsWith(uri, rootUri)) {
         string localPath = remoteName2Local(uri);
         if (!FileOps::isFileIgnored(rootPath, localPath, opts.absoluteIgnorePatterns, opts.relativeIgnorePatterns)) {
-            openFiles.insert(localPath);
-            updates[localPath] = move(openParams.textDocument->text);
+            updates[localPath] = {move(openParams.textDocument->text), /* newlyOpened */ true, /* newlyClosed */ false};
         }
     }
 }
 
 void LSPLoop::preprocessSorbetWorkspaceEdit(const DidCloseTextDocumentParams &closeParams,
-                                            UnorderedMap<string, string> &updates) {
+                                            UnorderedMap<string, LSPLoop::SorbetWorkspaceFileUpdate> &updates) const {
     string_view uri = closeParams.textDocument->uri;
     if (absl::StartsWith(uri, rootUri)) {
         string localPath = remoteName2Local(uri);
         if (!FileOps::isFileIgnored(rootPath, localPath, opts.absoluteIgnorePatterns, opts.relativeIgnorePatterns)) {
-            auto it = openFiles.find(localPath);
-            if (it != openFiles.end()) {
-                openFiles.erase(it);
-            }
             // Use contents of file on disk.
-            updates[localPath] = readFile(localPath, *opts.fs);
+            updates[localPath] = {readFile(localPath, *opts.fs), /* newlyOpened */ false, /* newlyClosed */ true};
         }
     }
 }
 
 void LSPLoop::preprocessSorbetWorkspaceEdit(const WatchmanQueryResponse &queryResponse,
-                                            UnorderedMap<string, string> &updates) {
+                                            UnorderedMap<string, LSPLoop::SorbetWorkspaceFileUpdate> &updates) const {
     for (auto file : queryResponse.files) {
         string localPath = absl::StrCat(rootPath, "/", file);
-        if (!FileOps::isFileIgnored(rootPath, localPath, opts.absoluteIgnorePatterns, opts.relativeIgnorePatterns) &&
-            openFiles.find(localPath) == openFiles.end()) {
-            updates[localPath] = readFile(localPath, *opts.fs);
+        if (!FileOps::isFileIgnored(rootPath, localPath, opts.absoluteIgnorePatterns, opts.relativeIgnorePatterns)) {
+            auto it = updates.find(localPath);
+            bool isFileOpenInEditor = openFiles.contains(localPath);
+            if (it != updates.end()) {
+                // File is newly opened (true), opened previously but now closed (false), or opened previously and still
+                // open (true).
+                isFileOpenInEditor = it->second.newlyOpened || (isFileOpenInEditor && !it->second.newlyClosed);
+            }
+            // Editor contents supercede file system updates.
+            if (!isFileOpenInEditor) {
+                // File may have been closed and then updated on disk, so make sure we preserve the 'closed' flag.
+                updates[localPath] = {readFile(localPath, *opts.fs), /* newlyOpened */ false,
+                                      /* newlyClosed */ it != updates.end() ? it->second.newlyClosed : false};
+            }
         }
     }
 }
 
-LSPResult LSPLoop::commitSorbetWorkspaceEdits(unique_ptr<core::GlobalState> gs, UnorderedMap<string, string> &updates) {
+LSPLoop::TypecheckRun
+LSPLoop::commitSorbetWorkspaceEdits(unique_ptr<core::GlobalState> gs,
+                                    UnorderedMap<string, LSPLoop::SorbetWorkspaceFileUpdate> &updates) const {
     if (!updates.empty()) {
-        vector<shared_ptr<core::File>> files;
-        files.reserve(updates.size());
+        optional<FileUpdates> maybeFileUpdates(FileUpdates{});
+        auto &fileUpdates = maybeFileUpdates.value();
+        fileUpdates.updatedFiles.reserve(updates.size());
         for (auto &update : updates) {
-            files.push_back(
-                make_shared<core::File>(string(update.first), move(update.second), core::File::Type::Normal));
+            auto file =
+                make_shared<core::File>(string(update.first), move(update.second.contents), core::File::Type::Normal);
+            if (update.second.newlyClosed) {
+                fileUpdates.closedFiles.push_back(file->path());
+            }
+            if (update.second.newlyOpened) {
+                fileUpdates.openedFiles.push_back(file->path());
+            }
+            fileUpdates.updatedFiles.push_back(move(file));
         }
-        return pushDiagnostics(tryFastPath(move(gs), files));
+        return tryFastPath(move(gs), move(maybeFileUpdates));
     } else {
-        return LSPResult{move(gs), {}};
+        TypecheckRun emptyRun;
+        emptyRun.gs = move(gs);
+        return emptyRun;
     }
 }
 
-LSPResult LSPLoop::handleSorbetWorkspaceEdit(unique_ptr<core::GlobalState> gs,
-                                             const DidChangeTextDocumentParams &changeParams) {
-    UnorderedMap<string, string> updates;
+LSPLoop::TypecheckRun LSPLoop::handleSorbetWorkspaceEdit(unique_ptr<core::GlobalState> gs,
+                                                         const DidChangeTextDocumentParams &changeParams) const {
+    UnorderedMap<string, LSPLoop::SorbetWorkspaceFileUpdate> updates;
     preprocessSorbetWorkspaceEdit(changeParams, updates);
     return commitSorbetWorkspaceEdits(move(gs), updates);
 }
 
-LSPResult LSPLoop::handleSorbetWorkspaceEdit(unique_ptr<core::GlobalState> gs,
-                                             const DidOpenTextDocumentParams &openParams) {
-    UnorderedMap<string, string> updates;
+LSPLoop::TypecheckRun LSPLoop::handleSorbetWorkspaceEdit(unique_ptr<core::GlobalState> gs,
+                                                         const DidOpenTextDocumentParams &openParams) const {
+    UnorderedMap<string, LSPLoop::SorbetWorkspaceFileUpdate> updates;
     preprocessSorbetWorkspaceEdit(openParams, updates);
     return commitSorbetWorkspaceEdits(move(gs), updates);
 }
 
-LSPResult LSPLoop::handleSorbetWorkspaceEdit(unique_ptr<core::GlobalState> gs,
-                                             const DidCloseTextDocumentParams &closeParams) {
-    UnorderedMap<string, string> updates;
+LSPLoop::TypecheckRun LSPLoop::handleSorbetWorkspaceEdit(unique_ptr<core::GlobalState> gs,
+                                                         const DidCloseTextDocumentParams &closeParams) const {
+    UnorderedMap<string, LSPLoop::SorbetWorkspaceFileUpdate> updates;
     preprocessSorbetWorkspaceEdit(closeParams, updates);
     return commitSorbetWorkspaceEdits(move(gs), updates);
 }
 
-LSPResult LSPLoop::handleSorbetWorkspaceEdit(unique_ptr<core::GlobalState> gs,
-                                             const WatchmanQueryResponse &queryResponse) {
-    UnorderedMap<string, string> updates;
+LSPLoop::TypecheckRun LSPLoop::handleSorbetWorkspaceEdit(unique_ptr<core::GlobalState> gs,
+                                                         const WatchmanQueryResponse &queryResponse) const {
+    UnorderedMap<string, LSPLoop::SorbetWorkspaceFileUpdate> updates;
     preprocessSorbetWorkspaceEdit(queryResponse, updates);
     return commitSorbetWorkspaceEdits(move(gs), updates);
 }
 
-LSPResult LSPLoop::handleSorbetWorkspaceEdits(unique_ptr<core::GlobalState> gs,
-                                              vector<unique_ptr<SorbetWorkspaceEdit>> &edits) {
+LSPLoop::TypecheckRun LSPLoop::handleSorbetWorkspaceEdits(unique_ptr<core::GlobalState> gs,
+                                                          vector<unique_ptr<SorbetWorkspaceEdit>> &edits) const {
     // path => new file contents
-    UnorderedMap<string, string> updates;
+    UnorderedMap<string, LSPLoop::SorbetWorkspaceFileUpdate> updates;
     for (auto &edit : edits) {
         switch (edit->type) {
             case SorbetWorkspaceEditType::EditorOpen: {

--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -23,7 +23,7 @@ unique_ptr<SymbolInformation> LSPLoop::symbolRef2SymbolInformation(const core::G
 }
 
 LSPResult LSPLoop::handleWorkspaceSymbols(unique_ptr<core::GlobalState> gs, const MessageId &id,
-                                          const WorkspaceSymbolParams &params) {
+                                          const WorkspaceSymbolParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::WorkspaceSymbol);
     if (!opts.lspWorkspaceSymbolsEnabled) {
         response->error =

--- a/main/lsp/updates.cc
+++ b/main/lsp/updates.cc
@@ -22,7 +22,7 @@ using namespace std;
 
 namespace sorbet::realmain::lsp {
 
-LSPLoop::ShowOperation::ShowOperation(LSPLoop &loop, string_view operationName, string_view description)
+LSPLoop::ShowOperation::ShowOperation(const LSPLoop &loop, string_view operationName, string_view description)
     : loop(loop), operationName(string(operationName)), description(string(description)) {
     if (loop.enableOperationNotifications) {
         auto params = make_unique<SorbetShowOperationParams>(this->operationName, this->description,
@@ -40,27 +40,72 @@ LSPLoop::ShowOperation::~ShowOperation() {
     }
 }
 
-core::FileRef LSPLoop::updateFile(const shared_ptr<core::File> &file) {
-    Timer timeit(logger, "updateFile");
-    core::FileRef fref;
-    if (!file) {
-        return fref;
-    }
-    fref = initialGS->findFileByPath(file->path());
+pair<unique_ptr<core::GlobalState>, ast::ParsedFile>
+updateFile(unique_ptr<core::GlobalState> gs, const shared_ptr<core::File> &file, const options::Options &opts) {
+    core::FileRef fref = gs->findFileByPath(file->path());
     if (fref.exists()) {
-        initialGS = core::GlobalState::replaceFile(move(initialGS), fref, move(file));
+        gs = core::GlobalState::replaceFile(move(gs), fref, file);
     } else {
-        fref = initialGS->enterFile(move(file));
+        fref = gs->enterFile(file);
+    }
+    fref.data(*gs).strictLevel = pipeline::decideStrictLevel(*gs, fref, opts);
+    std::unique_ptr<KeyValueStore> kvstore; // nullptr
+    return make_pair(move(gs), pipeline::indexOne(opts, *gs, fref, kvstore));
+}
+
+LSPResult LSPLoop::commitTypecheckRun(TypecheckRun run) {
+    Timer timeit(logger, "commitTypecheckRun");
+    if (run.updates) {
+        auto &updates = run.updates.value();
+        // Update editor state.
+        for (auto closedFile : updates.closedFiles) {
+            auto it = openFiles.find(closedFile);
+            if (it != openFiles.end()) {
+                openFiles.erase(it);
+            }
+        }
+        for (auto openedFile : updates.openedFiles) {
+            openFiles.insert(string(openedFile));
+        }
+
+        // Clear out state associated with old finalGS.
+        if (!run.tookFastPath) {
+            indexedFinalGS.clear();
+        }
+
+        for (auto &ast : updates.updatedFileIndexes) {
+            indexedFinalGS[ast.file.id()] = move(ast);
+        }
+
+        {
+            core::UnfreezeFileTable fileTableAccess(*initialGS);
+            for (auto &file : updates.updatedFiles) {
+                // Update initialGS and index.
+                auto rv = updateFile(move(initialGS), file, opts);
+                initialGS = move(rv.first);
+                const auto id = rv.second.file.id();
+                if (id >= indexed.size()) {
+                    indexed.resize(id + 1);
+                }
+                indexed[id] = move(rv.second);
+            }
+            // Drop any indexing errors produced during `updateFile`.
+            // (Note: Flushing is disabled in LSP mode, so we have to drain.)
+            errorQueue->drainWithQueryResponses();
+        }
+
+        for (auto &entry : updates.updatedFileHashes) {
+            auto fref = initialGS->findFileByPath(entry.first);
+            ENFORCE(fref.exists());
+            const auto id = fref.id();
+            if (id >= globalStateHashes.size()) {
+                globalStateHashes.resize(id + 1);
+            }
+            globalStateHashes[fref.id()] = move(entry.second);
+        }
     }
 
-    fref.data(*initialGS).strictLevel = pipeline::decideStrictLevel(*initialGS, fref, opts);
-    auto t = pipeline::indexOne(opts, *initialGS, fref, kvstore);
-    int id = t.file.id();
-    if (id >= indexed.size()) {
-        indexed.resize(id + 1);
-    }
-    indexed[id] = move(t);
-    return fref;
+    return pushDiagnostics(move(run));
 }
 
 vector<core::FileHash> LSPLoop::computeStateHashes(const vector<shared_ptr<core::File>> &files) const {
@@ -155,44 +200,60 @@ void tryApplyDefLocSaver(const core::GlobalState &gs, vector<ast::ParsedFile> &i
     }
 }
 
-LSPLoop::TypecheckRun LSPLoop::runSlowPath() {
+LSPLoop::TypecheckRun LSPLoop::runSlowPath(std::optional<FileUpdates> updates) const {
     ShowOperation slowPathOp(*this, "SlowPath", "Typechecking...");
     Timer timeit(logger, "slow_path");
     ENFORCE(initialGS->errorQueue->isEmpty());
     prodCategoryCounterInc("lsp.updates", "slowpath");
     logger->debug("Taking slow path");
 
+    UnorderedSet<int> updatedFiles;
     vector<ast::ParsedFile> indexedCopies;
+    auto finalGS = initialGS->deepCopy(true);
+    // Index the updated files using finalGS.
+    if (updates) {
+        auto &fileUpdates = updates.value();
+        core::UnfreezeFileTable fileTableAccess(*finalGS);
+        for (auto &file : fileUpdates.updatedFiles) {
+            auto pair = updateFile(move(finalGS), file, opts);
+            finalGS = move(pair.first);
+            auto &ast = pair.second;
+            if (ast.tree) {
+                indexedCopies.emplace_back(ast::ParsedFile{ast.tree->deepCopy(), ast.file});
+                updatedFiles.insert(ast.file.id());
+                fileUpdates.updatedFileIndexes.push_back(move(ast));
+            }
+        }
+    }
+
+    // Copy the indexes of unchanged files.
     for (const auto &tree : indexed) {
         // Note: indexed entries for payload files don't have any contents.
-        if (tree.tree) {
+        if (tree.tree && !updatedFiles.contains(tree.file.id())) {
             indexedCopies.emplace_back(ast::ParsedFile{tree.tree->deepCopy(), tree.file});
         }
     }
 
-    auto finalGs = initialGS->deepCopy(true);
-    // Discard indexed trees from old version of finalGS.
-    indexedFinalGS.clear();
-    auto resolved = pipeline::resolve(finalGs, move(indexedCopies), opts, workers, skipConfigatron);
-    tryApplyDefLocSaver(*finalGs, resolved);
-    tryApplyLocalVarSaver(*finalGs, resolved);
+    auto resolved = pipeline::resolve(finalGS, move(indexedCopies), opts, workers, skipConfigatron);
+    tryApplyDefLocSaver(*finalGS, resolved);
+    tryApplyLocalVarSaver(*finalGS, resolved);
     vector<core::FileRef> affectedFiles;
     for (auto &tree : resolved) {
         ENFORCE(tree.file.exists());
         affectedFiles.push_back(tree.file);
     }
-    pipeline::typecheck(finalGs, move(resolved), opts, workers);
+    pipeline::typecheck(finalGS, move(resolved), opts, workers);
     auto out = initialGS->errorQueue->drainWithQueryResponses();
-    finalGs->lspTypecheckCount++;
-    return TypecheckRun{move(out.first), move(affectedFiles), move(out.second), move(finalGs), false};
+    finalGS->lspTypecheckCount++;
+    return TypecheckRun{move(out.first), move(affectedFiles), move(out.second), move(finalGS), move(updates), false};
 }
 
-bool LSPLoop::canTakeFastPath(const vector<shared_ptr<core::File>> &changedFiles,
-                              const vector<core::FileHash> &hashes) const {
+bool LSPLoop::canTakeFastPath(const FileUpdates &updates, const vector<core::FileHash> &hashes) const {
     if (disableFastPath) {
         logger->debug("Taking sad path because happy path is disabled.");
         return false;
     }
+    auto &changedFiles = updates.updatedFiles;
     logger->debug("Trying to see if happy path is available after {} file changes", changedFiles.size());
 
     ENFORCE(changedFiles.size() == hashes.size());
@@ -200,17 +261,16 @@ bool LSPLoop::canTakeFastPath(const vector<shared_ptr<core::File>> &changedFiles
     {
         for (auto &f : changedFiles) {
             ++i;
-            ENFORCE(f);
             auto fref = initialGS->findFileByPath(f->path());
             if (!fref.exists()) {
-                logger->debug("Taking sad path because {} is a new file", changedFiles[i]->path());
+                logger->debug("Taking sad path because {} is a new file", f->path());
                 return false;
             } else {
                 auto &oldHash = globalStateHashes[fref.id()];
                 ENFORCE(oldHash.definitions.hierarchyHash != core::GlobalStateHash::HASH_STATE_NOT_COMPUTED);
                 if (hashes[i].definitions.hierarchyHash != core::GlobalStateHash::HASH_STATE_INVALID &&
                     hashes[i].definitions.hierarchyHash != oldHash.definitions.hierarchyHash) {
-                    logger->debug("Taking sad path because {} has changed definitions", changedFiles[i]->path());
+                    logger->debug("Taking sad path because {} has changed definitions", f->path());
                     return false;
                 }
             }
@@ -219,58 +279,50 @@ bool LSPLoop::canTakeFastPath(const vector<shared_ptr<core::File>> &changedFiles
     return true;
 }
 
-LSPLoop::TypecheckRun LSPLoop::tryFastPath(unique_ptr<core::GlobalState> gs,
-                                           const vector<shared_ptr<core::File>> &changedFiles,
-                                           const vector<core::FileRef> &filesForQuery) {
+LSPLoop::TypecheckRun LSPLoop::tryFastPath(unique_ptr<core::GlobalState> gs, std::optional<FileUpdates> maybeUpdates,
+                                           const vector<core::FileRef> &filesForQuery) const {
     auto finalGs = move(gs);
     // We assume finalGs is a copy of initialGS, which has had the inferencer & resolver run.
     ENFORCE(finalGs->lspTypecheckCount > 0,
             "Tried to run fast path with a GlobalState object that never had inferencer and resolver runs.");
-    logger->debug("Trying to see if happy path is available after {} file changes", changedFiles.size());
 
-    bool takeFastPath = false;
+    bool takeFastPath = true;
     vector<core::FileRef> subset;
     vector<core::NameHash> changedHashes;
-    {
+    if (maybeUpdates.has_value()) {
         Timer timeit(logger, "fast_path_decision");
-        auto hashes = computeStateHashes(changedFiles);
-        ENFORCE(changedFiles.size() == hashes.size());
-        takeFastPath = canTakeFastPath(changedFiles, hashes);
+
+        auto &updates = maybeUpdates.value();
+        auto hashes = computeStateHashes(updates.updatedFiles);
+        logger->debug("Trying to see if happy path is available after {} file changes", updates.updatedFiles.size());
+        ENFORCE(updates.updatedFiles.size() == hashes.size());
+        takeFastPath = canTakeFastPath(updates, hashes);
 
         int i = -1;
-        {
-            core::UnfreezeFileTable fileTableAccess(*initialGS);
-            for (auto &f : changedFiles) {
-                ++i;
-                auto fref = updateFile(f);
-                if (globalStateHashes.size() <= fref.id()) {
-                    // New file
-                    ENFORCE(!takeFastPath);
-                    globalStateHashes.resize(fref.id() + 1);
-                } else if (takeFastPath) {
-                    // Existing file on fast path
-                    auto &oldHash = globalStateHashes[fref.id()];
-                    for (auto &p : hashes[i].definitions.methodHashes) {
-                        auto fnd = oldHash.definitions.methodHashes.find(p.first);
-                        ENFORCE(fnd != oldHash.definitions.methodHashes.end(), "definitionHash should have failed");
-                        if (fnd->second != p.second) {
-                            changedHashes.emplace_back(p.first);
-                        }
+        for (auto &f : updates.updatedFiles) {
+            ++i;
+            auto fref = initialGS->findFileByPath(f->path());
+            if (fref.exists() && takeFastPath) {
+                // Update to existing file on fast path
+                auto &oldHash = globalStateHashes[fref.id()];
+                for (auto &p : hashes[i].definitions.methodHashes) {
+                    auto fnd = oldHash.definitions.methodHashes.find(p.first);
+                    ENFORCE(fnd != oldHash.definitions.methodHashes.end(), "definitionHash should have failed");
+                    if (fnd->second != p.second) {
+                        changedHashes.emplace_back(p.first);
                     }
-                    finalGs = core::GlobalState::replaceFile(move(finalGs), fref, changedFiles[i]);
-                    subset.emplace_back(fref);
                 }
-                globalStateHashes[fref.id()] = hashes[i];
+                finalGs = core::GlobalState::replaceFile(move(finalGs), fref, f);
+                subset.emplace_back(fref);
             }
-            core::NameHash::sortAndDedupe(changedHashes);
+            // Note: We may not have an id yet for this file if it is brand new, so we store hashes with their paths.
+            updates.updatedFileHashes.push_back(make_pair(f->path(), hashes[i]));
         }
+        core::NameHash::sortAndDedupe(changedHashes);
     }
 
     if (takeFastPath) {
         Timer timeit(logger, "fast_path");
-        // Drop any indexing errors produced during `updateFile`, as we are going to run indexing a second time with
-        // finalGS. (Note: Flushing is disabled in LSP mode, so we have to drain.)
-        errorQueue->drainWithQueryResponses();
         int i = -1;
         for (auto &oldHash : globalStateHashes) {
             i++;
@@ -293,10 +345,12 @@ LSPLoop::TypecheckRun LSPLoop::tryFastPath(unique_ptr<core::GlobalState> gs,
         ENFORCE(initialGS->errorQueue->isEmpty());
         vector<ast::ParsedFile> updatedIndexed;
         for (auto &f : subset) {
+            unique_ptr<KeyValueStore> kvstore; // nullptr
             auto t = pipeline::indexOne(opts, *finalGs, f, kvstore);
-            const int id = t.file.id();
-            indexedFinalGS[id] = move(t);
-            updatedIndexed.emplace_back(ast::ParsedFile{indexedFinalGS[id].tree->deepCopy(), indexedFinalGS[id].file});
+            updatedIndexed.emplace_back(ast::ParsedFile{t.tree->deepCopy(), t.file});
+            // We can't have changed files without file updates.
+            ENFORCE(maybeUpdates.has_value());
+            (*maybeUpdates).updatedFileIndexes.push_back(move(t));
         }
 
         for (auto &f : filesForQuery) {
@@ -315,9 +369,9 @@ LSPLoop::TypecheckRun LSPLoop::tryFastPath(unique_ptr<core::GlobalState> gs,
         pipeline::typecheck(finalGs, move(resolved), opts, workers);
         auto out = initialGS->errorQueue->drainWithQueryResponses();
         finalGs->lspTypecheckCount++;
-        return TypecheckRun{move(out.first), move(subset), move(out.second), move(finalGs), true};
+        return TypecheckRun{move(out.first), move(subset), move(out.second), move(finalGs), move(maybeUpdates), true};
     } else {
-        return runSlowPath();
+        return runSlowPath(move(maybeUpdates));
     }
 }
 } // namespace sorbet::realmain::lsp


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Mark ~all LSP methods as `const`. This change moves all `LSPLoop` mutations to a few core functions.

Previously, `handleSorbetWorkspaceEdit`, `tryFastPath`, and `runSlowPath` would each mutate a bunch of things in LSPLoop as they processed an incoming edit:

* `handleSorbetWorkspaceEdit` would update the set of files currently open in the editor.
* `tryFastPath`/`runSlowPath` would update:
  * Indexed ASTs.
  * The contents of files stored in `initialGS`.
  * Global state hashes (used to determine if update takes fast path)

Now, all of these updates are encapsulated in a `FileUpdates` struct that is contained on the output of a typechecker run. A non-const method, `commitTypecheckRun`, commits those updates to `LSPLoop` and pushes diagnostics out to the editor.

In addition, I have removed some action-at-a-distance from LSP queries. Previously, `runLSPQuery` mutated `initialGS` because `tryFastPath` could technically take a slow path and clone `initialGS` before typechecking. This mutation is incompatible with `const`. Thus, I have removed this method, and changed `tryFastPath`/`runSlowPath` to accept an optional `Query` parameter.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is a necessary step toward making the "slow path" cancelable. A subsequent PR will add in the ability to abort a running slow path, which will skip committing the updates and re-enqueue the un-committed edits for processing. 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

All existing tests pass. I added a new test to cover a new corner case that has arisen now that `handleSorbetWorkspaceEdit` no longer mutates `openFiles`.
