### PR TITLE
Disable fast path

### DIFF
--- a/test/fuzz/fuzz_doc_symbols.cc
+++ b/test/fuzz/fuzz_doc_symbols.cc
@@ -35,7 +35,7 @@ sorbet::realmain::lsp::LSPWrapper mkLSPWrapper() {
     auto opts = mkOpts();
     static const auto commonGs = mkGlobalState(opts, kvstore);
     // TODO how to use opts and avoid another mkOpts()?
-    auto lspWrapper = sorbet::realmain::lsp::LSPWrapper(commonGs->deepCopy(true), mkOpts(), console, false);
+    auto lspWrapper = sorbet::realmain::lsp::LSPWrapper(commonGs->deepCopy(true), mkOpts(), console, true);
     lspWrapper.enableAllExperimentalFeatures();
     return lspWrapper;
 }


### PR DESCRIPTION
This disables the fast path in a fuzzer to make it run faster (ironic).

### Motivation
A lot of time was being spent in `initializeLSP` in the document symbols fuzzer. A big contributor to this slowness was a call to [`computeStateHashes`][1]. This call only occurs when we enable the fast path, because when the fast path is enabled, we use the state hashes to check whether we can use the fast path or not for a given edit. Since we're going to be running the slow path anyway in this fuzzer, we don't need to enable the fast path.

This doesn't actually improve perf for actual Sorbet users, just this fuzzer.

[1]: https://github.com/sorbet/sorbet/blob/master/main/lsp/request_dispatch.cc#L98

### Test plan
None.