### PR TITLE
Allow fuzz args

### DIFF
--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -27,12 +27,17 @@ mkdir -p fuzz_corpus
 find test/testdata -iname "*.rb" | grep -v disable | xargs -n 1 -I % cp % fuzz_corpus
 mkdir -p fuzz_crashers/original
 
-echo "running"
 # use top 10 frames to tell different errors apart
 export ASAN_OPTIONS="dedup_token_length=10"
+# set FUZZ_ARGS to a space-delimited list of other args to pass to the fuzzer, for instance
+# --stress-incremental-resolver. by default it is empty.
+FUZZ_ARGS="${FUZZ_ARGS:-}"
+
+echo "running with FUZZ_ARGS: $FUZZ_ARGS"
 nice "./bazel-bin/test/fuzz/$what" \
   -use_value_profile=1 \
   -only_ascii=1 \
   -dict=test/fuzz/ruby.dict \
   -artifact_prefix=fuzz_crashers/original/ \
-  fuzz_corpus
+  fuzz_corpus \
+  $FUZZ_ARGS

--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -38,5 +38,5 @@ nice "./bazel-bin/test/fuzz/$what" \
   -only_ascii=1 \
   -dict=test/fuzz/ruby.dict \
   -artifact_prefix=fuzz_crashers/original/ \
-  fuzz_corpus \
-  "$FUZZ_ARGS"
+  "$FUZZ_ARGS" \
+  fuzz_corpus

--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -35,7 +35,6 @@ FUZZ_ARGS="${FUZZ_ARGS:---}"
 
 echo "running with FUZZ_ARGS: $FUZZ_ARGS"
 nice "./bazel-bin/test/fuzz/$what" \
-  -use_value_profile=1 \
   -only_ascii=1 \
   -dict=test/fuzz/ruby.dict \
   -artifact_prefix=fuzz_crashers/original/ \

--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 set -euo pipefail
+cd "$(dirname "$0")"
+cd "../.."
+# we're now at the root of the repo.
 
 what=""
 if [ "$#" -eq 0 ]; then

--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -30,8 +30,8 @@ mkdir -p fuzz_crashers/original
 # use top 10 frames to tell different errors apart
 export ASAN_OPTIONS="dedup_token_length=10"
 # set FUZZ_ARGS to a space-delimited list of other args to pass to the fuzzer, for instance
-# --stress-incremental-resolver. by default it is empty.
-FUZZ_ARGS="${FUZZ_ARGS:-}"
+# --stress-incremental-resolver. by default it is '--'.
+FUZZ_ARGS="${FUZZ_ARGS:---}"
 
 echo "running with FUZZ_ARGS: $FUZZ_ARGS"
 nice "./bazel-bin/test/fuzz/$what" \
@@ -40,4 +40,4 @@ nice "./bazel-bin/test/fuzz/$what" \
   -dict=test/fuzz/ruby.dict \
   -artifact_prefix=fuzz_crashers/original/ \
   fuzz_corpus \
-  $FUZZ_ARGS
+  "$FUZZ_ARGS"

--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -41,14 +41,11 @@ mkdir -p fuzz_crashers/original
 
 # use top 10 frames to tell different errors apart
 export ASAN_OPTIONS="dedup_token_length=10"
-# set FUZZ_ARGS to a space-delimited list of other args to pass to the fuzzer, for instance
-# --stress-incremental-resolver. by default it is '--'.
-FUZZ_ARGS="${FUZZ_ARGS:---}"
 
-echo "running with FUZZ_ARGS: $FUZZ_ARGS"
+echo "running with args: '$@'"
 nice "./bazel-bin/test/fuzz/$what" \
   -only_ascii=1 \
   -dict=test/fuzz/ruby.dict \
   -artifact_prefix=fuzz_crashers/original/ \
-  "$FUZZ_ARGS" \
+  "$@" \
   fuzz_corpus

--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -5,15 +5,24 @@ cd "$(dirname "$0")"
 cd "../.."
 # we're now at the root of the repo.
 
-what=""
 if [ "$#" -eq 0 ]; then
-  what="fuzz_dash_e"
-elif [ "$#" -eq 1 ]; then
-  what="$1"
-else
-  echo "usage: $0 [<fuzz_target>]"
-  exit 1
+cat <<EOF
+usage:
+  $0 <fuzz_target> [<options>]
+
+example fuzz_target:
+  fuzz_dash_e
+  fuzz_doc_symbols
+  fuzz_hover
+
+example options:
+  --stress-incremental-resolver
+EOF
+exit 1
 fi
+
+what="$1"
+shift
 
 echo "building $what"
 bazel build "//test/fuzz:$what" --config=fuzz -c opt

--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -42,7 +42,7 @@ mkdir -p fuzz_crashers/original
 # use top 10 frames to tell different errors apart
 export ASAN_OPTIONS="dedup_token_length=10"
 
-echo "running with args: '$@'"
+echo "running"
 nice "./bazel-bin/test/fuzz/$what" \
   -only_ascii=1 \
   -dict=test/fuzz/ruby.dict \


### PR DESCRIPTION
This updates fuzz.sh to allow a `FUZZ_ARGS` env var, so that options like `--stress-incremental-resolver` can be passed in to the fuzzer.

### Motivation
In #1435, I re-formatted the line which runs the fuzzer to not be so long. But that caused me to miss the fact that I removed the `--stress-incremental-resolver` arg. (sorry! 🙇 )

This doesn't add back the arg itself (because not all fuzzers want to `--stress-incremental-resolver`), but it adds a way to pass arbitrary args to your fuzzer.

I'll follow up with updates to the other fuzzer scripts.

### Test plan
None.