### PR TITLE
Update more scripts

### DIFF
--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -34,7 +34,7 @@ if ! command -v llvm-symbolizer >/dev/null; then
   exit 1
 fi
 
-echo "setting up files"
+echo "setting up fuzz_corpus"
 mkdir -p fuzz_corpus
 find test/testdata -iname "*.rb" | grep -v disable | xargs -n 1 -I % cp % fuzz_corpus
 mkdir -p fuzz_crashers/original

--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -43,7 +43,7 @@ mkdir -p fuzz_crashers/original
 export ASAN_OPTIONS="dedup_token_length=10"
 
 echo "running"
-"./bazel-bin/test/fuzz/$target" \
+nice "./bazel-bin/test/fuzz/$target" \
   -only_ascii=1 \
   -dict=test/fuzz/ruby.dict \
   -artifact_prefix=fuzz_crashers/original/ \

--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -43,7 +43,7 @@ mkdir -p fuzz_crashers/original
 export ASAN_OPTIONS="dedup_token_length=10"
 
 echo "running"
-nice "./bazel-bin/test/fuzz/$target" \
+"./bazel-bin/test/fuzz/$target" \
   -only_ascii=1 \
   -dict=test/fuzz/ruby.dict \
   -artifact_prefix=fuzz_crashers/original/ \

--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -8,9 +8,9 @@ cd "../.."
 if [ "$#" -lt 1 ]; then
 cat <<EOF
 usage:
-  $0 <fuzz_target> [<options>]
+  $0 <target> [<options>]
 
-example fuzz_target:
+example target:
   fuzz_dash_e
   fuzz_doc_symbols
   fuzz_hover
@@ -21,11 +21,11 @@ EOF
 exit 1
 fi
 
-fuzz_target="$1"
+target="$1"
 shift
 
-echo "building $fuzz_target"
-bazel build "//test/fuzz:$fuzz_target" --config=fuzz -c opt
+echo "building $target"
+bazel build "//test/fuzz:$target" --config=fuzz -c opt
 
 # we want the bazel build command to run before this check so that bazel can download itself.
 export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain/bin"
@@ -43,7 +43,7 @@ mkdir -p fuzz_crashers/original
 export ASAN_OPTIONS="dedup_token_length=10"
 
 echo "running"
-nice "./bazel-bin/test/fuzz/$fuzz_target" \
+nice "./bazel-bin/test/fuzz/$target" \
   -only_ascii=1 \
   -dict=test/fuzz/ruby.dict \
   -artifact_prefix=fuzz_crashers/original/ \

--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -5,7 +5,7 @@ cd "$(dirname "$0")"
 cd "../.."
 # we're now at the root of the repo.
 
-if [ "$#" -eq 0 ]; then
+if [ "$#" -lt 1 ]; then
 cat <<EOF
 usage:
   $0 <fuzz_target> [<options>]

--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -21,11 +21,11 @@ EOF
 exit 1
 fi
 
-what="$1"
+fuzz_target="$1"
 shift
 
-echo "building $what"
-bazel build "//test/fuzz:$what" --config=fuzz -c opt
+echo "building $fuzz_target"
+bazel build "//test/fuzz:$fuzz_target" --config=fuzz -c opt
 
 # we want the bazel build command to run before this check so that bazel can download itself.
 export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain/bin"
@@ -43,7 +43,7 @@ mkdir -p fuzz_crashers/original
 export ASAN_OPTIONS="dedup_token_length=10"
 
 echo "running"
-nice "./bazel-bin/test/fuzz/$what" \
+nice "./bazel-bin/test/fuzz/$fuzz_target" \
   -only_ascii=1 \
   -dict=test/fuzz/ruby.dict \
   -artifact_prefix=fuzz_crashers/original/ \

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -27,9 +27,9 @@ bazel build "//test/fuzz:$what" --config=fuzz -c opt
 echo "making command file"
 cmds="$(mktemp)"
 for f in fuzz_crashers/original/crash-*; do
-  echo "./tools/scripts/fuzz_minimize_crash.sh '$f' 2>/dev/null" >> "$cmds"
+  echo "tools/scripts/fuzz_minimize_crash.sh '$f' 2>/dev/null" >>"$cmds"
 done
 
 echo "running in parallel"
-parallel --joblog - < "$cmds"
+parallel --joblog - <"$cmds"
 rm "$cmds"

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -6,15 +6,15 @@ bazel build //test/fuzz:fuzz_dash_e --config=fuzz -c opt
 
 # shellcheck disable=SC2207
 input_src=(
-    $(find 'fuzz_crashers/original' -name "crash-*" | sort)
+  $(find 'fuzz_crashers/original' -name "crash-*" | sort)
 )
 
 COMMAND_FILE=$(mktemp)
 
 for this_src in "${input_src[@]}" DUMMY; do
-    if [[ ! "$this_src" == DUMMY ]]; then
-        echo "./tools/scripts/fuzz_minimize_crash.sh \"$this_src\" 2>/dev/null" >> "$COMMAND_FILE"
-    fi
+  if [[ ! "$this_src" == DUMMY ]]; then
+    echo "./tools/scripts/fuzz_minimize_crash.sh \"$this_src\" 2>/dev/null" >> "$COMMAND_FILE"
+  fi
 done
 
 parallel --joblog - < "$COMMAND_FILE"

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -5,7 +5,23 @@ cd "$(dirname "$0")"
 cd "../.."
 # we're now at the root of the repo.
 
-bazel build //test/fuzz:fuzz_dash_e --config=fuzz -c opt
+if [ "$#" -eq 0 ]; then
+cat <<EOF
+usage:
+  $0 <fuzz_target>
+
+example fuzz_target:
+  fuzz_dash_e
+  fuzz_doc_symbols
+  fuzz_hover
+EOF
+exit 1
+fi
+
+what="$1"
+shift
+
+bazel build "//test/fuzz:$what" --config=fuzz -c opt
 
 cmds="$(mktemp)"
 

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -10,7 +10,7 @@ bazel build //test/fuzz:fuzz_dash_e --config=fuzz -c opt
 cmds="$(mktemp)"
 
 for this_src in fuzz_crashers/original/crash-*; do
-  echo "./tools/scripts/fuzz_minimize_crash.sh \"$this_src\" 2>/dev/null" >> "$cmds"
+  echo "./tools/scripts/fuzz_minimize_crash.sh '$this_src' 2>/dev/null" >> "$cmds"
 done
 
 parallel --joblog - < "$cmds"

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -29,6 +29,7 @@ bazel build "//test/fuzz:$target" --config=fuzz -c opt
 
 echo "making command file"
 cmds="$(mktemp)"
+trap "rm '$cmds'" EXIT
 for f in fuzz_crashers/original/crash-*; do
   # this breaks if any of the extra args in $*, or $target, or $f, contain spaces. for instance if this script was
   # called like this: $0 fuzz_dash_e --extra-opt 'foo bar'
@@ -37,4 +38,3 @@ done
 
 echo "running in parallel"
 parallel --joblog - <"$cmds"
-rm "$cmds"

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -21,12 +21,14 @@ fi
 what="$1"
 shift
 
+echo "building $what"
 bazel build "//test/fuzz:$what" --config=fuzz -c opt
 
+echo "making command file"
 cmds="$(mktemp)"
-
 for f in fuzz_crashers/original/crash-*; do
   echo "./tools/scripts/fuzz_minimize_crash.sh '$f' 2>/dev/null" >> "$cmds"
 done
 
+echo "running in parallel"
 parallel --joblog - < "$cmds"

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -32,3 +32,4 @@ done
 
 echo "running in parallel"
 parallel --joblog - < "$cmds"
+rm "$cmds"

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -9,10 +9,8 @@ bazel build //test/fuzz:fuzz_dash_e --config=fuzz -c opt
 
 cmds="$(mktemp)"
 
-for this_src in fuzz_crashers/original/crash-* DUMMY; do
-  if [[ ! "$this_src" == DUMMY ]]; then
+for this_src in fuzz_crashers/original/crash-*; do
     echo "./tools/scripts/fuzz_minimize_crash.sh \"$this_src\" 2>/dev/null" >> "$cmds"
-  fi
 done
 
 parallel --joblog - < "$cmds"

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -10,7 +10,7 @@ bazel build //test/fuzz:fuzz_dash_e --config=fuzz -c opt
 cmds="$(mktemp)"
 
 for this_src in fuzz_crashers/original/crash-*; do
-    echo "./tools/scripts/fuzz_minimize_crash.sh \"$this_src\" 2>/dev/null" >> "$cmds"
+  echo "./tools/scripts/fuzz_minimize_crash.sh \"$this_src\" 2>/dev/null" >> "$cmds"
 done
 
 parallel --joblog - < "$cmds"

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -5,7 +5,7 @@ cd "$(dirname "$0")"
 cd "../.."
 # we're now at the root of the repo.
 
-if [ "$#" -eq 0 ]; then
+if [ "$#" -lt 1 ]; then
 cat <<EOF
 usage:
   $0 <fuzz_target> [<options>]

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 set -exuo pipefail
+cd "$(dirname "$0")"
+cd "../.."
+# we're now at the root of the repo.
 
 bazel build //test/fuzz:fuzz_dash_e --config=fuzz -c opt
 

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -8,12 +8,15 @@ cd "../.."
 if [ "$#" -eq 0 ]; then
 cat <<EOF
 usage:
-  $0 <fuzz_target>
+  $0 <fuzz_target> [<options>]
 
 example fuzz_target:
   fuzz_dash_e
   fuzz_doc_symbols
   fuzz_hover
+
+example options:
+  --stress-incremental-resolver
 EOF
 exit 1
 fi
@@ -27,7 +30,9 @@ bazel build "//test/fuzz:$fuzz_target" --config=fuzz -c opt
 echo "making command file"
 cmds="$(mktemp)"
 for f in fuzz_crashers/original/crash-*; do
-  echo "tools/scripts/fuzz_minimize_crash.sh '$f' 2>/dev/null" >>"$cmds"
+  # this breaks if any of the extra args in $@ have spaces, for instance if this script was called like this:
+  # $0 fuzz_dash_e --extra-opt 'foo bar'
+  echo "tools/scripts/fuzz_minimize_crash.sh $f $* 2>/dev/null" >>"$cmds"
 done
 
 echo "running in parallel"

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -7,14 +7,9 @@ cd "../.."
 
 bazel build //test/fuzz:fuzz_dash_e --config=fuzz -c opt
 
-# shellcheck disable=SC2207
-input_src=(
-  $(find 'fuzz_crashers/original' -name "crash-*" | sort)
-)
-
 cmds="$(mktemp)"
 
-for this_src in "${input_src[@]}" DUMMY; do
+for this_src in fuzz_crashers/original/crash-* DUMMY; do
   if [[ ! "$this_src" == DUMMY ]]; then
     echo "./tools/scripts/fuzz_minimize_crash.sh \"$this_src\" 2>/dev/null" >> "$cmds"
   fi

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -30,8 +30,8 @@ bazel build "//test/fuzz:$target" --config=fuzz -c opt
 echo "making command file"
 cmds="$(mktemp)"
 for f in fuzz_crashers/original/crash-*; do
-  # this breaks if any of the extra args in $@ have spaces, for instance if this script was called like this:
-  # $0 fuzz_dash_e --extra-opt 'foo bar'
+  # this breaks if any of the extra args in $*, or $target, or $f, contain spaces. for instance if this script was
+  # called like this: $0 fuzz_dash_e --extra-opt 'foo bar'
   echo "tools/scripts/fuzz_minimize_crash.sh $target $f $* 2>/dev/null" >>"$cmds"
 done
 

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -29,7 +29,7 @@ bazel build "//test/fuzz:$target" --config=fuzz -c opt
 
 echo "making command file"
 cmds="$(mktemp)"
-trap "rm '$cmds'" EXIT
+trap 'rm "$cmds"' EXIT
 
 # https://stackoverflow.com/questions/2937407
 if ! compgen -G "fuzz_crashers/original/crash-*" >/dev/null; then

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -9,8 +9,8 @@ bazel build //test/fuzz:fuzz_dash_e --config=fuzz -c opt
 
 cmds="$(mktemp)"
 
-for this_src in fuzz_crashers/original/crash-*; do
-  echo "./tools/scripts/fuzz_minimize_crash.sh '$this_src' 2>/dev/null" >> "$cmds"
+for f in fuzz_crashers/original/crash-*; do
+  echo "./tools/scripts/fuzz_minimize_crash.sh '$f' 2>/dev/null" >> "$cmds"
 done
 
 parallel --joblog - < "$cmds"

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -8,9 +8,9 @@ cd "../.."
 if [ "$#" -lt 1 ]; then
 cat <<EOF
 usage:
-  $0 <fuzz_target> [<options>]
+  $0 <target> [<options>]
 
-example fuzz_target:
+example target:
   fuzz_dash_e
   fuzz_doc_symbols
   fuzz_hover
@@ -21,11 +21,11 @@ EOF
 exit 1
 fi
 
-fuzz_target="$1"
+target="$1"
 shift
 
-echo "building $fuzz_target"
-bazel build "//test/fuzz:$fuzz_target" --config=fuzz -c opt
+echo "building $target"
+bazel build "//test/fuzz:$target" --config=fuzz -c opt
 
 echo "making command file"
 cmds="$(mktemp)"

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -32,7 +32,7 @@ cmds="$(mktemp)"
 for f in fuzz_crashers/original/crash-*; do
   # this breaks if any of the extra args in $@ have spaces, for instance if this script was called like this:
   # $0 fuzz_dash_e --extra-opt 'foo bar'
-  echo "tools/scripts/fuzz_minimize_crash.sh $f $* 2>/dev/null" >>"$cmds"
+  echo "tools/scripts/fuzz_minimize_crash.sh $target $f $* 2>/dev/null" >>"$cmds"
 done
 
 echo "running in parallel"

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -30,6 +30,13 @@ bazel build "//test/fuzz:$target" --config=fuzz -c opt
 echo "making command file"
 cmds="$(mktemp)"
 trap "rm '$cmds'" EXIT
+
+# https://stackoverflow.com/questions/2937407
+if ! compgen -G "fuzz_crashers/original/crash-*" >/dev/null; then
+  echo "fatal: no crashers"
+  exit 1
+fi
+
 for f in fuzz_crashers/original/crash-*; do
   # this breaks if any of the extra args in $*, or $target, or $f, contain spaces. for instance if this script was
   # called like this: $0 fuzz_dash_e --extra-opt 'foo bar'

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -18,11 +18,11 @@ EOF
 exit 1
 fi
 
-what="$1"
+fuzz_target="$1"
 shift
 
-echo "building $what"
-bazel build "//test/fuzz:$what" --config=fuzz -c opt
+echo "building $fuzz_target"
+bazel build "//test/fuzz:$fuzz_target" --config=fuzz -c opt
 
 echo "making command file"
 cmds="$(mktemp)"

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -exuo pipefail
+set -euo pipefail
 cd "$(dirname "$0")"
 cd "../.."
 # we're now at the root of the repo.

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -12,12 +12,12 @@ input_src=(
   $(find 'fuzz_crashers/original' -name "crash-*" | sort)
 )
 
-COMMAND_FILE=$(mktemp)
+cmds="$(mktemp)"
 
 for this_src in "${input_src[@]}" DUMMY; do
   if [[ ! "$this_src" == DUMMY ]]; then
-    echo "./tools/scripts/fuzz_minimize_crash.sh \"$this_src\" 2>/dev/null" >> "$COMMAND_FILE"
+    echo "./tools/scripts/fuzz_minimize_crash.sh \"$this_src\" 2>/dev/null" >> "$cmds"
   fi
 done
 
-parallel --joblog - < "$COMMAND_FILE"
+parallel --joblog - < "$cmds"

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -82,9 +82,9 @@ export ASAN_OPTIONS="dedup_token_length=10"
   -use_value_profile=1 \
   -dict=test/fuzz/ruby.dict \
   -minimize_crash=1 \
-  "$crasher" \
   -exact_artifact_path="$output_file" \
   "$@" \
+  "$crasher" \
   &
 
 child=$!

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -32,6 +32,7 @@ if [ -f "$done_file" ]; then
   fi
   exit
 fi
+
 if [ -f "$output_file" ]; then
   echo "Reusing previous minimized state"
   crash_full_path=$(mktemp)

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -21,12 +21,12 @@ mkdir -p fuzz_crashers/fixed/min fuzz_crashers/fixed/original
 
 file_arg="$(basename "$crasher")"
 crash_full_path="$(realpath "$crasher")"
-output_file="fuzz_crashers/min/${file_arg}"
-if [ -f "${output_file}.done" ]; then
+output_file="fuzz_crashers/min/$file_arg"
+if [ -f "$output_file.done" ]; then
     echo "already minimized"
-    if "bazel-bin/test/fuzz/fuzz_dash_e" "${output_file}.done"; then
+    if "bazel-bin/test/fuzz/fuzz_dash_e" "$output_file.done"; then
       echo "already fixed"
-      mv "${output_file}.done" "fuzz_crashers/fixed/min/${file_arg}"
+      mv "$output_file.done" "fuzz_crashers/fixed/min/$file_arg"
     fi
     exit 0
 fi
@@ -38,7 +38,7 @@ fi
 
 if "bazel-bin/test/fuzz/fuzz_dash_e" "${crash_full_path}" ${FUZZ_ARG}; then
   echo "already fixed"
-  mv "${crash_full_path}" "fuzz_crashers/fixed/original/${file_arg}"
+  mv "${crash_full_path}" "fuzz_crashers/fixed/original/$file_arg"
   exit 0
 fi
 
@@ -73,5 +73,5 @@ child=$!
 wait "$child"
 
 if [ -z "$interrupted" ]; then
-  mv "${output_file}" "${output_file}.done"
+  mv "$output_file" "$output_file.done"
 fi

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -28,15 +28,15 @@ shift
 
 mkdir -p fuzz_crashers/fixed/min fuzz_crashers/fixed/original fuzz_crashers/min
 
-file_arg="$(basename "$crasher")"
-output_file="fuzz_crashers/min/$file_arg"
+crasher_name="$(basename "$crasher")"
+output_file="fuzz_crashers/min/$crasher_name"
 done_file="$output_file.done"
 
 if [ -f "$done_file" ]; then
   echo "already minimized"
   if "./bazel-bin/test/fuzz/$target" "$done_file"; then
     echo "already fixed"
-    mv "$done_file" "fuzz_crashers/fixed/min/$file_arg"
+    mv "$done_file" "fuzz_crashers/fixed/min/$crasher_name"
   fi
   exit
 fi
@@ -49,7 +49,7 @@ fi
 
 if "./bazel-bin/test/fuzz/$target" "$crasher" "$@"; then
   echo "already fixed"
-  mv "$crasher" "fuzz_crashers/fixed/original/$file_arg"
+  mv "$crasher" "fuzz_crashers/fixed/original/$crasher_name"
   exit
 fi
 
@@ -83,7 +83,7 @@ export ASAN_OPTIONS="dedup_token_length=10"
   -dict=test/fuzz/ruby.dict \
   -minimize_crash=1 \
   "$crasher" \
-  -exact_artifact_path=fuzz_crashers/min/"$file_arg" \
+  -exact_artifact_path=fuzz_crashers/min/"$crasher_name" \
   "$@" \
   &
 

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -81,7 +81,7 @@ fi
 export ASAN_OPTIONS="dedup_token_length=10"
 
 # start a backgrounded command that we'll monitor
-"./bazel-bin/test/fuzz/$target" \
+nice "./bazel-bin/test/fuzz/$target" \
   -dict=test/fuzz/ruby.dict \
   -minimize_crash=1 \
   -exact_artifact_path="$output_file" \

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -44,18 +44,18 @@ fi
 
 interrupted=
 
-handler_int() {
+handle_INT() {
   kill -INT "$child" 2>/dev/null
   interrupted=1
 }
 
-handler_term() {
+handle_TERM() {
   kill -TERM "$child" 2>/dev/null
   interrupted=1
 }
 
-trap handler_int SIGINT
-trap handler_term SIGTERM
+trap handle_INT SIGINT
+trap handle_TERM SIGTERM
 
 mkdir -p "fuzz_crashers/min/"
 PATH=$PATH:$(pwd)/bazel-sorbet/external/llvm_toolchain/bin/

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -22,11 +22,13 @@ mkdir -p fuzz_crashers/fixed/min fuzz_crashers/fixed/original fuzz_crashers/min
 file_arg="$(basename "$crasher")"
 crash_full_path="$(realpath "$crasher")"
 output_file="fuzz_crashers/min/$file_arg"
-if [ -f "$output_file.done" ]; then
+done_file="$output_file.done"
+
+if [ -f "$done_file" ]; then
   echo "already minimized"
-  if "bazel-bin/test/fuzz/fuzz_dash_e" "$output_file.done"; then
+  if "bazel-bin/test/fuzz/fuzz_dash_e" "$done_file"; then
     echo "already fixed"
-    mv "$output_file.done" "fuzz_crashers/fixed/min/$file_arg"
+    mv "$done_file" "fuzz_crashers/fixed/min/$file_arg"
   fi
   exit 0
 fi
@@ -82,5 +84,5 @@ wait "$child"
 if "$cancelled"; then
   echo "cancelled"
 else
-  mv "$output_file" "$output_file.done"
+  mv "$output_file" "$done_file"
 fi

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -8,11 +8,18 @@ cd "../.."
 if [ "$#" -lt 1 ]; then
 cat <<EOF
 usage:
-  $0 <crasher>
+  $0 <fuzz_target> <crasher>
+
+example fuzz_target:
+  fuzz_dash_e
+  fuzz_doc_symbols
+  fuzz_hover
 EOF
 exit 1
 fi
 
+fuzz_target="$1"
+shift
 crasher="$1"
 shift
 
@@ -27,7 +34,7 @@ done_file="$output_file.done"
 
 if [ -f "$done_file" ]; then
   echo "already minimized"
-  if "./bazel-bin/test/fuzz/fuzz_dash_e" "$done_file"; then
+  if "./bazel-bin/test/fuzz/$fuzz_target" "$done_file"; then
     echo "already fixed"
     mv "$done_file" "fuzz_crashers/fixed/min/$file_arg"
   fi
@@ -40,7 +47,7 @@ if [ -f "$output_file" ]; then
   cp "$output_file" "$crash_full_path"
 fi
 
-if "./bazel-bin/test/fuzz/fuzz_dash_e" "$crash_full_path" "$FUZZ_ARG"; then
+if "./bazel-bin/test/fuzz/$fuzz_target" "$crash_full_path" "$FUZZ_ARG"; then
   echo "already fixed"
   mv "$crash_full_path" "fuzz_crashers/fixed/original/$file_arg"
   exit
@@ -71,7 +78,7 @@ fi
 export ASAN_OPTIONS="dedup_token_length=10"
 
 # start a backgrounded command that we'll monitor
-"./bazel-bin/test/fuzz/fuzz_dash_e" \
+"./bazel-bin/test/fuzz/$fuzz_target" \
   -use_value_profile=1 \
   -dict=test/fuzz/ruby.dict \
   -minimize_crash=1 \

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -8,9 +8,9 @@ cd "../.."
 if [ "$#" -lt 1 ]; then
 cat <<EOF
 usage:
-  $0 <fuzz_target> <crasher> [<options>]
+  $0 <target> <crasher> [<options>]
 
-example fuzz_target:
+example target:
   fuzz_dash_e
   fuzz_doc_symbols
   fuzz_hover
@@ -21,7 +21,7 @@ EOF
 exit 1
 fi
 
-fuzz_target="$1"
+target="$1"
 shift
 crasher="$1"
 shift
@@ -35,7 +35,7 @@ done_file="$output_file.done"
 
 if [ -f "$done_file" ]; then
   echo "already minimized"
-  if "./bazel-bin/test/fuzz/$fuzz_target" "$done_file"; then
+  if "./bazel-bin/test/fuzz/$target" "$done_file"; then
     echo "already fixed"
     mv "$done_file" "fuzz_crashers/fixed/min/$file_arg"
   fi
@@ -48,7 +48,7 @@ if [ -f "$output_file" ]; then
   cp "$output_file" "$crash_full_path"
 fi
 
-if "./bazel-bin/test/fuzz/$fuzz_target" "$crash_full_path" "$@"; then
+if "./bazel-bin/test/fuzz/$target" "$crash_full_path" "$@"; then
   echo "already fixed"
   mv "$crash_full_path" "fuzz_crashers/fixed/original/$file_arg"
   exit
@@ -79,7 +79,7 @@ fi
 export ASAN_OPTIONS="dedup_token_length=10"
 
 # start a backgrounded command that we'll monitor
-"./bazel-bin/test/fuzz/$fuzz_target" \
+"./bazel-bin/test/fuzz/$target" \
   -use_value_profile=1 \
   -dict=test/fuzz/ruby.dict \
   -minimize_crash=1 \

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 set -exuo pipefail
+cd "$(dirname "$0")"
+cd "../.."
+# we're now at the root of the repo.
 
 if (( $# != 1 )); then
     echo "Illegal number of parameters. Need a single file to minimize"
@@ -8,18 +11,16 @@ fi
 
 FUZZ_ARG="--stress-incremental-resolver" # to run incremental resolver
 
-dir="$( dirname "${BASH_SOURCE[0]}" )"
-
-mkdir -p "${dir}/../../fuzz_crashers/fixed/min/" "${dir}/../../fuzz_crashers/fixed/original/"
+mkdir -p "fuzz_crashers/fixed/min/" "fuzz_crashers/fixed/original/"
 
 file_arg="$(basename "$1")"
 crash_full_path="$(realpath "$1")"
-output_file="${dir}/../../fuzz_crashers/min/${file_arg}"
+output_file="fuzz_crashers/min/${file_arg}"
 if [ -f "${output_file}.done" ]; then
     echo "already minimized"
-    if "${dir}/../../bazel-bin/test/fuzz/fuzz_dash_e" "${output_file}.done"; then
+    if "bazel-bin/test/fuzz/fuzz_dash_e" "${output_file}.done"; then
       echo "already fixed"
-      mv "${output_file}.done" "${dir}/../../fuzz_crashers/fixed/min/${file_arg}"
+      mv "${output_file}.done" "fuzz_crashers/fixed/min/${file_arg}"
     fi
     exit 0
 fi
@@ -29,9 +30,9 @@ if [ -f "$output_file" ]; then
     cp "$output_file" "$crash_full_path"
 fi
 
-if "${dir}/../../bazel-bin/test/fuzz/fuzz_dash_e" "${crash_full_path}" ${FUZZ_ARG}; then
+if "bazel-bin/test/fuzz/fuzz_dash_e" "${crash_full_path}" ${FUZZ_ARG}; then
   echo "already fixed"
-  mv "${crash_full_path}" "${dir}/../../fuzz_crashers/fixed/original/${file_arg}"
+  mv "${crash_full_path}" "fuzz_crashers/fixed/original/${file_arg}"
   exit 0
 fi
 
@@ -52,14 +53,13 @@ handler_term()
 trap handler_int SIGINT
 trap handler_term SIGTERM
 
-mkdir -p "${dir}/../../fuzz_crashers/min/"
+mkdir -p "fuzz_crashers/min/"
 PATH=$PATH:$(pwd)/bazel-sorbet/external/llvm_toolchain/bin/
 export PATH
 
 command -v llvm-symbolizer >/dev/null 2>&1 || { echo 'will need llvm-symbolizer' ; exit 1; }
 
 (
-    cd "$dir"/../..
     ASAN_OPTIONS=dedup_token_length=10 ./bazel-bin/test/fuzz/fuzz_dash_e -use_value_profile=1 -dict=test/fuzz/ruby.dict -minimize_crash=1 "$crash_full_path" -exact_artifact_path=fuzz_crashers/min/"$file_arg" ${FUZZ_ARG}
 ) & # start a subshell that we'll monitor
 

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -42,7 +42,7 @@ if [ -f "$done_file" ]; then
 fi
 
 if [ -f "$output_file" ]; then
-  echo "Reusing previous minimized state"
+  echo "reusing previous minimized state"
   crasher="$(mktemp)"
   cp "$output_file" "$crasher"
 fi

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -29,7 +29,6 @@ shift
 mkdir -p fuzz_crashers/fixed/min fuzz_crashers/fixed/original fuzz_crashers/min
 
 file_arg="$(basename "$crasher")"
-crash_full_path="$(realpath "$crasher")"
 output_file="fuzz_crashers/min/$file_arg"
 done_file="$output_file.done"
 
@@ -44,13 +43,13 @@ fi
 
 if [ -f "$output_file" ]; then
   echo "Reusing previous minimized state"
-  crash_full_path="$(mktemp)"
-  cp "$output_file" "$crash_full_path"
+  crasher="$(mktemp)"
+  cp "$output_file" "$crasher"
 fi
 
-if "./bazel-bin/test/fuzz/$target" "$crash_full_path" "$@"; then
+if "./bazel-bin/test/fuzz/$target" "$crasher" "$@"; then
   echo "already fixed"
-  mv "$crash_full_path" "fuzz_crashers/fixed/original/$file_arg"
+  mv "$crasher" "fuzz_crashers/fixed/original/$file_arg"
   exit
 fi
 
@@ -83,7 +82,7 @@ export ASAN_OPTIONS="dedup_token_length=10"
   -use_value_profile=1 \
   -dict=test/fuzz/ruby.dict \
   -minimize_crash=1 \
-  "$crash_full_path" \
+  "$crasher" \
   -exact_artifact_path=fuzz_crashers/min/"$file_arg" \
   "$@" \
   &

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -33,22 +33,22 @@ output_file="fuzz_crashers/min/$crasher_name"
 done_file="$output_file.done"
 
 if [ -f "$done_file" ]; then
-  echo "already minimized"
+  echo "$crasher: already minimized"
   if "./bazel-bin/test/fuzz/$target" "$done_file"; then
-    echo "already fixed"
+    echo "$crasher: already fixed"
     mv "$done_file" "fuzz_crashers/fixed/min/$crasher_name"
   fi
   exit
 fi
 
 if [ -f "$output_file" ]; then
-  echo "reusing previous minimized state"
+  echo "$crasher: reusing previous minimized state"
   crasher="$(mktemp)"
   cp "$output_file" "$crasher"
 fi
 
 if "./bazel-bin/test/fuzz/$target" "$crasher" "$@"; then
-  echo "already fixed"
+  echo "$crasher: already fixed"
   mv "$crasher" "fuzz_crashers/fixed/original/$crasher_name"
   exit
 fi
@@ -91,7 +91,7 @@ child=$!
 wait "$child"
 
 if "$cancelled"; then
-  echo "cancelled"
+  echo "$crasher: cancelled"
 else
   mv "$output_file" "$done_file"
 fi

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -23,17 +23,17 @@ file_arg="$(basename "$crasher")"
 crash_full_path="$(realpath "$crasher")"
 output_file="fuzz_crashers/min/$file_arg"
 if [ -f "$output_file.done" ]; then
-    echo "already minimized"
-    if "bazel-bin/test/fuzz/fuzz_dash_e" "$output_file.done"; then
-      echo "already fixed"
-      mv "$output_file.done" "fuzz_crashers/fixed/min/$file_arg"
-    fi
-    exit 0
+  echo "already minimized"
+  if "bazel-bin/test/fuzz/fuzz_dash_e" "$output_file.done"; then
+    echo "already fixed"
+    mv "$output_file.done" "fuzz_crashers/fixed/min/$file_arg"
+  fi
+  exit 0
 fi
 if [ -f "$output_file" ]; then
-    echo "Reusing previous minimized state"
-    crash_full_path=$(mktemp)
-    cp "$output_file" "$crash_full_path"
+  echo "Reusing previous minimized state"
+  crash_full_path=$(mktemp)
+  cp "$output_file" "$crash_full_path"
 fi
 
 if "bazel-bin/test/fuzz/fuzz_dash_e" "${crash_full_path}" ${FUZZ_ARG}; then
@@ -46,14 +46,14 @@ interrupted=
 
 handler_int()
 {
-    kill -INT "$child" 2>/dev/null
-    interrupted=1
+  kill -INT "$child" 2>/dev/null
+  interrupted=1
 }
 
 handler_term()
 {
-    kill -TERM "$child" 2>/dev/null
-    interrupted=1
+  kill -TERM "$child" 2>/dev/null
+  interrupted=1
 }
 
 trap handler_int SIGINT
@@ -66,7 +66,7 @@ export PATH
 command -v llvm-symbolizer >/dev/null 2>&1 || { echo 'will need llvm-symbolizer' ; exit 1; }
 
 (
-    ASAN_OPTIONS=dedup_token_length=10 ./bazel-bin/test/fuzz/fuzz_dash_e -use_value_profile=1 -dict=test/fuzz/ruby.dict -minimize_crash=1 "$crash_full_path" -exact_artifact_path=fuzz_crashers/min/"$file_arg" ${FUZZ_ARG}
+  ASAN_OPTIONS=dedup_token_length=10 ./bazel-bin/test/fuzz/fuzz_dash_e -use_value_profile=1 -dict=test/fuzz/ruby.dict -minimize_crash=1 "$crash_full_path" -exact_artifact_path=fuzz_crashers/min/"$file_arg" ${FUZZ_ARG}
 ) & # start a subshell that we'll monitor
 
 child=$!

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -65,8 +65,11 @@ if ! command -v llvm-symbolizer >/dev/null; then
   exit 1
 fi
 
+# use top 10 frames to tell different errors apart
+export ASAN_OPTIONS="dedup_token_length=10"
+
 (
-  ASAN_OPTIONS=dedup_token_length=10 ./bazel-bin/test/fuzz/fuzz_dash_e -use_value_profile=1 -dict=test/fuzz/ruby.dict -minimize_crash=1 "$crash_full_path" -exact_artifact_path=fuzz_crashers/min/"$file_arg" ${FUZZ_ARG}
+  ./bazel-bin/test/fuzz/fuzz_dash_e -use_value_profile=1 -dict=test/fuzz/ruby.dict -minimize_crash=1 "$crash_full_path" -exact_artifact_path=fuzz_crashers/min/"$file_arg" ${FUZZ_ARG}
 ) & # start a subshell that we'll monitor
 
 child=$!

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -44,14 +44,12 @@ fi
 
 interrupted=
 
-handler_int()
-{
+handler_int() {
   kill -INT "$child" 2>/dev/null
   interrupted=1
 }
 
-handler_term()
-{
+handler_term() {
   kill -TERM "$child" 2>/dev/null
   interrupted=1
 }

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -83,7 +83,7 @@ export ASAN_OPTIONS="dedup_token_length=10"
   -dict=test/fuzz/ruby.dict \
   -minimize_crash=1 \
   "$crasher" \
-  -exact_artifact_path=fuzz_crashers/min/"$crasher_name" \
+  -exact_artifact_path="$output_file" \
   "$@" \
   &
 

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -36,9 +36,9 @@ if [ -f "$output_file" ]; then
   cp "$output_file" "$crash_full_path"
 fi
 
-if "bazel-bin/test/fuzz/fuzz_dash_e" "${crash_full_path}" "$FUZZ_ARG"; then
+if "bazel-bin/test/fuzz/fuzz_dash_e" "$crash_full_path" "$FUZZ_ARG"; then
   echo "already fixed"
-  mv "${crash_full_path}" "fuzz_crashers/fixed/original/$file_arg"
+  mv "$crash_full_path" "fuzz_crashers/fixed/original/$file_arg"
   exit 0
 fi
 

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -82,7 +82,6 @@ export ASAN_OPTIONS="dedup_token_length=10"
 
 # start a backgrounded command that we'll monitor
 "./bazel-bin/test/fuzz/$target" \
-  -use_value_profile=1 \
   -dict=test/fuzz/ruby.dict \
   -minimize_crash=1 \
   -exact_artifact_path="$output_file" \

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -13,12 +13,14 @@ EOF
 exit 1
 fi
 
+crasher="$1"
+
 FUZZ_ARG="--stress-incremental-resolver" # to run incremental resolver
 
 mkdir -p "fuzz_crashers/fixed/min/" "fuzz_crashers/fixed/original/"
 
-file_arg="$(basename "$1")"
-crash_full_path="$(realpath "$1")"
+file_arg="$(basename "$crasher")"
+crash_full_path="$(realpath "$crasher")"
 output_file="fuzz_crashers/min/${file_arg}"
 if [ -f "${output_file}.done" ]; then
     echo "already minimized"

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -42,16 +42,16 @@ if "bazel-bin/test/fuzz/fuzz_dash_e" "${crash_full_path}" ${FUZZ_ARG}; then
   exit 0
 fi
 
-interrupted=
+interrupted=false
 
 handle_INT() {
   kill -INT "$child" 2>/dev/null
-  interrupted=1
+  interrupted=true
 }
 
 handle_TERM() {
   kill -TERM "$child" 2>/dev/null
-  interrupted=1
+  interrupted=true
 }
 
 trap handle_INT SIGINT
@@ -70,6 +70,6 @@ command -v llvm-symbolizer >/dev/null 2>&1 || { echo 'will need llvm-symbolizer'
 child=$!
 wait "$child"
 
-if [ -z "$interrupted" ]; then
+if ! "$interrupted"; then
   mv "$output_file" "$output_file.done"
 fi

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -26,7 +26,7 @@ done_file="$output_file.done"
 
 if [ -f "$done_file" ]; then
   echo "already minimized"
-  if "bazel-bin/test/fuzz/fuzz_dash_e" "$done_file"; then
+  if "./bazel-bin/test/fuzz/fuzz_dash_e" "$done_file"; then
     echo "already fixed"
     mv "$done_file" "fuzz_crashers/fixed/min/$file_arg"
   fi
@@ -39,7 +39,7 @@ if [ -f "$output_file" ]; then
   cp "$output_file" "$crash_full_path"
 fi
 
-if "bazel-bin/test/fuzz/fuzz_dash_e" "$crash_full_path" "$FUZZ_ARG"; then
+if "./bazel-bin/test/fuzz/fuzz_dash_e" "$crash_full_path" "$FUZZ_ARG"; then
   echo "already fixed"
   mv "$crash_full_path" "fuzz_crashers/fixed/original/$file_arg"
   exit

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -15,6 +15,9 @@ example target:
   fuzz_doc_symbols
   fuzz_hover
 
+example crasher:
+  fuzz_crashers/original/crash-[...]
+
 example options:
   --stress-incremental-resolver
 EOF

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -58,10 +58,12 @@ trap handle_INT SIGINT
 trap handle_TERM SIGTERM
 
 mkdir -p "fuzz_crashers/min/"
-PATH=$PATH:$(pwd)/bazel-sorbet/external/llvm_toolchain/bin/
-export PATH
 
-command -v llvm-symbolizer >/dev/null 2>&1 || { echo 'will need llvm-symbolizer' ; exit 1; }
+export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain/bin"
+if ! command -v llvm-symbolizer >/dev/null; then
+  echo "fatal: command not found: llvm-symbolizer"
+  exit 1
+fi
 
 (
   ASAN_OPTIONS=dedup_token_length=10 ./bazel-bin/test/fuzz/fuzz_dash_e -use_value_profile=1 -dict=test/fuzz/ruby.dict -minimize_crash=1 "$crash_full_path" -exact_artifact_path=fuzz_crashers/min/"$file_arg" ${FUZZ_ARG}

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -71,7 +71,7 @@ fi
 export ASAN_OPTIONS="dedup_token_length=10"
 
 # start a backgrounded command that we'll monitor
-./bazel-bin/test/fuzz/fuzz_dash_e \
+"./bazel-bin/test/fuzz/fuzz_dash_e" \
   -use_value_profile=1 \
   -dict=test/fuzz/ruby.dict \
   -minimize_crash=1 \

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -17,7 +17,7 @@ crasher="$1"
 
 FUZZ_ARG="--stress-incremental-resolver" # to run incremental resolver
 
-mkdir -p fuzz_crashers/fixed/min fuzz_crashers/fixed/original
+mkdir -p fuzz_crashers/fixed/min fuzz_crashers/fixed/original fuzz_crashers/min
 
 file_arg="$(basename "$crasher")"
 crash_full_path="$(realpath "$crasher")"
@@ -56,8 +56,6 @@ handle_TERM() {
 
 trap handle_INT SIGINT
 trap handle_TERM SIGTERM
-
-mkdir -p "fuzz_crashers/min/"
 
 export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain/bin"
 if ! command -v llvm-symbolizer >/dev/null; then

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -30,7 +30,7 @@ if [ -f "$done_file" ]; then
     echo "already fixed"
     mv "$done_file" "fuzz_crashers/fixed/min/$file_arg"
   fi
-  exit 0
+  exit
 fi
 if [ -f "$output_file" ]; then
   echo "Reusing previous minimized state"
@@ -41,7 +41,7 @@ fi
 if "bazel-bin/test/fuzz/fuzz_dash_e" "$crash_full_path" "$FUZZ_ARG"; then
   echo "already fixed"
   mv "$crash_full_path" "fuzz_crashers/fixed/original/$file_arg"
-  exit 0
+  exit
 fi
 
 cancelled=false

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -17,7 +17,7 @@ crasher="$1"
 
 FUZZ_ARG="--stress-incremental-resolver" # to run incremental resolver
 
-mkdir -p "fuzz_crashers/fixed/min/" "fuzz_crashers/fixed/original/"
+mkdir -p fuzz_crashers/fixed/min fuzz_crashers/fixed/original
 
 file_arg="$(basename "$crasher")"
 crash_full_path="$(realpath "$crasher")"

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -14,6 +14,7 @@ exit 1
 fi
 
 crasher="$1"
+shift
 
 FUZZ_ARG="--stress-incremental-resolver" # to run incremental resolver
 

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -81,6 +81,7 @@ fi
 export ASAN_OPTIONS="dedup_token_length=10"
 
 # start a backgrounded command that we'll monitor
+echo "$crasher: running"
 nice "./bazel-bin/test/fuzz/$target" \
   -dict=test/fuzz/ruby.dict \
   -minimize_crash=1 \
@@ -96,4 +97,5 @@ if "$cancelled"; then
   echo "$crasher: cancelled"
 else
   mv "$output_file" "$done_file"
+  echo "$crasher: done"
 fi

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -87,7 +87,7 @@ export ASAN_OPTIONS="dedup_token_length=10"
   "$crasher" \
   &
 
-child=$!
+child="$!"
 wait "$child"
 
 if "$cancelled"; then

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -5,7 +5,7 @@ cd "$(dirname "$0")"
 cd "../.."
 # we're now at the root of the repo.
 
-if [ "$#" -lt 1 ]; then
+if [ "$#" -lt 2 ]; then
 cat <<EOF
 usage:
   $0 <target> <crasher> [<options>]

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -8,12 +8,15 @@ cd "../.."
 if [ "$#" -lt 1 ]; then
 cat <<EOF
 usage:
-  $0 <fuzz_target> <crasher>
+  $0 <fuzz_target> <crasher> [<options>]
 
 example fuzz_target:
   fuzz_dash_e
   fuzz_doc_symbols
   fuzz_hover
+
+example options:
+  --stress-incremental-resolver
 EOF
 exit 1
 fi
@@ -22,8 +25,6 @@ fuzz_target="$1"
 shift
 crasher="$1"
 shift
-
-FUZZ_ARG="--stress-incremental-resolver" # to run incremental resolver
 
 mkdir -p fuzz_crashers/fixed/min fuzz_crashers/fixed/original fuzz_crashers/min
 
@@ -47,7 +48,7 @@ if [ -f "$output_file" ]; then
   cp "$output_file" "$crash_full_path"
 fi
 
-if "./bazel-bin/test/fuzz/$fuzz_target" "$crash_full_path" "$FUZZ_ARG"; then
+if "./bazel-bin/test/fuzz/$fuzz_target" "$crash_full_path" "$@"; then
   echo "already fixed"
   mv "$crash_full_path" "fuzz_crashers/fixed/original/$file_arg"
   exit
@@ -84,7 +85,7 @@ export ASAN_OPTIONS="dedup_token_length=10"
   -minimize_crash=1 \
   "$crash_full_path" \
   -exact_artifact_path=fuzz_crashers/min/"$file_arg" \
-  "$FUZZ_ARG" \
+  "$@" \
   &
 
 child=$!

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -36,7 +36,7 @@ if [ -f "$output_file" ]; then
   cp "$output_file" "$crash_full_path"
 fi
 
-if "bazel-bin/test/fuzz/fuzz_dash_e" "${crash_full_path}" ${FUZZ_ARG}; then
+if "bazel-bin/test/fuzz/fuzz_dash_e" "${crash_full_path}" "$FUZZ_ARG"; then
   echo "already fixed"
   mv "${crash_full_path}" "fuzz_crashers/fixed/original/$file_arg"
   exit 0
@@ -73,7 +73,7 @@ export ASAN_OPTIONS="dedup_token_length=10"
   -minimize_crash=1 \
   "$crash_full_path" \
   -exact_artifact_path=fuzz_crashers/min/"$file_arg" \
-  ${FUZZ_ARG} \
+  "$FUZZ_ARG" \
   &
 
 child=$!

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -69,7 +69,14 @@ fi
 export ASAN_OPTIONS="dedup_token_length=10"
 
 # start a backgrounded command that we'll monitor
-./bazel-bin/test/fuzz/fuzz_dash_e -use_value_profile=1 -dict=test/fuzz/ruby.dict -minimize_crash=1 "$crash_full_path" -exact_artifact_path=fuzz_crashers/min/"$file_arg" ${FUZZ_ARG} &
+./bazel-bin/test/fuzz/fuzz_dash_e \
+  -use_value_profile=1 \
+  -dict=test/fuzz/ruby.dict \
+  -minimize_crash=1 \
+  "$crash_full_path" \
+  -exact_artifact_path=fuzz_crashers/min/"$file_arg" \
+  ${FUZZ_ARG} \
+  &
 
 child=$!
 wait "$child"

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -35,7 +35,7 @@ fi
 
 if [ -f "$output_file" ]; then
   echo "Reusing previous minimized state"
-  crash_full_path=$(mktemp)
+  crash_full_path="$(mktemp)"
   cp "$output_file" "$crash_full_path"
 fi
 

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -68,9 +68,8 @@ fi
 # use top 10 frames to tell different errors apart
 export ASAN_OPTIONS="dedup_token_length=10"
 
-(
-  ./bazel-bin/test/fuzz/fuzz_dash_e -use_value_profile=1 -dict=test/fuzz/ruby.dict -minimize_crash=1 "$crash_full_path" -exact_artifact_path=fuzz_crashers/min/"$file_arg" ${FUZZ_ARG}
-) & # start a subshell that we'll monitor
+# start a backgrounded command that we'll monitor
+./bazel-bin/test/fuzz/fuzz_dash_e -use_value_profile=1 -dict=test/fuzz/ruby.dict -minimize_crash=1 "$crash_full_path" -exact_artifact_path=fuzz_crashers/min/"$file_arg" ${FUZZ_ARG} &
 
 child=$!
 wait "$child"

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -42,16 +42,16 @@ if "bazel-bin/test/fuzz/fuzz_dash_e" "${crash_full_path}" ${FUZZ_ARG}; then
   exit 0
 fi
 
-interrupted=false
+cancelled=false
 
 handle_INT() {
   kill -INT "$child" 2>/dev/null
-  interrupted=true
+  cancelled=true
 }
 
 handle_TERM() {
   kill -TERM "$child" 2>/dev/null
-  interrupted=true
+  cancelled=true
 }
 
 trap handle_INT SIGINT
@@ -81,6 +81,8 @@ export ASAN_OPTIONS="dedup_token_length=10"
 child=$!
 wait "$child"
 
-if ! "$interrupted"; then
+if "$cancelled"; then
+  echo "cancelled"
+else
   mv "$output_file" "$output_file.done"
 fi

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -5,8 +5,12 @@ cd "$(dirname "$0")"
 cd "../.."
 # we're now at the root of the repo.
 
-if (( $# != 1 )); then
-    echo "Illegal number of parameters. Need a single file to minimize"
+if [ "$#" -lt 1 ]; then
+cat <<EOF
+usage:
+  $0 <crasher>
+EOF
+exit 1
 fi
 
 FUZZ_ARG="--stress-incremental-resolver" # to run incremental resolver

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -exuo pipefail
+set -euo pipefail
 cd "$(dirname "$0")"
 cd "../.."
 # we're now at the root of the repo.


### PR DESCRIPTION
This modernizes the `fuzz_*` scripts to

- allow specifying what target to build
- allow passing in other options

It also generally cleans up things like inconsistent indentation, unquoted variables, etc.

I recommend reviewing by commit. There's a *lot* of commits, but each one is (hopefully) small, self-contained, and easily reviewable.

### Motivation
To prepare to do large-scale fuzzing with the new `fuzz_doc_symbols`.

### Test plan
None.