### PR TITLE
runtime: Fix error message when an Enum instance is passed instead of an Array

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
@@ -140,7 +140,7 @@ module T::Types
         obj.class
       else
         # Get the real class name for other `Enumerable` as we don't want them to be collapsed as a `T::Array[T.untyped]`
-        obj.class
+        T.unsafe(obj).class
       end
     end
 

--- a/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
@@ -139,7 +139,8 @@ module T::Types
         # enumerating the object is a destructive operation and might hang.
         obj.class
       else
-        self.class.new(type_from_instances(obj))
+        # Get the real class name for other `Enumerable` as we don't want them to be collapsed as a `T::Array[T.untyped]`
+        obj.class
       end
     end
 

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -186,6 +186,10 @@ module Opus::Types::Test
       end
     end
 
+    class MyEnum
+      include Enumerable
+    end
+
     describe "TypedArray" do
       it 'fails if value is not an array' do
         type = T::Array[Integer]
@@ -267,6 +271,14 @@ module Opus::Types::Test
         msg = type.error_message_for_obj({foo: 17})
         assert_equal(
           "Expected type T::Array[Symbol], got T::Hash[Symbol, Integer]",
+          msg)
+      end
+
+      it 'gives the right error when passed an Enum' do
+        type = T::Array[Integer]
+        msg = type.error_message_for_obj(MyEnum.new)
+        assert_equal(
+          "Expected type T::Array[Integer], got Opus::Types::Test::TypesTest::MyEnum",
           msg)
       end
 


### PR DESCRIPTION
### Motivation

Be the following snippet:

```ruby
# typed: true

require 'sorbet-runtime'

class Foo
  extend T::Sig

  sig { params(a: T::Array[Integer]).void }
  def foo(a) end
end

class Bar
  include ::Enumerable
end

Foo.new.foo(Bar.new)
```

When ran with `sorbet-runtime` here the error message displayed:

```
Parameter 'a': Expected type T::Array[Integer], got T::Array[T.untyped] (TypeError)
Caller: test.rb:16
Definition: test.rb:9
```

Notice the type displayed: `T::Array[T.untyped]`.

This can be really misleading for someone trying to find why there is a type error and why it's seen has an `Array[T.untyped]`.

With this PR applied, here's the new error message:

```
Parameter 'a': Expected type T::Array[Integer], got Bar (TypeError)
Caller: test.rb:16
Definition: test.rb:9
```

I think it's better to show the real type.

### Test plan

See included automated tests.
