### PR TITLE
Avoid one slow path

### DIFF
--- a/test/fuzz/fuzz_doc_symbols.cc
+++ b/test/fuzz/fuzz_doc_symbols.cc
@@ -53,12 +53,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, const std::size_t siz
     std::string contents((const char *)data, size);
     auto lspWrapper = mkLSPWrapper(contents);
     int nextId = 0;
-    sorbet::test::initializeLSP(rootPath, rootUri, lspWrapper, nextId);
-    const auto responses =
-        lspWrapper.getLSPResponsesFor(sorbet::test::LSPMessage(std::make_unique<sorbet::test::RequestMessage>(
-            "2.0", nextId++, sorbet::test::LSPMethod::TextDocumentDocumentSymbol,
-            std::make_unique<sorbet::test::DocumentSymbolParams>(
-                std::make_unique<sorbet::test::TextDocumentIdentifier>(fileUri)))));
-    sorbet::fatalLogger->info("num responses: {}", responses.size());
+    ENFORCE(sorbet::test::initializeLSP(rootPath, rootUri, lspWrapper, nextId).size() == 0);
+    ENFORCE(lspWrapper
+                .getLSPResponsesFor(sorbet::test::LSPMessage(std::make_unique<sorbet::test::RequestMessage>(
+                    "2.0", nextId++, sorbet::test::LSPMethod::TextDocumentDocumentSymbol,
+                    std::make_unique<sorbet::test::DocumentSymbolParams>(
+                        std::make_unique<sorbet::test::TextDocumentIdentifier>(fileUri)))))
+                .size() == 1);
     return 0;
 }


### PR DESCRIPTION
This avoids an extra slow path by having the first slow path include the file we want to get the symbols for.

This also outputs the number of responses we got back.

### Motivation
To speed up a fuzzer.

### Test plan

```
$ tools/scripts/fuzz.sh fuzz_doc_symbols
```

is about 2x faster measured in execs/sec.
