### PR TITLE
Always report internal errors

### DIFF
--- a/core/Error.cc
+++ b/core/Error.cc
@@ -141,7 +141,7 @@ void ErrorBuilder::addAutocorrect(AutocorrectSuggestion &&autocorrect) {
     this->autocorrects.emplace_back(move(autocorrect));
 }
 
-// This will sometimes be bypassed in lieue of just calling build() so put your
+// This will sometimes be bypassed in lieu of just calling build() so put your
 // logic in build() instead.
 ErrorBuilder::~ErrorBuilder() {
     if (state == State::DidBuild) {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1284,10 +1284,7 @@ bool GlobalState::hasAnyDslPlugin() const {
 }
 
 bool GlobalState::shouldReportErrorOn(Loc loc, ErrorClass what) const {
-    if (what == errors::Internal::InternalError) {
-        return true;
-    }
-    if (what == errors::Internal::FileNotFound) {
+    if (what.minLevel == StrictLevel::Internal) {
         return true;
     }
     if (this->silenceErrors) {
@@ -1296,9 +1293,6 @@ bool GlobalState::shouldReportErrorOn(Loc loc, ErrorClass what) const {
     StrictLevel level = StrictLevel::Strong;
     if (loc.file().exists()) {
         level = loc.file().data(*this).strictLevel;
-    }
-    if (what.code == errors::Internal::InternalError.code) {
-        return true;
     }
     if (suppressedErrorClasses.count(what.code) != 0) {
         return false;

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1248,9 +1248,7 @@ ErrorBuilder GlobalState::beginError(Loc loc, ErrorClass what) const {
     if (what == errors::Internal::InternalError) {
         Exception::failInFuzzer();
     }
-    bool report = (what == errors::Internal::InternalError) || (what == errors::Internal::FileNotFound) ||
-                  (shouldReportErrorOn(loc, what) && !this->silenceErrors);
-    return ErrorBuilder(*this, report, loc, what);
+    return ErrorBuilder(*this, shouldReportErrorOn(loc, what), loc, what);
 }
 
 void GlobalState::suppressErrorClass(int code) {
@@ -1286,6 +1284,15 @@ bool GlobalState::hasAnyDslPlugin() const {
 }
 
 bool GlobalState::shouldReportErrorOn(Loc loc, ErrorClass what) const {
+    if (what == errors::Internal::InternalError) {
+        return true;
+    }
+    if (what == errors::Internal::FileNotFound) {
+        return true;
+    }
+    if (this->silenceErrors) {
+        return false;
+    }
     StrictLevel level = StrictLevel::Strong;
     if (loc.file().exists()) {
         level = loc.file().data(*this).strictLevel;

--- a/test/fuzz/fuzz_doc_symbols.cc
+++ b/test/fuzz/fuzz_doc_symbols.cc
@@ -12,6 +12,7 @@ const auto console = spdlog::stdout_logger_mt("console");
 const auto typeErrors = spdlog::stdout_logger_mt("typeErrors");
 const auto rootPath = "/tmp";
 const auto rootUri = fmt::format("file://{}", rootPath);
+const auto fileUri = sorbet::test::filePathToUri(rootUri, "file.rb");
 
 sorbet::realmain::options::Options mkOpts() {
     sorbet::realmain::options::Options opts;
@@ -45,7 +46,6 @@ extern "C" int LLVMFuzzerInitialize(const int *argc, const char ***argv) {
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, const std::size_t size) {
-    auto fileUri = sorbet::test::filePathToUri(rootUri, "file.rb");
     std::string contents((const char *)data, size);
     auto lspWrapper = mkLSPWrapper();
     int nextId = 0;

--- a/test/fuzz/fuzz_doc_symbols.cc
+++ b/test/fuzz/fuzz_doc_symbols.cc
@@ -54,9 +54,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, const std::size_t siz
     auto lspWrapper = mkLSPWrapper(contents);
     int nextId = 0;
     sorbet::test::initializeLSP(rootPath, rootUri, lspWrapper, nextId);
-    lspWrapper.getLSPResponsesFor(sorbet::test::LSPMessage(std::make_unique<sorbet::test::RequestMessage>(
-        "2.0", nextId++, sorbet::test::LSPMethod::TextDocumentDocumentSymbol,
-        std::make_unique<sorbet::test::DocumentSymbolParams>(
-            std::make_unique<sorbet::test::TextDocumentIdentifier>(fileUri)))));
+    const auto responses =
+        lspWrapper.getLSPResponsesFor(sorbet::test::LSPMessage(std::make_unique<sorbet::test::RequestMessage>(
+            "2.0", nextId++, sorbet::test::LSPMethod::TextDocumentDocumentSymbol,
+            std::make_unique<sorbet::test::DocumentSymbolParams>(
+                std::make_unique<sorbet::test::TextDocumentIdentifier>(fileUri)))));
+    sorbet::fatalLogger->info("num responses: {}", responses.size());
     return 0;
 }

--- a/test/fuzz/fuzz_doc_symbols.cc
+++ b/test/fuzz/fuzz_doc_symbols.cc
@@ -45,11 +45,11 @@ extern "C" int LLVMFuzzerInitialize(const int *argc, const char ***argv) {
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, const std::size_t size) {
+    auto fileUri = sorbet::test::filePathToUri(rootUri, "file.rb");
+    std::string contents((const char *)data, size);
     auto lspWrapper = mkLSPWrapper();
     int nextId = 0;
     sorbet::test::initializeLSP(rootPath, rootUri, lspWrapper, nextId);
-    std::string contents((const char *)data, size);
-    auto fileUri = sorbet::test::filePathToUri(rootUri, "file.rb");
     lspWrapper.getLSPResponsesFor(sorbet::test::LSPMessage(std::make_unique<sorbet::test::NotificationMessage>(
         "2.0", sorbet::test::LSPMethod::TextDocumentDidOpen,
         std::make_unique<sorbet::test::DidOpenTextDocumentParams>(

--- a/test/fuzz/fuzz_doc_symbols.cc
+++ b/test/fuzz/fuzz_doc_symbols.cc
@@ -22,18 +22,18 @@ sorbet::realmain::options::Options mkOpts() {
 }
 
 std::unique_ptr<sorbet::core::GlobalState> mkGlobalState(const sorbet::realmain::options::Options &opts,
-                                                         std::unique_ptr<sorbet::KeyValueStore> &kvstore) {
+                                                         std::unique_ptr<sorbet::KeyValueStore> &kvStore) {
     auto gs = std::make_unique<sorbet::core::GlobalState>(
         (std::make_shared<sorbet::core::ErrorQueue>(*typeErrors, *console)));
-    sorbet::payload::createInitialGlobalState(gs, opts, kvstore);
+    sorbet::payload::createInitialGlobalState(gs, opts, kvStore);
     gs->errorQueue->ignoreFlushes = true;
     return gs;
 }
 
 sorbet::realmain::lsp::LSPWrapper mkLSPWrapper() {
-    std::unique_ptr<sorbet::KeyValueStore> kvstore;
+    std::unique_ptr<sorbet::KeyValueStore> kvStore;
     auto opts = mkOpts();
-    static const auto commonGs = mkGlobalState(opts, kvstore);
+    static const auto commonGs = mkGlobalState(opts, kvStore);
     // TODO how to use opts and avoid another mkOpts()?
     auto lspWrapper = sorbet::realmain::lsp::LSPWrapper(commonGs->deepCopy(true), mkOpts(), console, true);
     lspWrapper.enableAllExperimentalFeatures();

--- a/test/fuzz/fuzz_doc_symbols.cc
+++ b/test/fuzz/fuzz_doc_symbols.cc
@@ -12,7 +12,8 @@ const auto console = spdlog::stdout_logger_mt("console");
 const auto typeErrors = spdlog::stdout_logger_mt("typeErrors");
 const auto rootPath = "/tmp";
 const auto rootUri = fmt::format("file://{}", rootPath);
-const auto fileUri = sorbet::test::filePathToUri(rootUri, "file.rb");
+const auto fileName = "file.rb";
+const auto fileUri = sorbet::test::filePathToUri(rootUri, fileName);
 
 sorbet::realmain::options::Options mkOpts() {
     sorbet::realmain::options::Options opts;


### PR DESCRIPTION
This came up when testing out the `fuzz_doc_symbols` fuzzer. It was failing [an enforce][1] related to `ErrorBuilder` when the input was [a test][2] which aliases many times.

@jvilk-stripe and I haven't been able to reproduce this enforce except in the `fuzz_doc_symbols` fuzzer. We should probably do that before merging this.

This also moves a check for `this->silenceErrors` to be earlier, possibly letting us do less work.

[1]: https://github.com/sorbet/sorbet/blob/b2f4c5753e344dda1ee110407aaf83faf99b2754/core/Error.cc#L114
[2]: https://github.com/sorbet/sorbet/blob/b2f4c5753e344dda1ee110407aaf83faf99b2754/test/testdata/resolver/infinite.rb

### Motivation
To ensure errors at `StrictLevel::Internal` are always reported, which appears to be what the enforce was trying to enforce. @DarkDimius confirmed that internal errors should always be reported, even when errors are silenced.

### Test plan
See above for discussion on testing. As mentioned, there's already a test for this, but it's only crashing the fuzzer.