### PR TITLE
Avoid duplicating existing constants

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -591,8 +591,7 @@ SymbolRef GlobalState::lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 f
 
     NameRef lookupName = name;
     u2 unique = 1;
-    auto bareName = ownerScope->members().find(lookupName);
-    auto res = bareName;
+    auto res = ownerScope->members().find(lookupName);
     while (res != ownerScope->members().end() && res->second.exists()) {
         if ((res->second.data(*this)->flags & flags) == flags) {
             return res->second;

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -581,6 +581,33 @@ void GlobalState::reserveMemory(u4 kb) {
 
 constexpr decltype(GlobalState::STRINGS_PAGE_SIZE) GlobalState::STRINGS_PAGE_SIZE;
 
+// look up a symbol whose flags match the desired flags. This might look through mangled names to discover one whose
+// flags match. If no sych symbol exists, then it will return noSymbol.
+SymbolRef GlobalState::lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 flags) const {
+    ENFORCE(owner.exists(), "looking up symbol from non-existing owner");
+    ENFORCE(name.exists(), "looking up symbol with non-existing name");
+    SymbolData ownerScope = owner.dataAllowingNone(*this);
+    histogramInc("symbol_lookup_by_name", ownerScope->members().size());
+
+    NameRef lookupName = name;
+    u2 unique = 1;
+    auto bareName = ownerScope->members().find(lookupName);
+    auto res = bareName;
+    while (res != ownerScope->members().end() && res->second.exists()) {
+        if ((res->second.data(*this)->flags & flags) == flags) {
+            return res->second;
+        }
+        lookupName = getNameUnique(UniqueNameKind::MangleRename, name, unique);
+        if (lookupName == core::Names::empty()) {
+            break;
+        }
+        res = ownerScope->members().find(lookupName);
+        unique++;
+    }
+    return Symbols::noSymbol();
+
+}
+
 SymbolRef GlobalState::enterSymbol(Loc loc, SymbolRef owner, NameRef name, u4 flags) {
     ENFORCE(owner.exists(), "entering symbol in to non-existing owner");
     ENFORCE(name.exists(), "entering symbol with non-existing name");
@@ -938,7 +965,7 @@ NameRef GlobalState::getNameUnique(UniqueNameKind uniqueNameKind, NameRef origin
         bucketId = (bucketId + probeCount) & mask;
         probeCount++;
     }
-    Exception::raise("should never happen");
+    return core::Names::empty();
 }
 
 NameRef GlobalState::freshNameUnique(UniqueNameKind uniqueNameKind, NameRef original, u2 num) {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -592,7 +592,8 @@ SymbolRef GlobalState::lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 f
     NameRef lookupName = name;
     u2 unique = 1;
     auto res = ownerScope->members().find(lookupName);
-    while (res != ownerScope->members().end() && res->second.exists()) {
+    while (res != ownerScope->members().end()) {
+        ENFORCE(res->second.exists());
         if ((res->second.data(*this)->flags & flags) == flags) {
             return res->second;
         }

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -597,8 +597,8 @@ SymbolRef GlobalState::lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 f
         if ((res->second.data(*this)->flags & flags) == flags) {
             return res->second;
         }
-        lookupName = getNameUnique(UniqueNameKind::MangleRename, name, unique);
-        if (lookupName == core::Names::empty()) {
+        lookupName = lookupNameUnique(UniqueNameKind::MangleRename, name, unique);
+        if (!lookupName.exists()) {
             break;
         }
         res = ownerScope->members().find(lookupName);
@@ -941,7 +941,7 @@ void GlobalState::expandNames(int growBy) {
     namesByHash.swap(new_namesByHash);
 }
 
-NameRef GlobalState::getNameUnique(UniqueNameKind uniqueNameKind, NameRef original, u2 num) const {
+NameRef GlobalState::lookupNameUnique(UniqueNameKind uniqueNameKind, NameRef original, u2 num) const {
     ENFORCE(num > 0, "num == 0, name overflow");
     const auto hs = _hash_mix_unique((u2)uniqueNameKind, UNIQUE, num, original.id());
     unsigned int hashTableSize = namesByHash.size();
@@ -964,7 +964,7 @@ NameRef GlobalState::getNameUnique(UniqueNameKind uniqueNameKind, NameRef origin
         bucketId = (bucketId + probeCount) & mask;
         probeCount++;
     }
-    return core::Names::empty();
+    return core::NameRef::noName();
 }
 
 NameRef GlobalState::freshNameUnique(UniqueNameKind uniqueNameKind, NameRef original, u2 num) {
@@ -1460,7 +1460,7 @@ SymbolRef GlobalState::staticInitForFile(Loc loc) {
 }
 
 SymbolRef GlobalState::lookupStaticInitForFile(Loc loc) const {
-    auto nm = getNameUnique(core::UniqueNameKind::Namer, core::Names::staticInit(), loc.file().id());
+    auto nm = lookupNameUnique(core::UniqueNameKind::Namer, core::Names::staticInit(), loc.file().id());
     auto ref = core::Symbols::rootSingleton().data(*this)->findMember(*this, nm);
     ENFORCE(ref.exists(), "looking up non-existent <static-init> for {}", loc.toString(*this));
     return ref;

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -605,7 +605,6 @@ SymbolRef GlobalState::lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 f
         unique++;
     }
     return Symbols::noSymbol();
-
 }
 
 SymbolRef GlobalState::enterSymbol(Loc loc, SymbolRef owner, NameRef name, u4 flags) {

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -91,7 +91,7 @@ public:
 
     NameRef enterNameUTF8(std::string_view nm);
 
-    NameRef getNameUnique(UniqueNameKind uniqueNameKind, NameRef original, u2 num) const;
+    NameRef lookupNameUnique(UniqueNameKind uniqueNameKind, NameRef original, u2 num) const;
     NameRef freshNameUnique(UniqueNameKind uniqueNameKind, NameRef original, u2 num);
 
     NameRef enterNameConstant(NameRef original);

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -70,6 +70,19 @@ public:
     SymbolRef enterStaticFieldSymbol(Loc loc, SymbolRef owner, NameRef name);
     ArgInfo &enterMethodArgumentSymbol(Loc loc, SymbolRef owner, NameRef name);
 
+    SymbolRef lookupSymbol(SymbolRef owner, NameRef name) {
+        return lookupSymbolWithFlags(owner, name, 0);
+    }
+    SymbolRef lookupClassSymbol(SymbolRef owner, NameRef name) {
+        return lookupSymbolWithFlags(owner, name, Symbol::Flags::CLASS);
+    }
+    SymbolRef lookupMethodSymbol(SymbolRef owner, NameRef name) {
+        return lookupSymbolWithFlags(owner, name, Symbol::Flags::METHOD);
+    }
+    SymbolRef lookupStaticFieldSymbol(SymbolRef owner, NameRef name) {
+        return lookupSymbolWithFlags(owner, name, Symbol::Flags::STATIC_FIELD);
+    }
+
     SymbolRef staticInitForFile(Loc loc);
     SymbolRef staticInitForClass(SymbolRef klass, Loc loc);
 
@@ -225,6 +238,8 @@ private:
 
     SymbolRef synthesizeClass(NameRef nameID, u4 superclass = Symbols::todo()._id, bool isModule = false);
     SymbolRef enterSymbol(Loc loc, SymbolRef owner, NameRef name, u4 flags);
+
+    SymbolRef lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 flags) const;
 
     SymbolRef getTopLevelClassSymbol(NameRef name);
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -210,7 +210,7 @@ SymbolRef guessOverload(Context ctx, SymbolRef inClass, SymbolRef primary,
         SymbolRef current = primary;
         while (current.data(ctx)->isOverloaded()) {
             i++;
-            NameRef overloadName = ctx.state.getNameUnique(UniqueNameKind::Overload, primary.data(ctx)->name, i);
+            NameRef overloadName = ctx.state.lookupNameUnique(UniqueNameKind::Overload, primary.data(ctx)->name, i);
             SymbolRef overload = primary.data(ctx)->owner.data(ctx)->findMember(ctx, overloadName);
             if (!overload.exists()) {
                 Exception::raise("Corruption of overloads?");

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -852,6 +852,7 @@ vector<ast::ParsedFile> resolve(unique_ptr<core::GlobalState> &gs, vector<ast::P
             what = resolver::Resolver::run(ctx, move(what), workers);
         }
         if (opts.stressIncrementalResolver) {
+            auto symbolsBefore = gs->symbolsUsed();
             for (auto &f : what) {
                 // Shift contents of file past current file's EOF, re-run incrementalResolve, assert that no locations
                 // appear before file's old EOF.
@@ -869,6 +870,7 @@ vector<ast::ParsedFile> resolve(unique_ptr<core::GlobalState> &gs, vector<ast::P
                 ENFORCE(reresolved.size() == 1);
                 f = checkNoDefinitionsInsideProhibitedLines(*gs, move(reresolved[0]), 0, prohibitedLines);
             }
+            ENFORCE(symbolsBefore == gs->symbolsUsed(), "Stressing the incremental resolver should not add any new symbols");
         }
     } catch (SorbetException &) {
         Exception::failInFuzzer();

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -870,7 +870,8 @@ vector<ast::ParsedFile> resolve(unique_ptr<core::GlobalState> &gs, vector<ast::P
                 ENFORCE(reresolved.size() == 1);
                 f = checkNoDefinitionsInsideProhibitedLines(*gs, move(reresolved[0]), 0, prohibitedLines);
             }
-            ENFORCE(symbolsBefore == gs->symbolsUsed(), "Stressing the incremental resolver should not add any new symbols");
+            ENFORCE(symbolsBefore == gs->symbolsUsed(),
+                    "Stressing the incremental resolver should not add any new symbols");
         }
     } catch (SorbetException &) {
         Exception::failInFuzzer();

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -245,7 +245,8 @@ public:
             bool isModule = klass->kind == ast::ClassDefKind::Module;
             if (!klass->symbol.data(ctx)->isClass()) {
                 // we might have already mangled the class symbol, so see if we have a symbol that is a class already
-                auto klassSymbol = ctx.state.lookupClassSymbol(klass->symbol.data(ctx)->owner, klass->symbol.data(ctx)->name);
+                auto klassSymbol =
+                    ctx.state.lookupClassSymbol(klass->symbol.data(ctx)->owner, klass->symbol.data(ctx)->name);
                 if (klassSymbol.exists()) {
                     klass->symbol = klassSymbol;
                 } else {
@@ -255,7 +256,8 @@ public:
                     }
                     auto origName = klass->symbol.data(ctx)->name;
                     ctx.state.mangleRenameSymbol(klass->symbol, klass->symbol.data(ctx)->name);
-                    klass->symbol = ctx.state.enterClassSymbol(klass->declLoc, klass->symbol.data(ctx)->owner, origName);
+                    klass->symbol =
+                        ctx.state.enterClassSymbol(klass->declLoc, klass->symbol.data(ctx)->owner, origName);
                     klass->symbol.data(ctx)->setIsModule(isModule);
 
                     auto oldSymCount = ctx.state.symbolsUsed();

--- a/test/cli/incremental-resolver/expect-failures/constant_redefinition.rb
+++ b/test/cli/incremental-resolver/expect-failures/constant_redefinition.rb
@@ -1,0 +1,5 @@
+# typed: strict
+module F
+  class A; end
+  A = nil
+end

--- a/test/cli/incremental-resolver/incremental-resolver.out
+++ b/test/cli/incremental-resolver/incremental-resolver.out
@@ -28,34 +28,18 @@ test/cli/incremental-resolver/expect-failures/constant_override.rb:3: Redefining
      2 |B = e
         ^
 
-test/cli/incremental-resolver/expect-failures/constant_override.rb:110: Redefining constant `B` https://srb.help/4012
-     110 |B = e
-          ^^^^^
-    test/cli/incremental-resolver/expect-failures/constant_override.rb:19: Previous definition
-    19 |
-    20 |
-    21 |
-    22 |
-    23 |
-    24 |
-    25 |
-    26 |
-    27 |
-
-test/cli/incremental-resolver/expect-failures/constant_override.rb:111: Redefining constant `B` https://srb.help/4012
-     111 |module B
-     112 |  extend T::Sig
-     113 |  sig { returns(T.all(B,T)) }
-     114 |  def foo; T.unsafe(nil); end
-     115 |end
-    test/cli/incremental-resolver/expect-failures/constant_override.rb:110: Previous definition
-     110 |B = e
-          ^
-
 test/cli/incremental-resolver/expect-failures/constant_override.rb:110: Method `e` does not exist on `T.class_of(<root>)` https://srb.help/7003
      110 |B = e
               ^
-Errors: 4
+Errors: 2
+----- test/cli/incremental-resolver/expect-failures/constant_redefinition.rb ---------------------
+test/cli/incremental-resolver/expect-failures/constant_redefinition.rb:4: Redefining constant `A` https://srb.help/4012
+     4 |  A = nil
+          ^^^^^^^
+    test/cli/incremental-resolver/expect-failures/constant_redefinition.rb:3: Previous definition
+     3 |  class A; end
+          ^^^^^^^
+Errors: 1
 ----- test/cli/incremental-resolver/expect-failures/multiple_sigs.rb ---------------------
 test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:3: Unused type annotation. No method def before next annotation https://srb.help/5040
      3 |  sig {void}

--- a/test/testdata/namer/constant_redefinition/class_then_constant.rb
+++ b/test/testdata/namer/constant_redefinition/class_then_constant.rb
@@ -1,0 +1,10 @@
+# typed: true
+# disable-fast-path: true
+
+class R; end
+R = 5 # error: Redefining constant `R`
+
+# this should not resolve as a class, so this will be an error
+x = R.new # error: Method `new` does not exist on `Integer` component of `Integer(5)`
+# this should resolve as the constant, so this would be fine
+puts R + 1

--- a/test/testdata/namer/constant_redefinition/class_then_constant_then_reopen.rb
+++ b/test/testdata/namer/constant_redefinition/class_then_constant_then_reopen.rb
@@ -1,0 +1,13 @@
+# typed: true
+# disable-fast-path: true
+
+class R; end
+R = 5 # error: Redefining constant `R`
+class R; end
+# even though we've reopened the class here, the constant R still
+# "wins", because the first definition of the class is what counts
+
+# this should not resolve as a class, so this will be an error
+x = R.new # error: Method `new` does not exist on `Integer` component of `Integer(5)`
+# this should resolve as the constant, so this would be fine
+puts R + 1

--- a/test/testdata/namer/constant_redefinition/constant_then_class.rb
+++ b/test/testdata/namer/constant_redefinition/constant_then_class.rb
@@ -1,0 +1,10 @@
+# typed: true
+# disable-fast-path: true
+
+R = 5
+class R; end # error: Redefining constant `R`
+
+# this should resolve as a class, so this would not be an error
+x = R.new
+# this should not resolve as the constant, so this will be an error
+puts R + 1 # error: Method `+` does not exist on `T.class_of(R)`

--- a/test/testdata/namer/constant_redefinition/constant_then_module.rb
+++ b/test/testdata/namer/constant_redefinition/constant_then_module.rb
@@ -1,0 +1,10 @@
+# typed: true
+# disable-fast-path: true
+
+R = 5
+module R; def self.x; end; end # error: Redefining constant `R`
+
+# this should resolve as a class, so this would not be an error
+x = R.x
+# this should not resolve as the constant, so this will be an error
+puts R + 1 # error: Method `+` does not exist on `T.class_of(R)`

--- a/test/testdata/namer/constant_redefinition/module_then_constant.rb
+++ b/test/testdata/namer/constant_redefinition/module_then_constant.rb
@@ -1,0 +1,10 @@
+# typed: true
+# disable-fast-path: true
+
+module R; def self.x; end; end
+R = 5 # error: Redefining constant `R`
+
+# this should not resolve as a class, so this will be an error
+x = R.x # error: Method `x` does not exist on `Integer` component of `Integer(5)`
+# this should resolve as the constant, so this would be fine
+puts R + 1

--- a/test/testdata/namer/constant_redefinition/module_then_constant_then_reopen.rb
+++ b/test/testdata/namer/constant_redefinition/module_then_constant_then_reopen.rb
@@ -1,0 +1,13 @@
+# typed: true
+# disable-fast-path: true
+
+module R; def self.x; end; end
+R = 5 # error: Redefining constant `R`
+module R; end
+# even though we've reopened the class here, the constant R still
+# "wins", because the first definition of the class is what counts
+
+# this should not resolve as a class, so this will be an error
+x = R.x # error: Method `x` does not exist on `Integer` component of `Integer(5)`
+# this should resolve as the constant, so this would be fine
+puts R + 1

--- a/test/testdata/namer/fuzz_shared_singletons.rb
+++ b/test/testdata/namer/fuzz_shared_singletons.rb
@@ -2,4 +2,4 @@
 # disable-fast-path: true
 A=class A; end # error: Redefining constant
 
-class A; end # error: Redefining constant
+class A; end


### PR DESCRIPTION
Fixes #1129 among others: this adds logic so that we can look up symbols by type, finding redefinitions if they exist, and plumbs this logic through the namer. These new functions live in `GlobalState` and can be thought of as companion functions to the `enterSymbol` functions that look up existing symbols.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Fuzzed test included in PR.
