### PR TITLE
Allow dealiasing to return default values other than untyped

### DIFF
--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -12,7 +12,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
     ENFORCE(md.symbol.exists());
     ENFORCE(!md.symbol.data(ctx)->isOverloaded());
     unique_ptr<CFG> res(new CFG); // private constructor
-    res->symbol = md.symbol.data(ctx)->dealias(ctx);
+    res->symbol = md.symbol.data(ctx)->dealiasMethod(ctx);
     if (res->symbol.data(ctx)->isAbstract()) {
         res->basicBlocks.clear();
         return res;

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -890,7 +890,7 @@ TypePtr Symbol::sealedSubclasses(const Context ctx) const {
     return result;
 }
 
-SymbolRef Symbol::dealias(const GlobalState &gs, int depthLimit) const {
+SymbolRef Symbol::dealiasWithDefault(const GlobalState &gs, int depthLimit, SymbolRef def) const {
     if (auto alias = cast_type<AliasType>(resultType.get())) {
         if (depthLimit == 0) {
             if (auto e = gs.beginError(loc(), errors::Internal::CyclicReferenceError)) {
@@ -898,9 +898,9 @@ SymbolRef Symbol::dealias(const GlobalState &gs, int depthLimit) const {
                             "expansion would have been to {}",
                             showFullName(gs), alias->symbol.data(gs)->showFullName(gs));
             }
-            return Symbols::untyped();
+            return def;
         }
-        return alias->symbol.data(gs)->dealias(gs, depthLimit - 1);
+        return alias->symbol.data(gs)->dealiasWithDefault(gs, depthLimit - 1, def);
     }
     return this->ref(gs);
 }

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -540,7 +540,16 @@ public:
     const InlinedVector<Loc, 2> &sealedLocs(const GlobalState &gs) const;
     TypePtr sealedSubclasses(const Context ctx) const;
 
-    SymbolRef dealias(const GlobalState &gs, int depthLimit = 42) const;
+    // if dealiasing fails here, then we return Untyped instead
+    SymbolRef dealias(const GlobalState &gs, int depthLimit = 42) const {
+        return dealiasWithDefault(gs, depthLimit, Symbols::untyped());
+    }
+    // if dealiasing fails here, then we return a bad alias method stub instead
+    SymbolRef dealiasMethod(const GlobalState &gs, int depthLimit = 42) const {
+        return dealiasWithDefault(gs, depthLimit, core::Symbols::Sorbet_Private_Static_badAliasMethodStub());
+    }
+
+    SymbolRef dealiasWithDefault(const GlobalState &gs, int depthLimit, SymbolRef def) const;
 
     bool ignoreInHashing(const GlobalState &gs) const;
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1615,9 +1615,9 @@ public:
             }
 
             core::SymbolRef fromMethod = owner.data(ctx)->findMemberNoDealias(ctx, fromName);
-            if (fromMethod.exists() && fromMethod.data(ctx)->dealias(ctx) != toMethod) {
+            if (fromMethod.exists() && fromMethod.data(ctx)->dealiasMethod(ctx) != toMethod) {
                 if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::BadAliasMethod)) {
-                    auto dealiased = fromMethod.data(ctx)->dealias(ctx);
+                    auto dealiased = fromMethod.data(ctx)->dealiasMethod(ctx);
                     if (fromMethod == dealiased) {
                         e.setHeader("Redefining the existing method `{}` as a method alias",
                                     fromMethod.data(ctx)->show(ctx));

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1604,7 +1604,8 @@ public:
             auto toName = args[1];
 
             auto owner = methodOwner(ctx);
-            core::SymbolRef toMethod = owner.data(ctx)->findMember(ctx, toName);
+            core::SymbolRef toMethod = owner.data(ctx)->findMemberNoDealias(ctx, toName);
+            toMethod = toMethod.data(ctx)->dealiasMethod(ctx);
             if (!toMethod.exists()) {
                 if (auto e = ctx.state.beginError(send->args[1]->loc, core::errors::Resolver::BadAliasMethod)) {
                     e.setHeader("Can't make method alias from `{}` to non existing method `{}`", fromName.show(ctx),

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1605,7 +1605,10 @@ public:
 
             auto owner = methodOwner(ctx);
             core::SymbolRef toMethod = owner.data(ctx)->findMemberNoDealias(ctx, toName);
-            toMethod = toMethod.data(ctx)->dealiasMethod(ctx);
+            if (toMethod.exists()) {
+                toMethod = toMethod.data(ctx)->dealiasMethod(ctx);
+            }
+
             if (!toMethod.exists()) {
                 if (auto e = ctx.state.beginError(send->args[1]->loc, core::errors::Resolver::BadAliasMethod)) {
                     e.setHeader("Can't make method alias from `{}` to non existing method `{}`", fromName.show(ctx),

--- a/test/testdata/cfg/fuzz_recursive_alias.rb
+++ b/test/testdata/cfg/fuzz_recursive_alias.rb
@@ -1,0 +1,4 @@
+# typed: true
+alias foo foo
+def foo; end # error: Too many alias expansions for symbol ::Object#foo, the alias is either too long or infinite.
+

--- a/test/testdata/cfg/fuzz_recursive_alias.rb
+++ b/test/testdata/cfg/fuzz_recursive_alias.rb
@@ -1,4 +1,4 @@
 # typed: true
 alias foo foo
-def foo; end # error: Too many alias expansions for symbol ::Object#foo, the alias is either too long or infinite.
+def foo; end # error-with-dupes: Too many alias expansions for symbol ::Object#foo, the alias is either too long or infinite.
 


### PR DESCRIPTION


### Motivation
Fixes #1390; calls to `dealias` will always return `T.untyped()` if they fail to resolve after some number of iterations, but we were calling `dealias` on a method. I've added some helper functions which act like `dealias` but can return other default values, and for unresolvable methods will use a sensible default. This can be easily expanded if we need it for other kinds of dealiasing, as well.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
