### PR TITLE
LSP: Separate methods for query runs and typechecking runs

### DIFF
--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -29,7 +29,7 @@ LSPLoop::LSPLoop(unique_ptr<core::GlobalState> gs, const options::Options &opts,
     rootPath = opts.rawInputDirNames.at(0);
 }
 
-variant<LSPLoop::TypecheckRun, pair<unique_ptr<ResponseError>, unique_ptr<core::GlobalState>>>
+variant<LSPLoop::QueryRun, pair<unique_ptr<ResponseError>, unique_ptr<core::GlobalState>>>
 LSPLoop::setupLSPQueryByLoc(unique_ptr<core::GlobalState> gs, string_view uri, const Position &pos,
                             const LSPMethod forMethod, bool errorIfFileIsUntyped) const {
     Timer timeit(logger, "setupLSPQueryByLoc");
@@ -44,7 +44,7 @@ LSPLoop::setupLSPQueryByLoc(unique_ptr<core::GlobalState> gs, string_view uri, c
     if (errorIfFileIsUntyped && fref.data(*gs).strictLevel < core::StrictLevel::True) {
         logger->info("Ignoring request on untyped file `{}`", uri);
         // Act as if the query returned no results.
-        return TypecheckRun{{}, {}, {}, move(gs), {}, true};
+        return QueryRun{move(gs), {}};
     }
 
     auto loc = lspPos2Loc(fref, pos, *gs);
@@ -55,10 +55,10 @@ LSPLoop::setupLSPQueryByLoc(unique_ptr<core::GlobalState> gs, string_view uri, c
                          move(gs));
     }
 
-    return tryFastPath(move(gs), {}, {fref}, core::lsp::Query::createLocQuery(*loc.get()));
+    return runQuery(move(gs), core::lsp::Query::createLocQuery(*loc.get()), {fref});
 }
 
-LSPLoop::TypecheckRun LSPLoop::setupLSPQueryBySymbol(unique_ptr<core::GlobalState> gs, core::SymbolRef sym) const {
+LSPLoop::QueryRun LSPLoop::setupLSPQueryBySymbol(unique_ptr<core::GlobalState> gs, core::SymbolRef sym) const {
     Timer timeit(logger, "setupLSPQueryBySymbol");
     ENFORCE(sym.exists());
     vector<core::FileRef> frefs;
@@ -79,7 +79,7 @@ LSPLoop::TypecheckRun LSPLoop::setupLSPQueryBySymbol(unique_ptr<core::GlobalStat
         }
     }
 
-    return tryFastPath(move(gs), {}, frefs, core::lsp::Query::createSymbolQuery(sym));
+    return runQuery(move(gs), core::lsp::Query::createSymbolQuery(sym), frefs);
 }
 
 bool LSPLoop::ensureInitialized(LSPMethod forMethod, const LSPMessage &msg,

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -190,8 +190,10 @@ class LSPLoop {
     TypecheckRun runSlowPath(FileUpdates updates) const;
     /** Returns `true` if the given changes can run on the fast path. */
     bool canTakeFastPath(const FileUpdates &updates, const std::vector<core::FileHash> &hashes) const;
-    /** Apply conservative heuristics to see if we can run a fast path, if not, bail out and run slowPath */
+    /** Applies conservative heuristics to see if we can run incremental typechecking on the update. If not, it bails
+     * out and takes slow path. */
     TypecheckRun runTypechecking(std::unique_ptr<core::GlobalState> gs, FileUpdates updates) const;
+    /** Runs the provided query against the given files, and returns matches. */
     QueryRun runQuery(std::unique_ptr<core::GlobalState> gs, const core::lsp::Query &q,
                       const std::vector<core::FileRef> &filesForQuery) const;
     /** Officially 'commits' the output of a `TypecheckRun` by updating the relevant state on LSPLoop and, if specified,

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -191,7 +191,7 @@ class LSPLoop {
     /** Returns `true` if the given changes can run on the fast path. */
     bool canTakeFastPath(const FileUpdates &updates, const std::vector<core::FileHash> &hashes) const;
     /** Apply conservative heuristics to see if we can run a fast path, if not, bail out and run slowPath */
-    TypecheckRun tryFastPath(std::unique_ptr<core::GlobalState> gs, FileUpdates updates) const;
+    TypecheckRun runTypechecking(std::unique_ptr<core::GlobalState> gs, FileUpdates updates) const;
     QueryRun runQuery(std::unique_ptr<core::GlobalState> gs, const core::lsp::Query &q,
                       const std::vector<core::FileRef> &filesForQuery) const;
     /** Officially 'commits' the output of a `TypecheckRun` by updating the relevant state on LSPLoop and, if specified,

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -185,7 +185,10 @@ class LSPLoop {
     struct QueryRun {
         std::unique_ptr<core::GlobalState> gs;
         std::vector<std::unique_ptr<core::lsp::QueryResponse>> responses;
+        // (Optional) Error that occurred during the query that you can pass on to the client.
+        std::unique_ptr<ResponseError> error = nullptr;
     };
+
     /** Conservatively rerun entire pipeline without caching any trees */
     TypecheckRun runSlowPath(FileUpdates updates) const;
     /** Returns `true` if the given changes can run on the fast path. */
@@ -215,9 +218,9 @@ class LSPLoop {
      * Returns `nullptr` if symbol kind is not supported by LSP
      * */
     std::unique_ptr<SymbolInformation> symbolRef2SymbolInformation(const core::GlobalState &gs, core::SymbolRef) const;
-    std::variant<LSPLoop::QueryRun, std::pair<std::unique_ptr<ResponseError>, std::unique_ptr<core::GlobalState>>>
-    setupLSPQueryByLoc(std::unique_ptr<core::GlobalState> gs, std::string_view uri, const Position &pos,
-                       const LSPMethod forMethod, bool errorIfFileIsUntyped = true) const;
+    LSPLoop::QueryRun setupLSPQueryByLoc(std::unique_ptr<core::GlobalState> gs, std::string_view uri,
+                                         const Position &pos, const LSPMethod forMethod,
+                                         bool errorIfFileIsUntyped = true) const;
     QueryRun setupLSPQueryBySymbol(std::unique_ptr<core::GlobalState> gs, core::SymbolRef symbol) const;
     LSPResult handleTextDocumentHover(std::unique_ptr<core::GlobalState> gs, const MessageId &id,
                                       const TextDocumentPositionParams &params) const;

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -176,21 +176,24 @@ class LSPLoop {
     struct TypecheckRun {
         std::vector<std::unique_ptr<core::Error>> errors;
         std::vector<core::FileRef> filesTypechecked;
-        std::vector<std::unique_ptr<core::lsp::QueryResponse>> responses;
         // The global state, post-typechecking.
         std::unique_ptr<core::GlobalState> gs;
         // The edit applied to `gs`.
         LSPLoop::FileUpdates updates;
         bool tookFastPath = false;
     };
+    struct QueryRun {
+        std::unique_ptr<core::GlobalState> gs;
+        std::vector<std::unique_ptr<core::lsp::QueryResponse>> responses;
+    };
     /** Conservatively rerun entire pipeline without caching any trees */
-    TypecheckRun runSlowPath(FileUpdates updates, const core::lsp::Query &q = core::lsp::Query::noQuery()) const;
+    TypecheckRun runSlowPath(FileUpdates updates) const;
     /** Returns `true` if the given changes can run on the fast path. */
     bool canTakeFastPath(const FileUpdates &updates, const std::vector<core::FileHash> &hashes) const;
     /** Apply conservative heuristics to see if we can run a fast path, if not, bail out and run slowPath */
-    TypecheckRun tryFastPath(std::unique_ptr<core::GlobalState> gs, FileUpdates updates,
-                             const std::vector<core::FileRef> &filesForQuery = {},
-                             const core::lsp::Query &q = core::lsp::Query::noQuery()) const;
+    TypecheckRun tryFastPath(std::unique_ptr<core::GlobalState> gs, FileUpdates updates) const;
+    QueryRun runQuery(std::unique_ptr<core::GlobalState> gs, const core::lsp::Query &q,
+                      const std::vector<core::FileRef> &filesForQuery) const;
     /** Officially 'commits' the output of a `TypecheckRun` by updating the relevant state on LSPLoop and, if specified,
      * sending diagnostics to the editor. */
     LSPResult commitTypecheckRun(TypecheckRun run);
@@ -210,10 +213,10 @@ class LSPLoop {
      * Returns `nullptr` if symbol kind is not supported by LSP
      * */
     std::unique_ptr<SymbolInformation> symbolRef2SymbolInformation(const core::GlobalState &gs, core::SymbolRef) const;
-    std::variant<LSPLoop::TypecheckRun, std::pair<std::unique_ptr<ResponseError>, std::unique_ptr<core::GlobalState>>>
+    std::variant<LSPLoop::QueryRun, std::pair<std::unique_ptr<ResponseError>, std::unique_ptr<core::GlobalState>>>
     setupLSPQueryByLoc(std::unique_ptr<core::GlobalState> gs, std::string_view uri, const Position &pos,
                        const LSPMethod forMethod, bool errorIfFileIsUntyped = true) const;
-    TypecheckRun setupLSPQueryBySymbol(std::unique_ptr<core::GlobalState> gs, core::SymbolRef symbol) const;
+    QueryRun setupLSPQueryBySymbol(std::unique_ptr<core::GlobalState> gs, core::SymbolRef symbol) const;
     LSPResult handleTextDocumentHover(std::unique_ptr<core::GlobalState> gs, const MessageId &id,
                                       const TextDocumentPositionParams &params) const;
     LSPResult handleTextDocumentDocumentSymbol(std::unique_ptr<core::GlobalState> gs, const MessageId &id,

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -23,7 +23,7 @@ LSPResult LSPLoop::handleTextDocumentCodeAction(unique_ptr<core::GlobalState> gs
     updates.updatedFiles.push_back(make_shared<core::File>(string(file.data(*gs).path()),
                                                            string(file.data(*gs).source()), core::File::Type::Normal));
     // Simply querying the file in question is insufficient since indexing errors would not be detected.
-    auto run = tryFastPath(move(gs), move(updates));
+    auto run = runTypechecking(move(gs), move(updates));
 
     auto loc = range2Loc(*run.gs, *params.range.get(), file);
     for (auto &error : run.errors) {

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -202,7 +202,7 @@ LSPResult LSPLoop::handleTextDocumentCompletion(unique_ptr<core::GlobalState> gs
     auto result =
         setupLSPQueryByLoc(move(gs), params.textDocument->uri, *params.position, LSPMethod::TextDocumentCompletion);
 
-    if (auto run = get_if<TypecheckRun>(&result)) {
+    if (auto run = get_if<QueryRun>(&result)) {
         gs = move(run->gs);
         auto &queryResponses = run->responses;
         vector<unique_ptr<CompletionItem>> items;

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -201,10 +201,13 @@ LSPResult LSPLoop::handleTextDocumentCompletion(unique_ptr<core::GlobalState> gs
 
     auto result =
         setupLSPQueryByLoc(move(gs), params.textDocument->uri, *params.position, LSPMethod::TextDocumentCompletion);
+    gs = move(result.gs);
 
-    if (auto run = get_if<QueryRun>(&result)) {
-        gs = move(run->gs);
-        auto &queryResponses = run->responses;
+    if (result.error) {
+        // An error happened while setting up the query.
+        response->error = move(result.error);
+    } else {
+        auto &queryResponses = result.responses;
         vector<unique_ptr<CompletionItem>> items;
         if (!queryResponses.empty()) {
             auto resp = move(queryResponses[0]);
@@ -240,13 +243,6 @@ LSPResult LSPLoop::handleTextDocumentCompletion(unique_ptr<core::GlobalState> gs
             }
         }
         response->result = make_unique<CompletionList>(false, move(items));
-    } else if (auto error = get_if<pair<unique_ptr<ResponseError>, unique_ptr<core::GlobalState>>>(&result)) {
-        // An error happened while setting up the query.
-        response->error = move(error->first);
-        gs = move(error->second);
-    } else {
-        // Should never happen, but satisfy the compiler.
-        ENFORCE(false, "Internal error: setupLSPQueryByLoc returned invalid value.");
     }
     return LSPResult::make(move(gs), move(response));
 }

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -17,7 +17,7 @@ LSPResult LSPLoop::handleTextDocumentDefinition(unique_ptr<core::GlobalState> gs
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.definition");
     auto result = setupLSPQueryByLoc(move(gs), params.textDocument->uri, *params.position,
                                      LSPMethod::TextDocumentDefinition, false);
-    if (auto run = get_if<TypecheckRun>(&result)) {
+    if (auto run = get_if<QueryRun>(&result)) {
         gs = move(run->gs);
         auto &queryResponses = run->responses;
         vector<unique_ptr<Location>> result;

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -17,9 +17,12 @@ LSPResult LSPLoop::handleTextDocumentDefinition(unique_ptr<core::GlobalState> gs
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.definition");
     auto result = setupLSPQueryByLoc(move(gs), params.textDocument->uri, *params.position,
                                      LSPMethod::TextDocumentDefinition, false);
-    if (auto run = get_if<QueryRun>(&result)) {
-        gs = move(run->gs);
-        auto &queryResponses = run->responses;
+    gs = move(result.gs);
+    if (result.error) {
+        // An error happened while setting up the query.
+        response->error = move(result.error);
+    } else {
+        auto &queryResponses = result.responses;
         vector<unique_ptr<Location>> result;
         if (!queryResponses.empty()) {
             const bool fileIsTyped =
@@ -46,13 +49,6 @@ LSPResult LSPLoop::handleTextDocumentDefinition(unique_ptr<core::GlobalState> gs
             }
         }
         response->result = move(result);
-    } else if (auto error = get_if<pair<unique_ptr<ResponseError>, unique_ptr<core::GlobalState>>>(&result)) {
-        // An error happened while setting up the query.
-        response->error = move(error->first);
-        gs = move(error->second);
-    } else {
-        // Should never happen, but satisfy the compiler.
-        ENFORCE(false, "Internal error: setupLSPQueryByLoc returned invalid value.");
     }
     return LSPResult::make(move(gs), move(response));
 }

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -38,9 +38,12 @@ LSPResult LSPLoop::handleTextDocumentHover(unique_ptr<core::GlobalState> gs, con
 
     auto result =
         setupLSPQueryByLoc(move(gs), params.textDocument->uri, *params.position, LSPMethod::TextDocumentHover);
-    if (auto run = get_if<QueryRun>(&result)) {
-        gs = move(run->gs);
-        auto &queryResponses = run->responses;
+    gs = move(result.gs);
+    if (result.error) {
+        // An error happened while setting up the query.
+        response->error = move(result.error);
+    } else {
+        auto &queryResponses = result.responses;
         if (queryResponses.empty()) {
             // Note: Need to specifically specify the variant type here so the null gets placed into the proper slot.
             response->result = variant<JSONNullObject, unique_ptr<Hover>>(JSONNullObject());
@@ -76,13 +79,6 @@ LSPResult LSPLoop::handleTextDocumentHover(unique_ptr<core::GlobalState> gs, con
             response->result =
                 make_unique<Hover>(formatRubyCode(clientHoverMarkupKind, resp->getRetType()->showWithMoreInfo(*gs)));
         }
-    } else if (auto error = get_if<pair<unique_ptr<ResponseError>, unique_ptr<core::GlobalState>>>(&result)) {
-        // An error happened while setting up the query.
-        response->error = move(error->first);
-        gs = move(error->second);
-    } else {
-        // Should never happen, but satisfy the compiler.
-        ENFORCE(false, "Internal error: setupLSPQueryByLoc returned invalid value.");
     }
     return LSPResult::make(move(gs), move(response));
 }

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -38,7 +38,7 @@ LSPResult LSPLoop::handleTextDocumentHover(unique_ptr<core::GlobalState> gs, con
 
     auto result =
         setupLSPQueryByLoc(move(gs), params.textDocument->uri, *params.position, LSPMethod::TextDocumentHover);
-    if (auto run = get_if<TypecheckRun>(&result)) {
+    if (auto run = get_if<QueryRun>(&result)) {
         gs = move(run->gs);
         auto &queryResponses = run->responses;
         if (queryResponses.empty()) {

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -25,12 +25,15 @@ LSPResult LSPLoop::handleTextDocumentReferences(unique_ptr<core::GlobalState> gs
 
     auto result = setupLSPQueryByLoc(move(gs), params.textDocument->uri, *params.position,
                                      LSPMethod::TextDocumentCompletion, false);
-    if (auto run1 = get_if<QueryRun>(&result)) {
-        gs = move(run1->gs);
+    gs = move(result.gs);
+    if (result.error) {
+        // An error happened while setting up the query.
+        response->error = move(result.error);
+    } else {
         // An explicit null indicates that we don't support this request (or that nothing was at the location).
         // Note: Need to correctly type variant here so it goes into right 'slot' of result variant.
         response->result = variant<JSONNullObject, vector<unique_ptr<Location>>>(JSONNullObject());
-        auto &queryResponses = run1->responses;
+        auto &queryResponses = result.responses;
         if (!queryResponses.empty()) {
             const bool fileIsTyped =
                 uri2FileRef(params.textDocument->uri).data(*gs).strictLevel >= core::StrictLevel::True;
@@ -66,13 +69,6 @@ LSPResult LSPLoop::handleTextDocumentReferences(unique_ptr<core::GlobalState> gs
                 response->result = move(locations);
             }
         }
-    } else if (auto error = get_if<pair<unique_ptr<ResponseError>, unique_ptr<core::GlobalState>>>(&result)) {
-        // An error happened while setting up the query.
-        response->error = move(error->first);
-        gs = move(error->second);
-    } else {
-        // Should never happen, but satisfy the compiler.
-        ENFORCE(false, "Internal error: setupLSPQueryByLoc returned invalid value.");
     }
     return LSPResult::make(move(gs), move(response));
 }

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -60,7 +60,7 @@ LSPResult LSPLoop::handleTextSignatureHelp(unique_ptr<core::GlobalState> gs, con
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.signatureHelp");
     auto result =
         setupLSPQueryByLoc(move(gs), params.textDocument->uri, *params.position, LSPMethod::TextDocumentSignatureHelp);
-    if (auto run = get_if<TypecheckRun>(&result)) {
+    if (auto run = get_if<QueryRun>(&result)) {
         gs = move(run->gs);
         auto &queryResponses = run->responses;
         int activeParameter = -1;

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -60,9 +60,12 @@ LSPResult LSPLoop::handleTextSignatureHelp(unique_ptr<core::GlobalState> gs, con
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.signatureHelp");
     auto result =
         setupLSPQueryByLoc(move(gs), params.textDocument->uri, *params.position, LSPMethod::TextDocumentSignatureHelp);
-    if (auto run = get_if<QueryRun>(&result)) {
-        gs = move(run->gs);
-        auto &queryResponses = run->responses;
+    gs = move(result.gs);
+    if (result.error) {
+        // An error happened while setting up the query.
+        response->error = move(result.error);
+    } else {
+        auto &queryResponses = result.responses;
         int activeParameter = -1;
         vector<unique_ptr<SignatureInformation>> signatures;
         if (!queryResponses.empty()) {
@@ -97,12 +100,6 @@ LSPResult LSPLoop::handleTextSignatureHelp(unique_ptr<core::GlobalState> gs, con
             result->activeParameter = activeParameter;
         }
         response->result = move(result);
-    } else if (auto error = get_if<pair<unique_ptr<ResponseError>, unique_ptr<core::GlobalState>>>(&result)) {
-        // An error happened while setting up the query.
-        response->error = move(error->first);
-    } else {
-        // Should never happen, but satisfy the compiler.
-        ENFORCE(false, "Internal error: setupLSPQueryByLoc returned invalid value.");
     }
     return LSPResult::make(move(gs), move(response));
 }

--- a/main/lsp/requests/sorbet_workspace_edit.cc
+++ b/main/lsp/requests/sorbet_workspace_edit.cc
@@ -126,7 +126,7 @@ LSPLoop::commitSorbetWorkspaceEdits(unique_ptr<core::GlobalState> gs,
             }
             fileUpdates.updatedFiles.push_back(move(file));
         }
-        return tryFastPath(move(gs), move(fileUpdates));
+        return runTypechecking(move(gs), move(fileUpdates));
     } else {
         return TypecheckRun{{}, {}, move(gs), {}, true};
     }

--- a/main/lsp/requests/sorbet_workspace_edit.cc
+++ b/main/lsp/requests/sorbet_workspace_edit.cc
@@ -128,7 +128,7 @@ LSPLoop::commitSorbetWorkspaceEdits(unique_ptr<core::GlobalState> gs,
         }
         return tryFastPath(move(gs), move(fileUpdates));
     } else {
-        return TypecheckRun{{}, {}, {}, move(gs), {}, true};
+        return TypecheckRun{{}, {}, move(gs), {}, true};
     }
 }
 

--- a/main/lsp/updates.cc
+++ b/main/lsp/updates.cc
@@ -276,7 +276,7 @@ bool LSPLoop::canTakeFastPath(const FileUpdates &updates, const vector<core::Fil
     return true;
 }
 
-LSPLoop::TypecheckRun LSPLoop::tryFastPath(unique_ptr<core::GlobalState> gs, FileUpdates updates) const {
+LSPLoop::TypecheckRun LSPLoop::runTypechecking(unique_ptr<core::GlobalState> gs, FileUpdates updates) const {
     // We assume gs is a copy of initialGS, which has had the inferencer & resolver run.
     ENFORCE(gs->lspTypecheckCount > 0,
             "Tried to run fast path with a GlobalState object that never had inferencer and resolver runs.");

--- a/main/lsp/updates.cc
+++ b/main/lsp/updates.cc
@@ -377,12 +377,14 @@ LSPLoop::QueryRun LSPLoop::runQuery(unique_ptr<core::GlobalState> gs, const core
     }
 
     ENFORCE(gs->lspQuery.isEmpty());
+    gs->lspQuery = q;
     auto resolved = pipeline::incrementalResolve(*gs, move(updatedIndexed), opts);
     tryApplyDefLocSaver(*gs, resolved);
     tryApplyLocalVarSaver(*gs, resolved);
     pipeline::typecheck(gs, move(resolved), opts, workers);
     auto out = initialGS->errorQueue->drainWithQueryResponses();
     gs->lspTypecheckCount++;
+    gs->lspQuery = core::lsp::Query::noQuery();
     return QueryRun{move(gs), move(out.second)};
 }
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/updates.cc
+++ b/main/lsp/updates.cc
@@ -198,7 +198,7 @@ void tryApplyDefLocSaver(const core::GlobalState &gs, vector<ast::ParsedFile> &i
     }
 }
 
-LSPLoop::TypecheckRun LSPLoop::runSlowPath(FileUpdates updates, const core::lsp::Query &q) const {
+LSPLoop::TypecheckRun LSPLoop::runSlowPath(FileUpdates updates) const {
     ShowOperation slowPathOp(*this, "SlowPath", "Typechecking...");
     Timer timeit(logger, "slow_path");
     ENFORCE(initialGS->errorQueue->isEmpty());
@@ -232,10 +232,7 @@ LSPLoop::TypecheckRun LSPLoop::runSlowPath(FileUpdates updates, const core::lsp:
     }
 
     ENFORCE(finalGS->lspQuery.isEmpty());
-    finalGS->lspQuery = q;
     auto resolved = pipeline::resolve(finalGS, move(indexedCopies), opts, workers, skipConfigatron);
-    tryApplyDefLocSaver(*finalGS, resolved);
-    tryApplyLocalVarSaver(*finalGS, resolved);
     vector<core::FileRef> affectedFiles;
     for (auto &tree : resolved) {
         ENFORCE(tree.file.exists());
@@ -245,7 +242,7 @@ LSPLoop::TypecheckRun LSPLoop::runSlowPath(FileUpdates updates, const core::lsp:
     auto out = initialGS->errorQueue->drainWithQueryResponses();
     finalGS->lspTypecheckCount++;
     finalGS->lspQuery = core::lsp::Query::noQuery();
-    return TypecheckRun{move(out.first), move(affectedFiles), move(out.second), move(finalGS), move(updates), false};
+    return TypecheckRun{move(out.first), move(affectedFiles), move(finalGS), move(updates), false};
 }
 
 bool LSPLoop::canTakeFastPath(const FileUpdates &updates, const vector<core::FileHash> &hashes) const {
@@ -279,12 +276,9 @@ bool LSPLoop::canTakeFastPath(const FileUpdates &updates, const vector<core::Fil
     return true;
 }
 
-LSPLoop::TypecheckRun LSPLoop::tryFastPath(unique_ptr<core::GlobalState> gs, FileUpdates updates,
-                                           const vector<core::FileRef> &filesForQuery,
-                                           const core::lsp::Query &q) const {
-    auto finalGs = move(gs);
-    // We assume finalGs is a copy of initialGS, which has had the inferencer & resolver run.
-    ENFORCE(finalGs->lspTypecheckCount > 0,
+LSPLoop::TypecheckRun LSPLoop::tryFastPath(unique_ptr<core::GlobalState> gs, FileUpdates updates) const {
+    // We assume gs is a copy of initialGS, which has had the inferencer & resolver run.
+    ENFORCE(gs->lspTypecheckCount > 0,
             "Tried to run fast path with a GlobalState object that never had inferencer and resolver runs.");
 
     bool takeFastPath = false;
@@ -311,7 +305,7 @@ LSPLoop::TypecheckRun LSPLoop::tryFastPath(unique_ptr<core::GlobalState> gs, Fil
                         changedHashes.emplace_back(p.first);
                     }
                 }
-                finalGs = core::GlobalState::replaceFile(move(finalGs), fref, f);
+                gs = core::GlobalState::replaceFile(move(gs), fref, f);
                 subset.emplace_back(fref);
             }
             // Note: We may not have an id yet for this file if it is brand new, so we store hashes with their paths.
@@ -331,7 +325,7 @@ LSPLoop::TypecheckRun LSPLoop::tryFastPath(unique_ptr<core::GlobalState> gs, Fil
             if (!intersection.empty()) {
                 auto ref = core::FileRef(i);
                 logger->debug("Added {} to update set as used a changed method",
-                              !ref.exists() ? "" : ref.data(*finalGs).path());
+                              !ref.exists() ? "" : ref.data(*gs).path());
                 subset.emplace_back(ref);
             }
         }
@@ -347,33 +341,48 @@ LSPLoop::TypecheckRun LSPLoop::tryFastPath(unique_ptr<core::GlobalState> gs, Fil
             unique_ptr<KeyValueStore> kvstore; // nullptr
             // TODO: Thread through kvstore.
             ENFORCE(this->kvstore == nullptr);
-            auto t = pipeline::indexOne(opts, *finalGs, f, kvstore);
+            auto t = pipeline::indexOne(opts, *gs, f, kvstore);
             updatedIndexed.emplace_back(ast::ParsedFile{t.tree->deepCopy(), t.file});
             updates.updatedFileIndexes.push_back(move(t));
         }
 
-        for (auto &f : filesForQuery) {
-            const int id = f.id();
-            const auto it = indexedFinalGS.find(id);
-            const auto &parsedFile = it == indexedFinalGS.end() ? indexed[id] : it->second;
-            if (parsedFile.tree) {
-                updatedIndexed.emplace_back(ast::ParsedFile{parsedFile.tree->deepCopy(), parsedFile.file});
-            }
-        }
-        subset.insert(subset.end(), filesForQuery.begin(), filesForQuery.end());
-
-        ENFORCE(finalGs->lspQuery.isEmpty());
-        finalGs->lspQuery = q;
-        auto resolved = pipeline::incrementalResolve(*finalGs, move(updatedIndexed), opts);
-        tryApplyDefLocSaver(*finalGs, resolved);
-        tryApplyLocalVarSaver(*finalGs, resolved);
-        pipeline::typecheck(finalGs, move(resolved), opts, workers);
+        ENFORCE(gs->lspQuery.isEmpty());
+        auto resolved = pipeline::incrementalResolve(*gs, move(updatedIndexed), opts);
+        pipeline::typecheck(gs, move(resolved), opts, workers);
         auto out = initialGS->errorQueue->drainWithQueryResponses();
-        finalGs->lspTypecheckCount++;
-        finalGs->lspQuery = core::lsp::Query::noQuery();
-        return TypecheckRun{move(out.first), move(subset), move(out.second), move(finalGs), move(updates), true};
+        gs->lspTypecheckCount++;
+        return TypecheckRun{move(out.first), move(subset), move(gs), move(updates), true};
     } else {
         return runSlowPath(move(updates));
     }
+}
+
+LSPLoop::QueryRun LSPLoop::runQuery(unique_ptr<core::GlobalState> gs, const core::lsp::Query &q,
+                                    const vector<core::FileRef> &filesForQuery) const {
+    // We assume gs is a copy of initialGS, which has had the inferencer & resolver run.
+    ENFORCE(gs->lspTypecheckCount > 0,
+            "Tried to run a query with a GlobalState object that never had inferencer and resolver runs.");
+
+    Timer timeit(logger, "query");
+    prodCategoryCounterInc("lsp.updates", "query");
+    ENFORCE(initialGS->errorQueue->isEmpty());
+    vector<ast::ParsedFile> updatedIndexed;
+    for (auto &f : filesForQuery) {
+        const int id = f.id();
+        const auto it = indexedFinalGS.find(id);
+        const auto &parsedFile = it == indexedFinalGS.end() ? indexed[id] : it->second;
+        if (parsedFile.tree) {
+            updatedIndexed.emplace_back(ast::ParsedFile{parsedFile.tree->deepCopy(), parsedFile.file});
+        }
+    }
+
+    ENFORCE(gs->lspQuery.isEmpty());
+    auto resolved = pipeline::incrementalResolve(*gs, move(updatedIndexed), opts);
+    tryApplyDefLocSaver(*gs, resolved);
+    tryApplyLocalVarSaver(*gs, resolved);
+    pipeline::typecheck(gs, move(resolved), opts, workers);
+    auto out = initialGS->errorQueue->drainWithQueryResponses();
+    gs->lspTypecheckCount++;
+    return QueryRun{move(gs), move(out.second)};
 }
 } // namespace sorbet::realmain::lsp


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Separates query runs from typechecking runs. Also renames `tryFastPath` to `runTypechecking`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Query runs make *no* mutations to the file table, and require special AST passes to respond to queries.

Typechecker runs *always* mutate the file table, and do not require special AST passes.

By separating the two, we enforce that query runs *never* mutate the file table. We also clean up control flow in `runTypechecking`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
