### PR TITLE
Fix #lambda? definition on Proc RBI

### DIFF
--- a/rbi/core/proc.rbi
+++ b/rbi/core/proc.rbi
@@ -35,7 +35,7 @@ class Proc < Object
   def hash(); end
 
   sig {returns(T::Boolean)}
-  def lambda(); end
+  def lambda?(); end
 
   sig {returns(T::Array[[Symbol, Symbol]])}
   def parameters(); end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The `Proc#lambda?` method in the core RBI was previously typoed as `Proc#lambda`. This PR resolves this.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This caused static checks to fail which would have been valid at runtime, and also meant that the static checks allowed the non-existant `Proc#lambda` method to be called.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
This is a simple typo fix and doesn't need tests.
