### PR TITLE
fix type signatures for Array methods (permutation/combination)

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1289,7 +1289,7 @@ class Array < Object
     params(
         arg0: Integer,
     )
-    .returns(T::Enumerator[Elem])
+    .returns(T::Enumerator[T::Array[Elem]])
   end
   sig do
     params(
@@ -1476,7 +1476,7 @@ class Array < Object
     params(
         arg0: Integer,
     )
-    .returns(T::Enumerator[Elem])
+    .returns(T::Enumerator[T::Array[Elem]])
   end
   def repeated_combination(arg0, &blk); end
 
@@ -1511,7 +1511,7 @@ class Array < Object
     params(
         arg0: Integer,
     )
-    .returns(T::Enumerator[Elem])
+    .returns(T::Enumerator[T::Array[Elem]])
   end
   def repeated_permutation(arg0, &blk); end
 

--- a/test/testdata/rbi/array.rb
+++ b/test/testdata/rbi/array.rb
@@ -20,6 +20,18 @@ T.assert_type!([1,2].zip([2]), T::Array[[Integer, T.nilable(Integer)]])
 
 [1, 2] - [1, nil]
 
+# array permutation/combinations with no block
+T.assert_type!([1,2].permutation, T::Enumerator[T::Array[Integer]])
+T.assert_type!([1,2].repeated_permutation(1), T::Enumerator[T::Array[Integer]])
+T.assert_type!([1,2].combination(1), T::Enumerator[T::Array[Integer]])
+T.assert_type!([1,2].repeated_combination(1), T::Enumerator[T::Array[Integer]])
+
+# array permutation/combinations with a block
+T.assert_type!([1,2].permutation {}, T::Array[Integer])
+T.assert_type!([1,2].repeated_permutation(1) {}, T::Array[Integer])
+T.assert_type!([1,2].combination(1) {}, T::Array[Integer])
+T.assert_type!([1,2].repeated_combination(1) {}, T::Array[Integer])
+
 # errors
 
 T::Array[Float].new.sum.nan? # error: Method `nan?` does not exist on `Integer` component of `T.any(Integer, Float)`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
updates Array permutation/combination type signatures

Array#permutation returns an Enumerator of permutations, `T::Enumerator[T::Array[Elem]]`
(T::Array[Elem]) when there is no block. If there is a block, the methods just return the input, which is `T::Array[Elem]`.

Corrects

    Array#permutation
    Array#repeated_permutation
    Array#repeated_combination


Array#combination appears to have already been fixed to have the correct signature in #1131.

See https://sorbet.run/#%23%20typed%3A%20true%0A%0Aextend%20T%3A%3ASig%0A%0Asig%20%7Bparams(val%3A%20T%3A%3AArray%5BInteger%5D).void%7D%0Adef%20foo(val)%0A%20%20val%0Aend%0A%0Aresult%20%3D%20%5B1%2C2%2C3%5D.permutation.to_a%0A%23%20%3D%3E%20%5B%5B1%2C%202%2C%203%5D%2C%20%5B1%2C%203%2C%202%5D%2C%20%5B2%2C%201%2C%203%5D%2C%20%5B2%2C%203%2C%201%5D%2C%20%5B3%2C%201%2C%202%5D%2C%20%5B3%2C%202%2C%201%5D%5D%0A%0AT.assert_type!(result%2C%20T%3A%3AArray%5BT%3A%3AArray%5BInteger%5D%5D)%0A%0A%23%20See%20https%3A%2F%2Fruby-doc.org%2Fcore-2.2.0%2FArray.html%23method-i-permutation%0A%23%20m%20should%20be%20a%20T%3A%3AArray%5BInteger%5D

(cc @elliottt, as we discussed this over slack)

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
fixing incorrect type signatures :)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I added in some tests. Is this the right thing to do for type signature changes, if necessary?
