### PR TITLE
Fix the snapshot update script

### DIFF
--- a/gems/sorbet/test/snapshot/update_one_bazel.sh
+++ b/gems/sorbet/test/snapshot/update_one_bazel.sh
@@ -33,7 +33,7 @@ info "├─ test_dir: $test_dir"
 
   # ----- Unpack the results archive -----
   info "├─ Unpacking test archive"
-  tar -xvf actual.tar.gz
+  tar -xvf "$(basename "${archive_path}")"
 
 
   # ----- Update sorbet/ -----


### PR DESCRIPTION
The `update_one_bazel.sh` script wasn't updated when support for ruby-2.6 was added.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Make `tools/scripts/update_exp_files.sh` work again.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
I've run the individual update rules successfully locally, and am re-running the whole script.
