### PR TITLE
Abstract common setup steps from check/update

### DIFF
--- a/gems/sorbet/test/snapshot/BUILD
+++ b/gems/sorbet/test/snapshot/BUILD
@@ -5,6 +5,12 @@ sh_library(
     srcs = ["logging.sh"],
 )
 
+sh_library(
+    name = "validate_utils",
+    srcs = ["validate_utils.sh"],
+    deps = [":logging"],
+)
+
 sh_binary(
     name = "run_one_bazel",
     srcs = ["run_one_bazel.sh"],

--- a/gems/sorbet/test/snapshot/check_one_bazel.sh
+++ b/gems/sorbet/test/snapshot/check_one_bazel.sh
@@ -6,94 +6,69 @@ set -euo pipefail
 shopt -s dotglob
 
 source "gems/sorbet/test/snapshot/logging.sh"
+source "gems/sorbet/test/snapshot/validate_utils.sh"
 
-# ----- Option parsing -----
-
-test_name=$1
-archive_path=$2
-
-if [[ "${test_name}" =~ partial/* ]]; then
-  is_partial=1
-else
-  is_partial=
-fi
-
-info "├─ test_name:    ${test_name}"
-info "├─ archive_path: ${archive_path}"
-info "├─ is_partial:   ${is_partial:-0}"
-
-# ----- Environment setup -----
-
-repo_root=$PWD
-
-test_dir="${repo_root}/gems/sorbet/test/snapshot/${test_name}"
+setup_validate_env "$@"
 
 # ----- Artifact validation -----
 
-(
-  cd "$test_dir"
+# ----- Check out.log -----
 
-  info "├─ Extracting test artifacts"
-  tar -xvf "$(basename "${archive_path}")"
-
-  # ----- Check out.log -----
-
-  info "Checking output log"
-  if [ "$is_partial" = "" ] || [ -f "expected/out.log" ]; then
-    if ! diff -u "expected/out.log" "actual/out.log"; then
-      error "├─ expected out.log did not match actual out.log"
-      error "└─ see output above."
-      exit 1
-    fi
+info "Checking output log"
+if [ "$is_partial" = "" ] || [ -f "expected/out.log" ]; then
+  if ! diff -u "expected/out.log" "actual/out.log"; then
+    error "├─ expected out.log did not match actual out.log"
+    error "└─ see output above."
+    exit 1
   fi
+fi
 
-  # ----- Check err.log -----
+# ----- Check err.log -----
 
-  if [ "$is_partial" = "" ] || [ -f "expected/err.log" ]; then
-    if ! diff -u "expected/err.log" "actual/err.log"; then
-      error "├─ expected err.log did not match actual err.log"
-      error "└─ see output above."
-      exit 1
-    fi
+if [ "$is_partial" = "" ] || [ -f "expected/err.log" ]; then
+  if ! diff -u "expected/err.log" "actual/err.log"; then
+    error "├─ expected err.log did not match actual err.log"
+    error "└─ see output above."
+    exit 1
   fi
+fi
 
-  # ----- Check sorbet/ -----
+# ----- Check sorbet/ -----
 
-  diff_total() {
-    info "├─ checking for total match"
-    if ! diff -ur "expected/sorbet" "actual/sorbet"; then
-      error "├─ expected sorbet/ folder did not match actual sorbet/ folder"
-      error "└─ see output above."
-      exit 1
-    fi
-  }
-
-  diff_partial() {
-    info "├─ checking for partial match"
-
-    set +e
-    diff -ur "expected/sorbet" "actual/sorbet" | \
-      grep -vF "Only in actual" > "partial-diff.log"
-    set -e
-
-    # File exists and is non-empty
-    if [ -s "partial-diff.log" ]; then
-      cat "partial-diff.log"
-      error "├─ expected sorbet/ folder did not match actual sorbet/ folder"
-      error "└─ see output above."
-      exit 1
-    fi
-  }
-
-  if [ "$is_partial" = "" ]; then
-    diff_total
-  elif [ -d "expected/sorbet" ]; then
-    diff_partial
-  else
-    # It's fine for a partial test to not have an expected dir.
-    # It means the test only cares about the exit code of srb init.
-    true
+diff_total() {
+  info "├─ checking for total match"
+  if ! diff -ur "expected/sorbet" "actual/sorbet"; then
+    error "├─ expected sorbet/ folder did not match actual sorbet/ folder"
+    error "└─ see output above."
+    exit 1
   fi
+}
 
-  success "└─ test passed."
-)
+diff_partial() {
+  info "├─ checking for partial match"
+
+  set +e
+  diff -ur "expected/sorbet" "actual/sorbet" | \
+    grep -vF "Only in actual" > "partial-diff.log"
+  set -e
+
+  # File exists and is non-empty
+  if [ -s "partial-diff.log" ]; then
+    cat "partial-diff.log"
+    error "├─ expected sorbet/ folder did not match actual sorbet/ folder"
+    error "└─ see output above."
+    exit 1
+  fi
+}
+
+if [ "$is_partial" = "" ]; then
+  diff_total
+elif [ -d "expected/sorbet" ]; then
+  diff_partial
+else
+  # It's fine for a partial test to not have an expected dir.
+  # It means the test only cares about the exit code of srb init.
+  true
+fi
+
+cleanup_validation

--- a/gems/sorbet/test/snapshot/snapshot.bzl
+++ b/gems/sorbet/test/snapshot/snapshot.bzl
@@ -87,10 +87,10 @@ def _snapshot_test(test_path, ruby):
             "{}/expected/**/*".format(test_path),
             "{}/gems/**/*".format(test_path),
         ]),
-        deps = [":logging"],
+        deps = [":logging", ":validate_utils"],
         args = [
-            test_path,
             "$(location {})".format(actual),
+            test_path,
         ],
 
         # NOTE: this is manual to avoid being caught with `//...`
@@ -111,11 +111,10 @@ def _snapshot_test(test_path, ruby):
         native.sh_test(
             name = update_name,
             data = [actual] + expected,
-            deps = [":logging"],
+            deps = [":logging", ":validate_utils"],
             srcs = ["update_one_bazel.sh"],
             args = [
                 "$(location {})".format(actual),
-                "$(location {}/expected)".format(test_path),
                 test_path,
             ],
 

--- a/gems/sorbet/test/snapshot/update_one_bazel.sh
+++ b/gems/sorbet/test/snapshot/update_one_bazel.sh
@@ -3,111 +3,81 @@
 set -euo pipefail
 shopt -s dotglob
 
-root_dir="$PWD"
-
 # shellcheck disable=SC1090
-source "$root_dir/gems/sorbet/test/snapshot/logging.sh"
+source "gems/sorbet/test/snapshot/logging.sh"
+source "gems/sorbet/test/snapshot/validate_utils.sh"
 
-# ----- Option parsing -----
+setup_validate_env "$@"
 
-archive_path=$1
-update_path=$2
-test_name=$3
+# ----- Update sorbet/ -----
 
-test_dir="${root_dir}/gems/sorbet/test/snapshot/${test_name}"
+diff_total() {
+  if ! diff -ur "expected/sorbet" "actual/sorbet"; then
+    attn "├─ updating expected/sorbet (total):"
+    rm -rf "$test_dir/expected/sorbet"
+    mkdir -p "$test_dir/expected"
+    cp -r "actual/sorbet" "$test_dir/expected"
+  fi
+}
 
-if [[ "${test_name}" =~ partial/* ]]; then
-  is_partial=1
+diff_partial() {
+  set +e
+  diff -ur "expected" "actual" | \
+    grep -vF "Only in actual" \
+    > "actual/partial-diff.log"
+  set -e
+
+  # File exists and is non-empty
+  if [ -s "actual/partial-diff.log" ]; then
+    attn "├─ updating expected/sorbet (partial):"
+
+    find "$test_dir/expected/sorbet" -print0 | while IFS= read -r -d '' expected_path; do
+      path_suffix="${expected_path#$test_dir/expected/sorbet}"
+      actual_path="actual/sorbet$path_suffix"
+
+      # Only ever update existing files, never grow this partial snapshot.
+      if [ -d "$expected_path" ]; then
+        if ! [ -d "$actual_path" ]; then
+          info "├─ removing dir: $expected_path"
+          rm -rfv "$expected_path"
+        fi
+      else
+        if [ -f "$actual_path" ]; then
+          info "├─ updating file: $expected_path"
+          cp -v "$actual_path" "$expected_path"
+        else
+          info "├─ removing file: $expected_path"
+          rm -fv "$expected_path"
+        fi
+      fi
+    done
+  fi
+}
+
+if [ -d expected/sorbet ]; then
+  if [ "$is_partial" = "" ]; then
+    info "├─ Performing total diff"
+    diff_total
+  else
+    info "├─ Performing partial diff"
+
+    # we know that there's an expected dir, as that is a pre-requesite for this
+    # test to be run by bazel
+    diff_partial
+  fi
 else
-  is_partial=
+  attn "├─ missing expected/sorbet directory, skipping update"
 fi
 
-info "├─ archive_path: $archive_path"
-info "├─ update_path: $update_path"
-info "├─ test_name: $test_name"
-info "├─ is_partial: ${is_partial:-}"
-info "├─ test_dir: $test_dir"
+# ----- Update logs -----
+if [ -f "expected/err.log" ]; then
+  info "├─ updating err.log"
+  cp actual/err.log expected/err.log
+fi
 
-(
-  cd "$test_dir"
+if [ -f "expected/out.log" ]; then
+  info "├─ updating out.log"
+  cp actual/out.log expected/out.log
+fi
 
-  # ----- Unpack the results archive -----
-  info "├─ Unpacking test archive"
-  tar -xvf "$(basename "${archive_path}")"
-
-
-  # ----- Update sorbet/ -----
-
-  diff_total() {
-    if ! diff -ur "expected/sorbet" "actual/sorbet"; then
-      attn "├─ updating expected/sorbet (total):"
-      rm -rf "$test_dir/expected/sorbet"
-      mkdir -p "$test_dir/expected"
-      cp -r "actual/sorbet" "$test_dir/expected"
-    fi
-  }
-
-  diff_partial() {
-    set +e
-    diff -ur "expected" "actual" | \
-      grep -vF "Only in actual" \
-      > "actual/partial-diff.log"
-    set -e
-
-    # File exists and is non-empty
-    if [ -s "actual/partial-diff.log" ]; then
-      attn "├─ updating expected/sorbet (partial):"
-
-      find "$test_dir/expected/sorbet" -print0 | while IFS= read -r -d '' expected_path; do
-        path_suffix="${expected_path#$test_dir/expected/sorbet}"
-        actual_path="actual/sorbet$path_suffix"
-
-        # Only ever update existing files, never grow this partial snapshot.
-        if [ -d "$expected_path" ]; then
-          if ! [ -d "$actual_path" ]; then
-            info "├─ removing dir: $expected_path"
-            rm -rfv "$expected_path"
-          fi
-        else
-          if [ -f "$actual_path" ]; then
-            info "├─ updating file: $expected_path"
-            cp -v "$actual_path" "$expected_path"
-          else
-            info "├─ removing file: $expected_path"
-            rm -fv "$expected_path"
-          fi
-        fi
-      done
-    fi
-  }
-
-  if [ -d expected/sorbet ]; then
-    if [ "$is_partial" = "" ]; then
-      info "├─ Performing total diff"
-      diff_total
-    else
-      info "├─ Performing partial diff"
-
-      # we know that there's an expected dir, as that is a pre-requesite for this
-      # test to be run by bazel
-      diff_partial
-    fi
-  else
-    attn "├─ missing expected/sorbet directory, skipping update"
-  fi
-
-  # ----- Update logs -----
-  if [ -f "expected/err.log" ]; then
-    info "├─ updating err.log"
-    cp actual/err.log expected/err.log
-  fi
-
-  if [ -f "expected/out.log" ]; then
-    info "├─ updating out.log"
-    cp actual/out.log expected/out.log
-  fi
-
-  rm -rf "actual"
-
-  success "└─ test passed."
-)
+cleanup_validation

--- a/gems/sorbet/test/snapshot/validate_utils.sh
+++ b/gems/sorbet/test/snapshot/validate_utils.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Parses args assuming the fixed format:
+# 1 = archive location
+# 2 = test_path, relative to gems/sorbet/test/snapshot
+#
+# Sets the variables:
+#   repo_root    = the repo root
+#   archive_path = the value of $1
+#   test_name    = the value of $2
+#   is_partial   = 1 when the test is a partial test
+#   test_dir     = the test directory within the repository
+#   update_path  = the expected directory within test_dir
+#
+# Changes to the test_dir, and extracts the archive
+setup_validate_env() {
+  repo_root=$PWD
+
+  archive_path=$1
+  test_name=$2
+
+  if [[ "${test_name}" =~ partial/* ]]; then
+    is_partial=1
+  else
+    is_partial=
+  fi
+
+  test_dir="$repo_root/gems/sorbet/test/snapshot/$test_name"
+
+  update_path="$test_dir/expected"
+
+  info "├─ archive_path: $archive_path"
+  info "├─ update_path:  $update_path"
+  info "├─ test_name:    $test_name"
+  info "├─ is_partial:   ${is_partial:-}"
+  info "├─ test_dir:     $test_dir"
+
+  pushd "$test_dir" || fatal "Unable to change to test_dir"
+
+  info "├─ Extracting test artifacts"
+  tar -xvf "$(basename "${archive_path}")"
+}
+
+# Leave the test directory that was setup by setup_validate_env, and print a
+# success message.
+cleanup_validation() {
+
+  # Cleanup the extracted run results
+  rm -rf actual
+
+  popd || fatal "Unable to leave test_dir"
+  success "└─ test passed."
+}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Common setup code for `check_one_bazel.sh` and `update_one_bazel.sh` has been abstracted out into a separate script.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This makes their argument format the same, and reduces the possibility of environmental changes required for one not being reflected in the other.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
I ran the update script and snapshot tests locally.
