### PR TITLE
runtime: Handle `implementation` of `Enumerable::each`

### DIFF
--- a/gems/sorbet-runtime/lib/sorbet-runtime.rb
+++ b/gems/sorbet-runtime/lib/sorbet-runtime.rb
@@ -98,4 +98,5 @@ require_relative 'types/props/serializable'
 require_relative 'types/props/type_validation'
 require_relative 'types/struct'
 
+require_relative 'types/model_ext'
 require_relative 'types/compatibility_patches'

--- a/gems/sorbet-runtime/lib/types/model_ext.rb
+++ b/gems/sorbet-runtime/lib/types/model_ext.rb
@@ -1,0 +1,27 @@
+# typed: strict
+# frozen_string_literal: true
+
+# Ruby model extensions.
+#
+# `sorbet-static` relies on some definitions that exist at compile-time in the RBIs.
+# Some of these definitions will never exist in real Ruby code but `sorbet-runtime` will need them to work.
+# We define them here.
+
+module Enumerable
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(:out)
+
+  # Sorbet define `Enumerable` as an interface where `each` should be implemented
+  # by the clients with `implementation`.
+  # We define it here so `sorbet-runtime` knows what's `each` expected signature.
+
+  sig do
+    abstract.
+    params(
+        blk: T.proc.params(arg0: Elem).returns(BasicObject),
+    )
+    .returns(T.untyped)
+  end
+  def each(&blk); end
+end

--- a/gems/sorbet-runtime/test/types/enums.rb
+++ b/gems/sorbet-runtime/test/types/enums.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+module Opus::Types::Test
+  class ValidateEnumsTest < Critic::Unit::UnitTest
+
+    it "succeeds when implementing Enumerable::each" do
+      klass = Class.new(BasicObject) do
+        include Enumerable
+        extend T::Generic
+        extend T::Sig
+
+        sig {
+          implementation
+            .params(blk: T.proc.params(arg0: Integer).returns(Integer))
+            .returns(T::Enumerable[Integer])
+        }
+        def each(&blk)
+          [1, 2, 3].each do |x|
+            yield x
+          end
+        end
+      end
+      klass.new.each { |x| x + 1 }
+    end
+
+    it "raises when implementing a bad interface for Enumerable::each" do
+      klass = Class.new(BasicObject) do
+        include Enumerable
+        extend T::Generic
+        extend T::Sig
+
+        sig {
+          implementation
+            .params(blk: T.proc.params(arg0: Integer).returns(Integer))
+            .returns(T::Enumerable[Integer])
+        }
+        def each(&blk); end # does not return `T::Enumerable[Integer]`, will raise
+      end
+      err = assert_raises(TypeError) do
+        klass.new.each { |x| x + 1 }
+      end
+      assert_includes(err.message, "Return value: Expected type T::Enumerable[Integer], got type NilClass")
+    end
+
+    it "raises when implementing each while not including Enumerable" do
+      klass = Class.new(BasicObject) do
+        extend T::Generic
+        extend T::Sig
+
+        sig {
+          implementation
+            .params(blk: T.proc.params(arg0: Integer).returns(Integer))
+            .returns(T::Enumerable[Integer])
+        }
+        def each(&blk); end # does not return `T::Enumerable[Integer]`, will raise
+      end
+      err = assert_raises(RuntimeError) do
+        klass.new.each { |x| x + 1 }
+      end
+      assert_includes(err.message, "You marked `each` as .implementation, but it doesn't match up with a corresponding abstract method.")
+    end
+  end
+end


### PR DESCRIPTION
Proposal to fix #1547.

### Motivation

The following code will pass `sorbet-static` but raise with `sorbet-runtime`:

```ruby
class Foo
  include(Enumerable)
  extend(T::Sig)

  sig do
    implementation
      .params(blk: T.proc.params(arg0: Integer).returns(Integer))
      .returns(T::Enumerable[Integer])
  end
  def each(&blk)
    [1, 2, 3].each do |x|
      yield x
    end
  end
end

foo = Foo.new
foo.each { |x|
  puts x
}
```

`sorbet-runtime` will raise the following:

```
Error in `validate_non_override_mode': You marked `each` as .implementation, but it doesn't match up with a corresponding abstract method. (RuntimeError)
  Either check for typos and for missing includes or super classes to make the parent method shows up
  ... or remove .implementation here: Foo at file.rb:XX
```

### Approach

The problem here is that `sorbet-static` tries to validate the `implementation` clause by looking at the super method. In this case to validate `Foo::each` it will look for `Enumerable::each` which doesn't exist at runtime.

The proposed solution is to include a definition and its signature for `Enumerable::each` at runtime. I simply included it in [`model_ext.rb`](gems/sorbet-runtime/lib/types/model_ext.rb).

At first I tried to add a special case for that at `https://github.com/sorbet/sorbet/blob/058f4dab45e71d254e9a08edf116faa4dead6e5c/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb#L45`. But the approach needed the `Enumerable::each` method and signature to be created by hand which seemed brittle.

Since all the work to parse signatures is already done, I just added the definition and let `sorbet-static` parse and check it. Not sure this is the correct approach. Seemed the simplest and safest to do that.

### Test plan

Added two new tests to show the expected behaviour: gems/sorbet-runtime/test/types/enums.rb