### PR TITLE
Move T::Types::OpusEnum lower in the list

### DIFF
--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -20,14 +20,14 @@ module T::Utils
       T::Range[T.untyped]
     elsif val.is_a?(Module)
       T::Types::Simple.new(val) # rubocop:disable PrisonGuard/UseOpusTypesShortcut
-    elsif defined?(::Opus) && defined?(::Opus::Enum) && val.is_a?(::Opus::Enum)
-      T::Types::OpusEnum.new(val) # rubocop:disable PrisonGuard/UseOpusTypesShortcut
     elsif val.is_a?(::Array)
       T::Types::FixedArray.new(val) # rubocop:disable PrisonGuard/UseOpusTypesShortcut
     elsif val.is_a?(::Hash)
       T::Types::FixedHash.new(val) # rubocop:disable PrisonGuard/UseOpusTypesShortcut
     elsif val.is_a?(T::Private::Methods::DeclBuilder)
       T::Private::Methods.finalize_proc(val.decl)
+    elsif defined?(::Opus) && defined?(::Opus::Enum) && val.is_a?(::Opus::Enum)
+      T::Types::OpusEnum.new(val) # rubocop:disable PrisonGuard/UseOpusTypesShortcut
     else
       raise "Invalid value for type constraint. Must be an #{T::Types::Base}, a " \
             "class/module, or an array. Got a `#{val.class}`."


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Introducing this earlier in the list caused the load order to change in
pay-server (because referencing `Opus::Enum` causes `lib/enum/enum.rb`
to be required), which seems to have revealed a bug in final methods.

The loading bug reproduces with just `puts Opus::Enum` in a file that
mentions `final!`, so I'm working on identifying and fixing the root
cause. This should let us bump sorbet-runtime in pay-server in the mean
time so that people can actually use Opus::Enum in type syntax.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Failure only reproduces in behavior; no way to test yet.