### PR TITLE
Clean up update exp files

### DIFF
--- a/tools/scripts/update_exp_files.sh
+++ b/tools/scripts/update_exp_files.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+cd "$(dirname "$0")"
+cd ../..
+# we are now at the repo root.
+
 COMMAND_FILE="$(mktemp)"
 trap 'rm -f "$COMMAND_FILE"' EXIT
 

--- a/tools/scripts/update_exp_files.sh
+++ b/tools/scripts/update_exp_files.sh
@@ -53,7 +53,9 @@ for this_src in "${rb_src[@]}" DUMMY; do
       if [ "$pass" = "autogen" ]; then
         args=("--stop-after=namer --skip-dsl-passes")
       fi
-      if [ -e "$candidate" ]; then
+      if ! [ -e "$candidate" ]; then
+        continue
+      fi
         if [ "$pass" = "document-symbols" ]; then
           echo bazel-bin/test/print_document_symbols \
             "${srcs[@]}" \
@@ -69,7 +71,6 @@ for this_src in "${rb_src[@]}" DUMMY; do
             2\>/dev/null \
             >>"$COMMAND_FILE"
         fi
-      fi
     done
   fi
 

--- a/tools/scripts/update_exp_files.sh
+++ b/tools/scripts/update_exp_files.sh
@@ -40,7 +40,7 @@ basename=
 srcs=()
 
 for this_src in "${rb_src[@]}" DUMMY; do
-  this_base=${this_src%__*}
+  this_base="${this_src%__*}"
   if [ "$this_base" = "$basename" ]; then
     srcs=("${srcs[@]}" "$this_src")
     continue

--- a/tools/scripts/update_exp_files.sh
+++ b/tools/scripts/update_exp_files.sh
@@ -33,38 +33,38 @@ bazel build \
 
 # shellcheck disable=SC2207
 rb_src=(
-    $(find test/testdata -name '*.rb' | sort)
+  $(find test/testdata -name '*.rb' | sort)
 )
 
 basename=
 srcs=()
 
 for this_src in "${rb_src[@]}" DUMMY; do
-    this_base=${this_src%__*}
-    if [ "$this_base" = "$basename" ]; then
-        srcs=("${srcs[@]}" "$this_src")
-        continue
-    fi
+  this_base=${this_src%__*}
+  if [ "$this_base" = "$basename" ]; then
+    srcs=("${srcs[@]}" "$this_src")
+    continue
+  fi
 
-    if [ "$basename" ]; then
-        for pass in "${passes[@]}" ; do
-            candidate="$basename.$pass.exp"
-            args=()
-            if [ "$pass" = "autogen" ]; then
-                args=("--stop-after=namer --skip-dsl-passes")
-            fi
-            if [ -e "$candidate" ]; then
-                if [ "$pass" = "document-symbols" ]; then
-                    echo bazel-bin/test/print_document_symbols "${srcs[@]}" \> "$candidate" 2\>/dev/null >> "$COMMAND_FILE"
-                else
-                    echo bazel-bin/main/sorbet --silence-dev-message  --suppress-non-critical --censor-for-snapshot-tests --print "$pass" --max-threads 0 "${args[@]}" "${srcs[@]}" \> "$candidate" 2\>/dev/null >> "$COMMAND_FILE"
-                fi
-            fi
-        done
-    fi
+  if [ "$basename" ]; then
+    for pass in "${passes[@]}" ; do
+      candidate="$basename.$pass.exp"
+      args=()
+      if [ "$pass" = "autogen" ]; then
+        args=("--stop-after=namer --skip-dsl-passes")
+      fi
+      if [ -e "$candidate" ]; then
+        if [ "$pass" = "document-symbols" ]; then
+          echo bazel-bin/test/print_document_symbols "${srcs[@]}" \> "$candidate" 2\>/dev/null >> "$COMMAND_FILE"
+        else
+          echo bazel-bin/main/sorbet --silence-dev-message  --suppress-non-critical --censor-for-snapshot-tests --print "$pass" --max-threads 0 "${args[@]}" "${srcs[@]}" \> "$candidate" 2\>/dev/null >> "$COMMAND_FILE"
+        fi
+      fi
+    done
+  fi
 
-    basename="$this_base"
-    srcs=("$this_src")
+  basename="$this_base"
+  srcs=("$this_src")
 done
 
 parallel --joblog - < "$COMMAND_FILE"

--- a/tools/scripts/update_exp_files.sh
+++ b/tools/scripts/update_exp_files.sh
@@ -46,7 +46,7 @@ for this_src in "${rb_src[@]}" DUMMY; do
     continue
   fi
 
-  if [ "$basename" ]; then
+  if [ -n "$basename" ]; then
     for pass in "${passes[@]}"; do
       candidate="$basename.$pass.exp"
       args=()

--- a/tools/scripts/update_exp_files.sh
+++ b/tools/scripts/update_exp_files.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+
 set -e
 
-COMMAND_FILE=$(mktemp)
+COMMAND_FILE="$(mktemp)"
 trap 'rm -f "$COMMAND_FILE"' EXIT
 
 passes=(

--- a/tools/scripts/update_exp_files.sh
+++ b/tools/scripts/update_exp_files.sh
@@ -56,21 +56,21 @@ for this_src in "${rb_src[@]}" DUMMY; do
       if ! [ -e "$candidate" ]; then
         continue
       fi
-        if [ "$pass" = "document-symbols" ]; then
-          echo bazel-bin/test/print_document_symbols \
-            "${srcs[@]}" \
-            \> "$candidate" \
-            2\>/dev/null \
-            >>"$COMMAND_FILE"
-        else
-          echo bazel-bin/main/sorbet \
-            --silence-dev-message --suppress-non-critical --censor-for-snapshot-tests \
-            --print "$pass" --max-threads 0 \
-            "${args[@]}" "${srcs[@]}" \
-            \> "$candidate" \
-            2\>/dev/null \
-            >>"$COMMAND_FILE"
-        fi
+      if [ "$pass" = "document-symbols" ]; then
+        echo bazel-bin/test/print_document_symbols \
+          "${srcs[@]}" \
+          \> "$candidate" \
+          2\>/dev/null \
+          >>"$COMMAND_FILE"
+      else
+        echo bazel-bin/main/sorbet \
+          --silence-dev-message --suppress-non-critical --censor-for-snapshot-tests \
+          --print "$pass" --max-threads 0 \
+          "${args[@]}" "${srcs[@]}" \
+          \> "$candidate" \
+          2\>/dev/null \
+          >>"$COMMAND_FILE"
+      fi
     done
   fi
 

--- a/tools/scripts/update_exp_files.sh
+++ b/tools/scripts/update_exp_files.sh
@@ -47,7 +47,7 @@ for this_src in "${rb_src[@]}" DUMMY; do
   fi
 
   if [ "$basename" ]; then
-    for pass in "${passes[@]}" ; do
+    for pass in "${passes[@]}"; do
       candidate="$basename.$pass.exp"
       args=()
       if [ "$pass" = "autogen" ]; then

--- a/tools/scripts/update_exp_files.sh
+++ b/tools/scripts/update_exp_files.sh
@@ -55,9 +55,19 @@ for this_src in "${rb_src[@]}" DUMMY; do
       fi
       if [ -e "$candidate" ]; then
         if [ "$pass" = "document-symbols" ]; then
-          echo bazel-bin/test/print_document_symbols "${srcs[@]}" \> "$candidate" 2\>/dev/null >> "$COMMAND_FILE"
+          echo bazel-bin/test/print_document_symbols \
+            "${srcs[@]}" \
+            \> "$candidate" \
+            2\>/dev/null \
+            >>"$COMMAND_FILE"
         else
-          echo bazel-bin/main/sorbet --silence-dev-message  --suppress-non-critical --censor-for-snapshot-tests --print "$pass" --max-threads 0 "${args[@]}" "${srcs[@]}" \> "$candidate" 2\>/dev/null >> "$COMMAND_FILE"
+          echo bazel-bin/main/sorbet \
+            --silence-dev-message --suppress-non-critical --censor-for-snapshot-tests \
+            --print "$pass" --max-threads 0 \
+            "${args[@]}" "${srcs[@]}" \
+            \> "$candidate" \
+            2\>/dev/null \
+            >>"$COMMAND_FILE"
         fi
       fi
     done

--- a/tools/scripts/update_exp_files.sh
+++ b/tools/scripts/update_exp_files.sh
@@ -4,7 +4,26 @@ set -e
 COMMAND_FILE=$(mktemp)
 trap 'rm -f "$COMMAND_FILE"' EXIT
 
-passes=(parse-tree parse-tree-json ast ast-raw dsl-tree dsl-tree-raw symbol-table symbol-table-raw name-tree name-tree-raw resolve-tree resolve-tree-raw cfg cfg-json flattened-tree flattened-tree-raw autogen document-symbols)
+passes=(
+  parse-tree
+  parse-tree-json
+  ast
+  ast-raw
+  dsl-tree
+  dsl-tree-raw
+  symbol-table
+  symbol-table-raw
+  name-tree
+  name-tree-raw
+  resolve-tree
+  resolve-tree-raw
+  cfg
+  cfg-json
+  flattened-tree
+  flattened-tree-raw
+  autogen
+  document-symbols
+)
 
 bazel build \
   //gems/sorbet/test/snapshot:update \


### PR DESCRIPTION
This does various cleanups in a script. No semantic changes.

### Motivation
To clean up.

## Test plan

Before making any commits, I changed `update_exp_files` to not do any Bazel
builds (for speed) and changed the `parallel` command to run the command file,
to simply cat the command file.

Then, before every commit, I ran `update_exp_files` and diffed the output with
the original output before any commits to ensure they were the same.