### PR TITLE
Use old value

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/class_utils.rb
+++ b/gems/sorbet-runtime/lib/types/private/class_utils.rb
@@ -96,9 +96,9 @@ module T::Private::ClassUtils
 
     overwritten = original_owner == mod
     T::Configuration.without_ruby_warnings do
-      T::Private::DeclState.current.skip_on_method_added = true
+      T::Private::DeclState.without_on_method_added do
       mod.send(:define_method, name, &blk) # rubocop:disable PrisonGuard/UsePublicSend
-      T::Private::DeclState.current.skip_on_method_added = false
+      end
     end
     mod.send(original_visibility, name) # rubocop:disable PrisonGuard/UsePublicSend
     new_method = mod.instance_method(name)

--- a/gems/sorbet-runtime/lib/types/private/class_utils.rb
+++ b/gems/sorbet-runtime/lib/types/private/class_utils.rb
@@ -97,7 +97,7 @@ module T::Private::ClassUtils
     overwritten = original_owner == mod
     T::Configuration.without_ruby_warnings do
       T::Private::DeclState.without_on_method_added do
-      mod.send(:define_method, name, &blk) # rubocop:disable PrisonGuard/UsePublicSend
+        mod.send(:define_method, name, &blk) # rubocop:disable PrisonGuard/UsePublicSend
       end
     end
     mod.send(original_visibility, name) # rubocop:disable PrisonGuard/UsePublicSend

--- a/gems/sorbet-runtime/lib/types/private/class_utils.rb
+++ b/gems/sorbet-runtime/lib/types/private/class_utils.rb
@@ -96,7 +96,7 @@ module T::Private::ClassUtils
 
     overwritten = original_owner == mod
     T::Configuration.without_ruby_warnings do
-      T::Private::DeclState.without_on_method_added do
+      T::Private::DeclState.current.without_on_method_added do
         mod.send(:define_method, name, &blk) # rubocop:disable PrisonGuard/UsePublicSend
       end
     end

--- a/gems/sorbet-runtime/lib/types/private/decl_state.rb
+++ b/gems/sorbet-runtime/lib/types/private/decl_state.rb
@@ -16,4 +16,15 @@ class T::Private::DeclState
   def reset!
     self.active_declaration = nil
   end
+
+  def self.without_on_method_added
+    begin
+      old_value = current.skip_on_method_added
+      current.skip_on_method_added = true
+      yield
+    ensure
+      current.skip_on_method_added = old_value
+    end
+    nil
+  end
 end

--- a/gems/sorbet-runtime/lib/types/private/decl_state.rb
+++ b/gems/sorbet-runtime/lib/types/private/decl_state.rb
@@ -25,6 +25,5 @@ class T::Private::DeclState
     ensure
       current.skip_on_method_added = old_value
     end
-    nil
   end
 end

--- a/gems/sorbet-runtime/lib/types/private/decl_state.rb
+++ b/gems/sorbet-runtime/lib/types/private/decl_state.rb
@@ -17,13 +17,14 @@ class T::Private::DeclState
     self.active_declaration = nil
   end
 
-  def self.without_on_method_added
+  def without_on_method_added
     begin
-      old_value = current.skip_on_method_added
-      current.skip_on_method_added = true
+      # explicit 'self' is needed here
+      old_value = self.skip_on_method_added
+      self.skip_on_method_added = true
       yield
     ensure
-      current.skip_on_method_added = old_value
+      self.skip_on_method_added = old_value
     end
   end
 end

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -37,7 +37,7 @@ module T::Private::Methods::CallValidation
     else
       T::Configuration.without_ruby_warnings do
         # get all the shims out of the way and put back the original method
-        T::Private::DeclState.without_on_method_added do
+        T::Private::DeclState.current.without_on_method_added do
           mod.send(:define_method, method_sig.method_name, original_method)
         end
         mod.send(original_visibility, method_sig.method_name)
@@ -172,7 +172,7 @@ module T::Private::Methods::CallValidation
     has_simple_procedure_types = all_args_are_simple && method_sig.return_type.is_a?(T::Private::Types::Void)
 
     T::Configuration.without_ruby_warnings do
-      T::Private::DeclState.without_on_method_added do
+      T::Private::DeclState.current.without_on_method_added do
         if has_fixed_arity && has_simple_method_types && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path
           create_validator_method_fast(mod, original_method, method_sig)
         elsif has_fixed_arity && has_simple_procedure_types && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -38,7 +38,7 @@ module T::Private::Methods::CallValidation
       T::Configuration.without_ruby_warnings do
         # get all the shims out of the way and put back the original method
         T::Private::DeclState.without_on_method_added do
-        mod.send(:define_method, method_sig.method_name, original_method)
+          mod.send(:define_method, method_sig.method_name, original_method)
         end
         mod.send(original_visibility, method_sig.method_name)
       end
@@ -173,13 +173,13 @@ module T::Private::Methods::CallValidation
 
     T::Configuration.without_ruby_warnings do
       T::Private::DeclState.without_on_method_added do
-      if has_fixed_arity && has_simple_method_types && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path
-        create_validator_method_fast(mod, original_method, method_sig)
-      elsif has_fixed_arity && has_simple_procedure_types && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path
-        create_validator_procedure_fast(mod, original_method, method_sig)
-      else
-        create_validator_slow(mod, original_method, method_sig)
-      end
+        if has_fixed_arity && has_simple_method_types && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path
+          create_validator_method_fast(mod, original_method, method_sig)
+        elsif has_fixed_arity && has_simple_procedure_types && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path
+          create_validator_procedure_fast(mod, original_method, method_sig)
+        else
+          create_validator_slow(mod, original_method, method_sig)
+        end
       end
     end
     mod.send(original_visibility, method_sig.method_name)

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -37,9 +37,9 @@ module T::Private::Methods::CallValidation
     else
       T::Configuration.without_ruby_warnings do
         # get all the shims out of the way and put back the original method
-        T::Private::DeclState.current.skip_on_method_added = true
+        T::Private::DeclState.without_on_method_added do
         mod.send(:define_method, method_sig.method_name, original_method)
-        T::Private::DeclState.current.skip_on_method_added = false
+        end
         mod.send(original_visibility, method_sig.method_name)
       end
     end
@@ -172,7 +172,7 @@ module T::Private::Methods::CallValidation
     has_simple_procedure_types = all_args_are_simple && method_sig.return_type.is_a?(T::Private::Types::Void)
 
     T::Configuration.without_ruby_warnings do
-      T::Private::DeclState.current.skip_on_method_added = true
+      T::Private::DeclState.without_on_method_added do
       if has_fixed_arity && has_simple_method_types && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path
         create_validator_method_fast(mod, original_method, method_sig)
       elsif has_fixed_arity && has_simple_procedure_types && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path
@@ -180,7 +180,7 @@ module T::Private::Methods::CallValidation
       else
         create_validator_slow(mod, original_method, method_sig)
       end
-      T::Private::DeclState.current.skip_on_method_added = false
+      end
     end
     mod.send(original_visibility, method_sig.method_name)
   end


### PR DESCRIPTION
We should put the old value of `skip_on_method_added` back at the end, instead of blindly setting it to false. (I realized this when you were adding some `skip_on_method_added` to pay-server.) 

Maybe also, instead of directly manipulating this flag, we should use something like

```rb
T::Configuration.without_on_method_added do
  # statements in here won't trigger our `_on_method_added` in T::Private::Methods
  # you may also nest these blocks arbitrarily and they won't clobber each other
end
```

If something like this ^ would be more preferred I'll repurpose this PR to do that.

### Motivation
To make sure we don't clobber someone else's skip.

### Test plan
No tests. Not sure if there could or should be tests for this.
