### PR TITLE
Silence mocha errors

### DIFF
--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -98,7 +98,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     end
 
     it 'does not call the constructor' do
-      MySerializable.any_instance.expects(:initialize).never
+      MySerializable.any_instance.expects(:new).never
       MySerializable.from_hash({})
     end
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We get errors from the ruby interpreter that say "hey, undefining
initialize is bad, consider not doing that" because under the hood
`expects` is going to undefine and then re-define the stubbed method.

Instead, let's stub `new` so that the ruby VM doesn't complain at us.
This means that `rake test` doesn't print anything to stdout except the
actual minitest output.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Run `rake test` and observe that it's quieter on this branch vs master.