### PR TITLE
Simulate choosing multiple overloads for common operations on int&float

### DIFF
--- a/rbi/core/float.rbi
+++ b/rbi/core/float.rbi
@@ -71,6 +71,12 @@ class Float < Numeric
     )
     .returns(Complex)
   end
+  sig do
+    params(
+        arg0: T.any(Integer, Float),
+    )
+    .returns(Float)
+  end
   def *(arg0); end
 
   sig do
@@ -135,6 +141,12 @@ class Float < Numeric
     )
     .returns(Complex)
   end
+  sig do
+    params(
+        arg0: T.any(Integer, Float),
+    )
+    .returns(Float)
+  end
   def +(arg0); end
 
   sig {returns(Float)}
@@ -170,6 +182,12 @@ class Float < Numeric
     )
     .returns(Complex)
   end
+  sig do
+    params(
+        arg0: T.any(Integer, Float),
+    )
+    .returns(Float)
+  end
   def -(arg0); end
 
   sig {returns(Float)}
@@ -204,6 +222,12 @@ class Float < Numeric
         arg0: Complex,
     )
     .returns(Complex)
+  end
+  sig do
+    params(
+        arg0: T.any(Integer, Float),
+    )
+    .returns(Float)
   end
   def /(arg0); end
 

--- a/rbi/core/integer.rbi
+++ b/rbi/core/integer.rbi
@@ -25,6 +25,12 @@ class Integer < Numeric
     )
     .returns(BigDecimal)
   end
+  sig do
+    params(
+        arg0: T.any(Integer, Float),
+    )
+    .returns(T.any(Integer, Float))
+  end
   def %(arg0); end
 
   sig do
@@ -64,6 +70,12 @@ class Integer < Numeric
         arg0: Complex,
     )
     .returns(Complex)
+  end
+  sig do
+    params(
+        arg0: T.any(Integer, Float),
+    )
+    .returns(T.any(Integer, Float))
   end
   def *(arg0); end
 
@@ -129,6 +141,12 @@ class Integer < Numeric
     )
     .returns(Complex)
   end
+  sig do
+    params(
+        arg0: T.any(Integer, Float),
+    )
+    .returns(T.any(Integer, Float))
+  end
   def +(arg0); end
 
   sig {returns(Integer)}
@@ -164,6 +182,12 @@ class Integer < Numeric
     )
     .returns(Complex)
   end
+  sig do
+    params(
+        arg0: T.any(Integer, Float),
+    )
+    .returns(T.any(Integer, Float))
+  end
   def -(arg0); end
 
   sig {returns(Integer)}
@@ -198,6 +222,12 @@ class Integer < Numeric
         arg0: Complex,
     )
     .returns(Complex)
+  end
+  sig do
+    params(
+        arg0: T.any(Integer, Float),
+    )
+    .returns(T.any(Integer, Float))
   end
   def /(arg0); end
 

--- a/test/cli/at/at.out
+++ b/test/cli/at/at.out
@@ -1,8 +1,8 @@
 test/cli/at/at.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
         ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L104: Method `Integer#+` has specified `arg0` as `Integer`
-     104 |        arg0: Integer,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L116: Method `Integer#+` has specified `arg0` as `Integer`
+     116 |        arg0: Integer,
                   ^^^^
   Got String("s") originating from:
     test/cli/at/at.rb:2:

--- a/test/cli/error-blacklist/error-blacklist.out
+++ b/test/cli/error-blacklist/error-blacklist.out
@@ -1,8 +1,8 @@
 test/cli/error-blacklist/error-blacklist.rb:3: Expected `Integer` but found `String("1")` for argument `arg0` https://srb.help/7002
      3 |1 + "1"
         ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L104: Method `Integer#+` has specified `arg0` as `Integer`
-     104 |        arg0: Integer,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L116: Method `Integer#+` has specified `arg0` as `Integer`
+     116 |        arg0: Integer,
                   ^^^^
   Got String("1") originating from:
     test/cli/error-blacklist/error-blacklist.rb:3:

--- a/test/cli/folder-input-dir-and-file/folder-input-dir-and-file.out
+++ b/test/cli/folder-input-dir-and-file/folder-input-dir-and-file.out
@@ -1,8 +1,8 @@
 test/cli/folder-input-dir-and-file/foo.rb:4: Expected `Integer` but found `String("foo.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "foo.rb"
         ^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L104: Method `Integer#+` has specified `arg0` as `Integer`
-     104 |        arg0: Integer,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L116: Method `Integer#+` has specified `arg0` as `Integer`
+     116 |        arg0: Integer,
                   ^^^^
   Got String("foo.rb") originating from:
     test/cli/folder-input-dir-and-file/foo.rb:4:
@@ -12,8 +12,8 @@ test/cli/folder-input-dir-and-file/foo.rb:4: Expected `Integer` but found `Strin
 test/cli/folder-input-dir-and-file/input/bar.rb:3: Expected `Integer` but found `String("bar.rb")` for argument `arg0` https://srb.help/7002
      3 |1 + "bar.rb"
         ^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L104: Method `Integer#+` has specified `arg0` as `Integer`
-     104 |        arg0: Integer,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L116: Method `Integer#+` has specified `arg0` as `Integer`
+     116 |        arg0: Integer,
                   ^^^^
   Got String("bar.rb") originating from:
     test/cli/folder-input-dir-and-file/input/bar.rb:3:
@@ -23,8 +23,8 @@ test/cli/folder-input-dir-and-file/input/bar.rb:3: Expected `Integer` but found 
 test/cli/folder-input-dir-and-file/input/subfolder/baz.rb:4: Expected `Integer` but found `String("baz.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "baz.rb"
         ^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L104: Method `Integer#+` has specified `arg0` as `Integer`
-     104 |        arg0: Integer,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L116: Method `Integer#+` has specified `arg0` as `Integer`
+     116 |        arg0: Integer,
                   ^^^^
   Got String("baz.rb") originating from:
     test/cli/folder-input-dir-and-file/input/subfolder/baz.rb:4:

--- a/test/cli/folder-input/folder-input.out
+++ b/test/cli/folder-input/folder-input.out
@@ -1,8 +1,8 @@
 test/cli/folder-input/foo.rb:4: Expected `Integer` but found `String("foo.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "foo.rb"
         ^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L104: Method `Integer#+` has specified `arg0` as `Integer`
-     104 |        arg0: Integer,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L116: Method `Integer#+` has specified `arg0` as `Integer`
+     116 |        arg0: Integer,
                   ^^^^
   Got String("foo.rb") originating from:
     test/cli/folder-input/foo.rb:4:
@@ -12,8 +12,8 @@ test/cli/folder-input/foo.rb:4: Expected `Integer` but found `String("foo.rb")` 
 test/cli/folder-input/input/bar.rb:3: Expected `Integer` but found `String("bar.rb")` for argument `arg0` https://srb.help/7002
      3 |1 + "bar.rb"
         ^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L104: Method `Integer#+` has specified `arg0` as `Integer`
-     104 |        arg0: Integer,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L116: Method `Integer#+` has specified `arg0` as `Integer`
+     116 |        arg0: Integer,
                   ^^^^
   Got String("bar.rb") originating from:
     test/cli/folder-input/input/bar.rb:3:
@@ -23,8 +23,8 @@ test/cli/folder-input/input/bar.rb:3: Expected `Integer` but found `String("bar.
 test/cli/folder-input/input/subfolder/baz.rb:4: Expected `Integer` but found `String("baz.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "baz.rb"
         ^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L104: Method `Integer#+` has specified `arg0` as `Integer`
-     104 |        arg0: Integer,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L116: Method `Integer#+` has specified `arg0` as `Integer`
+     116 |        arg0: Integer,
                   ^^^^
   Got String("baz.rb") originating from:
     test/cli/folder-input/input/subfolder/baz.rb:4:

--- a/test/cli/ignore-slash/ignore-slash.out
+++ b/test/cli/ignore-slash/ignore-slash.out
@@ -1,8 +1,8 @@
 bar.rb:4: Expected `Integer` but found `String("bar.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "bar.rb"
         ^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L104: Method `Integer#+` has specified `arg0` as `Integer`
-     104 |        arg0: Integer,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L116: Method `Integer#+` has specified `arg0` as `Integer`
+     116 |        arg0: Integer,
                   ^^^^
   Got String("bar.rb") originating from:
     bar.rb:4:

--- a/test/cli/ignore/ignore.out
+++ b/test/cli/ignore/ignore.out
@@ -1,8 +1,8 @@
 bar.rb:4: Expected `Integer` but found `String("bar.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "bar.rb"
         ^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L104: Method `Integer#+` has specified `arg0` as `Integer`
-     104 |        arg0: Integer,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L116: Method `Integer#+` has specified `arg0` as `Integer`
+     116 |        arg0: Integer,
                   ^^^^
   Got String("bar.rb") originating from:
     bar.rb:4:
@@ -12,8 +12,8 @@ bar.rb:4: Expected `Integer` but found `String("bar.rb")` for argument `arg0` ht
 subfolder2/subfolder/bar.rb:4: Expected `Integer` but found `String("subfolder2/subfolder/bar.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "subfolder2/subfolder/bar.rb"
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L104: Method `Integer#+` has specified `arg0` as `Integer`
-     104 |        arg0: Integer,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L116: Method `Integer#+` has specified `arg0` as `Integer`
+     116 |        arg0: Integer,
                   ^^^^
   Got String("subfolder2/subfolder/bar.rb") originating from:
     subfolder2/subfolder/bar.rb:4:

--- a/test/cli/override-typed-bad/override-typed-bad.out
+++ b/test/cli/override-typed-bad/override-typed-bad.out
@@ -3,8 +3,8 @@ test/cli/override-typed-bad/override-typed-bad.rb: Useless override of strictnes
 test/cli/override-typed-bad/override-typed-bad.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
         ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L104: Method `Integer#+` has specified `arg0` as `Integer`
-     104 |        arg0: Integer,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L116: Method `Integer#+` has specified `arg0` as `Integer`
+     116 |        arg0: Integer,
                   ^^^^
   Got String("s") originating from:
     test/cli/override-typed-bad/override-typed-bad.rb:2:

--- a/test/cli/override-typed/override-typed.out
+++ b/test/cli/override-typed/override-typed.out
@@ -1,8 +1,8 @@
 test/cli/override-typed/override-typed.rb:1: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      1 |1 + "s"
         ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L104: Method `Integer#+` has specified `arg0` as `Integer`
-     104 |        arg0: Integer,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L116: Method `Integer#+` has specified `arg0` as `Integer`
+     116 |        arg0: Integer,
                   ^^^^
   Got String("s") originating from:
     test/cli/override-typed/override-typed.rb:1:
@@ -12,8 +12,8 @@ Errors: 1
 ./test/cli/override-typed/override-typed.rb:1: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      1 |1 + "s"
         ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L104: Method `Integer#+` has specified `arg0` as `Integer`
-     104 |        arg0: Integer,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L116: Method `Integer#+` has specified `arg0` as `Integer`
+     116 |        arg0: Integer,
                   ^^^^
   Got String("s") originating from:
     ./test/cli/override-typed/override-typed.rb:1:
@@ -23,8 +23,8 @@ Errors: 1
 test/cli/override-typed/override-typed.rb:1: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      1 |1 + "s"
         ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L104: Method `Integer#+` has specified `arg0` as `Integer`
-     104 |        arg0: Integer,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L116: Method `Integer#+` has specified `arg0` as `Integer`
+     116 |        arg0: Integer,
                   ^^^^
   Got String("s") originating from:
     test/cli/override-typed/override-typed.rb:1:

--- a/test/cli/remove-path-prefix-https/remove-path-prefix-https.out
+++ b/test/cli/remove-path-prefix-https/remove-path-prefix-https.out
@@ -1,8 +1,8 @@
 test/cli/remove-path-prefix-https/remove-path-prefix-https.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
         ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L104: Method `Integer#+` has specified `arg0` as `Integer`
-     104 |        arg0: Integer,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L116: Method `Integer#+` has specified `arg0` as `Integer`
+     116 |        arg0: Integer,
                   ^^^^
   Got String("s") originating from:
     test/cli/remove-path-prefix-https/remove-path-prefix-https.rb:2:

--- a/test/cli/remove-path-prefix-no-match/remove-path-prefix-no-match.out
+++ b/test/cli/remove-path-prefix-no-match/remove-path-prefix-no-match.out
@@ -1,8 +1,8 @@
 test/cli/remove-path-prefix-no-match/remove-path-prefix-no-match.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
         ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L104: Method `Integer#+` has specified `arg0` as `Integer`
-     104 |        arg0: Integer,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L116: Method `Integer#+` has specified `arg0` as `Integer`
+     116 |        arg0: Integer,
                   ^^^^
   Got String("s") originating from:
     test/cli/remove-path-prefix-no-match/remove-path-prefix-no-match.rb:2:

--- a/test/cli/remove-path-prefix/remove-path-prefix.out
+++ b/test/cli/remove-path-prefix/remove-path-prefix.out
@@ -1,8 +1,8 @@
 remove-path-prefix.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
         ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L104: Method `Integer#+` has specified `arg0` as `Integer`
-     104 |        arg0: Integer,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L116: Method `Integer#+` has specified `arg0` as `Integer`
+     116 |        arg0: Integer,
                   ^^^^
   Got String("s") originating from:
     remove-path-prefix.rb:2:

--- a/test/cli/suggest-typos/suggest-typos.out
+++ b/test/cli/suggest-typos/suggest-typos.out
@@ -1,7 +1,7 @@
 -e:1: Method `to_` does not exist on `Integer` component of `Integer(1)` https://srb.help/7003
      1 |1.to_
         ^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L743: Did you mean: `Integer#to_c`?
-     743 |  def to_c(); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L773: Did you mean: `Integer#to_c`?
+     773 |  def to_c(); end
             ^^^^^^^^^^
 Errors: 1

--- a/test/testdata/rbi/int_float.rb
+++ b/test/testdata/rbi/int_float.rb
@@ -1,0 +1,13 @@
+# typed: true
+
+class A
+  extend T::Sig
+
+  sig {params(x: T.any(Integer,Float), y: T.any(Integer, Float)).returns(T.any(Integer,Float))}
+  def bar(x, y)
+    x + y
+    x - y
+    x / y
+    x * y
+  end
+end


### PR DESCRIPTION
### Motivation
Sorbet overload resolution is very simple and self contained and thus allows us to not leak complexity of it into IDE/Inference/etc. Properly supporting this usecase for arbitrary classes is hard, as it requires leaking all of this complexity.

At the same time, we see this complaint in practice only for 2 common classes: float and integer(I think I only saw this mentioned for other classes like... twice?)
So, rather than fixing it "for reals" that would take weeks if not months, including making future progress on related areas slower, this fixes the common usecase as one-off.


### Test plan

See included automated tests.

cc @apz-stripe, @zanker-stripe 
