### PR TITLE
rbi: Use correct return type for `String#unpack`

### DIFF
--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -806,7 +806,7 @@ class String < Object
     params(
         arg0: String,
     )
-    .returns(T::Array[String])
+    .returns(T::Array[T.nilable(T.any(Integer, Float, String))])
   end
   def unpack(arg0); end
 

--- a/test/testdata/rbi/string.rb
+++ b/test/testdata/rbi/string.rb
@@ -12,3 +12,6 @@ x, y, z = s.rpartition('')
 T.assert_type!(x, String)
 T.assert_type!(y, String)
 T.assert_type!(z, String)
+
+u = "abcdefg\0\0abc".unpack('CdAD')
+T.assert_type!(u, T::Array[T.nilable(T.any(Integer, Float, String))])


### PR DESCRIPTION
### Motivation

The current definition in RBI for `String#unpack` states it returns an `T::Array[String]`.

[Documentation](https://www.rubydoc.info/stdlib/core/String:unpack) and experiments show it can return more than that:

```
irb(main):024:0> "abcdefg\0\0abc".unpack('CdAD')
=> [97, 5.61700690309813e-310, "a", nil]
```

This PR changes the return type to `T::Array[T.nilable(T.any(Integer, Float, String))]`.