### PR TITLE
Add test inspired by some pay-server usages

### DIFF
--- a/test/testdata/resolver/nested_sealed.rb
+++ b/test/testdata/resolver/nested_sealed.rb
@@ -58,7 +58,6 @@ def nested_inheritance_nested_case(x)
   when Ok
     T.reveal_type(x) # error: Revealed type: `Ok`
   when Error
-    T.reveal_type(x) # error: Revealed type: `Error`
     case x
     when Bad1
       T.reveal_type(x) # error: Revealed type: `Bad1`

--- a/test/testdata/resolver/nested_sealed.rb
+++ b/test/testdata/resolver/nested_sealed.rb
@@ -1,0 +1,73 @@
+# typed: true
+
+module Result
+  extend T::Helpers
+  sealed!
+end
+
+class Ok
+  include Result
+end
+
+module Error
+  include Result
+
+  extend T::Helpers
+  sealed!
+end
+
+class Bad1
+  include Error
+end
+
+class Bad2
+  include Error
+end
+
+extend T::Sig
+
+sig {params(x: Result).void}
+def nested_inheritance_flattened_case(x)
+  case x
+  when Ok
+    T.reveal_type(x) # error: Revealed type: `Ok`
+  when Bad1
+    T.reveal_type(x) # error: Revealed type: `Bad1`
+  when Bad2
+    T.reveal_type(x) # error: Revealed type: `Bad2`
+  else
+    T.absurd(x)
+  end
+end
+
+sig {params(x: Result).void}
+def nested_inheritance_flattened_case_missing(x)
+  case x
+  when Ok
+    T.reveal_type(x) # error: Revealed type: `Ok`
+  when Bad1
+    T.reveal_type(x) # error: Revealed type: `Bad1`
+  else
+    T.absurd(x) # error: Control flow could reach `T.absurd` because the type `Bad2` wasn't handled
+  end
+end
+
+sig {params(x: Result).void}
+def nested_inheritance_nested_case(x)
+  case x
+  when Ok
+    T.reveal_type(x) # error: Revealed type: `Ok`
+  when Error
+    T.reveal_type(x) # error: Revealed type: `Error`
+    case x
+    when Bad1
+      T.reveal_type(x) # error: Revealed type: `Bad1`
+    when Bad2
+      T.reveal_type(x) # error: Revealed type: `Bad2`
+    else
+      T.absurd(x)
+    end
+  else
+    T.absurd(x)
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I found some places in pay-server that were essentially doing this but
with manually crafted type aliases and union types instead of sealed.

I wanted to see if sealed would be able to support this and luckily
enough it behaves just the way I expected it to, so I figured I'd add a
test.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.