### PR TITLE
Some quick renames for sealed subclasses

### DIFF
--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -538,7 +538,7 @@ public:
 
     void recordSealedSubclass(MutableContext ctx, SymbolRef subclass);
     const InlinedVector<Loc, 2> &sealedLocs(const GlobalState &gs) const;
-    TypePtr sealedSubclasses(const Context ctx) const;
+    TypePtr sealedSubclassesToUnion(const Context ctx) const;
 
     // if dealiasing fails here, then we return Untyped instead
     SymbolRef dealias(const GlobalState &gs, int depthLimit = 42) const {

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -253,7 +253,7 @@ NameDef names[] = {
 
     // This behaves like the above two names, in the sense that we use a member
     // on a class to lookup an associated symbol with some extra info.
-    {"sealedClassesList", "<sealedClassesList>"},
+    {"sealedSubclasses", "sealed_subclasses"},
 
     // This name is used as a key in SymbolInfo::members to store the module
     // registered via the `mixes_in_class_method` name.

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -176,7 +176,7 @@ TypePtr Types::dropSubtypesOf(Context ctx, const TypePtr &from, SymbolRef klass)
             if (c->isUntyped()) {
                 result = from;
             } else if (cdata->isClassSealed() && (cdata->isClassAbstract() || cdata->isClassModule())) {
-                result = dropSubtypesOf(ctx, cdata->sealedSubclasses(ctx), klass);
+                result = dropSubtypesOf(ctx, cdata->sealedSubclassesToUnion(ctx), klass);
             } else if (c->symbol == klass || c->derivesFrom(ctx, klass)) {
                 result = Types::bottom();
             } else {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -297,15 +297,15 @@ public:
             klass->symbol.data(ctx)->setClassSealed();
 
             auto classOfKlass = klass->symbol.data(ctx)->singletonClass(ctx);
-            auto sealedClassesList =
-                ctx.state.enterMethodSymbol(send->loc, classOfKlass, core::Names::sealedClassesList());
+            auto sealedSubclasses =
+                ctx.state.enterMethodSymbol(send->loc, classOfKlass, core::Names::sealedSubclasses());
             auto &blkArg =
-                ctx.state.enterMethodArgumentSymbol(core::Loc::none(), sealedClassesList, core::Names::blkArg());
+                ctx.state.enterMethodArgumentSymbol(core::Loc::none(), sealedSubclasses, core::Names::blkArg());
             blkArg.flags.isBlock = true;
 
             // T.noreturn here represents the zero-length list of subclasses of this sealed class.
             // We will use T.any to record subclasses when they're resolved.
-            sealedClassesList.data(ctx)->resultType = core::Types::arrayOf(ctx, core::Types::bottom());
+            sealedSubclasses.data(ctx)->resultType = core::Types::arrayOf(ctx, core::Types::bottom());
         }
         if (send->fun == core::Names::declareInterface() || send->fun == core::Names::declareAbstract()) {
             klass->symbol.data(ctx)->setClassAbstract();


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

    Symbol::sealedSubclasses       -> Symbol::sealedSubclassesToUnion
    core::Names::sealedClassesList -> core::Names::sealedSubclasses

This is in anticipation of wanting to use the name `sealed_subclasses`
as the name of the actual Ruby method that will back this in the
runtime.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing automated tests