### PR TITLE
Fix infer segfault due to moved TestedKnowledge

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -543,8 +543,8 @@ void Environment::assumeKnowledge(core::Context ctx, bool isTrue, core::LocalVar
     }
 
     auto &knowledgeToChoose = isTrue ? thisKnowledge.truthy : thisKnowledge.falsy;
-    auto yesTests = knowledgeToChoose->yesTypeTests;
-    auto noTests = knowledgeToChoose->noTypeTests;
+    auto &yesTests = knowledgeToChoose->yesTypeTests;
+    auto &noTests = knowledgeToChoose->noTypeTests;
 
     for (auto &typeTested : yesTests) {
         if (filter.find(typeTested.first) == filter.end()) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -538,7 +538,6 @@ void Environment::assumeKnowledge(core::Context ctx, bool isTrue, core::LocalVar
         vars[cond].knownTruthy = true;
     }
 
-
     if (isDead) {
         return;
     }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -538,13 +538,16 @@ void Environment::assumeKnowledge(core::Context ctx, bool isTrue, core::LocalVar
         vars[cond].knownTruthy = true;
     }
 
-    auto &knowledgeToChoose = isTrue ? thisKnowledge.truthy : thisKnowledge.falsy;
 
     if (isDead) {
         return;
     }
 
-    for (auto &typeTested : knowledgeToChoose->yesTypeTests) {
+    auto &knowledgeToChoose = isTrue ? thisKnowledge.truthy : thisKnowledge.falsy;
+    auto yesTests = knowledgeToChoose->yesTypeTests;
+    auto noTests = knowledgeToChoose->noTypeTests;
+
+    for (auto &typeTested : yesTests) {
         if (filter.find(typeTested.first) == filter.end()) {
             continue;
         }
@@ -568,7 +571,7 @@ void Environment::assumeKnowledge(core::Context ctx, bool isTrue, core::LocalVar
         setTypeAndOrigin(typeTested.first, tp);
     }
 
-    for (auto &typeTested : knowledgeToChoose->noTypeTests) {
+    for (auto &typeTested : noTests) {
         if (filter.find(typeTested.first) == filter.end()) {
             continue;
         }

--- a/test/testdata/infer/fuzz_oneline_conditional.rb
+++ b/test/testdata/infer/fuzz_oneline_conditional.rb
@@ -1,0 +1,7 @@
+# typed: true
+if foo # error: Method `foo` does not exist on `T.class_of(<root>)`
+  bar = 3
+end
+quz = foo if quz || bar # error: Method `foo` does not exist on `T.class_of(<root>)`
+           # ^^^ error: This code is unreachable
+quz


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes #1558; the segfault was because a specific use of `setTypeAndOrigin` was invalidating a local pointer to a `TestedKnowledge` value; we can fix this by grabbing the information we need (two specific vectors) out of that value earlier.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Added the fuzzed test case.
