### PR TITLE
Update sorbet-typed to remove directories and make sorbet-typed repo configurable

### DIFF
--- a/gems/sorbet/lib/fetch-rbis.rb
+++ b/gems/sorbet/lib/fetch-rbis.rb
@@ -19,7 +19,7 @@ class Sorbet::Private::FetchRBIs
   XDG_CACHE_HOME = ENV['XDG_CACHE_HOME'] || "#{ENV['HOME']}/.cache"
   RBI_CACHE_DIR = "#{XDG_CACHE_HOME}/sorbet/sorbet-typed"
 
-  SORBET_TYPED_REPO = 'https://github.com/sorbet/sorbet-typed.git'
+  SORBET_TYPED_REPO = ENV['SRB_SORBET_TYPED_REPO'] || 'https://github.com/sorbet/sorbet-typed.git'
   SORBET_TYPED_REVISION = ENV['SRB_SORBET_TYPED_REVISION'] || 'origin/master'
 
   HEADER = Sorbet::Private::Serialize.header(false, 'sorbet-typed')

--- a/gems/sorbet/lib/fetch-rbis.rb
+++ b/gems/sorbet/lib/fetch-rbis.rb
@@ -14,7 +14,7 @@ class Sorbet::Private::FetchRBIs
   SORBET_DIR = 'sorbet'
   SORBET_CONFIG_FILE = "#{SORBET_DIR}/config"
   SORBET_RBI_LIST = "#{SORBET_DIR}/rbi_list"
-  SORBET_RBI_SORBET_TYPED = "#{SORBET_DIR}/rbi/sorbet-typed/"
+  SORBET_RBI_SORBET_TYPED = "#{SORBET_DIR}/rbi/sorbet-typed"
 
   XDG_CACHE_HOME = ENV['XDG_CACHE_HOME'] || "#{ENV['HOME']}/.cache"
   RBI_CACHE_DIR = "#{XDG_CACHE_HOME}/sorbet/sorbet-typed"
@@ -100,6 +100,20 @@ class Sorbet::Private::FetchRBIs
     end
   end
 
+  # Remove extra rbi files if there are any.
+  T::Sig::WithoutRuntime.sig {params(vendor_paths: T::Array[String]).void}
+  def self.remove_extra_rbis(vendor_paths)
+    relative_vendor_paths = vendor_paths.map { |path| path.sub(RBI_CACHE_DIR, '') }
+    rbis = Dir.glob("#{SORBET_RBI_SORBET_TYPED}/lib/**/*.rbi")
+    # Use uniq to make sure 'ruby/all/' isn't included multiple times.
+    current_rbi_paths = rbis.map { |rbi| rbi.split("/")[0...-1].join("/").sub(SORBET_RBI_SORBET_TYPED, '') }.uniq
+    # Get any sorbet-typed directories that are in the current 'sorbet/'
+    # directory and not in the vendor cache, and delete them.
+    (current_rbi_paths - relative_vendor_paths).each do |extra_dir|
+      FileUtils.remove_dir("#{SORBET_RBI_SORBET_TYPED}#{extra_dir}")
+    end
+  end
+
   T::Sig::WithoutRuntime.sig {void}
   def self.main
     fetch_sorbet_typed
@@ -114,11 +128,12 @@ class Sorbet::Private::FetchRBIs
 
     if vendor_paths.length > 0
       vendor_rbis_within_paths(vendor_paths)
+      remove_extra_rbis(vendor_paths)
     end
   end
 
   def self.output_file
-    SORBET_RBI_SORBET_TYPED
+    "#{SORBET_RBI_SORBET_TYPED}/"
   end
 end
 


### PR DESCRIPTION
This includes two changes, I can split them into separate PRs if we want that, but the first is pretty minor so I figured it was fine to include here:

- Make it possible to pull in sorbet-typed RBIs from a configurable sorbet-typed repo. This can be done by setting the `SRB_SORBET_TYPED_REPO` environment variable to a git URL. This is useful for testing major changes to sorbet-typed, where previously we had to go into `~/.cache/sorbet/sorbet-typed/` and mess with the git repo in there.
- Make sorbet-typed delete RBI files that are no longer relevant, e.g. because the gem has been removed from the project, the RBI's version is no longer compatible with your current version of the gem, or the RBI was removed from the sorbet-typed repo entirely.

### Motivation
Fixes #1260.

I noticed this when `gem.rbi` was deleted from sorbet-typed last week, and running `srb rbi sorbet-typed` didn't delete the file. It's also relevant with Rails 6 being out, since anyone upgrading from 5.2 would have a lingering RBI for `~>5.2.0` which isn't compatible with their new Rails version.

### Test plan
There aren't any existing tests, so I figured it was fine not to add any for this command for now. You can test this by:

- Set up this branch on a project with sorbet already instantiated
- Create a file like `sorbet/rbi/sorbet-typed/lib/fake-gem/all/fake-gem.rbi`, it doesn't need to have anything in it.
- Run `srb rbi sorbet-typed`
- Note that the `fake-gem.rbi` has been deleted.

You can also verify this by adding an incompatible version to an existing gem you already have type definitions for, e.g. add `sorbet/rbi/sorbet-typed/lib/activerecord/~>9.0.0/activerecord.rbi` and run `srb rbi sorbet-typed` to delete it.

I'm sure there are ways to make this code simpler, I'd be happy to hear any feedback :)