### PR TITLE
For >year test corpus no longer does sharding.

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -1,5 +1,5 @@
 cc_binary(
-    name = "test_corpus_sharded",
+    name = "test_corpus_runner",
     testonly = 1,
     srcs = [
         "LSPTest.cc",

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -53,7 +53,7 @@ def pipeline_tests(suite_name, all_paths, test_name_prefix, filter = "*", extra_
             args = ["--single_test=$(location {})".format(sentinel), "--gtest_filter={}/*".format(filter)] + extra_args,
             data = native.glob([
                 "{}/{}*".format(path, prefix),
-            ]) + ["test_corpus_sharded"],
+            ]) + ["test_corpus_runner"],
             size = "small",
             tags = tags + extra_tags,
         )

--- a/test/test_corpus_forwarder.sh
+++ b/test/test_corpus_forwarder.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -eux
 
-test/test_corpus_sharded "$@"
+test/test_corpus_runner "$@"

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -18,7 +18,7 @@ compilation_database(
         "//test/fuzz:fuzz_doc_symbols",
         "//test/fuzz:fuzz_dash_e",
         "//test/fuzz:fuzz_dash_e_impl",
-        "//test:test_corpus_sharded",
+        "//test:test_corpus_runner",
         "//test:print_document_symbols",
         "//test/helpers:helpers",
         "//test:hello-test",


### PR DESCRIPTION
We do it in bazel now

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
