### PR TITLE
Revert "runtime: Fix error message when an Enum instance is passed instead of an Array (#1523)"

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
@@ -139,8 +139,7 @@ module T::Types
         # enumerating the object is a destructive operation and might hang.
         obj.class
       else
-        # Get the real class name for other `Enumerable` as we don't want them to be collapsed as a `T::Array[T.untyped]`
-        T.unsafe(obj).class
+        self.class.new(type_from_instances(obj))
       end
     end
 

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -186,10 +186,6 @@ module Opus::Types::Test
       end
     end
 
-    class MyEnum
-      include Enumerable
-    end
-
     describe "TypedArray" do
       it 'fails if value is not an array' do
         type = T::Array[Integer]
@@ -271,14 +267,6 @@ module Opus::Types::Test
         msg = type.error_message_for_obj({foo: 17})
         assert_equal(
           "Expected type T::Array[Symbol], got T::Hash[Symbol, Integer]",
-          msg)
-      end
-
-      it 'gives the right error when passed an Enum' do
-        type = T::Array[Integer]
-        msg = type.error_message_for_obj(MyEnum.new)
-        assert_equal(
-          "Expected type T::Array[Integer], got Opus::Types::Test::TypesTest::MyEnum",
           msg)
       end
 


### PR DESCRIPTION


This reverts commit e60749d6318835d4e730ada5dfc98e80df3e7de1.
It broke master
cc @Morriar 


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
