### PR TITLE
add LSP capability textDocument/documentHighlight

### DIFF
--- a/main/lsp/LSPMessage.cc
+++ b/main/lsp/LSPMessage.cc
@@ -145,6 +145,7 @@ bool LSPMessage::isDelayable() const {
         case LSPMethod::TextDocumentHover:
         case LSPMethod::TextDocumentCompletion:
         case LSPMethod::TextDocumentSignatureHelp:
+        case LSPMethod::TextDocumentDocumentHighlight:
         // These are file updates. They shouldn't be delayed (but they can be combined/expedited).
         case LSPMethod::TextDocumentDidOpen:
         case LSPMethod::TextDocumentDidChange:

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -58,13 +58,15 @@ LSPLoop::QueryRun LSPLoop::setupLSPQueryByLoc(unique_ptr<core::GlobalState> gs, 
 }
 
 LSPLoop::QueryRun LSPLoop::setupLSPQueryBySymbol(unique_ptr<core::GlobalState> gs, core::SymbolRef sym,
-                                                 optional<string_view> uri) const {
+                                                 optional<string_view> overSingleFile) const {
     Timer timeit(logger, "setupLSPQueryBySymbol");
     ENFORCE(sym.exists());
     vector<core::FileRef> frefs;
-    if (uri.has_value()) {
-        auto fref = uri2FileRef(uri.value());
-        frefs.emplace_back(fref);
+    if (overSingleFile.has_value()) {
+        auto fref = uri2FileRef(overSingleFile.value());
+        if (fref.exists()) {
+            frefs.emplace_back(fref);
+        }
     } else {
         const core::NameHash symNameHash(*gs, sym.data(*gs)->name.data(*gs));
         // Locate files that contain the same Name as the symbol. Is an overapproximation, but a good first filter.

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -57,24 +57,30 @@ LSPLoop::QueryRun LSPLoop::setupLSPQueryByLoc(unique_ptr<core::GlobalState> gs, 
     return runQuery(move(gs), core::lsp::Query::createLocQuery(*loc.get()), {fref});
 }
 
-LSPLoop::QueryRun LSPLoop::setupLSPQueryBySymbol(unique_ptr<core::GlobalState> gs, core::SymbolRef sym) const {
+LSPLoop::QueryRun LSPLoop::setupLSPQueryBySymbol(unique_ptr<core::GlobalState> gs, core::SymbolRef sym,
+                                                 optional<string_view> uri) const {
     Timer timeit(logger, "setupLSPQueryBySymbol");
     ENFORCE(sym.exists());
     vector<core::FileRef> frefs;
-    const core::NameHash symNameHash(*gs, sym.data(*gs)->name.data(*gs));
-    // Locate files that contain the same Name as the symbol. Is an overapproximation, but a good first filter.
-    int i = -1;
-    for (auto &hash : globalStateHashes) {
-        i++;
-        const auto &usedSends = hash.usages.sends;
-        const auto &usedConstants = hash.usages.constants;
-        auto ref = core::FileRef(i);
+    if (uri.has_value()) {
+        auto fref = uri2FileRef(uri.value());
+        frefs.emplace_back(fref);
+    } else {
+        const core::NameHash symNameHash(*gs, sym.data(*gs)->name.data(*gs));
+        // Locate files that contain the same Name as the symbol. Is an overapproximation, but a good first filter.
+        int i = -1;
+        for (auto &hash : globalStateHashes) {
+            i++;
+            const auto &usedSends = hash.usages.sends;
+            const auto &usedConstants = hash.usages.constants;
+            auto ref = core::FileRef(i);
 
-        const bool fileIsValid = ref.exists() && ref.data(*gs).sourceType == core::File::Type::Normal;
-        if (fileIsValid &&
-            (std::find(usedSends.begin(), usedSends.end(), symNameHash) != usedSends.end() ||
-             std::find(usedConstants.begin(), usedConstants.end(), symNameHash) != usedConstants.end())) {
-            frefs.emplace_back(ref);
+            const bool fileIsValid = ref.exists() && ref.data(*gs).sourceType == core::File::Type::Normal;
+            if (fileIsValid &&
+                (std::find(usedSends.begin(), usedSends.end(), symNameHash) != usedSends.end() ||
+                 std::find(usedConstants.begin(), usedConstants.end(), symNameHash) != usedConstants.end())) {
+                frefs.emplace_back(ref);
+            }
         }
     }
 

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -221,9 +221,12 @@ class LSPLoop {
     LSPLoop::QueryRun setupLSPQueryByLoc(std::unique_ptr<core::GlobalState> gs, std::string_view uri,
                                          const Position &pos, const LSPMethod forMethod,
                                          bool errorIfFileIsUntyped = true) const;
-    QueryRun setupLSPQueryBySymbol(std::unique_ptr<core::GlobalState> gs, core::SymbolRef symbol) const;
+    QueryRun setupLSPQueryBySymbol(std::unique_ptr<core::GlobalState> gs, core::SymbolRef symbol,
+                                   const std::optional<std::string_view> uri = std::nullopt) const;
     LSPResult handleTextDocumentHover(std::unique_ptr<core::GlobalState> gs, const MessageId &id,
                                       const TextDocumentPositionParams &params) const;
+    LSPResult handleTextDocumentDocumentHighlight(std::unique_ptr<core::GlobalState> gs, const MessageId &id,
+                                                  const TextDocumentPositionParams &params) const;
     LSPResult handleTextDocumentDocumentSymbol(std::unique_ptr<core::GlobalState> gs, const MessageId &id,
                                                const DocumentSymbolParams &params) const;
     LSPResult handleWorkspaceSymbols(std::unique_ptr<core::GlobalState> gs, const MessageId &id,
@@ -231,6 +234,9 @@ class LSPLoop {
     std::pair<std::unique_ptr<core::GlobalState>, std::vector<std::unique_ptr<Location>>>
     getReferencesToSymbol(std::unique_ptr<core::GlobalState> gs, core::SymbolRef symbol,
                           std::vector<std::unique_ptr<Location>> locations = {}) const;
+    std::pair<std::unique_ptr<core::GlobalState>, std::vector<std::unique_ptr<DocumentHighlight>>>
+    getHighlightsToSymbolInFile(std::unique_ptr<core::GlobalState> gs, std::string_view uri, core::SymbolRef symbol,
+                                std::vector<std::unique_ptr<DocumentHighlight>> highlights = {}) const;
     LSPResult handleTextDocumentReferences(std::unique_ptr<core::GlobalState> gs, const MessageId &id,
                                            const ReferenceParams &params) const;
     LSPResult handleTextDocumentDefinition(std::unique_ptr<core::GlobalState> gs, const MessageId &id,

--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -177,7 +177,7 @@ LSPResult LSPLoop::processRequestInternal(unique_ptr<core::GlobalState> gs, cons
             serverCap->definitionProvider = true;
             serverCap->documentSymbolProvider = opts.lspDocumentSymbolEnabled;
             serverCap->workspaceSymbolProvider = opts.lspWorkspaceSymbolsEnabled;
-            serverCap->documentHighlightProvider = true;
+            serverCap->documentHighlightProvider = opts.lspDocumentHighlightEnabled;
             serverCap->hoverProvider = true;
             serverCap->referencesProvider = true;
 

--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -177,6 +177,7 @@ LSPResult LSPLoop::processRequestInternal(unique_ptr<core::GlobalState> gs, cons
             serverCap->definitionProvider = true;
             serverCap->documentSymbolProvider = opts.lspDocumentSymbolEnabled;
             serverCap->workspaceSymbolProvider = opts.lspWorkspaceSymbolsEnabled;
+            serverCap->documentHighlightProvider = true;
             serverCap->hoverProvider = true;
             serverCap->referencesProvider = true;
 
@@ -200,6 +201,9 @@ LSPResult LSPLoop::processRequestInternal(unique_ptr<core::GlobalState> gs, cons
 
             response->result = make_unique<InitializeResult>(move(serverCap));
             return LSPResult::make(move(gs), move(response));
+        } else if (method == LSPMethod::TextDocumentDocumentHighlight) {
+            auto &params = get<unique_ptr<TextDocumentPositionParams>>(rawParams);
+            return handleTextDocumentDocumentHighlight(move(gs), id, *params);
         } else if (method == LSPMethod::TextDocumentDocumentSymbol) {
             auto &params = get<unique_ptr<DocumentSymbolParams>>(rawParams);
             return handleTextDocumentDocumentSymbol(move(gs), id, *params);

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -1,0 +1,91 @@
+
+#include "absl/strings/match.h"
+#include "core/lsp/QueryResponse.h"
+#include "main/lsp/lsp.h"
+
+using namespace std;
+
+namespace sorbet::realmain::lsp {
+
+pair<unique_ptr<core::GlobalState>, vector<unique_ptr<DocumentHighlight>>>
+LSPLoop::getHighlightsToSymbolInFile(unique_ptr<core::GlobalState> gs, string_view const uri, core::SymbolRef symbol,
+                                     vector<unique_ptr<DocumentHighlight>> highlights) const {
+    if (symbol.exists()) {
+        auto run2 = setupLSPQueryBySymbol(move(gs), symbol, uri);
+        gs = move(run2.gs);
+        auto locations = extractLocations(*gs, run2.responses);
+        for (auto const &location : locations) {
+            auto highlight = make_unique<DocumentHighlight>(move(location->range));
+            highlights.push_back(move(highlight));
+        }
+    }
+    return make_pair(move(gs), move(highlights));
+}
+
+vector<unique_ptr<DocumentHighlight>> locationsToDocumentHighlights(vector<unique_ptr<Location>> const locations) {
+    vector<unique_ptr<DocumentHighlight>> highlights;
+    for (auto const &location : locations) {
+        auto highlight = make_unique<DocumentHighlight>(move(location->range));
+        highlights.push_back(move(highlight));
+    }
+    return highlights;
+}
+
+LSPResult LSPLoop::handleTextDocumentDocumentHighlight(unique_ptr<core::GlobalState> gs, const MessageId &id,
+                                                       const TextDocumentPositionParams &params) const {
+    auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentDocumentHighlight);
+    prodCategoryCounterInc("lsp.messages.processed", "textDocument.documentHighlight");
+    auto uri = params.textDocument->uri;
+    auto result = setupLSPQueryByLoc(move(gs), uri, *params.position, LSPMethod::TextDocumentCompletion, false);
+    gs = move(result.gs);
+    if (result.error) {
+        // An error happened while setting up the query.
+        response->error = move(result.error);
+    } else {
+        // An explicit null indicates that we don't support this request (or that nothing was at the location).
+        // Note: Need to correctly type variant here so it goes into right 'slot' of result variant.
+        response->result = variant<JSONNullObject, vector<unique_ptr<DocumentHighlight>>>(JSONNullObject());
+        auto &queryResponses = result.responses;
+        if (!queryResponses.empty()) {
+            const bool fileIsTyped = uri2FileRef(uri).data(*gs).strictLevel >= core::StrictLevel::True;
+            auto resp = move(queryResponses[0]);
+            // N.B.: Ignores literals.
+            // If file is untyped, only supports find reference requests from constants and class definitions.
+            if (auto constResp = resp->isConstant()) {
+                std::vector<std::unique_ptr<Location>> locations;
+                tie(gs, response->result) = getHighlightsToSymbolInFile(move(gs), uri, constResp->symbol);
+            } else if (auto defResp = resp->isDefinition()) {
+                if (fileIsTyped || defResp->symbol.data(*gs)->isClass()) {
+                    std::vector<std::unique_ptr<Location>> locations;
+                    tie(gs, response->result) = getHighlightsToSymbolInFile(move(gs), uri, defResp->symbol);
+                }
+            } else if (fileIsTyped && resp->isIdent()) {
+                auto identResp = resp->isIdent();
+                auto loc = identResp->owner.data(*gs)->loc();
+                if (loc.exists()) {
+                    auto run2 =
+                        runQuery(move(gs), core::lsp::Query::createVarQuery(identResp->owner, identResp->variable),
+                                 {loc.file()});
+                    gs = move(run2.gs);
+                    auto locations = extractLocations(*gs, run2.responses);
+                    response->result = locationsToDocumentHighlights(move(locations));
+                }
+            } else if (fileIsTyped && resp->isSend()) {
+                auto sendResp = resp->isSend();
+                auto start = sendResp->dispatchResult.get();
+                vector<unique_ptr<DocumentHighlight>> highlights;
+                while (start != nullptr) {
+                    if (start->main.method.exists() && !start->main.receiver->isUntyped()) {
+                        tie(gs, highlights) =
+                            getHighlightsToSymbolInFile(move(gs), uri, start->main.method, move(highlights));
+                    }
+                    start = start->secondary.get();
+                }
+                response->result = move(highlights);
+            }
+        }
+    }
+    return LSPResult::make(move(gs), move(response));
+}
+
+} // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -34,7 +34,14 @@ vector<unique_ptr<DocumentHighlight>> locationsToDocumentHighlights(vector<uniqu
 LSPResult LSPLoop::handleTextDocumentDocumentHighlight(unique_ptr<core::GlobalState> gs, const MessageId &id,
                                                        const TextDocumentPositionParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentDocumentHighlight);
+    if (!opts.lspDocumentHighlightEnabled) {
+        response->error = make_unique<ResponseError>(
+            (int)LSPErrorCodes::InvalidRequest, "The `Highlight` LSP feature is experimental and disabled by default.");
+        return LSPResult::make(move(gs), move(response));
+    }
+
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.documentHighlight");
+
     auto uri = params.textDocument->uri;
     auto result = setupLSPQueryByLoc(move(gs), uri, *params.position, LSPMethod::TextDocumentCompletion, false);
     gs = move(result.gs);

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -1318,6 +1318,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                      "textDocument/didChange",
                                      "textDocument/didClose",
                                      "textDocument/didOpen",
+                                     "textDocument/documentHighlight",
                                      "textDocument/documentSymbol",
                                      "textDocument/hover",
                                      "textDocument/publishDiagnostics",
@@ -1333,6 +1334,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
         makeDiscriminatedUnion(methodField, {
                                                 {"initialize", InitializeParams},
                                                 {"shutdown", makeOptional(JSONNull)},
+                                                {"textDocument/documentHighlight", TextDocumentPositionParams},
                                                 {"textDocument/documentSymbol", DocumentSymbolParams},
                                                 {"textDocument/definition", TextDocumentPositionParams},
                                                 {"textDocument/hover", TextDocumentPositionParams},
@@ -1356,6 +1358,9 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
         {
             {"initialize", InitializeResult},
             {"shutdown", JSONNull},
+            // DocumentHighlight[] | null
+            // Sorbet only uses DocumentSymbol[].
+            {"textDocument/documentHighlight", makeVariant({JSONNull, makeArray(DocumentHighlight)})},
             // DocumentSymbol[] | SymbolInformation[] | null
             // Sorbet only uses DocumentSymbol[].
             {"textDocument/documentSymbol", makeVariant({JSONNull, makeArray(DocumentSymbol)})},

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -104,6 +104,7 @@ int LSPWrapper::getTypecheckCount() const {
 void LSPWrapper::enableAllExperimentalFeatures() {
     enableExperimentalFeature(LSPExperimentalFeature::Autocomplete);
     enableExperimentalFeature(LSPExperimentalFeature::WorkspaceSymbols);
+    enableExperimentalFeature(LSPExperimentalFeature::DocumentHighlight);
     enableExperimentalFeature(LSPExperimentalFeature::DocumentSymbol);
     enableExperimentalFeature(LSPExperimentalFeature::SignatureHelp);
     enableExperimentalFeature(LSPExperimentalFeature::QuickFix);
@@ -119,6 +120,9 @@ void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
             break;
         case LSPExperimentalFeature::WorkspaceSymbols:
             opts.lspWorkspaceSymbolsEnabled = true;
+            break;
+        case LSPExperimentalFeature::DocumentHighlight:
+            opts.lspDocumentHighlightEnabled = true;
             break;
         case LSPExperimentalFeature::DocumentSymbol:
             opts.lspDocumentSymbolEnabled = true;

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -44,6 +44,7 @@ public:
         DocumentSymbol = 6,
         SignatureHelp = 7,
         QuickFix = 8,
+        DocumentHighlight = 9,
     };
 
     // N.B.: Sorbet assumes we 'own' this object; keep it alive to avoid memory errors.

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -338,6 +338,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                     "Enable experimental LSP feature: Workspace Symbols");
     options.add_options("advanced")("enable-experimental-lsp-document-symbol",
                                     "Enable experimental LSP feature: Document Symbol");
+    options.add_options("advanced")("enable-experimental-lsp-document-highlight",
+                                    "Enable experimental LSP feature: Document Highlight");
     options.add_options("advanced")("enable-experimental-lsp-signature-help",
                                     "Enable experimental LSP feature: Signature Help");
     options.add_options("advanced")("enable-experimental-lsp-quick-fix", "Enable experimental LSP feature: Quick Fix");
@@ -663,6 +665,8 @@ void readOptions(Options &opts,
             enableAllLSPFeatures || raw["enable-experimental-lsp-workspace-symbols"].as<bool>();
         opts.lspDocumentSymbolEnabled =
             enableAllLSPFeatures || raw["enable-experimental-lsp-document-symbol"].as<bool>();
+        opts.lspDocumentHighlightEnabled =
+            enableAllLSPFeatures || raw["enable-experimental-lsp-document-highlight"].as<bool>();
         opts.lspSignatureHelpEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-signature-help"].as<bool>();
 
         if (raw.count("lsp-directories-missing-from-client") > 0) {

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -195,6 +195,7 @@ struct Options {
     bool lspAutocompleteEnabled = false;
     bool lspQuickFixEnabled = false;
     bool lspWorkspaceSymbolsEnabled = false;
+    bool lspDocumentHighlightEnabled = false;
     bool lspDocumentSymbolEnabled = false;
     bool lspSignatureHelpEnabled = false;
     bool lspHoverEnabled = false;

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -198,7 +198,6 @@ struct Options {
     bool lspDocumentHighlightEnabled = false;
     bool lspDocumentSymbolEnabled = false;
     bool lspSignatureHelpEnabled = false;
-    bool lspHoverEnabled = false;
 
     std::string inlineInput; // passed via -e
     std::string debugLogFile;

--- a/main/options/test/options_test.cc
+++ b/main/options/test/options_test.cc
@@ -72,6 +72,7 @@ TEST(OptionsTest, DefaultConstructorMatchesReadOptions) {
     EXPECT_EQ(empty.lspQuickFixEnabled, opts.lspQuickFixEnabled);
     EXPECT_EQ(empty.lspWorkspaceSymbolsEnabled, opts.lspWorkspaceSymbolsEnabled);
     EXPECT_EQ(empty.lspDocumentSymbolEnabled, opts.lspDocumentSymbolEnabled);
+    EXPECT_EQ(empty.lspDocumentHighlightEnabled, opts.lspDocumentHighlightEnabled);
     EXPECT_EQ(empty.lspSignatureHelpEnabled, opts.lspSignatureHelpEnabled);
     EXPECT_EQ(empty.inlineInput, opts.inlineInput);
     EXPECT_EQ(empty.debugLogFile, opts.debugLogFile);

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -82,6 +82,9 @@ Usage:
       --enable-experimental-lsp-document-symbol
                                 Enable experimental LSP feature: Document
                                 Symbol
+      --enable-experimental-lsp-document-highlight
+                                Enable experimental LSP feature: Document
+                                Highlight
       --enable-experimental-lsp-signature-help
                                 Enable experimental LSP feature: Signature
                                 Help

--- a/test/helpers/lsp.cc
+++ b/test/helpers/lsp.cc
@@ -143,6 +143,13 @@ unique_ptr<LSPMessage> makeDefinitionRequest(int id, std::string_view uri, int l
                                                 make_unique<Position>(line, character))));
 }
 
+unique_ptr<LSPMessage> makeDocumentHighlightRequest(int id, std::string_view uri, int line, int character) {
+    return make_unique<LSPMessage>(make_unique<RequestMessage>(
+        "2.0", id, LSPMethod::TextDocumentDocumentHighlight,
+        make_unique<TextDocumentPositionParams>(make_unique<TextDocumentIdentifier>(string(uri)),
+                                                make_unique<Position>(line, character))));
+}
+
 /** Checks that we are properly advertising Sorbet LSP's capabilities to clients. */
 void checkServerCapabilities(const ServerCapabilities &capabilities) {
     // Properties checked in the same order they are described in the LSP spec.
@@ -178,7 +185,7 @@ void checkServerCapabilities(const ServerCapabilities &capabilities) {
     EXPECT_FALSE(capabilities.typeDefinitionProvider.has_value());
     EXPECT_FALSE(capabilities.implementationProvider.has_value());
     EXPECT_TRUE(capabilities.referencesProvider.value_or(false));
-    EXPECT_FALSE(capabilities.documentHighlightProvider.has_value());
+    EXPECT_TRUE(capabilities.documentHighlightProvider.has_value());
     EXPECT_TRUE(capabilities.documentSymbolProvider.value_or(false));
     EXPECT_TRUE(capabilities.workspaceSymbolProvider.value_or(false));
     EXPECT_TRUE(capabilities.codeActionProvider.has_value());

--- a/test/helpers/lsp.h
+++ b/test/helpers/lsp.h
@@ -17,6 +17,9 @@ makeInitializeParams(std::variant<std::string, JSONNullObject> rootPath,
 /** Create an LSPMessage containing a textDocument/definition request. */
 std::unique_ptr<LSPMessage> makeDefinitionRequest(int id, std::string_view uri, int line, int character);
 
+/** Create an LSPMessage containing a textDocument/documentHighlight request. */
+std::unique_ptr<LSPMessage> makeDocumentHighlightRequest(int id, std::string_view uri, int line, int character);
+
 /** Create an LSPMessage containing a textDocument/didChange request. */
 std::unique_ptr<LSPMessage> makeDidChange(std::string_view uri, std::string_view contents, int version);
 

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -76,6 +76,9 @@ public:
     // Returns a Location object for this assertion's filename and range.
     std::unique_ptr<Location> getLocation(std::string_view uriPrefix);
 
+    // Returns a DocumentHighlight object for this assertion's range.
+    std::unique_ptr<DocumentHighlight> getDocumentHighlight();
+
     virtual std::string toString() const = 0;
 };
 
@@ -143,6 +146,13 @@ public:
                    int version);
 
     std::string toString() const override;
+};
+
+class HighlightAssertion {
+public:
+    static void check(const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents,
+                      LSPWrapper &wrapper, int &nextId, std::string_view uriPrefix, std::string_view symbol,
+                      const Location &queryLoc, const std::vector<std::shared_ptr<RangeAssertion>> &allLocs);
 };
 
 // # disable-fast-path: true

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -85,10 +85,6 @@ unique_ptr<LSPMessage> ProtocolTest::getDefinition(string_view path, int line, i
     return makeDefinitionRequest(nextId++, getUri(path), line, character);
 }
 
-unique_ptr<LSPMessage> ProtocolTest::getDocumentHighlight(string_view path, int line, int character) {
-    return getDocumentHighlight(nextId++, getUri(path), line, character);
-}
-
 unique_ptr<LSPMessage> ProtocolTest::watchmanFileUpdate(vector<string> updatedFilePaths) {
     auto req = make_unique<NotificationMessage>("2.0", LSPMethod::SorbetWatchmanFileChange,
                                                 make_unique<WatchmanQueryResponse>("", "", false, updatedFilePaths));

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -85,6 +85,10 @@ unique_ptr<LSPMessage> ProtocolTest::getDefinition(string_view path, int line, i
     return makeDefinitionRequest(nextId++, getUri(path), line, character);
 }
 
+unique_ptr<LSPMessage> ProtocolTest::getDocumentHighlight(string_view path, int line, int character) {
+    return getDocumentHighlight(nextId++, getUri(path), line, character);
+}
+
 unique_ptr<LSPMessage> ProtocolTest::watchmanFileUpdate(vector<string> updatedFilePaths) {
     auto req = make_unique<NotificationMessage>("2.0", LSPMethod::SorbetWatchmanFileChange,
                                                 make_unique<WatchmanQueryResponse>("", "", false, updatedFilePaths));

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -56,6 +56,8 @@ protected:
 
     std::unique_ptr<LSPMessage> getDefinition(std::string_view path, int line, int character);
 
+    std::unique_ptr<LSPMessage> getDocumentHighlight(std::string_view path, int line, int character);
+
     std::unique_ptr<LSPMessage> cancelRequest(int id);
 
     void writeFilesToFS(std::vector<std::pair<std::string, std::string>> files);

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -56,8 +56,6 @@ protected:
 
     std::unique_ptr<LSPMessage> getDefinition(std::string_view path, int line, int character);
 
-    std::unique_ptr<LSPMessage> getDocumentHighlight(std::string_view path, int line, int character);
-
     std::unique_ptr<LSPMessage> cancelRequest(int id);
 
     void writeFilesToFS(std::vector<std::pair<std::string, std::string>> files);

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -812,6 +812,16 @@ TEST_P(LSPTest, All) {
                     // Check that a reference request at this location returns entryAssertions.
                     UsageAssertion::check(test.sourceFileContents, *lspWrapper, nextId, rootUri, symbol, *queryLoc,
                                           entryAssertions);
+                    // Check that a highlight request at this location returns all of the entryAssertions for the same
+                    // file as the request.
+                    vector<shared_ptr<RangeAssertion>> filteredEntryAssertions;
+                    for (auto &e : entryAssertions) {
+                        if (absl::StartsWith(e->getLocation(rootUri)->uri, queryLoc->uri)) {
+                            filteredEntryAssertions.push_back(e);
+                        }
+                    }
+                    HighlightAssertion::check(test.sourceFileContents, *lspWrapper, nextId, rootUri, symbol, *queryLoc,
+                                              filteredEntryAssertions);
                 } else {
                     ADD_FAILURE() << fmt::format(
                         "Found usage comment for label {0} version {1} without matching def comment. Please add a `# "

--- a/test/testdata/lsp/definitions_and_usages_untyped__untyped.rb
+++ b/test/testdata/lsp/definitions_and_usages_untyped__untyped.rb
@@ -14,7 +14,7 @@ module Untyped
 end
 
 def main
-  # go-to-def/find refs should work on constant refs.
+  # go-to-def/find-refs/highlight should work on constant refs.
   TypedFoo.new.bar
 # ^^^^^^^^ usage: TypedFoo
              # ^^^ def: (nothing) 2

--- a/test/testdata/lsp/highlight.rb
+++ b/test/testdata/lsp/highlight.rb
@@ -1,0 +1,45 @@
+# typed: true
+
+class TestClass
+    # ^^^^^^^^^ def: TestClass
+  def method(a, b, &block)
+           # ^ def: arga
+              # ^ def: b
+                  # ^^^^^ def: block
+    c = a + b
+  # ^ def: c
+      # ^ usage: arga
+          # ^ usage: b
+    d = c + 3
+      # ^ usage: c
+
+    block.call
+  # ^^^^^ usage: block
+  end
+
+  def method_reusing_argnames(
+    a: 42,
+  # ^ def: adef 2
+    b: 15
+  # ^ def: bdef 2
+  )
+  a + b
+# ^ usage: adef 2
+    # ^ usage: bdef 2
+  end
+end
+
+# Introduced to avoid awkward indenting.
+if $0 == __FILE__
+  # Ensure multiple variables named 'a' are not confused, and that 'a' references
+  # point back to latest assignment.
+  a = 3
+# ^ def: outera 1
+  a = 5
+# ^ def: outera 2
+  c = a + 1
+    # ^ usage: outera 2
+  d = TestClass.new()
+    # ^^^^^^^^^ usage: TestClass
+  d.method(1, 2) {}
+end

--- a/test/testdata/lsp/highlight_simple.rb
+++ b/test/testdata/lsp/highlight_simple.rb
@@ -1,0 +1,16 @@
+# typed: true
+
+class TestClass
+    # ^^^^^^^^^ def: TestClass
+  def method(a)
+           # ^ def: arga
+    a
+  # ^ usage: arga
+  end
+end
+
+# Introduced to avoid awkward indenting.
+if $0 == __FILE__
+  d = TestClass.new()
+    # ^^^^^^^^^ usage: TestClass
+end


### PR DESCRIPTION
@jvilk-stripe -- I've submitted the PR to be able to pull the CI release build. I haven't tries the LSP functionality yet but a review pass would be great since the LSP tests seem ✅ locally.

This adds the LSP functionality for `textDocument/documentHighlight` ([Microsoft specification for documentHighlight](https://microsoft.github.io/language-server-protocol/specification#textDocument_documentHighlight)).

When a user selects a piece of text, the LSP responds with a list of ranges to highlight in the current file which relate to the initiate selection. 

Currently, highlighting uses the same information `textDocument/references` does. That means  this will work for typed files otherwise it can only handle Ruby constants in untyped files. Compared to regular fuzzy-highlighting, this will only respond with highlights for an identifier reference within the scope it is valid in which is the added benefit!

This does not implement the response field `kind?: DocumentHighlightKind`, which identifies the response values as the more specific highlights:
- `Text`, a textual occurrence -- typically a fuzzy response.
- `Read`, a read-access of a symbol, like reading a variable.
- `Write`, a write-access of a symbol, like writing to a variable.

By default, the editor will consider no `kind` as a `Text` response.

After poking in VSCode I noticed there are [distinguishing styling for the types](https://github.com/microsoft/vscode/blob/466e5ef6c2188d61a8c93c53748aa9e9788bcfc9/src/vs/editor/contrib/wordHighlighter/wordHighlighter.ts#L427-L452). In particular, the styling settings, [found here](https://code.visualstudio.com/api/references/theme-color#editor-colors), are:
- `editor.wordHighlight{Background,Border}` for read-access
- `editor.wordHighlightStrong{Background,Border}` for write-access
- `editor.selectionHighlight{Background,Border}` for fuzzy text.

It wasn't obvious whether that information could be pulled out of the LSP query `DispatchResult` so I didn't dig any further.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
LSP features :)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
Updated the tests so that all of the `def` + `usage` assertions will also check the highlight query. It differs by only checking the query returns values for all assertions in one file rather than all of them.