### PR TITLE
Avoid trying to print emptytree

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -557,7 +557,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                     auto block = MK::InsSeq(loc, std::move(stats), std::move(expr));
                     result.swap(block);
                 } else {
-                    unique_ptr<Expression> res = MK::EmptyTree();
+                    unique_ptr<Expression> res = MK::Nil(loc);
                     result.swap(res);
                 }
             },

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1621,7 +1621,7 @@ public:
         ENFORCE(args.args.size() == 1);
         auto ty = core::Types::widen(ctx, args.args.front()->type);
         auto loc = args.locs.args[0];
-        if (!ty->isUntyped()) {
+        if (!ty->isUntyped() && loc.exists()) {
             if (auto e = ctx.state.beginError(loc, core::errors::Infer::UntypedConstantSuggestion)) {
                 e.setHeader("Suggested type for constant without type annotation: `{}`", ty->show(ctx));
                 e.replaceWith(fmt::format("Initialize as `{}`", ty->show(ctx)), loc, "T.let({}, {})", loc.source(ctx),

--- a/test/testdata/desugar/assign_empty_parens.rb
+++ b/test/testdata/desugar/assign_empty_parens.rb
@@ -1,0 +1,2 @@
+# typed: strict
+U = ()

--- a/test/testdata/desugar/assign_empty_stmts.rb
+++ b/test/testdata/desugar/assign_empty_stmts.rb
@@ -1,0 +1,3 @@
+# typed: strict
+U = begin
+end

--- a/test/testdata/desugar/assign_keyword.rb
+++ b/test/testdata/desugar/assign_keyword.rb
@@ -1,0 +1,2 @@
+# typed: strict
+U = redo # error: Unsupported node type `Redo`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes #1533 by not printing suggestions about `Loc::none()`. Also turn one usage of `EmptyTree` into `Nil` to avoid more confusing location-less error messages.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Included two tests from #1533.
