### PR TITLE
Add positive? and negative? methods to Numeric.

### DIFF
--- a/rbi/core/numeric.rbi
+++ b/rbi/core/numeric.rbi
@@ -416,6 +416,10 @@ class Numeric < Object
   end
   def modulo(arg0); end
 
+  # Returns `true` if `num` is less than 0.
+  sig {returns(T::Boolean}
+  def negative?(); end
+
   # Returns `self` if `num` is not zero, `nil` otherwise.
   #
   # This behavior is useful when chaining comparisons:
@@ -439,6 +443,10 @@ class Numeric < Object
   # Returns an array; \[num.abs, num.arg\].
   sig {returns([Numeric, Numeric])}
   def polar(); end
+
+  # Returns `true` if `num` is greater than 0.
+  sig {returns(T::Boolean}
+  def positive?(); end
 
   # Returns the most exact division (rational for integers, float for
   # floats).

--- a/rbi/core/numeric.rbi
+++ b/rbi/core/numeric.rbi
@@ -417,7 +417,7 @@ class Numeric < Object
   def modulo(arg0); end
 
   # Returns `true` if `num` is less than 0.
-  sig {returns(T::Boolean}
+  sig {returns(T::Boolean)}
   def negative?(); end
 
   # Returns `self` if `num` is not zero, `nil` otherwise.
@@ -445,7 +445,7 @@ class Numeric < Object
   def polar(); end
 
   # Returns `true` if `num` is greater than 0.
-  sig {returns(T::Boolean}
+  sig {returns(T::Boolean)}
   def positive?(); end
 
   # Returns the most exact division (rational for integers, float for


### PR DESCRIPTION
### Motivation
These methods were missing and I wanted them to be typed :)

### Test plan
See included automated tests.

`positive?`: https://ruby-doc.org/core-2.5.0/Numeric.html#method-i-positive-3F
`negative?`: https://ruby-doc.org/core-2.5.0/Numeric.html#method-i-negative-3F