### PR TITLE
Add helper methods to codegenned classes + clean up test_corpus

### DIFF
--- a/main/lsp/json_types.cc
+++ b/main/lsp/json_types.cc
@@ -101,7 +101,7 @@ unique_ptr<Range> Range::fromLoc(const core::GlobalState &gs, core::Loc loc) {
                               make_unique<Position>(pair.second.line - 1, pair.second.column - 1));
 }
 
-core::Loc Range::toLoc(const core::GlobalState &gs, core::FileRef file) {
+core::Loc Range::toLoc(const core::GlobalState &gs, core::FileRef file) const {
     ENFORCE(start->line >= 0);
     ENFORCE(start->character >= 0);
     ENFORCE(end->line >= 0);
@@ -111,6 +111,42 @@ core::Loc Range::toLoc(const core::GlobalState &gs, core::FileRef file) {
     auto ePos = core::Loc::pos2Offset(file.data(gs), core::Loc::Detail{(u4)end->line + 1, (u4)end->character + 1});
 
     return core::Loc(file, sPos, ePos);
+}
+
+int Range::cmp(const Range &b) const {
+    const int startCmp = start->cmp(*b.start);
+    if (startCmp != 0) {
+        return startCmp;
+    }
+    return end->cmp(*b.end);
+}
+
+bool Range::operator<(const Range &b) const {
+    return cmp(b) < 0;
+}
+
+int Location::cmp(const Location &b) const {
+    const int uriCmp = uri.compare(b.uri);
+    if (uriCmp != 0) {
+        return uriCmp;
+    }
+    return range->cmp(*b.range);
+}
+
+bool Location::operator<(const Location &b) const {
+    return cmp(b) < 0;
+}
+
+int Position::cmp(const Position &b) const {
+    const int lineCmp = line - b.line;
+    if (lineCmp != 0) {
+        return lineCmp;
+    }
+    return character - b.character;
+}
+
+bool Position::operator<(const Position &b) const {
+    return cmp(b) < 0;
 }
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/json_types.cc
+++ b/main/lsp/json_types.cc
@@ -121,10 +121,6 @@ int Range::cmp(const Range &b) const {
     return end->cmp(*b.end);
 }
 
-bool Range::operator<(const Range &b) const {
-    return cmp(b) < 0;
-}
-
 unique_ptr<Range> Range::copy() const {
     return make_unique<Range>(start->copy(), end->copy());
 }
@@ -137,20 +133,12 @@ int Location::cmp(const Location &b) const {
     return range->cmp(*b.range);
 }
 
-bool Location::operator<(const Location &b) const {
-    return cmp(b) < 0;
-}
-
 int Position::cmp(const Position &b) const {
     const int lineCmp = line - b.line;
     if (lineCmp != 0) {
         return lineCmp;
     }
     return character - b.character;
-}
-
-bool Position::operator<(const Position &b) const {
-    return cmp(b) < 0;
 }
 
 unique_ptr<Position> Position::copy() const {

--- a/main/lsp/json_types.cc
+++ b/main/lsp/json_types.cc
@@ -125,6 +125,10 @@ bool Range::operator<(const Range &b) const {
     return cmp(b) < 0;
 }
 
+unique_ptr<Range> Range::copy() const {
+    return make_unique<Range>(start->copy(), end->copy());
+}
+
 int Location::cmp(const Location &b) const {
     const int uriCmp = uri.compare(b.uri);
     if (uriCmp != 0) {
@@ -147,6 +151,10 @@ int Position::cmp(const Position &b) const {
 
 bool Position::operator<(const Position &b) const {
     return cmp(b) < 0;
+}
+
+unique_ptr<Position> Position::copy() const {
+    return make_unique<Position>(line, character);
 }
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/json_types.h
+++ b/main/lsp/json_types.h
@@ -2,6 +2,7 @@
 #define RUBY_TYPER_LSP_JSON_TYPES_H
 
 #include "common/common.h"
+#include "core/core.h"
 #include "rapidjson/document.h"
 
 #include <optional>

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -160,7 +160,7 @@ LSPResult LSPLoop::pushDiagnostics(TypecheckRun run) {
                 // diagnostics
                 if (errorsAccumulated.find(file) != errorsAccumulated.end()) {
                     for (auto &e : errorsAccumulated[file]) {
-                        auto range = loc2Range(gs, e->loc);
+                        auto range = Range::fromLoc(gs, e->loc);
                         if (range == nullptr) {
                             continue;
                         }

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -312,8 +312,6 @@ std::string methodDetail(const core::GlobalState &gs, core::SymbolRef method, co
 core::TypePtr getResultType(const core::GlobalState &gs, core::TypePtr type, core::SymbolRef inWhat,
                             core::TypePtr receiver, const std::unique_ptr<core::TypeConstraint> &constr);
 SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef);
-int cmpPositions(const Position &a, const Position &b);
-int cmpRanges(const Range &a, const Range &b);
 
 } // namespace sorbet::realmain::lsp
 #endif // RUBY_TYPER_LSPLOOP_H

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -312,9 +312,6 @@ std::string methodDetail(const core::GlobalState &gs, core::SymbolRef method, co
 core::TypePtr getResultType(const core::GlobalState &gs, core::TypePtr type, core::SymbolRef inWhat,
                             core::TypePtr receiver, const std::unique_ptr<core::TypeConstraint> &constr);
 SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef);
-// returns nullptr if this loc doesn't exist
-std::unique_ptr<Range> loc2Range(const core::GlobalState &gs, core::Loc loc);
-std::unique_ptr<core::Loc> range2Loc(const core::GlobalState &gs, const Range &range, core::FileRef file);
 int cmpPositions(const Position &a, const Position &b);
 int cmpRanges(const Range &a, const Range &b);
 

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -129,7 +129,8 @@ LSPLoop::extractLocations(const core::GlobalState &gs,
         }
     }
     // Dedupe locations
-    fast_sort(locations, [](const unique_ptr<Location> &a, const unique_ptr<Location> &b) -> bool { return *a < *b; });
+    fast_sort(locations,
+              [](const unique_ptr<Location> &a, const unique_ptr<Location> &b) -> bool { return a->cmp(*b) < 0; });
     locations.resize(std::distance(locations.begin(),
                                    std::unique(locations.begin(), locations.end(),
                                                [](const unique_ptr<Location> &a,

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -89,33 +89,8 @@ string LSPLoop::fileRef2Uri(const core::GlobalState &gs, core::FileRef file) con
     return uri;
 } // namespace sorbet::realmain::lsp
 
-unique_ptr<Range> loc2Range(const core::GlobalState &gs, core::Loc loc) {
-    if (!loc.exists()) {
-        // this will happen if e.g. we disable the stdlib (e.g. to speed up testing in fuzzers).
-        return nullptr;
-    }
-    auto pair = loc.position(gs);
-    // All LSP numbers are zero-based, ours are 1-based.
-    return make_unique<Range>(make_unique<Position>(pair.first.line - 1, pair.first.column - 1),
-                              make_unique<Position>(pair.second.line - 1, pair.second.column - 1));
-}
-
-unique_ptr<core::Loc> range2Loc(const core::GlobalState &gs, const Range &range, core::FileRef file) {
-    ENFORCE(range.start->line >= 0);
-    ENFORCE(range.start->character >= 0);
-    ENFORCE(range.end->line >= 0);
-    ENFORCE(range.end->character >= 0);
-
-    auto start = core::Loc::pos2Offset(file.data(gs),
-                                       core::Loc::Detail{(u4)range.start->line + 1, (u4)range.start->character + 1});
-    auto end =
-        core::Loc::pos2Offset(file.data(gs), core::Loc::Detail{(u4)range.end->line + 1, (u4)range.end->character + 1});
-
-    return make_unique<core::Loc>(file, start, end);
-}
-
 unique_ptr<Location> LSPLoop::loc2Location(const core::GlobalState &gs, core::Loc loc) const {
-    auto range = loc2Range(gs, loc);
+    auto range = Range::fromLoc(gs, loc);
     if (range == nullptr) {
         return nullptr;
     }

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -114,35 +114,6 @@ unique_ptr<Location> LSPLoop::loc2Location(const core::GlobalState &gs, core::Lo
     return make_unique<Location>(uri, std::move(range));
 }
 
-int cmpPositions(const Position &a, const Position &b) {
-    const int line = a.line - b.line;
-    if (line != 0) {
-        return line;
-    }
-    return a.character - b.character;
-}
-
-int cmpLocations(const Location &a, const Location &b) {
-    const int fileCmp = a.uri.compare(b.uri);
-    if (fileCmp != 0) {
-        return fileCmp;
-    }
-    const int startCmp = cmpPositions(*a.range->start, *b.range->start);
-    if (startCmp != 0) {
-        return startCmp;
-    }
-    return cmpPositions(*a.range->end, *b.range->end);
-}
-
-int cmpRanges(const Range &a, const Range &b) {
-    const int cmpStart = cmpPositions(*a.start, *b.start);
-    if (cmpStart != 0) {
-        // One starts before the other.
-        return cmpStart;
-    }
-    return cmpPositions(*a.end, *b.end);
-}
-
 vector<unique_ptr<Location>>
 LSPLoop::extractLocations(const core::GlobalState &gs,
                           const vector<unique_ptr<core::lsp::QueryResponse>> &queryResponses,
@@ -158,14 +129,11 @@ LSPLoop::extractLocations(const core::GlobalState &gs,
         }
     }
     // Dedupe locations
-    fast_sort(locations, [](const unique_ptr<Location> &a, const unique_ptr<Location> &b) -> bool {
-        return cmpLocations(*a, *b) < 0;
-    });
-    locations.resize(std::distance(
-        locations.begin(), std::unique(locations.begin(), locations.end(),
-                                       [](const unique_ptr<Location> &a, const unique_ptr<Location> &b) -> bool {
-                                           return cmpLocations(*a, *b) == 0;
-                                       })));
+    fast_sort(locations, [](const unique_ptr<Location> &a, const unique_ptr<Location> &b) -> bool { return *a < *b; });
+    locations.resize(std::distance(locations.begin(),
+                                   std::unique(locations.begin(), locations.end(),
+                                               [](const unique_ptr<Location> &a,
+                                                  const unique_ptr<Location> &b) -> bool { return a->cmp(*b) == 0; })));
     return locations;
 }
 

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -37,8 +37,8 @@ std::unique_ptr<DocumentSymbol> symbolRef2DocumentSymbol(const core::GlobalState
     }
     auto kind = symbolRef2SymbolKind(gs, symRef);
     // TODO: this range should cover body. Currently it doesn't.
-    auto range = loc2Range(gs, sym->loc());
-    auto selectionRange = loc2Range(gs, sym->loc());
+    auto range = Range::fromLoc(gs, sym->loc());
+    auto selectionRange = Range::fromLoc(gs, sym->loc());
     if (range == nullptr || selectionRange == nullptr) {
         return nullptr;
     }

--- a/main/lsp/tools/generate_lsp_messages.h
+++ b/main/lsp/tools/generate_lsp_messages.h
@@ -631,6 +631,7 @@ public:
 
 class JSONObjectType final : public JSONClassType {
 private:
+    std::vector<std::string> extraMethodDefinitions;
     std::vector<std::shared_ptr<FieldDef>> fieldDefs;
     std::vector<std::shared_ptr<FieldDef>> getRequiredFields() {
         std::vector<std::shared_ptr<FieldDef>> reqFields;
@@ -641,8 +642,9 @@ private:
     }
 
 public:
-    JSONObjectType(std::string_view typeName, std::vector<std::shared_ptr<FieldDef>> fieldDefs)
-        : JSONClassType(typeName), fieldDefs(fieldDefs) {}
+    JSONObjectType(std::string_view typeName, std::vector<std::shared_ptr<FieldDef>> fieldDefs,
+                   std::vector<std::string> extraMethodDefinitions)
+        : JSONClassType(typeName), extraMethodDefinitions(extraMethodDefinitions), fieldDefs(fieldDefs) {}
 
     BaseKind getCPPBaseKind() const {
         return BaseKind::ObjectKind;
@@ -698,6 +700,7 @@ public:
         }
         fmt::format_to(
             out, "std::unique_ptr<rapidjson::Value> toJSONValue(rapidjson::MemoryPoolAllocator<> &alloc) const;\n");
+        fmt::format_to(out, "{}\n", fmt::join(extraMethodDefinitions.begin(), extraMethodDefinitions.end(), "\n"));
         fmt::format_to(out, "}};\n");
     }
 

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -95,7 +95,6 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                classTypes,
                                {
                                    "int cmp(const Position &b) const;",
-                                   "bool operator <(const Position &b) const;",
                                    "std::unique_ptr<Position> copy() const;",
                                });
 
@@ -110,7 +109,6 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                 "static std::unique_ptr<Range> fromLoc(const core::GlobalState &gs, core::Loc loc);",
                                 "core::Loc toLoc(const core::GlobalState &gs, core::FileRef file) const;",
                                 "int cmp(const Range &b) const;",
-                                "bool operator <(const Range &b) const;",
                                 "std::unique_ptr<Range> copy() const;",
                             });
 
@@ -122,7 +120,6 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                classTypes,
                                {
                                    "int cmp(const Location &b) const;",
-                                   "bool operator <(const Location &b) const;",
                                });
 
     auto DiagnosticRelatedInformation = makeObject("DiagnosticRelatedInformation",

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -96,6 +96,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                {
                                    "int cmp(const Position &b) const;",
                                    "bool operator <(const Position &b) const;",
+                                   "std::unique_ptr<Position> copy() const;",
                                });
 
     auto Range = makeObject("Range",
@@ -110,6 +111,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                 "core::Loc toLoc(const core::GlobalState &gs, core::FileRef file) const;",
                                 "int cmp(const Range &b) const;",
                                 "bool operator <(const Range &b) const;",
+                                "std::unique_ptr<Range> copy() const;",
                             });
 
     auto Location = makeObject("Location",

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -92,7 +92,11 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                    makeField("line", JSONInt),
                                    makeField("character", JSONInt),
                                },
-                               classTypes);
+                               classTypes,
+                               {
+                                   "int cmp(const Position &b) const;",
+                                   "bool operator <(const Position &b) const;",
+                               });
 
     auto Range = makeObject("Range",
                             {
@@ -103,7 +107,9 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                             {
                                 "// Returns nullptr if loc does not exist",
                                 "static std::unique_ptr<Range> fromLoc(const core::GlobalState &gs, core::Loc loc);",
-                                "core::Loc toLoc(const core::GlobalState &gs, core::FileRef file);",
+                                "core::Loc toLoc(const core::GlobalState &gs, core::FileRef file) const;",
+                                "int cmp(const Range &b) const;",
+                                "bool operator <(const Range &b) const;",
                             });
 
     auto Location = makeObject("Location",
@@ -111,7 +117,11 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                    makeField("uri", JSONString),
                                    makeField("range", Range),
                                },
-                               classTypes);
+                               classTypes,
+                               {
+                                   "int cmp(const Location &b) const;",
+                                   "bool operator <(const Location &b) const;",
+                               });
 
     auto DiagnosticRelatedInformation = makeObject("DiagnosticRelatedInformation",
                                                    {

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -29,8 +29,9 @@ shared_ptr<FieldDef> makeField(const string jsonName, const string cppName, shar
 }
 
 shared_ptr<JSONObjectType> makeObject(const string name, vector<shared_ptr<FieldDef>> fields,
-                                      vector<shared_ptr<JSONObjectType>> &classTypes) {
-    shared_ptr<JSONObjectType> ct = make_shared<JSONObjectType>(name, fields);
+                                      vector<shared_ptr<JSONObjectType>> &classTypes,
+                                      vector<string> extraMethodDefinitions = {}) {
+    shared_ptr<JSONObjectType> ct = make_shared<JSONObjectType>(name, fields, extraMethodDefinitions);
     classTypes.push_back(ct);
     return ct;
 }
@@ -98,7 +99,12 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                 makeField("start", Position),
                                 makeField("end", Position),
                             },
-                            classTypes);
+                            classTypes,
+                            {
+                                "// Returns nullptr if loc does not exist",
+                                "static std::unique_ptr<Range> fromLoc(const core::GlobalState &gs, core::Loc loc);",
+                                "core::Loc toLoc(const core::GlobalState &gs, core::FileRef file);",
+                            });
 
     auto Location = makeObject("Location",
                                {

--- a/test/helpers/lsp.h
+++ b/test/helpers/lsp.h
@@ -23,17 +23,15 @@ std::unique_ptr<LSPMessage> makeDidChange(std::string_view uri, std::string_view
 /** Checks that we are properly advertising Sorbet LSP's capabilities to clients. */
 void checkServerCapabilities(const ServerCapabilities &capabilities);
 
-/** Asserts that the LSPMessage is a ResponseMessage with the given id. Returns true on success, fails
- * the test otherwise. */
-bool assertResponseMessage(int expectedId, const LSPMessage &response);
+/** Asserts that the LSPMessage is a ResponseMessage with the given id. */
+void assertResponseMessage(int expectedId, const LSPMessage &response);
 
 /** Asserts that the LSPMessage is a ResponseMessage with an error of the given code and that
- * contains the given message. Returns true on success, fails otherwise. */
-bool assertResponseError(int code, std::string_view msg, const LSPMessage &response);
+ * contains the given message. */
+void assertResponseError(int code, std::string_view msg, const LSPMessage &response);
 
-/** Asserts that the LSPMessage is a NotificationMessage with the given method. Returns true on
- * success, fails the test otherwise. */
-bool assertNotificationMessage(const LSPMethod expectedMethod, const LSPMessage &response);
+/** Asserts that the LSPMessage is a NotificationMessage with the given method. */
+void assertNotificationMessage(const LSPMethod expectedMethod, const LSPMessage &response);
 
 /** Retrieves the PublishDiagnosticsParam from a publishDiagnostics message, if applicable. Non-fatal fails and returns
  * an empty optional if it cannot be found. */

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -276,10 +276,8 @@ RangeAssertion::parseAssertions(const UnorderedMap<string, shared_ptr<core::File
 }
 
 unique_ptr<Location> RangeAssertion::getLocation(string_view uriPrefix) {
-    auto newRange = make_unique<Range>(make_unique<Position>(range->start->line, range->start->character),
-                                       make_unique<Position>(range->end->line, range->end->character));
     auto uri = filePathToUri(uriPrefix, filename);
-    return make_unique<Location>(uri, move(newRange));
+    return make_unique<Location>(uri, range->copy());
 }
 
 pair<string_view, int> getSymbolAndVersion(string_view assertionContents) {
@@ -799,8 +797,7 @@ bool containsLine(string_view text, string_view line) {
 void HoverAssertion::check(const UnorderedMap<string, shared_ptr<core::File>> &sourceFileContents, LSPWrapper &wrapper,
                            int &nextId, string_view uriPrefix, string errorPrefix) {
     auto uri = filePathToUri(uriPrefix, filename);
-    auto pos = make_unique<TextDocumentPositionParams>(
-        make_unique<TextDocumentIdentifier>(uri), make_unique<Position>(range->start->line, range->start->character));
+    auto pos = make_unique<TextDocumentPositionParams>(make_unique<TextDocumentIdentifier>(uri), range->start->copy());
     auto id = nextId++;
     auto msg = LSPMessage(make_unique<RequestMessage>("2.0", id, LSPMethod::TextDocumentHover, move(pos)));
     auto responses = wrapper.getLSPResponsesFor(msg);

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -119,12 +119,12 @@ int RangeAssertion::compare(string_view otherFilename, const Range &otherRange) 
     if (range->end->character == RangeAssertion::END_OF_LINE_POS) {
         // This assertion matches the whole line.
         // (Will match diagnostics that span multiple lines for parity with existing test logic.)
-        int targetLine = range->start->line;
+        const int targetLine = range->start->line;
         const int cmp = targetLine - otherRange.start->line;
         if (cmp >= 0 && targetLine <= otherRange.end->line) {
             return 0;
         } else {
-            return targetLine - otherRange.start->line;
+            return cmp;
         }
     }
     return range->cmp(otherRange);
@@ -862,10 +862,7 @@ void ApplyCodeActionAssertion::check(const UnorderedMap<std::string, std::shared
     for (auto &c : *codeAction.edit.value()->documentChanges) {
         auto filename = uriToFilePath(rootUri, c->textDocument->uri);
         auto it = sourceFileContents.find(filename);
-        if (it == sourceFileContents.end()) {
-            ADD_FAILURE() << fmt::format("Unable to find referenced source file `{}`", filename);
-            return;
-        }
+        ASSERT_NE(it, sourceFileContents.end()) << fmt::format("Unable to find referenced source file `{}`", filename);
         auto &file = it->second;
 
         auto expectedUpdatedFilePath =

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -69,6 +69,8 @@ public:
      * Range.cmp, this function supports line-only ranges. */
     int compare(std::string_view otherFilename, const Range &otherRange);
 
+    bool operator<(const RangeAssertion &b) const;
+
     // Returns a Location object for this assertion's filename and range.
     std::unique_ptr<Location> getLocation(std::string_view uriPrefix);
 

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -64,12 +64,12 @@ public:
     RangeAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine);
     virtual ~RangeAssertion() = default;
 
-    /** Compares this assertion's filename and range with the given filename and range. Returns 0 if it matches, a
-     * negative int if range comes before otherRange, and a positive int if otherRange comes before range. Unlike
-     * Range.cmp, this function supports line-only ranges. */
-    int compare(std::string_view otherFilename, const Range &otherRange);
+    /** Checks if the provided filename and range matches the assertion. Returns 0 if they match, a
+     * negative int if they come after, and a positive int if they come before. Unlike
+     * `cmp`, this function has special logic for line-only ranges. */
+    int matches(std::string_view otherFilename, const Range &otherRange);
 
-    bool operator<(const RangeAssertion &b) const;
+    int cmp(const RangeAssertion &b) const;
 
     // Returns a Location object for this assertion's filename and range.
     std::unique_ptr<Location> getLocation(std::string_view uriPrefix);

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -9,10 +9,6 @@
 namespace sorbet::test {
 using namespace sorbet::realmain::lsp;
 
-// Compares the two ranges. Returns -1 if `a` comes before `b`, 1 if `b` comes before `a`, and 0 if they are equivalent.
-// If range `a` starts at the same character as `b` but ends earlier, it comes before `b`.
-int rangeComparison(const Range &a, const Range &b);
-
 // Compares the two errors. Returns -1 if `a` comes before `b`, 1 if `b` comes before `a`, and 0 if they are equivalent.
 // Compares filenames, then ranges, and then compares messages in the event of a tie.
 int errorComparison(std::string_view aFilename, const Range &a, std::string_view aMessage, std::string_view bFilename,
@@ -68,9 +64,9 @@ public:
     RangeAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine);
     virtual ~RangeAssertion() = default;
 
-    /** Compares this assertion's filename and range with the given filename and range. Returns 0 if it matches, -1 if
-     * range comes before otherRange, and 1 if otherRange comes before range. Unlike rangeComparison, this function
-     * supports line-only ranges. */
+    /** Compares this assertion's filename and range with the given filename and range. Returns 0 if it matches, a
+     * negative int if range comes before otherRange, and a positive int if otherRange comes before range. Unlike
+     * Range.cmp, this function supports line-only ranges. */
     int compare(std::string_view otherFilename, const Range &otherRange);
 
     // Returns a Location object for this assertion's filename and range.

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -180,10 +180,7 @@ vector<unique_ptr<Location>> ProtocolTest::getDefinitions(std::string_view uri, 
 
 void ProtocolTest::assertDiagnostics(vector<unique_ptr<LSPMessage>> messages, vector<ExpectedDiagnostic> expected) {
     for (auto &msg : messages) {
-        if (!assertNotificationMessage(LSPMethod::TextDocumentPublishDiagnostics, *msg)) {
-            // Assertion failed: Received a non-diagnostic. No need to continue.
-            return;
-        }
+        ASSERT_NO_FATAL_FAILURE(assertNotificationMessage(LSPMethod::TextDocumentPublishDiagnostics, *msg));
     }
 
     // Convert ExpectedDiagnostic into ErrorAssertion objects.

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -78,7 +78,7 @@ TEST_F(ProtocolTest, Cancellation) {
         ASSERT_NE(idIt, requestIds.end())
             << fmt::format("Received cancellation response for invalid request id: {}", (*errorMsg->id()).asInt());
         requestIds.erase(idIt);
-        assertResponseError(-32800, "cancel", *errorMsg);
+        ASSERT_NO_FATAL_FAILURE(assertResponseError(-32800, "cancel", *errorMsg));
     }
     ASSERT_EQ(requestIds.size(), 0);
 }
@@ -90,7 +90,7 @@ TEST_F(ProtocolTest, DefinitionError) {
     auto defResponses = send(*getDefinition("foobar.rb", 6, 1));
     ASSERT_EQ(defResponses.size(), 1) << "Expected a single response to a definition request to an untyped document.";
 
-    assertResponseMessage(nextId - 1, *defResponses.at(0));
+    ASSERT_NO_FATAL_FAILURE(assertResponseMessage(nextId - 1, *defResponses.at(0)));
 
     auto &respMsg = defResponses.at(0)->asResponse();
     ASSERT_TRUE(respMsg.result);
@@ -136,7 +136,7 @@ TEST_F(ProtocolTest, MergeDidChangeAfterCancellation) {
     int diagnosticCount = 0;
     for (auto &msg : msgs) {
         if (msg->isResponse()) {
-            assertResponseError(-32800, "cancel", *msg);
+            ASSERT_NO_FATAL_FAILURE(assertResponseError(-32800, "cancel", *msg));
             cancelRequestCount++;
         } else if (msg->isNotification() && msg->method() == LSPMethod::TextDocumentPublishDiagnostics) {
             diagnosticCount++;
@@ -249,7 +249,7 @@ TEST_F(ProtocolTest, NotInitialized) {
     auto msgs = send(*getDefinition("foo.rb", 12, 24));
     ASSERT_EQ(msgs.size(), 1);
     auto &msg1 = msgs.at(0);
-    assertResponseError(-32002, "not initialize", *msg1);
+    ASSERT_NO_FATAL_FAILURE(assertResponseError(-32002, "not initialize", *msg1));
 }
 
 // There's a different code path that checks for workspace edits before initialization occurs.
@@ -287,11 +287,10 @@ TEST_F(ProtocolTest, EmptyRootUriInitialization) {
     // Check the response for the expected URI.
     EXPECT_EQ(diagnostics.size(), 1);
     auto &msg = diagnostics.at(0);
-    if (assertNotificationMessage(LSPMethod::TextDocumentPublishDiagnostics, *msg)) {
-        // Will fail test if this does not parse.
-        if (auto diagnosticParams = getPublishDiagnosticParams(msg->asNotification())) {
-            EXPECT_EQ((*diagnosticParams)->uri, "memory://yolo1.rb");
-        }
+    ASSERT_NO_FATAL_FAILURE(assertNotificationMessage(LSPMethod::TextDocumentPublishDiagnostics, *msg));
+    // Will fail test if this does not parse.
+    if (auto diagnosticParams = getPublishDiagnosticParams(msg->asNotification())) {
+        EXPECT_EQ((*diagnosticParams)->uri, "memory://yolo1.rb");
     }
 }
 
@@ -322,11 +321,10 @@ TEST_F(ProtocolTest, MonacoInitialization) {
     // Check the response for the expected URI.
     EXPECT_EQ(diagnostics.size(), 1);
     auto &msg = diagnostics.at(0);
-    if (assertNotificationMessage(LSPMethod::TextDocumentPublishDiagnostics, *msg)) {
-        // Will fail test if this does not parse.
-        if (auto diagnosticParams = getPublishDiagnosticParams(msg->asNotification())) {
-            EXPECT_EQ((*diagnosticParams)->uri, "memory://yolo1.rb");
-        }
+    ASSERT_NO_FATAL_FAILURE(assertNotificationMessage(LSPMethod::TextDocumentPublishDiagnostics, *msg));
+    // Will fail test if this does not parse.
+    if (auto diagnosticParams = getPublishDiagnosticParams(msg->asNotification())) {
+        EXPECT_EQ((*diagnosticParams)->uri, "memory://yolo1.rb");
     }
 }
 

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -498,17 +498,16 @@ void updateDiagnostics(string_view rootUri, UnorderedMap<string, string> &testFi
         if (isTestMessage(*response)) {
             continue;
         }
-        if (assertNotificationMessage(LSPMethod::TextDocumentPublishDiagnostics, *response)) {
-            auto maybeDiagnosticParams = getPublishDiagnosticParams(response->asNotification());
-            ASSERT_TRUE(maybeDiagnosticParams.has_value());
-            auto &diagnosticParams = *maybeDiagnosticParams;
-            auto filename = uriToFilePath(rootUri, diagnosticParams->uri);
-            EXPECT_NE(testFileUris.end(), testFileUris.find(filename))
-                << fmt::format("Diagnostic URI is not a test file URI: {}", diagnosticParams->uri);
+        ASSERT_NO_FATAL_FAILURE(assertNotificationMessage(LSPMethod::TextDocumentPublishDiagnostics, *response));
+        auto maybeDiagnosticParams = getPublishDiagnosticParams(response->asNotification());
+        ASSERT_TRUE(maybeDiagnosticParams.has_value());
+        auto &diagnosticParams = *maybeDiagnosticParams;
+        auto filename = uriToFilePath(rootUri, diagnosticParams->uri);
+        EXPECT_NE(testFileUris.end(), testFileUris.find(filename))
+            << fmt::format("Diagnostic URI is not a test file URI: {}", diagnosticParams->uri);
 
-            // Will explicitly overwrite older diagnostics that are irrelevant.
-            diagnostics[filename] = move(diagnosticParams->diagnostics);
-        }
+        // Will explicitly overwrite older diagnostics that are irrelevant.
+        diagnostics[filename] = move(diagnosticParams->diagnostics);
     }
 }
 

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -786,7 +786,7 @@ TEST_P(LSPTest, All) {
             // Sort assertions in (filename, range) order
             fast_sort(entryAssertions,
                       [](const shared_ptr<RangeAssertion> &a, const shared_ptr<RangeAssertion> &b) -> bool {
-                          return errorComparison(a->filename, *a->range, "", b->filename, *b->range, "") < 0;
+                          return a->compare(b->filename, *b->range) < 0;
                       });
 
             auto &defAssertions = entry.second.first;

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -775,7 +775,7 @@ TEST_P(LSPTest, All) {
             // Sort assertions in (filename, range) order
             fast_sort(entryAssertions,
                       [](const shared_ptr<RangeAssertion> &a, const shared_ptr<RangeAssertion> &b) -> bool {
-                          return a->compare(b->filename, *b->range) < 0;
+                          return a->cmp(*b) < 0;
                       });
 
             auto &defAssertions = entry.second.first;

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -609,8 +609,8 @@ void testQuickFixCodeActions(LSPWrapper &lspWrapper, Expectations &test, Unorder
             auto it = applyCodeActionAssertions.begin();
             while (it != applyCodeActionAssertions.end()) {
                 auto codeActionAssertion = it->get();
-                if (!(cmpPositions(*error->range->start, *codeActionAssertion->range->start) <= 0 &&
-                      cmpPositions(*error->range->end, *codeActionAssertion->range->end) >= 0)) {
+                if (!(error->range->start->cmp(*codeActionAssertion->range->start) <= 0 &&
+                      error->range->end->cmp(*codeActionAssertion->range->end) >= 0)) {
                     ++it;
                     continue;
                 }
@@ -786,7 +786,7 @@ TEST_P(LSPTest, All) {
             // Sort assertions in (filename, range) order
             fast_sort(entryAssertions,
                       [](const shared_ptr<RangeAssertion> &a, const shared_ptr<RangeAssertion> &b) -> bool {
-                          return errorComparison(a->filename, *a->range, "", b->filename, *b->range, "") == -1;
+                          return errorComparison(a->filename, *a->range, "", b->filename, *b->range, "") < 0;
                       });
 
             auto &defAssertions = entry.second.first;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR cleans up a few things:
* Adds helper methods to codegenned classes (mostly comparators)
* Removes redundant helpers, some of which were duplicated between the main codebase and test_corpus (mostly comparators)
* Uses the handy `ASSERT_NO_FATAL_FAILURE` macro in gtest to propagate assertion failures & unindent a bunch of code. gtest doesn't use exceptions, but this is one way to emulate them.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

@sushain97 brought up these possible improvements while he was working on adding code action tests to test_corpus, and I decided to go ahead and implement them.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No new tests, but the existing tests should continue to pass.
