### PR TITLE
Move InvalidDeclareVariables error to typed: false

### DIFF
--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -7,7 +7,7 @@ constexpr ErrorClass DynamicConstant{5001, StrictLevel::True};
 constexpr ErrorClass StubConstant{5002, StrictLevel::False};
 constexpr ErrorClass InvalidMethodSignature{5003, StrictLevel::False};
 constexpr ErrorClass InvalidTypeDeclaration{5004, StrictLevel::False};
-constexpr ErrorClass InvalidDeclareVariables{5005, StrictLevel::True};
+constexpr ErrorClass InvalidDeclareVariables{5005, StrictLevel::False};
 constexpr ErrorClass DuplicateVariableDeclaration{5006, StrictLevel::True};
 // constexpr ErrorClass UndeclaredVariable{5007, StrictLevel::Strict};
 constexpr ErrorClass DynamicSuperclass{5008, StrictLevel::True};

--- a/test/testdata/resolver/let_errors_false.rb
+++ b/test/testdata/resolver/let_errors_false.rb
@@ -1,0 +1,10 @@
+# typed: false
+class LetErrorsFalse
+  def self.not_initialize_self
+    @a = T.let(0, Integer) # error: Singleton instance variables must be declared inside the class body
+  end
+
+  def not_initialize
+    @a = T.let(0, Integer) # error: Instance variables must be declared inside `initialize`
+  end
+end


### PR DESCRIPTION
I'd like to make http://go/e/5005 an error even in typed: false files.
Adding an instance variable affects global state, and thus can have the
weird effect of silencing errors that manifest as other weird errors
down the line.

There are only 6 places in pay-server that were doing this, so I think
it's a relatively non-intrusive change.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Pre-work to relax the constraint that instance variables must be declared in
`initialize` in certain situations.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.