### PR TITLE
Relax constraint that ivars are declared in initialize

### DIFF
--- a/test/testdata/dsl/attr_multi.rb.dsl-tree.exp
+++ b/test/testdata/dsl/attr_multi.rb.dsl-tree.exp
@@ -14,7 +14,7 @@ class <emptyTree>::<C Test><<C <todo sym>>> < (::<todo sym>)
   end
 
   def a=<<C <todo sym>>>(a, &<blk>)
-    @a = a
+    @a = ::T.let(a, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
   end
 
   <self>.sig() do ||
@@ -38,7 +38,7 @@ class <emptyTree>::<C Test><<C <todo sym>>> < (::<todo sym>)
   end
 
   def b=<<C <todo sym>>>(b, &<blk>)
-    @b = b
+    @b = ::T.let(b, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
   end
 
   <self>.sig() do ||
@@ -46,7 +46,7 @@ class <emptyTree>::<C Test><<C <todo sym>>> < (::<todo sym>)
   end
 
   def c=<<C <todo sym>>>(c, &<blk>)
-    @c = c
+    @c = ::T.let(c, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
   end
 
   <self>.sig() do ||

--- a/test/testdata/dsl/attr_multi.rb.symbol-table-raw.exp
+++ b/test/testdata/dsl/attr_multi.rb.symbol-table-raw.exp
@@ -1,5 +1,8 @@
 class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4})
   class <C <U Test>> < <C <U Object>> () @ Loc {file=test/testdata/dsl/attr_multi.rb start=3:1 end=3:11}
+    field <C <U Test>><U @a> -> String | NilClass @ Loc {file=test/testdata/dsl/attr_multi.rb start=7:18 end=7:19}
+    field <C <U Test>><U @b> -> Integer | NilClass @ Loc {file=test/testdata/dsl/attr_multi.rb start=10:18 end=10:19}
+    field <C <U Test>><U @c> -> Integer | NilClass @ Loc {file=test/testdata/dsl/attr_multi.rb start=10:22 end=10:23}
     method <C <U Test>><U a> (<blk>) -> String | NilClass @ Loc {file=test/testdata/dsl/attr_multi.rb start=7:3 end=7:19}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/dsl/attr_multi.rb start=??? end=???}
     method <C <U Test>><U a=> (a, <blk>) -> String | NilClass @ Loc {file=test/testdata/dsl/attr_multi.rb start=7:3 end=7:19}

--- a/test/testdata/dsl/attr_strict.rb
+++ b/test/testdata/dsl/attr_strict.rb
@@ -1,0 +1,20 @@
+# typed: strict
+
+class Test
+  extend T::Sig
+
+  sig {returns(String)}
+  attr_accessor :non_nil_accessor # error-with-dupes: Use of undeclared variable `@non_nil_accessor`
+  sig {returns(T.nilable(String))}
+  attr_accessor :nilable_accessor
+
+  sig {returns(String)}
+  attr_reader :non_nil_reader # error: Use of undeclared variable `@non_nil_reader`
+  sig {returns(T.nilable(String))}
+  attr_reader :nilable_reader # error: Use of undeclared variable `@nilable_reader`
+
+  sig {params(non_nil_writer: String).returns(String)}
+  attr_writer :non_nil_writer # error: Use of undeclared variable `@non_nil_writer`
+  sig {params(nilable_writer: String).returns(T.nilable(String))}
+  attr_writer :nilable_writer
+end

--- a/test/testdata/resolver/lazy_field.rb
+++ b/test/testdata/resolver/lazy_field.rb
@@ -1,0 +1,15 @@
+# typed: strict
+
+class Module
+  include T::Sig
+end
+
+class A
+  sig {returns(String)}
+  def get_user_cached
+    @foo = T.let(@foo, T.nilable(String))
+    T.reveal_type(@foo) # error: Revealed type: `T.nilable(String)`
+    @foo ||= ENV.fetch('USER')
+    T.reveal_type(@foo) # error: Revealed type: `String`
+  end
+end

--- a/test/testdata/resolver/let_errors.rb
+++ b/test/testdata/resolver/let_errors.rb
@@ -15,9 +15,9 @@ class LetErrors
   @@cv = T.let(:foo, Symbol)
   @@cv = T.let(:bar, Symbol) # explicitly not an error: the type is the same
 
-  @d = T.let("hi", String)
-  @d = T.let(0, Integer) # error: Redeclaring variable `@d` with mismatching type
+  @d = T.let("hi", String) # error: Redeclaring variable `@d` with mismatching type
+  @d = T.let(0, Integer)
 
-  @@dv = T.let(:foo, Symbol)
-  @@dv = T.let(0.0, Float) # error: Redeclaring variable `@@dv` with mismatching type
+  @@dv = T.let(:foo, Symbol) # error: Redeclaring variable `@@dv` with mismatching type
+  @@dv = T.let(0.0, Float)
 end

--- a/test/testdata/resolver/let_errors_nilable.rb
+++ b/test/testdata/resolver/let_errors_nilable.rb
@@ -1,0 +1,72 @@
+# typed: strict
+
+# Because we have a type_member
+# disable-fast-path: true
+
+class Module
+  include T::Sig
+end
+
+class A
+  sig {void}
+  def foo
+    @foo = T.let(nil, T.nilable(Integer))
+  end
+end
+
+class B
+  sig {void}
+  def self.foo
+    @foo = T.let(nil, T.nilable(Integer))
+  end
+end
+
+class C
+  sig {void}
+  def foo
+    @foo = T.let(0, Integer) # error: Instance variables must be declared inside `initialize` or declared nilable
+  end
+end
+
+class D
+  sig {void}
+  def self.foo
+    @foo = T.let(0, Integer) # error: Singleton instance variables must be declared inside the class body or declared nilable
+  end
+end
+
+# Would like to make this error
+class E
+  sig {void}
+  def foo
+    @x = T.let(nil, T.nilable(Integer)) # error: Redeclaring variable `@x` with mismatching type
+  end
+
+  sig {void}
+  def bar
+    @x = T.let(nil, T.nilable(String))
+  end
+end
+
+class Box
+  extend T::Generic
+
+  Elem = type_member
+
+  sig {void}
+  def nilable_elem
+    @nilable_elem = T.let(nil, T.nilable(Elem))
+  end
+
+  sig {void}
+  def non_nil_elem
+    @non_nil_elem = T.let(T.unsafe(nil), Elem) # error: Instance variables must be declared inside `initialize` or declared nilable
+  end
+end
+
+class F
+  sig {void}
+  def foo
+    @foo = T.let(nil, T.nilable(Box[Integer]))
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

If instance variables are declared nilable and only in one place globally,
then we're fine allowing the instance variables to be defined someplace
other than `initialize`.

This allows typing the `@x ||= compute_x` pattern more easily.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.