### PR TITLE
Add extra error context for class redefinition

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -424,9 +424,8 @@ private:
                 job.klass.data(ctx)->setSuperClass(resolved);
             } else {
                 if (auto e = ctx.state.beginError(job.ancestor->loc, core::errors::Resolver::RedefinitionOfParents)) {
-                    e.setHeader("Class parents redefined for class `{}`", job.klass.data(ctx)->show(ctx));
-                    e.addErrorLine(job.ancestor->loc, "Parent redefined from `{}` to `{}`",
-                                   job.klass.data(ctx)->superClass().show(ctx), resolved.show(ctx));
+                    e.setHeader("Parent of class `{}` redefined from `{}` to `{}`", job.klass.data(ctx)->show(ctx),
+                                job.klass.data(ctx)->superClass().show(ctx), resolved.show(ctx));
                 }
             }
         } else {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -425,6 +425,8 @@ private:
             } else {
                 if (auto e = ctx.state.beginError(job.ancestor->loc, core::errors::Resolver::RedefinitionOfParents)) {
                     e.setHeader("Class parents redefined for class `{}`", job.klass.data(ctx)->show(ctx));
+                    e.addErrorLine(job.ancestor->loc, "Parent redefined from `{}` to `{}`",
+                                   job.klass.data(ctx)->superClass().show(ctx), resolved.show(ctx));
                 }
             }
         } else {

--- a/test/testdata/namer/superclass_redefinition.rb
+++ b/test/testdata/namer/superclass_redefinition.rb
@@ -4,5 +4,5 @@ end
 class B
 end
 
-class A < B # error: parents redefined
+class A < B # error: Parent of class `A` redefined from `Object` to `B`
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Quick PR after feedback about not knowing how to debug a class parent redefinition error: this just adds another error line that also prints what the original parent definition was as well as what the new parent definition is. It could be more informative if we knew _where_ the first parent was defined, but even this ought to help.

e.g. given this file

```ruby
class A; end
class B; end
class C < A; end
class C < B; end
```

we now get the error message
```
./foo.rb:5: Class parents redefined for class C https://srb.help/5012
     5 |class C < B; end
                  ^
    ./foo.rb:5: Parent redefined from A to B
     5 |class C < B; end
                  ^
```

where the second line is new to this PR.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
