### PR TITLE
Update minitest DSL to allow table-driven tests

### DIFF
--- a/dsl/Minitest.cc
+++ b/dsl/Minitest.cc
@@ -48,35 +48,38 @@ unique_ptr<ast::Expression> replaceDSLSingle(core::MutableContext ctx, ast::Send
         return nullptr;
     }
 
-    if (!send->recv->isSelfReference()) {
-        return nullptr;
-    }
+    if (send->recv->isSelfReference()) {
+        if (send->args.empty() && send->fun == core::Names::before()) {
+            return ast::MK::Method0(send->loc, send->loc, core::Names::initialize(),
+                                    prepareBody(ctx, std::move(send->block->body)), ast::MethodDef::DSLSynthesized);
+        }
 
-    if (send->args.empty() && send->fun == core::Names::before()) {
-        return ast::MK::Method0(send->loc, send->loc, core::Names::initialize(),
-                                prepareBody(ctx, std::move(send->block->body)), ast::MethodDef::DSLSynthesized);
-    }
+        if (send->args.size() != 1) {
+            return nullptr;
+        }
+        auto &arg = send->args[0];
+        auto argString = to_s(ctx, arg);
 
-    if (send->args.size() != 1) {
-        return nullptr;
-    }
-    auto &arg = send->args[0];
-    auto argString = to_s(ctx, arg);
-
-    vector<unique_ptr<ast::Expression>> stats;
-    if (send->fun == core::Names::describe()) {
-        ast::ClassDef::ANCESTORS_store ancestors;
-        ancestors.emplace_back(ast::MK::Self(arg->loc));
-        ast::ClassDef::RHS_store rhs;
-        rhs.emplace_back(prepareBody(ctx, std::move(send->block->body)));
-        auto name = ast::MK::UnresolvedConstant(arg->loc, ast::MK::EmptyTree(),
-                                                ctx.state.enterNameConstant("<class_" + argString + ">"));
-        return ast::MK::Class(send->loc, send->loc, std::move(name), std::move(ancestors), std::move(rhs),
-                              ast::ClassDefKind::Class);
-    } else if (send->fun == core::Names::it()) {
-        auto name = ctx.state.enterNameUTF8("<test_" + argString + ">");
-        return ast::MK::Method0(send->loc, send->loc, std::move(name), prepareBody(ctx, std::move(send->block->body)),
-                                ast::MethodDef::DSLSynthesized);
+        vector<unique_ptr<ast::Expression>> stats;
+        if (send->fun == core::Names::describe()) {
+            ast::ClassDef::ANCESTORS_store ancestors;
+            ancestors.emplace_back(ast::MK::Self(arg->loc));
+            ast::ClassDef::RHS_store rhs;
+            rhs.emplace_back(prepareBody(ctx, std::move(send->block->body)));
+            auto name = ast::MK::UnresolvedConstant(arg->loc, ast::MK::EmptyTree(),
+                                                    ctx.state.enterNameConstant("<class_" + argString + ">"));
+            return ast::MK::Class(send->loc, send->loc, std::move(name), std::move(ancestors), std::move(rhs),
+                                  ast::ClassDefKind::Class);
+        } else if (send->fun == core::Names::it()) {
+            auto name = ctx.state.enterNameUTF8("<test_" + argString + ">");
+            return ast::MK::Method0(send->loc, send->loc, std::move(name),
+                                    prepareBody(ctx, std::move(send->block->body)), ast::MethodDef::DSLSynthesized);
+        }
+    } else if (send->fun == core::Names::each() && send->args.empty()) {
+        auto noArgs = ast::Send::ARGS_store{};
+        return ast::MK::Send(send->loc, std::move(send->recv), send->fun, std::move(noArgs), send->flags,
+                             ast::MK::Block(send->block->loc, prepareBody(ctx, std::move(send->block->body)),
+                                            std::move(send->block->args)));
     }
 
     return nullptr;

--- a/test/testdata/dsl/minitest_each.rb
+++ b/test/testdata/dsl/minitest_each.rb
@@ -1,0 +1,25 @@
+# typed: true
+class MyTest
+  def outside_method
+  end
+
+  [true, false].each do |value|
+    puts value
+    it "works outside" do
+      outside_method
+    end
+  end
+
+  [true, false].each do |value|
+    puts value
+    describe "some inner tests" do
+      def inside_method
+      end
+
+      it "works inside" do
+        outside_method
+        inside_method
+      end
+    end
+  end
+end

--- a/test/testdata/dsl/minitest_each.rb.dsl-tree.exp
+++ b/test/testdata/dsl/minitest_each.rb.dsl-tree.exp
@@ -1,0 +1,33 @@
+class <emptyTree>::<C MyTest><<C <todo sym>>> < (::<todo sym>)
+  def outside_method<<C <todo sym>>>(&<blk>)
+    <emptyTree>
+  end
+
+  [true, false].each() do |value|
+    begin
+      <self>.puts(value)
+      def <test_works outside><<C <todo sym>>>(&<blk>)
+        <self>.outside_method()
+      end
+    end
+  end
+
+  [true, false].each() do |value|
+    begin
+      <self>.puts(value)
+      class <emptyTree>::<C <class_some inner tests>><<C <todo sym>>> < (<self>)
+        begin
+          def inside_method<<C <todo sym>>>(&<blk>)
+            <emptyTree>
+          end
+          def <test_works inside><<C <todo sym>>>(&<blk>)
+            begin
+              <self>.outside_method()
+              <self>.inside_method()
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a hacky workaround. If we see any method at all called `each`,
we descend into the body of the block, and do the normal processing.

This doesn't support any other kind of looping, and the `.each` call
must be the top-level send.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Commit summary

The diff looks a lot better ignoring whitespace. [?w=1](1656/files?w=1)


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This allows getting more test files at Stripe into `typed: true`. Previously,
any test which wrapped an `it` block in a call to `each` wouldn't typecheck,
because this DSL pass wouldn't trigger.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.