### PR TITLE
Hash sig presence

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1077,6 +1077,7 @@ u4 Symbol::methodShapeHash(const GlobalState &gs) const {
     result = mix(result, this->flags | METHOD_FLAGS_IGNORED_IN_SHAPE_HASH);
     result = mix(result, this->owner._id);
     result = mix(result, this->superClassOrRebind._id);
+    result = mix(result, this->hasSig());
 
     for (const auto &e : arguments()) {
         // Changing name of keyword arg is a shape change.

--- a/test/testdata/lsp/fast_path/method_add_sig.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_add_sig.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-fast-path: method_add_sig.rb
+# assert-slow-path: method_add_sig.rb
 # TODO(jvilk): Can this be covered on the fast path?
 
 class A extend T::Sig

--- a/test/testdata/lsp/sig_deletion.1.rbupdate
+++ b/test/testdata/lsp/sig_deletion.1.rbupdate
@@ -1,0 +1,7 @@
+# typed: true
+# assert-slow-path: true
+class Foo
+  extend T::Sig
+
+  def foo; 1; end
+end

--- a/test/testdata/lsp/sig_deletion.rb
+++ b/test/testdata/lsp/sig_deletion.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+class Foo
+  extend T::Sig
+  sig { returns(String) }
+  def foo; 1; end # error: Returning value that does not conform to method result type
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes #1381 by treating whether a method has a `sig` as part of the hash. This _will_ cause sig deletion to take the slow path, but sig deletion should hopefully be pretty rare.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Added relevant test case.
