### PR TITLE
Fix namer resolution of redefined methods

### DIFF
--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -79,6 +79,7 @@ public:
     SymbolRef lookupMethodSymbol(SymbolRef owner, NameRef name) {
         return lookupSymbolWithFlags(owner, name, Symbol::Flags::METHOD);
     }
+    SymbolRef lookupMethodSuchThat(SymbolRef owner, NameRef name, std::function<bool(SymbolRef)> pred) const;
     SymbolRef lookupStaticFieldSymbol(SymbolRef owner, NameRef name) {
         return lookupSymbolWithFlags(owner, name, Symbol::Flags::STATIC_FIELD);
     }
@@ -239,6 +240,7 @@ private:
     SymbolRef synthesizeClass(NameRef nameID, u4 superclass = Symbols::todo()._id, bool isModule = false);
     SymbolRef enterSymbol(Loc loc, SymbolRef owner, NameRef name, u4 flags);
 
+    SymbolRef lookupSymbolSuchThat(SymbolRef owner, NameRef name, std::function<bool(SymbolRef)> pred) const;
     SymbolRef lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 flags) const;
 
     SymbolRef getTopLevelClassSymbol(NameRef name);

--- a/test/testdata/namer/redefinition_method.rb
+++ b/test/testdata/namer/redefinition_method.rb
@@ -1,5 +1,4 @@
 # typed: true
-# disable-fast-path: true
 class Main
     extend T::Sig
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes an issue described in #1667 where the namer wouldn't resolve symbols correctly: in short, for LSP's sake, we need to be able to look up method symbols by parameter-list shape, so that when we check a file like this twice we know that only the second `f` is actually a redefinition:
```ruby
def f; end
def f(x); end
```
Because we now look up by parameter-matching, we can find the correct `f` symbols if need be.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Instead of adding a new test case, this simply allows one of the existing tests to test the fast path where it previously did not.
