### PR TITLE
Fixing `Module#name`

### DIFF
--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -941,7 +941,7 @@ class Module < Object
 
   # Returns the name of the module *mod* . Returns nil for anonymous
   # modules.
-  sig {returns(String)}
+  sig {returns(T.nilable(String))}
   def name(); end
 
   # Invokes `Module.prepend_features` on each parameter in reverse order.


### PR DESCRIPTION
`Module#name` can return `nil`.

### Motivation
`Module#name` can return `nil`. Here's some example code:
```
klass = Class.new # a `Class`

klass.name        # this is nil
klass.ancestors   # this is `T::Array[Module]` and includes `klass`

# `Class#name` is `sig {returns(T.nilable(String))}`
# `Module#name` is `sig {returns(String)}
```

### Test plan
Please advise on testing if applicable.
