### PR TITLE
Add an additional subtype check in Types::lub for AppliedType

### DIFF
--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -198,6 +198,9 @@ TypePtr Types::lub(Context ctx, const TypePtr &t1, const TypePtr &t2) {
             if (isSubType(ctx, t2, t1)) {
                 return t1;
             }
+            if (isSubType(ctx, t1, t2)) {
+                return t2;
+            }
             return OrType::make_shared(t1, t2);
         }
 

--- a/test/testdata/infer/lub_generics.rb
+++ b/test/testdata/infer/lub_generics.rb
@@ -1,0 +1,20 @@
+# typed: true
+
+module M
+end
+
+class A
+  extend T::Generic
+  Elem = type_member
+
+  include M
+end
+
+class Test
+  extend T::Sig
+
+  sig {params(x: T.any(A[Integer], M)).void}
+  def test(x)
+    T.reveal_type(x) # error: Revealed type: `M`
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Currently, if a generic `A` includes the module `M`, the type `T.any(A[Integer], M)` doesn't reduce to `M`. This change adds an additional subtype check in in the case of `Types::lub` that deals with `AppliedType` that fixes this behavior.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
