### PR TITLE
More obvious failure for T.absurd on send

### DIFF
--- a/test/testdata/infer/exhaustiveness.rb
+++ b/test/testdata/infer/exhaustiveness.rb
@@ -185,3 +185,18 @@ sig {params(x: Integer).void}
 def only_keyword_arg(x)
   T.absurd(x: nil) if x.nil? # error: Control flow could reach `T.absurd` because the type `{x: NilClass}` wasn't handled
 end
+
+sig {returns(T.any(Integer, String))}
+def looks_like_a_variable
+  T.unsafe(nil) ? 0 : ''
+end
+
+sig {void}
+def rejects_absurd_on_non_variable
+  case looks_like_a_variable
+  when Integer
+  when String
+  else
+    T.absurd(looks_like_a_variable) # error: `T.absurd` expects to be called on a variable, not a method call
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It's almost always an error to use `T.absurd` with a send, not a variable,
because Sorbet never tracks flow sensitivity on the result of a method.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.