### PR TITLE
Fetch all remotes when updating sorbet-typed

### DIFF
--- a/gems/sorbet/lib/fetch-rbis.rb
+++ b/gems/sorbet/lib/fetch-rbis.rb
@@ -35,7 +35,7 @@ class Sorbet::Private::FetchRBIs
     end
 
     FileUtils.cd(RBI_CACHE_DIR) do
-      IO.popen(%w{git fetch origin}) {|pipe| pipe.read}
+      IO.popen(%w{git fetch --all}) {|pipe| pipe.read}
       raise "Failed to git fetch" if $?.exitstatus != 0
       IO.popen(%w{git checkout -q} + [SORBET_TYPED_REVISION]) {|pipe| pipe.read}
       raise "Failed to git checkout" if $?.exitstatus != 0


### PR DESCRIPTION
### Motivation
Previously, if you added a remote to the cached sorbet-typed repo, it wasn't pulling in new commits from that repository.

For example:

- Go to `~/.cache/sorbet/sorbet-typed/`
- Add a git remote, e.g. `git remote add fork https://github.com/connorshea/sorbet-typed`
- In your project using sorbet, run `SORBET_TYPED_REVISION='fork/master' srb rbi sorbet-typed`
- Note that the fork is now used.
- Push a new commit to the fork's master branch.
- Run `SORBET_TYPED_REVISION='fork/master' srb rbi sorbet-typed` again
- Note that the fork was still used, but it didn't pull in the commit you've just pushed, because it only fetched new information from `origin`, not `fork`.

### Test plan

You can test the above and see that it now fetches new commits for all remotes :)

It uses [`git fetch --all`](https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt---all) to do this.