### PR TITLE
Add infinite? and finite? methods for Numeric.

### DIFF
--- a/rbi/core/numeric.rbi
+++ b/rbi/core/numeric.rbi
@@ -345,6 +345,10 @@ class Numeric < Object
   end
   def fdiv(arg0); end
 
+  # Returns `true` if `num` is a finite number, otherwise returns `false`.
+  sig {returns(T::Boolean)}
+  def finite?; end
+
   # Returns the largest number less than or equal to `num` with a precision
   # of `ndigits` decimal digits (default: 0).
   #
@@ -379,6 +383,11 @@ class Numeric < Object
   # Returns zero.
   sig {returns(Numeric)}
   def imaginary(); end
+
+  # Returns `nil`, `-1`, or `1` depending on whether the value is
+  # finite, `-Infinity`, or `+Infinity`.
+  sig {returns(T.nilable(Integer))}
+  def infinite?; end
 
   # Returns `true` if `num` is an
   # [Integer](https://ruby-doc.org/core-2.6.3/Integer.html).


### PR DESCRIPTION
### Motivation

These methods were missing and I wanted them to be typed :)

`infinite?` is really weird, in that it doesn't return a boolean but `-1`, `1`, or `nil` depending on the Numeric it's run on.

### Test plan

See included automated tests.

Docs:
- `finite?`: https://ruby-doc.org/core-2.6.2/Numeric.html#method-i-finite-3F
- `infinite?`: https://ruby-doc.org/core-2.6.2/Numeric.html#method-i-infinite-3F