### PR TITLE
Wrap Regexp literal in T.let

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1311,8 +1311,9 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 unique_ptr<Expression> cnst = MK::Constant(loc, core::Symbols::Regexp());
                 auto pattern = desugarDString(dctx, loc, std::move(regexpNode->regex));
                 auto opts = node2TreeImpl(dctx, std::move(regexpNode->opts));
-                auto send = MK::Send2(loc, std::move(cnst), core::Names::new_(), std::move(pattern), std::move(opts));
-                result.swap(send);
+                auto send = MK::Send2(loc, cnst->deepCopy(), core::Names::new_(), std::move(pattern), std::move(opts));
+                auto let = MK::Let(loc, std::move(send), std::move(cnst));
+                result.swap(let);
             },
             [&](parser::Regopt *regopt) {
                 unique_ptr<Expression> acc = MK::Int(loc, 0);

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1311,9 +1311,8 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 unique_ptr<Expression> cnst = MK::Constant(loc, core::Symbols::Regexp());
                 auto pattern = desugarDString(dctx, loc, std::move(regexpNode->regex));
                 auto opts = node2TreeImpl(dctx, std::move(regexpNode->opts));
-                auto send = MK::Send2(loc, cnst->deepCopy(), core::Names::new_(), std::move(pattern), std::move(opts));
-                auto let = MK::Let(loc, std::move(send), std::move(cnst));
-                result.swap(let);
+                auto send = MK::Send2(loc, std::move(cnst), core::Names::new_(), std::move(pattern), std::move(opts));
+                result.swap(send);
             },
             [&](parser::Regopt *regopt) {
                 unique_ptr<Expression> acc = MK::Int(loc, 0);

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1308,10 +1308,10 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 result.swap(send);
             },
             [&](parser::Regexp *regexpNode) {
-                unique_ptr<Expression> regexp = MK::Constant(loc, core::Symbols::Regexp());
-                auto regex = desugarDString(dctx, loc, std::move(regexpNode->regex));
+                unique_ptr<Expression> cnst = MK::Constant(loc, core::Symbols::Regexp());
+                auto pattern = desugarDString(dctx, loc, std::move(regexpNode->regex));
                 auto opts = node2TreeImpl(dctx, std::move(regexpNode->opts));
-                auto send = MK::Send2(loc, std::move(regexp), core::Names::new_(), std::move(regex), std::move(opts));
+                auto send = MK::Send2(loc, std::move(cnst), core::Names::new_(), std::move(pattern), std::move(opts));
                 result.swap(send);
             },
             [&](parser::Regopt *regopt) {

--- a/dsl/Regexp.cc
+++ b/dsl/Regexp.cc
@@ -1,0 +1,36 @@
+#include "dsl/Regexp.h"
+#include "ast/Helpers.h"
+#include "ast/ast.h"
+#include "core/Context.h"
+#include "core/Names.h"
+#include "core/core.h"
+#include "dsl/dsl.h"
+
+using namespace std;
+
+namespace sorbet::dsl {
+
+vector<unique_ptr<ast::Expression>> Regexp::replaceDSL(core::MutableContext ctx, ast::Assign *asgn) {
+    auto lhs = ast::cast_tree<ast::UnresolvedConstantLit>(asgn->lhs.get());
+    if (lhs == nullptr) {
+        return {};
+    }
+
+    auto send = ast::cast_tree<ast::Send>(asgn->rhs.get());
+    if (send == nullptr || send->fun != core::Names::new_()) {
+        return {};
+    }
+
+    auto recv = ast::cast_tree<ast::ConstantLit>(send->recv.get());
+    if (recv == nullptr || recv->symbol != core::Symbols::Regexp()) {
+        return {};
+    }
+
+    vector<unique_ptr<ast::Expression>> stats;
+    auto type = ast::MK::Constant(send->loc, core::Symbols::Regexp());
+    auto newRhs = ast::MK::Let(send->loc, std::move(asgn->rhs), std::move(type));
+    stats.emplace_back(ast::MK::Assign(asgn->loc, std::move(asgn->lhs), std::move(newRhs)));
+    return stats;
+}
+
+}; // namespace sorbet::dsl

--- a/dsl/Regexp.h
+++ b/dsl/Regexp.h
@@ -1,0 +1,26 @@
+#ifndef SORBET_DSL_REGEXP_H
+#define SORBET_DSL_REGEXP_H
+#include "ast/ast.h"
+
+namespace sorbet::dsl {
+
+/**
+ * This class desugars things of the form
+ *
+ *   A = Regexp.new(...)
+ *
+ * into
+ *
+ *   A = T.let(Regexp.new(...), Regexp)
+ *
+ */
+class Regexp final {
+public:
+    static std::vector<std::unique_ptr<ast::Expression>> replaceDSL(core::MutableContext ctx, ast::Assign *asgn);
+
+    Regexp() = delete;
+};
+
+} // namespace sorbet::dsl
+
+#endif

--- a/dsl/dsl.cc
+++ b/dsl/dsl.cc
@@ -15,6 +15,7 @@
 #include "dsl/Prop.h"
 #include "dsl/ProtobufDescriptorPool.h"
 #include "dsl/Rails.h"
+#include "dsl/Regexp.h"
 #include "dsl/Struct.h"
 #include "dsl/attr_reader.h"
 #include "main/pipeline/semantic_extension/SemanticExtension.h"
@@ -52,6 +53,12 @@ public:
                     }
 
                     nodes = ProtobufDescriptorPool::replaceDSL(ctx, assign);
+                    if (!nodes.empty()) {
+                        replaceNodes[stat.get()] = std::move(nodes);
+                        return;
+                    }
+
+                    nodes = Regexp::replaceDSL(ctx, assign);
                     if (!nodes.empty()) {
                         replaceNodes[stat.get()] = std::move(nodes);
                         return;

--- a/test/testdata/desugar/regexp.rb.ast.exp
+++ b/test/testdata/desugar/regexp.rb.ast.exp
@@ -1,17 +1,17 @@
 class <emptyTree><<C <root>>> < ()
   def foo<<C <todo sym>>>(&<blk>)
     begin
-      ::Regexp.new("abc", 0)
+      ::T.let(::Regexp.new("abc", 0), ::Regexp)
       <emptyTree>::<C Regexp>.new("abc")
-      ::Regexp.new("abc", 0.|(1))
+      ::T.let(::Regexp.new("abc", 0.|(1)), ::Regexp)
       <emptyTree>::<C Regexp>.new("abc", <emptyTree>::<C Regexp>::<C IGNORECASE>)
-      ::Regexp.new("abc", 0.|(1).|(2).|(4))
+      ::T.let(::Regexp.new("abc", 0.|(1).|(2).|(4)), ::Regexp)
       <emptyTree>::<C Regexp>.new("abc", 0.|(<emptyTree>::<C Regexp>::<C IGNORECASE>).|(<emptyTree>::<C Regexp>::<C EXTENDED>).|(<emptyTree>::<C Regexp>::<C MULTILINE>))
       a = "a"
       c = "c"
-      ::Regexp.new(a.to_s().concat("b").concat(c.to_s()), 0)
+      ::T.let(::Regexp.new(a.to_s().concat("b").concat(c.to_s()), 0), ::Regexp)
       <emptyTree>::<C Regexp>.new(a.+("b").+(c))
-      ::Regexp.new("abc", 0)
+      ::T.let(::Regexp.new("abc", 0), ::Regexp)
     end
   end
 end

--- a/test/testdata/desugar/regexp.rb.ast.exp
+++ b/test/testdata/desugar/regexp.rb.ast.exp
@@ -1,17 +1,17 @@
 class <emptyTree><<C <root>>> < ()
   def foo<<C <todo sym>>>(&<blk>)
     begin
-      ::T.let(::Regexp.new("abc", 0), ::Regexp)
+      ::Regexp.new("abc", 0)
       <emptyTree>::<C Regexp>.new("abc")
-      ::T.let(::Regexp.new("abc", 0.|(1)), ::Regexp)
+      ::Regexp.new("abc", 0.|(1))
       <emptyTree>::<C Regexp>.new("abc", <emptyTree>::<C Regexp>::<C IGNORECASE>)
-      ::T.let(::Regexp.new("abc", 0.|(1).|(2).|(4)), ::Regexp)
+      ::Regexp.new("abc", 0.|(1).|(2).|(4))
       <emptyTree>::<C Regexp>.new("abc", 0.|(<emptyTree>::<C Regexp>::<C IGNORECASE>).|(<emptyTree>::<C Regexp>::<C EXTENDED>).|(<emptyTree>::<C Regexp>::<C MULTILINE>))
       a = "a"
       c = "c"
-      ::T.let(::Regexp.new(a.to_s().concat("b").concat(c.to_s()), 0), ::Regexp)
+      ::Regexp.new(a.to_s().concat("b").concat(c.to_s()), 0)
       <emptyTree>::<C Regexp>.new(a.+("b").+(c))
-      ::T.let(::Regexp.new("abc", 0), ::Regexp)
+      ::Regexp.new("abc", 0)
     end
   end
 end

--- a/test/testdata/desugar/regexp_strict.rb
+++ b/test/testdata/desugar/regexp_strict.rb
@@ -1,5 +1,13 @@
 # typed: strict
 
+extend T::Sig
+
 class A
   X = /foo/
+end
+
+sig {void}
+def foo
+  a = /foo/
+  a = 1
 end

--- a/test/testdata/desugar/regexp_strict.rb
+++ b/test/testdata/desugar/regexp_strict.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class A
+  X = /foo/
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We've had two questions internally about why this didn't work when string
literals did. Note that when we desugar this, we were already forcing it to
resolve to the resolved `core::Symbols::Regexp()` constant, rather than
delaying resolution.

Also, from Ruby's perspective, this is a special node type, and behaves like
any other literal. This change closes the gap between what people expect of
Sorbet and how it actually works.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.