### PR TITLE
Generalize the types of the Binding methods

### DIFF
--- a/rbi/core/binding.rbi
+++ b/rbi/core/binding.rbi
@@ -49,7 +49,7 @@ class Binding < Object
   # ```ruby
   # binding.eval("defined?(#{symbol}) == 'local-variable'")
   # ```
-  sig {params(symbol: Symbol).returns(T::Boolean)}
+  sig {params(symbol: T.any(String, Symbol)).returns(T::Boolean)}
   def local_variable_defined?(symbol); end
 
   # Returns the value of the local variable `symbol`.
@@ -67,7 +67,7 @@ class Binding < Object
   # ```ruby
   # binding.eval("#{symbol}")
   # ```
-  sig {params(symbol: Symbol).returns(T.untyped)}
+  sig {params(symbol: T.any(String, Symbol)).returns(T.untyped)}
   def local_variable_get(symbol); end
 
   # Set local variable named `symbol` as `obj`.
@@ -94,7 +94,7 @@ class Binding < Object
   # ```
   #
   # if `obj` can be dumped in Ruby code.
-  sig {params(symbol: Symbol, obj: T.untyped).returns(T.untyped)}
+  sig {params(symbol: T.any(String, Symbol), obj: T.untyped).returns(T.untyped)}
   def local_variable_set(symbol, obj); end
 
   # Returns the bound receiver of the binding object.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Methods on the Binding class can accept `String` arguments as well as `Symbol`s.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
