### PR TITLE
Implement Go to Type Definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,15 @@ aaa = T.let(A.new, T.any(A, B))
 # ^ type: AorB
 ```
 
+If a location should not report any definition or usage, then use the magic
+label `(nothing)`:
+
+```ruby
+# typed: false
+class A; end
+aaa = A.new
+# ^ def: (nothing)
+```
 
 #### Testing hover
 

--- a/README.md
+++ b/README.md
@@ -422,6 +422,37 @@ If a location should not report any definition or usage, then use the magic labe
 # ^ def: (nothing)
 ```
 
+#### Testing "Go to Type Definition"
+
+This is somewhat similar to "Find Definition" above, but also slightly different
+because there's no analogue of "Find All Type Definitions."
+
+```ruby
+class A; end
+#     ^ type-def: some-label
+
+aaa = A.new
+# ^ type: some-label
+```
+
+The `type: some-label` assertion says "please simulate a Go to Type Definition
+here, named `some-label`" and the `type-def: some-label` assertion says "assert
+that the results for `some-label` are exactly these locations."
+
+That means if the type definition could return multiple locs, the assertions
+will have to cover all results:
+
+```ruby
+class A; end
+#     ^ type-def: AorB
+class B; end
+#     ^ type-def: AorB
+
+aaa = T.let(A.new, T.any(A, B))
+# ^ type: AorB
+```
+
+
 #### Testing hover
 
 LSP tests can also assert the contents of hover responses with `hover` assertions:

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -78,10 +78,17 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
     // Iterate. Ensures that we match "Foo" in "Foo::Bar" references.
     while (lit && symbol.exists() && lit->original) {
         if (lspQuery.matchesLoc(lit->loc) || lspQuery.matchesSymbol(symbol)) {
+            // This basically approximates the cfg::Alias case from Environment::processBinding.
             core::TypeAndOrigins tp;
-            auto resultType = symbol.data(ctx.state)->resultType;
-            tp.type = resultType != nullptr ? resultType : core::Types::untyped(ctx, symbol);
-            tp.origins.emplace_back(symbol.data(ctx.state)->loc());
+            tp.origins.emplace_back(symbol.data(ctx)->loc());
+
+            if (symbol.data(ctx)->isClass()) {
+                tp.type = symbol.data(ctx)->lookupSingletonClass(ctx).data(ctx)->externalType(ctx);
+            } else {
+                auto resultType = symbol.data(ctx)->resultType;
+                tp.type = resultType == nullptr ? core::Types::untyped(ctx, symbol) : resultType;
+            }
+
             core::lsp::QueryResponse::pushQueryResponse(
                 ctx, core::lsp::ConstantResponse(ctx.owner, symbol, lit->loc, symbol.data(ctx)->name, tp, tp));
         }

--- a/main/lsp/LSPMessage.cc
+++ b/main/lsp/LSPMessage.cc
@@ -138,6 +138,7 @@ bool LSPMessage::isDelayable() const {
         // Definition, reference, and workspace symbol requests are typically requested directly by the user, so we
         // shouldn't delay processing them.
         case LSPMethod::TextDocumentDefinition:
+        case LSPMethod::TextDocumentTypeDefinition:
         case LSPMethod::TextDocumentCodeAction:
         case LSPMethod::TextDocumentReferences:
         case LSPMethod::WorkspaceSymbol:

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -189,6 +189,8 @@ class LSPLoop {
                                            const ReferenceParams &params) const;
     LSPResult handleTextDocumentDefinition(std::unique_ptr<core::GlobalState> gs, const MessageId &id,
                                            const TextDocumentPositionParams &params) const;
+    LSPResult handleTextDocumentTypeDefinition(std::unique_ptr<core::GlobalState> gs, const MessageId &id,
+                                               const TextDocumentPositionParams &params) const;
     LSPResult handleTextDocumentCompletion(std::unique_ptr<core::GlobalState> gs, const MessageId &id,
                                            const CompletionParams &params) const;
     LSPResult handleTextDocumentCodeAction(std::unique_ptr<core::GlobalState> gs, const MessageId &id,

--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -173,6 +173,9 @@ LSPResult LSPLoop::processRequestInternal(unique_ptr<core::GlobalState> gs, cons
         } else if (method == LSPMethod::TextDocumentDefinition) {
             auto &params = get<unique_ptr<TextDocumentPositionParams>>(rawParams);
             return handleTextDocumentDefinition(move(gs), id, *params);
+        } else if (method == LSPMethod::TextDocumentTypeDefinition) {
+            auto &params = get<unique_ptr<TextDocumentPositionParams>>(rawParams);
+            return handleTextDocumentTypeDefinition(move(gs), id, *params);
         } else if (method == LSPMethod::TextDocumentHover) {
             auto &params = get<unique_ptr<TextDocumentPositionParams>>(rawParams);
             return handleTextDocumentHover(move(gs), id, *params);

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -1,11 +1,72 @@
+#include "common/typecase.h"
 #include "core/lsp/QueryResponse.h"
 #include "main/lsp/lsp.h"
 
 using namespace std;
 
 namespace sorbet::realmain::lsp {
+
+namespace {
+vector<core::Loc> locsForType(const core::GlobalState &gs, core::TypePtr type) {
+    vector<core::Loc> result;
+    if (type->isUntyped()) {
+        return result;
+    }
+    typecase(
+        type.get(), [&](core::ClassType *t) { result.emplace_back(t->symbol.data(gs)->loc()); },
+        [&](core::AppliedType *t) { result.emplace_back(t->klass.data(gs)->loc()); },
+        [&](core::OrType *t) {
+            for (auto loc : locsForType(gs, t->left)) {
+                result.emplace_back(loc);
+            }
+            for (auto loc : locsForType(gs, t->right)) {
+                result.emplace_back(loc);
+            }
+        },
+        [&](core::AndType *t) {
+            for (auto loc : locsForType(gs, t->left)) {
+                result.emplace_back(loc);
+            }
+            for (auto loc : locsForType(gs, t->right)) {
+                result.emplace_back(loc);
+            }
+        });
+    return result;
+}
+} // namespace
+
 LSPResult LSPLoop::handleTextDocumentTypeDefinition(unique_ptr<core::GlobalState> gs, const MessageId &id,
                                                     const TextDocumentPositionParams &params) const {
-    Exception::raise("TODO(jez) Implement this");
+    auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentTypeDefinition);
+    prodCategoryCounterInc("lsp.messages.processed", "textDocument.typeDefinition");
+    auto result = setupLSPQueryByLoc(move(gs), params.textDocument->uri, *params.position,
+                                     LSPMethod::TextDocumentTypeDefinition, false);
+    gs = move(result.gs);
+    if (result.error) {
+        // An error happened while setting up the query.
+        response->error = move(result.error);
+    } else {
+        auto &queryResponses = result.responses;
+        vector<unique_ptr<Location>> result;
+        if (!queryResponses.empty()) {
+            const bool fileIsTyped =
+                config.uri2FileRef(*gs, params.textDocument->uri).data(*gs).strictLevel >= core::StrictLevel::True;
+            auto resp = move(queryResponses[0]);
+
+            // Only support go-to-type-definition on constants in untyped files.
+            if (resp->isConstant() || (fileIsTyped && (resp->isIdent() || resp->isLiteral()))) {
+                for (auto loc : locsForType(*gs, resp->getRetType())) {
+                    addLocIfExists(*gs, result, loc);
+                }
+            } else if (fileIsTyped && resp->isSend()) {
+                auto sendResp = resp->isSend();
+                for (auto loc : locsForType(*gs, sendResp->dispatchResult->returnType)) {
+                    addLocIfExists(*gs, result, loc);
+                }
+            }
+        }
+        response->result = move(result);
+    }
+    return LSPResult::make(move(gs), move(response));
 }
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -1,0 +1,11 @@
+#include "core/lsp/QueryResponse.h"
+#include "main/lsp/lsp.h"
+
+using namespace std;
+
+namespace sorbet::realmain::lsp {
+LSPResult LSPLoop::handleTextDocumentTypeDefinition(unique_ptr<core::GlobalState> gs, const MessageId &id,
+                                                    const TextDocumentPositionParams &params) const {
+    Exception::raise("TODO(jez) Implement this");
+}
+} // namespace sorbet::realmain::lsp

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -1330,6 +1330,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                      "textDocument/codeAction",
                                      "textDocument/completion",
                                      "textDocument/definition",
+                                     "textDocument/typeDefinition",
                                      "textDocument/didChange",
                                      "textDocument/didClose",
                                      "textDocument/didOpen",
@@ -1350,6 +1351,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                                 {"shutdown", makeOptional(JSONNull)},
                                                 {"textDocument/documentSymbol", DocumentSymbolParams},
                                                 {"textDocument/definition", TextDocumentPositionParams},
+                                                {"textDocument/typeDefinition", TextDocumentPositionParams},
                                                 {"textDocument/hover", TextDocumentPositionParams},
                                                 {"textDocument/completion", CompletionParams},
                                                 {"textDocument/references", ReferenceParams},
@@ -1377,6 +1379,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
             // Location | Location[] | LocationLink[] | null
             // Sorbet only uses Location[].
             {"textDocument/definition", makeVariant({JSONNull, makeArray(Location)})},
+            {"textDocument/typeDefinition", makeVariant({JSONNull, makeArray(Location)})},
             {"textDocument/hover", makeVariant({JSONNull, Hover})},
             // CompletionItem[] | CompletionList | null
             // Sorbet only sends CompletionList.

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -132,7 +132,7 @@ void assertLocationsMatch(const UnorderedMap<string, shared_ptr<core::File>> &so
                 auto actualFilePath = uriToFilePath(uriPrefix, actualLocation->uri);
                 ADD_FAILURE_AT(actualFilePath.c_str(), actualLocation->range->start->line + 1)
                     << fmt::format("Sorbet reported unexpected reference to symbol `{}`.\nGiven symbol "
-                                   "at:\n{}\nSorbet reported an unexpected reference at:\n{}",
+                                   "at:\n{}\nSorbet reported an unexpected (additional?) reference at:\n{}",
                                    symbol,
                                    prettyPrintRangeComment(
                                        locSourceLine, *RangeAssertion::makeRange(line, character, character + 1), ""),
@@ -167,7 +167,7 @@ void assertLocationsMatch(const UnorderedMap<string, shared_ptr<core::File>> &so
         auto actualFilePath = uriToFilePath(uriPrefix, actualLocation->uri);
         ADD_FAILURE_AT(actualFilePath.c_str(), actualLocation->range->start->line + 1) << fmt::format(
             "Sorbet reported unexpected reference to symbol `{}`.\nGiven symbol "
-            "at:\n{}\nSorbet reported an unexpected reference at:\n{}",
+            "at:\n{}\nSorbet reported an unexpected (additional?) reference at:\n{}",
             symbol,
             prettyPrintRangeComment(locSourceLine, *RangeAssertion::makeRange(line, character, character + 1), ""),
             prettyPrintRangeComment(getLine(sourceFileContents, uriPrefix, *actualLocation), *actualLocation->range,
@@ -542,17 +542,33 @@ shared_ptr<TypeDefAssertion> TypeDefAssertion::make(string_view filename, unique
 }
 
 void TypeDefAssertion::check(const UnorderedMap<string, shared_ptr<core::File>> &sourceFileContents,
-                             LSPWrapper &lspWrapper, int &nextId, string_view uriPrefix, const Location &queryLoc) {
+                             LSPWrapper &lspWrapper, int &nextId, string_view uriPrefix, string_view symbol,
+                             const Location &queryLoc, const std::vector<std::shared_ptr<RangeAssertion>> &allLocs) {
     const int line = queryLoc.range->start->line;
     // Can only query with one character, so just use the first one.
-    // const int character = queryLoc.range->start->character;
-    // auto locSourceLine = getLine(sourceFileContents, uriPrefix, queryLoc);
-    // auto defSourceLine = getLine(sourceFileContents, uriPrefix, *getLocation(uriPrefix));
+    const int character = queryLoc.range->start->character;
+    auto locSourceLine = getLine(sourceFileContents, uriPrefix, queryLoc);
     string locFilename = uriToFilePath(uriPrefix, queryLoc.uri);
-    // string defUri = filePathToUri(uriPrefix, filename);
 
-    ADD_FAILURE_AT(locFilename.c_str(), line) << fmt::format(
-        "TODO(jez) Implement the actual checks for `type` and `type-def` once Go To Type Definition is implemented");
+    const int id = nextId++;
+    auto request = make_unique<LSPMessage>(make_unique<RequestMessage>(
+        "2.0", id, LSPMethod::TextDocumentTypeDefinition,
+        make_unique<TextDocumentPositionParams>(make_unique<TextDocumentIdentifier>(string(queryLoc.uri)),
+                                                make_unique<Position>(line, character))));
+    auto responses = lspWrapper.getLSPResponsesFor(*request);
+    ASSERT_EQ(1, responses.size());
+
+    ASSERT_NO_FATAL_FAILURE(assertResponseMessage(id, *responses.at(0)));
+    auto &respMsg = responses.at(0)->asResponse();
+    ASSERT_TRUE(respMsg.result.has_value());
+    ASSERT_FALSE(respMsg.error.has_value());
+
+    auto &locations = extractLocations(respMsg);
+    fast_sort(locations,
+              [&](const unique_ptr<Location> &a, const unique_ptr<Location> &b) -> bool { return a->cmp(*b) < 0; });
+
+    assertLocationsMatch(sourceFileContents, uriPrefix, symbol, allLocs, line, character, locSourceLine, locFilename,
+                         locations);
 }
 
 string TypeDefAssertion::toString() const {

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -101,6 +101,9 @@ void assertLocationsMatch(const UnorderedMap<string, shared_ptr<core::File>> &so
                           string_view symbol, const vector<shared_ptr<RangeAssertion>> &allLocs, int line,
                           int character, string_view locSourceLine, string_view locFilename,
                           vector<unique_ptr<Location>> &locations) {
+    fast_sort(locations,
+              [&](const unique_ptr<Location> &a, const unique_ptr<Location> &b) -> bool { return a->cmp(*b) < 0; });
+
     auto expectedLocationsIt = allLocs.begin();
     auto actualLocationsIt = locations.begin();
     while (expectedLocationsIt != allLocs.end() && actualLocationsIt != locations.end()) {
@@ -506,9 +509,6 @@ void UsageAssertion::check(const UnorderedMap<string, shared_ptr<core::File>> &s
         return;
     }
 
-    fast_sort(locations,
-              [&](const unique_ptr<Location> &a, const unique_ptr<Location> &b) -> bool { return a->cmp(*b) < 0; });
-
     assertLocationsMatch(sourceFileContents, uriPrefix, symbol, allLocs, line, character, locSourceLine, locFilename,
                          locations);
 }
@@ -586,9 +586,6 @@ void TypeDefAssertion::check(const UnorderedMap<string, shared_ptr<core::File>> 
             NOTHING_LABEL);
         return;
     }
-
-    fast_sort(locations,
-              [&](const unique_ptr<Location> &a, const unique_ptr<Location> &b) -> bool { return a->cmp(*b) < 0; });
 
     assertLocationsMatch(sourceFileContents, uriPrefix, symbol, typeDefs, line, character, locSourceLine, locFilename,
                          locations);

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -155,8 +155,9 @@ public:
     TypeDefAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
                      std::string_view symbol);
 
-    void check(const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents, LSPWrapper &wrapper,
-               int &nextId, std::string_view uriPrefix, const Location &queryLoc);
+    static void check(const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents,
+                      LSPWrapper &wrapper, int &nextId, std::string_view uriPrefix, std::string_view symbol,
+                      const Location &queryLoc, const std::vector<std::shared_ptr<RangeAssertion>> &allLocs);
 
     std::string toString() const override;
 };

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -829,17 +829,10 @@ TEST_P(LSPTest, All) {
         for (auto &[symbol, typeDefAndAssertions] : typeDefMap) {
             auto &[typeDefs, typeAssertions] = typeDefAndAssertions;
             for (auto &typeAssertion : typeAssertions) {
-                if (!typeDefs.empty()) {
-                    auto queryLoc = typeAssertion->getLocation(rootUri);
-                    // Check that a type definition request at this location returns type-def.
-                    TypeDefAssertion::check(test.sourceFileContents, *lspWrapper, nextId, rootUri, symbol, *queryLoc,
-                                            typeDefs);
-                } else {
-                    ADD_FAILURE() << fmt::format(
-                        "Found 'type:' comment for label {0} without any matching type-def comments. Please add a `# "
-                        "^^ type-def: {0}` assertion that points where 'Go to Type Definition' should jump to.",
-                        typeAssertion->symbol);
-                }
+                auto queryLoc = typeAssertion->getLocation(rootUri);
+                // Check that a type definition request at this location returns type-def.
+                TypeDefAssertion::check(test.sourceFileContents, *lspWrapper, nextId, rootUri, symbol, *queryLoc,
+                                        typeDefs);
             }
         }
     }

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -756,8 +756,11 @@ TEST_P(LSPTest, All) {
         UnorderedMap<string, pair<UnorderedMap<int, shared_ptr<DefAssertion>>, vector<shared_ptr<RangeAssertion>>>>
             defUsageMap;
 
-        // symbol => [ TypeDefAssertion, TypeAssertion[] ]
-        UnorderedMap<string, pair<shared_ptr<TypeDefAssertion>, vector<shared_ptr<TypeAssertion>>>> typeDefMap;
+        // symbol => [ TypeDefAssertion[], TypeAssertion[] ]
+        //
+        // (The first element of the pair is only ever TypeDefAssertions but we only ever care that they're
+        // RangeAssertions, so rather than fiddle with up casting, we'll just make the whole vector RangeAssertions)
+        UnorderedMap<string, pair<vector<shared_ptr<RangeAssertion>>, vector<shared_ptr<TypeAssertion>>>> typeDefMap;
         for (auto &assertion : assertions) {
             if (auto defAssertion = dynamic_pointer_cast<DefAssertion>(assertion)) {
                 auto &entry = defUsageMap[defAssertion->symbol];
@@ -773,12 +776,10 @@ TEST_P(LSPTest, All) {
                 auto &entry = defUsageMap[usageAssertion->symbol];
                 entry.second.push_back(usageAssertion);
             } else if (auto typeDefAssertion = dynamic_pointer_cast<TypeDefAssertion>(assertion)) {
-                auto &[typeDef, _typeAssertions] = typeDefMap[typeDefAssertion->symbol];
-                EXPECT_NE(typeDef, nullptr)
-                    << fmt::format("Found multiple type-def comments for label `{}`.", typeDefAssertion->symbol);
-                typeDef = typeDefAssertion;
+                auto &[typeDefs, _typeAssertions] = typeDefMap[typeDefAssertion->symbol];
+                typeDefs.push_back(typeDefAssertion);
             } else if (auto typeAssertion = dynamic_pointer_cast<TypeAssertion>(assertion)) {
-                auto &[_typeDef, typeAssertions] = typeDefMap[typeAssertion->symbol];
+                auto &[_typeDefs, typeAssertions] = typeDefMap[typeAssertion->symbol];
                 typeAssertions.push_back(typeAssertion);
             }
         }
@@ -826,15 +827,16 @@ TEST_P(LSPTest, All) {
 
         // Check each type-def/type assertion.
         for (auto &[symbol, typeDefAndAssertions] : typeDefMap) {
-            auto &[typeDef, typeAssertions] = typeDefAndAssertions;
+            auto &[typeDefs, typeAssertions] = typeDefAndAssertions;
             for (auto &typeAssertion : typeAssertions) {
-                if (typeDef != nullptr) {
+                if (!typeDefs.empty()) {
                     auto queryLoc = typeAssertion->getLocation(rootUri);
                     // Check that a type definition request at this location returns type-def.
-                    typeDef->check(test.sourceFileContents, *lspWrapper, nextId, rootUri, *queryLoc);
+                    TypeDefAssertion::check(test.sourceFileContents, *lspWrapper, nextId, rootUri, symbol, *queryLoc,
+                                            typeDefs);
                 } else {
                     ADD_FAILURE() << fmt::format(
-                        "Found 'type:' comment for label {0} without matching type-def comment. Please add a `# "
+                        "Found 'type:' comment for label {0} without any matching type-def comments. Please add a `# "
                         "^^ type-def: {0}` assertion that points where 'Go to Type Definition' should jump to.",
                         typeAssertion->symbol);
                 }

--- a/test/testdata/lsp/go_to_type_definition.rb
+++ b/test/testdata/lsp/go_to_type_definition.rb
@@ -1,0 +1,51 @@
+# typed: true
+
+class A; end
+#     ^ type-def: A
+#     ^ type-def: AB
+#     ^ type-def: ABMN
+
+class B
+#     ^ type-def: B
+#     ^ type-def: AB
+#     ^ type-def: ABMN
+  extend T::Sig
+
+  sig {returns(A)}
+  def self.returns_A; A.new; end
+end
+
+module M; end
+#     ^ type-def: MN
+#     ^ type-def: ABMN
+module N; end
+#     ^ type-def: MN
+#     ^ type-def: ABMN
+
+class TestClass
+  a_inst = A.new
+  # ^ type: A
+  puts a_inst
+  #    ^ type: A
+
+  puts B.returns_A
+  #      ^ type: A
+
+  a_cls = A
+  # ^ type: A
+  puts a_cls
+  puts A
+  #    ^ type: A
+
+  a_or_b = T.let(A.new, T.any(A, B))
+  puts a_or_b
+  #    ^ type: AB
+
+  m_or_n = T.cast(nil, T.all(M, N))
+  puts m_or_n
+  #    ^ type: MN
+
+  a_or_b_or_mn = T.let(A.new, T.any(A, B, T.all(M, N)))
+  puts a_or_b_or_mn
+  #    ^ type: ABMN
+end

--- a/test/testdata/lsp/go_to_type_definition_applied.rb
+++ b/test/testdata/lsp/go_to_type_definition_applied.rb
@@ -1,0 +1,28 @@
+# typed: strict
+
+class BoxA
+#     ^ type-def: BoxA
+#     ^ type-def: AB
+  extend T::Generic
+  Elem = type_member
+end
+
+class BoxB
+#     ^ type-def: AB
+  extend T::Generic
+  Elem = type_member
+end
+
+class TestClass
+  box_a = BoxA[Integer].new
+  puts box_a
+  #    ^ type: BoxA
+
+  ab = T.let(BoxA[Integer].new, T.any(BoxA[Integer], BoxB[String]))
+  puts ab
+  #    ^ type: AB
+
+  bare_box_a = BoxA.new
+  puts T.reveal_type(bare_box_a) # error: Revealed type: `BoxA[T.untyped]`
+  #                  ^ type: BoxA
+end

--- a/test/testdata/lsp/go_to_type_definition_false.rb
+++ b/test/testdata/lsp/go_to_type_definition_false.rb
@@ -1,0 +1,9 @@
+# typed: false
+
+class A; end
+#     ^ type-def: A
+
+class TestClass
+  puts A
+  #    ^ type: A
+end

--- a/test/testdata/lsp/go_to_type_definition_false.rb
+++ b/test/testdata/lsp/go_to_type_definition_false.rb
@@ -6,4 +6,9 @@ class A; end
 class TestClass
   puts A
   #    ^ type: A
+
+  # Doesn't work since inference doesn't run on this file
+  a = A.new
+  puts a
+  #    ^ type: (nothing)
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

=> #1500

### Commit summary

I recommend reviewing by commit.

- **Implement test harness for TypeDefAssertion** (2b98bac6c)

  It ended up growing support to assert that one 
  textDocument/typeDefinition request respond with multiple locs (for 
  cases like to go type definition on a union type).

- **Boilerplate for new TypeDefinition handler** (cd2ba2b42)


- **Implement handleTextDocumentTypeDefinition** (63b9b936e)

  Note that we never try to add a loc for untyped, because it wiil try to 
  jump to T::Utils::RuntimeProfiled.

- **Add some tests** (fafab8684)

  I did some testing locally to check that adding deleting things that I 
  would expect to make this test fail actually made it fail.




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.