### PR TITLE
Preserve BlockArgs after namer

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -118,6 +118,7 @@ class NameInserter {
         }
         if (parsedArg.block) {
             argInfo.flags.isBlock = true;
+            localExpr = make_unique<ast::BlockArg>(parsedArg.loc, move(localExpr));
         }
         if (parsedArg.repeated) {
             argInfo.flags.isRepeated = true;

--- a/test/testdata/namer/arguments.rb.flattened-tree-raw.exp
+++ b/test/testdata/namer/arguments.rb.flattened-tree-raw.exp
@@ -52,9 +52,9 @@ InsSeq{
               default_ = Literal{ value = 2 }
             }, Local{
               localVariable = <U f>
-            }, Local{
+            }, BlockArg{ expr = Local{
               localVariable = <U g>
-            }]
+            } }]
           rhs = InsSeq{
             stats = [
               Array{

--- a/test/testdata/resolver/field.rb.flattened-tree-raw.exp
+++ b/test/testdata/resolver/field.rb.flattened-tree-raw.exp
@@ -8,9 +8,9 @@ ClassDef{
       name = <U foo><<U foo>>
       args = [Local{
           localVariable = <U a>
-        }, Local{
+        }, BlockArg{ expr = Local{
           localVariable = <U <blk>>
-        }]
+        } }]
       rhs = Assign{
         lhs = UnresolvedIdent{
           kind = Instance

--- a/test/testdata/resolver/resolve_tree_printing.rb.flattened-tree-raw.exp
+++ b/test/testdata/resolver/resolve_tree_printing.rb.flattened-tree-raw.exp
@@ -50,9 +50,9 @@ InsSeq{
         MethodDef{
           flags = 0
           name = <U has_while><<U has_while>>
-          args = [Local{
+          args = [BlockArg{ expr = Local{
               localVariable = <U <blk>>
-            }]
+            } }]
           rhs = While{
             cond = Literal{ value = 1 }
             body = Send{
@@ -70,9 +70,9 @@ InsSeq{
         MethodDef{
           flags = 0
           name = <U has_constant_with_resolution_scope><<U has_constant_with_resolution_scope>>
-          args = [Local{
+          args = [BlockArg{ expr = Local{
               localVariable = <U <blk>>
-            }]
+            } }]
           rhs = ConstantLit{
             orig = UnresolvedConstantLit{
               scope = EmptyTree
@@ -86,9 +86,9 @@ InsSeq{
         MethodDef{
           flags = 0
           name = <U has_global_field><<U has_global_field>>
-          args = [Local{
+          args = [BlockArg{ expr = Local{
               localVariable = <U <blk>>
-            }]
+            } }]
           rhs = Field{
             symbol = <U $S>
           }
@@ -97,9 +97,9 @@ InsSeq{
         MethodDef{
           flags = 0
           name = <U has_class_field><<U has_class_field>>
-          args = [Local{
+          args = [BlockArg{ expr = Local{
               localVariable = <U <blk>>
-            }]
+            } }]
           rhs = UnresolvedIdent{
             kind = Class
             name = <U @@f>
@@ -109,9 +109,9 @@ InsSeq{
         MethodDef{
           flags = 0
           name = <U has_next><<U has_next>>
-          args = [Local{
+          args = [BlockArg{ expr = Local{
               localVariable = <U <blk>>
-            }]
+            } }]
           rhs = Send{
             recv = Local{
               localVariable = <U <self>>
@@ -130,9 +130,9 @@ InsSeq{
         MethodDef{
           flags = 0
           name = <U has_break><<U has_break>>
-          args = [Local{
+          args = [BlockArg{ expr = Local{
               localVariable = <U <blk>>
-            }]
+            } }]
           rhs = Send{
             recv = Local{
               localVariable = <U <self>>
@@ -151,18 +151,18 @@ InsSeq{
         MethodDef{
           flags = 0
           name = <U has_return><<U has_return>>
-          args = [Local{
+          args = [BlockArg{ expr = Local{
               localVariable = <U <blk>>
-            }]
+            } }]
           rhs = Return{ expr = Literal{ value = 1 } }
         }
 
         MethodDef{
           flags = 0
           name = <U has_cast><<U has_cast>>
-          args = [Local{
+          args = [BlockArg{ expr = Local{
               localVariable = <U <blk>>
-            }]
+            } }]
           rhs = InsSeq{
             stats = [
               Send{


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
The namer will process arguments and reconstruct a tree in-place, but we previously were not preserving the block-ness of block args, turning them into positional args. This would manifest if we re-ran the namer over the same tree, something we do in `namer_test.cc`, as the two methods not actually having the same signature.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
