### PR TITLE
Make shortlink for slack invite

### DIFF
--- a/website/blog/2019-06-20-open-sourcing-sorbet.md
+++ b/website/blog/2019-06-20-open-sourcing-sorbet.md
@@ -77,7 +77,7 @@ reports:
 
 [ask us questions on stack overflow]:
   https://stackoverflow.com/questions/tagged/sorbet
-[chat with us on slack]: https://sorbet.org/slack
+[chat with us on slack]: /slack
 [report issues on github]: https://github.com/sorbet/sorbet/issues
 
 ## Acknowledgements

--- a/website/blog/2019-06-20-open-sourcing-sorbet.md
+++ b/website/blog/2019-06-20-open-sourcing-sorbet.md
@@ -77,8 +77,7 @@ reports:
 
 [ask us questions on stack overflow]:
   https://stackoverflow.com/questions/tagged/sorbet
-[chat with us on slack]:
-  https://join.slack.com/t/sorbet-ruby/shared_invite/enQtNjU5MzA2NzU0OTYxLWNiZjcyZmM4MDE5YjIxZjAyMmE0NWYwYzU3MDNmNzNhNWY4YTNhOWE5YWU3NGQ4Y2Y4MDc5ZjAzNjI3NjcwYTE
+[chat with us on slack]: https://sorbet.org/slack
 [report issues on github]: https://github.com/sorbet/sorbet/issues
 
 ## Acknowledgements

--- a/website/pages/en/community.js
+++ b/website/pages/en/community.js
@@ -63,7 +63,7 @@ class Index extends React.Component {
                 },
                 {
                   title: `Chat with us`,
-                  content: `We have a [Slack community](https://sorbet.org/slack) for general discussions. Topics include discussion of Sorbet internals, learning how others use Sorbet, and showing off projects built with Sorbet.`,
+                  content: `We have a [Slack community](/slack) for general discussions. Topics include discussion of Sorbet internals, learning how others use Sorbet, and showing off projects built with Sorbet.`,
                 },
                 {
                   title: `Report issues`,

--- a/website/pages/en/community.js
+++ b/website/pages/en/community.js
@@ -63,7 +63,7 @@ class Index extends React.Component {
                 },
                 {
                   title: `Chat with us`,
-                  content: `We have a [Slack community](https://join.slack.com/t/sorbet-ruby/shared_invite/enQtNjU5MzA2NzU0OTYxLWNiZjcyZmM4MDE5YjIxZjAyMmE0NWYwYzU3MDNmNzNhNWY4YTNhOWE5YWU3NGQ4Y2Y4MDc5ZjAzNjI3NjcwYTE) for general discussions. Topics include discussion of Sorbet internals, learning how others use Sorbet, and showing off projects built with Sorbet.`,
+                  content: `We have a [Slack community](https://sorbet.org/slack) for general discussions. Topics include discussion of Sorbet internals, learning how others use Sorbet, and showing off projects built with Sorbet.`,
                 },
                 {
                   title: `Report issues`,

--- a/website/static/slack/index.html
+++ b/website/static/slack/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<meta charset="utf-8">
+<title>Redirecting…</title>
+<link rel="canonical" href="https://sorbet.org/slack">
+<meta http-equiv="refresh" content="0; url=https://join.slack.com/t/sorbet-ruby/shared_invite/enQtNjU5MzA2NzU0OTYxLWNiZjcyZmM4MDE5YjIxZjAyMmE0NWYwYzU3MDNmNzNhNWY4YTNhOWE5YWU3NGQ4Y2Y4MDc5ZjAzNjI3NjcwYTE">
+<a href="https://join.slack.com/t/sorbet-ruby/shared_invite/enQtNjU5MzA2NzU0OTYxLWNiZjcyZmM4MDE5YjIxZjAyMmE0NWYwYzU3MDNmNzNhNWY4YTNhOWE5YWU3NGQ4Y2Y4MDc5ZjAzNjI3NjcwYTE">Click here if you are not redirected.</a>
+</html>


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This makes it easier to link people to the Slack invite for example in
GitHub issues, Stack Overflow answers, or tweets.

After this lands, this link will work: https://sorbet.org/slack

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested that it worked on localhost.