### PR TITLE
[WIP] Fix type member resolution when constant redefinitions exist

### DIFF
--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -207,6 +207,8 @@ public:
 
     std::vector<std::unique_ptr<pipeline::semantic_extension::SemanticExtension>> semanticExtensions;
 
+    SymbolRef lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 flags) const;
+
 private:
     bool shouldReportErrorOn(Loc loc, ErrorClass what) const;
     struct DeepCloneHistoryEntry {
@@ -246,7 +248,6 @@ private:
 
     SymbolRef lookupSymbolSuchThat(SymbolRef owner, NameRef name, std::function<bool(SymbolRef)> pred) const;
     SymbolRef lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 flags) const;
-
     SymbolRef getTopLevelClassSymbol(NameRef name);
 
     std::string toStringWithOptions(bool showFull, bool showRaw) const;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -245,9 +245,6 @@ private:
 
     SymbolRef synthesizeClass(NameRef nameID, u4 superclass = Symbols::todo()._id, bool isModule = false);
     SymbolRef enterSymbol(Loc loc, SymbolRef owner, NameRef name, u4 flags);
-
-    SymbolRef lookupSymbolSuchThat(SymbolRef owner, NameRef name, std::function<bool(SymbolRef)> pred) const;
-    SymbolRef lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 flags) const;
     SymbolRef getTopLevelClassSymbol(NameRef name);
 
     std::string toStringWithOptions(bool showFull, bool showRaw) const;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -163,7 +163,7 @@ private:
             }
             scope = scope->parent.get();
         }
-        return nesting->scope.data(ctx)->findMemberTransitive(ctx, name); // ctx.state.lookupSymbolWithFlags(nesting->scope, name, flags);
+        return nesting->scope.data(ctx)->findMemberTransitive(ctx, name);
     }
 
     static bool isAlreadyResolved(core::Context ctx, const ast::ConstantLit &original) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -200,7 +200,8 @@ private:
     }
 
     static core::SymbolRef resolveConstant(core::Context ctx, shared_ptr<Nesting> nesting,
-                                           const unique_ptr<ast::UnresolvedConstantLit> &c, bool &resolutionFailed, u4 flags) {
+                                           const unique_ptr<ast::UnresolvedConstantLit> &c, bool &resolutionFailed,
+                                           u4 flags) {
         if (ast::isa_tree<ast::EmptyTree>(c->scope.get())) {
             core::SymbolRef result = resolveLhs(ctx, nesting, c->cnst, flags);
             return result;
@@ -311,8 +312,8 @@ private:
             return true;
         }
 
-        auto resolved =
-            resolveConstant(ctx.withOwner(job.scope->scope), job.scope, job.out->original, job.resolutionFailed, job.expectedConstantFlags);
+        auto resolved = resolveConstant(ctx.withOwner(job.scope->scope), job.scope, job.out->original,
+                                        job.resolutionFailed, job.expectedConstantFlags);
         if (!resolved.exists()) {
             return false;
         }
@@ -594,7 +595,8 @@ public:
 
             // We also enter a ResolutionItem for the lhs of a type alias so even if the type alias isn't used,
             // we'll still emit a warning when the rhs of a type alias doesn't resolve.
-            auto item = ResolutionItem{nesting_, id, core::Symbol::Flags::STATIC_FIELD_TYPE_ALIAS};
+            auto item = ResolutionItem{
+                nesting_, id, core::Symbol::Flags::STATIC_FIELD_TYPE_ALIAS & core::Symbol::Flags::STATIC_FIELD};
 
             this->todo_.emplace_back(std::move(item));
             return asgn;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -163,7 +163,7 @@ private:
             }
             scope = scope->parent.get();
         }
-        return ctx.state.lookupSymbolWithFlags(nesting->scope, name, flags);
+        return nesting->scope.data(ctx)->findMemberTransitive(ctx, name); // ctx.state.lookupSymbolWithFlags(nesting->scope, name, flags);
     }
 
     static bool isAlreadyResolved(core::Context ctx, const ast::ConstantLit &original) {
@@ -595,8 +595,7 @@ public:
 
             // We also enter a ResolutionItem for the lhs of a type alias so even if the type alias isn't used,
             // we'll still emit a warning when the rhs of a type alias doesn't resolve.
-            auto item = ResolutionItem{
-                nesting_, id, core::Symbol::Flags::STATIC_FIELD_TYPE_ALIAS & core::Symbol::Flags::STATIC_FIELD};
+            auto item = ResolutionItem{nesting_, id, 0};
 
             this->todo_.emplace_back(std::move(item));
             return asgn;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -595,7 +595,7 @@ public:
 
             // We also enter a ResolutionItem for the lhs of a type alias so even if the type alias isn't used,
             // we'll still emit a warning when the rhs of a type alias doesn't resolve.
-            auto item = ResolutionItem{nesting_, id, 0};
+            auto item = ResolutionItem{nesting_, id, core::Symbol::Flags::STATIC_FIELD_TYPE_ALIAS};
 
             this->todo_.emplace_back(std::move(item));
             return asgn;

--- a/test/testdata/namer/fuzz_type_template_overwrite.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/fuzz_type_template_overwrite.rb.symbol-table-raw.exp
@@ -5,5 +5,5 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
   class <S <C <U A>> $1>[<C <U B>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/fuzz_type_template_overwrite.rb start=2:7 end=2:8}
     method <S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/fuzz_type_template_overwrite.rb start=2:1 end=5:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/fuzz_type_template_overwrite.rb start=??? end=???}
-    type-member(=) <S <C <U A>> $1><C <U B>> -> LambdaParam(<S <C <U A>> $1><C <U B>>, lower=T.noreturn, upper=<any>) @ Loc {file=test/testdata/namer/fuzz_type_template_overwrite.rb start=4:3 end=4:20}
+    type-member(=) <S <C <U A>> $1><C <U B>> -> LambdaParam(<S <C <U A>> $1><C <U B>>, lower=T.untyped, upper=T.untyped) @ Loc {file=test/testdata/namer/fuzz_type_template_overwrite.rb start=4:3 end=4:20}
 

--- a/test/testdata/resolver/fuzz_type_alias_and_member.rb
+++ b/test/testdata/resolver/fuzz_type_alias_and_member.rb
@@ -1,0 +1,6 @@
+# typed: true
+class Foo
+  A = T.type_alias(Foo) # error: Type aliases are not allowed in generic classes
+  A = type_member # error: Redefining constant `Foo::A`
+    # ^^^^^^^^^^^ error: Method `type_member` does not exist on `T.class_of(Foo)`
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes #1559; the issue fundamentally is that the resolver does its own name lookup but wasn't aware of the name-disambiguating work done in the namer. Consequently, in the program
```ruby
class Foo
  A = T.type_alias(Foo)
  A = type_member
end
```
an implementation detail of the namer would try to resolve `Foo::A$1` by looking up the meaning of `Foo::A` (because resolution uses the names found in the `UnresolvedConstant`) and that in turn led it to change the symbol associated with the type alias assignment to `Foo::A`, re-stitch that symbol into the AST, and then when we try to process `A = T.type_alias(Foo)` in a different pass we get into an anomalous situation where we "know" that `A` is a type member (because the associated symbol _is_ the type member symbol) but it doesn't look like one!

The fix I've written here is that the resolver can also look up constants by field type: this means that when we look up `Foo::A` in a type alias context, we'll only ever find a type alias. We don't _always_ want to do this, because otherwise we'll sidestep errors that we actually want to find where some constant in a nested scope isn't actually a thing that's scoped, but sometimes we do.

WIP for the following open questions/design decisions:
- this so far has only come up in the context of a "fake" resolution item used to force certain errors that otherwise would go unnoticed without a use-site (specifically when we have a `type_alias` whose RHS is not valid). If that's the _only_ situation where this can happen, maybe we can come up with a different way of forcing that resolution to happen!
- are there other instances where we'll want to definitely search for constants of a given type in resolution?
- right now, this just looks up based on the same flags used internally in a symbol, but this also exposes those details more broadly. This could be advantageous—e.g. we could grab the flags from the symbol, select only the type flags, and use them to look up only symbols of a corresponding type much more easily and much more quickly than a whole chain of `if (isClass()) { lookupClassSymbol() } else (ifMethod()) { ... }`, but it's worth considering whether to use a different set of flags in the resolution item and then go through other helper functions so we can keep the `Flags` internal.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
