### PR TITLE
Delete duplicated definition of `exit` and `exit!`

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -328,64 +328,6 @@ module Kernel
   end
   def extend(mod); end
 
-  # Initiates the termination of the Ruby script by raising the `SystemExit`
-  # exception. This exception may be caught. The optional parameter is used
-  # to return a status code to the invoking environment. `true` and `FALSE`
-  # of *status* means success and failure respectively. The interpretation
-  # of other integer values are system dependent.
-  #
-  # ```ruby
-  # begin
-  #   exit
-  #   puts "never get here"
-  # rescue SystemExit
-  #   puts "rescued a SystemExit exception"
-  # end
-  # puts "after begin block"
-  # ```
-  #
-  # *produces:*
-  #
-  #     rescued a SystemExit exception
-  #     after begin block
-  #
-  # Just prior to termination, Ruby executes any `at_exit` functions (see
-  # Kernel::at\_exit) and runs any object finalizers (see
-  # [ObjectSpace.define\_finalizer](https://ruby-doc.org/core-2.6.3/ObjectSpace.html#method-c-define_finalizer)
-  # ).
-  #
-  # ```ruby
-  # at_exit { puts "at_exit function" }
-  # ObjectSpace.define_finalizer("string",  proc { puts "in finalizer" })
-  # exit
-  # ```
-  #
-  # *produces:*
-  #
-  #     at_exit function
-  #     in finalizer
-  sig do
-    params(
-        status: Integer,
-    )
-    .returns(T.untyped)
-  end
-  def exit(status=T.unsafe(nil)); end
-
-  # Exits the process immediately. No exit handlers are run. *status* is
-  # returned to the underlying system as the exit status.
-  #
-  # ```ruby
-  # Process.exit!(true)
-  # ```
-  sig do
-    params(
-        status: Integer,
-    )
-    .returns(T.untyped)
-  end
-  def exit!(status=T.unsafe(nil)); end
-
   # Creates a subprocess. If a block is specified, that block is run in the
   # subprocess, and the subprocess terminates with a status of zero.
   # Otherwise, the `fork` call returns twice, once in the parent, returning

--- a/test/cli/cache-dsl/cache-dsl.out
+++ b/test/cli/cache-dsl/cache-dsl.out
@@ -2,8 +2,8 @@ No errors! Great job.
 test/cli/cache-dsl/attr_accessor.rb:7: Method `prop=` does not exist on `A` https://srb.help/7003
      7 |a.prop = 7
         ^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1384: Did you mean: `Kernel#proc`?
-    1384 |  def proc(&blk); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1326: Did you mean: `Kernel#proc`?
+    1326 |  def proc(&blk); end
             ^^^^^^^^^^^^^^
 
 test/cli/cache-dsl/attr_accessor.rb:8: Method `prop` does not exist on `A` https://srb.help/7003
@@ -18,8 +18,8 @@ Errors: 2
 test/cli/cache-dsl/attr_accessor.rb:7: Method `prop=` does not exist on `A` https://srb.help/7003
      7 |a.prop = 7
         ^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1384: Did you mean: `Kernel#proc`?
-    1384 |  def proc(&blk); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1326: Did you mean: `Kernel#proc`?
+    1326 |  def proc(&blk); end
             ^^^^^^^^^^^^^^
 
 test/cli/cache-dsl/attr_accessor.rb:8: Method `prop` does not exist on `A` https://srb.help/7003

--- a/test/cli/errors/errors.out
+++ b/test/cli/errors/errors.out
@@ -12,8 +12,8 @@ test/cli/errors/errors.rb:5: Unable to resolve constant `MyConstantWithTypo` htt
 test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
     15 |    raise arg # raise is defined by stdlib
             ^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1960: Method `Kernel#raise (overload.1)` has specified `arg0` as `String`
-    1960 |        arg0: String,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1902: Method `Kernel#raise (overload.1)` has specified `arg0` as `String`
+    1902 |        arg0: String,
                   ^^^^
   Got Integer originating from:
     test/cli/errors/errors.rb:13:
@@ -66,8 +66,8 @@ test/cli/errors/errors.rb:5: Unable to resolve constant `MyConstantWithTypo` htt
 test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
     15 |    raise arg # raise is defined by stdlib
             ^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1960: Method `Kernel#raise (overload.1)` has specified `arg0` as `String`
-    1960 |        arg0: String,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1902: Method `Kernel#raise (overload.1)` has specified `arg0` as `String`
+    1902 |        arg0: String,
                   ^^^^
   Got Integer originating from:
     test/cli/errors/errors.rb:13:
@@ -120,8 +120,8 @@ test/cli/errors/errors.rb:5: Unable to resolve constant `MyConstantWithTypo` htt
 test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
     15 |    raise arg # raise is defined by stdlib
             ^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1960: Method `Kernel#raise (overload.1)` has specified `arg0` as `String`
-    1960 |        arg0: String,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1902: Method `Kernel#raise (overload.1)` has specified `arg0` as `String`
+    1902 |        arg0: String,
                   ^^^^
   Got Integer originating from:
     test/cli/errors/errors.rb:13:

--- a/test/cli/incremental-resolver/incremental-resolver.out
+++ b/test/cli/incremental-resolver/incremental-resolver.out
@@ -69,8 +69,8 @@ test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:68: Method `sig` 
 test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:68: Method `void` does not exist on `Object` https://srb.help/7003
     68 |  sig {void}
                ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1189: Did you mean: `Kernel#load`?
-    1189 |  def load(filename, arg0=T.unsafe(nil)); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1131: Did you mean: `Kernel#load`?
+    1131 |  def load(filename, arg0=T.unsafe(nil)); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:69: Method `sig` does not exist on `Object` https://srb.help/7003
@@ -80,7 +80,7 @@ test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:69: Method `sig` 
 test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:69: Method `void` does not exist on `Object` https://srb.help/7003
     69 |  sig {void}
                ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1189: Did you mean: `Kernel#load`?
-    1189 |  def load(filename, arg0=T.unsafe(nil)); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1131: Did you mean: `Kernel#load`?
+    1131 |  def load(filename, arg0=T.unsafe(nil)); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 7

--- a/test/cli/suggest-kernel/suggest-kernel.out
+++ b/test/cli/suggest-kernel/suggest-kernel.out
@@ -2,7 +2,7 @@ test/cli/suggest-kernel/suggest-kernel.rb:4: Method `raise` does not exist on `F
      4 |    raise "hi"
             ^^^^^^^^^^
   Did you mean to `include Kernel` in this module?
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1980: Did you mean: `Kernel#raise`?
-    1980 |  def raise(arg0=T.unsafe(nil), arg1=T.unsafe(nil), arg2=T.unsafe(nil)); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1922: Did you mean: `Kernel#raise`?
+    1922 |  def raise(arg0=T.unsafe(nil), arg1=T.unsafe(nil), arg2=T.unsafe(nil)); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 1


### PR DESCRIPTION
I found the definition of `exit` and `exit!` in `Kernel` is duplicated. So proposing to delete one of them.

* `def exit` can be found at both:
  * https://github.com/sorbet/sorbet/blob/master/rbi/core/kernel.rbi#L373
  * https://github.com/sorbet/sorbet/blob/master/rbi/core/kernel.rbi#L1065