### PR TITLE
After `rbi gems` run `suggest-typed` (#1146)

### DIFF
--- a/gems/sorbet/bin/srb-rbi
+++ b/gems/sorbet/bin/srb-rbi
@@ -200,7 +200,10 @@ If instead you want to explore your files locally, here are some things to try:
     when 'sorbet-typed', Sorbet::Private::FetchRBIs.output_file, Sorbet::Private::FetchRBIs::SORBET_RBI_LIST
       make_step(Sorbet::Private::FetchRBIs)
     when 'gems', Sorbet::Private::GemGeneratorTracepoint.output_file
-      make_step(Sorbet::Private::GemGeneratorTracepoint)
+      -> do
+        make_step(Sorbet::Private::GemGeneratorTracepoint).call
+        make_step(Sorbet::Private::SuggestTyped).call
+      end
     when 'hidden-definitions', Sorbet::Private::HiddenMethodFinder.output_file
       make_step(Sorbet::Private::HiddenMethodFinder)
     when 'todo', Sorbet::Private::TodoRBI.output_file


### PR DESCRIPTION
### Motivation

Per Jake's suggestion
(https://github.com/sorbet/sorbet/issues/1146#issuecomment-507883405)

Fixes problem where `rbi gems` produces incorrect sigils

[Fix #1146]

### Test plan

I couldn't figure out how to test this. I read the "Writing tests" section of the readme, and I tried to write a test in `test/cli` but maybe that was a bad choice because `main/sorbet` in the `.sh` doesn't seem to work the way `srb` does? For example, if I do `main/sorbet rbi gems`, I get: "gems: File Not Found". I'm obviously missing something fundamental, sorry.