### PR TITLE
Disallow type_parameters in attr functions

### DIFF
--- a/core/errors/dsl.h
+++ b/core/errors/dsl.h
@@ -6,5 +6,6 @@ namespace sorbet::core::errors::DSL {
 constexpr ErrorClass BadAttrArg{3501, StrictLevel::True};
 constexpr ErrorClass BadWrapInstance{3502, StrictLevel::True};
 constexpr ErrorClass PrivateMethodMismatch{3503, StrictLevel::False};
+constexpr ErrorClass BadAttrType{3504, StrictLevel::True};
 } // namespace sorbet::core::errors::DSL
 #endif

--- a/test/testdata/dsl/attr_parameters.rb
+++ b/test/testdata/dsl/attr_parameters.rb
@@ -1,0 +1,14 @@
+# typed: true
+
+class A
+  extend T::Sig
+
+  sig { type_parameters(:K).returns(T.type_parameter(:K)) } # error: The type for an `attr_reader` cannot contain `type_parameters`
+  attr_reader :foo
+
+  sig { type_parameters(:K).params(bar: T.type_parameter(:K)).returns(T.type_parameter(:K)) } # error: The type for an `attr_writer` cannot contain `type_parameters`
+  attr_writer :bar
+
+  sig { type_parameters(:K).returns(T.type_parameter(:K)) } # error: The type for an `attr_accessor` cannot contain `type_parameters`
+  attr_accessor :baz
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
There's no reason to use this, and it'll end up failing at instantiation anyway(c.f. [this sorbet.run example](https://sorbet.run/#%23%20typed%3A%20true%0Aclass%20Foo%0A%20%20extend%20T%3A%3ASig%0A%20%20sig%20%7Btype_parameters(%3AA).returns(T.type_parameter(%3AA))%7D%0A%20%20attr_reader%20%3Afoo%0Aend%0A%0AT.reveal_type(Foo.new.foo))) and it causes confusing errors in other situations. This fixes #1710 for similar reasons.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Added a test case including the relevant error messages.