### PR TITLE
Fix crash with empty sealed classes

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -867,7 +867,7 @@ TypePtr Symbol::sealedSubclassesToUnion(const Context ctx) const {
     auto currentClasses = appliedType->targs[0];
     if (currentClasses->isBottom()) {
         // Declared sealed parent class, but never saw any children.
-        return make_type<ClassType>(this->ref(ctx));
+        return Types::bottom();
     }
 
     auto result = Types::bottom();

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -176,7 +176,9 @@ TypePtr Types::dropSubtypesOf(Context ctx, const TypePtr &from, SymbolRef klass)
             if (c->isUntyped()) {
                 result = from;
             } else if (cdata->isClassSealed() && (cdata->isClassAbstract() || cdata->isClassModule())) {
-                result = dropSubtypesOf(ctx, cdata->sealedSubclassesToUnion(ctx), klass);
+                auto subclasses = cdata->sealedSubclassesToUnion(ctx);
+                ENFORCE(!Types::equiv(ctx, subclasses, from), "sealedSubclassesToUnion about to cause infinte loop");
+                result = dropSubtypesOf(ctx, subclasses, klass);
             } else if (c->symbol == klass || c->derivesFrom(ctx, klass)) {
                 result = Types::bottom();
             } else {

--- a/test/testdata/resolver/empty_sealed.rb
+++ b/test/testdata/resolver/empty_sealed.rb
@@ -1,0 +1,16 @@
+# typed: true
+extend T::Sig
+
+module Bottom
+  extend T::Helpers
+  sealed!
+end
+
+sig {params(x: Bottom).void}
+def foo(x)
+  case x
+  when nil
+  else
+    T.absurd(x)
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It used to be the case that `dropSubtypesOf` on a sealed class with no
subclasses infinitely looped because we would "convert it to the sealed
subclasses union" by just returning itself and recursing.

It's actually fine to make a sealed class with no subclasses convert to
`T.noreturn` for the purposes of `dropSubtypesOf` because given that we know
the class is abstract or that it's a module and it has no subclasses, it's
never inhabited and thus behaves like bottom.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
Verified that this test triggered a crash before the fix.