### PR TITLE
Avoid generating repeating RBI constants

### DIFF
--- a/gems/sorbet/lib/hidden-definition-finder.rb
+++ b/gems/sorbet/lib/hidden-definition-finder.rb
@@ -189,12 +189,15 @@ class Sorbet::Private::HiddenMethodFinder
   def serialize_constants(source, rbi, klass, is_singleton, source_symbols, rbi_symbols)
     source_by_name = source.map {|v| [v["name"]["name"], v]}.to_h
     ret = []
+    seen_constants = Set.new
 
     rbi.each do |rbi_entry|
+      next if seen_constants.include?(rbi_entry["name"]["name"])
       source_entry = source_by_name[rbi_entry["name"]["name"]]
 
       ret << serialize_alias(source_entry, rbi_entry, klass, source_symbols, rbi_symbols)
       ret << serialize_class(source_entry, rbi_entry, klass, source_symbols, rbi_symbols, source_by_name)
+      seen_constants.add(rbi_entry["name"]["name"])
     end
 
     ret.compact.join("\n")


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes #1727. The underlying problem is that we rely on symbol tables where the names would be generated via the `NameRef.show` function, which is also used in error output. The change made in #1705 modified this function to avoid showing the user the `$x` suffixes that would show up when we have redefined constants, because otherwise they'd show up in messages from LSP in weird places. But unfortunately, this broke RBI generation, because previously we'd look through the symbol tables and throw the `$x`-suffixed names away because they were invalid Ruby. Because we no longer suffix those names, we now regenerate constants for them. This just keeps a cache to make sure we don't regenerate those.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
