### PR TITLE
Revert "Don't show mangled names in `show` (#1705)"

### DIFF
--- a/core/Names.cc
+++ b/core/Names.cc
@@ -123,9 +123,7 @@ string Name::show(const GlobalState &gs) const {
             } else if (this->unique.uniqueNameKind == UniqueNameKind::Overload) {
                 return absl::StrCat(this->unique.original.data(gs)->show(gs), " (overload.", this->unique.num, ")");
             } else if (this->unique.uniqueNameKind == UniqueNameKind::MangleRename) {
-                // we use `show` extensively in user-facing output, so even though this is a mangled name we will want
-                // to present it to the user as though it were the original name
-                return this->unique.original.data(gs)->show(gs);
+                return fmt::format("{}${}", this->unique.original.data(gs)->show(gs), this->unique.num);
             } else if (this->unique.uniqueNameKind == UniqueNameKind::OpusEnum) {
                 // The entire goal of UniqueNameKind::OpusEnum is to have Name::show print the name as if on the
                 // original name, so that our OpusEnum DSL-synthesized class names are kept as an implementation detail.

--- a/test/testdata/namer/class_and_alias.rb.flattened-tree.exp
+++ b/test/testdata/namer/class_and_alias.rb.flattened-tree.exp
@@ -2,13 +2,13 @@ begin
   class <emptyTree><<C <root>>> < ()
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::A = 91
+        ::A$1 = 91
         begin
-          ::Sorbet::Private::Static.keep_for_ide(::A)
+          ::Sorbet::Private::Static.keep_for_ide(::A$1)
           <emptyTree>
         end
         begin
-          ::Sorbet::Private::Static.keep_for_ide(::B)
+          ::Sorbet::Private::Static.keep_for_ide(::B$1)
           <emptyTree>
         end
         ::B = 91
@@ -16,7 +16,7 @@ begin
       end
     end
   end
-  class ::A<<C A>> < (::<todo sym>)  end
-  class ::B<B$1> < (::<todo sym>)  end
+  class ::A$1<<C A>> < (::<todo sym>)  end
+  class ::B$1<B$1> < (::<todo sym>)  end
   <emptyTree>
 end


### PR DESCRIPTION
This reverts commit c1bec037b99e086e22e77833395893516123b6c0.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes #1727.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
