### PR TITLE
Avoid updating variable knowledge when types haven't changed

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -588,8 +588,12 @@ void Environment::mergeWith(core::Context ctx, const Environment &other, core::L
         auto var = pair.first;
         const auto &otherTO = other.getTypeAndOrigin(ctx, var);
         auto &thisTO = pair.second.typeAndOrigins;
+
+        bool sameType;
         if (thisTO.type.get() != nullptr) {
-            thisTO.type = core::Types::any(ctx, thisTO.type, otherTO.type);
+            auto temp = core::Types::any(ctx, thisTO.type, otherTO.type);
+            sameType = thisTO.type == temp;
+            thisTO.type = move(temp);
             thisTO.type->sanityCheck(ctx);
             for (auto origin : otherTO.origins) {
                 if (!absl::c_linear_search(thisTO.origins, origin)) {
@@ -599,14 +603,16 @@ void Environment::mergeWith(core::Context ctx, const Environment &other, core::L
             pair.second.knownTruthy = pair.second.knownTruthy && other.getKnownTruthy(var);
         } else {
             thisTO = otherTO;
+            sameType = false;
             pair.second.knownTruthy = other.getKnownTruthy(var);
         }
 
         if (((bb->flags & cfg::CFG::LOOP_HEADER) != 0) && bb->outerLoops <= inWhat.maxLoopWrite[var]) {
             continue;
         }
-        bool canBeFalsy = core::Types::canBeFalsy(ctx, otherTO.type) && !other.getKnownTruthy(var);
-        bool canBeTruthy = core::Types::canBeTruthy(ctx, otherTO.type);
+
+        bool canBeFalsy = sameType || (core::Types::canBeFalsy(ctx, otherTO.type) && !other.getKnownTruthy(var));
+        bool canBeTruthy = sameType || core::Types::canBeTruthy(ctx, otherTO.type);
 
         if (canBeTruthy) {
             auto &thisKnowledge = getKnowledge(var);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Avoid expensive knowledge updates in `Environment::mergeWith` when the type of the variable in question hasn't changed.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
