### PR TITLE
Some random LSP cleanups

### DIFF
--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -75,13 +75,19 @@ void LSPConfiguration::configure(const InitializeParams &params) {
     }
 }
 
-unique_ptr<core::Loc> LSPConfiguration::lspPos2Loc(const core::FileRef fref, const Position &pos,
-                                                   const core::GlobalState &gs) const {
+// LSP Spec: line / col in Position are 0-based
+// Sorbet:   line / col in core::Loc are 1-based (like most editors)
+// LSP Spec: distinguishes Position (zero-width) and Range (start & end)
+// Sorbet:   zero-width core::Loc is a Position
+//
+// https://microsoft.github.io/language-server-protocol/specification#text-documents
+core::Loc LSPConfiguration::lspPos2Loc(const core::FileRef fref, const Position &pos,
+                                       const core::GlobalState &gs) const {
     core::Loc::Detail reqPos;
     reqPos.line = pos.line + 1;
     reqPos.column = pos.character + 1;
     auto offset = core::Loc::pos2Offset(fref.data(gs), reqPos);
-    return make_unique<core::Loc>(core::Loc(fref, offset, offset));
+    return core::Loc{fref, offset, offset};
 }
 
 string LSPConfiguration::localName2Remote(string_view filePath) const {

--- a/main/lsp/LSPConfiguration.h
+++ b/main/lsp/LSPConfiguration.h
@@ -67,7 +67,7 @@ public:
     std::string fileRef2Uri(const core::GlobalState &gs, const core::FileRef) const;
     std::string remoteName2Local(std::string_view uri) const;
     std::string localName2Remote(std::string_view filePath) const;
-    std::unique_ptr<core::Loc> lspPos2Loc(core::FileRef fref, const Position &pos, const core::GlobalState &gs) const;
+    core::Loc lspPos2Loc(core::FileRef fref, const Position &pos, const core::GlobalState &gs) const;
     // returns nullptr if this loc doesn't exist
     std::unique_ptr<Location> loc2Location(const core::GlobalState &gs, core::Loc loc) const;
     bool isFileIgnored(std::string_view filePath) const;

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -39,14 +39,7 @@ LSPLoop::QueryRun LSPLoop::setupLSPQueryByLoc(unique_ptr<core::GlobalState> gs, 
     }
 
     auto loc = config.lspPos2Loc(fref, pos, *gs);
-    if (!loc) {
-        auto error = make_unique<ResponseError>(
-            (int)LSPErrorCodes::InvalidParams,
-            fmt::format("Did not find location at uri {} in {}", uri, convertLSPMethodToString(forMethod)));
-        return LSPLoop::QueryRun{move(gs), {}, move(error)};
-    }
-
-    return runQuery(move(gs), core::lsp::Query::createLocQuery(*loc.get()), {fref});
+    return runQuery(move(gs), core::lsp::Query::createLocQuery(loc), {fref});
 }
 
 LSPLoop::QueryRun LSPLoop::setupLSPQueryBySymbol(unique_ptr<core::GlobalState> gs, core::SymbolRef sym) const {

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -305,10 +305,10 @@ LSPResult LSPLoop::handleTextDocumentCompletion(unique_ptr<core::GlobalState> gs
                     }
                     return leftPair.first._id < rightPair.first._id;
                 });
-                for (auto &entry : methodsSorted) {
-                    if (entry.second[0].exists()) {
-                        fast_sort(entry.second, [&](auto lhs, auto rhs) -> bool { return lhs._id < rhs._id; });
-                        items.push_back(getCompletionItem(*gs, entry.second[0], receiverType,
+                for (auto &[methodName, methodSymbols] : methodsSorted) {
+                    if (methodSymbols[0].exists()) {
+                        fast_sort(methodSymbols, [&](auto lhs, auto rhs) -> bool { return lhs._id < rhs._id; });
+                        items.push_back(getCompletionItem(*gs, methodSymbols[0], receiverType,
                                                           sendResp->dispatchResult->main.constr));
                     }
                 }

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -81,10 +81,7 @@ LSPResult LSPLoop::handleTextSignatureHelp(unique_ptr<core::GlobalState> gs, con
                 }
                 auto src = fref.data(*gs).source();
                 auto loc = config.lspPos2Loc(fref, *params.position, *gs);
-                if (!loc) {
-                    return LSPResult{move(gs), {}};
-                }
-                string_view call_str = src.substr(sendLocIndex, loc->endPos() - sendLocIndex);
+                string_view call_str = src.substr(sendLocIndex, loc.endPos() - sendLocIndex);
                 int numberCommas = absl::c_count(call_str, ',');
                 // Active parameter depends on number of ,'s in the current string being typed. (0 , = first arg, 1 , =
                 // 2nd arg)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Just random small things I've found while reading the code. Not urgent, happy
to accept feedback.


### Commit summary


- **Use tuple destructing to give good names** (8dc5b62c7)


- **No need to use pointer with core::Loc** (470482f87)

  Both unique_ptr and core::Loc are 1 byte, so no need to prefer
  unique_ptr based on fitting in a register.

  lspPos2Loc never returns `nullptr`, so no need to use it to check for
  error conditions.

  If we did want to check for error conditions, `core::Loc` already has
  `core::Loc::none(core::File{})` + `loc.exists()` (i.e., every Loc might
  already not exist, like SymbolRef and NameRef).



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.