### PR TITLE
Some more completion.cc refactors

### DIFF
--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -1,4 +1,7 @@
+#include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/str_split.h"
 #include "common/FileOps.h"
 #include "lsp.h"
 
@@ -193,4 +196,108 @@ SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef sym
     return SymbolKind::Unknown;
 }
 
+/**
+ * Retrieves the documentation above a symbol.
+ * - Returned documentation has one trailing newline (if it exists)
+ * - Assumes that valid ruby syntax is used.
+ * - Strips the first whitespace character from a comment e.g
+ *      # a comment
+ *      #a comment
+ *   are the same.
+ */
+optional<string> findDocumentation(string_view sourceCode, int beginIndex) {
+    // Everything in the file before the method definition.
+    string_view preDefinition = sourceCode.substr(0, sourceCode.rfind('\n', beginIndex));
+
+    // Get all the lines before it.
+    std::vector<string_view> all_lines = absl::StrSplit(preDefinition, '\n');
+
+    // if there are no lines before the method definition, we're at the top of the file.
+    if (all_lines.empty()) {
+        return nullopt;
+    }
+
+    std::vector<string_view> documentation_lines;
+
+    // Iterate from the last line, to the first line
+    for (auto it = all_lines.rbegin(); it != all_lines.rend(); it++) {
+        string_view line = absl::StripAsciiWhitespace(*it);
+
+        // Short circuit when line is empty
+        if (line.empty()) {
+            break;
+        }
+
+        // Handle single-line sig block
+        else if (absl::StartsWith(line, "sig")) {
+            // Do nothing for a one-line sig block
+        }
+
+        // Handle multi-line sig block
+        else if (absl::StartsWith(line, "end")) {
+            // ASSUMPTION: We either hit the start of file, a `sig do` or an `end`
+            it++;
+            while (
+                // SOF
+                it != all_lines.rend()
+                // Start of sig block
+                && !absl::StartsWith(absl::StripAsciiWhitespace(*it), "sig do")
+                // Invalid end keyword
+                && !absl::StartsWith(absl::StripAsciiWhitespace(*it), "end")) {
+                it++;
+            };
+
+            // We have either
+            // 1) Reached the start of the file
+            // 2) Found a `sig do`
+            // 3) Found an invalid end keyword
+            if (it == all_lines.rend() || absl::StartsWith(absl::StripAsciiWhitespace(*it), "end")) {
+                break;
+            }
+
+            // Reached a sig block.
+            line = absl::StripAsciiWhitespace(*it);
+            ENFORCE(absl::StartsWith(line, "sig do"));
+
+            // Stop looking if this is a single-line block e.g `sig do; <block>; end`
+            if (absl::StartsWith(line, "sig do;") && absl::EndsWith(line, "end")) {
+                break;
+            }
+
+            // Else, this is a valid sig block. Move on to any possible documentation.
+        }
+
+        // Handle a comment line. Do not count typing declarations.
+        else if (absl::StartsWith(line, "#") && !absl::StartsWith(line, "# typed:")) {
+            // Account for whitespace before comment e.g
+            // # abc -> "abc"
+            // #abc -> "abc"
+            int skip_after_hash = absl::StartsWith(line, "# ") ? 2 : 1;
+
+            string_view comment = line.substr(line.find('#') + skip_after_hash);
+
+            documentation_lines.push_back(comment);
+
+            // Account for yarddoc lines by inserting an extra newline right before
+            // the yarddoc line (note that we are reverse iterating)
+            if (absl::StartsWith(comment, "@")) {
+                documentation_lines.push_back(string_view(""));
+            }
+        }
+
+        // No other cases applied to this line, so stop looking.
+        else {
+            break;
+        }
+    }
+
+    string documentation = absl::StrJoin(documentation_lines.rbegin(), documentation_lines.rend(), "\n");
+    documentation = absl::StripTrailingAsciiWhitespace(documentation);
+
+    if (documentation.empty())
+        return nullopt;
+    else {
+        return documentation;
+    }
+}
 } // namespace sorbet::realmain::lsp


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Purely hygienic. This should have no runtime effect. I justified each change in
a commit:


- **Early exit to reduce nesting** (30b851915)


- **Use more auto** (c9ae431fd)


- **Add `return` to get it to format on two lines** (18323d1e8)


- **Remove OrType case** (aa98ab3d9)

  It's never the case that a DispatchResult component is an OrType. I
  verified this by going into calls.cc where the DispatchComponent
  receiver is populated and adding an ENFORCE to verify.

- **Move findDocumentation implementation elsewhere** (748bb5258)

  It was defined in completion.cc, but also used in hover.cc. That's a bad
  practice in my opinion.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.