### PR TITLE
Rework canBeTruthy to not rely on dropSubtypesOf

### DIFF
--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -214,7 +214,7 @@ TypePtr Types::dropSubtypesOf(Context ctx, const TypePtr &from, SymbolRef klass)
 }
 
 bool Types::canBeTruthy(Context ctx, const TypePtr &what) {
-    bool isTruthy = false;
+    bool isTruthy = true;
     typecase(
         what.get(), [&](OrType *o) { isTruthy = canBeTruthy(ctx, o->left) || canBeTruthy(ctx, o->right); },
         [&](AndType *a) { isTruthy = canBeTruthy(ctx, a->left) && canBeTruthy(ctx, a->right); },
@@ -228,7 +228,7 @@ bool Types::canBeTruthy(Context ctx, const TypePtr &what) {
             isTruthy = sym == core::Symbols::untyped() ||
                        (sym != core::Symbols::FalseClass() && sym != core::Symbols::NilClass());
         },
-        [&](ProxyType *c) { isTruthy = canBeTruthy(ctx, c->underlying()); }, [&](Type *) {});
+        [&](ProxyType *c) { isTruthy = canBeTruthy(ctx, c->underlying()); }, [&](Type *) { isTruthy = true; });
 
     return isTruthy;
 }

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -214,21 +214,19 @@ TypePtr Types::dropSubtypesOf(Context ctx, const TypePtr &from, SymbolRef klass)
 }
 
 bool Types::canBeTruthy(Context ctx, const TypePtr &what) {
-    if (what->isUntyped()) {
-        return true;
-    }
-
     bool isTruthy = false;
     typecase(
         what.get(), [&](OrType *o) { isTruthy = canBeTruthy(ctx, o->left) || canBeTruthy(ctx, o->right); },
         [&](AndType *a) { isTruthy = canBeTruthy(ctx, a->left) && canBeTruthy(ctx, a->right); },
         [&](ClassType *c) {
             auto sym = c->symbol;
-            isTruthy = sym != core::Symbols::FalseClass() && sym != core::Symbols::NilClass();
+            isTruthy = sym == core::Symbols::untyped() ||
+                       (sym != core::Symbols::FalseClass() && sym != core::Symbols::NilClass());
         },
         [&](AppliedType *c) {
             auto sym = c->klass;
-            isTruthy = sym != core::Symbols::FalseClass() && sym != core::Symbols::NilClass();
+            isTruthy = isTruthy = sym == core::Symbols::untyped() ||
+                                  (sym != core::Symbols::FalseClass() && sym != core::Symbols::NilClass());
         },
         [&](ProxyType *c) { isTruthy = canBeTruthy(ctx, c->underlying()); }, [&](Type *) {});
 

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -214,20 +214,21 @@ TypePtr Types::dropSubtypesOf(Context ctx, const TypePtr &from, SymbolRef klass)
 }
 
 bool Types::canBeTruthy(Context ctx, const TypePtr &what) {
-    bool isTruthy = false;
+    if (what->isUntyped()) {
+        return true;
+    }
 
+    bool isTruthy = false;
     typecase(
         what.get(), [&](OrType *o) { isTruthy = canBeTruthy(ctx, o->left) || canBeTruthy(ctx, o->right); },
         [&](AndType *a) { isTruthy = canBeTruthy(ctx, a->left) && canBeTruthy(ctx, a->right); },
         [&](ClassType *c) {
             auto sym = c->symbol;
-            isTruthy = sym == core::Symbols::untyped() ||
-                       (sym != core::Symbols::FalseClass() && sym != core::Symbols::NilClass());
+            isTruthy = sym != core::Symbols::FalseClass() && sym != core::Symbols::NilClass();
         },
         [&](AppliedType *c) {
             auto sym = c->klass;
-            isTruthy = sym == core::Symbols::untyped() ||
-                       (sym != core::Symbols::FalseClass() && sym != core::Symbols::NilClass());
+            isTruthy = sym != core::Symbols::FalseClass() && sym != core::Symbols::NilClass();
         },
         [&](ProxyType *c) { isTruthy = canBeTruthy(ctx, c->underlying()); }, [&](Type *) {});
 

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -225,8 +225,8 @@ bool Types::canBeTruthy(Context ctx, const TypePtr &what) {
         },
         [&](AppliedType *c) {
             auto sym = c->klass;
-            isTruthy = isTruthy = sym == core::Symbols::untyped() ||
-                                  (sym != core::Symbols::FalseClass() && sym != core::Symbols::NilClass());
+            isTruthy = sym == core::Symbols::untyped() ||
+                       (sym != core::Symbols::FalseClass() && sym != core::Symbols::NilClass());
         },
         [&](ProxyType *c) { isTruthy = canBeTruthy(ctx, c->underlying()); }, [&](Type *) {});
 

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -591,7 +591,7 @@ void Environment::mergeWith(core::Context ctx, const Environment &other, core::L
         bool sameType;
         if (thisTO.type.get() != nullptr) {
             auto temp = core::Types::any(ctx, thisTO.type, otherTO.type);
-            sameType = temp == otherTO.type;
+            sameType = temp == otherTO.type || temp == thisTO.type;
             thisTO.type = move(temp);
             thisTO.type->sanityCheck(ctx);
             for (auto origin : otherTO.origins) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -588,11 +588,8 @@ void Environment::mergeWith(core::Context ctx, const Environment &other, core::L
         auto var = pair.first;
         const auto &otherTO = other.getTypeAndOrigin(ctx, var);
         auto &thisTO = pair.second.typeAndOrigins;
-        bool sameType;
         if (thisTO.type.get() != nullptr) {
-            auto temp = core::Types::any(ctx, thisTO.type, otherTO.type);
-            sameType = temp == otherTO.type || temp == thisTO.type;
-            thisTO.type = move(temp);
+            thisTO.type = core::Types::any(ctx, thisTO.type, otherTO.type);
             thisTO.type->sanityCheck(ctx);
             for (auto origin : otherTO.origins) {
                 if (!absl::c_linear_search(thisTO.origins, origin)) {
@@ -602,15 +599,14 @@ void Environment::mergeWith(core::Context ctx, const Environment &other, core::L
             pair.second.knownTruthy = pair.second.knownTruthy && other.getKnownTruthy(var);
         } else {
             thisTO = otherTO;
-            sameType = false;
             pair.second.knownTruthy = other.getKnownTruthy(var);
         }
 
         if (((bb->flags & cfg::CFG::LOOP_HEADER) != 0) && bb->outerLoops <= inWhat.maxLoopWrite[var]) {
             continue;
         }
-        bool canBeFalsy = sameType || (core::Types::canBeFalsy(ctx, otherTO.type) && !other.getKnownTruthy(var));
-        bool canBeTruthy = sameType || core::Types::canBeTruthy(ctx, otherTO.type);
+        bool canBeFalsy = core::Types::canBeFalsy(ctx, otherTO.type) && !other.getKnownTruthy(var);
+        bool canBeTruthy = core::Types::canBeTruthy(ctx, otherTO.type);
 
         if (canBeTruthy) {
             auto &thisKnowledge = getKnowledge(var);

--- a/test/testdata/perf/enum_canBeTruthy_regression.rb
+++ b/test/testdata/perf/enum_canBeTruthy_regression.rb
@@ -56,9 +56,6 @@ class Test < Opus::Enum
   Val39 = new('39')
   Val40 = new('40')
 end
-# typed: true
-
-require 'test-big-enum'
 
 class A
   extend T::Sig

--- a/test/testdata/perf/enum_canBeTruthy_regression.rb
+++ b/test/testdata/perf/enum_canBeTruthy_regression.rb
@@ -1,61 +1,57 @@
 # typed: true
 #
 # This test will time out when `dropSubtypesOf` is called too frequently on
-# values of type `Test`.
+# values of type `Test`. The original case for this was with `canBeTruthy`,
+# which was previously implemented in terms of `dropSubtypesOf`.
 
-module Opus
-  class Enum
-    extend T::Generic
-    def initialize(x = nil)
-    end
-  end
+class Test
+  extend T::Helpers
+
+  abstract!
+  sealed!
 end
 
-class Test < Opus::Enum
-  include T::Props::Serializable
-  Elem = type_template(fixed: self)
-  Val0 = new('0')
-  Val1 = new('1')
-  Val2 = new('2')
-  Val3 = new('3')
-  Val4 = new('4')
-  Val5 = new('5')
-  Val6 = new('6')
-  Val7 = new('7')
-  Val8 = new('8')
-  Val9 = new('9')
-  Val10 = new('10')
-  Val11 = new('11')
-  Val12 = new('12')
-  Val13 = new('13')
-  Val14 = new('14')
-  Val15 = new('15')
-  Val16 = new('16')
-  Val17 = new('17')
-  Val18 = new('18')
-  Val19 = new('19')
-  Val20 = new('20')
-  Val21 = new('21')
-  Val22 = new('22')
-  Val23 = new('23')
-  Val24 = new('24')
-  Val25 = new('25')
-  Val26 = new('26')
-  Val27 = new('27')
-  Val28 = new('28')
-  Val29 = new('29')
-  Val30 = new('30')
-  Val31 = new('31')
-  Val32 = new('32')
-  Val33 = new('33')
-  Val34 = new('34')
-  Val35 = new('35')
-  Val36 = new('36')
-  Val37 = new('37')
-  Val38 = new('38')
-  Val39 = new('39')
-  Val40 = new('40')
-end
+class Val0  < Test; end
+class Val1  < Test; end
+class Val2  < Test; end
+class Val3  < Test; end
+class Val4  < Test; end
+class Val5  < Test; end
+class Val6  < Test; end
+class Val7  < Test; end
+class Val8  < Test; end
+class Val9  < Test; end
+class Val10 < Test; end
+class Val11 < Test; end
+class Val12 < Test; end
+class Val13 < Test; end
+class Val14 < Test; end
+class Val15 < Test; end
+class Val16 < Test; end
+class Val17 < Test; end
+class Val18 < Test; end
+class Val19 < Test; end
+class Val20 < Test; end
+class Val21 < Test; end
+class Val22 < Test; end
+class Val23 < Test; end
+class Val24 < Test; end
+class Val25 < Test; end
+class Val26 < Test; end
+class Val27 < Test; end
+class Val28 < Test; end
+class Val29 < Test; end
+class Val30 < Test; end
+class Val31 < Test; end
+class Val32 < Test; end
+class Val33 < Test; end
+class Val34 < Test; end
+class Val35 < Test; end
+class Val36 < Test; end
+class Val37 < Test; end
+class Val38 < Test; end
+class Val39 < Test; end
+class Val40 < Test; end
 
 class A
   extend T::Sig
@@ -142,9 +138,11 @@ class A
     @x4 = T.let(x, Test)
     @y4 = T.let(x, Test)
     @z4 = T.let(x, Test)
-
-    @metadata = T.let({x: x.serialize}, T::Hash[Symbol, T.any(String,Symbol)])
-
-    freeze
+    @a5 = T.let(x, Test)
+    @b5 = T.let(x, Test)
+    @c5 = T.let(x, Test)
+    @x5 = T.let(x, Test)
+    @y5 = T.let(x, Test)
+    @z5 = T.let(x, Test)
   end
 end

--- a/test/testdata/perf/enum_canBeTruthy_regression.rb
+++ b/test/testdata/perf/enum_canBeTruthy_regression.rb
@@ -60,66 +60,58 @@ end
 class A
   extend T::Sig
 
-  sig {returns(T::Hash[Symbol, T.any(String,Symbol)])}
-  attr_reader :metadata
-
-  sig {returns(Test).checked(:tests)}
-  attr_reader :x
-
-  ALLOWED_CHARS_RE = T.let(Regexp.new('^[\w\-\.,:]+$'), Regexp)
-
   sig {params(str: String, props: T::Hash[Symbol,Symbol], x: Test).void}
   def initialize(str, props, x)
-    if str !~ ALLOWED_CHARS_RE
+    if str.empty?
       raise "oh no"
     end
 
     props.each do |k,v|
     end
 
-    if str !~ ALLOWED_CHARS_RE
+    if str.empty?
       raise "oh no"
     end
 
     props.each do |k,v|
     end
 
-    if str !~ ALLOWED_CHARS_RE
+    if str.empty?
       raise "oh no"
     end
 
     props.each do |k,v|
     end
 
-    if str !~ ALLOWED_CHARS_RE
+    if str.empty?
       raise "oh no"
     end
 
     props.each do |k,v|
     end
 
-    if str !~ ALLOWED_CHARS_RE
+    if str.empty?
       raise "oh no"
     end
 
     props.each do |k,v|
     end
 
-    if str !~ ALLOWED_CHARS_RE
+    if str.empty?
       raise "oh no"
     end
 
     props.each do |k,v|
     end
 
-    if str !~ ALLOWED_CHARS_RE
+    if str.empty?
       raise "oh no"
     end
 
     props.each do |k,v|
     end
 
-    if str !~ ALLOWED_CHARS_RE
+    if str.empty?
       raise "oh no"
     end
 

--- a/test/testdata/perf/enum_canBeTruthy_regression.rb
+++ b/test/testdata/perf/enum_canBeTruthy_regression.rb
@@ -1,0 +1,161 @@
+# typed: true
+#
+# This test will time out when `dropSubtypesOf` is called too frequently on
+# values of type `Test`.
+
+module Opus
+  class Enum
+    extend T::Generic
+    def initialize(x = nil)
+    end
+  end
+end
+
+class Test < Opus::Enum
+  include T::Props::Serializable
+  Elem = type_template(fixed: self)
+  Val0 = new('0')
+  Val1 = new('1')
+  Val2 = new('2')
+  Val3 = new('3')
+  Val4 = new('4')
+  Val5 = new('5')
+  Val6 = new('6')
+  Val7 = new('7')
+  Val8 = new('8')
+  Val9 = new('9')
+  Val10 = new('10')
+  Val11 = new('11')
+  Val12 = new('12')
+  Val13 = new('13')
+  Val14 = new('14')
+  Val15 = new('15')
+  Val16 = new('16')
+  Val17 = new('17')
+  Val18 = new('18')
+  Val19 = new('19')
+  Val20 = new('20')
+  Val21 = new('21')
+  Val22 = new('22')
+  Val23 = new('23')
+  Val24 = new('24')
+  Val25 = new('25')
+  Val26 = new('26')
+  Val27 = new('27')
+  Val28 = new('28')
+  Val29 = new('29')
+  Val30 = new('30')
+  Val31 = new('31')
+  Val32 = new('32')
+  Val33 = new('33')
+  Val34 = new('34')
+  Val35 = new('35')
+  Val36 = new('36')
+  Val37 = new('37')
+  Val38 = new('38')
+  Val39 = new('39')
+  Val40 = new('40')
+end
+# typed: true
+
+require 'test-big-enum'
+
+class A
+  extend T::Sig
+
+  sig {returns(T::Hash[Symbol, T.any(String,Symbol)])}
+  attr_reader :metadata
+
+  sig {returns(Test).checked(:tests)}
+  attr_reader :x
+
+  ALLOWED_CHARS_RE = T.let(Regexp.new('^[\w\-\.,:]+$'), Regexp)
+
+  sig {params(str: String, props: T::Hash[Symbol,Symbol], x: Test).void}
+  def initialize(str, props, x)
+    if str !~ ALLOWED_CHARS_RE
+      raise "oh no"
+    end
+
+    props.each do |k,v|
+    end
+
+    if str !~ ALLOWED_CHARS_RE
+      raise "oh no"
+    end
+
+    props.each do |k,v|
+    end
+
+    if str !~ ALLOWED_CHARS_RE
+      raise "oh no"
+    end
+
+    props.each do |k,v|
+    end
+
+    if str !~ ALLOWED_CHARS_RE
+      raise "oh no"
+    end
+
+    props.each do |k,v|
+    end
+
+    if str !~ ALLOWED_CHARS_RE
+      raise "oh no"
+    end
+
+    props.each do |k,v|
+    end
+
+    if str !~ ALLOWED_CHARS_RE
+      raise "oh no"
+    end
+
+    props.each do |k,v|
+    end
+
+    if str !~ ALLOWED_CHARS_RE
+      raise "oh no"
+    end
+
+    props.each do |k,v|
+    end
+
+    if str !~ ALLOWED_CHARS_RE
+      raise "oh no"
+    end
+
+    props.each do |k,v|
+    end
+
+    @a1 = T.let(x, Test)
+    @b1 = T.let(x, Test)
+    @c1 = T.let(x, Test)
+    @x1 = T.let(x, Test)
+    @y1 = T.let(x, Test)
+    @z1 = T.let(x, Test)
+    @a2 = T.let(x, Test)
+    @b2 = T.let(x, Test)
+    @c2 = T.let(x, Test)
+    @x2 = T.let(x, Test)
+    @y2 = T.let(x, Test)
+    @z2 = T.let(x, Test)
+    @a3 = T.let(x, Test)
+    @b3 = T.let(x, Test)
+    @c3 = T.let(x, Test)
+    @x3 = T.let(x, Test)
+    @y3 = T.let(x, Test)
+    @z3 = T.let(x, Test)
+    @a4 = T.let(x, Test)
+    @b4 = T.let(x, Test)
+    @c4 = T.let(x, Test)
+    @x4 = T.let(x, Test)
+    @y4 = T.let(x, Test)
+    @z4 = T.let(x, Test)
+
+    @metadata = T.let({x: x.serialize}, T::Hash[Symbol, T.any(String,Symbol)])
+
+    freeze
+  end
+end


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Rework `canBeTruthy` to not rely on `dropSubtypesOf`, as it's potentially very expensive when it causes a large Enum to be expanded out.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
