### PR TITLE
Two random, no-op NameKind cleanups

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -911,13 +911,13 @@ NameRef GlobalState::enterNameUTF8(string_view nm) {
 
 NameRef GlobalState::enterNameConstant(NameRef original) {
     ENFORCE(original.exists(), "making a constant name over non-existing name");
-    ENFORCE(original.data(*this)->kind == UTF8 ||
-                (original.data(*this)->kind == UNIQUE &&
+    ENFORCE(original.data(*this)->kind == NameKind::UTF8 ||
+                (original.data(*this)->kind == NameKind::UNIQUE &&
                  (original.data(*this)->unique.uniqueNameKind == UniqueNameKind::ResolverMissingClass ||
                   original.data(*this)->unique.uniqueNameKind == UniqueNameKind::OpusEnum)),
             "making a constant name over wrong name kind");
 
-    const auto hs = _hash_mix_constant(CONSTANT, original.id());
+    const auto hs = _hash_mix_constant(NameKind::CONSTANT, original.id());
     unsigned int hashTableSize = namesByHash.size();
     unsigned int mask = hashTableSize - 1;
     auto bucketId = hs & mask;
@@ -927,7 +927,7 @@ NameRef GlobalState::enterNameConstant(NameRef original) {
         auto &bucket = namesByHash[bucketId];
         if (bucket.first == hs) {
             auto &nm2 = names[bucket.second];
-            if (nm2.kind == CONSTANT && nm2.cnst.original == original) {
+            if (nm2.kind == NameKind::CONSTANT && nm2.cnst.original == original) {
                 counterInc("names.constant.hit");
                 return nm2.ref(*this);
             } else {
@@ -962,7 +962,7 @@ NameRef GlobalState::enterNameConstant(NameRef original) {
     auto idx = names.size();
     names.emplace_back();
 
-    names[idx].kind = CONSTANT;
+    names[idx].kind = NameKind::CONSTANT;
     names[idx].cnst.original = original;
     ENFORCE(names[idx].hash(*this) == hs);
     wasModified_ = true;
@@ -1005,7 +1005,7 @@ void GlobalState::expandNames(int growBy) {
 
 NameRef GlobalState::lookupNameUnique(UniqueNameKind uniqueNameKind, NameRef original, u2 num) const {
     ENFORCE(num > 0, "num == 0, name overflow");
-    const auto hs = _hash_mix_unique((u2)uniqueNameKind, UNIQUE, num, original.id());
+    const auto hs = _hash_mix_unique((u2)uniqueNameKind, NameKind::UNIQUE, num, original.id());
     unsigned int hashTableSize = namesByHash.size();
     unsigned int mask = hashTableSize - 1;
     auto bucketId = hs & mask;
@@ -1015,7 +1015,7 @@ NameRef GlobalState::lookupNameUnique(UniqueNameKind uniqueNameKind, NameRef ori
         auto &bucket = namesByHash[bucketId];
         if (bucket.first == hs) {
             auto &nm2 = names[bucket.second];
-            if (nm2.kind == UNIQUE && nm2.unique.uniqueNameKind == uniqueNameKind && nm2.unique.num == num &&
+            if (nm2.kind == NameKind::UNIQUE && nm2.unique.uniqueNameKind == uniqueNameKind && nm2.unique.num == num &&
                 nm2.unique.original == original) {
                 counterInc("names.unique.hit");
                 return nm2.ref(*this);
@@ -1031,7 +1031,7 @@ NameRef GlobalState::lookupNameUnique(UniqueNameKind uniqueNameKind, NameRef ori
 
 NameRef GlobalState::freshNameUnique(UniqueNameKind uniqueNameKind, NameRef original, u2 num) {
     ENFORCE(num > 0, "num == 0, name overflow");
-    const auto hs = _hash_mix_unique((u2)uniqueNameKind, UNIQUE, num, original.id());
+    const auto hs = _hash_mix_unique((u2)uniqueNameKind, NameKind::UNIQUE, num, original.id());
     unsigned int hashTableSize = namesByHash.size();
     unsigned int mask = hashTableSize - 1;
     auto bucketId = hs & mask;
@@ -1041,7 +1041,7 @@ NameRef GlobalState::freshNameUnique(UniqueNameKind uniqueNameKind, NameRef orig
         auto &bucket = namesByHash[bucketId];
         if (bucket.first == hs) {
             auto &nm2 = names[bucket.second];
-            if (nm2.kind == UNIQUE && nm2.unique.uniqueNameKind == uniqueNameKind && nm2.unique.num == num &&
+            if (nm2.kind == NameKind::UNIQUE && nm2.unique.uniqueNameKind == uniqueNameKind && nm2.unique.num == num &&
                 nm2.unique.original == original) {
                 counterInc("names.unique.hit");
                 return nm2.ref(*this);
@@ -1077,7 +1077,7 @@ NameRef GlobalState::freshNameUnique(UniqueNameKind uniqueNameKind, NameRef orig
     auto idx = names.size();
     names.emplace_back();
 
-    names[idx].kind = UNIQUE;
+    names[idx].kind = NameKind::UNIQUE;
     names[idx].unique.num = num;
     names[idx].unique.uniqueNameKind = uniqueNameKind;
     names[idx].unique.original = original;

--- a/core/Hashing.h
+++ b/core/Hashing.h
@@ -32,7 +32,7 @@ inline unsigned int _hash(std::string_view utf8) {
         res = mix(res, *it - '!'); // "!" is the first printable letter in ASCII.
         // This will help Latin1 but may harm utf8 multibyte
     }
-    return res * HASH_MULT2 + _NameKind2Id_UTF8(UTF8);
+    return res * HASH_MULT2 + _NameKind2Id_UTF8(NameKind::UTF8);
 }
 } // namespace sorbet::core
 #endif // SORBET_HASHING_H

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -30,8 +30,6 @@ unsigned int Name::hash(const GlobalState &gs) const {
             return _hash_mix_unique((u2)unique.uniqueNameKind, UNIQUE, unique.num, unique.original.id());
         case CONSTANT:
             return _hash_mix_constant(CONSTANT, cnst.original.id());
-        default:
-            Exception::raise("Unknown name kind? {}", kind);
     }
 }
 
@@ -85,8 +83,6 @@ string Name::showRaw(const GlobalState &gs) const {
         }
         case CONSTANT:
             return fmt::format("<C {}>", this->cnst.original.showRaw(gs));
-        default:
-            Exception::notImplemented();
     }
 }
 
@@ -108,8 +104,6 @@ string Name::toString(const GlobalState &gs) const {
             }
         case CONSTANT:
             return fmt::format("<C {}>", this->cnst.original.toString(gs));
-        default:
-            Exception::notImplemented();
     }
 }
 
@@ -142,8 +136,6 @@ string_view Name::shortName(const GlobalState &gs) const {
             return this->unique.original.data(gs)->shortName(gs);
         case CONSTANT:
             return this->cnst.original.data(gs)->shortName(gs);
-        default:
-            Exception::notImplemented();
     }
 }
 
@@ -170,8 +162,6 @@ void Name::sanityCheck(const GlobalState &gs) const {
             ENFORCE(current == const_cast<GlobalState &>(gs).enterNameConstant(this->cnst.original),
                     "Name table corrupted, re-entering CONSTANT name gives different id");
             break;
-        default:
-            Exception::notImplemented();
     }
 }
 
@@ -195,8 +185,6 @@ bool Name::isClassName(const GlobalState &gs) const {
                         (this->cnst.original.data(gs)->unique.uniqueNameKind == UniqueNameKind::ResolverMissingClass ||
                          this->cnst.original.data(gs)->unique.uniqueNameKind == UniqueNameKind::OpusEnum));
             return true;
-        default:
-            Exception::notImplemented();
     }
 }
 
@@ -311,9 +299,6 @@ Name Name::deepCopy(const GlobalState &to) const {
         case CONSTANT:
             out.cnst.original = NameRef(to, this->cnst.original.id());
             break;
-
-        default:
-            Exception::notImplemented();
     }
 
     return out;

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -24,20 +24,20 @@ unsigned int Name::hash(const GlobalState &gs) const {
     // TODO: use https://github.com/Cyan4973/xxHash
     // !!! keep this in sync with GlobalState.enter*
     switch (kind) {
-        case UTF8:
+        case NameKind::UTF8:
             return _hash(raw.utf8);
-        case UNIQUE:
-            return _hash_mix_unique((u2)unique.uniqueNameKind, UNIQUE, unique.num, unique.original.id());
-        case CONSTANT:
-            return _hash_mix_constant(CONSTANT, cnst.original.id());
+        case NameKind::UNIQUE:
+            return _hash_mix_unique((u2)unique.uniqueNameKind, NameKind::UNIQUE, unique.num, unique.original.id());
+        case NameKind::CONSTANT:
+            return _hash_mix_constant(NameKind::CONSTANT, cnst.original.id());
     }
 }
 
 string Name::showRaw(const GlobalState &gs) const {
     switch (this->kind) {
-        case UTF8:
+        case NameKind::UTF8:
             return fmt::format("<U {}>", string(raw.utf8.begin(), raw.utf8.end()));
-        case UNIQUE: {
+        case NameKind::UNIQUE: {
             string kind;
             switch (this->unique.uniqueNameKind) {
                 case UniqueNameKind::Parser:
@@ -81,16 +81,16 @@ string Name::showRaw(const GlobalState &gs) const {
                 return fmt::format("<{} {} ${}>", kind, this->unique.original.data(gs)->showRaw(gs), this->unique.num);
             }
         }
-        case CONSTANT:
+        case NameKind::CONSTANT:
             return fmt::format("<C {}>", this->cnst.original.showRaw(gs));
     }
 }
 
 string Name::toString(const GlobalState &gs) const {
     switch (this->kind) {
-        case UTF8:
+        case NameKind::UTF8:
             return string(raw.utf8.begin(), raw.utf8.end());
-        case UNIQUE:
+        case NameKind::UNIQUE:
             if (this->unique.uniqueNameKind == UniqueNameKind::Singleton) {
                 return fmt::format("<Class:{}>", this->unique.original.data(gs)->show(gs));
             } else if (this->unique.uniqueNameKind == UniqueNameKind::Overload) {
@@ -102,16 +102,16 @@ string Name::toString(const GlobalState &gs) const {
             } else {
                 return fmt::format("{}${}", this->unique.original.data(gs)->show(gs), this->unique.num);
             }
-        case CONSTANT:
+        case NameKind::CONSTANT:
             return fmt::format("<C {}>", this->cnst.original.toString(gs));
     }
 }
 
 string Name::show(const GlobalState &gs) const {
     switch (this->kind) {
-        case UTF8:
+        case NameKind::UTF8:
             return string(raw.utf8.begin(), raw.utf8.end());
-        case UNIQUE:
+        case NameKind::UNIQUE:
             if (this->unique.uniqueNameKind == UniqueNameKind::Singleton) {
                 return fmt::format("<Class:{}>", this->unique.original.data(gs)->show(gs));
             } else if (this->unique.uniqueNameKind == UniqueNameKind::Overload) {
@@ -124,17 +124,17 @@ string Name::show(const GlobalState &gs) const {
                 // Thus, we fall through.
             }
             return this->unique.original.data(gs)->show(gs);
-        case CONSTANT:
+        case NameKind::CONSTANT:
             return this->cnst.original.show(gs);
     }
 }
 string_view Name::shortName(const GlobalState &gs) const {
     switch (this->kind) {
-        case UTF8:
+        case NameKind::UTF8:
             return string_view(raw.utf8.begin(), raw.utf8.end() - raw.utf8.begin());
-        case UNIQUE:
+        case NameKind::UNIQUE:
             return this->unique.original.data(gs)->shortName(gs);
-        case CONSTANT:
+        case NameKind::CONSTANT:
             return this->cnst.original.data(gs)->shortName(gs);
     }
 }
@@ -145,11 +145,11 @@ void Name::sanityCheck(const GlobalState &gs) const {
     }
     NameRef current = this->ref(gs);
     switch (this->kind) {
-        case UTF8:
+        case NameKind::UTF8:
             ENFORCE(current == const_cast<GlobalState &>(gs).enterNameUTF8(this->raw.utf8),
                     "Name table corrupted, re-entering UTF8 name gives different id");
             break;
-        case UNIQUE: {
+        case NameKind::UNIQUE: {
             ENFORCE(this->unique.original._id < current._id, "unique name id not bigger than original");
             ENFORCE(this->unique.num > 0, "unique num == 0");
             NameRef current2 = const_cast<GlobalState &>(gs).freshNameUnique(this->unique.uniqueNameKind,
@@ -157,7 +157,7 @@ void Name::sanityCheck(const GlobalState &gs) const {
             ENFORCE(current == current2, "Name table corrupted, re-entering UNIQUE name gives different id");
             break;
         }
-        case CONSTANT:
+        case NameKind::CONSTANT:
             ENFORCE(this->cnst.original._id < current._id, "constant name id not bigger than original");
             ENFORCE(current == const_cast<GlobalState &>(gs).enterNameConstant(this->cnst.original),
                     "Name table corrupted, re-entering CONSTANT name gives different id");
@@ -172,16 +172,16 @@ NameRef Name::ref(const GlobalState &gs) const {
 
 bool Name::isClassName(const GlobalState &gs) const {
     switch (this->kind) {
-        case UTF8:
+        case NameKind::UTF8:
             return false;
-        case UNIQUE: {
+        case NameKind::UNIQUE: {
             return (this->unique.uniqueNameKind == Singleton || this->unique.uniqueNameKind == MangleRename ||
                     this->unique.uniqueNameKind == OpusEnum) &&
                    this->unique.original.data(gs)->isClassName(gs);
         }
-        case CONSTANT:
-            ENFORCE(this->cnst.original.data(gs)->kind == UTF8 ||
-                    this->cnst.original.data(gs)->kind == UNIQUE &&
+        case NameKind::CONSTANT:
+            ENFORCE(this->cnst.original.data(gs)->kind == NameKind::UTF8 ||
+                    this->cnst.original.data(gs)->kind == NameKind::UNIQUE &&
                         (this->cnst.original.data(gs)->unique.uniqueNameKind == UniqueNameKind::ResolverMissingClass ||
                          this->cnst.original.data(gs)->unique.uniqueNameKind == UniqueNameKind::OpusEnum));
             return true;
@@ -255,28 +255,28 @@ string NameRef::show(const GlobalState &gs) const {
 
 NameRef NameRef::addEq(GlobalState &gs) const {
     auto name = this->data(gs);
-    ENFORCE(name->kind == UTF8, "addEq over non-utf8 name");
+    ENFORCE(name->kind == NameKind::UTF8, "addEq over non-utf8 name");
     string nameEq = absl::StrCat(name->raw.utf8, "=");
     return gs.enterNameUTF8(nameEq);
 }
 
 NameRef NameRef::addQuestion(GlobalState &gs) const {
     auto name = this->data(gs);
-    ENFORCE(name->kind == UTF8, "addQuestion over non-utf8 name");
+    ENFORCE(name->kind == NameKind::UTF8, "addQuestion over non-utf8 name");
     string nameEq = absl::StrCat(name->raw.utf8, "?");
     return gs.enterNameUTF8(nameEq);
 }
 
 NameRef NameRef::addAt(GlobalState &gs) const {
     auto name = this->data(gs);
-    ENFORCE(name->kind == UTF8, "addAt over non-utf8 name");
+    ENFORCE(name->kind == NameKind::UTF8, "addAt over non-utf8 name");
     string nameEq = absl::StrCat("@", name->raw.utf8);
     return gs.enterNameUTF8(nameEq);
 }
 
 NameRef NameRef::prepend(GlobalState &gs, string_view s) const {
     auto name = this->data(gs);
-    ENFORCE(name->kind == UTF8, "prepend over non-utf8 name");
+    ENFORCE(name->kind == NameKind::UTF8, "prepend over non-utf8 name");
     string nameEq = absl::StrCat(s, name->raw.utf8);
     return gs.enterNameUTF8(nameEq);
 }
@@ -286,17 +286,17 @@ Name Name::deepCopy(const GlobalState &to) const {
     out.kind = this->kind;
 
     switch (this->kind) {
-        case UTF8:
+        case NameKind::UTF8:
             out.raw = this->raw;
             break;
 
-        case UNIQUE:
+        case NameKind::UNIQUE:
             out.unique.uniqueNameKind = this->unique.uniqueNameKind;
             out.unique.num = this->unique.num;
             out.unique.original = NameRef(to, this->unique.original.id());
             break;
 
-        case CONSTANT:
+        case NameKind::CONSTANT:
             out.cnst.original = NameRef(to, this->cnst.original.id());
             break;
     }

--- a/core/Names.h
+++ b/core/Names.h
@@ -11,7 +11,7 @@
 namespace sorbet::core {
 class GlobalState;
 class Name;
-enum NameKind : u1 {
+enum class NameKind : u1 {
     UTF8 = 1,
     UNIQUE = 2,
     CONSTANT = 3,
@@ -20,17 +20,17 @@ enum NameKind : u1 {
 CheckSize(NameKind, 1, 1);
 
 inline int _NameKind2Id_UTF8(NameKind nm) {
-    ENFORCE(nm == UTF8);
+    ENFORCE(nm == NameKind::UTF8);
     return 1;
 }
 
 inline int _NameKind2Id_UNIQUE(NameKind nm) {
-    ENFORCE(nm == UNIQUE);
+    ENFORCE(nm == NameKind::UNIQUE);
     return 2;
 }
 
 inline int _NameKind2Id_CONSTANT(NameKind nm) {
-    ENFORCE(nm == CONSTANT);
+    ENFORCE(nm == NameKind::CONSTANT);
     return 3;
 }
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -774,11 +774,12 @@ string ArgInfo::argumentName(const GlobalState &gs) const {
 
 namespace {
 bool isSingletonName(const GlobalState &gs, core::NameRef name) {
-    return name.data(gs)->kind == UNIQUE && name.data(gs)->unique.uniqueNameKind == UniqueNameKind::Singleton;
+    return name.data(gs)->kind == NameKind::UNIQUE && name.data(gs)->unique.uniqueNameKind == UniqueNameKind::Singleton;
 }
 
 bool isMangledSingletonName(const GlobalState &gs, core::NameRef name) {
-    return name.data(gs)->kind == UNIQUE && name.data(gs)->unique.uniqueNameKind == UniqueNameKind::MangleRename &&
+    return name.data(gs)->kind == NameKind::UNIQUE &&
+           name.data(gs)->unique.uniqueNameKind == UniqueNameKind::MangleRename &&
            isSingletonName(gs, name.data(gs)->unique.original);
 }
 } // namespace

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -17,13 +17,13 @@ com::stripe::rubytyper::Name Proto::toProto(const GlobalState &gs, NameRef name)
     com::stripe::rubytyper::Name protoName;
     protoName.set_name(name.show(gs));
     switch (name.data(gs)->kind) {
-        case UTF8:
+        case NameKind::UTF8:
             protoName.set_kind(com::stripe::rubytyper::Name::UTF8);
             break;
-        case UNIQUE:
+        case NameKind::UNIQUE:
             protoName.set_kind(com::stripe::rubytyper::Name::UNIQUE);
             break;
-        case CONSTANT:
+        case NameKind::CONSTANT:
             protoName.set_kind(com::stripe::rubytyper::Name::CONSTANT);
             break;
     }

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -238,7 +238,7 @@ shared_ptr<File> SerializerImpl::unpickleFile(UnPickler &p) {
 }
 
 void SerializerImpl::pickle(Pickler &p, const Name &what) {
-    p.putU1(what.kind);
+    p.putU1(static_cast<u1>(what.kind));
     switch (what.kind) {
         case NameKind::UTF8:
             p.putStr(what.raw.utf8);

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -128,7 +128,7 @@ TEST(CoreTest, Substitute) { // NOLINT
 
     auto other2 = subst.substitute(other1);
     ASSERT_TRUE(other2.exists());
-    ASSERT_TRUE(other2.data(gs2)->kind == UTF8);
+    ASSERT_TRUE(other2.data(gs2)->kind == NameKind::UTF8);
     ASSERT_EQ("<U other>", other2.showRaw(gs2));
 }
 

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -136,7 +136,7 @@ public:
     unique_ptr<Node> accessible(unique_ptr<Node> node) {
         if (auto *id = parser::cast_node<Ident>(node.get())) {
             auto name = id->name.data(gs_);
-            ENFORCE(name->kind == core::UTF8);
+            ENFORCE(name->kind == core::NameKind::UTF8);
             if (driver_->lex.is_declared(name->show(gs_))) {
                 return make_unique<LVar>(node->loc, id->name);
             } else {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I happened to notice these two things while I was working on autocompletion.

- **Don't use `default` to case over NameKind** (5be376101)

  This silences the exhaustiveness checking that clang will do for enums.

- **Use an enum class instead of an enum** (cf937fd4a)

  This way, the enum variants don't polute the `core` namespace, and
  you're forced to use `core::NameKind` to access them.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No change to tests.