### PR TITLE
Fix /talks redirect link for talks page

### DIFF
--- a/website/static/talks/index.html
+++ b/website/static/talks/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 <meta charset="utf-8">
 <title>Redirecting…</title>
-<link rel="canonical" href="https://sorbet.org/docs/talks">
-<meta http-equiv="refresh" content="0; url=../docs/talks">
-<a href="../docs/talks">Click here if you are not redirected.</a>
+<link rel="canonical" href="https://sorbet.org/docs/talks/talks">
+<meta http-equiv="refresh" content="0; url=../docs/talks/talks">
+<a href="../docs/talks/talks">Click here if you are not redirected.</a>
 </html>


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

https://sorbet.org/talks used to be a short link for "wherever the talks page
is."


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.