### PR TITLE
Add retry logic to mac builds

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -29,6 +29,10 @@ steps:
     branches: "master"
     agents:
       os: mac
+    # TODO(jez) We should only retry for specific error.
+    # The one we were trying to fix was `'foo.h': file not found`
+    retry:
+     automatic: true
 
   - label: ":linux: test-static-sanitized.sh"
     command: .buildkite/test-static-sanitized.sh
@@ -55,6 +59,10 @@ steps:
     artifact_paths: _out_/**/*
     agents:
       os: mac
+    # TODO(jez) We should only retry for specific error.
+    # The one we were trying to fix was `'foo.h': file not found`
+    retry:
+     automatic: true
 
   - label: ":linux: build-static-release.sh"
     command: .buildkite/build-static-release.sh


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We should probably look into why we're getting so many "file not found"
errors from bazel when building on macOS but I'd rather just not have
them flake when these builds are ~always safe to retry.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
