### PR TITLE
Fix typos in website docs

### DIFF
--- a/website/docs/abstract.md
+++ b/website/docs/abstract.md
@@ -45,7 +45,7 @@ end
 ## Implementing an abstract method
 
 To implement an abstract method, define the method in the implementing class or
-module with an identicaly signature as the parent, except replacing `abstract`
+module with an identical signature as the parent, except replacing `abstract`
 with `implementation`.
 
 ```ruby
@@ -126,7 +126,7 @@ A.foo
 ```
 
 This is hard to statically analyze, as it involves looking into the body of the
-`self.included` method, which might have abritrary computation. As a compromise,
+`self.included` method, which might have arbitrary computation. As a compromise,
 Sorbet provides a new construct: `mixes_in_class_methods`. At runtime, it
 behaves as if we'd defined `self.included` like above, but will declare to `srb`
 statically what module is being extended.

--- a/website/docs/adopting.md
+++ b/website/docs/adopting.md
@@ -83,7 +83,7 @@ Now that we've initialized Sorbet, type checking Sorbet should be as simple as:
 ❯ srb tc
 ```
 
-<!-- TODO(jez) It's hard to describe succintly which files will be checked if we
+<!-- TODO(jez) It's hard to describe succinctly which files will be checked if we
      suggest-typed by default and ignore files -->
 
 By default, this will type check every Ruby file in the current folder. To

--- a/website/docs/exhaustiveness.md
+++ b/website/docs/exhaustiveness.md
@@ -117,7 +117,7 @@ actually do something with it!
 error. It lets us catch the problem statically before causing all sorts of
 problems down the line.
 
-We can enable exhaustivness checking in Sorbet using `T.absurd(...)`:
+We can enable exhaustiveness checking in Sorbet using `T.absurd(...)`:
 
 ```ruby
 sig {params(x: T.any(A, B, C)).void}

--- a/website/docs/final.md
+++ b/website/docs/final.md
@@ -37,7 +37,7 @@ end
 
 ## Final methods
 
-Final methods can't be overriden or redefined. This is a powerful guarantee: it
+Final methods can't be overridden or redefined. This is a powerful guarantee: it
 means that inheritance can't affect what code will be run when calling a method
 on a class.
 
@@ -116,7 +116,7 @@ final modules cannot be included or extended. But more than that, every method
 in a final class or module must be made into a final method.
 
 It might seem redundant to require final classes to mark all methods final too,
-("How could a method be overriden in a subclass if the act of subclassing is
+("How could a method be overridden in a subclass if the act of subclassing is
 prohibited?") but the answer is ([like many](gradual.md)) that this protects
 against untyped code. This guarantees that untyped or ignored code can't
 redefine methods at runtime in a class that is marked `final!` statically.
@@ -191,7 +191,7 @@ sig(:final) {void}
 The reason for this difference is that this gives us stronger runtime
 guarantees. In general, any Ruby method might be overridden at any time, with no
 warning. So the **absence** of an `overridable` or `abstract` attribute on a
-method signature does not guarantee that a method is never overriden. Given
+method signature does not guarantee that a method is never overridden. Given
 these circumstances, it's fine for override / abstract checks to be done lazily,
 because the stakes for eliding an error for them wrong is relatively low.
 
@@ -246,7 +246,7 @@ puts C.new.foo
 ```
 
 At runtime, this does not raise and prints 2, showing that a final method has
-been overriden. This is why we strongly recommend calling
+been overridden. This is why we strongly recommend calling
 `T::Configuration.enable_final_checks_on_hooks` before using final.
 
 ## Known static limitations

--- a/website/docs/procs.md
+++ b/website/docs/procs.md
@@ -68,7 +68,7 @@ def foo(&blk)
 end
 ```
 
-Because we used `block_given?` above, Sorbet will know that ouside the `if`
+Because we used `block_given?` above, Sorbet will know that outside the `if`
 expression `blk` might be `nil`, while inside the `if` it's not `nil`.
 
 ## Annotating methods that use `yield`

--- a/website/docs/runtime.md
+++ b/website/docs/runtime.md
@@ -281,7 +281,7 @@ T::Configuration.enable_checking_for_sigs_marked_checked_tests
 ```
 
 For example, this should probably be placed as the first line of any `rake test`
-target, as well as any other entrypoint to a project's tests. If this line is
+target, as well as any other entry point to a project's tests. If this line is
 absent, `.checked(:tests)` sigs behave as if they had been `.checked(:never)`.
 
 ## What's next?

--- a/website/docs/sealed.md
+++ b/website/docs/sealed.md
@@ -107,7 +107,7 @@ exhaustiveness.
 ## Sealed classes vs sealed modules
 
 Throughout this doc we've been talking about sealed classes and sealed modules
-as if they were interchangable. But they're actually different in one key way:
+as if they were interchangeable. But they're actually different in one key way:
 
 - Sealed modules only require being declared `sealed!`
 - Sealed classes require being declared both `sealed!` and `abstract!`

--- a/website/docs/tconfiguration.md
+++ b/website/docs/tconfiguration.md
@@ -45,7 +45,7 @@ method with a signature is called incorrectly. For those, see the next section.
 
 ## Errors from invalid method calls
 
-To customize the behvaior when a method with a sig is called and the argument
+To customize the behavior when a method with a sig is called and the argument
 types or return types don't match the actual value present at runtime, use this:
 
 ```ruby

--- a/website/docs/type-aliases.md
+++ b/website/docs/type-aliases.md
@@ -77,7 +77,7 @@ def bar; 3; end
 ```
 
 Note that because type aliases are a Sorbet construct, they cannot be used in
-certrain runtime contexts. For instance, it is not possible to match an
+certain runtime contexts. For instance, it is not possible to match an
 expression against a type alias in a `case` expression.
 
 ```ruby

--- a/website/docs/type-annotations.md
+++ b/website/docs/type-annotations.md
@@ -129,5 +129,5 @@ a file marked `# typed: true`, but this is an intentional part of Sorbet's
 implementation of [gradual typing](gradual.md). In the `# typed: true`
 strictness level, unannotated methods, instance variables, and constants are
 assumed to be `T.untyped`. This allows a programmer to write untyped or
-partially-typed definitions while still benefitting from type checking when
+partially-typed definitions while still benefiting from type checking when
 static type information is present.


### PR DESCRIPTION
I claim these fixes are sound but not complete. No attempts to examine grammar or pursue better prose, and `aspell` isn't exhaustive.

    $ for x in website/docs/*.md; do aspell -c "$x"; done