### PR TITLE
Remove mention of implementation from website docs

### DIFF
--- a/website/docs/abstract.md
+++ b/website/docs/abstract.md
@@ -46,7 +46,7 @@ end
 
 To implement an abstract method, define the method in the implementing class or
 module with an identical signature as the parent, except replacing `abstract`
-with `implementation`.
+with `override`.
 
 ```ruby
 class HelloWorld
@@ -54,7 +54,7 @@ class HelloWorld
   include Runnable
 
   # This implements the abstract `main` method from our Runnable module:
-  sig {implementation.params(args: T::Array[String]).void}
+  sig {override.params(args: T::Array[String]).void}
   def main(args)
     puts 'Hello, world!'
   end
@@ -162,7 +162,7 @@ class A # error: Missing definition for abstract method
 
   extend T::Sig
 
-  sig {implementation.void}
+  sig {override.void}
   def self.bar; end
 end
 

--- a/website/docs/final.md
+++ b/website/docs/final.md
@@ -182,7 +182,6 @@ abstract methods:
 sig {overridable.void}
 sig {override.void}
 sig {abstract.void}
-sig {implementation.void}
 
 # But this one is outside the block:
 sig(:final) {void}

--- a/website/docs/override-checking.md
+++ b/website/docs/override-checking.md
@@ -7,37 +7,35 @@ Sorbet supports method override checking. These checks are implemented as `sig`
 annotations:
 
 - `overridable` means children can override this method
-- `override` means this method overrides a method on its parent (or ancestor)
+- `override` means this method overrides a method on its parent (or ancestor),
+  which may or may not be an abstract or interface method
 - `abstract` means this method is abstract (has no implementation) and must be
   implemented by being overridden in all concrete subclasses.
-- `implementation` means this method implements an abstract method
 
-These annotations can be chained, for example `.implementation.overridable` lets
-a grandchild class override a concrete implementation of its parent.
+These annotations can be chained, for example `.override.overridable` lets a
+grandchild class override a concrete implementation of its parent.
 
 Use this table to track when annotations can be used, although the error
 messages are the canonical source of truth. ✅ means "this pairing is allowed"
-while ❌ means "this is an error" (most of these errors are static errors,
-though some are still only implemented in the runtime).
+while ❌ means "this is an error".
 
 > Below, `standard` (for the child or parent) means "has a `sig`, but has none
 > of the special modifiers."
 
-| ↓Parent \ Child → | no sig | `standard` | `override` | `implementation` |
-| ----------------- | :----: | :--------: | :--------: | :--------------: |
-| no sig            |   ✅   |     ✅     |     ✅     |        ❌        |
-| `standard`        |   ✅   |     ✅     |     ❌     |        ❌        |
-| `overridable`     |   ✅   |     ❌     |     ✅     |        ❌        |
-| `override`        |   ✅   |     ❌     |     ✅     |        ❌        |
-| `implementation`  |   ✅   |     ❌     |     ❌     |        ❌        |
-| `abstract`        |   ✅   |     ❌     |     ❌     |        ✅        |
+| ↓Parent \ Child → | no sig | `standard` | `override` |
+| ----------------- | :----: | :--------: | :--------: |
+| no sig            |   ✅   |     ✅     |     ✅     |
+| `standard`        |   ✅   |     ✅     |     ❌     |
+| `overridable`     |   ✅   |     ❌     |     ✅     |
+| `override`        |   ✅   |     ❌     |     ✅     |
+| `abstract`        |   ✅   |     ❌     |     ✅     |
 
 Some other things are checked that don't fit into the above table:
 
-- It is an error to mark a method `override` or `implementation` if the method
-  doesn't actually override anything.
+- It is an error to mark a method `override` if the method doesn't actually
+  override anything.
 - If the implementation methods are inherited--from either a class or mixin--the
-  methods don't need the `implementation` annotation.
+  methods don't need the `override` annotation.
 
 Note that the **absence** of `abstract` or `overridable` does **not** mean that
 a method is never overridden. To declare that a method can never be overridden,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
We no longer use `implementation` and instead use `override` pervasively. This updates the website docs accordingly.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
