### PR TITLE
Adds `def` line below the `sig` in lsp hover hint.

### DIFF
--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -215,6 +215,8 @@ bool hasSimilarName(const core::GlobalState &gs, core::NameRef name, std::string
 bool hideSymbol(const core::GlobalState &gs, core::SymbolRef sym);
 std::string methodDetail(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver,
                          core::TypePtr retType, const std::unique_ptr<core::TypeConstraint> &constraint);
+std::string methodDefinition(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver,
+                             core::TypePtr retType, const std::unique_ptr<core::TypeConstraint> &constraint);
 core::TypePtr getResultType(const core::GlobalState &gs, core::TypePtr type, core::SymbolRef inWhat,
                             core::TypePtr receiver, const std::unique_ptr<core::TypeConstraint> &constr);
 SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef);

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -13,7 +13,7 @@ using namespace std;
 namespace sorbet::test {
 // Matches '    #    ^^^^^ label: dafhdsjfkhdsljkfh*&#&*%'
 // and '    # label: foobar'.
-const regex rangeAssertionRegex("(#[ ]*)(\\^*)[ ]*([a-zA-Z-]+):[ ]+(.*)$");
+const regex rangeAssertionRegex("(#[ ]*)(\\^*)[ ]*([a-zA-Z-]+): (.*)$");
 
 const regex whitespaceRegex("^[ ]*$");
 

--- a/test/testdata/lsp/hover_method_includes_defs.rb
+++ b/test/testdata/lsp/hover_method_includes_defs.rb
@@ -1,0 +1,138 @@
+# typed: true
+
+# rubocop:disable all
+
+module OuterModule
+  extend T::Sig
+
+  sig {params(name: String).returns(Integer)}
+  def module_method(name)
+    name.length
+  end
+
+  sig {params(name: String).returns(Integer)}
+  def self.module_self_method(name)
+    name.length
+  end
+
+  sig {returns T.untyped}
+  def module_usages
+    s = "Foo"
+    [
+      module_method(s),
+      # ^ hover: def module_method(name)
+      OuterModule.module_self_method(s),
+      #           ^ hover: def self.module_self_method(name)
+      OuterModule::module_self_method(s),
+      #            ^ hover: def self.module_self_method(name)
+    ]
+  end
+
+  class InnerClass
+    extend T::Sig
+    sig {params(name: String).void}
+    def initialize(name)
+      @name = name
+    end
+
+    sig {params(name: String).returns(Integer)}
+    def self.class_self_method(name)
+      name.length
+    end
+  
+    sig {void}
+    def no_args_return_void
+      # no args
+    end
+
+    sig {returns(Integer)}
+    def no_args_return_value
+      "no args".length
+    end
+
+    sig {params(fname: String, lname: String).returns(String)}
+    def positional_args(fname, lname)
+      "#{fname}:#{lname}"
+    end
+
+    sig {params(fname: String, lname: String).returns(String)}
+    def keyword_args_no_defaults(fname:, lname:)
+      "#{fname}:#{lname}"
+    end
+
+    sig {params(fname: String, lname: String).returns(String)}
+    def keyword_args_with_defaults(fname: "Jane", lname: "Doe")
+      "#{fname}:#{lname}"
+    end
+
+    sig {params(names: String).returns(String)}
+    def splat_args(*names)
+      names.join ':'
+    end
+
+    sig {params(blk: T.proc.params(arg0: Integer).returns(String)).returns(String)}
+    def block_args(&blk)
+      blk.call(1)
+    end
+
+    sig {params(pos: String, splat: String, required_key: String, optional_key: String, block_arg: T.proc.params(a: String).returns(String)).returns(String)}
+    def multiple_arg_types(pos, *splat, required_key:, optional_key: "Jane", &block_arg)
+      "#{pos} #{required_key} #{optional_key} #{splat.join ':'} #{block_arg.call(pos)}"
+    end
+
+    sig {returns T.untyped}
+    def class_usages
+      s = "Foo"
+      qualified = InnerClass.new(s)
+                             # ^ hover: def initialize(name)
+      [
+        no_args_return_void,
+        # ^ hover: def no_args_return_void
+        no_args_return_value,
+        # ^ hover: def no_args_return_value
+        positional_args(s, s),
+        # ^ hover: def positional_args(fname, lname)
+        keyword_args_no_defaults(fname: s, lname: s),
+        # ^ hover: def keyword_args_no_defaults(fname:, lname:)
+        keyword_args_with_defaults,
+        # ^ hover: def keyword_args_with_defaults(fname:…, lname:…)
+        splat_args,
+        # ^ hover: def splat_args(*names)
+        splat_args(s, s, s, s, s),
+        # ^ hover: def splat_args(*names)
+        block_args {|x| "blk#{x}"},
+        # ^ hover: def block_args(&blk)
+        multiple_arg_types(s, s, s, s, required_key: s) {|x| x},
+        # ^ hover: def multiple_arg_types(
+        # ^ hover:   pos,
+        # ^ hover:   *splat,
+        # ^ hover:   required_key:,
+        # ^ hover:   optional_key:…,
+        # ^ hover:   &block_arg
+        # ^ hover: )
+        InnerClass::class_self_method(s),
+        #           ^ hover: def self.class_self_method(name)
+        qualified.no_args_return_void,
+        #         ^ hover: def no_args_return_void
+        qualified.no_args_return_value,
+        #         ^ hover: def no_args_return_value
+        qualified.positional_args(s, s),
+        #         ^ hover: def positional_args(fname, lname)
+        qualified.keyword_args_no_defaults(fname: s, lname: s),
+        #         ^ hover: def keyword_args_no_defaults(fname:, lname:)
+        qualified.keyword_args_with_defaults(fname: s, lname: s),
+        #         ^ hover: def keyword_args_with_defaults(fname:…, lname:…)
+        qualified.splat_args(s, s, s, s, s),
+        #         ^ hover: def splat_args(*names)
+        qualified.multiple_arg_types(s, s, s, s, required_key: s) {|x| x},
+        #         ^ hover: def multiple_arg_types(
+        #         ^ hover:   pos,
+        #         ^ hover:   *splat,
+        #         ^ hover:   required_key:,
+        #         ^ hover:   optional_key:…,
+        #         ^ hover:   &block_arg
+        #         ^ hover: )
+      ]
+    end
+  end
+end


### PR DESCRIPTION
Since method signatures can read ambiguously in hover hints (e.g.,
is a param a positional or keyword arg?), include the method's `def`
to allow the user to disambiguate without having to jump to the
method definition.

### Motivation
Resolves #1640

### Test plan
Added automated tests.
