### PR TITLE
Don't show hover-text for synthetic methods.

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1190,7 +1190,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
         }
         throw;
     }
-} // namespace sorbet::infer
+}
 
 void Environment::cloneFrom(const Environment &rhs) {
     this->isDead = rhs.isDead;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -790,8 +790,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                 if (send->link || lspQueryMatch) {
                     retainedResult = make_shared<core::DispatchResult>(std::move(dispatched));
                 }
-                if (lspQueryMatch && retainedResult->main.method.exists() &&
-                    !retainedResult->main.method.isSynthetic()) {
+                if (lspQueryMatch &&
+                    !(retainedResult->main.method.exists() && retainedResult->main.method.isSynthetic())) {
                     core::lsp::QueryResponse::pushQueryResponse(
                         ctx, core::lsp::SendResponse(bind.loc, retainedResult, send->fun));
                 }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -791,8 +791,10 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                     retainedResult = make_shared<core::DispatchResult>(std::move(dispatched));
                 }
                 if (lspQueryMatch) {
-                    core::lsp::QueryResponse::pushQueryResponse(
-                        ctx, core::lsp::SendResponse(bind.loc, retainedResult, send->fun));
+                    if (!(retainedResult->main.method.exists() && retainedResult->main.method.isSynthetic())) {
+                        core::lsp::QueryResponse::pushQueryResponse(
+                            ctx, core::lsp::SendResponse(bind.loc, retainedResult, send->fun));
+                    }
                 }
                 if (send->link) {
                     // This should eventually become ENFORCEs but currently they are wrong

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -790,11 +790,10 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                 if (send->link || lspQueryMatch) {
                     retainedResult = make_shared<core::DispatchResult>(std::move(dispatched));
                 }
-                if (lspQueryMatch) {
-                    if (!(retainedResult->main.method.exists() && retainedResult->main.method.isSynthetic())) {
-                        core::lsp::QueryResponse::pushQueryResponse(
-                            ctx, core::lsp::SendResponse(bind.loc, retainedResult, send->fun));
-                    }
+                if (lspQueryMatch && retainedResult->main.method.exists() &&
+                    !retainedResult->main.method.isSynthetic()) {
+                    core::lsp::QueryResponse::pushQueryResponse(
+                        ctx, core::lsp::SendResponse(bind.loc, retainedResult, send->fun));
                 }
                 if (send->link) {
                     // This should eventually become ENFORCEs but currently they are wrong
@@ -1191,7 +1190,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
         }
         throw;
     }
-}
+} // namespace sorbet::infer
 
 void Environment::cloneFrom(const Environment &rhs) {
     this->isDead = rhs.isDead;

--- a/test/testdata/lsp/go_to_type_definition_applied.rb
+++ b/test/testdata/lsp/go_to_type_definition_applied.rb
@@ -25,4 +25,11 @@ class TestClass
   bare_box_a = BoxA.new
   puts T.reveal_type(bare_box_a) # error: Revealed type: `BoxA[T.untyped]`
   #                  ^ type: BoxA
+
+  # TODO for https://github.com/sorbet/sorbet/issues/1777
+  tup = [ 0 ]
+  T.reveal_type(tup) # error: [Integer(0)] (1-tuple)
+  #             ^ hover [Integer(0)] (1-tuple)
+  T.reveal_type([ 0 ]) # error: [Integer(0)] (1-tuple)
+  #                 ^ TODO: hover: [Integer(0)] (1-tuple)
 end

--- a/test/testdata/lsp/hover_method_hides_synthetic_args.rb
+++ b/test/testdata/lsp/hover_method_hides_synthetic_args.rb
@@ -12,3 +12,23 @@ def main
   A.new.bar(10)
        # ^ hover: sig {params(x: Integer).returns(String)}
 end
+
+# Tests for https://github.com/sorbet/sorbet/issues/1776
+def issue_1776
+  [
+    # Test hovering over first item in array
+    "foo",
+    #   ^ hover: String("foo")
+    #    ^ hover: String("foo")
+    #     ^ hover: null
+
+    # Test hovering over comment
+    # ^ hover: null
+    
+    # Test hovering over last item in array
+    123
+    # ^ hover: Integer(123)
+    #  ^ hover: Integer(123)
+    #   ^ hover: null
+  ]
+end

--- a/test/testdata/lsp/hover_untyped_proc_arg.rb
+++ b/test/testdata/lsp/hover_untyped_proc_arg.rb
@@ -3,8 +3,8 @@
 def main
   a = T.let([], T.untyped)
   a.map do |foo, bar|
-          # ^ hover: sig {returns(T.untyped)}
-                # ^ hover: sig {returns(T.untyped)}
+    # TODO: ^ hover: T.untyped
+    # TODO:      ^ hover: T.untyped
   end
   b = T.let([], T::Array[T.untyped])
   b.map do |foo|


### PR DESCRIPTION
### Motivation
Resolves #1776 

### Test plan
Manually test by hovering over a comment in an array to verify that the `<build-array>` method is not shown:

```
    example = [
      "foo",
      # hovering over this line used to reproduce issue #1776 
      42,
    ]
```
Although this doesn't solve #1777, it does change how that issue behaves.  Added a test for #1777 to give the person who tackles that issue a convenient starting place.