### PR TITLE
Include def in hover text for method definitions.

### DIFF
--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -215,8 +215,7 @@ bool hasSimilarName(const core::GlobalState &gs, core::NameRef name, std::string
 bool hideSymbol(const core::GlobalState &gs, core::SymbolRef sym);
 std::string methodDetail(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver,
                          core::TypePtr retType, const std::unique_ptr<core::TypeConstraint> &constraint);
-std::string methodDefinition(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver,
-                             core::TypePtr retType, const std::unique_ptr<core::TypeConstraint> &constraint);
+std::string methodDefinition(const core::GlobalState &gs, core::SymbolRef method);
 core::TypePtr getResultType(const core::GlobalState &gs, core::TypePtr type, core::SymbolRef inWhat,
                             core::TypePtr receiver, const std::unique_ptr<core::TypeConstraint> &constr);
 SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef);

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -145,8 +145,7 @@ string methodDetail(const core::GlobalState &gs, core::SymbolRef method, core::T
 // iff a `def` would be this wide or wider, expand it to be a multi-line def.
 constexpr int WIDTH_CUTOFF_FOR_MULTILINE_DEF = 80;
 
-string methodDefinition(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver,
-                        core::TypePtr retType, const unique_ptr<core::TypeConstraint> &constraint) {
+string methodDefinition(const core::GlobalState &gs, core::SymbolRef method) {
     ENFORCE(method.exists());
     // handle this case anyways so that we don't crash in prod when this method is mis-used
     if (!method.exists()) {

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -20,7 +20,7 @@ string methodInfoString(const core::GlobalState &gs, const core::TypePtr &retTyp
             }
             contents = absl::StrCat(
                 contents, methodDetail(gs, dispatchComponent.method, dispatchComponent.receiver, retType, constraint),
-                "\n", methodDefinition(gs, dispatchComponent.method, dispatchComponent.receiver, retType, constraint));
+                "\n", methodDefinition(gs, dispatchComponent.method));
         }
         start = start->secondary.get();
     }
@@ -93,9 +93,11 @@ LSPResult LSPLoop::handleTextDocumentHover(unique_ptr<core::GlobalState> gs, con
             response->result =
                 make_unique<Hover>(formatHoverText(config.clientHoverMarkupKind, methodInfo, documentation));
         } else if (auto defResp = resp->isDefinition()) {
-            response->result = make_unique<Hover>(formatHoverText(
-                config.clientHoverMarkupKind,
-                methodDetail(*gs, defResp->symbol, nullptr, defResp->retType.type, nullptr), documentation));
+            string typeString =
+                absl::StrCat(methodDetail(*gs, defResp->symbol, nullptr, defResp->retType.type, nullptr), "\n",
+                             methodDefinition(*gs, defResp->symbol));
+            response->result =
+                make_unique<Hover>(formatHoverText(config.clientHoverMarkupKind, typeString, documentation));
         } else if (auto constResp = resp->isConstant()) {
             const auto &data = constResp->symbol.data(*gs);
             auto type = constResp->retType.type;

--- a/test/testdata/lsp/hover_method_includes_defs.rb
+++ b/test/testdata/lsp/hover_method_includes_defs.rb
@@ -7,11 +7,13 @@ module OuterModule
 
   sig {params(name: String).returns(Integer)}
   def module_method(name)
+    # ^ hover: def module_method(name)
     name.length
   end
 
   sig {params(name: String).returns(Integer)}
   def self.module_self_method(name)
+    # ^ hover: def self.module_self_method(name)
     name.length
   end
 
@@ -32,6 +34,7 @@ module OuterModule
     extend T::Sig
     sig {params(name: String).void}
     def initialize(name)
+      # ^ hover: def initialize(name)
       @name = name
     end
 
@@ -62,6 +65,7 @@ module OuterModule
 
     sig {params(fname: String, lname: String).returns(String)}
     def keyword_args_with_defaults(fname: "Jane", lname: "Doe")
+      # ^ hover: def keyword_args_with_defaults(fname:…, lname:…)
       "#{fname}:#{lname}"
     end
 


### PR DESCRIPTION
To make the hover text for methods more consistent, show `def` in the hover text for method defintions (and not just method usages).

# Motivation
Improvement for #1640 

### Test plan
Added test cases to `hover_method_includes_defs.rb`.
