### PR TITLE
Array#concat has a splat argument

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -773,7 +773,7 @@ class Array < Object
     )
     .returns(T::Array[T.any(Elem, T.type_parameter(:T))])
   end
-  def concat(arrays); end
+  def concat(*arrays); end
 
   # Returns the number of elements.
   #


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The `Array#concat` methos has a variadic [`*arrays`](https://ruby-doc.org/core-2.6.4/Array.html#method-i-concat) argument, but Sorbet only accepts a single argument. This PR changes the shim definition to accept variadic arguments. 

### Motivation
Achieve parity between shims and the language.

### Test plan
Shims (rbi files) don't appear to be tested other than for special cases; as such I don't intend to add tests.