### PR TITLE
Add sigs to minitest-generated methods

### DIFF
--- a/dsl/Minitest.cc
+++ b/dsl/Minitest.cc
@@ -13,9 +13,7 @@ namespace sorbet::dsl {
 
 namespace {
 unique_ptr<ast::Expression> addSigVoid(unique_ptr<ast::Expression> expr) {
-    ast::InsSeq::STATS_store stats;
-    stats.emplace_back(ast::MK::SigVoid(expr->loc, ast::MK::Hash0(expr->loc)));
-    return make_unique<ast::InsSeq>(expr->loc, std::move(stats), std::move(expr));
+    return ast::MK::InsSeq1(expr->loc, ast::MK::SigVoid(expr->loc, ast::MK::Hash0(expr->loc)), std::move(expr));
 }
 } // namespace
 

--- a/dsl/Minitest.h
+++ b/dsl/Minitest.h
@@ -19,6 +19,7 @@ namespace sorbet::dsl {
  *
  *    class MyTest
  *      class <class_foo> < self
+ *        sig {void}
  *        def <test_bar>
  *          baz
  *        end

--- a/test/testdata/dsl/minitest.rb.dsl-tree.exp
+++ b/test/testdata/dsl/minitest.rb.dsl-tree.exp
@@ -4,8 +4,16 @@ class <emptyTree><<C <root>>> < ()
       <emptyTree>
     end
 
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({}).void()
+    end
+
     def <test_works outside><<C <todo sym>>>(&<blk>)
       <self>.outside_method()
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({}).void()
     end
 
     def <test_allows constants inside of IT><<C <todo sym>>>(&<blk>)
@@ -17,6 +25,9 @@ class <emptyTree><<C <root>>> < ()
         def inside_method<<C <todo sym>>>(&<blk>)
           <emptyTree>
         end
+        ::T::Sig::WithoutRuntime.sig() do ||
+          <self>.params({}).void()
+        end
         def <test_works inside><<C <todo sym>>>(&<blk>)
           begin
             <self>.outside_method()
@@ -26,8 +37,16 @@ class <emptyTree><<C <root>>> < ()
       end
     end
 
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({}).void()
+    end
+
     def initialize<<C <todo sym>>>(&<blk>)
       @foo = <emptyTree>::<C T>.let(3, <emptyTree>::<C Integer>)
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({}).void()
     end
 
     def <test_can read foo><<C <todo sym>>>(&<blk>)
@@ -44,8 +63,14 @@ class <emptyTree><<C <root>>> < ()
 
     class <emptyTree>::<C <class_Object>><<C <todo sym>>> < (<self>)
       begin
+        ::T::Sig::WithoutRuntime.sig() do ||
+          <self>.params({}).void()
+        end
         def <test_Object><<C <todo sym>>>(&<blk>)
           <emptyTree>
+        end
+        ::T::Sig::WithoutRuntime.sig() do ||
+          <self>.params({}).void()
         end
         def <test_Object><<C <todo sym>>>(&<blk>)
           <emptyTree>

--- a/test/testdata/dsl/minitest.rb.dsl-tree.exp
+++ b/test/testdata/dsl/minitest.rb.dsl-tree.exp
@@ -4,20 +4,22 @@ class <emptyTree><<C <root>>> < ()
       <emptyTree>
     end
 
-    ::T::Sig::WithoutRuntime.sig() do ||
-      <self>.params({}).void()
+    begin
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.params({}).void()
+      end
+      def <test_works outside><<C <todo sym>>>(&<blk>)
+        <self>.outside_method()
+      end
     end
 
-    def <test_works outside><<C <todo sym>>>(&<blk>)
-      <self>.outside_method()
-    end
-
-    ::T::Sig::WithoutRuntime.sig() do ||
-      <self>.params({}).void()
-    end
-
-    def <test_allows constants inside of IT><<C <todo sym>>>(&<blk>)
-      <emptyTree>::<C CONST> = 10
+    begin
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.params({}).void()
+      end
+      def <test_allows constants inside of IT><<C <todo sym>>>(&<blk>)
+        <emptyTree>::<C CONST> = 10
+      end
     end
 
     class <emptyTree>::<C <class_some inner tests>><<C <todo sym>>> < (<self>)
@@ -25,32 +27,36 @@ class <emptyTree><<C <root>>> < ()
         def inside_method<<C <todo sym>>>(&<blk>)
           <emptyTree>
         end
-        ::T::Sig::WithoutRuntime.sig() do ||
-          <self>.params({}).void()
-        end
-        def <test_works inside><<C <todo sym>>>(&<blk>)
-          begin
-            <self>.outside_method()
-            <self>.inside_method()
+        begin
+          ::T::Sig::WithoutRuntime.sig() do ||
+            <self>.params({}).void()
+          end
+          def <test_works inside><<C <todo sym>>>(&<blk>)
+            begin
+              <self>.outside_method()
+              <self>.inside_method()
+            end
           end
         end
       end
     end
 
-    ::T::Sig::WithoutRuntime.sig() do ||
-      <self>.params({}).void()
+    begin
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.params({}).void()
+      end
+      def initialize<<C <todo sym>>>(&<blk>)
+        @foo = <emptyTree>::<C T>.let(3, <emptyTree>::<C Integer>)
+      end
     end
 
-    def initialize<<C <todo sym>>>(&<blk>)
-      @foo = <emptyTree>::<C T>.let(3, <emptyTree>::<C Integer>)
-    end
-
-    ::T::Sig::WithoutRuntime.sig() do ||
-      <self>.params({}).void()
-    end
-
-    def <test_can read foo><<C <todo sym>>>(&<blk>)
-      <emptyTree>::<C T>.assert_type!(@foo, <emptyTree>::<C Integer>)
+    begin
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.params({}).void()
+      end
+      def <test_can read foo><<C <todo sym>>>(&<blk>)
+        <emptyTree>::<C T>.assert_type!(@foo, <emptyTree>::<C Integer>)
+      end
     end
 
     def self.random_method<<C <todo sym>>>(&<blk>)
@@ -63,17 +69,21 @@ class <emptyTree><<C <root>>> < ()
 
     class <emptyTree>::<C <class_Object>><<C <todo sym>>> < (<self>)
       begin
-        ::T::Sig::WithoutRuntime.sig() do ||
-          <self>.params({}).void()
+        begin
+          ::T::Sig::WithoutRuntime.sig() do ||
+            <self>.params({}).void()
+          end
+          def <test_Object><<C <todo sym>>>(&<blk>)
+            <emptyTree>
+          end
         end
-        def <test_Object><<C <todo sym>>>(&<blk>)
-          <emptyTree>
-        end
-        ::T::Sig::WithoutRuntime.sig() do ||
-          <self>.params({}).void()
-        end
-        def <test_Object><<C <todo sym>>>(&<blk>)
-          <emptyTree>
+        begin
+          ::T::Sig::WithoutRuntime.sig() do ||
+            <self>.params({}).void()
+          end
+          def <test_Object><<C <todo sym>>>(&<blk>)
+            <emptyTree>
+          end
         end
       end
     end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Typing tests as `typed: strict` is difficult, as adding `sig` annotations to `before` and `it` blocks will yield problems at runtime. Having the minitest dsl pass add sigs to the internal AST means that the file is typable as `strict`, but won't run into runtime issues with `sig`.

Fixes #1801 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
