### PR TITLE
Report errors for duplicate type members in every file

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -783,7 +783,8 @@ public:
                     e.setHeader("Duplicate type member `{}`", typeName->cnst.data(ctx)->show(ctx));
                     e.addErrorLine(existingTypeMember.data(ctx)->loc(), "Also defined here");
                 }
-                if (auto e = ctx.state.beginError(existingTypeMember.data(ctx)->loc(), core::errors::Namer::InvalidTypeDefinition)) {
+                if (auto e = ctx.state.beginError(existingTypeMember.data(ctx)->loc(),
+                                                  core::errors::Namer::InvalidTypeDefinition)) {
                     e.setHeader("Duplicate type member `{}`", typeName->cnst.data(ctx)->show(ctx));
                     e.addErrorLine(asgn->loc, "Also defined here");
                 }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -781,6 +781,11 @@ public:
             if (existingTypeMember.data(ctx)->loc().file() != asgn->loc.file()) {
                 if (auto e = ctx.state.beginError(asgn->loc, core::errors::Namer::InvalidTypeDefinition)) {
                     e.setHeader("Duplicate type member `{}`", typeName->cnst.data(ctx)->show(ctx));
+                    e.addErrorLine(existingTypeMember.data(ctx)->loc(), "Also defined here");
+                }
+                if (auto e = ctx.state.beginError(existingTypeMember.data(ctx)->loc(), core::errors::Namer::InvalidTypeDefinition)) {
+                    e.setHeader("Duplicate type member `{}`", typeName->cnst.data(ctx)->show(ctx));
+                    e.addErrorLine(asgn->loc, "Also defined here");
                 }
             }
 

--- a/test/testdata/namer/type_member_redefs__1.rb
+++ b/test/testdata/namer/type_member_redefs__1.rb
@@ -20,5 +20,5 @@ end
 
 class D
   extend T::Generic
-  R = type_member
+  R = type_member # error: Duplicate type member `R`
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes a nondeterministic master failure; if we redefine a `type_member` across files, then report an error in every file, not just the last one we saw.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
