### PR TITLE
Disable checking each element in an `Enumerable`

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
@@ -50,9 +50,7 @@ module T::Types
         # Users don't want these walked
         return true
       when Enumerator
-        obj.each do |elem|
-          return false unless @type.valid?(elem)
-        end
+        # Strict enumerators can be unbounded: see `[:foo, :bar].cycle`
         return true
       when Range
         @type.valid?(obj.first) && @type.valid?(obj.last)

--- a/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
@@ -46,11 +46,8 @@ module T::Types
           return false if !key_type.valid?(key) || !value_type.valid?(val)
         end
         return true
-      when Enumerator::Lazy
-        # Users don't want these walked
-        return true
       when Enumerator
-        # Strict enumerators can be unbounded: see `[:foo, :bar].cycle`
+        # Enumerators can be unbounded: see `[:foo, :bar].cycle`
         return true
       when Range
         @type.valid?(obj.first) && @type.valid?(obj.last)

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -341,15 +341,6 @@ module Opus::Types::Test
         assert_nil(msg)
       end
 
-      it 'fails if the type is wrong' do
-        type = T::Enumerator[Float]
-        value = [1, 2, 3].each
-        msg = type.error_message_for_obj(value)
-        expected_error = "Expected type T::Enumerator[Float], " \
-                         "got T::Enumerator[Integer]"
-        assert_equal(expected_error, msg)
-      end
-
       it 'can have its metatype instantiated' do
         assert_equal([1, 2, 3], T::Enumerator[Integer].new do |x|
           x << 1
@@ -504,6 +495,13 @@ module Opus::Types::Test
       it 'does not check lazy enumerables (for now)' do
         type = T::Enumerable[Integer]
         value = ["bad"].lazy
+        msg = type.error_message_for_obj(value)
+        assert_nil(msg)
+      end
+
+      it 'does not check potentially non-finite enumerables' do
+        type = T::Enumerable[Integer]
+        value = ["bad"].cycle
         msg = type.error_message_for_obj(value)
         assert_nil(msg)
       end


### PR DESCRIPTION
Enumerables are not neccessarily finite, so checking each value within
can cause infinite loops at runtime.

For example, the following code does not terminate.

```ruby
T.let([42].cycle, Enumerable[Integer])
```

This PR disables exaustively iterating over an enumerator and checking
the type of each element.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation

https://github.com/sorbet/sorbet/issues/1792


### Test plan

I've added a test for exactly this case.

