### PR TITLE
Avoid duplicating mixins in resolver

### DIFF
--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -119,6 +119,7 @@ public:
 
     inline InlinedVector<SymbolRef, 4> &mixins() {
         ENFORCE(isClassOrModule());
+        unsetClassLinearizationComputed();
         return mixins_;
     }
 
@@ -449,6 +450,11 @@ public:
     inline void setClassLinearizationComputed() {
         ENFORCE(isClassOrModule());
         flags |= Symbol::Flags::CLASS_OR_MODULE_LINEARIZATION_COMPUTED;
+    }
+
+    inline void unsetClassLinearizationComputed() {
+        ENFORCE(isClassOrModule());
+        flags &= ~Symbol::Flags::CLASS_OR_MODULE_LINEARIZATION_COMPUTED;
     }
 
     inline void setClassFinal() {

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -119,7 +119,6 @@ public:
 
     inline InlinedVector<SymbolRef, 4> &mixins() {
         ENFORCE(isClassOrModule());
-        unsetClassLinearizationComputed();
         return mixins_;
     }
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -127,6 +127,12 @@ public:
         return mixins_;
     }
 
+    void addMixin(SymbolRef sym) {
+        ENFORCE(isClassOrModule());
+        mixins_.emplace_back(sym);
+        unsetClassLinearizationComputed();
+    }
+
     inline InlinedVector<SymbolRef, 4> &typeMembers() {
         ENFORCE(isClassOrModule());
         return typeParams;
@@ -451,11 +457,6 @@ public:
         flags |= Symbol::Flags::CLASS_OR_MODULE_LINEARIZATION_COMPUTED;
     }
 
-    inline void unsetClassLinearizationComputed() {
-        ENFORCE(isClassOrModule());
-        flags &= ~Symbol::Flags::CLASS_OR_MODULE_LINEARIZATION_COMPUTED;
-    }
-
     inline void setClassFinal() {
         ENFORCE(isClassOrModule());
         flags |= Symbol::Flags::CLASS_OR_MODULE_FINAL;
@@ -642,6 +643,11 @@ private:
 
     SymbolRef findMemberTransitiveInternal(const GlobalState &gs, NameRef name, u4 mask, u4 flags,
                                            int maxDepth = 100) const;
+
+    inline void unsetClassLinearizationComputed() {
+        ENFORCE(isClassOrModule());
+        flags &= ~Symbol::Flags::CLASS_OR_MODULE_LINEARIZATION_COMPUTED;
+    }
 };
 // CheckSize(Symbol, 144, 8); // This is under too much churn to be worth checking
 

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -362,7 +362,7 @@ void Resolver::finalizeSymbols(core::GlobalState &gs) {
             if (!singleton.exists()) {
                 singleton = sym.data(gs)->singletonClass(gs);
             }
-            singleton.data(gs)->mixins().emplace_back(classMethods);
+            singleton.data(gs)->addMixin(classMethods);
         }
     }
 

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -248,13 +248,13 @@ int maybeAddMixin(core::GlobalState &gs, core::SymbolRef forSym, InlinedVector<c
 // tails of class linearization aren't copied around.
 // In order to obtain Ruby-side ancestors, one would need to walk superclass chain and concatenate `mixins`.
 // The algorithm is harder to explain than to code, so just follow code & tests if `testdata/resolver/linearization`
-ParentLinearizationInformation computeLinearization(core::GlobalState &gs, core::SymbolRef ofClass) {
+ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, core::SymbolRef ofClass) {
     ENFORCE(ofClass.exists());
     auto data = ofClass.data(gs);
     ENFORCE(data->isClassOrModule());
     if (!data->isClassOrModuleLinearizationComputed()) {
         if (data->superClass().exists()) {
-            computeLinearization(gs, data->superClass());
+            computeClassLinearization(gs, data->superClass());
         }
         InlinedVector<core::SymbolRef, 4> currentMixins = data->mixins();
         InlinedVector<core::SymbolRef, 4> newMixins;
@@ -268,7 +268,7 @@ ParentLinearizationInformation computeLinearization(core::GlobalState &gs, core:
                 continue;
             }
             ENFORCE(mixin.data(gs)->isClassOrModule());
-            ParentLinearizationInformation mixinLinearization = computeLinearization(gs, mixin);
+            ParentLinearizationInformation mixinLinearization = computeClassLinearization(gs, mixin);
 
             if (!mixin.data(gs)->isClassOrModuleModule()) {
                 if (mixin != core::Symbols::BasicObject()) {
@@ -311,13 +311,13 @@ void fullLinearizationSlowImpl(core::GlobalState &gs, const ParentLinearizationI
             if (m.data(gs)->isClassOrModuleModule()) {
                 acc.emplace_back(m);
             } else {
-                fullLinearizationSlowImpl(gs, computeLinearization(gs, m), acc);
+                fullLinearizationSlowImpl(gs, computeClassLinearization(gs, m), acc);
             }
         }
     }
     if (info.superClass.exists()) {
         if (!absl::c_linear_search(acc, info.superClass)) {
-            fullLinearizationSlowImpl(gs, computeLinearization(gs, info.superClass), acc);
+            fullLinearizationSlowImpl(gs, computeClassLinearization(gs, info.superClass), acc);
         }
     }
 };
@@ -327,7 +327,7 @@ InlinedVector<core::SymbolRef, 4> ParentLinearizationInformation::fullLinearizat
     return res;
 }
 
-void computeLinearization(core::GlobalState &gs) {
+void Resolver::computeLinearization(core::GlobalState &gs) {
     Timer timer(gs.errorQueue->logger, "resolver.compute_linearization");
 
     // TODO: this does not support `prepend`
@@ -336,7 +336,7 @@ void computeLinearization(core::GlobalState &gs) {
         if (!data->isClassOrModule()) {
             continue;
         }
-        computeLinearization(gs, core::SymbolRef(&gs, i));
+        computeClassLinearization(gs, core::SymbolRef(&gs, i));
     }
 }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -453,11 +453,7 @@ private:
             }
         } else {
             ENFORCE(resolved.data(ctx)->isClassOrModule());
-            auto classData = job.klass.data(ctx);
-            auto fnd = absl::c_find(classData->mixins(), resolved);
-            if (fnd == classData->mixins().end()) {
-                classData->mixins().emplace_back(resolved);
-            }
+            job.klass.data(ctx)->mixins().emplace_back(resolved);
         }
 
         return true;
@@ -1845,6 +1841,7 @@ vector<ast::ParsedFile> Resolver::runTreePasses(core::MutableContext ctx, vector
     auto workers = WorkerPool::create(0, ctx.state.tracer());
     trees = ResolveConstantsWalk::resolveConstants(ctx, std::move(trees), *workers);
     trees = resolveMixesInClassMethods(ctx, std::move(trees));
+    finalizeSymbols(ctx.state);
     trees = resolveTypeParams(ctx, std::move(trees));
     trees = resolveSigs(ctx, std::move(trees));
     sanityCheck(ctx, trees);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -454,7 +454,7 @@ private:
         } else {
             ENFORCE(resolved.data(ctx)->isClassOrModule());
             auto classData = job.klass.data(ctx);
-            auto fnd = find(classData->mixins().begin(), classData->mixins().end(), resolved);
+            auto fnd = absl::c_find(classData->mixins(), resolved);
             if (fnd == classData->mixins().end()) {
                 classData->mixins().emplace_back(resolved);
             }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -456,7 +456,7 @@ private:
             auto classData = job.klass.data(ctx);
             auto fnd = find(classData->mixins().begin(), classData->mixins().end(), resolved);
             if (fnd == classData->mixins().end()) {
-                job.klass.data(ctx)->mixins().emplace_back(resolved);
+                classData->mixins().emplace_back(resolved);
             }
         }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1842,7 +1842,7 @@ vector<ast::ParsedFile> Resolver::runTreePasses(core::MutableContext ctx, vector
     auto workers = WorkerPool::create(0, ctx.state.tracer());
     trees = ResolveConstantsWalk::resolveConstants(ctx, std::move(trees), *workers);
     trees = resolveMixesInClassMethods(ctx, std::move(trees));
-    finalizeSymbols(ctx.state);
+    computeLinearization(ctx.state);
     trees = resolveTypeParams(ctx, std::move(trees));
     trees = resolveSigs(ctx, std::move(trees));
     sanityCheck(ctx, trees);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -453,8 +453,7 @@ private:
             }
         } else {
             ENFORCE(resolved.data(ctx)->isClassOrModule());
-            job.klass.data(ctx)->unsetClassLinearizationComputed();
-            job.klass.data(ctx)->mixins().emplace_back(resolved);
+            job.klass.data(ctx)->addMixin(resolved);
         }
 
         return true;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1842,13 +1842,11 @@ void Resolver::sanityCheck(core::MutableContext ctx, vector<ast::ParsedFile> &tr
 }
 
 vector<ast::ParsedFile> Resolver::runTreePasses(core::MutableContext ctx, vector<ast::ParsedFile> trees) {
-    ctx.state.tracer().error("running tree passes");
     auto workers = WorkerPool::create(0, ctx.state.tracer());
     trees = ResolveConstantsWalk::resolveConstants(ctx, std::move(trees), *workers);
     trees = resolveMixesInClassMethods(ctx, std::move(trees));
     trees = resolveTypeParams(ctx, std::move(trees));
     trees = resolveSigs(ctx, std::move(trees));
-    finalizeSymbols(ctx.state);
     sanityCheck(ctx, trees);
     // This check is FAR too slow to run on large codebases, especially with sanitizers on.
     // But it can be super useful to uncomment when debugging certain issues.

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -453,6 +453,7 @@ private:
             }
         } else {
             ENFORCE(resolved.data(ctx)->isClassOrModule());
+            job.klass.data(ctx)->unsetClassLinearizationComputed();
             job.klass.data(ctx)->mixins().emplace_back(resolved);
         }
 

--- a/resolver/resolver.h
+++ b/resolver/resolver.h
@@ -25,6 +25,7 @@ public:
 private:
     static void finalizeAncestors(core::GlobalState &gs);
     static void finalizeSymbols(core::GlobalState &gs);
+    static void computeLinearization(core::GlobalState &gs);
     static std::vector<ast::ParsedFile> resolveTypeParams(core::MutableContext ctx, std::vector<ast::ParsedFile> trees);
     static std::vector<ast::ParsedFile> resolveSigs(core::MutableContext ctx, std::vector<ast::ParsedFile> trees);
     static std::vector<ast::ParsedFile> resolveMixesInClassMethods(core::MutableContext ctx,

--- a/test/testdata/core/fuzz_bad_subtyping.rb
+++ b/test/testdata/core/fuzz_bad_subtyping.rb
@@ -1,4 +1,5 @@
 # typed: true
+# disable-fast-path: true
 # Found by fuzzer: https://github.com/sorbet/sorbet/issues/1132
 module MyEnumerable
 extend T::Generic

--- a/test/testdata/core/fuzz_bad_subtyping.rb
+++ b/test/testdata/core/fuzz_bad_subtyping.rb
@@ -1,5 +1,4 @@
 # typed: true
-# disable-fast-path: true
 # Found by fuzzer: https://github.com/sorbet/sorbet/issues/1132
 module MyEnumerable
 extend T::Generic

--- a/test/testdata/resolver/abstract_out_of_order.rb
+++ b/test/testdata/resolver/abstract_out_of_order.rb
@@ -1,5 +1,4 @@
 # typed: true
-# disable-fast-path: true
 class Impl # error: Missing definition for abstract method
   include Interface
 end

--- a/test/testdata/resolver/abstract_override.rb
+++ b/test/testdata/resolver/abstract_override.rb
@@ -1,5 +1,4 @@
 # typed: true
-# disable-fast-path: true
 module Interface
   extend T::Sig
   extend T::Helpers

--- a/test/testdata/resolver/abstract_types.rb
+++ b/test/testdata/resolver/abstract_types.rb
@@ -1,5 +1,4 @@
 # typed: true
-# disable-fast-path: true
 
 class Abstract
   extend T::Sig

--- a/test/testdata/resolver/abstract_validation.rb
+++ b/test/testdata/resolver/abstract_validation.rb
@@ -1,6 +1,5 @@
 # typed: true
 # Fast path causes duplicate errors.
-# disable-fast-path: true
 
 module AbstractMixin
   extend T::Sig

--- a/test/testdata/resolver/final_method.rb
+++ b/test/testdata/resolver/final_method.rb
@@ -1,5 +1,4 @@
 # typed: false
-# disable-fast-path: true
 
 class Redefine
   extend T::Sig

--- a/test/testdata/resolver/final_module.rb
+++ b/test/testdata/resolver/final_module.rb
@@ -1,6 +1,5 @@
 # typed: false
 # The fast path causes duplicate errors.
-# disable-fast-path: true
 
 class FinalClass
   extend T::Helpers


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This enables us to safely test the fast-path more by getting rid of redundant errors. The resolver would always add resolved mixins to the mixin list of a symbol, and in non-incremental mode, we'd run linearization to prune those, but we don't run linearization in incremental mode (or for that matter when we have already computed it once) which means we can't rely on linearization to prune it. This fix simply does not add new mixins to the list if they are already present.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Allowed some tests to be exercised now that they succeed in the fast-path.
