### PR TITLE
Fix deadlock when exiting Sorbet.

### DIFF
--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -134,6 +134,7 @@ unique_ptr<Joinable> LSPPreprocessor::runPreprocessor(QueueState &incomingQueue,
                     &incomingQueue));
                 // Only terminate once incoming queue is drained.
                 if (incomingQueue.terminate && incomingQueue.pendingRequests.empty()) {
+                    logger->debug("Preprocessor terminating");
                     return;
                 }
                 msg = move(incomingQueue.pendingRequests.front());
@@ -198,13 +199,14 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP() {
                     incomingQueue.pendingRequests.push_back(move(msg));
                 }
             },
-            [&incomingQueue, &incomingMtx](int watchmanExitCode) {
+            [&incomingQueue, &incomingMtx, logger = this->logger](int watchmanExitCode) {
                 {
                     absl::MutexLock lck(&incomingMtx);
                     if (!incomingQueue.terminate) {
                         incomingQueue.terminate = true;
                         incomingQueue.errorCode = watchmanExitCode;
                     }
+                    logger->debug("Watchman terminating");
                 }
             });
     }
@@ -238,6 +240,7 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP() {
             } catch (FileReadException e) {
                 // Failed to read from input stream. Ignore. NotifyOnDestruction will take care of exiting cleanly.
             }
+            logger->debug("Reader thread terminating");
         });
 
     // Bridges the gap between the {reader, watchman} threads and the coordinator thread.
@@ -246,8 +249,10 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP() {
     mainThreadId = this_thread::get_id();
     unique_ptr<core::GlobalState> gs;
     {
-        // Ensure Watchman thread gets unstuck when thread exits.
+        // Ensure Watchman thread gets unstuck when thread exits prior to initialization.
         NotifyNotificationOnDestruction notify(initializedNotification);
+        // Ensure preprocessor, reader, and watchman threads get unstuck when thread exits.
+        NotifyOnDestruction notifyIncoming(incomingMtx, incomingQueue.terminate);
         bool exitProcessed = false;
         while (true) {
             unique_ptr<LSPMessage> msg;
@@ -302,6 +307,7 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP() {
         }
     }
 
+    logger->debug("Processor terminating");
     if (gs) {
         return gs;
     } else {

--- a/test/cli/lsp-common-case-exit/lsp-common-case-exit.out
+++ b/test/cli/lsp-common-case-exit/lsp-common-case-exit.out
@@ -1,0 +1,5 @@
+Content-Length: 268
+
+{"jsonrpc":"2.0","id":0,"requestMethod":"initialize","result":{"capabilities":{"textDocumentSync":1,"hoverProvider":true,"definitionProvider":true,"typeDefinitionProvider":true,"referencesProvider":true,"documentSymbolProvider":false,"workspaceSymbolProvider":false}}}Content-Length: 65
+
+{"jsonrpc":"2.0","id":1,"requestMethod":"shutdown","result":null}

--- a/test/cli/lsp-common-case-exit/lsp-common-case-exit.sh
+++ b/test/cli/lsp-common-case-exit/lsp-common-case-exit.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -e
+
+# we need to keep output & input pipes open
+# if we don't do anything special, they will be
+# closed after the first command is run.
+
+in_pipe="$(mktemp -u)"
+mkfifo -m 600 "$in_pipe"
+
+#out_pipe="$(mktemp -u)"
+#mkfifo -m 600 "$out_pipe"
+
+cleanup() {
+    rm "$in_pipe"
+}
+trap cleanup exit
+
+# TODO: Delurk this and support running Sorbet with a trace input.
+main/sorbet --silence-dev-message --lsp --disable-watchman --dir test/cli/lsp-common-case-exit < "$in_pipe" &
+sorbet_pid=$!
+
+# This should be
+# exec {IN_FD}>"$in_pipe"
+# but mac os has ancient version of bash.
+exec 100>"$in_pipe"
+IN_FD=100
+
+echo -e 'Content-Length: 2053\r\n\r\n{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"processId":1,"rootPath":"/Users/jvilk/stripe/pay-server","rootUri":"file:///Users/jvilk/stripe/pay-server","capabilities":{"workspace":{"applyEdit":true,"workspaceEdit":{"documentChanges":true},"didChangeConfiguration":{"dynamicRegistration":true},"didChangeWatchedFiles":{"dynamicRegistration":true},"symbol":{"dynamicRegistration":true,"symbolKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]}},"executeCommand":{"dynamicRegistration":true},"configuration":true,"workspaceFolders":true},"textDocument":{"publishDiagnostics":{"relatedInformation":true},"synchronization":{"dynamicRegistration":true,"willSave":true,"willSaveWaitUntil":true,"didSave":true},"completion":{"dynamicRegistration":true,"contextSupport":true,"completionItem":{"snippetSupport":true,"commitCharactersSupport":true,"documentationFormat":["markdown","plaintext"]},"completionItemKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25]}},"hover":{"dynamicRegistration":true,"contentFormat":["markdown","plaintext"]},"signatureHelp":{"dynamicRegistration":true,"signatureInformation":{"documentationFormat":["markdown","plaintext"]}},"definition":{"dynamicRegistration":true},"references":{"dynamicRegistration":true},"documentHighlight":{"dynamicRegistration":true},"documentSymbol":{"dynamicRegistration":true,"symbolKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]}},"codeAction":{"dynamicRegistration":true},"codeLens":{"dynamicRegistration":true},"formatting":{"dynamicRegistration":true},"rangeFormatting":{"dynamicRegistration":true},"onTypeFormatting":{"dynamicRegistration":true},"rename":{"dynamicRegistration":true},"documentLink":{"dynamicRegistration":true},"typeDefinition":{"dynamicRegistration":true},"implementation":{"dynamicRegistration":true},"colorProvider":{"dynamicRegistration":true}}},"trace":"off","workspaceFolders":[{"uri":"file:///Users/jvilk/stripe/pay-server","name":"pay-server"}]}}Content-Length: 52\r\n\r\n{"jsonrpc":"2.0","method":"initialized","params":{}}Content-Length: 58\r\n\r\n{"jsonrpc":"2.0","id":1,"method":"shutdown","params":null}Content-Length: 47\r\n\r\n{"jsonrpc":"2.0","method":"exit","params":null}'>&"$IN_FD"
+# Should exit cleanly.
+wait $sorbet_pid


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Added a test to ensure this common case never regresses again.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sorbet doesn't exit cleanly because `incomingQueue.terminate` never gets flipped, so the preprocessor thread keeps the process alive.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
