### PR TITLE
This change most likely fixes the LSP deadlock.

### DIFF
--- a/main/lsp/TimeTravelingGlobalState.cc
+++ b/main/lsp/TimeTravelingGlobalState.cc
@@ -192,7 +192,7 @@ void TimeTravelingGlobalState::commitEdits(LSPFileUpdates &update) {
     update.updatedFileHashes = computeStateHashes(update.updatedFiles);
     update.canTakeFastPath = canTakeFastPath(update);
 
-    TimeTravelUpdate newUpdate{update.version};
+    TimeTravelUpdate newUpdate{update.versionEnd};
     newUpdate.update.fileUpdates = update.updatedFiles;
     newUpdate.update.hashUpdates = update.updatedFileHashes;
 
@@ -213,7 +213,7 @@ void TimeTravelingGlobalState::commitEdits(LSPFileUpdates &update) {
         }
     }
     auto frefs = applyUpdate(newUpdate, false);
-    latestVersion = update.version;
+    latestVersion = update.versionEnd;
 
     log.push_back(move(newUpdate));
 

--- a/main/lsp/json_types.h
+++ b/main/lsp/json_types.h
@@ -17,8 +17,9 @@ namespace sorbet::realmain::lsp {
  * Placed into json_types.h because it is referenced from InitializedParams.
  */
 struct LSPFileUpdates {
-    // Used to identify this specific edit.
-    u4 version = 0;
+    // This specific update contains versions [versionStart, versionEnd].
+    u4 versionEnd = 0;
+    u4 versionStart = 0;
     std::vector<std::shared_ptr<core::File>> updatedFiles;
     bool canTakeFastPath = false;
     // Indicates that this update contains a new file. Is a hack for TimeTravelingGlobalState.


### PR DESCRIPTION
Changes LSPFileUpdates to track the range of edit versions that they contain so we:

A) Can properly time-travel to *before* the set of updates occurred to make fast path decisions in the past.
B) Can avoid accidentally throwing way undo history for merged updates.

I've added tests for these edge cases.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

LSP was deadlocking on people.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
