### PR TITLE
Rescue runtime errors from real_const_get

### DIFF
--- a/gems/sorbet/lib/constant_cache.rb
+++ b/gems/sorbet/lib/constant_cache.rb
@@ -138,7 +138,7 @@ class Sorbet::Private::ConstantLookupCache
         rescue LoadError => err
           puts "Got #{err.class} when trying to get nested name #{name}::#{nested}"
           next
-        rescue NameError, ArgumentError => err
+        rescue NameError, ArgumentError, RuntimeError => err
           puts "Got #{err.class} when trying to get nested name #{name}::#{nested}_"
           # some stuff fails to load, like
           # `const_get': uninitialized constant YARD::Parser::Ruby::Legacy::RipperParser (NameError)

--- a/gems/sorbet/test/snapshot/partial/local_gem/expected/sorbet/rbi/gems/my_gem.rbi
+++ b/gems/sorbet/test/snapshot/partial/local_gem/expected/sorbet/rbi/gems/my_gem.rbi
@@ -8,6 +8,6 @@
 #   https://github.com/sorbet/sorbet-typed/new/master?filename=lib/my_gem/all/my_gem.rbi
 #
 # my_gem-0.0.0
-class MyGem
+module MyGem
   def my_gem_thing; end
 end

--- a/gems/sorbet/test/snapshot/partial/local_gem/gems/0.0.0/gems/my_gem-0.0.0/lib/my_gem.rb
+++ b/gems/sorbet/test/snapshot/partial/local_gem/gems/0.0.0/gems/my_gem-0.0.0/lib/my_gem.rb
@@ -1,7 +1,9 @@
 # frozen_string_literals: true
 
-class MyGem
+module MyGem
   def my_gem_thing
     puts 'hello, world!'
   end
+
+  autoload :Test, 'my_gem/test'
 end

--- a/gems/sorbet/test/snapshot/partial/local_gem/gems/0.0.0/gems/my_gem-0.0.0/lib/my_gem/test.rb
+++ b/gems/sorbet/test/snapshot/partial/local_gem/gems/0.0.0/gems/my_gem-0.0.0/lib/my_gem/test.rb
@@ -1,8 +1,4 @@
-begin
-  require 'a-missing-gem'
-rescue LoadError
-  raise 'a runtime error'
-end
+raise 'a runtime error'
 
 module MyGem
   class Test

--- a/gems/sorbet/test/snapshot/partial/local_gem/gems/0.0.0/gems/my_gem-0.0.0/lib/my_gem/test.rb
+++ b/gems/sorbet/test/snapshot/partial/local_gem/gems/0.0.0/gems/my_gem-0.0.0/lib/my_gem/test.rb
@@ -1,0 +1,10 @@
+begin
+  require 'a-missing-gem'
+rescue LoadError
+  raise 'a runtime error'
+end
+
+module MyGem
+  class Test
+  end
+end


### PR DESCRIPTION
This rescues RuntimeErrors that are raised while Sorbet requires all your code.

### Motivation
Sometimes gems will have files with `require` statements for other gems that are not actual dependencies of the gem requiring them. In the usual course of events these files just won't get required so it's not a problem but when Sorbet requires everything this can cause issues. If just a `LoadError` is raised this should be fine as those will be rescued but sometimes, such as I was seeing in [`ActiveAdmin`](https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/cancan_adapter.rb#L5) they'll raise custom errors. The ones I've been running into are `RuntimeError` as are those seen in the following issue: https://github.com/sorbet/sorbet/issues/1820


### Test plan
I added some code the local gem test that simulates behavior similar to what I had been seeing in ActiveAdmin here:
- https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin.rb#L27
- https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/cancan_adapter.rb#L5

Not sure if this local gem partial is the right place so happy to move it if there's a better place.