### PR TITLE
Raise NoMethodError when calling setter for constant property

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -486,11 +486,7 @@ class T::Props::Decorator
   sig {params(name: Symbol, rules: Rules).void}
   private def define_getter_and_setter(name, rules)
     T::Configuration.without_ruby_warnings do
-      if rules[:immutable]
-        @class.send(:define_method, "#{name}=") do |_x|
-          raise T::Props::ImmutableProp.new("#{self.class}##{name} cannot be modified after creation.")
-        end
-      else
+      if !rules[:immutable]
         @class.send(:define_method, "#{name}=") do |x|
           self.class.decorator.prop_set(self, name, x, rules)
         end

--- a/gems/sorbet-runtime/test/types/props/decorator.rb
+++ b/gems/sorbet-runtime/test/types/props/decorator.rb
@@ -284,10 +284,10 @@ class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest
 
     it 'does not allow setting' do
       m = ImmutablePropStruct.new(immutable: 'hello')
-      e = assert_raises(T::Props::ImmutableProp) do
+      e = assert_raises(NoMethodError) do
         m.immutable = 'world'
       end
-      assert_match(/ImmutablePropStruct#immutable/, e.message)
+      assert_match(/undefined method `immutable='/, e.message)
     end
 
     it 'const creates an immutable prop' do
@@ -331,7 +331,7 @@ class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest
     e = assert_raises do
       MatrixStruct.new.c = nil
     end
-    assert_match(/cannot be modified/, e.message)
+    assert_match(/undefined method `c='/, e.message)
     e = assert_raises do
       MatrixStruct.new.d = nil
     end


### PR DESCRIPTION
Skip setter generation for setters on immutable props.
 
### Motivation
Currently we generate setters for properties even if they are immutable. Upon calling a setter on an immutable prop leads to a raised `T::Props::ImmutableProp` which adds many many additional lines to generated RBI files. This removes that definition and relies on simply _not_ having defined setters on immutable properties. 

### Test plan
Existing tests were updated to test for `NoMethodError`
