### PR TITLE
Remove a whole bunch of TODO(jez) comments

### DIFF
--- a/dsl/Command.cc
+++ b/dsl/Command.cc
@@ -40,7 +40,6 @@ bool isCommand(core::MutableContext ctx, ast::ClassDef *klass) {
 
 void Command::patchDSL(core::MutableContext ctx, ast::ClassDef *klass) {
     if (ctx.state.runningUnderAutogen) {
-        // TODO(jez) Verify whether this DSL pass is safe to run in for autogen
         return;
     }
 

--- a/dsl/DSLBuilder.cc
+++ b/dsl/DSLBuilder.cc
@@ -22,7 +22,6 @@ vector<unique_ptr<ast::Expression>> DSLBuilder::replaceDSL(core::MutableContext 
     vector<unique_ptr<ast::Expression>> empty;
 
     if (ctx.state.runningUnderAutogen) {
-        // TODO(jez) Verify whether this DSL pass is safe to run in for autogen
         return empty;
     }
 

--- a/dsl/InterfaceWrapper.cc
+++ b/dsl/InterfaceWrapper.cc
@@ -13,7 +13,6 @@ using namespace std;
 namespace sorbet::dsl {
 unique_ptr<ast::Expression> InterfaceWrapper::replaceDSL(core::MutableContext ctx, unique_ptr<ast::Send> send) {
     if (ctx.state.runningUnderAutogen) {
-        // TODO(jez) Verify whether this DSL pass is safe to run in for autogen
         return send;
     }
 

--- a/dsl/Minitest.cc
+++ b/dsl/Minitest.cc
@@ -104,7 +104,6 @@ unique_ptr<ast::Expression> recurse(core::MutableContext ctx, unique_ptr<ast::Ex
 vector<unique_ptr<ast::Expression>> Minitest::replaceDSL(core::MutableContext ctx, ast::Send *send) {
     vector<unique_ptr<ast::Expression>> stats;
     if (ctx.state.runningUnderAutogen) {
-        // TODO(jez) Verify whether this DSL pass is safe to run in for autogen
         return stats;
     }
 

--- a/dsl/MixinEncryptedProp.cc
+++ b/dsl/MixinEncryptedProp.cc
@@ -28,7 +28,6 @@ vector<unique_ptr<ast::Expression>> MixinEncryptedProp::replaceDSL(core::Mutable
     vector<unique_ptr<ast::Expression>> empty;
 
     if (ctx.state.runningUnderAutogen) {
-        // TODO(jez) Verify whether this DSL pass is safe to run in for autogen
         return empty;
     }
 

--- a/dsl/OpusEnum.cc
+++ b/dsl/OpusEnum.cc
@@ -122,7 +122,6 @@ vector<unique_ptr<ast::Expression>> processStat(core::MutableContext ctx, ast::C
 
 void OpusEnum::patchDSL(core::MutableContext ctx, ast::ClassDef *klass) {
     if (ctx.state.runningUnderAutogen) {
-        // TODO(jez) Verify whether this DSL pass is safe to run in for autogen
         return;
     }
 

--- a/dsl/Prop.cc
+++ b/dsl/Prop.cc
@@ -355,7 +355,6 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
 
 void Prop::patchDSL(core::MutableContext ctx, ast::ClassDef *klass) {
     if (ctx.state.runningUnderAutogen) {
-        // TODO(jez) Verify whether this DSL pass is safe to run in for autogen
         return;
     }
     auto synthesizeInitialize = false;

--- a/dsl/Struct.cc
+++ b/dsl/Struct.cc
@@ -49,7 +49,6 @@ vector<unique_ptr<ast::Expression>> Struct::replaceDSL(core::MutableContext ctx,
     vector<unique_ptr<ast::Expression>> empty;
 
     if (ctx.state.runningUnderAutogen) {
-        // TODO(jez) Verify whether this DSL pass is safe to run in for autogen
         return empty;
     }
 

--- a/dsl/attr_reader.cc
+++ b/dsl/attr_reader.cc
@@ -210,7 +210,6 @@ vector<unique_ptr<ast::Expression>> AttrReader::replaceDSL(core::MutableContext 
     vector<unique_ptr<ast::Expression>> empty;
 
     if (ctx.state.runningUnderAutogen) {
-        // TODO(jez) Verify whether this DSL pass is safe to run in for autogen
         return empty;
     }
 

--- a/main/options/ConfigParser.cc
+++ b/main/options/ConfigParser.cc
@@ -50,7 +50,6 @@ cxxopts::ParseResult ConfigParser::parseConfig(std::shared_ptr<spdlog::logger> l
     if (noConfigCount == 0) {
         auto configFilename = "sorbet/config";
         if (FileOps::exists(configFilename)) {
-            // TODO(jez) Recurse upwards to find file in parent directory
             readArgsFromFile(logger, configFilename, stringArgs);
         }
     }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -486,7 +486,7 @@ public:
         if (sym.data(ctx)->arguments().size() != parsedArgs.size()) {
             if (auto e = ctx.state.beginError(loc, core::errors::Namer::RedefinitionOfMethod)) {
                 if (sym != ctx.owner) {
-                    // TODO(jez) Subtracting 1 because of the block arg we added everywhere.
+                    // Subtracting 1 because of the block arg we added everywhere.
                     // Eventually we should be more principled about how we report this.
                     e.setHeader(
                         "Method alias `{}` redefined without matching argument count. Expected: `{}`, got: `{}`",
@@ -494,7 +494,7 @@ public:
                     e.addErrorLine(ctx.owner.data(ctx)->loc(), "Previous alias definition");
                     e.addErrorLine(sym.data(ctx)->loc(), "Dealiased definition");
                 } else {
-                    // TODO(jez) Subtracting 1 because of the block arg we added everywhere.
+                    // Subtracting 1 because of the block arg we added everywhere.
                     // Eventually we should be more principled about how we report this.
                     e.setHeader("Method `{}` redefined without matching argument count. Expected: `{}`, got: `{}`",
                                 sym.show(ctx), sym.data(ctx)->arguments().size() - 1, parsedArgs.size() - 1);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -468,9 +468,6 @@ private:
         }
         Timer timeit(ctx.state.errorQueue->logger, "resolver.registerSealedSubclass");
 
-        // TODO(jez) Would it ever make sense to put an AppliedType into the union?
-        // TODO(jez) Do we want to make sure that the child class doesn't have any type members?
-
         ancestorSym.data(ctx)->recordSealedSubclass(ctx, job.klass);
     }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1145,8 +1145,8 @@ private:
         ast::InsSeq::STATS_store lets;
 
         if (mdef->symbol.data(ctx)->isAbstract()) {
-            // TODO(jez) Check that abstract methods don't have defined bodies earlier (currently done in infer)
-            // so that we can unblock checking default arguments of abstract methods
+            // If we checked that abstract methods don't have defined bodies earlier (currently done in infer)
+            // we could also use this technique to check default arguments of abstract methods.
             return;
         }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Commit summary
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


- **Remove some TODOs that blame to me** (3c1e0025e)

  After sitting in the codebase for more 6 months, I don't think these are
  valuable to ever do. Things work just fine.

- **Remove TODOs from namer.cc** (732a3690a)

  There was a time where I thought this was a hack. The more I think about
  it, I think it's quite fine.

- **Unattribute a comment in resolver.cc** (7d9cf9d22)

  After a year on the team, I never did this, and I don't think we benefit
  that much from it.

  On second thought, does it even make sense for an abstract method to
  have a default argument? It won't apply to the child... Maybe we should
  just make this an error?

- **Answer two comments in resolver: No and no** (d06ee5187)


- **Remove todo to recursively find sorbet/config** (5a9b6c168)

  At some point we agreed this was too much action at a distance in a
  place we wanted to keep simple, and I forgot to remove the TODO





### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a