### PR TITLE
Accept 'const TypeConstraint*' instead of smartptr

### DIFF
--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -178,7 +178,7 @@ class LSPLoop {
                                            const CodeActionParams &params) const;
     std::unique_ptr<CompletionItem> getCompletionItem(const core::GlobalState &gs, core::SymbolRef what,
                                                       core::TypePtr receiverType,
-                                                      const std::unique_ptr<core::TypeConstraint> &constraint) const;
+                                                      const core::TypeConstraint *constraint) const;
     void findSimilarConstantOrIdent(const core::GlobalState &gs, const core::TypePtr receiverType,
                                     std::vector<std::unique_ptr<CompletionItem>> &items) const;
     void sendShowMessageNotification(MessageType messageType, std::string_view message) const;
@@ -214,10 +214,10 @@ std::optional<std::string> findDocumentation(std::string_view sourceCode, int be
 bool hasSimilarName(const core::GlobalState &gs, core::NameRef name, std::string_view pattern);
 bool hideSymbol(const core::GlobalState &gs, core::SymbolRef sym);
 std::string methodDetail(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver,
-                         core::TypePtr retType, const std::unique_ptr<core::TypeConstraint> &constraint);
+                         core::TypePtr retType, const core::TypeConstraint *constraint);
 std::string methodDefinition(const core::GlobalState &gs, core::SymbolRef method);
 core::TypePtr getResultType(const core::GlobalState &gs, core::TypePtr type, core::SymbolRef inWhat,
-                            core::TypePtr receiver, const std::unique_ptr<core::TypeConstraint> &constr);
+                            core::TypePtr receiver, const core::TypeConstraint *constr);
 SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef);
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -70,7 +70,7 @@ bool hasSimilarName(const core::GlobalState &gs, core::NameRef name, string_view
 constexpr int NUM_ARGS_CUTOFF_FOR_MULTILINE_SIG = 4;
 
 string methodDetail(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver, core::TypePtr retType,
-                    const unique_ptr<core::TypeConstraint> &constraint) {
+                    const core::TypeConstraint *constraint) {
     ENFORCE(method.exists());
     // handle this case anyways so that we don't crash in prod when this method is mis-used
     if (!method.exists()) {
@@ -210,7 +210,7 @@ string methodDefinition(const core::GlobalState &gs, core::SymbolRef method) {
 }
 
 core::TypePtr getResultType(const core::GlobalState &gs, core::TypePtr type, core::SymbolRef inWhat,
-                            core::TypePtr receiver, const unique_ptr<core::TypeConstraint> &constr) {
+                            core::TypePtr receiver, const core::TypeConstraint *constr) {
     core::Context ctx(gs, inWhat);
     auto resultType = type;
     if (auto *proxy = core::cast_type<core::ProxyType>(receiver.get())) {

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -82,7 +82,7 @@ string methodSnippet(const core::GlobalState &gs, core::SymbolRef method) {
 
 unique_ptr<CompletionItem> LSPLoop::getCompletionItem(const core::GlobalState &gs, core::SymbolRef what,
                                                       core::TypePtr receiverType,
-                                                      const unique_ptr<core::TypeConstraint> &constraint) const {
+                                                      const core::TypeConstraint *constraint) const {
     ENFORCE(what.exists());
     auto item = make_unique<CompletionItem>(string(what.data(gs)->name.data(gs)->shortName(gs)));
     auto resultType = what.data(gs)->resultType;
@@ -188,8 +188,8 @@ LSPResult LSPLoop::handleTextDocumentCompletion(unique_ptr<core::GlobalState> gs
             for (auto &[methodName, methodSymbols] : methods) {
                 if (methodSymbols[0].exists()) {
                     fast_sort(methodSymbols, [&](auto lhs, auto rhs) -> bool { return lhs._id < rhs._id; });
-                    items.push_back(
-                        getCompletionItem(*gs, methodSymbols[0], receiverType, sendResp->dispatchResult->main.constr));
+                    items.push_back(getCompletionItem(*gs, methodSymbols[0], receiverType,
+                                                      sendResp->dispatchResult->main.constr.get()));
                 }
             }
         } else if (auto identResp = resp->isIdent()) {

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -19,8 +19,9 @@ string methodInfoString(const core::GlobalState &gs, const core::TypePtr &retTyp
                 contents += "\n";
             }
             contents = absl::StrCat(
-                contents, methodDetail(gs, dispatchComponent.method, dispatchComponent.receiver, retType, constraint),
-                "\n", methodDefinition(gs, dispatchComponent.method));
+                contents,
+                methodDetail(gs, dispatchComponent.method, dispatchComponent.receiver, retType, constraint.get()), "\n",
+                methodDefinition(gs, dispatchComponent.method));
         }
         start = start->secondary.get();
     }

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -33,9 +33,9 @@ void addSignatureHelpItem(const core::GlobalState &gs, core::SymbolRef method,
         if (i != args.size() - 1) {
             methodDocumentation += ", ";
         }
-        parameter->documentation =
-            getResultType(gs, arg.type, method, resp.dispatchResult->main.receiver, resp.dispatchResult->main.constr)
-                ->show(gs);
+        parameter->documentation = getResultType(gs, arg.type, method, resp.dispatchResult->main.receiver,
+                                                 resp.dispatchResult->main.constr.get())
+                                       ->show(gs);
         parameters.push_back(move(parameter));
         i += 1;
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is pre-work for some completion related changes. Accepting a `const *` is
in many ways nicer than being forced to accept a `shared_ptr`.

<https://herbsutter.com/2013/06/05/gotw-91-solution-smart-pointer-parameters/>


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests