### PR TITLE
Fix bug: Argument types not included properly in method symbol hashes

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1102,7 +1102,7 @@ u4 Symbol::hash(const GlobalState &gs) const {
         if (!type) {
             type = Types::untypedUntracked();
         }
-        result = mix(result, type);
+        result = mix(result, type->hash(gs));
         result = mix(result, _hash(arg.name.data(gs)->shortName(gs)));
     }
     for (const auto &e : typeParams) {

--- a/test/testdata/lsp/fast_path/method_signature_update_static__def.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_signature_update_static__def.1.rbupdate
@@ -1,0 +1,9 @@
+# typed: strict
+# assert-fast-path: method_signature_update_static__def.rb,method_signature_update_static__usage.rb
+
+module Foobar extend T::Sig
+  sig {params(s: String).returns(String)}
+  def self.bar(s)
+    "${s}"
+  end
+end

--- a/test/testdata/lsp/fast_path/method_signature_update_static__def.rb
+++ b/test/testdata/lsp/fast_path/method_signature_update_static__def.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+module Foobar extend T::Sig
+  sig {params(s: Integer).returns(String)}
+  def self.bar(s)
+    "${s}"
+  end
+end

--- a/test/testdata/lsp/fast_path/method_signature_update_static__usage.rb
+++ b/test/testdata/lsp/fast_path/method_signature_update_static__usage.rb
@@ -1,0 +1,9 @@
+# typed: strict
+
+module Bat extend T::Sig
+  sig {returns(String)}
+  def foo
+    Foobar.bar("hello") # error: Expected `Integer`
+    #      ^ hover: sig {params(s: Integer).returns(String)}
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Prior to this change, argument types were not included properly in method symbol hashes

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I noticed that, after changing the type of an argument of a static method, Sorbet was not re-typechecking files that contained calls to that method.

I added a failing test, dug in, and found the culprit: we were including the *type* object itself in the hash rather than its hash. C++ implicitly converted it to an unsigned int.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated test.
