### PR TITLE
Fix slack invite link

### DIFF
--- a/website/static/slack/index.html
+++ b/website/static/slack/index.html
@@ -3,6 +3,6 @@
 <meta charset="utf-8">
 <title>Redirecting…</title>
 <link rel="canonical" href="https://sorbet.org/slack">
-<meta http-equiv="refresh" content="0; url=https://join.slack.com/t/sorbet-ruby/shared_invite/enQtNjU5MzA2NzU0OTYxLWNiZjcyZmM4MDE5YjIxZjAyMmE0NWYwYzU3MDNmNzNhNWY4YTNhOWE5YWU3NGQ4Y2Y4MDc5ZjAzNjI3NjcwYTE">
-<a href="https://join.slack.com/t/sorbet-ruby/shared_invite/enQtNjU5MzA2NzU0OTYxLWNiZjcyZmM4MDE5YjIxZjAyMmE0NWYwYzU3MDNmNzNhNWY4YTNhOWE5YWU3NGQ4Y2Y4MDc5ZjAzNjI3NjcwYTE">Click here if you are not redirected.</a>
+<meta http-equiv="refresh" content="0; url=https://join.slack.com/t/sorbet-ruby/shared_invite/enQtNjU5MzA2NzU0OTYxLTIyZDBjNzA5ZGRkOTcxZjk0M2U3OGY2NGY4MGRiYWU1OWJlYjdjM2UxYzliMWNmNTI2YmZjMmRhMWNiNGIyZGQ">
+<a href="https://join.slack.com/t/sorbet-ruby/shared_invite/enQtNjU5MzA2NzU0OTYxLTIyZDBjNzA5ZGRkOTcxZjk0M2U3OGY2NGY4MGRiYWU1OWJlYjdjM2UxYzliMWNmNTI2YmZjMmRhMWNiNGIyZGQ">Click here if you are not redirected.</a>
 </html>


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

For some reason, Slack decided to invalidate our previous link without
telling us.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Opened this link in incognito window to make sure I saw the invite page.