### PR TITLE
Hierarchy-aware completion

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -9,6 +9,121 @@ namespace sorbet::realmain::lsp {
 
 namespace {
 
+core::NameRef originalName(const core::GlobalState &gs, core::NameRef name) {
+    switch (name.data(gs)->kind) {
+        case core::NameKind::UTF8:
+            return name;
+        case core::NameKind::UNIQUE:
+            return originalName(gs, name.data(gs)->unique.original);
+        case core::NameKind::CONSTANT:
+            return originalName(gs, name.data(gs)->cnst.original);
+    }
+}
+
+vector<core::SymbolRef> ancestorsImpl(const core::GlobalState &gs, core::SymbolRef sym, vector<core::SymbolRef> &&acc) {
+    // The implementation here is similar to Symbols::derivesFrom.
+    ENFORCE(sym.data(gs)->isClassOrModuleLinearizationComputed());
+    acc.emplace_back(sym);
+
+    for (auto mixin : sym.data(gs)->mixins()) {
+        acc.emplace_back(mixin);
+    }
+
+    if (sym.data(gs)->superClass().exists()) {
+        return ancestorsImpl(gs, sym.data(gs)->superClass(), move(acc));
+    } else {
+        return move(acc);
+    }
+}
+
+// Basically the same as Module#ancestors from Ruby--but don't depend on it being exactly equal.
+// For us, it's just something that's vaguely ordered from "most specific" to "least specific" ancestor.
+vector<core::SymbolRef> ancestors(const core::GlobalState &gs, core::SymbolRef receiver) {
+    return ancestorsImpl(gs, receiver, vector<core::SymbolRef>{});
+}
+
+struct SimilarMethod final {
+    int depth;
+    core::SymbolRef receiver;
+    core::SymbolRef method;
+
+    // Populated later
+    core::TypePtr receiverType = nullptr;
+    shared_ptr<core::TypeConstraint> constr = nullptr;
+};
+
+// First of pair is "found at this depth in the ancestor hierarchy"
+// Second of pair is method symbol found at that depth, with name similar to prefix.
+vector<SimilarMethod> similarMethodsForClass(const core::GlobalState &gs, core::SymbolRef receiver,
+                                             string_view prefix) {
+    auto result = vector<SimilarMethod>{};
+
+    int depth = -1;
+    for (auto ancestor : ancestors(gs, receiver)) {
+        depth++;
+        for (auto [memberName, memberSymbol] : ancestor.data(gs)->members()) {
+            if (!memberSymbol.data(gs)->isMethod()) {
+                continue;
+            }
+
+            if (hasSimilarName(gs, memberName, prefix)) {
+                result.emplace_back(SimilarMethod{depth, receiver, memberSymbol});
+            }
+        }
+    }
+
+    return result;
+}
+
+vector<SimilarMethod> mergeSimilarMethods(vector<SimilarMethod> &&left, vector<SimilarMethod> &&right) {
+    left.insert(left.end(), right.begin(), right.end());
+    return std::move(left);
+}
+
+vector<SimilarMethod> similarMethodsForReceiver(const core::GlobalState &gs, const core::TypePtr receiver,
+                                                string_view prefix) {
+    auto result = vector<SimilarMethod>{};
+
+    typecase(
+        receiver.get(), [&](core::ClassType *type) { result = similarMethodsForClass(gs, type->symbol, prefix); },
+        [&](core::AppliedType *type) { result = similarMethodsForClass(gs, type->klass, prefix); },
+        [&](core::AndType *type) {
+            // We take the union here rather than take the intersection. (Better to suggest a method that someone
+            // is looking for and then give a type error, rather than have them sit wondering why it's missing.)
+            result = mergeSimilarMethods(similarMethodsForReceiver(gs, type->left, prefix),
+                                         similarMethodsForReceiver(gs, type->right, prefix));
+        },
+        [&](core::ProxyType *type) { result = similarMethodsForReceiver(gs, type->underlying(), prefix); },
+        [&](core::Type *type) { return; });
+
+    return result;
+}
+
+// Walk a core::DispatchResult to find methods similar to `prefix` on any of its DispatchComponents' receivers.
+vector<SimilarMethod> allSimilarMethods(const core::GlobalState &gs, core::DispatchResult &dispatchResult,
+                                        string_view prefix) {
+    auto result = similarMethodsForReceiver(gs, dispatchResult.main.receiver, prefix);
+
+    // Convert to shared_ptr and take ownership
+    shared_ptr<core::TypeConstraint> constr = move(dispatchResult.main.constr);
+
+    for (auto &similarMethod : result) {
+        ENFORCE(similarMethod.receiverType == nullptr, "About to overwrite non-null receiverType");
+        similarMethod.receiverType = dispatchResult.main.receiver;
+
+        ENFORCE(similarMethod.constr == nullptr, "About to overwrite non-null constr");
+        similarMethod.constr = constr;
+    }
+
+    if (dispatchResult.secondary != nullptr) {
+        // Right now we completely ignore the secondaryKind (either AND or OR), and always union.
+        // (See comment for AndType in similarMethodsForReceiver.)
+        result = mergeSimilarMethods(move(result), allSimilarMethods(gs, *dispatchResult.secondary, prefix));
+    }
+
+    return result;
+}
+
 string methodSnippet(const core::GlobalState &gs, core::SymbolRef method) {
     auto shortName = method.data(gs)->name.data(gs)->shortName(gs);
     vector<string> typeAndArgNames;
@@ -129,25 +244,38 @@ LSPResult LSPLoop::handleTextDocumentCompletion(unique_ptr<core::GlobalState> gs
         auto resp = move(queryResponses[0]);
 
         if (auto sendResp = resp->isSend()) {
-            auto pattern = sendResp->callerSideName.data(*gs)->shortName(*gs);
-            auto receiverType = sendResp->dispatchResult->main.receiver;
-            logger->debug("Looking for method similar to {}", pattern);
-            auto methodsMap = findSimilarMethodsIn(*gs, receiverType, pattern);
-            auto methods = vector<pair<core::NameRef, vector<core::SymbolRef>>>(methodsMap.begin(), methodsMap.end());
-            fast_sort(methods, [&](auto leftPair, auto rightPair) -> bool {
-                auto leftShortName = leftPair.first.data(*gs)->shortName(*gs);
-                auto rightShortName = rightPair.first.data(*gs)->shortName(*gs);
+            auto prefix = sendResp->callerSideName.data(*gs)->shortName(*gs);
+            logger->debug("Looking for method similar to {}", prefix);
+
+            auto similarMethods = allSimilarMethods(*gs, *sendResp->dispatchResult, prefix);
+            fast_sort(similarMethods, [&](const auto &left, const auto &right) -> bool {
+                if (left.depth != right.depth) {
+                    return left.depth < right.depth;
+                }
+
+                auto leftShortName = left.method.data(*gs)->name.data(*gs)->shortName(*gs);
+                auto rightShortName = right.method.data(*gs)->name.data(*gs)->shortName(*gs);
                 if (leftShortName != rightShortName) {
                     return leftShortName < rightShortName;
                 }
-                return leftPair.first._id < rightPair.first._id;
+
+                return left.method._id < right.method._id;
             });
-            for (auto &[methodName, methodSymbols] : methods) {
-                if (methodSymbols[0].exists()) {
-                    fast_sort(methodSymbols, [&](auto lhs, auto rhs) -> bool { return lhs._id < rhs._id; });
-                    items.push_back(getCompletionItem(*gs, methodSymbols[0], receiverType,
-                                                      sendResp->dispatchResult->main.constr.get()));
+
+            auto deduped = vector<SimilarMethod>{};
+            auto lastName = core::NameRef::noName();
+            for (auto &similarMethod : similarMethods) {
+                auto name = originalName(*gs, similarMethod.method.data(*gs)->name);
+
+                if (lastName != name) {
+                    deduped.emplace_back(similarMethod);
+                    lastName = name;
                 }
+            }
+
+            for (auto &similarMethod : deduped) {
+                items.push_back(getCompletionItem(*gs, similarMethod.method, similarMethod.receiverType,
+                                                  similarMethod.constr.get()));
             }
         } else if (auto identResp = resp->isIdent()) {
             findSimilarConstantOrIdent(*gs, identResp->retType.type, items);

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -7,49 +7,6 @@ using namespace std;
 
 namespace sorbet::realmain::lsp {
 
-UnorderedMap<core::NameRef, vector<core::SymbolRef>>
-mergeMaps(UnorderedMap<core::NameRef, vector<core::SymbolRef>> &&first,
-          UnorderedMap<core::NameRef, vector<core::SymbolRef>> &&second) {
-    for (auto &other : second) {
-        first[other.first].insert(first[other.first].end(), make_move_iterator(other.second.begin()),
-                                  make_move_iterator(other.second.end()));
-    }
-    return std::move(first);
-};
-
-UnorderedMap<core::NameRef, vector<core::SymbolRef>> findSimilarMethodsIn(const core::GlobalState &gs,
-                                                                          core::TypePtr receiver, string_view name) {
-    UnorderedMap<core::NameRef, vector<core::SymbolRef>> result;
-    typecase(
-        receiver.get(),
-        [&](core::ClassType *c) {
-            const auto &owner = c->symbol.data(gs);
-            for (auto member : owner->membersStableOrderSlow(gs)) {
-                auto sym = member.second;
-                if (sym.data(gs)->isMethod() && hasSimilarName(gs, sym.data(gs)->name, name)) {
-                    result[sym.data(gs)->name].emplace_back(sym);
-                }
-            }
-            for (auto mixin : owner->mixins()) {
-                result = mergeMaps(std::move(result),
-                                   findSimilarMethodsIn(gs, core::make_type<core::ClassType>(mixin), name));
-            }
-            if (owner->superClass().exists()) {
-                result =
-                    mergeMaps(std::move(result),
-                              findSimilarMethodsIn(gs, core::make_type<core::ClassType>(owner->superClass()), name));
-            }
-        },
-        [&](core::AndType *c) {
-            result = mergeMaps(findSimilarMethodsIn(gs, c->left, name), findSimilarMethodsIn(gs, c->right, name));
-        },
-        [&](core::AppliedType *c) {
-            result = findSimilarMethodsIn(gs, core::make_type<core::ClassType>(c->klass), name);
-        },
-        [&](core::ProxyType *c) { result = findSimilarMethodsIn(gs, c->underlying(), name); },
-        [&](core::Type *c) { return; });
-    return result;
-}
 namespace {
 
 string methodSnippet(const core::GlobalState &gs, core::SymbolRef method) {

--- a/test/testdata/lsp/completion/class_and_module.rb
+++ b/test/testdata/lsp/completion/class_and_module.rb
@@ -3,6 +3,9 @@
 module M
   def foo_from_m
   end
+
+  def method_in_parent
+  end
 end
 
 class A
@@ -13,9 +16,12 @@ class A
   def bar_from_a
   end
 
-  def car
+  def method_in_child_but_long
   end
 end
 
 A.new.foo # error: does not exist
 #        ^ completion: foo_from_a, foo_from_m
+
+A.new.method_in_ # error: does not exist
+#            ^ completion: method_in_child_but_long, method_in_parent

--- a/test/testdata/lsp/completion/depth.rb
+++ b/test/testdata/lsp/completion/depth.rb
@@ -1,0 +1,17 @@
+# typed: true
+
+class Depth2
+  def duplicate_method_1; end
+  def duplicate_method_2; end
+end
+
+class Depth1 < Depth2
+  def duplicate_method_1; end
+  def duplicate_method_2; end
+end
+
+# This test is designed to capture existing behavior, not test that we don't
+# regress this behavior. If this changes, it's fine.
+
+Depth1.new.duplicate_ # error: does not exist
+#                    ^ completion: duplicate_method_1, duplicate_method_2, duplicate_method_1, duplicate_method_2

--- a/test/testdata/lsp/completion/intersection.rb
+++ b/test/testdata/lsp/completion/intersection.rb
@@ -1,0 +1,39 @@
+# typed: true
+
+module M
+  def foo_common_1; end
+  def foo_common_2; end
+  def foo_only_on_a; end
+end
+module N
+  def foo_common_1; end
+  def foo_common_2; end
+  def foo_only_on_b; end
+end
+
+module Nullary
+  def some_method; end
+end
+
+module Unary
+  def some_method(x); end
+end
+
+# The behavior here is the *same as* T.any. (Maybe you expected it to be the dual.)
+# See the comment in union.rb for more.
+
+def test
+  ab = T.let(T.unsafe(nil), T.all(M, N))
+  ab.foo_
+#        ^ completion: foo_common_1, foo_common_2, foo_only_on_a, foo_only_on_b
+# ^^^^^^^ error: does not exist on `M`
+# ^^^^^^^ error: does not exist on `N`
+
+  # TODO(jez) This is a weird case. There are two methods named `some_method`.
+  # We've decided to show *all* methods, but the arity on each component is different.
+  nullary_or_unary = T.let(T.unsafe(nil), T.all(Nullary, Unary))
+  nullary_or_unary.some_
+#                       ^ completion: some_method
+# ^^^^^^^^^^^^^^^^ error: does not exist on `Nullary`
+# ^^^^^^^^^^^^^^^^ error: does not exist on `Unary`
+end

--- a/test/testdata/lsp/completion/intersection.rb
+++ b/test/testdata/lsp/completion/intersection.rb
@@ -34,6 +34,6 @@ def test
   nullary_or_unary = T.let(T.unsafe(nil), T.all(Nullary, Unary))
   nullary_or_unary.some_
 #                       ^ completion: some_method
-# ^^^^^^^^^^^^^^^^ error: does not exist on `Nullary`
-# ^^^^^^^^^^^^^^^^ error: does not exist on `Unary`
+# ^^^^^^^^^^^^^^^^^^^^^^ error: does not exist on `Nullary`
+# ^^^^^^^^^^^^^^^^^^^^^^ error: does not exist on `Unary`
 end

--- a/test/testdata/lsp/completion/overloads_test.rb
+++ b/test/testdata/lsp/completion/overloads_test.rb
@@ -10,9 +10,10 @@ class A
 end
 
 A.new.my_metho # error: does not exist
-#             ^ completion: my_method, my_method, my_method, my_method, my_method
+#             ^ completion: my_method
 
-# TODO(jez) The above is not the right behavior.
+# TODO(jez) Eventually, we might want to expand this to show all overloads,
+# minus the one that we enter with UniqueNameKind::Overload.
 #
 # There are 3 symbols here. One of them was mangle renamed?
 # Looks like we mangleRenameSymbol in resolver before fillInInfoFromSig.

--- a/test/testdata/lsp/completion/redefinition.rb
+++ b/test/testdata/lsp/completion/redefinition.rb
@@ -1,0 +1,17 @@
+# typed: true
+
+class A
+  # Imagine that this class exists somewhere else in a `typed: false` file.
+  # That is, this situation is definitely one that could occur in real code.
+  def some_method; end
+  def some_method(x); end # error: redefined
+end
+
+# We should pretty much always ignore mangled names that result from method
+# redefinition for the purposes of completion items.
+
+def test
+  a = A.new
+  a.some_ # error: does not exist
+#        ^ completion: some_method
+end

--- a/test/testdata/lsp/completion/union.rb
+++ b/test/testdata/lsp/completion/union.rb
@@ -11,13 +11,39 @@ class B
   def foo_only_on_b; end
 end
 
-# This test exists to document behavior that is currently broken and should be
-# fixed. We shouldn't suggest `foo_only_on_a`.
+class Nullary
+  def some_method; end
+end
+
+class Unary
+  def some_method(x); end
+end
+
+# Note how we suggest methods on either component. This is intential. People
+# would think it's a bug if completion "stopped working" for nilable receivers.
+# We'd rather show them the method then show them that it doesn't type check
+# because it's nil.
 
 def test
   ab = T.let(A.new, T.any(A, B))
   ab.foo_
-#        ^ completion: foo_common_1, foo_common_2, foo_only_on_a
+#        ^ completion: foo_common_1, foo_common_2, foo_only_on_a, foo_only_on_b
 # ^^^^^^^ error: Method `foo_` does not exist on `A` component of `T.any(A, B)`
 # ^^^^^^^ error: Method `foo_` does not exist on `B` component of `T.any(A, B)`
+
+  maybe_a = T.let(nil, T.nilable(A))
+  maybe_a.foo_only
+#                 ^ completion: foo_only_on_a
+# ^^^^^^^^^^^^^^^^ error: Method `foo_only` does not exist on `A` component of `T.nilable(A)`
+# ^^^^^^^^^^^^^^^^ error: Method `foo_only` does not exist on `NilClass` component of `T.nilable(A)`
+
+  # TODO(jez) This is a weird case. There are two methods named `some_method`.
+  # We've decided to show *all* methods, not just the intersection of methods.
+  # And, the arity on each component is different. But we'll only show one of
+  # the sigs, arbitrarily.
+  nullary_or_unary = T.let(Nullary.new, T.any(Nullary, Unary))
+  nullary_or_unary.some_
+#                       ^ completion: some_method
+# ^^^^^^^^^^^^^^^^ error: does not exist on `Nullary`
+# ^^^^^^^^^^^^^^^^ error: does not exist on `Unary`
 end

--- a/test/testdata/lsp/completion/union.rb
+++ b/test/testdata/lsp/completion/union.rb
@@ -44,6 +44,6 @@ def test
   nullary_or_unary = T.let(Nullary.new, T.any(Nullary, Unary))
   nullary_or_unary.some_
 #                       ^ completion: some_method
-# ^^^^^^^^^^^^^^^^ error: does not exist on `Nullary`
-# ^^^^^^^^^^^^^^^^ error: does not exist on `Unary`
+# ^^^^^^^^^^^^^^^^^^^^^^ error: does not exist on `Unary`
+# ^^^^^^^^^^^^^^^^^^^^^^ error: does not exist on `Nullary`
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is a start to be able to use more heuristics to better order the list of
completion results. The heuristic this implements is "methods on my class are
probably more relevant than methods on Object."

This is just a heuristic, and we'll be refining it in future PRs.

Another thing that happened in the process is that all completion items are
deduped by the method name being completed. I'm going back and forth on this
choice, but for now I think it's net good.


### Commit summary

The whole diff looks kind of weird because the implementation logically shares
nothing in common with what used to be there. Review by commit if you want to
just see the new implementation.

- **Remove the old implementation** (6c8e89b13)


- **Add the new implementation** (d95855f27)


- **Add lots of tests** (cf7af3c8c)



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.