### PR TITLE
Preserve arg defaults in fast path

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -76,7 +76,11 @@ class NameInserter {
     unique_ptr<ast::Expression> arg2Symbol(core::MutableContext ctx, int pos, ast::ParsedArg parsedArg) {
         if (pos < ctx.owner.data(ctx)->arguments().size()) {
             // TODO: check that flags match;
-            auto localExpr = make_unique<ast::Local>(parsedArg.loc, parsedArg.local);
+            unique_ptr<ast::Reference> localExpr = make_unique<ast::Local>(parsedArg.loc, parsedArg.local);
+            if (parsedArg.default_) {
+                localExpr = make_unique<ast::OptionalArg>(parsedArg.loc, move(localExpr), move(parsedArg.default_));
+            }
+
             ctx.owner.data(ctx)->arguments()[pos].loc = parsedArg.loc;
             return move(localExpr);
         }

--- a/test/testdata/dsl/t_struct/default_bad.rb
+++ b/test/testdata/dsl/t_struct/default_bad.rb
@@ -1,5 +1,4 @@
 # typed: true
-# disable-fast-path: true
 # TODO enable on the fast path
 
 class DefaultBad < T::Struct

--- a/test/testdata/resolver/optional_cyclic.rb
+++ b/test/testdata/resolver/optional_cyclic.rb
@@ -1,5 +1,4 @@
 # typed: true
-# disable-fast-path: true
 class Test
   extend T::Sig
 

--- a/test/testdata/resolver/optional_nested.rb
+++ b/test/testdata/resolver/optional_nested.rb
@@ -1,5 +1,4 @@
 # typed: true
-# disable-fast-path: true
 module M
   class C
     extend T::Sig

--- a/test/testdata/resolver/optional_nil.rb
+++ b/test/testdata/resolver/optional_nil.rb
@@ -1,5 +1,4 @@
 # typed: true
-# disable-fast-path: true
 class Test
   extend T::Sig
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
We had an early return in `arg2symbol` for when an arg had already been created (e.g. by an earlier pass) that was silently dropping the default values of arguments, which resulted in disappearing error messages in LSP. This replicates the appropriate logic.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Enabled several fast-path tests.
