### PR TITLE
Explicit sortText to control sort order

### DIFF
--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -178,7 +178,7 @@ class LSPLoop {
                                            const CodeActionParams &params) const;
     std::unique_ptr<CompletionItem> getCompletionItem(const core::GlobalState &gs, core::SymbolRef what,
                                                       core::TypePtr receiverType,
-                                                      const core::TypeConstraint *constraint) const;
+                                                      const core::TypeConstraint *constraint, size_t sortIdx) const;
     void findSimilarConstantOrIdent(const core::GlobalState &gs, const core::TypePtr receiverType,
                                     std::vector<std::unique_ptr<CompletionItem>> &items) const;
     void sendShowMessageNotification(MessageType messageType, std::string_view message) const;

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -955,6 +955,12 @@ void CompletionAssertion::check(const UnorderedMap<string, shared_ptr<core::File
     ASSERT_TRUE(response.result.has_value());
 
     auto &completionList = get<unique_ptr<CompletionList>>(*response.result);
+    fast_sort(completionList->items, [&](const auto &left, const auto &right) -> bool {
+        string leftText = left->sortText.has_value() ? left->sortText.value() : left->label;
+        string rightText = right->sortText.has_value() ? right->sortText.value() : right->label;
+
+        return leftText < rightText;
+    });
 
     // TODO(jez) Add ability to expect CompletionItemKind of each item
     string actualMessage =

--- a/test/testdata/lsp/completion/grandchild.rb
+++ b/test/testdata/lsp/completion/grandchild.rb
@@ -1,0 +1,21 @@
+# typed: true
+
+# The aaa/bbb/ccc bits would cause the completion items to be sorted
+# alphabetically (and thus incorrectly) by an LSP client, but we set an
+# explicit `sortText` on each item to override this behavior, and ensure that
+# our heuristics are in sole control of the sort order.
+
+class Parent
+  def method_from_aaa_parent; end
+end
+
+class Child < Parent
+  def method_from_bbb_child; end
+end
+
+class GrandChild < Child
+  def method_from_ccc_grand_child; end
+end
+
+GrandChild.new.method_from_ # error: does not exist
+#                          ^ completion: method_from_ccc_grand_child, method_from_bbb_child, method_from_aaa_parent


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I was only testing in Vim. My Vim plugin doesn't actually respect the LSP spec
it seems, as it keeps the completion items in the same order we return them.

In fact, VS Code respects the spec, which is to sort them by `sortText` if it
exists or `label` if it doesn't. Yay for testing in VS Code.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.