### PR TITLE
More accurate autocompletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,20 @@ Add the `, ...` suffix to the end of a partial list of completion results, and
 the test harness will ensure that the listed identifiers match a prefix of the
 completion items. This prefix must still be listed in order.
 
+If a location should report zero completion items, use the special message
+`(nothing)`:
+
+```ruby
+class A
+  def self.foo_1; end
+  def self.foo_2; end
+
+  zzz
+#    ^ completion: (nothing)
+end
+```
+
+
 #### Testing incremental typechecking
 
 In LSP mode, Sorbet runs file updates on a *fast path* or a *slow path*. It checks the structure of the

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -120,7 +120,7 @@ SimilarMethodsByName allSimilarMethods(const core::GlobalState &gs, core::Dispat
     }
 
     if (dispatchResult.secondary != nullptr) {
-        // Right now we completely ignore the secondaryKind (either AND or OR), and always union.
+        // Right now we completely ignore the secondaryKind (either AND or OR), and always intersect.
         // (See comment above mergeSimilarMethods)
         result = mergeSimilarMethods(result, allSimilarMethods(gs, *dispatchResult.secondary, prefix));
     }

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -964,8 +964,10 @@ void CompletionAssertion::check(const UnorderedMap<string, shared_ptr<core::File
 
     // TODO(jez) Add ability to expect CompletionItemKind of each item
     string actualMessage =
-        fmt::format("{}", fmt::map_join(completionList->items.begin(), completionList->items.end(), ", ",
-                                        [](const auto &item) -> string { return item->label; }));
+        completionList->items.size() == 0
+            ? "(nothing)"
+            : fmt::format("{}", fmt::map_join(completionList->items.begin(), completionList->items.end(), ", ",
+                                              [](const auto &item) -> string { return item->label; }));
 
     auto partial = absl::EndsWith(this->message, ", ...");
     if (partial) {

--- a/test/testdata/lsp/completion/depth.rb
+++ b/test/testdata/lsp/completion/depth.rb
@@ -1,7 +1,9 @@
 # typed: true
 
 class Depth2
+  # Parent with really good documentation
   def duplicate_method_1; end
+  # Parent with really good documentation
   def duplicate_method_2; end
 end
 
@@ -10,8 +12,9 @@ class Depth1 < Depth2
   def duplicate_method_2; end
 end
 
-# This test is designed to capture existing behavior, not test that we don't
-# regress this behavior. If this changes, it's fine.
+# We want to only show the method with that name at the lowest depth.
+# Note this isn't captured by the test, but we currently show the docs from
+# the child, even if the parent's docs would be better to show.
 
 Depth1.new.duplicate_ # error: does not exist
-#                    ^ completion: duplicate_method_1, duplicate_method_2, duplicate_method_1, duplicate_method_2
+#                    ^ completion: duplicate_method_1, duplicate_method_2

--- a/test/testdata/lsp/completion/intersection.rb
+++ b/test/testdata/lsp/completion/intersection.rb
@@ -19,18 +19,17 @@ module Unary
   def some_method(x); end
 end
 
-# The behavior here is the *same as* T.any. (Maybe you expected it to be the dual.)
-# See the comment in union.rb for more.
-
 def test
   ab = T.let(T.unsafe(nil), T.all(M, N))
   ab.foo_
-#        ^ completion: foo_common_1, foo_common_2, foo_only_on_a, foo_only_on_b
+#        ^ completion: foo_common_1, foo_common_2
 # ^^^^^^^ error: does not exist on `M`
 # ^^^^^^^ error: does not exist on `N`
 
   # TODO(jez) This is a weird case. There are two methods named `some_method`.
-  # We've decided to show *all* methods, but the arity on each component is different.
+  # We've decided to show all methods with the same name, but the arity on each
+  # component is different, so it'll be impossible to call even though we
+  # suggest it.
   nullary_or_unary = T.let(T.unsafe(nil), T.all(Nullary, Unary))
   nullary_or_unary.some_
 #                       ^ completion: some_method

--- a/test/testdata/lsp/completion/overloads_test.rb
+++ b/test/testdata/lsp/completion/overloads_test.rb
@@ -9,22 +9,8 @@ class A
   def my_method(x); end
 end
 
-A.new.my_metho # error: does not exist
-#             ^ completion: my_method
+# Not possible to see in the test, but in VS Code though these items have the
+# same name, they show up with different sigs.
 
-# TODO(jez) Eventually, we might want to expand this to show all overloads,
-# minus the one that we enter with UniqueNameKind::Overload.
-#
-# There are 3 symbols here. One of them was mangle renamed?
-# Looks like we mangleRenameSymbol in resolver before fillInInfoFromSig.
-#
-# class ::A < ::Object () @ overloads_test.rb:5
-#   method ::A#foo$1 (x, <blk>) @ overloads_test.rb:9
-#     argument x<> @ Loc {file=overloads_test.rb start=9:11 end=9:12}
-#     argument <blk><block> @ Loc {file=overloads_test.rb start=??? end=???}
-#   method ::A#foo (overload.1) (x, <blk>) -> Sorbet::Private::Static::Void @ overloads_test.rb:8
-#     argument x<> -> S @ Loc {file=overloads_test.rb start=8:15 end=8:16}
-#     argument <blk><block> -> T.untyped @ Loc {file=??? start=??? end=???}
-#   method ::A#foo (x, <blk>) -> Sorbet::Private::Static::Void @ overloads_test.rb:9
-#     argument x<> -> I @ Loc {file=overloads_test.rb start=7:15 end=7:16}
-#     argument <blk><block> -> T.untyped @ Loc {file=??? start=??? end=???}
+A.new.my_metho # error: does not exist
+#             ^ completion: my_method, my_method

--- a/test/testdata/lsp/completion/redefinition.rb
+++ b/test/testdata/lsp/completion/redefinition.rb
@@ -12,6 +12,7 @@ end
 
 def test
   a = A.new
+  # TODO(jez) Assert that we get the right redefinition based on the sig.
   a.some_ # error: does not exist
 #        ^ completion: some_method
 end

--- a/test/testdata/lsp/completion/union.rb
+++ b/test/testdata/lsp/completion/union.rb
@@ -19,28 +19,23 @@ class Unary
   def some_method(x); end
 end
 
-# Note how we suggest methods on either component. This is intential. People
-# would think it's a bug if completion "stopped working" for nilable receivers.
-# We'd rather show them the method then show them that it doesn't type check
-# because it's nil.
-
 def test
   ab = T.let(A.new, T.any(A, B))
   ab.foo_
-#        ^ completion: foo_common_1, foo_common_2, foo_only_on_a, foo_only_on_b
+#        ^ completion: foo_common_1, foo_common_2
 # ^^^^^^^ error: Method `foo_` does not exist on `A` component of `T.any(A, B)`
 # ^^^^^^^ error: Method `foo_` does not exist on `B` component of `T.any(A, B)`
 
   maybe_a = T.let(nil, T.nilable(A))
   maybe_a.foo_only
-#                 ^ completion: foo_only_on_a
+#                 ^ completion: (nothing)
 # ^^^^^^^^^^^^^^^^ error: Method `foo_only` does not exist on `A` component of `T.nilable(A)`
 # ^^^^^^^^^^^^^^^^ error: Method `foo_only` does not exist on `NilClass` component of `T.nilable(A)`
 
   # TODO(jez) This is a weird case. There are two methods named `some_method`.
-  # We've decided to show *all* methods, not just the intersection of methods.
-  # And, the arity on each component is different. But we'll only show one of
-  # the sigs, arbitrarily.
+  # We've decided to show all methods with the same name, but the arity on each
+  # component is different, so it'll be impossible to call even though we
+  # suggest it.
   nullary_or_unary = T.let(Nullary.new, T.any(Nullary, Unary))
   nullary_or_unary.some_
 #                       ^ completion: some_method


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Review by commit

- **Multiple changes to completion** (0d0988f66)

  - take the intersection of the dispatch components, not the union
  - don't dedup by original name, dedup by name (this means overloaded
   methods show up multiple times)
  - ... but throw away mangle renamed names (this means redefined methods
   show up with their redefined arity)
  - correctly dedup by depth (always shows only the child method, never
   the parent--we can easily tweak this if we want)

- **Add ability to assert zero completion item results** (11b6330c0)


- **The tests change because behavior changed** (4cf3b4eef)



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests change in behavior; this is enough.