### PR TITLE
Correctly detect generic type argument changes on fast path

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1080,7 +1080,12 @@ SymbolRef Symbol::enclosingClass(const GlobalState &gs) const {
 }
 
 u4 Symbol::hash(const GlobalState &gs) const {
-    u4 result = _hash(name.data(gs)->shortName(gs));
+    u4 result;
+    if (name.data(gs)->shortName(gs).find("bar") == 0) {
+        result = 1;
+    }
+
+    result = _hash(name.data(gs)->shortName(gs));
     result = mix(result, !this->resultType ? 0 : this->resultType->hash(gs));
     result = mix(result, this->flags);
     result = mix(result, this->owner._id);

--- a/core/Types.h
+++ b/core/Types.h
@@ -744,5 +744,16 @@ public:
     virtual std::string typeName() const final;
 };
 
+class UnresolvedAppliedType final : public ClassType {
+public:
+    const core::SymbolRef klass;
+    const std::vector<TypePtr> targs;
+    UnresolvedAppliedType(SymbolRef klass, std::vector<TypePtr> targs)
+        : ClassType(core::Symbols::untyped()), klass(klass), targs(std::move(targs)){};
+    virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
+    virtual std::string show(const GlobalState &gs) const final;
+    virtual std::string typeName() const final;
+};
+
 } // namespace sorbet::core
 #endif // SORBET_TYPES_H

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -38,6 +38,15 @@ string UnresolvedClassType::show(const GlobalState &gs) const {
         fmt::map_join(this->names, "::", [&](const auto &el) -> string { return el.data(gs)->show(gs); }));
 }
 
+string UnresolvedAppliedType::toStringWithTabs(const GlobalState &gs, int tabs) const {
+    return this->show(gs);
+}
+
+string UnresolvedAppliedType::show(const GlobalState &gs) const {
+    return fmt::format("{}[{}] (unresolved)", this->klass.data(gs)->show(gs),
+                       fmt::map_join(targs, ", ", [&](auto targ) { return targ->show(gs); }));
+}
+
 string LiteralType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return fmt::format("{}({})", this->underlying()->toStringWithTabs(gs, tabs), showValue(gs));
 }
@@ -424,6 +433,10 @@ string TypeVar::typeName() const {
 
 string UnresolvedClassType::typeName() const {
     return "UnresolvedClassType";
+}
+
+string UnresolvedAppliedType::typeName() const {
+    return "UnresolvedAppliedType";
 }
 
 string ClassType::typeName() const {

--- a/test/testdata/lsp/fast_path/method_signature_update_generics__def.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_signature_update_generics__def.1.rbupdate
@@ -1,0 +1,9 @@
+# typed: strict
+# assert-fast-path: method_signature_update_generics__def.rb,method_signature_update_generics__usage.rb
+
+module Foobar extend T::Sig
+  sig {params(s: T::Array[String]).returns(String)}
+  def self.bar(s)
+    "${s[0]}"
+  end
+end

--- a/test/testdata/lsp/fast_path/method_signature_update_generics__def.rb
+++ b/test/testdata/lsp/fast_path/method_signature_update_generics__def.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+module Foobar extend T::Sig
+  sig {params(s: T::Array[Integer]).returns(String)}
+  def self.bar(s)
+    "${s[0]}"
+  end
+end

--- a/test/testdata/lsp/fast_path/method_signature_update_generics__usage.rb
+++ b/test/testdata/lsp/fast_path/method_signature_update_generics__usage.rb
@@ -1,0 +1,9 @@
+# typed: strict
+
+module Bat extend T::Sig
+  sig {returns(String)}
+  def foo
+    Foobar.bar(["hello"]) # error: Expected `T::Array[Integer]`
+    #      ^ hover: sig {params(s: T::Array[Integer]).returns(String)}
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Correctly detect generic type argument changes on fast path.

* The fast path supports changing method argument types.
* We use hashes to determine if a method's signature has changed.
* `Type::hash()` just returns a hash of `toString()`, so we only detect a type change if `A->toString() != B->toString() `
* We run hashing after parsing, and before resolver passes.
* Prior to resolver passes, generic types are `T.undefined`.

This change introduces an `UnresolvedAppliedType`, which is similar to `UnresolvedClassType`. It is identical to `T.untyped`, but `toString()` is different.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Before this change, changing a method argument from `T::Array[Foo]` to `T::Array[Bar]` would not trigger a re-typechecking of call sites, as the method signature hash would view them as the same type.

Fixes https://github.com/sorbet/sorbet/issues/1845 .

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
