### PR TITLE
Make prefix-rooted matches take precendence in completion

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1,3 +1,4 @@
+#include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "common/typecase.h"
 #include "core/lsp/QueryResponse.h"
@@ -261,6 +262,13 @@ LSPResult LSPLoop::handleTextDocumentCompletion(unique_ptr<core::GlobalState> gs
                 auto leftShortName = left.method.data(*gs)->name.data(*gs)->shortName(*gs);
                 auto rightShortName = right.method.data(*gs)->name.data(*gs)->shortName(*gs);
                 if (leftShortName != rightShortName) {
+                    if (absl::StartsWith(leftShortName, prefix) && !absl::StartsWith(rightShortName, prefix)) {
+                        return true;
+                    }
+                    if (!absl::StartsWith(leftShortName, prefix) && absl::StartsWith(rightShortName, prefix)) {
+                        return false;
+                    }
+
                     return leftShortName < rightShortName;
                 }
 

--- a/test/testdata/lsp/completion/non_prefix.rb
+++ b/test/testdata/lsp/completion/non_prefix.rb
@@ -1,0 +1,8 @@
+# typed: true
+extend T::Sig
+
+sig {params(x: T::Array[Integer]).void}
+def foo(x)
+  x.me # error: does not exist
+  #   ^ completion: member?, method, methods, __method__, define_singleton_method, ...
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is actually what VS Code does for you, and I don't think it's in the spec,
but I want to be able to use this in tests, so I implemented our ranking such
that it does that manually.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.