### PR TITLE
Complete method names even with parse errors

### DIFF
--- a/core/errors/parser.h
+++ b/core/errors/parser.h
@@ -4,5 +4,9 @@
 
 namespace sorbet::core::errors::Parser {
 constexpr ErrorClass ParserError{2001, StrictLevel::False};
+
+// These errors should all be "recovered" parser errors.
+// Sorbet will take the fast path for all these errors.
+constexpr ErrorClass MethodWithoutSelector{2002, StrictLevel::False};
 } // namespace sorbet::core::errors::Parser
 #endif

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -52,6 +52,7 @@ NameDef names[] = {
     {"defined_p", "defined?"},
     {"undef"},
     {"each"},
+    {"missingFun", "<missing-fun>"},
 
     // used in CFG for temporaries
     {"whileTemp", "<whileTemp>"},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -491,6 +491,9 @@ DispatchResult dispatchCallSymbol(Context ctx, DispatchArgs args,
             return result;
         } else if (args.name == core::Names::super()) {
             return DispatchResult(Types::untypedUntracked(), std::move(args.selfType), Symbols::untyped());
+        } else if (args.name == Names::missingFun()) {
+            // We already emitted an error for this in the parser
+            return DispatchResult(Types::untypedUntracked(), std::move(args.selfType), Symbols::untyped());
         }
         auto result = DispatchResult(Types::untypedUntracked(), std::move(args.selfType), Symbols::noSymbol());
         if (auto e = ctx.state.beginError(args.locs.call, errors::Infer::UnknownMethod)) {

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -254,8 +254,10 @@ LSPResult LSPLoop::handleTextDocumentCompletion(unique_ptr<core::GlobalState> gs
         auto resp = move(queryResponses[0]);
 
         if (auto sendResp = resp->isSend()) {
-            auto prefix = sendResp->callerSideName.data(*gs)->shortName(*gs);
-            logger->debug("Looking for method similar to {}", prefix);
+            auto prefix = sendResp->callerSideName == core::Names::missingFun()
+                              ? ""
+                              : sendResp->callerSideName.data(*gs)->shortName(*gs);
+            logger->debug("Looking for method similar to '{}'", prefix);
 
             auto similarMethodsByName = allSimilarMethods(*gs, *sendResp->dispatchResult, prefix);
             for (auto &[methodName, similarMethods] : similarMethodsByName) {

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -409,7 +409,7 @@ public:
     unique_ptr<Node> call_method_missing_fun(unique_ptr<Node> receiver, const token *dot) {
         auto dotLoc = tokLoc(dot);
         auto level = ruby_parser::dlevel::ERROR;
-        auto err = ruby_parser::dclass::UnexpectedToken;
+        auto err = ruby_parser::dclass::MethodWithoutSelector;
         driver_->external_diagnostic(level, err, dotLoc.endPos(), dotLoc.endPos(), "syntax error");
 
         auto loc = receiver != nullptr ? receiver->loc.join(dotLoc) : dotLoc;

--- a/parser/Parser.cc
+++ b/parser/Parser.cc
@@ -47,7 +47,10 @@ public:
             }
             core::Loc loc(file, translatePos(diag.location().beginPos, maxOff - 1),
                           translatePos(diag.location().endPos, maxOff));
-            if (auto e = gs.beginError(loc, core::errors::Parser::ParserError)) {
+            auto sorbetErrorClass = diag.error_class() == ruby_parser::dclass::MethodWithoutSelector
+                                        ? core::errors::Parser::MethodWithoutSelector
+                                        : core::errors::Parser::ParserError;
+            if (auto e = gs.beginError(loc, sorbetErrorClass)) {
                 e.setHeader("Parse {}: {}", level, fmt::format(dclassStrings[(int)diag.error_class()], diag.data()));
             }
         }

--- a/test/testdata/lsp/completion/no_method_name.rb
+++ b/test/testdata/lsp/completion/no_method_name.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+class A
+  def foo; end
+end
+
+A.new. # error: Parse Error
+#     ^ completion: foo, ...

--- a/test/testdata/lsp/completion/no_method_name.rb.ast.exp
+++ b/test/testdata/lsp/completion/no_method_name.rb.ast.exp
@@ -1,0 +1,9 @@
+class <emptyTree><<C <root>>> < ()
+  class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
+    def foo<<C <todo sym>>>(&<blk>)
+      <emptyTree>
+    end
+  end
+
+  <emptyTree>::<C A>.new().<missing-fun>()
+end

--- a/test/testdata/lsp/fast_path/no_method_name.1.rbupdate
+++ b/test/testdata/lsp/fast_path/no_method_name.1.rbupdate
@@ -1,0 +1,7 @@
+# typed: true
+# assert-fast-path: no_method_name.rb
+class A
+  def foo; end
+end
+
+A.new. # error: Parse Error: unexpected token: syntax error

--- a/test/testdata/lsp/fast_path/no_method_name.rb
+++ b/test/testdata/lsp/fast_path/no_method_name.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+class A
+  def foo; end
+end
+
+A.new

--- a/third_party/parser/cc/grammars/typedruby.ypp
+++ b/third_party/parser/cc/grammars/typedruby.ypp
@@ -2061,6 +2061,10 @@ opt_block_args_tail:
                     {
                       $$ = driver.build.index(self, $1, $2, $3, $4);
                     }
+                | primary_value call_op
+                    {
+                      $$ = driver.build.call_method_missing_fun(self, $1, $2);
+                    }
 
      brace_block: tLCURLY brace_body tRCURLY
                     {

--- a/third_party/parser/codegen/generate_diagnostics.cc
+++ b/third_party/parser/codegen/generate_diagnostics.cc
@@ -68,6 +68,9 @@ tuple<string, string> MESSAGES[] = {
 
     // TypedRuby diagnostics
     {"NotStaticCpathInGeninst", "Type name in generic instance must be a static constant path"},
+
+    // Error messages from Sorbet trying to gracefully recover from parse errors
+    {"MethodWithoutSelector", "unexpected token: {}"},
 };
 
 void generateDclass() {

--- a/third_party/parser/include/ruby_parser/builder.hh
+++ b/third_party/parser/include/ruby_parser/builder.hh
@@ -31,6 +31,7 @@ struct builder {
 	ForeignPtr(*blockarg)(SelfPtr builder, const token* amper, const token* name);
 	ForeignPtr(*callLambda)(SelfPtr builder, const token* lambda);
 	ForeignPtr(*call_method)(SelfPtr builder, ForeignPtr receiver, const token* dot, const token* selector, const token* lparen, const node_list* args, const token* rparen);
+	ForeignPtr(*call_method_missing_fun)(SelfPtr builder, ForeignPtr receiver, const token* dot);
 	ForeignPtr(*case_)(SelfPtr builder, const token* case_, ForeignPtr expr, const node_list* whenBodies, const token* elseTok, ForeignPtr elseBody, const token* end);
 	ForeignPtr(*character)(SelfPtr builder, const token* char_);
 	ForeignPtr(*complex)(SelfPtr builder, const token* tok);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We now parse this:

```ruby
x.
```

like this:

```ruby
x.<missing-fun>
```

(instead of parsing an empty tree). This lets us recover from the parse error enough to serve autocompletion results on the file. I also made sure that we take the fast path for these syntax errors, with a test.

I suggest reviewing by commit.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.