### PR TITLE
Only skip serialization of repeated static fields

### DIFF
--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -23,40 +23,40 @@ com::stripe::rubytyper::Name Proto::toProto(const GlobalState &gs, NameRef name)
             break;
         case NameKind::UNIQUE:
             protoName.set_kind(com::stripe::rubytyper::Name::UNIQUE);
-            switch(name.data(gs)->unique.uniqueNameKind) {
-            case UniqueNameKind::Parser:
-                protoName.set_unique(com::stripe::rubytyper::Name::PARSER);
-                break;
-            case UniqueNameKind::Desugar:
-                protoName.set_unique(com::stripe::rubytyper::Name::DESUGAR);
-                break;
-            case UniqueNameKind::Namer:
-                protoName.set_unique(com::stripe::rubytyper::Name::NAMER);
-                break;
-            case UniqueNameKind::MangleRename:
-                protoName.set_unique(com::stripe::rubytyper::Name::MANGLE_RENAME);
-                break;
-            case UniqueNameKind::Singleton:
-                protoName.set_unique(com::stripe::rubytyper::Name::SINGLETON);
-                break;
-            case UniqueNameKind::Overload:
-                protoName.set_unique(com::stripe::rubytyper::Name::OVERLOAD);
-                break;
-            case UniqueNameKind::TypeVarName:
-                protoName.set_unique(com::stripe::rubytyper::Name::TYPE_VAR_NAME);
-                break;
-            case UniqueNameKind::PositionalArg:
-                protoName.set_unique(com::stripe::rubytyper::Name::POSITIONAL_ARG);
-                break;
-            case UniqueNameKind::MangledKeywordArg:
-                protoName.set_unique(com::stripe::rubytyper::Name::MANGLED_KEYWORD_ARG);
-                break;
-            case UniqueNameKind::ResolverMissingClass:
-                protoName.set_unique(com::stripe::rubytyper::Name::RESOLVER_MISSING_CLASS);
-                break;
-            case UniqueNameKind::OpusEnum:
-                protoName.set_unique(com::stripe::rubytyper::Name::OPUS_ENUM);
-                break;
+            switch (name.data(gs)->unique.uniqueNameKind) {
+                case UniqueNameKind::Parser:
+                    protoName.set_unique(com::stripe::rubytyper::Name::PARSER);
+                    break;
+                case UniqueNameKind::Desugar:
+                    protoName.set_unique(com::stripe::rubytyper::Name::DESUGAR);
+                    break;
+                case UniqueNameKind::Namer:
+                    protoName.set_unique(com::stripe::rubytyper::Name::NAMER);
+                    break;
+                case UniqueNameKind::MangleRename:
+                    protoName.set_unique(com::stripe::rubytyper::Name::MANGLE_RENAME);
+                    break;
+                case UniqueNameKind::Singleton:
+                    protoName.set_unique(com::stripe::rubytyper::Name::SINGLETON);
+                    break;
+                case UniqueNameKind::Overload:
+                    protoName.set_unique(com::stripe::rubytyper::Name::OVERLOAD);
+                    break;
+                case UniqueNameKind::TypeVarName:
+                    protoName.set_unique(com::stripe::rubytyper::Name::TYPE_VAR_NAME);
+                    break;
+                case UniqueNameKind::PositionalArg:
+                    protoName.set_unique(com::stripe::rubytyper::Name::POSITIONAL_ARG);
+                    break;
+                case UniqueNameKind::MangledKeywordArg:
+                    protoName.set_unique(com::stripe::rubytyper::Name::MANGLED_KEYWORD_ARG);
+                    break;
+                case UniqueNameKind::ResolverMissingClass:
+                    protoName.set_unique(com::stripe::rubytyper::Name::RESOLVER_MISSING_CLASS);
+                    break;
+                case UniqueNameKind::OpusEnum:
+                    protoName.set_unique(com::stripe::rubytyper::Name::OPUS_ENUM);
+                    break;
             }
             break;
         case NameKind::CONSTANT:

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -16,12 +16,48 @@ namespace sorbet::core {
 com::stripe::rubytyper::Name Proto::toProto(const GlobalState &gs, NameRef name) {
     com::stripe::rubytyper::Name protoName;
     protoName.set_name(name.show(gs));
+    protoName.set_unique(com::stripe::rubytyper::Name::NOT_UNIQUE);
     switch (name.data(gs)->kind) {
         case NameKind::UTF8:
             protoName.set_kind(com::stripe::rubytyper::Name::UTF8);
             break;
         case NameKind::UNIQUE:
             protoName.set_kind(com::stripe::rubytyper::Name::UNIQUE);
+            switch(name.data(gs)->unique.uniqueNameKind) {
+            case UniqueNameKind::Parser:
+                protoName.set_unique(com::stripe::rubytyper::Name::PARSER);
+                break;
+            case UniqueNameKind::Desugar:
+                protoName.set_unique(com::stripe::rubytyper::Name::DESUGAR);
+                break;
+            case UniqueNameKind::Namer:
+                protoName.set_unique(com::stripe::rubytyper::Name::NAMER);
+                break;
+            case UniqueNameKind::MangleRename:
+                protoName.set_unique(com::stripe::rubytyper::Name::MANGLE_RENAME);
+                break;
+            case UniqueNameKind::Singleton:
+                protoName.set_unique(com::stripe::rubytyper::Name::SINGLETON);
+                break;
+            case UniqueNameKind::Overload:
+                protoName.set_unique(com::stripe::rubytyper::Name::OVERLOAD);
+                break;
+            case UniqueNameKind::TypeVarName:
+                protoName.set_unique(com::stripe::rubytyper::Name::TYPE_VAR_NAME);
+                break;
+            case UniqueNameKind::PositionalArg:
+                protoName.set_unique(com::stripe::rubytyper::Name::POSITIONAL_ARG);
+                break;
+            case UniqueNameKind::MangledKeywordArg:
+                protoName.set_unique(com::stripe::rubytyper::Name::MANGLED_KEYWORD_ARG);
+                break;
+            case UniqueNameKind::ResolverMissingClass:
+                protoName.set_unique(com::stripe::rubytyper::Name::RESOLVER_MISSING_CLASS);
+                break;
+            case UniqueNameKind::OpusEnum:
+                protoName.set_unique(com::stripe::rubytyper::Name::OPUS_ENUM);
+                break;
+            }
             break;
         case NameKind::CONSTANT:
             protoName.set_kind(com::stripe::rubytyper::Name::CONSTANT);

--- a/gems/sorbet/lib/hidden-definition-finder.rb
+++ b/gems/sorbet/lib/hidden-definition-finder.rb
@@ -191,8 +191,8 @@ class Sorbet::Private::HiddenMethodFinder
     ret = []
 
     rbi.each do |rbi_entry|
-      # skip synthetic constants
-      next if rbi_entry["name"]["kind"] == "UNIQUE"
+      # skip duplicated constant fields
+      next if rbi_entry["name"]["kind"] == "UNIQUE" and rbi_entry["kind"] == "STATIC_FIELD"
 
       source_entry = source_by_name[rbi_entry["name"]["name"]]
 

--- a/gems/sorbet/lib/hidden-definition-finder.rb
+++ b/gems/sorbet/lib/hidden-definition-finder.rb
@@ -192,7 +192,7 @@ class Sorbet::Private::HiddenMethodFinder
 
     rbi.each do |rbi_entry|
       # skip duplicated constant fields
-      next if rbi_entry["name"]["kind"] == "UNIQUE" and rbi_entry["kind"] == "STATIC_FIELD"
+      next if rbi_entry["name"]["kind"] == "UNIQUE" and rbi_entry["name"]["unique"] == "MANGLE_RENAME"
 
       source_entry = source_by_name[rbi_entry["name"]["name"]]
 

--- a/gems/sorbet/test/snapshot/total/empty/expected/sorbet/rbi/sorbet-typed/lib/bundler/all/bundler.rbi
+++ b/gems/sorbet/test/snapshot/total/empty/expected/sorbet/rbi/sorbet-typed/lib/bundler/all/bundler.rbi
@@ -5,7 +5,7 @@
 #
 #   https://github.com/sorbet/sorbet-typed/edit/master/lib/bundler/all/bundler.rbi
 #
-# typed: strong
+# typed: true
 
 module Bundler
   FREEBSD = ::T.let(nil, ::T.untyped)

--- a/gems/sorbet/test/snapshot/total/sorbet-runtime/expected/sorbet/rbi/sorbet-typed/lib/bundler/all/bundler.rbi
+++ b/gems/sorbet/test/snapshot/total/sorbet-runtime/expected/sorbet/rbi/sorbet-typed/lib/bundler/all/bundler.rbi
@@ -5,7 +5,7 @@
 #
 #   https://github.com/sorbet/sorbet-typed/edit/master/lib/bundler/all/bundler.rbi
 #
-# typed: strong
+# typed: true
 
 module Bundler
   FREEBSD = ::T.let(nil, ::T.untyped)

--- a/proto/Name.proto
+++ b/proto/Name.proto
@@ -10,6 +10,22 @@ message Name {
         CONSTANT = 3;
     };
 
+    enum UniqueKind {
+         NOT_UNIQUE = 0;
+         PARSER = 1;
+         DESUGAR = 2;
+         NAMER = 3;
+         MANGLE_RENAME = 4;
+         SINGLETON = 5;
+         OVERLOAD = 6;
+         TYPE_VAR_NAME = 7;
+         POSITIONAL_ARG = 8;
+         MANGLED_KEYWORD_ARG = 9;
+         RESOLVER_MISSING_CLASS = 10;
+         OPUS_ENUM = 11;
+    };
+
     Kind kind = 1;
     string name = 2;
+    UniqueKind unique = 3;
 }

--- a/test/cli/symbol-table-json/symbol-table-json.out
+++ b/test/cli/symbol-table-json/symbol-table-json.out
@@ -12,7 +12,8 @@ No errors! Great job.
    "id": <redacted>,
    "name": {
     "kind": "UNIQUE",
-    "name": "\u003cClass:\u003croot\u003e\u003e"
+    "name": "\u003cClass:\u003croot\u003e\u003e",
+    "unique": "SINGLETON"
    },
    "kind": "CLASS_OR_MODULE",
    "id": <redacted>,
@@ -21,7 +22,8 @@ No errors! Great job.
      "id": <redacted>,
      "name": {
       "kind": "UNIQUE",
-      "name": "\u003cstatic-init\u003e"
+      "name": "\u003cstatic-init\u003e",
+      "unique": "NAMER"
      },
      "kind": "METHOD",
      "arguments": [
@@ -49,7 +51,8 @@ No errors! Great job.
    "id": <redacted>,
    "name": {
     "kind": "UNIQUE",
-    "name": "\u003cClass:A\u003e"
+    "name": "\u003cClass:A\u003e",
+    "unique": "SINGLETON"
    },
    "kind": "CLASS_OR_MODULE",
    "id": <redacted>,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes #1832: we previously would avoid serializing anything that had a mangled name at all, but that was too wide a hammer and would prevent needed symbols from being serialized into RBIs. We need to winnow down the allowed symbols and disallowed symbols.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This does not yet have an included test; we still need to build proper tests for `srb init`-style problems.
