### PR TITLE
Add sig for method CSV.generate

### DIFF
--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -285,6 +285,30 @@ class CSV < Object
   end
   def initialize(io=T.unsafe(nil), options=T.unsafe(nil)); end
 
+  # This method wraps a [`String`](https://docs.ruby-lang.org/en/2.6.0/String.html)
+  # you provide, or an empty default 
+  # [`String`](https://docs.ruby-lang.org/en/2.6.0/String.html), 
+  # in a [`CSV`](https://docs.ruby-lang.org/en/2.6.0/CSV.html) object which is passed 
+  # to the provided block. You can use the block to append 
+  # [`CSV`](https://docs.ruby-lang.org/en/2.6.0/CSV.html) rows to the 
+  # [`String`](https://docs.ruby-lang.org/en/2.6.0/String.html) and when 
+  # the block exits, the final String will be returned.
+  #
+  # # To a String
+  # csv_string = CSV.generate do |csv|
+  #   csv << ["row", "of", "CSV", "data"]
+  #   csv << ["another", "row"]
+  #   # ...
+  # end
+  sig do
+    params(
+        str: T.nilable(String),
+        options: T::Hash[Symbol, T.untyped],
+    )
+    .returns(T.nilable(String))
+  end
+  def self.generate(str=nil, options=T.unsafe(nil)); end
+
   # This method can be used to easily parse
   # [`CSV`](https://docs.ruby-lang.org/en/2.6.0/CSV.html) out of a
   # [`String`](https://docs.ruby-lang.org/en/2.6.0/String.html). You may either

--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -302,8 +302,8 @@ class CSV < Object
   # end
   sig do
     params(
-        str: T.nilable(String),
-        options: T::Hash[Symbol, T.untyped],
+      str: T.nilable(T.any(String,T::Hash[Symbol, T.untyped])),
+      options: T::Hash[Symbol, T.untyped],
     )
     .returns(T.nilable(String))
   end


### PR DESCRIPTION
Add Sig for Method generate on T.class_of(CSV)


### Motivation
Found error when type checking CSV.generate.

```ruby
string_csv = CSV.generate do |csv|
      csv << [
        'Name',
        'Closed Date',
        'Product Code'
      ]
end
```
```bash
Method generate does not exist on T.class_of(CSV) https://srb.help/7003
    14 |    string_csv = CSV.generate do |csv|
    15 |      csv << [
    16 |        'Name',
    17 |        'Closed Date',
    18 |        'Product Code'
       |...
```
