### PR TITLE
Add source code links to gemspecs.

### DIFF
--- a/gems/sorbet-runtime/sorbet-runtime.gemspec
+++ b/gems/sorbet-runtime/sorbet-runtime.gemspec
@@ -7,6 +7,9 @@ Gem::Specification.new do |s|
   s.files       = Dir.glob('lib/**/*')
   s.homepage    = 'https://sorbet.run'
   s.license     = 'Apache-2.0'
+  s.metadata = {
+    "source_code_uri" => "https://github.com/sorbet/sorbet"
+  }
 
   s.required_ruby_version = ['>= 2.3.0', '< 2.7.0.preview1']
 

--- a/gems/sorbet-static/sorbet-static.gemspec
+++ b/gems/sorbet-static/sorbet-static.gemspec
@@ -9,6 +9,9 @@ Gem::Specification.new do |s|
   s.executables = []
   s.homepage    = 'https://sorbet.run'
   s.license     = 'Apache-2.0'
+  s.metadata = {
+    "source_code_uri" => "https://github.com/sorbet/sorbet"
+  }
 
   # We include a pre-built binary (in libexec/), making us platform dependent.
   s.platform = Gem::Platform::CURRENT

--- a/gems/sorbet/sorbet.gemspec
+++ b/gems/sorbet/sorbet.gemspec
@@ -9,6 +9,9 @@ Gem::Specification.new do |s|
   s.executables = Dir.glob('bin/**/*').map {|path| path.gsub('bin/', '')}
   s.homepage    = 'https://sorbet.run'
   s.license     = 'Apache-2.0'
+  s.metadata = {
+    "source_code_uri" => "https://github.com/sorbet/sorbet"
+  }
 
   s.add_dependency 'sorbet-static', '0.0.0'
 


### PR DESCRIPTION
### Motivation
RubyGems has a "Source Code" link in the sidebar if you provide this information. You can see this on [activesupport](https://rubygems.org/gems/activesupport), for example. Right now the sorbet gems only have a home page.

Documentation for the `metadata` hash is here: https://guides.rubygems.org/specification-reference/#metadata