### PR TITLE
Document installation requirements for minimal environments (#948)

### DIFF
--- a/website/docs/adopting.md
+++ b/website/docs/adopting.md
@@ -20,6 +20,10 @@ gem 'sorbet-runtime'
 ❯ bundle install
 ```
 
+This should install cleanly in most Ruby development environments, but see
+["What platforms does Sorbet support?" in the FAQ](/docs/faq#what-platforms-does-sorbet-support)
+for some important caveats.
+
 ### Verify installation
 
 To test that everything is working so far, we can run these commands:

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -115,8 +115,28 @@ expect it to work on Ruby 2.3 through 2.6.
 
 The static check is only tested on macOS 10.14 (Mojave) and Ubuntu 18 (Bionic
 Beaver). We expect it to work on macOS 10.10 (Yosemite) and most Linux
-distributions. We use static linking on both platforms, so it should not depend
-on system libraries.
+distributions where `glibc`, `git` and `bash` are present. We use static linking
+on both platforms, so it should not depend on system libraries.
+
+If you are using one of the official minimal Ruby Docker images you will need to
+install the extra dependencies yourself:
+
+```Dockerfile
+FROM ruby:2.6-alpine
+
+RUN apk add --no-cache --update \
+    git \
+    bash \
+    ca-certificates \
+    wget
+
+ENV GLIBC_RELEASE_VERSION 2.30-r0
+RUN wget -nv -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
+    wget -nv https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_RELEASE_VERSION}/glibc-${GLIBC_RELEASE_VERSION}.apk && \
+    apk add glibc-${GLIBC_RELEASE_VERSION}.apk && \
+    rm /etc/apk/keys/sgerrand.rsa.pub && \
+    rm glibc-${GLIBC_RELEASE_VERSION}.apk
+```
 
 There is currently no Windows support.
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR adds documentation about the dependencies `bash`, `git`, and `glibc`. Fixes #948.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

As per #948, there are some undocumented installation requirements worth calling out explictly.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

![image](https://user-images.githubusercontent.com/4092/65939996-bf614500-e46a-11e9-9efd-bbeb5a4a4e5f.png)


![image](https://user-images.githubusercontent.com/4092/65939966-ae183880-e46a-11e9-9162-0c99e4c1da23.png)

