### PR TITLE
Hide private completion items unless allowed

### DIFF
--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -70,9 +70,10 @@ string LoadSelf::showRaw(core::Context ctx, int tabs) {
 }
 
 Send::Send(core::LocalVariable recv, core::NameRef fun, core::Loc receiverLoc,
-           const InlinedVector<core::LocalVariable, 2> &args, InlinedVector<core::Loc, 2> argLocs,
+           const InlinedVector<core::LocalVariable, 2> &args, InlinedVector<core::Loc, 2> argLocs, bool isPrivateOk,
            const shared_ptr<core::SendAndBlockLink> &link)
-    : recv(recv), fun(fun), receiverLoc(receiverLoc), argLocs(std::move(argLocs)), link(move(link)) {
+    : recv(recv), fun(fun), receiverLoc(receiverLoc), argLocs(std::move(argLocs)), isPrivateOk(isPrivateOk),
+      link(move(link)) {
     this->args.resize(args.size());
     int i = 0;
     for (const auto &e : args) {

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -87,16 +87,17 @@ public:
     core::Loc receiverLoc;
     InlinedVector<VariableUseSite, 2> args;
     InlinedVector<core::Loc, 2> argLocs;
+    bool isPrivateOk;
     std::shared_ptr<core::SendAndBlockLink> link;
 
     Send(core::LocalVariable recv, core::NameRef fun, core::Loc receiverLoc,
          const InlinedVector<core::LocalVariable, 2> &args, InlinedVector<core::Loc, 2> argLocs,
-         const std::shared_ptr<core::SendAndBlockLink> &link = nullptr);
+         bool isPrivateOk = false, const std::shared_ptr<core::SendAndBlockLink> &link = nullptr);
 
     virtual std::string toString(core::Context ctx);
     virtual std::string showRaw(core::Context ctx, int tabs = 0);
 };
-CheckSize(Send, 152, 8);
+CheckSize(Send, 160, 8);
 
 class Return final : public Instruction {
 public:

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -10,11 +10,14 @@ class TypeConstraint;
 
 class SendResponse final {
 public:
-    SendResponse(core::Loc termLoc, std::shared_ptr<core::DispatchResult> dispatchResult, core::NameRef callerSideName)
-        : dispatchResult(std::move(dispatchResult)), callerSideName(callerSideName), termLoc(termLoc){};
+    SendResponse(core::Loc termLoc, std::shared_ptr<core::DispatchResult> dispatchResult, core::NameRef callerSideName,
+                 bool isPrivateOk)
+        : dispatchResult(std::move(dispatchResult)), callerSideName(callerSideName), termLoc(termLoc),
+          isPrivateOk(isPrivateOk){};
     const std::shared_ptr<core::DispatchResult> dispatchResult;
     const core::NameRef callerSideName;
     const core::Loc termLoc;
+    const bool isPrivateOk;
 };
 
 class IdentResponse final {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -802,7 +802,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                 }
                 if (lspQueryMatch) {
                     core::lsp::QueryResponse::pushQueryResponse(
-                        ctx, core::lsp::SendResponse(bind.loc, retainedResult, send->fun));
+                        ctx, core::lsp::SendResponse(bind.loc, retainedResult, send->fun, send->isPrivateOk));
                 }
                 if (send->link) {
                     // This should eventually become ENFORCEs but currently they are wrong

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -280,7 +280,13 @@ LSPResult LSPLoop::handleTextDocumentCompletion(unique_ptr<core::GlobalState> gs
                 }
 
                 // Since each list is sorted by depth, taking the first elem dedups by depth within each name.
-                deduped.emplace_back(similarMethods[0]);
+                auto similarMethod = similarMethods[0];
+
+                if (similarMethod.method.data(*gs)->isPrivate() && !sendResp->isPrivateOk) {
+                    continue;
+                }
+
+                deduped.emplace_back(similarMethod);
             }
 
             fast_sort(deduped, [&](const auto &left, const auto &right) -> bool {

--- a/test/testdata/lsp/completion/private.rb
+++ b/test/testdata/lsp/completion/private.rb
@@ -1,0 +1,24 @@
+# typed: true
+
+class A
+  extend T::Sig
+
+  sig {returns(Integer)}
+  private def my_method_private
+    0
+  end
+
+  sig {returns(Integer)}
+  def my_method_public
+    0
+  end
+
+  sig {returns(Integer)}
+  def foo
+    my_method_ # error: does not exist
+    #         ^ completion: my_method_private, my_method_public
+  end
+end
+
+A.new.my_method_ # error: does not exist
+#               ^ completion: my_method_public


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

My original motivation for this change is that I wanted a way to only show
keyword completion items if there was no explicit receiver. It turns out that
"no explicit receiver" is also the criteria in which private methods are
allowed to be called, and also hiding private method completion items seems
like a nice to have, so this PR kills 2 birds with one stone (well, the keyword
completion change is stacked on this PR).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.