### PR TITLE
Have `T.class_of(A)` call externalType on the singleton

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1098,7 +1098,7 @@ public:
         SymbolRef self = unwrapSymbol(thisType);
         auto singleton = self.data(ctx)->lookupSingletonClass(ctx);
         if (singleton.exists()) {
-            res.returnType = make_type<ClassType>(singleton);
+            res.returnType = singleton.data(ctx)->externalType(ctx);
         } else {
             res.returnType = Types::classClass();
         }

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -494,7 +494,7 @@ core::TypePtr interpretTCombinator(core::MutableContext ctx, ast::Send *send, co
                 }
                 return core::Types::untypedUntracked();
             }
-            return core::make_type<core::ClassType>(singleton);
+            return singleton.data(ctx)->externalType(ctx);
         }
         case core::Names::untyped()._id:
             return core::Types::untyped(ctx, args.untypedBlame);

--- a/test/testdata/infer/generics/generics_class_of.rb
+++ b/test/testdata/infer/generics/generics_class_of.rb
@@ -1,0 +1,22 @@
+# typed: strict
+
+class A
+  extend T::Sig
+  extend T::Generic
+  Elem = type_template
+end
+
+class Test
+  extend T::Sig
+
+  # This exercises the parsing of `T.class_of(X)` where `X` has type_template
+  # members, ensuring that we're calling `externalType` on the singleton instead
+  # of just  making a `ClassType`.
+  sig {params(arg: T.class_of(A)).void}
+  def test(arg)
+    if arg < A
+      T.reveal_type(arg) # error: Revealed type: `T.class_of(A)[T.untyped]`
+    end
+  end
+
+end

--- a/test/testdata/infer/generics/generics_class_of.rb
+++ b/test/testdata/infer/generics/generics_class_of.rb
@@ -9,6 +9,10 @@ end
 class Test
   extend T::Sig
 
+  sig {params(arg: T.class_of(Test)).void}
+  def arg_test(arg)
+  end
+
   # This exercises the parsing of `T.class_of(X)` where `X` has type_template
   # members, ensuring that we're calling `externalType` on the singleton instead
   # of just  making a `ClassType`.
@@ -17,6 +21,10 @@ class Test
     if arg < A
       T.reveal_type(arg) # error: Revealed type: `T.class_of(A)[T.untyped]`
     end
+
+    # Exercise the `Object#class` intrinsic, ensuring that it calls
+    # `externalType` instead of just making a `ClassType` of the singleton.
+    self.arg_test(self.class)
   end
 
 end

--- a/test/testdata/infer/generics/generics_class_of.rb
+++ b/test/testdata/infer/generics/generics_class_of.rb
@@ -9,7 +9,7 @@ end
 class Test
   extend T::Sig
 
-  sig {params(arg: T.class_of(Test)).void}
+  sig {params(arg: T.class_of(A)).void}
   def arg_test(arg)
   end
 
@@ -24,7 +24,7 @@ class Test
 
     # Exercise the `Object#class` intrinsic, ensuring that it calls
     # `externalType` instead of just making a `ClassType` of the singleton.
-    self.arg_test(self.class)
+    self.arg_test(A.new.class)
   end
 
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The handling of `T.class_of(X)` in `type_syntax.cc` was making a `ClassType` instead of an `AppliedType` when `X` had type_template members defined on it. This fixes the problem by using `externalType` instead.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixes a bug where some branches were reported as being unreachable:
```ruby
# typed: strict

class A
  extend T::Sig
  extend T::Generic
  Elem = type_template
end

class Test
  extend T::Sig

  # This exercises the parsing of `T.class_of(X)` where `X` has type_template
  # members, ensuring that we're calling `externalType` on the singleton instead
  # of just  making a `ClassType`.
  sig {params(arg: T.class_of(A)).void}
  def test(arg)
    if arg < A
      T.reveal_type(arg) # error: Revealed type: `T.class_of(A)[T.untyped]`
      # ^^^ This is reported as unreachable on master
    end
  end

end
```

[-> sorbet.run](https://sorbet.run/#%23%20typed%3A%20strict%0A%0Aclass%20A%0A%20%20extend%20T%3A%3ASig%0A%20%20extend%20T%3A%3AGeneric%0A%20%20Elem%20%3D%20type_template%0Aend%0A%0Aclass%20Test%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20%23%20This%20exercises%20the%20parsing%20of%20%60T.class_of(X)%60%20where%20%60X%60%20has%20type_template%0A%20%20%23%20members%2C%20ensuring%20that%20we're%20calling%20%60externalType%60%20on%20the%20singleton%20instead%0A%20%20%23%20of%20just%20%20making%20a%20%60ClassType%60.%0A%20%20sig%20%7Bparams(arg%3A%20T.class_of(A)).void%7D%0A%20%20def%20test(arg)%0A%20%20%20%20if%20arg%20%3C%20A%0A%20%20%20%20%20%20T.reveal_type(arg)%20%23%20error%3A%20Revealed%20type%3A%20%60T.class_of(A)%5BT.untyped%5D%60%0A%20%20%20%20end%0A%20%20end%0A%0Aend)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
