### PR TITLE
Dumb keyword completion

### DIFF
--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -193,9 +193,10 @@ class LSPLoop {
                                            const CompletionParams &params) const;
     LSPResult handleTextDocumentCodeAction(std::unique_ptr<core::GlobalState> gs, const MessageId &id,
                                            const CodeActionParams &params) const;
-    std::unique_ptr<CompletionItem> getCompletionItem(const core::GlobalState &gs, core::SymbolRef what,
-                                                      core::TypePtr receiverType,
-                                                      const core::TypeConstraint *constraint, size_t sortIdx) const;
+    std::unique_ptr<CompletionItem> getCompletionItemForSymbol(const core::GlobalState &gs, core::SymbolRef what,
+                                                               core::TypePtr receiverType,
+                                                               const core::TypeConstraint *constraint,
+                                                               size_t sortIdx) const;
     void findSimilarConstantOrIdent(const core::GlobalState &gs, const core::TypePtr receiverType,
                                     std::vector<std::unique_ptr<CompletionItem>> &items) const;
     void sendShowMessageNotification(MessageType messageType, std::string_view message) const;

--- a/rbi/core/class.rbi
+++ b/rbi/core/class.rbi
@@ -155,7 +155,6 @@ class Class < Module
   # BasicObject.superclass   #=> nil
   # ```
   sig {returns(T.nilable(Class))}
-  sig {returns(Class)}
   def superclass(); end
 
   sig {void}

--- a/test/testdata/lsp/completion/keywords.rb
+++ b/test/testdata/lsp/completion/keywords.rb
@@ -1,0 +1,133 @@
+# typed: true
+
+# TODO(jez) These show up as IdentResponse's; currently unhandled
+# __ENCODING__
+# __LINE__
+# __FILE__
+
+# TODO(jez) These show up as ConstantResponse's; currently unhandled
+# BEGIN
+# END
+
+# `alias_method` is not a keyword
+alia # error: does not exist
+#   ^ alias, alias_method
+
+an # error: does not exist
+# ^ and, ancestors
+
+begi # error: does not exist
+#   ^ completion: begin
+
+brea # error: does not exist
+#   ^ completion: break
+
+cas # error: does not exist
+#  ^ completion: case
+
+clas # error: does not exist
+#   ^ completion: class, ...
+
+de # error: does not exist
+# ^ completion: def, defined?, ...
+
+defined # error: does not exist
+#      ^ completion: defined?, ...
+
+d # error: does not exist
+#^ completion: def, defined?, do, ...
+
+# `else` is more common--be sureit comes before `ensure`
+els # error: does not exist
+#  ^ completion: else, elsif
+
+elsi # error: does not exist
+#   ^ completion: elsif
+
+# `end` is more common--be sure it comes before `ensure`
+en # error: does not exist
+# ^ completion: end, ensure, ...
+
+ensur # error: does not exist
+#    ^ completion: ensure
+
+fals # error: does not exist
+#   ^ completion: false
+
+fo # error: does not exist
+# ^ completion: for, ...
+
+# `i` is a prefix of two keywords
+i # error: does not exist
+#^ completion: if, in, ...
+
+modul # error: does not exist
+#    ^ completion: module, ...
+
+nex # error: does not exist
+#  ^ completion: next
+
+ni # error: does not exist
+# ^ completion: nil, ...
+
+no # error: does not exist
+# ^ completion: not
+
+o # error: does not exist
+#^ completion: or, ...
+
+red # error: does not exist
+#  ^ completion: redo
+
+rescu # error: does not exist
+#    ^ completion: rescue
+
+retr # error: does not exist
+#   ^ completion: retry
+
+retur # error: does not exist
+#    ^ completion: return
+
+sel # error: does not exist
+#  ^ completion: self, ...
+
+supe # error: does not exist
+#   ^ completion: super, superclass
+
+# then is special; see below
+
+tru # error: does not exist
+#  ^ completion: true, ...
+
+# undef is special; see below
+
+unles # error: does not exist
+#    ^ completion: unless
+
+unti # error: does not exist
+#   ^ completion: until
+
+whe # error: does not exist
+#  ^ completion: when
+
+whil # error: does not exist
+#   ^ completion: while
+
+yiel # error: does not exist
+#   ^ completion: yield, ...
+
+# then is both a keyword and a method
+# 1) if ... then ... else ... end
+# 2) A.new.then
+the # error: does not exist
+#  ^ completion: then, then
+
+# ... so when keywords aren't allowed, only the method is suggested
+class A; end
+A.new.the # error: does not exist
+#        ^ completion: then
+
+# undefMethod comes before undef because undef is a method on Kernel
+# but undefMethod is a method on Module (Module < Object < Kernel)
+unde # error: does not exist
+#   ^ completion: undefMethod, undef


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We don't want `de` to complete to `define_method` and instead want `def`.


### Commit summary

Review by commit.

- **Dumb keyword completion** (e83ba7d62)

  "Dumb" here means that it never does something smart like completing to
  a snippet that lets you enter method names and which inserts the
  trailing `end`, etc. It's just string matching on the list of Ruby
  keywords.

- **Add a test for new behavior** (3548f32ec)

  I verified that it was failing. I also verified each of these results in
  VS Code while creating the test file.

  There are some edge-ish cases at the end of the file.

- **unrelated: Fix RBI for superclass** (b22e2392e)

  While looking at the completion results for `supe`, I noticed that
  `superclass` is overloaded but doesn't actually act overloaded (Sorbet
  only resolves overloads by arguments, not by `returns`. When there's
  ambiguity, it always takes the first one, so I kept the first one. Also,
  the documentation comment above says that `superclass` might return
  `nil`, so I think it's the most accurate too.)



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.