### PR TITLE
Stop attempting to recover from parse errors for completion

### DIFF
--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -406,22 +406,6 @@ public:
         }
     }
 
-    unique_ptr<Node> call_method_missing_fun(unique_ptr<Node> receiver, const token *dot, std::string last_token) {
-        auto dotLoc = tokLoc(dot);
-        auto level = ruby_parser::dlevel::ERROR;
-        auto err = ruby_parser::dclass::MethodWithoutSelector;
-        driver_->external_diagnostic(level, err, dotLoc.endPos(), dotLoc.endPos(), last_token);
-
-        auto loc = receiver != nullptr ? receiver->loc.join(dotLoc) : dotLoc;
-        auto method = core::Names::missingFun();
-        auto args = sorbet::parser::NodeVec{};
-        if ((dot != nullptr) && dot->string() == "&.") {
-            return make_unique<CSend>(loc, std::move(receiver), method, std::move(args));
-        } else {
-            return make_unique<Send>(loc, std::move(receiver), method, std::move(args));
-        }
-    }
-
     unique_ptr<Node> case_(const token *case_, unique_ptr<Node> expr, sorbet::parser::NodeVec whenBodies,
                            const token *elseTok, unique_ptr<Node> elseBody, const token *end) {
         return make_unique<Case>(tokLoc(case_).join(tokLoc(end)), std::move(expr), std::move(whenBodies),
@@ -1178,11 +1162,6 @@ ForeignPtr call_method(SelfPtr builder, ForeignPtr receiver, const token *dot, c
         build->call_method(build->cast_node(receiver), dot, selector, lparen, build->convertNodeList(args), rparen));
 }
 
-ForeignPtr call_method_missing_fun(SelfPtr builder, ForeignPtr receiver, const token *dot, std::string next_token) {
-    auto build = cast_builder(builder);
-    return build->toForeign(build->call_method_missing_fun(build->cast_node(receiver), dot, next_token));
-}
-
 ForeignPtr case_(SelfPtr builder, const token *case_, ForeignPtr expr, const node_list *whenBodies,
                  const token *elseTok, ForeignPtr elseBody, const token *end) {
     auto build = cast_builder(builder);
@@ -1696,7 +1675,6 @@ struct ruby_parser::builder Builder::interface = {
     blockarg,
     callLambda,
     call_method,
-    call_method_missing_fun,
     case_,
     character,
     complex,

--- a/test/testdata/lsp/completion/no_method_name.rb
+++ b/test/testdata/lsp/completion/no_method_name.rb
@@ -1,8 +1,0 @@
-# typed: true
-
-class A
-  def foo; end
-end
-
-A.new. # error: unexpected token $end
-#     ^ completion: foo, ...

--- a/test/testdata/lsp/completion/no_method_name.rb.ast.exp
+++ b/test/testdata/lsp/completion/no_method_name.rb.ast.exp
@@ -1,9 +1,0 @@
-class <emptyTree><<C <root>>> < ()
-  class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
-    def foo<<C <todo sym>>>(&<blk>)
-      <emptyTree>
-    end
-  end
-
-  <emptyTree>::<C A>.new().<missing-fun>()
-end

--- a/test/testdata/lsp/fast_path/no_method_name.1.rbupdate
+++ b/test/testdata/lsp/fast_path/no_method_name.1.rbupdate
@@ -1,7 +1,0 @@
-# typed: true
-# assert-fast-path: no_method_name.rb
-class A
-  def foo; end
-end
-
-A.new. # error: unexpected token $end

--- a/test/testdata/lsp/fast_path/no_method_name.rb
+++ b/test/testdata/lsp/fast_path/no_method_name.rb
@@ -1,7 +1,0 @@
-# typed: true
-
-class A
-  def foo; end
-end
-
-A.new

--- a/third_party/parser/cc/grammars/typedruby.ypp
+++ b/third_party/parser/cc/grammars/typedruby.ypp
@@ -2073,18 +2073,6 @@ opt_block_args_tail:
                     {
                       $$ = driver.build.index(self, $1, $2, $3, $4);
                     }
-                | primary_value call_op
-                    {
-                      std::string last_token = "syntax error";
-
-                      int token_type = static_cast<int>(driver.last_token->type());
-                      const char* token_str_name = yytname_[yytranslate_(token_type)];
-
-                      if (token_str_name != nullptr) {
-                        last_token = token_str_name;
-                      }
-                      $$ = driver.build.call_method_missing_fun(self, $1, $2, last_token);
-                    }
 
      brace_block: tLCURLY brace_body tRCURLY
                     {

--- a/third_party/parser/include/ruby_parser/builder.hh
+++ b/third_party/parser/include/ruby_parser/builder.hh
@@ -31,7 +31,6 @@ struct builder {
 	ForeignPtr(*blockarg)(SelfPtr builder, const token* amper, const token* name);
 	ForeignPtr(*callLambda)(SelfPtr builder, const token* lambda);
 	ForeignPtr(*call_method)(SelfPtr builder, ForeignPtr receiver, const token* dot, const token* selector, const token* lparen, const node_list* args, const token* rparen);
-	ForeignPtr(*call_method_missing_fun)(SelfPtr builder, ForeignPtr receiver, const token* dot, std::string last_token);
 	ForeignPtr(*case_)(SelfPtr builder, const token* case_, ForeignPtr expr, const node_list* whenBodies, const token* elseTok, ForeignPtr elseBody, const token* end);
 	ForeignPtr(*character)(SelfPtr builder, const token* char_);
 	ForeignPtr(*complex)(SelfPtr builder, const token* tok);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


This approach didn't end up working because I didn't test it well
enough. It didn't actually recover from the parse error inside a method
def like this:

    def foo
      A.
    end

I spent a little bit of time trying to figure out why and didn't see
anything obvious. Given that it seems to only work in limited scenarios,
I think it's more dangerous to keep this in than out. We can work around
this somehow else.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Deletes the tests.