### PR TITLE
Add stress-incremental tests

### DIFF
--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -28,6 +28,7 @@ const UnorderedMap<
         {"type", TypeAssertion::make},
         {"type-def", TypeDefAssertion::make},
         {"disable-fast-path", BooleanPropertyAssertion::make},
+        {"disable-stress-incremental", BooleanPropertyAssertion::make},
         {"exhaustive-apply-code-action", BooleanPropertyAssertion::make},
         {"assert-fast-path", FastPathAssertion::make},
         {"assert-slow-path", BooleanPropertyAssertion::make},

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -522,15 +522,11 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
         auto expectation = test.expectations.find("parse-tree");
         if (expectation != test.expectations.end()) {
             got["parse-tree"].append(nodes->toString(*gs)).append("\n");
-            auto newErrors = errorQueue->drainAllErrors();
-            errors.insert(errors.end(), make_move_iterator(newErrors.begin()), make_move_iterator(newErrors.end()));
         }
 
         expectation = test.expectations.find("parse-tree-json");
         if (expectation != test.expectations.end()) {
             got["parse-tree-json"].append(nodes->toJSON(*gs)).append("\n");
-            auto newErrors = errorQueue->drainAllErrors();
-            errors.insert(errors.end(), make_move_iterator(newErrors.begin()), make_move_iterator(newErrors.end()));
         }
 
         ast::ParsedFile file;
@@ -540,15 +536,11 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
         expectation = test.expectations.find("ast");
         if (expectation != test.expectations.end()) {
             got["ast"].append(file.tree->toString(*gs)).append("\n");
-            auto newErrors = errorQueue->drainAllErrors();
-            errors.insert(errors.end(), make_move_iterator(newErrors.begin()), make_move_iterator(newErrors.end()));
         }
 
         expectation = test.expectations.find("ast-raw");
         if (expectation != test.expectations.end()) {
             got["ast-raw"].append(file.tree->showRaw(*gs)).append("\n");
-            auto newErrors = errorQueue->drainAllErrors();
-            errors.insert(errors.end(), make_move_iterator(newErrors.begin()), make_move_iterator(newErrors.end()));
         }
 
         // DSL pass
@@ -557,15 +549,11 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
         expectation = test.expectations.find("dsl-tree");
         if (expectation != test.expectations.end()) {
             got["dsl-tree"].append(file.tree->toString(*gs)).append("\n");
-            auto newErrors = errorQueue->drainAllErrors();
-            errors.insert(errors.end(), make_move_iterator(newErrors.begin()), make_move_iterator(newErrors.end()));
         }
 
         expectation = test.expectations.find("dsl-tree-raw");
         if (expectation != test.expectations.end()) {
             got["dsl-tree-raw"].append(file.tree->showRaw(*gs)).append("\n");
-            auto newErrors = errorQueue->drainAllErrors();
-            errors.insert(errors.end(), make_move_iterator(newErrors.begin()), make_move_iterator(newErrors.end()));
         }
 
         // local vars
@@ -583,15 +571,11 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
         expectation = test.expectations.find("name-tree");
         if (expectation != test.expectations.end()) {
             got["name-tree"].append(file.tree->toString(*gs)).append("\n");
-            auto newErrors = errorQueue->drainAllErrors();
-            errors.insert(errors.end(), make_move_iterator(newErrors.begin()), make_move_iterator(newErrors.end()));
         }
 
         expectation = test.expectations.find("name-tree-raw");
         if (expectation != test.expectations.end()) {
             got["name-tree-raw"].append(file.tree->showRaw(*gs));
-            auto newErrors = errorQueue->drainAllErrors();
-            errors.insert(errors.end(), make_move_iterator(newErrors.begin()), make_move_iterator(newErrors.end()));
         }
 
         newTrees.emplace_back(move(file));
@@ -606,15 +590,11 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
         expectation = test.expectations.find("resolve-tree");
         if (expectation != test.expectations.end()) {
             got["resolve-tree"].append(resolvedTree.tree->toString(*gs)).append("\n");
-            auto newErrors = errorQueue->drainAllErrors();
-            errors.insert(errors.end(), make_move_iterator(newErrors.begin()), make_move_iterator(newErrors.end()));
         }
 
         expectation = test.expectations.find("resolve-tree-raw");
         if (expectation != test.expectations.end()) {
             got["resolve-tree-raw"].append(resolvedTree.tree->showRaw(*gs)).append("\n");
-            auto newErrors = errorQueue->drainAllErrors();
-            errors.insert(errors.end(), make_move_iterator(newErrors.begin()), make_move_iterator(newErrors.end()));
         }
     }
 
@@ -632,6 +612,9 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
             TEST_COUT << gotPhase.first << " OK" << '\n';
         }
     }
+
+    // and drain all the remaining errors
+    errorQueue->drainAllErrors();
 
     EXPECT_EQ(symbolsBefore, gs->symbolsUsed())
         << "the incremental resolver should not add new symbols";

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -516,9 +516,7 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
             make_shared<core::File>((string)f.file.data(*gs).path(), move(newSource), f.file.data(*gs).sourceType);
         gs = core::GlobalState::replaceFile(move(gs), f.file, move(newFile));
 
-        unique_ptr<KeyValueStore> kvstore;
         // this replicates the logic of pipeline::indexOne
-
         auto nodes = parser::Parser::run(*gs, f.file);
         auto expectation = test.expectations.find("parse-tree");
         if (expectation != test.expectations.end()) {
@@ -530,9 +528,8 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
             got["parse-tree-json"].append(nodes->toJSON(*gs)).append("\n");
         }
 
-        ast::ParsedFile file;
         core::MutableContext ctx(*gs, core::Symbols::root());
-        file = testSerialize(*gs, ast::ParsedFile{ast::desugar::node2Tree(ctx, move(nodes)), f.file});
+        ast::ParsedFile file = testSerialize(*gs, ast::ParsedFile{ast::desugar::node2Tree(ctx, move(nodes)), f.file});
 
         expectation = test.expectations.find("ast");
         if (expectation != test.expectations.end()) {
@@ -584,8 +581,6 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
 
     // resolver
     trees = resolver::Resolver::runTreePasses(ctx, move(newTrees));
-    auto newErrors = errorQueue->drainAllErrors();
-    errors.insert(errors.end(), make_move_iterator(newErrors.begin()), make_move_iterator(newErrors.end()));
 
     for (auto &resolvedTree : newTrees) {
         expectation = test.expectations.find("resolve-tree");

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -596,13 +596,13 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
 
     for (auto &gotPhase : got) {
         auto expectation = test.expectations.find(gotPhase.first);
-        ASSERT_TRUE(expectation != test.expectations.end()) << "missing expectation for " << gotPhase.first;
+        ASSERT_TRUE(expectation != test.expectations.end()) << "[stress-incremental] missing expectation for " << gotPhase.first;
         ASSERT_TRUE(expectation->second.size() == 1)
-            << "found unexpected multiple expectations of type " << gotPhase.first;
+            << "[stress-incremental] found unexpected multiple expectations of type " << gotPhase.first;
 
         auto checker = test.folder + expectation->second.begin()->second;
         auto expect = FileOps::read(checker.c_str());
-        EXPECT_EQ(expect, gotPhase.second) << "Mismatch on: " << checker;
+        EXPECT_EQ(expect, gotPhase.second) << "[stress-incremental] Mismatch on: " << checker;
         if (expect == gotPhase.second) {
             TEST_COUT << gotPhase.first << " OK" << '\n';
         }

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -497,7 +497,8 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
 
     // now we test the incremental resolver
 
-    auto disableStressIncremental = BooleanPropertyAssertion::getValue("disable-stress-incremental", assertions).value_or(false);
+    auto disableStressIncremental =
+        BooleanPropertyAssertion::getValue("disable-stress-incremental", assertions).value_or(false);
     auto isAutogenTest = test.expectations.find("autogen") != test.expectations.end();
     if (disableStressIncremental || isAutogenTest) {
         TEST_COUT << "errors OK" << '\n';
@@ -511,8 +512,8 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
     for (auto &f : trees) {
         const int prohibitedLines = f.file.data(*gs).source().size();
         auto newSource = fmt::format("{}\n{}", string(prohibitedLines, '\n'), f.file.data(*gs).source());
-        auto newFile = make_shared<core::File>((string)f.file.data(*gs).path(), move(newSource),
-                                               f.file.data(*gs).sourceType);
+        auto newFile =
+            make_shared<core::File>((string)f.file.data(*gs).path(), move(newSource), f.file.data(*gs).sourceType);
         gs = core::GlobalState::replaceFile(move(gs), f.file, move(newFile));
 
         unique_ptr<KeyValueStore> kvstore;
@@ -598,7 +599,6 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
         }
     }
 
-
     for (auto &gotPhase : got) {
         auto expectation = test.expectations.find(gotPhase.first);
         ASSERT_TRUE(expectation != test.expectations.end()) << "missing expectation for " << gotPhase.first;
@@ -616,8 +616,7 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
     // and drain all the remaining errors
     errorQueue->drainAllErrors();
 
-    EXPECT_EQ(symbolsBefore, gs->symbolsUsed())
-        << "the incremental resolver should not add new symbols";
+    EXPECT_EQ(symbolsBefore, gs->symbolsUsed()) << "the incremental resolver should not add new symbols";
 
     TEST_COUT << "errors OK" << '\n';
 } // namespace sorbet::test

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -596,7 +596,8 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
 
     for (auto &gotPhase : got) {
         auto expectation = test.expectations.find(gotPhase.first);
-        ASSERT_TRUE(expectation != test.expectations.end()) << "[stress-incremental] missing expectation for " << gotPhase.first;
+        ASSERT_TRUE(expectation != test.expectations.end())
+            << "[stress-incremental] missing expectation for " << gotPhase.first;
         ASSERT_TRUE(expectation->second.size() == 1)
             << "[stress-incremental] found unexpected multiple expectations of type " << gotPhase.first;
 

--- a/test/testdata/autogen/no_dsls.rb
+++ b/test/testdata/autogen/no_dsls.rb
@@ -1,3 +1,4 @@
 # typed: strict
+# disable-stress-incremental: true
 
 A = Struct.new(:a)

--- a/test/testdata/autogen/no_dsls.rb.autogen.exp
+++ b/test/testdata/autogen/no_dsls.rb.autogen.exp
@@ -16,12 +16,12 @@ requires: []
  name=[A]
  nesting=[]
  resolved=[A]
- loc=test/testdata/autogen/no_dsls.rb:3
+ loc=test/testdata/autogen/no_dsls.rb:4
  is_defining_ref=1
 [ref id=1]
  scope=[]
  name=[Struct]
  nesting=[]
  resolved=[Struct]
- loc=test/testdata/autogen/no_dsls.rb:3
+ loc=test/testdata/autogen/no_dsls.rb:4
  is_defining_ref=0

--- a/test/testdata/desugar/line_literal.rb
+++ b/test/testdata/desugar/line_literal.rb
@@ -1,3 +1,4 @@
 # typed: true
+# disable-stress-incremental: true
 puts "
 #{__LINE__}"

--- a/test/testdata/desugar/line_literal.rb.ast.exp
+++ b/test/testdata/desugar/line_literal.rb.ast.exp
@@ -1,3 +1,3 @@
 class <emptyTree><<C <root>>> < ()
-  <self>.puts("\n".concat(3.to_s()).to_s())
+  <self>.puts("\n".concat(4.to_s()).to_s())
 end

--- a/test/testdata/infer/overloads_test.rb
+++ b/test/testdata/infer/overloads_test.rb
@@ -1,4 +1,5 @@
 # typed: true
+# disable-stress-incremental: true
 
 # MutableContext::permitOverloadDefinitions is aware of this file name. Don't rename this file.
 class HasOverloads

--- a/test/testdata/lsp/completion/overloads_test.rb
+++ b/test/testdata/lsp/completion/overloads_test.rb
@@ -1,4 +1,5 @@
 # typed: true
+# disable-stress-incremental: true
 
 class I; end
 class S; end

--- a/test/testdata/namer/fuzz_repeated_kwarg.rb
+++ b/test/testdata/namer/fuzz_repeated_kwarg.rb
@@ -1,4 +1,5 @@
 # typed: false
+# disable-stress-incremental: true
 # from fuzzer: https://github.com/sorbet/sorbet/issues/1133
 def f1(x, x); end # error: Duplicated argument name `x`
 def f2(x, x=0); end # error: Duplicated argument name `x`

--- a/test/testdata/parser/misc.rb
+++ b/test/testdata/parser/misc.rb
@@ -1,4 +1,5 @@
 # typed: false
+# disable-stress-incremental: true
 # contains miscellaneous syntactic features in order of implementation
 # in our parser.
 

--- a/test/testdata/parser/misc.rb.ast.exp
+++ b/test/testdata/parser/misc.rb.ast.exp
@@ -116,7 +116,7 @@ class <emptyTree><<C <root>>> < ()
 
   x.to_hash()
 
-  86
+  87
 
   while true
     nil

--- a/test/testdata/resolver/overloads_test.rb
+++ b/test/testdata/resolver/overloads_test.rb
@@ -1,5 +1,6 @@
 # typed: true
 # disable-fast-path: true
+# disable-stress-incremental: true
 extend T::Sig
 
 sig {params(s: Integer).void}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
For more thorough testing of the fast-path; this adds a section to PosTests that performs the same operations as `--stress-incremental-resolver`: namely, adding whitespace to the beginning of the file and running the fast-path resolver again, and then checking to ensure that the parsed structures are identical.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Some of the tests were disabled: some of these genuinely cannot be tested with this option (in particular, any test that uses `__LINE__` is going to produce a different AST if we modify the whitespace) while a few others are bugs that need to be addressed. (The others that fail are attempting to add new symbols to the symbol table, so we need to discover why.)