### PR TITLE
LSP: When beginning a slow path, update the last committed epoch.

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1431,7 +1431,11 @@ void GlobalState::startCommitEpoch(u4 fromEpoch, u4 toEpoch) {
     // easily assert here to ensure that we are not moving backward in time.
     currentlyProcessingLSPEpoch->store(toEpoch);
     lspEpochInvalidator->store(toEpoch);
-    // Signifies that we have processed a bunch of epochs on the fast path before this one.
+    // lastCommittedLSPEpoch currently contains the epoch of the last slow path we processed. Since then, we may have
+    // committed several fast paths. So, update it to the epoch of the last fast path committed.
+    // We do it this way rather than keep it up-to-date after every fast path to reduce footguns, especially in testing.
+    // With this design, when starting a commit epoch, you have to specify the (from, to] range, and it is compiler
+    // enforced.
     lastCommittedLSPEpoch->store(fromEpoch);
 }
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1421,16 +1421,18 @@ bool GlobalState::wasTypecheckingCanceled() const {
     return lspEpochInvalidator->load() != currentlyProcessingLSPEpoch->load();
 }
 
-void GlobalState::startCommitEpoch(u4 epoch) {
+void GlobalState::startCommitEpoch(u4 fromEpoch, u4 toEpoch) {
     absl::MutexLock lock(epochMutex.get());
-    ENFORCE(epoch != currentlyProcessingLSPEpoch->load());
+    ENFORCE(fromEpoch != toEpoch);
+    ENFORCE(toEpoch != currentlyProcessingLSPEpoch->load());
+    ENFORCE(toEpoch != lastCommittedLSPEpoch->load());
     // epoch should be a version 'ahead' of currentlyProcessingLSPEpoch. The distance between the two is the number of
     // fast path edits that have come in since the last slow path. Since epochs overflow, there's nothing that I can
     // easily assert here to ensure that we are not moving backward in time.
-    currentlyProcessingLSPEpoch->store(epoch);
-    lspEpochInvalidator->store(epoch);
-    // These should always be different.
-    ENFORCE(epoch != lastCommittedLSPEpoch->load());
+    currentlyProcessingLSPEpoch->store(toEpoch);
+    lspEpochInvalidator->store(toEpoch);
+    // Signifies that we have processed a bunch of epochs on the fast path before this one.
+    lastCommittedLSPEpoch->store(fromEpoch);
 }
 
 optional<pair<u4, u4>> GlobalState::getRunningSlowPath() const {

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -197,7 +197,7 @@ public:
     bool tryCommitEpoch(u4 epoch, bool isCancelable, std::function<void()> typecheck);
     // [LSP] Run only from the typechecking thread.
     // Indicates an intent to begin committing a specific epoch.
-    void startCommitEpoch(u4 epoch);
+    void startCommitEpoch(u4 fromEpoch, u4 toEpoch);
     // [LSP] Returns 'true' if the currently running typecheck run has been canceled.
     bool wasTypecheckingCanceled() const;
     // [LSP] If a slow path is running on this GlobalState or its descendent, returns a pair of the committed

--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -163,7 +163,7 @@ void LSPLoop::maybeStartCommitSlowPathEdit(core::GlobalState &gs, const LSPMessa
         // commit for an epoch if this message will trigger a cancelable slow path.
         const auto &params = get<unique_ptr<SorbetWorkspaceEditParams>>(msg.asNotification().params);
         if (!params->updates.canTakeFastPath) {
-            gs.startCommitEpoch(params->updates.versionEnd);
+            gs.startCommitEpoch(params->updates.versionStart - 1, params->updates.versionEnd);
         }
     }
 }

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -656,7 +656,4 @@ TEST(SlowPathCancelation, DoesNotIncludeOldEditsInCombinedEdit) { // NOLINT
     ASSERT_EQ(updates->updatedFiles[0]->source(), fooV4);
 }
 
-// Fast path, barrier, slow path
-// New edit: Fast path given slow path.
-
 } // namespace sorbet::realmain::lsp::test


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

When beginning a slow path, update the last committed epoch.

Avoids re-processing fast path edits when a slow path gets canceled.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Reduce activity in the message queue lock critical section when merging updates / making a cancelation decision.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
