### PR TITLE
Complete `x.f` to `x.foo` not `x.foo()` for 0 args

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,36 @@ class A
 end
 ```
 
+To write a test for the snippet that would be inserted into the document if a
+particular completion item was selected, you can make two files:
+
+```
+# -- test/testdata/lsp/completion/mytest.rb --
+class A
+  def self.foo_1; end
+end
+
+A.foo_
+#     ^ apply-completion: [A] item: 0
+```
+
+The `apply-completion` assertion says "make sure the file `mytest.A.rbedited`
+contains the result of inserting the completion snippet for the 0th completion
+item into the file."
+
+```
+# -- test/testdata/lsp/completion/mytest.A.rbedited --
+class A
+  def self.foo_1; end
+end
+
+A.foo_1${0}
+#     ^ apply-completion: [A] item: 0
+```
+
+As you can see, the fancy `${...}` (tabstop placeholders) show up verbatim in
+the output if they were sent in the completion response.
+
 
 #### Testing incremental typechecking
 

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -196,7 +196,7 @@ class LSPLoop {
     std::unique_ptr<CompletionItem> getCompletionItemForSymbol(const core::GlobalState &gs, core::SymbolRef what,
                                                                core::TypePtr receiverType,
                                                                const core::TypeConstraint *constraint,
-                                                               size_t sortIdx) const;
+                                                               std::string_view prefix, size_t sortIdx) const;
     void findSimilarConstantOrIdent(const core::GlobalState &gs, const core::TypePtr receiverType,
                                     std::vector<std::unique_ptr<CompletionItem>> &items) const;
     void sendShowMessageNotification(MessageType messageType, std::string_view message) const;

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -223,7 +223,11 @@ string methodSnippet(const core::GlobalState &gs, core::SymbolRef method) {
         }
     }
 
-    return fmt::format("{}({}){}", shortName, fmt::join(typeAndArgNames, ", "), "${0}");
+    if (typeAndArgNames.empty()) {
+        return fmt::format("{}{}", shortName, "${0}");
+    } else {
+        return fmt::format("{}({}){}", shortName, fmt::join(typeAndArgNames, ", "), "${0}");
+    }
 }
 
 unique_ptr<CompletionItem> getCompletionItemForKeyword(const LSPConfiguration &config, const RubyKeyword &rubyKeyword,

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -260,6 +260,32 @@ public:
     std::string toString() const override;
 };
 
+// ^ apply-completion: [version] index
+class ApplyCompletionAssertion final : public RangeAssertion {
+public:
+    static std::shared_ptr<ApplyCompletionAssertion> make(std::string_view filename, std::unique_ptr<Range> &range,
+                                                          int assertionLine, std::string_view assertionContents,
+                                                          std::string_view assertionType);
+
+    /** Checks all ApplyCompletionAssertions within the assertion vector. Skips over non-ApplyCompletionAssertions. */
+    static void checkAll(const std::vector<std::shared_ptr<RangeAssertion>> &assertions,
+                         const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents,
+                         LSPWrapper &wrapper, int &nextId, std::string_view uriPrefix, std::string errorPrefix = "");
+
+    ApplyCompletionAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
+                             std::string_view version, int index);
+
+    // The part between [..] in the assertion which specifies which `.[..].rbedited` file to compare against
+    const std::string version;
+    // Index into CompletionItem list of which item to apply (zero-indexed)
+    const int index;
+
+    void check(const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents, LSPWrapper &wrapper,
+               int &nextId, std::string_view uriPrefix, std::string errorPrefix = "");
+
+    std::string toString() const override;
+};
+
 // # ^^^ apply-code-action: [version] title
 class ApplyCodeActionAssertion final : public RangeAssertion {
 public:

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -993,6 +993,7 @@ TEST_P(LSPTest, All) {
 
     // Completion assertions
     CompletionAssertion::checkAll(assertions, test.sourceFileContents, *lspWrapper, nextId, rootUri);
+    ApplyCompletionAssertion::checkAll(assertions, test.sourceFileContents, *lspWrapper, nextId, rootUri);
 
     // Fast path tests: Asserts that certain changes take the fast/slow path, and produce any expected diagnostics.
     {

--- a/test/testdata/lsp/completion/no_parens.A.rbedited
+++ b/test/testdata/lsp/completion/no_parens.A.rbedited
@@ -1,0 +1,8 @@
+# typed: true
+
+class A
+  def foo_1; end
+end
+
+A.new.foo_1()${0} # error: does not exist
+#         ^ apply-completion: [A] item: 0

--- a/test/testdata/lsp/completion/no_parens.A.rbedited
+++ b/test/testdata/lsp/completion/no_parens.A.rbedited
@@ -4,5 +4,5 @@ class A
   def foo_1; end
 end
 
-A.new.foo_1()${0} # error: does not exist
+A.new.foo_1${0} # error: does not exist
 #         ^ apply-completion: [A] item: 0

--- a/test/testdata/lsp/completion/no_parens.rb
+++ b/test/testdata/lsp/completion/no_parens.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+class A
+  def foo_1; end
+end
+
+A.new.foo_ # error: does not exist
+#         ^ apply-completion: [A] item: 0

--- a/test/testdata/lsp/completion/overloads_test.A.rbedited
+++ b/test/testdata/lsp/completion/overloads_test.A.rbedited
@@ -16,7 +16,7 @@ end
 # The order here doesn't particularly matter; if you're here because you made a
 # change to the order that broke this test, feel free to update the test.
 
-A.new.my_metho # error: does not exist
+A.new.my_method(${1:S})${0} # error: does not exist
 #             ^ completion: my_method, my_method
 #             ^ apply-completion: [A] item: 0
 #             ^ apply-completion: [B] item: 1

--- a/test/testdata/lsp/completion/overloads_test.B.rbedited
+++ b/test/testdata/lsp/completion/overloads_test.B.rbedited
@@ -16,7 +16,7 @@ end
 # The order here doesn't particularly matter; if you're here because you made a
 # change to the order that broke this test, feel free to update the test.
 
-A.new.my_metho # error: does not exist
+A.new.my_method(${1:I})${0} # error: does not exist
 #             ^ completion: my_method, my_method
 #             ^ apply-completion: [A] item: 0
 #             ^ apply-completion: [B] item: 1

--- a/test/testdata/lsp/completion/snippet_arity.A.rbedited
+++ b/test/testdata/lsp/completion/snippet_arity.A.rbedited
@@ -1,0 +1,23 @@
+# typed: true
+
+class Test
+  def test_method_nullary; end
+
+  def test_method_unary(x); end
+
+  def test_method_binary(x, y); end
+
+  def test_method_kwarg(x:); end
+end
+
+Test.new.test_method_nullary${0} # error: does not exist
+#                        ^ apply-completion: [A] item: 0
+
+Test.new.test_method_unar # error: does not exist
+#                        ^ apply-completion: [B] item: 0
+
+Test.new.test_method_bina # error: does not exist
+#                        ^ apply-completion: [C] item: 0
+
+Test.new.test_method_kwar # error: does not exist
+#                        ^ apply-completion: [D] item: 0

--- a/test/testdata/lsp/completion/snippet_arity.B.rbedited
+++ b/test/testdata/lsp/completion/snippet_arity.B.rbedited
@@ -1,0 +1,23 @@
+# typed: true
+
+class Test
+  def test_method_nullary; end
+
+  def test_method_unary(x); end
+
+  def test_method_binary(x, y); end
+
+  def test_method_kwarg(x:); end
+end
+
+Test.new.test_method_null # error: does not exist
+#                        ^ apply-completion: [A] item: 0
+
+Test.new.test_method_unary(${1})${0} # error: does not exist
+#                        ^ apply-completion: [B] item: 0
+
+Test.new.test_method_bina # error: does not exist
+#                        ^ apply-completion: [C] item: 0
+
+Test.new.test_method_kwar # error: does not exist
+#                        ^ apply-completion: [D] item: 0

--- a/test/testdata/lsp/completion/snippet_arity.C.rbedited
+++ b/test/testdata/lsp/completion/snippet_arity.C.rbedited
@@ -1,0 +1,23 @@
+# typed: true
+
+class Test
+  def test_method_nullary; end
+
+  def test_method_unary(x); end
+
+  def test_method_binary(x, y); end
+
+  def test_method_kwarg(x:); end
+end
+
+Test.new.test_method_null # error: does not exist
+#                        ^ apply-completion: [A] item: 0
+
+Test.new.test_method_unar # error: does not exist
+#                        ^ apply-completion: [B] item: 0
+
+Test.new.test_method_binary(${1}, ${2})${0} # error: does not exist
+#                        ^ apply-completion: [C] item: 0
+
+Test.new.test_method_kwar # error: does not exist
+#                        ^ apply-completion: [D] item: 0

--- a/test/testdata/lsp/completion/snippet_arity.D.rbedited
+++ b/test/testdata/lsp/completion/snippet_arity.D.rbedited
@@ -1,0 +1,23 @@
+# typed: true
+
+class Test
+  def test_method_nullary; end
+
+  def test_method_unary(x); end
+
+  def test_method_binary(x, y); end
+
+  def test_method_kwarg(x:); end
+end
+
+Test.new.test_method_null # error: does not exist
+#                        ^ apply-completion: [A] item: 0
+
+Test.new.test_method_unar # error: does not exist
+#                        ^ apply-completion: [B] item: 0
+
+Test.new.test_method_bina # error: does not exist
+#                        ^ apply-completion: [C] item: 0
+
+Test.new.test_method_kwarg(x: ${1})${0} # error: does not exist
+#                        ^ apply-completion: [D] item: 0

--- a/test/testdata/lsp/completion/snippet_arity.rb
+++ b/test/testdata/lsp/completion/snippet_arity.rb
@@ -1,0 +1,23 @@
+# typed: true
+
+class Test
+  def test_method_nullary; end
+
+  def test_method_unary(x); end
+
+  def test_method_binary(x, y); end
+
+  def test_method_kwarg(x:); end
+end
+
+Test.new.test_method_null # error: does not exist
+#                        ^ apply-completion: [A] item: 0
+
+Test.new.test_method_unar # error: does not exist
+#                        ^ apply-completion: [B] item: 0
+
+Test.new.test_method_bina # error: does not exist
+#                        ^ apply-completion: [C] item: 0
+
+Test.new.test_method_kwar # error: does not exist
+#                        ^ apply-completion: [D] item: 0

--- a/test/testdata/lsp/completion/snippet_types.A.rbedited
+++ b/test/testdata/lsp/completion/snippet_types.A.rbedited
@@ -1,0 +1,11 @@
+# typed: true
+
+class Test
+  extend T::Sig
+
+  sig {params(x: Integer).void}
+  def x_is_integer(x); end
+end
+
+Test.new.x_is_integer(${1:Integer})${0} # error: does not exist
+#             ^ apply-completion: [A] item: 0

--- a/test/testdata/lsp/completion/snippet_types.rb
+++ b/test/testdata/lsp/completion/snippet_types.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+class Test
+  extend T::Sig
+
+  sig {params(x: Integer).void}
+  def x_is_integer(x); end
+end
+
+Test.new.x_is_ # error: does not exist
+#             ^ apply-completion: [A] item: 0


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Our rubocops ban putting the parens there, so we should probably not put
the parens there.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I can't test this yet. I have some ideas on how to write tests for these
things, but I haven't implemented them yet (note that the snippet text from
before was also untested).