### PR TITLE
Relax runtime override checks

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
@@ -58,11 +58,7 @@ module T::Private::Methods::SignatureValidation
   def self.validate_override_mode(signature, super_signature)
     case signature.mode
     when *Modes::OVERRIDE_MODES
-      if !Modes::OVERRIDABLE_MODES.include?(super_signature.mode)
-        raise "You declared `#{signature.method_name}` as #{pretty_mode(signature)}, but the method it overrides is not declared as `overridable` or `abstract`.\n" \
-              "  Parent definition: #{method_loc_str(super_signature.method)}\n" \
-              "  Child definition:  #{method_loc_str(signature.method)}\n"
-      end
+      # Peaceful
     when *Modes::NON_OVERRIDE_MODES
       if super_signature.mode == Modes.standard
         # Peaceful

--- a/gems/sorbet-runtime/test/types/method_modes.rb
+++ b/gems/sorbet-runtime/test/types/method_modes.rb
@@ -95,7 +95,7 @@ class Opus::Types::Test::MethodModesTest < Critic::Unit::UnitTest
       klass.new.foo
     end
 
-    it "raises when overriding a standard method with .override" do
+    it "succeeds when overriding a standard method with .override" do
       parent = Class.new do
         extend T::Sig
         extend T::Helpers
@@ -109,16 +109,6 @@ class Opus::Types::Test::MethodModesTest < Critic::Unit::UnitTest
         sig {override.returns(Object)}
         def foo; end
       end
-
-      err = assert_raises(RuntimeError) do
-        klass.new.foo
-      end
-
-      assert_includes(
-        err.message,
-        "You declared `foo` as .override, but the method it overrides is not declared as `overridable` or `abstract`.\n" \
-        "  Parent definition: #{parent} at #{__FILE__}"
-      )
     end
 
     it "succeeds when overriding an unannotated method with bare sig" do


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Stepping stone to getting rid of `overridable`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
