### PR TITLE
TStruct's InvalidTypeError should trigger `call_validation_error_handler`

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -143,22 +143,40 @@ class T::Props::Decorator
       end
 
       if rules[:raise_on_nil_write]
-        T::Private::Casts.cast(val, type, "T::Struct.set")
+        raise T::Props::InvalidValueError.new("Can't set #{@class.name}.#{prop} to #{val.inspect} " \
+        "(instance of #{val.class}) - need a #{type}")
       end
     end
 
     # T::Props::CustomType is not a real object based class so that we can not run real type check call.
     # T::Props::CustomType.valid?() is only a helper function call.
+    valid =
+      if type.is_a?(T::Props::CustomType) && T::Props::Utils.optional_prop?(rules)
+        type.valid?(val)
+      else
+        type_object.valid?(val)
+      end
 
-    # TODO: understand the value of type here and whether we can just feed it to Casts or not
-    # T::Private::Casts.cast(val, type, "T::Struct.set")
-    # valid =
-    #   if type.is_a?(T::Props::CustomType) && T::Props::Utils.optional_prop?(rules)
-    #     type.valid?(val)
-    #   else
-    #     type_object.valid?(val)
-    #   end
-    T::Private::Casts.cast(val, type, "T::Struct.set")
+    if !valid
+      raise T::Props::InvalidValueError.new("Can't set #{@class.name}.#{prop} to #{val.inspect} " \
+        "(instance of #{val.class}) - need a #{type_object}")
+    end
+  rescue T::Props::InvalidValueError => err
+    caller_loc = T.must(caller_locations(8, 1))[0]
+
+    pretty_message = "Parameter '#{prop}': #{err.message}\n" \
+      "Caller: #{caller_loc.path}:#{caller_loc.lineno}\n"
+
+    T::Configuration.call_validation_error_handler(
+      rules,
+      message: err.message,
+      pretty_message: pretty_message,
+      kind: 'Parameter',
+      name: prop,
+      type: type,
+      value: val,
+      location: caller_loc,
+    )
   end
 
   # For performance, don't use named params here.

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -168,7 +168,7 @@ class T::Props::Decorator
       "Caller: #{caller_loc.path}:#{caller_loc.lineno}\n"
 
     T::Configuration.call_validation_error_handler(
-      rules,
+      nil,
       message: err.message,
       pretty_message: pretty_message,
       kind: 'Parameter',

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -143,23 +143,22 @@ class T::Props::Decorator
       end
 
       if rules[:raise_on_nil_write]
-        raise T::Props::InvalidValueError.new("Can't set #{@class.name}.#{prop} to #{val.inspect} " \
-        "(instance of #{val.class}) - need a #{type}")
+        T::Private::Casts.cast(val, type, "T::Struct.set")
       end
     end
 
     # T::Props::CustomType is not a real object based class so that we can not run real type check call.
     # T::Props::CustomType.valid?() is only a helper function call.
-    valid =
-      if type.is_a?(T::Props::CustomType) && T::Props::Utils.optional_prop?(rules)
-        type.valid?(val)
-      else
-        type_object.valid?(val)
-      end
-    if !valid
-      raise T::Props::InvalidValueError.new("Can't set #{@class.name}.#{prop} to #{val.inspect} " \
-        "(instance of #{val.class}) - need a #{type_object}")
-    end
+
+    # TODO: understand the value of type here and whether we can just feed it to Casts or not
+    # T::Private::Casts.cast(val, type, "T::Struct.set")
+    # valid =
+    #   if type.is_a?(T::Props::CustomType) && T::Props::Utils.optional_prop?(rules)
+    #     type.valid?(val)
+    #   else
+    #     type_object.valid?(val)
+    #   end
+    T::Private::Casts.cast(val, type, "T::Struct.set")
   end
 
   # For performance, don't use named params here.

--- a/gems/sorbet-runtime/test/types/props/constructor.rb
+++ b/gems/sorbet-runtime/test/types/props/constructor.rb
@@ -44,7 +44,7 @@ class Opus::Types::Test::Props::ConstructorTest < Critic::Unit::UnitTest
   end
 
   it 'checks types' do
-    assert_raises(T::Props::InvalidValueError) do
+    assert_raises(TypeError) do
       MyStruct.new(name: 100)
     end
   end

--- a/gems/sorbet-runtime/test/types/props/decorator.rb
+++ b/gems/sorbet-runtime/test/types/props/decorator.rb
@@ -175,13 +175,12 @@ class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest
   describe 'validating prop values' do
     it 'validates subdoc hashes have the correct values' do
 
-      assert_raises(T::Props::InvalidValueError) do
+      assert_raises(TypeError) do
         StructHash.new(the_hash: {'foo' => {}})
       end
 
       # no raise:
       StructHash.new(the_hash: {'foo' => StructHash::InnerStruct.new})
-
     end
   end
 

--- a/gems/sorbet-runtime/test/types/props/struct.rb
+++ b/gems/sorbet-runtime/test/types/props/struct.rb
@@ -44,10 +44,10 @@ class Opus::Types::Test::Props::StructTest < Critic::Unit::UnitTest
   end
 
   it 'type check hash field correspondingly' do
-    assert_raises(T::Props::InvalidValueError) do
+    assert_raises(TypeError) do
       StructWithPredefinedHash.new(hash_field1: {a: 'foo', b: 200}, hash_field2: {a: 100, b: 200})
     end
-    assert_raises(T::Props::InvalidValueError) do
+    assert_raises(TypeError) do
       StructWithPredefinedHash.new(hash_field1: {a: 100, b: 200}, hash_field2: {a: 'foo', b: 200})
     end
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Based on the conversation starting [here](https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1569599513127700), we want T::Struct to route type error on its prop through the sorbet runtime configuration. (Context copied below).

I change the logic in `decorator.rb` so that when user gives a prop a value with wrong type, it'll trigger the error through `call_validation_error_handler`. I try to compose the message the same way it is used in [`call_validation.rb`#1158](https://github.com/sorbet/sorbet/blob/master/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb#L1158), but given that there is no "method_signature" in here, I passed the prop's `rules` instead.

Here is a sample pretty error message:
```
"Parameter 'the_hash': Can't set Opus::Types::Test::Props::DecoratorTest::StructHash.the_hash to {\"foo\"=>{}} (instance of Hash) - need a T::Hash[String, Opus::Types::Test::Props::DecoratorTest::StructHash::InnerStruct]
  Caller: /home/dev/sorbet/gems/sorbet-runtime/test/types/props/decorator.rb:179\n
```


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


Context 
https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1569599513127700
> hdoan: Today I noticed that T::Struct T::Props::InvalidValueError does not go through Sorbet’s runtime-configuration for errors. This is quite unexpected, because we thought it’d be safe to put sorbet types and catch/resolve errors without it affect production (where we only log sorbet errors).
Why is that and shall we make the error going through runtime configuration errors as well? If this is desirable, I can look into making the change.
> jez: yeah those codepaths are different for bad historical reasons. feel free to send a PR to change it

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Will add once confirmed this is a good direction to go down

~See included automated tests.~
