### PR TITLE
Fix merge race for test_corpus global state

### DIFF
--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -204,7 +204,7 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
 
         expectation = test.expectations.find("parse-tree-whitequark");
         if (expectation != test.expectations.end()) {
-            got["parse-tree-whitequark"].append(nodes->toWhitequark(gs)).append("\n");
+            got["parse-tree-whitequark"].append(nodes->toWhitequark(*gs)).append("\n");
             auto newErrors = errorQueue->drainAllErrors();
             errors.insert(errors.end(), make_move_iterator(newErrors.begin()), make_move_iterator(newErrors.end()));
         }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
One PR changed `GlobalState` in pos test to a unique ptr and go into a merge race with a PR that added stuff using non-indirected `GlobalState`. This fixes it.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
