### PR TITLE
Fix initialize exception with nil arg

### DIFF
--- a/rbi/core/exception.rbi
+++ b/rbi/core/exception.rbi
@@ -169,7 +169,7 @@ class Exception < Object
 
   sig do
     params(
-        arg0: String,
+        arg0: T.any(String, NilClass),
     )
     .void
   end

--- a/test/testdata/rbi/exception.rb
+++ b/test/testdata/rbi/exception.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+StandardError.new
+StandardError.new(nil)
+StandardError.new('msg')


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
These are synonymous:

```StandardError.new```
```StandardError.new(nil)```

Sorbet currently enforces the param to be a String


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
