### PR TITLE
Prevent bare T::Array

### DIFF
--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -585,24 +585,13 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
 
             auto sym = maybeAliased.data(ctx)->dealias(ctx);
             if (sym.data(ctx)->isClassOrModule()) {
-                // this is a special-case because T_Array and co all have zero typeArguments() internally, but we want
-                // to subject them to the same checks we have down below if they get used with no type arguments at all
-                if (sym == core::Symbols::T_Hash() || sym == core::Symbols::T_Array() ||
-                    sym == core::Symbols::T_Set() || sym == core::Symbols::T_Range() ||
-                    sym == core::Symbols::T_Enumerable() || sym == core::Symbols::T_Enumerator()) {
-                    if (auto e = ctx.state.beginError(i->loc, core::errors::Resolver::GenericClassWithoutTypeArgs)) {
-                        e.setHeader("Malformed type declaration. Generic class without type arguments `{}`",
-                                    sym.show(ctx));
-                        if (sym == core::Symbols::T_Hash()) {
-                            // Hash is special because it has arity 3 but you're only supposed to write the first 2
-                            e.replaceWith("Add type arguments", i->loc, "{}[T.untyped, T.untyped]", i->loc.source(ctx));
-                        } else {
-                            e.replaceWith("Add type arguments", i->loc, "{}[T.untyped]", i->loc.source(ctx));
-                        }
-                    }
-                }
+                // the T::Type generics internally have a typeArity of 0, so this allows us to check against them in the
+                // same way that we check against types like `Array`
+                bool isBuiltinGeneric = sym == core::Symbols::T_Hash() || sym == core::Symbols::T_Array() ||
+                                        sym == core::Symbols::T_Set() || sym == core::Symbols::T_Range() ||
+                                        sym == core::Symbols::T_Enumerable() || sym == core::Symbols::T_Enumerator();
 
-                if (sym.data(ctx)->typeArity(ctx) > 0) {
+                if (isBuiltinGeneric || sym.data(ctx)->typeArity(ctx) > 0) {
                     // This set **should not** grow over time.
                     bool isStdlibWhitelisted = sym == core::Symbols::Hash() || sym == core::Symbols::Array() ||
                                                sym == core::Symbols::Set() || sym == core::Symbols::Range() ||
@@ -612,16 +601,22 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
                     if (auto e = ctx.state.beginError(i->loc, level)) {
                         e.setHeader("Malformed type declaration. Generic class without type arguments `{}`",
                                     sym.show(ctx));
-                        if (sym == core::Symbols::Hash()) {
+                        // if we're looking at `Array`, we want the autocorrect to include `T::`, but we don't need to
+                        // if we're already looking at `T::Array` instead.
+                        auto typePrefix = isBuiltinGeneric ? "T::" : "";
+                        if (sym == core::Symbols::Hash() || sym == core::Symbols::T_Hash()) {
                             // Hash is special because it has arity 3 but you're only supposed to write the first 2
-                            e.replaceWith("Add type arguments", i->loc, "T::{}[T.untyped, T.untyped]",
+                            e.replaceWith("Add type arguments", i->loc, "{}{}[T.untyped, T.untyped]", typePrefix,
                                           i->loc.source(ctx));
-                        } else if (isStdlibWhitelisted) {
+                        } else if (isStdlibWhitelisted || isBuiltinGeneric) {
+                            // the default provided here for builtin generic types is 1, and that might need to change
+                            // if we add other builtin generics (but ideally we should never need to do so!)
+                            auto numTypeArgs = isBuiltinGeneric ? 1 : sym.data(ctx)->typeArity(ctx);
                             vector<string> untypeds;
-                            for (int i = 0; i < sym.data(ctx)->typeArity(ctx); i++) {
+                            for (int i = 0; i < numTypeArgs; i++) {
                                 untypeds.emplace_back("T.untyped");
                             }
-                            e.replaceWith("Add type arguments", i->loc, "T::{}[{}]", i->loc.source(ctx),
+                            e.replaceWith("Add type arguments", i->loc, "{}{}[{}]", typePrefix, i->loc.source(ctx),
                                           absl::StrJoin(untypeds, ", "));
                         }
                     }

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -603,7 +603,7 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
                                     sym.show(ctx));
                         // if we're looking at `Array`, we want the autocorrect to include `T::`, but we don't need to
                         // if we're already looking at `T::Array` instead.
-                        auto typePrefix = isBuiltinGeneric ? "T::" : "";
+                        auto typePrefix = isBuiltinGeneric ? "" : "T::";
                         if (sym == core::Symbols::Hash() || sym == core::Symbols::T_Hash()) {
                             // Hash is special because it has arity 3 but you're only supposed to write the first 2
                             e.replaceWith("Add type arguments", i->loc, "{}{}[T.untyped, T.untyped]", typePrefix,

--- a/test/cli/autocorrect-bare-stdlib-generics/autocorrect-bare-stdlib-generics.out
+++ b/test/cli/autocorrect-bare-stdlib-generics/autocorrect-bare-stdlib-generics.out
@@ -1,0 +1,24 @@
+5c5
+< sig { params(stuff: T::Array).void }
+---
+> sig { params(stuff: T::Array[T.untyped]).void }
+8c8
+< sig { params(stuff: T::Hash).void }
+---
+> sig { params(stuff: T::Hash[T.untyped, T.untyped]).void }
+11c11
+< sig { params(stuff: T::Set).void }
+---
+> sig { params(stuff: T::Set[T.untyped]).void }
+14c14
+< sig { params(stuff: T::Range).void }
+---
+> sig { params(stuff: T::Range[T.untyped]).void }
+17c17
+< sig { params(stuff: T::Enumerable).void }
+---
+> sig { params(stuff: T::Enumerable[T.untyped]).void }
+20c20
+< sig { params(stuff: T::Enumerator).void }
+---
+> sig { params(stuff: T::Enumerator[T.untyped]).void }

--- a/test/cli/autocorrect-bare-stdlib-generics/autocorrect-bare-stdlib-generics.rb
+++ b/test/cli/autocorrect-bare-stdlib-generics/autocorrect-bare-stdlib-generics.rb
@@ -1,0 +1,21 @@
+# typed: strict
+
+extend T::Sig
+
+sig { params(stuff: T::Array).void }
+def bare_array(stuff); end
+
+sig { params(stuff: T::Hash).void }
+def bare_hash(stuff); end
+
+sig { params(stuff: T::Set).void }
+def bare_set(stuff); end
+
+sig { params(stuff: T::Range).void }
+def bare_range(stuff); end
+
+sig { params(stuff: T::Enumerable).void }
+def bare_enumerable(stuff); end
+
+sig { params(stuff: T::Enumerator).void }
+def bare_enumerator(stuff); end

--- a/test/cli/autocorrect-bare-stdlib-generics/autocorrect-bare-stdlib-generics.sh
+++ b/test/cli/autocorrect-bare-stdlib-generics/autocorrect-bare-stdlib-generics.sh
@@ -1,0 +1,6 @@
+tmp="$(mktemp)"
+file="test/cli/autocorrect-bare-stdlib-generics/autocorrect-bare-stdlib-generics.rb"
+cp "$file" "$tmp"
+main/sorbet --silence-dev-message -a "$tmp"
+diff "$file" "$tmp"
+rm "$tmp"

--- a/test/testdata/resolver/bare_stdlib_generics.rb
+++ b/test/testdata/resolver/bare_stdlib_generics.rb
@@ -1,0 +1,21 @@
+# typed: strict
+
+extend T::Sig
+
+sig { params(stuff: T::Array).void } # error: Malformed type declaration. Generic class without type arguments `T::Array`
+def bare_array(stuff); end
+
+sig { params(stuff: T::Hash).void } # error: Malformed type declaration. Generic class without type arguments `T::Hash`
+def bare_hash(stuff); end
+
+sig { params(stuff: T::Set).void } # error: Malformed type declaration. Generic class without type arguments `T::Set`
+def bare_set(stuff); end
+
+sig { params(stuff: T::Range).void } # error: Malformed type declaration. Generic class without type arguments `T::Range`
+def bare_range(stuff); end
+
+sig { params(stuff: T::Enumerable).void } # error: Malformed type declaration. Generic class without type arguments `T::Enumerable`
+def bare_enumerable(stuff); end
+
+sig { params(stuff: T::Enumerator).void } # error: Malformed type declaration. Generic class without type arguments `T::Enumerator`
+def bare_enumerator(stuff); end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes #1902; we statically allow `T::Array` with no type parameters but this does not work at runtime and can sometimes cause confusing runtime errors. This turns bare usage of any stdlib generic types into an error, and also offers an autocorrect to the version that includes `T.untyped` as argument (e.g. converting bare `T::Array` into `T::Array[T.untyped]`).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
