### PR TITLE
Fix fastpath constant-then-class errors

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -258,6 +258,13 @@ public:
                 }
             } else {
                 klass->symbol.data(ctx)->setIsModule(isModule);
+                auto renamed = ctx.state.findRenamedSymbol(klass->symbol.data(ctx)->owner, klass->symbol);
+                if (renamed.exists()) {
+                    if (auto e = ctx.state.beginError(klass->loc, core::errors::Namer::ModuleKindRedefinition)) {
+                        e.setHeader("Redefining constant `{}`", klass->symbol.data(ctx)->show(ctx));
+                        e.addErrorLine(renamed.data(ctx)->loc(), "Previous definition");
+                    }
+                }
             }
         }
         return klass;

--- a/test/cli/incremental-resolver/incremental-resolver.out
+++ b/test/cli/incremental-resolver/incremental-resolver.out
@@ -35,10 +35,20 @@ test/cli/incremental-resolver/expect-failures/constant_override.rb:3: Redefining
      2 |B = e
         ^
 
+test/cli/incremental-resolver/expect-failures/constant_override.rb:111: Redefining constant `B` https://srb.help/4012
+     111 |module B
+     112 |  extend T::Sig
+     113 |  sig { returns(T.all(B,T)) }
+     114 |  def foo; T.unsafe(nil); end
+     115 |end
+    test/cli/incremental-resolver/expect-failures/constant_override.rb:13: Previous definition
+    13 |
+    14 |
+
 test/cli/incremental-resolver/expect-failures/constant_override.rb:110: Method `e` does not exist on `T.class_of(<root>)` https://srb.help/7003
      110 |B = e
               ^
-Errors: 2
+Errors: 3
 ----- test/cli/incremental-resolver/expect-failures/constant_redefinition.rb ---------------------
 test/cli/incremental-resolver/expect-failures/constant_redefinition.rb:4: Redefining constant `A` https://srb.help/4012
      4 |  A = nil

--- a/test/testdata/namer/class_and_alias.rb
+++ b/test/testdata/namer/class_and_alias.rb
@@ -1,5 +1,4 @@
 # typed: true
-# disable-fast-path: true
 A = 91
 class A # error: Redefining constant `A`
 end

--- a/test/testdata/namer/class_and_alias.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/class_and_alias.rb.symbol-table-raw.exp
@@ -1,15 +1,15 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/class_and_alias.rb start=3:1 end=9:7}, Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4})
+class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/class_and_alias.rb start=2:1 end=8:7}, Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4})
   class <S <C <U <root>>> $1> < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/class_and_alias.rb start=3:1 end=9:7}
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/class_and_alias.rb start=2:1 end=8:7}
       argument <blk><block> @ Loc {file=test/testdata/namer/class_and_alias.rb start=??? end=???}
-  class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/namer/class_and_alias.rb start=4:1 end=4:8}
-  static-field <M <C <U A>> $1> -> Integer(91) @ Loc {file=test/testdata/namer/class_and_alias.rb start=3:1 end=3:2}
-  class <S <C <U A>> $1> < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/class_and_alias.rb start=4:1 end=4:8}
-    method <S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/class_and_alias.rb start=4:1 end=5:4}
+  class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/namer/class_and_alias.rb start=3:1 end=3:8}
+  static-field <M <C <U A>> $1> -> Integer(91) @ Loc {file=test/testdata/namer/class_and_alias.rb start=2:1 end=2:2}
+  class <S <C <U A>> $1> < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/class_and_alias.rb start=3:1 end=3:8}
+    method <S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/class_and_alias.rb start=3:1 end=4:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/class_and_alias.rb start=??? end=???}
-  static-field <C <U B>> -> Integer(91) @ Loc {file=test/testdata/namer/class_and_alias.rb start=9:1 end=9:2}
-  class <M <C <U B>> $1> < <C <U Object>> () @ Loc {file=test/testdata/namer/class_and_alias.rb start=7:1 end=7:8}
-  class <M <S <C <U B>> $1> $1> < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/class_and_alias.rb start=7:7 end=7:8}
-    method <M <S <C <U B>> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/class_and_alias.rb start=7:1 end=8:4}
+  static-field <C <U B>> -> Integer(91) @ Loc {file=test/testdata/namer/class_and_alias.rb start=8:1 end=8:2}
+  class <M <C <U B>> $1> < <C <U Object>> () @ Loc {file=test/testdata/namer/class_and_alias.rb start=6:1 end=6:8}
+  class <M <S <C <U B>> $1> $1> < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/class_and_alias.rb start=6:7 end=6:8}
+    method <M <S <C <U B>> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/class_and_alias.rb start=6:1 end=7:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/class_and_alias.rb start=??? end=???}
 

--- a/test/testdata/namer/constant_redefinition/constant_then_class.rb
+++ b/test/testdata/namer/constant_redefinition/constant_then_class.rb
@@ -1,5 +1,4 @@
 # typed: true
-# disable-fast-path: true
 
 R = 5
 class R; end # error: Redefining constant `R`

--- a/test/testdata/namer/constant_redefinition/constant_then_module.rb
+++ b/test/testdata/namer/constant_redefinition/constant_then_module.rb
@@ -1,6 +1,5 @@
 # typed: true
 
-
 R = 5
 module R; def self.x; end; end # error: Redefining constant `R`
 

--- a/test/testdata/namer/constant_redefinition/constant_then_module.rb
+++ b/test/testdata/namer/constant_redefinition/constant_then_module.rb
@@ -1,5 +1,5 @@
 # typed: true
-# disable-fast-path: true
+
 
 R = 5
 module R; def self.x; end; end # error: Redefining constant `R`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
We weren't re-reporting certain errors in the namer when the thing that caused a redefinition was a class. This adds support for this and enables the fast path tests in ~two~ three namer tests.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
