### PR TITLE
Cancelable slow path responsiveness improvements

### DIFF
--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -249,6 +249,8 @@ void LSPPreprocessor::preprocessAndEnqueue(QueueState &state, unique_ptr<LSPMess
             canonicalizeEdits(nextVersion++, move(params), newParams->updates);
             if (newParams->updates.updatedFiles.empty()) {
                 // No need to commit; these file system updates are ignored.
+                // Reclaim edit version, as we didn't actually use this one.
+                nextVersion--;
                 return;
             }
             msg = makeAndCommitWorkspaceEdit(move(newParams), move(msg));

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -248,6 +248,10 @@ void LSPPreprocessor::preprocessAndEnqueue(QueueState &state, unique_ptr<LSPMess
             auto &params = get<unique_ptr<WatchmanQueryResponse>>(msg->asNotification().params);
             auto newParams = make_unique<SorbetWorkspaceEditParams>();
             canonicalizeEdits(nextVersion++, move(params), newParams->updates);
+            if (newParams->updates.updatedFiles.empty()) {
+                // No need to commit; these file system updates are ignored.
+                return;
+            }
             msg = makeAndCommitWorkspaceEdit(move(newParams), move(msg));
             shouldEnqueue = shouldMerge = true;
             break;

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -98,7 +98,6 @@ void LSPPreprocessor::mergeFileChanges(absl::Mutex &mtx, QueueState &state) {
                 if (msg->isNotification() && msg->method() == LSPMethod::SorbetWorkspaceEdit) {
                     Timer timeit(logger, "tryCancelSlowPath");
                     auto &params = get<unique_ptr<SorbetWorkspaceEditParams>>(msg->asNotification().params);
-                    // Note: This line calls indexer to re-create the index trees, so it's somewhat expensive.
                     auto combinedUpdates = ttgs.getCombinedUpdates(committed + 1, params->updates.versionEnd);
                     if (combinedUpdates.canTakeFastPath && gs.tryCancelSlowPath(params->updates.versionEnd)) {
                         logger->debug("[Preprocessor] Canceling typechecking, as edits {} thru {} can take fast path.",

--- a/main/lsp/TimeTravelingGlobalState.h
+++ b/main/lsp/TimeTravelingGlobalState.h
@@ -20,10 +20,12 @@ namespace sorbet::realmain::lsp {
  */
 class TimeTravelingGlobalState final {
 private:
-    // Contains file updates and their respective hash updates.
+    // Contains file updates and their respective hash+index updates.
     struct GlobalStateUpdate {
         std::vector<std::shared_ptr<core::File>> fileUpdates;
         std::vector<core::FileHash> hashUpdates;
+        // Note: Undo updates do not contain indexes.
+        std::vector<ast::ParsedFile> updatedFileIndexes;
     };
 
     /**

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -237,7 +237,8 @@ TEST(LSPPreprocessor, IgnoresWatchmanUpdatesFromOpenFiles) { // NOLINT
     ASSERT_TRUE(state.pendingRequests.size() == 1);
 
     const auto updates = getUpdates(state, 0).value();
-    EXPECT_EQ(updates->versionEnd - updates->versionStart + 1, 2);
+    // Version didn't change because it ignored the watchman update.
+    EXPECT_EQ(updates->versionEnd - updates->versionStart, 0);
     EXPECT_FALSE(updates->canTakeFastPath);
     EXPECT_TRUE(updates->hasNewFiles);
     ASSERT_EQ(updates->updatedFiles.size(), 1);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Cancelable slow path responsiveness improvements:

* (Minor) If a watchman update contains no unignored file updates, don't bother enqueuing it. Previously, we were enqueueing it, and wasting time merging it with pending updates.
* (Bigger) Use parallel index. I noticed that Sorbet's preprocessor had trouble keeping up after git because we weren't doing this before.
* (Bigger) Don't re-index files when combining updates to cancel the slow path. Instead, keep a log of index trees associated with updates and copy those.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Improve Sorbet responsiveness. Message latency seemed to be going up, and I think this is part of the reason why!

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Most of these are performance optimizations, so no external behavior should be impacted. The existing tests should catch regressions.

Since it is EOD Friday right now, I plan to merge this sometime on Monday, after I manually QA test it a bit more.
