### PR TITLE
Type alias/member ordering

### DIFF
--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -59,6 +59,7 @@ constexpr ErrorClass UndeclaredOverride{5051, StrictLevel::True};
 constexpr ErrorClass InvalidTypeMemberBounds{5052, StrictLevel::False};
 constexpr ErrorClass ParentTypeBoundsMismatch{5053, StrictLevel::False};
 constexpr ErrorClass ImplementationDeprecated{5054, StrictLevel::False};
+constexpr ErrorClass TypeMemberCycle{5055, StrictLevel::False};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -820,13 +820,9 @@ public:
             }
             sym = ctx.state.enterTypeMember(asgn->loc, onSymbol, typeName->cnst, variance);
 
-            // Ensure that every type member has a LambdaParam with bounds, but give
-            // both bounds as T.untyped. The reason for this is that the bounds will
-            // be fixed up in the resolver, but if the type is used out of order (as
-            // in test/testdata/todo/fixed_ordering.rb) `T.untyped` will be used for
-            // the value of the type, instead of `<any>`
-            auto untyped = core::Types::untyped(ctx, sym);
-            sym.data(ctx)->resultType = core::make_type<core::LambdaParam>(sym, untyped, untyped);
+            // The todo bounds will be fixed by the resolver in ResolveTypeParamsWalk.
+            auto todo = core::make_type<core::ClassType>(core::Symbols::todo());
+            sym.data(ctx)->resultType = core::make_type<core::LambdaParam>(sym, todo, todo);
 
             if (isTypeTemplate) {
                 auto context = ctx.owner.data(ctx)->enclosingClass(ctx);

--- a/rbi/sorbet/sorbet.rbi
+++ b/rbi/sorbet/sorbet.rbi
@@ -181,7 +181,6 @@ end
 ::Sorbet::Private::Static::IOLike = T.type_alias(
   T.any(
     IO,
-    StringIO,
-    Tempfile
+    StringIO
   )
 )

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -345,11 +345,8 @@ private:
             return true;
         }
         if (isFullyResolved(ctx, job.rhs)) {
-            auto allowSelfType = true;
-            auto allowRebind = false;
-            auto allowTypeMember = true;
-            job.lhs.data(ctx)->resultType = TypeSyntax::getResultType(
-                ctx, *(job.rhs), ParsedSig{}, TypeSyntaxArgs{allowSelfType, allowRebind, allowTypeMember, job.lhs});
+            // this todo will be resolved during ResolveTypeParamsWalk below
+            job.lhs.data(ctx)->resultType = core::make_type<core::ClassType>(core::Symbols::todo());
             return true;
         }
 
@@ -847,117 +844,332 @@ public:
 };
 
 class ResolveTypeParamsWalk {
+    // A type_member, type_template, or T.type_alias that needs to have types
+    // resolved.
+    struct ResolveAssignItem {
+        // The symbol being populated, either a type alias or an individual
+        // type_member.
+        core::SymbolRef lhs;
+
+        // The type_member, type_template, or type_alias of the RHS.
+        ast::Send *rhs;
+
+        // The symbols that this alias depends on that have type members.
+        vector<core::SymbolRef> dependencies;
+    };
+
+    vector<ResolveAssignItem> todoAssigns_;
+
+    // State for tracking type usage inside of a type alias or type member
+    // definition
+    bool trackDependencies_ = false;
+    vector<bool> classOfDepth_;
+    vector<core::SymbolRef> dependencies_;
+
+    bool isInsideClassOf() const {
+        return !classOfDepth_.empty() && classOfDepth_.back();
+    }
+
+    void clearTypeContext(bool tracking) {}
+
+    static bool isTodo(core::TypePtr type) {
+        auto *todo = core::cast_type<core::ClassType>(type.get());
+        return todo != nullptr && todo->symbol == core::Symbols::todo();
+    }
+
+    static bool isLHSResolved(core::MutableContext ctx, core::SymbolRef sym) {
+        if (sym.data(ctx)->isTypeMember()) {
+            auto *lambdaParam = core::cast_type<core::LambdaParam>(sym.data(ctx)->resultType.get());
+            ENFORCE(lambdaParam != nullptr);
+
+            // both bounds are set to todo in the namer, so it's sufficient to
+            // just check one here.
+            return !isTodo(lambdaParam->lowerBound);
+        } else {
+            return !isTodo(sym.data(ctx)->resultType);
+        }
+    }
+
+    static bool isGenericResolved(core::MutableContext ctx, core::SymbolRef sym) {
+        ENFORCE(sym.data(ctx)->isClassOrModule());
+
+        return absl::c_all_of(sym.data(ctx)->typeMembers(), [&](core::SymbolRef tm) { return isLHSResolved(ctx, tm); });
+    }
+
+    static void resolveTypeMember(core::MutableContext ctx, core::SymbolRef lhs, ast::Send *rhs) {
+        auto data = lhs.data(ctx);
+
+        core::LambdaParam *parentType = nullptr;
+        auto parentMember = data->owner.data(ctx)->superClass().data(ctx)->findMember(ctx, data->name);
+        if (parentMember.exists()) {
+            if (parentMember.data(ctx)->isTypeMember()) {
+                parentType = core::cast_type<core::LambdaParam>(parentMember.data(ctx)->resultType.get());
+                ENFORCE(parentType != nullptr);
+            } else if (auto e = ctx.state.beginError(rhs->loc, core::errors::Resolver::ParentTypeBoundsMismatch)) {
+                const auto parentShow = parentMember.data(ctx)->show(ctx);
+                e.setHeader("`{}` is a type member but `{}` is not a type member", data->show(ctx), parentShow);
+                e.addErrorLine(parentMember.data(ctx)->loc(), "`{}` definition", parentShow);
+            }
+        }
+
+        // Initialize the resultType to a LambdaParam with default bounds
+        auto lambdaParam = core::make_type<core::LambdaParam>(lhs, core::Types::bottom(), core::Types::top());
+        data->resultType = lambdaParam;
+        auto *memberType = core::cast_type<core::LambdaParam>(lambdaParam.get());
+
+        // When no args are supplied, this implies that the upper and lower
+        // bounds of the type parameter are top and bottom.
+        ast::Hash *hash = nullptr;
+        if (rhs->args.size() == 1) {
+            hash = ast::cast_tree<ast::Hash>(rhs->args[0].get());
+        } else if (rhs->args.size() == 2) {
+            hash = ast::cast_tree<ast::Hash>(rhs->args[1].get());
+        }
+
+        if (hash) {
+            int i = -1;
+            for (auto &keyExpr : hash->keys) {
+                i++;
+                auto lit = ast::cast_tree<ast::Literal>(keyExpr.get());
+                if (lit && lit->isSymbol(ctx)) {
+                    ParsedSig emptySig;
+                    auto allowSelfType = true;
+                    auto allowRebind = false;
+                    auto allowTypeMember = false;
+                    core::TypePtr resTy =
+                        TypeSyntax::getResultType(ctx, *(hash->values[i]), emptySig,
+                                                  TypeSyntaxArgs{allowSelfType, allowRebind, allowTypeMember, lhs});
+
+                    switch (lit->asSymbol(ctx)._id) {
+                        case core::Names::fixed()._id:
+                            memberType->lowerBound = resTy;
+                            memberType->upperBound = resTy;
+                            break;
+
+                        case core::Names::lower()._id:
+                            memberType->lowerBound = resTy;
+                            break;
+
+                        case core::Names::upper()._id:
+                            memberType->upperBound = resTy;
+                            break;
+                    }
+                }
+            }
+        }
+
+        // If the parent bounds existis, validate the new bounds against
+        // those of the parent.
+        // NOTE: these errors could be better for cases involving
+        // `fixed`.
+        if (parentType != nullptr) {
+            if (!core::Types::isSubType(ctx, parentType->lowerBound, memberType->lowerBound)) {
+                if (auto e = ctx.state.beginError(rhs->loc, core::errors::Resolver::ParentTypeBoundsMismatch)) {
+                    e.setHeader("parent lower bound `{}` is not a subtype of lower bound `{}`",
+                                parentType->lowerBound->show(ctx), memberType->lowerBound->show(ctx));
+                }
+            }
+            if (!core::Types::isSubType(ctx, memberType->upperBound, parentType->upperBound)) {
+                if (auto e = ctx.state.beginError(rhs->loc, core::errors::Resolver::ParentTypeBoundsMismatch)) {
+                    e.setHeader("upper bound `{}` is not a subtype of parent upper bound `{}`",
+                                memberType->upperBound->show(ctx), parentType->upperBound->show(ctx));
+                }
+            }
+        }
+
+        // Ensure that the new lower bound is a subtype of the upper
+        // bound. This will be a no-op in the case that the type member
+        // is fixed.
+        if (!core::Types::isSubType(ctx, memberType->lowerBound, memberType->upperBound)) {
+            if (auto e = ctx.state.beginError(rhs->loc, core::errors::Resolver::InvalidTypeMemberBounds)) {
+                e.setHeader("`{}` is not a subtype of `{}`", memberType->lowerBound->show(ctx),
+                            memberType->upperBound->show(ctx));
+            }
+        }
+    }
+
+    static void resolveTypeAlias(core::MutableContext ctx, core::SymbolRef lhs, ast::Send *rhs) {
+        // this is provided by ResolveConstantsWalk
+        ENFORCE(!rhs->args.empty());
+
+        auto allowSelfType = true;
+        auto allowRebind = false;
+        auto allowTypeMember = true;
+        lhs.data(ctx)->resultType = TypeSyntax::getResultType(
+            ctx, *(rhs->args[0]), ParsedSig{}, TypeSyntaxArgs{allowSelfType, allowRebind, allowTypeMember, lhs});
+    }
+
+    static bool resolveJob(core::MutableContext ctx, ResolveAssignItem &job) {
+        ENFORCE(job.lhs.data(ctx)->isTypeAlias() || job.lhs.data(ctx)->isTypeMember());
+
+        if (isLHSResolved(ctx, job.lhs)) {
+            return true;
+        }
+
+        auto it = std::remove_if(job.dependencies.begin(), job.dependencies.end(),
+                                 [&](core::SymbolRef dep) { return isGenericResolved(ctx, dep); });
+        job.dependencies.erase(it, job.dependencies.end());
+        if (!job.dependencies.empty()) {
+            return false;
+        }
+
+        switch (job.rhs->fun._id) {
+            case core::Names::typeTemplate()._id:
+            case core::Names::typeMember()._id: {
+                auto superclass = job.lhs.data(ctx)->owner.data(ctx)->superClass();
+                if (!isGenericResolved(ctx, superclass)) {
+                    return false;
+                }
+
+                resolveTypeMember(ctx, job.lhs, job.rhs);
+                break;
+            }
+
+            case core::Names::typeAlias()._id:
+                resolveTypeAlias(ctx, job.lhs, job.rhs);
+                break;
+        }
+
+        return true;
+    }
+
 public:
+    unique_ptr<ast::Send> preTransformSend(core::MutableContext ctx, unique_ptr<ast::Send> send) {
+        switch (send->fun._id) {
+            case core::Names::typeMember()._id:
+            case core::Names::typeTemplate()._id:
+            case core::Names::typeAlias()._id:
+                trackDependencies_ = true;
+                classOfDepth_.clear();
+                dependencies_.clear();
+                break;
+
+            default:
+                if (trackDependencies_) {
+                    classOfDepth_.emplace_back(send->fun._id == core::Names::classOf()._id);
+                }
+                break;
+        }
+
+        return send;
+    }
+
+    unique_ptr<ast::ConstantLit> postTransformConstantLit(core::MutableContext ctx, unique_ptr<ast::ConstantLit> lit) {
+        if (trackDependencies_) {
+            core::SymbolRef symbol = lit->symbol;
+            if (symbol == core::Symbols::T() || !symbol.data(ctx)->isClassOrModule()) {
+                return lit;
+            }
+
+            // crawl up uses of `T.class_of` to find the right singleton symbol.
+            // This is for cases like `T.class_of(T.class_of(A))`.
+            for (auto it = classOfDepth_.rbegin(); it != classOfDepth_.rend() && *it; ++it) {
+                // ignore this as a potential dependency if the singleton
+                // doesn't exist -- this is an indication that there are no type
+                // members on the singleton.
+                symbol = symbol.data(ctx)->lookupSingletonClass(ctx);
+                if (!symbol.exists()) {
+                    return lit;
+                }
+            }
+
+            if (!symbol.data(ctx)->typeMembers().empty()) {
+                dependencies_.emplace_back(symbol);
+            }
+        }
+
+        return lit;
+    }
+
+    unique_ptr<ast::Send> postTransformSend(core::MutableContext ctx, unique_ptr<ast::Send> send) {
+        switch (send->fun._id) {
+            case core::Names::typeMember()._id:
+            case core::Names::typeTemplate()._id:
+            case core::Names::typeAlias()._id:
+                trackDependencies_ = false;
+                break;
+
+            default:
+                if (trackDependencies_) {
+                    classOfDepth_.pop_back();
+                }
+                break;
+        }
+
+        return send;
+    }
+
     unique_ptr<ast::Assign> postTransformAssign(core::MutableContext ctx, unique_ptr<ast::Assign> asgn) {
         auto *id = ast::cast_tree<ast::ConstantLit>(asgn->lhs.get());
         if (id == nullptr || !id->symbol.exists()) {
             return asgn;
         }
 
-        auto sym = id->symbol;
-        auto data = sym.data(ctx);
-        if (data->isTypeAlias()) {
+        auto *send = ast::cast_tree<ast::Send>(asgn->rhs.get());
+        if (send == nullptr) {
             return asgn;
         }
 
-        if (data->isTypeMember()) {
-            auto send = ast::cast_tree<ast::Send>(asgn->rhs.get());
-            ENFORCE(send->recv->isSelfReference());
-            ENFORCE(send->fun == core::Names::typeMember() || send->fun == core::Names::typeTemplate());
-            auto *memberType = core::cast_type<core::LambdaParam>(data->resultType.get());
-            ENFORCE(memberType != nullptr);
+        auto sym = id->symbol;
+        auto data = sym.data(ctx);
+        if (data->isTypeAlias() || data->isTypeMember()) {
+            ENFORCE(!data->isTypeMember() || send->recv->isSelfReference());
+            ENFORCE(send->fun == core::Names::typeAlias() || send->fun == core::Names::typeMember() ||
+                    send->fun == core::Names::typeTemplate());
 
-            // NOTE: the resultType is set back in the namer to be a LambdaParam
-            // with `T.untyped` for its bounds. We fix that here by setting the
-            // bounds to top and bottom.
-            memberType->lowerBound = core::Types::bottom();
-            memberType->upperBound = core::Types::top();
-
-            core::LambdaParam *parentType = nullptr;
-            auto parentMember = data->owner.data(ctx)->superClass().data(ctx)->findMember(ctx, data->name);
-            if (parentMember.exists()) {
-                if (parentMember.data(ctx)->isTypeMember()) {
-                    parentType = core::cast_type<core::LambdaParam>(parentMember.data(ctx)->resultType.get());
-                    ENFORCE(parentType != nullptr);
-                } else if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::ParentTypeBoundsMismatch)) {
-                    const auto parentShow = parentMember.data(ctx)->show(ctx);
-                    e.setHeader("`{}` is a type member but `{}` is not a type member", data->show(ctx), parentShow);
-                    e.addErrorLine(parentMember.data(ctx)->loc(), "`{}` definition", parentShow);
-                }
+            auto job = ResolveAssignItem{sym, send, dependencies_};
+            if (!resolveJob(ctx, job)) {
+                todoAssigns_.emplace_back(std::move(job));
             }
+        }
 
-            // When no args are supplied, this implies that the upper and lower
-            // bounds of the type parameter are top and bottom.
-            ast::Hash *hash = nullptr;
-            if (send->args.size() == 1) {
-                hash = ast::cast_tree<ast::Hash>(send->args[0].get());
-            } else if (send->args.size() == 2) {
-                hash = ast::cast_tree<ast::Hash>(send->args[1].get());
-            }
+        trackDependencies_ = false;
+        dependencies_.clear();
+        classOfDepth_.clear();
 
-            if (hash) {
-                int i = -1;
-                for (auto &keyExpr : hash->keys) {
-                    i++;
-                    auto lit = ast::cast_tree<ast::Literal>(keyExpr.get());
-                    if (lit && lit->isSymbol(ctx)) {
-                        ParsedSig emptySig;
-                        auto allowSelfType = true;
-                        auto allowRebind = false;
-                        auto allowTypeMember = false;
-                        core::TypePtr resTy =
-                            TypeSyntax::getResultType(ctx, *(hash->values[i]), emptySig,
-                                                      TypeSyntaxArgs{allowSelfType, allowRebind, allowTypeMember, sym});
+        return asgn;
+    }
 
-                        switch (lit->asSymbol(ctx)._id) {
-                            case core::Names::fixed()._id:
-                                memberType->lowerBound = resTy;
-                                memberType->upperBound = resTy;
-                                break;
+    static vector<ast::ParsedFile> run(core::MutableContext ctx, vector<ast::ParsedFile> trees) {
+        ResolveTypeParamsWalk params;
+        Timer timeit(ctx.state.errorQueue->logger, "resolver.type_params");
+        for (auto &tree : trees) {
+            tree.tree = ast::TreeMap::apply(ctx, params, std::move(tree.tree));
+        }
 
-                            case core::Names::lower()._id:
-                                memberType->lowerBound = resTy;
-                                break;
+        // loop over any out-of-order type_member/type_alias references
+        bool progress = true;
+        while (progress && !params.todoAssigns_.empty()) {
+            auto origSize = params.todoAssigns_.size();
+            auto it = std::remove_if(params.todoAssigns_.begin(), params.todoAssigns_.end(),
+                                     [&](ResolveAssignItem &job) { return resolveJob(ctx, job); });
+            params.todoAssigns_.erase(it, params.todoAssigns_.end());
+            progress = params.todoAssigns_.size() != origSize;
+        }
 
-                            case core::Names::upper()._id:
-                                memberType->upperBound = resTy;
-                                break;
-                        }
-                    }
+        // If there was a step with no progress, there's a cycle in the
+        // type member/alias declarations. This is handled by reporting an error
+        // at `typed: false`, and marking all of the involved type
+        // members/aliases as T.untyped.
+        if (!params.todoAssigns_.empty()) {
+            for (auto &job : params.todoAssigns_) {
+                auto data = job.lhs.data(ctx);
+
+                if (data->isTypeMember()) {
+                    data->resultType = core::make_type<core::LambdaParam>(job.lhs, core::Types::untypedUntracked(),
+                                                                          core::Types::untypedUntracked());
+                } else {
+                    data->resultType = core::Types::untypedUntracked();
                 }
-            }
 
-            // If the parent bounds existis, validate the new bounds against
-            // those of the parent.
-            // NOTE: these errors could be better for cases involving
-            // `fixed`.
-            if (parentType != nullptr) {
-                if (!core::Types::isSubType(ctx, parentType->lowerBound, memberType->lowerBound)) {
-                    if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::ParentTypeBoundsMismatch)) {
-                        e.setHeader("parent lower bound `{}` is not a subtype of lower bound `{}`",
-                                    parentType->lowerBound->show(ctx), memberType->lowerBound->show(ctx));
-                    }
-                }
-                if (!core::Types::isSubType(ctx, memberType->upperBound, parentType->upperBound)) {
-                    if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::ParentTypeBoundsMismatch)) {
-                        e.setHeader("upper bound `{}` is not a subtype of parent upper bound `{}`",
-                                    memberType->upperBound->show(ctx), parentType->upperBound->show(ctx));
-                    }
-                }
-            }
-
-            // Ensure that the new lower bound is a subtype of the upper
-            // bound. This will be a no-op in the case that the type member
-            // is fixed.
-            if (!core::Types::isSubType(ctx, memberType->lowerBound, memberType->upperBound)) {
-                if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidTypeMemberBounds)) {
-                    e.setHeader("`{}` is not a subtype of `{}`", memberType->lowerBound->show(ctx),
-                                memberType->upperBound->show(ctx));
+                if (auto e = ctx.state.beginError(data->loc(), core::errors::Resolver::TypeMemberCycle)) {
+                    auto flavor = data->isTypeAlias() ? "alias" : "member";
+                    e.setHeader("Type {} `{}` is involved in a cycle", flavor, data->show(ctx));
                 }
             }
         }
 
-        return asgn;
+        return trees;
     }
 };
 
@@ -1007,7 +1219,8 @@ private:
             method.data(ctx)->setHasGeneratedSig();
         } else {
             // HasGeneratedSig can be already set in incremental runs. Make sure we update it.
-            // TODO: In future, enforce that the previous LOC was a tombstone if we're actually unsetting generated sig.
+            // TODO: In future, enforce that the previous LOC was a tombstone if we're actually unsetting generated
+            // sig.
             method.data(ctx)->unsetHasGeneratedSig();
         }
         if (!sig.typeArgs.empty()) {
@@ -1157,7 +1370,8 @@ private:
             auto argType = argSym.type;
 
             if (auto *optArgExp = ast::cast_tree<ast::OptionalArg>(argExp.get())) {
-                // Using optArgExp's loc will make errors point to the arg list, even though the T.let is in the body.
+                // Using optArgExp's loc will make errors point to the arg list, even though the T.let is in the
+                // body.
                 auto let = make_unique<ast::Cast>(optArgExp->loc, argType, optArgExp->default_->deepCopy(),
                                                   core::Names::let());
                 lets.emplace_back(std::move(let));
@@ -1458,7 +1672,8 @@ private:
         auto prior = scope.data(ctx)->findMember(ctx, uid->name);
         if (prior.exists()) {
             if (core::Types::equiv(ctx, prior.data(ctx)->resultType, cast->type)) {
-                // We already have a symbol for this field, and it matches what we already saw, so we can short circuit.
+                // We already have a symbol for this field, and it matches what we already saw, so we can short
+                // circuit.
                 return true;
             } else {
                 // We do some normalization here to ensure that the file / line we report the error on doesn't
@@ -1534,11 +1749,11 @@ public:
                                                core::Names::suggestType(), move(rhs));
                 }
             } else if (!core::isa_type<core::AliasType>(data->resultType.get())) {
-                // If we've already resolved a temporary constant, we still want to run resolveConstantType to report
-                // errors (e.g. so that a stand-in untyped value won't suppress errors in subsequent typechecking runs)
-                // but we only want to run this on constants that are value-level and not class or type aliases. The
-                // check for isa_type<AliasType> makes sure that we skip aliases of the form `X = Integer` and only run
-                // this over constant value assignments like `X = 5` or `Y = 5; X = Y`.
+                // If we've already resolved a temporary constant, we still want to run resolveConstantType to
+                // report errors (e.g. so that a stand-in untyped value won't suppress errors in subsequent
+                // typechecking runs) but we only want to run this on constants that are value-level and not class
+                // or type aliases. The check for isa_type<AliasType> makes sure that we skip aliases of the form `X
+                // = Integer` and only run this over constant value assignments like `X = 5` or `Y = 5; X = Y`.
                 if (resolveConstantType(ctx, asgn->rhs, sym) == nullptr) {
                     if (auto e = ctx.state.beginError(asgn->rhs->loc,
                                                       core::errors::Resolver::ConstantMissingTypeAnnotation)) {
@@ -1804,7 +2019,7 @@ ast::ParsedFilesOrCancelled Resolver::run(core::MutableContext ctx, vector<ast::
     if (ctx.state.wasTypecheckingCanceled()) {
         return ast::ParsedFilesOrCancelled();
     }
-    trees = resolveTypeParams(ctx, std::move(trees));
+    trees = ResolveTypeParamsWalk::run(ctx, std::move(trees));
     if (ctx.state.wasTypecheckingCanceled()) {
         return ast::ParsedFilesOrCancelled();
     }
@@ -1815,16 +2030,6 @@ ast::ParsedFilesOrCancelled Resolver::run(core::MutableContext ctx, vector<ast::
     sanityCheck(ctx, trees);
 
     return ast::ParsedFilesOrCancelled(move(trees));
-}
-
-vector<ast::ParsedFile> Resolver::resolveTypeParams(core::MutableContext ctx, vector<ast::ParsedFile> trees) {
-    ResolveTypeParamsWalk sigs;
-    Timer timeit(ctx.state.errorQueue->logger, "resolver.type_params");
-    for (auto &tree : trees) {
-        tree.tree = ast::TreeMap::apply(ctx, sigs, std::move(tree.tree));
-    }
-
-    return trees;
 }
 
 vector<ast::ParsedFile> Resolver::resolveSigs(core::MutableContext ctx, vector<ast::ParsedFile> trees) {
@@ -1861,7 +2066,7 @@ vector<ast::ParsedFile> Resolver::runTreePasses(core::MutableContext ctx, vector
     trees = ResolveConstantsWalk::resolveConstants(ctx, std::move(trees), *workers);
     trees = resolveMixesInClassMethods(ctx, std::move(trees));
     computeLinearization(ctx.state);
-    trees = resolveTypeParams(ctx, std::move(trees));
+    trees = ResolveTypeParamsWalk::run(ctx, std::move(trees));
     trees = resolveSigs(ctx, std::move(trees));
     sanityCheck(ctx, trees);
     // This check is FAR too slow to run on large codebases, especially with sanitizers on.

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -847,6 +847,9 @@ class ResolveTypeParamsWalk {
     // A type_member, type_template, or T.type_alias that needs to have types
     // resolved.
     struct ResolveAssignItem {
+        // The owner at the time the assignment was encountered.
+        core::SymbolRef owner;
+
         // The symbol being populated, either a type alias or an individual
         // type_member.
         core::SymbolRef lhs;
@@ -1019,12 +1022,12 @@ class ResolveTypeParamsWalk {
                     return false;
                 }
 
-                resolveTypeMember(ctx, job.lhs, job.rhs);
+                resolveTypeMember(ctx.withOwner(job.owner), job.lhs, job.rhs);
                 break;
             }
 
             case core::Names::typeAlias()._id:
-                resolveTypeAlias(ctx, job.lhs, job.rhs);
+                resolveTypeAlias(ctx.withOwner(job.owner), job.lhs, job.rhs);
                 break;
         }
 
@@ -1129,7 +1132,7 @@ public:
             ENFORCE(send->fun == core::Names::typeAlias() || send->fun == core::Names::typeMember() ||
                     send->fun == core::Names::typeTemplate());
 
-            auto job = ResolveAssignItem{sym, send, dependencies_};
+            auto job = ResolveAssignItem{ctx.owner, sym, send, dependencies_};
             if (!resolveJob(ctx, job)) {
                 todoAssigns_.emplace_back(std::move(job));
             }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1024,21 +1024,15 @@ class ResolveTypeParamsWalk {
             return false;
         }
 
-        switch (job.rhs->fun._id) {
-            case core::Names::typeTemplate()._id:
-            case core::Names::typeMember()._id: {
-                auto superclass = job.lhs.data(ctx)->owner.data(ctx)->superClass();
-                if (!isGenericResolved(ctx, superclass)) {
-                    return false;
-                }
-
-                resolveTypeMember(ctx.withOwner(job.owner), job.lhs, job.rhs);
-                break;
+        if (job.lhs.data(ctx)->isTypeMember()) {
+            auto superclass = job.lhs.data(ctx)->owner.data(ctx)->superClass();
+            if (!isGenericResolved(ctx, superclass)) {
+                return false;
             }
 
-            case core::Names::typeAlias()._id:
-                resolveTypeAlias(ctx.withOwner(job.owner), job.lhs, job.rhs);
-                break;
+            resolveTypeMember(ctx.withOwner(job.owner), job.lhs, job.rhs);
+        } else {
+            resolveTypeAlias(ctx.withOwner(job.owner), job.lhs, job.rhs);
         }
 
         return true;

--- a/resolver/resolver.h
+++ b/resolver/resolver.h
@@ -26,7 +26,6 @@ private:
     static void finalizeAncestors(core::GlobalState &gs);
     static void finalizeSymbols(core::GlobalState &gs);
     static void computeLinearization(core::GlobalState &gs);
-    static std::vector<ast::ParsedFile> resolveTypeParams(core::MutableContext ctx, std::vector<ast::ParsedFile> trees);
     static std::vector<ast::ParsedFile> resolveSigs(core::MutableContext ctx, std::vector<ast::ParsedFile> trees);
     static std::vector<ast::ParsedFile> resolveMixesInClassMethods(core::MutableContext ctx,
                                                                    std::vector<ast::ParsedFile> trees);

--- a/test/testdata/infer/generics/bounds.rb
+++ b/test/testdata/infer/generics/bounds.rb
@@ -1,4 +1,5 @@
 # typed: true
+# disable-fast-path: true
 
 class Animal; end
 class Cat < Animal; end

--- a/test/testdata/infer/generics/bounds_super.rb
+++ b/test/testdata/infer/generics/bounds_super.rb
@@ -1,4 +1,5 @@
 # typed: true
+# disable-fast-path: true
 
 class Animal; end
 class Cat < Animal; end

--- a/test/testdata/rbi/ruby_typer.rb
+++ b/test/testdata/rbi/ruby_typer.rb
@@ -7,5 +7,5 @@ extend T::Sig
 
 sig {params(x: Sorbet::Private::Static::IOLike).void}
 def foo(x)
-  T.reveal_type(x) # error: Revealed type: `T.any(IO, StringIO, Tempfile)`
+  T.reveal_type(x) # error: Revealed type: `T.any(IO, StringIO)`
 end

--- a/test/testdata/resolver/bool_alias.rb
+++ b/test/testdata/resolver/bool_alias.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+module T
+  X = T.let(nil, T.untyped)
+  Boolean = T.let(nil, T.untyped)
+end

--- a/test/testdata/resolver/type_alias_order.rb
+++ b/test/testdata/resolver/type_alias_order.rb
@@ -1,0 +1,13 @@
+# typed: true
+
+# This is a regression test for the ResolveTypeParamsWalk pass of the resolver,
+# ensuring that type aliases are tracked as dependencies to other type aliases.
+
+module Foo
+  Table = T.type_alias(Types::TABLE)
+  Values = T.let([], Table)
+end
+
+module Types
+  TABLE = T.type_alias(T::Array[Integer])
+end

--- a/test/testdata/resolver/type_member_bad_parent.rb
+++ b/test/testdata/resolver/type_member_bad_parent.rb
@@ -1,4 +1,5 @@
 # typed: true
+# disable-fast-path: true
 
 class Parent
   Elem = 3

--- a/test/testdata/resolver/type_member_cycle.rb
+++ b/test/testdata/resolver/type_member_cycle.rb
@@ -1,0 +1,24 @@
+# typed: true
+
+class A
+  extend T::Sig
+  extend T::Generic
+
+  X = type_member(fixed: B)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^ error: Type member `A::X` is involved in a cycle
+end
+
+class B
+  extend T::Sig
+  extend T::Generic
+
+  X = type_member(fixed: A)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^ error: Type member `B::X` is involved in a cycle
+
+  sig {returns(X)}
+  def test
+    10
+  end
+end
+
+T.reveal_type(B.new.test) # error: Revealed type: `T.untyped`

--- a/test/testdata/resolver/type_member_cycle.rb
+++ b/test/testdata/resolver/type_member_cycle.rb
@@ -1,4 +1,5 @@
 # typed: true
+# disable-fast-path: true
 
 class A
   extend T::Sig

--- a/test/testdata/resolver/type_member_enum_order.rb
+++ b/test/testdata/resolver/type_member_enum_order.rb
@@ -1,0 +1,23 @@
+# typed: true
+
+class EnumsDoEnum < Opus::Enum
+  enums do
+    Elem = type_template(fixed: self)
+    X = new(:failing_send)
+  end
+end
+
+module Opus
+  class Enum
+    extend T::Generic
+    Elem = type_template
+    extend Enumerable
+    def initialize(x = nil)
+    end
+
+    def self.each(&blk)
+    end
+  end
+end
+
+T.reveal_type(EnumsDoEnum.first) # error: Revealed type: `T.nilable(EnumsDoEnum)`

--- a/test/testdata/resolver/type_member_fixed_order.rb
+++ b/test/testdata/resolver/type_member_fixed_order.rb
@@ -1,4 +1,5 @@
 # typed: true
+# disable-fast-path: true
 
 class B < A
   extend T::Generic

--- a/test/testdata/resolver/type_member_fixed_order.rb
+++ b/test/testdata/resolver/type_member_fixed_order.rb
@@ -1,0 +1,13 @@
+# typed: true
+
+class B < A
+  extend T::Generic
+  X = type_template(fixed: String)
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: parent lower bound `Integer`
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: upper bound `String`
+end
+
+class A
+  extend T::Generic
+  X = type_template(fixed: Integer)
+end

--- a/test/testdata/resolver/type_member_out_of_order.rb
+++ b/test/testdata/resolver/type_member_out_of_order.rb
@@ -1,0 +1,23 @@
+# typed: true
+
+Alias1 = T.type_alias(A)
+Alias2 = T.type_alias(B)
+
+class A
+  extend T::Generic
+  X = type_member(fixed: B)
+end
+
+class B
+  extend T::Sig
+  extend T::Generic
+
+  X = type_member(fixed: Integer)
+
+  sig {returns(X)}
+  def test
+    10
+  end
+end
+
+T.reveal_type(B.new.test) # error: Revealed type: `Integer`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The resolver was handling type aliases before type members, which in some cases would cause the bounds of a type member to be fixed as `T.untyped` in a call to `externalType`. This PR fixes that by tracking ordering dependencies between aliases and type members, and resolving them only once their dependencies have been resolved.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This bug was blocking the attached class PR #1855, as it adds a type member to every singleton class.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
Added and updated some tests.

See included automated tests.
