### PR TITLE
call patchDSL once per classDef

### DIFF
--- a/dsl/dsl.cc
+++ b/dsl/dsl.cc
@@ -37,6 +37,10 @@ public:
         Prop::patchDSL(ctx, classDef.get());
         TypeMembers::patchDSL(ctx, classDef.get());
 
+        for (auto &extension : ctx.state.semanticExtensions) {
+            extension->patchDSL(ctx, classDef.get());
+        }
+
         ast::Expression *prevStat = nullptr;
         UnorderedMap<ast::Expression *, vector<unique_ptr<ast::Expression>>> replaceNodes;
         for (auto &stat : classDef->rhs) {
@@ -70,14 +74,6 @@ public:
 
                 [&](ast::Send *send) {
                     vector<unique_ptr<ast::Expression>> nodes;
-
-                    for (auto &extension : ctx.state.semanticExtensions) {
-                        nodes = extension->replaceDSL(ctx.state, send);
-                        if (!nodes.empty()) {
-                            replaceNodes[stat.get()] = std::move(nodes);
-                            return;
-                        }
-                    }
 
                     nodes = MixinEncryptedProp::replaceDSL(ctx, send);
                     if (!nodes.empty()) {

--- a/main/pipeline/semantic_extension/SemanticExtension.h
+++ b/main/pipeline/semantic_extension/SemanticExtension.h
@@ -14,9 +14,8 @@ class GlobalSubstitution;
 } // namespace core
 
 namespace ast {
-class Send;
 class MethodDef;
-class Expression;
+class ClassDef;
 } // namespace ast
 
 namespace cfg {
@@ -27,7 +26,7 @@ namespace pipeline::semantic_extension {
 class SemanticExtension {
 public:
     virtual void typecheck(const core::GlobalState &, cfg::CFG &, std::unique_ptr<ast::MethodDef> &) const = 0;
-    virtual std::vector<std::unique_ptr<ast::Expression>> replaceDSL(core::GlobalState &, ast::Send *) const = 0;
+    virtual void patchDSL(const core::GlobalState &, ast::ClassDef *) const = 0;
     virtual ~SemanticExtension() = default;
     virtual std::unique_ptr<SemanticExtension> deepCopy(const core::GlobalState &from, core::GlobalState &to) = 0;
     virtual void merge(const core::GlobalState &from, core::GlobalState &to, core::GlobalSubstitution &subst) = 0;


### PR DESCRIPTION
I think this will be more useful to get called once per class. I actually wanted once per file, but we seem to wrap the outside of everything in a class, so the extension can pick to do its own traversal from this point. 

I think if we want to fix this in the future, we should but it was the easiest path forward for now.

### Motivation
Even if there aren't any `send`s I still need this pass to be called

### Test plan
```
$ s -e 'class Foo; end; 1 ' -p dsl-tree
class <emptyTree><<C <root>>> < ()
  class <emptyTree>::<C Foo><<C <todo sym>>> < (::<todo sym>)
    <emptyTree>
  end

  1
end
No errors! Great job.
```
