### PR TITLE
Enforce Opus::Enum correctness with Sorbet

### DIFF
--- a/core/errors/dsl.h
+++ b/core/errors/dsl.h
@@ -8,5 +8,6 @@ constexpr ErrorClass BadWrapInstance{3502, StrictLevel::True};
 constexpr ErrorClass PrivateMethodMismatch{3503, StrictLevel::False};
 constexpr ErrorClass BadAttrType{3504, StrictLevel::True};
 constexpr ErrorClass BadModuleFunction{3505, StrictLevel::True};
+constexpr ErrorClass OpusEnumOutsideEnumsDo{3506, StrictLevel::False};
 } // namespace sorbet::core::errors::DSL
 #endif

--- a/core/errors/dsl.h
+++ b/core/errors/dsl.h
@@ -9,5 +9,6 @@ constexpr ErrorClass PrivateMethodMismatch{3503, StrictLevel::False};
 constexpr ErrorClass BadAttrType{3504, StrictLevel::True};
 constexpr ErrorClass BadModuleFunction{3505, StrictLevel::True};
 constexpr ErrorClass OpusEnumOutsideEnumsDo{3506, StrictLevel::False};
+constexpr ErrorClass OpusEnumConstNotEnumValue{3506, StrictLevel::False};
 } // namespace sorbet::core::errors::DSL
 #endif

--- a/test/testdata/dsl/opus_enum.rb
+++ b/test/testdata/dsl/opus_enum.rb
@@ -14,15 +14,20 @@ module Opus
 
     sig {override.params(blk: T.untyped).returns(T.untyped)}
     def self.each(&blk); end
+
+    sig {params(blk: T.proc.void).void}
+    def self.enums(&blk); end
   end
 end
 
 class MyEnum < Opus::Enum
   Elem = type_template
 
+  enums do
   X = new
   Y = new('y')
   Z = T.let(new, self)
+  end
 end
 
 T.reveal_type(MyEnum::X) # error: Revealed type: `MyEnum::X`
@@ -30,8 +35,10 @@ T.reveal_type(MyEnum::Y) # error: Revealed type: `MyEnum::Y`
 T.reveal_type(MyEnum::Z) # error: Revealed type: `MyEnum::Z`
 
 class NotAnEnum
+  enums do # error: does not exist
   X = new # error: Constants must have type annotations
   Y = T.let(new, self)
+  end
 end
 
 T.reveal_type(NotAnEnum::X) # error: Revealed type: `T.untyped`

--- a/test/testdata/dsl/opus_enum_alias.rb
+++ b/test/testdata/dsl/opus_enum_alias.rb
@@ -7,11 +7,15 @@ module Opus
     extend T::Generic
     def initialize(x = nil)
     end
+    def self.enums(&blk)
+    end
   end
 end
 
 class MyEnum < Opus::Enum
+  enums do
   X = new
+  end
 end
 
 # We probably never want to allow this

--- a/test/testdata/dsl/opus_enum_all.rb
+++ b/test/testdata/dsl/opus_enum_all.rb
@@ -3,13 +3,18 @@ extend T::Sig
 
 module Opus
   class Enum
+    extend T::Sig
     extend T::Generic
+    sig {params(blk: T.proc.void).void}
+    def self.enums(&blk); end
   end
 end
 
 class MyEnum < Opus::Enum
+  enums do
   A = new
   B = new
+  end
 end
 
 # It used to be the case that this caused "unsupported usage of bare type",

--- a/test/testdata/dsl/opus_enum_exhaustiveness.rb
+++ b/test/testdata/dsl/opus_enum_exhaustiveness.rb
@@ -10,13 +10,19 @@ module Opus
     sig {params(x: T.nilable(String)).void}
     def initialize(x = nil)
     end
+
+    sig {params(blk: T.proc.void).void}
+    def self.enums(&blk)
+    end
   end
 end
 
 class MyEnum < Opus::Enum
+  enums do
   A = new
   B = new
   C = new
+  end
 end
 
 sig {params(x: MyEnum).void}

--- a/test/testdata/dsl/opus_enum_snapshot.rb
+++ b/test/testdata/dsl/opus_enum_snapshot.rb
@@ -32,13 +32,17 @@ class EnumsDoEnum < Opus::Enum
   end
 
   def something_outside; end
-  SomethingElseOutside = 1
 end
 
 class BadConsts < Opus::Enum
   Before = new # error: must be within the `enums do` block
+  StaticField1 = 1 # error: must be unique instances of the enum
   enums do
     Inside = new
+    StaticField2 = 2 # error: must be unique instances of the enum
   end
   After = new # error: must be within the `enums do` block
+  StaticField3 = 3 # error: must be unique instances of the enum
+  StaticField4 = T.let(1, Integer) # error: must be unique instances of the enum
+  Elem = type_template(fixed: self)
 end

--- a/test/testdata/dsl/opus_enum_snapshot.rb
+++ b/test/testdata/dsl/opus_enum_snapshot.rb
@@ -34,3 +34,11 @@ class EnumsDoEnum < Opus::Enum
   def something_outside; end
   SomethingElseOutside = 1
 end
+
+class BadConsts < Opus::Enum
+  Before = new # error: must be within the `enums do` block
+  enums do
+    Inside = new
+  end
+  After = new # error: must be within the `enums do` block
+end

--- a/test/testdata/dsl/opus_enum_snapshot.rb
+++ b/test/testdata/dsl/opus_enum_snapshot.rb
@@ -4,18 +4,24 @@ module Opus
     extend T::Generic
     def initialize(x = nil)
     end
+    def self.enums(&blk)
+    end
   end
 end
 
 class MyEnum < Opus::Enum
+  enums do
   X = new
   Y = new('y')
   Z = T.let(new, self)
+  end
 end
 
 class NotAnEnum
+  enums do # error: does not exist
   X = new
   Y = T.let(new, self)
+  end
 end
 
 class EnumsDoEnum < Opus::Enum

--- a/test/testdata/dsl/opus_enum_snapshot.rb.dsl-tree.exp
+++ b/test/testdata/dsl/opus_enum_snapshot.rb.dsl-tree.exp
@@ -100,8 +100,6 @@ class <emptyTree><<C <root>>> < ()
     def something_outside<<C <todo sym>>>(&<blk>)
       <emptyTree>
     end
-
-    <emptyTree>::<C SomethingElseOutside> = 1
   end
 
   class <emptyTree>::<C BadConsts><<C <todo sym>>> < (<emptyTree>::<C Opus>::<C Enum>)
@@ -121,6 +119,8 @@ class <emptyTree><<C <root>>> < ()
 
     <emptyTree>::<C Before> = ::T.let(<emptyTree>::<C Before$1>.instance(), <emptyTree>::<C Before$1>)
 
+    <emptyTree>::<C StaticField1> = 1
+
     class <emptyTree>::<C Inside$1><<C <todo sym>>> < (<emptyTree>::<C BadConsts>)
       <emptyTree>::<C Elem> = <self>.type_template({:"fixed" => <emptyTree>::<C BadConsts>})
 
@@ -131,6 +131,8 @@ class <emptyTree><<C <root>>> < ()
 
     <emptyTree>::<C Inside> = ::T.let(<emptyTree>::<C Inside$1>.instance(), <emptyTree>::<C Inside$1>)
 
+    <emptyTree>::<C StaticField2> = 2
+
     class <emptyTree>::<C After$1><<C <todo sym>>> < (<emptyTree>::<C BadConsts>)
       <emptyTree>::<C Elem> = <self>.type_template({:"fixed" => <emptyTree>::<C BadConsts>})
 
@@ -140,5 +142,11 @@ class <emptyTree><<C <root>>> < ()
     end
 
     <emptyTree>::<C After> = ::T.let(<emptyTree>::<C After$1>.instance(), <emptyTree>::<C After$1>)
+
+    <emptyTree>::<C StaticField3> = 3
+
+    <emptyTree>::<C StaticField4> = <emptyTree>::<C T>.let(1, <emptyTree>::<C Integer>)
+
+    <emptyTree>::<C Elem> = <self>.type_template({:"fixed" => <self>})
   end
 end

--- a/test/testdata/dsl/opus_enum_snapshot.rb.dsl-tree.exp
+++ b/test/testdata/dsl/opus_enum_snapshot.rb.dsl-tree.exp
@@ -6,6 +6,10 @@ class <emptyTree><<C <root>>> < ()
       def initialize<<C <todo sym>>>(x = nil, &<blk>)
         <emptyTree>
       end
+
+      def self.enums<<C <todo sym>>>(&blk)
+        <emptyTree>
+      end
     end
   end
 
@@ -48,9 +52,12 @@ class <emptyTree><<C <root>>> < ()
   end
 
   class <emptyTree>::<C NotAnEnum><<C <todo sym>>> < (::<todo sym>)
-    <emptyTree>::<C X> = <self>.new()
-
-    <emptyTree>::<C Y> = <emptyTree>::<C T>.let(<self>.new(), <self>)
+    <self>.enums() do ||
+      begin
+        <emptyTree>::<C X> = <self>.new()
+        <emptyTree>::<C Y> = <emptyTree>::<C T>.let(<self>.new(), <self>)
+      end
+    end
   end
 
   class <emptyTree>::<C EnumsDoEnum><<C <todo sym>>> < (<emptyTree>::<C Opus>::<C Enum>)

--- a/test/testdata/dsl/opus_enum_snapshot.rb.dsl-tree.exp
+++ b/test/testdata/dsl/opus_enum_snapshot.rb.dsl-tree.exp
@@ -103,4 +103,42 @@ class <emptyTree><<C <root>>> < ()
 
     <emptyTree>::<C SomethingElseOutside> = 1
   end
+
+  class <emptyTree>::<C BadConsts><<C <todo sym>>> < (<emptyTree>::<C Opus>::<C Enum>)
+    <self>.extend(::T::Helpers)
+
+    <self>.abstract!()
+
+    <self>.sealed!()
+
+    class <emptyTree>::<C Before$1><<C <todo sym>>> < (<emptyTree>::<C BadConsts>)
+      <emptyTree>::<C Elem> = <self>.type_template({:"fixed" => <emptyTree>::<C BadConsts>})
+
+      <self>.include(::Singleton)
+
+      <self>.final!()
+    end
+
+    <emptyTree>::<C Before> = ::T.let(<emptyTree>::<C Before$1>.instance(), <emptyTree>::<C Before$1>)
+
+    class <emptyTree>::<C Inside$1><<C <todo sym>>> < (<emptyTree>::<C BadConsts>)
+      <emptyTree>::<C Elem> = <self>.type_template({:"fixed" => <emptyTree>::<C BadConsts>})
+
+      <self>.include(::Singleton)
+
+      <self>.final!()
+    end
+
+    <emptyTree>::<C Inside> = ::T.let(<emptyTree>::<C Inside$1>.instance(), <emptyTree>::<C Inside$1>)
+
+    class <emptyTree>::<C After$1><<C <todo sym>>> < (<emptyTree>::<C BadConsts>)
+      <emptyTree>::<C Elem> = <self>.type_template({:"fixed" => <emptyTree>::<C BadConsts>})
+
+      <self>.include(::Singleton)
+
+      <self>.final!()
+    end
+
+    <emptyTree>::<C After> = ::T.let(<emptyTree>::<C After$1>.instance(), <emptyTree>::<C After$1>)
+  end
 end

--- a/test/testdata/dsl/opus_enum_type_syntax.rb
+++ b/test/testdata/dsl/opus_enum_type_syntax.rb
@@ -10,14 +10,20 @@ module Opus
     sig {params(x: T.nilable(String)).void}
     def initialize(x = nil)
     end
+
+    sig {params(blk: T.proc.void).void}
+    def self.enums(&blk)
+    end
   end
 end
 
 class MyEnum < Opus::Enum
+  enums do
   A = new
   B = new
   C = new
   D = new
+  end
 end
 
 sig {params(x: T.any(MyEnum::A, MyEnum::B)).void}

--- a/test/testdata/perf/sealed_registration_perf.rb
+++ b/test/testdata/perf/sealed_registration_perf.rb
@@ -5,6 +5,7 @@
 class HugeEnum < Opus::Enum
   include T::Props::Serializable
   Elem = type_template(fixed: self)
+  enums do
   Val000 = new()
   Val001 = new()
   Val002 = new()
@@ -1005,4 +1006,5 @@ class HugeEnum < Opus::Enum
   Val997 = new()
   Val998 = new()
   Val999 = new()
+  end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These errors used to be errors enforced by how Opus::LoadHooks worked (we'd
finalize the Opus::Enum after the file had finished loading, so you'd really
have to do hacky things to get a constant defined that we couldn't see and
complain about).

Now that we don't use Opus::LoadHooks, it's possible to define a constant on
our class after we're done looking at the constants on our class at runtime, so
we need to enforce that these enum value constants are the only constants
statically. This is also how we guarantee that each enum is only stored into
one name.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.