### PR TITLE
pass in a unique_ptr so all the walking functions can work on it

### DIFF
--- a/dsl/dsl.cc
+++ b/dsl/dsl.cc
@@ -38,7 +38,7 @@ public:
         TypeMembers::patchDSL(ctx, classDef.get());
 
         for (auto &extension : ctx.state.semanticExtensions) {
-            classDef = extension->patchDSL(ctx, classDef);
+            classDef = extension->patchDSL(ctx, move(classDef));
         }
 
         ast::Expression *prevStat = nullptr;

--- a/dsl/dsl.cc
+++ b/dsl/dsl.cc
@@ -38,7 +38,7 @@ public:
         TypeMembers::patchDSL(ctx, classDef.get());
 
         for (auto &extension : ctx.state.semanticExtensions) {
-            extension->patchDSL(ctx, classDef.get());
+            classDef = extension->patchDSL(ctx, classDef);
         }
 
         ast::Expression *prevStat = nullptr;

--- a/main/pipeline/semantic_extension/SemanticExtension.h
+++ b/main/pipeline/semantic_extension/SemanticExtension.h
@@ -27,7 +27,8 @@ namespace pipeline::semantic_extension {
 class SemanticExtension {
 public:
     virtual void typecheck(const core::GlobalState &, cfg::CFG &, std::unique_ptr<ast::MethodDef> &) const = 0;
-    virtual std::unique_ptr<ast::Expression> patchDSL(const core::GlobalState &, std::unique_ptr<ast::ClassDef>) const = 0;
+    virtual std::unique_ptr<ast::Expression> patchDSL(const core::GlobalState &,
+                                                      std::unique_ptr<ast::ClassDef>) const = 0;
     virtual ~SemanticExtension() = default;
     virtual std::unique_ptr<SemanticExtension> deepCopy(const core::GlobalState &from, core::GlobalState &to) = 0;
     virtual void merge(const core::GlobalState &from, core::GlobalState &to, core::GlobalSubstitution &subst) = 0;

--- a/main/pipeline/semantic_extension/SemanticExtension.h
+++ b/main/pipeline/semantic_extension/SemanticExtension.h
@@ -14,6 +14,7 @@ class GlobalSubstitution;
 } // namespace core
 
 namespace ast {
+class Expression;
 class MethodDef;
 class ClassDef;
 } // namespace ast
@@ -26,7 +27,7 @@ namespace pipeline::semantic_extension {
 class SemanticExtension {
 public:
     virtual void typecheck(const core::GlobalState &, cfg::CFG &, std::unique_ptr<ast::MethodDef> &) const = 0;
-    virtual void patchDSL(const core::GlobalState &, ast::ClassDef *) const = 0;
+    virtual std::unique_ptr<ast::Expression> patchDSL(const core::GlobalState &, std::unique_ptr<ast::ClassDef>) const = 0;
     virtual ~SemanticExtension() = default;
     virtual std::unique_ptr<SemanticExtension> deepCopy(const core::GlobalState &from, core::GlobalState &to) = 0;
     virtual void merge(const core::GlobalState &from, core::GlobalState &to, core::GlobalSubstitution &subst) = 0;


### PR DESCRIPTION
This changes the ownership model so that tree walkers can be used by the DSL extensions

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
