### PR TITLE
pass MutableContext instead of GlobalState

### DIFF
--- a/main/pipeline/semantic_extension/SemanticExtension.h
+++ b/main/pipeline/semantic_extension/SemanticExtension.h
@@ -11,6 +11,7 @@ namespace sorbet {
 namespace core {
 class GlobalState;
 class GlobalSubstitution;
+class MutableContext;
 } // namespace core
 
 namespace ast {
@@ -26,7 +27,7 @@ namespace pipeline::semantic_extension {
 class SemanticExtension {
 public:
     virtual void typecheck(const core::GlobalState &, cfg::CFG &, std::unique_ptr<ast::MethodDef> &) const = 0;
-    virtual void patchDSL(const core::GlobalState &, ast::ClassDef *) const = 0;
+    virtual void patchDSL(core::MutableContext &, ast::ClassDef *) const = 0;
     virtual ~SemanticExtension() = default;
     virtual std::unique_ptr<SemanticExtension> deepCopy(const core::GlobalState &from, core::GlobalState &to) = 0;
     virtual void merge(const core::GlobalState &from, core::GlobalState &to, core::GlobalSubstitution &subst) = 0;


### PR DESCRIPTION
To use the treewalkers we need a CTX. Should this be mutable? or const? I'm just copying the param that is passed into the dsl walker but happy to change to whatever will work

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
