### PR TITLE
Set strict level on fast path.

### DIFF
--- a/main/lsp/updates.cc
+++ b/main/lsp/updates.cc
@@ -256,6 +256,8 @@ LSPLoop::TypecheckRun LSPLoop::runTypechecking(unique_ptr<core::GlobalState> gs,
                     }
                 }
                 gs = core::GlobalState::replaceFile(move(gs), fref, f);
+                // If file doesn't have a typed: sigil, then we need to ensure it's typechecked using typed: false.
+                fref.data(*gs).strictLevel = pipeline::decideStrictLevel(*gs, fref, config.opts);
                 subset.emplace_back(fref);
             }
         }

--- a/test/testdata/lsp/missing_typed_sigil.A.rbedited
+++ b/test/testdata/lsp/missing_typed_sigil.A.rbedited
@@ -12,7 +12,7 @@ class Hello
 end
 
 def main
-  puts Helo.new
+  puts Gem.new
   #    ^^^^ error: Unable to resolve constant `Helo`
   #    ^^^^ apply-code-action: [A] Replace with `Gem`
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Set strict level on fast path. I noticed this ENFORCE triggering in a test repo.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Prevents an ENFORCE when doing a code action request on a file w/o a typed sigil.

This ENFORCE does not trigger on normal fast/slow paths since we set the strictLevel during request pre-processing.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
