### PR TITLE
LSP: Fix crash in hover on untyped arguments

### DIFF
--- a/core/lsp/QueryResponse.cc
+++ b/core/lsp/QueryResponse.cc
@@ -59,7 +59,8 @@ core::TypePtr QueryResponse::getRetType() const {
     } else if (auto def = isDefinition()) {
         return def->retType.type;
     } else {
-        return core::TypePtr();
+        // Should never happen, as the above checks should be exhaustive.
+        Exception::raise("Invalid QueryResponse object.");
     }
 }
 

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -120,8 +120,13 @@ LSPResult LSPLoop::handleTextDocumentHover(unique_ptr<core::GlobalState> gs, con
             response->result = make_unique<Hover>(
                 formatHoverText(config.clientHoverMarkupKind, type->showWithMoreInfo(*gs), documentation));
         } else {
-            response->result = make_unique<Hover>(formatHoverText(
-                config.clientHoverMarkupKind, resp->getRetType()->showWithMoreInfo(*gs), documentation));
+            core::TypePtr retType = resp->getRetType();
+            // Some untyped arguments have null types.
+            if (!retType) {
+                retType = core::Types::untypedUntracked();
+            }
+            response->result = make_unique<Hover>(
+                formatHoverText(config.clientHoverMarkupKind, retType->showWithMoreInfo(*gs), documentation));
         }
     }
     return LSPResult::make(move(gs), move(response));

--- a/test/testdata/lsp/hover_untyped_keyword_arg.rb
+++ b/test/testdata/lsp/hover_untyped_keyword_arg.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+module Test
+  def foo(bar: nil)
+    #     ^^^ hover: T.untyped
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

LSP: Fix crash in hover on untyped arguments

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I noticed hover was crashing for a number of folks, and managed to replicate locally. Untyped arguments sometimes have null types. I added in logic to handle null types, and added a test.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
