### PR TITLE
Add `ENV.keys`

### DIFF
--- a/rbi/sorbet/sorbet.rbi
+++ b/rbi/sorbet/sorbet.rbi
@@ -151,6 +151,11 @@ class Sorbet::Private::Static::ENVClass
     .returns(T::Hash[String, T.nilable(String)])
   end
   def update(key, &blk); end
+
+  sig do
+    returns(T::Array[String])
+  end
+  def keys; end
 end
 # [`ENV`](https://docs.ruby-lang.org/en/2.6.0/ENV.html) is a hash-like accessor
 # for environment variables.


### PR DESCRIPTION
Add `ENV.keys` to Sorbet's standard library.

### Motivation

Sorbet currently doesn't recognise `ENV.keys`. But it's part of the standard library: https://github.com/ruby/ruby/blob/master/spec/ruby/core/env/keys_spec.rb


### Test plan

I'm not sure how best to test this, open to ideas.