### PR TITLE
Numeric#round requires zero arguments

### DIFF
--- a/rbi/core/numeric.rbi
+++ b/rbi/core/numeric.rbi
@@ -512,7 +512,7 @@ class Numeric < Object
     )
     .returns(Numeric)
   end
-  def round(arg0); end
+  def round(arg0 = 0); end
 
   sig do
     params(


### PR DESCRIPTION
### Motivation
Fixes [this error](https://sorbet.run/#n%20%3D%20T.let(1.5%2C%20Numeric)%0An.round).


### Test plan
Not sure how to test, open to ideas. See https://github.com/ruby/ruby/blob/master/spec/ruby/core/numeric/round_spec.rb#L11 for confirmation that this is expected.
