### PR TITLE
Add `String#encode`

### DIFF
--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -862,6 +862,17 @@ class String < Object
   sig {returns(T::Boolean)}
   def empty?(); end
 
+  # The first form returns a copy of str transcoded to encoding encoding.
+  # TODO: support other forms @ https://docs.ruby-lang.org/en/2.6.0/String.html#method-i-encode
+  sig do
+    params(
+      encoding: T.nilable(String),
+      options: T.untyped
+    )
+    .returns(T::Boolean)
+  end
+  def encode(encoding = T.unsafe(nil), options = T.unsafe({})); end
+
   # Returns the [`Encoding`](https://docs.ruby-lang.org/en/2.6.0/Encoding.html)
   # object that represents the encoding of obj.
   sig {returns(Encoding)}


### PR DESCRIPTION
### Motivation
Fixes https://sorbet.run/#%22%22.encode

I've only supported the most straightforward version of `String#encode` initially because I don't really understand how multiple signatures are meant to work.


### Test plan
Method should be in std lib:

https://docs.ruby-lang.org/en/2.6.0/String.html#method-i-encode
https://github.com/ruby/ruby/blob/master/spec/ruby/core/string/encode_spec.rb