### PR TITLE
Add subtyping rules for SelfTypeParam

### DIFF
--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -1014,10 +1014,23 @@ bool isSubTypeUnderConstraintSingle(Context ctx, TypeConstraint &constr, Untyped
         auto *self1 = cast_type<SelfTypeParam>(t1.get());
         auto *self2 = cast_type<SelfTypeParam>(t2.get());
         if (self1 != nullptr || self2 != nullptr) {
-            if (self1 == nullptr || self2 == nullptr) {
-                return false;
+            // NOTE: SelfTypeParam is used both with LambdaParam and TypeVar, so
+            // we can only check bounds when a LambdaParam is present.
+            if (self1 == nullptr) {
+                if (auto *lambdaParam = cast_type<LambdaParam>(self2->definition.data(ctx)->resultType.get())) {
+                    return Types::isSubTypeUnderConstraint(ctx, constr, t1, lambdaParam->lowerBound, mode);
+                } else {
+                    return false;
+                }
+            } else if (self2 == nullptr) {
+                if (auto *lambdaParam = cast_type<LambdaParam>(self1->definition.data(ctx)->resultType.get())) {
+                    return Types::isSubTypeUnderConstraint(ctx, constr, lambdaParam->upperBound, t2, mode);
+                } else {
+                    return false;
+                }
+            } else {
+                return self1->definition == self2->definition;
             }
-            return self1->definition == self2->definition;
         }
     }
 

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -1029,7 +1029,13 @@ bool isSubTypeUnderConstraintSingle(Context ctx, TypeConstraint &constr, Untyped
                     return false;
                 }
             } else {
-                return self1->definition == self2->definition;
+                if (self1->definition == self2->definition) {
+                    return true;
+                }
+
+                auto *lambda1 = cast_type<LambdaParam>(self1->definition.data(ctx)->resultType.get());
+                auto *lambda2 = cast_type<LambdaParam>(self2->definition.data(ctx)->resultType.get());
+                return lambda1 && lambda2 && Types::isSubTypeUnderConstraint(ctx, constr, lambda1->upperBound, lambda2->lowerBound, mode);
             }
         }
     }

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -1035,7 +1035,8 @@ bool isSubTypeUnderConstraintSingle(Context ctx, TypeConstraint &constr, Untyped
 
                 auto *lambda1 = cast_type<LambdaParam>(self1->definition.data(ctx)->resultType.get());
                 auto *lambda2 = cast_type<LambdaParam>(self2->definition.data(ctx)->resultType.get());
-                return lambda1 && lambda2 && Types::isSubTypeUnderConstraint(ctx, constr, lambda1->upperBound, lambda2->lowerBound, mode);
+                return lambda1 && lambda2 &&
+                       Types::isSubTypeUnderConstraint(ctx, constr, lambda1->upperBound, lambda2->lowerBound, mode);
             }
         }
     }

--- a/test/testdata/infer/self_type_param_bounded.rb
+++ b/test/testdata/infer/self_type_param_bounded.rb
@@ -2,22 +2,51 @@
 
 class Animal; end
 class Cat < Animal; end
+class Serval < Cat; end
 
 class A
   extend T::Sig
   extend T::Generic
 
-  X = type_template(upper: Animal)
+  T1 = type_member(upper: Animal, lower: Cat)
 
-  sig {params(x: X).void}
-  def self.useless_cast(x)
-    x = T.cast(x, Animal) # error: Useless cast
+  sig {params(x: T1).void}
+  def test1(x)
+    T.cast(x, Animal) # error: Useless cast
+  end
+end
+
+class B
+  extend T::Sig
+  extend T::Generic
+
+  T1 = type_member(upper: Object)
+  T2 = type_member(lower: Object)
+
+  sig {params(x: T1).void}
+  def test1(x)
+    T.reveal_type(test2(x)) # error: Revealed type: `B::T2`
   end
 
-  Y = type_member(upper: Cat)
+  sig {params(x: T2).returns(T2)}
+  def test2(x)
+    x
+  end
+end
 
-  sig {params(y: Y).void}
-  def useless_cast(y)
-    y = T.cast(y, Cat) # error: Useless cast
+module C
+  extend T::Sig
+  extend T::Generic
+
+  Out = type_member(:out, upper: Animal)
+  In = type_member(:in, lower: Cat)
+
+  sig {void}
+  def test1
+    C.test1(self)
+  end
+
+  sig {params(x: C[Animal,Cat]).void}
+  def self.test1(x)
   end
 end

--- a/test/testdata/infer/self_type_param_bounded.rb
+++ b/test/testdata/infer/self_type_param_bounded.rb
@@ -1,0 +1,23 @@
+# typed: strict
+
+class Animal; end
+class Cat < Animal; end
+
+class A
+  extend T::Sig
+  extend T::Generic
+
+  X = type_template(upper: Animal)
+
+  sig {params(x: X).void}
+  def self.useless_cast(x)
+    x = T.cast(x, Animal) # error: Useless cast
+  end
+
+  Y = type_member(upper: Cat)
+
+  sig {params(y: Y).void}
+  def useless_cast(y)
+    y = T.cast(y, Cat) # error: Useless cast
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
We can use bounds on type members/templates in `isSubType` to allow `SelfTypeParam` to participate in subtyping relations that don't involve other `SelfTypeParam` instances.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This allows us to remove a number of redundant casts.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
