### PR TITLE
Fix the return type of String#encode

### DIFF
--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -869,7 +869,7 @@ class String < Object
       encoding: T.nilable(String),
       options: T.untyped
     )
-    .returns(T::Boolean)
+    .returns(String)
   end
   def encode(encoding = T.unsafe(nil), options = T.unsafe({})); end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
#1933 specified the return type of `String#encode` as `T::Boolean`, when it should instead be `String`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fix the build.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
