### PR TITLE
Revert "Add `String#encode`"

### DIFF
--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -862,17 +862,6 @@ class String < Object
   sig {returns(T::Boolean)}
   def empty?(); end
 
-  # The first form returns a copy of str transcoded to encoding encoding.
-  # TODO: support other forms @ https://docs.ruby-lang.org/en/2.6.0/String.html#method-i-encode
-  sig do
-    params(
-      encoding: T.nilable(String),
-      options: T.untyped
-    )
-    .returns(T::Boolean)
-  end
-  def encode(encoding = T.unsafe(nil), options = T.unsafe({})); end
-
   # Returns the [`Encoding`](https://docs.ruby-lang.org/en/2.6.0/Encoding.html)
   # object that represents the encoding of obj.
   sig {returns(Encoding)}


### PR DESCRIPTION
Reverts sorbet/sorbet#1933

There are some problems with this signature, the return type is `T::Boolean` instead of `String`, and the encoding argument should accept more than just a `String`.