### PR TITLE
Add --sleep-in-slow-path flag

### DIFF
--- a/common/Timer.h
+++ b/common/Timer.h
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <memory>
 #include <string>
+#include <thread>
 
 namespace sorbet {
 class Timer {
@@ -21,6 +22,15 @@ public:
           std::initializer_list<std::pair<ConstExprStr, std::string>> args);
     ~Timer();
     FlowId getFlowEdge();
+
+    // TODO We could add more overloads for this if we need them (to create other kinds of Timers)
+    // We could also make this more generic to allow more sleep duration types.
+    static void timedSleep(const std::chrono::microseconds &sleep_duration, spdlog::logger &log, ConstExprStr name) {
+        Timer timer(log, name);
+        auto dur = std::chrono::duration<double, std::milli>(sleep_duration);
+        log.debug("{}: sleeping for {}ms", name.str, dur.count());
+        std::this_thread::sleep_for(sleep_duration);
+    }
 
 private:
     spdlog::logger &log;

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1261,6 +1261,7 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     result->ensureCleanStrings = this->ensureCleanStrings;
     result->runningUnderAutogen = this->runningUnderAutogen;
     result->censorForSnapshotTests = this->censorForSnapshotTests;
+    result->sleepInSlowPath = this->sleepInSlowPath;
 
     if (keepId) {
         result->globalStateId = this->globalStateId;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -175,6 +175,8 @@ public:
     bool runningUnderAutogen = false;
     bool censorForSnapshotTests = false;
 
+    bool sleepInSlowPath = false;
+
     std::unique_ptr<GlobalState> deepCopy(bool keepId = false) const;
     mutable std::shared_ptr<ErrorQueue> errorQueue;
 

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -402,6 +402,7 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("dev")("wait-for-dbg", "Wait for debugger on start");
     options.add_options("dev")("stress-incremental-resolver",
                                "Force incremental updates to discover resolver & namer bugs");
+    options.add_options("dev")("sleep-in-slow-path", "Add some sleeps to slow path to artificially slow it down");
     options.add_options("dev")("simulate-crash", "Crash on start");
     options.add_options("dev")("silence-dev-message", "Silence \"You are running a development build\" message");
     options.add_options("dev")("censor-for-snapshot-tests",
@@ -777,6 +778,7 @@ void readOptions(Options &opts,
         opts.suggestTyped = raw["suggest-typed"].as<bool>();
         opts.waitForDebugger = raw["wait-for-dbg"].as<bool>();
         opts.stressIncrementalResolver = raw["stress-incremental-resolver"].as<bool>();
+        opts.sleepInSlowPath = raw["sleep-in-slow-path"].as<bool>();
         opts.suggestRuntimeProfiledType = raw["suggest-runtime-profiled"].as<bool>();
         opts.enableCounters = raw["counters"].as<bool>();
         opts.silenceDevMessage = raw["silence-dev-message"].as<bool>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -135,6 +135,7 @@ struct Options {
     bool disableWatchman = false;
     std::string watchmanPath = "watchman";
     bool stressIncrementalResolver = false;
+    bool sleepInSlowPath = false;
     bool noErrorCount = false;
     bool autocorrect = false;
     bool waitForDebugger = false;

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -419,6 +419,9 @@ int realmain(int argc, char *argv[]) {
     if (opts.censorForSnapshotTests) {
         gs->censorForSnapshotTests = true;
     }
+    if (opts.sleepInSlowPath) {
+        gs->sleepInSlowPath = true;
+    }
     if (opts.reserveMemKiB > 0) {
         gs->reserveMemory(opts.reserveMemKiB);
     }

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -163,6 +163,8 @@ Usage:
       --stress-incremental-resolver
                                 Force incremental updates to discover
                                 resolver & namer bugs
+      --sleep-in-slow-path      Add some sleeps to slow path to artificially
+                                slow it down
       --simulate-crash          Crash on start
       --silence-dev-message     Silence "You are running a development build"
                                 message


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This helps make it apparent which edits are in the fast path and which edits
are in the slow path.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Decided to leave this untested, because it will necessarily be a slow CLI test
to run, and also it's designed for interactive use by someone on our team so if
it regresses probably the person on our team who's trying to use it will have
enough information to fix it. And also I don't expect it to break particularly
often.