### PR TITLE
Add corrected type for String#encode

### DIFF
--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -862,6 +862,10 @@ class String < Object
   sig {returns(T::Boolean)}
   def empty?(); end
 
+  # The one-encoding form returns a copy of str transcoded to encoding
+  # encoding. The two-encoding form returns a copy of str transcoded
+  # from src_encoding to dst_encoding. The final, zero-encoding form
+  # returns a copy of str transcoded to `Encoding.default_internal`.
   sig do
     params(
       arg0: T.any(String, Encoding),

--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -862,6 +862,29 @@ class String < Object
   sig {returns(T::Boolean)}
   def empty?(); end
 
+  sig do
+    params(
+      arg0: T.any(String, Encoding),
+      arg1: T.any(String, Encoding),
+      arg2: T::Hash[Symbol, T.untyped]
+    )
+    .returns(String)
+  end
+  sig do
+    params(
+      arg0: T.any(String, Encoding),
+      arg1: T::Hash[Symbol, T.untyped]
+    )
+    .returns(String)
+  end
+  sig do
+    params(
+      arg0: T::Hash[Symbol, T.untyped]
+    )
+    .returns(String)
+  end
+  def encode(arg0=T.unsafe(nil), arg1=T.unsafe(nil), arg2=T.unsafe(nil)); end
+
   # Returns the [`Encoding`](https://docs.ruby-lang.org/en/2.6.0/Encoding.html)
   # object that represents the encoding of obj.
   sig {returns(Encoding)}
@@ -2418,4 +2441,5 @@ class String < Object
     .returns(T.nilable(String))
   end
   def slice(arg0, arg1=T.unsafe(nil)); end
+
 end

--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -2445,5 +2445,4 @@ class String < Object
     .returns(T.nilable(String))
   end
   def slice(arg0, arg1=T.unsafe(nil)); end
-
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
We had to roll back #1933 because it was blocking internal upgrades and included an error (specifically in that it implemented the return type as `T::Boolean` instead of as `String`.) This fixes that and adds the other type signatures as well.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. I also ran this over the monorepo and the only problem was that we need to remove the existing `#encode` that's present in a missing methods file.
