### PR TITLE
sync-rdoc: Accept path to a single RBI file

### DIFF
--- a/rbi/tools/sync-rdoc.rb
+++ b/rbi/tools/sync-rdoc.rb
@@ -578,6 +578,11 @@ class SyncRDoc
     store.complete(:private)
 
     argv.each do |dir|
+      if File.exist?(dir) && File.extname(dir) == '.rbi'
+        process_file!(RBIFile.new(dir))
+        next
+      end
+
       Dir.glob(File.join('**', '*.rbi'), base: dir) do |path|
         process_file!(RBIFile.new(File.join(dir, path)))
       end


### PR DESCRIPTION
### Motivation

Sometime you only want to sync the doc for one file and not the whole directory.

With this PR, `sync-rdoc` accepts it:

```sh
rbi/tools/sync-rdoc.rb rbi/stdlib/etc.rbi
```

You can also mix directories and files:

```sh
rbi/tools/sync-rdoc.rb rbi/core/ rbi/stdlib/erb.rbi
```

### Test plan

If there tests for `sync-rdoc`?
