### PR TITLE
sync-rdoc: Allow users to specify the RDoc store path

### DIFF
--- a/rbi/tools/sync-rdoc.rb
+++ b/rbi/tools/sync-rdoc.rb
@@ -445,7 +445,12 @@ class SyncRDoc
 
   private def store
     return @store if defined?(@store)
-    @store = driver.stores.find {|s| s.source == 'ruby'}
+
+    @store = if defined?(@store_path)
+      RDoc::Store.new(@store_path)
+    else
+      driver.stores.find {|s| s.source == 'ruby'}
+    end
     rdoc.store = @store
     @store
   end
@@ -566,6 +571,10 @@ class SyncRDoc
 
       opts.on("--[no-]diff", "Print changes for changed docs") do |d|
         @diff = d
+      end
+
+      opts.on("--rdoc-store=PATH", "Path to the RDoc store to get the documentation from") do |p|
+        @store_path = p
       end
     end
     parser.parse!


### PR DESCRIPTION
### Motivation

Because all my `rdoc` are generated in a custom directory, my default RDoc store was empty and `rdoc-sync` did not find any documentation for my RBIs:

```
X has existing doc but can't find it with ri; not clobbering
```

This PR allows the user to specify from which directory the store should be loaded:

```
rbi/tools/sync-rdoc.rb rbi/ --rdoc-store /path/to/my/store
```

### Test plan

Are there tests for this tool?