### PR TITLE
mark all variants of GlobalState.toString as const

### DIFF
--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -127,22 +127,22 @@ public:
 
     // These methods are here to make it easier to print the symbol table in lldb.
     // (don't have to remember the default args)
-    std::string toString() {
+    std::string toString() const {
         bool showFull = false;
         bool showRaw = false;
         return toStringWithOptions(showFull, showRaw);
     }
-    std::string toStringFull() {
+    std::string toStringFull() const {
         bool showFull = true;
         bool showRaw = false;
         return toStringWithOptions(showFull, showRaw);
     }
-    std::string showRaw() {
+    std::string showRaw() const {
         bool showFull = false;
         bool showRaw = true;
         return toStringWithOptions(showFull, showRaw);
     }
-    std::string showRawFull() {
+    std::string showRawFull() const {
         bool showFull = true;
         bool showRaw = true;
         return toStringWithOptions(showFull, showRaw);


### PR DESCRIPTION
I was debugging something in `lldb` and I got:
```
(lldb) p gs.toString()
error: 'this' argument to member function 'toString' has type 'const sorbet::core::GlobalState', but function is not marked const
```

The underlying thing it is calling is `const` so the top one should be, right?

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
