### PR TITLE
more consting

### DIFF
--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -136,7 +136,7 @@ void CFG::sanityCheck(core::Context ctx) {
     }
 }
 
-string CFG::toString(core::Context ctx) {
+string CFG::toString(core::Context ctx) const {
     fmt::memory_buffer buf;
     string symbolName = this->symbol.data(ctx)->showFullName(ctx);
     fmt::format_to(buf,
@@ -169,7 +169,7 @@ string CFG::toString(core::Context ctx) {
     return to_string(buf);
 }
 
-string CFG::showRaw(core::Context ctx) {
+string CFG::showRaw(core::Context ctx) const {
     fmt::memory_buffer buf;
     string symbolName = this->symbol.data(ctx)->showFullName(ctx);
     fmt::format_to(buf,
@@ -202,7 +202,7 @@ string CFG::showRaw(core::Context ctx) {
     return to_string(buf);
 }
 
-string BasicBlock::toString(core::Context ctx) {
+string BasicBlock::toString(core::Context ctx) const {
     fmt::memory_buffer buf;
     fmt::format_to(
         buf, "block[id={}]({})\n", this->id,
@@ -212,7 +212,7 @@ string BasicBlock::toString(core::Context ctx) {
     if (this->outerLoops > 0) {
         fmt::format_to(buf, "outerLoops: {}\n", this->outerLoops);
     }
-    for (Binding &exp : this->exprs) {
+    for (const Binding &exp : this->exprs) {
         fmt::format_to(buf, "{} = {}\n", exp.bind.toString(ctx), exp.value->toString(ctx));
     }
     if (this->bexit.cond.variable.exists()) {
@@ -223,7 +223,7 @@ string BasicBlock::toString(core::Context ctx) {
     return to_string(buf);
 }
 
-string BasicBlock::showRaw(core::Context ctx) {
+string BasicBlock::showRaw(core::Context ctx) const {
     fmt::memory_buffer buf;
     fmt::format_to(
         buf, "block[id={}]({})\n", this->id,
@@ -233,7 +233,7 @@ string BasicBlock::showRaw(core::Context ctx) {
     if (this->outerLoops > 0) {
         fmt::format_to(buf, "outerLoops: {}\n", this->outerLoops);
     }
-    for (Binding &exp : this->exprs) {
+    for (const Binding &exp : this->exprs) {
         fmt::format_to(buf, "Binding {{\n&nbsp;bind = {},\n&nbsp;value = {},\n}}\n", exp.bind.showRaw(ctx, 1),
                        exp.value->showRaw(ctx, 1));
     }

--- a/cfg/CFG.h
+++ b/cfg/CFG.h
@@ -64,8 +64,8 @@ public:
         counterInc("basicblocks");
     };
 
-    std::string toString(core::Context ctx);
-    std::string showRaw(core::Context ctx);
+    std::string toString(core::Context ctx) const;
+    std::string showRaw(core::Context ctx) const;
 };
 
 class CFGContext;
@@ -96,9 +96,9 @@ public:
     };
 
     // Abbreviated debug output, useful if you already know what you're looking at
-    std::string toString(core::Context ctx);
+    std::string toString(core::Context ctx) const;
     // Verbose debug output
-    std::string showRaw(core::Context ctx);
+    std::string showRaw(core::Context ctx) const;
 
     // Flags
     static constexpr int LOOP_HEADER = 1 << 0;

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -25,19 +25,19 @@ Return::Return(core::LocalVariable what) : what(what) {
     categoryCounterInc("cfg", "return");
 }
 
-string SolveConstraint::toString(core::Context ctx) {
+string SolveConstraint::toString(core::Context ctx) const {
     return fmt::format("Solve<{}>", this->link->fun.toString(ctx));
 }
 
-string SolveConstraint::showRaw(core::Context ctx, int tabs) {
+string SolveConstraint::showRaw(core::Context ctx, int tabs) const {
     return fmt::format("Solve {{ link = {} }}", this->link->fun.showRaw(ctx));
 }
 
-string Return::toString(core::Context ctx) {
+string Return::toString(core::Context ctx) const {
     return fmt::format("return {}", this->what.toString(ctx));
 }
 
-string Return::showRaw(core::Context ctx, int tabs) {
+string Return::showRaw(core::Context ctx, int tabs) const {
     return fmt::format("Return {{\n{0}&nbsp;what = {1},\n{0}}}", spacesForTabLevel(tabs),
                        this->what.showRaw(ctx, tabs + 1));
 }
@@ -47,11 +47,11 @@ BlockReturn::BlockReturn(shared_ptr<core::SendAndBlockLink> link, core::LocalVar
     categoryCounterInc("cfg", "blockreturn");
 }
 
-string BlockReturn::toString(core::Context ctx) {
+string BlockReturn::toString(core::Context ctx) const {
     return fmt::format("blockreturn<{}> {}", this->link->fun.toString(ctx), this->what.toString(ctx));
 }
 
-string BlockReturn::showRaw(core::Context ctx, int tabs) {
+string BlockReturn::showRaw(core::Context ctx, int tabs) const {
     return fmt::format("BlockReturn {{\n{0}&nbsp;link = {1},\n{0}&nbsp;what = {2},\n{0}}}", spacesForTabLevel(tabs),
                        this->link->fun.showRaw(ctx), this->what.showRaw(ctx, tabs + 1));
 }
@@ -61,11 +61,11 @@ LoadSelf::LoadSelf(shared_ptr<core::SendAndBlockLink> link, core::LocalVariable 
     categoryCounterInc("cfg", "loadself");
 }
 
-string LoadSelf::toString(core::Context ctx) {
+string LoadSelf::toString(core::Context ctx) const {
     return "loadSelf";
 }
 
-string LoadSelf::showRaw(core::Context ctx, int tabs) {
+string LoadSelf::showRaw(core::Context ctx, int tabs) const {
     return fmt::format("LoadSelf {{}}", spacesForTabLevel(tabs));
 }
 
@@ -88,7 +88,7 @@ Literal::Literal(const core::TypePtr &value) : value(move(value)) {
     categoryCounterInc("cfg", "literal");
 }
 
-string Literal::toString(core::Context ctx) {
+string Literal::toString(core::Context ctx) const {
     string res;
     typecase(
         this->value.get(), [&](core::LiteralType *l) { res = l->showValue(ctx); },
@@ -107,7 +107,7 @@ string Literal::toString(core::Context ctx) {
     return res;
 }
 
-string Literal::showRaw(core::Context ctx, int tabs) {
+string Literal::showRaw(core::Context ctx, int tabs) const {
     return fmt::format("Literal {{ value = {} }}", this->value->show(ctx));
 }
 
@@ -119,39 +119,39 @@ Alias::Alias(core::SymbolRef what) : what(what) {
     categoryCounterInc("cfg", "alias");
 }
 
-string Ident::toString(core::Context ctx) {
+string Ident::toString(core::Context ctx) const {
     return this->what.toString(ctx);
 }
 
-string Ident::showRaw(core::Context ctx, int tabs) {
+string Ident::showRaw(core::Context ctx, int tabs) const {
     return fmt::format("Ident {{\n{0}&nbsp;what = {1},\n{0}}}", spacesForTabLevel(tabs), this->what.showRaw(ctx));
 }
 
-string Alias::toString(core::Context ctx) {
+string Alias::toString(core::Context ctx) const {
     return fmt::format("alias {}", this->what.data(ctx)->name.data(ctx)->toString(ctx));
 }
 
-string Alias::showRaw(core::Context ctx, int tabs) {
+string Alias::showRaw(core::Context ctx, int tabs) const {
     return fmt::format("Alias {{ what = {} }}", this->what.data(ctx)->show(ctx));
 }
 
-string Send::toString(core::Context ctx) {
+string Send::toString(core::Context ctx) const {
     return fmt::format("{}.{}({})", this->recv.toString(ctx), this->fun.data(ctx)->toString(ctx),
                        fmt::map_join(this->args, ", ", [&](const auto &arg) -> string { return arg.toString(ctx); }));
 }
 
-string Send::showRaw(core::Context ctx, int tabs) {
+string Send::showRaw(core::Context ctx, int tabs) const {
     return fmt::format(
         "Send {{\n{0}&nbsp;recv = {1},\n{0}&nbsp;fun = {2},\n{0}&nbsp;args = ({3}),\n{0}}}", spacesForTabLevel(tabs),
         this->recv.toString(ctx), this->fun.data(ctx)->showRaw(ctx),
         fmt::map_join(this->args, ", ", [&](const auto &arg) -> string { return arg.showRaw(ctx, tabs + 1); }));
 }
 
-string LoadArg::toString(core::Context ctx) {
+string LoadArg::toString(core::Context ctx) const {
     return fmt::format("load_arg({})", this->argument(ctx).argumentName(ctx));
 }
 
-string LoadArg::showRaw(core::Context ctx, int tabs) {
+string LoadArg::showRaw(core::Context ctx, int tabs) const {
     return fmt::format("LoadArg {{ argument = {} }}", this->argument(ctx).argumentName(ctx));
 }
 
@@ -159,45 +159,45 @@ const core::ArgInfo &LoadArg::argument(const core::GlobalState &gs) const {
     return this->method.data(gs)->arguments()[this->argId];
 }
 
-string LoadYieldParams::toString(core::Context ctx) {
+string LoadYieldParams::toString(core::Context ctx) const {
     return fmt::format("load_yield_params({})", this->link->fun.toString(ctx));
 }
 
-string LoadYieldParams::showRaw(core::Context ctx, int tabs) {
+string LoadYieldParams::showRaw(core::Context ctx, int tabs) const {
     return fmt::format("LoadYieldParams {{ link = {0} }}", this->link->fun.showRaw(ctx));
 }
 
-string Unanalyzable::toString(core::Context ctx) {
+string Unanalyzable::toString(core::Context ctx) const {
     return "<unanalyzable>";
 }
 
-string Unanalyzable::showRaw(core::Context ctx, int tabs) {
+string Unanalyzable::showRaw(core::Context ctx, int tabs) const {
     return fmt::format("Unanalyzable {{}}", spacesForTabLevel(tabs));
 }
 
-string NotSupported::toString(core::Context ctx) {
+string NotSupported::toString(core::Context ctx) const {
     return fmt::format("NotSupported({})", why);
 }
 
-string NotSupported::showRaw(core::Context ctx, int tabs) {
+string NotSupported::showRaw(core::Context ctx, int tabs) const {
     return fmt::format("NotSupported {{\n{0}&nbsp;why = {1},\n{0}}}", spacesForTabLevel(tabs), why);
 }
 
-string Cast::toString(core::Context ctx) {
+string Cast::toString(core::Context ctx) const {
     return fmt::format("cast({}, {});", this->value.toString(ctx), this->type->toString(ctx));
 }
 
-string Cast::showRaw(core::Context ctx, int tabs) {
+string Cast::showRaw(core::Context ctx, int tabs) const {
     return fmt::format("Cast {{\n{0}&nbsp;cast = T.{1},\n{0}&nbsp;value = {2},\n{0}&nbsp;type = {3},\n{0}}}",
                        spacesForTabLevel(tabs), this->cast.data(ctx)->show(ctx), this->value.showRaw(ctx, tabs + 1),
                        this->type->show(ctx));
 }
 
-string TAbsurd::toString(core::Context ctx) {
+string TAbsurd::toString(core::Context ctx) const {
     return fmt::format("T.absurd({})", this->what.toString(ctx));
 }
 
-string TAbsurd::showRaw(core::Context ctx, int tabs) {
+string TAbsurd::showRaw(core::Context ctx, int tabs) const {
     return fmt::format("TAbsurd {{\n{0}&nbsp;what = {1},\n{0}}}", spacesForTabLevel(tabs),
                        this->what.showRaw(ctx, tabs + 1));
 }

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -33,8 +33,8 @@ public:
 class Instruction {
 public:
     virtual ~Instruction() = default;
-    virtual std::string toString(core::Context ctx) = 0;
-    virtual std::string showRaw(core::Context ctx, int tabs = 0) = 0;
+    virtual std::string toString(core::Context ctx) const = 0;
+    virtual std::string showRaw(core::Context ctx, int tabs = 0) const = 0;
     Instruction() = default;
     bool isSynthetic = false;
 };
@@ -55,8 +55,8 @@ public:
     core::LocalVariable what;
 
     Ident(core::LocalVariable what);
-    virtual std::string toString(core::Context ctx);
-    virtual std::string showRaw(core::Context ctx, int tabs = 0);
+    virtual std::string toString(core::Context ctx) const;
+    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
 };
 CheckSize(Ident, 24, 8);
 
@@ -66,8 +66,8 @@ public:
 
     Alias(core::SymbolRef what);
 
-    virtual std::string toString(core::Context ctx);
-    virtual std::string showRaw(core::Context ctx, int tabs = 0);
+    virtual std::string toString(core::Context ctx) const;
+    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
 };
 CheckSize(Alias, 16, 8);
 
@@ -75,8 +75,8 @@ class SolveConstraint final : public Instruction {
 public:
     std::shared_ptr<core::SendAndBlockLink> link;
     SolveConstraint(const std::shared_ptr<core::SendAndBlockLink> &link) : link(link){};
-    virtual std::string toString(core::Context ctx);
-    virtual std::string showRaw(core::Context ctx, int tabs = 0);
+    virtual std::string toString(core::Context ctx) const;
+    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
 };
 CheckSize(SolveConstraint, 32, 8);
 
@@ -94,8 +94,8 @@ public:
          const InlinedVector<core::LocalVariable, 2> &args, InlinedVector<core::Loc, 2> argLocs,
          bool isPrivateOk = false, const std::shared_ptr<core::SendAndBlockLink> &link = nullptr);
 
-    virtual std::string toString(core::Context ctx);
-    virtual std::string showRaw(core::Context ctx, int tabs = 0);
+    virtual std::string toString(core::Context ctx) const;
+    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
 };
 CheckSize(Send, 160, 8);
 
@@ -104,8 +104,8 @@ public:
     VariableUseSite what;
 
     Return(core::LocalVariable what);
-    virtual std::string toString(core::Context ctx);
-    virtual std::string showRaw(core::Context ctx, int tabs = 0);
+    virtual std::string toString(core::Context ctx) const;
+    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
 };
 CheckSize(Return, 40, 8);
 
@@ -115,8 +115,8 @@ public:
     VariableUseSite what;
 
     BlockReturn(std::shared_ptr<core::SendAndBlockLink> link, core::LocalVariable what);
-    virtual std::string toString(core::Context ctx);
-    virtual std::string showRaw(core::Context ctx, int tabs = 0);
+    virtual std::string toString(core::Context ctx) const;
+    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
 };
 CheckSize(BlockReturn, 56, 8);
 
@@ -125,8 +125,8 @@ public:
     std::shared_ptr<core::SendAndBlockLink> link;
     core::LocalVariable fallback;
     LoadSelf(std::shared_ptr<core::SendAndBlockLink> link, core::LocalVariable fallback);
-    virtual std::string toString(core::Context ctx);
-    virtual std::string showRaw(core::Context ctx, int tabs = 0);
+    virtual std::string toString(core::Context ctx) const;
+    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
 };
 CheckSize(LoadSelf, 40, 8);
 
@@ -135,8 +135,8 @@ public:
     core::TypePtr value;
 
     Literal(const core::TypePtr &value);
-    virtual std::string toString(core::Context ctx);
-    virtual std::string showRaw(core::Context ctx, int tabs = 0);
+    virtual std::string toString(core::Context ctx) const;
+    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
 };
 CheckSize(Literal, 32, 8);
 
@@ -145,8 +145,8 @@ public:
     Unanalyzable() {
         categoryCounterInc("cfg", "unanalyzable");
     };
-    virtual std::string toString(core::Context ctx);
-    virtual std::string showRaw(core::Context ctx, int tabs = 0);
+    virtual std::string toString(core::Context ctx) const;
+    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
 };
 CheckSize(Unanalyzable, 16, 8);
 
@@ -157,8 +157,8 @@ public:
     NotSupported(std::string_view why) : why(why) {
         categoryCounterInc("cfg", "notsupported");
     };
-    virtual std::string toString(core::Context ctx);
-    virtual std::string showRaw(core::Context ctx, int tabs = 0);
+    virtual std::string toString(core::Context ctx) const;
+    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
 };
 CheckSize(NotSupported, 40, 8);
 
@@ -172,8 +172,8 @@ public:
     };
 
     const core::ArgInfo &argument(const core::GlobalState &gs) const;
-    virtual std::string toString(core::Context ctx);
-    virtual std::string showRaw(core::Context ctx, int tabs = 0);
+    virtual std::string toString(core::Context ctx) const;
+    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
 };
 CheckSize(LoadArg, 24, 8);
 
@@ -184,8 +184,8 @@ public:
     LoadYieldParams(const std::shared_ptr<core::SendAndBlockLink> &link) : link(link) {
         categoryCounterInc("cfg", "loadarg");
     };
-    virtual std::string toString(core::Context ctx);
-    virtual std::string showRaw(core::Context ctx, int tabs = 0);
+    virtual std::string toString(core::Context ctx) const;
+    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
 };
 CheckSize(LoadYieldParams, 32, 8);
 
@@ -198,8 +198,8 @@ public:
     Cast(core::LocalVariable value, const core::TypePtr &type, core::NameRef cast)
         : value(value), type(type), cast(cast) {}
 
-    virtual std::string toString(core::Context ctx);
-    virtual std::string showRaw(core::Context ctx, int tabs = 0);
+    virtual std::string toString(core::Context ctx) const;
+    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
 };
 CheckSize(Cast, 64, 8);
 
@@ -211,8 +211,8 @@ public:
         categoryCounterInc("cfg", "tabsurd");
     }
 
-    virtual std::string toString(core::Context ctx);
-    virtual std::string showRaw(core::Context ctx, int tabs = 0);
+    virtual std::string toString(core::Context ctx) const;
+    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
 };
 CheckSize(TAbsurd, 40, 8);
 

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -16,11 +16,11 @@
 using namespace std;
 namespace sorbet::autogen {
 
-Definition &DefinitionRef::data(ParsedFile &pf) {
+const Definition &DefinitionRef::data(const ParsedFile &pf) const {
     return pf.defs[_id];
 }
 
-Reference &ReferenceRef::data(ParsedFile &pf) {
+const Reference &ReferenceRef::data(const ParsedFile &pf) const {
     return pf.refs[_id];
 }
 
@@ -248,7 +248,7 @@ ParsedFile Autogen::generate(core::Context ctx, ast::ParsedFile tree) {
     return pf;
 }
 
-vector<core::NameRef> ParsedFile::showFullName(core::Context ctx, DefinitionRef id) {
+vector<core::NameRef> ParsedFile::showFullName(core::Context ctx, DefinitionRef id) const {
     auto &def = id.data(*this);
     if (!def.defining_ref.exists()) {
         return {};
@@ -259,7 +259,7 @@ vector<core::NameRef> ParsedFile::showFullName(core::Context ctx, DefinitionRef 
     return scope;
 }
 
-string ParsedFile::toString(core::Context ctx) {
+string ParsedFile::toString(core::Context ctx) const {
     fmt::memory_buffer out;
     auto nameToString = [&](const auto &nm) -> string { return nm.data(ctx)->show(ctx); };
 

--- a/main/autogen/autogen.h
+++ b/main/autogen/autogen.h
@@ -22,15 +22,15 @@ struct DefinitionRef {
     DefinitionRef() : _id(NONE_ID){};
     DefinitionRef(u4 id) : _id(id) {}
 
-    u4 id() {
+    u4 id() const {
         return _id;
     }
 
-    bool exists() {
+    bool exists() const {
         return _id != NONE_ID;
     }
 
-    Definition &data(ParsedFile &pf);
+    const Definition &data(const ParsedFile &pf) const;
 };
 
 struct ReferenceRef {
@@ -38,15 +38,15 @@ struct ReferenceRef {
     ReferenceRef() : _id(NONE_ID){};
     ReferenceRef(u4 id) : _id(id) {}
 
-    u4 id() {
+    u4 id() const {
         return _id;
     }
 
-    bool exists() {
+    bool exists() const {
         return _id != NONE_ID;
     }
 
-    Reference &data(ParsedFile &pf);
+    const Reference &data(const ParsedFile &pf) const;
 };
 
 struct Definition {
@@ -89,9 +89,9 @@ struct ParsedFile {
     std::vector<Reference> refs;
     std::vector<core::NameRef> requires;
 
-    std::string toString(core::Context ctx);
+    std::string toString(core::Context ctx) const;
     std::string toMsgpack(core::Context ctx, int version);
-    std::vector<core::NameRef> showFullName(core::Context ctx, DefinitionRef id);
+    std::vector<core::NameRef> showFullName(core::Context ctx, DefinitionRef id) const;
     std::vector<std::string> listAllClasses(core::Context ctx);
 };
 

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -102,7 +102,7 @@ void showHelper(core::Context ctx, fmt::memory_buffer &buf, const DefTree &node,
     }
 }
 
-string DefTree::show(core::Context ctx, int level) {
+string DefTree::show(core::Context ctx, int level) const {
     fmt::memory_buffer buf;
     showHelper(ctx, buf, *this, 0);
     return to_string(buf);

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -70,7 +70,7 @@ public:
     bool root() const;
     core::NameRef name() const;
     std::string path(core::Context ctx) const;
-    std::string show(core::Context ctx, int level = 0); // Render the entire tree
+    std::string show(core::Context ctx, int level = 0) const; // Render the entire tree
     std::string fullName(core::Context) const;
 
     std::string renderAutoloadSrc(core::Context ctx, const AutoloaderConfig &) const;

--- a/namer/configatron/configatron.cc
+++ b/namer/configatron/configatron.cc
@@ -63,14 +63,14 @@ struct Path {
 
     Path(Path *parent, string selector) : parent(parent), selector(move(selector)){};
 
-    string toString() {
+    string toString() const {
         if (parent) {
             return parent->toString() + "." + selector;
         };
         return selector;
     }
 
-    string show(core::GlobalState &gs) {
+    string show(core::GlobalState &gs) const {
         fmt::memory_buffer buf;
         if (myType) {
             fmt::format_to(buf, "{} -> {}", toString(), myType->toString(gs));


### PR DESCRIPTION
As a spiritual successor to https://github.com/sorbet/sorbet/pull/1943 I didn't actually need these but I thought it would be good to get all our toStrings to be constable.

Found them with
```
gg ::show | grep -v const
gg ::toString | grep -v const
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
