### PR TITLE
Introduce runtime utility changes for lazy T.type_alias

### DIFF
--- a/gems/sorbet-runtime/lib/sorbet-runtime.rb
+++ b/gems/sorbet-runtime/lib/sorbet-runtime.rb
@@ -57,6 +57,7 @@ require_relative 'types/types/untyped'
 require_relative 'types/private/types/not_typed'
 require_relative 'types/private/types/void'
 require_relative 'types/private/types/string_holder'
+require_relative 'types/private/types/type_alias'
 
 require_relative 'types/types/type_variable'
 require_relative 'types/types/type_member'

--- a/gems/sorbet-runtime/lib/types/private/types/type_alias.rb
+++ b/gems/sorbet-runtime/lib/types/private/types/type_alias.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+# typed: true
+
+module T::Private::Types
+  # Wraps a proc for a type alias to defer its evaluation.
+  class TypeAlias < T::Types::Base
+
+    def initialize(callable)
+      @callable = callable
+    end
+
+    # @override Base
+    def name
+      aliased_type.name
+    end
+
+    # @override Base
+    def valid?(obj)
+      aliased_type.valid?(obj)
+    end
+
+    def aliased_type
+      @aliased_type ||= T::Utils.coerce(@callable.call)
+    end
+  end
+end

--- a/gems/sorbet-runtime/lib/types/props/type_validation.rb
+++ b/gems/sorbet-runtime/lib/types/props/type_validation.rb
@@ -64,6 +64,8 @@ module T::Props::TypeValidation
         type.types.map {|subtype| find_invalid_subtype(subtype)}.compact.first
       when T::Types::Enum, T::Types::ClassOf
         nil
+      when T::Private::Types::TypeAlias
+        find_invalid_subtype(type.aliased_type)
       when T::Types::Simple
         # TODO Could we manage to define a whitelist, consisting of something
         # like primitives, subdocs, DataInterfaces, and collections/enums/unions

--- a/gems/sorbet-runtime/lib/types/types/base.rb
+++ b/gems/sorbet-runtime/lib/types/types/base.rb
@@ -41,6 +41,14 @@ module T::Types
     def subtype_of?(t2)
       t1 = self
 
+      if t2.is_a?(T::Private::Types::TypeAlias)
+        t2 = t2.aliased_type
+      end
+
+      if t1.is_a?(T::Private::Types::TypeAlias)
+        return t1.aliased_type.subtype_of?(t2)
+      end
+
       # pairs to cover: 1  (_, _)
       #                 2  (_, And)
       #                 3  (_, Or)
@@ -134,7 +142,8 @@ module T::Types
     end
 
     def ==(other)
-      other.class == self.class && other.name == self.name
+      (T::Utils.resolve_alias(other).class == T::Utils.resolve_alias(self).class) &&
+        other.name == self.name
     end
 
     alias_method :eql?, :==

--- a/gems/sorbet-runtime/lib/types/types/intersection.rb
+++ b/gems/sorbet-runtime/lib/types/types/intersection.rb
@@ -8,6 +8,7 @@ module T::Types
 
     def initialize(types)
       @types = types.flat_map do |type|
+        type = T::Utils.resolve_alias(type)
         if type.is_a?(Intersection)
           # Simplify nested intersections (mostly so `name` returns a nicer value)
           type.types

--- a/gems/sorbet-runtime/lib/types/types/union.rb
+++ b/gems/sorbet-runtime/lib/types/types/union.rb
@@ -8,6 +8,7 @@ module T::Types
 
     def initialize(types)
       @types = types.flat_map do |type|
+        type = T::Utils.resolve_alias(type)
         if type.is_a?(Union)
           # Simplify nested unions (mostly so `name` returns a nicer value)
           type.types

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -4,7 +4,9 @@
 module T::Utils
   # Used to convert from a type specification to a `T::Types::Base`.
   def self.coerce(val)
-    if val.is_a?(T::Types::Base)
+    if val.is_a?(T::Private::Types::TypeAlias)
+      val.aliased_type
+    elsif val.is_a?(T::Types::Base)
       val
     elsif val == ::Array
       T::Array[T.untyped]
@@ -74,6 +76,16 @@ module T::Utils
   # Unwraps all the sigs.
   def self.run_all_sig_blocks
     T::Private::Methods.run_all_sig_blocks
+  end
+
+  # Return the underlying type for a type alias. Otherwise returns type.
+  def self.resolve_alias(type)
+    case type
+    when T::Private::Types::TypeAlias
+      type.aliased_type
+    else
+      type
+    end
   end
 
   # Give a type which is a subclass of T::Types::Base, determines if the type is a simple nilable type (union of NilClass and something else).

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -152,6 +152,7 @@ end
 module T::Utils
   def self.arity(method); end
   def self.coerce(val); end
+  def self.resolve_alias(type); end
   def self.run_all_sig_blocks; end
   def self.signature_for_instance_method(mod, method_name); end
   def self.unwrap_nilable(type); end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This is part 1 of 2 for changing the `T.type_alias(type)` interface to be lazy `T.type_alias {type}`. See https://github.com/sorbet/sorbet/pull/1929 for the rest of the changes.

I am splitting this so I can land changes inside of Stripe's internal codebase separately from the `type_alias` interface change, making the whole thing less risky.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
