### PR TITLE
Factor out doTextDocumentCompletion

### DIFF
--- a/test/helpers/lsp.h
+++ b/test/helpers/lsp.h
@@ -8,6 +8,10 @@
 namespace sorbet::test {
 using namespace sorbet::realmain::lsp;
 
+std::string filePathToUri(std::string_view prefixUrl, std::string_view filePath);
+
+std::string uriToFilePath(std::string_view prefixUrl, std::string_view uri);
+
 /** Creates the parameters to the `initialize` message, which advertises the client's capabilities. */
 std::unique_ptr<InitializeParams>
 makeInitializeParams(std::variant<std::string, JSONNullObject> rootPath,
@@ -36,6 +40,11 @@ void assertNotificationMessage(const LSPMethod expectedMethod, const LSPMessage 
 /** Retrieves the PublishDiagnosticsParam from a publishDiagnostics message, if applicable. Non-fatal fails and returns
  * an empty optional if it cannot be found. */
 std::optional<PublishDiagnosticsParams *> getPublishDiagnosticParams(NotificationMessage &notifMsg);
+
+/** Use the LSPWrapper to make a textDocument/completion request.
+ */
+std::unique_ptr<CompletionList> doTextDocumentCompletion(LSPWrapper &lspWrapper, const Range &range, int &nextId,
+                                                         std::string_view filename, std::string_view uriPrefix);
 
 /** Sends boilerplate initialization / initialized messages to start a new LSP session. */
 std::vector<std::unique_ptr<LSPMessage>>


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I plan to use this helper to add another completion-related assertion
(asserting the result of accepting a single completion item result).

It does some client-specific things like treating the list as being
sorted by sortText or label, and could grow other things that a client
would need to implement to be compliant.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Just moves things around; covered by existing tests.