### PR TITLE
always force the cfg to show

### DIFF
--- a/tools/scripts/cfg-view.sh
+++ b/tools/scripts/cfg-view.sh
@@ -10,7 +10,7 @@ if [ "${RAW:-}" != "" ]; then
 else
   print="cfg"
 fi
-"$dir"/../../bazel-bin/main/sorbet --silence-dev-message --suppress-non-critical --print "$print" "$@" > "$dot"
+"$dir"/../../bazel-bin/main/sorbet --silence-dev-message --suppress-non-critical --typed=true --print "$print" "$@" > "$dot"
 dot -Tsvg "$dot" > "$svg"
 if command -v open &> /dev/null; then
   open -a "Google Chrome" "$svg"


### PR DESCRIPTION
When I run this on a random ruby file without a `typed` sigil, it shows a white page. Can we always just force the pass to run by typing the file?

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
