### PR TITLE
Don't include merged edits or canceled requests in the latency metric.

### DIFF
--- a/common/Timer.cc
+++ b/common/Timer.cc
@@ -34,11 +34,15 @@ FlowId Timer::getFlowEdge() {
     return this->self;
 }
 
+void Timer::cancel() {
+    this->canceled = true;
+}
+
 Timer::~Timer() {
     auto clock = chrono::steady_clock::now();
     auto dur = clock - start;
-    if (dur > std::chrono::milliseconds(1)) {
-        // the trick ^^^ is to skip double comparison in the common case and use the most efficient represnetation.
+    if (!canceled && dur > std::chrono::milliseconds(1)) {
+        // the trick ^^^ is to skip double comparison in the common case and use the most efficient representation.
         auto dur = std::chrono::duration<double, std::milli>(clock - start);
         log.debug("{}: {}ms", this->name.str, dur.count());
         sorbet::timingAdd(this->name, start, clock, move(args), self, prev);

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -23,6 +23,9 @@ public:
     ~Timer();
     FlowId getFlowEdge();
 
+    // Don't report timer when it gets destructed.
+    void cancel();
+
     // TODO We could add more overloads for this if we need them (to create other kinds of Timers)
     // We could also make this more generic to allow more sleep duration types.
     static void timedSleep(const std::chrono::microseconds &sleep_duration, spdlog::logger &log, ConstExprStr name) {
@@ -39,6 +42,7 @@ private:
     FlowId self;
     std::vector<std::pair<ConstExprStr, std::string>> args;
     const std::chrono::time_point<std::chrono::steady_clock> start;
+    bool canceled = false;
 };
 } // namespace sorbet
 

--- a/main/lsp/LSPMessage.h
+++ b/main/lsp/LSPMessage.h
@@ -58,9 +58,9 @@ public:
     /** A tracer for following LSP message in time traces. May contain multiple tracers if other messages were merged
      * into this one.*/
     std::vector<FlowId> startTracers;
-    /** Used to calculate latency of message processing. May contain multiple timers if other messages were merged into
-     * this one. */
-    std::vector<std::unique_ptr<Timer>> timers;
+    /** Used to calculate latency of message processing. If this message represents multiple edits, it contains the
+     * oldest timer.*/
+    std::unique_ptr<Timer> timer;
 
     /** If `true`, then this LSPMessage contains a canceled LSP request. */
     bool canceled = false;

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -70,11 +70,10 @@ void LSPPreprocessor::mergeFileChanges(absl::Mutex &mtx, QueueState &state) {
                 }
             }
 
-            // Merge updates, timers, and tracers.
+            // Merge updates and tracers, and cancel its timer to avoid a distorted latency metric.
             auto &mergeableParams = get<unique_ptr<SorbetWorkspaceEditParams>>(mergeMsg.asNotification().params);
             mergeEdits(msgParams->updates, mergeableParams->updates);
-            msg.timers.insert(msg.timers.end(), make_move_iterator(mergeMsg.timers.begin()),
-                              make_move_iterator(mergeMsg.timers.end()));
+            msg.timer->cancel();
             msg.startTracers.insert(msg.startTracers.end(), mergeMsg.startTracers.begin(), mergeMsg.startTracers.end());
             // Delete the update we just merged and move on to next item.
             it = pendingRequests.erase(it);
@@ -124,6 +123,8 @@ void cancelRequest(std::deque<std::unique_ptr<LSPMessage>> &pendingRequests, con
             if (request.id == cancelParams.id) {
                 // We didn't start processing it yet -- great! Cancel it and return.
                 current->canceled = true;
+                // Don't report a latency metric for canceled requests.
+                current->timer->cancel();
                 return;
             }
         }
@@ -146,7 +147,7 @@ unique_ptr<LSPMessage> LSPPreprocessor::makeAndCommitWorkspaceEdit(unique_ptr<So
     }
     auto newMsg =
         make_unique<LSPMessage>(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetWorkspaceEdit, move(params)));
-    newMsg->timers = move(oldMsg->timers);
+    newMsg->timer = move(oldMsg->timer);
     newMsg->startTracers = move(oldMsg->startTracers);
     return newMsg;
 }

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -73,6 +73,7 @@ void LSPPreprocessor::mergeFileChanges(absl::Mutex &mtx, QueueState &state) {
             // Merge updates and tracers, and cancel its timer to avoid a distorted latency metric.
             auto &mergeableParams = get<unique_ptr<SorbetWorkspaceEditParams>>(mergeMsg.asNotification().params);
             mergeEdits(msgParams->updates, mergeableParams->updates);
+            ENFORCE(msg.timer);
             msg.timer->cancel();
             msg.startTracers.insert(msg.startTracers.end(), mergeMsg.startTracers.begin(), mergeMsg.startTracers.end());
             // Delete the update we just merged and move on to next item.
@@ -124,6 +125,7 @@ void cancelRequest(std::deque<std::unique_ptr<LSPMessage>> &pendingRequests, con
                 // We didn't start processing it yet -- great! Cancel it and return.
                 current->canceled = true;
                 // Don't report a latency metric for canceled requests.
+                ENFORCE(current->timer);
                 current->timer->cancel();
                 return;
             }

--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -111,7 +111,7 @@ CounterState mergeCounters(CounterState counters) {
 void tagNewRequest(const std::shared_ptr<spd::logger> &logger, LSPMessage &msg) {
     Timer timeit(logger, "tagNewRequest");
     msg.startTracers.push_back(timeit.getFlowEdge());
-    msg.timers.push_back(make_unique<Timer>(logger, "processing_time"));
+    msg.timer = make_unique<Timer>(logger, "processing_time");
 }
 
 unique_ptr<Joinable> LSPPreprocessor::runPreprocessor(QueueState &incomingQueue, absl::Mutex &incomingMtx,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Don't include merged edits or canceled requests in the latency metric.

They don't count.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The latency metric doesn't seem to reflect the user experience. After shipping the cancelable slow path we received a lot of positive feedback, but the metric didn't budge much. We suspect that it may be due to garbage data from merged edits and canceled requests, which are a frequent occurrence while Sorbet is backed up with a slow typechecking pass.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No tests included. I don't think it's worth explicitly testing.
