### PR TITLE
If slow path is running and a new slow path edit comes in, cancel the running slow path.

### DIFF
--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -99,9 +99,20 @@ void LSPPreprocessor::mergeFileChanges(absl::Mutex &mtx, QueueState &state) {
                     Timer timeit(logger, "tryCancelSlowPath");
                     auto &params = get<unique_ptr<SorbetWorkspaceEditParams>>(msg->asNotification().params);
                     auto combinedUpdates = ttgs.getCombinedUpdates(committed + 1, params->updates.versionEnd);
-                    if (combinedUpdates.canTakeFastPath && gs.tryCancelSlowPath(params->updates.versionEnd)) {
-                        logger->debug("[Preprocessor] Canceling typechecking, as edits {} thru {} can take fast path.",
-                                      params->updates.versionStart, params->updates.versionEnd);
+                    // Cancel if combined updates end up taking the fast path, or if the new updates will just take the
+                    // slow path a second time when the current slow path finishes.
+                    if ((combinedUpdates.canTakeFastPath || !params->updates.canTakeFastPath) &&
+                        gs.tryCancelSlowPath(params->updates.versionEnd)) {
+                        if (combinedUpdates.canTakeFastPath) {
+                            logger->debug(
+                                "[Preprocessor] Canceling typechecking, as edits {} thru {} can take fast path.",
+                                combinedUpdates.versionStart, combinedUpdates.versionEnd);
+                        } else {
+                            logger->debug(
+                                "[Preprocessor] Canceling typechecking, as new edits {} thru {} will just take "
+                                "the slow path again.",
+                                params->updates.versionStart, params->updates.versionEnd);
+                        }
                         params->updates = move(combinedUpdates);
                     }
                     break;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

If slow path is running and a new slow path edit comes in, cancel the running slow path.

Notably, the only time edits will *not* cause the slow path to be canceled now is:
* If they take the fast path without the currently-typechecking changes, but would take the slow path with those changes.
* If there is a non-delayable request at the head of the queue.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Avoids making the user suffer through repeated slow paths.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
