### PR TITLE
Don't alias when the source and target are the same symbol

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1988,6 +1988,11 @@ public:
                 return send;
             }
 
+            // No need to make an alias when they're already the same symbol.
+            if (fromMethod == toMethod) {
+                return send;
+            }
+
             core::SymbolRef alias = ctx.state.enterMethodSymbol(send->loc, owner, fromName);
             alias.data(ctx)->resultType = core::make_type<core::AliasType>(toMethod);
 

--- a/test/testdata/cfg/fuzz_recursive_alias.rb
+++ b/test/testdata/cfg/fuzz_recursive_alias.rb
@@ -1,4 +1,5 @@
 # typed: true
-alias foo foo
-def foo; end # error-with-dupes: Too many alias expansions for symbol ::Object#foo, the alias is either too long or infinite.
 
+# This isn't expected to error now, as we don't record self-aliases
+alias foo foo
+def foo; end

--- a/test/testdata/resolver/invalid_alias.rb
+++ b/test/testdata/resolver/invalid_alias.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+class BadAliasingClassMethod1
+  class << self
+    def hello
+      'HELLO WORLD'
+    end
+
+    alias_method :hello, :hello
+  end
+end
+
+def main
+  BadAliasingClassMethod1.hello
+end

--- a/test/testdata/resolver/invalid_alias.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/invalid_alias.rb.symbol-table-raw.exp
@@ -1,0 +1,24 @@
+class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4}, Loc {file=test/testdata/resolver/invalid_alias.rb start=3:1 end=15:4})
+  class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/invalid_alias.rb start=3:1 end=15:4}
+      argument <blk><block> @ Loc {file=test/testdata/resolver/invalid_alias.rb start=??? end=???}
+  class <C <U BadAliasingClassMethod1>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/invalid_alias.rb start=3:1 end=3:30}
+  class <S <C <U BadAliasingClassMethod1>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/resolver/invalid_alias.rb start=4:3 end=4:8}
+    type-member(+) <S <C <U BadAliasingClassMethod1>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U BadAliasingClassMethod1>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=BadAliasingClassMethod1) @ Loc {file=test/testdata/resolver/invalid_alias.rb start=3:7 end=3:30}
+    method <S <C <U BadAliasingClassMethod1>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/invalid_alias.rb start=3:1 end=11:4}
+      argument <blk><block> @ Loc {file=test/testdata/resolver/invalid_alias.rb start=??? end=???}
+    method <S <C <U BadAliasingClassMethod1>> $1><U hello> (<blk>) @ Loc {file=test/testdata/resolver/invalid_alias.rb start=5:5 end=5:14}
+      argument <blk><block> @ Loc {file=test/testdata/resolver/invalid_alias.rb start=??? end=???}
+  class <S <S <C <U BadAliasingClassMethod1>> $1> $1>[<C <U <AttachedClass>>>] < <S <S <C <U Object>> $1> $1> () @ Loc {file=test/testdata/resolver/invalid_alias.rb start=4:3 end=4:8}
+    type-member(+) <S <S <C <U BadAliasingClassMethod1>> $1> $1><C <U <AttachedClass>>> -> LambdaParam(<S <S <C <U BadAliasingClassMethod1>> $1> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {
+  klass = <S <C <U BadAliasingClassMethod1>> $1>
+  targs = [
+    <C <U <AttachedClass>>> = BadAliasingClassMethod1
+  ]
+}) @ Loc {file=test/testdata/resolver/invalid_alias.rb start=4:3 end=4:8}
+    method <S <S <C <U BadAliasingClassMethod1>> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/invalid_alias.rb start=4:3 end=10:6}
+      argument <blk><block> @ Loc {file=test/testdata/resolver/invalid_alias.rb start=??? end=???}
+  class <C <U Object>> < <C <U BasicObject>> (<C <U Kernel>>) @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed}
+    method <C <U Object>><U main> (<blk>) @ Loc {file=test/testdata/resolver/invalid_alias.rb start=13:1 end=13:9}
+      argument <blk><block> @ Loc {file=test/testdata/resolver/invalid_alias.rb start=??? end=???}
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Fixes #1955 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
We shouldn't alias symbols to themselves.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
