### PR TITLE
Etc#getpwuid takes an Integer, not a String

### DIFF
--- a/rbi/stdlib/etc.rbi
+++ b/rbi/stdlib/etc.rbi
@@ -376,7 +376,7 @@ module Etc
   # #=> #<struct Etc::Passwd name="root", passwd="x", uid=0, gid=0, gecos="root",dir="/root", shell="/bin/bash">
   # ```
   sig do
-    params(uid: String).returns(T.nilable(Etc::Passwd))
+    params(uid: Integer).returns(T.nilable(Etc::Passwd))
   end
   def self.getpwuid(uid); end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Fix the Etc#getpwuid signature introduced in #1940.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fix the build.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
