### PR TITLE
Use textEdit instead of insertText for completion

### DIFF
--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -196,8 +196,10 @@ class LSPLoop {
     std::unique_ptr<CompletionItem> getCompletionItemForSymbol(const core::GlobalState &gs, core::SymbolRef what,
                                                                core::TypePtr receiverType,
                                                                const core::TypeConstraint *constraint,
+                                                               const core::Loc queryLoc, std::string_view prefix,
                                                                size_t sortIdx) const;
     void findSimilarConstantOrIdent(const core::GlobalState &gs, const core::TypePtr receiverType,
+                                    const core::Loc queryLoc,
                                     std::vector<std::unique_ptr<CompletionItem>> &items) const;
     void sendShowMessageNotification(MessageType messageType, std::string_view message) const;
     LSPResult handleTextSignatureHelp(std::unique_ptr<core::GlobalState> gs, const MessageId &id,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This gives us control over how to edit the document when a completion
result is taken, rather than having VS Code "figure it out."

VS Code takes some serious liberties with `insertText`:

```
/**
 * ...
 *
 * The `insertText` is subject to interpretation by the client side.
 * Some tools might not take the string literally. For example
 * VS Code when code complete is requested in this example `con<cursor position>`
 * and a completion item with an `insertText` of `console` is provided it
 * will only insert `sole`. Therefore it is recommended to use `textEdit` instead
 * since it avoids additional client side interpretation.
 */
```

In particular, for something like this:

```
x.fo
#   ^ completion: foo
```

VS Code will delete the `fo` and insert `foo`. But if instead we send
the insertText as just `o` (i.e., remove the `fo` prefix), it will
**still** delete the `fo` and **only** insert `o`.

That's annoying to deal with, because it would mean that to write tests
for snippets, we'd have to re-implement the same heuristic that VS Code
uses to handle `insertText`. Rather than do that, we can just tell VS
Code exactly how to edit the document by sending a `TextEdit` object,
which has a `Range` to replace and a `string` to replace it with.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This will be tested in a stacked PR that adds the ability to test the
state of the document after a completion edit is performed.