### PR TITLE
Etc#getpwuid can be called with zero args

### DIFF
--- a/rbi/stdlib/etc.rbi
+++ b/rbi/stdlib/etc.rbi
@@ -378,7 +378,7 @@ module Etc
   sig do
     params(uid: Integer).returns(T.nilable(Etc::Passwd))
   end
-  def self.getpwuid(uid); end
+  def self.getpwuid(uid=T.unsafe(nil)); end
 
   # Provides a convenient Ruby iterator which executes a block for each entry in
   # the /etc/group file.

--- a/test/testdata/rbi/etc.rb
+++ b/test/testdata/rbi/etc.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+T.reveal_type(Etc.getpwuid) # error: Revealed type: `T.nilable(Etc::Passwd)`
+T.reveal_type(Etc.getpwuid(10)) # error: Revealed type: `T.nilable(Etc::Passwd)`
+
+Etc.getpwuid("foo") # error: Expected `Integer` but found `String("foo")`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
`Etc#getpwuid` can be called with zero args, this adds a default to allow this. Additionally, this adds a test for `Etc#getpwuid`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Follow on fixes from #1940.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
