### PR TITLE
Add apply-completion test assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,36 @@ class A
 end
 ```
 
+To write a test for the snippet that would be inserted into the document if a
+particular completion item was selected, you can make two files:
+
+```
+# -- test/testdata/lsp/completion/mytest.rb --
+class A
+  def self.foo_1; end
+end
+
+A.foo_
+#     ^ apply-completion: [A] item: 0
+```
+
+The `apply-completion` assertion says "make sure the file `mytest.A.rbedited`
+contains the result of inserting the completion snippet for the 0th completion
+item into the file."
+
+```
+# -- test/testdata/lsp/completion/mytest.A.rbedited --
+class A
+  def self.foo_1; end
+end
+
+A.foo_1${0}
+#     ^ apply-completion: [A] item: 0
+```
+
+As you can see, the fancy `${...}` (tabstop placeholders) show up verbatim in
+the output if they were sent in the completion response.
+
 
 #### Testing incremental typechecking
 

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -34,6 +34,7 @@ const UnorderedMap<
         {"assert-slow-path", BooleanPropertyAssertion::make},
         {"hover", HoverAssertion::make},
         {"completion", CompletionAssertion::make},
+        {"apply-completion", ApplyCompletionAssertion::make},
         {"apply-code-action", ApplyCodeActionAssertion::make},
         {"no-stdlib", BooleanPropertyAssertion::make},
 };
@@ -962,6 +963,92 @@ void CompletionAssertion::check(const UnorderedMap<string, shared_ptr<core::File
 
 string CompletionAssertion::toString() const {
     return fmt::format("completion: {}", message);
+}
+
+shared_ptr<ApplyCompletionAssertion> ApplyCompletionAssertion::make(string_view filename, unique_ptr<Range> &range,
+                                                                    int assertionLine, string_view assertionContents,
+                                                                    string_view assertionType) {
+    static const regex versionIndexRegex(R"(^\[(\w+)\]\s+item:\s+(\d+)$)");
+
+    smatch matches;
+    string assertionContentsString = string(assertionContents);
+    if (regex_search(assertionContentsString, matches, versionIndexRegex)) {
+        auto version = matches[1].str();
+        auto index = stoi(matches[2].str());
+        return make_shared<ApplyCompletionAssertion>(filename, range, assertionLine, version, index);
+    }
+
+    ADD_FAILURE_AT(string(filename).c_str(), assertionLine + 1)
+        << fmt::format("Improperly formatted apply-completion assertion. Expected '[<version>] <index>'. Found '{}'",
+                       assertionContents);
+
+    return nullptr;
+}
+
+ApplyCompletionAssertion::ApplyCompletionAssertion(string_view filename, unique_ptr<Range> &range, int assertionLine,
+                                                   string_view version, int index)
+    : RangeAssertion(filename, range, assertionLine), version(string(version)), index(index) {}
+
+void ApplyCompletionAssertion::checkAll(const vector<shared_ptr<RangeAssertion>> &assertions,
+                                        const UnorderedMap<string, shared_ptr<core::File>> &sourceFileContents,
+                                        LSPWrapper &wrapper, int &nextId, string_view uriPrefix, string errorPrefix) {
+    for (auto assertion : assertions) {
+        if (auto assertionOfType = dynamic_pointer_cast<ApplyCompletionAssertion>(assertion)) {
+            assertionOfType->check(sourceFileContents, wrapper, nextId, uriPrefix, errorPrefix);
+        }
+    }
+}
+
+void ApplyCompletionAssertion::check(const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents,
+                                     LSPWrapper &wrapper, int &nextId, std::string_view uriPrefix,
+                                     std::string errorPrefix) {
+    auto completionList = doTextDocumentCompletion(wrapper, *this->range, nextId, this->filename, uriPrefix);
+    ASSERT_NE(completionList, nullptr) << "doTextDocumentCompletion failed; see error above.";
+
+    auto &items = completionList->items;
+    ASSERT_LE(0, this->index);
+    ASSERT_LT(this->index, items.size());
+
+    auto &completionItem = items[this->index];
+
+    auto it = sourceFileContents.find(this->filename);
+    ASSERT_NE(it, sourceFileContents.end()) << fmt::format("Unable to find source file `{}`", this->filename);
+    auto &file = it->second;
+
+    auto expectedUpdatedFilePath =
+        fmt::format("{}.{}.rbedited", this->filename.substr(0, this->filename.size() - strlen(".rb")), this->version);
+
+    string expectedEditedFileContents;
+    try {
+        expectedEditedFileContents = FileOps::read(expectedUpdatedFilePath);
+    } catch (FileNotFoundException e) {
+        ADD_FAILURE_AT(filename.c_str(), this->assertionLine + 1) << fmt::format(
+            "Missing {} which should contain test file after applying code actions.", expectedUpdatedFilePath);
+        return;
+    }
+
+    ASSERT_NE(completionItem->textEdit, nullopt);
+    auto &textEdit = completionItem->textEdit.value();
+
+    // TODO(jez) Share this code with CodeAction (String -> TextEdit -> ())
+    auto beginLine = static_cast<u4>(textEdit->range->start->line + 1);
+    auto beginCol = static_cast<u4>(textEdit->range->start->character + 1);
+    auto beginOffset = core::Loc::pos2Offset(*file, {beginLine, beginCol});
+
+    auto endLine = static_cast<u4>(textEdit->range->end->line + 1);
+    auto endCol = static_cast<u4>(textEdit->range->end->character + 1);
+    auto endOffset = core::Loc::pos2Offset(*file, {endLine, endCol});
+
+    string actualEditedFileContents = string(file->source());
+    actualEditedFileContents.replace(beginOffset, endOffset - beginOffset, textEdit->newText);
+
+    EXPECT_EQ(expectedEditedFileContents, actualEditedFileContents) << fmt::format(
+        "The expected (rbedited) file contents for this completion did not match the actual file contents post-edit",
+        expectedUpdatedFilePath);
+}
+
+string ApplyCompletionAssertion::toString() const {
+    return fmt::format("apply-completion: [{}] item: {}", version, index);
 }
 
 shared_ptr<ApplyCodeActionAssertion> ApplyCodeActionAssertion::make(string_view filename, unique_ptr<Range> &range,

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -260,6 +260,32 @@ public:
     std::string toString() const override;
 };
 
+// ^ apply-completion: [version] index
+class ApplyCompletionAssertion final : public RangeAssertion {
+public:
+    static std::shared_ptr<ApplyCompletionAssertion> make(std::string_view filename, std::unique_ptr<Range> &range,
+                                                          int assertionLine, std::string_view assertionContents,
+                                                          std::string_view assertionType);
+
+    /** Checks all ApplyCompletionAssertions within the assertion vector. Skips over non-ApplyCompletionAssertions. */
+    static void checkAll(const std::vector<std::shared_ptr<RangeAssertion>> &assertions,
+                         const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents,
+                         LSPWrapper &wrapper, int &nextId, std::string_view uriPrefix, std::string errorPrefix = "");
+
+    ApplyCompletionAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
+                             std::string_view version, int index);
+
+    // The part between [..] in the assertion which specifies which `.[..].rbedited` file to compare against
+    const std::string version;
+    // Index into CompletionItem list of which item to apply (zero-indexed)
+    const int index;
+
+    void check(const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents, LSPWrapper &wrapper,
+               int &nextId, std::string_view uriPrefix, std::string errorPrefix = "");
+
+    std::string toString() const override;
+};
+
 // # ^^^ apply-code-action: [version] title
 class ApplyCodeActionAssertion final : public RangeAssertion {
 public:

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -993,6 +993,7 @@ TEST_P(LSPTest, All) {
 
     // Completion assertions
     CompletionAssertion::checkAll(assertions, test.sourceFileContents, *lspWrapper, nextId, rootUri);
+    ApplyCompletionAssertion::checkAll(assertions, test.sourceFileContents, *lspWrapper, nextId, rootUri);
 
     // Fast path tests: Asserts that certain changes take the fast/slow path, and produce any expected diagnostics.
     {

--- a/test/testdata/lsp/completion/no_parens.A.rbedited
+++ b/test/testdata/lsp/completion/no_parens.A.rbedited
@@ -1,0 +1,8 @@
+# typed: true
+
+class A
+  def foo_1; end
+end
+
+A.new.foo_1()${0} # error: does not exist
+#         ^ apply-completion: [A] item: 0

--- a/test/testdata/lsp/completion/no_parens.rb
+++ b/test/testdata/lsp/completion/no_parens.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+class A
+  def foo_1; end
+end
+
+A.new.foo_ # error: does not exist
+#         ^ apply-completion: [A] item: 0


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This gives us the ability to test the document after a completion item's edit
is committed to the document.

It's stacked on top of #1963, which changed the way we ask the language client
to commit these edits (to be more explicit).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I've added one test just to make sure things don't break, and done a lot of
testing in VS Code to make sure that my interpretation of the spec actually
matches up with what I've built for this harness.

In a stacked PR, I plan to add more tests for all of the edge case-y things
about how snippets work.