### PR TITLE
Complete `x.f` to `x.foo` not `x.foo()` for 0 args

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -223,7 +223,11 @@ string methodSnippet(const core::GlobalState &gs, core::SymbolRef method) {
         }
     }
 
-    return fmt::format("{}({}){}", shortName, fmt::join(typeAndArgNames, ", "), "${0}");
+    if (typeAndArgNames.empty()) {
+        return fmt::format("{}{}", shortName, "${0}");
+    } else {
+        return fmt::format("{}({}){}", shortName, fmt::join(typeAndArgNames, ", "), "${0}");
+    }
 }
 
 unique_ptr<CompletionItem> getCompletionItemForKeyword(const core::GlobalState &gs, const LSPConfiguration &config,

--- a/test/testdata/lsp/completion/no_parens.A.rbedited
+++ b/test/testdata/lsp/completion/no_parens.A.rbedited
@@ -4,5 +4,5 @@ class A
   def foo_1; end
 end
 
-A.new.foo_1()${0} # error: does not exist
+A.new.foo_1${0} # error: does not exist
 #         ^ apply-completion: [A] item: 0

--- a/test/testdata/lsp/completion/overloads_test.A.rbedited
+++ b/test/testdata/lsp/completion/overloads_test.A.rbedited
@@ -16,7 +16,7 @@ end
 # The order here doesn't particularly matter; if you're here because you made a
 # change to the order that broke this test, feel free to update the test.
 
-A.new.my_metho # error: does not exist
+A.new.my_method(${1:S})${0} # error: does not exist
 #             ^ completion: my_method, my_method
 #             ^ apply-completion: [A] item: 0
 #             ^ apply-completion: [B] item: 1

--- a/test/testdata/lsp/completion/overloads_test.B.rbedited
+++ b/test/testdata/lsp/completion/overloads_test.B.rbedited
@@ -16,7 +16,7 @@ end
 # The order here doesn't particularly matter; if you're here because you made a
 # change to the order that broke this test, feel free to update the test.
 
-A.new.my_metho # error: does not exist
+A.new.my_method(${1:I})${0} # error: does not exist
 #             ^ completion: my_method, my_method
 #             ^ apply-completion: [A] item: 0
 #             ^ apply-completion: [B] item: 1

--- a/test/testdata/lsp/completion/snippet_arity.A.rbedited
+++ b/test/testdata/lsp/completion/snippet_arity.A.rbedited
@@ -1,0 +1,23 @@
+# typed: true
+
+class Test
+  def test_method_nullary; end
+
+  def test_method_unary(x); end
+
+  def test_method_binary(x, y); end
+
+  def test_method_kwarg(x:); end
+end
+
+Test.new.test_method_nullary${0} # error: does not exist
+#                        ^ apply-completion: [A] item: 0
+
+Test.new.test_method_unar # error: does not exist
+#                        ^ apply-completion: [B] item: 0
+
+Test.new.test_method_bina # error: does not exist
+#                        ^ apply-completion: [C] item: 0
+
+Test.new.test_method_kwar # error: does not exist
+#                        ^ apply-completion: [D] item: 0

--- a/test/testdata/lsp/completion/snippet_arity.B.rbedited
+++ b/test/testdata/lsp/completion/snippet_arity.B.rbedited
@@ -1,0 +1,23 @@
+# typed: true
+
+class Test
+  def test_method_nullary; end
+
+  def test_method_unary(x); end
+
+  def test_method_binary(x, y); end
+
+  def test_method_kwarg(x:); end
+end
+
+Test.new.test_method_null # error: does not exist
+#                        ^ apply-completion: [A] item: 0
+
+Test.new.test_method_unary(${1})${0} # error: does not exist
+#                        ^ apply-completion: [B] item: 0
+
+Test.new.test_method_bina # error: does not exist
+#                        ^ apply-completion: [C] item: 0
+
+Test.new.test_method_kwar # error: does not exist
+#                        ^ apply-completion: [D] item: 0

--- a/test/testdata/lsp/completion/snippet_arity.C.rbedited
+++ b/test/testdata/lsp/completion/snippet_arity.C.rbedited
@@ -1,0 +1,23 @@
+# typed: true
+
+class Test
+  def test_method_nullary; end
+
+  def test_method_unary(x); end
+
+  def test_method_binary(x, y); end
+
+  def test_method_kwarg(x:); end
+end
+
+Test.new.test_method_null # error: does not exist
+#                        ^ apply-completion: [A] item: 0
+
+Test.new.test_method_unar # error: does not exist
+#                        ^ apply-completion: [B] item: 0
+
+Test.new.test_method_binary(${1}, ${2})${0} # error: does not exist
+#                        ^ apply-completion: [C] item: 0
+
+Test.new.test_method_kwar # error: does not exist
+#                        ^ apply-completion: [D] item: 0

--- a/test/testdata/lsp/completion/snippet_arity.D.rbedited
+++ b/test/testdata/lsp/completion/snippet_arity.D.rbedited
@@ -1,0 +1,23 @@
+# typed: true
+
+class Test
+  def test_method_nullary; end
+
+  def test_method_unary(x); end
+
+  def test_method_binary(x, y); end
+
+  def test_method_kwarg(x:); end
+end
+
+Test.new.test_method_null # error: does not exist
+#                        ^ apply-completion: [A] item: 0
+
+Test.new.test_method_unar # error: does not exist
+#                        ^ apply-completion: [B] item: 0
+
+Test.new.test_method_bina # error: does not exist
+#                        ^ apply-completion: [C] item: 0
+
+Test.new.test_method_kwarg(x: ${1})${0} # error: does not exist
+#                        ^ apply-completion: [D] item: 0

--- a/test/testdata/lsp/completion/snippet_arity.rb
+++ b/test/testdata/lsp/completion/snippet_arity.rb
@@ -1,0 +1,23 @@
+# typed: true
+
+class Test
+  def test_method_nullary; end
+
+  def test_method_unary(x); end
+
+  def test_method_binary(x, y); end
+
+  def test_method_kwarg(x:); end
+end
+
+Test.new.test_method_null # error: does not exist
+#                        ^ apply-completion: [A] item: 0
+
+Test.new.test_method_unar # error: does not exist
+#                        ^ apply-completion: [B] item: 0
+
+Test.new.test_method_bina # error: does not exist
+#                        ^ apply-completion: [C] item: 0
+
+Test.new.test_method_kwar # error: does not exist
+#                        ^ apply-completion: [D] item: 0

--- a/test/testdata/lsp/completion/snippet_types.A.rbedited
+++ b/test/testdata/lsp/completion/snippet_types.A.rbedited
@@ -1,0 +1,11 @@
+# typed: true
+
+class Test
+  extend T::Sig
+
+  sig {params(x: Integer).void}
+  def x_is_integer(x); end
+end
+
+Test.new.x_is_integer(${1:Integer})${0} # error: does not exist
+#             ^ apply-completion: [A] item: 0

--- a/test/testdata/lsp/completion/snippet_types.rb
+++ b/test/testdata/lsp/completion/snippet_types.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+class Test
+  extend T::Sig
+
+  sig {params(x: Integer).void}
+  def x_is_integer(x); end
+end
+
+Test.new.x_is_ # error: does not exist
+#             ^ apply-completion: [A] item: 0


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Our rubocops ban putting the parens after a nullary method call, so we should
probably not put the parens there.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

In addition to the tests for the nullary snippet, I added a bunch of tests for
all kinds of places where we expect interesting snippet-related behavior.