### PR TITLE
Add extend T::Generic to every fake Opus::Enum class

### DIFF
--- a/dsl/OpusEnum.cc
+++ b/dsl/OpusEnum.cc
@@ -134,8 +134,8 @@ vector<unique_ptr<ast::Expression>> processStat(core::MutableContext ctx, ast::C
     ast::ClassDef::ANCESTORS_store parent;
     parent.emplace_back(klass->name->deepCopy());
     ast::ClassDef::RHS_store classRhs;
-    classRhs.emplace_back(ast::MK::Send1(loc, ast::MK::Self(loc), core::Names::extend(),
-                                         ast::MK::Constant(loc, core::Symbols::T_Generic())));
+    classRhs.emplace_back(ast::MK::Send1(stat->loc, ast::MK::Self(stat->loc), core::Names::extend(),
+                                         ast::MK::Constant(stat->loc, core::Symbols::T_Generic())));
     classRhs.emplace_back(ast::MK::Assign(
         stat->loc, ast::MK::UnresolvedConstant(stat->loc, ast::MK::EmptyTree(), core::Names::Constants::Elem()),
         ast::MK::Send1(

--- a/dsl/OpusEnum.cc
+++ b/dsl/OpusEnum.cc
@@ -134,6 +134,8 @@ vector<unique_ptr<ast::Expression>> processStat(core::MutableContext ctx, ast::C
     ast::ClassDef::ANCESTORS_store parent;
     parent.emplace_back(klass->name->deepCopy());
     ast::ClassDef::RHS_store classRhs;
+    classRhs.emplace_back(ast::MK::Send1(loc, ast::MK::Self(loc), core::Names::extend(),
+                                         ast::MK::Constant(loc, core::Symbols::T_Generic())));
     classRhs.emplace_back(ast::MK::Assign(
         stat->loc, ast::MK::UnresolvedConstant(stat->loc, ast::MK::EmptyTree(), core::Names::Constants::Elem()),
         ast::MK::Send1(

--- a/test/testdata/dsl/opus_enum_not_generic.rb
+++ b/test/testdata/dsl/opus_enum_not_generic.rb
@@ -1,0 +1,22 @@
+# typed: strict
+
+module Opus
+  class Enum
+    extend T::Sig
+
+    sig {params(x: T.nilable(String)).void}
+    def initialize(x = nil)
+    end
+
+    sig {params(blk: T.proc.void).void}
+    def self.enums(&blk); end
+  end
+end
+
+class MyEnum < Opus::Enum
+  enums do
+  X = new
+  end
+end
+
+T.reveal_type(MyEnum::X) # error: Revealed type: `MyEnum::X`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This will help us upgrade Opus::Enum in pay-server incrementally, so that we
don't have to upgrade Sorbet and pay-server in lock step.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.