### PR TITLE
Allow semantic extensions to know when file typechecking has finished

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -712,6 +712,9 @@ ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const 
         {
             core::ErrorRegion errs(ctx, f);
             result.tree = ast::TreeMap::apply(ctx, collector, move(resolved.tree));
+            for (auto &extension : ctx.state.semanticExtensions) {
+                extension->finishTypecheckFile(ctx.state, f);
+            }
         }
         if (opts.print.CFG.enabled) {
             opts.print.CFG.fmt("}}\n\n");

--- a/main/pipeline/semantic_extension/SemanticExtension.h
+++ b/main/pipeline/semantic_extension/SemanticExtension.h
@@ -12,6 +12,7 @@ namespace core {
 class GlobalState;
 class GlobalSubstitution;
 class MutableContext;
+class FileRef;
 } // namespace core
 
 namespace ast {
@@ -26,6 +27,7 @@ class CFG;
 namespace pipeline::semantic_extension {
 class SemanticExtension {
 public:
+    virtual void finishTypecheckFile(const core::GlobalState &, const core::FileRef &) const = 0;
     virtual void typecheck(const core::GlobalState &, cfg::CFG &, std::unique_ptr<ast::MethodDef> &) const = 0;
     virtual void patchDSL(core::MutableContext &, ast::ClassDef *) const = 0;
     virtual ~SemanticExtension() = default;


### PR DESCRIPTION

### Motivation
Allow semantic extensions to know when they can cleanup their per-file state.


### Test plan
None. This isn't a end-user-visible feature and is being build in collaboration with folks who extend Sorbet.