### PR TITLE
wip: Make completion feel faster

### DIFF
--- a/common/web_tracer_framework/tracing.cc
+++ b/common/web_tracer_framework/tracing.cc
@@ -4,6 +4,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_replace.h"
 #include "common/Counters_impl.h"
+#include "common/JSON.h"
 #include "common/web_tracer_framework/tracing.h"
 #include "version/version.h"
 #include <chrono>
@@ -52,7 +53,8 @@ bool Tracing::storeTraces(const CounterState &counters, string_view fileName) {
         string maybeArgs;
         if (!e.args.empty()) {
             maybeArgs = fmt::format(",\"args\":{{{}}}", fmt::map_join(e.args, ",", [](const auto &nameValue) -> string {
-                                        return fmt::format("\"{}\":\"{}\"", nameValue.first, nameValue.second);
+                                        return fmt::format("\"{}\":\"{}\"", JSON::escape(nameValue.first),
+                                                           JSON::escape(nameValue.second));
                                     }));
         }
 

--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -86,7 +86,14 @@ core::Loc LSPConfiguration::lspPos2Loc(const core::FileRef fref, const Position 
     core::Loc::Detail reqPos;
     reqPos.line = pos.line + 1;
     reqPos.column = pos.character + 1;
-    auto offset = core::Loc::pos2Offset(fref.data(gs), reqPos);
+    auto file = fref.data(gs);
+    auto l = reqPos.line - 1;
+    auto &lineBreaks = file.lineBreaks();
+    if (!(0 <= l && l < lineBreaks.size())) {
+        return core::Loc::none(fref);
+    }
+    auto lineOffset = lineBreaks[l];
+    auto offset = lineOffset + reqPos.column;
     return core::Loc{fref, offset, offset};
 }
 

--- a/main/lsp/LSPMessage.cc
+++ b/main/lsp/LSPMessage.cc
@@ -144,7 +144,6 @@ bool LSPMessage::isDelayable() const {
         case LSPMethod::WorkspaceSymbol:
         // These requests involve a specific file location, and should never be delayed.
         case LSPMethod::TextDocumentHover:
-        case LSPMethod::TextDocumentCompletion:
         case LSPMethod::TextDocumentSignatureHelp:
         // These are file updates. They shouldn't be delayed (but they can be combined/expedited).
         case LSPMethod::TextDocumentDidOpen:
@@ -167,6 +166,9 @@ bool LSPMessage::isDelayable() const {
         case LSPMethod::TextDocumentPublishDiagnostics:
         case LSPMethod::SorbetShowOperation:
         case LSPMethod::SorbetTypecheckRunInfo:
+        // This request involes a specific file location and SHOULD never be delayed but we need completion to be fast.
+        // TODO(jez) Check if we still need this after pre-emptible slow path
+        case LSPMethod::TextDocumentCompletion:
             return true;
     }
 }

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -359,8 +359,16 @@ LSPResult LSPLoop::handleTextDocumentCompletion(unique_ptr<core::GlobalState> gs
 
     auto uri = params.textDocument->uri;
     auto fref = config.uri2FileRef(*gs, uri);
+    if (!fref.exists()) {
+        response->result = make_unique<CompletionList>(false, vector<unique_ptr<CompletionItem>>{});
+        return LSPResult::make(move(gs), move(response));
+    }
     auto pos = *params.position;
     auto queryLoc = config.lspPos2Loc(fref, pos, *gs);
+    if (!queryLoc.exists()) {
+        response->result = make_unique<CompletionList>(false, vector<unique_ptr<CompletionItem>>{});
+        return LSPResult::make(move(gs), move(response));
+    }
     auto result = setupLSPQueryByLoc(move(gs), uri, pos, LSPMethod::TextDocumentCompletion);
     gs = move(result.gs);
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Commit summary
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


- **Fix JSON quoting in web-trace-file generation** (18ca5811a)


- **Lie and say textDocument/completion is delayable** (2ba694444)

  By our own definition, textDocument/completion is not delayable (need to
  finish processing the current edit before servicing it, because the
  input references position information).

  But the thing is, the common case is that completion requests come in
  between two edits that if we could merge them, we could take the fast
  path. So for the sake of hacking responsiveness into the IDE, we're
  compromising on our principles and pretending that
  textDocument/completion is delayable.

- **Early exit from copying all unchanged index results** (440bebcc8)

  We spend about 2 seconds deep copying all index results into the next
  edit. Instead of blocking, we should allow this operation to short
  circuit if we've been cancelled.

  This puts two atomic load operations inside a loop, which greatly
  increases the amount of potential synchronization needed. But
  empirically, it made completion feel faster, so I think it's fine.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.