### PR TITLE
When canceling a slow path for a slow path, actually provide a new GlobalState object

### DIFF
--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -118,6 +118,7 @@ void LSPPreprocessor::mergeFileChanges(absl::Mutex &mtx, QueueState &state) {
                                 "[Preprocessor] Canceling typechecking, as new edits {} thru {} will just take "
                                 "the slow path again.",
                                 params->updates.versionStart, params->updates.versionEnd);
+                            combinedUpdates.updatedGS = getTypecheckingGS();
                         }
                         params->updates = move(combinedUpdates);
                     }

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -512,6 +512,12 @@ TEST(SlowPathCancelation, CancelsRunningSlowPathWhenSlowPathEditComesIn) { // NO
 
     // Processor thread: Try to typecheck. Should return false because it has been canceled.
     EXPECT_FALSE(gs->tryCommitEpoch(epoch, true, []() -> void {}));
+
+    // Ensure that new update has a new global state defined.
+    auto maybeUpdates = getUpdates(state, 0);
+    ASSERT_TRUE(maybeUpdates.has_value());
+    auto &updates = maybeUpdates.value();
+    EXPECT_TRUE(updates->updatedGS.has_value());
 }
 
 TEST(SlowPathCancelation, DoesNotCancelRunningSlowPathWhenFastPathEditComesIn) { // NOLINT


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

When canceling a slow path for a slow path, actually provide a new GlobalState object

Otherwise, it can't be typechecked!

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes a big bug in the cancel-slow-for-slow change.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
