### PR TITLE
move this inside

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1596,8 +1596,8 @@ SymbolRef GlobalState::staticInitForFile(Loc loc) {
     auto nm = freshNameUnique(core::UniqueNameKind::Namer, core::Names::staticInit(), loc.file().id());
     auto prevCount = this->symbolsUsed();
     auto sym = enterMethodSymbol(loc, core::Symbols::rootSingleton(), nm);
-    auto blkLoc = core::Loc::none(loc.file());
     if (prevCount != this->symbolsUsed()) {
+        auto blkLoc = core::Loc::none(loc.file());
         auto &blkSym = this->enterMethodArgumentSymbol(blkLoc, sym, core::Names::blkArg());
         blkSym.flags.isBlock = true;
     }


### PR DESCRIPTION
While i was debugging something unrelated I noticed this variable isn't symmetric with the other function call and had this outside the if for some reason

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
