### PR TITLE
Allow T::Enum or Opus::Enum everywhere it's used

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -288,6 +288,10 @@ void GlobalState::initEmpty() {
     id.data(*this)->setIsModule(false);
     ENFORCE(id == Symbols::OpusEnum());
 
+    id = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Enum());
+    id.data(*this)->setIsModule(false);
+    ENFORCE(id == Symbols::T_Enum());
+
     // Root members
     Symbols::root().dataAllowingNone(*this)->members()[core::Names::Constants::NoSymbol()] = Symbols::noSymbol();
     Symbols::root().dataAllowingNone(*this)->members()[core::Names::Constants::Top()] = Symbols::top();

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -393,6 +393,10 @@ public:
         return SymbolRef(nullptr, 82);
     }
 
+    static SymbolRef T_Enum() {
+        return SymbolRef(nullptr, 83);
+    }
+
     static constexpr int MAX_PROC_ARITY = 10;
     static SymbolRef Proc0() {
         return SymbolRef(nullptr, MAX_SYNTHETIC_SYMBOLS - MAX_PROC_ARITY * 3 - 3);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -326,7 +326,8 @@ TypePtr unwrapType(Context ctx, Loc loc, const TypePtr &tp) {
     }
 
     if (auto *classType = cast_type<ClassType>(tp.get())) {
-        if (classType->symbol.data(ctx)->derivesFrom(ctx, core::Symbols::OpusEnum())) {
+        if (classType->symbol.data(ctx)->derivesFrom(ctx, core::Symbols::OpusEnum()) ||
+            classType->symbol.data(ctx)->derivesFrom(ctx, core::Symbols::T_Enum())) {
             // Opus::Enum instances are allowed to stand for themselves in type syntax positions.
             // See the note in type_syntax.cc regarding Opus::Enum.
             return tp;

--- a/dsl/OpusEnum.cc
+++ b/dsl/OpusEnum.cc
@@ -33,7 +33,7 @@ bool isOpusEnum(core::MutableContext ctx, ast::ClassDef *klass) {
     if (scope == nullptr) {
         return false;
     }
-    if (scope->cnst != core::Names::Constants::Opus()) {
+    if (scope->cnst != core::Names::Constants::Opus() && scope->cnst != core::Names::Constants::T()) {
         return false;
     }
     if (ast::isa_tree<ast::EmptyTree>(scope->scope.get())) {
@@ -56,6 +56,7 @@ ast::Send *asEnumsDo(ast::Expression *stat) {
     }
 }
 
+// TODO(jez) Change this error message after making everything T::Enum
 vector<unique_ptr<ast::Expression>> badConst(core::MutableContext ctx, core::Loc headerLoc, core::Loc line1Loc) {
     if (auto e = ctx.state.beginError(headerLoc, core::errors::DSL::OpusEnumConstNotEnumValue)) {
         e.setHeader("All constants defined on an `{}` must be unique instances of the enum", "Opus::Enum");

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -556,6 +556,9 @@ class T::Props::Decorator
   if defined?(Opus) && defined?(Opus::Enum)
     TYPES_NOT_NEEDING_CLONE << Opus::Enum
   end
+  if defined?(T::Enum)
+    TYPES_NOT_NEEDING_CLONE << T::Enum
+  end
 
   sig {params(type: PropType).returns(T::Boolean)}
   private def shallow_clone_ok(type)

--- a/gems/sorbet-runtime/lib/types/props/utils.rb
+++ b/gems/sorbet-runtime/lib/types/props/utils.rb
@@ -28,6 +28,8 @@ module T::Props::Utils
       # being defined.
       if defined?(Opus) && defined?(Opus::Enum) && what.class == Opus::Enum
         what
+      elsif defined?(T::Enum) && what.class == T::Enum
+        what
       else
         what.clone
       end

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -30,6 +30,8 @@ module T::Utils
       T::Private::Methods.finalize_proc(val.decl)
     elsif defined?(::Opus) && defined?(::Opus::Enum) && val.is_a?(::Opus::Enum)
       T::Types::OpusEnum.new(val) # rubocop:disable PrisonGuard/UseOpusTypesShortcut
+    elsif defined?(::T::Enum) && val.is_a?(::T::Enum)
+      T::Types::OpusEnum.new(val) # rubocop:disable PrisonGuard/UseOpusTypesShortcut
     else
       raise "Invalid value for type constraint. Must be an #{T::Types::Base}, a " \
             "class/module, or an array. Got a `#{val.class}`."

--- a/gems/sorbet-runtime/test/pay-server-shims.rbi
+++ b/gems/sorbet-runtime/test/pay-server-shims.rbi
@@ -12,4 +12,6 @@ end
 
 class Opus::Ownership; end
 
+# TODO(jez) Shouldn't need either of these after T::Enum is in sorbet-runtime
 class Opus::Enum; end
+class T::Enum; end

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -602,7 +602,8 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
             // want there to be one name for every type; making an alias for a type should always be
             // syntactically declared with T.type_alias.
             if (auto resultType = core::cast_type<core::ClassType>(maybeAliased.data(ctx)->resultType.get())) {
-                if (resultType->symbol.data(ctx)->derivesFrom(ctx, core::Symbols::OpusEnum())) {
+                if (resultType->symbol.data(ctx)->derivesFrom(ctx, core::Symbols::OpusEnum()) ||
+                    resultType->symbol.data(ctx)->derivesFrom(ctx, core::Symbols::T_Enum())) {
                     result.type = maybeAliased.data(ctx)->resultType;
                     return;
                 }

--- a/test/testdata/dsl/t_enum_exhaustiveness.rb
+++ b/test/testdata/dsl/t_enum_exhaustiveness.rb
@@ -1,0 +1,49 @@
+# typed: strict
+
+extend T::Sig
+
+module T
+  class Enum
+    extend T::Sig
+
+    sig {params(x: T.nilable(String)).void}
+    def initialize(x = nil)
+    end
+
+    sig {params(blk: T.proc.void).void}
+    def self.enums(&blk)
+    end
+  end
+end
+
+class MyEnum < T::Enum
+  enums do
+  A = new
+  B = new
+  C = new
+  end
+end
+
+sig {params(x: MyEnum).void}
+def all_cases_handled(x)
+  case x
+  when MyEnum::A
+    T.reveal_type(x) # error: Revealed type: `MyEnum::A`
+  when MyEnum::B
+    T.reveal_type(x) # error: Revealed type: `MyEnum::B`
+  when MyEnum::C
+    T.reveal_type(x) # error: Revealed type: `MyEnum::C`
+  else
+    T.absurd(x)
+  end
+end
+
+sig {params(x: MyEnum).void}
+def missing_case(x)
+  case x
+  when MyEnum::A
+  when MyEnum::B
+  else
+    T.absurd(x) # error: Control flow could reach `T.absurd` because the type `MyEnum::C` wasn't handled
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The Opus::Enum open source path will probably look like:

- Rename in pay-server (`Opus::Enum` -> `T::Enum`)
- Get tests passing
- Copy to Sorbet
- Bump sorbet-runtime in pay-server
  - Delete `lib/enum/`

I was poking around at how much work this would be yesterday, and I think it'll
probably be a little bit of work, so probably not right now.

But while I was investigating, I prepared this PR to get further in a couple of
spots, so I figured I'd may as well commit it so we have it already whenever we
do want to prioritize `T::Enum`.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.