### PR TITLE
Fallback to locating sorbet-static using gem open

### DIFF
--- a/gems/sorbet/bin/srb
+++ b/gems/sorbet/bin/srb
@@ -72,10 +72,19 @@ typecheck() {
     gems_path="${without_bin_srb%/sorbet*}"
     # /path/to/gems/sorbet-static-0.0.1-darwin-17/libexec/sorbet
     # (assumes people only have one platform-depdendent gem installed per version)
-    sorbet=("$gems_path/sorbet-static$version_suffix"*/libexec/sorbet)
+    guess_sorbet=("$gems_path/sorbet-static$version_suffix"*/libexec/sorbet)
+
+    if [[ -f "${guess_sorbet[0]}" ]]; then
+      sorbet="${guess_sorbet[0]}"
+    else
+      # 0.0.1
+      version="${version_suffix#-}"
+      # Resort to locating using the GEM_PATH, this takes ~200ms
+      sorbet="$(VISUAL=echo gem open sorbet-static -v "${version}")/libexec/sorbet"
+    fi
 
     # shellcheck disable=SC2086
-    "${sorbet[0]}" "${args[@]}"
+    "${sorbet}" "${args[@]}"
   fi
 }
 


### PR DESCRIPTION
### Motivation
In certain circumstances, it's possible that the `sorbet-static` gem is not directly located next to the `sorbet` gem.

For example, when using [nixos](https://nixos.org/) and [bundix](https://github.com/nix-community/bundix), the individual gems are downloaded all over the place and then symlink into the GEM_PATH.

### Test plan
I was able to make `bundle exec srb init` work with my patch.

Previously:
```
/nix/store/0n05y3w0kscianzl9nljjb63v0kp1ppi-ruby2.6.5-sorbet-0.4.4886/lib/ruby/gems/2.6.0/gems/sorbet-0.4.4886/bin/srb: line 85: /nix/store/0n05y3w0kscianzl9nljjb63v0kp1ppi-ruby2.6.5-sorbet-0.4.4886/lib/ruby/gems/2.6.0/gems/sorbet-static-0.4.4886*/libexec/sorbet: No such file or directory
```

/cc @Morriar 
