### PR TITLE
Add type information to JSON.parse

### DIFF
--- a/rbi/stdlib/json.rbi
+++ b/rbi/stdlib/json.rbi
@@ -265,7 +265,7 @@ module JSON
 
   sig do
     params(
-      json: ::T.untyped,
+      json: String,
       args: ::T.untyped,
     )
     .returns(::T.untyped)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Adds type information for the `json` argument in `JSON.parse`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
JSON.parse only takes strings and raises an exception if you pass in a nil. Therefore we can type the `json` argument as `String`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
