### PR TITLE
Array#assoc returns a nilable Array

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -636,7 +636,7 @@ class Array < Object
     params(
         arg0: Elem,
     )
-    .returns(T::Array[Elem])
+    .returns(T.nilable(T::Array[Elem]))
   end
   def assoc(arg0); end
 


### PR DESCRIPTION
### Motivation

From the [documentation](https://github.com/sorbet/sorbet/blob/master/rbi/core/array.rbi#L633) `Array#assoc` can return `nil`:

 ```ruby
  s1 = [ "colors", "red", "blue", "green" ]
  s2 = [ "letters", "a", "b", "c" ]
  s3 = "foo"
  a  = [ s1, s2, s3 ]
  a.assoc("foo")      #=> nil
 ```