### PR TITLE
Allow Hash.[] to apply hash

### DIFF
--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -162,7 +162,7 @@ class Hash < Object
   # ```
   sig do
     type_parameters(:U, :V).params(
-      arg0: T::Array[[T.type_parameter(:U), T.type_parameter(:V)]],
+      arg0: T.any(T::Array[[T.type_parameter(:U), T.type_parameter(:V)]], T::Hash[T.type_parameter(:U), T.type_parameter(:V)]),
     )
     .returns(T::Hash[T.type_parameter(:U), T.type_parameter(:V)])
   end

--- a/test/testdata/rbi/hash.rb
+++ b/test/testdata/rbi/hash.rb
@@ -8,6 +8,9 @@ h[:foo] = :bar
 # Bad practise but not a type error
 Hash.new([])
 
+# Hash.[] with hash not a type error
+Hash[test: 'test']
+
 # to_a and Hash[] play nice together
 T.assert_type!(
   Hash[T::Hash[String, String].new.to_a],

--- a/test/testdata/resolver/bad_hash.rb
+++ b/test/testdata/resolver/bad_hash.rb
@@ -1,5 +1,5 @@
 # typed: true
 T.let({}, Hash[Integer, String])
         # ^^^^^^^^^^^^^^^^^^^^^ error: Use `T::Hash[...]`, not `Hash[...]` to declare a typed `Hash`
-        # ^^^^^^^^^^^^^^^^^^^^^ error: Expected `T::Array[[U, V]]` but found `T.class_of(Integer)` for argument `arg0`
-        # ^^^^^^^^^^^^^^^^^^^^^ error: Expected `T::Array[[U, V]]` but found `T.class_of(String)` for argument `arg0`
+        # ^^^^^^^^^^^^^^^^^^^^^ error: Expected `T.any(T::Array[[U, V]], T::Hash[U, V])` but found `T.class_of(Integer)` for argument `arg0`
+        # ^^^^^^^^^^^^^^^^^^^^^ error: Expected `T.any(T::Array[[U, V]], T::Hash[U, V])` but found `T.class_of(String)` for argument `arg0`


### PR DESCRIPTION
### Motivation
```
# typed: true
Hash[test: 'test']
```
Above code cause type error but it is correct code.

### Test plan
See included automated tests.
