### PR TITLE
LSP: Clean up configuration object and make LSPOutput thread safe.

### DIFF
--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -84,7 +84,7 @@ void LSPConfiguration::clientInitialize(const InitializeParams &params) {
         cconfig.enableTypecheckInfo = initOptions->enableTypecheckInfo.value_or(false);
         cconfig.enableSorbetURIs = initOptions->supportsSorbetURIs.value_or(false);
     }
-    clientConfig = make_unique<LSPClientConfiguration>(move(cconfig));
+    clientConfig = make_shared<LSPClientConfiguration>(move(cconfig));
 }
 
 // LSP Spec: line / col in Position are 0-based

--- a/main/lsp/LSPConfiguration.h
+++ b/main/lsp/LSPConfiguration.h
@@ -44,7 +44,9 @@ struct LSPClientConfiguration {
  * The language server's configuration information.
  */
 class LSPConfiguration {
-    void assertInitialized() const;
+    std::shared_ptr<const LSPClientConfiguration> clientConfig;
+    std::atomic<bool> initialized;
+    void assertClientConfig() const;
 
 public:
     // The following properties are configured when the language server is created.
@@ -63,19 +65,19 @@ public:
 
     // The following properties are configured during initialization.
 
-    /**
-     * If 'true', then the initialization routine is complete and clientConfig is available.
-     */
-    std::atomic<bool> initialized;
-    std::unique_ptr<const LSPClientConfiguration> clientConfig;
-
     LSPConfiguration(const options::Options &opts, const std::shared_ptr<LSPOutput> &output, WorkerPool &workers,
                      const std::shared_ptr<spdlog::logger> &logger, bool skipConfigatron = false,
                      bool disableFastPath = false);
 
-    // Note: Should only be called from LSPPreprocessor.
     void clientInitialize(const InitializeParams &initializeParams);
+    void markInitialized();
 
+    /**
+     * If 'true', then the initialization routine is complete.
+     */
+    bool isInitialized() const;
+
+    const LSPClientConfiguration &getClientConfig() const;
     core::FileRef uri2FileRef(const core::GlobalState &gs, std::string_view uri) const;
     std::string fileRef2Uri(const core::GlobalState &gs, const core::FileRef) const;
     std::string remoteName2Local(std::string_view uri) const;

--- a/main/lsp/LSPOutput.cc
+++ b/main/lsp/LSPOutput.cc
@@ -55,4 +55,12 @@ void LSPStdout::rawWrite(unique_ptr<LSPMessage> msg) {
     cout << outResult << flush;
 }
 
+void LSPOutputToVector::rawWrite(unique_ptr<LSPMessage> msg) {
+    output.push_back(move(msg));
+}
+
+vector<unique_ptr<LSPMessage>> LSPOutputToVector::getOutput() {
+    return move(output);
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPOutput.cc
+++ b/main/lsp/LSPOutput.cc
@@ -32,7 +32,18 @@ void LSPOutput::write(unique_ptr<LSPMessage> msg) {
     } else if (msg->isNotification()) {
         ENFORCE(isServerNotification(msg->method()));
     }
-    rawWrite(move(msg));
+    {
+        absl::MutexLock lock(&mtx);
+        rawWrite(move(msg));
+    }
+}
+
+void LSPOutput::write(unique_ptr<ResponseMessage> msg) {
+    write(make_unique<LSPMessage>(move(msg)));
+}
+
+void LSPOutput::write(unique_ptr<NotificationMessage> msg) {
+    write(make_unique<LSPMessage>(move(msg)));
 }
 
 LSPStdout::LSPStdout(shared_ptr<spdlog::logger> &logger) : logger(logger) {}

--- a/main/lsp/LSPOutput.cc
+++ b/main/lsp/LSPOutput.cc
@@ -33,6 +33,7 @@ void LSPOutput::write(unique_ptr<LSPMessage> msg) {
         ENFORCE(isServerNotification(msg->method()));
     }
     {
+        // Protect with a lock to make it possible for multiple threads to concurrently write to the same output object.
         absl::MutexLock lock(&mtx);
         rawWrite(move(msg));
     }

--- a/main/lsp/LSPOutput.h
+++ b/main/lsp/LSPOutput.h
@@ -3,6 +3,7 @@
 
 #include "absl/synchronization/mutex.h"
 #include <memory>
+#include <vector>
 
 namespace spdlog {
 class logger;
@@ -45,6 +46,18 @@ protected:
 
 public:
     LSPStdout(std::shared_ptr<spdlog::logger> &logger);
+};
+
+class LSPOutputToVector final : public LSPOutput {
+    std::vector<std::unique_ptr<LSPMessage>> output;
+
+protected:
+    void rawWrite(std::unique_ptr<LSPMessage> msg) override;
+
+public:
+    LSPOutputToVector() = default;
+
+    std::vector<std::unique_ptr<LSPMessage>> getOutput();
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -244,7 +244,7 @@ void LSPPreprocessor::preprocessAndEnqueue(QueueState &state, unique_ptr<LSPMess
         case LSPMethod::Initialize: {
             // Update configuration object. Needed to intelligently process edits.
             const auto &params = get<unique_ptr<InitializeParams>>(msg->asRequest().params);
-            config->clientInitialize(*params);
+            config->setClientConfig(make_shared<LSPClientConfiguration>(*params));
             shouldEnqueue = true;
             break;
         }

--- a/main/lsp/LSPPreprocessor.h
+++ b/main/lsp/LSPPreprocessor.h
@@ -87,6 +87,8 @@ class LSPPreprocessor final {
      */
     std::unique_ptr<core::GlobalState> getTypecheckingGS() const;
 
+    bool ensureInitialized(const LSPMethod forMethod, const LSPMessage &msg) const;
+
 public:
     LSPPreprocessor(std::unique_ptr<core::GlobalState> initialGS, const std::shared_ptr<LSPConfiguration> &config,
                     u4 initialVersion = 0);

--- a/main/lsp/LSPPreprocessor.h
+++ b/main/lsp/LSPPreprocessor.h
@@ -34,7 +34,6 @@ struct QueueState {
  * - Clones initialGS so that the typechecking thread can perform typechecking on the clone.
  */
 class LSPPreprocessor final {
-private:
     /**
      * This global state is used for indexing. It accumulates a huge nametable of all global things,
      * and is updated as global things are added/removed/updated. It is never discarded.
@@ -43,9 +42,7 @@ private:
      * it to the processing thread for use during typechecking.
      */
     TimeTravelingGlobalState ttgs;
-    LSPConfiguration config;
-    WorkerPool &workers;
-    std::shared_ptr<spdlog::logger> logger;
+    std::shared_ptr<LSPConfiguration> config;
     std::unique_ptr<KeyValueStore> kvstore; // always null for now.
     /** ID of the thread that owns the preprocessor and is allowed to invoke methods on it. */
     std::thread::id owner;
@@ -91,8 +88,8 @@ private:
     std::unique_ptr<core::GlobalState> getTypecheckingGS() const;
 
 public:
-    LSPPreprocessor(std::unique_ptr<core::GlobalState> initialGS, LSPConfiguration config, WorkerPool &workers,
-                    const std::shared_ptr<spdlog::logger> &logger, u4 initialVersion = 0);
+    LSPPreprocessor(std::unique_ptr<core::GlobalState> initialGS, const std::shared_ptr<LSPConfiguration> &config,
+                    u4 initialVersion = 0);
 
     /**
      * Performs pre-processing on the incoming LSP request and appends it to the queue.

--- a/main/lsp/LSPPreprocessor.h
+++ b/main/lsp/LSPPreprocessor.h
@@ -32,6 +32,8 @@ struct QueueState {
  * - Determines if edits should take the fast or slow path.
  * - Is the source-of-truth for the latest file updates.
  * - Clones initialGS so that the typechecking thread can perform typechecking on the clone.
+ * - Early rejects messages that are sent prior to initialization completion.
+ * - Determines if a running slow path should be canceled, and undertakes canceling if so.
  */
 class LSPPreprocessor final {
     /**

--- a/main/lsp/ShowOperation.cc
+++ b/main/lsp/ShowOperation.cc
@@ -13,17 +13,16 @@ unique_ptr<LSPMessage> makeShowOperation(std::string operationName, std::string 
         make_unique<SorbetShowOperationParams>(move(operationName), move(description), status)));
 }
 
-ShowOperation::ShowOperation(LSPOutput &output, const LSPConfiguration &config, std::string operationName,
-                             std::string description)
-    : output(output), config(config), operationName(move(operationName)), description(move(description)) {
-    if (config.enableOperationNotifications) {
-        output.write(makeShowOperation(this->operationName, this->description, SorbetOperationStatus::Start));
+ShowOperation::ShowOperation(const LSPConfiguration &config, std::string operationName, std::string description)
+    : config(config), operationName(move(operationName)), description(move(description)) {
+    if (config.clientConfig->enableOperationNotifications) {
+        config.output->write(makeShowOperation(this->operationName, this->description, SorbetOperationStatus::Start));
     }
 }
 
 ShowOperation::~ShowOperation() {
-    if (config.enableOperationNotifications) {
-        output.write(makeShowOperation(this->operationName, this->description, SorbetOperationStatus::End));
+    if (config.clientConfig->enableOperationNotifications) {
+        config.output->write(makeShowOperation(this->operationName, this->description, SorbetOperationStatus::End));
     }
 }
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/ShowOperation.cc
+++ b/main/lsp/ShowOperation.cc
@@ -15,13 +15,13 @@ unique_ptr<LSPMessage> makeShowOperation(std::string operationName, std::string 
 
 ShowOperation::ShowOperation(const LSPConfiguration &config, std::string operationName, std::string description)
     : config(config), operationName(move(operationName)), description(move(description)) {
-    if (config.clientConfig->enableOperationNotifications) {
+    if (config.getClientConfig().enableOperationNotifications) {
         config.output->write(makeShowOperation(this->operationName, this->description, SorbetOperationStatus::Start));
     }
 }
 
 ShowOperation::~ShowOperation() {
-    if (config.clientConfig->enableOperationNotifications) {
+    if (config.getClientConfig().enableOperationNotifications) {
         config.output->write(makeShowOperation(this->operationName, this->description, SorbetOperationStatus::End));
     }
 }

--- a/main/lsp/ShowOperation.h
+++ b/main/lsp/ShowOperation.h
@@ -13,14 +13,12 @@ class LSPConfiguration;
  * starts and ends. Is used to provide user feedback in the status line of VS Code.
  */
 class ShowOperation final {
-    LSPOutput &output;
     const LSPConfiguration &config;
     const std::string operationName;
     const std::string description;
 
 public:
-    ShowOperation(LSPOutput &output, const LSPConfiguration &config, std::string operationName,
-                  std::string description);
+    ShowOperation(const LSPConfiguration &config, std::string operationName, std::string description);
     ~ShowOperation();
 };
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/TimeTravelingGlobalState.h
+++ b/main/lsp/TimeTravelingGlobalState.h
@@ -39,9 +39,7 @@ private:
         GlobalStateUpdate update;
         GlobalStateUpdate undoUpdate;
     };
-    const LSPConfiguration config;
-    std::shared_ptr<spdlog::logger> logger;
-    WorkerPool &workers;
+    std::shared_ptr<const LSPConfiguration> config;
     std::unique_ptr<KeyValueStore> kvstore; // always null for now.
     std::unique_ptr<core::GlobalState> gs;
 
@@ -67,8 +65,8 @@ private:
     std::vector<core::FileHash> computeStateHashes(const std::vector<std::shared_ptr<core::File>> &files) const;
 
 public:
-    TimeTravelingGlobalState(const LSPConfiguration &config, const std::shared_ptr<spdlog::logger> &logger,
-                             WorkerPool &workers, std::unique_ptr<core::GlobalState> gs, u4 initialVersion);
+    TimeTravelingGlobalState(const std::shared_ptr<LSPConfiguration> &config, std::unique_ptr<core::GlobalState> gs,
+                             u4 initialVersion);
 
     /**
      * Travels GlobalState forwards and backwards in time. No-op if version == current version.

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -59,17 +59,6 @@ LSPLoop::QueryRun LSPLoop::setupLSPQueryBySymbol(unique_ptr<core::GlobalState> g
     return runQuery(move(gs), core::lsp::Query::createSymbolQuery(sym), frefs);
 }
 
-bool LSPLoop::ensureInitialized(LSPMethod forMethod, const LSPMessage &msg) const {
-    // Note: During initialization, the preprocessor sends ShowOperation notifications to the main thread to forward to
-    // the client ("Indexing..."). So, whitelist those messages as OK to process prior to initialization.
-    if (config->initialized || forMethod == LSPMethod::Initialize || forMethod == LSPMethod::Initialized ||
-        forMethod == LSPMethod::Exit || forMethod == LSPMethod::Shutdown || forMethod == LSPMethod::SorbetError ||
-        forMethod == LSPMethod::SorbetShowOperation) {
-        return true;
-    }
-    return false;
-}
-
 LSPResult LSPLoop::pushDiagnostics(TypecheckRun run) {
     ENFORCE(!run.canceled);
     const core::GlobalState &gs = *run.gs;
@@ -78,7 +67,7 @@ LSPResult LSPLoop::pushDiagnostics(TypecheckRun run) {
     UnorderedMap<core::FileRef, vector<std::unique_ptr<core::Error>>> errorsAccumulated;
     vector<unique_ptr<LSPMessage>> responses;
 
-    if (config->clientConfig->enableTypecheckInfo) {
+    if (config->getClientConfig().enableTypecheckInfo) {
         vector<string> pathsTypechecked;
         for (auto &f : filesTypechecked) {
             pathsTypechecked.emplace_back(f.data(gs).path());

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -11,15 +11,13 @@ using namespace std;
 
 namespace sorbet::realmain::lsp {
 
-LSPLoop::LSPLoop(std::unique_ptr<core::GlobalState> initialGS, LSPConfiguration config,
-                 const shared_ptr<spd::logger> &logger, WorkerPool &workers, LSPOutput &output)
-    : config(config), preprocessor(move(initialGS), config, workers, logger), logger(logger), workers(workers),
-      output(output), lastMetricUpdateTime(chrono::steady_clock::now()) {}
+LSPLoop::LSPLoop(std::unique_ptr<core::GlobalState> initialGS, const std::shared_ptr<LSPConfiguration> &config)
+    : config(config), preprocessor(move(initialGS), config), lastMetricUpdateTime(chrono::steady_clock::now()) {}
 
 LSPLoop::QueryRun LSPLoop::setupLSPQueryByLoc(unique_ptr<core::GlobalState> gs, string_view uri, const Position &pos,
                                               const LSPMethod forMethod, bool errorIfFileIsUntyped) const {
-    Timer timeit(logger, "setupLSPQueryByLoc");
-    auto fref = config.uri2FileRef(*gs, uri);
+    Timer timeit(config->logger, "setupLSPQueryByLoc");
+    auto fref = config->uri2FileRef(*gs, uri);
     if (!fref.exists()) {
         auto error = make_unique<ResponseError>(
             (int)LSPErrorCodes::InvalidParams,
@@ -28,17 +26,17 @@ LSPLoop::QueryRun LSPLoop::setupLSPQueryByLoc(unique_ptr<core::GlobalState> gs, 
     }
 
     if (errorIfFileIsUntyped && fref.data(*gs).strictLevel < core::StrictLevel::True) {
-        logger->info("Ignoring request on untyped file `{}`", uri);
+        config->logger->info("Ignoring request on untyped file `{}`", uri);
         // Act as if the query returned no results.
         return QueryRun{move(gs), {}};
     }
 
-    auto loc = config.lspPos2Loc(fref, pos, *gs);
+    auto loc = config->lspPos2Loc(fref, pos, *gs);
     return runQuery(move(gs), core::lsp::Query::createLocQuery(loc), {fref});
 }
 
 LSPLoop::QueryRun LSPLoop::setupLSPQueryBySymbol(unique_ptr<core::GlobalState> gs, core::SymbolRef sym) const {
-    Timer timeit(logger, "setupLSPQueryBySymbol");
+    Timer timeit(config->logger, "setupLSPQueryBySymbol");
     ENFORCE(sym.exists());
     vector<core::FileRef> frefs;
     const core::NameHash symNameHash(*gs, sym.data(*gs)->name.data(*gs));
@@ -64,7 +62,7 @@ LSPLoop::QueryRun LSPLoop::setupLSPQueryBySymbol(unique_ptr<core::GlobalState> g
 bool LSPLoop::ensureInitialized(LSPMethod forMethod, const LSPMessage &msg) const {
     // Note: During initialization, the preprocessor sends ShowOperation notifications to the main thread to forward to
     // the client ("Indexing..."). So, whitelist those messages as OK to process prior to initialization.
-    if (config.initialized || forMethod == LSPMethod::Initialize || forMethod == LSPMethod::Initialized ||
+    if (config->initialized || forMethod == LSPMethod::Initialize || forMethod == LSPMethod::Initialized ||
         forMethod == LSPMethod::Exit || forMethod == LSPMethod::Shutdown || forMethod == LSPMethod::SorbetError ||
         forMethod == LSPMethod::SorbetShowOperation) {
         return true;
@@ -80,7 +78,7 @@ LSPResult LSPLoop::pushDiagnostics(TypecheckRun run) {
     UnorderedMap<core::FileRef, vector<std::unique_ptr<core::Error>>> errorsAccumulated;
     vector<unique_ptr<LSPMessage>> responses;
 
-    if (config.enableTypecheckInfo) {
+    if (config->clientConfig->enableTypecheckInfo) {
         vector<string> pathsTypechecked;
         for (auto &f : filesTypechecked) {
             pathsTypechecked.emplace_back(f.data(gs).path());
@@ -134,7 +132,7 @@ LSPResult LSPLoop::pushDiagnostics(TypecheckRun run) {
                 if (file.data(gs).sourceType == core::File::Type::Payload) {
                     uri = string(file.data(gs).path());
                 } else {
-                    uri = config.fileRef2Uri(gs, file);
+                    uri = config->fileRef2Uri(gs, file);
                 }
             }
 
@@ -163,7 +161,7 @@ LSPResult LSPLoop::pushDiagnostics(TypecheckRun run) {
                                     } else {
                                         message = sectionHeader;
                                     }
-                                    auto location = config.loc2Location(gs, errorLine.loc);
+                                    auto location = config->loc2Location(gs, errorLine.loc);
                                     if (location == nullptr) {
                                         continue;
                                     }
@@ -174,7 +172,7 @@ LSPResult LSPLoop::pushDiagnostics(TypecheckRun run) {
                             // Add link to error documentation.
                             relatedInformation.push_back(make_unique<DiagnosticRelatedInformation>(
                                 make_unique<Location>(
-                                    absl::StrCat(config.opts.errorUrlBase, e->what.code),
+                                    absl::StrCat(config->opts.errorUrlBase, e->what.code),
                                     make_unique<Range>(make_unique<Position>(0, 0), make_unique<Position>(0, 0))),
                                 "Click for more information on this error."));
                             diagnostic->relatedInformation = move(relatedInformation);
@@ -195,12 +193,12 @@ LSPResult LSPLoop::pushDiagnostics(TypecheckRun run) {
 constexpr chrono::minutes STATSD_INTERVAL = chrono::minutes(5);
 
 bool LSPLoop::shouldSendCountersToStatsd(chrono::time_point<chrono::steady_clock> currentTime) const {
-    return !config.opts.statsdHost.empty() && (currentTime - lastMetricUpdateTime) > STATSD_INTERVAL;
+    return !config->opts.statsdHost.empty() && (currentTime - lastMetricUpdateTime) > STATSD_INTERVAL;
 }
 
 void LSPLoop::sendCountersToStatsd(chrono::time_point<chrono::steady_clock> currentTime) {
     ENFORCE(this_thread::get_id() == mainThreadId, "sendCounterToStatsd can only be called from the main LSP thread.");
-    const auto &opts = config.opts;
+    const auto &opts = config->opts;
     // Record rusage-related stats.
     StatsD::addRusageStats();
     auto counters = getAndClearThreadCounters();

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -2,7 +2,6 @@
 #define RUBY_TYPER_LSPLOOP_H
 
 #include "ast/ast.h"
-#include "common/concurrency/WorkerPool.h"
 #include "common/kvstore/KeyValueStore.h"
 #include "core/ErrorQueue.h"
 #include "core/NameHash.h"
@@ -57,7 +56,7 @@ class LSPLoop {
     friend class LSPWrapper;
 
     /** Encapsulates the active configuration for the language server. */
-    LSPConfiguration config;
+    std::shared_ptr<const LSPConfiguration> config;
     /** The LSP preprocessor standardizes incoming messages and combines edits. */
     LSPPreprocessor preprocessor;
     /** Trees that have been indexed (with initialGS) and can be reused between different runs */
@@ -72,10 +71,6 @@ class LSPLoop {
     /** Concrete error queue shared by all global states */
     std::shared_ptr<core::ErrorQueue> errorQueue;
     std::unique_ptr<KeyValueStore> kvstore; // always null for now.
-    std::shared_ptr<spdlog::logger> logger;
-    WorkerPool &workers;
-    /** Used to send asynchronous notifications to the client. */
-    LSPOutput &output;
     /**
      * The time that LSP last sent metrics to statsd -- if `opts.statsdHost` was specified.
      */
@@ -181,8 +176,7 @@ class LSPLoop {
     void maybeStartCommitSlowPathEdit(core::GlobalState &gs, const LSPMessage &msg) const;
 
 public:
-    LSPLoop(std::unique_ptr<core::GlobalState> initialGS, LSPConfiguration config,
-            const std::shared_ptr<spd::logger> &logger, WorkerPool &workers, LSPOutput &output);
+    LSPLoop(std::unique_ptr<core::GlobalState> initialGS, const std::shared_ptr<LSPConfiguration> &config);
     /**
      * Runs the language server on a dedicated thread. Returns the final global state if it exits cleanly, or nullopt
      * on error.

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -127,8 +127,6 @@ class LSPLoop {
     LSPResult commitTypecheckRun(TypecheckRun run);
     LSPResult pushDiagnostics(TypecheckRun run);
 
-    bool ensureInitialized(const LSPMethod forMethod, const LSPMessage &msg) const;
-
     LSPLoop::QueryRun setupLSPQueryByLoc(std::unique_ptr<core::GlobalState> gs, std::string_view uri,
                                          const Position &pos, const LSPMethod forMethod,
                                          bool errorIfFileIsUntyped = true) const;

--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -134,7 +134,7 @@ unique_ptr<Joinable> LSPPreprocessor::runPreprocessor(QueueState &incomingQueue,
                     &incomingQueue));
                 // Only terminate once incoming queue is drained.
                 if (incomingQueue.terminate && incomingQueue.pendingRequests.empty()) {
-                    logger->debug("Preprocessor terminating");
+                    config->logger->debug("Preprocessor terminating");
                     return;
                 }
                 msg = move(incomingQueue.pendingRequests.front());
@@ -185,7 +185,8 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(int inputFd) {
     QueueState processingQueue;
 
     unique_ptr<watchman::WatchmanProcess> watchmanProcess;
-    const auto &opts = config.opts;
+    const auto &opts = config->opts;
+    auto &logger = config->logger;
     if (!opts.disableWatchman) {
         if (opts.rawInputDirNames.size() != 1 || !opts.rawInputFileNames.empty()) {
             logger->error("Watchman support currently only works when Sorbet is run with a single input directory. If "
@@ -196,7 +197,7 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(int inputFd) {
         // The lambda below intentionally does not capture `this`.
         watchmanProcess = make_unique<watchman::WatchmanProcess>(
             logger, opts.watchmanPath, opts.rawInputDirNames.at(0), vector<string>({"rb", "rbi"}),
-            [&incomingQueue, &incomingMtx, logger = this->logger,
+            [&incomingQueue, &incomingMtx, logger = logger,
              &initializedNotification](std::unique_ptr<WatchmanQueryResponse> response) {
                 auto notifMsg =
                     make_unique<NotificationMessage>("2.0", LSPMethod::SorbetWatchmanFileChange, move(response));
@@ -210,7 +211,7 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(int inputFd) {
                     incomingQueue.pendingRequests.push_back(move(msg));
                 }
             },
-            [&incomingQueue, &incomingMtx, logger = this->logger](int watchmanExitCode) {
+            [&incomingQueue, &incomingMtx, logger = logger](int watchmanExitCode) {
                 {
                     absl::MutexLock lck(&incomingMtx);
                     if (!incomingQueue.terminate) {
@@ -222,7 +223,7 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(int inputFd) {
             });
     }
 
-    auto readerThread = runInAThread("lspReader", [&incomingQueue, &incomingMtx, logger = this->logger, inputFd] {
+    auto readerThread = runInAThread("lspReader", [&incomingQueue, &incomingMtx, logger = logger, inputFd] {
         // Thread that executes this lambda is called reader thread.
         // This thread _intentionally_ does not capture `this`.
         NotifyOnDestruction notify(incomingMtx, incomingQueue.terminate);
@@ -300,10 +301,10 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(int inputFd) {
             auto result = processRequestInternal(move(gs), *msg);
             gs = move(result.gs);
             for (auto &msg : result.responses) {
-                output.write(move(msg));
+                config->output->write(move(msg));
             }
 
-            if (config.initialized && !initializedNotification.HasBeenNotified()) {
+            if (config->initialized && !initializedNotification.HasBeenNotified()) {
                 initializedNotification.Notify();
             }
 

--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -304,7 +304,7 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(int inputFd) {
                 config->output->write(move(msg));
             }
 
-            if (config->initialized && !initializedNotification.HasBeenNotified()) {
+            if (config->isInitialized() && !initializedNotification.HasBeenNotified()) {
                 initializedNotification.Notify();
             }
 

--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -44,21 +44,6 @@ LSPResult LSPLoop::processRequestInternal(unique_ptr<core::GlobalState> gs, cons
     // TODO(jvilk): Make Timer accept multiple FlowIds so we can show merged messages correctly.
     Timer timeit(logger, "process_request");
     const LSPMethod method = msg.method();
-
-    if (!ensureInitialized(method, msg)) {
-        logger->error("Serving request before got an Initialize & Initialized handshake from IDE");
-        vector<unique_ptr<LSPMessage>> responses;
-        if (!msg.isNotification()) {
-            auto id = msg.id().value_or(0);
-            auto response = make_unique<ResponseMessage>("2.0", id, msg.method());
-            response->error = make_unique<ResponseError>((int)LSPErrorCodes::ServerNotInitialized,
-                                                         "IDE did not initialize Sorbet correctly. No requests should "
-                                                         "be made before Initialize & Initialized have been completed");
-            responses.push_back(make_unique<LSPMessage>(move(response)));
-        }
-        return LSPResult{move(gs), move(responses)};
-    }
-
     if (msg.isNotification()) {
         Timer timeit(logger, "notification", {{"method", convertLSPMethodToString(method)}});
         // The preprocessor should canonicalize these messages into SorbetWorkspaceEdits, so they should never appear

--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -40,6 +40,8 @@ LSPResult LSPLoop::processRequests(unique_ptr<core::GlobalState> gs, vector<uniq
 }
 
 LSPResult LSPLoop::processRequestInternal(unique_ptr<core::GlobalState> gs, const LSPMessage &msg) {
+    // Note: Before this function runs, LSPPreprocessor has already early-rejected any invalid messages sent prior to
+    // the initialization handshake. So, we know that `msg` is valid to process given the current state of the server.
     auto &logger = config->logger;
     // TODO(jvilk): Make Timer accept multiple FlowIds so we can show merged messages correctly.
     Timer timeit(logger, "process_request");

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -8,7 +8,7 @@ LSPResult LSPLoop::handleTextDocumentCodeAction(unique_ptr<core::GlobalState> gs
                                                 const CodeActionParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentCodeAction);
 
-    if (!config.opts.lspQuickFixEnabled) {
+    if (!config->opts.lspQuickFixEnabled) {
         response->error = make_unique<ResponseError>(
             (int)LSPErrorCodes::InvalidRequest, "The `Quick Fix` LSP feature is experimental and disabled by default.");
         return LSPResult::make(move(gs), move(response));
@@ -18,7 +18,7 @@ LSPResult LSPLoop::handleTextDocumentCodeAction(unique_ptr<core::GlobalState> gs
 
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.codeAction");
 
-    core::FileRef file = config.uri2FileRef(*gs, params.textDocument->uri);
+    core::FileRef file = config->uri2FileRef(*gs, params.textDocument->uri);
     LSPFileUpdates updates;
     updates.canTakeFastPath = true;
     ENFORCE(file.id() < globalStateHashes.size());
@@ -45,7 +45,7 @@ LSPResult LSPLoop::handleTextDocumentCodeAction(unique_ptr<core::GlobalState> gs
                 for (auto &edit : autocorrect.edits) {
                     auto range = Range::fromLoc(*run.gs, edit.loc);
                     if (range != nullptr) {
-                        editsByFile[config.fileRef2Uri(*run.gs, edit.loc.file())].emplace_back(
+                        editsByFile[config->fileRef2Uri(*run.gs, edit.loc.file())].emplace_back(
                             make_unique<TextEdit>(std::move(range), edit.replacement));
                     }
                 }

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -252,7 +252,8 @@ unique_ptr<CompletionItem> getCompletionItemForKeyword(const core::GlobalState &
     }
     item->insertTextFormat = InsertTextFormat::PlainText;
 
-    item->documentation = make_unique<MarkupContent>(config.clientCompletionItemMarkupKind, rubyKeyword.documentation);
+    item->documentation =
+        make_unique<MarkupContent>(config.clientConfig->clientCompletionItemMarkupKind, rubyKeyword.documentation);
 
     return item;
 }
@@ -287,7 +288,7 @@ unique_ptr<CompletionItem> LSPLoop::getCompletionItemForSymbol(const core::Globa
         auto replacementRange = Range::fromLoc(gs, replacementLoc);
 
         string replacementText;
-        if (config.clientCompletionItemSnippetSupport) {
+        if (config->clientConfig->clientCompletionItemSnippetSupport) {
             item->insertTextFormat = InsertTextFormat::Snippet;
             replacementText = methodSnippet(gs, what);
         } else {
@@ -312,7 +313,7 @@ unique_ptr<CompletionItem> LSPLoop::getCompletionItemForSymbol(const core::Globa
                 item->deprecated = true;
             }
             item->documentation =
-                make_unique<MarkupContent>(config.clientCompletionItemMarkupKind, documentation.value());
+                make_unique<MarkupContent>(config->clientConfig->clientCompletionItemMarkupKind, documentation.value());
         }
     } else if (what.data(gs)->isStaticField()) {
         item->kind = CompletionItemKind::Constant;
@@ -327,7 +328,7 @@ void LSPLoop::findSimilarConstantOrIdent(const core::GlobalState &gs, const core
                                          const core::Loc queryLoc, vector<unique_ptr<CompletionItem>> &items) const {
     if (auto c = core::cast_type<core::ClassType>(receiverType.get())) {
         auto pattern = c->symbol.data(gs)->name.data(gs)->shortName(gs);
-        logger->debug("Looking for constant similar to {}", pattern);
+        config->logger->debug("Looking for constant similar to {}", pattern);
         core::SymbolRef owner = c->symbol;
         do {
             owner = owner.data(gs)->owner;
@@ -348,7 +349,7 @@ void LSPLoop::findSimilarConstantOrIdent(const core::GlobalState &gs, const core
 LSPResult LSPLoop::handleTextDocumentCompletion(unique_ptr<core::GlobalState> gs, const MessageId &id,
                                                 const CompletionParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentCompletion);
-    if (!config.opts.lspAutocompleteEnabled) {
+    if (!config->opts.lspAutocompleteEnabled) {
         response->error =
             make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest,
                                        "The `Autocomplete` LSP feature is experimental and disabled by default.");
@@ -358,9 +359,9 @@ LSPResult LSPLoop::handleTextDocumentCompletion(unique_ptr<core::GlobalState> gs
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.completion");
 
     auto uri = params.textDocument->uri;
-    auto fref = config.uri2FileRef(*gs, uri);
+    auto fref = config->uri2FileRef(*gs, uri);
     auto pos = *params.position;
-    auto queryLoc = config.lspPos2Loc(fref, pos, *gs);
+    auto queryLoc = config->lspPos2Loc(fref, pos, *gs);
     auto result = setupLSPQueryByLoc(move(gs), uri, pos, LSPMethod::TextDocumentCompletion);
     gs = move(result.gs);
 
@@ -377,7 +378,7 @@ LSPResult LSPLoop::handleTextDocumentCompletion(unique_ptr<core::GlobalState> gs
 
         if (auto sendResp = resp->isSend()) {
             auto prefix = sendResp->callerSideName.data(*gs)->shortName(*gs);
-            logger->debug("Looking for method similar to {}", prefix);
+            config->logger->debug("Looking for method similar to {}", prefix);
 
             // isPrivateOk means that there is no syntactic receiver. This check prevents completing `x.de` to `x.def`
             auto similarKeywords = sendResp->isPrivateOk ? allSimilarKeywords(prefix) : vector<RubyKeyword>{};
@@ -436,7 +437,7 @@ LSPResult LSPLoop::handleTextDocumentCompletion(unique_ptr<core::GlobalState> gs
             // TODO(jez) Do something smarter here than "all matching keywords always come first"
             for (auto &similarKeyword : similarKeywords) {
                 items.push_back(
-                    getCompletionItemForKeyword(*gs, config, similarKeyword, queryLoc, prefix, items.size()));
+                    getCompletionItemForKeyword(*gs, *config, similarKeyword, queryLoc, prefix, items.size()));
             }
             for (auto &similarMethod : deduped) {
                 items.push_back(getCompletionItemForSymbol(*gs, similarMethod.method, similarMethod.receiverType,

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -253,7 +253,7 @@ unique_ptr<CompletionItem> getCompletionItemForKeyword(const core::GlobalState &
     item->insertTextFormat = InsertTextFormat::PlainText;
 
     item->documentation =
-        make_unique<MarkupContent>(config.clientConfig->clientCompletionItemMarkupKind, rubyKeyword.documentation);
+        make_unique<MarkupContent>(config.getClientConfig().clientCompletionItemMarkupKind, rubyKeyword.documentation);
 
     return item;
 }
@@ -288,7 +288,7 @@ unique_ptr<CompletionItem> LSPLoop::getCompletionItemForSymbol(const core::Globa
         auto replacementRange = Range::fromLoc(gs, replacementLoc);
 
         string replacementText;
-        if (config->clientConfig->clientCompletionItemSnippetSupport) {
+        if (config->getClientConfig().clientCompletionItemSnippetSupport) {
             item->insertTextFormat = InsertTextFormat::Snippet;
             replacementText = methodSnippet(gs, what);
         } else {
@@ -312,8 +312,8 @@ unique_ptr<CompletionItem> LSPLoop::getCompletionItemForSymbol(const core::Globa
             if (documentation->find("@deprecated") != documentation->npos) {
                 item->deprecated = true;
             }
-            item->documentation =
-                make_unique<MarkupContent>(config->clientConfig->clientCompletionItemMarkupKind, documentation.value());
+            item->documentation = make_unique<MarkupContent>(config->getClientConfig().clientCompletionItemMarkupKind,
+                                                             documentation.value());
         }
     } else if (what.data(gs)->isStaticField()) {
         item->kind = CompletionItemKind::Constant;

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -5,7 +5,7 @@ using namespace std;
 
 namespace sorbet::realmain::lsp {
 void LSPLoop::addLocIfExists(const core::GlobalState &gs, vector<unique_ptr<Location>> &locs, core::Loc loc) const {
-    auto location = config.loc2Location(gs, loc);
+    auto location = config->loc2Location(gs, loc);
     if (location != nullptr) {
         locs.push_back(std::move(location));
     }
@@ -26,7 +26,7 @@ LSPResult LSPLoop::handleTextDocumentDefinition(unique_ptr<core::GlobalState> gs
         vector<unique_ptr<Location>> result;
         if (!queryResponses.empty()) {
             const bool fileIsTyped =
-                config.uri2FileRef(*gs, params.textDocument->uri).data(*gs).strictLevel >= core::StrictLevel::True;
+                config->uri2FileRef(*gs, params.textDocument->uri).data(*gs).strictLevel >= core::StrictLevel::True;
             auto resp = move(queryResponses[0]);
 
             // Only support go-to-definition on constants in untyped files.

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -71,7 +71,7 @@ std::unique_ptr<DocumentSymbol> symbolRef2DocumentSymbol(const core::GlobalState
 LSPResult LSPLoop::handleTextDocumentDocumentSymbol(unique_ptr<core::GlobalState> gs, const MessageId &id,
                                                     const DocumentSymbolParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentDocumentSymbol);
-    if (!config.opts.lspDocumentSymbolEnabled) {
+    if (!config->opts.lspDocumentSymbolEnabled) {
         response->error =
             make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest,
                                        "The `Document Symbol` LSP feature is experimental and disabled by default.");
@@ -81,7 +81,7 @@ LSPResult LSPLoop::handleTextDocumentDocumentSymbol(unique_ptr<core::GlobalState
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.documentSymbol");
     vector<unique_ptr<DocumentSymbol>> result;
     string_view uri = params.textDocument->uri;
-    auto fref = config.uri2FileRef(*gs, uri);
+    auto fref = config->uri2FileRef(*gs, uri);
     for (u4 idx = 1; idx < gs->symbolsUsed(); idx++) {
         core::SymbolRef ref(gs.get(), idx);
         if (!hideSymbol(*gs, ref) &&

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -77,6 +77,7 @@ LSPResult LSPLoop::handleTextDocumentHover(unique_ptr<core::GlobalState> gs, con
             }
         }
 
+        auto clientHoverMarkupKind = config->clientConfig->clientHoverMarkupKind;
         if (auto sendResp = resp->isSend()) {
             auto retType = sendResp->dispatchResult->returnType;
             auto start = sendResp->dispatchResult.get();
@@ -97,14 +98,12 @@ LSPResult LSPLoop::handleTextDocumentHover(unique_ptr<core::GlobalState> gs, con
             } else {
                 typeString = methodInfoString(*gs, retType, *sendResp->dispatchResult, constraint);
             }
-            response->result =
-                make_unique<Hover>(formatHoverText(config.clientHoverMarkupKind, typeString, documentation));
+            response->result = make_unique<Hover>(formatHoverText(clientHoverMarkupKind, typeString, documentation));
         } else if (auto defResp = resp->isDefinition()) {
             string typeString =
                 absl::StrCat(methodDetail(*gs, defResp->symbol, nullptr, defResp->retType.type, nullptr), "\n",
                              methodDefinition(*gs, defResp->symbol));
-            response->result =
-                make_unique<Hover>(formatHoverText(config.clientHoverMarkupKind, typeString, documentation));
+            response->result = make_unique<Hover>(formatHoverText(clientHoverMarkupKind, typeString, documentation));
         } else if (auto constResp = resp->isConstant()) {
             const auto &data = constResp->symbol.data(*gs);
             auto type = constResp->retType.type;
@@ -117,8 +116,8 @@ LSPResult LSPLoop::handleTextDocumentHover(unique_ptr<core::GlobalState> gs, con
                 // `Foo`.
                 type = core::make_type<core::MetaType>(type);
             }
-            response->result = make_unique<Hover>(
-                formatHoverText(config.clientHoverMarkupKind, type->showWithMoreInfo(*gs), documentation));
+            response->result =
+                make_unique<Hover>(formatHoverText(clientHoverMarkupKind, type->showWithMoreInfo(*gs), documentation));
         } else {
             core::TypePtr retType = resp->getRetType();
             // Some untyped arguments have null types.
@@ -126,7 +125,7 @@ LSPResult LSPLoop::handleTextDocumentHover(unique_ptr<core::GlobalState> gs, con
                 retType = core::Types::untypedUntracked();
             }
             response->result = make_unique<Hover>(
-                formatHoverText(config.clientHoverMarkupKind, retType->showWithMoreInfo(*gs), documentation));
+                formatHoverText(clientHoverMarkupKind, retType->showWithMoreInfo(*gs), documentation));
         }
     }
     return LSPResult::make(move(gs), move(response));

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -77,7 +77,7 @@ LSPResult LSPLoop::handleTextDocumentHover(unique_ptr<core::GlobalState> gs, con
             }
         }
 
-        auto clientHoverMarkupKind = config->clientConfig->clientHoverMarkupKind;
+        auto clientHoverMarkupKind = config->getClientConfig().clientHoverMarkupKind;
         if (auto sendResp = resp->isSend()) {
             auto retType = sendResp->dispatchResult->returnType;
             auto start = sendResp->dispatchResult.get();

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -21,7 +21,7 @@ LSPLoop::getReferencesToSymbol(unique_ptr<core::GlobalState> gs, core::SymbolRef
 LSPResult LSPLoop::handleTextDocumentReferences(unique_ptr<core::GlobalState> gs, const MessageId &id,
                                                 const ReferenceParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentReferences);
-    ShowOperation op(output, config, "References", "Finding all references...");
+    ShowOperation op(*config, "References", "Finding all references...");
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.references");
 
     auto result = setupLSPQueryByLoc(move(gs), params.textDocument->uri, *params.position,
@@ -37,7 +37,7 @@ LSPResult LSPLoop::handleTextDocumentReferences(unique_ptr<core::GlobalState> gs
         auto &queryResponses = result.responses;
         if (!queryResponses.empty()) {
             const bool fileIsTyped =
-                config.uri2FileRef(*gs, params.textDocument->uri).data(*gs).strictLevel >= core::StrictLevel::True;
+                config->uri2FileRef(*gs, params.textDocument->uri).data(*gs).strictLevel >= core::StrictLevel::True;
             auto resp = move(queryResponses[0]);
             // N.B.: Ignores literals.
             // If file is untyped, only supports find reference requests from constants and class definitions.

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -50,7 +50,7 @@ void addSignatureHelpItem(const core::GlobalState &gs, core::SymbolRef method,
 LSPResult LSPLoop::handleTextSignatureHelp(unique_ptr<core::GlobalState> gs, const MessageId &id,
                                            const TextDocumentPositionParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentSignatureHelp);
-    if (!config.opts.lspSignatureHelpEnabled) {
+    if (!config->opts.lspSignatureHelpEnabled) {
         response->error =
             make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest,
                                        "The `Signature Help` LSP feature is experimental and disabled by default.");
@@ -74,13 +74,13 @@ LSPResult LSPLoop::handleTextSignatureHelp(unique_ptr<core::GlobalState> gs, con
             if (auto sendResp = resp->isSend()) {
                 auto sendLocIndex = sendResp->termLoc.beginPos();
 
-                auto fref = config.uri2FileRef(*gs, params.textDocument->uri);
+                auto fref = config->uri2FileRef(*gs, params.textDocument->uri);
                 if (!fref.exists()) {
                     // TODO(jvilk): This should probably return *something*; it's a request!
                     return LSPResult{move(gs), {}};
                 }
                 auto src = fref.data(*gs).source();
-                auto loc = config.lspPos2Loc(fref, *params.position, *gs);
+                auto loc = config->lspPos2Loc(fref, *params.position, *gs);
                 string_view call_str = src.substr(sendLocIndex, loc.endPos() - sendLocIndex);
                 int numberCommas = absl::c_count(call_str, ',');
                 // Active parameter depends on number of ,'s in the current string being typed. (0 , = first arg, 1 , =

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -50,7 +50,7 @@ LSPResult LSPLoop::handleTextDocumentTypeDefinition(unique_ptr<core::GlobalState
         vector<unique_ptr<Location>> result;
         if (!queryResponses.empty()) {
             const bool fileIsTyped =
-                config.uri2FileRef(*gs, params.textDocument->uri).data(*gs).strictLevel >= core::StrictLevel::True;
+                config->uri2FileRef(*gs, params.textDocument->uri).data(*gs).strictLevel >= core::StrictLevel::True;
             auto resp = move(queryResponses[0]);
 
             // Only support go-to-type-definition on constants in untyped files.

--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -10,7 +10,7 @@ namespace sorbet::realmain::lsp {
  * Converts a symbol into a SymbolInformation object.
  * Returns `nullptr` if symbol kind is not supported by LSP
  */
-unique_ptr<SymbolInformation> symbolRef2SymbolInformation(const LSPConfiguration config, const core::GlobalState &gs,
+unique_ptr<SymbolInformation> symbolRef2SymbolInformation(const LSPConfiguration &config, const core::GlobalState &gs,
                                                           core::SymbolRef symRef) {
     auto sym = symRef.data(gs);
     if (!sym->loc().file().exists() || hideSymbol(gs, symRef)) {
@@ -30,7 +30,7 @@ unique_ptr<SymbolInformation> symbolRef2SymbolInformation(const LSPConfiguration
 LSPResult LSPLoop::handleWorkspaceSymbols(unique_ptr<core::GlobalState> gs, const MessageId &id,
                                           const WorkspaceSymbolParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::WorkspaceSymbol);
-    if (!config.opts.lspWorkspaceSymbolsEnabled) {
+    if (!config->opts.lspWorkspaceSymbolsEnabled) {
         response->error =
             make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest,
                                        "The `Workspace Symbols` LSP feature is experimental and disabled by default.");
@@ -41,12 +41,12 @@ LSPResult LSPLoop::handleWorkspaceSymbols(unique_ptr<core::GlobalState> gs, cons
 
     vector<unique_ptr<SymbolInformation>> result;
     string_view searchString = params.query;
-    ShowOperation op(output, config, "WorkspaceSymbols", fmt::format("Searching for symbol `{}`...", searchString));
+    ShowOperation op(*config, "WorkspaceSymbols", fmt::format("Searching for symbol `{}`...", searchString));
 
     for (u4 idx = 1; idx < gs->symbolsUsed(); idx++) {
         core::SymbolRef ref(gs.get(), idx);
         if (hasSimilarName(*gs, ref.data(*gs)->name, searchString)) {
-            auto data = symbolRef2SymbolInformation(config, *gs, ref);
+            auto data = symbolRef2SymbolInformation(*config, *gs, ref);
             if (data) {
                 result.push_back(move(data));
             }

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -29,8 +29,17 @@ static auto typeErrorsConsole = make_shared<spd::logger>("typeDiagnostics", null
 static auto nullOpts = makeOptions("");
 static auto workers = WorkerPool::create(0, *logger);
 
-LSPConfiguration makeConfig(const options::Options &opts = nullOpts) {
-    return LSPConfiguration(opts, logger, true, false);
+shared_ptr<LSPConfiguration> makeConfig(const options::Options &opts = nullOpts, bool enableShowOpNotifs = false,
+                                        bool initialize = true) {
+    auto config = make_shared<LSPConfiguration>(opts, make_shared<LSPOutputToVector>(), *workers, logger, true, false);
+    InitializeParams initParams("", "", make_unique<ClientCapabilities>());
+    initParams.initializationOptions = make_unique<SorbetInitializationOptions>();
+    initParams.initializationOptions.value()->supportsOperationNotifications = enableShowOpNotifs;
+    config->clientInitialize(initParams);
+    if (initialize) {
+        config->markInitialized();
+    }
+    return config;
 }
 
 unique_ptr<core::GlobalState> makeGS(const options::Options &opts = nullOpts) {
@@ -43,12 +52,12 @@ unique_ptr<core::GlobalState> makeGS(const options::Options &opts = nullOpts) {
 
 static auto nullConfig = makeConfig();
 
-TimeTravelingGlobalState makeTTGS(const LSPConfiguration &config = nullConfig, u4 initialVersion = 0) {
-    return TimeTravelingGlobalState(config, logger, *workers, makeGS(config.opts), initialVersion);
+TimeTravelingGlobalState makeTTGS(const shared_ptr<LSPConfiguration> &config = nullConfig, u4 initialVersion = 0) {
+    return TimeTravelingGlobalState(config, makeGS(config->opts), initialVersion);
 }
 
-LSPPreprocessor makePreprocessor(const LSPConfiguration &config = nullConfig, u4 initialVersion = 0) {
-    return LSPPreprocessor(makeGS(config.opts), config, *workers, logger, initialVersion);
+LSPPreprocessor makePreprocessor(const shared_ptr<LSPConfiguration> &config = nullConfig, u4 initialVersion = 0) {
+    return LSPPreprocessor(makeGS(config->opts), config, initialVersion);
 }
 
 bool comesBeforeSymmetric(const TimeTravelingGlobalState &ttgs, u4 a, u4 b) {
@@ -234,7 +243,7 @@ TEST(LSPPreprocessor, IgnoresWatchmanUpdatesFromOpenFiles) { // NOLINT
     preprocessor.preprocessAndEnqueue(state, makeOpen("foo.rb", 1, fileContents), mtx);
     preprocessor.preprocessAndEnqueue(state, makeWatchman({"foo.rb"}), mtx);
 
-    ASSERT_TRUE(state.pendingRequests.size() == 1);
+    ASSERT_EQ(1, state.pendingRequests.size());
 
     const auto updates = getUpdates(state, 0).value();
     // Version didn't change because it ignored the watchman update.
@@ -326,17 +335,30 @@ TEST(LSPPreprocessor, Initialized) { // NOLINT
     QueueState state;
     absl::Mutex mtx;
     auto options = makeOptions("");
-    auto config = makeConfig(options);
-    config.enableOperationNotifications = true;
+    auto config = makeConfig(options, true, false);
     auto preprocessor = makePreprocessor(config);
+    auto output = dynamic_pointer_cast<LSPOutputToVector>(config->output);
+
+    // Sending a request prior to initialization should cause an error.
+    EXPECT_FALSE(config->isInitialized());
+    preprocessor.preprocessAndEnqueue(state, makeHoverReq(1, "foo.rb", 1, 1), mtx);
+    auto errorMsgs = output->getOutput();
+    ASSERT_EQ(1, errorMsgs.size());
+    ASSERT_TRUE(errorMsgs[0]->isResponse());
+    ASSERT_TRUE(errorMsgs[0]->asResponse().error.has_value());
+
     auto msg = make_unique<LSPMessage>(
         make_unique<NotificationMessage>("2.0", LSPMethod::Initialized, make_unique<InitializedParams>()));
     preprocessor.preprocessAndEnqueue(state, move(msg), mtx);
+    EXPECT_TRUE(config->isInitialized());
 
-    ASSERT_EQ(3, state.pendingRequests.size());
-    EXPECT_EQ(state.pendingRequests[0]->method(), LSPMethod::SorbetShowOperation);
-    EXPECT_EQ(state.pendingRequests[1]->method(), LSPMethod::SorbetShowOperation);
-    EXPECT_EQ(state.pendingRequests[2]->method(), LSPMethod::Initialized);
+    ASSERT_EQ(1, state.pendingRequests.size());
+    EXPECT_EQ(state.pendingRequests[0]->method(), LSPMethod::Initialized);
+
+    auto outputMsgs = output->getOutput();
+    ASSERT_EQ(2, outputMsgs.size());
+    EXPECT_EQ(outputMsgs[0]->method(), LSPMethod::SorbetShowOperation);
+    EXPECT_EQ(outputMsgs[1]->method(), LSPMethod::SorbetShowOperation);
 }
 
 // When a request in the queue is canceled, the preprocessor should merge any edits that happen immediately before and

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -35,7 +35,7 @@ shared_ptr<LSPConfiguration> makeConfig(const options::Options &opts = nullOpts,
     InitializeParams initParams("", "", make_unique<ClientCapabilities>());
     initParams.initializationOptions = make_unique<SorbetInitializationOptions>();
     initParams.initializationOptions.value()->supportsOperationNotifications = enableShowOpNotifs;
-    config->clientInitialize(initParams);
+    config->setClientConfig(make_shared<LSPClientConfiguration>(initParams));
     if (initialize) {
         config->markInitialized();
     }

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -9,10 +9,10 @@
 #include <string_view>
 namespace sorbet::realmain::lsp {
 
+class LSPOutputToVector;
+
 class LSPWrapper final {
     static const std::string EMPTY_STRING;
-
-    class LSPOutputToVector;
 
     /** The LSP 'server', which runs in the same thread as LSPWrapper. */
     std::unique_ptr<LSPLoop> lspLoop;

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -14,9 +14,6 @@ class LSPWrapper final {
 
     class LSPOutputToVector;
 
-    /** If true, then LSPLoop is initialized and is ready to receive requests. */
-    bool initialized = false;
-
     /** The LSP 'server', which runs in the same thread as LSPWrapper. */
     std::unique_ptr<LSPLoop> lspLoop;
 
@@ -29,7 +26,8 @@ class LSPWrapper final {
     std::unique_ptr<WorkerPool> workers;
     std::shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink;
     std::shared_ptr<spd::logger> typeErrorsConsole;
-    std::unique_ptr<LSPOutputToVector> output;
+    std::shared_ptr<LSPConfiguration> config;
+    std::shared_ptr<LSPOutputToVector> output;
 
     /** Contains shared constructor logic. */
     void instantiate(std::unique_ptr<core::GlobalState> gs, const std::shared_ptr<spdlog::logger> &logger,

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -454,8 +454,8 @@ int realmain(int argc, char *argv[]) {
                       "If you're developing an LSP extension to some editor, make sure to run sorbet with `-v` flag,"
                       "it will enable outputing the LSP session to stderr(`Write: ` and `Read: ` log lines)",
                       Version::full_version_string);
-        lsp::LSPStdout output(logger);
-        lsp::LSPLoop loop(move(gs), lsp::LSPConfiguration(opts, logger), logger, *workers, output);
+        auto output = make_shared<lsp::LSPStdout>(logger);
+        lsp::LSPLoop loop(move(gs), make_shared<lsp::LSPConfiguration>(opts, output, *workers, logger));
         gs = loop.runLSP(STDIN_FILENO).value_or(nullptr);
 #endif
     } else {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

LSP: Clean up configuration object. Reduces the number of objects 'plumbed' through the various LSP components by placing them on a single shared object (e.g., logger, WorkerPool).

I've also moved the client configuration options, which are only available post-initialization, into a new object.

Now that LSPConfiguration is shared, I've updated the logic so that LSPPreprocessor is solely responsible for:

* Populating the client configuration object.
* Setting the initialization boolean.
* Rejecting invalid messages received pre-initialization.

It is the only thread w/ write access to the object. All other threads have a `const` reference to the object.

I've also changed LSPOutput to be thread-safe so I can share it among threads. As a corollary, the LSPPreprocessor can now directly send a "show operation" notification to the client.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Without these changes, the typechecker thread I'm introducing will need a third copy of all of these objects. It will also need to send messages to the client independent of the message processing / coordinator thread.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
