### PR TITLE
Signature of Array#slice! is incorrect

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1967,14 +1967,14 @@ class Array < Object
     params(
         arg0: T::Range[Integer],
     )
-    .returns(T::Array[Elem])
+    .returns(T.nilable(T::Array[Elem]))
   end
   sig do
     params(
         arg0: Integer,
         arg1: Integer,
     )
-    .returns(T::Array[Elem])
+    .returns(T.nilable(T::Array[Elem]))
   end
   sig do
     params(


### PR DESCRIPTION
Fix for https://github.com/sorbet/sorbet/issues/1988

Updates the type signature.

### Motivation
Per the docs and current Ruby behavior, `Array#slice!` can return `nil`.

See https://ruby-doc.org/core-2.6.4/Array.html#method-i-slice-21
