### PR TITLE
use many more MK::

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -10,7 +10,7 @@ namespace sorbet::ast {
 class MK {
 public:
     static std::unique_ptr<Expression> EmptyTree() {
-        return std::ast::MK::EmptyTree();
+        return std::make_unique<ast::EmptyTree>();
     }
 
     static std::unique_ptr<Block> Block(core::Loc loc, std::unique_ptr<Expression> body, MethodDef::ARGS_store args) {

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -38,8 +38,7 @@ public:
     }
 
     static std::unique_ptr<Literal> Literal(core::Loc loc, const core::TypePtr &tpe) {
-        auto lit = std::make_unique<ast::Literal>(loc, tpe);
-        return lit;
+        return std::make_unique<ast::Literal>(loc, tpe);
     }
 
     static std::unique_ptr<Expression> Return(core::Loc loc, std::unique_ptr<Expression> expr) {

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -98,7 +98,7 @@ public:
 
     static std::unique_ptr<Reference> OptionalArg(core::Loc loc, std::unique_ptr<Reference> inner,
                                                   std::unique_ptr<Expression> default_) {
-        return std::make_unique<ast::OptionalArg>(loc, std::move(inner), std::move(default_));
+        return std::ast::MK::OptionalArg(loc, std::move(inner), std::move(default_));
     }
 
     static std::unique_ptr<Reference> KeywordArg(core::Loc loc, std::unique_ptr<Reference> inner) {

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -10,7 +10,7 @@ namespace sorbet::ast {
 class MK {
 public:
     static std::unique_ptr<Expression> EmptyTree() {
-        return std::make_unique<ast::EmptyTree>();
+        return std::ast::MK::EmptyTree();
     }
 
     static std::unique_ptr<Block> Block(core::Loc loc, std::unique_ptr<Expression> body, MethodDef::ARGS_store args) {

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -37,22 +37,6 @@ public:
         return send;
     }
 
-    static std::unique_ptr<Literal> Literal(core::Loc loc, const core::TypePtr &tpe) {
-        return std::make_unique<ast::Literal>(loc, tpe);
-    }
-
-    static std::unique_ptr<Expression> Return(core::Loc loc, std::unique_ptr<Expression> expr) {
-        return std::make_unique<ast::Return>(loc, std::move(expr));
-    }
-
-    static std::unique_ptr<Expression> Next(core::Loc loc, std::unique_ptr<Expression> expr) {
-        return std::make_unique<ast::Next>(loc, std::move(expr));
-    }
-
-    static std::unique_ptr<Expression> Break(core::Loc loc, std::unique_ptr<Expression> expr) {
-        return std::make_unique<ast::Break>(loc, std::move(expr));
-    }
-
     static std::unique_ptr<Expression> Send0(core::Loc loc, std::unique_ptr<Expression> recv, core::NameRef fun) {
         Send::ARGS_store nargs;
         return Send(loc, std::move(recv), fun, std::move(nargs));
@@ -81,6 +65,22 @@ public:
         nargs.emplace_back(std::move(arg2));
         nargs.emplace_back(std::move(arg3));
         return Send(loc, std::move(recv), fun, std::move(nargs));
+    }
+
+    static std::unique_ptr<Literal> Literal(core::Loc loc, const core::TypePtr &tpe) {
+        return std::make_unique<ast::Literal>(loc, tpe);
+    }
+
+    static std::unique_ptr<Expression> Return(core::Loc loc, std::unique_ptr<Expression> expr) {
+        return std::make_unique<ast::Return>(loc, std::move(expr));
+    }
+
+    static std::unique_ptr<Expression> Next(core::Loc loc, std::unique_ptr<Expression> expr) {
+        return std::make_unique<ast::Next>(loc, std::move(expr));
+    }
+
+    static std::unique_ptr<Expression> Break(core::Loc loc, std::unique_ptr<Expression> expr) {
+        return std::make_unique<ast::Break>(loc, std::move(expr));
     }
 
     static std::unique_ptr<Expression> Nil(core::Loc loc) {

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -98,7 +98,7 @@ public:
 
     static std::unique_ptr<Reference> OptionalArg(core::Loc loc, std::unique_ptr<Reference> inner,
                                                   std::unique_ptr<Expression> default_) {
-        return std::ast::MK::OptionalArg(loc, std::move(inner), std::move(default_));
+        return std::make_unique<ast::OptionalArg>(loc, std::move(inner), std::move(default_));
     }
 
     static std::unique_ptr<Reference> KeywordArg(core::Loc loc, std::unique_ptr<Reference> inner) {

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -90,7 +90,7 @@ public:
 
     static std::unique_ptr<ConstantLit> Constant(core::Loc loc, core::SymbolRef symbol) {
         ENFORCE(symbol.exists());
-        return std::make_unique<ast::ConstantLit>(loc, symbol, nullptr);
+        return std::make_unique<ConstantLit>(loc, symbol, nullptr);
     }
 
     static std::unique_ptr<Reference> Local(core::Loc loc, core::NameRef name) {
@@ -209,7 +209,7 @@ public:
 
     static std::unique_ptr<UnresolvedConstantLit> UnresolvedConstant(core::Loc loc, std::unique_ptr<Expression> scope,
                                                                      core::NameRef name) {
-        return std::make_unique<ast::UnresolvedConstantLit>(loc, std::move(scope), name);
+        return std::make_unique<UnresolvedConstantLit>(loc, std::move(scope), name);
     }
 
     static std::unique_ptr<Expression> Int(core::Loc loc, int64_t val) {
@@ -389,7 +389,7 @@ public:
 class BehaviorHelpers final {
 public:
     // Recursively check if all children of an expression are EmptyTree's or InsSeq's that only contain EmptyTree's
-    static bool checkEmptyDeep(const std::unique_ptr<ast::Expression> &);
+    static bool checkEmptyDeep(const std::unique_ptr<Expression> &);
 
     // Does a class/module definition define "behavior"? A class definition that only serves as a
     // namespace for inner-definitions is not considered to have behavior.
@@ -400,7 +400,7 @@ public:
     //     def m; end <-- Behavior in A::B
     //   end
     // end
-    static bool checkClassDefinesBehavior(const std::unique_ptr<ast::ClassDef> &);
+    static bool checkClassDefinesBehavior(const std::unique_ptr<ClassDef> &);
 };
 
 } // namespace sorbet::ast

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -23,7 +23,8 @@ public:
         return Block(loc, std::move(body), std::move(args));
     }
 
-    static std::unique_ptr<ast::Block> Block1(core::Loc loc, std::unique_ptr<Expression> body, std::unique_ptr<Expression> arg1) {
+    static std::unique_ptr<ast::Block> Block1(core::Loc loc, std::unique_ptr<Expression> body,
+                                              std::unique_ptr<Expression> arg1) {
         MethodDef::ARGS_store args;
         args.emplace_back(move(arg1));
         return Block(loc, std::move(body), std::move(args));
@@ -375,7 +376,8 @@ public:
             typecase(
                 arg, [&](class RestArg *rest) { arg = rest->expr.get(); },
                 [&](class KeywordArg *kw) { arg = kw->expr.get(); },
-                [&](class OptionalArg *opt) { arg = opt->expr.get(); }, [&](class BlockArg *blk) { arg = blk->expr.get(); },
+                [&](class OptionalArg *opt) { arg = opt->expr.get(); },
+                [&](class BlockArg *blk) { arg = blk->expr.get(); },
                 [&](class ShadowArg *shadow) { arg = shadow->expr.get(); },
                 // ENFORCES are last so that we don't pay the price of casting in the fast path.
                 [&](UnresolvedIdent *opt) { ENFORCE(false, "Namer should have created a Local for this arg."); },

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -23,6 +23,12 @@ public:
         return Block(loc, std::move(body), std::move(args));
     }
 
+    static std::unique_ptr<ast::Block> Block1(core::Loc loc, std::unique_ptr<Expression> body, std::unique_ptr<Expression> arg1) {
+        MethodDef::ARGS_store args;
+        args.emplace_back(move(arg1));
+        return Block(loc, std::move(body), std::move(args));
+    }
+
     static std::unique_ptr<Expression> Send(core::Loc loc, std::unique_ptr<Expression> recv, core::NameRef fun,
                                             Send::ARGS_store args, u4 flags = 0,
                                             std::unique_ptr<ast::Block> blk = nullptr) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1354,7 +1354,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                         elems.emplace_back(node2TreeImpl(dctx, std::move(stat)));
                     };
                     unique_ptr<Expression> arr = make_unique<Array>(loc, std::move(elems));
-                    unique_ptr<Expression> res = make_unique<Return>(loc, std::move(arr));
+                    unique_ptr<Expression> res = MK::Return(loc, std::move(arr));
                     result.swap(res);
                 } else if (ret->exprs.size() == 1) {
                     if (parser::isa_node<parser::BlockPass>(ret->exprs[0].get())) {
@@ -1365,11 +1365,11 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                         result.swap(res);
                     } else {
                         unique_ptr<Expression> res =
-                            make_unique<Return>(loc, node2TreeImpl(dctx, std::move(ret->exprs[0])));
+                            MK::Return(loc, node2TreeImpl(dctx, std::move(ret->exprs[0])));
                         result.swap(res);
                     }
                 } else {
-                    unique_ptr<Expression> res = make_unique<Return>(loc, MK::EmptyTree());
+                    unique_ptr<Expression> res = MK::Return(loc, MK::EmptyTree());
                     result.swap(res);
                 }
             },

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -875,9 +875,9 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
             [&](parser::Module *module) {
                 ClassDef::RHS_store body = scopeNodeToBody(dctx, std::move(module->body));
                 ClassDef::ANCESTORS_store ancestors;
-                unique_ptr<Expression> res = MK::Class(
-                    module->loc, module->declLoc, node2TreeImpl(dctx, std::move(module->name)),
-                    std::move(ancestors), std::move(body), ClassDefKind::Module);
+                unique_ptr<Expression> res =
+                    MK::Class(module->loc, module->declLoc, node2TreeImpl(dctx, std::move(module->name)),
+                              std::move(ancestors), std::move(body), ClassDefKind::Module);
                 result.swap(res);
             },
             [&](parser::Class *claz) {
@@ -888,9 +888,9 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 } else {
                     ancestors.emplace_back(node2TreeImpl(dctx, std::move(claz->superclass)));
                 }
-                unique_ptr<Expression> res = MK::Class(
-                    claz->loc, claz->declLoc, node2TreeImpl(dctx, std::move(claz->name)),
-                    std::move(ancestors), std::move(body), ClassDefKind::Class);
+                unique_ptr<Expression> res =
+                    MK::Class(claz->loc, claz->declLoc, node2TreeImpl(dctx, std::move(claz->name)),
+                              std::move(ancestors), std::move(body), ClassDefKind::Class);
                 result.swap(res);
             },
             [&](parser::Arg *arg) {
@@ -1036,8 +1036,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 auto body = node2TreeImpl(dctx, std::move(wl->body));
                 unique_ptr<Expression> res =
                     isKwbegin ? doUntil(dctx, loc, std::move(cond), std::move(body))
-                              : MK::While(loc, MK::Send0(loc, std::move(cond), core::Names::bang()),
-                                                   std::move(body));
+                              : MK::While(loc, MK::Send0(loc, std::move(cond), core::Names::bang()), std::move(body));
                 result.swap(res);
             },
             [&](parser::Nil *wl) {
@@ -1110,7 +1109,8 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 unique_ptr<parser::Node> masgn =
                     make_unique<parser::Masgn>(loc, std::move(mlhsNode), make_unique<parser::LVar>(loc, temp));
 
-                auto body = MK::InsSeq1(loc, node2TreeImpl(dctx, std::move(masgn)), node2TreeImpl(dctx, std::move(for_->body)));
+                auto body =
+                    MK::InsSeq1(loc, node2TreeImpl(dctx, std::move(masgn)), node2TreeImpl(dctx, std::move(for_->body)));
 
                 auto block = MK::Block1(loc, std::move(body), make_unique<RestArg>(loc, MK::Local(loc, temp)));
 
@@ -1361,8 +1361,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                         unique_ptr<Expression> res = MK::Break(loc, MK::EmptyTree());
                         result.swap(res);
                     } else {
-                        unique_ptr<Expression> res =
-                            MK::Return(loc, node2TreeImpl(dctx, std::move(ret->exprs[0])));
+                        unique_ptr<Expression> res = MK::Return(loc, node2TreeImpl(dctx, std::move(ret->exprs[0])));
                         result.swap(res);
                     }
                 } else {
@@ -1394,8 +1393,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                         unique_ptr<Expression> res = MK::Break(loc, MK::EmptyTree());
                         result.swap(res);
                     } else {
-                        unique_ptr<Expression> res =
-                            MK::Break(loc, node2TreeImpl(dctx, std::move(ret->exprs[0])));
+                        unique_ptr<Expression> res = MK::Break(loc, node2TreeImpl(dctx, std::move(ret->exprs[0])));
                         result.swap(res);
                     }
                 } else {
@@ -1427,8 +1425,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                         unique_ptr<Expression> res = MK::Break(loc, MK::EmptyTree());
                         result.swap(res);
                     } else {
-                        unique_ptr<Expression> res =
-                            MK::Next(loc, node2TreeImpl(dctx, std::move(ret->exprs[0])));
+                        unique_ptr<Expression> res = MK::Next(loc, node2TreeImpl(dctx, std::move(ret->exprs[0])));
                         result.swap(res);
                     }
                 } else {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -405,7 +405,7 @@ unique_ptr<Expression> doUntil(DesugarContext dctx, core::Loc loc, unique_ptr<Ex
                                unique_ptr<Expression> body) {
     auto breaker = MK::If(loc, std::move(cond), MK::Break(loc, MK::EmptyTree()), MK::EmptyTree());
     auto breakWithBody = MK::InsSeq1(loc, std::move(body), std::move(breaker));
-    return make_unique<While>(loc, MK::True(loc), std::move(breakWithBody));
+    return MK::While(loc, MK::True(loc), std::move(breakWithBody));
 }
 
 unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) {
@@ -1008,7 +1008,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
             [&](parser::While *wl) {
                 auto cond = node2TreeImpl(dctx, std::move(wl->cond));
                 auto body = node2TreeImpl(dctx, std::move(wl->body));
-                unique_ptr<Expression> res = make_unique<While>(loc, std::move(cond), std::move(body));
+                unique_ptr<Expression> res = MK::While(loc, std::move(cond), std::move(body));
                 result.swap(res);
             },
             [&](parser::WhilePost *wl) {
@@ -1019,14 +1019,14 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 unique_ptr<Expression> res =
                     isKwbegin
                         ? doUntil(dctx, loc, MK::Send0(loc, std::move(cond), core::Names::bang()), std::move(body))
-                        : make_unique<While>(loc, std::move(cond), std::move(body));
+                        : MK::While(loc, std::move(cond), std::move(body));
                 result.swap(res);
             },
             [&](parser::Until *wl) {
                 auto cond = node2TreeImpl(dctx, std::move(wl->cond));
                 auto body = node2TreeImpl(dctx, std::move(wl->body));
                 unique_ptr<Expression> res =
-                    make_unique<While>(loc, MK::Send0(loc, std::move(cond), core::Names::bang()), std::move(body));
+                    MK::While(loc, MK::Send0(loc, std::move(cond), core::Names::bang()), std::move(body));
                 result.swap(res);
             },
             // This is the same as WhilePost, but the cond negation is in the other branch.
@@ -1036,7 +1036,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 auto body = node2TreeImpl(dctx, std::move(wl->body));
                 unique_ptr<Expression> res =
                     isKwbegin ? doUntil(dctx, loc, std::move(cond), std::move(body))
-                              : make_unique<While>(loc, MK::Send0(loc, std::move(cond), core::Names::bang()),
+                              : MK::While(loc, MK::Send0(loc, std::move(cond), core::Names::bang()),
                                                    std::move(body));
                 result.swap(res);
             },

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -875,8 +875,8 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
             [&](parser::Module *module) {
                 ClassDef::RHS_store body = scopeNodeToBody(dctx, std::move(module->body));
                 ClassDef::ANCESTORS_store ancestors;
-                unique_ptr<Expression> res = make_unique<ClassDef>(
-                    module->loc, module->declLoc, core::Symbols::todo(), node2TreeImpl(dctx, std::move(module->name)),
+                unique_ptr<Expression> res = MK::Class(
+                    module->loc, module->declLoc, node2TreeImpl(dctx, std::move(module->name)),
                     std::move(ancestors), std::move(body), ClassDefKind::Module);
                 result.swap(res);
             },
@@ -888,8 +888,8 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 } else {
                     ancestors.emplace_back(node2TreeImpl(dctx, std::move(claz->superclass)));
                 }
-                unique_ptr<Expression> res = make_unique<ClassDef>(
-                    claz->loc, claz->declLoc, core::Symbols::todo(), node2TreeImpl(dctx, std::move(claz->name)),
+                unique_ptr<Expression> res = MK::Class(
+                    claz->loc, claz->declLoc, node2TreeImpl(dctx, std::move(claz->name)),
                     std::move(ancestors), std::move(body), ClassDefKind::Class);
                 result.swap(res);
             },

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1110,9 +1110,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 unique_ptr<parser::Node> masgn =
                     make_unique<parser::Masgn>(loc, std::move(mlhsNode), make_unique<parser::LVar>(loc, temp));
 
-                InsSeq::STATS_store stats;
-                stats.emplace_back(node2TreeImpl(dctx, std::move(masgn)));
-                auto body = make_unique<InsSeq>(loc, std::move(stats), node2TreeImpl(dctx, std::move(for_->body)));
+                auto body = MK::InsSeq1(loc, node2TreeImpl(dctx, std::move(masgn)), node2TreeImpl(dctx, std::move(for_->body)));
 
                 auto block = MK::Block1(loc, std::move(body), make_unique<RestArg>(loc, MK::Local(loc, temp)));
 

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1272,8 +1272,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                     if (lastMerge != nullptr) {
                         res = std::move(lastMerge);
                     } else {
-                        // Empty array
-                        res = MK::Hash(loc, std::move(keys), std::move(values));
+                        res = MK::Hash0(loc);
                     }
                 } else {
                     res = MK::Hash(loc, std::move(keys), std::move(values));

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -211,7 +211,7 @@ unique_ptr<MethodDef> buildMethod(DesugarContext dctx, core::Loc loc, core::Loc 
 
     if (args.empty() || !isa_tree<BlockArg>(args.back().get())) {
         auto blkLoc = core::Loc::none(loc.file());
-        args.emplace_back(make_unique<BlockArg>(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
+        args.emplace_back(MK::BlockArg(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
     }
 
     const auto &blkArg = cast_tree<BlockArg>(args.back().get());
@@ -898,35 +898,34 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 result.swap(res);
             },
             [&](parser::Restarg *arg) {
-                unique_ptr<Expression> res = make_unique<RestArg>(loc, MK::Local(arg->nameLoc, arg->name));
+                unique_ptr<Expression> res = MK::RestArg(loc, MK::Local(arg->nameLoc, arg->name));
                 result.swap(res);
             },
             [&](parser::Kwrestarg *arg) {
-                unique_ptr<Expression> res =
-                    make_unique<RestArg>(loc, make_unique<KeywordArg>(loc, MK::Local(loc, arg->name)));
+                unique_ptr<Expression> res = MK::RestArg(loc, MK::KeywordArg(loc, MK::Local(loc, arg->name)));
                 result.swap(res);
             },
             [&](parser::Kwarg *arg) {
-                unique_ptr<Expression> res = make_unique<KeywordArg>(loc, MK::Local(loc, arg->name));
+                unique_ptr<Expression> res = MK::KeywordArg(loc, MK::Local(loc, arg->name));
                 result.swap(res);
             },
             [&](parser::Blockarg *arg) {
-                unique_ptr<Expression> res = make_unique<BlockArg>(loc, MK::Local(loc, arg->name));
+                unique_ptr<Expression> res = MK::BlockArg(loc, MK::Local(loc, arg->name));
                 result.swap(res);
             },
             [&](parser::Kwoptarg *arg) {
                 unique_ptr<Expression> res =
-                    make_unique<OptionalArg>(loc, make_unique<KeywordArg>(loc, MK::Local(arg->nameLoc, arg->name)),
-                                             node2TreeImpl(dctx, std::move(arg->default_)));
+                    MK::OptionalArg(loc, MK::KeywordArg(loc, MK::Local(arg->nameLoc, arg->name)),
+                                    node2TreeImpl(dctx, std::move(arg->default_)));
                 result.swap(res);
             },
             [&](parser::Optarg *arg) {
-                unique_ptr<Expression> res = make_unique<OptionalArg>(loc, MK::Local(arg->nameLoc, arg->name),
-                                                                      node2TreeImpl(dctx, std::move(arg->default_)));
+                unique_ptr<Expression> res = MK::OptionalArg(loc, MK::Local(arg->nameLoc, arg->name),
+                                                             node2TreeImpl(dctx, std::move(arg->default_)));
                 result.swap(res);
             },
             [&](parser::Shadowarg *arg) {
-                unique_ptr<Expression> res = make_unique<ShadowArg>(loc, MK::Local(loc, arg->name));
+                unique_ptr<Expression> res = MK::ShadowArg(loc, MK::Local(loc, arg->name));
                 result.swap(res);
             },
             [&](parser::DefMethod *method) {
@@ -1112,7 +1111,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 auto body =
                     MK::InsSeq1(loc, node2TreeImpl(dctx, std::move(masgn)), node2TreeImpl(dctx, std::move(for_->body)));
 
-                auto block = MK::Block1(loc, std::move(body), make_unique<RestArg>(loc, MK::Local(loc, temp)));
+                auto block = MK::Block1(loc, std::move(body), MK::RestArg(loc, MK::Local(loc, temp)));
 
                 Send::ARGS_store noargs;
                 auto res = MK::Send(loc, node2TreeImpl(dctx, std::move(for_->expr)), core::Names::each(),

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1420,7 +1420,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                         elems.emplace_back(node2TreeImpl(dctx, std::move(stat)));
                     };
                     unique_ptr<Expression> arr = make_unique<Array>(loc, std::move(elems));
-                    unique_ptr<Expression> res = make_unique<Next>(loc, std::move(arr));
+                    unique_ptr<Expression> res = MK::Next(loc, std::move(arr));
                     result.swap(res);
                 } else if (ret->exprs.size() == 1) {
                     if (parser::isa_node<parser::BlockPass>(ret->exprs[0].get())) {
@@ -1431,11 +1431,11 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                         result.swap(res);
                     } else {
                         unique_ptr<Expression> res =
-                            make_unique<Next>(loc, node2TreeImpl(dctx, std::move(ret->exprs[0])));
+                            MK::Next(loc, node2TreeImpl(dctx, std::move(ret->exprs[0])));
                         result.swap(res);
                     }
                 } else {
-                    unique_ptr<Expression> res = make_unique<Next>(loc, MK::EmptyTree());
+                    unique_ptr<Expression> res = MK::Next(loc, MK::EmptyTree());
                     result.swap(res);
                 }
             },

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1188,7 +1188,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                                 lastMerge = std::move(var);
                             }
                         } else {
-                            unique_ptr<Expression> current = make_unique<Array>(loc, std::move(elems));
+                            unique_ptr<Expression> current = MK::Array(loc, std::move(elems));
                             /* reassign instead of clear to work around https://bugs.llvm.org/show_bug.cgi?id=37553 */
                             elems = Array::ENTRY_store();
                             if (lastMerge != nullptr) {
@@ -1210,10 +1210,10 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                         res = std::move(lastMerge);
                     } else {
                         // Empty array
-                        res = make_unique<Array>(loc, std::move(elems));
+                        res = MK::Array(loc, std::move(elems));
                     }
                 } else {
-                    res = make_unique<Array>(loc, std::move(elems));
+                    res = MK::Array(loc, std::move(elems));
                     if (lastMerge != nullptr) {
                         res = MK::Send1(loc, std::move(lastMerge), core::Names::concat(), std::move(res));
                     }
@@ -1351,7 +1351,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                         }
                         elems.emplace_back(node2TreeImpl(dctx, std::move(stat)));
                     };
-                    unique_ptr<Expression> arr = make_unique<Array>(loc, std::move(elems));
+                    unique_ptr<Expression> arr = MK::Array(loc, std::move(elems));
                     unique_ptr<Expression> res = MK::Return(loc, std::move(arr));
                     result.swap(res);
                 } else if (ret->exprs.size() == 1) {
@@ -1384,7 +1384,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                         }
                         elems.emplace_back(node2TreeImpl(dctx, std::move(stat)));
                     };
-                    unique_ptr<Expression> arr = make_unique<Array>(loc, std::move(elems));
+                    unique_ptr<Expression> arr = MK::Array(loc, std::move(elems));
                     unique_ptr<Expression> res = MK::Break(loc, std::move(arr));
                     result.swap(res);
                 } else if (ret->exprs.size() == 1) {
@@ -1417,7 +1417,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                         }
                         elems.emplace_back(node2TreeImpl(dctx, std::move(stat)));
                     };
-                    unique_ptr<Expression> arr = make_unique<Array>(loc, std::move(elems));
+                    unique_ptr<Expression> arr = MK::Array(loc, std::move(elems));
                     unique_ptr<Expression> res = MK::Next(loc, std::move(arr));
                     result.swap(res);
                 } else if (ret->exprs.size() == 1) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1251,7 +1251,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                                 lastMerge = std::move(expr);
                             }
                         } else {
-                            unique_ptr<Expression> current = make_unique<Hash>(loc, std::move(keys), std::move(values));
+                            unique_ptr<Expression> current = MK::Hash(loc, std::move(keys), std::move(values));
                             /* reassign instead of clear to work around https://bugs.llvm.org/show_bug.cgi?id=37553 */
                             keys = Hash::ENTRY_store();
                             values = Hash::ENTRY_store();
@@ -1273,10 +1273,10 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                         res = std::move(lastMerge);
                     } else {
                         // Empty array
-                        res = make_unique<Hash>(loc, std::move(keys), std::move(values));
+                        res = MK::Hash(loc, std::move(keys), std::move(values));
                     }
                 } else {
-                    res = make_unique<Hash>(loc, std::move(keys), std::move(values));
+                    res = MK::Hash(loc, std::move(keys), std::move(values));
                     if (lastMerge != nullptr) {
                         res = MK::Send1(loc, std::move(lastMerge), core::Names::merge(), std::move(res));
                     }

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1361,7 +1361,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                         if (auto e = dctx.ctx.state.beginError(ret->loc, core::errors::Desugar::UnsupportedNode)) {
                             e.setHeader("Block argument should not be given");
                         }
-                        unique_ptr<Expression> res = make_unique<Break>(loc, MK::EmptyTree());
+                        unique_ptr<Expression> res = MK::Break(loc, MK::EmptyTree());
                         result.swap(res);
                     } else {
                         unique_ptr<Expression> res =
@@ -1387,22 +1387,22 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                         elems.emplace_back(node2TreeImpl(dctx, std::move(stat)));
                     };
                     unique_ptr<Expression> arr = make_unique<Array>(loc, std::move(elems));
-                    unique_ptr<Expression> res = make_unique<Break>(loc, std::move(arr));
+                    unique_ptr<Expression> res = MK::Break(loc, std::move(arr));
                     result.swap(res);
                 } else if (ret->exprs.size() == 1) {
                     if (parser::isa_node<parser::BlockPass>(ret->exprs[0].get())) {
                         if (auto e = dctx.ctx.state.beginError(ret->loc, core::errors::Desugar::UnsupportedNode)) {
                             e.setHeader("Block argument should not be given");
                         }
-                        unique_ptr<Expression> res = make_unique<Break>(loc, MK::EmptyTree());
+                        unique_ptr<Expression> res = MK::Break(loc, MK::EmptyTree());
                         result.swap(res);
                     } else {
                         unique_ptr<Expression> res =
-                            make_unique<Break>(loc, node2TreeImpl(dctx, std::move(ret->exprs[0])));
+                            MK::Break(loc, node2TreeImpl(dctx, std::move(ret->exprs[0])));
                         result.swap(res);
                     }
                 } else {
-                    unique_ptr<Expression> res = make_unique<Break>(loc, MK::EmptyTree());
+                    unique_ptr<Expression> res = MK::Break(loc, MK::EmptyTree());
                     result.swap(res);
                 }
             },
@@ -1427,7 +1427,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                         if (auto e = dctx.ctx.state.beginError(ret->loc, core::errors::Desugar::UnsupportedNode)) {
                             e.setHeader("Block argument should not be given");
                         }
-                        unique_ptr<Expression> res = make_unique<Break>(loc, MK::EmptyTree());
+                        unique_ptr<Expression> res = MK::Break(loc, MK::EmptyTree());
                         result.swap(res);
                     } else {
                         unique_ptr<Expression> res =

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1143,7 +1143,7 @@ unique_ptr<ast::Expression> SerializerImpl::unpickleExpr(serialize::UnPickler &p
             auto tmp = unpickleExpr(p, gs, file);
             unique_ptr<ast::Reference> ref(static_cast<ast::Reference *>(tmp.release()));
             auto default_ = unpickleExpr(p, gs, file);
-            return make_unique<ast::OptionalArg>(loc, std::move(ref), std::move(default_));
+            return ast::MK::OptionalArg(loc, std::move(ref), std::move(default_));
         }
         case 30: {
             return make_unique<ast::ZSuperArgs>(loc);

--- a/dsl/DSLBuilder.cc
+++ b/dsl/DSLBuilder.cc
@@ -86,7 +86,7 @@ vector<unique_ptr<ast::Expression>> DSLBuilder::replaceDSL(core::MutableContext 
         unique_ptr<ast::Reference> arg = ast::MK::Local(nameLoc, name);
         if (implied) {
             auto default_ = ast::MK::Send0(loc, ast::MK::T(loc), core::Names::untyped());
-            arg = make_unique<ast::OptionalArg>(loc, move(arg), move(default_));
+            arg = ast::MK::OptionalArg(loc, move(arg), move(default_));
         }
         stats.emplace_back(ast::MK::Method1(loc, loc, name, move(arg), ast::MK::EmptyTree(),
                                             ast::MethodDef::SelfMethod | ast::MethodDef::DSLSynthesized));

--- a/dsl/Struct.cc
+++ b/dsl/Struct.cc
@@ -109,7 +109,7 @@ vector<unique_ptr<ast::Expression>> Struct::replaceDSL(core::MutableContext ctx,
         if (keywordInit) {
             argName = ast::MK::KeywordArg(loc, move(argName));
         }
-        newArgs.emplace_back(make_unique<ast::OptionalArg>(loc, move(argName), ast::MK::Nil(loc)));
+        newArgs.emplace_back(ast::MK::OptionalArg(loc, move(argName), ast::MK::Nil(loc)));
 
         body.emplace_back(ast::MK::Method0(loc, loc, name, ast::MK::EmptyTree(), ast::MethodDef::DSLSynthesized));
         body.emplace_back(ast::MK::Method1(loc, loc, name.addEq(ctx), ast::MK::Local(loc, core::Names::arg0()),

--- a/flattener/flatten.cc
+++ b/flattener/flatten.cc
@@ -51,7 +51,7 @@ unique_ptr<ast::Expression> extractClassInit(core::Context ctx, unique_ptr<ast::
     if (inits.size() == 1) {
         return std::move(inits.front());
     }
-    return make_unique<ast::InsSeq>(klass->declLoc, std::move(inits), make_unique<ast::EmptyTree>());
+    return make_unique<ast::InsSeq>(klass->declLoc, std::move(inits), ast::MK::EmptyTree());
 }
 
 class FlattenWalk {
@@ -121,7 +121,7 @@ public:
         classDef->rhs = addMethods(ctx, std::move(classDef->rhs));
         classes[classStack.back()] = std::move(classDef);
         classStack.pop_back();
-        return make_unique<ast::EmptyTree>();
+        return ast::MK::EmptyTree();
     };
 
     unique_ptr<ast::Expression> postTransformMethodDef(core::Context ctx, unique_ptr<ast::MethodDef> methodDef) {
@@ -132,7 +132,7 @@ public:
 
         methods.methods[methods.stack.back()] = std::move(methodDef);
         methods.stack.pop_back();
-        return make_unique<ast::EmptyTree>();
+        return ast::MK::EmptyTree();
     };
 
     unique_ptr<ast::Expression> addClasses(core::Context ctx, unique_ptr<ast::Expression> tree) {

--- a/flattener/flatten.cc
+++ b/flattener/flatten.cc
@@ -51,7 +51,7 @@ unique_ptr<ast::Expression> extractClassInit(core::Context ctx, unique_ptr<ast::
     if (inits.size() == 1) {
         return std::move(inits.front());
     }
-    return make_unique<ast::InsSeq>(klass->declLoc, std::move(inits), ast::MK::EmptyTree());
+    return ast::MK::InsSeq(klass->declLoc, std::move(inits), ast::MK::EmptyTree());
 }
 
 class FlattenWalk {
@@ -175,7 +175,7 @@ public:
         auto insSeq = ast::cast_tree<ast::InsSeq>(tree.get());
         if (insSeq == nullptr) {
             ast::InsSeq::STATS_store stats;
-            tree = make_unique<ast::InsSeq>(tree->loc, std::move(stats), std::move(tree));
+            tree = ast::MK::InsSeq(tree->loc, std::move(stats), std::move(tree));
             return addMethods(ctx, std::move(tree));
         }
 

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -4,6 +4,7 @@
 #include "common/typecase.h"
 #include "core/core.h"
 #include "core/errors/namer.h"
+#include "ast/Helpers.h"
 
 using namespace std;
 

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -42,7 +42,7 @@ class LocalNameInserter {
             },
             [&](ast::OptionalArg *opt) {
                 named = nameArg(move(opt->expr));
-                named.expr = make_unique<ast::OptionalArg>(arg->loc, move(named.expr), move(opt->default_));
+                named.expr = ast::MK::OptionalArg(arg->loc, move(named.expr), move(opt->default_));
             },
             [&](ast::BlockArg *blk) {
                 named = nameArg(move(blk->expr));

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -35,11 +35,11 @@ class LocalNameInserter {
             },
             [&](ast::RestArg *rest) {
                 named = nameArg(move(rest->expr));
-                named.expr = make_unique<ast::RestArg>(arg->loc, move(named.expr));
+                named.expr = ast::MK::RestArg(arg->loc, move(named.expr));
             },
             [&](ast::KeywordArg *kw) {
                 named = nameArg(move(kw->expr));
-                named.expr = make_unique<ast::KeywordArg>(arg->loc, move(named.expr));
+                named.expr = ast::MK::KeywordArg(arg->loc, move(named.expr));
             },
             [&](ast::OptionalArg *opt) {
                 named = nameArg(move(opt->expr));
@@ -47,11 +47,11 @@ class LocalNameInserter {
             },
             [&](ast::BlockArg *blk) {
                 named = nameArg(move(blk->expr));
-                named.expr = make_unique<ast::BlockArg>(arg->loc, move(named.expr));
+                named.expr = ast::MK::BlockArg(arg->loc, move(named.expr));
             },
             [&](ast::ShadowArg *shadow) {
                 named = nameArg(move(shadow->expr));
-                named.expr = make_unique<ast::ShadowArg>(arg->loc, move(named.expr));
+                named.expr = ast::MK::ShadowArg(arg->loc, move(named.expr));
             },
             [&](ast::Local *local) {
                 named.name = local->localVariable._name;

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -1,10 +1,10 @@
 #include "local_vars.h"
 #include "absl/strings/match.h"
+#include "ast/Helpers.h"
 #include "ast/treemap/treemap.h"
 #include "common/typecase.h"
 #include "core/core.h"
 #include "core/errors/namer.h"
-#include "ast/Helpers.h"
 
 using namespace std;
 

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -13,6 +13,7 @@
 #include "absl/strings/escaping.h" // BytesToHexString
 #include "absl/strings/match.h"
 #include "ast/desugar/Desugar.h"
+#include "ast/Helpers.h"
 #include "ast/substitute/substitute.h"
 #include "ast/treemap/treemap.h"
 #include "cfg/CFG.h"

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -178,7 +178,7 @@ ast::ParsedFile runLocalVars(core::GlobalState &gs, ast::ParsedFile tree) {
 }
 
 ast::ParsedFile emptyParsedFile(core::FileRef file) {
-    return {make_unique<ast::EmptyTree>(), file};
+    return {ast::MK::EmptyTree(), file};
 }
 
 ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, core::FileRef file,
@@ -676,7 +676,7 @@ vector<ast::ParsedFile> index(unique_ptr<core::GlobalState> &gs, vector<core::Fi
 }
 
 ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Options &opts) {
-    ast::ParsedFile result{make_unique<ast::EmptyTree>(), resolved.file};
+    ast::ParsedFile result{ast::MK::EmptyTree(), resolved.file};
     core::FileRef f = resolved.file;
 
     resolved = definition_validator::runOne(ctx, std::move(resolved));

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -12,8 +12,8 @@
 #include "ProgressIndicator.h"
 #include "absl/strings/escaping.h" // BytesToHexString
 #include "absl/strings/match.h"
-#include "ast/desugar/Desugar.h"
 #include "ast/Helpers.h"
+#include "ast/desugar/Desugar.h"
 #include "ast/substitute/substitute.h"
 #include "ast/treemap/treemap.h"
 #include "cfg/CFG.h"

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -742,7 +742,7 @@ public:
             if (auto e = ctx.state.beginError(send->loc, core::errors::Namer::InvalidTypeDefinition)) {
                 e.setHeader("Types must be defined in class or module scopes");
             }
-            return make_unique<ast::EmptyTree>();
+            return ast::MK::EmptyTree();
         }
         if (ctx.owner == core::Symbols::root()) {
             if (auto e = ctx.state.beginError(send->loc, core::errors::Namer::RootTypeMember)) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -78,7 +78,7 @@ class NameInserter {
             // TODO: check that flags match;
             unique_ptr<ast::Reference> localExpr = make_unique<ast::Local>(parsedArg.loc, parsedArg.local);
             if (parsedArg.default_) {
-                localExpr = make_unique<ast::OptionalArg>(parsedArg.loc, move(localExpr), move(parsedArg.default_));
+                localExpr = ast::MK::OptionalArg(parsedArg.loc, move(localExpr), move(parsedArg.default_));
             }
 
             ctx.owner.data(ctx)->arguments()[pos].loc = parsedArg.loc;
@@ -114,7 +114,7 @@ class NameInserter {
 
         if (parsedArg.default_) {
             argInfo.flags.isDefault = true;
-            localExpr = make_unique<ast::OptionalArg>(parsedArg.loc, move(localExpr), move(parsedArg.default_));
+            localExpr = ast::MK::OptionalArg(parsedArg.loc, move(localExpr), move(parsedArg.default_));
         }
 
         if (parsedArg.keyword) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -501,7 +501,7 @@ private:
         } else if (ancestor->isSelfReference()) {
             auto loc = ancestor->loc;
             auto enclosingClass = ctx.owner.data(ctx)->enclosingClass(ctx);
-            auto nw = make_unique<ast::UnresolvedConstantLit>(loc, std::move(ancestor), enclosingClass.data(ctx)->name);
+            auto nw = ast::MK::UnresolvedConstant(loc, std::move(ancestor), enclosingClass.data(ctx)->name);
             auto out = make_unique<ast::ConstantLit>(loc, enclosingClass, std::move(nw));
             job.ancestor = out.get();
             ancestor = std::move(out);

--- a/test/hello-test.cc
+++ b/test/hello-test.cc
@@ -157,7 +157,7 @@ TEST(PreOrderTreeMap, CountTrees) { // NOLINT
 
     unique_ptr<ast::Expression> methodDef =
         make_unique<ast::MethodDef>(loc, loc, methodSym, name, std::move(args), std::move(rhs), false);
-    unique_ptr<ast::Expression> emptyTree = make_unique<ast::EmptyTree>();
+    unique_ptr<ast::Expression> emptyTree = ast::MK::EmptyTree();
     unique_ptr<ast::Expression> cnst = make_unique<ast::UnresolvedConstantLit>(loc, std::move(emptyTree), name);
 
     ast::ClassDef::RHS_store classrhs;


### PR DESCRIPTION
I've noticed folks have added things to Helpers.h but haven't converted all the callsites so we have an inconsistent state. This tries to use the `MK::` helpers in as many places as possible.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
