### PR TITLE
Make the parser recover from more errors

### DIFF
--- a/test/cli/autogen-classlist/autogen-classlist.out
+++ b/test/cli/autogen-classlist/autogen-classlist.out
@@ -10,4 +10,4 @@ test/cli/autogen-classlist/b.rb:5: class definition in method body https://srb.h
      5 |    class InMethod; end # Not allowed
             ^^^^^
 Errors: 1
-
+Foo

--- a/test/testdata/parser/error_recovery_assign.rb
+++ b/test/testdata/parser/error_recovery_assign.rb
@@ -1,0 +1,5 @@
+# typed: false
+# Should still see at least method def (not body)
+def test_bad_assign(x)
+  x =
+end # error: unexpected token

--- a/test/testdata/parser/error_recovery_assign.rb.parse-tree.exp
+++ b/test/testdata/parser/error_recovery_assign.rb.parse-tree.exp
@@ -1,0 +1,4 @@
+Begin {
+  stmts = [
+  ]
+}

--- a/test/testdata/parser/error_recovery_assign.rb.parse-tree.exp
+++ b/test/testdata/parser/error_recovery_assign.rb.parse-tree.exp
@@ -1,4 +1,11 @@
-Begin {
-  stmts = [
-  ]
+DefMethod {
+  name = <U test_bad_assign>
+  args = Args {
+    args = [
+      Arg {
+        name = <U x>
+      }
+    ]
+  }
+  body = NULL
 }

--- a/test/testdata/parser/error_recovery_const_case.rb
+++ b/test/testdata/parser/error_recovery_const_case.rb
@@ -1,0 +1,8 @@
+# typed: false
+
+def foo(x)
+  Integer::
+  case x
+  when Integer # error: unexpected token
+  end
+end # error: unexpected token

--- a/test/testdata/parser/error_recovery_const_case.rb.parse-tree.exp
+++ b/test/testdata/parser/error_recovery_const_case.rb.parse-tree.exp
@@ -7,8 +7,5 @@ DefMethod {
       }
     ]
   }
-  body = Const {
-    scope = NULL
-    name = <C <U Integer>>
-  }
+  body = NULL
 }

--- a/test/testdata/parser/error_recovery_const_case.rb.parse-tree.exp
+++ b/test/testdata/parser/error_recovery_const_case.rb.parse-tree.exp
@@ -1,0 +1,14 @@
+DefMethod {
+  name = <U foo>
+  args = Args {
+    args = [
+      Arg {
+        name = <U x>
+      }
+    ]
+  }
+  body = Const {
+    scope = NULL
+    name = <C <U Integer>>
+  }
+}

--- a/test/testdata/parser/error_recovery_constant_only_scope.rb
+++ b/test/testdata/parser/error_recovery_constant_only_scope.rb
@@ -1,0 +1,5 @@
+# typed: false
+# Should still see at least method def (not body)
+def test_constant_only_scope
+  A::
+end # error: unexpected token

--- a/test/testdata/parser/error_recovery_constant_only_scope.rb.parse-tree.exp
+++ b/test/testdata/parser/error_recovery_constant_only_scope.rb.parse-tree.exp
@@ -1,0 +1,4 @@
+Begin {
+  stmts = [
+  ]
+}

--- a/test/testdata/parser/error_recovery_missing_fun.rb
+++ b/test/testdata/parser/error_recovery_missing_fun.rb
@@ -1,0 +1,21 @@
+# typed: false
+
+def test_method_without_fun_name(x)
+  x.
+end
+
+def test_method_without_fun_name_plus_before(x)
+  before = 1
+  x.
+end
+
+def test_method_without_fun_name_plus_after(x)
+  x.
+  after = 1
+end
+
+def test_method_without_fun_name_before_and_after(x)
+  before = 1
+  x.
+  after = 1
+end # error: unexpected token

--- a/test/testdata/parser/error_recovery_missing_fun.rb.parse-tree.exp
+++ b/test/testdata/parser/error_recovery_missing_fun.rb.parse-tree.exp
@@ -1,0 +1,4 @@
+Begin {
+  stmts = [
+  ]
+}

--- a/test/testdata/parser/error_recovery_multiple_stmts.rb
+++ b/test/testdata/parser/error_recovery_multiple_stmts.rb
@@ -1,0 +1,7 @@
+# typed: false
+
+def test_method_with_multiple_stmts
+  x = 1
+  x = ; # error: unexpected token
+  y = 1
+end

--- a/test/testdata/parser/error_recovery_multiple_stmts.rb.parse-tree.exp
+++ b/test/testdata/parser/error_recovery_multiple_stmts.rb.parse-tree.exp
@@ -1,0 +1,12 @@
+DefMethod {
+  name = <U test_method_with_multiple_stmts>
+  args = NULL
+  body = Assign {
+    lhs = LVarLhs {
+      name = <U y>
+    }
+    rhs = Integer {
+      val = "1"
+    }
+  }
+}

--- a/third_party/parser/cc/grammars/typedruby.ypp
+++ b/third_party/parser/cc/grammars/typedruby.ypp
@@ -493,9 +493,9 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby25 &driver) {
                       $1->emplace_back($3);
                       $$ = $1;
                     }
-                | error stmt
+                | error
                     {
-                      $$ = driver.alloc.node_list($2);
+                      $$ = driver.alloc.node_list();
                     }
 
    stmt_or_begin: stmt


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We care far more about preserving a method def if it existed before a parse
error was introduced, than about tracking the actual contents of the method
bodies (if we see the same method / class structure, we can take the fast
path).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

I tested this on pay-server too, but pay-server is a particularly bad test for
this change: every single file / method / line in pay-server currently parses,
and this change only affects files that don't parse. I added some of the tests
that are top-of-mind for me right now, but I'm only so confident that we won't
need to revert this because it doesn't actually give us the fast path results
that we're looking for.