### PR TITLE
Break compatibility with Ruby syntax

### DIFF
--- a/test/testdata/deviations/keyword_method_names.rb
+++ b/test/testdata/deviations/keyword_method_names.rb
@@ -1,0 +1,283 @@
+# typed: false
+
+# We intentionally deviate from Ruby syntax in these cases, namely when a
+# method call is broken across two lines between the '.' and the name of the
+# method. We tested this on Stripe's codebase and found no call sites where a
+# keyword was both (1) being used as a method name and (2) broken across two
+# lines like this.
+#
+# We decided that this was a worthwile tradeoff, because it makes it far easier
+# for the parser to recover gracefully and locally from syntax errors.
+
+def method_named_alias(x)
+  x.alias # ok
+  x
+    .alias # ok
+  x.
+    alias # error: unexpected token
+end
+
+def method_named_and(x)
+  x.and # ok
+  x
+    .and # ok
+  x.
+    and # error: unexpected token
+end
+
+def method_named_begin(x)
+  x.begin # ok
+  x
+    .begin # ok
+  x.
+    begin # error: unexpected token
+end
+
+def method_named_break(x)
+  x.break # ok
+  x
+    .break # ok
+  x.
+    break # error: unexpected token
+end
+
+def method_named_case(x)
+  x.case # ok
+  x
+    .case # ok
+  x.
+    case # error: unexpected token
+end
+
+def method_named_class(x)
+  x.class # ok
+  x
+    .class # ok
+  x.
+    class # error: unexpected token
+end
+
+def method_named_defined?(x)
+  x.defined? # ok
+  x
+    .defined? # ok
+  x.
+    defined? # error: unexpected token
+end
+
+def method_named_do(x)
+  x.do # ok
+  x
+    .do # ok
+  x.
+    do # error: unexpected token
+end
+
+def method_named_else(x)
+  x.else # ok
+  x
+    .else # ok
+  x.
+    else # error: unexpected token
+end
+
+def method_named_elsif(x)
+  x.elsif # ok
+  x
+    .elsif # ok
+  x.
+    elsif # error: unexpected token
+end
+
+def method_named_ensure(x)
+  x.ensure # ok
+  x
+    .ensure # ok
+  x.
+    ensure # error: unexpected token
+end
+
+def method_named_false(x)
+  x.false # ok
+  x
+    .false # ok
+  x.
+    false # error: unexpected token
+end
+
+def method_named_for(x)
+  x.for # ok
+  x
+    .for # ok
+  x.
+    for # error: unexpected token
+end
+
+def method_named_if(x)
+  x.if # ok
+  x
+    .if # ok
+  x.
+    if # error: unexpected token
+end
+
+def method_named_in(x)
+  x.in # ok
+  x
+    .in # ok
+  x.
+    in # error: unexpected token
+end
+
+def method_named_module(x)
+  x.module # ok
+  x
+    .module # ok
+  x.
+    module # error: unexpected token
+end
+
+def method_named_next(x)
+  x.next # ok
+  x
+    .next # ok
+  x.
+    next # error: unexpected token
+end
+
+def method_named_nil(x)
+  x.nil # ok
+  x
+    .nil # ok
+  x.
+    nil # error: unexpected token
+end
+
+def method_named_not(x)
+  x.not # ok
+  x
+    .not # ok
+  x.
+    not # error: unexpected token
+end
+
+def method_named_or(x)
+  x.or # ok
+  x
+    .or # ok
+  x.
+    or # error: unexpected token
+end
+
+def method_named_redo(x)
+  x.redo # ok
+  x
+    .redo # ok
+  x.
+    redo # error: unexpected token
+end
+
+def method_named_rescue(x)
+  x.rescue # ok
+  x
+    .rescue # ok
+  x.
+    rescue # error: unexpected token
+end
+
+def method_named_retry(x)
+  x.retry # ok
+  x
+    .retry # ok
+  x.
+    retry # error: unexpected token
+end
+
+def method_named_return(x)
+  x.return # ok
+  x
+    .return # ok
+  x.
+    return # error: unexpected token
+end
+
+def method_named_self(x)
+  x.self # ok
+  x
+    .self # ok
+  x.
+    self # error: unexpected token
+end
+
+def method_named_super(x)
+  x.super # ok
+  x
+    .super # ok
+  x.
+    super # error: unexpected token
+end
+
+def method_named_then(x)
+  x.then # ok
+  x
+    .then # ok
+  x.
+    then # error: unexpected token
+end
+
+def method_named_true(x)
+  x.true # ok
+  x
+    .true # ok
+  x.
+    true # error: unexpected token
+end
+
+def method_named_unless(x)
+  x.unless # ok
+  x
+    .unless # ok
+  x.
+    unless # error: unexpected token
+end
+
+def method_named_until(x)
+  x.until # ok
+  x
+    .until # ok
+  x.
+    until # error: unexpected token
+end
+
+def method_named_when(x)
+  x.when # ok
+  x
+    .when # ok
+  x.
+    when # error: unexpected token
+end
+
+def method_named_while(x)
+  x.while # ok
+  x
+    .while # ok
+  x.
+    while # error: unexpected token
+end
+def method_named_yield(x)
+  x.yield # ok
+  x
+    .yield # ok
+  x.
+    yield # error: unexpected token
+end
+
+# This test has to be last, because otherwise it screws up all the other tests
+# (end is special). We can't test `x.def` in this file for similar reasons.
+def method_named_end(x)
+  x.end # ok
+  x
+    .end # ok
+  x.
+    end # error: unexpected token
+end

--- a/test/testdata/deviations/keyword_method_names.rb.parse-tree.exp
+++ b/test/testdata/deviations/keyword_method_names.rb.parse-tree.exp
@@ -1,0 +1,381 @@
+Begin {
+  stmts = [
+    DefMethod {
+      name = <U method_named_alias>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_and>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_begin>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_break>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_case>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_class>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_defined?>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_do>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_else>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_elsif>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_ensure>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = Ensure {
+        body = NULL
+        ensure = NULL
+      }
+    }
+    DefMethod {
+      name = <U method_named_false>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_for>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_if>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_in>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_module>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_next>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_nil>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_not>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_or>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_redo>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_rescue>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_retry>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_return>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_self>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_super>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_then>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_true>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_unless>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_until>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_when>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_while>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_yield>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U method_named_end>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+  ]
+}

--- a/test/testdata/error_recovery_send_after_end.rb
+++ b/test/testdata/error_recovery_send_after_end.rb
@@ -1,0 +1,20 @@
+# typed: false
+
+# We don't recover from this code well as we'd like: ideally, this should parse
+# the method call to `x.if` inside the `def foo`, but instead it puts the
+# method call outside the MethodDef node.
+#
+# This is part of a larger problem that a single mismatched `end` can really
+# screw over our ability to recover (see error_recovery_if_no_end.rb).
+#
+# This code is empirically rare (doesn't accur at all at Stripe), but it's
+# unclear how often code like this comes up when people are making edits.
+
+def foo
+  x.end
+
+  x.
+    end # error: unexpected token
+
+  x.if
+end # error: unexpected token

--- a/test/testdata/error_recovery_send_after_end.rb.parse-tree.exp
+++ b/test/testdata/error_recovery_send_after_end.rb.parse-tree.exp
@@ -1,0 +1,20 @@
+Begin {
+  stmts = [
+    DefMethod {
+      name = <U foo>
+      args = NULL
+      body = NULL
+    }
+    Send {
+      receiver = Send {
+        receiver = NULL
+        method = <U x>
+        args = [
+        ]
+      }
+      method = <U if>
+      args = [
+      ]
+    }
+  ]
+}

--- a/test/testdata/parser/error_recovery_const_case.rb
+++ b/test/testdata/parser/error_recovery_const_case.rb
@@ -2,7 +2,7 @@
 
 def foo(x)
   Integer::
-  case x
-  when Integer # error: unexpected token
+  case x # error: unexpected token
+  when Integer
   end
 end # error: unexpected token

--- a/test/testdata/parser/error_recovery_constant_only_scope.rb.parse-tree.exp
+++ b/test/testdata/parser/error_recovery_constant_only_scope.rb.parse-tree.exp
@@ -1,4 +1,5 @@
-Begin {
-  stmts = [
-  ]
+DefMethod {
+  name = <U test_constant_only_scope>
+  args = NULL
+  body = NULL
 }

--- a/test/testdata/parser/error_recovery_if_no_end.rb
+++ b/test/testdata/parser/error_recovery_if_no_end.rb
@@ -1,0 +1,19 @@
+# typed: false
+
+# We still don't recover from this error as much as we'd like to.
+#
+# Some options for handling this better:
+# - tweak the parser somehow?
+# - make sure that cancellable slow path is really good
+# - drive people towards using completion snippets for `if` / `else` / `end`
+
+class A
+  def foo
+    if true
+  end
+end
+
+class B
+  def bar
+  end
+end # error: unexpected token

--- a/test/testdata/parser/error_recovery_if_no_end.rb.parse-tree.exp
+++ b/test/testdata/parser/error_recovery_if_no_end.rb.parse-tree.exp
@@ -1,0 +1,4 @@
+Begin {
+  stmts = [
+  ]
+}

--- a/test/testdata/parser/error_recovery_missing_fun.rb
+++ b/test/testdata/parser/error_recovery_missing_fun.rb
@@ -2,12 +2,12 @@
 
 def test_method_without_fun_name(x)
   x.
-end
+end # error: unexpected token
 
 def test_method_without_fun_name_plus_before(x)
   before = 1
   x.
-end
+end # error: unexpected token
 
 def test_method_without_fun_name_plus_after(x)
   x.
@@ -18,4 +18,4 @@ def test_method_without_fun_name_before_and_after(x)
   before = 1
   x.
   after = 1
-end # error: unexpected token
+end

--- a/test/testdata/parser/error_recovery_missing_fun.rb.parse-tree.exp
+++ b/test/testdata/parser/error_recovery_missing_fun.rb.parse-tree.exp
@@ -1,4 +1,80 @@
 Begin {
   stmts = [
+    DefMethod {
+      name = <U test_method_without_fun_name>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U test_method_without_fun_name_plus_before>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U test_method_without_fun_name_plus_after>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = Send {
+        receiver = LVar {
+          name = <U x>
+        }
+        method = <U after=>
+        args = [
+          Integer {
+            val = "1"
+          }
+        ]
+      }
+    }
+    DefMethod {
+      name = <U test_method_without_fun_name_before_and_after>
+      args = Args {
+        args = [
+          Arg {
+            name = <U x>
+          }
+        ]
+      }
+      body = Begin {
+        stmts = [
+          Assign {
+            lhs = LVarLhs {
+              name = <U before>
+            }
+            rhs = Integer {
+              val = "1"
+            }
+          }
+          Send {
+            receiver = LVar {
+              name = <U x>
+            }
+            method = <U after=>
+            args = [
+              Integer {
+                val = "1"
+              }
+            ]
+          }
+        ]
+      }
+    }
   ]
 }

--- a/third_party/parser/cc/lexer.rl
+++ b/third_party/parser/cc/lexer.rl
@@ -1560,10 +1560,76 @@ void lexer::set_state_expr_value() {
   #
   # Transitions to `expr_arg` afterwards.
   #
+  # KEEP IN SYNC WITH expr_dot_after_newline!
+  #
   expr_dot := |*
       constant
       => { emit(token_type::tCONSTANT);
            fnext *arg_or_cmdarg(); fbreak; };
+
+      call_or_var
+      => { emit(token_type::tIDENTIFIER);
+           fnext *arg_or_cmdarg(); fbreak; };
+
+      bareword ambiguous_fid_suffix
+      => { emit(token_type::tFID, tok(ts, tm), ts, tm);
+           fnext *arg_or_cmdarg(); p = tm - 1; fbreak; };
+
+      # See the comment in `expr_fname`.
+      operator_fname      |
+      operator_arithmetic |
+      operator_rest
+      => { emit_table(PUNCTUATION);
+           fnext expr_arg; fbreak; };
+
+      # This breaks compatibility with Ruby for better partial parses (useful
+      # for LSP especially). See comment for expr_dot_after_newline below.
+      w_newline
+      => { fhold; fgoto expr_dot_after_newline; };
+
+      w_any;
+
+      c_any
+      => { fhold; fgoto expr_end; };
+
+      c_eof => do_eof;
+  *|;
+
+  # KEEP IN SYNC WITH expr_dot!
+  #
+  # This state breaks from valid Ruby syntax, but in a way that enables Sorbet
+  # to recover better from parse errors. Recovering from parse errors is
+  # important because it lets us service LSP queries faster.
+  #
+  # Specifically, this state makes is so that any keyword seen after w_newline
+  # is emitted as a keyword (like kEND) instead of a tIDENTIFIER. Examples:
+  #
+  #   # Valid Ruby, valid in Sorbet (no newline between '.' and 'end')
+  #   def foo
+  #     x.end
+  #   end
+  #
+  #   # Parse error in Ruby and Sorbet, but Sorbet at least sees the method def
+  #   # with an empty body (Ruby wouldn't even see an empty method def)
+  #   def foo
+  #     x.
+  #   end
+  #
+  #   # Valid Ruby, not valid in Sorbet (newline between '.' and 'end')
+  #   def foo
+  #     x.
+  #       end
+  #   end
+  #
+  expr_dot_after_newline := |*
+      constant
+      => { emit(token_type::tCONSTANT);
+           fnext *arg_or_cmdarg(); fbreak; };
+
+      # This is different from expr_dot. Here, keywords are NOT identifiers.
+      keyword
+      => { emit_table(KEYWORDS);
+           fnext expr_end; fbreak; };
 
       call_or_var
       => { emit(token_type::tIDENTIFIER);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This change break compatibility with valid Ruby syntax, but in a way that
enables Sorbet to recover better from parse errors. Recovering from parse
errors is important because it lets us service LSP queries faster.

Specifically, this change makes it so that any keyword seen after a newline
is emitted as a keyword (like kEND) instead of a tIDENTIFIER. Examples:

```ruby
# Valid Ruby, valid in Sorbet (no newline between '.' and 'end')
def foo
  x.end
end

# Parse error in Ruby and Sorbet, but Sorbet at least sees the method def
# with an empty body (Ruby wouldn't even see an empty method def)
def foo
  x.
end

# Valid Ruby, not valid in Sorbet (newline between '.' and 'end')
def foo
  x.
    end
end
```


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I added a bunch of test cases. This change is also based off another PR, some
of whose test cases change behavior.


### Commit summary

- **Break compatibility with Ruby syntax** (5ccd27b31)


- **Update existing tests** (b1f09fc49)


- **Add test to deviations** (293e93b20)


- **Add some tests that we don't recover from well** (4a70abbf0)


