### PR TITLE
stop copying in the default_ tree and instead move it

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1002,7 +1002,12 @@ string KeywordArg::toStringWithTabs(const core::GlobalState &gs, int tabs) const
 }
 
 string OptionalArg::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
-    return this->expr->toStringWithTabs(gs, tabs) + " = " + this->default_->toStringWithTabs(gs, tabs);
+    stringstream buf;
+    buf << this->expr->toStringWithTabs(gs, tabs);
+    if (this->default_) {
+        buf << " = " << this->default_->toStringWithTabs(gs, tabs);
+    }
+    return buf.str();
 }
 
 string ShadowArg::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
@@ -1160,8 +1165,10 @@ string OptionalArg::showRaw(const core::GlobalState &gs, int tabs) {
     buf << nodeName() << "{" << '\n';
     printTabs(buf, tabs + 1);
     buf << "expr = " + expr->showRaw(gs, tabs + 1) << '\n';
-    printTabs(buf, tabs + 1);
-    buf << "default_ = " + default_->showRaw(gs, tabs + 1) << '\n';
+    if (default_) {
+        printTabs(buf, tabs + 1);
+        buf << "default_ = " + default_->showRaw(gs, tabs + 1) << '\n';
+    }
     printTabs(buf, tabs);
     buf << "}";
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2083,7 +2083,7 @@ public:
     unique_ptr<ast::Expression> postTransformMethodDef(core::MutableContext ctx, unique_ptr<ast::MethodDef> original) {
         ENFORCE(original->symbol != core::Symbols::todo(), "These should have all been resolved: {}",
                 original->toString(ctx));
-        for (auto &arg: original->args) {
+        for (auto &arg : original->args) {
             if (auto optionalArg = ast::cast_tree<ast::OptionalArg>(arg.get())) {
                 ENFORCE(!optionalArg->default_);
             }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2081,6 +2081,11 @@ public:
     unique_ptr<ast::Expression> postTransformMethodDef(core::MutableContext ctx, unique_ptr<ast::MethodDef> original) {
         ENFORCE(original->symbol != core::Symbols::todo(), "These should have all been resolved: {}",
                 original->toString(ctx));
+        for (auto &arg: original->args) {
+            if (auto optionalArg = ast::cast_tree<ast::OptionalArg>(arg.get())) {
+                ENFORCE(!optionalArg->default_);
+            }
+        }
         return original;
     }
     unique_ptr<ast::Expression> postTransformUnresolvedConstantLit(core::MutableContext ctx,

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1462,7 +1462,7 @@ private:
             if (auto *optArgExp = ast::cast_tree<ast::OptionalArg>(argExp.get())) {
                 // Using optArgExp's loc will make errors point to the arg list, even though the T.let is in the
                 // body.
-                auto let = make_unique<ast::Cast>(optArgExp->loc, argType, optArgExp->default_->deepCopy(),
+                auto let = make_unique<ast::Cast>(optArgExp->loc, argType, move(optArgExp->default_),
                                                   core::Names::let());
                 lets.emplace_back(std::move(let));
             }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1462,8 +1462,8 @@ private:
             if (auto *optArgExp = ast::cast_tree<ast::OptionalArg>(argExp.get())) {
                 // Using optArgExp's loc will make errors point to the arg list, even though the T.let is in the
                 // body.
-                auto let = make_unique<ast::Cast>(optArgExp->loc, argType, move(optArgExp->default_),
-                                                  core::Names::let());
+                auto let =
+                    make_unique<ast::Cast>(optArgExp->loc, argType, move(optArgExp->default_), core::Names::let());
                 lets.emplace_back(std::move(let));
             }
         }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1447,12 +1447,6 @@ private:
     void injectOptionalArgs(core::MutableContext ctx, ast::MethodDef *mdef) {
         ast::InsSeq::STATS_store lets;
 
-        if (mdef->symbol.data(ctx)->isAbstract()) {
-            // If we checked that abstract methods don't have defined bodies earlier (currently done in infer)
-            // we could also use this technique to check default arguments of abstract methods.
-            return;
-        }
-
         int i = -1;
         for (auto &argSym : mdef->symbol.data(ctx)->arguments()) {
             i++;
@@ -1472,7 +1466,7 @@ private:
             }
         }
 
-        if (!lets.empty()) {
+        if (!lets.empty() && !mdef->symbol.data(ctx)->isAbstract()) {
             auto loc = mdef->rhs->loc;
             mdef->rhs = ast::MK::InsSeq(loc, std::move(lets), std::move(mdef->rhs));
         }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1460,11 +1460,15 @@ private:
             auto argType = argSym.type;
 
             if (auto *optArgExp = ast::cast_tree<ast::OptionalArg>(argExp.get())) {
-                // Using optArgExp's loc will make errors point to the arg list, even though the T.let is in the
-                // body.
-                auto let =
-                    make_unique<ast::Cast>(optArgExp->loc, argType, move(optArgExp->default_), core::Names::let());
-                lets.emplace_back(std::move(let));
+                if (!argType) {
+                    optArgExp->default_ = nullptr;
+                } else {
+                    // Using optArgExp's loc will make errors point to the arg list, even though the T.let is in the
+                    // body.
+                    auto let =
+                        make_unique<ast::Cast>(optArgExp->loc, argType, move(optArgExp->default_), core::Names::let());
+                    lets.emplace_back(std::move(let));
+                }
             }
         }
 
@@ -1640,13 +1644,11 @@ private:
                         i++;
                     }
 
-                    if (!isOverloaded) {
-                        injectOptionalArgs(ctx, mdef);
-                    }
-
                     // OVERLOAD
                     lastSigs.clear();
                 }
+
+                injectOptionalArgs(ctx, mdef);
 
                 if (mdef->symbol.data(ctx)->isAbstract()) {
                     if (!ast::isa_tree<ast::EmptyTree>(mdef->rhs.get())) {

--- a/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
+++ b/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
@@ -65,7 +65,6 @@ InsSeq{
               expr = Local{
                 localVariable = <U b>
               }
-              default_ = Literal{ value = 1 }
             }, Local{
               localVariable = <U c>
             }, Local{
@@ -74,7 +73,6 @@ InsSeq{
               expr = Local{
                 localVariable = <U e>
               }
-              default_ = Literal{ value = 2 }
             }, Local{
               localVariable = <U f>
             }, Local{


### PR DESCRIPTION
While I was working on some other stuff I noticed this seems to be the last use of this AST node. I think getting it out of this weird spot in the tree and into the `T.let` seems better? I think I'm going to want this anyways for my work to move these to be just a `Send`. I think I'll even want this to be an assignment instead of just a `T.cast` but I can do that in another PR.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
