### PR TITLE
Fix JSON quoting in web-trace-file generation

### DIFF
--- a/common/web_tracer_framework/tracing.cc
+++ b/common/web_tracer_framework/tracing.cc
@@ -4,6 +4,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_replace.h"
 #include "common/Counters_impl.h"
+#include "common/JSON.h"
 #include "common/web_tracer_framework/tracing.h"
 #include "version/version.h"
 #include <chrono>
@@ -52,7 +53,8 @@ bool Tracing::storeTraces(const CounterState &counters, string_view fileName) {
         string maybeArgs;
         if (!e.args.empty()) {
             maybeArgs = fmt::format(",\"args\":{{{}}}", fmt::map_join(e.args, ",", [](const auto &nameValue) -> string {
-                                        return fmt::format("\"{}\":\"{}\"", nameValue.first, nameValue.second);
+                                        return fmt::format("\"{}\":\"{}\"", JSON::escape(nameValue.first),
+                                                           JSON::escape(nameValue.second));
                                     }));
         }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Some method names have quotes in them. Like

```ruby
it '"has quotes"' do
end
```

is actually

```ruby
def test_"has_quotes"
end
```

which meant that sometimes we'd generate bad web trace files.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested manually.