### PR TITLE
Take fast path for parse errors

### DIFF
--- a/main/lsp/TimeTravelingGlobalState.cc
+++ b/main/lsp/TimeTravelingGlobalState.cc
@@ -137,7 +137,7 @@ vector<core::FileHash> TimeTravelingGlobalState::computeStateHashes(const vector
 
     shared_ptr<BlockingBoundedQueue<vector<pair<int, core::FileHash>>>> resultq =
         make_shared<BlockingBoundedQueue<vector<pair<int, core::FileHash>>>>(files.size());
-    auto lspParseErrorsTakeFastPath = config.opts.lspParseErrorsTakeFastPath;
+    auto lspParseErrorsTakeFastPath = config->opts.lspParseErrorsTakeFastPath;
     config->workers.multiplexJob("lspStateHash", [fileq, resultq, files, &logger, lspParseErrorsTakeFastPath]() {
         vector<pair<int, core::FileHash>> threadResult;
         int processedByThread = 0;
@@ -211,7 +211,7 @@ void TimeTravelingGlobalState::commitEdits(LSPFileUpdates &update) {
             // Reversal of a new file is... an empty file...
             auto emptyFile = make_shared<core::File>(string(file->path()), "", core::File::Type::Normal);
             newUpdate.undoUpdate.hashUpdates.push_back(
-                pipeline::computeFileHash(emptyFile, *config->logger, config.opts.lspParseErrorsTakeFastPath));
+                pipeline::computeFileHash(emptyFile, *config->logger, config->opts.lspParseErrorsTakeFastPath));
             newUpdate.undoUpdate.fileUpdates.push_back(move(emptyFile));
         }
     }

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -100,6 +100,7 @@ void LSPWrapper::enableAllExperimentalFeatures() {
     enableExperimentalFeature(LSPExperimentalFeature::DocumentSymbol);
     enableExperimentalFeature(LSPExperimentalFeature::SignatureHelp);
     enableExperimentalFeature(LSPExperimentalFeature::QuickFix);
+    enableExperimentalFeature(LSPExperimentalFeature::ParseErrorsTakeFastPath);
 }
 
 void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
@@ -118,6 +119,9 @@ void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
             break;
         case LSPExperimentalFeature::SignatureHelp:
             opts.lspSignatureHelpEnabled = true;
+            break;
+        case LSPExperimentalFeature::ParseErrorsTakeFastPath:
+            opts.lspParseErrorsTakeFastPath = true;
             break;
     }
 }

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -40,6 +40,7 @@ public:
         DocumentSymbol = 6,
         SignatureHelp = 7,
         QuickFix = 8,
+        ParseErrorsTakeFastPath = 9,
     };
 
     // N.B.: Sorbet assumes we 'own' this object; keep it alive to avoid memory errors.

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -347,6 +347,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("enable-experimental-lsp-signature-help",
                                     "Enable experimental LSP feature: Signature Help");
     options.add_options("advanced")("enable-experimental-lsp-quick-fix", "Enable experimental LSP feature: Quick Fix");
+    options.add_options("advanced")("enable-experimental-lsp-parse-errors-take-fast-path",
+                                    "Enable experimental LSP feature: Parse errors take the fast path");
     options.add_options("advanced")("enable-all-experimental-lsp-features", "Enable every experimental LSP feature.");
     options.add_options("advanced")(
         "ignore",
@@ -671,6 +673,8 @@ void readOptions(Options &opts,
         opts.lspDocumentSymbolEnabled =
             enableAllLSPFeatures || raw["enable-experimental-lsp-document-symbol"].as<bool>();
         opts.lspSignatureHelpEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-signature-help"].as<bool>();
+        opts.lspParseErrorsTakeFastPath =
+            enableAllLSPFeatures || raw["enable-experimental-lsp-parse-errors-take-fast-path"].as<bool>();
 
         if (raw.count("lsp-directories-missing-from-client") > 0) {
             auto lspDirsMissingFromClient = raw["lsp-directories-missing-from-client"].as<vector<string>>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -202,6 +202,7 @@ struct Options {
     bool lspDocumentSymbolEnabled = false;
     bool lspSignatureHelpEnabled = false;
     bool lspHoverEnabled = false;
+    bool lspParseErrorsTakeFastPath = false;
 
     std::string inlineInput; // passed via -e
     std::string debugLogFile;

--- a/main/options/test/options_test.cc
+++ b/main/options/test/options_test.cc
@@ -73,6 +73,7 @@ TEST(OptionsTest, DefaultConstructorMatchesReadOptions) {
     EXPECT_EQ(empty.lspWorkspaceSymbolsEnabled, opts.lspWorkspaceSymbolsEnabled);
     EXPECT_EQ(empty.lspDocumentSymbolEnabled, opts.lspDocumentSymbolEnabled);
     EXPECT_EQ(empty.lspSignatureHelpEnabled, opts.lspSignatureHelpEnabled);
+    EXPECT_EQ(empty.lspParseErrorsTakeFastPath, opts.lspParseErrorsTakeFastPath);
     EXPECT_EQ(empty.inlineInput, opts.inlineInput);
     EXPECT_EQ(empty.debugLogFile, opts.debugLogFile);
     EXPECT_EQ(empty.webTraceFile, opts.webTraceFile);

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -36,7 +36,8 @@ ast::ParsedFilesOrCancelled typecheck(std::unique_ptr<core::GlobalState> &gs, st
 
 ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Options &opts);
 
-core::FileHash computeFileHash(std::shared_ptr<core::File> forWhat, spdlog::logger &logger);
+core::FileHash computeFileHash(std::shared_ptr<core::File> forWhat, spdlog::logger &logger,
+                               bool lspParseErrorsTakeFastPath);
 
 core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::FileRef file,
                                     const options::Options &opts);

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -87,6 +87,9 @@ Usage:
                                 Help
       --enable-experimental-lsp-quick-fix
                                 Enable experimental LSP feature: Quick Fix
+      --enable-experimental-lsp-parse-errors-take-fast-path
+                                Enable experimental LSP feature: Parse errors
+                                take the fast path
       --enable-all-experimental-lsp-features
                                 Enable every experimental LSP feature.
       --ignore string           Ignores input files that contain the given

--- a/test/testdata/lsp/fast_path/parse_errors.1.rbupdate
+++ b/test/testdata/lsp/fast_path/parse_errors.1.rbupdate
@@ -1,0 +1,18 @@
+# typed: true
+# assert-fast-path: parse_errors.rb
+class A
+  def foo; end
+end
+
+def test_1
+  A.new.
+end # error: unexpected token
+
+def test_2
+  x = 1
+  x
+end
+
+def test_3
+  A
+end

--- a/test/testdata/lsp/fast_path/parse_errors.2.rbupdate
+++ b/test/testdata/lsp/fast_path/parse_errors.2.rbupdate
@@ -1,0 +1,18 @@
+# typed: true
+# assert-fast-path: parse_errors.rb
+class A
+  def foo; end
+end
+
+def test_1
+  A.new.
+end # error: unexpected token
+
+def test_2
+  x = 1
+  x =
+end # error: unexpected token
+
+def test_3
+  A
+end

--- a/test/testdata/lsp/fast_path/parse_errors.3.rbupdate
+++ b/test/testdata/lsp/fast_path/parse_errors.3.rbupdate
@@ -1,0 +1,18 @@
+# typed: true
+# assert-fast-path: parse_errors.rb
+class A
+  def foo; end
+end
+
+def test_1
+  A.new.
+end # error: unexpected token
+
+def test_2
+  x = 1
+  x =
+end # error: unexpected token
+
+def test_3
+  A::
+end # error: unexpected token

--- a/test/testdata/lsp/fast_path/parse_errors.rb
+++ b/test/testdata/lsp/fast_path/parse_errors.rb
@@ -1,0 +1,18 @@
+# typed: true
+
+class A
+  def foo; end
+end
+
+def test_1
+  A.new
+end
+
+def test_2
+  x = 1
+  x
+end
+
+def test_3
+  A
+end

--- a/test/testdata/lsp/field_edits.1.rbupdate
+++ b/test/testdata/lsp/field_edits.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: field_edits.rb
 class C
   @@foo = T.let(3, Integer)
 

--- a/test/testdata/lsp/field_edits.1.rbupdate.document-symbols.exp
+++ b/test/testdata/lsp/field_edits.1.rbupdate.document-symbols.exp
@@ -34,22 +34,22 @@
                     "kind": 14,
                     "range": {
                         "start": {
-                            "line": 3,
-                            "character": 2
+                            "line": 1,
+                            "character": 10
                         },
                         "end": {
-                            "line": 3,
-                            "character": 7
+                            "line": 1,
+                            "character": 15
                         }
                     },
                     "selectionRange": {
                         "start": {
-                            "line": 3,
-                            "character": 2
+                            "line": 1,
+                            "character": 10
                         },
                         "end": {
-                            "line": 3,
-                            "character": 7
+                            "line": 1,
+                            "character": 15
                         }
                     },
                     "children": []


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We expect this to significantly reduce the number of times we need to take the slow_path, because for many common syntax errors we'll be able to recover from them after #1992 and #1993.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I wrote a couple fast path tests that assert we should be taking the fast path for certain kinds of edits.

I think we'll gain more confidence from this change by observing the metrics in pay-server.