### PR TITLE
Print expected then actual in document-symbols tests

### DIFF
--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -829,7 +829,7 @@ void testDocumentSymbols(LSPWrapper &lspWrapper, Expectations &test, int &nextId
         get<variant<JSONNullObject, vector<unique_ptr<DocumentSymbol>>>>(*expectedResp.result);
 
     // Simple string comparison, just like other *.exp files.
-    EXPECT_EQ(documentSymbolsToString(receivedSymbolResponse), documentSymbolsToString(expectedSymbolResponse))
+    EXPECT_EQ(documentSymbolsToString(expectedSymbolResponse), documentSymbolsToString(receivedSymbolResponse))
         << "Mismatch on: " << expectedSymbolsPath;
 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This way the `-` lines in the diff are the current/expected values, and
the `+` lines are the new/actual values. I was reading these backwards
and I couldn't make sense of one of my test failures.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See e.g., this test failure where they're backwards:

https://buildkite.com/sorbet/sorbet/builds/6826#3b61b81c-74da-4739-adf7-22efba50523e/220-267