### PR TITLE
wip: Example of bad docment-symbols behavior

### DIFF
--- a/test/testdata/lsp/bad_field_edits.1.rbupdate
+++ b/test/testdata/lsp/bad_field_edits.1.rbupdate
@@ -1,0 +1,6 @@
+# typed: true
+# assert-fast-path: bad_field_edits.rb
+class A
+  @@foo = T.let(0, Integer)
+end
+

--- a/test/testdata/lsp/bad_field_edits.1.rbupdate.document-symbols.exp
+++ b/test/testdata/lsp/bad_field_edits.1.rbupdate.document-symbols.exp
@@ -1,0 +1,60 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "requestMethod": "textDocument/documentSymbol",
+    "result": [
+        {
+            "name": "A",
+            "detail": "",
+            "kind": 5,
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 0
+                },
+                "end": {
+                    "line": 2,
+                    "character": 7
+                }
+            },
+            "selectionRange": {
+                "start": {
+                    "line": 2,
+                    "character": 0
+                },
+                "end": {
+                    "line": 2,
+                    "character": 7
+                }
+            },
+            "children": [
+                {
+                    "name": "@@foo",
+                    "detail": "",
+                    "kind": 14,
+                    "range": {
+                        "start": {
+                            "line": 1,
+                            "character": 11
+                        },
+                        "end": {
+                            "line": 1,
+                            "character": 16
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 1,
+                            "character": 11
+                        },
+                        "end": {
+                            "line": 1,
+                            "character": 16
+                        }
+                    },
+                    "children": []
+                }
+            ]
+        }
+    ]
+}

--- a/test/testdata/lsp/bad_field_edits.rb
+++ b/test/testdata/lsp/bad_field_edits.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+class A
+  @@foo = T.let(0, Integer)
+end

--- a/test/testdata/lsp/bad_field_edits.rb.document-symbols.exp
+++ b/test/testdata/lsp/bad_field_edits.rb.document-symbols.exp
@@ -1,0 +1,60 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "requestMethod": "textDocument/documentSymbol",
+    "result": [
+        {
+            "name": "A",
+            "detail": "",
+            "kind": 5,
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 0
+                },
+                "end": {
+                    "line": 2,
+                    "character": 7
+                }
+            },
+            "selectionRange": {
+                "start": {
+                    "line": 2,
+                    "character": 0
+                },
+                "end": {
+                    "line": 2,
+                    "character": 7
+                }
+            },
+            "children": [
+                {
+                    "name": "@@foo",
+                    "detail": "",
+                    "kind": 14,
+                    "range": {
+                        "start": {
+                            "line": 3,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 3,
+                            "character": 7
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 3,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 3,
+                            "character": 7
+                        }
+                    },
+                    "children": []
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
cc @jvilk-stripe
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I believe this is an example of a potential misbehavior of the document-symbols
feature, specifically for this reason:

1. The tests pass (as evidenced by CI).
1. `*.1.rbupdate` takes the fast path (as evidenced by the assertion)
1. The only thing the edit adds is a comment (the fast path assertion) and a
   newline.
1. There's a **diff** between the two document symbols files:

```diff
--- test/testdata/lsp/bad_field_edits.rb.document-symbols.exp	2019-10-21 21:51:30.000000000 -0700
+++ test/testdata/lsp/bad_field_edits.1.rbupdate.document-symbols.exp	2019-10-21 21:56:42.000000000 -0700
@@ -34,22 +34,22 @@
                     "kind": 14,
                     "range": {
                         "start": {
-                            "line": 3,
-                            "character": 2
+                            "line": 1,
+                            "character": 11
                         },
                         "end": {
-                            "line": 3,
-                            "character": 7
+                            "line": 1,
+                            "character": 16
                         }
                     },
                     "selectionRange": {
                         "start": {
-                            "line": 3,
-                            "character": 2
+                            "line": 1,
+                            "character": 11
                         },
                         "end": {
-                            "line": 3,
-                            "character": 7
+                            "line": 1,
+                            "character": 16
                         }
                     },
                     "children": []

```

Which is to say: taking the fast path changes the locs of the document symbols
result for the field!


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.