### PR TITLE
Don't crash on YAML parse error

### DIFF
--- a/core/errors/namer.h
+++ b/core/errors/namer.h
@@ -22,6 +22,7 @@ constexpr ErrorClass RootTypeMember{4016, StrictLevel::False};
 constexpr ErrorClass DynamicConstantAssignment{4017, StrictLevel::False};
 constexpr ErrorClass RepeatedArgument{4018, StrictLevel::False};
 constexpr ErrorClass MultipleBehaviorDefs{4019, StrictLevel::False};
+constexpr ErrorClass YAMLSyntaxError{4020, StrictLevel::False};
 } // namespace sorbet::core::errors::Namer
 
 #endif

--- a/test/cli/configatron-yaml-error/configatron-yaml-error.out
+++ b/test/cli/configatron-yaml-error/configatron-yaml-error.out
@@ -1,0 +1,2 @@
+???: YAML syntax error parsing file test/cli/configatron-yaml-error/configatron-yaml-error.yaml: end of map not found https://srb.help/4020
+Errors: 1

--- a/test/cli/configatron-yaml-error/configatron-yaml-error.rb
+++ b/test/cli/configatron-yaml-error/configatron-yaml-error.rb
@@ -1,0 +1,2 @@
+# typed: true
+''

--- a/test/cli/configatron-yaml-error/configatron-yaml-error.sh
+++ b/test/cli/configatron-yaml-error/configatron-yaml-error.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+main/sorbet --silence-dev-message --configatron-file=test/cli/configatron-yaml-error/configatron-yaml-error.yaml test/cli/configatron-yaml-error/configatron-yaml-error.rb 2>&1

--- a/test/cli/configatron-yaml-error/configatron-yaml-error.yaml
+++ b/test/cli/configatron-yaml-error/configatron-yaml-error.yaml
@@ -1,0 +1,2 @@
+default: &default {}
+  test_bool: true


### PR DESCRIPTION
I could try to make a core::File and a core::Loc to report the error on, but it
seems like creating files is pretty tightly coupled to pipeline.cc and
strictness levels, so I figured I'd just avoid it.

To be clear: the `YAML::ParserException` has enough information in it to craft
a Loc if we really want to, I just didn't want to put a ton of time into it.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Someone ran into this again at Stripe today.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.