### PR TITLE
Remove flag for fast path parse error change

### DIFF
--- a/main/lsp/TimeTravelingGlobalState.cc
+++ b/main/lsp/TimeTravelingGlobalState.cc
@@ -137,8 +137,7 @@ vector<core::FileHash> TimeTravelingGlobalState::computeStateHashes(const vector
 
     shared_ptr<BlockingBoundedQueue<vector<pair<int, core::FileHash>>>> resultq =
         make_shared<BlockingBoundedQueue<vector<pair<int, core::FileHash>>>>(files.size());
-    auto lspParseErrorsTakeFastPath = config->opts.lspParseErrorsTakeFastPath;
-    config->workers.multiplexJob("lspStateHash", [fileq, resultq, files, &logger, lspParseErrorsTakeFastPath]() {
+    config->workers.multiplexJob("lspStateHash", [fileq, resultq, files, &logger]() {
         vector<pair<int, core::FileHash>> threadResult;
         int processedByThread = 0;
         int job;
@@ -151,7 +150,7 @@ vector<core::FileHash> TimeTravelingGlobalState::computeStateHashes(const vector
                         threadResult.emplace_back(job, core::FileHash{});
                         continue;
                     }
-                    auto hash = pipeline::computeFileHash(files[job], logger, lspParseErrorsTakeFastPath);
+                    auto hash = pipeline::computeFileHash(files[job], logger);
                     threadResult.emplace_back(job, move(hash));
                 }
             }
@@ -210,8 +209,7 @@ void TimeTravelingGlobalState::commitEdits(LSPFileUpdates &update) {
             update.hasNewFiles = true;
             // Reversal of a new file is... an empty file...
             auto emptyFile = make_shared<core::File>(string(file->path()), "", core::File::Type::Normal);
-            newUpdate.undoUpdate.hashUpdates.push_back(
-                pipeline::computeFileHash(emptyFile, *config->logger, config->opts.lspParseErrorsTakeFastPath));
+            newUpdate.undoUpdate.hashUpdates.push_back(pipeline::computeFileHash(emptyFile, *config->logger));
             newUpdate.undoUpdate.fileUpdates.push_back(move(emptyFile));
         }
     }

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -76,7 +76,6 @@ void LSPWrapper::enableAllExperimentalFeatures() {
     enableExperimentalFeature(LSPExperimentalFeature::DocumentSymbol);
     enableExperimentalFeature(LSPExperimentalFeature::SignatureHelp);
     enableExperimentalFeature(LSPExperimentalFeature::QuickFix);
-    enableExperimentalFeature(LSPExperimentalFeature::ParseErrorsTakeFastPath);
 }
 
 void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
@@ -95,9 +94,6 @@ void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
             break;
         case LSPExperimentalFeature::SignatureHelp:
             opts.lspSignatureHelpEnabled = true;
-            break;
-        case LSPExperimentalFeature::ParseErrorsTakeFastPath:
-            opts.lspParseErrorsTakeFastPath = true;
             break;
     }
 }

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -37,7 +37,6 @@ public:
         DocumentSymbol = 6,
         SignatureHelp = 7,
         QuickFix = 8,
-        ParseErrorsTakeFastPath = 9,
     };
 
     // N.B.: Sorbet assumes we 'own' this object; keep it alive to avoid memory errors.

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -347,8 +347,6 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("enable-experimental-lsp-signature-help",
                                     "Enable experimental LSP feature: Signature Help");
     options.add_options("advanced")("enable-experimental-lsp-quick-fix", "Enable experimental LSP feature: Quick Fix");
-    options.add_options("advanced")("enable-experimental-lsp-parse-errors-take-fast-path",
-                                    "Enable experimental LSP feature: Parse errors take the fast path");
     options.add_options("advanced")("enable-all-experimental-lsp-features", "Enable every experimental LSP feature.");
     options.add_options("advanced")(
         "ignore",
@@ -673,8 +671,6 @@ void readOptions(Options &opts,
         opts.lspDocumentSymbolEnabled =
             enableAllLSPFeatures || raw["enable-experimental-lsp-document-symbol"].as<bool>();
         opts.lspSignatureHelpEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-signature-help"].as<bool>();
-        opts.lspParseErrorsTakeFastPath =
-            enableAllLSPFeatures || raw["enable-experimental-lsp-parse-errors-take-fast-path"].as<bool>();
 
         if (raw.count("lsp-directories-missing-from-client") > 0) {
             auto lspDirsMissingFromClient = raw["lsp-directories-missing-from-client"].as<vector<string>>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -202,7 +202,6 @@ struct Options {
     bool lspDocumentSymbolEnabled = false;
     bool lspSignatureHelpEnabled = false;
     bool lspHoverEnabled = false;
-    bool lspParseErrorsTakeFastPath = false;
 
     std::string inlineInput; // passed via -e
     std::string debugLogFile;

--- a/main/options/test/options_test.cc
+++ b/main/options/test/options_test.cc
@@ -73,7 +73,6 @@ TEST(OptionsTest, DefaultConstructorMatchesReadOptions) {
     EXPECT_EQ(empty.lspWorkspaceSymbolsEnabled, opts.lspWorkspaceSymbolsEnabled);
     EXPECT_EQ(empty.lspDocumentSymbolEnabled, opts.lspDocumentSymbolEnabled);
     EXPECT_EQ(empty.lspSignatureHelpEnabled, opts.lspSignatureHelpEnabled);
-    EXPECT_EQ(empty.lspParseErrorsTakeFastPath, opts.lspParseErrorsTakeFastPath);
     EXPECT_EQ(empty.inlineInput, opts.inlineInput);
     EXPECT_EQ(empty.debugLogFile, opts.debugLogFile);
     EXPECT_EQ(empty.webTraceFile, opts.webTraceFile);

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -36,8 +36,7 @@ ast::ParsedFilesOrCancelled typecheck(std::unique_ptr<core::GlobalState> &gs, st
 
 ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Options &opts);
 
-core::FileHash computeFileHash(std::shared_ptr<core::File> forWhat, spdlog::logger &logger,
-                               bool lspParseErrorsTakeFastPath);
+core::FileHash computeFileHash(std::shared_ptr<core::File> forWhat, spdlog::logger &logger);
 
 core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::FileRef file,
                                     const options::Options &opts);

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -87,9 +87,6 @@ Usage:
                                 Help
       --enable-experimental-lsp-quick-fix
                                 Enable experimental LSP feature: Quick Fix
-      --enable-experimental-lsp-parse-errors-take-fast-path
-                                Enable experimental LSP feature: Parse errors
-                                take the fast path
       --enable-all-experimental-lsp-features
                                 Enable every experimental LSP feature.
       --ignore string           Ignores input files that contain the given


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Over yesterday and today, a small handful of Stripes have tried this out and
not experienced anything catastrophic. Let's just ship it.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.