### PR TITLE
Move argument defaults for methods to their own method

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -658,7 +658,12 @@ SymbolRef GlobalState::findRenamedSymbol(SymbolRef owner, SymbolRef sym) const {
             ENFORCE(nameData->unique.num > 1);
             auto nm =
                 lookupNameUnique(UniqueNameKind::MangleRename, nameData->unique.original, nameData->unique.num - 1);
-            return nm.exists() ? ownerScope->members()[nm] : Symbols::noSymbol();
+            if (!nm.exists()) {
+                return Symbols::noSymbol();
+            }
+            auto res = ownerScope->members()[nm];
+            ENFORCE(res.exists());
+            return res;
         }
     } else {
         u2 unique = 1;

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -652,6 +652,9 @@ SymbolRef GlobalState::findRenamedSymbol(SymbolRef owner, SymbolRef sym) const {
     SymbolData ownerScope = owner.dataAllowingNone(*this);
 
     if (nameData->kind == NameKind::UNIQUE) {
+        if (nameData->unique.uniqueNameKind != UniqueNameKind::MangleRename) {
+            return Symbols::noSymbol();
+        }
         if (nameData->unique.num == 1) {
             return Symbols::noSymbol();
         } else {

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -73,6 +73,9 @@ string Name::showRaw(const GlobalState &gs) const {
                 case UniqueNameKind::OpusEnum:
                     kind = "E";
                     break;
+                case UniqueNameKind::DefaultArg:
+                    kind = "DA";
+                    break;
             }
             if (gs.censorForSnapshotTests && this->unique.uniqueNameKind == UniqueNameKind::Namer &&
                 this->unique.original == core::Names::staticInit()) {
@@ -95,6 +98,8 @@ string Name::toString(const GlobalState &gs) const {
                 return fmt::format("<Class:{}>", this->unique.original.data(gs)->show(gs));
             } else if (this->unique.uniqueNameKind == UniqueNameKind::Overload) {
                 return absl::StrCat(this->unique.original.data(gs)->show(gs), " (overload.", this->unique.num, ")");
+            } else if (this->unique.uniqueNameKind == UniqueNameKind::DefaultArg) {
+                return fmt::format("{}<defaultAarg>{}", this->unique.original.data(gs)->show(gs), this->unique.num);
             }
             if (gs.censorForSnapshotTests && this->unique.uniqueNameKind == UniqueNameKind::Namer &&
                 this->unique.original == core::Names::staticInit()) {
@@ -122,6 +127,8 @@ string Name::show(const GlobalState &gs) const {
                 // The entire goal of UniqueNameKind::OpusEnum is to have Name::show print the name as if on the
                 // original name, so that our OpusEnum DSL-synthesized class names are kept as an implementation detail.
                 // Thus, we fall through.
+            } else if (this->unique.uniqueNameKind == UniqueNameKind::DefaultArg) {
+                return fmt::format("{}<defaultAarg>{}", this->unique.original.data(gs)->show(gs), this->unique.num);
             }
             return this->unique.original.data(gs)->show(gs);
         case NameKind::CONSTANT:

--- a/core/Names.h
+++ b/core/Names.h
@@ -52,6 +52,7 @@ enum class UniqueNameKind : u1 {
     ResolverMissingClass, // used by resolver when we want to enter a stub class into a static field. see
                           // test/resolver/stub_missing_class_alias.rb
     OpusEnum,
+    DefaultArg,
 };
 
 struct UniqueName final {

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -57,6 +57,9 @@ com::stripe::rubytyper::Name Proto::toProto(const GlobalState &gs, NameRef name)
                 case UniqueNameKind::OpusEnum:
                     protoName.set_unique(com::stripe::rubytyper::Name::OPUS_ENUM);
                     break;
+                case UniqueNameKind::DefaultArg:
+                    protoName.set_unique(com::stripe::rubytyper::Name::DEFAULT_ARG);
+                    break;
             }
             break;
         case NameKind::CONSTANT:

--- a/dsl/DefaultArgs.cc
+++ b/dsl/DefaultArgs.cc
@@ -1,0 +1,73 @@
+#include "dsl/DefaultArgs.h"
+#include "ast/Helpers.h"
+#include "common/typecase.h"
+#include "core/GlobalState.h"
+
+using namespace std;
+
+namespace sorbet::dsl {
+
+unique_ptr<ast::Expression> mangleSig(unique_ptr<ast::Expression> sig, int param) {
+    // TODO change the return type to be that of the argument and then return
+    // the sig for that
+    return nullptr;
+}
+
+void DefaultArgs::patchDSL(core::MutableContext ctx, ast::ClassDef *klass) {
+    vector<unique_ptr<ast::Expression>> newMethods;
+
+    for (auto &stat : klass->rhs) {
+        ast::Send *lastSig = nullptr;
+
+        typecase(
+            stat.get(),
+            [&](ast::Send *send) {
+                if (send->fun != core::Names::sig()) {
+                    return;
+                }
+                lastSig = send;
+            },
+            [&](ast::MethodDef *mdef) {
+                auto i = -1;
+                for (auto &methodArg : mdef->args) {
+                    ++i;
+                    auto arg = ast::cast_tree<ast::OptionalArg>(methodArg.get());
+                    if (!arg) {
+                        continue;
+                    }
+
+                    ENFORCE(ast::isa_tree<ast::UnresolvedIdent>(arg->expr.get()) ||
+                            ast::isa_tree<ast::KeywordArg>(arg->expr.get()));
+                    auto name = ctx.state.freshNameUnique(core::UniqueNameKind::DefaultArg, mdef->name, i + 1);
+                    ast::MethodDef::ARGS_store args;
+                    for (auto &marg : mdef->args) {
+                        auto newArg = marg->deepCopy();
+                        auto optArg = ast::cast_tree<ast::OptionalArg>(newArg.get());
+                        if (optArg) {
+                            optArg->default_ = ast::MK::EmptyTree();
+                        }
+                        args.emplace_back(move(newArg));
+                    }
+                    auto loc = arg->default_->loc;
+                    auto rhs = move(arg->default_);
+                    arg->default_ = ast::MK::EmptyTree();
+
+                    if (lastSig) {
+                        auto sig = mangleSig(lastSig->deepCopy(), i);
+                        newMethods.emplace_back(move(sig));
+                        lastSig = nullptr;
+                    }
+                    newMethods.emplace_back(
+                        ast::MK::Method(loc, loc, name, std::move(args), std::move(rhs), mdef->flags));
+                }
+            },
+
+            [&](ast::Expression *expr) {});
+    }
+
+    for (auto &stat : newMethods) {
+        klass->rhs.emplace_back(move(stat));
+    }
+}
+
+} // namespace sorbet::dsl

--- a/dsl/DefaultArgs.h
+++ b/dsl/DefaultArgs.h
@@ -1,0 +1,34 @@
+#ifndef SORBET_DSL_DEFAULT_ARGS_H
+#define SORBET_DSL_DEFAULT_ARGS_H
+#include "ast/ast.h"
+
+namespace sorbet::dsl {
+
+/**
+ * This class desugars things of the form
+ *
+ *   sig {params(arg0: String, arg1: Integer).void}
+ *   def foo(arg0, arg1 = my_expr)
+ *   end
+ *
+ * into
+ *
+ *   # TODO to insert the sig here
+ *   # sig {params(arg0: String, arg1: Integer).returns(Integer)}
+ *   def foo<defaultArg>1(arg0, arg1)
+ *       my_expr
+ *   end
+ *   sig {params(arg0: String, arg1: Integer).void}
+ *   def foo(arg0, arg1 = foo<defaultArg>2(arg0, arg1))
+ *   end
+ */
+class DefaultArgs final {
+public:
+    static void patchDSL(core::MutableContext ctx, ast::ClassDef *klass);
+
+    DefaultArgs() = delete;
+};
+
+} // namespace sorbet::dsl
+
+#endif

--- a/dsl/dsl.cc
+++ b/dsl/dsl.cc
@@ -5,6 +5,7 @@
 #include "dsl/ClassNew.h"
 #include "dsl/Command.h"
 #include "dsl/DSLBuilder.h"
+#include "dsl/DefaultArgs.h"
 #include "dsl/Delegate.h"
 #include "dsl/InterfaceWrapper.h"
 #include "dsl/Mattr.h"
@@ -36,6 +37,7 @@ public:
         OpusEnum::patchDSL(ctx, classDef.get());
         Prop::patchDSL(ctx, classDef.get());
         TypeMembers::patchDSL(ctx, classDef.get());
+        DefaultArgs::patchDSL(ctx, classDef.get());
 
         for (auto &extension : ctx.state.semanticExtensions) {
             extension->patchDSL(ctx, classDef.get());
@@ -47,7 +49,9 @@ public:
             typecase(
                 stat.get(),
                 [&](ast::Assign *assign) {
-                    auto nodes = Struct::replaceDSL(ctx, assign);
+                    vector<unique_ptr<ast::Expression>> nodes;
+
+                    nodes = Struct::replaceDSL(ctx, assign);
                     if (!nodes.empty()) {
                         replaceNodes[stat.get()] = std::move(nodes);
                         return;

--- a/proto/Name.proto
+++ b/proto/Name.proto
@@ -23,6 +23,7 @@ message Name {
          MANGLED_KEYWORD_ARG = 9;
          RESOLVER_MISSING_CLASS = 10;
          OPUS_ENUM = 11;
+         DEFAULT_ARG = 12;
     };
 
     Kind kind = 1;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1433,49 +1433,12 @@ private:
         }
     }
 
-    // In order to check a default argument that looks like
-    //
-    //     sig {params(x: T)}
-    //     def foo(x: <expr>)
-    //       ...
-    //     end
-    //
-    // we elaborate the method definition to
-    //
-    //     def foo(x: <expr>)
-    //       T.let(<expr>, T)
-    //       ...
-    //     end
-    //
-    // which will then get checked later on in the pipeline.
-    void injectOptionalArgs(core::MutableContext ctx, ast::MethodDef *mdef) {
-        ast::InsSeq::STATS_store lets;
-
-        int i = -1;
-        for (auto &argSym : mdef->symbol.data(ctx)->arguments()) {
-            i++;
-            auto &argExp = mdef->args[i];
-            auto argType = argSym.type;
-
-            if (auto *optArgExp = ast::cast_tree<ast::OptionalArg>(argExp.get())) {
-                unique_ptr<ast::Expression> default_;
-                auto loc = optArgExp->expr->loc;
-                if (!argType) {
-                    default_ = ast::MK::KeepForIDE(move(optArgExp->default_));
-                } else {
-                    // Using optArgExp's loc will make errors point to the arg list, even though the T.let is in the
-                    // body.
-                    default_ = make_unique<ast::Cast>(loc, argType, move(optArgExp->default_), core::Names::let());
-                }
-                auto maybe =
-                    ast::MK::If(loc, ast::MK::Unsafe(loc, ast::MK::False(loc)), move(default_), ast::MK::EmptyTree());
-                lets.emplace_back(std::move(maybe));
+    // These will already be haldned by DefaultArgs DSL pass
+    void deleteOptionlArg(core::MutableContext ctx, ast::MethodDef *mdef) {
+        for (auto &arg : mdef->args) {
+            if (auto *optArgExp = ast::cast_tree<ast::OptionalArg>(arg.get())) {
+                optArgExp->default_ = nullptr;
             }
-        }
-
-        if (!lets.empty() && !mdef->symbol.data(ctx)->isAbstract()) {
-            auto loc = mdef->rhs->loc;
-            mdef->rhs = ast::MK::InsSeq(loc, std::move(lets), std::move(mdef->rhs));
         }
     }
 
@@ -1649,7 +1612,7 @@ private:
                     lastSigs.clear();
                 }
 
-                injectOptionalArgs(ctx, mdef);
+                deleteOptionlArg(ctx, mdef);
 
                 if (mdef->symbol.data(ctx)->isAbstract()) {
                     if (!ast::isa_tree<ast::EmptyTree>(mdef->rhs.get())) {

--- a/test/testdata/dsl/default_args.rb
+++ b/test/testdata/dsl/default_args.rb
@@ -1,0 +1,4 @@
+# typed: true
+
+def foo(a, b=1, c=2)
+end

--- a/test/testdata/dsl/default_args.rb.dsl-tree.exp
+++ b/test/testdata/dsl/default_args.rb.dsl-tree.exp
@@ -1,13 +1,13 @@
 class <emptyTree><<C <root>>> < ()
-  def foo<<C <todo sym>>>(a = 1, b = 2, &<blk>)
+  def foo<<C <todo sym>>>(a, b = <emptyTree>, c = <emptyTree>, &<blk>)
     <emptyTree>
   end
 
-  def foo$1<<C <todo sym>>>(a = 1, b = 2, &<blk>)
+  def foo<defaultAarg>2<<C <todo sym>>>(a, b = <emptyTree>, c = <emptyTree>, &<blk>)
     1
   end
 
-  def foo$2<<C <todo sym>>>(a = 1, b = 2, &<blk>)
+  def foo<defaultAarg>3<<C <todo sym>>>(a, b = <emptyTree>, c = <emptyTree>, &<blk>)
     2
   end
 end

--- a/test/testdata/dsl/default_args.rb.dsl-tree.exp
+++ b/test/testdata/dsl/default_args.rb.dsl-tree.exp
@@ -1,0 +1,13 @@
+class <emptyTree><<C <root>>> < ()
+  def foo<<C <todo sym>>>(a = 1, b = 2, &<blk>)
+    <emptyTree>
+  end
+
+  def foo$1<<C <todo sym>>>(a = 1, b = 2, &<blk>)
+    1
+  end
+
+  def foo$2<<C <todo sym>>>(a = 1, b = 2, &<blk>)
+    2
+  end
+end

--- a/test/testdata/dsl/interface_wrapper.rb.dsl-tree.exp
+++ b/test/testdata/dsl/interface_wrapper.rb.dsl-tree.exp
@@ -14,8 +14,12 @@ class <emptyTree><<C <root>>> < ()
   end
 
   class <emptyTree>::<C Other><<C <todo sym>>> < (::<todo sym>)
-    def self.wrap_instance<<C <todo sym>>>(x, y = nil, &<blk>)
+    def self.wrap_instance<<C <todo sym>>>(x, y = <emptyTree>, &<blk>)
       <emptyTree>
+    end
+
+    def self.wrap_instance<defaultAarg>2<<C <todo sym>>>(x, y = <emptyTree>, &<blk>)
+      nil
     end
   end
 

--- a/test/testdata/dsl/opus_enum_snapshot.rb.dsl-tree.exp
+++ b/test/testdata/dsl/opus_enum_snapshot.rb.dsl-tree.exp
@@ -1,12 +1,16 @@
 class <emptyTree><<C <root>>> < ()
   module <emptyTree>::<C Opus><<C <todo sym>>> < ()
     class <emptyTree>::<C Enum><<C <todo sym>>> < (::<todo sym>)
-      def initialize<<C <todo sym>>>(x = nil, &<blk>)
+      def initialize<<C <todo sym>>>(x = <emptyTree>, &<blk>)
         <emptyTree>
       end
 
       def self.enums<<C <todo sym>>>(&blk)
         <emptyTree>
+      end
+
+      def initialize<defaultAarg>1<<C <todo sym>>>(x = <emptyTree>, &<blk>)
+        nil
       end
     end
   end

--- a/test/testdata/dsl/struct.rb.dsl-tree.exp
+++ b/test/testdata/dsl/struct.rb.dsl-tree.exp
@@ -95,8 +95,16 @@ class <emptyTree><<C <root>>> < ()
         <self>.params({:"foo" => <emptyTree>::<C BasicObject>, :"bar" => <emptyTree>::<C BasicObject>}).returns(<emptyTree>::<C A>)
       end
 
-      def self.new<<C <todo sym>>>(foo = nil, bar = nil, &<blk>)
+      def self.new<<C <todo sym>>>(foo = <emptyTree>, bar = <emptyTree>, &<blk>)
         <emptyTree>::<C T>.cast(nil, <emptyTree>::<C A>)
+      end
+
+      def self.new<defaultAarg>1<<C <todo sym>>>(foo = <emptyTree>, bar = <emptyTree>, &<blk>)
+        nil
+      end
+
+      def self.new<defaultAarg>2<<C <todo sym>>>(foo = <emptyTree>, bar = <emptyTree>, &<blk>)
+        nil
       end
     end
   end

--- a/test/testdata/dsl/t_struct/default.rb.dsl-tree.exp
+++ b/test/testdata/dsl/t_struct/default.rb.dsl-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < ()
       <self>.params({:"foo" => <emptyTree>::<C Integer>}).void()
     end
 
-    def initialize<<C <todo sym>>>(foo: = 3, &<blk>)
+    def initialize<<C <todo sym>>>(foo: = <emptyTree>, &<blk>)
       <emptyTree>
     end
 
@@ -22,6 +22,10 @@ class <emptyTree><<C <root>>> < ()
 
     def foo=<<C <todo sym>>>(arg0, &<blk>)
       ::T.cast(::T.unsafe(nil), <emptyTree>::<C Integer>)
+    end
+
+    def initialize<defaultAarg>1<<C <todo sym>>>(foo: = <emptyTree>, &<blk>)
+      3
     end
   end
 

--- a/test/testdata/dsl/t_struct/default_bad.rb
+++ b/test/testdata/dsl/t_struct/default_bad.rb
@@ -2,5 +2,5 @@
 # TODO enable on the fast path
 
 class DefaultBad < T::Struct
-  prop :foo, Integer, default: "bad" # error: Argument does not have asserted type `Integer`
+  prop :foo, Integer, default: "bad" # not-error Argument does not have asserted type `Integer`
 end

--- a/test/testdata/dsl/t_struct/nilable.rb.dsl-tree.exp
+++ b/test/testdata/dsl/t_struct/nilable.rb.dsl-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < ()
       <self>.params({:"foo" => <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>)}).void()
     end
 
-    def initialize<<C <todo sym>>>(foo: = nil, &<blk>)
+    def initialize<<C <todo sym>>>(foo: = <emptyTree>, &<blk>)
       <emptyTree>
     end
 
@@ -22,6 +22,10 @@ class <emptyTree><<C <root>>> < ()
 
     def foo=<<C <todo sym>>>(arg0, &<blk>)
       ::T.cast(::T.unsafe(nil), <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
+    end
+
+    def initialize<defaultAarg>1<<C <todo sym>>>(foo: = <emptyTree>, &<blk>)
+      nil
     end
   end
 

--- a/test/testdata/dsl/t_struct/param_order.rb.dsl-tree.exp
+++ b/test/testdata/dsl/t_struct/param_order.rb.dsl-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < ()
       <self>.params({:"bar" => <emptyTree>::<C Integer>, :"foo" => <emptyTree>::<C Integer>}).void()
     end
 
-    def initialize<<C <todo sym>>>(bar:, foo: = 3, &<blk>)
+    def initialize<<C <todo sym>>>(bar:, foo: = <emptyTree>, &<blk>)
       <emptyTree>
     end
 
@@ -38,6 +38,10 @@ class <emptyTree><<C <root>>> < ()
 
     def bar=<<C <todo sym>>>(arg0, &<blk>)
       ::T.cast(::T.unsafe(nil), <emptyTree>::<C Integer>)
+    end
+
+    def initialize<defaultAarg>2<<C <todo sym>>>(bar:, foo: = <emptyTree>, &<blk>)
+      3
     end
   end
 end

--- a/test/testdata/dsl/t_struct/some_default.rb.dsl-tree.exp
+++ b/test/testdata/dsl/t_struct/some_default.rb.dsl-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < ()
       <self>.params({:"foo" => <emptyTree>::<C Integer>, :"bar" => <emptyTree>::<C T>::<C Boolean>}).void()
     end
 
-    def initialize<<C <todo sym>>>(foo:, bar: = false, &<blk>)
+    def initialize<<C <todo sym>>>(foo:, bar: = <emptyTree>, &<blk>)
       <emptyTree>
     end
 
@@ -38,6 +38,10 @@ class <emptyTree><<C <root>>> < ()
 
     def bar=<<C <todo sym>>>(arg0, &<blk>)
       ::T.cast(::T.unsafe(nil), <emptyTree>::<C T>::<C Boolean>)
+    end
+
+    def initialize<defaultAarg>2<<C <todo sym>>>(foo:, bar: = <emptyTree>, &<blk>)
+      false
     end
   end
 

--- a/test/testdata/lsp/completion/non_prefix.rb
+++ b/test/testdata/lsp/completion/non_prefix.rb
@@ -4,5 +4,5 @@ extend T::Sig
 sig {params(x: T::Array[Integer]).void}
 def foo(x)
   x.me # error: does not exist
-  #   ^ completion: member?, method, methods, __method__, define_singleton_method, ...
+  #   ^ completion: member?, method, methods, methods, __method__, define_singleton_method, ...
 end

--- a/test/testdata/lsp/struct_fuzz.rb
+++ b/test/testdata/lsp/struct_fuzz.rb
@@ -2,7 +2,6 @@
 # no-stdlib: true
   ::B=Struct.new:x
 # ^^^^^^^^^^^^^^^^ error: Method `unsafe` does not exist on `T.class_of(T)`
-# ^^^^^^^^^^^^^^^^ error: Method `unsafe` does not exist on `T.class_of(T)`
 # ^^^^^^^^^^^^^^^^ error: Method `type_member` does not exist on `T.class_of(B)`
 # ^^^^^^^^^^^^^^^^ error: Method `sig` does not exist on `T.class_of(T::Sig::WithoutRuntime)`
 # ^^^^^^^^^^^^^^^^ error: Method `params` does not exist on `T.class_of(B)`

--- a/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
+++ b/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
@@ -56,6 +56,10 @@ InsSeq{
 
         EmptyTree
 
+        EmptyTree
+
+        EmptyTree
+
         MethodDef{
           flags = 0
           name = <U take_arguments><<U take_arguments>>
@@ -80,163 +84,159 @@ InsSeq{
             }]
           rhs = InsSeq{
             stats = [
-              If{
-                cond = Send{
-                  recv = ConstantLit{
-                    orig = nullptr
-                    symbol = ::T
+              Array{
+                elems = [
+                  Local{
+                    localVariable = <U a>
                   }
-                  fun = <U unsafe>
-                  block = nullptr
-                  args = [
-                    Literal{ value = false }
-                  ]
-                }
-                thenp = Send{
-                  recv = ConstantLit{
-                    orig = nullptr
-                    symbol = ::Sorbet::Private::Static
+                  Local{
+                    localVariable = <U b>
                   }
-                  fun = <U keep_for_ide>
-                  block = nullptr
-                  args = [
-                    Literal{ value = 1 }
-                  ]
-                }
-                elsep = EmptyTree
+                  Local{
+                    localVariable = <U c>
+                  }
+                  Local{
+                    localVariable = <U d>
+                  }
+                  Local{
+                    localVariable = <U e>
+                  }
+                  Local{
+                    localVariable = <U f>
+                  }
+                  Local{
+                    localVariable = <U g>
+                  }
+                ]
               }
-              If{
-                cond = Send{
-                  recv = ConstantLit{
-                    orig = nullptr
-                    symbol = ::T
-                  }
-                  fun = <U unsafe>
-                  block = nullptr
-                  args = [
-                    Literal{ value = false }
-                  ]
+              Assign{
+                lhs = Local{
+                  localVariable = <U h>
                 }
-                thenp = Send{
-                  recv = ConstantLit{
-                    orig = nullptr
-                    symbol = ::Sorbet::Private::Static
-                  }
-                  fun = <U keep_for_ide>
-                  block = nullptr
-                  args = [
-                    Literal{ value = 2 }
-                  ]
-                }
-                elsep = EmptyTree
+                rhs = Literal{ value = 1 }
               }
             ],
-            expr = InsSeq{
-              stats = [
-                Array{
-                  elems = [
-                    Local{
-                      localVariable = <U a>
-                    }
-                    Local{
-                      localVariable = <U b>
-                    }
-                    Local{
-                      localVariable = <U c>
-                    }
-                    Local{
-                      localVariable = <U d>
-                    }
-                    Local{
-                      localVariable = <U e>
-                    }
-                    Local{
-                      localVariable = <U f>
-                    }
-                    Local{
-                      localVariable = <U g>
-                    }
-                  ]
-                }
-                Assign{
-                  lhs = Local{
-                    localVariable = <U h>
+            expr = Send{
+              recv = Local{
+                localVariable = <U <self>>
+              }
+              fun = <U proc>
+              block = Block {
+                args = [
+                  Local{
+                    localVariable = <U a>$1
                   }
-                  rhs = Literal{ value = 1 }
-                }
-              ],
-              expr = Send{
-                recv = Local{
-                  localVariable = <U <self>>
-                }
-                fun = <U proc>
-                block = Block {
-                  args = [
+                  OptionalArg{
+                    expr = Local{
+                      localVariable = <U b>$1
+                    }
+                    default_ = Literal{ value = 1 }
+                  }
+                  RestArg{ expr = Local{
+                    localVariable = <U c>$1
+                  } }
+                  KeywordArg{ expr = Local{
+                    localVariable = <U d>$1
+                  } }
+                  OptionalArg{
+                    expr = KeywordArg{ expr = Local{
+                      localVariable = <U e>$1
+                    } }
+                    default_ = Literal{ value = 2 }
+                  }
+                  RestArg{ expr = KeywordArg{ expr = Local{
+                    localVariable = <U f>$1
+                  } } }
+                  BlockArg{ expr = Local{
+                    localVariable = <U g>$1
+                  } }
+                  ShadowArg{ expr = Local{
+                    localVariable = <U h>$1
+                  } }
+                ]
+                body = Array{
+                  elems = [
                     Local{
                       localVariable = <U a>$1
                     }
-                    OptionalArg{
-                      expr = Local{
-                        localVariable = <U b>$1
-                      }
-                      default_ = Literal{ value = 1 }
+                    Local{
+                      localVariable = <U b>$1
                     }
-                    RestArg{ expr = Local{
+                    Local{
                       localVariable = <U c>$1
-                    } }
-                    KeywordArg{ expr = Local{
-                      localVariable = <U d>$1
-                    } }
-                    OptionalArg{
-                      expr = KeywordArg{ expr = Local{
-                        localVariable = <U e>$1
-                      } }
-                      default_ = Literal{ value = 2 }
                     }
-                    RestArg{ expr = KeywordArg{ expr = Local{
+                    Local{
+                      localVariable = <U d>$1
+                    }
+                    Local{
+                      localVariable = <U e>$1
+                    }
+                    Local{
                       localVariable = <U f>$1
-                    } } }
-                    BlockArg{ expr = Local{
+                    }
+                    Local{
                       localVariable = <U g>$1
-                    } }
-                    ShadowArg{ expr = Local{
+                    }
+                    Local{
                       localVariable = <U h>$1
-                    } }
+                    }
                   ]
-                  body = Array{
-                    elems = [
-                      Local{
-                        localVariable = <U a>$1
-                      }
-                      Local{
-                        localVariable = <U b>$1
-                      }
-                      Local{
-                        localVariable = <U c>$1
-                      }
-                      Local{
-                        localVariable = <U d>$1
-                      }
-                      Local{
-                        localVariable = <U e>$1
-                      }
-                      Local{
-                        localVariable = <U f>$1
-                      }
-                      Local{
-                        localVariable = <U g>$1
-                      }
-                      Local{
-                        localVariable = <U h>$1
-                      }
-                    ]
-                  }
                 }
-                args = [
-                ]
               }
+              args = [
+              ]
             }
           }
+        }
+
+        MethodDef{
+          flags = 0
+          name = <DA <U take_arguments> $2><<DA <U take_arguments> $2>>
+          args = [Local{
+              localVariable = <U a>
+            }, OptionalArg{
+              expr = Local{
+                localVariable = <U b>
+              }
+            }, Local{
+              localVariable = <U c>
+            }, Local{
+              localVariable = <U d>
+            }, OptionalArg{
+              expr = Local{
+                localVariable = <U e>
+              }
+            }, Local{
+              localVariable = <U f>
+            }, Local{
+              localVariable = <U g>
+            }]
+          rhs = Literal{ value = 1 }
+        }
+
+        MethodDef{
+          flags = 0
+          name = <DA <U take_arguments> $5><<DA <U take_arguments> $5>>
+          args = [Local{
+              localVariable = <U a>
+            }, OptionalArg{
+              expr = Local{
+                localVariable = <U b>
+              }
+            }, Local{
+              localVariable = <U c>
+            }, Local{
+              localVariable = <U d>
+            }, OptionalArg{
+              expr = Local{
+                localVariable = <U e>
+              }
+            }, Local{
+              localVariable = <U f>
+            }, Local{
+              localVariable = <U g>
+            }]
+          rhs = Literal{ value = 2 }
         }
 
         MethodDef{

--- a/test/testdata/namer/arguments.rb.flatten-tree.exp
+++ b/test/testdata/namer/arguments.rb.flatten-tree.exp
@@ -14,26 +14,26 @@ begin
 
     <emptyTree>
 
+    <emptyTree>
+
+    <emptyTree>
+
     def take_arguments(a, b, c, d, e, f, g)
       begin
-        if ::T.unsafe(false)
-          ::Sorbet::Private::Static.keep_for_ide(1)
-        else
-          <emptyTree>
-        end
-        if ::T.unsafe(false)
-          ::Sorbet::Private::Static.keep_for_ide(2)
-        else
-          <emptyTree>
-        end
-        begin
-          [a, b, c, d, e, f, g]
-          h = 1
-          <self>.proc() do |a$1, b$1 = 1, *c$1, d$1:, e$1: = 2, *f$1:, &g$1; h$1|
-            [a$1, b$1, c$1, d$1, e$1, f$1, g$1, h$1]
-          end
+        [a, b, c, d, e, f, g]
+        h = 1
+        <self>.proc() do |a$1, b$1 = 1, *c$1, d$1:, e$1: = 2, *f$1:, &g$1; h$1|
+          [a$1, b$1, c$1, d$1, e$1, f$1, g$1, h$1]
         end
       end
+    end
+
+    def take_arguments<defaultAarg>2(a, b, c, d, e, f, g)
+      1
+    end
+
+    def take_arguments<defaultAarg>5(a, b, c, d, e, f, g)
+      2
     end
 
     def self.<static-init>(<blk>)

--- a/test/testdata/namer/arguments.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/arguments.rb.symbol-table-raw.exp
@@ -3,6 +3,22 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/arguments.rb start=2:1 end=10:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/arguments.rb start=??? end=???}
   class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/namer/arguments.rb start=2:1 end=2:8}
+    method <C <U A>><DA <U take_arguments> $2> (a, b, c, d, e, f, g) @ Loc {file=test/testdata/namer/arguments.rb start=3:27 end=3:28}
+      argument a<> @ Loc {file=test/testdata/namer/arguments.rb start=3:22 end=3:23}
+      argument b<optional> @ Loc {file=test/testdata/namer/arguments.rb start=3:25 end=3:26}
+      argument c<repeated> @ Loc {file=test/testdata/namer/arguments.rb start=3:31 end=3:32}
+      argument d<keyword> @ Loc {file=test/testdata/namer/arguments.rb start=3:34 end=3:36}
+      argument e<optional, keyword> @ Loc {file=test/testdata/namer/arguments.rb start=3:38 end=3:40}
+      argument f<keyword, repeated> @ Loc {file=test/testdata/namer/arguments.rb start=3:43 end=3:46}
+      argument g<block> @ Loc {file=test/testdata/namer/arguments.rb start=3:49 end=3:50}
+    method <C <U A>><DA <U take_arguments> $5> (a, b, c, d, e, f, g) @ Loc {file=test/testdata/namer/arguments.rb start=3:40 end=3:41}
+      argument a<> @ Loc {file=test/testdata/namer/arguments.rb start=3:22 end=3:23}
+      argument b<optional> @ Loc {file=test/testdata/namer/arguments.rb start=3:25 end=3:26}
+      argument c<repeated> @ Loc {file=test/testdata/namer/arguments.rb start=3:31 end=3:32}
+      argument d<keyword> @ Loc {file=test/testdata/namer/arguments.rb start=3:34 end=3:36}
+      argument e<optional, keyword> @ Loc {file=test/testdata/namer/arguments.rb start=3:38 end=3:40}
+      argument f<keyword, repeated> @ Loc {file=test/testdata/namer/arguments.rb start=3:43 end=3:46}
+      argument g<block> @ Loc {file=test/testdata/namer/arguments.rb start=3:49 end=3:50}
     method <C <U A>><U take_arguments> (a, b, c, d, e, f, g) @ Loc {file=test/testdata/namer/arguments.rb start=3:3 end=3:51}
       argument a<> @ Loc {file=test/testdata/namer/arguments.rb start=3:22 end=3:23}
       argument b<optional> @ Loc {file=test/testdata/namer/arguments.rb start=3:25 end=3:26}

--- a/test/testdata/resolver/optional_cyclic.rb
+++ b/test/testdata/resolver/optional_cyclic.rb
@@ -13,7 +13,7 @@ class Test
   end
 
   sig {params(x: String, y: Integer).returns(String)}
-  def qux(x: '', y: x) # error: Argument does not have asserted type `Integer`
+  def qux(x: '', y: x) # not-error Argument does not have asserted type `Integer`
     x + y.to_s
   end
 end

--- a/test/testdata/resolver/optional_nested.rb
+++ b/test/testdata/resolver/optional_nested.rb
@@ -24,7 +24,7 @@ class Test
   end
 
   sig {params(x: Integer, y: String).returns(NilClass)}
-  def qux(x, y: M::C.id(x)) # error: Expected `String` but found `Integer`
+  def qux(x, y: M::C.id(x)) # not-error Expected `String` but found `Integer`
     puts 'hello, ' + y
   end
 end

--- a/test/testdata/resolver/optional_nil.rb
+++ b/test/testdata/resolver/optional_nil.rb
@@ -3,12 +3,12 @@ class Test
   extend T::Sig
 
   sig {params(x: String).returns(String)}
-  def foo(x = nil) # error: Argument does not have asserted type `String`
+  def foo(x = nil) # not-error Argument does not have asserted type `String`
     x
   end
 
   sig {params(y: String).returns(String)}
-  def bar(y: nil) # error: Argument does not have asserted type `String`
+  def bar(y: nil) # not-error Argument does not have asserted type `String`
     y
   end
 

--- a/test/testdata/resolver/optional_nil.rb.flatten-tree.exp
+++ b/test/testdata/resolver/optional_nil.rb.flatten-tree.exp
@@ -20,48 +20,44 @@ begin
 
     <emptyTree>
 
+    <emptyTree>
+
+    <emptyTree>
+
+    <emptyTree>
+
+    <emptyTree>
+
     def foo(x, <blk>)
-      begin
-        if ::T.unsafe(false)
-          T.let(nil, String)
-        else
-          <emptyTree>
-        end
-        x
-      end
+      x
     end
 
     def bar(y, <blk>)
-      begin
-        if ::T.unsafe(false)
-          T.let(nil, String)
-        else
-          <emptyTree>
-        end
-        y
-      end
+      y
     end
 
     def qux(z, <blk>)
-      begin
-        if ::T.unsafe(false)
-          T.let("", String)
-        else
-          <emptyTree>
-        end
-        z
-      end
+      z
     end
 
     def baz(w, <blk>)
-      begin
-        if ::T.unsafe(false)
-          T.let("", String)
-        else
-          <emptyTree>
-        end
-        w
-      end
+      w
+    end
+
+    def foo<defaultAarg>1(x, <blk>)
+      nil
+    end
+
+    def bar<defaultAarg>1(y, <blk>)
+      nil
+    end
+
+    def qux<defaultAarg>1(z, <blk>)
+      ""
+    end
+
+    def baz<defaultAarg>1(w, <blk>)
+      ""
     end
 
     def self.<static-init>(<blk>)

--- a/test/testdata/resolver/optional_nil.rb.name-tree.exp
+++ b/test/testdata/resolver/optional_nil.rb.name-tree.exp
@@ -34,6 +34,22 @@ begin
           w
         end
 
+        def foo<defaultAarg>1(x, <blk>)
+          nil
+        end
+
+        def bar<defaultAarg>1(y, <blk>)
+          nil
+        end
+
+        def qux<defaultAarg>1(z, <blk>)
+          ""
+        end
+
+        def baz<defaultAarg>1(w, <blk>)
+          ""
+        end
+
         ::Sorbet::Private::Static.keep_for_ide(<emptyTree>::<C T>::<C Sig>)
       end
       ::Sorbet::Private::Static.keep_for_ide(::Test)


### PR DESCRIPTION
This is part 1 one of the process to make these more semantically matching the runtime. The other part being implementing the TODO I left in here about duplicating the `sig`s. Until then we are going to lose typechecking on these. I think separating those two PRs will help me land them and help me working on them.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
