### PR TITLE
disable flakey test

### DIFF
--- a/test/cli/lsp-watchman-exit/lsp-watchman-exit.out
+++ b/test/cli/lsp-watchman-exit/lsp-watchman-exit.out
@@ -1,3 +1,0 @@
-Error running Watchman (with `/fake/watchman/path -j -p--no-pretty`).
-Watchman is required for Sorbet to detect changes to files made outside of your code editor.
-Don't need Watchman? Run Sorbet with `--disable-watchman`.

--- a/test/cli/lsp-watchman-exit/lsp-watchman-exit.sh
+++ b/test/cli/lsp-watchman-exit/lsp-watchman-exit.sh
@@ -1,2 +1,0 @@
-# Hold stdin open while Sorbet executes to prevent reader thread from closing process early.
-yes " " | main/sorbet --silence-dev-message --lsp --watchman-path /fake/watchman/path --dir test/cli/lsp-watchman-exit 2>&1


### PR DESCRIPTION
This has failed a bunch this week. While @jvilk-stripe investigates, lets disable it so we stop getting flakes like:
* https://buildkite.com/sorbet/sorbet/builds/6956#fd5dc920-8548-455b-9436-9b2a7456e60c
* https://buildkite.com/sorbet/sorbet/builds/6870#a25c555d-57fa-496e-af79-4bafe2bbf392/102-235
* https://buildkite.com/sorbet/sorbet/builds/6883#5be48b47-a65f-4012-9072-5c09169681df

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
