### PR TITLE
Fix update_testdata_exp.sh for document-symbols

### DIFF
--- a/test/print_document_symbols.cc
+++ b/test/print_document_symbols.cc
@@ -8,19 +8,69 @@
 
 namespace sorbet::realmain::lsp {
 using namespace std;
+
+namespace {
+constexpr string_view uriPrefix = "file:///"sv;
+
+// Given a path to a *.rb or *.rbupdate file, returns the set of edits to apply to Sorbet before requesting document
+// symbols along with the URI of the document.
+pair<string, vector<string>> findEditsToApply(string_view filePath) {
+    const auto idx = filePath.rfind('.');
+    if (idx == string_view::npos) {
+        Exception::raise("Invalid file path: {}", filePath);
+    }
+    string_view extension = filePath.substr(idx);
+    OSFileSystem fs;
+    vector<string> fileContents;
+    string uri;
+    fileContents.push_back(fs.readFile(filePath));
+    if (extension == ".rbupdate") {
+        // Find basename[.]version.rbupdate
+        const auto versionIdx = filePath.rfind('.', idx - 1);
+        if (versionIdx == string_view::npos) {
+            Exception::raise("rbupdate file is missing version number: {}", filePath);
+        }
+        string_view baseName = filePath.substr(0, versionIdx);
+        uri = absl::StrCat(uriPrefix, baseName, ".rb");
+        string_view versionString = filePath.substr(versionIdx + 1, idx - versionIdx);
+        int version = stoi(string(versionString));
+        for (version = version - 1; version >= 0; version--) {
+            try {
+                fileContents.push_back(fs.readFile(fmt::format("{}.{}.rbupdate", baseName, version)));
+            } catch (FileNotFoundException e) {
+                // Ignore.
+            }
+        }
+        fileContents.push_back(fs.readFile(fmt::format("{}.rb", baseName)));
+        reverse(fileContents.begin(), fileContents.end());
+    } else {
+        uri = absl::StrCat(uriPrefix, filePath);
+    }
+    return make_pair(uri, move(fileContents));
+}
+
 int printDocumentSymbols(string_view filePath) {
     LSPWrapper lspWrapper("", false);
     lspWrapper.enableAllExperimentalFeatures();
     int nextId = 1;
-    string uriPrefix = "file:///";
+    int fileId = 1;
+    auto [fileUri, fileEdits] = findEditsToApply(filePath);
     test::initializeLSP("", uriPrefix, lspWrapper, nextId);
-    string fileUri = uriPrefix + string(filePath);
     {
-        OSFileSystem fs;
-        auto params = make_unique<DidOpenTextDocumentParams>(
-            make_unique<TextDocumentItem>(fileUri, "ruby", 1, fs.readFile(filePath)));
+        // Initialize empty file.
+        auto params =
+            make_unique<DidOpenTextDocumentParams>(make_unique<TextDocumentItem>(fileUri, "ruby", fileId++, ""));
         auto notif = make_unique<NotificationMessage>("2.0", LSPMethod::TextDocumentDidOpen, move(params));
-        // Discard responses; it's OK if the file has errors.
+        // Discard responses.
+        lspWrapper.getLSPResponsesFor(make_unique<LSPMessage>(move(notif)));
+    }
+
+    for (auto &fileEdit : fileEdits) {
+        vector<unique_ptr<TextDocumentContentChangeEvent>> edits;
+        edits.push_back(make_unique<TextDocumentContentChangeEvent>(fileEdit));
+        auto params = make_unique<DidChangeTextDocumentParams>(
+            make_unique<VersionedTextDocumentIdentifier>(fileUri, fileId++), move(edits));
+        auto notif = make_unique<NotificationMessage>("2.0", LSPMethod::TextDocumentDidChange, move(params));
         lspWrapper.getLSPResponsesFor(make_unique<LSPMessage>(move(notif)));
     }
 
@@ -45,6 +95,7 @@ int printDocumentSymbols(string_view filePath) {
         return 1;
     }
 }
+} // namespace
 } // namespace sorbet::realmain::lsp
 
 int main(int argc, char *argv[]) {
@@ -53,5 +104,5 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    return sorbet::realmain::lsp::printDocumentSymbols(argv[1]);
+    return sorbet::test::printDocumentSymbols(argv[1]);
 }

--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -35,7 +35,7 @@ passes=(
   cfg-raw
   cfg-json
   autogen
-  # document-symbols
+  document-symbols
 )
 
 bazel build //main:sorbet //test:print_document_symbols -c opt


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Background:

* LSP test_corpus tests can apply an edit to file `foo.rb` with files named `foo.[version].rbupdate`
* These rbupdate files can have document-symbols expectation files, which assert that the language server returns the given document symbols after applying the edit.
* @jez recently introduced a test that triggers a bug where document symbols does not return the correct location information for an update run on the fast path.
* Before this change, running `print_document_symbols` on file `foo.[version].rbupdate` would pass a file named `foo.[version].rbupdate` to the language server and then request its symbols. It
* As a result, running `print_document_symbols` on Jez's test would not trigger the bug, because it doesn't emulate the user editing the file.

This update changes `print_document_symbols` to work correctly on `.rbupdate` files by correctly passing the sequence of edits to the language server before making the document symbols request.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

@ptarjan noticed that the update script produced document-symbols exp files that didn't pass the tests.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Manually tested that invoking the update script no longer produces a diff for the existing exp files.
