### PR TITLE
better error message

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1061,8 +1061,8 @@ void Symbol::sanityCheck(const GlobalState &gs) const {
             const_cast<GlobalState &>(gs).enterSymbol(this->loc(), this->owner, this->name, this->flags);
         ENFORCE(current == current2);
         for (auto &e : members()) {
-            ENFORCE(e.first.exists(), "symbol without a name in scope");
-            ENFORCE(e.second.exists(), "name corresponding to a <none> in scope");
+            ENFORCE(e.first.exists(), name.toString(gs) + " has a member symbol without a name");
+            ENFORCE(e.second.exists(), name.toString(gs) + "." + e.first.toString(gs) + " corresponds to a <none>");
         }
     }
     if (this->isMethod()) {


### PR DESCRIPTION
```
Exception::raise(): core/Symbols.cc:1065 enforced condition e.second.exists() has failed: <Class:Tmpname>.create$1 corresponds to a <none>
```

is much more helpful to tell me what is going on

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
