### PR TITLE
Fix `start_with?` signature

### DIFF
--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -1752,7 +1752,7 @@ class String < Object
   # ```
   sig do
     params(
-        arg0: String,
+        arg0: T.any(String, Regexp),
     )
     .returns(T::Boolean)
   end


### PR DESCRIPTION
### Motivation

As noted in the documentation of `String#start_with?`, its parameters can be a `String` or a `Regexp`. The current RBI wasn't reflecting that.

### Test plan

No tests.