### PR TITLE
Fix some `File` method parameter types

### DIFF
--- a/rbi/core/file.rbi
+++ b/rbi/core/file.rbi
@@ -123,7 +123,7 @@ class File < IO
   # ```
   sig do
     params(
-        file: String,
+        file: T.any(String, Pathname),
         suffix: String,
     )
     .returns(String)
@@ -293,7 +293,7 @@ class File < IO
   # ```
   sig do
     params(
-        file: String,
+        file: T.any(String, Pathname),
     )
     .returns(String)
   end
@@ -389,7 +389,7 @@ class File < IO
   # ```
   sig do
     params(
-        path: String,
+        path: T.any(String, Pathname),
     )
     .returns(String)
   end
@@ -511,7 +511,7 @@ class File < IO
   sig do
     params(
         pattern: String,
-        path: String,
+        path: T.any(String, Pathname),
         flags: Integer,
     )
     .returns(T::Boolean)
@@ -852,7 +852,7 @@ class File < IO
   # ```
   sig do
     params(
-        file: String,
+        file: T.any(String, Pathname),
     )
     .returns([String, String])
   end


### PR DESCRIPTION
- `File.basename`,
- `File.dirname`,
- `File.extname`,
- `File.fnmatch`, and
- `File.split`

all accept `String` or `Pathname` parameters since at least Ruby 2.2.

This can be confirmed by checking the C code in `file.c` and `dir.c` to see that these methods process their path/filename parameters using `FilePathStringValue` which properly converts `Pathname`s to `String`s.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
```
foo.rb:150: Expected String but found Pathname for argument file https://srb.help/7002
     150 |    basename = File.basename(relative_to_root, '.*')
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    https://github.com/sorbet/sorbet/tree/19e6ed2468a2cf62794e21bf255f24c894b8cb4c/rbi/core/file.rbi#L126: Method File.basename has specified file as String
     126 |        file: String,
                  ^^^^
  Got Pathname originating from:
    foo.rb:149:
     149 |    relative_to_root = Pathname.new(file_path).relative_path_from(root)
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No tests.
