### PR TITLE
Fix `Enumerator#initialize` parameter type

### DIFF
--- a/rbi/core/enumerator.rbi
+++ b/rbi/core/enumerator.rbi
@@ -193,7 +193,7 @@ class Enumerator < Object
 
   sig do
     params(
-        arg0: Integer,
+        arg0: T.any(Integer, T.proc.returns(Integer)),
         blk: T.proc.params(arg0: Enumerator::Yielder).void,
     )
     .void


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`Enumerator#initialize` takes either an `Integer` or a callable that returns an `Integer` as its optional parameter. The current RBI was missing the latter callable type.

```ruby
Enumerator.new(5) { }.size        #=> 5
Enumerator.new(-> { 5 }) { }.size #=> 5
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No tests.
