### PR TITLE
Upgrade to LLVM9

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -188,9 +188,9 @@ build:ubsan --define unsanitized=false
 build:ubsan --copt=-DHAS_SANITIZER
 
 # Bazel links C++ files with $CC, not $CXX, this breaks UBSan
-build:sanitize-linux --linkopt=external/llvm_toolchain/lib/clang/8.0.0/lib/linux/libclang_rt.asan_cxx-x86_64.a
-build:sanitize-linux --linkopt=external/llvm_toolchain/lib/clang/8.0.0/lib/linux/libclang_rt.ubsan_standalone_cxx-x86_64.a
-build:sanitize-linux --linkopt=external/llvm_toolchain/lib/clang/8.0.0/lib/linux/libclang_rt.ubsan_standalone-x86_64.a
+build:sanitize-linux --linkopt=external/llvm_toolchain/lib/clang/9.0.0/lib/linux/libclang_rt.asan_cxx-x86_64.a
+build:sanitize-linux --linkopt=external/llvm_toolchain/lib/clang/9.0.0/lib/linux/libclang_rt.ubsan_standalone_cxx-x86_64.a
+build:sanitize-linux --linkopt=external/llvm_toolchain/lib/clang/9.0.0/lib/linux/libclang_rt.ubsan_standalone-x86_64.a
 build:sanitize-linux --config=sanitize
 
 build:sanitize-mac --config=sanitize

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,7 +9,7 @@ load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 llvm_toolchain(
     name = "llvm_toolchain",
     absolute_paths = True,
-    llvm_version = "8.0.0",
+    llvm_version = "9.0.0",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -66,7 +66,7 @@ bool comesBeforeSymmetric(const TimeTravelingGlobalState &ttgs, u4 a, u4 b) {
 
 unique_ptr<LSPMessage> makeOpen(string_view path, u4 version, string_view source) {
     auto params = make_unique<DidOpenTextDocumentParams>(
-        make_unique<TextDocumentItem>(string(path), "ruby", version, string(source)));
+        make_unique<TextDocumentItem>(string(path), "ruby", static_cast<double>(version), string(source)));
     return make_unique<LSPMessage>(
         make_unique<NotificationMessage>("2.0", LSPMethod::TextDocumentDidOpen, move(params)));
 }
@@ -76,7 +76,7 @@ unique_ptr<LSPMessage> makeChange(string_view path, u4 version, string_view sour
     vector<unique_ptr<TextDocumentContentChangeEvent>> changes;
     changes.push_back(move(contentChange));
     auto params = make_unique<DidChangeTextDocumentParams>(
-        make_unique<VersionedTextDocumentIdentifier>(string(path), version), move(changes));
+        make_unique<VersionedTextDocumentIdentifier>(string(path), static_cast<double>(version)), move(changes));
     return make_unique<LSPMessage>(
         make_unique<NotificationMessage>("2.0", LSPMethod::TextDocumentDidChange, move(params)));
 }

--- a/test/helpers/lsp.cc
+++ b/test/helpers/lsp.cc
@@ -321,7 +321,7 @@ vector<unique_ptr<LSPMessage>> initializeLSP(string_view rootPath, string_view r
 }
 
 unique_ptr<LSPMessage> makeDidChange(std::string_view uri, std::string_view contents, int version) {
-    auto textDoc = make_unique<VersionedTextDocumentIdentifier>(string(uri), version);
+    auto textDoc = make_unique<VersionedTextDocumentIdentifier>(string(uri), static_cast<double>(version));
     auto textDocChange = make_unique<TextDocumentContentChangeEvent>(string(contents));
     vector<unique_ptr<TextDocumentContentChangeEvent>> textChanges;
     textChanges.push_back(move(textDocChange));

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -60,7 +60,7 @@ unique_ptr<LSPMessage> ProtocolTest::changeFile(string_view path, string_view ne
     sourceFileContents[string(path)] =
         make_shared<core::File>(string(path), string(newContents), core::File::Type::Normal);
     auto uri = getUri(path);
-    auto textDocIdent = make_unique<VersionedTextDocumentIdentifier>(uri, version);
+    auto textDocIdent = make_unique<VersionedTextDocumentIdentifier>(uri, static_cast<double>(version));
     vector<unique_ptr<TextDocumentContentChangeEvent>> changeEvents;
     changeEvents.push_back(make_unique<TextDocumentContentChangeEvent>(string(newContents)));
     auto didChangeParams = make_unique<DidChangeTextDocumentParams>(move(textDocIdent), move(changeEvents));

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -144,7 +144,7 @@ package(default_visibility = ["//visibility:public"])
     git_repository(
         name = "com_grail_bazel_toolchain",
         remote = "https://github.com/DarkDimius/bazel-toolchain.git",
-        commit = "ac74022b3e4357e9f6d0f55b08cf491f55cff2d8",
+        commit = "4db2af1249fa1c20f5f12830e4ad209e56c870a4",
         shallow_since = "1561409079 -0700",
     )
 

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -144,7 +144,7 @@ package(default_visibility = ["//visibility:public"])
     git_repository(
         name = "com_grail_bazel_toolchain",
         remote = "https://github.com/DarkDimius/bazel-toolchain.git",
-        commit = "fc345f29d7a2b5dd431be006b36be1b3d3936987",
+        commit = "ac74022b3e4357e9f6d0f55b08cf491f55cff2d8",
         shallow_since = "1561409079 -0700",
     )
 


### PR DESCRIPTION
### Motivation
Keep up to date with all the things.

This PR triggers a bug in bazel where bazel doesn't corrently invalidate stuff.
In order to fix the bug:
```
bazel clean --expunge
# if you are using bazel disk cache
rm -rf <path to disk cache>
mkdir -p <path to disk cache>
```



### Test plan
CI will fail. I'll need to rotate workers.

See included automated tests.
