### PR TITLE
Don't look at stuff if you aren't a UniqueNameKind::MangleRename

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -661,7 +661,12 @@ SymbolRef GlobalState::findRenamedSymbol(SymbolRef owner, SymbolRef sym) const {
             ENFORCE(nameData->unique.num > 1);
             auto nm =
                 lookupNameUnique(UniqueNameKind::MangleRename, nameData->unique.original, nameData->unique.num - 1);
-            return nm.exists() ? ownerScope->members()[nm] : Symbols::noSymbol();
+            if (!nm.exists()) {
+                return Symbols::noSymbol();
+            }
+            auto res = ownerScope->members()[nm];
+            ENFORCE(res.exists());
+            return res;
         }
     } else {
         u2 unique = 1;

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -652,6 +652,9 @@ SymbolRef GlobalState::findRenamedSymbol(SymbolRef owner, SymbolRef sym) const {
     SymbolData ownerScope = owner.dataAllowingNone(*this);
 
     if (nameData->kind == NameKind::UNIQUE) {
+        if (nameData->unique.uniqueNameKind != UniqueNameKind::MangleRename) {
+            return Symbols::noSymbol();
+        }
         if (nameData->unique.num == 1) {
             return Symbols::noSymbol();
         } else {


### PR DESCRIPTION
This cost me a day debugging. It turns out if we are using a different kind of unique symbol, this method was inserting `noSymbol`s into the symbol table at the `n-1`th position for whatever you were looking at.

I put an enforce to prove that the previous one is actually present too.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
