### PR TITLE
Add definition and signature for `Hash#dig`

### DIFF
--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_4_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_4_3_hidden.rbi.exp
@@ -3058,8 +3058,6 @@ class Hash
 
   def default_proc=(default_proc); end
 
-  def dig(*_); end
-
   def fetch_values(*_); end
 
   def flatten(*_); end

--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_3_hidden.rbi.exp
@@ -8058,8 +8058,6 @@ class Hash
 
   def default_proc=(default_proc); end
 
-  def dig(*_); end
-
   def fetch_values(*_); end
 
   def filter!(); end

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_4_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_4_3_hidden.rbi.exp
@@ -3064,8 +3064,6 @@ class Hash
 
   def default_proc=(default_proc); end
 
-  def dig(*_); end
-
   def fetch_values(*_); end
 
   def flatten(*_); end

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_3_hidden.rbi.exp
@@ -8064,8 +8064,6 @@ class Hash
 
   def default_proc=(default_proc); end
 
-  def dig(*_); end
-
   def fetch_values(*_); end
 
   def filter!(); end

--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -362,6 +362,23 @@ class Hash < Object
   sig {returns(T::Enumerator[[K, V]])}
   def delete_if(&blk); end
 
+  # Retrieves the value object corresponding to the each key objects repeatedly.
+  #
+  # ~~~ruby
+  # h = { foo: {bar: {baz: 1}}}
+  #
+  # h.dig(:foo, :bar, :baz)           #=> 1
+  # h.dig(:foo, :zot)                 #=> nil
+  # ~~~
+  sig do
+    params(
+      key: K,
+      rest: T.untyped
+    )
+    .returns(T.untyped)
+  end
+  def dig(key, *rest); end
+
   # Calls *block* once for each key in *hsh*, passing the key-value pair as
   # parameters.
   #


### PR DESCRIPTION
### Motivation

Adding the definition and signature for [`Hash#dig`](https://ruby-doc.org/core-2.3.0_preview1/Hash.html#method-i-dig).

Since `dig `reason about nested hashes the actual type of the returned value is quite complex to represent. I chose `T.nilable(BasicObject)` as for simplicity, I'm happy to apply a better suggestion.

### Test plan

No tests.
