### PR TITLE
Trevor/fix type members constant assignment

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1133,7 +1133,7 @@ public:
 
     unique_ptr<ast::ConstantLit> postTransformConstantLit(core::MutableContext ctx, unique_ptr<ast::ConstantLit> lit) {
         if (trackDependencies_) {
-            core::SymbolRef symbol = lit->symbol;
+            core::SymbolRef symbol = lit->symbol.data(ctx)->dealias(ctx);
             if (symbol == core::Symbols::T()) {
                 return lit;
             }

--- a/test/testdata/resolver/type_member_constant_assignment.rb
+++ b/test/testdata/resolver/type_member_constant_assignment.rb
@@ -1,0 +1,17 @@
+# typed: true
+
+module A
+  Result = T.type_alias {B::Result[Integer]}
+end
+
+module B
+  Result = C::Result
+end
+
+module C
+  module Result
+    extend T::Generic
+
+    X = type_member(:out)
+  end
+end

--- a/test/testdata/resolver/type_member_constant_assignment.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/type_member_constant_assignment.rb.symbol-table-raw.exp
@@ -6,7 +6,7 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     static-field-type-alias <C <U A>><C <U Result>> -> AppliedType {
       klass = <C <U C>><C <U Result>>
       targs = [
-        <C <U X>> = T.untyped
+        <C <U X>> = Integer
       ]
     } @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=4:3 end=4:9}
   class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=3:8 end=3:9}

--- a/test/testdata/resolver/type_member_constant_assignment.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/type_member_constant_assignment.rb.symbol-table-raw.exp
@@ -1,0 +1,38 @@
+class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4}, Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=3:1 end=17:4})
+  class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=3:1 end=17:4}
+      argument <blk><block> @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=??? end=???}
+  module <C <U A>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=3:1 end=3:9}
+    static-field-type-alias <C <U A>><C <U Result>> -> AppliedType {
+      klass = <C <U C>><C <U Result>>
+      targs = [
+        <C <U X>> = T.untyped
+      ]
+    } @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=4:3 end=4:9}
+  class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=3:8 end=3:9}
+    type-member(+) <S <C <U A>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=3:8 end=3:9}
+    method <S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=3:1 end=5:4}
+      argument <blk><block> @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=??? end=???}
+  module <C <U B>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=7:1 end=7:9}
+    static-field <C <U B>><C <U Result>> -> AliasType { symbol = <C <U C>><C <U Result>> } @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=8:3 end=8:9}
+  class <S <C <U B>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=7:8 end=7:9}
+    type-member(+) <S <C <U B>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U B>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=B) @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=7:8 end=7:9}
+    method <S <C <U B>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=7:1 end=9:4}
+      argument <blk><block> @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=??? end=???}
+  module <C <U C>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=11:1 end=11:9}
+    module <C <U C>><C <U Result>>[<C <U X>>] < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=12:3 end=12:16}
+      type-member(+) <C <U C>><C <U Result>><C <U X>> -> LambdaParam(<C <U C>><C <U Result>><C <U X>>, lower=T.noreturn, upper=<any>) @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=15:5 end=15:26}
+    class <C <U C>><S <C <U Result>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> (<C <U Generic>>, <C <U Helpers>>) @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=12:10 end=12:16}
+      type-member(+) <C <U C>><S <C <U Result>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U C>><S <C <U Result>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {
+  klass = <C <U C>><C <U Result>>
+  targs = [
+    <C <U X>> = <any>
+  ]
+}) @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=12:10 end=12:16}
+      method <C <U C>><S <C <U Result>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=12:3 end=16:6}
+        argument <blk><block> @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=??? end=???}
+  class <S <C <U C>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=11:8 end=11:9}
+    type-member(+) <S <C <U C>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U C>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=C) @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=11:8 end=11:9}
+    method <S <C <U C>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=11:1 end=17:4}
+      argument <blk><block> @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=??? end=???}
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
When collecting dependencies for type member resolution, constant assignments weren't being de-aliased.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixes #2038.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
