### PR TITLE
`String::start_with?` also accept a Regexp as parameter

### DIFF
--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -1752,7 +1752,7 @@ class String < Object
   # ```
   sig do
     params(
-        arg0: String,
+        arg0: T.any(String, Regexp)
     )
     .returns(T::Boolean)
   end


### PR DESCRIPTION
### Motivation

As of Ruby 2.6, `String::start_with?` accept both a `String` and a `Regexp`: https://ruby-doc.org/core-2.6.3/String.html#method-i-start_with-3F

### Test plan

No tests.
