### PR TITLE
Use "Delete" instead of "Replace with" for autocorrects which only delete code

### DIFF
--- a/core/Error.cc
+++ b/core/Error.cc
@@ -129,15 +129,16 @@ void ErrorBuilder::addAutocorrect(AutocorrectSuggestion &&autocorrect) {
     for (auto &edit : autocorrect.edits) {
         u4 n = edit.loc.endPos() - edit.loc.beginPos();
         if (gs.autocorrect) {
-            auto line = edit.replacement == ""
-                ? ErrorLine::from(edit.loc, "Deleted")
-                : ErrorLine::from(edit.loc, "{} `{}`", n == 0 ? "Inserted" : "Replaced with", edit.replacement);
+            auto line =
+                edit.replacement == ""
+                    ? ErrorLine::from(edit.loc, "Deleted")
+                    : ErrorLine::from(edit.loc, "{} `{}`", n == 0 ? "Inserted" : "Replaced with", edit.replacement);
 
             addErrorSection(ErrorSection("Autocorrect: Done", {line}));
         } else {
-            auto line = edit.replacement == ""
-                ? ErrorLine::from(edit.loc, "Delete")
-                : ErrorLine::from(edit.loc, "{} `{}`", n == 0 ? "Insert" : "Replace with", edit.replacement);
+            auto line = edit.replacement == "" ? ErrorLine::from(edit.loc, "Delete")
+                                               : ErrorLine::from(edit.loc, "{} `{}`",
+                                                                 n == 0 ? "Insert" : "Replace with", edit.replacement);
 
             addErrorSection(ErrorSection("Autocorrect: Use `-a` to autocorrect", {line}));
         }

--- a/core/Error.cc
+++ b/core/Error.cc
@@ -129,13 +129,17 @@ void ErrorBuilder::addAutocorrect(AutocorrectSuggestion &&autocorrect) {
     for (auto &edit : autocorrect.edits) {
         u4 n = edit.loc.endPos() - edit.loc.beginPos();
         if (gs.autocorrect) {
-            auto verb = n == 0 ? "Inserted" : "Replaced with";
-            addErrorSection(
-                ErrorSection("Autocorrect: Done", {ErrorLine::from(edit.loc, "{} `{}`", verb, edit.replacement)}));
+            auto line = edit.replacement == ""
+                ? ErrorLine::from(edit.loc, "Deleted")
+                : ErrorLine::from(edit.loc, "{} `{}`", n == 0 ? "Inserted" : "Replaced with", edit.replacement);
+
+            addErrorSection(ErrorSection("Autocorrect: Done", {line}));
         } else {
-            auto verb = n == 0 ? "Insert" : "Replace with";
-            addErrorSection(ErrorSection("Autocorrect: Use `-a` to autocorrect",
-                                         {ErrorLine::from(edit.loc, "{} `{}`", verb, edit.replacement)}));
+            auto line = edit.replacement == ""
+                ? ErrorLine::from(edit.loc, "Delete")
+                : ErrorLine::from(edit.loc, "{} `{}`", n == 0 ? "Insert" : "Replace with", edit.replacement);
+
+            addErrorSection(ErrorSection("Autocorrect: Use `-a` to autocorrect", {line}));
         }
     }
     this->autocorrects.emplace_back(move(autocorrect));

--- a/test/cli/rbi-with-code/rbi-with-code.out
+++ b/test/cli/rbi-with-code/rbi-with-code.out
@@ -2,7 +2,7 @@ test/cli/rbi-with-code/rbi-with-code.rbi:2: RBI methods must not have code https
      2 |  1
           ^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/rbi-with-code/rbi-with-code.rbi:2: Replace with ``
+    test/cli/rbi-with-code/rbi-with-code.rbi:2: Delete
      2 |  1
           ^
 
@@ -10,7 +10,7 @@ test/cli/rbi-with-code/rbi-with-code.rbi:6: RBI methods must not have code https
      6 |  1
           ^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/rbi-with-code/rbi-with-code.rbi:6: Replace with ``
+    test/cli/rbi-with-code/rbi-with-code.rbi:6: Delete
      6 |  1
      7 |  2
 
@@ -18,7 +18,7 @@ test/cli/rbi-with-code/rbi-with-code.rbi:7: RBI methods must not have code https
      7 |  2
           ^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/rbi-with-code/rbi-with-code.rbi:6: Replace with ``
+    test/cli/rbi-with-code/rbi-with-code.rbi:6: Delete
      6 |  1
      7 |  2
 Errors: 3


### PR DESCRIPTION
### Motivation
Any autocorrect which deletes code, such as abstract method bodies, print the following message:

```
test.rb:13: Abstract methods must not contain any code in their body https://srb.help/5019
    13 |    2
            ^
  Autocorrect: Use `-a` to autocorrect
    test.rb:13: Replace with
    13 |    2
            ^
```

The "Replace with" description here is not elegant and does not really describe what the autocorrect is going to do. 

This PR shows the message "Delete" for blank replacements instead:

```
  Autocorrect: Use `-a` to autocorrect
    test.rb:13: Delete
    13 |    2
            ^
```

### Test plan
I have modified the existing automated tests to use "Delete" instead of "Replace with" where appropriate.
