### PR TITLE
Always redeclare Elem even in RBIs

### DIFF
--- a/rbi/gems/msgpack.rbi
+++ b/rbi/gems/msgpack.rbi
@@ -149,7 +149,7 @@ end
 
 class MessagePack::ExtensionValue < Struct
   include ::MessagePack::CoreExt
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 
   sig {returns(::T.untyped)}
   def payload(); end

--- a/rbi/gems/msgpack.rbi
+++ b/rbi/gems/msgpack.rbi
@@ -149,6 +149,8 @@ end
 
 class MessagePack::ExtensionValue < Struct
   include ::MessagePack::CoreExt
+  Elem = type_member(:out, fixed: T.untyped)
+
   sig {returns(::T.untyped)}
   def payload(); end
 

--- a/rbi/stdlib/net.rbi
+++ b/rbi/stdlib/net.rbi
@@ -5812,6 +5812,8 @@ end
 # :   nil indicates [RFC-822] group syntax. Otherwise, returns [RFC-822] domain
 #     name.
 class Net::IMAP::Address < Struct
+  Elem = type_member(:out, fixed: T.untyped)
+
   sig {returns(::T.untyped)}
   def host(); end
 
@@ -6683,6 +6685,8 @@ end
 # :   Returns a hash that represents parameters of the Content-Disposition
 #     field.
 class Net::IMAP::ContentDisposition < Struct
+  Elem = type_member(:out, fixed: T.untyped)
+
   sig {returns(::T.untyped)}
   def dsp_type(); end
 
@@ -6745,6 +6749,8 @@ end
 # raw\_data
 # :   Returns the raw data string.
 class Net::IMAP::ContinuationRequest < Struct
+  Elem = type_member(:out, fixed: T.untyped)
+
   sig {returns(::T.untyped)}
   def data(); end
 
@@ -6882,6 +6888,8 @@ end
 # message\_id
 # :   Returns a string that represents the message-id.
 class Net::IMAP::Envelope < Struct
+  Elem = type_member(:out, fixed: T.untyped)
+
   sig {returns(::T.untyped)}
   def bcc(); end
 
@@ -7063,6 +7071,8 @@ end
 #     UID
 # :       A number expressing the unique identifier of the message.
 class Net::IMAP::FetchData < Struct
+  Elem = type_member(:out, fixed: T.untyped)
+
   sig {returns(::T.untyped)}
   def attr(); end
 
@@ -7173,6 +7183,8 @@ end
 # rights
 # :   The access rights the indicated user has to the mailbox.
 class Net::IMAP::MailboxACLItem < Struct
+  Elem = type_member(:out, fixed: T.untyped)
+
   sig {returns(::T.untyped)}
   def mailbox(); end
 
@@ -7249,6 +7261,8 @@ end
 # name
 # :   Returns the mailbox name.
 class Net::IMAP::MailboxList < Struct
+  Elem = type_member(:out, fixed: T.untyped)
+
   sig {returns(::T.untyped)}
   def attr(); end
 
@@ -7326,6 +7340,8 @@ end
 # quota
 # :   Quota limit imposed on the mailbox.
 class Net::IMAP::MailboxQuota < Struct
+  Elem = type_member(:out, fixed: T.untyped)
+
   sig {returns(::T.untyped)}
   def mailbox(); end
 
@@ -7395,6 +7411,8 @@ end
 # quotaroots
 # :   Zero or more quotaroots that affect the quota on the specified mailbox.
 class Net::IMAP::MailboxQuotaRoot < Struct
+  Elem = type_member(:out, fixed: T.untyped)
+
   sig {returns(::T.untyped)}
   def mailbox(); end
 
@@ -7584,6 +7602,8 @@ end
 # data
 # :   Returns the data, if it exists.
 class Net::IMAP::ResponseCode < Struct
+  Elem = type_member(:out, fixed: T.untyped)
+
   sig {returns(::T.untyped)}
   def data(); end
 
@@ -7700,6 +7720,8 @@ class Net::IMAP::ResponseParser
 end
 
 class Net::IMAP::ResponseParser::Token < Struct
+  Elem = type_member(:out, fixed: T.untyped)
+
   sig {returns(::T.untyped)}
   def symbol(); end
 
@@ -7758,6 +7780,8 @@ end
 # text
 # :   Returns the text.
 class Net::IMAP::ResponseText < Struct
+  Elem = type_member(:out, fixed: T.untyped)
+
   sig {returns(::T.untyped)}
   def code(); end
 
@@ -7812,6 +7836,8 @@ end
 # :   Returns a hash. Each key is one of "MESSAGES", "RECENT", "UIDNEXT",
 #     "UIDVALIDITY", "UNSEEN". Each value is a number.
 class Net::IMAP::StatusData < Struct
+  Elem = type_member(:out, fixed: T.untyped)
+
   sig {returns(::T.untyped)}
   def attr(); end
 
@@ -7883,6 +7909,8 @@ end
 # raw\_data
 # :   Returns the raw data string.
 class Net::IMAP::TaggedResponse < Struct
+  Elem = type_member(:out, fixed: T.untyped)
+
   sig {returns(::T.untyped)}
   def data(); end
 
@@ -7961,6 +7989,8 @@ end
 #     [`Net::IMAP::ThreadMember`](https://docs.ruby-lang.org/en/2.6.0/Net/IMAP.html#ThreadMember)
 #     objects for mail items that are children of this in the thread.
 class Net::IMAP::ThreadMember < Struct
+  Elem = type_member(:out, fixed: T.untyped)
+
   sig {returns(::T.untyped)}
   def children(); end
 
@@ -8028,6 +8058,8 @@ end
 # raw\_data
 # :   Returns the raw data string.
 class Net::IMAP::UntaggedResponse < Struct
+  Elem = type_member(:out, fixed: T.untyped)
+
   sig {returns(::T.untyped)}
   def data(); end
 

--- a/rbi/stdlib/net.rbi
+++ b/rbi/stdlib/net.rbi
@@ -5812,7 +5812,7 @@ end
 # :   nil indicates [RFC-822] group syntax. Otherwise, returns [RFC-822] domain
 #     name.
 class Net::IMAP::Address < Struct
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 
   sig {returns(::T.untyped)}
   def host(); end
@@ -6685,7 +6685,7 @@ end
 # :   Returns a hash that represents parameters of the Content-Disposition
 #     field.
 class Net::IMAP::ContentDisposition < Struct
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 
   sig {returns(::T.untyped)}
   def dsp_type(); end
@@ -6749,7 +6749,7 @@ end
 # raw\_data
 # :   Returns the raw data string.
 class Net::IMAP::ContinuationRequest < Struct
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 
   sig {returns(::T.untyped)}
   def data(); end
@@ -6888,7 +6888,7 @@ end
 # message\_id
 # :   Returns a string that represents the message-id.
 class Net::IMAP::Envelope < Struct
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 
   sig {returns(::T.untyped)}
   def bcc(); end
@@ -7071,7 +7071,7 @@ end
 #     UID
 # :       A number expressing the unique identifier of the message.
 class Net::IMAP::FetchData < Struct
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 
   sig {returns(::T.untyped)}
   def attr(); end
@@ -7183,7 +7183,7 @@ end
 # rights
 # :   The access rights the indicated user has to the mailbox.
 class Net::IMAP::MailboxACLItem < Struct
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 
   sig {returns(::T.untyped)}
   def mailbox(); end
@@ -7261,7 +7261,7 @@ end
 # name
 # :   Returns the mailbox name.
 class Net::IMAP::MailboxList < Struct
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 
   sig {returns(::T.untyped)}
   def attr(); end
@@ -7340,7 +7340,7 @@ end
 # quota
 # :   Quota limit imposed on the mailbox.
 class Net::IMAP::MailboxQuota < Struct
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 
   sig {returns(::T.untyped)}
   def mailbox(); end
@@ -7411,7 +7411,7 @@ end
 # quotaroots
 # :   Zero or more quotaroots that affect the quota on the specified mailbox.
 class Net::IMAP::MailboxQuotaRoot < Struct
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 
   sig {returns(::T.untyped)}
   def mailbox(); end
@@ -7602,7 +7602,7 @@ end
 # data
 # :   Returns the data, if it exists.
 class Net::IMAP::ResponseCode < Struct
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 
   sig {returns(::T.untyped)}
   def data(); end
@@ -7720,7 +7720,7 @@ class Net::IMAP::ResponseParser
 end
 
 class Net::IMAP::ResponseParser::Token < Struct
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 
   sig {returns(::T.untyped)}
   def symbol(); end
@@ -7780,7 +7780,7 @@ end
 # text
 # :   Returns the text.
 class Net::IMAP::ResponseText < Struct
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 
   sig {returns(::T.untyped)}
   def code(); end
@@ -7836,7 +7836,7 @@ end
 # :   Returns a hash. Each key is one of "MESSAGES", "RECENT", "UIDNEXT",
 #     "UIDVALIDITY", "UNSEEN". Each value is a number.
 class Net::IMAP::StatusData < Struct
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 
   sig {returns(::T.untyped)}
   def attr(); end
@@ -7909,7 +7909,7 @@ end
 # raw\_data
 # :   Returns the raw data string.
 class Net::IMAP::TaggedResponse < Struct
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 
   sig {returns(::T.untyped)}
   def data(); end
@@ -7989,7 +7989,7 @@ end
 #     [`Net::IMAP::ThreadMember`](https://docs.ruby-lang.org/en/2.6.0/Net/IMAP.html#ThreadMember)
 #     objects for mail items that are children of this in the thread.
 class Net::IMAP::ThreadMember < Struct
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 
   sig {returns(::T.untyped)}
   def children(); end
@@ -8058,7 +8058,7 @@ end
 # raw\_data
 # :   Returns the raw data string.
 class Net::IMAP::UntaggedResponse < Struct
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 
   sig {returns(::T.untyped)}
   def data(); end

--- a/rbi/stdlib/openssl.rbi
+++ b/rbi/stdlib/openssl.rbi
@@ -1342,7 +1342,7 @@ end
 # ```
 class OpenSSL::ASN1::Constructive < OpenSSL::ASN1::ASN1Data
   include ::Enumerable
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
   # Calls the given block once for each element in self, passing that element as
   # parameter *asn1*. If no block is given, an enumerator is returned instead.
   #
@@ -1610,11 +1610,11 @@ class OpenSSL::ASN1::PrintableString < OpenSSL::ASN1::Primitive
 end
 
 class OpenSSL::ASN1::Sequence < OpenSSL::ASN1::Constructive
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 end
 
 class OpenSSL::ASN1::Set < OpenSSL::ASN1::Constructive
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 end
 
 class OpenSSL::ASN1::T61String < OpenSSL::ASN1::Primitive
@@ -2042,7 +2042,7 @@ end
 # [`OpenSSL::SSL::SSLSocket`](https://docs.ruby-lang.org/en/2.6.0/OpenSSL/SSL/SSLSocket.html).
 module OpenSSL::Buffering
   include ::Enumerable
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 
   # Default size to read from or write to the SSLSocket for buffer operations.
   BLOCK_SIZE = ::T.let(nil, ::T.untyped)
@@ -3131,7 +3131,7 @@ end
 # See also http://www.openssl.org/docs/apps/config.html
 class OpenSSL::Config
   include ::Enumerable
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 
   # The default system configuration file for openssl
   DEFAULT_CONFIG_FILE = ::T.let(nil, ::T.untyped)
@@ -8245,7 +8245,7 @@ class OpenSSL::SSL::SSLServer
 end
 
 class OpenSSL::SSL::SSLSocket
-  Elem = type_member(:out, fixed: T.untyped)
+  Elem = type_member(fixed: T.untyped)
 
   include ::OpenSSL::SSL::SocketForwarder
   include ::OpenSSL::Buffering

--- a/rbi/stdlib/openssl.rbi
+++ b/rbi/stdlib/openssl.rbi
@@ -1342,6 +1342,7 @@ end
 # ```
 class OpenSSL::ASN1::Constructive < OpenSSL::ASN1::ASN1Data
   include ::Enumerable
+  Elem = type_member(:out, fixed: T.untyped)
   # Calls the given block once for each element in self, passing that element as
   # parameter *asn1*. If no block is given, an enumerator is returned instead.
   #
@@ -1609,9 +1610,11 @@ class OpenSSL::ASN1::PrintableString < OpenSSL::ASN1::Primitive
 end
 
 class OpenSSL::ASN1::Sequence < OpenSSL::ASN1::Constructive
+  Elem = type_member(:out, fixed: T.untyped)
 end
 
 class OpenSSL::ASN1::Set < OpenSSL::ASN1::Constructive
+  Elem = type_member(:out, fixed: T.untyped)
 end
 
 class OpenSSL::ASN1::T61String < OpenSSL::ASN1::Primitive
@@ -2039,6 +2042,8 @@ end
 # [`OpenSSL::SSL::SSLSocket`](https://docs.ruby-lang.org/en/2.6.0/OpenSSL/SSL/SSLSocket.html).
 module OpenSSL::Buffering
   include ::Enumerable
+  Elem = type_member(:out, fixed: T.untyped)
+
   # Default size to read from or write to the SSLSocket for buffer operations.
   BLOCK_SIZE = ::T.let(nil, ::T.untyped)
 
@@ -3126,6 +3131,8 @@ end
 # See also http://www.openssl.org/docs/apps/config.html
 class OpenSSL::Config
   include ::Enumerable
+  Elem = type_member(:out, fixed: T.untyped)
+
   # The default system configuration file for openssl
   DEFAULT_CONFIG_FILE = ::T.let(nil, ::T.untyped)
 
@@ -8238,6 +8245,8 @@ class OpenSSL::SSL::SSLServer
 end
 
 class OpenSSL::SSL::SSLSocket
+  Elem = type_member(:out, fixed: T.untyped)
+
   include ::OpenSSL::SSL::SocketForwarder
   include ::OpenSSL::Buffering
   include ::Enumerable

--- a/rbi/stdlib/optparse.rbi
+++ b/rbi/stdlib/optparse.rbi
@@ -967,6 +967,10 @@ class OptionParser
   class OptionMap < Hash
     include OptionParser::Completion
 
+    K = type_member(:out, fixed: T.untyped)
+    V = type_member(:out, fixed: T.untyped)
+    Elem = type_member(:out, fixed: T.untyped)
+
     sig {params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped)}
     def candidate(key, icase = false, pat = nil); end
 
@@ -1550,6 +1554,9 @@ class OptionParser
   # [`OptionParser::Completion`](https://docs.ruby-lang.org/en/2.6.0/OptionParser/Completion.html).
   class CompletingHash < Hash
     include OptionParser::Completion
+    K = type_member(:out, fixed: T.untyped)
+    V = type_member(:out, fixed: T.untyped)
+    Elem = type_member(:out, fixed: T.untyped)
 
     # Completion for hash key.
     sig {params(key: T.untyped).returns(T.untyped)}

--- a/rbi/stdlib/optparse.rbi
+++ b/rbi/stdlib/optparse.rbi
@@ -967,9 +967,9 @@ class OptionParser
   class OptionMap < Hash
     include OptionParser::Completion
 
-    K = type_member(:out, fixed: T.untyped)
-    V = type_member(:out, fixed: T.untyped)
-    Elem = type_member(:out, fixed: T.untyped)
+    K = type_member(fixed: T.untyped)
+    V = type_member(fixed: T.untyped)
+    Elem = type_member(fixed: T.untyped)
 
     sig {params(key: T.untyped, icase: T.untyped, pat: T.untyped).returns(T.untyped)}
     def candidate(key, icase = false, pat = nil); end
@@ -1554,9 +1554,9 @@ class OptionParser
   # [`OptionParser::Completion`](https://docs.ruby-lang.org/en/2.6.0/OptionParser/Completion.html).
   class CompletingHash < Hash
     include OptionParser::Completion
-    K = type_member(:out, fixed: T.untyped)
-    V = type_member(:out, fixed: T.untyped)
-    Elem = type_member(:out, fixed: T.untyped)
+    K = type_member(fixed: T.untyped)
+    V = type_member(fixed: T.untyped)
+    Elem = type_member(fixed: T.untyped)
 
     # Completion for hash key.
     sig {params(key: T.untyped).returns(T.untyped)}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This fixes the other situations pt was seeing where `beginError` was getting called in RBI processing with an error we silenced: a number of things subclassed `Enuemrable` things (especially `Struct`) without also redeclaring the type member. This adds those type members in.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
