### PR TITLE
Treat __STDLIB_INTERNAL like strict instead of true

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1443,7 +1443,7 @@ bool GlobalState::shouldReportErrorOn(Loc loc, ErrorClass what) const {
             }
         } else if (level == StrictLevel::Stdlib) {
             level = StrictLevel::Strict;
-            if (what == errors::Resolver::OverloadNotAllowed || what == errors::Resolver::VariantTypeMemberInClass) {
+            if (what == errors::Resolver::OverloadNotAllowed || what == errors::Resolver::VariantTypeMemberInClass || what == errors::Infer::UntypedMethod) {
                 return false;
             }
         }

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1443,7 +1443,8 @@ bool GlobalState::shouldReportErrorOn(Loc loc, ErrorClass what) const {
             }
         } else if (level == StrictLevel::Stdlib) {
             level = StrictLevel::Strict;
-            if (what == errors::Resolver::OverloadNotAllowed || what == errors::Resolver::VariantTypeMemberInClass || what == errors::Infer::UntypedMethod) {
+            if (what == errors::Resolver::OverloadNotAllowed || what == errors::Resolver::VariantTypeMemberInClass ||
+                what == errors::Infer::UntypedMethod) {
                 return false;
             }
         }

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1442,7 +1442,7 @@ bool GlobalState::shouldReportErrorOn(Loc loc, ErrorClass what) const {
                 return false;
             }
         } else if (level == StrictLevel::Stdlib) {
-            level = StrictLevel::True;
+            level = StrictLevel::Strict;
             if (what == errors::Resolver::OverloadNotAllowed || what == errors::Resolver::VariantTypeMemberInClass) {
                 return false;
             }

--- a/rbi/stdlib/etc.rbi
+++ b/rbi/stdlib/etc.rbi
@@ -564,6 +564,10 @@ end
 class Etc::Group < Struct
   extend T::Generic
   Elem = type_member(:out, fixed: T.untyped)
+  class << self
+    extend T::Generic
+    Elem = type_member(fixed: T.untyped)
+  end
 end
 
 # [`Passwd`](https://docs.ruby-lang.org/en/2.6.0/Etc.html#Passwd)
@@ -618,4 +622,8 @@ end
 class Etc::Passwd < Struct
   extend T::Generic
   Elem = type_member(:out, fixed: T.untyped)
+  class << self
+    extend T::Generic
+    Elem = type_member(fixed: T.untyped)
+  end
 end

--- a/rbi/stdlib/gem.rbi
+++ b/rbi/stdlib/gem.rbi
@@ -463,6 +463,8 @@ end
 # for restrictions on the format and size of metadata items you may add to a
 # specification.
 class Gem::Specification < Gem::BasicSpecification
+  Elem = type_template(fixed: T.untyped)
+
   CURRENT_SPECIFICATION_VERSION = T.let(T.unsafe(nil), Integer)
   EMPTY = T.let(T.unsafe(nil), T::Array[T.untyped])
   MARSHAL_FIELDS = T.let(T.unsafe(nil), T::Hash[T.untyped, T.untyped])


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This will catch regressions from #2054 and #2061 and in general will force a stricter set of standards on our stdlib RBI files. Currently WIP because I'm running this by everyone to make sure we're all okay with it, but it's a pretty simple change.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
