### PR TITLE
fix comments to match the code

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -299,7 +299,7 @@ void GlobalState::initEmpty() {
     Symbols::root().dataAllowingNone(*this)->members()[core::Names::Constants::Bottom()] = Symbols::bottom();
     Context ctx(*this, Symbols::root());
 
-    // Synthesize <Magic>#build_hash(*vs : T.untyped) => Hash
+    // Synthesize <Magic>#<build-hash>(*vs : T.untyped) => Hash
     SymbolRef method = enterMethodSymbol(Loc::none(), Symbols::MagicSingleton(), Names::buildHash());
     {
         auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg0());

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -311,7 +311,7 @@ void GlobalState::initEmpty() {
         auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
         arg.flags.isBlock = true;
     }
-    // Synthesize <Magic>#build_array(*vs : T.untyped) => Array
+    // Synthesize <Magic>#<build-array>(*vs : T.untyped) => Array
     method = enterMethodSymbol(Loc::none(), Symbols::MagicSingleton(), Names::buildArray());
     {
         auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg0());


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
These methods end up with `<>`s in them. This PR just makes them match up
```
$ gg '<Magic>#'
core/GlobalState.cc:    // Synthesize <Magic>#<build-hash>(*vs : T.untyped) => Hash
core/GlobalState.cc:    // Synthesize <Magic>#<build-array>(*vs : T.untyped) => Array
core/GlobalState.cc:    // Synthesize <Magic>#<splat>(a: Array) => Untyped
core/GlobalState.cc:    // Synthesize <Magic>#<defined>(arg0: Object) => Boolean
core/GlobalState.cc:    // Synthesize <Magic>#<expandSplat>(arg0: T.untyped, arg1: Integer, arg2: Integer) => T.untyped
core/GlobalState.cc:    // Synthesize <Magic>#<call-with-splat>(args: *T.untyped) => T.untyped
core/GlobalState.cc:    // Synthesize <Magic>#<call-with-block>(args: *T.untyped) => T.untyped
core/GlobalState.cc:    // Synthesize <Magic>#<call-with-splat-and-block>(args: *T.untyped) => T.untyped
core/GlobalState.cc:    // Synthesize <Magic>#<suggest-type>(arg: *T.untyped) => T.untyped
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
