### PR TITLE
Improve `symbol-search` tests for multiple assertions/responses per line

### DIFF
--- a/test/helpers/lsp.cc
+++ b/test/helpers/lsp.cc
@@ -2,6 +2,7 @@
 #include <cxxopts.hpp>
 // has to go first as it violates requirements
 
+#include "absl/strings/match.h"
 #include "common/common.h"
 #include "common/sort.h"
 #include "test/helpers/lsp.h"
@@ -14,7 +15,7 @@ string filePathToUri(string_view prefixUrl, string_view filePath) {
 }
 
 bool isUriATestFile(string_view prefixUrl, string_view uri) {
-    return uri.substr(0, prefixUrl.length()) == prefixUrl;
+    return absl::StartsWith(uri, prefixUrl);
 }
 
 string uriToFilePath(string_view prefixUrl, string_view uri) {

--- a/test/helpers/lsp.cc
+++ b/test/helpers/lsp.cc
@@ -13,8 +13,12 @@ string filePathToUri(string_view prefixUrl, string_view filePath) {
     return fmt::format("{}/{}", prefixUrl, filePath);
 }
 
+bool isUriATestFile(string_view prefixUrl, string_view uri) {
+    return uri.substr(0, prefixUrl.length()) == prefixUrl;
+}
+
 string uriToFilePath(string_view prefixUrl, string_view uri) {
-    if (uri.substr(0, prefixUrl.length()) != prefixUrl) {
+    if (!isUriATestFile(prefixUrl, uri)) {
         ADD_FAILURE() << fmt::format(
             "Unrecognized URI: `{}` is not contained in root URI `{}`, and thus does not correspond to a test file.",
             uri, prefixUrl);

--- a/test/helpers/lsp.h
+++ b/test/helpers/lsp.h
@@ -10,6 +10,8 @@ using namespace sorbet::realmain::lsp;
 
 std::string filePathToUri(std::string_view prefixUrl, std::string_view filePath);
 
+bool isUriATestFile(std::string_view prefixUrl, std::string_view uri);
+
 std::string uriToFilePath(std::string_view prefixUrl, std::string_view uri);
 
 /** Creates the parameters to the `initialize` message, which advertises the client's capabilities. */

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -326,17 +326,10 @@ public:
     void check(const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents, LSPWrapper &wrapper,
                int &nextId, std::string_view uriPrefix, const Location &queryLoc);
 
-    std::string toString() const override;
-
-private:
-    /** Checks all SymbolSearchAssertions for the given symbol query. */
-    static void checkAllForQuery(const std::string query,
-                                 const std::vector<std::shared_ptr<SymbolSearchAssertion>> &assertions,
-                                 const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents,
-                                 LSPWrapper &wrapper, int &nextId, std::string_view uriPrefix, std::string errorPrefix);
-
     /** Returns true if the given symbol matches this assertion. */
     bool matches(std::string_view uriPrefix, std::shared_ptr<SymbolInformation> symbol);
+
+    std::string toString() const override;
 };
 
 } // namespace sorbet::test

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -320,12 +320,6 @@ public:
                          const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents,
                          LSPWrapper &wrapper, int &nextId, std::string_view uriPrefix, std::string errorPrefix = "");
 
-    /** Checks all SymbolSearchAssertions for the given symbol query. */
-    static void checkAllForQuery(const std::string query,
-                                 const std::vector<std::shared_ptr<SymbolSearchAssertion>> &assertions,
-                                 const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents,
-                                 LSPWrapper &wrapper, int &nextId, std::string_view uriPrefix, std::string errorPrefix);
-
     SymbolSearchAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
                           std::string_view query);
 
@@ -333,6 +327,16 @@ public:
                int &nextId, std::string_view uriPrefix, const Location &queryLoc);
 
     std::string toString() const override;
+
+private:
+    /** Checks all SymbolSearchAssertions for the given symbol query. */
+    static void checkAllForQuery(const std::string query,
+                                 const std::vector<std::shared_ptr<SymbolSearchAssertion>> &assertions,
+                                 const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents,
+                                 LSPWrapper &wrapper, int &nextId, std::string_view uriPrefix, std::string errorPrefix);
+
+    /** Returns true if the given symbol matches this assertion. */
+    bool matches(std::string_view uriPrefix, std::shared_ptr<SymbolInformation> symbol);
 };
 
 } // namespace sorbet::test

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -305,7 +305,7 @@ public:
     std::string toString() const override;
 };
 
-// # symbol-search: "query"
+// # symbol-search: "query" [, name="expected-name"]
 class SymbolSearchAssertion final : public RangeAssertion {
 public:
     static std::shared_ptr<SymbolSearchAssertion> make(std::string_view filename, std::unique_ptr<Range> &range,
@@ -313,6 +313,7 @@ public:
                                                        std::string_view assertionType);
 
     const std::string query;
+    const std::optional<std::string> name;
     const int rank = 0;
 
     /** Checks all SymbolSearchAssertions within the assertion vector. Skips over non-CompletionAssertions. */
@@ -321,7 +322,7 @@ public:
                          LSPWrapper &wrapper, int &nextId, std::string_view uriPrefix, std::string errorPrefix = "");
 
     SymbolSearchAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
-                          std::string_view query);
+                          std::string_view query, std::optional<std::string> name);
 
     void check(const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents, LSPWrapper &wrapper,
                int &nextId, std::string_view uriPrefix, const Location &queryLoc);

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -5,6 +5,7 @@
 #include "main/lsp/lsp.h"
 #include "main/lsp/wrapper.h"
 #include "test/helpers/expectations.h"
+#include <regex>
 
 namespace sorbet::test {
 using namespace sorbet::realmain::lsp;
@@ -72,7 +73,7 @@ public:
     int cmp(const RangeAssertion &b) const;
 
     // Returns a Location object for this assertion's filename and range.
-    std::unique_ptr<Location> getLocation(std::string_view uriPrefix);
+    std::unique_ptr<Location> getLocation(std::string_view uriPrefix) const;
 
     virtual std::string toString() const = 0;
 };
@@ -305,7 +306,17 @@ public:
     std::string toString() const override;
 };
 
-// # symbol-search: "query" [, name="expected-name"]
+// # ^^^ symbol-search: "query" [, optional_key = value ]*
+// Checks that a `workspace/symbol` result for the given "query" returns a result
+// that matches the indicated range in the given file.  Options:
+// * `name = "str"` => the result's `name` must *exactly* match the given string
+//   (useful for synthetic results, like the `foo=` of an `attr_writer`)
+// * `container = "str"` => the `containerName` must *exactly* match the given string
+// * `uri = "substr"` => the `location->uri` must *contain* the given string,
+//   rather than matching the containing file
+//   (container + uri can be useful for matching entries in `rbi` files)
+// * `rank = int` => for each query, verifies that any ranked assertions
+//   appear in order of *ascending* rank
 class SymbolSearchAssertion final : public RangeAssertion {
 public:
     static std::shared_ptr<SymbolSearchAssertion> make(std::string_view filename, std::unique_ptr<Range> &range,
@@ -314,7 +325,9 @@ public:
 
     const std::string query;
     const std::optional<std::string> name;
-    const int rank = 0;
+    const std::optional<std::string> container;
+    const std::optional<int> rank;
+    const std::optional<std::string> uri; // uses substring match
 
     /** Checks all SymbolSearchAssertions within the assertion vector. Skips over non-CompletionAssertions. */
     static void checkAll(const std::vector<std::shared_ptr<RangeAssertion>> &assertions,
@@ -322,13 +335,14 @@ public:
                          LSPWrapper &wrapper, int &nextId, std::string_view uriPrefix, std::string errorPrefix = "");
 
     SymbolSearchAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
-                          std::string_view query, std::optional<std::string> name);
+                          std::string_view query, std::optional<std::string> name, std::optional<std::string> container,
+                          std::optional<int> rank, std::optional<std::string> uri);
 
     void check(const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents, LSPWrapper &wrapper,
                int &nextId, std::string_view uriPrefix, const Location &queryLoc);
 
     /** Returns true if the given symbol matches this assertion. */
-    bool matches(std::string_view uriPrefix, std::shared_ptr<SymbolInformation> symbol);
+    bool matches(std::string_view uriPrefix, const SymbolInformation &symbol) const;
 
     std::string toString() const override;
 };

--- a/test/testdata/lsp/workspace_symbols_fullname.rb
+++ b/test/testdata/lsp/workspace_symbols_fullname.rb
@@ -25,3 +25,9 @@ module Bar
     end
   end
 end
+
+class Baz
+  attr_accessor :foo
+  #              ^^^ symbol-search: "foo", name="foo"
+  #              ^^^ symbol-search: "foo", name="foo="
+end

--- a/test/testdata/lsp/workspace_symbols_fullname.rb
+++ b/test/testdata/lsp/workspace_symbols_fullname.rb
@@ -1,6 +1,5 @@
 # typed: true
 
-
 def foo
   # ^^^ symbol-search: "foo"
 end

--- a/test/testdata/lsp/workspace_symbols_fullname.rb
+++ b/test/testdata/lsp/workspace_symbols_fullname.rb
@@ -25,9 +25,3 @@ module Bar
     end
   end
 end
-
-class Baz
-  attr_accessor :foo
-  #              ^^^ symbol-search: "foo", name="foo"
-  #              ^^^ symbol-search: "foo", name="foo="
-end

--- a/test/testdata/lsp/workspace_symbols_stdlib.rb
+++ b/test/testdata/lsp/workspace_symbols_stdlib.rb
@@ -1,0 +1,10 @@
+# typed: true
+
+# // Verify `workspace/symbol` can return symbols from standard library, too
+# symbol-search: "conjugate", container="::Complex", uri="complex.rbi"
+# symbol-search: "conjugate", container="::Float", uri="float.rbi"
+# symbol-search: "conjugate", container="::Numeric", uri="numeric.rbi"
+
+# // Multiple symbols from same rbi file?
+# symbol-search: "encoding", name="encoding", container="::Regexp", uri="regexp.rbi"
+# symbol-search: "encoding", name="fixed_encoding?", container="::Regexp", uri="regexp.rbi"


### PR DESCRIPTION
### Motivation
Address shortcomings in PR#2063, specifically when one line contains multiple results, and add an optional `name` to `symbol-search` to allow tests to disambiguate between multiple results for the same/overlapping ranges.

### Test plan
Sample output, which includes reference to `attr_accessor` (two results for same region of code):
https://gist.github.com/mkillianey-stripe/a9f959bee7e21c015d565ebc0b4d2df9#file-gistfile1-txt-L12-L52