### PR TITLE
Revert "Fix update_testdata_exp.sh for document-symbols (#2025)"

### DIFF
--- a/test/print_document_symbols.cc
+++ b/test/print_document_symbols.cc
@@ -8,69 +8,19 @@
 
 namespace sorbet::realmain::lsp {
 using namespace std;
-
-namespace {
-constexpr string_view uriPrefix = "file:///"sv;
-
-// Given a path to a *.rb or *.rbupdate file, returns the set of edits to apply to Sorbet before requesting document
-// symbols along with the URI of the document.
-pair<string, vector<string>> findEditsToApply(string_view filePath) {
-    const auto idx = filePath.rfind('.');
-    if (idx == string_view::npos) {
-        Exception::raise("Invalid file path: {}", filePath);
-    }
-    string_view extension = filePath.substr(idx);
-    OSFileSystem fs;
-    vector<string> fileContents;
-    string uri;
-    fileContents.push_back(fs.readFile(filePath));
-    if (extension == ".rbupdate") {
-        // Find basename[.]version.rbupdate
-        const auto versionIdx = filePath.rfind('.', idx - 1);
-        if (versionIdx == string_view::npos) {
-            Exception::raise("rbupdate file is missing version number: {}", filePath);
-        }
-        string_view baseName = filePath.substr(0, versionIdx);
-        uri = absl::StrCat(uriPrefix, baseName, ".rb");
-        string_view versionString = filePath.substr(versionIdx + 1, idx - versionIdx);
-        int version = stoi(string(versionString));
-        for (version = version - 1; version >= 0; version--) {
-            try {
-                fileContents.push_back(fs.readFile(fmt::format("{}.{}.rbupdate", baseName, version)));
-            } catch (FileNotFoundException e) {
-                // Ignore.
-            }
-        }
-        fileContents.push_back(fs.readFile(fmt::format("{}.rb", baseName)));
-        reverse(fileContents.begin(), fileContents.end());
-    } else {
-        uri = absl::StrCat(uriPrefix, filePath);
-    }
-    return make_pair(uri, move(fileContents));
-}
-
 int printDocumentSymbols(string_view filePath) {
     LSPWrapper lspWrapper("", false);
     lspWrapper.enableAllExperimentalFeatures();
     int nextId = 1;
-    int fileId = 1;
-    auto [fileUri, fileEdits] = findEditsToApply(filePath);
+    string uriPrefix = "file:///";
     test::initializeLSP("", uriPrefix, lspWrapper, nextId);
+    string fileUri = uriPrefix + string(filePath);
     {
-        // Initialize empty file.
-        auto params =
-            make_unique<DidOpenTextDocumentParams>(make_unique<TextDocumentItem>(fileUri, "ruby", fileId++, ""));
+        OSFileSystem fs;
+        auto params = make_unique<DidOpenTextDocumentParams>(
+            make_unique<TextDocumentItem>(fileUri, "ruby", 1, fs.readFile(filePath)));
         auto notif = make_unique<NotificationMessage>("2.0", LSPMethod::TextDocumentDidOpen, move(params));
-        // Discard responses.
-        lspWrapper.getLSPResponsesFor(make_unique<LSPMessage>(move(notif)));
-    }
-
-    for (auto &fileEdit : fileEdits) {
-        vector<unique_ptr<TextDocumentContentChangeEvent>> edits;
-        edits.push_back(make_unique<TextDocumentContentChangeEvent>(fileEdit));
-        auto params = make_unique<DidChangeTextDocumentParams>(
-            make_unique<VersionedTextDocumentIdentifier>(fileUri, fileId++), move(edits));
-        auto notif = make_unique<NotificationMessage>("2.0", LSPMethod::TextDocumentDidChange, move(params));
+        // Discard responses; it's OK if the file has errors.
         lspWrapper.getLSPResponsesFor(make_unique<LSPMessage>(move(notif)));
     }
 
@@ -95,7 +45,6 @@ int printDocumentSymbols(string_view filePath) {
         return 1;
     }
 }
-} // namespace
 } // namespace sorbet::realmain::lsp
 
 int main(int argc, char *argv[]) {
@@ -104,5 +53,5 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    return sorbet::test::printDocumentSymbols(argv[1]);
+    return sorbet::realmain::lsp::printDocumentSymbols(argv[1]);
 }

--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -35,7 +35,7 @@ passes=(
   cfg-raw
   cfg-json
   autogen
-  document-symbols
+  # document-symbols
 )
 
 bazel build //main:sorbet //test:print_document_symbols -c opt


### PR DESCRIPTION
This reverts commit 410f8bdc8efbdd7cbb5a85b5fd704bcaba4d61b7.

This seems to have broken master? Trying to revert

https://buildkite.com/sorbet/sorbet/builds/7145#ad9ab375-eb15-4829-9a1e-6dbf519037d8/116-224

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
