### PR TITLE
Allow visibility modifiers with symbols

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -452,23 +452,45 @@ public:
     }
 
     unique_ptr<ast::Expression> postTransformSend(core::MutableContext ctx, unique_ptr<ast::Send> original) {
-        ast::MethodDef *mdef;
-        if (original->args.size() == 1 && (mdef = ast::cast_tree<ast::MethodDef>(original->args[0].get())) != nullptr) {
+        core::SymbolRef method;
+        if (original->args.size() == 1) {
+            if (auto mdef = ast::cast_tree<ast::MethodDef>(original->args[0].get())) {
+                // this handles the `private def foo` case
+                method = mdef->symbol;
+            } else if (auto sym = ast::cast_tree<ast::Literal>(original->args[0].get())) {
+                // this handles the `private :foo` case
+                if (!sym->isSymbol(ctx)) {
+                    return original;
+                }
+                auto name = sym->asSymbol(ctx);
+                auto owner = ctx.owner;
+                if (original->fun._id == core::Names::privateClassMethod()._id) {
+                    owner = owner.data(ctx)->singletonClass(ctx);
+                }
+                method = ctx.state.lookupMethodSymbol(owner, name);
+                if (method == core::Symbols::noSymbol()) {
+                    return original;
+                }
+            } else {
+                return original;
+            }
             switch (original->fun._id) {
                 case core::Names::private_()._id:
                 case core::Names::privateClassMethod()._id:
-                    mdef->symbol.data(ctx)->setPrivate();
+                    method.data(ctx)->setPrivate();
                     break;
                 case core::Names::protected_()._id:
-                    mdef->symbol.data(ctx)->setProtected();
+                    method.data(ctx)->setProtected();
                     break;
                 case core::Names::public_()._id:
-                    mdef->symbol.data(ctx)->setPublic();
+                    method.data(ctx)->setPublic();
                     break;
                 default:
                     return original;
             }
-            return std::move(original->args[0]);
+            if (ast::isa_tree<ast::MethodDef>(original->args[0].get())) {
+                return std::move(original->args[0]);
+            }
         }
         return original;
     }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -660,6 +660,8 @@ public:
         ENFORCE(method->args.size() == method->symbol.data(ctx)->arguments().size());
         ENFORCE(method->args.size() == method->symbol.data(ctx)->arguments().size(), "{}: {} != {}",
                 method->name.showRaw(ctx), method->args.size(), method->symbol.data(ctx)->arguments().size());
+        // all methods at definition time are public, but their visibility may be changed later
+        method->symbol.data(ctx)->setPublic();
         // Not all information is unfortunately available in the symbol. Original argument names aren't.
         // method->args.clear();
         return method;

--- a/test/testdata/namer/module_function.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/module_function.rb.symbol-table-raw.exp
@@ -10,7 +10,7 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     method <S <C <U C>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/module_function.rb start=19:1 end=33:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/module_function.rb start=??? end=???}
   module <C <U Funcs>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/namer/module_function.rb start=2:1 end=2:13}
-    method <C <U Funcs>><U f> (x, <blk>) -> Integer @ Loc {file=test/testdata/namer/module_function.rb start=6:3 end=6:11}
+    method <C <U Funcs>><U f> : private (x, <blk>) -> Integer @ Loc {file=test/testdata/namer/module_function.rb start=6:3 end=6:11}
       argument x<> -> Integer @ Loc {file=test/testdata/namer/module_function.rb start=5:15 end=5:16}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/namer/module_function.rb start=??? end=???}
     method <C <U Funcs>><U g> : private (s, <blk>) -> Symbol @ Loc {file=test/testdata/namer/module_function.rb start=11:19 end=11:27}

--- a/test/testdata/namer/visibility.rb
+++ b/test/testdata/namer/visibility.rb
@@ -1,0 +1,21 @@
+# typed: true
+
+class A
+  def f1; end
+  public def f2; end
+  private def f3; end
+  protected def f4; end
+  private_class_method def self.f5; end
+end
+
+class B
+  def f1; end
+  def f2; end
+  def f3; end
+  def f4; end
+  def self.f5; end
+  public :f2
+  private :f3
+  protected :f4
+  private_class_method :f5
+end

--- a/test/testdata/namer/visibility.rb
+++ b/test/testdata/namer/visibility.rb
@@ -19,3 +19,37 @@ class B
   protected :f4
   private_class_method :f5
 end
+
+
+class C
+  private :foo
+  def foo; end  # this does not end up being private
+end
+
+class Foo1
+  def foo;  # this does not end up being private
+  end
+  private_class_method :foo
+end
+
+class Foo2
+  def self.foo;  # this does not end up being private
+  end
+  private :foo
+end
+
+class Foo3
+  def self.foo;
+  end
+  class <<self
+    private :foo
+  end
+end
+
+class Foo4
+  class <<self
+    def foo;
+    end
+    private :foo
+  end
+end

--- a/test/testdata/namer/visibility.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/visibility.rb.symbol-table-raw.exp
@@ -1,0 +1,35 @@
+class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4}, Loc {file=test/testdata/namer/visibility.rb start=3:1 end=21:4})
+  class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=3:1 end=21:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+  class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/namer/visibility.rb start=3:1 end=3:8}
+    method <C <U A>><U f1> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=4:3 end=4:9}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+    method <C <U A>><U f2> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=5:10 end=5:16}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+    method <C <U A>><U f3> : private (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=6:11 end=6:17}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+    method <C <U A>><U f4> : protected (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=7:13 end=7:19}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+  class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/visibility.rb start=3:7 end=3:8}
+    type-member(+) <S <C <U A>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/namer/visibility.rb start=3:7 end=3:8}
+    method <S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=3:1 end=9:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+    method <S <C <U A>> $1><U f5> : private (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=8:24 end=8:35}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+  class <C <U B>> < <C <U Object>> () @ Loc {file=test/testdata/namer/visibility.rb start=11:1 end=11:8}
+    method <C <U B>><U f1> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=12:3 end=12:9}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+    method <C <U B>><U f2> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=13:3 end=13:9}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+    method <C <U B>><U f3> : private (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=14:3 end=14:9}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+    method <C <U B>><U f4> : protected (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=15:3 end=15:9}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+  class <S <C <U B>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/visibility.rb start=11:7 end=11:8}
+    type-member(+) <S <C <U B>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U B>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=B) @ Loc {file=test/testdata/namer/visibility.rb start=11:7 end=11:8}
+    method <S <C <U B>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=11:1 end=21:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+    method <S <C <U B>> $1><U f5> : private (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=16:3 end=16:14}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+

--- a/test/testdata/namer/visibility.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/visibility.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4}, Loc {file=test/testdata/namer/visibility.rb start=3:1 end=21:4})
+class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4}, Loc {file=test/testdata/namer/visibility.rb start=3:1 end=55:4})
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=3:1 end=21:4}
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=3:1 end=55:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
   class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/namer/visibility.rb start=3:1 end=3:8}
     method <C <U A>><U f1> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=4:3 end=4:9}
@@ -31,5 +31,58 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     method <S <C <U B>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=11:1 end=21:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
     method <S <C <U B>> $1><U f5> : private (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=16:3 end=16:14}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+  class <C <U C>> < <C <U Object>> () @ Loc {file=test/testdata/namer/visibility.rb start=24:1 end=24:8}
+    method <C <U C>><U foo> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=26:3 end=26:10}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+  class <S <C <U C>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/visibility.rb start=24:7 end=24:8}
+    type-member(+) <S <C <U C>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U C>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=C) @ Loc {file=test/testdata/namer/visibility.rb start=24:7 end=24:8}
+    method <S <C <U C>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=24:1 end=27:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+  class <C <U Foo1>> < <C <U Object>> () @ Loc {file=test/testdata/namer/visibility.rb start=29:1 end=29:11}
+    method <C <U Foo1>><U foo> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=30:3 end=30:10}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+  class <S <C <U Foo1>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/visibility.rb start=29:7 end=29:11}
+    type-member(+) <S <C <U Foo1>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Foo1>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Foo1) @ Loc {file=test/testdata/namer/visibility.rb start=29:7 end=29:11}
+    method <S <C <U Foo1>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=29:1 end=33:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+  class <C <U Foo2>> < <C <U Object>> () @ Loc {file=test/testdata/namer/visibility.rb start=35:1 end=35:11}
+  class <S <C <U Foo2>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/visibility.rb start=35:7 end=35:11}
+    type-member(+) <S <C <U Foo2>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Foo2>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Foo2) @ Loc {file=test/testdata/namer/visibility.rb start=35:7 end=35:11}
+    method <S <C <U Foo2>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=35:1 end=39:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+    method <S <C <U Foo2>> $1><U foo> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=36:3 end=36:15}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+  class <C <U Foo3>> < <C <U Object>> () @ Loc {file=test/testdata/namer/visibility.rb start=41:1 end=41:11}
+  class <S <C <U Foo3>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/visibility.rb start=44:3 end=44:8}
+    type-member(+) <S <C <U Foo3>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Foo3>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Foo3) @ Loc {file=test/testdata/namer/visibility.rb start=41:7 end=41:11}
+    method <S <C <U Foo3>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=41:1 end=47:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+    method <S <C <U Foo3>> $1><U foo> : private (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=42:3 end=42:15}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+  class <S <S <C <U Foo3>> $1> $1>[<C <U <AttachedClass>>>] < <S <S <C <U Object>> $1> $1> () @ Loc {file=test/testdata/namer/visibility.rb start=44:3 end=44:8}
+    type-member(+) <S <S <C <U Foo3>> $1> $1><C <U <AttachedClass>>> -> LambdaParam(<S <S <C <U Foo3>> $1> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {
+  klass = <S <C <U Foo3>> $1>
+  targs = [
+    <C <U <AttachedClass>>> = Foo3
+  ]
+}) @ Loc {file=test/testdata/namer/visibility.rb start=44:3 end=44:8}
+    method <S <S <C <U Foo3>> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=44:3 end=46:6}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+  class <C <U Foo4>> < <C <U Object>> () @ Loc {file=test/testdata/namer/visibility.rb start=49:1 end=49:11}
+  class <S <C <U Foo4>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/visibility.rb start=50:3 end=50:8}
+    type-member(+) <S <C <U Foo4>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Foo4>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Foo4) @ Loc {file=test/testdata/namer/visibility.rb start=49:7 end=49:11}
+    method <S <C <U Foo4>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=49:1 end=55:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+    method <S <C <U Foo4>> $1><U foo> : private (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=51:5 end=51:12}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+  class <S <S <C <U Foo4>> $1> $1>[<C <U <AttachedClass>>>] < <S <S <C <U Object>> $1> $1> () @ Loc {file=test/testdata/namer/visibility.rb start=50:3 end=50:8}
+    type-member(+) <S <S <C <U Foo4>> $1> $1><C <U <AttachedClass>>> -> LambdaParam(<S <S <C <U Foo4>> $1> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {
+  klass = <S <C <U Foo4>> $1>
+  targs = [
+    <C <U <AttachedClass>>> = Foo4
+  ]
+}) @ Loc {file=test/testdata/namer/visibility.rb start=50:3 end=50:8}
+    method <S <S <C <U Foo4>> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=50:3 end=54:6}
       argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
 

--- a/test/testdata/rewriter/generic_module_function.rb
+++ b/test/testdata/rewriter/generic_module_function.rb
@@ -8,14 +8,14 @@
 # generic classes. This shouldn't be a problem with the DSL-ified
 # version.
 
-module M
+class M
   extend T::Sig
   extend T::Helpers
   extend T::Generic
 
-  A = type_member(:in)
+  A = type_member
 
-  interface!
+  abstract!
 
   sig {abstract.params(x: A).void}
   def foo(x); end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Support `private def :blah`.

### Motivation
We already handle cases like `private def foo` but this allows us to handle cases like `private :foo`.

An open question: should we raise an error if the method in question does not appear to exist? This branch does not implement such an error, but it might also be useful for a programmer who has written

```ruby
class A
    def foo; end
    private :food # will be an error if `A` does not implement `def food` elsewhere
end 
```

to be warned of this failure ahead-of-time. My concern was that this would run afoul of some metaprogramming patterns, but we could also e.g. implement it only at `typed: strict`, where we expect metaprogramming to be less common.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Added a new test specifically for this feature.