### PR TITLE
Fix signature of Array#select! to return nilable

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1885,7 +1885,7 @@ class Array < Object
     params(
         blk: T.proc.params(arg0: Elem).returns(BasicObject),
     )
-    .returns(T::Array[Elem])
+    .returns(T.nilable(T::Array[Elem]))
   end
   sig {returns(T::Enumerator[Elem])}
   def select!(&blk); end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixes #2075

### Test plan
This is similar to the change made in #1235, and only changes the signature to reflect what the documentation already says (i.e. that `select!` might return `nil` if no changes were made to the array).

I couldn't find any pre-existing tests for these kind of methods in [`test/testdata/rbi/array.rb`](https://github.com/sorbet/sorbet/blob/557d1cf1ab19c4257f2c6c9e7710575e831ac941/test/testdata/rbi/array.rb)