### PR TITLE
Add --default-strictness option

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1296,6 +1296,7 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
 
     result->silenceErrors = this->silenceErrors;
     result->autocorrect = this->autocorrect;
+    result->defaultStrictness = this->defaultStrictness;
     result->suggestRuntimeProfiledType = this->suggestRuntimeProfiledType;
     result->ensureCleanStrings = this->ensureCleanStrings;
     result->runningUnderAutogen = this->runningUnderAutogen;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -159,6 +159,7 @@ public:
     int globalStateId;
     bool silenceErrors = false;
     bool autocorrect = false;
+    std::optional<StrictLevel> defaultStrictness = std::nullopt;
     bool suggestRuntimeProfiledType = false;
 
     // We have a lot of internal names of form `<something>` that's chosen with `<` and `>` as you can't make

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -367,6 +367,9 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("no-error-count", "Do not print the error count summary line");
     options.add_options("advanced")("autogen-version", "Autogen version to output", cxxopts::value<int>());
     options.add_options("advanced")("stripe-mode", "Enable Stripe specific error enforcement", cxxopts::value<bool>());
+    options.add_options("advanced")(
+        "default-strictness", "Specifies a default strictness level to use for files without a '#typed: ' comment.",
+        cxxopts::value<string>()->default_value("false"));
 
     options.add_options("advanced")(
         "autogen-autoloader-exclude-require",
@@ -804,6 +807,7 @@ void readOptions(Options &opts,
         opts.debugLogFile = raw["debug-log-file"].as<string>();
         opts.webTraceFile = raw["web-trace-file"].as<string>();
         opts.reserveMemKiB = raw["reserve-mem-kb"].as<u8>();
+        opts.defaultStrictness = text2StrictLevel(raw["default-strictness"].as<string>(), logger);
         if (raw.count("autogen-version") > 0) {
             if (!opts.print.AutogenMsgPack.enabled) {
                 logger->error("`{}` must also include `{}`", "--autogen-version", "-p autogen-msgpack");

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -369,7 +369,7 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("stripe-mode", "Enable Stripe specific error enforcement", cxxopts::value<bool>());
     options.add_options("advanced")(
         "default-strictness", "Specifies a default strictness level to use for files without a '#typed: ' comment.",
-        cxxopts::value<string>()->default_value("false"));
+        cxxopts::value<string>());
 
     options.add_options("advanced")(
         "autogen-autoloader-exclude-require",
@@ -807,7 +807,11 @@ void readOptions(Options &opts,
         opts.debugLogFile = raw["debug-log-file"].as<string>();
         opts.webTraceFile = raw["web-trace-file"].as<string>();
         opts.reserveMemKiB = raw["reserve-mem-kb"].as<u8>();
-        opts.defaultStrictness = text2StrictLevel(raw["default-strictness"].as<string>(), logger);
+        if (raw["default-strictness"].count()) {
+            opts.defaultStrictness = text2StrictLevel(raw["default-strictness"].as<string>(), logger);
+        } else {
+            opts.defaultStrictness = std::nullopt;
+        }
         if (raw.count("autogen-version") > 0) {
             if (!opts.print.AutogenMsgPack.enabled) {
                 logger->error("`{}` must also include `{}`", "--autogen-version", "-p autogen-msgpack");

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -153,6 +153,7 @@ struct Options {
     std::vector<std::string> configatronDirs;
     std::vector<std::string> configatronFiles;
     UnorderedMap<std::string, core::StrictLevel> strictnessOverrides;
+    core::StrictLevel defaultStrictness;
     UnorderedMap<std::string, std::string> dslPluginTriggers;
     std::vector<std::string> dslRubyExtraArgs;
     std::string storeState = "";

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -153,7 +153,7 @@ struct Options {
     std::vector<std::string> configatronDirs;
     std::vector<std::string> configatronFiles;
     UnorderedMap<std::string, core::StrictLevel> strictnessOverrides;
-    core::StrictLevel defaultStrictness;
+    std::optional<core::StrictLevel> defaultStrictness;
     UnorderedMap<std::string, std::string> dslPluginTriggers;
     std::vector<std::string> dslRubyExtraArgs;
     std::string storeState = "";

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -378,7 +378,7 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
         level = fnd->second;
     } else {
         if (fileData.originalSigil == core::StrictLevel::None) {
-            level = core::StrictLevel::False;
+            level = opts.defaultStrictness;
         } else {
             level = fileData.originalSigil;
         }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -378,7 +378,7 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
         level = fnd->second;
     } else {
         if (fileData.originalSigil == core::StrictLevel::None) {
-            level = opts.defaultStrictness;
+            level = opts.defaultStrictness.value_or(core::StrictLevel::False);
         } else {
             level = fileData.originalSigil;
         }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -421,6 +421,7 @@ int realmain(int argc, char *argv[]) {
     if (opts.autocorrect) {
         gs->autocorrect = true;
     }
+    gs->defaultStrictness = opts.defaultStrictness;
     if (opts.suggestRuntimeProfiledType) {
         gs->suggestRuntimeProfiledType = true;
     }

--- a/test/cli/default-strictness/default-strictness.out
+++ b/test/cli/default-strictness/default-strictness.out
@@ -1,0 +1,11 @@
+test/cli/default-strictness/default-strictness.rb:1: Expected `String` but found `Symbol(:"error")` for argument `arg0` https://srb.help/7002
+     1 |"x" + :error
+        ^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/string.rbi#L58: Method `String#+` has specified `arg0` as `String`
+    58 |        arg0: String,
+                ^^^^
+  Got Symbol(:"error") originating from:
+    test/cli/default-strictness/default-strictness.rb:1:
+     1 |"x" + :error
+              ^^^^^^
+Errors: 1

--- a/test/cli/default-strictness/default-strictness.rb
+++ b/test/cli/default-strictness/default-strictness.rb
@@ -1,0 +1,10 @@
+"x" + :error
+
+module Foo
+  extend T::Sig
+
+  sig { returns(Integer) }
+  def bar
+    3
+  end
+end

--- a/test/cli/default-strictness/default-strictness.sh
+++ b/test/cli/default-strictness/default-strictness.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+main/sorbet --silence-dev-message --default-strictness true test/cli/default-strictness/default-strictness.rb 2>&1

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -108,6 +108,8 @@ Usage:
       --no-error-count          Do not print the error count summary line
       --autogen-version arg     Autogen version to output
       --stripe-mode             Enable Stripe specific error enforcement
+      --default-strictness arg  Specifies a default strictness level to use
+                                for files without a '#typed: ' comment.
       --autogen-autoloader-exclude-require arg
                                 Names that should be excluded from top-level
                                 require statements in autoloader output. (e.g.


### PR DESCRIPTION
This PR adds an `--default-strictness` option to explicitly specify a strictness level which files without a sigil should use. If the option is specified, files without a sigil:

  - Use whichever level is specified, instead of "false", and
  - Can use `sig`s.

The strictness level specified by `--default-strictness` has lower precedence than a sigil or typed override.

The implementation is designed not to interfere with any code which does not specify `--default-strictness`. That is, files without a sigil will still use "false" strictness and not allow `sig`s when the `--default-strictness` option is not specified.

### Motivation
This is a key part of implementing #1773, which requires a method of specifying a default strictness to be in place. Once #1773 is fully implemented, the diffs by `srb init` will be significantly smaller, which will make adopting Sorbet in an existing project easier.

### Test plan
See included automated tests. I have added a test for `--default-strictness`, and the existing "forgot-typed" test covers behavior when `--default-strictness` is not specified.
