### PR TITLE
in CFG.toString s/core::Context/core::GlobalState

### DIFF
--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -26,21 +26,21 @@ Return::Return(core::LocalVariable what) : what(what) {
     categoryCounterInc("cfg", "return");
 }
 
-string SolveConstraint::toString(core::Context ctx) const {
-    return fmt::format("Solve<{}, {}>", this->send.toString(ctx), this->link->fun.toString(ctx));
+string SolveConstraint::toString(const core::GlobalState &gs) const {
+    return fmt::format("Solve<{}, {}>", this->send.toString(gs), this->link->fun.toString(gs));
 }
 
-string SolveConstraint::showRaw(core::Context ctx, int tabs) const {
-    return fmt::format("Solve {{ send = {}, link = {} }}", this->send.toString(ctx), this->link->fun.showRaw(ctx));
+string SolveConstraint::showRaw(const core::GlobalState &gs, int tabs) const {
+    return fmt::format("Solve {{ send = {}, link = {} }}", this->send.toString(gs), this->link->fun.showRaw(gs));
 }
 
-string Return::toString(core::Context ctx) const {
-    return fmt::format("return {}", this->what.toString(ctx));
+string Return::toString(const core::GlobalState &gs) const {
+    return fmt::format("return {}", this->what.toString(gs));
 }
 
-string Return::showRaw(core::Context ctx, int tabs) const {
+string Return::showRaw(const core::GlobalState &gs, int tabs) const {
     return fmt::format("Return {{\n{0}&nbsp;what = {1},\n{0}}}", spacesForTabLevel(tabs),
-                       this->what.showRaw(ctx, tabs + 1));
+                       this->what.showRaw(gs, tabs + 1));
 }
 
 BlockReturn::BlockReturn(shared_ptr<core::SendAndBlockLink> link, core::LocalVariable what)
@@ -48,13 +48,13 @@ BlockReturn::BlockReturn(shared_ptr<core::SendAndBlockLink> link, core::LocalVar
     categoryCounterInc("cfg", "blockreturn");
 }
 
-string BlockReturn::toString(core::Context ctx) const {
-    return fmt::format("blockreturn<{}> {}", this->link->fun.toString(ctx), this->what.toString(ctx));
+string BlockReturn::toString(const core::GlobalState &gs) const {
+    return fmt::format("blockreturn<{}> {}", this->link->fun.toString(gs), this->what.toString(gs));
 }
 
-string BlockReturn::showRaw(core::Context ctx, int tabs) const {
+string BlockReturn::showRaw(const core::GlobalState &gs, int tabs) const {
     return fmt::format("BlockReturn {{\n{0}&nbsp;link = {1},\n{0}&nbsp;what = {2},\n{0}}}", spacesForTabLevel(tabs),
-                       this->link->fun.showRaw(ctx), this->what.showRaw(ctx, tabs + 1));
+                       this->link->fun.showRaw(gs), this->what.showRaw(gs, tabs + 1));
 }
 
 LoadSelf::LoadSelf(shared_ptr<core::SendAndBlockLink> link, core::LocalVariable fallback)
@@ -62,11 +62,11 @@ LoadSelf::LoadSelf(shared_ptr<core::SendAndBlockLink> link, core::LocalVariable 
     categoryCounterInc("cfg", "loadself");
 }
 
-string LoadSelf::toString(core::Context ctx) const {
+string LoadSelf::toString(const core::GlobalState &gs) const {
     return "loadSelf";
 }
 
-string LoadSelf::showRaw(core::Context ctx, int tabs) const {
+string LoadSelf::showRaw(const core::GlobalState &gs, int tabs) const {
     return fmt::format("LoadSelf {{}}", spacesForTabLevel(tabs));
 }
 
@@ -89,10 +89,10 @@ Literal::Literal(const core::TypePtr &value) : value(move(value)) {
     categoryCounterInc("cfg", "literal");
 }
 
-string Literal::toString(core::Context ctx) const {
+string Literal::toString(const core::GlobalState &gs) const {
     string res;
     typecase(
-        this->value.get(), [&](core::LiteralType *l) { res = l->showValue(ctx); },
+        this->value.get(), [&](core::LiteralType *l) { res = l->showValue(gs); },
         [&](core::ClassType *l) {
             if (l->symbol == core::Symbols::NilClass()) {
                 res = "nil";
@@ -101,15 +101,15 @@ string Literal::toString(core::Context ctx) const {
             } else if (l->symbol == core::Symbols::TrueClass()) {
                 res = "true";
             } else {
-                res = fmt::format("literal({})", this->value->toStringWithTabs(ctx, 0));
+                res = fmt::format("literal({})", this->value->toStringWithTabs(gs, 0));
             }
         },
-        [&](core::Type *t) { res = fmt::format("literal({})", this->value->toStringWithTabs(ctx, 0)); });
+        [&](core::Type *t) { res = fmt::format("literal({})", this->value->toStringWithTabs(gs, 0)); });
     return res;
 }
 
-string Literal::showRaw(core::Context ctx, int tabs) const {
-    return fmt::format("Literal {{ value = {} }}", this->value->show(ctx));
+string Literal::showRaw(const core::GlobalState &gs, int tabs) const {
+    return fmt::format("Literal {{ value = {} }}", this->value->show(gs));
 }
 
 Ident::Ident(core::LocalVariable what) : what(what) {
@@ -120,102 +120,102 @@ Alias::Alias(core::SymbolRef what) : what(what) {
     categoryCounterInc("cfg", "alias");
 }
 
-string Ident::toString(core::Context ctx) const {
-    return this->what.toString(ctx);
+string Ident::toString(const core::GlobalState &gs) const {
+    return this->what.toString(gs);
 }
 
-string Ident::showRaw(core::Context ctx, int tabs) const {
-    return fmt::format("Ident {{\n{0}&nbsp;what = {1},\n{0}}}", spacesForTabLevel(tabs), this->what.showRaw(ctx));
+string Ident::showRaw(const core::GlobalState &gs, int tabs) const {
+    return fmt::format("Ident {{\n{0}&nbsp;what = {1},\n{0}}}", spacesForTabLevel(tabs), this->what.showRaw(gs));
 }
 
-string Alias::toString(core::Context ctx) const {
-    return fmt::format("alias {}", this->what.data(ctx)->name.data(ctx)->toString(ctx));
+string Alias::toString(const core::GlobalState &gs) const {
+    return fmt::format("alias {}", this->what.data(gs)->name.data(gs)->toString(gs));
 }
 
-string Alias::showRaw(core::Context ctx, int tabs) const {
-    return fmt::format("Alias {{ what = {} }}", this->what.data(ctx)->show(ctx));
+string Alias::showRaw(const core::GlobalState &gs, int tabs) const {
+    return fmt::format("Alias {{ what = {} }}", this->what.data(gs)->show(gs));
 }
 
-string Send::toString(core::Context ctx) const {
-    return fmt::format("{}.{}({})", this->recv.toString(ctx), this->fun.data(ctx)->toString(ctx),
-                       fmt::map_join(this->args, ", ", [&](const auto &arg) -> string { return arg.toString(ctx); }));
+string Send::toString(const core::GlobalState &gs) const {
+    return fmt::format("{}.{}({})", this->recv.toString(gs), this->fun.data(gs)->toString(gs),
+                       fmt::map_join(this->args, ", ", [&](const auto &arg) -> string { return arg.toString(gs); }));
 }
 
-string Send::showRaw(core::Context ctx, int tabs) const {
+string Send::showRaw(const core::GlobalState &gs, int tabs) const {
     return fmt::format(
         "Send {{\n{0}&nbsp;recv = {1},\n{0}&nbsp;fun = {2},\n{0}&nbsp;args = ({3}),\n{0}}}", spacesForTabLevel(tabs),
-        this->recv.toString(ctx), this->fun.data(ctx)->showRaw(ctx),
-        fmt::map_join(this->args, ", ", [&](const auto &arg) -> string { return arg.showRaw(ctx, tabs + 1); }));
+        this->recv.toString(gs), this->fun.data(gs)->showRaw(gs),
+        fmt::map_join(this->args, ", ", [&](const auto &arg) -> string { return arg.showRaw(gs, tabs + 1); }));
 }
 
-string LoadArg::toString(core::Context ctx) const {
-    return fmt::format("load_arg({})", this->argument(ctx).argumentName(ctx));
+string LoadArg::toString(const core::GlobalState &gs) const {
+    return fmt::format("load_arg({})", this->argument(gs).argumentName(gs));
 }
 
-string LoadArg::showRaw(core::Context ctx, int tabs) const {
-    return fmt::format("LoadArg {{ argument = {} }}", this->argument(ctx).argumentName(ctx));
+string LoadArg::showRaw(const core::GlobalState &gs, int tabs) const {
+    return fmt::format("LoadArg {{ argument = {} }}", this->argument(gs).argumentName(gs));
 }
 
 const core::ArgInfo &LoadArg::argument(const core::GlobalState &gs) const {
     return this->method.data(gs)->arguments()[this->argId];
 }
 
-string LoadYieldParams::toString(core::Context ctx) const {
-    return fmt::format("load_yield_params({})", this->link->fun.toString(ctx));
+string LoadYieldParams::toString(const core::GlobalState &gs) const {
+    return fmt::format("load_yield_params({})", this->link->fun.toString(gs));
 }
 
-string LoadYieldParams::showRaw(core::Context ctx, int tabs) const {
-    return fmt::format("LoadYieldParams {{ link = {0} }}", this->link->fun.showRaw(ctx));
+string LoadYieldParams::showRaw(const core::GlobalState &gs, int tabs) const {
+    return fmt::format("LoadYieldParams {{ link = {0} }}", this->link->fun.showRaw(gs));
 }
 
-string Unanalyzable::toString(core::Context ctx) const {
+string Unanalyzable::toString(const core::GlobalState &gs) const {
     return "<unanalyzable>";
 }
 
-string Unanalyzable::showRaw(core::Context ctx, int tabs) const {
+string Unanalyzable::showRaw(const core::GlobalState &gs, int tabs) const {
     return fmt::format("Unanalyzable {{}}", spacesForTabLevel(tabs));
 }
 
-string NotSupported::toString(core::Context ctx) const {
+string NotSupported::toString(const core::GlobalState &gs) const {
     return fmt::format("NotSupported({})", why);
 }
 
-string NotSupported::showRaw(core::Context ctx, int tabs) const {
+string NotSupported::showRaw(const core::GlobalState &gs, int tabs) const {
     return fmt::format("NotSupported {{\n{0}&nbsp;why = {1},\n{0}}}", spacesForTabLevel(tabs), why);
 }
 
-string Cast::toString(core::Context ctx) const {
-    return fmt::format("cast({}, {});", this->value.toString(ctx), this->type->toString(ctx));
+string Cast::toString(const core::GlobalState &gs) const {
+    return fmt::format("cast({}, {});", this->value.toString(gs), this->type->toString(gs));
 }
 
-string Cast::showRaw(core::Context ctx, int tabs) const {
+string Cast::showRaw(const core::GlobalState &gs, int tabs) const {
     return fmt::format("Cast {{\n{0}&nbsp;cast = T.{1},\n{0}&nbsp;value = {2},\n{0}&nbsp;type = {3},\n{0}}}",
-                       spacesForTabLevel(tabs), this->cast.data(ctx)->show(ctx), this->value.showRaw(ctx, tabs + 1),
-                       this->type->show(ctx));
+                       spacesForTabLevel(tabs), this->cast.data(gs)->show(gs), this->value.showRaw(gs, tabs + 1),
+                       this->type->show(gs));
 }
 
-string TAbsurd::toString(core::Context ctx) const {
-    return fmt::format("T.absurd({})", this->what.toString(ctx));
+string TAbsurd::toString(const core::GlobalState &gs) const {
+    return fmt::format("T.absurd({})", this->what.toString(gs));
 }
 
-string TAbsurd::showRaw(core::Context ctx, int tabs) const {
+string TAbsurd::showRaw(const core::GlobalState &gs, int tabs) const {
     return fmt::format("TAbsurd {{\n{0}&nbsp;what = {1},\n{0}}}", spacesForTabLevel(tabs),
-                       this->what.showRaw(ctx, tabs + 1));
+                       this->what.showRaw(gs, tabs + 1));
 }
 
-string VariableUseSite::toString(core::Context ctx) const {
+string VariableUseSite::toString(const core::GlobalState &gs) const {
     if (this->type) {
-        return fmt::format("{}: {}", this->variable.toString(ctx), this->type->show(ctx));
+        return fmt::format("{}: {}", this->variable.toString(gs), this->type->show(gs));
     }
-    return this->variable.toString(ctx);
+    return this->variable.toString(gs);
 }
 
-string VariableUseSite::showRaw(core::Context ctx, int tabs) const {
+string VariableUseSite::showRaw(const core::GlobalState &gs, int tabs) const {
     if (this->type == nullptr) {
-        return fmt::format("VariableUseSite {{ variable = {} }}", this->variable.showRaw(ctx));
+        return fmt::format("VariableUseSite {{ variable = {} }}", this->variable.showRaw(gs));
     } else {
         return fmt::format("VariableUseSite {{\n{0}&nbsp;variable = {1},\n{0}&nbsp;type = {2},\n{0}}}",
-                           spacesForTabLevel(tabs), this->variable.showRaw(ctx), this->type->show(ctx));
+                           spacesForTabLevel(tabs), this->variable.showRaw(gs), this->type->show(gs));
     }
 }
 } // namespace sorbet::cfg

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -21,8 +21,8 @@ public:
     const VariableUseSite &operator=(const VariableUseSite &rhs) = delete;
     VariableUseSite(VariableUseSite &&) = default;
     VariableUseSite &operator=(VariableUseSite &&rhs) = default;
-    std::string toString(core::Context ctx) const;
-    std::string showRaw(core::Context ctx, int tabs = 0) const;
+    std::string toString(const core::GlobalState &gs) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
 };
 
 // TODO: convert it to implicitly numbered instead of explicitly bound
@@ -33,8 +33,8 @@ public:
 class Instruction {
 public:
     virtual ~Instruction() = default;
-    virtual std::string toString(core::Context ctx) const = 0;
-    virtual std::string showRaw(core::Context ctx, int tabs = 0) const = 0;
+    virtual std::string toString(const core::GlobalState &gs) const = 0;
+    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) const = 0;
     Instruction() = default;
     bool isSynthetic = false;
 };
@@ -55,8 +55,8 @@ public:
     core::LocalVariable what;
 
     Ident(core::LocalVariable what);
-    virtual std::string toString(core::Context ctx) const;
-    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
+    virtual std::string toString(const core::GlobalState &gs) const;
+    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
 };
 CheckSize(Ident, 24, 8);
 
@@ -66,8 +66,8 @@ public:
 
     Alias(core::SymbolRef what);
 
-    virtual std::string toString(core::Context ctx) const;
-    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
+    virtual std::string toString(const core::GlobalState &gs) const;
+    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
 };
 CheckSize(Alias, 16, 8);
 
@@ -77,8 +77,8 @@ public:
     core::LocalVariable send;
     SolveConstraint(const std::shared_ptr<core::SendAndBlockLink> &link, core::LocalVariable send)
         : link(link), send(send){};
-    virtual std::string toString(core::Context ctx) const;
-    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
+    virtual std::string toString(const core::GlobalState &gs) const;
+    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
 };
 CheckSize(SolveConstraint, 40, 8);
 
@@ -96,8 +96,8 @@ public:
          const InlinedVector<core::LocalVariable, 2> &args, InlinedVector<core::Loc, 2> argLocs,
          bool isPrivateOk = false, const std::shared_ptr<core::SendAndBlockLink> &link = nullptr);
 
-    virtual std::string toString(core::Context ctx) const;
-    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
+    virtual std::string toString(const core::GlobalState &gs) const;
+    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
 };
 CheckSize(Send, 160, 8);
 
@@ -106,8 +106,8 @@ public:
     VariableUseSite what;
 
     Return(core::LocalVariable what);
-    virtual std::string toString(core::Context ctx) const;
-    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
+    virtual std::string toString(const core::GlobalState &gs) const;
+    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
 };
 CheckSize(Return, 40, 8);
 
@@ -117,8 +117,8 @@ public:
     VariableUseSite what;
 
     BlockReturn(std::shared_ptr<core::SendAndBlockLink> link, core::LocalVariable what);
-    virtual std::string toString(core::Context ctx) const;
-    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
+    virtual std::string toString(const core::GlobalState &gs) const;
+    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
 };
 CheckSize(BlockReturn, 56, 8);
 
@@ -127,8 +127,8 @@ public:
     std::shared_ptr<core::SendAndBlockLink> link;
     core::LocalVariable fallback;
     LoadSelf(std::shared_ptr<core::SendAndBlockLink> link, core::LocalVariable fallback);
-    virtual std::string toString(core::Context ctx) const;
-    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
+    virtual std::string toString(const core::GlobalState &gs) const;
+    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
 };
 CheckSize(LoadSelf, 40, 8);
 
@@ -137,8 +137,8 @@ public:
     core::TypePtr value;
 
     Literal(const core::TypePtr &value);
-    virtual std::string toString(core::Context ctx) const;
-    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
+    virtual std::string toString(const core::GlobalState &gs) const;
+    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
 };
 CheckSize(Literal, 32, 8);
 
@@ -147,8 +147,8 @@ public:
     Unanalyzable() {
         categoryCounterInc("cfg", "unanalyzable");
     };
-    virtual std::string toString(core::Context ctx) const;
-    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
+    virtual std::string toString(const core::GlobalState &gs) const;
+    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
 };
 CheckSize(Unanalyzable, 16, 8);
 
@@ -159,8 +159,8 @@ public:
     NotSupported(std::string_view why) : why(why) {
         categoryCounterInc("cfg", "notsupported");
     };
-    virtual std::string toString(core::Context ctx) const;
-    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
+    virtual std::string toString(const core::GlobalState &gs) const;
+    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
 };
 CheckSize(NotSupported, 40, 8);
 
@@ -174,8 +174,8 @@ public:
     };
 
     const core::ArgInfo &argument(const core::GlobalState &gs) const;
-    virtual std::string toString(core::Context ctx) const;
-    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
+    virtual std::string toString(const core::GlobalState &gs) const;
+    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
 };
 CheckSize(LoadArg, 24, 8);
 
@@ -186,8 +186,8 @@ public:
     LoadYieldParams(const std::shared_ptr<core::SendAndBlockLink> &link) : link(link) {
         categoryCounterInc("cfg", "loadarg");
     };
-    virtual std::string toString(core::Context ctx) const;
-    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
+    virtual std::string toString(const core::GlobalState &gs) const;
+    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
 };
 CheckSize(LoadYieldParams, 32, 8);
 
@@ -200,8 +200,8 @@ public:
     Cast(core::LocalVariable value, const core::TypePtr &type, core::NameRef cast)
         : value(value), type(type), cast(cast) {}
 
-    virtual std::string toString(core::Context ctx) const;
-    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
+    virtual std::string toString(const core::GlobalState &gs) const;
+    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
 };
 CheckSize(Cast, 64, 8);
 
@@ -213,8 +213,8 @@ public:
         categoryCounterInc("cfg", "tabsurd");
     }
 
-    virtual std::string toString(core::Context ctx) const;
-    virtual std::string showRaw(core::Context ctx, int tabs = 0) const;
+    virtual std::string toString(const core::GlobalState &gs) const;
+    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
 };
 CheckSize(TAbsurd, 40, 8);
 


### PR DESCRIPTION
None of these things use the Context. I think the person who changed all the ones in Symbol just forgot these.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
