### PR TITLE
Fix `T.type_alias` signature in `sorbet` gem shim

### DIFF
--- a/gems/sorbet/lib/t.rb
+++ b/gems/sorbet/lib/t.rb
@@ -25,7 +25,7 @@ module T
   def self.proc; end
   def self.self_type; end
   def self.class_of(klass); end
-  def self.type_alias(type); end
+  def self.type_alias(type=nil, &blk); end
   def self.type_parameter(name); end
 
   def self.cast(value, type, checked: true); value; end


### PR DESCRIPTION
### Motivation

It seems this shim wasn't updated when the signature of `T.type_alias` was changed.

### Test plan

No tests.
