### PR TITLE
Add implementation of T::Enum to sorbet-runtime

### DIFF
--- a/gems/sorbet-runtime/lib/sorbet-runtime.rb
+++ b/gems/sorbet-runtime/lib/sorbet-runtime.rb
@@ -99,6 +99,8 @@ require_relative 'types/props/constructor'
 require_relative 'types/props/pretty_printable'
 require_relative 'types/props/serializable'
 require_relative 'types/props/type_validation'
+
 require_relative 'types/struct'
+require_relative 'types/enum'
 
 require_relative 'types/compatibility_patches'

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -356,6 +356,7 @@ module T::Configuration
     String
     Symbol
     Time
+    T::Enum
   }).freeze
 
   def self.scalar_types

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -382,6 +382,15 @@ module T::Configuration
     end
   end
 
+  def self.enable_legacy_t_enum_migration_mode
+    @legacy_t_enum_migration_mode = true
+  end
+  def self.disable_legacy_t_enum_migration_mode
+    @legacy_t_enum_migration_mode = false
+  end
+  def self.legacy_t_enum_migration_mode?
+    @legacy_t_enum_migration_mode || false
+  end
 
   private_class_method def self.validate_lambda_given!(value)
     if !value.nil? && !value.respond_to?(:call)

--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -129,12 +129,12 @@ class T::Enum
 
 
   sig {returns(T.self_type)}
-  def dup # rubocop:disable PrisonGuard/BanBuiltinMethodOverride
+  def dup
     self
   end
 
   sig {returns(T.self_type).checked(:tests)}
-  def clone # rubocop:disable PrisonGuard/BanBuiltinMethodOverride
+  def clone
     self
   end
 
@@ -193,7 +193,7 @@ class T::Enum
   end
 
   sig {params(other: BasicObject).returns(T::Boolean).checked(:never)}
-  def ==(other) # rubocop:disable PrisonGuard/NoIncompleteEquality
+  def ==(other)
     case other
     when String
       comparison_assertion_failed(:==, other)
@@ -301,7 +301,7 @@ class T::Enum
     # Freeze the Enum class and bind the constant names into each of the instances.
     @mapping = {}
     self.constants(false).each do |const_name|
-      instance = self.const_get(const_name, false) # rubocop:disable PrisonGuard/NoDynamicConstAccess
+      instance = self.const_get(const_name, false)
       if !instance.is_a?(self)
         raise "Invalid constant #{self}::#{const_name} on enum. " \
           "All constants defined for an enum must be instances itself (e.g. `Foo = new`)."

--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 # typed: strict
-require_relative '../../extn'
-Opus::AutogenLoader.init(__FILE__)
 
 # Enumerations allow for type-safe declarations of a fixed set of values.
 #
@@ -42,6 +40,7 @@ Opus::AutogenLoader.init(__FILE__)
 # WARNING: Enum instances are singletons that are shared among all their users. Their internals
 # should be kept immutable to avoid unpredictable action at a distance.
 class T::Enum
+  extend T::Sig
   extend T::Props::CustomType
 
   # TODO(jez) Might want to restrict this, or make subclasses provide this type

--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -107,10 +107,10 @@ class T::Enum
     return nil if instance.nil?
 
     if self == T::Enum
-      Opus::Error.hard("Cannot call T::Enum.serialize directly. You must call on a specific child class.")
+      raise "Cannot call T::Enum.serialize directly. You must call on a specific child class."
     end
     if instance.class != self
-      Opus::Error.hard("Cannot call #serialize on a value that is not an instance of #{self}.")
+      raise "Cannot call #serialize on a value that is not an instance of #{self}."
     end
     instance.serialize
   end
@@ -119,7 +119,7 @@ class T::Enum
   sig {params(mongo_value: SerializedVal).returns(T.experimental_attached_class).checked(:never)}
   def self.deserialize(mongo_value)
     if self == T::Enum
-      Opus::Error.hard("Cannot call T::Enum.deserialize directly. You must call on a specific child class.")
+      raise "Cannot call T::Enum.deserialize directly. You must call on a specific child class."
     end
     self.from_serialized(mongo_value)
   end
@@ -184,10 +184,9 @@ class T::Enum
   # See https://ruby-doc.org/core-2.4.0/String.html#method-i-3D-3D
   sig {returns(String)}
   def to_str
-    Opus::Error.soft(
+    T::Configuration.soft_assert_handler(
       'Implicit conversion of Enum instances to strings is not allowed. Call #serialize instead.',
       storytime: {class: self.class.name},
-      notify: 'nroman',
     )
     serialize.to_s
   end
@@ -216,7 +215,7 @@ class T::Enum
 
   sig {params(method: Symbol, other: T.untyped).void}
   private def comparison_assertion_failed(method, other)
-    Opus::Error.soft(
+    T::Configuration.soft_assert_handler(
       'Enum to string comparison not allowed. Compare to the Enum instance directly instead. See go/enum-migration',
       storytime: {
         class: self.class.name,
@@ -224,8 +223,7 @@ class T::Enum
         other: other,
         other_class: other.class.name,
         method: method,
-      },
-      notify: 'nroman',
+      }
     )
   end
 

--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -1,0 +1,328 @@
+# frozen_string_literal: true
+# typed: strict
+require_relative '../../extn'
+Opus::AutogenLoader.init(__FILE__)
+
+# Enumerations allow for type-safe declarations of a fixed set of values.
+#
+# Every value is a singleton instance of the class (i.e. `Suit::SPADE.is_a?(Suit) == true`).
+#
+# Each value has a corresponding serialized value. By default this is the constant's name converted
+# to lowercase (e.g. `Suit::Club.serialize == 'club'`); however a custom value may be passed to the
+# constructor. Enum will `freeze` the serialized value.
+#
+# @example Declaring an Enum:
+#   class Suit < T::Enum
+#     enums do
+#       CLUB = T.let(new, Suit)
+#       SPADE = T.let(new, Suit)
+#       DIAMOND = T.let(new, Suit)
+#       HEART = T.let(new, Suit)
+#     end
+#   end
+#
+# @example Custom serialization value:
+#   class Status < T::Enum
+#     enums do
+#       READY = T.let(new('rdy'), Status)
+#       ...
+#     end
+#   end
+#
+# @example Accessing values:
+#   Suit::SPADE
+#
+# @example Converting from serialized value to enum instance:
+#   Suit.from_serialized('club') == Suit::CLUB
+#
+# @example Using enums in type signatures:
+#   sig {params(suit: Suit).returns(Boolean)}
+#   def is_red?(suit); ...; end
+#
+# WARNING: Enum instances are singletons that are shared among all their users. Their internals
+# should be kept immutable to avoid unpredictable action at a distance.
+class T::Enum
+  extend T::Props::CustomType
+
+  # TODO(jez) Might want to restrict this, or make subclasses provide this type
+  SerializedVal = T.type_alias {T.untyped}
+  private_constant :SerializedVal
+
+  ## Enum class methods ##
+  sig {returns(T::Array[T.experimental_attached_class])}
+  def self.values
+    if @values.nil?
+      raise "Attempting to access values of #{self.class} before it has been initialized." \
+        " Enums are not initialized until the 'enums do' block they are defined in has finished running."
+    end
+    @values
+  end
+
+  # Convert from serialized value to enum instance.
+  #
+  # Note: It would have been nice to make this method final before people started overriding it.
+  # Note: Failed CriticalMethodsNoRuntimeTypingTest
+  #
+  # @return [self]
+  # @raise [KeyError] if serialized value does not match any instance.
+  sig {overridable.params(serialized_val: SerializedVal).returns(T.experimental_attached_class).checked(:never)}
+  def self.from_serialized(serialized_val)
+    if @mapping.nil?
+      raise "Attempting to access serialization map of #{self.class} before it has been initialized." \
+        " Enums are not initialized until the 'enums do' block they are defined in has finished running."
+    end
+    res = @mapping[serialized_val]
+    if res.nil?
+      raise KeyError.new("Enum #{self} key not found: #{serialized_val.inspect}")
+    end
+    res
+  end
+
+  # Note: It would have been nice to make this method final before people started overriding it.
+  # @return [Boolean] Does the given serialized value correspond with any of this enum's values.
+  sig {overridable.params(serialized_val: SerializedVal).returns(T::Boolean)}
+  def self.has_serialized?(serialized_val)
+    if @mapping.nil?
+      raise "Attempting to access serialization map of #{self.class} before it has been initialized." \
+        " Enums are not initialized until the 'enums do' block they are defined in has finished running."
+    end
+    @mapping.include?(serialized_val)
+  end
+
+
+  ## T::Props::CustomType
+
+  # Note: Failed CriticalMethodsNoRuntimeTypingTest
+  sig {params(value: T.untyped).returns(T::Boolean).checked(:never)}
+  def self.instance?(value)
+    value.is_a?(self)
+  end
+
+  # Note: Failed CriticalMethodsNoRuntimeTypingTest
+  sig {params(instance: T.nilable(T::Enum)).returns(SerializedVal).checked(:never)}
+  def self.serialize(instance)
+    # This is needed otherwise if a Chalk::ODM::Document with a property of the shape
+    # T::Hash[T.nilable(MyEnum), Integer] and a value that looks like {nil => 0} is
+    # serialized, we throw the error on L102.
+    return nil if instance.nil?
+
+    if self == T::Enum
+      Opus::Error.hard("Cannot call T::Enum.serialize directly. You must call on a specific child class.")
+    end
+    if instance.class != self
+      Opus::Error.hard("Cannot call #serialize on a value that is not an instance of #{self}.")
+    end
+    instance.serialize
+  end
+
+  # Note: Failed CriticalMethodsNoRuntimeTypingTest
+  sig {params(mongo_value: SerializedVal).returns(T.experimental_attached_class).checked(:never)}
+  def self.deserialize(mongo_value)
+    if self == T::Enum
+      Opus::Error.hard("Cannot call T::Enum.deserialize directly. You must call on a specific child class.")
+    end
+    self.from_serialized(mongo_value)
+  end
+
+
+  ## Enum instance methods ##
+
+
+  sig {returns(T.self_type)}
+  def dup # rubocop:disable PrisonGuard/BanBuiltinMethodOverride
+    self
+  end
+
+  sig {returns(T.self_type).checked(:tests)}
+  def clone # rubocop:disable PrisonGuard/BanBuiltinMethodOverride
+    self
+  end
+
+  # Note: Failed CriticalMethodsNoRuntimeTypingTest
+  sig {returns(SerializedVal).checked(:never)}
+  def serialize
+    assert_bound!
+    @serialized_val
+  end
+
+  sig {params(args: T.untyped).returns(T.untyped)}
+  def to_json(*args)
+    serialize.to_json(*args)
+  end
+
+  sig {returns(String)}
+  def to_s
+    inspect
+  end
+
+  sig {returns(String)}
+  def inspect
+    "#<#{self.class.name}::#{@const_name || '__UNINITIALIZED__'}>"
+  end
+
+  sig {params(other: BasicObject).returns(T.nilable(Integer))}
+  def <=>(other)
+    case other
+    when self.class
+      self.serialize <=> other.serialize
+    else
+      nil
+    end
+  end
+
+
+  ## Migrating from `make_accessible` / `make_accessible_DEPRECATED` ##
+  #
+  # TODO [nroman] Remove these once the migration is complete
+
+  # NB: Do not call this method. This exists to allow for a safe migration path in places where enum
+  # values are compared directly against string values.
+  #
+  # Ruby's string has a weird quirk where `'my_string' == obj` calls obj.==('my_string') if obj
+  # responds to the `to_str` method. It does not actually call `to_str` however.
+  #
+  # See https://ruby-doc.org/core-2.4.0/String.html#method-i-3D-3D
+  sig {returns(String)}
+  def to_str
+    Opus::Error.soft(
+      'Implicit conversion of Enum instances to strings is not allowed. Call #serialize instead.',
+      storytime: {class: self.class.name},
+      notify: 'nroman',
+    )
+    serialize.to_s
+  end
+
+  sig {params(other: BasicObject).returns(T::Boolean).checked(:never)}
+  def ==(other) # rubocop:disable PrisonGuard/NoIncompleteEquality
+    case other
+    when String
+      comparison_assertion_failed(:==, other)
+      self.serialize == other
+    else
+      super(other)
+    end
+  end
+
+  sig {params(other: BasicObject).returns(T::Boolean).checked(:never)}
+  def ===(other)
+    case other
+    when String
+      comparison_assertion_failed(:===, other)
+      self.serialize == other
+    else
+      super(other)
+    end
+  end
+
+  sig {params(method: Symbol, other: T.untyped).void}
+  private def comparison_assertion_failed(method, other)
+    Opus::Error.soft(
+      'Enum to string comparison not allowed. Compare to the Enum instance directly instead. See go/enum-migration',
+      storytime: {
+        class: self.class.name,
+        self: self.inspect,
+        other: other,
+        other_class: other.class.name,
+        method: method,
+      },
+      notify: 'nroman',
+    )
+  end
+
+
+  ## Private implementation ##
+
+
+  sig {params(serialized_val: SerializedVal).void}
+  private def initialize(serialized_val=nil)
+    raise 'T::Enum is abstract' if self.class == T::Enum
+    if !self.class.started_initializing?
+      raise "Must instantiate all enum values of #{self.class} inside 'enums do'."
+    end
+    if self.class.fully_initialized?
+      raise "Cannot instantiate a new enum value of #{self.class} after it has been initialized."
+    end
+
+    serialized_val = serialized_val.frozen? ? serialized_val : serialized_val.dup.freeze
+    @serialized_val = T.let(serialized_val, T.nilable(SerializedVal))
+    @const_name = T.let(nil, T.nilable(Symbol))
+  end
+
+  sig {returns(NilClass).checked(:never)}
+  private def assert_bound!
+    if @const_name.nil?
+      raise "Attempting to access Enum value on #{self.class} before it has been initialized." \
+        " Enums are not initialized until the 'enums do' block they are defined in has finished running."
+    end
+  end
+
+  sig {params(const_name: Symbol).void}
+  def _bind_name(const_name)
+    @const_name = const_name
+    @serialized_val = const_to_serialized_val(const_name) if @serialized_val.nil?
+    freeze
+  end
+
+  sig {params(const_name: Symbol).returns(String)}
+  private def const_to_serialized_val(const_name)
+    # Historical note: We convert to lowercase names because the majority of existing calls to
+    # `make_accessible` were arrays of lowercase strings. Doing this conversion allowed for the
+    # least amount of repetition in migrated declarations.
+    const_name.to_s.downcase.freeze
+  end
+
+  sig {returns(T::Boolean)}
+  def self.started_initializing?
+    @started_initializing = T.let(@started_initializing, T.nilable(T::Boolean))
+    @started_initializing ||= false
+  end
+
+  sig {returns(T::Boolean)}
+  def self.fully_initialized?
+    @fully_initialized = T.let(@fully_initialized, T.nilable(T::Boolean))
+    @fully_initialized ||= false
+  end
+
+  # Entrypoint for allowing people to register new enum values.
+  # All enum values must be defined within this block.
+  sig {params(blk: T.proc.void).void}
+  def self.enums(&blk)
+    raise "enums cannot be defined for T::Enum" if self == T::Enum
+    raise "Enum #{self} was already initialized" if @fully_initialized
+    raise "Enum #{self} is still initializing" if @started_initializing
+
+    @started_initializing = true
+
+    yield
+
+    @values = T.let(nil, T.nilable(T::Array[T.experimental_attached_class]))
+    @mapping = T.let(nil, T.nilable(T::Hash[SerializedVal, T.experimental_attached_class]))
+
+    # Freeze the Enum class and bind the constant names into each of the instances.
+    @mapping = {}
+    self.constants(false).each do |const_name|
+      instance = self.const_get(const_name, false) # rubocop:disable PrisonGuard/NoDynamicConstAccess
+      if !instance.is_a?(self)
+        raise "Invalid constant #{self}::#{const_name} on enum. " \
+          "All constants defined for an enum must be instances itself (e.g. `Foo = new`)."
+      end
+
+      instance._bind_name(const_name)
+      serialized = instance.serialize
+      if @mapping.include?(serialized)
+        raise "Enum values must have unique serializations. Value '#{serialized}' is repeated on #{self}."
+      end
+      @mapping[serialized] = instance
+    end
+    @values = @mapping.values.sort.freeze
+    @mapping.freeze
+    @fully_initialized = true
+  end
+
+  sig {params(child_class: Module).void}
+  def self.inherited(child_class)
+    super
+
+    raise "Inheriting from children of T::Enum is prohibited" if self != T::Enum
+  end
+end

--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -170,10 +170,6 @@ class T::Enum
   end
 
 
-  ## Migrating from `make_accessible` / `make_accessible_DEPRECATED` ##
-  #
-  # TODO [nroman] Remove these once the migration is complete
-
   # NB: Do not call this method. This exists to allow for a safe migration path in places where enum
   # values are compared directly against string values.
   #

--- a/gems/sorbet-runtime/test/test_helper.rb
+++ b/gems/sorbet-runtime/test/test_helper.rb
@@ -10,6 +10,7 @@ require 'mocha/minitest'
 
 require 'pathname'
 require 'tempfile'
+require 'json'
 
 require_relative '../lib/sorbet-runtime'
 

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -216,8 +216,6 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
     #   MyEnum < T::Enum
     #     Foo = new
     #   end
-    #
-    # rubocop:disable PrisonGuard/NoDynamicConstAccess
 
     it 'does not allow duplicated serialized_vals' do
       ex = assert_raises(RuntimeError) do
@@ -293,7 +291,6 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
         ex.message
       )
     end
-    # rubocop:enable PrisonGuard/NoDynamicConstAccess
   end
 
   describe 'string value comparison assertions' do
@@ -311,10 +308,10 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
 
     it 'raises an assertion if string is lhs of comparison' do
       expect_soft_error(ENUM_COMPARE_MSG)
-      assert_equal(true, 'spade' == CardSuit::SPADE) # rubocop:disable Style/YodaCondition (that's the point of this test)
+      assert_equal(true, 'spade' == CardSuit::SPADE)
 
       expect_soft_error(ENUM_COMPARE_MSG)
-      assert_equal(false, 'diamond' == CardSuit::SPADE) # rubocop:disable Style/YodaCondition (that's the point of this test)
+      assert_equal(false, 'diamond' == CardSuit::SPADE)
     end
 
     it 'raises an assertion if string is rhs of comparison' do
@@ -327,18 +324,18 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
 
     it 'raises an assertion if string is lhs of === comparison' do
       expect_soft_error(ENUM_COMPARE_MSG)
-      assert_equal(true, 'spade' === CardSuit::SPADE) # rubocop:disable Style/CaseEquality
+      assert_equal(true, 'spade' === CardSuit::SPADE)
 
       expect_soft_error(ENUM_COMPARE_MSG)
-      assert_equal(false, 'club' === CardSuit::SPADE) # rubocop:disable Style/CaseEquality
+      assert_equal(false, 'club' === CardSuit::SPADE)
     end
 
     it 'raises an assertion if string is rhs of === comparison' do
       expect_soft_error(ENUM_COMPARE_MSG)
-      assert_equal(true, CardSuit::SPADE === 'spade') # rubocop:disable Style/CaseEquality
+      assert_equal(true, CardSuit::SPADE === 'spade')
 
       expect_soft_error(ENUM_COMPARE_MSG)
-      assert_equal(false, CardSuit::CLUB === 'spade') # rubocop:disable Style/CaseEquality
+      assert_equal(false, CardSuit::CLUB === 'spade')
     end
 
     it 'raises an assertion for a string in a `when` compared to an enum value' do

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -1,0 +1,371 @@
+# frozen_string_literal: true
+# typed: false
+require_relative '../../../extn'
+Opus::AutogenLoader.init(__FILE__)
+
+class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
+  include Critic::Helpers::Errors
+  include Critic::Helpers::Constants
+
+  class CardSuit < T::Enum
+    enums do
+      CLUB = new
+      SPADE = new
+      DIAMOND = new
+      HEART = new
+    end
+  end
+
+  class CardSuitCustom < T::Enum
+    enums do
+      CLUB = new('_club_')
+      SPADE = new('_spade_')
+      DIAMOND = new('_diamond_')
+      HEART = new('_heart_')
+    end
+  end
+
+  describe 'serialize' do
+    describe 'default serialization' do
+      it 'downcases the constant names' do
+        assert_equal('club', CardSuit::CLUB.serialize)
+        assert_equal('spade', CardSuit::SPADE.serialize)
+        assert_equal('diamond', CardSuit::DIAMOND.serialize)
+        assert_equal('heart', CardSuit::HEART.serialize)
+      end
+    end
+
+    describe 'custom serialized values' do
+      it 'uses the provided serialized values' do
+        assert_equal('_club_', CardSuitCustom::CLUB.serialize)
+        assert_equal('_spade_', CardSuitCustom::SPADE.serialize)
+        assert_equal('_diamond_', CardSuitCustom::DIAMOND.serialize)
+        assert_equal('_heart_', CardSuitCustom::HEART.serialize)
+      end
+    end
+  end
+
+  describe 'desired properties' do
+    it 'basic ancestry' do
+      assert(CardSuit::DIAMOND.is_a?(CardSuit))
+      assert(CardSuit < T::Enum)
+    end
+
+    it 'works with case statements' do
+      suit = CardSuit::SPADE
+      case suit
+      when CardSuit::HEART, CardSuit::DIAMOND, CardSuit::CLUB
+        flunk
+      when CardSuit::SPADE
+        true
+      else
+        flunk
+      end
+    end
+  end
+
+  describe 'inspect' do
+    it 'prints the full constant name' do
+      assert_equal('#<T::Enum::Test::EnumTest::CardSuit::SPADE>', CardSuit::SPADE.inspect)
+    end
+  end
+
+  describe 'sorting' do
+    it 'sorts according to serialized_val' do
+      assert_equal(CardSuit::CLUB, CardSuit.values.min) # 'c' is first alphabetically
+      assert_equal(CardSuit::SPADE, CardSuit.values.max)
+    end
+  end
+
+  describe 'to_s' do
+    it 'prints the full constant name' do
+      assert_equal('#<T::Enum::Test::EnumTest::CardSuit::SPADE>', CardSuit::SPADE.to_s)
+    end
+  end
+
+  describe 'values' do
+    it 'returns an array of enum instances' do
+      assert_equal(
+        [CardSuit::CLUB, CardSuit::DIAMOND, CardSuit::HEART, CardSuit::SPADE],
+        CardSuit.values
+      )
+    end
+
+    it 'is a frozen array' do
+      ex = assert_raises(RuntimeError) do
+        CardSuit.values << 'foo'
+      end
+      assert_match(/can't modify frozen Array/, ex.message)
+    end
+  end
+
+  describe 'from_serialized' do
+    it 'returns the corresponding enum instance' do
+      club = CardSuit.from_serialized('club')
+      assert_equal(CardSuit::CLUB, club)
+      assert_equal(CardSuit::CLUB.object_id, club.object_id)
+    end
+
+    it 'returns the corresponding enum instance with custom serialization' do
+      club = CardSuitCustom.from_serialized('_club_')
+      assert_equal(CardSuitCustom::CLUB, club)
+      assert_equal(CardSuitCustom::CLUB.object_id, club.object_id)
+    end
+
+    it 'raises KeyError for a value that does it does not contain' do
+      assert_raises(KeyError) do
+        CardSuit.from_serialized('whoopsies')
+      end
+    end
+  end
+
+  describe 'has_serialized?' do
+    it 'works for default serializations' do
+      assert_equal(true, CardSuit.has_serialized?('heart'))
+      assert_equal(false, CardSuit.has_serialized?('blerg'))
+    end
+
+    it 'works for custom serializations' do
+      assert_equal(true, CardSuitCustom.has_serialized?('_spade_'))
+      assert_equal(false, CardSuitCustom.has_serialized?('spade'))
+      assert_equal(false, CardSuitCustom.has_serialized?('blerg'))
+    end
+  end
+
+  describe 'to_json' do
+    it 'serializes to a JSON string' do
+      assert_equal('"club"', CardSuit::CLUB.to_json)
+    end
+
+    it 'serializes to a string when used as a hash value' do
+      h = {
+        key1: CardSuit::SPADE,
+        key2: CardSuitCustom::HEART,
+      }
+      assert_equal("{\"key1\":\"spade\",\"key2\":\"_heart_\"}", h.to_json)
+    end
+
+    it 'serializes hash keys with the inspect string' do
+      h = {
+        CardSuit::SPADE => 'x',
+        CardSuitCustom::HEART => 'y',
+      }
+      assert_equal(
+        {
+          "#<T::Enum::Test::EnumTest::CardSuit::SPADE>" => "x",
+          "#<T::Enum::Test::EnumTest::CardSuitCustom::HEART>" => "y",
+        },
+        JSON.parse(h.to_json))
+    end
+  end
+
+  describe 'T::Props::CustomType integration' do
+    it 'supports instance? checks on the Enum class' do
+      assert_equal(true, CardSuit.instance?(CardSuit::SPADE))
+      assert_equal(false, CardSuit.instance?(CardSuit))
+      assert_equal(false, CardSuit.instance?(CardSuitCustom::HEART))
+      assert_equal(false, CardSuit.instance?(nil))
+    end
+
+    it 'supports class level serialize' do
+      assert_equal('spade', CardSuit.serialize(CardSuit::SPADE))
+      assert_equal('_spade_', CardSuitCustom.serialize(CardSuitCustom::SPADE))
+    end
+
+    it 'does not allow serialization of strings' do
+      assert_raises_hard_error(/Cannot call #serialize on a value that is not an instance of .*CardSuit/) do
+        CardSuit.serialize("heart")
+      end
+    end
+
+    it 'does not allow a different instance type to be serialized' do
+      assert_raises_hard_error(/Cannot call #serialize on a value that is not an instance of .*CardSuitCustom/) do
+        CardSuitCustom.serialize(CardSuit::HEART) # mixed Custom and non-Custom
+      end
+    end
+
+    it 'does not allow T::Enum.serialize to be called directly' do
+      assert_raises_hard_error(/Cannot call T::Enum.serialize directly/) do
+        T::Enum.serialize(CardSuit::HEART)
+      end
+    end
+
+    it 'supports class-level deserialize' do
+      assert_equal(CardSuit::CLUB, CardSuit.deserialize('club'))
+    end
+
+    it 'does not allow calling T::Enum.deserialize directly' do
+      assert_raises_hard_error(/Cannot call T::Enum.deserialize directly/) do
+        T::Enum.deserialize('abcdef')
+      end
+    end
+  end
+
+  describe 'enum declaration validation' do
+    # NB: Constants declared like `FOO = bar` are not added to classes that are declared with blocks
+    # (e.g. `Class.new do ...`). To get around this in these tests we `const_set` directly.
+    #
+    # For purposes of these tests, the  declaration of the following form
+    #
+    #   Opus::LoadHooks.class_with_load_hooks(T::Enum) do
+    #     const_set(:FOO, new)
+    #   end
+    #
+    # is equivalent to:
+    #
+    #   MyEnum < T::Enum
+    #     Foo = new
+    #   end
+    #
+    # rubocop:disable PrisonGuard/NoDynamicConstAccess
+
+    it 'does not allow duplicated serialized_vals' do
+      ex = assert_raises(RuntimeError) do
+        Class.new(T::Enum) do
+          enums do
+            const_set(:FOO, new('a'))
+            const_set(:BAR, new('b'))
+            const_set(:BAZ, new('a'))
+          end
+        end
+      end
+      assert_match(/Enum values must have unique serializations. Value 'a' is repeated/, ex.message)
+    end
+
+    it 'does not allow for constants on an enum that are not instances of itself' do
+      ex = assert_raises(RuntimeError) do
+        Class.new(T::Enum) do
+          enums do
+            const_set(:FOO, new('a'))
+            const_set(:THIS_IS_BAD, 'mystring')
+          end
+        end
+      end
+      assert_match(/Invalid constant .*::THIS_IS_BAD on enum/, ex.message)
+    end
+
+    it 'does not allow more values to be added to an enum after it has been defined' do
+      ex = assert_raises(RuntimeError) do
+        CardSuit.send(:new, 'another_val')
+      end
+      assert_equal(
+        'Cannot instantiate a new enum value of T::Enum::Test::EnumTest::CardSuit after it has been initialized.',
+        ex.message
+      )
+    end
+
+    it 'returns the same object for #dup and #clone' do
+      assert_equal(CardSuit::DIAMOND.object_id, CardSuit::DIAMOND.dup.object_id)
+      assert_equal(CardSuit::DIAMOND.object_id, CardSuit::DIAMOND.clone.object_id)
+    end
+
+    it 'does not allow the T::Enum to be instantiated' do
+      ex = assert_raises(RuntimeError) do
+        T::Enum.send(:new, 'another_val')
+      end
+      assert_equal(
+        'T::Enum is abstract',
+        ex.message
+      )
+    end
+
+    it 'does not allow Enum classes to be inherited from' do
+      ex = assert_raises(RuntimeError) do
+        Class.new(CardSuit) do
+          const_set(:FOO, new('a'))
+        end
+      end
+      assert_equal('Inheriting from children of T::Enum is prohibited', ex.message)
+    end
+
+    it 'raises if an uninitialized enum is serialized' do
+      ex = assert_raises(RuntimeError) do
+        Class.new(T::Enum) do
+          enums do
+            const_set(:FOO, new('a'))
+            # At this point FOO has not been initialized yet
+            const_get(:FOO, false).serialize
+          end
+        end
+      end
+      assert_match(
+        /Attempting to access Enum value on #<.*> before it has been initialized/,
+        ex.message
+      )
+    end
+    # rubocop:enable PrisonGuard/NoDynamicConstAccess
+  end
+
+  describe 'string value comparison assertions' do
+    ENUM_COMPARE_MSG = 'Enum to string comparison not allowed. Compare to the Enum instance directly instead. See go/enum-migration'
+
+    it 'raises an assertion if to_str is called and also returns the serialized value' do
+      expect_soft_error('Implicit conversion of Enum instances to strings is not allowed. Call #serialize instead.')
+      assert_equal('heart', CardSuit::HEART.to_str)
+    end
+
+    it 'raises an assertion if to_str is called (implicitly) and also returns the serialized value' do
+      expect_soft_error('Implicit conversion of Enum instances to strings is not allowed. Call #serialize instead.')
+      assert_equal('foo heart', 'foo ' + CardSuit::HEART)
+    end
+
+    it 'raises an assertion if string is lhs of comparison' do
+      expect_soft_error(ENUM_COMPARE_MSG)
+      assert_equal(true, 'spade' == CardSuit::SPADE) # rubocop:disable Style/YodaCondition (that's the point of this test)
+
+      expect_soft_error(ENUM_COMPARE_MSG)
+      assert_equal(false, 'diamond' == CardSuit::SPADE) # rubocop:disable Style/YodaCondition (that's the point of this test)
+    end
+
+    it 'raises an assertion if string is rhs of comparison' do
+      expect_soft_error(ENUM_COMPARE_MSG)
+      assert_equal(true, CardSuit::SPADE == 'spade')
+
+      expect_soft_error(ENUM_COMPARE_MSG)
+      assert_equal(false, CardSuit::SPADE == 'diamond')
+    end
+
+    it 'raises an assertion if string is lhs of === comparison' do
+      expect_soft_error(ENUM_COMPARE_MSG)
+      assert_equal(true, 'spade' === CardSuit::SPADE) # rubocop:disable Style/CaseEquality
+
+      expect_soft_error(ENUM_COMPARE_MSG)
+      assert_equal(false, 'club' === CardSuit::SPADE) # rubocop:disable Style/CaseEquality
+    end
+
+    it 'raises an assertion if string is rhs of === comparison' do
+      expect_soft_error(ENUM_COMPARE_MSG)
+      assert_equal(true, CardSuit::SPADE === 'spade') # rubocop:disable Style/CaseEquality
+
+      expect_soft_error(ENUM_COMPARE_MSG)
+      assert_equal(false, CardSuit::CLUB === 'spade') # rubocop:disable Style/CaseEquality
+    end
+
+    it 'raises an assertion for a string in a `when` compared to an enum value' do
+      val = CardSuit::SPADE
+
+      2.times {expect_soft_error(ENUM_COMPARE_MSG)}
+      matched = case val
+      when 'club' then false
+      when 'spade' then true
+      else false
+      end
+      assert_equal(true, matched)
+    end
+
+    it 'raises an assertion for a enum in a `when` compared to an string value' do
+      val = 'spade'
+
+      2.times {expect_soft_error(ENUM_COMPARE_MSG)}
+      matched = case val
+      when CardSuit::CLUB then false
+      when CardSuit::SPADE then true
+      end
+      assert_equal(true, matched)
+    end
+
+    it 'can be used with an assert' do
+      assert(CardSuit::SPADE, 'some message')
+    end
+  end
+end

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 # typed: false
-require_relative '../../../extn'
-Opus::AutogenLoader.init(__FILE__)
+require_relative '../test_helper'
 
+module T::Enum::Test; end
 class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
-  include Critic::Helpers::Errors
-  include Critic::Helpers::Constants
-
   class CardSuit < T::Enum
     enums do
       CLUB = new

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -208,7 +208,7 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
     #
     # For purposes of these tests, the  declaration of the following form
     #
-    #   Opus::LoadHooks.class_with_load_hooks(T::Enum) do
+    #   Class.new(T::Enum) do
     #     const_set(:FOO, new)
     #   end
     #


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Open sources Stripe's runtime implementation of enums.


### Commit summary

I recommend reviewing by commit, as there are a couple of changes to take care
of.


- **Initial copy from pay-server** (4307fba64)


- **Remove the rubocop comments** (827ff17a6)


- **Replace Opus::Error with raise / soft_assert_handler** (3caf424f0)


- **Scaffolding to be able to run outside of pay-server** (5aa5b7b9d)


- **Fix some comments** (cb0f96a6e)


- **require 'json' in tests** (7a9a7336f)

  Our `to_json` helpers only work when `require 'json'` has been run. We
  can either

  - not test it
  - require 'json' in all the tests
  - attempt to sandbox the JSON tests somehow

  I figured it'd be easiest to just `require 'json'` in the tests.

- **T::Configuration.legacy_t_enum_migration_mode** (295209baa)


- **Add tests for legacy migration mode** (65c39c848)


### Rollout plan

1. Merge this
2. Publish new runtime version
3. Bump pay-server + delete the existing implementation



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

### Credits

I wrote very little of this code. Huge thanks to @nroman-stripe for implementing this (nearly 2 years ago at this point).