### PR TITLE
replace "core::errors::rewriter" "core::errors::Rewriter"

### DIFF
--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -2,7 +2,7 @@
 #define SORBET_CORE_ERRORS_DSL_H
 #include "core/Error.h"
 
-namespace sorbet::core::errors::rewriter {
+namespace sorbet::core::errors::Rewriter {
 constexpr ErrorClass BadAttrArg{3501, StrictLevel::True};
 constexpr ErrorClass BadWrapInstance{3502, StrictLevel::True};
 constexpr ErrorClass PrivateMethodMismatch{3503, StrictLevel::False};
@@ -10,5 +10,5 @@ constexpr ErrorClass BadAttrType{3504, StrictLevel::True};
 constexpr ErrorClass BadModuleFunction{3505, StrictLevel::True};
 constexpr ErrorClass OpusEnumOutsideEnumsDo{3506, StrictLevel::False};
 constexpr ErrorClass OpusEnumConstNotEnumValue{3506, StrictLevel::False};
-} // namespace sorbet::core::errors::rewriter
+} // namespace sorbet::core::errors::Rewriter
 #endif

--- a/rewriter/InterfaceWrapper.cc
+++ b/rewriter/InterfaceWrapper.cc
@@ -21,14 +21,14 @@ unique_ptr<ast::Expression> InterfaceWrapper::run(core::MutableContext ctx, uniq
     }
 
     if (!ast::isa_tree<ast::UnresolvedConstantLit>(send->recv.get())) {
-        if (auto e = ctx.state.beginError(send->recv->loc, core::errors::rewriter::BadWrapInstance)) {
+        if (auto e = ctx.state.beginError(send->recv->loc, core::errors::Rewriter::BadWrapInstance)) {
             e.setHeader("Unsupported wrap_instance() on a non-constant-literal");
         }
         return send;
     }
 
     if (send->args.size() != 1) {
-        if (auto e = ctx.state.beginError(send->loc, core::errors::rewriter::BadWrapInstance)) {
+        if (auto e = ctx.state.beginError(send->loc, core::errors::Rewriter::BadWrapInstance)) {
             e.setHeader("Wrong number of arguments to `{}`. Expected: `{}`, got: `{}`", "wrap_instance", 0,
                         send->args.size());
         }

--- a/rewriter/OpusEnum.cc
+++ b/rewriter/OpusEnum.cc
@@ -58,7 +58,7 @@ ast::Send *asEnumsDo(ast::Expression *stat) {
 
 // TODO(jez) Change this error message after making everything T::Enum
 vector<unique_ptr<ast::Expression>> badConst(core::MutableContext ctx, core::Loc headerLoc, core::Loc line1Loc) {
-    if (auto e = ctx.state.beginError(headerLoc, core::errors::rewriter::OpusEnumConstNotEnumValue)) {
+    if (auto e = ctx.state.beginError(headerLoc, core::errors::Rewriter::OpusEnumConstNotEnumValue)) {
         e.setHeader("All constants defined on an `{}` must be unique instances of the enum", "Opus::Enum");
         e.addErrorLine(line1Loc, "Enclosing definition here");
     }
@@ -117,7 +117,7 @@ vector<unique_ptr<ast::Expression>> processStat(core::MutableContext ctx, ast::C
     // So we're good to process this thing as a new Opus::Enum value.
 
     if (fromWhere != FromWhere::Inside) {
-        if (auto e = ctx.state.beginError(stat->loc, core::errors::rewriter::OpusEnumOutsideEnumsDo)) {
+        if (auto e = ctx.state.beginError(stat->loc, core::errors::Rewriter::OpusEnumOutsideEnumsDo)) {
             e.setHeader("Definition of enum value `{}` must be within the `{}` block for this `{}`",
                         lhs->cnst.show(ctx), "enums do", "Opus::Enum");
             e.addErrorLine(klass->declLoc, "Enclosing definition here");

--- a/rewriter/Private.cc
+++ b/rewriter/Private.cc
@@ -24,14 +24,14 @@ vector<unique_ptr<ast::Expression>> Private::run(core::MutableContext ctx, ast::
     }
 
     if (send->fun == core::Names::private_() && mdef->isSelf()) {
-        if (auto e = ctx.state.beginError(send->loc, core::errors::rewriter::PrivateMethodMismatch)) {
+        if (auto e = ctx.state.beginError(send->loc, core::errors::Rewriter::PrivateMethodMismatch)) {
             e.setHeader("Use `{}` to define private class methods", "private_class_method");
             auto beginPos = send->loc.beginPos();
             auto replacementLoc = core::Loc{send->loc.file(), beginPos, beginPos + 7};
             e.replaceWith("Replace with `private_class_method`", replacementLoc, "private_class_method");
         }
     } else if (send->fun == core::Names::privateClassMethod() && !mdef->isSelf()) {
-        if (auto e = ctx.state.beginError(send->loc, core::errors::rewriter::PrivateMethodMismatch)) {
+        if (auto e = ctx.state.beginError(send->loc, core::errors::Rewriter::PrivateMethodMismatch)) {
             e.setHeader("Use `{}` to define private instance methods", "private");
             auto beginPos = send->loc.beginPos();
             auto replacementLoc = core::Loc{send->loc.file(), beginPos, beginPos + 20};

--- a/rewriter/attr_reader.cc
+++ b/rewriter/attr_reader.cc
@@ -31,7 +31,7 @@ pair<core::NameRef, core::Loc> getName(core::MutableContext ctx, ast::Expression
             if (validAttr) {
                 res = nameRef;
             } else {
-                if (auto e = ctx.state.beginError(name->loc, core::errors::rewriter::BadAttrArg)) {
+                if (auto e = ctx.state.beginError(name->loc, core::errors::Rewriter::BadAttrArg)) {
                     e.setHeader("Bad attribute name \"{}\"", absl::CEscape(shortName));
                 }
                 res = core::Names::empty();
@@ -40,7 +40,7 @@ pair<core::NameRef, core::Loc> getName(core::MutableContext ctx, ast::Expression
         }
     }
     if (!res.exists()) {
-        if (auto e = ctx.state.beginError(name->loc, core::errors::rewriter::BadAttrArg)) {
+        if (auto e = ctx.state.beginError(name->loc, core::errors::Rewriter::BadAttrArg)) {
             e.setHeader("arg must be a Symbol or String");
         }
     }
@@ -130,7 +130,7 @@ void ensureSafeSig(core::MutableContext ctx, const core::NameRef attrFun, const 
     ast::Send *cur = body;
     while (cur != nullptr) {
         if (cur->fun == core::Names::typeParameters()) {
-            if (auto e = ctx.state.beginError(sig->loc, core::errors::rewriter::BadAttrType)) {
+            if (auto e = ctx.state.beginError(sig->loc, core::errors::Rewriter::BadAttrType)) {
                 e.setHeader("The type for an `{}` cannot contain `{}`", attrFun.show(ctx), "type_parameters");
             }
             body->args[0] = ast::MK::Untyped(body->args[0]->loc);

--- a/rewriter/module_function.cc
+++ b/rewriter/module_function.cc
@@ -122,7 +122,7 @@ vector<unique_ptr<ast::Expression>> ModuleFunction::run(core::MutableContext ctx
                 if (validAttr) {
                     methodName = nameRef;
                 } else {
-                    if (auto e = ctx.state.beginError(lit->loc, core::errors::rewriter::BadModuleFunction)) {
+                    if (auto e = ctx.state.beginError(lit->loc, core::errors::Rewriter::BadModuleFunction)) {
                         e.setHeader("Bad attribute name \"{}\"", absl::CEscape(shortName));
                     }
                 }
@@ -135,7 +135,7 @@ vector<unique_ptr<ast::Expression>> ModuleFunction::run(core::MutableContext ctx
             stats.emplace_back(ast::MK::Method(loc, loc, methodName, std::move(args), ast::MK::EmptyTree(),
                                                ast::MethodDef::SelfMethod | ast::MethodDef::RewriterSynthesized));
         } else {
-            if (auto e = ctx.state.beginError(arg->loc, core::errors::rewriter::BadModuleFunction)) {
+            if (auto e = ctx.state.beginError(arg->loc, core::errors::Rewriter::BadModuleFunction)) {
                 e.setHeader("Bad argument to `{}`: must be a symbol, string, method definition, or nothing",
                             "module_function");
             }


### PR DESCRIPTION
I made a mistake in my codemod and got the capitalization wrong

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
