### PR TITLE
Stop putting defaulted args in the completion snippet

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -212,6 +212,9 @@ string methodSnippet(const core::GlobalState &gs, core::SymbolRef method) {
             if (argSym.flags.isBlock) {
                 continue;
             }
+            if (argSym.flags.isDefault) {
+                continue;
+            }
             if (argSym.flags.isKeyword) {
                 absl::StrAppend(&s, argSym.name.data(gs)->shortName(gs), ": ");
             }

--- a/test/testdata/lsp/completion/snippet_default.A.rbedited
+++ b/test/testdata/lsp/completion/snippet_default.A.rbedited
@@ -1,0 +1,11 @@
+# typed: true
+
+class Test
+  extend T::Sig
+
+  sig {params(x: Integer, y: Symbol, z: String).void}
+  def method_with_defaults(x, y:, z: ''); end
+end
+
+Test.new.method_with_defaults(${1:Integer}, y: ${2:Symbol}, z: ${3:String})${0} # error: does not exist
+#                           ^ apply-completion: [A] item: 0

--- a/test/testdata/lsp/completion/snippet_default.A.rbedited
+++ b/test/testdata/lsp/completion/snippet_default.A.rbedited
@@ -7,5 +7,5 @@ class Test
   def method_with_defaults(x, y:, z: ''); end
 end
 
-Test.new.method_with_defaults(${1:Integer}, y: ${2:Symbol}, z: ${3:String})${0} # error: does not exist
+Test.new.method_with_defaults(${1:Integer}, y: ${2:Symbol})${0} # error: does not exist
 #                           ^ apply-completion: [A] item: 0

--- a/test/testdata/lsp/completion/snippet_default.rb
+++ b/test/testdata/lsp/completion/snippet_default.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+class Test
+  extend T::Sig
+
+  sig {params(x: Integer, y: Symbol, z: String).void}
+  def method_with_defaults(x, y:, z: ''); end
+end
+
+Test.new.method_with_default # error: does not exist
+#                           ^ apply-completion: [A] item: 0


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Methods that have lots of keyword args with defaults are annoying because
Sorbet puts a really big snippet into the doc, and then people end up just
deleting the keyword arg.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Review by commit to see the old vs new behavior.