### PR TITLE
LSP: Don't crash when user opens file outside of workspace.

### DIFF
--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -131,7 +131,7 @@ string LSPConfiguration::localName2Remote(string_view filePath) const {
 string LSPConfiguration::remoteName2Local(string_view uri) const {
     assertHasClientConfig();
     const bool isSorbetURI = absl::StartsWith(uri, sorbetScheme);
-    if (!absl::StartsWith(uri, clientConfig->rootUri) && (!clientConfig->enableSorbetURIs || !isSorbetURI)) {
+    if (!isUriInWorkspace(uri)) {
         logger->error("Unrecognized URI received from client: {}", uri);
         return string(uri);
     }
@@ -159,7 +159,7 @@ string LSPConfiguration::remoteName2Local(string_view uri) const {
 
 core::FileRef LSPConfiguration::uri2FileRef(const core::GlobalState &gs, string_view uri) const {
     assertHasClientConfig();
-    if (!absl::StartsWith(uri, clientConfig->rootUri) && !absl::StartsWith(uri, sorbetScheme)) {
+    if (!isUriInWorkspace(uri)) {
         return core::FileRef();
     }
     auto needle = remoteName2Local(uri);
@@ -218,7 +218,8 @@ bool LSPConfiguration::isFileIgnored(string_view filePath) const {
 
 bool LSPConfiguration::isUriInWorkspace(string_view uri) const {
     assertHasClientConfig();
-    return absl::StartsWith(uri, clientConfig->rootUri);
+    return absl::StartsWith(uri, clientConfig->rootUri) ||
+           (clientConfig->enableSorbetURIs && absl::StartsWith(uri, sorbetScheme));
 }
 
 void LSPConfiguration::markInitialized() {

--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -131,7 +131,7 @@ string LSPConfiguration::localName2Remote(string_view filePath) const {
 string LSPConfiguration::remoteName2Local(string_view uri) const {
     assertHasClientConfig();
     const bool isSorbetURI = absl::StartsWith(uri, sorbetScheme);
-    if (!absl::StartsWith(uri, clientConfig->rootUri) && !clientConfig->enableSorbetURIs && !isSorbetURI) {
+    if (!absl::StartsWith(uri, clientConfig->rootUri) && (!clientConfig->enableSorbetURIs || !isSorbetURI)) {
         logger->error("Unrecognized URI received from client: {}", uri);
         return string(uri);
     }

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -21,6 +21,14 @@ unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentCodeAction(LSPTypechecker
 
     const core::GlobalState &gs = typechecker.state();
     core::FileRef file = config->uri2FileRef(gs, params.textDocument->uri);
+    if (!file.exists()) {
+        // File is an invalid URI. Perhaps the user opened a file that is not within the VS Code workspace?
+        // Don't send an error, as it's not the user's fault and isn't actionable. Instead, send an empty list of code
+        // actions.
+        response->result = move(result);
+        return response;
+    }
+
     LSPFileUpdates updates;
     updates.canTakeFastPath = true;
     const auto &globalStateHashes = typechecker.getFileHashes();

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -445,4 +445,21 @@ TEST_F(ProtocolTest, SorbetURIsWork) {
     ASSERT_EQ(readFile(myMethodDefLoc->uri), fileContents);
 }
 
+// Tests that Sorbet does not crash when a file URI falls outside of the workspace.
+TEST_F(ProtocolTest, DoesNotCrashOnNonWorkspaceURIs) {
+    const bool supportsMarkdown = false;
+    auto initOptions = make_unique<SorbetInitializationOptions>();
+    initOptions->supportsSorbetURIs = true;
+
+    auto initializeResponses = sorbet::test::initializeLSP(
+        "/Users/jvilk/stripe/areallybigfoldername", "file://Users/jvilk/stripe/areallybigfoldername", *lspWrapper,
+        nextId, supportsMarkdown, make_optional(move(initOptions)));
+
+    auto fileUri = "file:///Users/jvilk/Desktop/test.rb";
+    auto didOpenParams =
+        make_unique<DidOpenTextDocumentParams>(make_unique<TextDocumentItem>(fileUri, "ruby", 1, "# typed: true\n1\n"));
+    auto didOpenNotif = make_unique<NotificationMessage>("2.0", LSPMethod::TextDocumentDidOpen, move(didOpenParams));
+    lspWrapper->getLSPResponsesFor(make_unique<LSPMessage>(move(didOpenNotif)));
+}
+
 } // namespace sorbet::test::lsp


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

LSP: Don't crash when user opens file outside of workspace.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

A user bumped into this bug, which caused Sorbet to enter a crashloop. :( 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I added an automated test, and manually tested the change.
