### PR TITLE
always remove options

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1436,7 +1436,7 @@ private:
     }
 
     // These will already be handled by DefaultArgs Rewriter pass
-    void deleteOptionlArg(core::MutableContext ctx, ast::MethodDef *mdef) {
+    void deleteOptionlArg(core::Context ctx, ast::MethodDef *mdef) {
         for (auto &arg : mdef->args) {
             if (auto *optArgExp = ast::cast_tree<ast::OptionalArg>(arg.get())) {
                 optArgExp->default_ = nullptr;
@@ -1614,8 +1614,6 @@ private:
                     // OVERLOAD
                     lastSigs.clear();
                 }
-
-                deleteOptionlArg(ctx, mdef);
 
                 if (mdef->symbol.data(ctx)->isAbstract()) {
                     if (!ast::isa_tree<ast::EmptyTree>(mdef->rhs.get())) {
@@ -1842,6 +1840,7 @@ public:
     }
 
     unique_ptr<ast::Expression> postTransformMethodDef(core::Context ctx, unique_ptr<ast::MethodDef> original) {
+        deleteOptionlArg(ctx, original.get());
         nestedBlockCounts.pop_back();
         return original;
     }

--- a/test/testdata/resolver/default_arg_in_block.rb
+++ b/test/testdata/resolver/default_arg_in_block.rb
@@ -1,0 +1,5 @@
+# typed: false
+map do
+  def foo(bar = [])
+  end
+end


### PR DESCRIPTION
For better or for worse, `processStatement` is only run in class bodes and `InsSeq` nodes, not in the middle of blocks. Should this always be the case or this is intentional? 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
