### PR TITLE
Don't create symbols for globals

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -79,6 +79,9 @@ core::LocalVariable unresolvedIdent2Local(CFGContext cctx, ast::UnresolvedIdent 
             ENFORCE(cctx.ctx.owner.data(cctx.ctx)->isMethod());
             klass = cctx.ctx.owner.data(cctx.ctx)->owner;
             break;
+        case ast::UnresolvedIdent::Global:
+            klass = core::Symbols::root();
+            break;
         default:
             // These should have been removed in the namer
             Exception::notImplemented();
@@ -89,8 +92,10 @@ core::LocalVariable unresolvedIdent2Local(CFGContext cctx, ast::UnresolvedIdent 
     if (!sym.exists()) {
         auto fnd = cctx.discoveredUndeclaredFields.find(id->name);
         if (fnd == cctx.discoveredUndeclaredFields.end()) {
-            if (auto e = cctx.ctx.state.beginError(id->loc, core::errors::CFG::UndeclaredVariable)) {
-                e.setHeader("Use of undeclared variable `{}`", id->name.show(cctx.ctx));
+            if (id->kind != ast::UnresolvedIdent::Global) {
+                if (auto e = cctx.ctx.state.beginError(id->loc, core::errors::CFG::UndeclaredVariable)) {
+                    e.setHeader("Use of undeclared variable `{}`", id->name.show(cctx.ctx));
+                }
             }
             auto ret = cctx.newTemporary(id->name);
             cctx.discoveredUndeclaredFields[id->name] = ret;

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -643,21 +643,6 @@ public:
         return method;
     }
 
-    unique_ptr<ast::Expression> postTransformUnresolvedIdent(core::MutableContext ctx,
-                                                             unique_ptr<ast::UnresolvedIdent> nm) {
-        ENFORCE(nm->kind != ast::UnresolvedIdent::Local, "Unresolved local left after `name_locals`");
-
-        if (nm->kind == ast::UnresolvedIdent::Global) {
-            auto sym = ctx.state.lookupSymbol(core::Symbols::root(), nm->name);
-            if (!sym.exists()) {
-                sym = ctx.state.enterFieldSymbol(nm->loc, core::Symbols::root(), nm->name);
-            }
-            return make_unique<ast::Field>(nm->loc, sym);
-        } else {
-            return nm;
-        }
-    }
-
     // Returns the SymbolRef corresponding to the class `self.class`, unless the
     // context is a class, in which case return it.
     core::SymbolRef contextClass(core::GlobalState &gs, core::SymbolRef ofWhat) const {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2062,6 +2062,12 @@ public:
         ENFORCE(false, "These should have all been removed: {}", original->toString(ctx));
         return original;
     }
+    unique_ptr<ast::Expression> postTransformUnresolvedIdent(core::MutableContext ctx,
+                                                             unique_ptr<ast::UnresolvedIdent> original) {
+        ENFORCE(original->kind != ast::UnresolvedIdent::Local, "{} should have been removed by local_vars",
+                original->toString(ctx));
+        return original;
+    }
     unique_ptr<ast::ConstantLit> postTransformConstantLit(core::MutableContext ctx,
                                                           unique_ptr<ast::ConstantLit> original) {
         ENFORCE(ResolveConstantsWalk::isAlreadyResolved(ctx, *original));

--- a/test/cli/stop-after-namer/stop-after-namer.out
+++ b/test/cli/stop-after-namer/stop-after-namer.out
@@ -1,6 +1,5 @@
 No errors! Great job.
 class ::<root> < ::<todo sym> () @ test/cli/stop-after-namer/stop-after-namer.rb:3
-  field #$global @ test/cli/stop-after-namer/stop-after-namer.rb:7
   class ::<Class:<root>>[<AttachedClass>] < ::<todo sym> ()
     method ::<Class:<root>>#<static-init> (<blk>) @ test/cli/stop-after-namer/stop-after-namer.rb:3
       argument <blk><block> @ Loc {file=test/cli/stop-after-namer/stop-after-namer.rb start=??? end=???}

--- a/test/testdata/desugar/for.rb.cfg.exp
+++ b/test/testdata/desugar/for.rb.cfg.exp
@@ -114,7 +114,7 @@ subgraph "cluster_::<Class:Main>#main" {
     "bb::<Class:Main>#main_1" [shape = parallelogram];
 
     "bb::<Class:Main>#main_0" [
-        label = "block[id=0, rubyBlockId=0]()\l@a$121: T.untyped = alias <C <undeclared-field-stub>>\l@@b$125: T.untyped = alias <C <undeclared-field-stub>>\l$c$129: T.untyped = alias $c\l<self>: T.class_of(Main) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Main>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Main>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<statTemp>$4: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$4: T.class_of(A).each()\l<selfRestore>$6: T.class_of(Main) = <self>\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l@a$121: T.untyped = alias <C <undeclared-field-stub>>\l@@b$125: T.untyped = alias <C <undeclared-field-stub>>\l$c$129: T.untyped = alias <C <undeclared-field-stub>>\l<self>: T.class_of(Main) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Main>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Main>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<statTemp>$4: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$4: T.class_of(A).each()\l<selfRestore>$6: T.class_of(Main) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#main_0" -> "bb::<Class:Main>#main_2" [style="bold"];

--- a/test/testdata/desugar/sclass.rb.flatten-tree.exp
+++ b/test/testdata/desugar/sclass.rb.flatten-tree.exp
@@ -9,7 +9,7 @@ begin
       begin
         <self>.puts(::A.a())
         <self>.puts(::B.b())
-        <self>.puts(#$c.c())
+        <self>.puts($c.c())
         <self>.puts(::D.singleton_class().d())
         <self>.puts(::E.e())
         <self>.puts(::F.f=(91))
@@ -30,7 +30,7 @@ begin
           ::Sorbet::Private::Static.keep_for_ide(::B)
           <emptyTree>
         end
-        #$c = ::Object.new()
+        $c = ::Object.new()
         begin
           <emptyTree>
           ::Sorbet::Private::Static.keep_for_ide(::D)

--- a/test/testdata/desugar/sclass.rb.symbol-table-raw.exp
+++ b/test/testdata/desugar/sclass.rb.symbol-table-raw.exp
@@ -1,5 +1,4 @@
 class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4}, Loc {file=test/testdata/desugar/sclass.rb start=2:1 end=94:5})
-  field <U $c> @ Loc {file=test/testdata/desugar/sclass.rb start=19:1 end=19:3}
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=2:1 end=94:5}
       argument <blk><block> @ Loc {file=test/testdata/desugar/sclass.rb start=??? end=???}

--- a/test/testdata/namer/gvar.rb.flatten-tree.exp
+++ b/test/testdata/namer/gvar.rb.flatten-tree.exp
@@ -3,7 +3,7 @@ begin
   class <emptyTree><<C <root>>> < ()
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        #$a = 1
+        $a = 1
         begin
           <emptyTree>
           ::Sorbet::Private::Static.keep_for_ide(::A)
@@ -19,13 +19,13 @@ begin
     <emptyTree>
 
     def meth(<blk>)
-      [#$a, #$b, #$c]
+      [$a, $b, $c]
     end
 
     def self.<static-init>(<blk>)
       begin
-        #$b = 2
-        #$a
+        $b = 2
+        $a
         <emptyTree>
       end
     end

--- a/test/testdata/namer/gvar.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/gvar.rb.symbol-table-raw.exp
@@ -1,7 +1,4 @@
 class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4}, Loc {file=test/testdata/namer/gvar.rb start=2:1 end=10:4})
-  field <U $a> @ Loc {file=test/testdata/namer/gvar.rb start=2:1 end=2:3}
-  field <U $b> @ Loc {file=test/testdata/namer/gvar.rb start=5:3 end=5:5}
-  field <U $c> @ Loc {file=test/testdata/namer/gvar.rb start=8:14 end=8:16}
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/gvar.rb start=2:1 end=10:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/gvar.rb start=??? end=???}

--- a/test/testdata/resolver/resolve_tree_printing.rb.flatten-tree-raw.exp
+++ b/test/testdata/resolver/resolve_tree_printing.rb.flatten-tree-raw.exp
@@ -112,8 +112,9 @@ InsSeq{
           args = [Local{
               localVariable = <U <blk>>
             }]
-          rhs = Field{
-            symbol = <U $S>
+          rhs = UnresolvedIdent{
+            kind = Global
+            name = <U $S>
           }
         }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
We don't need global variables in the symbol table, we can handle them much like we do other `UnresolvedIdent`s. This unblocks some other follow-on flattening work.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
