### PR TITLE
Add compatability patch to rspec-mock InstanceMethodStasher

### DIFF
--- a/gems/sorbet-runtime/lib/types/compatibility_patches.rb
+++ b/gems/sorbet-runtime/lib/types/compatibility_patches.rb
@@ -31,11 +31,6 @@ if defined? ::RSpec::Mocks::AnyInstance
           T::Private::Methods.maybe_run_sig_block_for_method(method)
           super(method_name)
         end
-
-        def stash
-          T::Private::Methods.maybe_run_sig_block_for_method(@object.method(@method))
-          super
-        end
       end
       ::RSpec::Mocks::AnyInstance::Recorder.prepend(RecorderExtensions)
     end

--- a/gems/sorbet-runtime/lib/types/compatibility_patches.rb
+++ b/gems/sorbet-runtime/lib/types/compatibility_patches.rb
@@ -37,15 +37,20 @@ if defined? ::RSpec::Mocks::AnyInstance
   end
 end
 
-module T
-  module CompatibilityPatches
-    module StasherExtensions
-      def stash
-        T::Private::Methods.maybe_run_sig_block_for_method(@object.method(@method))
-        super
+if defined? ::RSpec::Mocks::InstanceMethodStasher
+  module T
+    module CompatibilityPatches
+      module StasherExtensions
+        def stash
+          if @klass.respond_to?(@method)
+            T::Private::Methods.maybe_run_sig_block_for_method(@klass.method(@method))
+          elsif @klass.method_defined?(@method, false)
+            T::Private::Methods.maybe_run_sig_block_for_method(@klass.instance_method(@method))
+          end
+          super
+        end
+        ::RSpec::Mocks::InstanceMethodStasher.prepend(StasherExtensions)
       end
     end
-    ::RSpec::Mocks::InstanceMethodStasher.prepend(StasherExtensions)
   end
 end
-

--- a/gems/sorbet-runtime/lib/types/compatibility_patches.rb
+++ b/gems/sorbet-runtime/lib/types/compatibility_patches.rb
@@ -31,8 +31,26 @@ if defined? ::RSpec::Mocks::AnyInstance
           T::Private::Methods.maybe_run_sig_block_for_method(method)
           super(method_name)
         end
+
+        def stash
+          T::Private::Methods.maybe_run_sig_block_for_method(@object.method(@method))
+          super
+        end
       end
       ::RSpec::Mocks::AnyInstance::Recorder.prepend(RecorderExtensions)
     end
   end
 end
+
+module T
+  module CompatibilityPatches
+    module StasherExtensions
+      def stash
+        T::Private::Methods.maybe_run_sig_block_for_method(@object.method(@method))
+        super
+      end
+    end
+    ::RSpec::Mocks::InstanceMethodStasher.prepend(StasherExtensions)
+  end
+end
+


### PR DESCRIPTION
This PR fixed the [bug reported here](https://github.com/sorbet/sorbet/issues/1481) that causes `rspec-mock#and_call_original` to fail when used on class methods. The PRed file already contains the solution to this problem for instance methods and already contains a good explanation of the problem:

```
# Work around an interaction bug with sorbet-runtime and rspec-mocks,
# which occurs when using *_any_instance_of and and_call_original.
#
# When a sig is defined, sorbet-runtime will replace the sigged method
# with a wrapper that, upon first invocation, re-wraps the method with a faster
# implementation.
#
# When expect_any_instance_of is used, rspec stores a reference to the first wrapper,
# to be restored later.
#
# The first wrapper is invoked as part of the test and sorbet-runtime replaces
# the method definition with the second wrapper.
#
# But when mocks are cleaned up, rspec restores back to the first wrapper.
# Upon subsequent invocations, the first wrapper is called, and sorbet-runtime
# throws a runtime error, since this is an unexpected state.
#
# We work around this by forcing re-wrapping before rspec stores a reference
# to the method.
```

This PR repeats the pattern used for instance methods for the class that handles class methods. 

### Motivation
This has been causing test failures for us at Flexport. I've already added this patch to our local configuration. 

### Test plan
Did not add tests because this builds upon existing untested functionality. I can add if necessary. 
