### PR TITLE
Re-enable document-symbols in update_exp_files, and fix rbupdate tests.

### DIFF
--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -54,7 +54,7 @@ def pipeline_tests(suite_name, all_paths, test_name_prefix, filter = "*", extra_
         else:
             data += [sentinel]
             data += native.glob(["{}.*.exp".format(prefix)])
-            data += native.glob(["{}.*.rbupdated".format(prefix)])
+            data += native.glob(["{}.*.rbupdate".format(prefix)])
             data += native.glob(["{}.*.rbedited".format(prefix)])
 
         native.sh_test(

--- a/test/print_document_symbols.cc
+++ b/test/print_document_symbols.cc
@@ -69,7 +69,7 @@ int printDocumentSymbols(string_view filePath) {
         vector<unique_ptr<TextDocumentContentChangeEvent>> edits;
         edits.push_back(make_unique<TextDocumentContentChangeEvent>(fileEdit));
         auto params = make_unique<DidChangeTextDocumentParams>(
-            make_unique<VersionedTextDocumentIdentifier>(fileUri, fileId++), move(edits));
+            make_unique<VersionedTextDocumentIdentifier>(fileUri, static_cast<double>(fileId++)), move(edits));
         auto notif = make_unique<NotificationMessage>("2.0", LSPMethod::TextDocumentDidChange, move(params));
         lspWrapper.getLSPResponsesFor(make_unique<LSPMessage>(move(notif)));
     }

--- a/test/print_document_symbols.cc
+++ b/test/print_document_symbols.cc
@@ -8,19 +8,69 @@
 
 namespace sorbet::realmain::lsp {
 using namespace std;
+
+namespace {
+constexpr string_view uriPrefix = "file:///"sv;
+
+// Given a path to a *.rb or *.rbupdate file, returns the set of edits to apply to Sorbet before requesting document
+// symbols along with the URI of the document.
+pair<string, vector<string>> findEditsToApply(string_view filePath) {
+    const auto idx = filePath.rfind('.');
+    if (idx == string_view::npos) {
+        Exception::raise("Invalid file path: {}", filePath);
+    }
+    string_view extension = filePath.substr(idx);
+    OSFileSystem fs;
+    vector<string> fileContents;
+    string uri;
+    fileContents.push_back(fs.readFile(filePath));
+    if (extension == ".rbupdate") {
+        // Find basename[.]version.rbupdate
+        const auto versionIdx = filePath.rfind('.', idx - 1);
+        if (versionIdx == string_view::npos) {
+            Exception::raise("rbupdate file is missing version number: {}", filePath);
+        }
+        string_view baseName = filePath.substr(0, versionIdx);
+        uri = absl::StrCat(uriPrefix, baseName, ".rb");
+        string_view versionString = filePath.substr(versionIdx + 1, idx - versionIdx);
+        int version = stoi(string(versionString));
+        for (version = version - 1; version >= 0; version--) {
+            try {
+                fileContents.push_back(fs.readFile(fmt::format("{}.{}.rbupdate", baseName, version)));
+            } catch (FileNotFoundException e) {
+                // Ignore.
+            }
+        }
+        fileContents.push_back(fs.readFile(fmt::format("{}.rb", baseName)));
+        reverse(fileContents.begin(), fileContents.end());
+    } else {
+        uri = absl::StrCat(uriPrefix, filePath);
+    }
+    return make_pair(uri, move(fileContents));
+}
+
 int printDocumentSymbols(string_view filePath) {
     LSPWrapper lspWrapper("", false);
     lspWrapper.enableAllExperimentalFeatures();
     int nextId = 1;
-    string uriPrefix = "file:///";
+    int fileId = 1;
+    auto [fileUri, fileEdits] = findEditsToApply(filePath);
     test::initializeLSP("", uriPrefix, lspWrapper, nextId);
-    string fileUri = uriPrefix + string(filePath);
     {
-        OSFileSystem fs;
-        auto params = make_unique<DidOpenTextDocumentParams>(
-            make_unique<TextDocumentItem>(fileUri, "ruby", 1, fs.readFile(filePath)));
+        // Initialize empty file.
+        auto params =
+            make_unique<DidOpenTextDocumentParams>(make_unique<TextDocumentItem>(fileUri, "ruby", fileId++, ""));
         auto notif = make_unique<NotificationMessage>("2.0", LSPMethod::TextDocumentDidOpen, move(params));
-        // Discard responses; it's OK if the file has errors.
+        // Discard responses.
+        lspWrapper.getLSPResponsesFor(make_unique<LSPMessage>(move(notif)));
+    }
+
+    for (auto &fileEdit : fileEdits) {
+        vector<unique_ptr<TextDocumentContentChangeEvent>> edits;
+        edits.push_back(make_unique<TextDocumentContentChangeEvent>(fileEdit));
+        auto params = make_unique<DidChangeTextDocumentParams>(
+            make_unique<VersionedTextDocumentIdentifier>(fileUri, fileId++), move(edits));
+        auto notif = make_unique<NotificationMessage>("2.0", LSPMethod::TextDocumentDidChange, move(params));
         lspWrapper.getLSPResponsesFor(make_unique<LSPMessage>(move(notif)));
     }
 
@@ -45,6 +95,7 @@ int printDocumentSymbols(string_view filePath) {
         return 1;
     }
 }
+} // namespace
 } // namespace sorbet::realmain::lsp
 
 int main(int argc, char *argv[]) {
@@ -53,5 +104,5 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    return sorbet::realmain::lsp::printDocumentSymbols(argv[1]);
+    return sorbet::test::printDocumentSymbols(argv[1]);
 }

--- a/test/testdata/lsp/bad_field_edits.1.rbupdate.document-symbols.exp
+++ b/test/testdata/lsp/bad_field_edits.1.rbupdate.document-symbols.exp
@@ -34,22 +34,22 @@
                     "kind": 14,
                     "range": {
                         "start": {
-                            "line": 3,
-                            "character": 2
+                            "line": 1,
+                            "character": 11
                         },
                         "end": {
-                            "line": 3,
-                            "character": 7
+                            "line": 1,
+                            "character": 16
                         }
                     },
                     "selectionRange": {
                         "start": {
-                            "line": 3,
-                            "character": 2
+                            "line": 1,
+                            "character": 11
                         },
                         "end": {
-                            "line": 3,
-                            "character": 7
+                            "line": 1,
+                            "character": 16
                         }
                     },
                     "children": []

--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -35,7 +35,7 @@ passes=(
   cfg-raw
   cfg-json
   autogen
-  # document-symbols
+  document-symbols
 )
 
 bazel build //main:sorbet //test:print_document_symbols -c opt


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Re-enable document-symbols in update_exp_files, and fix rbupdate tests.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

1. document-symbols was disabled in update_exp_files because it produced output that disagreed with known-good *.exp files. I fixed that issue, but the fix was reverted because it didn't compile with llvm 9. I've fixed that second issue now, so it's ready to be merged.
2. I noticed that document-symbols produced a different exp file for an existing test, and that test continued to pass. Digging in, I discovered that *.rbupdate tests were broken by a recent change by @ptarjan (minor typo in a bazel file). I've fixed that issue.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
