### PR TITLE
Fix flattening semantics

### DIFF
--- a/rewriter/flatten.cc
+++ b/rewriter/flatten.cc
@@ -4,8 +4,6 @@
 #include "ast/treemap/treemap.h"
 #include "core/core.h"
 
-#include <iostream>
-
 #include <utility>
 
 using namespace std;

--- a/test/testdata/desugar/sclass.rb
+++ b/test/testdata/desugar/sclass.rb
@@ -61,10 +61,12 @@ class G
     def wrapper
         class << self
             def inner
-                T.reveal_type(self) # error: type: `T.class_of(G)`
+                T.reveal_type(self) # error: type: `G`
             end
         end
-        inner # error: Method `inner` does not exist on `G`
+        inner # this would not be allowed dynamically, but we treat
+              # methods defined within instance methods as instance
+              # methods
     end
     def self.g
         "g"

--- a/test/testdata/desugar/sclass.rb.flatten-tree.exp
+++ b/test/testdata/desugar/sclass.rb.flatten-tree.exp
@@ -192,6 +192,8 @@ begin
 
     <emptyTree>
 
+    <emptyTree>
+
     def wrapper(<blk>)
       begin
         <self>.inner()
@@ -202,6 +204,10 @@ begin
       "g"
     end
 
+    def inner(<blk>)
+      ::T.reveal_type(<self>)
+    end
+
     def self.<static-init>(<blk>)
       begin
         <emptyTree>
@@ -210,16 +216,8 @@ begin
     end
   end
   class <singleton class><<Class:G>> < ()
-    <emptyTree>
-
-    <emptyTree>
-
-    def inner(<blk>)
-      ::T.reveal_type(<self>)
-    end
-
     def self.<static-init>(<blk>)
-      <emptyTree>
+      :"inner"
     end
   end
   class ::H<<C H>> < (::<todo sym>)

--- a/test/testdata/desugar/sclass.rb.symbol-table-raw.exp
+++ b/test/testdata/desugar/sclass.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4}, Loc {file=test/testdata/desugar/sclass.rb start=2:1 end=94:5})
+class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4}, Loc {file=test/testdata/desugar/sclass.rb start=2:1 end=96:5})
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=2:1 end=94:5}
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=2:1 end=96:5}
       argument <blk><block> @ Loc {file=test/testdata/desugar/sclass.rb start=??? end=???}
   class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/desugar/sclass.rb start=2:1 end=2:8}
   class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/desugar/sclass.rb start=2:7 end=2:8}
@@ -92,15 +92,15 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     method <S <S <C <U F>> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=48:3 end=57:8}
       argument <blk><block> @ Loc {file=test/testdata/desugar/sclass.rb start=??? end=???}
   class <C <U G>> < <C <U Object>> () @ Loc {file=test/testdata/desugar/sclass.rb start=60:1 end=60:8}
+    method <C <U G>><U inner> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=63:13 end=63:22}
+      argument <blk><block> @ Loc {file=test/testdata/desugar/sclass.rb start=??? end=???}
     method <C <U G>><U wrapper> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=61:5 end=61:16}
       argument <blk><block> @ Loc {file=test/testdata/desugar/sclass.rb start=??? end=???}
   class <S <C <U G>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/desugar/sclass.rb start=62:9 end=62:14}
     type-member(+) <S <C <U G>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U G>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=G) @ Loc {file=test/testdata/desugar/sclass.rb start=60:7 end=60:8}
-    method <S <C <U G>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=60:1 end=72:4}
+    method <S <C <U G>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=60:1 end=74:4}
       argument <blk><block> @ Loc {file=test/testdata/desugar/sclass.rb start=??? end=???}
-    method <S <C <U G>> $1><U g> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=69:5 end=69:15}
-      argument <blk><block> @ Loc {file=test/testdata/desugar/sclass.rb start=??? end=???}
-    method <S <C <U G>> $1><U inner> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=63:13 end=63:22}
+    method <S <C <U G>> $1><U g> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=71:5 end=71:15}
       argument <blk><block> @ Loc {file=test/testdata/desugar/sclass.rb start=??? end=???}
   class <S <S <C <U G>> $1> $1>[<C <U <AttachedClass>>>] < <S <S <C <U Object>> $1> $1> () @ Loc {file=test/testdata/desugar/sclass.rb start=62:9 end=62:14}
     type-member(+) <S <S <C <U G>> $1> $1><C <U <AttachedClass>>> -> LambdaParam(<S <S <C <U G>> $1> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {
@@ -111,28 +111,28 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
 }) @ Loc {file=test/testdata/desugar/sclass.rb start=62:9 end=62:14}
     method <S <S <C <U G>> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=62:9 end=66:12}
       argument <blk><block> @ Loc {file=test/testdata/desugar/sclass.rb start=??? end=???}
-  class <C <U H>> < <C <U Object>> () @ Loc {file=test/testdata/desugar/sclass.rb start=74:1 end=74:8}
-  class <S <C <U H>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/desugar/sclass.rb start=75:5 end=75:10}
-    type-member(+) <S <C <U H>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U H>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=H) @ Loc {file=test/testdata/desugar/sclass.rb start=74:7 end=74:8}
-    method <S <C <U H>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=74:1 end=82:4}
+  class <C <U H>> < <C <U Object>> () @ Loc {file=test/testdata/desugar/sclass.rb start=76:1 end=76:8}
+  class <S <C <U H>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/desugar/sclass.rb start=77:5 end=77:10}
+    type-member(+) <S <C <U H>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U H>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=H) @ Loc {file=test/testdata/desugar/sclass.rb start=76:7 end=76:8}
+    method <S <C <U H>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=76:1 end=84:4}
       argument <blk><block> @ Loc {file=test/testdata/desugar/sclass.rb start=??? end=???}
-    class <S <C <U H>> $1><C <U H2>> < <C <U Object>> () @ Loc {file=test/testdata/desugar/sclass.rb start=76:9 end=76:17}
-    class <S <C <U H>> $1><S <C <U H2>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/desugar/sclass.rb start=76:15 end=76:17}
-      type-member(+) <S <C <U H>> $1><S <C <U H2>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U H>> $1><S <C <U H2>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=T.class_of(H)::H2) @ Loc {file=test/testdata/desugar/sclass.rb start=76:15 end=76:17}
-      method <S <C <U H>> $1><S <C <U H2>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=76:9 end=80:12}
+    class <S <C <U H>> $1><C <U H2>> < <C <U Object>> () @ Loc {file=test/testdata/desugar/sclass.rb start=78:9 end=78:17}
+    class <S <C <U H>> $1><S <C <U H2>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/desugar/sclass.rb start=78:15 end=78:17}
+      type-member(+) <S <C <U H>> $1><S <C <U H2>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U H>> $1><S <C <U H2>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=T.class_of(H)::H2) @ Loc {file=test/testdata/desugar/sclass.rb start=78:15 end=78:17}
+      method <S <C <U H>> $1><S <C <U H2>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=78:9 end=82:12}
         argument <blk><block> @ Loc {file=test/testdata/desugar/sclass.rb start=??? end=???}
-      method <S <C <U H>> $1><S <C <U H2>> $1><U h> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=77:13 end=77:23}
+      method <S <C <U H>> $1><S <C <U H2>> $1><U h> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=79:13 end=79:23}
         argument <blk><block> @ Loc {file=test/testdata/desugar/sclass.rb start=??? end=???}
-  class <S <S <C <U H>> $1> $1>[<C <U <AttachedClass>>>] < <S <S <C <U Object>> $1> $1> () @ Loc {file=test/testdata/desugar/sclass.rb start=75:5 end=75:10}
+  class <S <S <C <U H>> $1> $1>[<C <U <AttachedClass>>>] < <S <S <C <U Object>> $1> $1> () @ Loc {file=test/testdata/desugar/sclass.rb start=77:5 end=77:10}
     type-member(+) <S <S <C <U H>> $1> $1><C <U <AttachedClass>>> -> LambdaParam(<S <S <C <U H>> $1> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {
   klass = <S <C <U H>> $1>
   targs = [
     <C <U <AttachedClass>>> = H
   ]
-}) @ Loc {file=test/testdata/desugar/sclass.rb start=75:5 end=75:10}
-    method <S <S <C <U H>> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=75:5 end=81:8}
+}) @ Loc {file=test/testdata/desugar/sclass.rb start=77:5 end=77:10}
+    method <S <S <C <U H>> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=77:5 end=83:8}
       argument <blk><block> @ Loc {file=test/testdata/desugar/sclass.rb start=??? end=???}
   class <C <U Object>> < <C <U BasicObject>> (<C <U Kernel>>) @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed}
-    method <C <U Object>><U main> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=84:1 end=84:9}
+    method <C <U Object>><U main> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=86:1 end=86:9}
       argument <blk><block> @ Loc {file=test/testdata/desugar/sclass.rb start=??? end=???}
 

--- a/test/testdata/infer/singleton_of_singleton.rb.cfg.exp
+++ b/test/testdata/infer/singleton_of_singleton.rb.cfg.exp
@@ -35,6 +35,24 @@ subgraph "cluster_::<Class:A>#foo" {
     "bb::<Class:A>#foo_1" -> "bb::<Class:A>#foo_1" [style="bold"];
 }
 
+subgraph "cluster_::<Class:A>#bar" {
+    label = "::<Class:A>#bar";
+    color = blue;
+    "bb::<Class:A>#bar_0" [shape = invhouse];
+    "bb::<Class:A>#bar_1" [shape = parallelogram];
+
+    "bb::<Class:A>#bar_0" [
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: T.class_of(A) = <self>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.class_of(A)\l<unconditional>\l"
+    ];
+
+    "bb::<Class:A>#bar_0" -> "bb::<Class:A>#bar_1" [style="bold"];
+    "bb::<Class:A>#bar_1" [
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::<Class:A>#bar_1" -> "bb::<Class:A>#bar_1" [style="bold"];
+}
+
 subgraph "cluster_::<Class:A>#<static-init>" {
     label = "::<Class:A>#<static-init>";
     color = blue;
@@ -51,42 +69,6 @@ subgraph "cluster_::<Class:A>#<static-init>" {
     ];
 
     "bb::<Class:A>#<static-init>_1" -> "bb::<Class:A>#<static-init>_1" [style="bold"];
-}
-
-subgraph "cluster_::<Class:<Class:A>>#bar" {
-    label = "::<Class:<Class:A>>#bar";
-    color = blue;
-    "bb::<Class:<Class:A>>#bar_0" [shape = invhouse];
-    "bb::<Class:<Class:A>>#bar_1" [shape = parallelogram];
-
-    "bb::<Class:<Class:A>>#bar_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(T.class_of(A)) = cast(<self>: NilClass, AppliedType {\l  klass = <S <S <C <U A>> $1> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <S <C <U A>> $1> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: T.class_of(T.class_of(A)) = <self>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.class_of(T.class_of(A))\l<unconditional>\l"
-    ];
-
-    "bb::<Class:<Class:A>>#bar_0" -> "bb::<Class:<Class:A>>#bar_1" [style="bold"];
-    "bb::<Class:<Class:A>>#bar_1" [
-        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
-    ];
-
-    "bb::<Class:<Class:A>>#bar_1" -> "bb::<Class:<Class:A>>#bar_1" [style="bold"];
-}
-
-subgraph "cluster_::<Class:<Class:A>>#<static-init>" {
-    label = "::<Class:<Class:A>>#<static-init>";
-    color = blue;
-    "bb::<Class:<Class:A>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<Class:A>>#<static-init>_1" [shape = parallelogram];
-
-    "bb::<Class:<Class:A>>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(T.class_of(A)) = cast(<self>: NilClass, AppliedType {\l  klass = <S <S <C <U A>> $1> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <S <C <U A>> $1> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
-    ];
-
-    "bb::<Class:<Class:A>>#<static-init>_0" -> "bb::<Class:<Class:A>>#<static-init>_1" [style="bold"];
-    "bb::<Class:<Class:A>>#<static-init>_1" [
-        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
-    ];
-
-    "bb::<Class:<Class:A>>#<static-init>_1" -> "bb::<Class:<Class:A>>#<static-init>_1" [style="bold"];
 }
 
 }

--- a/test/testdata/resolver/class_ivar.rb
+++ b/test/testdata/resolver/class_ivar.rb
@@ -8,7 +8,7 @@ end
 class B
   def foo
     def self.bar
-      @x = T.let(0, Integer) # error: The singleton instance variable `@x` must be declared inside the class body or declared nilable
+      @x = T.let(0, Integer) # error: The instance variable `@x` must be declared inside `initialize` or declared nilable
     end
   end
 end

--- a/test/testdata/resolver/flatten.rb
+++ b/test/testdata/resolver/flatten.rb
@@ -13,3 +13,22 @@ class A
     end
   end
 end
+
+A.new.foo
+A.foo # error: Method `foo` does not exist on `T.class_of(A)`
+
+A.new.food
+A.food # error: Method `food` does not exist on `T.class_of(A)`
+
+A.new.foos
+A.foos # error: Method `foos` does not exist on `T.class_of(A)`
+
+
+A.sfoo
+A.new.sfoo # error: Method `sfoo` does not exist on `A`
+
+A.new.sfood
+A.sfood # error: Method `sfood` does not exist on `T.class_of(A)`
+
+A.sfoos
+A.new.sfoos # error: Method `sfoos` does not exist on `A`

--- a/test/testdata/resolver/flatten.rb.flatten-tree.exp
+++ b/test/testdata/resolver/flatten.rb.flatten-tree.exp
@@ -22,6 +22,8 @@ begin
 
     <emptyTree>
 
+    <emptyTree>
+
     def foo(<blk>)
       begin
         :"food"
@@ -40,25 +42,13 @@ begin
       <emptyTree>
     end
 
-    def self.foos(<blk>)
+    def foos(<blk>)
       <emptyTree>
     end
 
-    def self.sfood(<blk>)
+    def sfood(<blk>)
       <emptyTree>
     end
-
-    def self.<static-init>(<blk>)
-      begin
-        <emptyTree>
-        <emptyTree>
-      end
-    end
-  end
-  class <singleton class><<Class:A>> < ()
-    <emptyTree>
-
-    <emptyTree>
 
     def self.sfoos(<blk>)
       <emptyTree>

--- a/test/testdata/resolver/flatten.rb.flatten-tree.exp
+++ b/test/testdata/resolver/flatten.rb.flatten-tree.exp
@@ -3,8 +3,23 @@ begin
   class <emptyTree><<C <root>>> < ()
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        <emptyTree>
-        ::Sorbet::Private::Static.keep_for_ide(::A)
+        begin
+          <emptyTree>
+          ::Sorbet::Private::Static.keep_for_ide(::A)
+          <emptyTree>
+        end
+        ::A.new().foo()
+        ::A.foo()
+        ::A.new().food()
+        ::A.food()
+        ::A.new().foos()
+        ::A.foos()
+        ::A.sfoo()
+        ::A.new().sfoo()
+        ::A.new().sfood()
+        ::A.sfood()
+        ::A.sfoos()
+        ::A.new().sfoos()
         <emptyTree>
       end
     end

--- a/test/testdata/resolver/flatten.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/flatten.rb.symbol-table-raw.exp
@@ -7,25 +7,16 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
       argument <blk><block> @ Loc {file=test/testdata/resolver/flatten.rb start=??? end=???}
     method <C <U A>><U food> (<blk>) @ Loc {file=test/testdata/resolver/flatten.rb start=4:5 end=4:13}
       argument <blk><block> @ Loc {file=test/testdata/resolver/flatten.rb start=??? end=???}
-  class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/resolver/flatten.rb start=2:1 end=15:4}
+    method <C <U A>><U foos> (<blk>) @ Loc {file=test/testdata/resolver/flatten.rb start=6:5 end=6:18}
+      argument <blk><block> @ Loc {file=test/testdata/resolver/flatten.rb start=??? end=???}
+    method <C <U A>><U sfood> (<blk>) @ Loc {file=test/testdata/resolver/flatten.rb start=10:5 end=10:14}
+      argument <blk><block> @ Loc {file=test/testdata/resolver/flatten.rb start=??? end=???}
+  class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/resolver/flatten.rb start=2:7 end=2:8}
     type-member(+) <S <C <U A>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/resolver/flatten.rb start=2:7 end=2:8}
     method <S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/flatten.rb start=2:1 end=15:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/flatten.rb start=??? end=???}
-    method <S <C <U A>> $1><U foos> (<blk>) @ Loc {file=test/testdata/resolver/flatten.rb start=6:5 end=6:18}
-      argument <blk><block> @ Loc {file=test/testdata/resolver/flatten.rb start=??? end=???}
     method <S <C <U A>> $1><U sfoo> (<blk>) @ Loc {file=test/testdata/resolver/flatten.rb start=9:3 end=9:16}
       argument <blk><block> @ Loc {file=test/testdata/resolver/flatten.rb start=??? end=???}
-    method <S <C <U A>> $1><U sfood> (<blk>) @ Loc {file=test/testdata/resolver/flatten.rb start=10:5 end=10:14}
-      argument <blk><block> @ Loc {file=test/testdata/resolver/flatten.rb start=??? end=???}
-  class <S <S <C <U A>> $1> $1>[<C <U <AttachedClass>>>] < <S <S <C <U Object>> $1> $1> () @ Loc {file=test/testdata/resolver/flatten.rb start=2:7 end=2:8}
-    type-member(+) <S <S <C <U A>> $1> $1><C <U <AttachedClass>>> -> LambdaParam(<S <S <C <U A>> $1> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {
-  klass = <S <C <U A>> $1>
-  targs = [
-    <C <U <AttachedClass>>> = A
-  ]
-}) @ Loc {file=test/testdata/resolver/flatten.rb start=2:7 end=2:8}
-    method <S <S <C <U A>> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/flatten.rb start=2:1 end=15:4}
-      argument <blk><block> @ Loc {file=test/testdata/resolver/flatten.rb start=??? end=???}
-    method <S <S <C <U A>> $1> $1><U sfoos> (<blk>) @ Loc {file=test/testdata/resolver/flatten.rb start=12:5 end=12:19}
+    method <S <C <U A>> $1><U sfoos> (<blk>) @ Loc {file=test/testdata/resolver/flatten.rb start=12:5 end=12:19}
       argument <blk><block> @ Loc {file=test/testdata/resolver/flatten.rb start=??? end=???}
 

--- a/test/testdata/resolver/flatten.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/flatten.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4}, Loc {file=test/testdata/resolver/flatten.rb start=2:1 end=15:4})
+class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4}, Loc {file=test/testdata/resolver/flatten.rb start=2:1 end=34:12})
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/flatten.rb start=2:1 end=15:4}
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/flatten.rb start=2:1 end=34:12}
       argument <blk><block> @ Loc {file=test/testdata/resolver/flatten.rb start=??? end=???}
   class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/flatten.rb start=2:1 end=2:8}
     method <C <U A>><U foo> (<blk>) @ Loc {file=test/testdata/resolver/flatten.rb start=3:3 end=3:10}

--- a/test/testdata/rewriter/flatten_nested_sclass.rb
+++ b/test/testdata/rewriter/flatten_nested_sclass.rb
@@ -9,7 +9,7 @@ class A
 end
 
 A.foo
-A.singleton_class.bar
+A.bar
 
 class B
   def foo;
@@ -20,7 +20,7 @@ class B
 end
 
 B.new.foo
-B.bar
+B.new.bar
 
 
 class C

--- a/test/testdata/rewriter/flatten_nested_sclass.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/flatten_nested_sclass.rb.symbol-table-raw.exp
@@ -3,9 +3,11 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=3:1 end=34:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=??? end=???}
   class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=3:1 end=3:8}
-  class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=3:1 end=9:4}
+  class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=5:5 end=5:10}
     type-member(+) <S <C <U A>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=3:7 end=3:8}
     method <S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=3:1 end=9:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=??? end=???}
+    method <S <C <U A>> $1><U bar> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=6:7 end=6:14}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=??? end=???}
     method <S <C <U A>> $1><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=4:3 end=4:15}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=??? end=???}
@@ -15,33 +17,17 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
   targs = [
     <C <U <AttachedClass>>> = A
   ]
-}) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=3:7 end=3:8}
-    method <S <S <C <U A>> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=3:1 end=9:4}
-      argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=??? end=???}
-    method <S <S <C <U A>> $1> $1><U bar> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=6:7 end=6:14}
-      argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=??? end=???}
-  class <S <S <S <C <U A>> $1> $1> $1>[<C <U <AttachedClass>>>] < <S <S <S <C <U Object>> $1> $1> $1> () @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=5:5 end=5:10}
-    type-member(+) <S <S <S <C <U A>> $1> $1> $1><C <U <AttachedClass>>> -> LambdaParam(<S <S <S <C <U A>> $1> $1> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {
-  klass = <S <S <C <U A>> $1> $1>
-  targs = [
-    <C <U <AttachedClass>>> = AppliedType {
-        klass = <S <C <U A>> $1>
-        targs = [
-          <C <U <AttachedClass>>> = A
-        ]
-      }
-  ]
 }) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=5:5 end=5:10}
-    method <S <S <S <C <U A>> $1> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=5:5 end=7:8}
+    method <S <S <C <U A>> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=5:5 end=7:8}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=??? end=???}
   class <C <U B>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=14:1 end=14:8}
+    method <C <U B>><U bar> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=17:7 end=17:14}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=??? end=???}
     method <C <U B>><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=15:3 end=15:10}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=??? end=???}
   class <S <C <U B>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=16:5 end=16:10}
     type-member(+) <S <C <U B>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U B>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=B) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=14:7 end=14:8}
     method <S <C <U B>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=14:1 end=20:4}
-      argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=??? end=???}
-    method <S <C <U B>> $1><U bar> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=17:7 end=17:14}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=??? end=???}
   class <S <S <C <U B>> $1> $1>[<C <U <AttachedClass>>>] < <S <S <C <U Object>> $1> $1> () @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=16:5 end=16:10}
     type-member(+) <S <S <C <U B>> $1> $1><C <U <AttachedClass>>> -> LambdaParam(<S <S <C <U B>> $1> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {
@@ -53,20 +39,22 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     method <S <S <C <U B>> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=16:5 end=18:8}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=??? end=???}
   class <C <U C>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=26:1 end=26:8}
-  class <S <C <U C>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=26:1 end=34:4}
+  class <S <C <U C>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=28:5 end=28:10}
     type-member(+) <S <C <U C>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U C>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=C) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=26:7 end=26:8}
     method <S <C <U C>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=26:1 end=34:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=??? end=???}
     method <S <C <U C>> $1><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=27:3 end=27:15}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=??? end=???}
-  class <S <S <C <U C>> $1> $1>[<C <U <AttachedClass>>>] < <S <S <C <U Object>> $1> $1> () @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=28:5 end=28:10}
+  class <S <S <C <U C>> $1> $1>[<C <U <AttachedClass>>>] < <S <S <C <U Object>> $1> $1> () @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=29:7 end=29:12}
     type-member(+) <S <S <C <U C>> $1> $1><C <U <AttachedClass>>> -> LambdaParam(<S <S <C <U C>> $1> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {
   klass = <S <C <U C>> $1>
   targs = [
     <C <U <AttachedClass>>> = C
   ]
 }) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=26:7 end=26:8}
-    method <S <S <C <U C>> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=26:1 end=34:4}
+    method <S <S <C <U C>> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=28:5 end=32:8}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=??? end=???}
+    method <S <S <C <U C>> $1> $1><U bar> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=30:9 end=30:16}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=??? end=???}
   class <S <S <S <C <U C>> $1> $1> $1>[<C <U <AttachedClass>>>] < <S <S <S <C <U Object>> $1> $1> $1> () @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=29:7 end=29:12}
     type-member(+) <S <S <S <C <U C>> $1> $1> $1><C <U <AttachedClass>>> -> LambdaParam(<S <S <S <C <U C>> $1> $1> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {
@@ -79,28 +67,7 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
         ]
       }
   ]
-}) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=26:7 end=26:8}
-    method <S <S <S <C <U C>> $1> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=28:5 end=32:8}
-      argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=??? end=???}
-    method <S <S <S <C <U C>> $1> $1> $1><U bar> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=30:9 end=30:16}
-      argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=??? end=???}
-  class <S <S <S <S <C <U C>> $1> $1> $1> $1>[<C <U <AttachedClass>>>] < <S <S <S <S <C <U Object>> $1> $1> $1> $1> () @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=29:7 end=29:12}
-    type-member(+) <S <S <S <S <C <U C>> $1> $1> $1> $1><C <U <AttachedClass>>> -> LambdaParam(<S <S <S <S <C <U C>> $1> $1> $1> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {
-  klass = <S <S <S <C <U C>> $1> $1> $1>
-  targs = [
-    <C <U <AttachedClass>>> = AppliedType {
-        klass = <S <S <C <U C>> $1> $1>
-        targs = [
-          <C <U <AttachedClass>>> = AppliedType {
-              klass = <S <C <U C>> $1>
-              targs = [
-                <C <U <AttachedClass>>> = C
-              ]
-            }
-        ]
-      }
-  ]
 }) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=29:7 end=29:12}
-    method <S <S <S <S <C <U C>> $1> $1> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=29:7 end=31:10}
+    method <S <S <S <C <U C>> $1> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=29:7 end=31:10}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=??? end=???}
 

--- a/test/testdata/rewriter/nesting.rb
+++ b/test/testdata/rewriter/nesting.rb
@@ -1,0 +1,57 @@
+# typed: strict
+
+class A
+  extend T::Sig
+  sig {void}
+  def outer
+    sig {void}
+    def inner; end
+  end
+end
+
+A.outer # error: Method `outer` does not exist on `T.class_of(A)`
+A.new.outer
+A.inner # error: Method `inner` does not exist on `T.class_of(A)`
+A.new.inner
+
+class B
+  extend T::Sig
+  sig {void}
+  def outer
+    sig {void}
+    def self.inner; end
+  end
+end
+
+B.outer # error: Method `outer` does not exist on `T.class_of(B)`
+B.new.outer
+B.inner # error: Method `inner` does not exist on `T.class_of(B)`
+B.new.inner
+
+class C
+  extend T::Sig
+  sig {void}
+  def self.outer
+    sig {void}
+    def inner; end
+  end
+end
+
+C.outer
+C.new.outer # error: Method `outer` does not exist on `C`
+C.inner # error: Method `inner` does not exist on `T.class_of(C)`
+C.new.inner
+
+class D
+  extend T::Sig
+  sig {void}
+  def self.outer
+    sig {void}
+    def self.inner; end
+  end
+end
+
+D.outer
+D.new.outer # error: Method `outer` does not exist on `D`
+D.inner
+D.new.inner # error: Method `inner` does not exist on `D`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
The semantics of flattening did not match the actual semantics of how Ruby treats nested method definitions. This brings it in line with what Ruby actually does.

One deviation is that

```ruby
def foo
  def self.bar; end
end
```

in Ruby adds a method `bar` to _just the instance that `foo` is invoked on and only after it is invoked_, e.g.

```ruby
class A
  def foo
    def self.bar; end
  end
end

A.new.foo
A.new.bar  # undefined method `bar`

a = A.new
a.foo
a.bar # okay this time
```

This flattening treats it as an instance method on `A` even though it's not universally accessible. That's not correct, but it's better than our current semantics, as we currently treat `bar` as a _static method on `A`_, which is arguably even less correct.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Added a test suite which tests four nesting possibilities with their expected results.
