### PR TITLE
Add try_deserialize which returns nil

### DIFF
--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -129,6 +129,18 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
     end
   end
 
+  describe 'try_deserialize' do
+    it 'returns the value for a valid serialization' do
+      suit = CardSuit.try_deserialize('club')
+      assert_equal(CardSuit::CLUB, suit)
+    end
+
+    it 'returns nil for an invalid serialization' do
+      suit = CardSuit.try_deserialize('blerg')
+      assert_nil(suit)
+    end
+  end
+
   describe 'to_json' do
     it 'serializes to a JSON string' do
       assert_equal('"club"', CardSuit::CLUB.to_json)

--- a/rbi/core/enum.rbi
+++ b/rbi/core/enum.rbi
@@ -11,6 +11,13 @@ class T::Enum
   #
   # Note: It would have been nice to make this method final before people started overriding it.
   # Note: Failed CriticalMethodsNoRuntimeTypingTest
+  sig {overridable.params(serialized_val: T.untyped).returns(T.nilable(T.experimental_attached_class)).checked(:never)}
+  def self.try_deserialize(serialized_val); end
+
+  # Convert from serialized value to enum instance.
+  #
+  # Note: It would have been nice to make this method final before people started overriding it.
+  # Note: Failed CriticalMethodsNoRuntimeTypingTest
   #
   # @return [self]
   # @raise [KeyError] if serialized value does not match any instance.

--- a/website/docs/tenum.md
+++ b/website/docs/tenum.md
@@ -150,6 +150,14 @@ Suit.deserialize('bad value')
 # => KeyError: Enum Suit key not found: "bad value"
 ```
 
+If this is not the behavior you want, you can use `try_deserialize` which
+returns `nil` when the value doesn't deserialize to anything:
+
+```ruby
+Suit.try_deserialize('bad value')
+# => nil
+```
+
 You can also ask whether a specific serialized value exists for an enum:
 
 ```ruby
@@ -160,7 +168,6 @@ Suit.has_serialized?('bad value')
 # => false
 ```
 
-<!-- TODO(jez) Add a version of deserialize that returns T.nilable? -->
 <!-- TODO(jez) Using enum *values* as type annotations / in unions -->
 <!-- TODO(jez) ^ Limitation: can't be used in type aliases... -->
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sometimes it'd be nice to return `nil` instead of `KeyError` when
deserialization fails. `deserialize` is a part of T::Props::CustomType,
so we can't change the API for that one. Instead, we should introduce a
new method. I've chosen the name `try_deserialize`.

At least two people have asked for this on Slack, and it was a pretty
obvious gap when writing the documentation, so considering it's easy to
implement, I think we should just do it.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.