### PR TITLE
better default handling

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1435,15 +1435,6 @@ private:
         }
     }
 
-    // These will already be handled by DefaultArgs Rewriter pass
-    void deleteOptionlArg(core::MutableContext ctx, ast::MethodDef *mdef) {
-        for (auto &arg : mdef->args) {
-            if (auto *optArgExp = ast::cast_tree<ast::OptionalArg>(arg.get())) {
-                optArgExp->default_ = nullptr;
-            }
-        }
-    }
-
     // Force errors from any signatures that didn't attach to methods.
     // `lastSigs` will always be empty after this function is called.
     void processLeftoverSigs(core::MutableContext ctx, InlinedVector<ast::Send *, 1> &lastSigs) {
@@ -1614,8 +1605,6 @@ private:
                     // OVERLOAD
                     lastSigs.clear();
                 }
-
-                deleteOptionlArg(ctx, mdef);
 
                 if (mdef->symbol.data(ctx)->isAbstract()) {
                     if (!ast::isa_tree<ast::EmptyTree>(mdef->rhs.get())) {
@@ -2050,11 +2039,6 @@ public:
     unique_ptr<ast::Expression> postTransformMethodDef(core::MutableContext ctx, unique_ptr<ast::MethodDef> original) {
         ENFORCE(original->symbol != core::Symbols::todo(), "These should have all been resolved: {}",
                 original->toString(ctx));
-        for (auto &arg : original->args) {
-            if (auto optionalArg = ast::cast_tree<ast::OptionalArg>(arg.get())) {
-                ENFORCE(!optionalArg->default_);
-            }
-        }
         return original;
     }
     unique_ptr<ast::Expression> postTransformUnresolvedConstantLit(core::MutableContext ctx,

--- a/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
+++ b/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
@@ -69,6 +69,7 @@ InsSeq{
               expr = Local{
                 localVariable = <U b>
               }
+              default_ = EmptyTree
             }, Local{
               localVariable = <U c>
             }, Local{
@@ -77,6 +78,7 @@ InsSeq{
               expr = Local{
                 localVariable = <U e>
               }
+              default_ = EmptyTree
             }, Local{
               localVariable = <U f>
             }, Local{
@@ -198,6 +200,7 @@ InsSeq{
               expr = Local{
                 localVariable = <U b>
               }
+              default_ = EmptyTree
             }, Local{
               localVariable = <U c>
             }, Local{
@@ -206,6 +209,7 @@ InsSeq{
               expr = Local{
                 localVariable = <U e>
               }
+              default_ = EmptyTree
             }, Local{
               localVariable = <U f>
             }, Local{
@@ -223,6 +227,7 @@ InsSeq{
               expr = Local{
                 localVariable = <U b>
               }
+              default_ = EmptyTree
             }, Local{
               localVariable = <U c>
             }, Local{
@@ -231,6 +236,7 @@ InsSeq{
               expr = Local{
                 localVariable = <U e>
               }
+              default_ = EmptyTree
             }, Local{
               localVariable = <U f>
             }, Local{

--- a/test/testdata/resolver/default_arg_in_block.rb
+++ b/test/testdata/resolver/default_arg_in_block.rb
@@ -1,0 +1,5 @@
+# typed: false
+map do
+  def foo(bar = [])
+  end
+end


### PR DESCRIPTION
In my previous PR there was a few things wrong:
* I shouldn't ever use `deepCopy`. That is a code smell
* The resolver shoudn't have anything to do with this

This PR should correct both of those problems. It still misses defaults in places like the included test but they will still stay in the tree this way and will be hoverable.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
