### PR TITLE
Fix CSV << return type

### DIFF
--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -364,7 +364,7 @@ class CSV < Object
   end
   def self.read(path, options=T.unsafe(nil)); end
 
-  sig { params(row: T.any(T::Array[T.untyped], CSV::Row)).void }
+  sig { params(row: T.any(T::Array[T.untyped], CSV::Row)).returns(CSV)) }
   def <<(row); end
 
   sig { params(str: String, options: T.untyped, blk: T.proc.params(csv: CSV).void).returns(String) }


### PR DESCRIPTION
## Description
I ran into this (apparent) bug when updating our codebase to the latest Sorbet. In a few places we chain usages of `<<` for example:

```
csv << row << [] 
```
And this works fine because `<<` returns a `CSV`. This is easy enough for us to work around but I think this signature is more correct.

### Motivation
This makes the `stblib` signatures more accurate.
