### PR TITLE
Allow duplicate T::Enum in hidden definitions

### DIFF
--- a/gems/sorbet/lib/hidden-definition-finder.rb
+++ b/gems/sorbet/lib/hidden-definition-finder.rb
@@ -124,6 +124,9 @@ class Sorbet::Private::HiddenMethodFinder
         # Make sure we don't load a sorbet/config in your cwd
         '--no-config',
         '--print=symbol-table-full-json',
+        # Duplicate T::Enum constants are ok because they are defined in both
+        # the source and the rbi
+        '--error-black-list=3506',
         # Method redefined with mismatched argument is ok since sometime
         # people monkeypatch over method
         '--error-black-list=4010',

--- a/gems/sorbet/lib/hidden-definition-finder.rb
+++ b/gems/sorbet/lib/hidden-definition-finder.rb
@@ -124,8 +124,9 @@ class Sorbet::Private::HiddenMethodFinder
         # Make sure we don't load a sorbet/config in your cwd
         '--no-config',
         '--print=symbol-table-full-json',
-        # Duplicate T::Enum constants are ok because they are defined in both
-        # the source and the rbi
+        # The hidden-definition serializer is not smart enough to put T::Enum
+        # constants it discovers inside an `enums do` block. We probably want
+        # to come up with a better long term solution here.
         '--error-black-list=3506',
         # Method redefined with mismatched argument is ok since sometime
         # people monkeypatch over method


### PR DESCRIPTION
As suggested by @jez [in slack](https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1573073991028400)

### Motivation

Currently, running `srb init` in a project with `T::Enum` usages fails with "All constants defined on an `Opus::Enum` must be unique instances of the enum https://srb.help/3506" but this error should be ignored when generating hidden definitions.