### PR TITLE
Avoid recursing into methods in namer

### DIFF
--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -775,6 +775,9 @@ private:
             }
         }
         // because this is a DefinitionMapper, we do not map over the body of the class
+        if (v->isRewriterSynthesized()) {
+            v->rhs = mapIt(move(v->rhs), ctx.withOwner(v->symbol));
+        }
 
         if constexpr (HAS_MEMBER_postTransformMethodDef<FUNC>::value) {
             return PostPonePostTransform_MethodDef<FUNC, CTX, HAS_MEMBER_postTransformMethodDef<FUNC>::value>::call(

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -772,7 +772,9 @@ private:
                 optArg->default_ = mapIt(move(optArg->default_), ctx.withOwner(v->symbol));
             }
         }
-        // because this is a DefinitionMapper, we do not map over the body of the class
+        // because this is a ShallowMap, we do not map over the body of the class unless it is synthesized by the
+        // rewriter pass, because we can be sure that typical Ruby code does not e.g. include constant definitions in
+        // the body of a method
         if (v->isRewriterSynthesized()) {
             v->rhs = mapIt(move(v->rhs), ctx.withOwner(v->symbol));
         }

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -720,8 +720,6 @@ public:
     }
 };
 
-
-
 /**
  * Given a tree transformer FUNC transform a tree.
  * Tree is guaranteed to be visited in the definition order.

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -772,7 +772,7 @@ private:
                 optArg->default_ = mapIt(move(optArg->default_), ctx.withOwner(v->symbol));
             }
         }
-        // because this is a ShallowMap, we do not map over the body of the class unless it is synthesized by the
+        // because this is a ShallowMap, we do not map over the body of the method unless it is synthesized by the
         // rewriter pass, because we can be sure that typical Ruby code does not e.g. include constant definitions in
         // the body of a method
         if (v->isRewriterSynthesized()) {

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -586,7 +586,7 @@ ast::ParsedFile runOne(core::Context ctx, ast::ParsedFile tree) {
     Timer timeit(ctx.state.tracer(), "validateSymbols");
 
     ValidateWalk validate;
-    tree.tree = ast::TreeMap::apply(ctx, validate, std::move(tree.tree));
+    tree.tree = ast::ShallowMap::apply(ctx, validate, std::move(tree.tree));
     return tree;
 }
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -976,7 +976,7 @@ std::vector<ast::ParsedFile> Namer::run(core::MutableContext ctx, std::vector<as
             {
                 Timer timeit(ctx.state.tracer(), "naming", {{"file", (string)file.data(ctx).path()}});
                 core::ErrorRegion errs(ctx.state, file);
-                tree.tree = ast::TreeMap::apply(ctx, nameInserter, std::move(tree.tree));
+                tree.tree = ast::ShallowMap::apply(ctx, nameInserter, std::move(tree.tree));
             }
         } catch (SorbetException &) {
             Exception::failInFuzzer();

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1134,6 +1134,21 @@ public:
         return klass;
     }
 
+    unique_ptr<ast::Expression> postTransformUnresolvedIdent(core::MutableContext ctx, unique_ptr<ast::UnresolvedIdent> nm) {
+        ENFORCE(nm->kind != ast::UnresolvedIdent::Local, "Unresolved local left after `name_locals`");
+
+        if (nm->kind == ast::UnresolvedIdent::Global) {
+            auto sym = ctx.state.lookupSymbol(core::Symbols::root(), nm->name);
+            if (!sym.exists()) {
+                sym = ctx.state.enterFieldSymbol(nm->loc, core::Symbols::root(), nm->name);
+            }
+            return make_unique<ast::Field>(nm->loc, sym);
+        } else {
+            return nm;
+        }
+    }
+
+
     unique_ptr<ast::Send> preTransformSend(core::MutableContext ctx, unique_ptr<ast::Send> send) {
         switch (send->fun._id) {
             case core::Names::typeAlias()._id:

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1134,21 +1134,6 @@ public:
         return klass;
     }
 
-    unique_ptr<ast::Expression> postTransformUnresolvedIdent(core::MutableContext ctx,
-                                                             unique_ptr<ast::UnresolvedIdent> nm) {
-        ENFORCE(nm->kind != ast::UnresolvedIdent::Local, "Unresolved local left after `name_locals`");
-
-        if (nm->kind == ast::UnresolvedIdent::Global) {
-            auto sym = ctx.state.lookupSymbol(core::Symbols::root(), nm->name);
-            if (!sym.exists()) {
-                sym = ctx.state.enterFieldSymbol(nm->loc, core::Symbols::root(), nm->name);
-            }
-            return make_unique<ast::Field>(nm->loc, sym);
-        } else {
-            return nm;
-        }
-    }
-
     unique_ptr<ast::Send> preTransformSend(core::MutableContext ctx, unique_ptr<ast::Send> send) {
         switch (send->fun._id) {
             case core::Names::typeAlias()._id:

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1134,7 +1134,8 @@ public:
         return klass;
     }
 
-    unique_ptr<ast::Expression> postTransformUnresolvedIdent(core::MutableContext ctx, unique_ptr<ast::UnresolvedIdent> nm) {
+    unique_ptr<ast::Expression> postTransformUnresolvedIdent(core::MutableContext ctx,
+                                                             unique_ptr<ast::UnresolvedIdent> nm) {
         ENFORCE(nm->kind != ast::UnresolvedIdent::Local, "Unresolved local left after `name_locals`");
 
         if (nm->kind == ast::UnresolvedIdent::Global) {
@@ -1147,7 +1148,6 @@ public:
             return nm;
         }
     }
-
 
     unique_ptr<ast::Send> preTransformSend(core::MutableContext ctx, unique_ptr<ast::Send> send) {
         switch (send->fun._id) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This will speed up the namer by letting us skip recursing over large subtrees. This introduces another `TreeMap`-like abstraction called a `ShallowMap` which does not recurse into the body of methods, and uses it in the namer and in the definition_validator.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
