### PR TITLE
Remove now-unused Field type from AST

### DIFF
--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -100,13 +100,6 @@ unique_ptr<Expression> Rescue::_deepCopy(const Expression *avoid, bool root) con
                                else_->_deepCopy(avoid), ensure->_deepCopy(avoid));
 }
 
-unique_ptr<Expression> Field::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_unique<Field>(loc, symbol);
-}
-
 unique_ptr<Expression> Local::_deepCopy(const Expression *avoid, bool root) const {
     if (!root && this == avoid) {
         throw DeepCopyError();

--- a/ast/TreeSanityChecks.cc
+++ b/ast/TreeSanityChecks.cc
@@ -71,10 +71,6 @@ void Hash::_sanityCheck() {
     ENFORCE(keys.size() == values.size());
 }
 
-void Field::_sanityCheck() {
-    ENFORCE(symbol.exists());
-}
-
 void If::_sanityCheck() {
     ENFORCE(cond);
     ENFORCE(thenp);

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -17,7 +17,6 @@ template class std::unique_ptr<sorbet::ast::Next>;
 template class std::unique_ptr<sorbet::ast::Return>;
 template class std::unique_ptr<sorbet::ast::RescueCase>;
 template class std::unique_ptr<sorbet::ast::Rescue>;
-template class std::unique_ptr<sorbet::ast::Field>;
 template class std::unique_ptr<sorbet::ast::Local>;
 template class std::unique_ptr<sorbet::ast::UnresolvedIdent>;
 template class std::unique_ptr<sorbet::ast::RestArg>;
@@ -147,11 +146,6 @@ Rescue::Rescue(core::Loc loc, unique_ptr<Expression> body, RESCUE_CASE_store res
       ensure(std::move(ensure)) {
     categoryCounterInc("trees", "rescue");
     histogramInc("trees.rescue.rescuecases", this->rescueCases.size());
-    _sanityCheck();
-}
-
-Field::Field(core::Loc loc, core::SymbolRef symbol) : Reference(loc), symbol(symbol) {
-    categoryCounterInc("trees", "field");
     _sanityCheck();
 }
 
@@ -609,10 +603,6 @@ string ConstantLit::showRaw(const core::GlobalState &gs, int tabs) {
     return buf.str();
 }
 
-string Field::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
-    return this->symbol.dataAllowingNone(gs)->showFullName(gs);
-}
-
 string Local::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     return this->localVariable.toString(gs);
 }
@@ -624,16 +614,6 @@ string Local::nodeName() {
 bool Expression::isSelfReference() const {
     auto asLocal = cast_tree_const<Local>(this);
     return asLocal && asLocal->localVariable == core::LocalVariable::selfVariable();
-}
-
-string Field::showRaw(const core::GlobalState &gs, int tabs) {
-    stringstream buf;
-    buf << nodeName() << "{" << '\n';
-    printTabs(buf, tabs + 1);
-    buf << "symbol = " << this->symbol.dataAllowingNone(gs)->name.data(gs)->showRaw(gs) << '\n';
-    printTabs(buf, tabs);
-    buf << "}";
-    return buf.str();
 }
 
 string Local::showRaw(const core::GlobalState &gs, int tabs) {
@@ -1042,9 +1022,6 @@ string If::nodeName() {
 }
 string While::nodeName() {
     return "While";
-}
-string Field::nodeName() {
-    return "Field";
 }
 string UnresolvedIdent::nodeName() {
     return "UnresolvedIdent";

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -318,21 +318,6 @@ private:
 };
 // CheckSize(Rescue, 64, 8);
 
-class Field final : public Reference {
-public:
-    core::SymbolRef symbol;
-
-    Field(core::Loc loc, core::SymbolRef symbol);
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
-    virtual std::unique_ptr<Expression> _deepCopy(const Expression *avoid, bool root = false) const;
-
-private:
-    virtual void _sanityCheck();
-};
-// CheckSize(Field, 24, 8);
-
 class Local final : public Reference {
 public:
     core::LocalVariable localVariable;

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -47,7 +47,6 @@ public:
     unique_ptr<Rescue> preTransformRescue(core::MutableContext ctx, unique_ptr<Rescue> original);
     unique_ptr<Expression> postTransformRescue(core::MutableContext ctx, unique_ptr<Rescue> original);
 
-    unique_ptr<Expression> postTransformField(core::MutableContext ctx, unique_ptr<Field> original);
     unique_ptr<Expression> postTransformUnresolvedIdent(core::MutableContext ctx, unique_ptr<UnresolvedIdent> original);
 
     unique_ptr<Assign> preTransformAssign(core::MutableContext ctx, unique_ptr<Assign> original);
@@ -135,7 +134,6 @@ GENERATE_HAS_MEMBER(postTransformNext);
 GENERATE_HAS_MEMBER(postTransformReturn);
 GENERATE_HAS_MEMBER(postTransformRescueCase);
 GENERATE_HAS_MEMBER(postTransformRescue);
-GENERATE_HAS_MEMBER(postTransformField);
 GENERATE_HAS_MEMBER(postTransformUnresolvedIdent);
 GENERATE_HAS_MEMBER(postTransformAssign);
 GENERATE_HAS_MEMBER(postTransformSend);
@@ -228,7 +226,6 @@ GENERATE_POSTPONE_POSTCLASS(Next);
 GENERATE_POSTPONE_POSTCLASS(Return);
 GENERATE_POSTPONE_POSTCLASS(RescueCase);
 GENERATE_POSTPONE_POSTCLASS(Rescue);
-GENERATE_POSTPONE_POSTCLASS(Field);
 GENERATE_POSTPONE_POSTCLASS(UnresolvedIdent);
 GENERATE_POSTPONE_POSTCLASS(Assign);
 GENERATE_POSTPONE_POSTCLASS(Send);
@@ -446,14 +443,6 @@ private:
                 ctx, move(v), func);
         }
 
-        return v;
-    }
-
-    unique_ptr<Expression> mapField(unique_ptr<Field> v, CTX ctx) {
-        if constexpr (HAS_MEMBER_postTransformField<FUNC>::value) {
-            return PostPonePostTransform_Field<FUNC, CTX, HAS_MEMBER_postTransformField<FUNC>::value>::call(
-                ctx, move(v), func);
-        }
         return v;
     }
 
@@ -684,8 +673,6 @@ private:
                 return mapReturn(std::unique_ptr<Return>(static_cast<Return *>(what.release())), ctx);
             } else if (isa_tree<Rescue>(what.get())) {
                 return mapRescue(std::unique_ptr<Rescue>(static_cast<Rescue *>(what.release())), ctx);
-            } else if (isa_tree<Field>(what.get())) {
-                return mapField(std::unique_ptr<Field>(static_cast<Field *>(what.release())), ctx);
             } else if (isa_tree<Assign>(what.get())) {
                 return mapAssign(std::unique_ptr<Assign>(static_cast<Assign *>(what.release())), ctx);
             } else if (isa_tree<Array>(what.get())) {

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -216,10 +216,6 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::Expression *what, BasicBlock 
                 ret = current;
             },
             [&](ast::UnresolvedConstantLit *a) { Exception::raise("Should have been eliminated by namer/resolver"); },
-            [&](ast::Field *a) {
-                current->exprs.emplace_back(cctx.target, a->loc, make_unique<Ident>(global2Local(cctx, a->symbol)));
-                ret = current;
-            },
             [&](ast::ConstantLit *a) {
                 if (a->symbol == core::Symbols::StubModule()) {
                     current->exprs.emplace_back(cctx.target, a->loc, make_unique<Alias>(core::Symbols::untyped()));
@@ -244,8 +240,6 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::Expression *what, BasicBlock 
                 core::LocalVariable lhs;
                 if (auto lhsIdent = ast::cast_tree<ast::ConstantLit>(a->lhs.get())) {
                     lhs = global2Local(cctx, lhsIdent->symbol);
-                } else if (auto field = ast::cast_tree<ast::Field>(a->lhs.get())) {
-                    lhs = global2Local(cctx, field->symbol);
                 } else if (auto lhsLocal = ast::cast_tree<ast::Local>(a->lhs.get())) {
                     lhs = lhsLocal->localVariable;
                 } else if (auto ident = ast::cast_tree<ast::UnresolvedIdent>(a->lhs.get())) {

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -785,10 +785,6 @@ void SerializerImpl::pickle(Pickler &p, FileRef file, const unique_ptr<ast::Expr
             p.putU4(a->cnst._id);
             pickle(p, file, a->scope);
         },
-        [&](ast::Field *a) {
-            pickleAstHeader(p, 9, a);
-            p.putU4(a->symbol._id);
-        },
         [&](ast::Local *a) {
             pickleAstHeader(p, 10, a);
             p.putU4(a->localVariable._name._id);
@@ -990,10 +986,6 @@ unique_ptr<ast::Expression> SerializerImpl::unpickleExpr(serialize::UnPickler &p
             NameRef cnst = unpickleNameRef(p, gs);
             auto scope = unpickleExpr(p, gs, file);
             return ast::MK::UnresolvedConstant(loc, std::move(scope), cnst);
-        }
-        case 9: {
-            SymbolRef sym(gs, p.getU4());
-            return make_unique<ast::Field>(loc, sym);
         }
         case 10: {
             NameRef nm = unpickleNameRef(p, gs);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
After #2088 we no longer use the `Field` type for anything, so this just removes it entirely.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
