### PR TITLE
Fix serialize_method returning null on invalid method names

### DIFF
--- a/gems/sorbet/lib/serialize.rb
+++ b/gems/sorbet/lib/serialize.rb
@@ -235,20 +235,20 @@ class Sorbet::Private::Serialize
 
   def serialize_method(method, static=false, with_sig: true)
     name = method.name.to_s
-    ret = String.new
-    if !valid_method_name(name)
-      ret << "# Illegal method name: #{name}"
-      return
-    end
+    return "# Illegal method name: #{name}" unless valid_method_name(name)
+
     parameters = from_method(method)
     # a hack for appeasing Sorbet in the presence of the Enumerable interface
     if name == 'each' && !parameters.any? {|(kind, _)| kind == :block}
       parameters.push([:block, "blk"])
     end
-    ret << serialize_sig(parameters) if with_sig
+
     args = parameters.map do |(kind, param_name)|
       to_sig(kind, param_name)
     end.compact.join(', ')
+    
+    ret = String.new
+    ret << serialize_sig(parameters) if with_sig
     ret << "  def #{static ? 'self.' : ''}#{name}(#{args}); end\n"
     ret
   end


### PR DESCRIPTION
There was an issue at https://github.com/sorbet/sorbet/blob/master/gems/sorbet/lib/serialize.rb#L241 - instead of returning the string `"# Illegal method name: #{name}" ` it would return nil. This would then bubble up into the hidden-definition-finder and cause a nil error:

```
        17: from /app/vendor/gems/gems/sorbet-0.4.4987/bin/srb-rbi:237:in `<main>'
	16: from /app/vendor/gems/gems/sorbet-0.4.4987/bin/srb-rbi:196:in `main'
	15: from /app/vendor/gems/gems/sorbet-0.4.4987/bin/srb-rbi:121:in `init'
	14: from /app/vendor/gems/gems/sorbet-0.4.4987/bin/srb-rbi:232:in `block in make_step'
	13: from /app/vendor/gems/gems/sorbet-0.4.4987/lib/hidden-definition-finder.rb:38:in `main'
	12: from /app/vendor/gems/gems/sorbet-0.4.4987/lib/hidden-definition-finder.rb:49:in `main'
	11: from /app/vendor/gems/gems/sorbet-0.4.4987/lib/hidden-definition-finder.rb:162:in `write_diff'
	10: from /app/vendor/gems/gems/sorbet-0.4.4987/lib/hidden-definition-finder.rb:193:in `serialize_constants'
	 9: from /app/vendor/gems/gems/sorbet-0.4.4987/lib/hidden-definition-finder.rb:193:in `each'
	 8: from /app/vendor/gems/gems/sorbet-0.4.4987/lib/hidden-definition-finder.rb:203:in `block in serialize_constants'
	 7: from /app/vendor/gems/gems/sorbet-0.4.4987/lib/hidden-definition-finder.rb:276:in `serialize_class'
	 6: from /app/vendor/gems/gems/sorbet-0.4.4987/lib/hidden-definition-finder.rb:193:in `serialize_constants'
	 5: from /app/vendor/gems/gems/sorbet-0.4.4987/lib/hidden-definition-finder.rb:193:in `each'
	 4: from /app/vendor/gems/gems/sorbet-0.4.4987/lib/hidden-definition-finder.rb:203:in `block in serialize_constants'
	 3: from /app/vendor/gems/gems/sorbet-0.4.4987/lib/hidden-definition-finder.rb:260:in `serialize_class'
	 2: from /app/vendor/gems/gems/sorbet-0.4.4987/lib/hidden-definition-finder.rb:285:in `without_errors'
	 1: from /app/vendor/gems/gems/sorbet-0.4.4987/lib/hidden-definition-finder.rb:285:in `reject'
/app/vendor/gems/gems/sorbet-0.4.4987/lib/hidden-definition-finder.rb:285:in `block in without_errors': undefined method `start_with?' for nil:NilClass (NoMethodError)
```

I've fixed the method to return the correct string, and rearranged a few lines to make it easier to read.