### PR TITLE
Enable sorbet-powered autocompletion for methods

### DIFF
--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -121,11 +121,9 @@ void LSPLoop::processRequestInternal(LSPMessage &msg) {
                 serverCap->signatureHelpProvider = move(sigHelpProvider);
             }
 
-            if (opts.lspAutocompleteEnabled || opts.lspAutocompleteMethodsEnabled) {
-                auto completionProvider = make_unique<CompletionOptions>();
-                completionProvider->triggerCharacters = {"."};
-                serverCap->completionProvider = move(completionProvider);
-            }
+            auto completionProvider = make_unique<CompletionOptions>();
+            completionProvider->triggerCharacters = {"."};
+            serverCap->completionProvider = move(completionProvider);
 
             response->result = make_unique<InitializeResult>(move(serverCap));
             config->output->write(move(response));

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -353,7 +353,7 @@ void LSPLoop::findSimilarConstantOrIdent(const core::GlobalState &gs, const core
 unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentCompletion(LSPTypechecker &typechecker, const MessageId &id,
                                                                   const CompletionParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentCompletion);
-    if (!config->opts.lspAutocompleteEnabled && !config->opts.lspAutocompleteMethodsEnabled) {
+    if (!config->opts.lspAutocompleteEnabled) {
         response->error =
             make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest,
                                        "The `Autocomplete` LSP feature is experimental and disabled by default.");

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -353,13 +353,6 @@ void LSPLoop::findSimilarConstantOrIdent(const core::GlobalState &gs, const core
 unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentCompletion(LSPTypechecker &typechecker, const MessageId &id,
                                                                   const CompletionParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentCompletion);
-    if (!config->opts.lspAutocompleteEnabled) {
-        response->error =
-            make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest,
-                                       "The `Autocomplete` LSP feature is experimental and disabled by default.");
-        return response;
-    }
-
     auto emptyResult = make_unique<CompletionList>(false, vector<unique_ptr<CompletionItem>>{});
 
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.completion");

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -77,7 +77,6 @@ void LSPWrapper::enableAllExperimentalFeatures() {
     enableExperimentalFeature(LSPExperimentalFeature::DocumentSymbol);
     enableExperimentalFeature(LSPExperimentalFeature::SignatureHelp);
     enableExperimentalFeature(LSPExperimentalFeature::QuickFix);
-    enableExperimentalFeature(LSPExperimentalFeature::AutocompleteMethods);
 }
 
 void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
@@ -99,9 +98,6 @@ void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
             break;
         case LSPExperimentalFeature::SignatureHelp:
             opts.lspSignatureHelpEnabled = true;
-            break;
-        case LSPExperimentalFeature::AutocompleteMethods:
-            opts.lspAutocompleteEnabled = true;
             break;
     }
 }

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -37,8 +37,7 @@ public:
         DocumentSymbol = 6,
         SignatureHelp = 7,
         QuickFix = 8,
-        AutocompleteMethods = 9,
-        DocumentHighlight = 10,
+        DocumentHighlight = 9,
     };
 
     // N.B.: Sorbet assumes we 'own' this object; keep it alive to avoid memory errors.

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -342,8 +342,6 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                     cxxopts::value<string>()->default_value(empty.watchmanPath));
     options.add_options("advanced")("enable-experimental-lsp-autocomplete",
                                     "Enable experimental LSP feature: Autocomplete");
-    options.add_options("advanced")("enable-experimental-lsp-autocomplete-methods",
-                                    "Enable experimental LSP feature: Autocomplete, but only for methods");
     options.add_options("advanced")("enable-experimental-lsp-workspace-symbols",
                                     "Enable experimental LSP feature: Workspace Symbols");
     options.add_options("advanced")("enable-experimental-lsp-document-symbol",
@@ -671,8 +669,6 @@ void readOptions(Options &opts,
 
         bool enableAllLSPFeatures = raw["enable-all-experimental-lsp-features"].as<bool>();
         opts.lspAutocompleteEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-autocomplete"].as<bool>();
-        opts.lspAutocompleteMethodsEnabled = enableAllLSPFeatures || opts.lspAutocompleteEnabled ||
-                                             raw["enable-experimental-lsp-autocomplete-methods"].as<bool>();
         opts.lspQuickFixEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-quick-fix"].as<bool>();
         opts.lspWorkspaceSymbolsEnabled =
             enableAllLSPFeatures || raw["enable-experimental-lsp-workspace-symbols"].as<bool>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -197,7 +197,6 @@ struct Options {
     std::vector<std::string> lspDirsMissingFromClient;
     // Booleans enabling various experimental LSP features. Each will be removed once corresponding feature stabilizes.
     bool lspAutocompleteEnabled = false;
-    bool lspAutocompleteMethodsEnabled = false;
     bool lspQuickFixEnabled = false;
     bool lspWorkspaceSymbolsEnabled = false;
     bool lspDocumentHighlightEnabled = false;

--- a/main/options/test/options_test.cc
+++ b/main/options/test/options_test.cc
@@ -69,7 +69,6 @@ TEST(OptionsTest, DefaultConstructorMatchesReadOptions) {
     EXPECT_EQ(empty.relativeIgnorePatterns.size(), opts.relativeIgnorePatterns.size());
     EXPECT_EQ(empty.inputFileNames.size(), opts.inputFileNames.size());
     EXPECT_EQ(empty.lspAutocompleteEnabled, opts.lspAutocompleteEnabled);
-    EXPECT_EQ(empty.lspAutocompleteMethodsEnabled, opts.lspAutocompleteMethodsEnabled);
     EXPECT_EQ(empty.lspQuickFixEnabled, opts.lspQuickFixEnabled);
     EXPECT_EQ(empty.lspWorkspaceSymbolsEnabled, opts.lspWorkspaceSymbolsEnabled);
     EXPECT_EQ(empty.lspDocumentSymbolEnabled, opts.lspDocumentSymbolEnabled);

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -76,9 +76,6 @@ Usage:
                                 using `watchman` on your PATH. (default: watchman)
       --enable-experimental-lsp-autocomplete
                                 Enable experimental LSP feature: Autocomplete
-      --enable-experimental-lsp-autocomplete-methods
-                                Enable experimental LSP feature:
-                                Autocomplete, but only for methods
       --enable-experimental-lsp-workspace-symbols
                                 Enable experimental LSP feature: Workspace
                                 Symbols

--- a/test/cli/lsp-common-case-exit/lsp-common-case-exit.out
+++ b/test/cli/lsp-common-case-exit/lsp-common-case-exit.out
@@ -1,5 +1,5 @@
-Content-Length: 302
+Content-Length: 351
 
-{"jsonrpc":"2.0","id":0,"requestMethod":"initialize","result":{"capabilities":{"textDocumentSync":1,"hoverProvider":true,"definitionProvider":true,"typeDefinitionProvider":true,"referencesProvider":true,"documentHighlightProvider":false,"documentSymbolProvider":false,"workspaceSymbolProvider":false}}}Content-Length: 65
+{"jsonrpc":"2.0","id":0,"requestMethod":"initialize","result":{"capabilities":{"textDocumentSync":1,"hoverProvider":true,"completionProvider":{"triggerCharacters":["."]},"definitionProvider":true,"typeDefinitionProvider":true,"referencesProvider":true,"documentHighlightProvider":false,"documentSymbolProvider":false,"workspaceSymbolProvider":false}}}Content-Length: 65
 
 {"jsonrpc":"2.0","id":1,"requestMethod":"shutdown","result":null}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We're ready to turn this on as the default for people.

Heads up there is one blocker in pay-server to disable the All-Autocomplete
plugin in Ruby files so that it doesn't compete with sorbet-powered
autocompletion.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->