### PR TITLE
Use TypeConstraint to populate snippet type

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -216,7 +216,8 @@ vector<core::LocalVariable> allSimilarLocals(const core::GlobalState &gs, const 
     return result;
 }
 
-string methodSnippet(const core::GlobalState &gs, core::SymbolRef method) {
+string methodSnippet(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiverType,
+                     const core::TypeConstraint *constraint) {
     auto shortName = method.data(gs)->name.data(gs)->shortName(gs);
     vector<string> typeAndArgNames;
 
@@ -234,7 +235,8 @@ string methodSnippet(const core::GlobalState &gs, core::SymbolRef method) {
                 absl::StrAppend(&s, argSym.name.data(gs)->shortName(gs), ": ");
             }
             if (argSym.type) {
-                absl::StrAppend(&s, "${", i++, ":", argSym.type->show(gs), "}");
+                absl::StrAppend(&s, "${", i++, ":",
+                                getResultType(gs, argSym.type, method, receiverType, constraint)->show(gs), "}");
             } else {
                 absl::StrAppend(&s, "${", i++, "}");
             }
@@ -353,7 +355,7 @@ unique_ptr<CompletionItem> LSPLoop::getCompletionItemForSymbol(const core::Globa
         string replacementText;
         if (config->getClientConfig().clientCompletionItemSnippetSupport) {
             item->insertTextFormat = InsertTextFormat::Snippet;
-            replacementText = methodSnippet(gs, what);
+            replacementText = methodSnippet(gs, what, receiverType, constraint);
         } else {
             item->insertTextFormat = InsertTextFormat::PlainText;
             replacementText = string(what.data(gs)->name.data(gs)->shortName(gs));

--- a/test/testdata/lsp/completion/snippet_types.A.rbedited
+++ b/test/testdata/lsp/completion/snippet_types.A.rbedited
@@ -9,3 +9,8 @@ end
 
 Test.new.x_is_integer(${1:Integer})${0} # error: does not exist
 #             ^ apply-completion: [A] item: 0
+
+# Snippet for applied generic should respect TypeConstraint
+xs = T::Hash[String, Integer].new
+xs.fetc # error: does not exist
+#      ^ apply-completion: [B] item: 0

--- a/test/testdata/lsp/completion/snippet_types.B.rbedited
+++ b/test/testdata/lsp/completion/snippet_types.B.rbedited
@@ -12,5 +12,5 @@ Test.new.x_is_ # error: does not exist
 
 # Snippet for applied generic should respect TypeConstraint
 xs = T::Hash[String, Integer].new
-xs.fetch(${1:Hash::K})${0} # error: does not exist
+xs.fetch(${1:String})${0} # error: does not exist
 #      ^ apply-completion: [B] item: 0

--- a/test/testdata/lsp/completion/snippet_types.B.rbedited
+++ b/test/testdata/lsp/completion/snippet_types.B.rbedited
@@ -12,5 +12,5 @@ Test.new.x_is_ # error: does not exist
 
 # Snippet for applied generic should respect TypeConstraint
 xs = T::Hash[String, Integer].new
-xs.fetc # error: does not exist
+xs.fetch(${1:Hash::K})${0} # error: does not exist
 #      ^ apply-completion: [B] item: 0


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Review by commit to see the change in behavior.

We used to use only the completed method's signature to populate the snippet.
Now we use the constraint on the resolved receiver to constrain the types of
the arguments, which means that generic type members can be made more specific.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.