### PR TITLE
keep data from `defined`

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1624,7 +1624,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 Send::ARGS_store args;
                 while (!isa_tree<EmptyTree>(value.get())) {
                     auto lit = cast_tree<UnresolvedConstantLit>(value.get());
-                    if (!lit) {
+                    if (lit == nullptr) {
                         args.clear();
                         break;
                     }

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1632,7 +1632,8 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                     value = std::move(lit->scope);
                 }
                 absl::c_reverse(args);
-                auto res = MK::Send(loc, MK::Constant(loc, core::Symbols::Magic()), core::Names::defined_p(), std::move(args));
+                auto res =
+                    MK::Send(loc, MK::Constant(loc, core::Symbols::Magic()), core::Names::defined_p(), std::move(args));
                 result.swap(res);
             },
             [&](parser::LineLiteral *line) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1621,7 +1621,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
             [&](parser::Defined *defined) {
                 auto value = node2TreeImpl(dctx, std::move(defined->value));
                 auto loc = value->loc;
-                Array::ENTRY_store args;
+                Send::ARGS_store args;
                 while (!isa_tree<EmptyTree>(value.get())) {
                     auto lit = cast_tree<UnresolvedConstantLit>(value.get());
                     if (!lit) {
@@ -1632,8 +1632,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                     value = std::move(lit->scope);
                 }
                 absl::c_reverse(args);
-                auto res = MK::Send1(loc, MK::Constant(loc, core::Symbols::Magic()), core::Names::defined_p(),
-                                     MK::Array(loc, std::move(args)));
+                auto res = MK::Send(loc, MK::Constant(loc, core::Symbols::Magic()), core::Names::defined_p(), std::move(args));
                 result.swap(res);
             },
             [&](parser::LineLiteral *line) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1633,7 +1633,8 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                     value = lit->scope.get();
                 }
                 absl::c_reverse(args);
-                auto res = MK::Send1(loc, MK::Constant(loc, core::Symbols::Magic()), core::Names::defined_p(), MK::Array(loc, std::move(args)));
+                auto res = MK::Send1(loc, MK::Constant(loc, core::Symbols::Magic()), core::Names::defined_p(),
+                                     MK::Array(loc, std::move(args)));
                 result.swap(res);
             },
             [&](parser::LineLiteral *line) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1619,18 +1619,17 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 result.swap(res);
             },
             [&](parser::Defined *defined) {
-                auto valuePtr = node2TreeImpl(dctx, std::move(defined->value));
-                auto loc = valuePtr->loc;
-                auto value = valuePtr.get();
+                auto value = node2TreeImpl(dctx, std::move(defined->value));
+                auto loc = value->loc;
                 Array::ENTRY_store args;
-                while (!isa_tree<EmptyTree>(value)) {
-                    auto lit = cast_tree<UnresolvedConstantLit>(value);
+                while (!isa_tree<EmptyTree>(value.get())) {
+                    auto lit = cast_tree<UnresolvedConstantLit>(value.get());
                     if (!lit) {
                         args.clear();
                         break;
                     }
                     args.emplace_back(MK::String(lit->loc, lit->cnst));
-                    value = lit->scope.get();
+                    value = std::move(lit->scope);
                 }
                 absl::c_reverse(args);
                 auto res = MK::Send1(loc, MK::Constant(loc, core::Symbols::Magic()), core::Names::defined_p(),

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -332,11 +332,12 @@ void GlobalState::initEmpty() {
         arg.flags.isBlock = true;
     }
 
-    // Synthesize <Magic>#<defined>(arg0: Object) => Boolean
+    // Synthesize <Magic>#<defined>(*arg0: String) => Boolean
     method = enterMethodSymbol(Loc::none(), Symbols::MagicSingleton(), Names::defined_p());
     {
         auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg0());
-        arg.type = Types::Object();
+        arg.flags.isRepeated = true;
+        arg.type = Types::String();
     }
     method.data(*this)->resultType = Types::any(ctx, Types::nilClass(), Types::String());
     {

--- a/test/testdata/desugar/defined.rb
+++ b/test/testdata/desugar/defined.rb
@@ -1,2 +1,4 @@
 # typed: true
-defined?(FOO)
+defined?(Foo::Bar)
+defined?(1)
+defined?(A+2)

--- a/test/testdata/desugar/defined.rb.desugar-tree.exp
+++ b/test/testdata/desugar/defined.rb.desugar-tree.exp
@@ -1,3 +1,7 @@
 class <emptyTree><<C <root>>> < ()
-  ::<Magic>.defined?(nil)
+  ::<Magic>.defined?(["Foo", "Bar"])
+
+  ::<Magic>.defined?([])
+
+  ::<Magic>.defined?([])
 end

--- a/test/testdata/desugar/defined.rb.desugar-tree.exp
+++ b/test/testdata/desugar/defined.rb.desugar-tree.exp
@@ -1,7 +1,7 @@
 class <emptyTree><<C <root>>> < ()
-  ::<Magic>.defined?(["Foo", "Bar"])
+  ::<Magic>.defined?("Foo", "Bar")
 
-  ::<Magic>.defined?([])
+  ::<Magic>.defined?()
 
-  ::<Magic>.defined?([])
+  ::<Magic>.defined?()
 end

--- a/test/testdata/parser/misc.rb.desugar-tree.exp
+++ b/test/testdata/parser/misc.rb.desugar-tree.exp
@@ -106,7 +106,7 @@ class <emptyTree><<C <root>>> < ()
 
   next([1, 2])
 
-  ::<Magic>.defined?(["X"])
+  ::<Magic>.defined?("X")
 
   <self>.super(ZSuperArgs)
 

--- a/test/testdata/parser/misc.rb.desugar-tree.exp
+++ b/test/testdata/parser/misc.rb.desugar-tree.exp
@@ -106,7 +106,7 @@ class <emptyTree><<C <root>>> < ()
 
   next([1, 2])
 
-  ::<Magic>.defined?(nil)
+  ::<Magic>.defined?(["X"])
 
   <self>.super(ZSuperArgs)
 


### PR DESCRIPTION
We should keep around this data for `defined` instead of throwing it away. Keeping it as a `String` won't typecheck it.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
