### PR TITLE
Improve argument mismatch error messages

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -561,16 +561,15 @@ public:
                 }
                 return;
             }
-            if (symArg.flags.isBlock != methodArg.block) {
-                if (auto e = ctx.state.beginError(loc, core::errors::Namer::RedefinitionOfMethod)) {
-                    e.setHeader("Method `{}` redefined with argument `{}` as a {} argument", sym.show(ctx),
-                                methodArg.local.toString(ctx), methodArg.block ? "block" : "non-block");
-                    e.addErrorLine(sym.data(ctx)->loc(),
-                                   "The corresponding argument `{}` in the previous definition was {}a block argument",
-                                   symArg.show(ctx), symArg.flags.isBlock ? "" : "not ");
-                }
-                return;
-            }
+            // because of how we synthesize block args, this condition should always be true. In particular: the last
+            // thing in our list of arguments will always be a block arg, either an explicit one or an implicit one, and
+            // the only situation in which a block arg will ever be seen is as the last argument in the
+            // list. Consequently, the only situation in which a block arg will be matched up with a non-block arg is
+            // when the lists are different lengths: but in that case, we'll have bailed out of this function already
+            // with the "without matching argument count" error above. So, as long as we have maintained the intended
+            // invariants around methods and arguments, we do not need to ever issue an error about non-matching
+            // isBlock-ness.
+            ENFORCE(symArg.flags.isBlock == methodArg.block);
             if (symArg.flags.isRepeated != methodArg.repeated) {
                 if (auto e = ctx.state.beginError(loc, core::errors::Namer::RedefinitionOfMethod)) {
                     e.setHeader("Method `{}` redefined with argument `{}` as a {} argument", sym.show(ctx),

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -552,35 +552,40 @@ public:
 
             if (symArg.flags.isKeyword != methodArg.keyword) {
                 if (auto e = ctx.state.beginError(loc, core::errors::Namer::RedefinitionOfMethod)) {
-                    e.setHeader(
-                        "Method `{}` redefined with mismatched argument attribute `{}`. Expected: `{}`, got: `{}`",
-                        sym.show(ctx), "isKeyword", symArg.flags.isKeyword, methodArg.keyword);
-                    e.addErrorLine(sym.data(ctx)->loc(), "Previous definition");
+                    e.setHeader("Method `{}` redefined with argument `{}` as a {} argument", sym.show(ctx),
+                                methodArg.local.toString(ctx), methodArg.keyword ? "keyword" : "non-keyword");
+                    e.addErrorLine(
+                        sym.data(ctx)->loc(),
+                        "The corresponding argument `{}` in the previous definition was {}a keyword argument",
+                        symArg.show(ctx), symArg.flags.isKeyword ? "" : "not ");
                 }
                 return;
             }
             if (symArg.flags.isBlock != methodArg.block) {
                 if (auto e = ctx.state.beginError(loc, core::errors::Namer::RedefinitionOfMethod)) {
-                    e.setHeader(
-                        "Method `{}` redefined with mismatched argument attribute `{}`. Expected: `{}`, got: `{}`",
-                        sym.show(ctx), "isBlock", symArg.flags.isBlock, methodArg.block);
-                    e.addErrorLine(sym.data(ctx)->loc(), "Previous definition");
+                    e.setHeader("Method `{}` redefined with argument `{}` as a {} argument", sym.show(ctx),
+                                methodArg.local.toString(ctx), methodArg.block ? "block" : "non-block");
+                    e.addErrorLine(sym.data(ctx)->loc(),
+                                   "The corresponding argument `{}` in the previous definition was {}a block argument",
+                                   symArg.show(ctx), symArg.flags.isBlock ? "" : "not ");
                 }
                 return;
             }
             if (symArg.flags.isRepeated != methodArg.repeated) {
                 if (auto e = ctx.state.beginError(loc, core::errors::Namer::RedefinitionOfMethod)) {
-                    e.setHeader(
-                        "Method `{}` redefined with mismatched argument attribute `{}`. Expected: `{}`, got: `{}`",
-                        sym.show(ctx), "isRepeated", symArg.flags.isRepeated, methodArg.repeated);
-                    e.addErrorLine(sym.data(ctx)->loc(), "Previous definition");
+                    e.setHeader("Method `{}` redefined with argument `{}` as a {} argument", sym.show(ctx),
+                                methodArg.local.toString(ctx), methodArg.repeated ? "splat" : "non-splat");
+                    e.addErrorLine(sym.data(ctx)->loc(),
+                                   "The corresponding argument `{}` in the previous definition was {}a splat argument",
+                                   symArg.show(ctx), symArg.flags.isRepeated ? "" : "not ");
                 }
                 return;
             }
             if (symArg.flags.isKeyword && symArg.name != methodArg.local._name) {
                 if (auto e = ctx.state.beginError(loc, core::errors::Namer::RedefinitionOfMethod)) {
-                    e.setHeader("Method `{}` redefined with mismatched argument name. Expected: `{}`, got: `{}`",
-                                sym.show(ctx), symArg.name.show(ctx), methodArg.local._name.show(ctx));
+                    e.setHeader(
+                        "Method `{}` redefined with mismatched keyword argument name. Expected: `{}`, got: `{}`",
+                        sym.show(ctx), symArg.name.show(ctx), methodArg.local._name.show(ctx));
                     e.addErrorLine(sym.data(ctx)->loc(), "Previous definition");
                 }
                 return;

--- a/test/testdata/infer/module_function_two.rb
+++ b/test/testdata/infer/module_function_two.rb
@@ -6,7 +6,7 @@ module Foo
     b
   end
 
-  def bar(a:) # error: Method `Foo.bar` redefined with mismatched argument attribute `isKeyword`.
+  def bar(a:) # error: Method `Foo.bar` redefined with argument `a` as a keyword argument
     a
   end
 end

--- a/test/testdata/namer/redefine.rb
+++ b/test/testdata/namer/redefine.rb
@@ -39,6 +39,15 @@ end
 T.reveal_type(wrong_args(a: 2)) # error: Revealed type: `T.untyped`
 
 sig {params(a: Integer).returns(Integer)}
+def wrong_args2(a:)
+  1
+end
+def wrong_args2(a) # error: Method `Object#wrong_args2` redefined with argument `a` as a non-keyword argument
+  2
+end
+T.reveal_type(wrong_args2(a: 2)) # error: Revealed type: `T.untyped`
+
+sig {params(a: Integer).returns(Integer)}
 def wrong_name(a)
   1
 end
@@ -55,6 +64,15 @@ def wrong_repeatedness(*a) # error: Method `Object#wrong_repeatedness` redefined
   2
 end
 T.reveal_type(wrong_repeatedness(3)) # error: Revealed type: `T.untyped`
+
+sig {params(a: Integer).returns(Integer)}
+def wrong_repeatedness2(*a)
+  1
+end
+def wrong_repeatedness2(a) # error: Method `Object#wrong_repeatedness2` redefined with argument `a` as a non-splat argument
+  2
+end
+T.reveal_type(wrong_repeatedness2(3)) # error: Revealed type: `T.untyped`
 
 sig {params(a: Integer).returns(Integer)}
 def wrong_blockness(a)

--- a/test/testdata/namer/redefine.rb
+++ b/test/testdata/namer/redefine.rb
@@ -33,7 +33,7 @@ sig {params(a: Integer).returns(Integer)}
 def wrong_args(a)
   1
 end
-def wrong_args(a:) # error: redefined with mismatched argument attribute `isKeyword`. Expected: `false`, got: `true`
+def wrong_args(a:) # error: Method `Object#wrong_args` redefined with argument `a` as a keyword argument
   2
 end
 T.reveal_type(wrong_args(a: 2)) # error: Revealed type: `T.untyped`
@@ -51,7 +51,7 @@ sig {params(a: Integer).returns(Integer)}
 def wrong_repeatedness(a)
   1
 end
-def wrong_repeatedness(*a) # error: redefined with mismatched argument attribute `isRepeated`. Expected: `false`, got: `true`
+def wrong_repeatedness(*a) # error: Method `Object#wrong_repeatedness` redefined with argument `a` as a splat argument
   2
 end
 T.reveal_type(wrong_repeatedness(3)) # error: Revealed type: `T.untyped`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
The previous error messages made reference to our internal names for argument attributes, which was confusing. This replaces them with more explanatory error messages. For example, the program

```ruby
def f(a); end
def f(b:); end

def g(*a); end
def g(b); end
```
with this PR now produces the error messages
```
./samp.rb:4: Method Object#f redefined with argument b as a keyword argument https://srb.help/4010
     4 |def f(b:); end
        ^^^^^^^^^
    ./samp.rb:3: The corresponding argument a in the previous definition was not a keyword argument
     3 |def f(a); end
        ^^^^^^^^

./samp.rb:7: Method Object#g redefined with argument b as a non-splat argument https://srb.help/4010
     7 |def g(b); end
        ^^^^^^^^
    ./samp.rb:6: The corresponding argument a in the previous definition was a splat argument
     6 |def g(*a); end
        ^^^^^^^^^
```

The previous error messages looked like this:
```
./samp.rb:4: Method Object#f redefined with mismatched argument attribute isKeyword. Expected: false, got: true https://srb.help/4010
     4 |def f(b:); end
        ^^^^^^^^^
    ./samp.rb:3: Previous definition
     3 |def f(a); end
        ^^^^^^^^

./samp.rb:7: Method Object#g redefined with mismatched argument attribute isRepeated. Expected: true, got: false https://srb.help/4010
     7 |def g(b); end
        ^^^^^^^^
    ./samp.rb:6: Previous definition
     6 |def g(*a); end
        ^^^^^^^^^
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
