### PR TITLE
Add support for pre-release Ruby versions

### DIFF
--- a/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
@@ -211,7 +211,8 @@ module Sorbet::Private
         match =
           location&.match(/^.*\/(ruby)\/([\d.]+)\//) || # ruby stdlib
           location&.match(/^.*\/(site_ruby)\/([\d.]+)\//) || # rubygems
-          location&.match(/^.*\/gems\/(?:ruby-)?[\d.a-z9-0-]+(?:@[^\/]+)?(?:\/bundler)?\/gems\/([^\/]+)-([^-\/]+)\//i) # gem
+          location&.match(/^.*\/gems\/(?:ruby-)?[\d.]+[-a-z0-9]*(?:@[^\/]+)?(?:\/bundler)?\/gems\/([^\/\    ]+)-([^\
+   -\/]+)\//i) # gem
         if match.nil?
           # uncomment to generate files for methods outside of gems
           # {

--- a/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
@@ -211,8 +211,9 @@ module Sorbet::Private
         match =
           location&.match(/^.*\/(ruby)\/([\d.]+)\//) || # ruby stdlib
           location&.match(/^.*\/(site_ruby)\/([\d.]+)\//) || # rubygems
+          location&.match(/^.*\/gems\/(?:ruby-)?[\d.a-z9-0-]+(?:@[^\/]+)?(?:\/bundler)?\/gems\/([^\/]+)-([^-\/]+)\//i) || # gem(1)
           location&.match(/^.*\/gems\/(?:ruby-)?[\d.]+[-a-z0-9]*(?:@[^\/]+)?(?:\/bundler)?\/gems\/([^\/\    ]+)-([^\
-   -\/]+)\//i) # gem
+   -\/]+)\//i) # gem(2)
         if match.nil?
           # uncomment to generate files for methods outside of gems
           # {

--- a/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
@@ -211,9 +211,9 @@ module Sorbet::Private
         match =
           location&.match(/^.*\/(ruby)\/([\d.]+)\//) || # ruby stdlib
           location&.match(/^.*\/(site_ruby)\/([\d.]+)\//) || # rubygems
-          location&.match(/^.*\/gems\/(?:ruby-)?[\d.a-z9-0-]+(?:@[^\/]+)?(?:\/bundler)?\/gems\/([^\/]+)-([^-\/]+)\//i) || # gem(1)
+          location&.match(/^.*\/gems\/(?:ruby-)?[\d]+(?:@[^\/]+)?(?:\/bundler)?\/gems\/([^\/]+)-([^-\/]+)\//i) || # gem(1)
           location&.match(/^.*\/gems\/(?:ruby-)?[\d.]+[-a-z0-9]*(?:@[^\/]+)?(?:\/bundler)?\/gems\/([^\/\    ]+)-([^\
-   -\/]+)\//i) # gem(2)
+   -\/]+)\//i) | # gem(2)
         if match.nil?
           # uncomment to generate files for methods outside of gems
           # {

--- a/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
@@ -211,7 +211,7 @@ module Sorbet::Private
         match =
           location&.match(/^.*\/(ruby)\/([\d.]+)\//) || # ruby stdlib
           location&.match(/^.*\/(site_ruby)\/([\d.]+)\//) || # rubygems
-          location&.match(/^.*\/gems\/(?:ruby-)?([\d.]+[-a-z0-9]*)(?:@[^\/]+)?(?:\/bundler)?\/gems\/([^\/]+)-([^-\/]+)\//i) # gem
+          location&.match(/^.*\/gems\/(?:ruby-)?[\d.a-z9-0-]+(?:@[^\/]+)?(?:\/bundler)?\/gems\/([^\/]+)-([^-\/]+)\//i) # gem
         if match.nil?
           # uncomment to generate files for methods outside of gems
           # {

--- a/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
@@ -211,7 +211,7 @@ module Sorbet::Private
         match =
           location&.match(/^.*\/(ruby)\/([\d.]+)\//) || # ruby stdlib
           location&.match(/^.*\/(site_ruby)\/([\d.]+)\//) || # rubygems
-          location&.match(/^.*\/gems\/(?:ruby-)?[\d]+(?:@[^\/]+)?(?:\/bundler)?\/gems\/([^\/]+)-([^-\/]+)\//i) || # gem(1)
+          location&.match(/^.*\/gems\/(?:ruby-)?[\d.]+(?:@[^\/]+)?(?:\/bundler)?\/gems\/([^\/]+)-([^-\/]+)\//i) || # gem(1)
           location&.match(/^.*\/gems\/(?:ruby-)?[\d.]+[-a-z0-9]*(?:@[^\/]+)?(?:\/bundler)?\/gems\/([^\/\    ]+)-([^\
    -\/]+)\//i) | # gem(2)
         if match.nil?

--- a/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
@@ -211,7 +211,7 @@ module Sorbet::Private
         match =
           location&.match(/^.*\/(ruby)\/([\d.]+)\//) || # ruby stdlib
           location&.match(/^.*\/(site_ruby)\/([\d.]+)\//) || # rubygems
-          location&.match(/^.*\/gems\/(?:ruby-)?[\d.]+(?:@[^\/]+)?(?:\/bundler)?\/gems\/([^\/]+)-([^-\/]+)\//i) # gem
+          location&.match(/^.*\/gems\/(?:ruby-)?([\d.]+[-a-z0-9]*)(?:@[^\/]+)?(?:\/bundler)?\/gems\/([^\/]+)-([^-\/]+)\//i) # gem
         if match.nil?
           # uncomment to generate files for methods outside of gems
           # {


### PR DESCRIPTION
Add support for pre-release Ruby versions, such as "ruby-2.7-0-preview2" or"ruby-2.7.0-rc1".

Changed regular expression in 1 line.

### Motivation

Currently "srb init" does not recognize pre-release Ruby versions, such as "ruby-2.7-0-preview2" or"ruby-2.7.0-rc1".

This removes a blocker for trying out early Ruby versions.
