### PR TITLE
Prevent constants in methods from Minitest DSL

### DIFF
--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -756,12 +756,7 @@ private:
                 optArg->default_ = mapIt(move(optArg->default_), ctx.withOwner(v->symbol));
             }
         }
-        // because this is a ShallowMap, we do not map over the body of the method unless it is synthesized by the
-        // rewriter pass, because we can be sure that typical Ruby code does not e.g. include constant definitions in
-        // the body of a method
-        if (v->isRewriterSynthesized()) {
-            v->rhs = mapIt(move(v->rhs), ctx.withOwner(v->symbol));
-        }
+        // because this is a ShallowMap, we do not map over the body of the method
 
         if constexpr (HAS_MEMBER_postTransformMethodDef<FUNC>::value) {
             return PostPonePostTransform_MethodDef<FUNC, CTX, HAS_MEMBER_postTransformMethodDef<FUNC>::value>::call(

--- a/ast/verifier/Verifier.cc
+++ b/ast/verifier/Verifier.cc
@@ -5,6 +5,8 @@ using namespace std;
 namespace sorbet::ast {
 
 class VerifierWalker {
+    u4 methodDepth = 0;
+
 public:
     unique_ptr<Expression> preTransformExpression(core::Context ctx, unique_ptr<Expression> original) {
         if (!isa_tree<EmptyTree>(original.get())) {
@@ -13,6 +15,23 @@ public:
 
         original->_sanityCheck();
 
+        return original;
+    }
+
+    unique_ptr<MethodDef> preTransformMethodDef(core::Context ctx, unique_ptr<MethodDef> original) {
+        methodDepth++;
+        return original;
+    }
+
+    unique_ptr<Expression> postTransformMethodDef(core::Context ctx, unique_ptr<MethodDef> original) {
+        methodDepth--;
+        return original;
+    }
+
+    unique_ptr<Expression> postTransformAssign(core::Context ctx, unique_ptr<Assign> original) {
+        if (ast::isa_tree<ast::UnresolvedConstantLit>(original->lhs.get())) {
+            ENFORCE(methodDepth == 0, "Found constant definition inside method definition");
+        }
         return original;
     }
 

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -67,7 +67,7 @@ public:
     }
 
     // we move sends if they are other minitest `describe` blocks, as those end up being classes anyway: consequently,
-    // we treat those the same wa we treat classes
+    // we treat those the same way we treat classes
     unique_ptr<ast::Send> preTransformSend(core::MutableContext ctx, unique_ptr<ast::Send> send) {
         if (!send->recv->isSelfReference() && send->args.size() == 1 && send->fun == core::Names::describe()) {
             classDepth++;

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -17,7 +17,7 @@ class ConstantMover {
     vector<unique_ptr<ast::Expression>> movedConstants;
 
 public:
-    unique_ptr<ast::Expression> createConstAssign(ast::Assign& asgn) {
+    unique_ptr<ast::Expression> createConstAssign(ast::Assign &asgn) {
         auto loc = asgn.loc;
         auto unsafeNil = ast::MK::Unsafe(loc, ast::MK::Nil(loc));
         if (auto send = ast::cast_tree<ast::Send>(asgn.rhs.get())) {
@@ -126,8 +126,9 @@ unique_ptr<ast::Expression> runSingle(core::MutableContext ctx, ast::Send *send)
         auto name = send->fun == core::Names::after() ? core::Names::afterAngles() : core::Names::initialize();
         ConstantMover constantMover;
         send->block->body = ast::TreeMap::apply(ctx, constantMover, move(send->block->body));
-        auto method = addSigVoid(ast::MK::Method0(send->loc, send->loc, name, prepareBody(ctx, std::move(send->block->body)),
-                                                  ast::MethodDef::RewriterSynthesized));
+        auto method =
+            addSigVoid(ast::MK::Method0(send->loc, send->loc, name, prepareBody(ctx, std::move(send->block->body)),
+                                        ast::MethodDef::RewriterSynthesized));
         return constantMover.addConstantsToExpression(send->loc, move(method));
     }
 

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -51,12 +51,12 @@ public:
     }
 
     unique_ptr<ast::ClassDef> preTransformClassDef(core::MutableContext ctx, unique_ptr<ast::ClassDef> classDef) {
-        classDepth ++;
+        classDepth++;
         return classDef;
     }
 
     unique_ptr<ast::Expression> postTransformClassDef(core::MutableContext ctx, unique_ptr<ast::ClassDef> classDef) {
-        classDepth --;
+        classDepth--;
         if (classDepth == 0) {
             movedConstants.emplace_back(move(classDef));
             return ast::MK::EmptyTree();

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -14,6 +14,7 @@ namespace sorbet::rewriter {
 
 namespace {
 class ConstantMover {
+    u4 classDepth = 0;
     vector<unique_ptr<ast::Expression>> movedConstants;
 
 public:
@@ -49,9 +50,18 @@ public:
         return asgn;
     }
 
+    unique_ptr<ast::ClassDef> preTransformClassDef(core::MutableContext ctx, unique_ptr<ast::ClassDef> classDef) {
+        classDepth ++;
+        return classDef;
+    }
+
     unique_ptr<ast::Expression> postTransformClassDef(core::MutableContext ctx, unique_ptr<ast::ClassDef> classDef) {
-        movedConstants.emplace_back(move(classDef));
-        return ast::MK::EmptyTree();
+        classDepth --;
+        if (classDepth == 0) {
+            movedConstants.emplace_back(move(classDef));
+            return ast::MK::EmptyTree();
+        }
+        return classDef;
     }
 
     vector<unique_ptr<ast::Expression>> getMovedConstants() {

--- a/test/testdata/rewriter/minitest.rb
+++ b/test/testdata/rewriter/minitest.rb
@@ -11,6 +11,15 @@ class MyTest
       CONST = 10
     end
 
+    it "allows let-ed constants inside of IT" do
+      C2 = T.let(10, Integer)
+    end
+
+    it "allows path constants inside of IT" do
+      C3 = Mod::C
+      C3.new
+    end
+
     describe "some inner tests" do
         def inside_method
         end
@@ -62,4 +71,10 @@ class MyTest
 end
 
 def junk
+end
+
+
+module Mod
+  class C
+  end
 end

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -14,13 +14,40 @@ class <emptyTree><<C <root>>> < ()
     end
 
     begin
-      <emptyTree>::<C CONST> = 10
+      <emptyTree>::<C CONST> = ::T.unsafe(nil)
       begin
         ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({}).void()
         end
         def <test_allows constants inside of IT><<C <todo sym>>>(&<blk>)
-          <emptyTree>
+          ::Module.const_set(:"CONST", 10)
+        end
+      end
+    end
+
+    begin
+      <emptyTree>::<C C2> = ::T.let(::T.unsafe(nil), <emptyTree>::<C Integer>)
+      begin
+        ::T::Sig::WithoutRuntime.sig() do ||
+          <self>.params({}).void()
+        end
+        def <test_allows let-ed constants inside of IT><<C <todo sym>>>(&<blk>)
+          ::Module.const_set(:"C2", <emptyTree>::<C T>.let(10, <emptyTree>::<C Integer>))
+        end
+      end
+    end
+
+    begin
+      <emptyTree>::<C C3> = <emptyTree>::<C Mod>::<C C>
+      begin
+        ::T::Sig::WithoutRuntime.sig() do ||
+          <self>.params({}).void()
+        end
+        def <test_allows path constants inside of IT><<C <todo sym>>>(&<blk>)
+          begin
+            <emptyTree>
+            <emptyTree>::<C C3>.new()
+          end
         end
       end
     end
@@ -126,5 +153,11 @@ class <emptyTree><<C <root>>> < ()
 
   def junk<<C <todo sym>>>(&<blk>)
     <emptyTree>
+  end
+
+  module <emptyTree>::<C Mod><<C <todo sym>>> < ()
+    class <emptyTree>::<C C><<C <todo sym>>> < (::<todo sym>)
+      <emptyTree>
+    end
   end
 end

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -14,11 +14,14 @@ class <emptyTree><<C <root>>> < ()
     end
 
     begin
-      ::T::Sig::WithoutRuntime.sig() do ||
-        <self>.params({}).void()
-      end
-      def <test_allows constants inside of IT><<C <todo sym>>>(&<blk>)
-        <emptyTree>::<C CONST> = 10
+      <emptyTree>::<C CONST> = 10
+      begin
+        ::T::Sig::WithoutRuntime.sig() do ||
+          <self>.params({}).void()
+        end
+        def <test_allows constants inside of IT><<C <todo sym>>>(&<blk>)
+          <emptyTree>
+        end
       end
     end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
The minitest DSL currently rewrites test blocks in such a way that they sometimes have constant definitions inside `MethodDef`s. We should prevent this if possible, as it helps maintain invariants and could help with future speedups to Sorbet.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
