### PR TITLE
Fix bug resulting in excessive responses to workspace/symbol requests

### DIFF
--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -46,7 +46,7 @@ vector<unique_ptr<SymbolInformation>> SymbolMatcher::symbolRef2SymbolInformation
         if (!loc.file().exists()) {
             continue;
         }
-        auto location = config.loc2Location(gs, sym->loc());
+        auto location = config.loc2Location(gs, loc);
         if (location == nullptr) {
             continue;
         }

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -1473,11 +1473,11 @@ void checkAllForQuery(std::string query, const vector<shared_ptr<SymbolSearchAss
         for (auto &symbolInfo : *symbolInfos) {
             symbolAssertionMatches.emplace_back(*symbolInfo, nullptr);
         }
-        constexpr int MAX_RESPONSES = 50;
-        if (symbolInfos->size() > MAX_RESPONSES) {
+        constexpr int MAX_RESULTS = 50; // see MAX_RESULTS in workspace_symbols.cc
+        if (symbolInfos->size() > MAX_RESULTS) {
             ADD_FAILURE() << fmt::format(
-                "Too many responses for a `workspace/symbol` request. [Expected no more than {}, got {}].",
-                MAX_RESPONSES, symbolInfos->size());
+                "Too many results for `workspace/symbol` request for `{}`. [Expected no more than {}, got {}].", query,
+                MAX_RESULTS, symbolInfos->size());
         }
     }
     matchSymbolsToAssertions(query, assertions, symbolAssertionMatches, sourceFileContents, uriPrefix, errorPrefix);

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -8,6 +8,7 @@
 #include "common/sort.h"
 #include "test/helpers/lsp.h"
 #include "test/helpers/position_assertions.h"
+#include <iterator>
 #include <regex>
 
 using namespace std;
@@ -1471,6 +1472,12 @@ void checkAllForQuery(std::string query, const vector<shared_ptr<SymbolSearchAss
             &get<variant<JSONNullObject, vector<unique_ptr<SymbolInformation>>>>(result))) {
         for (auto &symbolInfo : *symbolInfos) {
             symbolAssertionMatches.emplace_back(*symbolInfo, nullptr);
+        }
+        constexpr int MAX_RESPONSES = 50;
+        if (symbolInfos->size() > MAX_RESPONSES) {
+            ADD_FAILURE() << fmt::format(
+                "Too many responses for a `workspace/symbol` request. [Expected no more than {}, got {}].",
+                MAX_RESPONSES, symbolInfos->size());
         }
     }
     matchSymbolsToAssertions(query, assertions, symbolAssertionMatches, sourceFileContents, uriPrefix, errorPrefix);

--- a/test/testdata/lsp/workspace_symbols_stdlib.rb
+++ b/test/testdata/lsp/workspace_symbols_stdlib.rb
@@ -8,3 +8,6 @@
 # // Multiple symbols from same rbi file?
 # symbol-search: "encoding", name="encoding", container="::Regexp", uri="regexp.rbi"
 # symbol-search: "encoding", name="fixed_encoding?", container="::Regexp", uri="regexp.rbi"
+
+# // Extremely common
+# symbol-search: "hash", name="hash", container="::Kernel", uri="kernel.rbi"


### PR DESCRIPTION
### Motivation
Fix performance regression introduced when expanding `workspace/symbol` search to support returning multiple locations for a symbol.

### Test plan
Local testing + additional assertions to verify limits in automated tests.
