### PR TITLE
Share formatRubyMarkup in hover & completion

### DIFF
--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -140,6 +140,8 @@ public:
 std::optional<std::string> findDocumentation(std::string_view sourceCode, int beginIndex);
 bool hasSimilarName(const core::GlobalState &gs, core::NameRef name, std::string_view pattern);
 bool hideSymbol(const core::GlobalState &gs, core::SymbolRef sym);
+std::unique_ptr<MarkupContent> formatRubyMarkup(MarkupKind markupKind, std::string_view rubyMarkup,
+                                                std::optional<std::string_view> explanation);
 std::string methodDetail(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver,
                          core::TypePtr retType, const core::TypeConstraint *constraint);
 std::string methodDefinition(const core::GlobalState &gs, core::SymbolRef method);

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -70,6 +70,22 @@ bool hasSimilarName(const core::GlobalState &gs, core::NameRef name, string_view
     return fnd != string_view::npos;
 }
 
+unique_ptr<MarkupContent> formatRubyMarkup(MarkupKind markupKind, string_view rubyMarkup,
+                                           optional<string_view> explanation) {
+    // format rubyMarkup
+    string formattedTypeString;
+    if (markupKind == MarkupKind::Markdown && rubyMarkup.length() > 0) {
+        formattedTypeString = fmt::format("```ruby\n{}\n```", rubyMarkup);
+    } else {
+        formattedTypeString = string(rubyMarkup);
+    }
+
+    string content =
+        absl::StrCat(formattedTypeString, explanation.has_value() ? "\n\n---\n\n" : "", explanation.value_or(""));
+
+    return make_unique<MarkupContent>(markupKind, move(content));
+}
+
 // iff a sig has more than this many parameters, then print it as a multi-line sig.
 constexpr int NUM_ARGS_CUTOFF_FOR_MULTILINE_SIG = 4;
 

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -291,12 +291,9 @@ unique_ptr<CompletionItem> getCompletionItemForKeyword(const core::GlobalState &
 
     item->detail = fmt::format("(sorbet) {}", rubyKeyword.documentation);
     if (rubyKeyword.snippet.has_value()) {
-        auto documentation = rubyKeyword.snippet.value();
+        auto rubyMarkup = rubyKeyword.snippet.value();
         auto markupKind = config.getClientConfig().clientCompletionItemMarkupKind;
-        if (markupKind == MarkupKind::Markdown) {
-            documentation = absl::StrCat("\n\n```ruby\n", documentation, "\n```");
-        }
-        item->documentation = make_unique<MarkupContent>(markupKind, documentation);
+        item->documentation = formatRubyMarkup(markupKind, rubyMarkup, rubyKeyword.documentation);
     }
 
     return item;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There are a number of cleanups that I want to make to share more code between
hover and completion, which will mean

1. Implementing improvements and fixes once
2. Making it more likely to notice problems with one more by leveraging the
   popularity of the other.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This particular feature of LSP is untested in the test suite. I tested locally
to make sure that the docs are still showing up as Ruby syntax highlighted
blocks for keyword snippets.