### PR TITLE
Show sig + def in completion results

### DIFF
--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -142,9 +142,8 @@ bool hasSimilarName(const core::GlobalState &gs, core::NameRef name, std::string
 bool hideSymbol(const core::GlobalState &gs, core::SymbolRef sym);
 std::unique_ptr<MarkupContent> formatRubyMarkup(MarkupKind markupKind, std::string_view rubyMarkup,
                                                 std::optional<std::string_view> explanation);
-std::string methodDetail(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver,
-                         core::TypePtr retType, const core::TypeConstraint *constraint);
-std::string methodDefinition(const core::GlobalState &gs, core::SymbolRef method);
+std::string prettyTypeForMethod(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver,
+                                core::TypePtr retType, const core::TypeConstraint *constraint);
 core::TypePtr getResultType(const core::GlobalState &gs, core::TypePtr type, core::SymbolRef inWhat,
                             core::TypePtr receiver, const core::TypeConstraint *constr);
 SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef);

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -89,8 +89,8 @@ unique_ptr<MarkupContent> formatRubyMarkup(MarkupKind markupKind, string_view ru
 // iff a sig has more than this many parameters, then print it as a multi-line sig.
 constexpr int NUM_ARGS_CUTOFF_FOR_MULTILINE_SIG = 4;
 
-string methodDetail(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver, core::TypePtr retType,
-                    const core::TypeConstraint *constraint) {
+string prettySigForMethod(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver,
+                          core::TypePtr retType, const core::TypeConstraint *constraint) {
     ENFORCE(method.exists());
     // handle this case anyways so that we don't crash in prod when this method is mis-used
     if (!method.exists()) {
@@ -165,7 +165,7 @@ string methodDetail(const core::GlobalState &gs, core::SymbolRef method, core::T
 // iff a `def` would be this wide or wider, expand it to be a multi-line def.
 constexpr int WIDTH_CUTOFF_FOR_MULTILINE_DEF = 80;
 
-string methodDefinition(const core::GlobalState &gs, core::SymbolRef method) {
+string prettyDefForMethod(const core::GlobalState &gs, core::SymbolRef method) {
     ENFORCE(method.exists());
     // handle this case anyways so that we don't crash in prod when this method is mis-used
     if (!method.exists()) {
@@ -227,6 +227,12 @@ string methodDefinition(const core::GlobalState &gs, core::SymbolRef method) {
                              fmt::join(arguments, argListSeparator), argListSuffix);
     }
     return result;
+}
+
+string prettyTypeForMethod(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver,
+                           core::TypePtr retType, const core::TypeConstraint *constraint) {
+    return fmt::format("{}\n{}", prettySigForMethod(gs, method, receiver, retType, constraint),
+                       prettyDefForMethod(gs, method));
 }
 
 core::TypePtr getResultType(const core::GlobalState &gs, core::TypePtr type, core::SymbolRef inWhat,

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -364,7 +364,7 @@ unique_ptr<CompletionItem> LSPLoop::getCompletionItemForSymbol(const core::Globa
     if (what.data(gs)->isMethod()) {
         item->kind = CompletionItemKind::Method;
         if (what.exists()) {
-            item->detail = methodDetail(gs, what, receiverType, nullptr, constraint);
+            item->detail = prettyTypeForMethod(gs, what, receiverType, nullptr, constraint);
         }
 
         u4 queryStart = queryLoc.beginPos();

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -50,7 +50,7 @@ std::unique_ptr<DocumentSymbol> symbolRef2DocumentSymbol(const core::GlobalState
     }
     auto result = make_unique<DocumentSymbol>(prefix + sym->name.show(gs), kind, move(range), move(selectionRange));
     if (sym->isMethod()) {
-        result->detail = methodDetail(gs, symRef, nullptr, nullptr, nullptr);
+        result->detail = prettyTypeForMethod(gs, symRef, nullptr, nullptr, nullptr);
     } else {
         // Currently released version of VSCode has a bug that requires this non-optional field to be present
         result->detail = "";

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -13,15 +13,13 @@ string methodInfoString(const core::GlobalState &gs, const core::TypePtr &retTyp
     auto start = &dispatchResult;
     ;
     while (start != nullptr) {
-        auto &dispatchComponent = start->main;
-        if (dispatchComponent.method.exists()) {
+        auto &component = start->main;
+        if (component.method.exists()) {
             if (!contents.empty()) {
                 contents += "\n";
             }
             contents = absl::StrCat(
-                contents,
-                methodDetail(gs, dispatchComponent.method, dispatchComponent.receiver, retType, constraint.get()), "\n",
-                methodDefinition(gs, dispatchComponent.method));
+                contents, prettyTypeForMethod(gs, component.method, component.receiver, retType, constraint.get()));
         }
         start = start->secondary.get();
     }
@@ -83,8 +81,7 @@ unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentHover(LSPTypechecker &typ
             }
             response->result = make_unique<Hover>(formatRubyMarkup(clientHoverMarkupKind, typeString, documentation));
         } else if (auto defResp = resp->isDefinition()) {
-            string typeString = absl::StrCat(methodDetail(gs, defResp->symbol, nullptr, defResp->retType.type, nullptr),
-                                             "\n", methodDefinition(gs, defResp->symbol));
+            string typeString = prettyTypeForMethod(gs, defResp->symbol, nullptr, defResp->retType.type, nullptr);
             response->result = make_unique<Hover>(formatRubyMarkup(clientHoverMarkupKind, typeString, documentation));
         } else if (auto constResp = resp->isConstant()) {
             const auto &data = constResp->symbol.data(gs);

--- a/test/testdata/lsp/document_symbols.rb.document-symbols.exp
+++ b/test/testdata/lsp/document_symbols.rb.document-symbols.exp
@@ -56,7 +56,7 @@
                 },
                 {
                     "name": "initialize",
-                    "detail": "sig {void}",
+                    "detail": "sig {void}\ndef initialize; end",
                     "kind": 9,
                     "range": {
                         "start": {
@@ -82,7 +82,7 @@
                 },
                 {
                     "name": "next",
-                    "detail": "sig {returns(Integer)}",
+                    "detail": "sig {returns(Integer)}\ndef next; end",
                     "kind": 6,
                     "range": {
                         "start": {
@@ -108,7 +108,7 @@
                 },
                 {
                     "name": "self.bar",
-                    "detail": "sig {returns(T.untyped)}",
+                    "detail": "sig {returns(T.untyped)}\ndef self.bar; end",
                     "kind": 6,
                     "range": {
                         "start": {
@@ -187,7 +187,7 @@
                 },
                 {
                     "name": "bye",
-                    "detail": "sig(:final) {params(x: String).returns(String)}",
+                    "detail": "sig(:final) {params(x: String).returns(String)}\ndef bye(x); end",
                     "kind": 6,
                     "range": {
                         "start": {
@@ -213,7 +213,7 @@
                 },
                 {
                     "name": "hi",
-                    "detail": "sig {params(x: String).returns(String)}",
+                    "detail": "sig {params(x: String).returns(String)}\ndef hi(x); end",
                     "kind": 6,
                     "range": {
                         "start": {
@@ -266,7 +266,7 @@
             "children": [
                 {
                     "name": "sum_many",
-                    "detail": "sig do\n  abstract\n  .params(\n    first: Integer,\n    second: Integer,\n    third: Integer,\n    fourth: Integer,\n    fifth: Integer\n  )\n  .returns(Integer)\nend",
+                    "detail": "sig do\n  abstract\n  .params(\n    first: Integer,\n    second: Integer,\n    third: Integer,\n    fourth: Integer,\n    fifth: Integer\n  )\n  .returns(Integer)\nend\ndef sum_many(first, second, third, fourth, fifth); end",
                     "kind": 6,
                     "range": {
                         "start": {
@@ -319,7 +319,7 @@
             "children": [
                 {
                     "name": "sum_many",
-                    "detail": "sig do\n  override\n  .params(\n    first: Integer,\n    second: Integer,\n    third: Integer,\n    fourth: Integer,\n    fifth: Integer\n  )\n  .returns(Integer)\nend",
+                    "detail": "sig do\n  override\n  .params(\n    first: Integer,\n    second: Integer,\n    third: Integer,\n    fourth: Integer,\n    fifth: Integer\n  )\n  .returns(Integer)\nend\ndef sum_many(first, second, third, fourth, fifth); end",
                     "kind": 6,
                     "range": {
                         "start": {

--- a/test/testdata/lsp/field_edits.1.rbupdate.document-symbols.exp
+++ b/test/testdata/lsp/field_edits.1.rbupdate.document-symbols.exp
@@ -56,7 +56,7 @@
                 },
                 {
                     "name": "bar",
-                    "detail": "sig {returns(T.untyped)}",
+                    "detail": "sig {returns(T.untyped)}\ndef bar; end",
                     "kind": 6,
                     "range": {
                         "start": {

--- a/test/testdata/lsp/field_edits.2.rbupdate.document-symbols.exp
+++ b/test/testdata/lsp/field_edits.2.rbupdate.document-symbols.exp
@@ -56,7 +56,7 @@
                 },
                 {
                     "name": "bar",
-                    "detail": "sig {returns(T.untyped)}",
+                    "detail": "sig {returns(T.untyped)}\ndef bar; end",
                     "kind": 6,
                     "range": {
                         "start": {

--- a/test/testdata/lsp/field_edits.rb.document-symbols.exp
+++ b/test/testdata/lsp/field_edits.rb.document-symbols.exp
@@ -56,7 +56,7 @@
                 },
                 {
                     "name": "bar",
-                    "detail": "sig {returns(T.untyped)}",
+                    "detail": "sig {returns(T.untyped)}\ndef bar; end",
                     "kind": 6,
                     "range": {
                         "start": {

--- a/test/testdata/lsp/good_field_edits.1.rbupdate.document-symbols.exp
+++ b/test/testdata/lsp/good_field_edits.1.rbupdate.document-symbols.exp
@@ -56,7 +56,7 @@
                 },
                 {
                     "name": "bar",
-                    "detail": "sig {returns(T.untyped)}",
+                    "detail": "sig {returns(T.untyped)}\ndef bar; end",
                     "kind": 6,
                     "range": {
                         "start": {

--- a/test/testdata/lsp/good_field_edits.rb.document-symbols.exp
+++ b/test/testdata/lsp/good_field_edits.rb.document-symbols.exp
@@ -56,7 +56,7 @@
                 },
                 {
                     "name": "bar",
-                    "detail": "sig {returns(T.untyped)}",
+                    "detail": "sig {returns(T.untyped)}\ndef bar; end",
                     "kind": 6,
                     "range": {
                         "start": {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

For hover, we show both the sig and method def for a method, because
some information like keyword / defaulted args are only present on the
method def.

We were not showing this in completion.

I made a new helper called prettyTypeForMethod which always calls the
`sig` part and the `def` part, and removed the two individual components
from the header to force everyone to go through the other two methods.

After this change, we show the `def` for completion results too. The colors are still bad; going to fix those next.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Before:

<img width="719" alt="Screen Shot 2019-11-11 at 6 55 04 PM" src="https://user-images.githubusercontent.com/5544532/68639878-cc864080-04ba-11ea-8cd4-9fc8628693c5.png">

After:

<img width="705" alt="Screen Shot 2019-11-11 at 7 38 37 PM" src="https://user-images.githubusercontent.com/5544532/68639903-e4f65b00-04ba-11ea-9c0f-b4f01873dcfb.png">
