### PR TITLE
Remove horizontal rule from doc preview

### DIFF
--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -80,8 +80,7 @@ unique_ptr<MarkupContent> formatRubyMarkup(MarkupKind markupKind, string_view ru
         formattedTypeString = string(rubyMarkup);
     }
 
-    string content =
-        absl::StrCat(formattedTypeString, explanation.has_value() ? "\n\n---\n\n" : "", explanation.value_or(""));
+    string content = absl::StrCat(formattedTypeString, explanation.has_value() ? "\n\n" : "", explanation.value_or(""));
 
     return make_unique<MarkupContent>(markupKind, move(content));
 }

--- a/test/testdata/lsp/hover.rb
+++ b/test/testdata/lsp/hover.rb
@@ -82,7 +82,6 @@ class BigFoo; extend T::Sig
     # ^^^^^^^^^^^^^^^^^^^^^ hover: ```ruby
     # ^^^^^^^^^^^^^^^^^^^^^ hover: sig {void}
     # ^^^^^^^^^^^^^^^^^^^^^ hover: ```
-    # ^^^^^^^^^^^^^^^^^^^^^ hover: ---
     # ^^^^^^^^^^^^^^^^^^^^^ hover: Tests return markdown output
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This affects both hover and completion. I think the horizontal rule looks
kind of clunky. Effective use of negative space and the fact that the
documentation is in a different font are enough to separate the top from
the bottom.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

Before:

<img width="708" alt="Screen Shot 2019-11-11 at 7 48 53 PM" src="https://user-images.githubusercontent.com/5544532/68640857-dd848100-04bd-11ea-9a76-048af9f92ded.png">

After:

<img width="702" alt="Screen Shot 2019-11-11 at 8 01 13 PM" src="https://user-images.githubusercontent.com/5544532/68640933-0ad12f00-04be-11ea-9a48-d97c481fba47.png">
