### PR TITLE
Revert "Prevent constants in methods from Minitest DSL (#2128)"

### DIFF
--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -756,7 +756,12 @@ private:
                 optArg->default_ = mapIt(move(optArg->default_), ctx.withOwner(v->symbol));
             }
         }
-        // because this is a ShallowMap, we do not map over the body of the method
+        // because this is a ShallowMap, we do not map over the body of the method unless it is synthesized by the
+        // rewriter pass, because we can be sure that typical Ruby code does not e.g. include constant definitions in
+        // the body of a method
+        if (v->isRewriterSynthesized()) {
+            v->rhs = mapIt(move(v->rhs), ctx.withOwner(v->symbol));
+        }
 
         if constexpr (HAS_MEMBER_postTransformMethodDef<FUNC>::value) {
             return PostPonePostTransform_MethodDef<FUNC, CTX, HAS_MEMBER_postTransformMethodDef<FUNC>::value>::call(

--- a/ast/verifier/Verifier.cc
+++ b/ast/verifier/Verifier.cc
@@ -5,8 +5,6 @@ using namespace std;
 namespace sorbet::ast {
 
 class VerifierWalker {
-    u4 methodDepth = 0;
-
 public:
     unique_ptr<Expression> preTransformExpression(core::Context ctx, unique_ptr<Expression> original) {
         if (!isa_tree<EmptyTree>(original.get())) {
@@ -15,23 +13,6 @@ public:
 
         original->_sanityCheck();
 
-        return original;
-    }
-
-    unique_ptr<MethodDef> preTransformMethodDef(core::Context ctx, unique_ptr<MethodDef> original) {
-        methodDepth++;
-        return original;
-    }
-
-    unique_ptr<Expression> postTransformMethodDef(core::Context ctx, unique_ptr<MethodDef> original) {
-        methodDepth--;
-        return original;
-    }
-
-    unique_ptr<Expression> postTransformAssign(core::Context ctx, unique_ptr<Assign> original) {
-        if (ast::isa_tree<ast::UnresolvedConstantLit>(original->lhs.get())) {
-            ENFORCE(methodDepth == 0, "Found constant definition inside method definition");
-        }
         return original;
     }
 

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -1,7 +1,6 @@
 #include "rewriter/Minitest.h"
 #include "ast/Helpers.h"
 #include "ast/ast.h"
-#include "ast/treemap/treemap.h"
 #include "core/Context.h"
 #include "core/Names.h"
 #include "core/core.h"
@@ -13,100 +12,6 @@ using namespace std;
 namespace sorbet::rewriter {
 
 namespace {
-class ConstantMover {
-    u4 classDepth = 0;
-    vector<unique_ptr<ast::Expression>> movedConstants;
-
-public:
-    unique_ptr<ast::Expression> createConstAssign(ast::Assign &asgn) {
-        auto loc = asgn.loc;
-        auto unsafeNil = ast::MK::Unsafe(loc, ast::MK::Nil(loc));
-        if (auto send = ast::cast_tree<ast::Send>(asgn.rhs.get())) {
-            if (send->fun == core::Names::let() && send->args.size() == 2) {
-                auto rhs = ast::MK::Let(loc, move(unsafeNil), send->args[1]->deepCopy());
-                return ast::MK::Assign(asgn.loc, move(asgn.lhs), move(rhs));
-            }
-        }
-
-        return ast::MK::Assign(asgn.loc, move(asgn.lhs), move(unsafeNil));
-    }
-
-    unique_ptr<ast::Expression> postTransformAssign(core::MutableContext ctx, unique_ptr<ast::Assign> asgn) {
-        if (auto cnst = ast::cast_tree<ast::UnresolvedConstantLit>(asgn->lhs.get())) {
-            if (ast::isa_tree<ast::UnresolvedConstantLit>(asgn->rhs.get())) {
-                movedConstants.emplace_back(move(asgn));
-                return ast::MK::EmptyTree();
-            }
-            auto name = ast::MK::Symbol(cnst->loc, cnst->cnst);
-
-            // if the constant is already in a T.let, preserve it, otherwise decay it to unsafe
-            movedConstants.emplace_back(createConstAssign(*asgn));
-
-            auto module = ast::MK::Constant(asgn->loc, core::Symbols::Module());
-            auto const_set = ctx.state.enterNameUTF8("const_set");
-            return ast::MK::Send2(asgn->loc, move(module), const_set, move(name), move(asgn->rhs));
-        }
-
-        return asgn;
-    }
-
-    // classdefs define new constants, so we always move those if they're the "top-level" classdef (i.e. if we have
-    // nested classdefs, we should only move the outermost one)
-    unique_ptr<ast::ClassDef> preTransformClassDef(core::MutableContext ctx, unique_ptr<ast::ClassDef> classDef) {
-        classDepth++;
-        return classDef;
-    }
-
-    unique_ptr<ast::Expression> postTransformClassDef(core::MutableContext ctx, unique_ptr<ast::ClassDef> classDef) {
-        classDepth--;
-        if (classDepth == 0) {
-            movedConstants.emplace_back(move(classDef));
-            return ast::MK::EmptyTree();
-        }
-        return classDef;
-    }
-
-    // we move sends if they are other minitest `describe` blocks, as those end up being classes anyway: consequently,
-    // we treat those the same way we treat classes
-    unique_ptr<ast::Send> preTransformSend(core::MutableContext ctx, unique_ptr<ast::Send> send) {
-        if (!send->recv->isSelfReference() && send->args.size() == 1 && send->fun == core::Names::describe()) {
-            classDepth++;
-        }
-        return send;
-    }
-
-    unique_ptr<ast::Expression> postTransformSend(core::MutableContext ctx, unique_ptr<ast::Send> send) {
-        if (!send->recv->isSelfReference() && send->args.size() == 1 && send->fun == core::Names::describe()) {
-            classDepth--;
-            if (classDepth == 0) {
-                movedConstants.emplace_back(move(send));
-                return ast::MK::EmptyTree();
-            }
-        }
-        return send;
-    }
-
-    vector<unique_ptr<ast::Expression>> getMovedConstants() {
-        return move(movedConstants);
-    }
-
-    unique_ptr<ast::Expression> addConstantsToExpression(core::Loc loc, unique_ptr<ast::Expression> expr) {
-        auto consts = getMovedConstants();
-
-        if (consts.empty()) {
-            return expr;
-        } else {
-            ast::InsSeq::STATS_store stats;
-
-            for (auto &m : consts) {
-                stats.emplace_back(move(m));
-            }
-
-            return ast::MK::InsSeq(loc, std::move(stats), move(expr));
-        }
-    }
-};
-
 unique_ptr<ast::Expression> addSigVoid(unique_ptr<ast::Expression> expr) {
     return ast::MK::InsSeq1(expr->loc, ast::MK::SigVoid(expr->loc, ast::MK::Hash0(expr->loc)), std::move(expr));
 }
@@ -156,12 +61,8 @@ unique_ptr<ast::Expression> runSingle(core::MutableContext ctx, ast::Send *send)
 
     if (send->args.empty() && (send->fun == core::Names::before() || send->fun == core::Names::after())) {
         auto name = send->fun == core::Names::after() ? core::Names::afterAngles() : core::Names::initialize();
-        ConstantMover constantMover;
-        send->block->body = ast::TreeMap::apply(ctx, constantMover, move(send->block->body));
-        auto method =
-            addSigVoid(ast::MK::Method0(send->loc, send->loc, name, prepareBody(ctx, std::move(send->block->body)),
-                                        ast::MethodDef::RewriterSynthesized));
-        return constantMover.addConstantsToExpression(send->loc, move(method));
+        return addSigVoid(ast::MK::Method0(send->loc, send->loc, name, prepareBody(ctx, std::move(send->block->body)),
+                                           ast::MethodDef::RewriterSynthesized));
     }
 
     if (send->args.size() != 1) {
@@ -180,13 +81,10 @@ unique_ptr<ast::Expression> runSingle(core::MutableContext ctx, ast::Send *send)
         return ast::MK::Class(send->loc, send->loc, std::move(name), std::move(ancestors), std::move(rhs),
                               ast::ClassDefKind::Class);
     } else if (send->fun == core::Names::it()) {
-        ConstantMover constantMover;
-        send->block->body = ast::TreeMap::apply(ctx, constantMover, move(send->block->body));
         auto name = ctx.state.enterNameUTF8("<test_" + argString + ">");
-        auto method = addSigVoid(ast::MK::Method0(send->loc, send->loc, std::move(name),
-                                                  prepareBody(ctx, std::move(send->block->body)),
-                                                  ast::MethodDef::RewriterSynthesized));
-        return constantMover.addConstantsToExpression(send->loc, move(method));
+        return addSigVoid(ast::MK::Method0(send->loc, send->loc, std::move(name),
+                                           prepareBody(ctx, std::move(send->block->body)),
+                                           ast::MethodDef::RewriterSynthesized));
     }
 
     return nullptr;

--- a/test/testdata/rewriter/minitest.rb
+++ b/test/testdata/rewriter/minitest.rb
@@ -11,15 +11,6 @@ class MyTest
       CONST = 10
     end
 
-    it "allows let-ed constants inside of IT" do
-      C2 = T.let(10, Integer)
-    end
-
-    it "allows path constants inside of IT" do
-      C3 = Mod::C
-      C3.new
-    end
-
     describe "some inner tests" do
         def inside_method
         end
@@ -71,10 +62,4 @@ class MyTest
 end
 
 def junk
-end
-
-
-module Mod
-  class C
-  end
 end

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -14,41 +14,11 @@ class <emptyTree><<C <root>>> < ()
     end
 
     begin
-      <emptyTree>::<C CONST> = ::T.unsafe(nil)
-      begin
-        ::T::Sig::WithoutRuntime.sig() do ||
-          <self>.params({}).void()
-        end
-        def <test_allows constants inside of IT><<C <todo sym>>>(&<blk>)
-          ::Module.const_set(:"CONST", 10)
-        end
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.params({}).void()
       end
-    end
-
-    begin
-      <emptyTree>::<C C2> = ::T.let(::T.unsafe(nil), <emptyTree>::<C Integer>)
-      begin
-        ::T::Sig::WithoutRuntime.sig() do ||
-          <self>.params({}).void()
-        end
-        def <test_allows let-ed constants inside of IT><<C <todo sym>>>(&<blk>)
-          ::Module.const_set(:"C2", <emptyTree>::<C T>.let(10, <emptyTree>::<C Integer>))
-        end
-      end
-    end
-
-    begin
-      <emptyTree>::<C C3> = <emptyTree>::<C Mod>::<C C>
-      begin
-        ::T::Sig::WithoutRuntime.sig() do ||
-          <self>.params({}).void()
-        end
-        def <test_allows path constants inside of IT><<C <todo sym>>>(&<blk>)
-          begin
-            <emptyTree>
-            <emptyTree>::<C C3>.new()
-          end
-        end
+      def <test_allows constants inside of IT><<C <todo sym>>>(&<blk>)
+        <emptyTree>::<C CONST> = 10
       end
     end
 
@@ -153,11 +123,5 @@ class <emptyTree><<C <root>>> < ()
 
   def junk<<C <todo sym>>>(&<blk>)
     <emptyTree>
-  end
-
-  module <emptyTree>::<C Mod><<C <todo sym>>> < ()
-    class <emptyTree>::<C C><<C <todo sym>>> < (::<todo sym>)
-      <emptyTree>
-    end
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Revert "Prevent constants in methods from Minitest DSL (#2128)"

This reverts commit e2e6d5bfb376a2f05c7ec84394d10ea92b000778.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.