### PR TITLE
Remove localsForMethod from LSPLoop

### DIFF
--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -83,8 +83,6 @@ class LSPLoop {
     std::vector<std::unique_ptr<DocumentHighlight>>
     getHighlightsToSymbolInFile(LSPTypechecker &typechecker, std::string_view uri, core::SymbolRef symbol,
                                 std::vector<std::unique_ptr<DocumentHighlight>> highlights = {}) const;
-    std::vector<core::LocalVariable> localsForMethod(const core::GlobalState &gs, LSPTypechecker &typechecker,
-                                                     const core::SymbolRef method) const;
     std::unique_ptr<ResponseMessage> handleTextDocumentReferences(LSPTypechecker &typechecker, const MessageId &id,
                                                                   const ReferenceParams &params) const;
     std::unique_ptr<ResponseMessage> handleTextDocumentDefinition(LSPTypechecker &typechecker, const MessageId &id,

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -357,10 +357,8 @@ unique_ptr<CompletionItem> getCompletionItemForLocal(const core::GlobalState &gs
     return item;
 }
 
-} // namespace
-
-vector<core::LocalVariable> LSPLoop::localsForMethod(const core::GlobalState &gs, LSPTypechecker &typechecker,
-                                                     const core::SymbolRef method) const {
+vector<core::LocalVariable> localsForMethod(const core::GlobalState &gs, LSPTypechecker &typechecker,
+                                            const core::SymbolRef method) {
     auto files = vector<core::FileRef>{};
     for (auto loc : method.data(gs)->locs()) {
         files.emplace_back(loc.file());
@@ -376,6 +374,8 @@ vector<core::LocalVariable> LSPLoop::localsForMethod(const core::GlobalState &gs
 
     return localVarFinder.result();
 }
+
+} // namespace
 
 unique_ptr<CompletionItem> LSPLoop::getCompletionItemForSymbol(const core::GlobalState &gs, core::SymbolRef what,
                                                                core::TypePtr receiverType,
@@ -395,6 +395,7 @@ unique_ptr<CompletionItem> LSPLoop::getCompletionItemForSymbol(const core::Globa
     if (!resultType) {
         resultType = core::Types::untypedUntracked();
     }
+
     if (what.data(gs)->isMethod()) {
         item->kind = CompletionItemKind::Method;
         item->detail = what.data(gs)->show(gs);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This can be a helper function instead of a method.

If we end up wanting to call it from more than one place, we can put it
somewhere publically accessible. (LSPLoop feels like a grab bag of lots
of unrelated things, so in my mind the fewer things there, the better).



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.