### PR TITLE
Fix nested minitest describe blocks

### DIFF
--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -69,14 +69,14 @@ public:
     // we move sends if they are other minitest `describe` blocks, as those end up being classes anyway: consequently,
     // we treat those the same way we treat classes
     unique_ptr<ast::Send> preTransformSend(core::MutableContext ctx, unique_ptr<ast::Send> send) {
-        if (!send->recv->isSelfReference() && send->args.size() == 1 && send->fun == core::Names::describe()) {
+        if (send->recv->isSelfReference() && send->args.size() == 1 && send->fun == core::Names::describe()) {
             classDepth++;
         }
         return send;
     }
 
     unique_ptr<ast::Expression> postTransformSend(core::MutableContext ctx, unique_ptr<ast::Send> send) {
-        if (!send->recv->isSelfReference() && send->args.size() == 1 && send->fun == core::Names::describe()) {
+        if (send->recv->isSelfReference() && send->args.size() == 1 && send->fun == core::Names::describe()) {
             classDepth--;
             if (classDepth == 0) {
                 movedConstants.emplace_back(move(send));

--- a/test/testdata/rewriter/minitest.rb
+++ b/test/testdata/rewriter/minitest.rb
@@ -68,6 +68,13 @@ class MyTest
     junk.it "ignores non-self calls" do
         junk
     end
+
+    describe "a non-ideal situation" do
+      it "contains nested describes" do
+        describe "nobody should write this but we should still handle it" do
+        end
+      end
+    end
 end
 
 def junk

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -149,6 +149,22 @@ class <emptyTree><<C <root>>> < ()
     <self>.junk().it("ignores non-self calls") do ||
       <self>.junk()
     end
+
+    class <emptyTree>::<C <class_a non-ideal situation>><<C <todo sym>>> < (<self>)
+      begin
+        class <emptyTree>::<C <class_nobody should write this but we should still handle it>><<C <todo sym>>> < (<self>)
+          <emptyTree>
+        end
+        begin
+          ::T::Sig::WithoutRuntime.sig() do ||
+            <self>.params({}).void()
+          end
+          def <test_contains nested describes><<C <todo sym>>>(&<blk>)
+            <emptyTree>
+          end
+        end
+      end
+    end
   end
 
   def junk<<C <todo sym>>>(&<blk>)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes the behavior of the Minitest DSL due to a misplaced `!`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
