### PR TITLE
Fix an enforce error

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -463,7 +463,7 @@ public:
                     return original;
                 }
                 auto name = sym->asSymbol(ctx);
-                auto owner = ctx.owner;
+                auto owner = ctx.owner.data(ctx)->enclosingClass(ctx);
                 if (original->fun._id == core::Names::privateClassMethod()._id) {
                     owner = owner.data(ctx)->singletonClass(ctx);
                 }

--- a/test/testdata/rewriter/flatten_module_private_class_method.rb
+++ b/test/testdata/rewriter/flatten_module_private_class_method.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+module A
+  def self.thing
+    private_class_method def self.bar
+    end
+  end
+end
+
+class B
+  def self.thing
+    private_class_method def self.bar
+    end
+  end
+end

--- a/test/testdata/rewriter/flatten_module_private_class_method.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/flatten_module_private_class_method.rb.symbol-table-raw.exp
@@ -1,0 +1,41 @@
+class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4}, Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=3:1 end=15:4})
+  class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=3:1 end=15:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=??? end=???}
+  module <C <U A>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=3:1 end=3:9}
+  class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=3:1 end=8:4}
+    type-member(+) <S <C <U A>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=3:8 end=3:9}
+    method <S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=3:1 end=8:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=??? end=???}
+    method <S <C <U A>> $1><U thing> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=4:3 end=4:17}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=??? end=???}
+  class <S <S <C <U A>> $1> $1>[<C <U <AttachedClass>>>] < <S <C <U Module>> $1> () @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=3:8 end=3:9}
+    type-member(+) <S <S <C <U A>> $1> $1><C <U <AttachedClass>>> -> LambdaParam(<S <S <C <U A>> $1> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {
+  klass = <S <C <U A>> $1>
+  targs = [
+    <C <U <AttachedClass>>> = A
+  ]
+}) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=3:8 end=3:9}
+    method <S <S <C <U A>> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=3:1 end=8:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=??? end=???}
+    method <S <S <C <U A>> $1> $1><U bar> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=5:26 end=5:38}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=??? end=???}
+  class <C <U B>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=10:1 end=10:8}
+  class <S <C <U B>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=10:1 end=15:4}
+    type-member(+) <S <C <U B>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U B>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=B) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=10:7 end=10:8}
+    method <S <C <U B>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=10:1 end=15:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=??? end=???}
+    method <S <C <U B>> $1><U thing> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=11:3 end=11:17}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=??? end=???}
+  class <S <S <C <U B>> $1> $1>[<C <U <AttachedClass>>>] < <S <S <C <U Object>> $1> $1> () @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=10:7 end=10:8}
+    type-member(+) <S <S <C <U B>> $1> $1><C <U <AttachedClass>>> -> LambdaParam(<S <S <C <U B>> $1> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {
+  klass = <S <C <U B>> $1>
+  targs = [
+    <C <U <AttachedClass>>> = B
+  ]
+}) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=10:7 end=10:8}
+    method <S <S <C <U B>> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=10:1 end=15:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=??? end=???}
+    method <S <S <C <U B>> $1> $1><U bar> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=12:26 end=12:38}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=??? end=???}
+


### PR DESCRIPTION
In a module context, the owner wasn't being set correctly when
processing `private_class_method` inside of a method definition.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This fixes an enforce error by ensuring that the owner used with `private_class_method` is a class, and not the enclosing method in the case that the send doesn't occur in a class/module declaration.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixing enforce errors.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
I've added a new test that triggers an enforce error on debug builds prior to this fix.

See included automated tests.
