### PR TITLE
Fix crash from malformed sig in DefaultArgs pass

### DIFF
--- a/rewriter/DefaultArgs.cc
+++ b/rewriter/DefaultArgs.cc
@@ -25,6 +25,10 @@ unique_ptr<ast::Expression> mangleSig(core::Context ctx, unique_ptr<ast::Express
 
     unique_ptr<ast::Expression> retType;
 
+    if (sig->block == nullptr) {
+        return ast::MK::EmptyTree();
+    }
+
     auto send = ast::cast_tree<ast::Send>(sig->block->body.get());
     if (!send) {
         return ast::MK::EmptyTree();

--- a/test/testdata/rewriter/default_args_malformed_sig.rb
+++ b/test/testdata/rewriter/default_args_malformed_sig.rb
@@ -3,6 +3,6 @@
 # This test used to crash the DefaultArgs pass because it tried to dereference
 # the block pointer to get it's body, but the block itself was nullptr.
 
-sig
+sig # error: does not exist
 def foo(x: nil)
 end

--- a/test/testdata/rewriter/default_args_malformed_sig.rb
+++ b/test/testdata/rewriter/default_args_malformed_sig.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+# This test used to crash the DefaultArgs pass because it tried to dereference
+# the block pointer to get it's body, but the block itself was nullptr.
+
+sig
+def foo(x: nil)
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This blocks adding completion for sigs, because as soon as someone would type
`sig` and wait for completion results, Sorbet would crash.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I verified that the test I added failed first, see here:

https://buildkite.com/sorbet/sorbet/builds/7417#563a6ea4-5f93-4967-aa2c-df6189410ada