### PR TITLE
Add RBI definition and signature for `Regexp::union`

### DIFF
--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_4_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_4_3_hidden.rbi.exp
@@ -3340,10 +3340,6 @@ class Regexp
   def match?(*_); end
 end
 
-class Regexp
-  def self.union(*_); end
-end
-
 class RubyVM::InstructionSequence
   def absolute_path(); end
 

--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_3_hidden.rbi.exp
@@ -8514,10 +8514,6 @@ class Regexp
   def match?(*_); end
 end
 
-class Regexp
-  def self.union(*_); end
-end
-
 module RubyVM::AbstractSyntaxTree
 end
 

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_4_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_4_3_hidden.rbi.exp
@@ -3346,10 +3346,6 @@ class Regexp
   def match?(*_); end
 end
 
-class Regexp
-  def self.union(*_); end
-end
-
 class RubyVM::InstructionSequence
   def absolute_path(); end
 

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_3_hidden.rbi.exp
@@ -8520,10 +8520,6 @@ class Regexp
   def match?(*_); end
 end
 
-class Regexp
-  def self.union(*_); end
-end
-
 module RubyVM::AbstractSyntaxTree
 end
 

--- a/rbi/core/regexp.rbi
+++ b/rbi/core/regexp.rbi
@@ -1270,4 +1270,27 @@ class Regexp < Object
     .returns(T::Boolean)
   end
   def eql?(other); end
+
+  # Return a `Regexp` object that is the union of the given *patterns*, i.e.,
+  # will match any of its parts. The *patterns* can be
+  # [Regexp](https://ruby-doc.org/core-2.4.1/Regexp.html) objects, in which case
+  # their options will be preserved, or Strings. If no patterns are given,
+  # returns `/(?!)/`. The behavior is unspecified if any given *pattern*
+  # contains capture.
+  #
+  # ~~~ruby
+  # Regexp.union                         #=> /(?!)/
+  # Regexp.union("penzance")             #=> /penzance/
+  # Regexp.union("a+b*c")                #=> /a\+b\*c/
+  # Regexp.union("skiing", "sledding")   #=> /skiing|sledding/
+  # Regexp.union(["skiing", "sledding"]) #=> /skiing|sledding/
+  # Regexp.union(/dogs/, /cats/i)        #=> /(?-mix:dogs)|(?i-mx:cats)/
+  # ~~~
+  #
+  # Note: the arguments for `::union` will try to be converted into a regular
+  # expression literal via to_regexp.
+  sig do
+    params(pats: T.untyped).returns(Regexp)
+  end
+  def self.union(*pats); end
 end


### PR DESCRIPTION
### Motivation

This one is hard to type:

```ruby
puts Regexp.union(/a/)
puts Regexp.union("b")
puts Regexp.union(/a/, "b")
puts Regexp.union([/a/, "b"])
puts Regexp.union([/a/, "b"], "c", /d/) # Should be rejected by Sorbet static
```

I tried something around those lines:

```ruby
  sig do
    params(
      pat0: T.any(String, Regexp, T::Array[T.any(String, Regexp)]),
      pats: T.any(String, Regexp)
    ).returns(Regexp)
  end
  def self.union(pat0, *pats); end
```

But I'm not able to reject the last use mixing array and string/re which, when ran will result in:

```
in `union': no implicit conversion of Array into String (TypeError)
```

Not being to have a perfectly safe signature I settled up for `T.untyped`:

```ruby
  sig do
    params(pats: T.untyped).returns(Regexp)
  end
  def self.union(*pats); end
```

Better idea someone?

### Test plan

None.