### PR TITLE
Fix `decode_www_form_component` default value for `enc`

### DIFF
--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -188,7 +188,7 @@ module URI
     )
     .returns(T::Array[[String, String]])
   end
-  def self.decode_www_form_component(str, enc=T.unsafe(nil)); end
+  def self.decode_www_form_component(str, enc=Encoding::UTF_8); end
 
   sig do
     params(

--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -840,7 +840,7 @@ class URI::Generic < Object
   #   Parser for internal use [URI::DEFAULT_PARSER by default].
   # `arg_check`::
   #   Check arguments [false by default].
-  # 
+  #
   # Creates a new URI::Generic instance from `generic` components without check.
   sig do
     params(


### PR DESCRIPTION
### Motivation

From the [doc](https://docs.ruby-lang.org/en/2.1.0/URI.html#method-c-encode_www_form), the default value for `enc` is actually a `Encoding::UTF_8`.

This removes the need of the `T.unsafe(nil)`.

### Test plan

None.