### PR TITLE
Fix signature for `Array#assoc`

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1566,8 +1566,8 @@ class Array < Object
   # a.rassoc("four")   #=> nil
   # ```
   sig do
-    type_parameters(:U).params(
-        arg0: T.type_parameter(:U),
+    params(
+        arg0: T.untyped,
     )
     .returns(T.nilable(Elem))
   end

--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -634,9 +634,9 @@ class Array < Object
   # ```
   sig do
     params(
-        arg0: Elem,
+      arg0: T.untyped,
     )
-    .returns(T.nilable(T::Array[Elem]))
+    .returns(T.nilable(Elem))
   end
   def assoc(arg0); end
 


### PR DESCRIPTION
### Motivation

Given the [following example](https://sorbet.run/#%23%20typed%3A%20true%0A%0Adef%20main%0A%20%20a%20%3D%20%5B%20%5B%22a%22%2C%20%22b%22%5D%2C%20%5B%22c%22%2C%20%22d%22%5D%5D%0A%20%20puts%20a.assoc(%22a%22)%20%23%20%3D%3E%20%5B%22a%22%2C%20%22b%22%5D%0Aend):

```ruby
a = [ ["a", "b"], ["c", "d"]]
puts a.assoc("a") # => ["a", "b"]
```

Sorbet says:

```
editor.rb:5: Expected [String, String] but found String("a") for argument arg0 https://srb.help/7002
     5 |  puts a.assoc("a") # => ["a", "b"]
               ^^^^^^^^^^^^
    https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#L637: Method Array#assoc has specified arg0 as [String, String]
     637 |        arg0: Elem,
                  ^^^^
  Got String("a") originating from:
    editor.rb:5:
     5 |  puts a.assoc("a") # => ["a", "b"]
                       ^^^
Errors: 1
```

The argument `String("a")` should be accepted (as stated by the [doc](https://ruby-doc.org/core-2.5.0/Array.html#method-i-assoc)). The signature was accepting only a `[String, String]`.

Also, the return value is `["a", "b"]` which is equivalent to `Elem` and not `T::Array[Elem]`.

### Test plan

None.