### PR TITLE
Revert "make our ruby have a big external library (#2158)"

### DIFF
--- a/third_party/ruby/ruby-2.4.BUILD
+++ b/third_party/ruby/ruby-2.4.BUILD
@@ -394,20 +394,8 @@ EOF
 """
 )
 
-
 cc_binary(
     name = "bin/ruby",
-    linkstatic = False,
-    srcs = [
-        "main.c",
-    ],
-    deps = [
-            ":libruby"
-    ]
-)
-
-cc_library(
-    name = "libruby",
 
     srcs = [
         "prelude.c",
@@ -421,6 +409,7 @@ cc_library(
         "enc/unicode.c",
         "enc/utf_8.c",
 
+        "main.c",
         "dln.c",
         "localeinit.c",
         "loadpath.c",

--- a/third_party/ruby/ruby-2.6.BUILD
+++ b/third_party/ruby/ruby-2.6.BUILD
@@ -415,17 +415,6 @@ EOF
 
 cc_binary(
     name = "bin/ruby",
-    linkstatic = False,
-    srcs = [
-        "main.c",
-    ],
-    deps = [
-            ":libruby"
-    ]
-)
-
-cc_library(
-    name = "libruby",
 
     srcs = [
         "prelude.c",
@@ -441,6 +430,7 @@ cc_library(
 
         "addr2line.c",
         "ast.c",
+        "main.c",
         "dln.c",
         "localeinit.c",
         "loadpath.c",


### PR DESCRIPTION
This reverts commit ccf3340957eb8ccb3cdccc857ec8c0b657135eb8.

It looks like this broke master https://buildkite.com/sorbet/sorbet/builds/7448 . I'll work on a fix.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
