### PR TITLE
switch on platform

### DIFF
--- a/third_party/ruby/ruby-2.4.BUILD
+++ b/third_party/ruby/ruby-2.4.BUILD
@@ -397,7 +397,10 @@ EOF
 
 cc_binary(
     name = "bin/ruby",
-    linkstatic = False,
+    linkstatic = select({
+        ":linux": False,
+        ":darwin": True,
+    }),
     srcs = [
         "main.c",
     ],

--- a/third_party/ruby/ruby-2.6.BUILD
+++ b/third_party/ruby/ruby-2.6.BUILD
@@ -415,7 +415,10 @@ EOF
 
 cc_binary(
     name = "bin/ruby",
-    linkstatic = False,
+    linkstatic = select({
+        ":linux": False,
+        ":darwin": True,
+    }),
     srcs = [
         "main.c",
     ],


### PR DESCRIPTION
Instead of reverting in https://github.com/sorbet/sorbet/pull/2160 I think this might fix it

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
```
$ ./bazel test @ruby_2_6_3//...
WARNING: Duplicate rc file: /Users/pt/stripe/sorbet/.bazelrc.local is read multiple times, most recently imported from /private/var/folders/c5/r629fx_91qg1rh64kgpp1x0m0000gn/T/bazel_bazel_rc_1573673424
WARNING: The following rc files are no longer being read, please transfer their contents or import their path into one of the standard rc files:
/var/folders/c5/r629fx_91qg1rh64kgpp1x0m0000gn/T//bazel_bazel_rc_1573673424
INFO: Invocation ID: 4c6f2c98-80e0-4354-bded-6e39510c736a
INFO: Analysed 1041 targets (1 packages loaded, 3451 targets configured).
INFO: Found 1040 targets and 1 test target...
INFO: Elapsed time: 1.867s, Critical Path: 0.02s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
@ruby_2_6_3//:smoke_test                                        (cached) PASSED in 0.6s

Executed 0 out of 1 test: 1 test passes.
INFO: Build completed successfully, 1 total action
```
See included automated tests.
