### PR TITLE
Convert sig suggestion to return std::optional

### DIFF
--- a/infer/SigSuggestion.h
+++ b/infer/SigSuggestion.h
@@ -6,8 +6,9 @@
 namespace sorbet::infer {
 class SigSuggestion final {
 public:
-    static bool maybeSuggestSig(core::Context ctx, core::ErrorBuilder &e, std::unique_ptr<cfg::CFG> &cfg,
-                                const core::TypePtr &methodReturnType, core::TypeConstraint &constr);
+    static std::optional<core::AutocorrectSuggestion> maybeSuggestSig(core::Context ctx, std::unique_ptr<cfg::CFG> &cfg,
+                                                                      const core::TypePtr &methodReturnType,
+                                                                      core::TypeConstraint &constr);
 };
 } // namespace sorbet::infer
 

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -219,7 +219,10 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
     if ((missingReturnType || cfg->symbol.data(ctx)->hasGeneratedSig()) && guessTypes) {
         if (auto e = ctx.state.beginError(cfg->symbol.data(ctx)->loc(), core::errors::Infer::UntypedMethod)) {
             e.setHeader("This function does not have a `{}`", "sig");
-            SigSuggestion::maybeSuggestSig(ctx, e, cfg, methodReturnType, *constr);
+            auto maybeAutocorrect = SigSuggestion::maybeSuggestSig(ctx, cfg, methodReturnType, *constr);
+            if (maybeAutocorrect.has_value()) {
+                e.addAutocorrect(move(maybeAutocorrect.value()));
+            }
         }
     }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The current implementation demands that it be passed an ErrorBuilder
instance.

- This is bad hygiene (out parameter instead of explicit return).
- For some reason it was returning a bool, but never using it??
- I'd like to be able to call this method even when there's no error
  builder (i.e., even when the file is not `typed: strict`) for sig
  completion.

Three wins is good enough for me.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No behavior changes; existing CI.