### PR TITLE
(whitespace only) Remove `if isMethod` check

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -424,44 +424,43 @@ unique_ptr<CompletionItem> LSPLoop::getCompletionItemForMethod(const core::Globa
         resultType = core::Types::untypedUntracked();
     }
 
-    if (what.data(gs)->isMethod()) {
-        item->kind = CompletionItemKind::Method;
-        item->detail = what.data(gs)->show(gs);
+    item->kind = CompletionItemKind::Method;
+    item->detail = what.data(gs)->show(gs);
 
-        u4 queryStart = queryLoc.beginPos();
-        u4 prefixSize = prefix.size();
-        auto replacementLoc = core::Loc{queryLoc.file(), queryStart - prefixSize, queryStart};
-        auto replacementRange = Range::fromLoc(gs, replacementLoc);
+    u4 queryStart = queryLoc.beginPos();
+    u4 prefixSize = prefix.size();
+    auto replacementLoc = core::Loc{queryLoc.file(), queryStart - prefixSize, queryStart};
+    auto replacementRange = Range::fromLoc(gs, replacementLoc);
 
-        string replacementText;
-        if (supportsSnippets) {
-            item->insertTextFormat = InsertTextFormat::Snippet;
-            replacementText = methodSnippet(gs, what, receiverType, constraint);
-        } else {
-            item->insertTextFormat = InsertTextFormat::PlainText;
-            replacementText = string(what.data(gs)->name.data(gs)->shortName(gs));
-        }
-
-        if (replacementRange != nullptr) {
-            item->textEdit = make_unique<TextEdit>(std::move(replacementRange), replacementText);
-        } else {
-            // TODO(jez) Why is replacementRange nullptr? instrument this and investigate when it fails
-            item->insertText = replacementText;
-        }
-
-        optional<string> documentation = nullopt;
-        if (what.data(gs)->loc().file().exists()) {
-            documentation =
-                findDocumentation(what.data(gs)->loc().file().data(gs).source(), what.data(gs)->loc().beginPos());
-        }
-
-        auto prettyType = prettyTypeForMethod(gs, what, receiverType, nullptr, constraint);
-        item->documentation = formatRubyMarkup(markupKind, prettyType, documentation);
-
-        if (documentation != nullopt && documentation->find("@deprecated") != documentation->npos) {
-            item->deprecated = true;
-        }
+    string replacementText;
+    if (supportsSnippets) {
+        item->insertTextFormat = InsertTextFormat::Snippet;
+        replacementText = methodSnippet(gs, what, receiverType, constraint);
+    } else {
+        item->insertTextFormat = InsertTextFormat::PlainText;
+        replacementText = string(what.data(gs)->name.data(gs)->shortName(gs));
     }
+
+    if (replacementRange != nullptr) {
+        item->textEdit = make_unique<TextEdit>(std::move(replacementRange), replacementText);
+    } else {
+        // TODO(jez) Why is replacementRange nullptr? instrument this and investigate when it fails
+        item->insertText = replacementText;
+    }
+
+    optional<string> documentation = nullopt;
+    if (what.data(gs)->loc().file().exists()) {
+        documentation =
+            findDocumentation(what.data(gs)->loc().file().data(gs).source(), what.data(gs)->loc().beginPos());
+    }
+
+    auto prettyType = prettyTypeForMethod(gs, what, receiverType, nullptr, constraint);
+    item->documentation = formatRubyMarkup(markupKind, prettyType, documentation);
+
+    if (documentation != nullopt && documentation->find("@deprecated") != documentation->npos) {
+        item->deprecated = true;
+    }
+
     return item;
 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is already ENFORCEd earlier in the file, and upheld at all the call
sites. This `if` was still laying around only because I forgot to remove
it when splitting out `getCompletionItemForSymbol` into two methods:
`...ForMethod` and `...ForConstant`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.