### PR TITLE
Suggest potential signature for sig autocompletion

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -289,6 +289,18 @@ void GlobalState::initEmpty() {
     id.data(*this)->setIsModule(false);
     ENFORCE(id == Symbols::T_Enum());
 
+    // T::Sig#sig
+    id = enterMethodSymbol(Loc::none(), Symbols::T_Sig(), Names::sig());
+    {
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), id, Names::arg0());
+        arg.flags.isDefault = true;
+    }
+    {
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), id, Names::blkArg());
+        arg.flags.isBlock = true;
+    }
+    ENFORCE(id == Symbols::sig());
+
     // Root members
     Symbols::root().dataAllowingNone(*this)->members()[core::Names::Constants::NoSymbol()] = Symbols::noSymbol();
     Symbols::root().dataAllowingNone(*this)->members()[core::Names::Constants::Top()] = Symbols::top();

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -393,6 +393,10 @@ public:
         return SymbolRef(nullptr, 82);
     }
 
+    static SymbolRef sig() {
+        return SymbolRef(nullptr, 83);
+    }
+
     static constexpr int MAX_PROC_ARITY = 10;
     static SymbolRef Proc0() {
         return SymbolRef(nullptr, MAX_SYNTHETIC_SYMBOLS - MAX_PROC_ARITY * 3 - 3);

--- a/core/lsp/Query.cc
+++ b/core/lsp/Query.cc
@@ -27,6 +27,11 @@ Query Query::createVarQuery(core::SymbolRef owner, core::LocalVariable variable)
     return Query(Query::Kind::VAR, core::Loc::none(), owner, variable);
 }
 
+Query Query::createSuggestSigQuery(core::SymbolRef method) {
+    ENFORCE(method.exists());
+    return Query(Query::Kind::SUGGEST_SIG, core::Loc::none(), method, core::LocalVariable());
+}
+
 bool Query::matchesSymbol(const core::SymbolRef &symbol) const {
     return kind == Query::Kind::SYMBOL && this->symbol == symbol;
 }
@@ -40,6 +45,10 @@ bool Query::matchesLoc(const core::Loc &loc) const {
 
 bool Query::matchesVar(const core::SymbolRef &owner, const core::LocalVariable &var) const {
     return kind == Query::Kind::VAR && var.exists() && this->symbol == owner && this->variable == var;
+}
+
+bool Query::matchesSuggestSig(const core::SymbolRef &method) const {
+    return kind == Query::Kind::SUGGEST_SIG && this->symbol == method;
 }
 
 bool Query::isEmpty() const {

--- a/core/lsp/Query.h
+++ b/core/lsp/Query.h
@@ -19,12 +19,15 @@ public:
         // Looking for all references to the given symbol.
         SYMBOL,
         // Looking for all references to the given variable.
-        VAR
+        VAR,
+        // Looking for the definition of a certain method for the purpose of suggesting a sig.
+        SUGGEST_SIG,
     };
 
     Kind kind;
     core::Loc loc;
     // If Kind == SYMBOL, this is the symbol that the query is looking for.
+    // If Kind == SUGGEST_SIG, this is the method to suggest a sig for.
     // If Kind == VAR, this is the owner of the variable.
     core::SymbolRef symbol;
     core::LocalVariable variable;
@@ -33,10 +36,12 @@ public:
     static Query createLocQuery(core::Loc loc);
     static Query createSymbolQuery(core::SymbolRef symbol);
     static Query createVarQuery(core::SymbolRef owner, core::LocalVariable variable);
+    static Query createSuggestSigQuery(core::SymbolRef method);
 
     bool matchesSymbol(const core::SymbolRef &symbol) const;
     bool matchesLoc(const core::Loc &loc) const;
     bool matchesVar(const core::SymbolRef &owner, const core::LocalVariable &var) const;
+    bool matchesSuggestSig(const core::SymbolRef &method) const;
     bool isEmpty() const;
 
 private:

--- a/core/lsp/QueryResponse.cc
+++ b/core/lsp/QueryResponse.cc
@@ -33,6 +33,10 @@ const DefinitionResponse *QueryResponse::isDefinition() const {
     return get_if<DefinitionResponse>(&response);
 }
 
+const EditResponse *QueryResponse::isEdit() const {
+    return get_if<EditResponse>(&response);
+}
+
 core::Loc QueryResponse::getLoc() const {
     if (auto ident = isIdent()) {
         return ident->termLoc;
@@ -44,6 +48,8 @@ core::Loc QueryResponse::getLoc() const {
         return constant->termLoc;
     } else if (auto def = isDefinition()) {
         return def->termLoc;
+    } else if (auto edit = isEdit()) {
+        return edit->loc;
     } else {
         return core::Loc::none();
     }
@@ -62,7 +68,7 @@ core::TypePtr QueryResponse::getRetType() const {
         return def->retType.type;
     } else {
         // Should never happen, as the above checks should be exhaustive.
-        Exception::raise("Invalid QueryResponse object.");
+        Exception::raise("QueryResponse is of type that does not have retType.");
     }
 }
 

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -64,7 +64,7 @@ public:
 
 class EditResponse final {
 public:
-    EditResponse(core::Loc loc, std::string replacement) : loc(loc), replacement(replacement){};
+    EditResponse(core::Loc loc, std::string replacement) : loc(loc), replacement(std::move(replacement)){};
     const core::Loc loc;
     const std::string replacement;
 };

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -62,7 +62,14 @@ public:
     const core::TypeAndOrigins retType;
 };
 
-typedef std::variant<SendResponse, IdentResponse, LiteralResponse, ConstantResponse, DefinitionResponse>
+class EditResponse final {
+public:
+    EditResponse(core::Loc loc, std::string replacement) : loc(loc), replacement(replacement){};
+    const core::Loc loc;
+    const std::string replacement;
+};
+
+typedef std::variant<SendResponse, IdentResponse, LiteralResponse, ConstantResponse, DefinitionResponse, EditResponse>
     QueryResponseVariant;
 
 /**
@@ -104,6 +111,11 @@ public:
      * Returns nullptr unless this is a Definition.
      */
     const DefinitionResponse *isDefinition() const;
+
+    /**
+     * Returns nullptr unless this is an Edit.
+     */
+    const EditResponse *isEdit() const;
 
     /**
      * Returns the source code location for the specific expression that this

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -480,7 +480,8 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
     edits.emplace_back(core::AutocorrectSuggestion::Edit{replacementLoc, replacementContents});
 
     if (ctx.state.lspQuery.matchesSuggestSig(methodSymbol)) {
-        core::lsp::QueryResponse::pushQueryResponse(ctx, core::lsp::EditResponse(replacementLoc, replacementContents));
+        core::lsp::QueryResponse::pushQueryResponse(
+            ctx, core::lsp::EditResponse(replacementLoc, std::move(replacementContents)));
     }
 
     if (auto edit = maybeSuggestExtendTSig(ctx, methodSymbol)) {

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -2,6 +2,7 @@
 #include "common/common.h"
 #include "core/Loc.h"
 #include "core/TypeConstraint.h"
+#include "core/lsp/QueryResponse.h"
 #include <optional>
 
 using namespace std;
@@ -474,8 +475,13 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
 
     vector<core::AutocorrectSuggestion::Edit> edits;
 
-    string sig = to_string(ss);
-    edits.emplace_back(core::AutocorrectSuggestion::Edit{replacementLoc, fmt::format("{}\n{}", sig, spaces)});
+    auto sig = to_string(ss);
+    auto replacementContents = fmt::format("{}\n{}", sig, spaces);
+    edits.emplace_back(core::AutocorrectSuggestion::Edit{replacementLoc, replacementContents});
+
+    if (ctx.state.lspQuery.matchesSuggestSig(methodSymbol)) {
+        core::lsp::QueryResponse::pushQueryResponse(ctx, core::lsp::EditResponse(replacementLoc, replacementContents));
+    }
 
     if (auto edit = maybeSuggestExtendTSig(ctx, methodSymbol)) {
         edits.emplace_back(edit.value());

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -3,6 +3,7 @@
 #include "core/Loc.h"
 #include "core/TypeConstraint.h"
 #include "core/errors/infer.h"
+#include "core/lsp/QueryResponse.h"
 #include "infer/SigSuggestion.h"
 #include "infer/environment.h"
 #include "infer/infer.h"
@@ -223,6 +224,9 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
             if (maybeAutocorrect.has_value()) {
                 e.addAutocorrect(move(maybeAutocorrect.value()));
             }
+        } else if (ctx.state.lspQuery.matchesSuggestSig(cfg->symbol)) {
+            // Force maybeSuggestSig to run just to respond to the query (discard the result)
+            SigSuggestion::maybeSuggestSig(ctx, cfg, methodReturnType, *constr);
         }
     }
 

--- a/main/lsp/BUILD
+++ b/main/lsp/BUILD
@@ -15,6 +15,7 @@ cc_library(
         "LSPTypecheckerCoordinator.h",
         "LocalVarFinder.h",
         "LocalVarSaver.h",
+        "NextMethodFinder.h",
         "ShowOperation.h",
         "TimeTravelingGlobalState.h",
         "json_types.h",

--- a/main/lsp/NextMethodFinder.cc
+++ b/main/lsp/NextMethodFinder.cc
@@ -1,0 +1,43 @@
+#include "NextMethodFinder.h"
+#include "core/GlobalState.h"
+
+using namespace std;
+
+namespace sorbet::realmain::lsp {
+
+unique_ptr<ast::MethodDef> NextMethodFinder::preTransformMethodDef(core::Context ctx,
+                                                                   unique_ptr<ast::MethodDef> methodDef) {
+    ENFORCE(methodDef->symbol.exists());
+    ENFORCE(methodDef->symbol != core::Symbols::todo());
+
+    auto currentMethod = methodDef->symbol;
+    auto currentLoc = currentMethod.data(ctx)->loc();
+
+    if (!currentLoc.exists() || currentLoc.file() != this->queryLoc.file()) {
+        // Defensive in case location information is disabled (e.g., certain fuzzer modes)
+        return methodDef;
+    }
+
+    if (currentLoc.beginPos() < queryLoc.beginPos()) {
+        // Current method is before query, not after.
+        return methodDef;
+    }
+
+    // Current method starts at or after query loc. Starting 'at' is fine, because it can happen in cases like this:
+    //   |def foo; end
+
+    if (this->result_.exists()) {
+        // We've already found a result after, so current is not the first.
+        return methodDef;
+    }
+
+    this->result_ = currentMethod;
+
+    return methodDef;
+}
+
+const core::SymbolRef NextMethodFinder::result() const {
+    return this->result_;
+}
+
+}; // namespace sorbet::realmain::lsp

--- a/main/lsp/NextMethodFinder.h
+++ b/main/lsp/NextMethodFinder.h
@@ -1,0 +1,23 @@
+#ifndef RUBY_TYPER_LSP_NEXTMETHODFINDER_H
+#define RUBY_TYPER_LSP_NEXTMETHODFINDER_H
+
+#include "ast/ast.h"
+#include <vector>
+
+namespace sorbet::realmain::lsp {
+
+class NextMethodFinder {
+    const core::Loc queryLoc;
+
+    core::SymbolRef result_;
+
+public:
+    NextMethodFinder(core::Loc queryLoc) : queryLoc(queryLoc), result_(core::Symbols::noSymbol()) {}
+
+    std::unique_ptr<ast::MethodDef> preTransformMethodDef(core::Context ctx, std::unique_ptr<ast::MethodDef> methodDef);
+
+    const core::SymbolRef result() const;
+};
+}; // namespace sorbet::realmain::lsp
+
+#endif // RUBY_TYPER_LSP_NEXTMETHODFINDER_H

--- a/main/lsp/NextMethodFinder.h
+++ b/main/lsp/NextMethodFinder.h
@@ -2,7 +2,6 @@
 #define RUBY_TYPER_LSP_NEXTMETHODFINDER_H
 
 #include "ast/ast.h"
-#include <vector>
 
 namespace sorbet::realmain::lsp {
 

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -93,8 +93,8 @@ class LSPLoop {
                                                                   const CompletionParams &params) const;
     std::unique_ptr<ResponseMessage> handleTextDocumentCodeAction(LSPTypechecker &typechecker, const MessageId &id,
                                                                   const CodeActionParams &params) const;
-    std::unique_ptr<CompletionItem> getCompletionItemForMethod(const core::GlobalState &gs, core::SymbolRef what,
-                                                               core::TypePtr receiverType,
+    std::unique_ptr<CompletionItem> getCompletionItemForMethod(const core::GlobalState &gs, LSPTypechecker &typechecker,
+                                                               core::SymbolRef what, core::TypePtr receiverType,
                                                                const core::TypeConstraint *constraint,
                                                                const core::Loc queryLoc, std::string_view prefix,
                                                                size_t sortIdx) const;

--- a/test/testdata/lsp/completion/sig.A.rbedited
+++ b/test/testdata/lsp/completion/sig.A.rbedited
@@ -1,0 +1,28 @@
+# typed: true
+#        ^ the sigil doesn't have to be strict for this to work
+
+# This test is not an exhaustive list of all the kinds of sigs that could be
+# suggested, but instead about what's interesting from an LSP standpoint.
+
+class Normal
+  extend T::Sig
+
+  sig {returns(NilClass)} # error: no block
+  #  ^ completion: sig
+  #  ^ apply-completion: [A] item: 0
+  def nullary_returns_nil
+  end
+
+  sig # error: no block
+  #  ^ completion: sig
+  #  ^ apply-completion: [B] item: 0
+  def typed_params_and_returns(x)
+    1 + x
+  end
+end
+
+class NoSigInScope
+  sig # error: does not exist
+  #  ^ completion: (nothing)
+  def no_results_without_extend_tsig; end
+end

--- a/test/testdata/lsp/completion/sig.B.rbedited
+++ b/test/testdata/lsp/completion/sig.B.rbedited
@@ -1,0 +1,28 @@
+# typed: true
+#        ^ the sigil doesn't have to be strict for this to work
+
+# This test is not an exhaustive list of all the kinds of sigs that could be
+# suggested, but instead about what's interesting from an LSP standpoint.
+
+class Normal
+  extend T::Sig
+
+  sig # error: no block
+  #  ^ completion: sig
+  #  ^ apply-completion: [A] item: 0
+  def nullary_returns_nil
+  end
+
+  sig {params(x: Integer).returns(Integer)} # error: no block
+  #  ^ completion: sig
+  #  ^ apply-completion: [B] item: 0
+  def typed_params_and_returns(x)
+    1 + x
+  end
+end
+
+class NoSigInScope
+  sig # error: does not exist
+  #  ^ completion: (nothing)
+  def no_results_without_extend_tsig; end
+end

--- a/test/testdata/lsp/completion/sig.rb
+++ b/test/testdata/lsp/completion/sig.rb
@@ -1,0 +1,28 @@
+# typed: true
+#        ^ the sigil doesn't have to be strict for this to work
+
+# This test is not an exhaustive list of all the kinds of sigs that could be
+# suggested, but instead about what's interesting from an LSP standpoint.
+
+class Normal
+  extend T::Sig
+
+  sig # error: no block
+  #  ^ completion: sig
+  #  ^ apply-completion: [A] item: 0
+  def nullary_returns_nil
+  end
+
+  sig # error: no block
+  #  ^ completion: sig
+  #  ^ apply-completion: [B] item: 0
+  def typed_params_and_returns(x)
+    1 + x
+  end
+end
+
+class NoSigInScope
+  sig # error: does not exist
+  #  ^ completion: (nothing)
+  def no_results_without_extend_tsig; end
+end

--- a/test/testdata/lsp/completion/sig_many_defs.A.rbedited
+++ b/test/testdata/lsp/completion/sig_many_defs.A.rbedited
@@ -1,0 +1,26 @@
+# typed: true
+
+# This test tests that the NextMethodFinder doesn't have an off-by-one error.
+
+class A
+  extend T::Sig
+
+  def returns_integer
+    0
+  end
+
+  def returns_string
+    ''
+  end
+
+  sig {returns(Symbol)} # error: no block
+  #  ^ apply-completion: [A] item: 0
+
+  def returns_symbol
+    :''
+  end
+
+  def returns_float
+    0.0
+  end
+end

--- a/test/testdata/lsp/completion/sig_many_defs.rb
+++ b/test/testdata/lsp/completion/sig_many_defs.rb
@@ -1,0 +1,26 @@
+# typed: true
+
+# This test tests that the NextMethodFinder doesn't have an off-by-one error.
+
+class A
+  extend T::Sig
+
+  def returns_integer
+    0
+  end
+
+  def returns_string
+    ''
+  end
+
+  sig # error: no block
+  #  ^ apply-completion: [A] item: 0
+
+  def returns_symbol
+    :''
+  end
+
+  def returns_float
+    0.0
+  end
+end

--- a/test/testdata/lsp/completion/sig_no_defs.A.rbedited
+++ b/test/testdata/lsp/completion/sig_no_defs.A.rbedited
@@ -1,0 +1,6 @@
+# typed: true
+
+extend T::Sig
+
+sig${0} # error: no block
+#  ^ apply-completion: [A] item: 0

--- a/test/testdata/lsp/completion/sig_no_defs.rb
+++ b/test/testdata/lsp/completion/sig_no_defs.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+extend T::Sig
+
+sig # error: no block
+#  ^ apply-completion: [A] item: 0

--- a/test/testdata/lsp/completion/sig_no_method.A.rbedited
+++ b/test/testdata/lsp/completion/sig_no_method.A.rbedited
@@ -1,0 +1,27 @@
+# typed: true
+class Module
+  include T::Sig
+end
+
+# This file tests that when sig suggestion fails to find a method def, it still
+# suggests `sig` because it the name of a method in scope.
+
+class Outer
+  def above_query; end
+
+  class Inner
+    # Even though there are method defs after this, none are in the right
+    # scope, so no suggested sig.
+
+    sig${0} # error: no block
+    #  ^ apply-completion: [A] item: 0
+  end
+
+  def below_query; end
+end
+
+def outside_on_root; end
+
+# No method def at all later in the file
+sig # error: no block
+#  ^ apply-completion: [B] item: 0

--- a/test/testdata/lsp/completion/sig_no_method.B.rbedited
+++ b/test/testdata/lsp/completion/sig_no_method.B.rbedited
@@ -1,0 +1,27 @@
+# typed: true
+class Module
+  include T::Sig
+end
+
+# This file tests that when sig suggestion fails to find a method def, it still
+# suggests `sig` because it the name of a method in scope.
+
+class Outer
+  def above_query; end
+
+  class Inner
+    # Even though there are method defs after this, none are in the right
+    # scope, so no suggested sig.
+
+    sig # error: no block
+    #  ^ apply-completion: [A] item: 0
+  end
+
+  def below_query; end
+end
+
+def outside_on_root; end
+
+# No method def at all later in the file
+sig${0} # error: no block
+#  ^ apply-completion: [B] item: 0

--- a/test/testdata/lsp/completion/sig_no_method.rb
+++ b/test/testdata/lsp/completion/sig_no_method.rb
@@ -1,0 +1,27 @@
+# typed: true
+class Module
+  include T::Sig
+end
+
+# This file tests that when sig suggestion fails to find a method def, it still
+# suggests `sig` because it the name of a method in scope.
+
+class Outer
+  def above_query; end
+
+  class Inner
+    # Even though there are method defs after this, none are in the right
+    # scope, so no suggested sig.
+
+    sig # error: no block
+    #  ^ apply-completion: [A] item: 0
+  end
+
+  def below_query; end
+end
+
+def outside_on_root; end
+
+# No method def at all later in the file
+sig # error: no block
+#  ^ apply-completion: [B] item: 0

--- a/test/testdata/lsp/completion/sig_root.A.rbedited
+++ b/test/testdata/lsp/completion/sig_root.A.rbedited
@@ -1,0 +1,8 @@
+# typed: true
+extend T::Sig
+
+# Tests an edge case arising from the difference between <root> and Object
+
+sig {returns(NilClass)} # error: no block
+#  ^ apply-completion: [A] item: 0
+def foo; end

--- a/test/testdata/lsp/completion/sig_root.rb
+++ b/test/testdata/lsp/completion/sig_root.rb
@@ -1,0 +1,8 @@
+# typed: true
+extend T::Sig
+
+# Tests an edge case arising from the difference between <root> and Object
+
+sig # error: no block
+#  ^ apply-completion: [A] item: 0
+def foo; end


### PR DESCRIPTION
### Summary

At a high level, suggesting a sig looks like this:

1.  Start with completion location
1.  Walk resolved tree to find the first method def after that position
1.  The method def is resolved, so it has a symbol--return that symbol
1.  Fire off an LSP query (of the newly minted query kind `SUGGEST_SIG`) that
    only matches inside the `SigSuggestion` code
1.  Update `SigSuggestion` to return create a query response (of the newly
    minted type `EditResponse`) that has the information needed to populate the
    completion item.


Those steps vaguely correspond to the individual commits; I recommend reviewing
by commit.



- **Add T::Sig#sig to GlobalState** (3d003e107)


- **New Query (SUGGEST_SIG) and QueryResponse (EditResponse)** (47c33908f)


- **NextMethodFinder: first MethodDef after Loc** (df9ee4aef)


- **Suggest potential signature for sig autocompletion** (d2b544365)


- **Add a lot of tests** (01ed7a471)


The diff looks large, but it's 50% tests, and each individual commit is <100 lines.

```
Add a lot of tests
  12 files changed, 245 insertions(+)

Suggest potential signature for sig autocompletion
  1 file changed, 86 insertions(+)

NextMethodFinder: first MethodDef after Loc
  5 files changed, 89 insertions(+), 6 deletions(-)

New Query (SUGGEST_SIG) and QueryResponse (EditResponse)
  6 files changed, 49 insertions(+), 7 deletions(-)

Add T::Sig#sig to GlobalState
  2 files changed, 16 insertions(+)
```


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Lots of new tests; also tested in VS Code.