### PR TITLE
Use describe 'foo'/it 'foo' instead of <class_foo>/<test_foo> in Minitest AST string repr

### DIFF
--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -58,8 +58,9 @@ vector<unique_ptr<SymbolInformation>> SymbolMatcher::symbolRef2SymbolInformation
     return results;
 }
 
-inline bool isNamespaceSeparator(char ch) {
-    return ch == ':' || ch == '.';
+/** Allow these symbols to act as namespace separators in user queries. */
+inline bool canBeLeadingNamespaceSeparator(char ch) {
+    return ch == ':' || ch == '.' || ch == '#' || ch == ' ';
 }
 
 /** Returns a pair of {rank, query_length_matched} for the given symbol/query. */
@@ -70,8 +71,11 @@ pair<int, string_view::const_iterator> partialMatchSymbol(string_view symbol, st
     auto queryIter = queryBegin;
     pair<int, string_view::const_iterator> result = {0, queryIter};
     // Consume leading namespacing punctuation, e.g. to make `::f` matchable against `module Foo`.
-    while (queryIter != queryEnd && isNamespaceSeparator(*queryIter)) {
+    while (queryIter != queryEnd && canBeLeadingNamespaceSeparator(*queryIter)) {
         queryIter++;
+    }
+    while (symbolIter != symbolEnd && canBeLeadingNamespaceSeparator(*symbolIter)) {
+        symbolIter++;
     }
     char previousSymbolCh = 0;
     char symbolCh = 0;

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -176,13 +176,13 @@ unique_ptr<ast::Expression> runSingle(core::MutableContext ctx, ast::Send *send)
         ast::ClassDef::RHS_store rhs;
         rhs.emplace_back(prepareBody(ctx, std::move(send->block->body)));
         auto name = ast::MK::UnresolvedConstant(arg->loc, ast::MK::EmptyTree(),
-                                                ctx.state.enterNameConstant("<class_" + argString + ">"));
+                                                ctx.state.enterNameConstant("<describe '" + argString + "'>"));
         return ast::MK::Class(send->loc, send->loc, std::move(name), std::move(ancestors), std::move(rhs),
                               ast::ClassDefKind::Class);
     } else if (send->fun == core::Names::it()) {
         ConstantMover constantMover;
         send->block->body = ast::TreeMap::apply(ctx, constantMover, move(send->block->body));
-        auto name = ctx.state.enterNameUTF8("<test_" + argString + ">");
+        auto name = ctx.state.enterNameUTF8("<it '" + argString + "'>");
         auto method = addSigVoid(ast::MK::Method0(send->loc, send->loc, std::move(name),
                                                   prepareBody(ctx, std::move(send->block->body)),
                                                   ast::MethodDef::RewriterSynthesized));

--- a/test/testdata/rewriter/minitest.rb
+++ b/test/testdata/rewriter/minitest.rb
@@ -71,7 +71,7 @@ class MyTest
 
     describe "a non-ideal situation" do
       it "contains nested describes" do
-        describe "nobody should write this but we should still handle it" do
+        describe "nobody should write this but we should still parse it" do
         end
       end
     end

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < ()
       ::T::Sig::WithoutRuntime.sig() do ||
         <self>.params({}).void()
       end
-      def <test_works outside><<C <todo sym>>>(&<blk>)
+      def <it 'works outside'><<C <todo sym>>>(&<blk>)
         <self>.outside_method()
       end
     end
@@ -19,7 +19,7 @@ class <emptyTree><<C <root>>> < ()
         ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({}).void()
         end
-        def <test_allows constants inside of IT><<C <todo sym>>>(&<blk>)
+        def <it 'allows constants inside of IT'><<C <todo sym>>>(&<blk>)
           ::Module.const_set(:"CONST", 10)
         end
       end
@@ -31,7 +31,7 @@ class <emptyTree><<C <root>>> < ()
         ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({}).void()
         end
-        def <test_allows let-ed constants inside of IT><<C <todo sym>>>(&<blk>)
+        def <it 'allows let-ed constants inside of IT'><<C <todo sym>>>(&<blk>)
           ::Module.const_set(:"C2", <emptyTree>::<C T>.let(10, <emptyTree>::<C Integer>))
         end
       end
@@ -43,7 +43,7 @@ class <emptyTree><<C <root>>> < ()
         ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({}).void()
         end
-        def <test_allows path constants inside of IT><<C <todo sym>>>(&<blk>)
+        def <it 'allows path constants inside of IT'><<C <todo sym>>>(&<blk>)
           begin
             <emptyTree>
             <emptyTree>::<C C3>.new()
@@ -52,7 +52,7 @@ class <emptyTree><<C <root>>> < ()
       end
     end
 
-    class <emptyTree>::<C <class_some inner tests>><<C <todo sym>>> < (<self>)
+    class <emptyTree>::<C <describe 'some inner tests'>><<C <todo sym>>> < (<self>)
       begin
         def inside_method<<C <todo sym>>>(&<blk>)
           <emptyTree>
@@ -61,7 +61,7 @@ class <emptyTree><<C <root>>> < ()
           ::T::Sig::WithoutRuntime.sig() do ||
             <self>.params({}).void()
           end
-          def <test_works inside><<C <todo sym>>>(&<blk>)
+          def <it 'works inside'><<C <todo sym>>>(&<blk>)
             begin
               <self>.outside_method()
               <self>.inside_method()
@@ -103,7 +103,7 @@ class <emptyTree><<C <root>>> < ()
       ::T::Sig::WithoutRuntime.sig() do ||
         <self>.params({}).void()
       end
-      def <test_can read foo><<C <todo sym>>>(&<blk>)
+      def <it 'can read foo'><<C <todo sym>>>(&<blk>)
         begin
           <emptyTree>::<C T>.assert_type!(@foo, <emptyTree>::<C Integer>)
           <self>.instance_helper()
@@ -119,13 +119,13 @@ class <emptyTree><<C <root>>> < ()
       @random_method_ivar = <emptyTree>::<C T>.let(3, <emptyTree>::<C Integer>)
     end
 
-    class <emptyTree>::<C <class_Object>><<C <todo sym>>> < (<self>)
+    class <emptyTree>::<C <describe 'Object'>><<C <todo sym>>> < (<self>)
       begin
         begin
           ::T::Sig::WithoutRuntime.sig() do ||
             <self>.params({}).void()
           end
-          def <test_Object><<C <todo sym>>>(&<blk>)
+          def <it 'Object'><<C <todo sym>>>(&<blk>)
             <emptyTree>
           end
         end
@@ -133,7 +133,7 @@ class <emptyTree><<C <root>>> < ()
           ::T::Sig::WithoutRuntime.sig() do ||
             <self>.params({}).void()
           end
-          def <test_Object><<C <todo sym>>>(&<blk>)
+          def <it 'Object'><<C <todo sym>>>(&<blk>)
             <emptyTree>
           end
         end
@@ -150,16 +150,16 @@ class <emptyTree><<C <root>>> < ()
       <self>.junk()
     end
 
-    class <emptyTree>::<C <class_a non-ideal situation>><<C <todo sym>>> < (<self>)
+    class <emptyTree>::<C <describe 'a non-ideal situation'>><<C <todo sym>>> < (<self>)
       begin
-        class <emptyTree>::<C <class_nobody should write this but we should still handle it>><<C <todo sym>>> < (<self>)
+        class <emptyTree>::<C <describe 'nobody should write this but we should still parse it'>><<C <todo sym>>> < (<self>)
           <emptyTree>
         end
         begin
           ::T::Sig::WithoutRuntime.sig() do ||
             <self>.params({}).void()
           end
-          def <test_contains nested describes><<C <todo sym>>>(&<blk>)
+          def <it 'contains nested describes'><<C <todo sym>>>(&<blk>)
             <emptyTree>
           end
         end


### PR DESCRIPTION
### Motivation
As part of #1911 , when `workspace/symbol` returns results from minitest-mangled methods, the Sorbet LSP currently displays them as:
```
    <class_Bar.normalize()> (::Foo::Test::BarTest)
    <test_is equivalent to baz> (::Foo::Test::BarTest::<class_Bar.normalize()>)
```
Tweak the string representation so that the result more closely matches the code:
```
    <describe 'Bar.normalize()'> (::Foo::Test::BarTest)
    <it 'is equivalent to baz'> (::Foo::Test::BarTest::<describe 'Bar.normalize()'>)
```
Which also has the pleasant side-effect of nice human-friendly query-matching:
<img width="462" alt="Screen Shot 2019-11-14 at 6 54 41 AM" src="https://user-images.githubusercontent.com/54541713/68868055-aecbfd80-06ab-11ea-8c77-bf536268a95f.png">

Note that after this change, using the LSP to match `Foo::Bar describe ` is a pleasant way to scan all of the `Foo::Bar` tests in a slightly-more discoverable way than `Foo:Bar:<class_`.

### Test plan
CI/automated tests.
