### PR TITLE
Add `--enable-all-beta-lsp-features` flag for LSP beta-testers

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -351,7 +351,12 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("enable-experimental-lsp-signature-help",
                                     "Enable experimental LSP feature: Signature Help");
     options.add_options("advanced")("enable-experimental-lsp-quick-fix", "Enable experimental LSP feature: Quick Fix");
-    options.add_options("advanced")("enable-all-experimental-lsp-features", "Enable every experimental LSP feature.");
+    options.add_options("advanced")(
+        "enable-all-experimental-lsp-features",
+        "Enable every experimental LSP feature. (WARNING: can be crashy; for developer use only. "
+        "End users should prefer to use `--enable-all-beta-lsp-features`, instead.)");
+    options.add_options("advanced")("enable-all-beta-lsp-features",
+                                    "Enable (expected-to-be-non-crashy) early-access LSP features.");
     options.add_options("advanced")(
         "ignore",
         "Ignores input files that contain the given string in their paths (relative to the input path passed to "
@@ -668,10 +673,11 @@ void readOptions(Options &opts,
                                   opts.inputFileNames.end());
 
         bool enableAllLSPFeatures = raw["enable-all-experimental-lsp-features"].as<bool>();
+        bool enableBetaLSPFeatures = enableAllLSPFeatures || raw["enable-all-beta-lsp-features"].as<bool>();
         opts.lspAutocompleteEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-autocomplete"].as<bool>();
         opts.lspQuickFixEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-quick-fix"].as<bool>();
         opts.lspWorkspaceSymbolsEnabled =
-            enableAllLSPFeatures || raw["enable-experimental-lsp-workspace-symbols"].as<bool>();
+            enableBetaLSPFeatures || raw["enable-experimental-lsp-workspace-symbols"].as<bool>();
         opts.lspDocumentSymbolEnabled =
             enableAllLSPFeatures || raw["enable-experimental-lsp-document-symbol"].as<bool>();
         opts.lspDocumentHighlightEnabled =

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -92,6 +92,12 @@ Usage:
                                 Enable experimental LSP feature: Quick Fix
       --enable-all-experimental-lsp-features
                                 Enable every experimental LSP feature.
+                                (WARNING: can be crashy; for developer use only. End
+                                users should prefer to use
+                                `--enable-all-beta-lsp-features`, instead.)
+      --enable-all-beta-lsp-features
+                                Enable (expected-to-be-non-crashy)
+                                early-access LSP features.
       --ignore string           Ignores input files that contain the given
                                 string in their paths (relative to the input
                                 path passed to Sorbet). Strings beginning with /


### PR DESCRIPTION
### Motivation
The `--enable-all-experimental-lsp-features` flag is useful for LSP developers who wish to minimize flag-twiddling while *developing* new features; this introduces a similar flag for LSP beta-testers who similarly wish to avoid flag-twiddling for each new feature entering the beta-testing phase.

### Test plan
Use locally.