### PR TITLE
Remove redundant arg from getCompletionItemForMethod

### DIFF
--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -93,8 +93,8 @@ class LSPLoop {
                                                                   const CompletionParams &params) const;
     std::unique_ptr<ResponseMessage> handleTextDocumentCodeAction(LSPTypechecker &typechecker, const MessageId &id,
                                                                   const CodeActionParams &params) const;
-    std::unique_ptr<CompletionItem> getCompletionItemForMethod(const core::GlobalState &gs, LSPTypechecker &typechecker,
-                                                               core::SymbolRef what, core::TypePtr receiverType,
+    std::unique_ptr<CompletionItem> getCompletionItemForMethod(LSPTypechecker &typechecker, core::SymbolRef what,
+                                                               core::TypePtr receiverType,
                                                                const core::TypeConstraint *constraint,
                                                                const core::Loc queryLoc, std::string_view prefix,
                                                                size_t sortIdx) const;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Anything that takes `LSPTypechecker` does not also need to take
`core::GlobalState`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.