### PR TITLE
Relax bar of "useful guess" for SUGGEST_SIG query

### DIFF
--- a/test/testdata/lsp/completion/sig_all_untyped.A.rbedited
+++ b/test/testdata/lsp/completion/sig_all_untyped.A.rbedited
@@ -1,0 +1,14 @@
+# typed: true
+extend T::Sig
+
+# For this method, we did not "guess something useful" (all the params +
+# return are untyped) so we would not usually emit an autocorrect suggesting
+# this sig. But when suggesting a sig for completion specifically, we suggest
+# the sig unconditionally, so that it at least gives users something to start
+# filling in the holes.
+
+sig {params(x: T.untyped).returns(T.untyped)} # error: no block
+#  ^ apply-completion: [A] item: 0
+def all_untyped(x)
+  T.unsafe(nil)
+end

--- a/test/testdata/lsp/completion/sig_all_untyped.rb
+++ b/test/testdata/lsp/completion/sig_all_untyped.rb
@@ -1,0 +1,14 @@
+# typed: true
+extend T::Sig
+
+# For this method, we did not "guess something useful" (all the params +
+# return are untyped) so we would not usually emit an autocorrect suggesting
+# this sig. But when suggesting a sig for completion specifically, we suggest
+# the sig unconditionally, so that it at least gives users something to start
+# filling in the holes.
+
+sig # error: no block
+#  ^ apply-completion: [A] item: 0
+def all_untyped(x)
+  T.unsafe(nil)
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

For the purpose of autocorrects / code actions, we only insert a sig when
we guessed a "useful" sig, namely at least one non-T.untyped somewhere
(this was partially motivated by the effort to let multiple runs of sig
suggestion incrementally improve the sigs each time).

But for the purpose of autocomplete, even so much as having names for all
the arguments already typed out is a benefit, regardless of whether they're
all untyped.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.