### PR TITLE
Replace T.untyped in sig snippet with tabstops

### DIFF
--- a/test/testdata/lsp/completion/sig.A.rbedited
+++ b/test/testdata/lsp/completion/sig.A.rbedited
@@ -7,7 +7,7 @@
 class Normal
   extend T::Sig
 
-  sig {returns(NilClass)} # error: no block
+  sig {returns(NilClass)}${0} # error: no block
   #  ^ completion: sig
   #  ^ apply-completion: [A] item: 0
   def nullary_returns_nil

--- a/test/testdata/lsp/completion/sig.B.rbedited
+++ b/test/testdata/lsp/completion/sig.B.rbedited
@@ -13,7 +13,7 @@ class Normal
   def nullary_returns_nil
   end
 
-  sig {params(x: Integer).returns(Integer)} # error: no block
+  sig {params(x: Integer).returns(Integer)}${0} # error: no block
   #  ^ completion: sig
   #  ^ apply-completion: [B] item: 0
   def typed_params_and_returns(x)

--- a/test/testdata/lsp/completion/sig_all_untyped.A.rbedited
+++ b/test/testdata/lsp/completion/sig_all_untyped.A.rbedited
@@ -7,7 +7,7 @@ extend T::Sig
 # the sig unconditionally, so that it at least gives users something to start
 # filling in the holes.
 
-sig {params(x: T.untyped).returns(T.untyped)} # error: no block
+sig {params(x: ${1:T.untyped}).returns(${2:T.untyped})}${0} # error: no block
 #  ^ apply-completion: [A] item: 0
 def all_untyped(x)
   T.unsafe(nil)

--- a/test/testdata/lsp/completion/sig_many_defs.A.rbedited
+++ b/test/testdata/lsp/completion/sig_many_defs.A.rbedited
@@ -13,7 +13,7 @@ class A
     ''
   end
 
-  sig {returns(Symbol)} # error: no block
+  sig {returns(Symbol)}${0} # error: no block
   #  ^ apply-completion: [A] item: 0
 
   def returns_symbol

--- a/test/testdata/lsp/completion/sig_root.A.rbedited
+++ b/test/testdata/lsp/completion/sig_root.A.rbedited
@@ -3,6 +3,6 @@ extend T::Sig
 
 # Tests an edge case arising from the difference between <root> and Object
 
-sig {returns(NilClass)} # error: no block
+sig {returns(NilClass)}${0} # error: no block
 #  ^ apply-completion: [A] item: 0
 def foo; end

--- a/test/testdata/lsp/completion/sig_snippet.A.rbedited
+++ b/test/testdata/lsp/completion/sig_snippet.A.rbedited
@@ -1,0 +1,46 @@
+# typed: true
+extend T::Sig
+
+sig {params(f: T.proc.params(y: T.untyped).returns(T.untyped)).void}
+def takes_untyped_proc(f)
+end
+
+sig {params(f: String).void}
+def takes_string(f)
+end
+
+sig {params(f: T::Array[T.untyped]).void}
+def takes_array_untyped(f)
+end
+
+sig {params(x: {y: String}).void}
+def takes_shape(x)
+end
+
+sig {params(x: T.proc.params(arg0: ${1:T.untyped}).returns(${2:T.untyped}), f: ${3:T.untyped}).returns(${4:T.untyped})}${0} # error: no block
+#  ^ apply-completion: [A] item: 0
+def passes_untyped_proc(x, f)
+  takes_untyped_proc(x)
+  T.unsafe(nil)
+end
+
+sig # error: no block
+#  ^ apply-completion: [B] item: 0
+def passes_string(x)
+  takes_string(x)
+  T.unsafe(nil)
+end
+
+sig # error: no block
+#  ^ apply-completion: [C] item: 0
+def passes_array_untyped(xs)
+  takes_array_untyped(xs)
+  T.unsafe(nil)
+end
+
+sig # error: no block
+#  ^ apply-completion: [D] item: 0
+def passes_shape(x)
+  takes_shape(x)
+  T.unsafe(nil)
+end

--- a/test/testdata/lsp/completion/sig_snippet.B.rbedited
+++ b/test/testdata/lsp/completion/sig_snippet.B.rbedited
@@ -1,0 +1,46 @@
+# typed: true
+extend T::Sig
+
+sig {params(f: T.proc.params(y: T.untyped).returns(T.untyped)).void}
+def takes_untyped_proc(f)
+end
+
+sig {params(f: String).void}
+def takes_string(f)
+end
+
+sig {params(f: T::Array[T.untyped]).void}
+def takes_array_untyped(f)
+end
+
+sig {params(x: {y: String}).void}
+def takes_shape(x)
+end
+
+sig # error: no block
+#  ^ apply-completion: [A] item: 0
+def passes_untyped_proc(x, f)
+  takes_untyped_proc(x)
+  T.unsafe(nil)
+end
+
+sig {params(x: String).returns(${1:T.untyped})}${0} # error: no block
+#  ^ apply-completion: [B] item: 0
+def passes_string(x)
+  takes_string(x)
+  T.unsafe(nil)
+end
+
+sig # error: no block
+#  ^ apply-completion: [C] item: 0
+def passes_array_untyped(xs)
+  takes_array_untyped(xs)
+  T.unsafe(nil)
+end
+
+sig # error: no block
+#  ^ apply-completion: [D] item: 0
+def passes_shape(x)
+  takes_shape(x)
+  T.unsafe(nil)
+end

--- a/test/testdata/lsp/completion/sig_snippet.C.rbedited
+++ b/test/testdata/lsp/completion/sig_snippet.C.rbedited
@@ -1,0 +1,46 @@
+# typed: true
+extend T::Sig
+
+sig {params(f: T.proc.params(y: T.untyped).returns(T.untyped)).void}
+def takes_untyped_proc(f)
+end
+
+sig {params(f: String).void}
+def takes_string(f)
+end
+
+sig {params(f: T::Array[T.untyped]).void}
+def takes_array_untyped(f)
+end
+
+sig {params(x: {y: String}).void}
+def takes_shape(x)
+end
+
+sig # error: no block
+#  ^ apply-completion: [A] item: 0
+def passes_untyped_proc(x, f)
+  takes_untyped_proc(x)
+  T.unsafe(nil)
+end
+
+sig # error: no block
+#  ^ apply-completion: [B] item: 0
+def passes_string(x)
+  takes_string(x)
+  T.unsafe(nil)
+end
+
+sig {params(xs: T::Array[${1:T.untyped}]).returns(${2:T.untyped})}${0} # error: no block
+#  ^ apply-completion: [C] item: 0
+def passes_array_untyped(xs)
+  takes_array_untyped(xs)
+  T.unsafe(nil)
+end
+
+sig # error: no block
+#  ^ apply-completion: [D] item: 0
+def passes_shape(x)
+  takes_shape(x)
+  T.unsafe(nil)
+end

--- a/test/testdata/lsp/completion/sig_snippet.D.rbedited
+++ b/test/testdata/lsp/completion/sig_snippet.D.rbedited
@@ -1,0 +1,46 @@
+# typed: true
+extend T::Sig
+
+sig {params(f: T.proc.params(y: T.untyped).returns(T.untyped)).void}
+def takes_untyped_proc(f)
+end
+
+sig {params(f: String).void}
+def takes_string(f)
+end
+
+sig {params(f: T::Array[T.untyped]).void}
+def takes_array_untyped(f)
+end
+
+sig {params(x: {y: String}).void}
+def takes_shape(x)
+end
+
+sig # error: no block
+#  ^ apply-completion: [A] item: 0
+def passes_untyped_proc(x, f)
+  takes_untyped_proc(x)
+  T.unsafe(nil)
+end
+
+sig # error: no block
+#  ^ apply-completion: [B] item: 0
+def passes_string(x)
+  takes_string(x)
+  T.unsafe(nil)
+end
+
+sig # error: no block
+#  ^ apply-completion: [C] item: 0
+def passes_array_untyped(xs)
+  takes_array_untyped(xs)
+  T.unsafe(nil)
+end
+
+sig {params(x: T::Hash[${1:T.untyped}, ${2:T.untyped}]).returns(${3:T.untyped})}${0} # error: no block
+#  ^ apply-completion: [D] item: 0
+def passes_shape(x)
+  takes_shape(x)
+  T.unsafe(nil)
+end

--- a/test/testdata/lsp/completion/sig_snippet.rb
+++ b/test/testdata/lsp/completion/sig_snippet.rb
@@ -1,0 +1,46 @@
+# typed: true
+extend T::Sig
+
+sig {params(f: T.proc.params(y: T.untyped).returns(T.untyped)).void}
+def takes_untyped_proc(f)
+end
+
+sig {params(f: String).void}
+def takes_string(f)
+end
+
+sig {params(f: T::Array[T.untyped]).void}
+def takes_array_untyped(f)
+end
+
+sig {params(x: {y: String}).void}
+def takes_shape(x)
+end
+
+sig # error: no block
+#  ^ apply-completion: [A] item: 0
+def passes_untyped_proc(x, f)
+  takes_untyped_proc(x)
+  T.unsafe(nil)
+end
+
+sig # error: no block
+#  ^ apply-completion: [B] item: 0
+def passes_string(x)
+  takes_string(x)
+  T.unsafe(nil)
+end
+
+sig # error: no block
+#  ^ apply-completion: [C] item: 0
+def passes_array_untyped(xs)
+  takes_array_untyped(xs)
+  T.unsafe(nil)
+end
+
+sig # error: no block
+#  ^ apply-completion: [D] item: 0
+def passes_shape(x)
+  takes_shape(x)
+  T.unsafe(nil)
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This lets people cycle through the `T.untyped` as if they're holes to be
filled in.

The code is kind of ugly but I couldn't think of a much easier way to
implement it without making `SigSuggestion.cc` aware of whether the LSP
client supports snippets (which seems like it violates the concerns of what
`infer/` should have to know about).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.