### PR TITLE
Disable clangd's buggy semantic highlighting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,10 @@
   "editor.formatOnSave": true,
   "editor.insertSpaces": true,
   "editor.rulers": [120],
+  // Clangd 9.0 has a new semantic highlighting feature, but it's buggy and causes
+  // syntax highlighting colors to "bleed" into adjacent lines. Thus, we disable it.
+  // We should revisit this option next time we upgrade clang.
+  "clangd.semanticHighlighting": false,
   "files.associations": {
     "*.rbi": "ruby",
     "*.rbupdated": "ruby",


### PR DESCRIPTION
Causes syntax highlighting colors to bleed into adjacent lines, causing a rainbow effect. Very distracting.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes syntax highlighting in VS Code.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Flipped on option, it fixed the issue. I also verified that @mkillianey-stripe had the same issue after upgrading to clangd 9.0.
