### PR TITLE
Disable wait_pop_timed timer in unbounded case to reduce log spam.

### DIFF
--- a/common/concurrency/ConcurrentQueue.h
+++ b/common/concurrency/ConcurrentQueue.h
@@ -30,12 +30,10 @@ template <class Elem, class Queue> class AbstractConcurrentBoundedQueue {
     Queue _queue;
     std::atomic<int> elementsLeftToPush; // double serves as a counter and as safe publication marker
     std::atomic<int> elementsPopped;
-    const bool unbounded;
 
 public:
     const int bound;
-    AbstractConcurrentBoundedQueue(int bound, bool unbounded = false) noexcept
-        : elementsLeftToPush(bound), elementsPopped(0), unbounded(unbounded), bound(bound) {}
+    AbstractConcurrentBoundedQueue(int bound) noexcept : elementsLeftToPush(bound), elementsPopped(0), bound(bound) {}
     AbstractConcurrentBoundedQueue(const AbstractConcurrentBoundedQueue &other) = delete;
     AbstractConcurrentBoundedQueue(AbstractConcurrentBoundedQueue &&other) = delete;
 
@@ -57,15 +55,13 @@ public:
 
     template <typename Rep, typename Period>
     inline DequeueResult wait_pop_timed(Elem &elem, std::chrono::duration<Rep, Period> const &timeout,
-                                        spdlog::logger &log) noexcept {
+                                        spdlog::logger &log, bool silent = false) noexcept {
         DequeueResult ret;
         if (!sorbet::emscripten_build) {
             ret.shouldRetry = elementsLeftToPush.load(std::memory_order_acquire) != 0;
             if (ret.shouldRetry) {
                 std::unique_ptr<sorbet::Timer> time;
-                // Don't create a timer in the unbounded case; the common case is a 250 ms timeout.
-                // If queue is unbounded, shouldRetry is ~always true regardless of if a queue entry will arrive soon.
-                if (!unbounded) {
+                if (!silent) {
                     time = std::make_unique<sorbet::Timer>(log, "wait_pop_timed");
                 }
                 ret.returned = _queue.wait_dequeue_timed(elem, timeout);
@@ -95,8 +91,7 @@ using ConcurrentBoundedQueue = AbstractConcurrentBoundedQueue<Elem, moodycamel::
 template <class Elem>
 class ConcurrentUnBoundedQueue : public AbstractConcurrentBoundedQueue<Elem, moodycamel::ConcurrentQueue<Elem>> {
 public:
-    ConcurrentUnBoundedQueue()
-        : AbstractConcurrentBoundedQueue<Elem, moodycamel::ConcurrentQueue<Elem>>(INT_MAX, true){};
+    ConcurrentUnBoundedQueue() : AbstractConcurrentBoundedQueue<Elem, moodycamel::ConcurrentQueue<Elem>>(INT_MAX){};
 };
 
 template <class Elem>
@@ -106,7 +101,7 @@ template <class Elem>
 class BlockingUnBoundedQueue : public AbstractConcurrentBoundedQueue<Elem, moodycamel::BlockingConcurrentQueue<Elem>> {
 public:
     BlockingUnBoundedQueue()
-        : AbstractConcurrentBoundedQueue<Elem, moodycamel::BlockingConcurrentQueue<Elem>>(INT_MAX, true){};
+        : AbstractConcurrentBoundedQueue<Elem, moodycamel::BlockingConcurrentQueue<Elem>>(INT_MAX){};
 };
 
 #ifdef _MACH_BOOLEAN_H_

--- a/common/concurrency/ConcurrentQueue.h
+++ b/common/concurrency/ConcurrentQueue.h
@@ -63,7 +63,7 @@ public:
             ret.shouldRetry = elementsLeftToPush.load(std::memory_order_acquire) != 0;
             if (ret.shouldRetry) {
                 std::unique_ptr<sorbet::Timer> time;
-                // Don't create a timer in the unbounded case; the common case is a timeout.
+                // Don't create a timer in the unbounded case; the common case is a 250 ms timeout.
                 // If queue is unbounded, shouldRetry is ~always true regardless of if a queue entry will arrive soon.
                 if (!unbounded) {
                     time = std::make_unique<sorbet::Timer>(log, "wait_pop_timed");

--- a/common/concurrency/ConcurrentQueue.h
+++ b/common/concurrency/ConcurrentQueue.h
@@ -63,7 +63,7 @@ public:
             ret.shouldRetry = elementsLeftToPush.load(std::memory_order_acquire) != 0;
             if (ret.shouldRetry) {
                 std::unique_ptr<sorbet::Timer> time;
-                // Don't create a timer in the unbounded case; the common case is a 250 ms timeout.
+                // Don't create a timer in the unbounded case; the common case is a timeout.
                 // If queue is unbounded, shouldRetry is ~always true regardless of if a queue entry will arrive soon.
                 if (!unbounded) {
                     time = std::make_unique<sorbet::Timer>(log, "wait_pop_timed");

--- a/common/concurrency/ConcurrentQueue.h
+++ b/common/concurrency/ConcurrentQueue.h
@@ -55,12 +55,15 @@ public:
 
     template <typename Rep, typename Period>
     inline DequeueResult wait_pop_timed(Elem &elem, std::chrono::duration<Rep, Period> const &timeout,
-                                        spdlog::logger &log) noexcept {
+                                        spdlog::logger &log, bool silent = false) noexcept {
         DequeueResult ret;
         if (!sorbet::emscripten_build) {
             ret.shouldRetry = elementsLeftToPush.load(std::memory_order_acquire) != 0;
             if (ret.shouldRetry) {
-                sorbet::Timer time(log, "wait_pop_timed");
+                std::unique_ptr<sorbet::Timer> time;
+                if (!silent) {
+                    time = std::make_unique<sorbet::Timer>(log, "wait_pop_timed");
+                }
                 ret.returned = _queue.wait_dequeue_timed(elem, timeout);
             } else { // all elements has been pushed, no need to wait.
                 ret.returned = _queue.try_dequeue(elem);

--- a/main/lsp/LSPTypecheckerCoordinator.cc
+++ b/main/lsp/LSPTypecheckerCoordinator.cc
@@ -61,8 +61,7 @@ unique_ptr<Joinable> LSPTypecheckerCoordinator::startTypecheckerThread() {
 
         while (!shouldTerminate) {
             function<void()> lambda;
-            // Note: Pass in 'true' for silent to avoid spamming log with wait_pop_timed entries.
-            auto result = lambdas.wait_pop_timed(lambda, WorkerPool::BLOCK_INTERVAL(), *config->logger, true);
+            auto result = lambdas.wait_pop_timed(lambda, WorkerPool::BLOCK_INTERVAL(), *config->logger);
             if (result.gotItem()) {
                 lambda();
             }

--- a/main/lsp/LSPTypecheckerCoordinator.cc
+++ b/main/lsp/LSPTypecheckerCoordinator.cc
@@ -61,7 +61,8 @@ unique_ptr<Joinable> LSPTypecheckerCoordinator::startTypecheckerThread() {
 
         while (!shouldTerminate) {
             function<void()> lambda;
-            auto result = lambdas.wait_pop_timed(lambda, WorkerPool::BLOCK_INTERVAL(), *config->logger);
+            // Note: Pass in 'true' for silent to avoid spamming log with wait_pop_timed entries.
+            auto result = lambdas.wait_pop_timed(lambda, WorkerPool::BLOCK_INTERVAL(), *config->logger, true);
             if (result.gotItem()) {
                 lambda();
             }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Disable wait_pop_timed timer in unbounded case to reduce log spam.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Silences logspam that happens every 250ms from typechecker coord thread. Unlike bounded usages of wait_pop_timed, the typechecker coord thread uses a unbounded queue that sets the expected number of queue entries to be MAX INT to create an effectively unbounded queue.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

N/A
