### PR TITLE
[WIP] Preemptible slow path

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -54,6 +54,8 @@ public:
 struct ParsedFile {
     std::unique_ptr<ast::Expression> tree;
     core::FileRef file;
+    // Used by LSP in assertions.
+    u4 fileVersion = 0;
 };
 
 /**

--- a/common/concurrency/ConcurrentQueue.h
+++ b/common/concurrency/ConcurrentQueue.h
@@ -83,6 +83,10 @@ public:
     int enqueuedEstimate() {
         return bound - elementsLeftToPush.load(std::memory_order_relaxed);
     }
+
+    size_t queueSizeEstimate() {
+        return _queue.size_approx();
+    }
 };
 
 template <class Elem>

--- a/core/NameHash.h
+++ b/core/NameHash.h
@@ -53,6 +53,7 @@ struct UsageHash {
 };
 
 struct FileHash {
+    u4 version;
     GlobalStateHash definitions;
     UsageHash usages;
 };

--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -32,10 +32,9 @@ MarkupKind getPreferredMarkupKind(vector<MarkupKind> formats) {
 } // namespace
 
 LSPConfiguration::LSPConfiguration(const options::Options &opts, const shared_ptr<LSPOutput> &output,
-                                   WorkerPool &workers, const shared_ptr<spdlog::logger> &logger, bool skipConfigatron,
-                                   bool disableFastPath)
-    : initialized(atomic<bool>(false)), opts(opts), output(output), workers(workers), logger(logger),
-      skipConfigatron(skipConfigatron), disableFastPath(disableFastPath), rootPath(getRootPath(opts, logger)) {}
+                                   const shared_ptr<spdlog::logger> &logger, bool skipConfigatron, bool disableFastPath)
+    : initialized(atomic<bool>(false)), opts(opts), output(output), logger(logger), skipConfigatron(skipConfigatron),
+      disableFastPath(disableFastPath), rootPath(getRootPath(opts, logger)) {}
 
 void LSPConfiguration::assertHasClientConfig() const {
     if (!clientConfig) {

--- a/main/lsp/LSPConfiguration.h
+++ b/main/lsp/LSPConfiguration.h
@@ -73,7 +73,6 @@ public:
     /** Command line / startup options. */
     const options::Options &opts;
     const std::shared_ptr<LSPOutput> output;
-    WorkerPool &workers;
     const std::shared_ptr<spdlog::logger> logger;
     /** If true, LSPLoop will skip configatron during type checking */
     const bool skipConfigatron;
@@ -84,7 +83,7 @@ public:
 
     // The following properties are configured during initialization.
 
-    LSPConfiguration(const options::Options &opts, const std::shared_ptr<LSPOutput> &output, WorkerPool &workers,
+    LSPConfiguration(const options::Options &opts, const std::shared_ptr<LSPOutput> &output,
                      const std::shared_ptr<spdlog::logger> &logger, bool skipConfigatron = false,
                      bool disableFastPath = false);
 

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -356,6 +356,8 @@ void LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<DidChangeTextDocumentPa
                                         LSPFileUpdates &updates) const {
     updates.versionStart = v;
     updates.versionEnd = v;
+    updates.expectedPreemptions = changeParams->sorbetTestingExpectedPreemptions.value_or(0);
+    updates.expectedCancelation = changeParams->sorbetTestingExpectedCancellation.value_or(false);
     string_view uri = changeParams->textDocument->uri;
     if (config->isUriInWorkspace(uri)) {
         string localPath = config->remoteName2Local(uri);
@@ -461,6 +463,8 @@ void LSPPreprocessor::mergeEdits(LSPFileUpdates &to, LSPFileUpdates &from) {
     to.canceledSlowPath = to.canceledSlowPath || from.canceledSlowPath;
     // `to` now includes the contents of `from`.
     to.versionEnd = from.versionEnd;
+    to.expectedPreemptions += from.expectedCancelation;
+    to.expectedCancelation = to.expectedCancelation || from.expectedCancelation;
     // No need to update versionStart, as to comes before from.
     ENFORCE(ttgs.comesBefore(to.versionStart, from.versionStart));
     if (to.canTakeFastPath) {

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -150,7 +150,9 @@ void LSPPreprocessor::mergeFileChanges(absl::Mutex &stateMtx, QueueState &state)
                     auto combinedUpdates = ttgs.getCombinedUpdates(committed + 1, params->updates.versionEnd);
                     // Cancel if combined updates end up taking the fast path, or if the new updates will just take the
                     // slow path a second time when the current slow path finishes.
-                    if ((combinedUpdates.canTakeFastPath || !params->updates.canTakeFastPath) &&
+                    // Don't bother canceling if the edit has already canceled the currently-running slow path.
+                    if (!combinedUpdates.canceledSlowPath &&
+                        (combinedUpdates.canTakeFastPath || !params->updates.canTakeFastPath) &&
                         gs.tryCancelSlowPath(params->updates.versionEnd)) {
                         if (combinedUpdates.canTakeFastPath) {
                             logger->debug(

--- a/main/lsp/LSPPreprocessor.h
+++ b/main/lsp/LSPPreprocessor.h
@@ -64,7 +64,7 @@ class LSPPreprocessor final {
      * Example: (E = edit, D = delayable non-edit, M = arbitrary non-edit)
      * {[M1][E1][E2][D1][E3]} => {[M1][E1-3][D1]}
      */
-    void mergeFileChanges(absl::Mutex &mtx, QueueState &state);
+    void mergeFileChanges(absl::Mutex &stateMtx, QueueState &state);
 
     std::unique_ptr<LSPMessage> makeAndCommitWorkspaceEdit(std::unique_ptr<SorbetWorkspaceEditParams> params,
                                                            std::unique_ptr<LSPMessage> oldMsg);
@@ -85,7 +85,7 @@ class LSPPreprocessor final {
      */
     std::unique_ptr<core::GlobalState> getTypecheckingGS() const;
 
-    bool ensureInitialized(const LSPMethod forMethod, const LSPMessage &msg) const;
+    bool ensureInitialized(LSPMethod forMethod, const LSPMessage &msg) const;
 
 public:
     LSPPreprocessor(std::unique_ptr<core::GlobalState> initialGS, const std::shared_ptr<LSPConfiguration> &config,
@@ -101,7 +101,7 @@ public:
      * * Indexes all files on filesystem if client sends an `initialized` message. If configured, will also send
      * progress notifications.
      *
-     * It grabs the mutex before reading/writing `state`.
+     * It grabs stateMutex before reading/writing `state`.
      */
     void preprocessAndEnqueue(QueueState &state, std::unique_ptr<LSPMessage> msg, absl::Mutex &stateMtx);
 

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -93,13 +93,14 @@ class LSPTypechecker final {
      * LSPTypechecker to its pre-slow-path state. */
     std::optional<LSPTypecheckerUndoState> cancellationUndoState;
     std::shared_ptr<std::shared_ptr<std::function<void()>>> preemptFunction;
+    /** Worker threads for slow path typechecking. */
+    WorkerPool &workers;
 
     std::shared_ptr<const LSPConfiguration> config;
 
     /** Conservatively reruns entire pipeline without caching any trees. Returns `true` if slow path successfully
-     * completed, or `false` if it was canceled. If `typecheckLock` is supplied, operation is cancelable and
-     * preemptible. */
-    bool runSlowPath(LSPFileUpdates updates, bool cancelableAndPreemptible);
+     * completed, or `false` if it was canceled. */
+    bool runSlowPath(LSPFileUpdates updates, bool cancelable);
     /** Runs incremental typechecking on the provided updates. */
     TypecheckRun runFastPath(LSPFileUpdates updates) const;
 
@@ -123,7 +124,7 @@ class LSPTypechecker final {
     std::vector<core::FileRef> restore(LSPTypecheckerUndoState &undoState);
 
 public:
-    LSPTypechecker(const std::shared_ptr<const LSPConfiguration> &config);
+    LSPTypechecker(std::shared_ptr<const LSPConfiguration> config, WorkerPool &workers);
     ~LSPTypechecker() = default;
 
     /**
@@ -138,7 +139,7 @@ public:
      * Typechecks the given input. Returns 'true' if the updates were committed, or 'false' if typechecking was
      * canceled. Guaranteed to return `true` if `cancelableAndPreemptible` is `false`.
      */
-    bool typecheck(LSPFileUpdates updates, bool cancelableAndPreemptible);
+    bool typecheck(LSPFileUpdates updates, bool cancelable);
 
     /**
      * Re-typechecks the provided input to re-produce error messages. Input *must* match already committed state!

--- a/main/lsp/LSPTypecheckerCoordinator.cc
+++ b/main/lsp/LSPTypecheckerCoordinator.cc
@@ -11,7 +11,7 @@ LSPTypecheckerCoordinator::LSPTypecheckerCoordinator(const shared_ptr<const LSPC
 void LSPTypecheckerCoordinator::asyncRunInternal(function<void()> &&lambda, bool canPreemptSlowPath) {
     if (hasDedicatedThread) {
         // We can only preempt if this lambda will run next. We have no notion of a queue of preemption lambdas.
-        if (canPreemptSlowPath && lambdas.enqueuedEstimate() - lambdas.doneEstimate() == 0) {
+        if (canPreemptSlowPath && lambdas.queueSizeEstimate() == 0) {
             if (typechecker.tryPreemptSlowPath(lambda)) {
                 // lambda is guaranteed to preempt slow path.
                 config->logger->debug("Preempting slow path.");
@@ -22,7 +22,7 @@ void LSPTypecheckerCoordinator::asyncRunInternal(function<void()> &&lambda, bool
         }
 
         // Debug
-        if (canPreemptSlowPath && lambdas.enqueuedEstimate() - lambdas.doneEstimate() > 0) {
+        if (canPreemptSlowPath && lambdas.queueSizeEstimate() > 0) {
             config->logger->debug("Preemption attempt failed: Blocking request exists in queue.");
         } else {
             config->logger->debug("Request cannot preempt.");

--- a/main/lsp/LSPTypecheckerCoordinator.cc
+++ b/main/lsp/LSPTypecheckerCoordinator.cc
@@ -8,33 +8,65 @@ using namespace std;
 LSPTypecheckerCoordinator::LSPTypecheckerCoordinator(const shared_ptr<const LSPConfiguration> &config)
     : shouldTerminate(false), typechecker(config), config(config), hasDedicatedThread(false) {}
 
-void LSPTypecheckerCoordinator::asyncRunInternal(function<void()> &&lambda) {
+void LSPTypecheckerCoordinator::asyncRunInternal(function<void()> &&lambda, bool canPreemptSlowPath) {
     if (hasDedicatedThread) {
+        // We can only preempt if this lambda will run next. We have no notion of a queue of preemption lambdas.
+        if (canPreemptSlowPath && lambdas.enqueuedEstimate() - lambdas.doneEstimate() == 0) {
+            if (typechecker.tryPreemptSlowPath(lambda)) {
+                // lambda is guaranteed to preempt slow path.
+                config->logger->debug("Preempting slow path.");
+                return;
+            } else {
+                config->logger->debug("Preemption attempt failed: tryPreemptSlowPath returned false.");
+            }
+        }
+
+        // Debug
+        if (canPreemptSlowPath && lambdas.enqueuedEstimate() - lambdas.doneEstimate() > 0) {
+            config->logger->debug("Preemption attempt failed: Blocking request exists in queue.");
+        } else {
+            config->logger->debug("Request cannot preempt.");
+        }
+
         lambdas.push(move(lambda), 1);
     } else {
         lambda();
     }
 }
 
-void LSPTypecheckerCoordinator::asyncRun(function<void(LSPTypechecker &)> &&lambda) {
-    asyncRunInternal([&typechecker = this->typechecker, lambda]() -> void { lambda(typechecker); });
+void LSPTypecheckerCoordinator::asyncRun(function<void(LSPTypechecker &)> &&lambda, bool waitUntilTaskStarts) {
+    absl::Notification notification;
+    asyncRunInternal(
+        [&typechecker = this->typechecker, lambda, waitUntilTaskStarts, &notification]() -> void {
+            if (waitUntilTaskStarts) {
+                notification.Notify();
+            }
+            lambda(typechecker);
+        },
+        false);
+
+    if (waitUntilTaskStarts) {
+        notification.WaitForNotification();
+    }
 }
 
-void LSPTypecheckerCoordinator::syncRun(function<void(LSPTypechecker &)> &&lambda) {
+void LSPTypecheckerCoordinator::syncRun(function<void(LSPTypechecker &)> &&lambda, bool canPreemptSlowPath) {
     absl::Notification notification;
     CounterState typecheckerCounters;
     // If typechecker is running on a dedicated thread, then we need to merge its metrics w/ coordinator thread's so we
     // report them.
     // Note: Capturing notification by reference is safe here, we we wait for the notification to happen prior to
     // returning.
-    asyncRunInternal([&typechecker = this->typechecker, lambda, &notification, &typecheckerCounters,
-                      hasDedicatedThread = this->hasDedicatedThread]() -> void {
-        lambda(typechecker);
-        if (hasDedicatedThread) {
-            typecheckerCounters = getAndClearThreadCounters();
-        }
-        notification.Notify();
-    });
+    asyncRunInternal(
+        [&typechecker = this->typechecker, lambda, &notification, &typecheckerCounters,
+         hasDedicatedThread = this->hasDedicatedThread]() -> void {
+            lambda(typechecker);
+            if (hasDedicatedThread) {
+                typecheckerCounters = getAndClearThreadCounters();
+            }
+            notification.Notify();
+        },
+        canPreemptSlowPath);
     notification.WaitForNotification();
     if (hasDedicatedThread) {
         counterConsume(move(typecheckerCounters));
@@ -43,10 +75,12 @@ void LSPTypecheckerCoordinator::syncRun(function<void(LSPTypechecker &)> &&lambd
 
 unique_ptr<core::GlobalState> LSPTypecheckerCoordinator::shutdown() {
     unique_ptr<core::GlobalState> gs;
-    syncRun([&](auto &typechecker) -> void {
-        shouldTerminate = true;
-        gs = typechecker.destroy();
-    });
+    syncRun(
+        [&](auto &typechecker) -> void {
+            shouldTerminate = true;
+            gs = typechecker.destroy();
+        },
+        false);
     return gs;
 }
 

--- a/main/lsp/LSPTypecheckerCoordinator.cc
+++ b/main/lsp/LSPTypecheckerCoordinator.cc
@@ -5,8 +5,8 @@
 namespace sorbet::realmain::lsp {
 using namespace std;
 
-LSPTypecheckerCoordinator::LSPTypecheckerCoordinator(const shared_ptr<const LSPConfiguration> &config)
-    : shouldTerminate(false), typechecker(config), config(config), hasDedicatedThread(false) {}
+LSPTypecheckerCoordinator::LSPTypecheckerCoordinator(shared_ptr<const LSPConfiguration> config, WorkerPool &workers)
+    : shouldTerminate(false), typechecker(config, workers), config(move(config)), hasDedicatedThread(false) {}
 
 void LSPTypecheckerCoordinator::asyncRunInternal(function<void()> &&lambda, bool canPreemptSlowPath) {
     if (hasDedicatedThread) {

--- a/main/lsp/LSPTypecheckerCoordinator.h
+++ b/main/lsp/LSPTypecheckerCoordinator.h
@@ -27,7 +27,7 @@ class LSPTypecheckerCoordinator final {
     void asyncRunInternal(std::function<void()> &&lambda, bool canPreemptSlowPath);
 
 public:
-    LSPTypecheckerCoordinator(const std::shared_ptr<const LSPConfiguration> &config);
+    LSPTypecheckerCoordinator(std::shared_ptr<const LSPConfiguration> config, WorkerPool &workers);
 
     /**
      * Runs lambda with exclusive access to GlobalState. lambda runs on typechecker thread. These cannot preeempt the

--- a/main/lsp/TimeTravelingGlobalState.cc
+++ b/main/lsp/TimeTravelingGlobalState.cc
@@ -148,7 +148,7 @@ vector<core::FileHash> TimeTravelingGlobalState::computeStateHashes(u4 version,
     shared_ptr<BlockingBoundedQueue<vector<pair<int, core::FileHash>>>> resultq =
         make_shared<BlockingBoundedQueue<vector<pair<int, core::FileHash>>>>(files.size());
 
-    // TODO: Use workers later?
+    // TODO: Use workers later? Pass in workers as argument, default to `0`?
     auto workers = WorkerPool::create(0, *config->logger);
     workers->multiplexJob("lspStateHash", [fileq, resultq, files, version, &logger]() {
         vector<pair<int, core::FileHash>> threadResult;
@@ -240,7 +240,8 @@ void TimeTravelingGlobalState::commitEdits(LSPFileUpdates &update) {
         fileToPos[fref.id()] = i;
     }
 
-    auto trees = pipeline::index(gs, frefs, config->opts, config->workers, kvstore);
+    auto workers = WorkerPool::create(0, *config->logger);
+    auto trees = pipeline::index(gs, frefs, config->opts, *workers, kvstore);
     update.updatedFileIndexes.resize(trees.size());
     newUpdate.update.updatedFileIndexes.resize(trees.size());
     for (auto &ast : trees) {

--- a/main/lsp/TimeTravelingGlobalState.h
+++ b/main/lsp/TimeTravelingGlobalState.h
@@ -62,7 +62,8 @@ private:
     // Internal function: Applies given update (or undoes it) and appropriately updates `activeVersion`.
     std::vector<core::FileRef> applyUpdate(TimeTravelUpdate &update, bool undo);
 
-    std::vector<core::FileHash> computeStateHashes(const std::vector<std::shared_ptr<core::File>> &files) const;
+    std::vector<core::FileHash> computeStateHashes(u4 version,
+                                                   const std::vector<std::shared_ptr<core::File>> &files) const;
 
 public:
     TimeTravelingGlobalState(const std::shared_ptr<LSPConfiguration> &config, std::unique_ptr<core::GlobalState> gs,

--- a/main/lsp/json_types.h
+++ b/main/lsp/json_types.h
@@ -22,6 +22,9 @@ struct LSPFileUpdates {
     u4 versionStart = 0;
     std::vector<std::shared_ptr<core::File>> updatedFiles;
     bool canTakeFastPath = false;
+    // Indicates that this update contains edits that canceled a previously-running slow path. Used to indicate that
+    // LSPTypechecker should roll back changes from that slow path.
+    bool canceledSlowPath = false;
     // Indicates that this update contains a new file. Is a hack for TimeTravelingGlobalState.
     bool hasNewFiles = false;
     std::vector<core::FileHash> updatedFileHashes;
@@ -30,6 +33,9 @@ struct LSPFileUpdates {
     std::vector<ast::ParsedFile> updatedFinalGSFileIndexes;
     // (Optional) Updated global state object to use to typecheck this update.
     std::optional<std::unique_ptr<core::GlobalState>> updatedGS;
+    // (Tests only) Indicates that the slow path expects to be preempted this many times. The slow path will wait until
+    // either this happens, or a timeout occurs.
+    int expectedPreemptions = 0;
 };
 
 class DeserializationError : public std::runtime_error {

--- a/main/lsp/json_types.h
+++ b/main/lsp/json_types.h
@@ -36,6 +36,8 @@ struct LSPFileUpdates {
     // (Tests only) Indicates that the slow path expects to be preempted this many times. The slow path will wait until
     // either this happens, or a timeout occurs.
     int expectedPreemptions = 0;
+    // (Tests only) Indicates that the slow path expects to be canceled.
+    bool expectedCancelation = false;
 };
 
 class DeserializationError : public std::runtime_error {

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -11,8 +11,9 @@ using namespace std;
 
 namespace sorbet::realmain::lsp {
 
-LSPLoop::LSPLoop(std::unique_ptr<core::GlobalState> initialGS, const std::shared_ptr<LSPConfiguration> &config)
-    : config(config), preprocessor(move(initialGS), config), typecheckerCoord(config),
+LSPLoop::LSPLoop(std::unique_ptr<core::GlobalState> initialGS, const std::shared_ptr<LSPConfiguration> &config,
+                 WorkerPool &workers)
+    : config(config), preprocessor(move(initialGS), config), typecheckerCoord(config, workers),
       lastMetricUpdateTime(chrono::steady_clock::now()) {}
 
 LSPQueryResult LSPLoop::queryByLoc(LSPTypechecker &typechecker, string_view uri, const Position &pos,

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -95,7 +95,7 @@ void LSPLoop::sendCountersToStatsd(chrono::time_point<chrono::steady_clock> curr
 
 int LSPLoop::getTypecheckCount() {
     int count = 0;
-    typecheckerCoord.syncRun([&count](const auto &tc) -> void { count = tc.state().lspTypecheckCount; });
+    typecheckerCoord.syncRun([&count](const auto &tc) -> void { count = tc.state().lspTypecheckCount.load(); }, false);
     return count;
 }
 

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -111,7 +111,8 @@ class LSPLoop {
     void maybeStartCommitSlowPathEdit(const LSPMessage &msg) const;
 
 public:
-    LSPLoop(std::unique_ptr<core::GlobalState> initialGS, const std::shared_ptr<LSPConfiguration> &config);
+    LSPLoop(std::unique_ptr<core::GlobalState> initialGS, const std::shared_ptr<LSPConfiguration> &config,
+            WorkerPool &workers);
     /**
      * Runs the language server on a dedicated thread. Returns the final global state if it exits cleanly, or nullopt
      * on error.

--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -105,7 +105,7 @@ void LSPLoop::maybeStartCommitSlowPathEdit(const LSPMessage &msg) const {
 }
 
 optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(shared_ptr<LSPInput> input) {
-    // Naming convention: thread that executes this function is called typechecking thread
+    // Naming convention: thread that executes this function is called coordinator thread
 
     // Incoming queue stores requests that arrive from the client and Watchman. No preprocessing is performed on
     // these messages (e.g., edits are not merged).

--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -48,28 +48,45 @@ void LSPLoop::processRequestInternal(LSPMessage &msg) {
         if (method == LSPMethod::SorbetWorkspaceEdit) {
             // Note: We increment `lsp.messages.processed` when the original requests were merged into this one.
             shared_ptr<SorbetWorkspaceEditParams> editParams = move(get<unique_ptr<SorbetWorkspaceEditParams>>(params));
+            const u4 end = editParams->updates.versionEnd;
+            const u4 start = editParams->updates.versionStart;
+            // Versions are sequential and wrap around. Use them to figure out how many edits are contained
+            // within this update.
+            const u4 merged = min(end - start, 0xFFFFFFFF - start + end);
             // Since std::function is copyable, we have to promote captured unique_ptrs into shared_ptrs.
-            // TODO(jvilk): Switch to asyncRun once I sort out how this interplays with cancelable slow path.
-            typecheckerCoord.syncRun([editParams](LSPTypechecker &typechecker) -> void {
-                const u4 end = editParams->updates.versionEnd;
-                const u4 start = editParams->updates.versionStart;
-                // Versions are sequential and wrap around. Use them to figure out how many edits are contained
-                // within this update.
-                const u4 merged = min(end - start, 0xFFFFFFFF - start + end);
-                // Only report stats if the edit was committed.
-                if (!typechecker.typecheck(move(editParams->updates))) {
-                    prodCategoryCounterInc("lsp.messages.processed", "sorbet/workspaceEdit");
-                    prodCategoryCounterAdd("lsp.messages.processed", "sorbet/mergedEdits", merged);
-                }
-            });
+            if (editParams->updates.canTakeFastPath) {
+                // Fast path: Block until complete and preempt slow path if running.
+                typecheckerCoord.syncRun(
+                    [editParams, merged](LSPTypechecker &typechecker) -> void {
+                        // Only report stats if the edit was committed.
+                        if (!typechecker.typecheck(move(editParams->updates), true)) {
+                            prodCategoryCounterInc("lsp.messages.processed", "sorbet/workspaceEdit");
+                            prodCategoryCounterAdd("lsp.messages.processed", "sorbet/mergedEdits", merged);
+                        }
+                    },
+                    true);
+            } else {
+                // Slow path. Run async.
+                typecheckerCoord.asyncRun(
+                    [editParams = move(editParams), merged](LSPTypechecker &typechecker) -> void {
+                        // Only report stats if the edit was committed.
+                        if (!typechecker.typecheck(move(editParams->updates), true)) {
+                            prodCategoryCounterInc("lsp.messages.processed", "sorbet/workspaceEdit");
+                            prodCategoryCounterAdd("lsp.messages.processed", "sorbet/mergedEdits", merged);
+                        }
+                    },
+                    true);
+            }
         } else if (method == LSPMethod::Initialized) {
             prodCategoryCounterInc("lsp.messages.processed", "initialized");
             auto &initParams = get<unique_ptr<InitializedParams>>(params);
             // TODO: Can we make this asynchronous?
-            typecheckerCoord.syncRun([&](LSPTypechecker &typechecker) -> void {
-                auto &updates = initParams->updates;
-                typechecker.initialize(move(updates));
-            });
+            typecheckerCoord.syncRun(
+                [&](LSPTypechecker &typechecker) -> void {
+                    auto &updates = initParams->updates;
+                    typechecker.initialize(move(updates));
+                },
+                true);
         } else if (method == LSPMethod::Exit) {
             prodCategoryCounterInc("lsp.messages.processed", "exit");
         } else if (method == LSPMethod::SorbetError) {
@@ -82,14 +99,16 @@ void LSPLoop::processRequestInternal(LSPMessage &msg) {
             }
         } else if (method == LSPMethod::SorbetFence) {
             // Ensure all prior messages have finished processing before sending response.
-            typecheckerCoord.syncRun([&](auto &tc) -> void {
-                // Send the same fence back to acknowledge the fence.
-                // NOTE: Fence is a notification rather than a request so that we don't have to worry about clashes with
-                // client-chosen IDs when using fences internally.
-                auto response =
-                    make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, move(msg.asNotification().params));
-                config->output->write(move(response));
-            });
+            typecheckerCoord.syncRun(
+                [&](auto &tc) -> void {
+                    // Send the same fence back to acknowledge the fence.
+                    // NOTE: Fence is a notification rather than a request so that we don't have to worry about clashes
+                    // with client-chosen IDs when using fences internally.
+                    auto response = make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence,
+                                                                     move(msg.asNotification().params));
+                    config->output->write(move(response));
+                },
+                false);
         }
     } else if (msg.isRequest()) {
         Timer timeit(logger, "request", {{"method", convertLSPMethodToString(method)}});
@@ -140,61 +159,71 @@ void LSPLoop::processRequestInternal(LSPMessage &msg) {
             config->output->write(move(response));
         } else if (method == LSPMethod::TextDocumentDocumentHighlight) {
             auto &params = get<unique_ptr<TextDocumentPositionParams>>(rawParams);
-            typecheckerCoord.syncRun([&](auto &typechecker) -> void {
-                config->output->write(handleTextDocumentDocumentHighlight(typechecker, id, *params));
-            });
+            typecheckerCoord.syncRun(
+                [&](auto &typechecker) -> void {
+                    config->output->write(handleTextDocumentDocumentHighlight(typechecker, id, *params));
+                },
+                true);
         } else if (method == LSPMethod::TextDocumentDocumentSymbol) {
             auto &params = get<unique_ptr<DocumentSymbolParams>>(rawParams);
-            typecheckerCoord.syncRun([&](auto &typechecker) -> void {
-                config->output->write(handleTextDocumentDocumentSymbol(typechecker, id, *params));
-            });
+            typecheckerCoord.syncRun(
+                [&](auto &typechecker) -> void {
+                    config->output->write(handleTextDocumentDocumentSymbol(typechecker, id, *params));
+                },
+                true);
         } else if (method == LSPMethod::WorkspaceSymbol) {
             auto &params = get<unique_ptr<WorkspaceSymbolParams>>(rawParams);
             typecheckerCoord.syncRun(
-                [&](auto &tc) -> void { config->output->write(handleWorkspaceSymbols(tc, id, *params)); });
+                [&](auto &tc) -> void { config->output->write(handleWorkspaceSymbols(tc, id, *params)); }, true);
         } else if (method == LSPMethod::TextDocumentDefinition) {
             auto &params = get<unique_ptr<TextDocumentPositionParams>>(rawParams);
             typecheckerCoord.syncRun(
-                [&](auto &tc) -> void { config->output->write(handleTextDocumentDefinition(tc, id, *params)); });
+                [&](auto &tc) -> void { config->output->write(handleTextDocumentDefinition(tc, id, *params)); }, true);
         } else if (method == LSPMethod::TextDocumentTypeDefinition) {
             auto &params = get<unique_ptr<TextDocumentPositionParams>>(rawParams);
             typecheckerCoord.syncRun(
-                [&](auto &tc) -> void { config->output->write(handleTextDocumentTypeDefinition(tc, id, *params)); });
+                [&](auto &tc) -> void { config->output->write(handleTextDocumentTypeDefinition(tc, id, *params)); },
+                true);
         } else if (method == LSPMethod::TextDocumentHover) {
             auto &params = get<unique_ptr<TextDocumentPositionParams>>(rawParams);
             typecheckerCoord.syncRun(
-                [&](auto &tc) -> void { config->output->write(handleTextDocumentHover(tc, id, *params)); });
+                [&](auto &tc) -> void { config->output->write(handleTextDocumentHover(tc, id, *params)); }, true);
         } else if (method == LSPMethod::TextDocumentCompletion) {
             auto &params = get<unique_ptr<CompletionParams>>(rawParams);
             typecheckerCoord.syncRun(
-                [&](auto &tc) -> void { config->output->write(handleTextDocumentCompletion(tc, id, *params)); });
+                [&](auto &tc) -> void { config->output->write(handleTextDocumentCompletion(tc, id, *params)); }, true);
         } else if (method == LSPMethod::TextDocumentCodeAction) {
             auto &params = get<unique_ptr<CodeActionParams>>(rawParams);
             typecheckerCoord.syncRun(
-                [&](auto &tc) -> void { config->output->write(handleTextDocumentCodeAction(tc, id, *params)); });
+                [&](auto &tc) -> void { config->output->write(handleTextDocumentCodeAction(tc, id, *params)); }, true);
         } else if (method == LSPMethod::TextDocumentSignatureHelp) {
             auto &params = get<unique_ptr<TextDocumentPositionParams>>(rawParams);
             typecheckerCoord.syncRun(
-                [&](auto &tc) -> void { config->output->write(handleTextSignatureHelp(tc, id, *params)); });
+                [&](auto &tc) -> void { config->output->write(handleTextSignatureHelp(tc, id, *params)); }, true);
         } else if (method == LSPMethod::TextDocumentReferences) {
             auto &params = get<unique_ptr<ReferenceParams>>(rawParams);
+            // Do *not* preempt the slow path for reference requests. They really need to use all cores for performance.
+            // TODO: Fix so this uses WorkerPool. Currently, it does not because I've disabled them for fast path.
             typecheckerCoord.syncRun(
-                [&](auto &tc) -> void { config->output->write(handleTextDocumentReferences(tc, id, *params)); });
+                [&](auto &tc) -> void { config->output->write(handleTextDocumentReferences(tc, id, *params)); }, false);
         } else if (method == LSPMethod::SorbetReadFile) {
             auto &params = get<unique_ptr<TextDocumentIdentifier>>(rawParams);
-            typecheckerCoord.syncRun([&](auto &tc) -> void {
-                auto response = make_unique<ResponseMessage>("2.0", id, method);
-                auto fref = config->uri2FileRef(tc.state(), params->uri);
-                if (fref.exists()) {
-                    response->result =
-                        make_unique<TextDocumentItem>(params->uri, "ruby", 0, string(fref.data(tc.state()).source()));
-                } else {
-                    response->error = make_unique<ResponseError>(
-                        (int)LSPErrorCodes::InvalidParams, fmt::format("Did not find file at uri {} in {}", params->uri,
-                                                                       convertLSPMethodToString(method)));
-                }
-                config->output->write(move(response));
-            });
+            typecheckerCoord.syncRun(
+                [&](auto &tc) -> void {
+                    auto response = make_unique<ResponseMessage>("2.0", id, method);
+                    auto fref = config->uri2FileRef(tc.state(), params->uri);
+                    if (fref.exists()) {
+                        response->result = make_unique<TextDocumentItem>(params->uri, "ruby", 0,
+                                                                         string(fref.data(tc.state()).source()));
+                    } else {
+                        response->error =
+                            make_unique<ResponseError>((int)LSPErrorCodes::InvalidParams,
+                                                       fmt::format("Did not find file at uri {} in {}", params->uri,
+                                                                   convertLSPMethodToString(method)));
+                    }
+                    config->output->write(move(response));
+                },
+                true);
         } else if (method == LSPMethod::Shutdown) {
             prodCategoryCounterInc("lsp.messages.processed", "shutdown");
             auto response = make_unique<ResponseMessage>("2.0", id, method);
@@ -205,6 +234,15 @@ void LSPLoop::processRequestInternal(LSPMessage &msg) {
             auto response = make_unique<ResponseMessage>("2.0", id, method);
             response->error = make_unique<ResponseError>(params->code, params->message);
             config->output->write(move(response));
+        } else if (method == LSPMethod::SorbetFence) {
+            // Non-preempting sync run. When it runs, all prior messages have finished processing.
+            typecheckerCoord.syncRun(
+                [&](auto &tc) -> void {
+                    // Inform client that all messages have finished processing.
+                    auto response = make_unique<ResponseMessage>("2.0", id, method);
+                    config->output->write(move(response));
+                },
+                false);
         } else {
             auto response = make_unique<ResponseMessage>("2.0", id, method);
             // Method parsed, but isn't a request. Use SorbetError for `requestMethod`, as `method` isn't valid for a

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -34,7 +34,7 @@ auto workers = WorkerPool::create(0, *logger);
 
 shared_ptr<LSPConfiguration> makeConfig(const options::Options &opts = nullOpts, bool enableShowOpNotifs = false,
                                         bool initialize = true) {
-    auto config = make_shared<LSPConfiguration>(opts, make_shared<LSPOutputToVector>(), *workers, logger, true, false);
+    auto config = make_shared<LSPConfiguration>(opts, make_shared<LSPOutputToVector>(), logger, true, false);
     InitializeParams initParams("", "", make_unique<ClientCapabilities>());
     initParams.initializationOptions = make_unique<SorbetInitializationOptions>();
     initParams.initializationOptions.value()->supportsOperationNotifications = enableShowOpNotifs;

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -814,10 +814,10 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
 
     auto DidChangeTextDocumentParams =
         makeObject("DidChangeTextDocumentParams",
-                   {
-                       makeField("textDocument", VersionedTextDocumentIdentifier),
-                       makeField("contentChanges", makeArray(TextDocumentContentChangeEvent)),
-                   },
+                   {makeField("textDocument", VersionedTextDocumentIdentifier),
+                    makeField("contentChanges", makeArray(TextDocumentContentChangeEvent)),
+                    makeField("sorbetTestingExpectedPreemptions", makeOptional(JSONInt)),
+                    makeField("sorbetTestingExpectedCancellation", makeOptional(JSONInt))},
                    classTypes);
 
     auto TextDocumentChangeRegistrationOptions =
@@ -1279,11 +1279,14 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                        "LSPFileUpdates updates;",
                    });
 
+    auto SorbetTypecheckRunStatus =
+        makeIntEnum("SorbetTypecheckRunStatus", {{"started", 1}, {"ended", 2}, {"canceled", 3}}, enumTypes);
+
     auto SorbetTypecheckRunInfo = makeObject("SorbetTypecheckRunInfo",
                                              {
-                                                 makeField("tookFastPath", JSONBool),
+                                                 makeField("status", SorbetTypecheckRunStatus),
+                                                 makeField("isFastPath", JSONBool),
                                                  makeField("filesTypechecked", makeArray(JSONString)),
-                                                 makeField("canceled", JSONBool),
                                              },
                                              classTypes);
 

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -1283,6 +1283,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                              {
                                                  makeField("tookFastPath", JSONBool),
                                                  makeField("filesTypechecked", makeArray(JSONString)),
+                                                 makeField("canceled", JSONBool),
                                              },
                                              classTypes);
 
@@ -1339,6 +1340,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                                 {"textDocument/codeAction", CodeActionParams},
                                                 {"workspace/symbol", WorkspaceSymbolParams},
                                                 {"sorbet/error", SorbetErrorParams},
+                                                {"sorbet/fence", makeOptional(JSONNull)},
                                                 {"sorbet/readFile", TextDocumentIdentifier},
                                             });
     auto RequestMessage =
@@ -1376,6 +1378,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
             // {"textDocument/codeAction", makeVariant({JSONNull, makeArray(CodeAction), makeArray(Command)})},
             {"workspace/symbol", makeVariant({JSONNull, makeArray(SymbolInformation)})},
             {"sorbet/error", SorbetErrorParams},
+            {"sorbet/fence", makeOptional(JSONNull)},
             {"sorbet/readFile", TextDocumentItem},
         });
     // N.B.: ResponseMessage.params must be optional, as it is not present when an error occurs.

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -80,8 +80,8 @@ LSPWrapper::LSPWrapper(unique_ptr<core::GlobalState> gs, shared_ptr<options::Opt
                        shared_ptr<spd::logger> typeErrorsConsole, bool disableFastPath)
     : logger(logger), workers(WorkerPool::create(opts->threads, *logger)), stderrColorSink(move(stderrColorSink)),
       typeErrorsConsole(move(typeErrorsConsole)), output(make_shared<LSPOutputToVector>()),
-      config_(make_shared<LSPConfiguration>(*opts, output, *workers, move(logger), true, disableFastPath)),
-      lspLoop(make_shared<LSPLoop>(std::move(gs), config_)), opts(move(opts)) {}
+      config_(make_shared<LSPConfiguration>(*opts, output, move(logger), true, disableFastPath)),
+      lspLoop(make_shared<LSPLoop>(std::move(gs), config_, *workers)), opts(move(opts)) {}
 
 SingleThreadedLSPWrapper::SingleThreadedLSPWrapper(unique_ptr<core::GlobalState> gs, shared_ptr<options::Options> opts,
                                                    shared_ptr<spd::logger> logger,

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -926,7 +926,8 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
 }
 
 ast::ParsedFilesOrCancelled typecheck(unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> what,
-                                      const options::Options &opts, WorkerPool &workers, bool preemptible) {
+                                      const options::Options &opts, WorkerPool &workers, bool cancelable,
+                                      bool preemptible) {
     vector<ast::ParsedFile> typecheck_result;
 
     {
@@ -957,38 +958,39 @@ ast::ParsedFilesOrCancelled typecheck(unique_ptr<core::GlobalState> &gs, vector<
 
         {
             ProgressIndicator cfgInferProgress(opts.showProgress, "CFG+Inference", what.size());
-            workers.multiplexJob(
-                "typecheck", [ctx, &opts, &typecheckMutex = gs->typecheckMutex, fileq, resultq, preemptible]() {
-                    typecheck_thread_result threadResult;
-                    ast::ParsedFile job;
-                    int processedByThread = 0;
-                    {
-                        for (auto result = fileq->try_pop(job); !result.done() && !ctx.state.wasTypecheckingCanceled();
-                             result = fileq->try_pop(job)) {
-                            unique_ptr<absl::ReaderMutexLock> lock;
-                            if (preemptible) {
-                                // Acquire a reader lock here. Parks the thread if the typechecker thread is trying to
-                                // grab the lock to preempt typechecking.
-                                lock = make_unique<absl::ReaderMutexLock>(typecheckMutex.get());
-                            }
-                            if (result.gotItem()) {
-                                processedByThread++;
-                                core::FileRef file = job.file;
-                                try {
-                                    threadResult.trees.emplace_back(typecheckOne(ctx, move(job), opts));
-                                } catch (SorbetException &) {
-                                    Exception::failInFuzzer();
-                                    ctx.state.tracer().error("Exception typing file: {} (backtrace is above)",
-                                                             file.data(ctx).path());
-                                }
+            workers.multiplexJob("typecheck", [ctx, &opts, &typecheckMutex = gs->typecheckMutex, fileq, resultq,
+                                               cancelable, preemptible]() {
+                typecheck_thread_result threadResult;
+                ast::ParsedFile job;
+                int processedByThread = 0;
+                {
+                    for (auto result = fileq->try_pop(job);
+                         !result.done() && (!cancelable || !ctx.state.wasTypecheckingCanceled());
+                         result = fileq->try_pop(job)) {
+                        unique_ptr<absl::ReaderMutexLock> lock;
+                        if (preemptible) {
+                            // Acquire a reader lock here. Parks the thread if the typechecker thread is trying to
+                            // grab the lock to preempt typechecking.
+                            lock = make_unique<absl::ReaderMutexLock>(typecheckMutex.get());
+                        }
+                        if (result.gotItem()) {
+                            processedByThread++;
+                            core::FileRef file = job.file;
+                            try {
+                                threadResult.trees.emplace_back(typecheckOne(ctx, move(job), opts));
+                            } catch (SorbetException &) {
+                                Exception::failInFuzzer();
+                                ctx.state.tracer().error("Exception typing file: {} (backtrace is above)",
+                                                         file.data(ctx).path());
                             }
                         }
                     }
-                    if (processedByThread > 0) {
-                        threadResult.counters = getAndClearThreadCounters();
-                        resultq->push(move(threadResult), processedByThread);
-                    }
-                });
+                }
+                if (processedByThread > 0) {
+                    threadResult.counters = getAndClearThreadCounters();
+                    resultq->push(move(threadResult), processedByThread);
+                }
+            });
 
             typecheck_thread_result threadResult;
             {
@@ -1002,7 +1004,7 @@ ast::ParsedFilesOrCancelled typecheck(unique_ptr<core::GlobalState> &gs, vector<
                     }
                     cfgInferProgress.reportProgress(fileq->doneEstimate());
                     gs->errorQueue->flushErrors();
-                    if (ctx.state.wasTypecheckingCanceled()) {
+                    if (cancelable && ctx.state.wasTypecheckingCanceled()) {
                         return ast::ParsedFilesOrCancelled();
                     }
 

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -32,7 +32,8 @@ std::vector<ast::ParsedFile> name(core::GlobalState &gs, std::vector<ast::Parsed
                                   const options::Options &opts, bool skipConfigatron = false);
 
 ast::ParsedFilesOrCancelled typecheck(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what,
-                                      const options::Options &opts, WorkerPool &workers, bool preemptible = false);
+                                      const options::Options &opts, WorkerPool &workers, bool cancelable = false,
+                                      bool preemptible = false);
 
 ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Options &opts);
 

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -32,11 +32,11 @@ std::vector<ast::ParsedFile> name(core::GlobalState &gs, std::vector<ast::Parsed
                                   const options::Options &opts, bool skipConfigatron = false);
 
 ast::ParsedFilesOrCancelled typecheck(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what,
-                                      const options::Options &opts, WorkerPool &workers);
+                                      const options::Options &opts, WorkerPool &workers, bool preemptible = false);
 
 ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Options &opts);
 
-core::FileHash computeFileHash(std::shared_ptr<core::File> forWhat, spdlog::logger &logger);
+core::FileHash computeFileHash(u4 version, std::shared_ptr<core::File> forWhat, spdlog::logger &logger);
 
 core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::FileRef file,
                                     const options::Options &opts);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -459,7 +459,7 @@ int realmain(int argc, char *argv[]) {
                       "it will enable outputing the LSP session to stderr(`Write: ` and `Read: ` log lines)",
                       Version::full_version_string);
         auto output = make_shared<lsp::LSPStdout>(logger);
-        lsp::LSPLoop loop(move(gs), make_shared<lsp::LSPConfiguration>(opts, output, *workers, logger));
+        lsp::LSPLoop loop(move(gs), make_shared<lsp::LSPConfiguration>(opts, output, logger), *workers);
         gs = loop.runLSP(make_shared<lsp::LSPFDInput>(logger, STDIN_FILENO)).value_or(nullptr);
 #endif
     } else {

--- a/test/helpers/lsp.h
+++ b/test/helpers/lsp.h
@@ -28,7 +28,9 @@ std::unique_ptr<LSPMessage> makeWorkspaceSymbolRequest(int id, std::string_view 
 std::unique_ptr<LSPMessage> makeOpen(std::string_view uri, std::string_view contents, int version);
 
 /** Create an LSPMessage containing a textDocument/didChange notification. */
-std::unique_ptr<LSPMessage> makeChange(std::string_view uri, std::string_view contents, int version);
+std::unique_ptr<LSPMessage> makeChange(std::string_view uri, std::string_view contents, int version,
+                                       std::optional<bool> expectedCancelation = std::nullopt,
+                                       std::optional<int> expectedPreemptions = std::nullopt);
 
 /** Create an LSPMessage containing a textDocument/didClose notification. */
 std::unique_ptr<LSPMessage> makeClose(std::string_view uri);
@@ -48,7 +50,7 @@ void assertNotificationMessage(LSPMethod expectedMethod, const LSPMessage &respo
 
 /** Retrieves the PublishDiagnosticsParam from a publishDiagnostics message, if applicable. Non-fatal fails and returns
  * an empty optional if it cannot be found. */
-std::optional<PublishDiagnosticsParams *> getPublishDiagnosticParams(NotificationMessage &notifMsg);
+std::optional<const PublishDiagnosticsParams *> getPublishDiagnosticParams(const NotificationMessage &notifMsg);
 
 /** Use the LSPWrapper to make a textDocument/completion request.
  */

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -888,7 +888,7 @@ FastPathAssertion::FastPathAssertion(string_view filename, unique_ptr<Range> &ra
 void FastPathAssertion::check(SorbetTypecheckRunInfo &info, string_view folder, int updateVersion,
                               string_view errorPrefix) {
     string updateFile = fmt::format("{}.{}.rbupdate", filename.substr(0, -3), updateVersion);
-    if (!info.tookFastPath) {
+    if (!info.isFastPath) {
         ADD_FAILURE_AT(updateFile.c_str(), assertionLine)
             << errorPrefix << "Expected file update to take fast path, but it took the slow path.";
     }

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -79,8 +79,6 @@ protected:
 
     void sendAsync(const LSPMessage &message);
 
-    std::unique_ptr<LSPMessage> readAsync();
-
     void assertDiagnostics(std::vector<std::unique_ptr<LSPMessage>> messages, std::vector<ExpectedDiagnostic> expected);
 
     std::string readFile(std::string_view uri);
@@ -94,6 +92,9 @@ protected:
      */
     void updateDiagnostics(const std::vector<std::unique_ptr<LSPMessage>> &messages);
     void updateDiagnostics(const LSPMessage &message);
+
+public:
+    std::unique_ptr<LSPMessage> readAsync();
 };
 
 } // namespace sorbet::test::lsp

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -43,13 +43,17 @@ protected:
     /** Get an absolute file URI for the given relative file path. */
     std::string getUri(std::string_view filePath);
 
-    std::vector<std::unique_ptr<LSPMessage>> initializeLSP();
+    std::vector<std::unique_ptr<LSPMessage>>
+    initializeLSP(bool supportsMarkdown = true,
+                  std::optional<std::unique_ptr<SorbetInitializationOptions>> opts = std::nullopt);
 
     std::unique_ptr<LSPMessage> openFile(std::string_view path, std::string_view contents);
 
     std::unique_ptr<LSPMessage> closeFile(std::string_view path);
 
-    std::unique_ptr<LSPMessage> changeFile(std::string_view path, std::string_view newContents, int version);
+    std::unique_ptr<LSPMessage> changeFile(std::string_view path, std::string_view newContents, int version,
+                                           std::optional<bool> expectedCancelation = std::nullopt,
+                                           std::optional<int> expectedPreemptions = std::nullopt);
 
     std::unique_ptr<LSPMessage> documentSymbol(std::string_view path);
 
@@ -71,6 +75,12 @@ protected:
 
     std::vector<std::unique_ptr<LSPMessage>> send(std::vector<std::unique_ptr<LSPMessage>> messages);
 
+    void sendAsyncRaw(const std::string &json);
+
+    void sendAsync(const LSPMessage &message);
+
+    std::unique_ptr<LSPMessage> readAsync();
+
     void assertDiagnostics(std::vector<std::unique_ptr<LSPMessage>> messages, std::vector<ExpectedDiagnostic> expected);
 
     std::string readFile(std::string_view uri);
@@ -83,6 +93,7 @@ protected:
      * invokes getLSPResponsesFor on lspWrapper, it should update diagnostics with this function.
      */
     void updateDiagnostics(const std::vector<std::unique_ptr<LSPMessage>> &messages);
+    void updateDiagnostics(const LSPMessage &message);
 };
 
 } // namespace sorbet::test::lsp

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -9,6 +9,29 @@ namespace sorbet::test::lsp {
 using namespace std;
 using namespace sorbet::realmain::lsp;
 
+namespace {
+void assertTypecheckRunInfo(const unique_ptr<LSPMessage> &msg, SorbetTypecheckRunStatus status, bool fastPath) {
+    ASSERT_NE(nullptr, msg);
+    ASSERT_EQ(true, msg->isNotification());
+    ASSERT_EQ(LSPMethod::SorbetTypecheckRunInfo, msg->method());
+
+    auto &info = get<unique_ptr<SorbetTypecheckRunInfo>>(msg->asNotification().params);
+    ASSERT_EQ(status, info->status);
+    ASSERT_EQ(fastPath, info->isFastPath);
+}
+
+/**void assertTypecheckRunInfo(const vector<unique_ptr<LSPMessage>> messages, SorbetTypecheckRunStatus status,
+                            bool tookFastPath) {
+    for (const auto &msg : messages) {
+        if (msg->isNotification() && msg->method() == LSPMethod::SorbetTypecheckRunInfo) {
+            assertTypecheckRunInfo(msg, status, tookFastPath);
+            return;
+        }
+    }
+    ADD_FAILURE() << "Expected a TypecheckInfo response, but received none!";
+}*/
+} // namespace
+
 TEST_P(ProtocolTest, MultithreadedWrapperWorks) {
     assertDiagnostics(initializeLSP(), {});
     vector<unique_ptr<LSPMessage>> requests;
@@ -17,6 +40,43 @@ TEST_P(ProtocolTest, MultithreadedWrapperWorks) {
     requests.push_back(
         changeFile("yolo1.rb", "# typed: true\nclass Foo1\n  def branch\n    1 + \"bear\"\n  end\nend\n", 3));
     assertDiagnostics(send(move(requests)), {{"yolo1.rb", 3, "bear"}});
+}
+
+TEST_P(ProtocolTest, CancelingSlowPathUpdatesDiagnostics) {
+    auto opts = make_unique<SorbetInitializationOptions>();
+    opts->enableTypecheckInfo = true;
+    initializeLSP(true, move(opts));
+    // New file; should take slow path.
+    send(*openFile("foo.rb", "#typed: true\nclass Foo\nend"));
+
+    // Send an update that should take slow path, and that will wait for a preemption to happen.
+    // The following happens asynchronously.
+    sendAsync(*changeFile("foo.rb", "#typed: true\nclass Foo\ndef me\nend", 2, true /* expected cancelation */));
+
+    // Wait for update to start.
+    ASSERT_NO_FATAL_FAILURE(assertTypecheckRunInfo(readAsync(), SorbetTypecheckRunStatus::started, false));
+
+    // Send an update that should take fast path (corrects syntax error).
+    sendAsync(*changeFile("foo.rb", "#typed: true\nclass Foo\nend", 3));
+
+    // Ensure that cancelation occurs.
+    ASSERT_NO_FATAL_FAILURE(assertTypecheckRunInfo(readAsync(), SorbetTypecheckRunStatus::canceled, false));
+
+    // Fast path should begin.
+    ASSERT_NO_FATAL_FAILURE(assertTypecheckRunInfo(readAsync(), SorbetTypecheckRunStatus::started, true));
+
+    // Keep reading until fast path ends.
+    vector<unique_ptr<LSPMessage>> diagnostics;
+    while (true) {
+        auto msg = readAsync();
+        ASSERT_NE(nullptr, msg);
+        if (msg->isNotification() && msg->method() == LSPMethod::SorbetTypecheckRunInfo) {
+            ASSERT_NO_FATAL_FAILURE(assertTypecheckRunInfo(msg, SorbetTypecheckRunStatus::ended, true));
+            break;
+        }
+        diagnostics.push_back(move(msg));
+    }
+    assertDiagnostics(move(diagnostics), {});
 }
 
 // Run these tests in multi-threaded mode.

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -20,16 +20,24 @@ void assertTypecheckRunInfo(const unique_ptr<LSPMessage> &msg, SorbetTypecheckRu
     ASSERT_EQ(fastPath, info->isFastPath);
 }
 
-/**void assertTypecheckRunInfo(const vector<unique_ptr<LSPMessage>> messages, SorbetTypecheckRunStatus status,
-                            bool tookFastPath) {
-    for (const auto &msg : messages) {
-        if (msg->isNotification() && msg->method() == LSPMethod::SorbetTypecheckRunInfo) {
-            assertTypecheckRunInfo(msg, status, tookFastPath);
-            return;
-        }
+void getMessagesDuringTypecheck(ProtocolTest &test, vector<unique_ptr<LSPMessage>> &diagnostics, bool fastPath,
+                                SorbetTypecheckRunStatus finalStatus = SorbetTypecheckRunStatus::ended,
+                                bool typecheckRunAlreadyStarted = false) {
+    if (!typecheckRunAlreadyStarted) {
+        ASSERT_NO_FATAL_FAILURE(assertTypecheckRunInfo(test.readAsync(), SorbetTypecheckRunStatus::started, fastPath));
     }
-    ADD_FAILURE() << "Expected a TypecheckInfo response, but received none!";
-}*/
+
+    // Keep reading until fast path ends.
+    while (true) {
+        auto msg = test.readAsync();
+        ASSERT_NE(nullptr, msg);
+        if (msg->isNotification() && msg->method() == LSPMethod::SorbetTypecheckRunInfo) {
+            ASSERT_NO_FATAL_FAILURE(assertTypecheckRunInfo(msg, finalStatus, fastPath));
+            break;
+        }
+        diagnostics.push_back(move(msg));
+    }
+}
 } // namespace
 
 TEST_P(ProtocolTest, MultithreadedWrapperWorks) {
@@ -42,7 +50,7 @@ TEST_P(ProtocolTest, MultithreadedWrapperWorks) {
     assertDiagnostics(send(move(requests)), {{"yolo1.rb", 3, "bear"}});
 }
 
-TEST_P(ProtocolTest, CancelingSlowPathUpdatesDiagnostics) {
+TEST_P(ProtocolTest, CancelingSlowPathForFastPathUpdatesDiagnostics) {
     auto opts = make_unique<SorbetInitializationOptions>();
     opts->enableTypecheckInfo = true;
     initializeLSP(true, move(opts));
@@ -67,24 +75,160 @@ TEST_P(ProtocolTest, CancelingSlowPathUpdatesDiagnostics) {
     // Ensure that cancelation occurs.
     ASSERT_NO_FATAL_FAILURE(assertTypecheckRunInfo(readAsync(), SorbetTypecheckRunStatus::canceled, false));
 
-    // Fast path should begin.
-    ASSERT_NO_FATAL_FAILURE(assertTypecheckRunInfo(readAsync(), SorbetTypecheckRunStatus::started, true));
-
-    // Keep reading until fast path ends.
+    // Should receive a diagnostic to clear earlier error.
     vector<unique_ptr<LSPMessage>> diagnostics;
-    while (true) {
-        auto msg = readAsync();
-        ASSERT_NE(nullptr, msg);
-        if (msg->isNotification() && msg->method() == LSPMethod::SorbetTypecheckRunInfo) {
-            ASSERT_NO_FATAL_FAILURE(assertTypecheckRunInfo(msg, SorbetTypecheckRunStatus::ended, true));
-            break;
-        }
-        diagnostics.push_back(move(msg));
-    }
-
-    // Fast path should reset errors.
+    ASSERT_NO_FATAL_FAILURE(getMessagesDuringTypecheck(*this, diagnostics, true));
     assertDiagnostics(move(diagnostics), {});
 }
+
+TEST_P(ProtocolTest, CancelingSlowPathForSlowPathUpdatesDiagnostics) {
+    auto opts = make_unique<SorbetInitializationOptions>();
+    opts->enableTypecheckInfo = true;
+    initializeLSP(true, move(opts));
+    // New file; should take slow path. It will have an error.
+    send(*openFile("foo.rb",
+                   "#typed: true\nclass Foo\nextend T::Sig\nsig {returns(String)}\ndef hello\n  10\nend\nend"));
+    assertDiagnostics({}, {{"foo.rb", 5, "Returning value that does not conform to method result type"}});
+
+    // Send an update that should take slow path, and that will wait for a preemption to happen.
+    // The following happens asynchronously.
+    sendAsync(*changeFile(
+        "foo.rb", "#typed: true\nclass Foo\nextend T::Sig\nsig {returns(String)}\ndef hello\n  10\nend\ndef me\nend", 2,
+        true /* expected cancelation */));
+
+    // Wait for update to start.
+    ASSERT_NO_FATAL_FAILURE(assertTypecheckRunInfo(readAsync(), SorbetTypecheckRunStatus::started, false));
+
+    // Send an update that should take slow path.
+    sendAsync(*changeFile("foo.rb",
+                          "#typed: true\nclass Foo\nextend T::Sig\nsig {returns(String)}\ndef hello\n  '10'\nend\ndef "
+                          "new_method\nend\nend",
+                          3));
+
+    // Ensure that cancelation occurs.
+    ASSERT_NO_FATAL_FAILURE(assertTypecheckRunInfo(readAsync(), SorbetTypecheckRunStatus::canceled, false));
+
+    // Should receive a diagnostic to clear earlier error.
+    vector<unique_ptr<LSPMessage>> diagnostics;
+    ASSERT_NO_FATAL_FAILURE(getMessagesDuringTypecheck(*this, diagnostics, false));
+    assertDiagnostics(move(diagnostics), {});
+}
+
+TEST_P(ProtocolTest, CanPreemptSlowPathWithFastPath) {
+    auto opts = make_unique<SorbetInitializationOptions>();
+    opts->enableTypecheckInfo = true;
+    initializeLSP(true, move(opts));
+    // New file; should take slow path. It will not have an error.
+    send(*openFile("foo.rb",
+                   "#typed: true\nclass Foo\nextend T::Sig\nsig {returns(String)}\ndef hello\n  '10'\nend\nend"));
+    assertDiagnostics({}, {});
+
+    // Take slow path, but expect 1 preemption. Introduces a typechecking error in return value of `hello`.
+    sendAsync(*changeFile(
+        "foo.rb",
+        "#typed: true\nclass Foo\nextend T::Sig\nsig {returns(String)}\ndef hello\n  10\nend\ndef hello2\nend\nend", 2,
+        0 /* expected cancelation */, 1 /* Expected preemptions */));
+
+    // Wait for update to start.
+    ASSERT_NO_FATAL_FAILURE(assertTypecheckRunInfo(readAsync(), SorbetTypecheckRunStatus::started, false));
+
+    // Fast path: Introduces new error to file. Ensures that files that are typechecked during preemption trump
+    // typechecker failures during slow path.
+    sendAsync(*changeFile("foo.rb",
+                          "#typed: true\nclass Foo\nextend T::Sig\nsig {returns(String)}\ndef hello\n  hello3\n  "
+                          "10\nend\ndef hello2\nend\nend",
+                          2, 0 /* expected cancelation */, 1 /* Expected preemptions */));
+
+    vector<unique_ptr<LSPMessage>> diagnostics;
+    ASSERT_NO_FATAL_FAILURE(getMessagesDuringTypecheck(*this, diagnostics, true));
+    ASSERT_NO_FATAL_FAILURE(getMessagesDuringTypecheck(*this, diagnostics, false, SorbetTypecheckRunStatus::ended,
+                                                       true /* typecheck run already started */));
+
+    assertDiagnostics(move(diagnostics),
+                      {{"foo.rb", 5, "Method `hello3` does not exist"},
+                       {"foo.rb", 6, "Returning value that does not conform to method result type"}});
+}
+
+TEST_P(ProtocolTest, CanPreemptSlowPathWithFastPathThatFixesSecondOrderErrors) {
+    auto opts = make_unique<SorbetInitializationOptions>();
+    opts->enableTypecheckInfo = true;
+    initializeLSP(true, move(opts));
+    // New files; should take slow path. It will not have an error.
+    vector<unique_ptr<LSPMessage>> messages;
+    messages.push_back(openFile(
+        "foo.rb", "#typed: true\nclass Foo\nextend T::Sig\nsig {returns(String)}\ndef hello\n  '10'\nend\nend"));
+    messages.push_back(openFile(
+        "bar.rb",
+        "#typed: true\nclass Bar\nextend T::Sig\nsig {returns(String)}\ndef hello\n  Foo.new.hello\nend\nend"));
+    send(move(messages));
+    assertDiagnostics({}, {});
+
+    // Take slow path, but expect 1 preemption. Introduces a typechecking error in return value of `hello`, and change
+    // return type of `hello` to break `bar.rb`.
+    sendAsync(*changeFile(
+        "foo.rb",
+        "#typed: true\nclass Foo\nextend T::Sig\nsig {returns(Integer)}\ndef hello\n  '10'\nend\ndef hello2\nend\nend",
+        2, 0 /* expected cancelation */, 1 /* Expected preemptions */));
+
+    // Wait for update to start.
+    ASSERT_NO_FATAL_FAILURE(assertTypecheckRunInfo(readAsync(), SorbetTypecheckRunStatus::started, false));
+
+    // Fast path: Fix both errors, introduce new error.
+    sendAsync(*changeFile("foo.rb",
+                          "#typed: true\nclass Foo\nextend T::Sig\nsig {returns(String)}\ndef hello\n  hello3\n  "
+                          "10\nend\ndef hello2\nend\nend",
+                          2, 0 /* expected cancelation */, 1 /* Expected preemptions */));
+
+    vector<unique_ptr<LSPMessage>> diagnostics;
+    ASSERT_NO_FATAL_FAILURE(getMessagesDuringTypecheck(*this, diagnostics, true));
+    ASSERT_NO_FATAL_FAILURE(getMessagesDuringTypecheck(*this, diagnostics, false, SorbetTypecheckRunStatus::ended,
+                                                       true /* typecheck run already started */));
+
+    assertDiagnostics(move(diagnostics),
+                      {{"foo.rb", 5, "Method `hello3` does not exist"},
+                       {"foo.rb", 6, "Returning value that does not conform to method result type"}});
+}
+
+// Tests:
+
+// Preemption typecheck
+// - Slow path modified a file that causes an error in two files.
+// - Fast path preempts and fixes both errors (i.e. fix is in file not explicitly changed)
+// Final state: Both errors are resolved.
+
+// Symbols exist during preemption
+// - Slow path adds a new file with new symbols.
+// - Go to definition runs on new file and should work.
+// - Bonus: Making 3 go-to-definition requests -- all three preempt despite queueing.
+
+// Preemption followed by cancelation.
+// - Slow path modified a file that causes an error.
+// - Fast path preempts and adds a new error to same file (possible?).
+// - Slow path gets canceled for a fast path with a third error.
+// Final state: Errors from fast path are the final ones reported.
+
+// Preemption clear errors in unedited files.
+// - Slow path modifies `foo.rb`, introduces error in `bar.rb`.
+// - Preempted fast path modifies `fez.rb`, causes `bar.rb` to be re-typechecked with two errors.
+// - Fast path cancels slow path that fixes `foo.rb` and undoes change to `fez.rb` which fixes one error in `bar.rb`.
+// ---> Important that `bar.rb` gets retypechecked not because of `fez` but because it had error before.
+
+// Preemption re-introduces error in unedited file.
+// - Init: `bar.rb` has error due to `fez.rb`. `foo.rb` has a single method in it.
+// - Slow path modifies `foo.rb`.
+// - Fast path modifies `fez.rb`, fixes error in `bar.rb`.
+// - Fast path cancels slow path that re-introduces error in `fez.rb`.
+// ---> Important that `bar.rb` gets retypechecked not because of `fez` but because it had error before.
+
+// Unit tests?
+
+// Cancelation does not affect fast path.
+// Cancelation edits can merge.
+// Cannot preempt resolver.
+
+// Later:
+
+// - Find all references stalls pipeline.
 
 // TODO: Could we take fast path but the hashes on a new file disagree?
 

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -1046,14 +1046,17 @@ TEST_P(LSPTest, All) {
             for (auto &r : responses) {
                 if (r->isNotification()) {
                     if (r->method() == LSPMethod::SorbetTypecheckRunInfo) {
-                        foundTypecheckRunInfo = true;
                         auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(r->asNotification().params);
-                        if (assertSlowPath.value_or(false)) {
-                            EXPECT_EQ(params->tookFastPath, false)
-                                << errorPrefix << "Expected Sorbet to take slow path, but it took the fast path.";
-                        }
-                        if (assertFastPath.has_value()) {
-                            (*assertFastPath)->check(*params, test.folder, version, errorPrefix);
+                        // Ignore started messages.
+                        if (params->status == SorbetTypecheckRunStatus::ended) {
+                            foundTypecheckRunInfo = true;
+                            if (assertSlowPath.value_or(false)) {
+                                EXPECT_EQ(params->tookFastPath, false)
+                                    << errorPrefix << "Expected Sorbet to take slow path, but it took the fast path.";
+                            }
+                            if (assertFastPath.has_value()) {
+                                (*assertFastPath)->check(*params, test.folder, version, errorPrefix);
+                            }
                         }
                     } else if (r->method() != LSPMethod::TextDocumentPublishDiagnostics) {
                         ADD_FAILURE() << errorPrefix


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

WIP: Preemptible slow path.

Contains changes that lets Sorbet process most LSP requests concurrently with slow path typechecking.

It currently crashes regularly, and I need to add testing infrastructure to test the changes.

Here's a sketch of the architecture:

* During the typechecking phase of a slow path, worker threads grab a reader lock on a mutex while typechecking. They periodically re-grab it to allow preemption to occur. Pre-emption cannot occur in passes before typechecker (e.g. resolver) as they mutate global state (e.g. the symbol table).
* The thread coordinating the workers (typechecking thread) periodically checks if it has been preempted. If so, it grabs a writer lock on the same mutex, which succeeds once all worker threads give up their reader locks. Once that is done, it runs the registered preemption function, resets the registered preemption function, and gives up the lock to resume typechecking. There can only be one preemption function at a time.
* When the message processing thread registers a preemption function (e.g., to process `hover`),  it *blocks* until the function runs. There is a guarantee that the slow path runs the preemption function, so it is safe to block like this.
* Fast path typechecking can preempt slow path typechecking, so errors appear quickly in documents the user is actively editing.

There are a few unintuitive logical consequences of this design:

* If the message processing thread registers a pre-emption function before the slow path finishes resolving, then the pre-emption function will not run until after resolver finishes.
* The slow path cannot be canceled if there is an un-run pre-emption function and resolver has not finished. In other words, preemption prevents cancelation prior to the typecheck phase.
* WorkerPool cannot be used during preemption because it will cause a deadlock -- all workers are waiting to acquire a lock to finish the slow path. Thus, requests that are performance sensitive to this restriction (currently, this is just find all references) must wait for the slow path to complete.
* If a slow path typecheck is canceled, then we must rollback the state changes made during that slow path _and all fast path typechecks that preempted it_. As a corollary, we must re-typecheck all files that previously had errors, and reset the error lists in files that have new errors. This state rollback cannot be done at the same time as cancelation, as the message processing thread may concurrently be processing a request that relies on state from the canceled slow path (e.g., a hover request). Instead, it happens when the edit that caused the cancelation in the first place is finally typechecked.

TODO:

* Let find all references use multiple threads.
* ENFORCEs to prevent footguns (e.g. using workerpool during preemption).
* Add useful metrics and logging.
* Test suite and test runner.
* Documentation for the final architecture.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Should dramatically improve Sorbet responsiveness when it is retypechecking the codebase.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I'm working on automated tests now.