### PR TITLE
[lsp] Faster/better workspace/symbol matching.

### DIFF
--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -90,7 +90,6 @@ PartialMatch partialMatchSymbol(string_view symbol, string_view::const_iterator 
     auto symbolIter = symbol.begin();
     auto symbolEnd = symbol.end();
     auto queryIter = queryBegin;
-    auto matchEnd = queryBegin;
     // Consume leading namespacing punctuation, e.g. to make `::f` matchable
     // against `module Foo`.
     while (queryIter != queryEnd && canBeLeadingNamespaceSeparator(*queryIter)) {
@@ -99,6 +98,7 @@ PartialMatch partialMatchSymbol(string_view symbol, string_view::const_iterator 
     while (symbolIter != symbolEnd && canBeLeadingNamespaceSeparator(*symbolIter)) {
         symbolIter++;
     }
+    auto matchEnd = queryIter;
     char previousSymbolCh = 0;
     char symbolCh = 0;
     uint score = 1;
@@ -132,7 +132,7 @@ PartialMatch partialMatchSymbol(string_view symbol, string_view::const_iterator 
                     break;
                 } else if (!prefixOnly) {
                     // middle of word...can sometimes match, but steep penalty
-                    score = 5 * score + symbolCharsConsumed;
+                    score = 5 * (score + symbolCharsConsumed);
                     matchEnd = queryIter;
                     break;
                 }

--- a/test/testdata/lsp/workspace_symbols_boundaries.rb
+++ b/test/testdata/lsp/workspace_symbols_boundaries.rb
@@ -1,0 +1,42 @@
+# typed: true
+
+require 'minitest/autorun'
+require 'minitest/spec'
+
+module Scope
+  class CustomThingTest
+    describe 'foo.bar() with no args' do
+      it 'will baz the qux' do
+        # ^^^^^^^ symbol-search: "CustomThing describe bar it baz"
+        # ^^^^^^^ symbol-search: "f b b q"
+      end
+    end
+  end
+
+  module FooBar
+    def baz_qux
+      # ^^^^^^^ symbol-search: "f b b q"
+    end
+    class Baz
+      def qux
+        # ^^^ symbol-search: "f b b q"
+      end
+    end
+  end
+
+  module Fob
+    def baz_qux
+      # // Shouldn't match because b in "Fob" isn't word boundary
+    end
+    class Arby
+      def baz_qux
+        # // Also shouldn't match because b in "Arby" isn't word boundary
+      end
+    end
+    class AndBarAndBaz
+      def qux
+        # ^^^ symbol-search: "f b b q"
+      end
+    end
+  end
+end

--- a/test/testdata/lsp/workspace_symbols_minitest.rb
+++ b/test/testdata/lsp/workspace_symbols_minitest.rb
@@ -1,0 +1,49 @@
+# typed: true
+
+require 'minitest/autorun'
+require 'minitest/spec'
+
+module Searchable
+  #    ^^^^^^^^^^ symbol-search: "searchable"
+  class Searchable
+    #   ^^^^^^^^^^ symbol-search: "searchable"
+
+    def searchable
+      #   ^^^^^^^^^^ symbol-search: "searchable"
+      'searchable'
+    end
+
+    describe 'searchable' do
+      #       ^^^^^^^^^^ symbol-search: "searchable"
+
+      before do
+        @searchable = searchable
+      end
+  
+      it 'searchable' do
+        # ^^^^^^^^^^ symbol-search: "searchable"
+        searchable
+      end
+
+      it 'does have each letter enclosed, theoretically matching but really terrible' do
+        # // ^    ^  ^        ^   ^        ^             ^       ^      ^    ^
+        # // don't return for symbol-search: "searchable"
+      end
+    end
+
+    describe 'does have each letter enclosed, theoretically matching but really terrible' do
+      # //       ^    ^  ^        ^   ^        ^             ^       ^      ^    ^
+      # // don't return for symbol-search: "searchable"
+      it 'searchable' do
+        # ^^^^^^^^^^ symbol-search: "searchable"
+        # // but do return this one
+        searchable
+      end
+
+      it 'does have each letter enclosed, theoretically matching but really terrible' do
+        # // ^    ^  ^        ^   ^        ^             ^       ^      ^    ^
+        # // don't return for symbol-search: "searchable"
+      end
+    end
+  end
+end

--- a/test/testdata/lsp/workspace_symbols_minitest_scope.rb
+++ b/test/testdata/lsp/workspace_symbols_minitest_scope.rb
@@ -1,0 +1,23 @@
+# typed: true
+
+require 'minitest/autorun'
+require 'minitest/spec'
+
+module Outer
+  class InnerTest
+    describe 'foo with bar' do
+      it 'baz and qux' do
+        # ^^^^^^^^^^^ symbol-search: "Inner:desc foo:it baz"
+        # ^^^^^^^^^^^ symbol-search: "Inner:desc bar:it qux"
+      end
+    end
+    describe 'foo' do
+      describe 'nested bar' do
+        it 'baz and qux' do
+          # ^^^^^^^^^^^ symbol-search: "Inner:desc foo:it baz"
+          # ^^^^^^^^^^^ symbol-search: "Inner:desc bar:it qux"
+        end
+      end
+    end
+  end
+end

--- a/test/testdata/lsp/workspace_symbols_namespaces.rb
+++ b/test/testdata/lsp/workspace_symbols_namespaces.rb
@@ -1,0 +1,63 @@
+# typed: true
+
+
+module Scope1
+  class A
+    def foobar
+      # ^^^^^^ symbol-search: "foobar", rank=0
+    end
+  end
+end
+
+# // Don't penalize prefix matches
+module Scope2
+  module F
+    module O
+      module O
+        module Bar
+          #    ^^^ symbol-search: "foobar", rank=10
+        end
+        module B
+          module Ar
+            #    ^^ symbol-search: "foobar", rank=10
+          end
+          module A
+            module R
+              #    ^ symbol-search: "foobar", rank=10
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+# // Don't let greedy prefix matching score these matches poorly
+module Scope3
+  module Fo
+    module Foo
+      module Ba
+        module Bar
+          #    ^^^ symbol-search: "foobar", rank=10
+          def ar
+            # ^^ symbol-search: "foobar", rank=10
+          end
+          def bar
+            # ^^^ symbol-search: "foobar", rank=10
+          end
+          def obar
+            # ^^^^ symbol-search: "foobar", rank=10
+          end
+        end
+        def bar
+          # ^^^ symbol-search: "foobar", rank=10
+        end
+      end
+      module B
+        module Ar
+          #    ^^ symbol-search: "foobar", rank=10
+        end
+      end
+    end
+  end
+end

--- a/test/testdata/lsp/workspace_symbols_sparse.rb
+++ b/test/testdata/lsp/workspace_symbols_sparse.rb
@@ -1,93 +1,70 @@
 # typed: true
 
-def fbb
-  # ^^^ symbol-search: "fbb", rank=0
-end
+def fbb; end
+#   ^^^ symbol-search: "fbb", rank=0
 
-def fb_baz
-  # ^^^^^^ symbol-search: "fbb", rank=10
-end
+def fb_baz; end
+#   ^^^^^^ symbol-search: "fbb", rank=10
 
-def foo_bar_baz
-  # ^^^^^^^^^^^ symbol-search: "fbb", rank=20
-end
+def foo_bar_baz; end
+#   ^^^^^^^^^^^ symbol-search: "fbb", rank=20
 
-def other_foo_bar_baz
-  # ^^^^^^^^^^^^^^^^^ symbol-search: "fbb", rank=30
-end
+def other_foo_bar_baz; end
+#   ^^^^^^^^^^^^^^^^^ symbol-search: "fbb", rank=30
 
-def xxfxxbxxbxx(xxx)
-  # ^^^^^^^^^^^^^^^^ symbol-search: "fbb", rank=40
-end
+def xfxbxbx; end
+#   ^^^^^^^ symbol-search: "fbb", rank=40
 
-def fbnomatch
-end
+def fbnomatch; end
 
 class A
-  def fbb
-    # ^^^ symbol-search: "fbb", rank=0
-  end
+  def fbb; end
+  #   ^^^ symbol-search: "fbb", rank=0
 
-  def fb_baz
-    # ^^^^^^ symbol-search: "fbb", rank=10
-  end
+  def fb_baz; end
+  #   ^^^^^^ symbol-search: "fbb", rank=10
 
-  def foo_bar_baz
-    # ^^^^^^^^^^^ symbol-search: "fbb", rank=20
-  end
+  def foo_bar_baz; end
+  #   ^^^^^^^^^^^ symbol-search: "fbb", rank=20
 
-  def other_foo_bar_baz
-    # ^^^^^^^^^^^^^^^^^ symbol-search: "fbb", rank=30
-  end
+  def other_foo_bar_baz; end
+  #   ^^^^^^^^^^^^^^^^^ symbol-search: "fbb", rank=30
 
-  def xxfxxbxxbxx(xxx)
-    # ^^^^^^^^^^^^^^^^ symbol-search: "fbb", rank=40
-  end
+  def xfxbxbx; end
+  #   ^^^^^^^ symbol-search: "fbb", rank=40
 
-  def fbnomatch
-  end
+  def fbnomatch; end
 end
 
 module B
-  def self.fbb
-    #      ^^^ symbol-search: "fbb", rank=0
-  end
+  def self.fbb; end
+  #        ^^^ symbol-search: "fbb", rank=0
 
-  def self.fb_baz
-    #      ^^^^^^ symbol-search: "fbb", rank=10
-  end
+  def self.fb_baz; end
+  #        ^^^^^^ symbol-search: "fbb", rank=10
 
-  def self.foo_bar_baz
-    #      ^^^^^^^^^^^ symbol-search: "fbb", rank=20
-  end
+  def self.foo_bar_baz; end
+  #        ^^^^^^^^^^^ symbol-search: "fbb", rank=20
 
-  def self.other_foo_bar_baz
-    #      ^^^^^^^^^^^^^^^^^ symbol-search: "fbb", rank=30
-  end
+  def self.other_foo_bar_baz; end
+  #        ^^^^^^^^^^^^^^^^^ symbol-search: "fbb", rank=30
 
-  def self.xxfxxbxxbxx(xxx)
-    #      ^^^^^^^^^^^^^^^^ symbol-search: "fbb", rank=40
-  end
+  def self.xfxbxbx; end
+  #        ^^^^^^^ symbol-search: "fbb", rank=40
 
-  def self.fbnomatch
-  end
+  def self.fbnomatch; end
 
   class C
     attr_reader :fbb
     #            ^^^ symbol-search: "fbb", rank=0
-
     attr_reader :fb_baz
     #            ^^^^^^ symbol-search: "fbb", rank=10
-
     attr_reader :foo_bar_baz
     #            ^^^^^^^^^^^ symbol-search: "fbb", rank=20
-
     attr_reader :other_foo_bar_baz
     #            ^^^^^^^^^^^ symbol-search: "fbb", rank=30
-    
-    attr_reader :xxfxxbxxbxx
-    #            ^^^^^^^^^^^ symbol-search: "fbb", rank=40
-
+    attr_reader :xfxbxbx
+    #            ^^^^^^^ symbol-search: "fbb", rank=40
     attr_reader :fbnomatch
   end
 
@@ -101,8 +78,8 @@ module B
       #^^^^^^^^^^^ symbol-search: "fbb", rank=20
       @other_foo_bar_baz = T.let(3, Integer)
       #^^^^^^^^^^^^^^^^^ symbol-search: "fbb", rank=30
-      @xxfxxbxxbxx = T.let(4, Integer)
-      #^^^^^^^^^^^ symbol-search: "fbb", rank=40
+      @xfxbxbx = T.let(4, Integer)
+      #^^^^^^^ symbol-search: "fbb", rank=40
       @fbnomatch = T.let(5, Integer)
     end
   end


### PR DESCRIPTION
### Motivation
Various improvements to `workspace/symbol` based on user testing/feedback.
* Don't return low-quality results when they are significantly worse than the best result. 
* Exponentially penalize middle-of-word matches to avoid clutter from verbose spec class/method names.
* Don't get trapped on a bad prefix match.
* Improved use of whitespace for matching spec-like tests.

### Test plan
Added several automated tests to capture edge cases, added timers to measure performance.