### PR TITLE
Add error code for 5054

### DIFF
--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -475,6 +475,10 @@ class C
 end
 ```
 
+## 5054
+
+Use of `implementation` has been replaced by `override`.
+
 ## 6002
 
 In `# typed: strict` files, Sorbet requires that all instance and class


### PR DESCRIPTION
Use of `implementation` has been replaced by `override`.

### Motivation

This is a breaking change and mentioning that the method has changed names is a quick fix.