### PR TITLE
Introduce LSPInput abstraction to send input to multithreaded LSP.

### DIFF
--- a/main/lsp/BUILD
+++ b/main/lsp/BUILD
@@ -8,6 +8,7 @@ cc_library(
     hdrs = [
         "DefLocSaver.h",
         "LSPConfiguration.h",
+        "LSPInput.h",
         "LSPMessage.h",
         "LSPOutput.h",
         "LSPPreprocessor.h",

--- a/main/lsp/LSPInput.cc
+++ b/main/lsp/LSPInput.cc
@@ -1,0 +1,111 @@
+#include "main/lsp/LSPInput.h"
+#include "common/FileOps.h"
+#include "main/lsp/LSPMessage.h"
+#include "spdlog/spdlog.h"
+#include <iterator>
+
+using namespace std;
+
+namespace sorbet::realmain::lsp {
+
+LSPFDInput::LSPFDInput(shared_ptr<spdlog::logger> logger, int inputFd) : logger(move(logger)), inputFd(inputFd) {}
+
+unique_ptr<LSPMessage> LSPFDInput::read(int timeoutMs) {
+    int length = -1;
+    string allRead;
+    {
+        // Break and return if a timeout occurs. Bound loop to prevent infinite looping here. There's typically only two
+        // lines in a header.
+        for (int i = 0; i < 10; i += 1) {
+            auto maybeLine = FileOps::readLineFromFd(inputFd, buffer, timeoutMs);
+            if (!maybeLine) {
+                // Line not read. Abort. Store what was read thus far back into buffer
+                // for use in next call to function.
+                buffer = absl::StrCat(allRead, buffer);
+                return nullptr;
+            }
+            const string &line = *maybeLine;
+            absl::StrAppend(&allRead, line, "\n");
+            if (line == "\r") {
+                // End of headers.
+                break;
+            }
+            sscanf(line.c_str(), "Content-Length: %i\r", &length);
+        }
+        logger->trace("final raw read: {}, length: {}", allRead, length);
+    }
+
+    if (length < 0) {
+        logger->trace("No \"Content-Length: %i\" header found.");
+        // Throw away what we've read and start over.
+        return nullptr;
+    }
+
+    if (buffer.length() < length) {
+        // Need to read more.
+        int moreNeeded = length - buffer.length();
+        vector<char> buf(moreNeeded);
+        int result = FileOps::readFd(inputFd, buf);
+        if (result > 0) {
+            buffer.append(buf.begin(), buf.begin() + result);
+        }
+        if (result == -1) {
+            Exception::raise("Error reading file or EOF.");
+        }
+        if (result != moreNeeded) {
+            // Didn't get enough data. Return read data to `buffer`.
+            buffer = absl::StrCat(allRead, buffer);
+            return nullptr;
+        }
+    }
+
+    ENFORCE(buffer.length() >= length);
+
+    string json = buffer.substr(0, length);
+    buffer.erase(0, length);
+    logger->debug("Read: {}\n", json);
+    return LSPMessage::fromClient(json);
+}
+
+unique_ptr<LSPMessage> LSPProgrammaticInput::read(int timeoutMs) {
+    absl::MutexLock lock(&mtx);
+    if (closed && available.empty()) {
+        throw sorbet::FileReadException("EOF");
+    }
+
+    mtx.AwaitWithTimeout(
+        absl::Condition(
+            +[](deque<unique_ptr<LSPMessage>> *available) -> bool { return !available->empty(); }, &available),
+        absl::Milliseconds(timeoutMs));
+
+    if (available.empty()) {
+        return nullptr;
+    }
+
+    auto msg = move(available.front());
+    available.pop_front();
+    return msg;
+}
+
+void LSPProgrammaticInput::write(unique_ptr<LSPMessage> message) {
+    absl::MutexLock lock(&mtx);
+    if (closed) {
+        Exception::raise("Cannot write to a closed input.");
+    }
+    available.push_back(move(message));
+}
+
+void LSPProgrammaticInput::write(vector<unique_ptr<LSPMessage>> messages) {
+    absl::MutexLock lock(&mtx);
+    available.insert(available.end(), make_move_iterator(messages.begin()), make_move_iterator(messages.end()));
+}
+
+void LSPProgrammaticInput::close() {
+    absl::MutexLock lock(&mtx);
+    if (closed) {
+        Exception::raise("Input already ended.");
+    }
+    closed = true;
+}
+
+} // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPInput.cc
+++ b/main/lsp/LSPInput.cc
@@ -97,6 +97,9 @@ void LSPProgrammaticInput::write(unique_ptr<LSPMessage> message) {
 
 void LSPProgrammaticInput::write(vector<unique_ptr<LSPMessage>> messages) {
     absl::MutexLock lock(&mtx);
+    if (closed) {
+        Exception::raise("Cannot write to a closed input.");
+    }
     available.insert(available.end(), make_move_iterator(messages.begin()), make_move_iterator(messages.end()));
 }
 

--- a/main/lsp/LSPInput.h
+++ b/main/lsp/LSPInput.h
@@ -1,0 +1,81 @@
+#ifndef RUBY_TYPER_LSP_LSPINPUT_H
+#define RUBY_TYPER_LSP_LSPINPUT_H
+
+#include "absl/synchronization/mutex.h"
+#include <deque>
+#include <memory>
+#include <vector>
+
+namespace spdlog {
+class logger;
+};
+
+namespace sorbet::realmain::lsp {
+class LSPMessage;
+class ResponseMessage;
+class NotificationMessage;
+
+/**
+ * Interface for receiving messages from the client. It is _not_ thread safe, and assumes that only one thread will be
+ * reading from it at a time.
+ */
+class LSPInput {
+public:
+    LSPInput() = default;
+    virtual ~LSPInput() = default;
+    /**
+     * Blockingly reads the next message from the client with the given timeout (in milliseconds). Returns nullptr if no
+     * message read within timeout.
+     *
+     * Throws a FileReadException on error or EOF.
+     */
+    virtual std::unique_ptr<LSPMessage> read(int timeoutMs = 100) = 0;
+};
+
+/**
+ * Reads messages from a file descriptor (like stdin).
+ *
+ * Throws a FileReadException on error or EOF.
+ */
+class LSPFDInput final : public LSPInput {
+    // Contains unparsed strings containing a partial message read from file descriptor.
+    std::string buffer;
+    // Used to log debug messages.
+    const std::shared_ptr<spdlog::logger> logger;
+
+public:
+    const int inputFd;
+    LSPFDInput(std::shared_ptr<spdlog::logger> logger, int inputFd);
+
+    std::unique_ptr<LSPMessage> read(int timeoutMs) override;
+};
+
+/**
+ * Input is provided programmatically via the `write` method. Threadsafe.
+ *
+ * Throws a FileReadException when stream has been closed.
+ */
+class LSPProgrammaticInput final : public LSPInput {
+    absl::Mutex mtx;
+    // Contains all available messages for processing.
+    std::deque<std::unique_ptr<LSPMessage>> available GUARDED_BY(mtx);
+    bool closed GUARDED_BY(mtx) = false;
+
+public:
+    LSPProgrammaticInput() = default;
+
+    std::unique_ptr<LSPMessage> read(int timeoutMs) override;
+
+    /** Send the given message to input. */
+    void write(std::unique_ptr<LSPMessage> message);
+
+    /** Send the given messages to input. */
+    void write(std::vector<std::unique_ptr<LSPMessage>> messages);
+
+    /** Closes the input. Causes an EOF to be thrown after all existing messages are read. */
+    void close();
+};
+
+} // namespace sorbet::realmain::lsp
+
+#endif

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -1,18 +1,11 @@
 #ifndef RUBY_TYPER_LSPLOOP_H
 #define RUBY_TYPER_LSPLOOP_H
 
-#include "ast/ast.h"
-#include "common/kvstore/KeyValueStore.h"
-#include "core/ErrorQueue.h"
-#include "core/NameHash.h"
 #include "core/core.h"
-#include "main/lsp/LSPConfiguration.h"
 #include "main/lsp/LSPMessage.h"
-#include "main/lsp/LSPOutput.h"
 #include "main/lsp/LSPPreprocessor.h"
 #include "main/lsp/LSPTypecheckerCoordinator.h"
 #include <chrono>
-#include <deque>
 #include <optional>
 
 //  _     ____  ____
@@ -24,6 +17,9 @@
 //
 // This is an implementation of LSP protocol (version 3.13) for Sorbet
 namespace sorbet::realmain::lsp {
+
+class LSPInput;
+class LSPConfiguration;
 
 enum class LSPErrorCodes {
     // Defined by JSON RPC
@@ -120,9 +116,9 @@ public:
      * Runs the language server on a dedicated thread. Returns the final global state if it exits cleanly, or nullopt
      * on error.
      *
-     * Reads input messages from inputFd.
+     * Reads input messages from the provided input object.
      */
-    std::optional<std::unique_ptr<core::GlobalState>> runLSP(int inputFd);
+    std::optional<std::unique_ptr<core::GlobalState>> runLSP(std::shared_ptr<LSPInput> input);
     void processRequest(std::unique_ptr<LSPMessage> msg);
     void processRequest(const std::string &json);
     /**

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -10,6 +10,7 @@
 #include "main/autogen/autogen.h"
 #include "main/autogen/autoloader.h"
 #include "main/autogen/subclasses.h"
+#include "main/lsp/LSPInput.h"
 #include "main/lsp/lsp.h"
 #endif
 
@@ -467,7 +468,7 @@ int realmain(int argc, char *argv[]) {
                       Version::full_version_string);
         auto output = make_shared<lsp::LSPStdout>(logger);
         lsp::LSPLoop loop(move(gs), make_shared<lsp::LSPConfiguration>(opts, output, *workers, logger));
-        gs = loop.runLSP(STDIN_FILENO).value_or(nullptr);
+        gs = loop.runLSP(make_shared<lsp::LSPFDInput>(logger, STDIN_FILENO)).value_or(nullptr);
 #endif
     } else {
         Timer timeall(logger, "wall_time");

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -11,6 +11,7 @@
 #include "main/autogen/autoloader.h"
 #include "main/autogen/subclasses.h"
 #include "main/lsp/LSPInput.h"
+#include "main/lsp/LSPOutput.h"
 #include "main/lsp/lsp.h"
 #endif
 
@@ -165,15 +166,6 @@ core::Loc findTyped(unique_ptr<core::GlobalState> &gs, core::FileRef file) {
 }
 
 #ifndef SORBET_REALMAIN_MIN
-class LSPStdout final : public lsp::LSPOutput {
-    void rawWrite(std::unique_ptr<lsp::LSPMessage> msg) {
-        auto json = msg->toJSON();
-        string outResult = fmt::format("Content-Length: {}\r\n\r\n{}", json.length(), json);
-        logger->debug("Write: {}\n", json);
-        cout << outResult << flush;
-    }
-};
-
 struct AutogenResult {
     struct Serialized {
         // Selectively populated based on print options


### PR DESCRIPTION
Introduce LSPInput abstraction to send input to multithreaded LSP.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Will make it possible to use multithreaded LSP in other scenarios besides STDIN (e.g. LSPWrapper).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Manually tested Sorbet with this change. Also tested via existing recorded tests. Will be tested further once I modify LSPWrapper to support multithreaded mode.
