### PR TITLE
Add an intrinsic for self.new that produces values of type T.attached_class

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -386,7 +386,6 @@ public:
     }
 
     static bool isSelfNew(ast::Send *send) {
-
         if (send->fun != core::Names::selfNew()) {
             return false;
         }

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -371,6 +371,29 @@ public:
                      std::move(arg));
     }
 
+    static std::unique_ptr<Expression> SelfNew(core::Loc loc, ast::Send::ARGS_store args, u4 flags = 0,
+                                               std::unique_ptr<ast::Block> block = nullptr) {
+        auto magic = Constant(loc, core::Symbols::Magic());
+        return Send(loc, std::move(magic), core::Names::selfNew(), std::move(args), flags, std::move(block));
+    }
+
+    static bool isMagicClass(ast::Expression *expr) {
+        if (auto *recv = cast_tree<ConstantLit>(expr)) {
+            return recv->symbol == core::Symbols::Magic();
+        } else {
+            return false;
+        }
+    }
+
+    static bool isSelfNew(ast::Send *send) {
+
+        if (send->fun != core::Names::selfNew()) {
+            return false;
+        }
+
+        return isMagicClass(send->recv.get());
+    }
+
     static class Local *arg2Local(Expression *arg) {
         while (true) {
             if (auto *local = cast_tree<class Local>(arg)) {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -427,6 +427,18 @@ void GlobalState::initEmpty() {
         auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
         arg.flags.isBlock = true;
     }
+    // Synthesize <Magic>#<self-new>(arg: *T.untyped) => T.untyped
+    method = enterMethodSymbol(Loc::none(), Symbols::MagicSingleton(), Names::selfNew());
+    {
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg0());
+        arg.type = Types::untyped(*this, method);
+        arg.flags.isRepeated = true;
+    }
+    method.data(*this)->resultType = Types::untyped(*this, method);
+    {
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
+        arg.flags.isBlock = true;
+    }
     // Synthesize <DeclBuilderForProcs>#<params>(args: Hash) => DeclBuilderForProcs
     method = enterMethodSymbol(Loc::none(), Symbols::DeclBuilderForProcsSingleton(), Names::params());
     {

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -275,6 +275,7 @@ NameDef names[] = {
     {"blockPassTemp", "<block-pass>"},
     {"forTemp"},
     {"new_", "new"},
+    {"selfNew", "<self-new>"},
     {"blockCall", "<block-call>"},
     {"blockBreakAssign", "<block-break-assign>"},
     {"arg", "<arg>"},

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -275,7 +275,6 @@ NameDef names[] = {
     {"blockPassTemp", "<block-pass>"},
     {"forTemp"},
     {"new_", "new"},
-    {"selfNew", "<self-new>"},
     {"blockCall", "<block-call>"},
     {"blockBreakAssign", "<block-break-assign>"},
     {"arg", "<arg>"},
@@ -338,6 +337,7 @@ NameDef names[] = {
     {"callWithBlock", "<call-with-block>"},
     {"callWithSplatAndBlock", "<call-with-splat-and-block>"},
     {"enumerable_to_h"},
+    {"selfNew", "<self-new>"},
 
     // GlobalState initEmpty()
     {"Top", "<any>", true},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1135,33 +1135,6 @@ public:
     }
 } Class_new;
 
-/**
- * This is a special version of `new` that will return `T.attached_class`
- * instead.
- */
-class Class_selfNew : public IntrinsicMethod {
-public:
-    void apply(Context ctx, DispatchArgs args, const Type *thisType, DispatchResult &res) const override {
-        SymbolRef self = unwrapSymbol(thisType);
-
-        auto attachedClass = self.data(ctx)->findMember(ctx, core::Names::Constants::AttachedClass());
-        if (!attachedClass.exists()) {
-            return;
-        }
-        auto instanceTy = make_type<SelfTypeParam>(attachedClass);
-        DispatchArgs innerArgs{Names::initialize(), args.locs, args.args, instanceTy, instanceTy, args.block};
-        auto dispatched = instanceTy->dispatchCall(ctx, innerArgs);
-
-        for (auto &err : res.main.errors) {
-            dispatched.main.errors.emplace_back(std::move(err));
-        }
-        res.main.errors.clear();
-        res.returnType = instanceTy;
-        res.main = move(dispatched.main);
-        res.main.sendTp = instanceTy;
-    }
-} Class_selfNew;
-
 class T_Generic_squareBrackets : public IntrinsicMethod {
 public:
     void apply(Context ctx, DispatchArgs args, const Type *thisType, DispatchResult &res) const override {
@@ -1732,6 +1705,70 @@ public:
     }
 } Magic_suggestUntypedConstantType;
 
+/**
+ * This is a special version of `new` that will return `T.attached_class`
+ * instead.
+ */
+class Magic_selfNew : public IntrinsicMethod {
+public:
+    void apply(Context ctx, DispatchArgs args, const Type *thisType, DispatchResult &res) const override {
+        // args[0] is the Class to create an instance of
+        // args[1..] are the arguments to the constructor
+
+        if (args.args.empty()) {
+            res.returnType = core::Types::untypedUntracked();
+            return;
+        }
+
+        auto selfTy = args.args[0]->type;
+        SymbolRef self = unwrapSymbol(selfTy.get());
+
+        InlinedVector<const TypeAndOrigins *, 2> sendArgStore;
+        InlinedVector<Loc, 2> sendArgLocs;
+        for (int i = 1; i < args.args.size(); ++i) {
+            sendArgStore.emplace_back(args.args[i]);
+            sendArgLocs.emplace_back(args.locs.args[i]);
+        }
+        CallLocs sendLocs{args.locs.call, args.locs.args[0], sendArgLocs};
+
+        TypePtr returnTy;
+        DispatchResult dispatched;
+        if (!self.data(ctx)->isSingletonClass(ctx)) {
+            // In the case that `self` is not a singleton class, we know that
+            // this was a call to `new` outside of a self context. Dispatch to
+            // an instance method named new, and see what happens.
+            DispatchArgs innerArgs{Names::new_(), sendLocs, sendArgStore, selfTy, selfTy, args.block};
+            dispatched = selfTy->dispatchCall(ctx, innerArgs);
+            returnTy = dispatched.returnType;
+        } else {
+            // Otherwise, we know that this is the proper new intrinsic, and we
+            // should be returning something of type `T.attached_class`
+            auto attachedClass = self.data(ctx)->findMember(ctx, core::Names::Constants::AttachedClass());
+
+            // TODO(trevor): I think this can actually be an enforce, as it
+            // should only ever happen if self is `T.untyped`
+            if (!attachedClass.exists()) {
+                return;
+            }
+            auto instanceTy = self.data(ctx)->attachedClass(ctx).data(ctx)->externalType(ctx);
+            DispatchArgs innerArgs{Names::initialize(), sendLocs, sendArgStore, instanceTy, instanceTy, args.block};
+            dispatched = instanceTy->dispatchCall(ctx, innerArgs);
+
+            // The return type from dispatch is ignored, and we return
+            // `T.attached_class` instead.
+            returnTy = make_type<SelfTypeParam>(attachedClass);
+        }
+
+        for (auto &err : res.main.errors) {
+            dispatched.main.errors.emplace_back(std::move(err));
+        }
+        res.main.errors.clear();
+        res.main = move(dispatched.main);
+        res.returnType = returnTy;
+        res.main.sendTp = returnTy;
+    }
+} Magic_selfNew;
+
 class DeclBuilderForProcs_void : public IntrinsicMethod {
 public:
     void apply(Context ctx, DispatchArgs args, const Type *thisType, DispatchResult &res) const override {
@@ -2137,7 +2174,6 @@ const vector<Intrinsic> intrinsicMethods{
     {Symbols::Object(), Intrinsic::Kind::Instance, Names::singletonClass(), &Object_class},
 
     {Symbols::Class(), Intrinsic::Kind::Instance, Names::new_(), &Class_new},
-    {Symbols::Class(), Intrinsic::Kind::Instance, Names::selfNew(), &Class_selfNew},
 
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::buildHash(), &Magic_buildHash},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::buildArray(), &Magic_buildArray},
@@ -2146,6 +2182,7 @@ const vector<Intrinsic> intrinsicMethods{
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::callWithBlock(), &Magic_callWithBlock},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::callWithSplatAndBlock(), &Magic_callWithSplatAndBlock},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::suggestType(), &Magic_suggestUntypedConstantType},
+    {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::selfNew(), &Magic_selfNew},
 
     {Symbols::DeclBuilderForProcsSingleton(), Intrinsic::Kind::Instance, Names::void_(), &DeclBuilderForProcs_void},
     {Symbols::DeclBuilderForProcsSingleton(), Intrinsic::Kind::Instance, Names::returns(),

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1745,11 +1745,9 @@ public:
             // should be returning something of type `T.attached_class`
             auto attachedClass = self.data(ctx)->findMember(ctx, core::Names::Constants::AttachedClass());
 
-            // TODO(trevor): I think this can actually be an enforce, as it
-            // should only ever happen if self is `T.untyped`
-            if (!attachedClass.exists()) {
-                return;
-            }
+            // AttachedClass will only be missing on `T.untyped`
+            ENFORCE(attachedClass.exists());
+
             auto instanceTy = self.data(ctx)->attachedClass(ctx).data(ctx)->externalType(ctx);
             DispatchArgs innerArgs{Names::initialize(), sendLocs, sendArgStore, instanceTy, instanceTy, args.block};
             dispatched = instanceTy->dispatchCall(ctx, innerArgs);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1752,7 +1752,7 @@ public:
             DispatchArgs innerArgs{Names::initialize(), sendLocs, sendArgStore, instanceTy, instanceTy, args.block};
             dispatched = instanceTy->dispatchCall(ctx, innerArgs);
 
-            // The return type from dispatch is ignored, and we return
+            // The return type from dispatched is ignored, and we return
             // `T.attached_class` instead.
             returnTy = make_type<SelfTypeParam>(attachedClass);
         }

--- a/gems/sorbet-runtime/test/types/attached_class.rb
+++ b/gems/sorbet-runtime/test/types/attached_class.rb
@@ -20,6 +20,20 @@ module Opus::Types::Test
       assert_equal(A.make.class, A)
     end
 
+    it 'can type self methods that use self.new' do
+
+      class Base
+        extend T::Sig
+
+        sig {returns(T.experimental_attached_class)}
+        def self.make
+          self.new
+        end
+      end
+
+      assert_equal(Base.make.class, Base)
+    end
+
     it 'does not throw when the returned value is bad' do
 
       class Base

--- a/gems/sorbet-runtime/test/types/attached_class.rb
+++ b/gems/sorbet-runtime/test/types/attached_class.rb
@@ -31,7 +31,10 @@ module Opus::Types::Test
         end
       end
 
+      class Child < Base; end
+
       assert_equal(Base.make.class, Base)
+      assert_equal(Child.make.class, Child)
     end
 
     it 'does not throw when the returned value is bad' do

--- a/rewriter/InterfaceWrapper.h
+++ b/rewriter/InterfaceWrapper.h
@@ -22,7 +22,7 @@ namespace sorbet::rewriter {
  */
 class InterfaceWrapper final {
 public:
-    static std::unique_ptr<ast::Expression> run(core::MutableContext ctx, std::unique_ptr<ast::Send> send);
+    static std::unique_ptr<ast::Expression> run(core::MutableContext ctx, ast::Send *send);
 
     InterfaceWrapper() = delete;
 };

--- a/rewriter/SelfNew.cc
+++ b/rewriter/SelfNew.cc
@@ -1,0 +1,29 @@
+#include "rewriter/SelfNew.h"
+#include "ast/Helpers.h"
+#include "ast/ast.h"
+#include "core/core.h"
+
+namespace sorbet::rewriter {
+
+std::unique_ptr<ast::Expression> SelfNew::run(core::MutableContext ctx, ast::Send *send) {
+    if (send->fun != core::Names::new_()) {
+        return nullptr;
+    }
+
+    auto *recv = ast::cast_tree<ast::Local>(send->recv.get());
+    if (recv == nullptr || recv->localVariable._name != core::Names::selfLocal()) {
+        return nullptr;
+    }
+
+    // This is unfortunate: the desugar pass adds a `self` node for the receiver
+    // if there is an EmptyTree after parsing, and the only way we can tell it
+    // wasn't there originally is to test if the Loc is zero-width.
+    if (recv->loc.beginPos() == recv->loc.endPos()) {
+        return nullptr;
+    }
+
+    return ast::MK::Send(send->loc, std::move(send->recv), core::Names::selfNew(),
+                         std::move(send->args));
+}
+
+} // namespace sorbet::rewriter

--- a/rewriter/SelfNew.cc
+++ b/rewriter/SelfNew.cc
@@ -18,10 +18,8 @@ std::unique_ptr<ast::Expression> SelfNew::run(core::MutableContext ctx, ast::Sen
         args.emplace_back(std::move(arg));
     }
 
-    auto magic = ast::MK::Constant(send->loc, core::Symbols::Magic());
 
-    return ast::MK::Send(send->loc, std::move(magic), core::Names::selfNew(), std::move(args), send->flags,
-                         std::move(send->block));
+    return ast::MK::SelfNew(send->loc, std::move(args), send->flags, std::move(send->block));
 }
 
 } // namespace sorbet::rewriter

--- a/rewriter/SelfNew.cc
+++ b/rewriter/SelfNew.cc
@@ -18,7 +18,6 @@ std::unique_ptr<ast::Expression> SelfNew::run(core::MutableContext ctx, ast::Sen
         args.emplace_back(std::move(arg));
     }
 
-
     return ast::MK::SelfNew(send->loc, std::move(args), send->flags, std::move(send->block));
 }
 

--- a/rewriter/SelfNew.h
+++ b/rewriter/SelfNew.h
@@ -1,0 +1,16 @@
+#ifndef SORBET_REWRITER_SELF_NEW_H
+#define SORBET_REWRITER_SELF_NEW_H
+
+#include "ast/ast.h"
+
+namespace sorbet::rewriter {
+
+class SelfNew final {
+public:
+    static std::unique_ptr<ast::Expression> run(core::MutableContext ctx, ast::Send *send);
+    SelfNew() = delete;
+};
+
+} // namespace sorbet::rewriter
+
+#endif /* SORBET_REWRITER_SELF_NEW_H */

--- a/rewriter/SelfNew.h
+++ b/rewriter/SelfNew.h
@@ -5,6 +5,18 @@
 
 namespace sorbet::rewriter {
 
+/**
+ * This class desugars `self.new` into a call to a special intrinsic:
+ *
+ *    self.new(arg1, ..., argN)
+ *
+ * =>
+ *
+ *    Magic.<self-new>(self, arg1, ..., argN)
+ *
+ * The `Magic.<self-new>` intrinsic will construct a value of type of the
+ * enclosing class, and return its type as `C::<AttachedClass>`
+ */
 class SelfNew final {
 public:
     static std::unique_ptr<ast::Expression> run(core::MutableContext ctx, ast::Send *send);

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -82,11 +82,11 @@ vector<unique_ptr<ast::Expression>> processStat(core::MutableContext ctx, ast::C
         return badConst(ctx, stat->loc, klass->loc);
     }
 
-    if (rhs->fun != core::Names::new_() && rhs->fun != core::Names::let()) {
+    if (rhs->fun != core::Names::selfNew() && rhs->fun != core::Names::let()) {
         return badConst(ctx, stat->loc, klass->loc);
     }
 
-    if (rhs->fun == core::Names::new_() && !rhs->recv->isSelfReference()) {
+    if (rhs->fun == core::Names::selfNew() && !ast::MK::isMagicClass(rhs->recv.get())) {
         return badConst(ctx, stat->loc, klass->loc);
     }
 
@@ -105,14 +105,14 @@ vector<unique_ptr<ast::Expression>> processStat(core::MutableContext ctx, ast::C
             return badConst(ctx, stat->loc, klass->loc);
         }
 
-        if (!(arg0->fun == core::Names::new_() && arg0->recv->isSelfReference())) {
+        if (!ast::MK::isSelfNew(arg0)) {
             return badConst(ctx, stat->loc, klass->loc);
         }
     }
 
     // By this point, we have something that looks like
     //
-    //   A = new | T.let(new, ...)
+    //   A = Magic.<self-new>(self) | T.let(Magic.<self-new>(self), ...)
     //
     // So we're good to process this thing as a new T::Enum value.
 

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -156,7 +156,11 @@ public:
     }
 
     unique_ptr<ast::Expression> postTransformSend(core::MutableContext ctx, unique_ptr<ast::Send> send) {
-        return InterfaceWrapper::run(ctx, std::move(send));
+        if (auto expr = InterfaceWrapper::run(ctx, send.get())) {
+            return expr;
+        }
+
+        return send;
     }
 
 private:

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -156,6 +156,8 @@ public:
         return classDef;
     }
 
+    // NOTE: this case differs from the `Send` typecase branch in `postTransformClassDef` above, as it will apply to all
+    // sends, not just those that are present in the RHS of a `ClassDef`.
     unique_ptr<ast::Expression> postTransformSend(core::MutableContext ctx, unique_ptr<ast::Send> send) {
         if (auto expr = InterfaceWrapper::run(ctx, send.get())) {
             return expr;

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -18,6 +18,7 @@
 #include "rewriter/ProtobufDescriptorPool.h"
 #include "rewriter/Rails.h"
 #include "rewriter/Regexp.h"
+#include "rewriter/SelfNew.h"
 #include "rewriter/Struct.h"
 #include "rewriter/TEnum.h"
 #include "rewriter/TypeMembers.h"
@@ -157,6 +158,10 @@ public:
 
     unique_ptr<ast::Expression> postTransformSend(core::MutableContext ctx, unique_ptr<ast::Send> send) {
         if (auto expr = InterfaceWrapper::run(ctx, send.get())) {
+            return expr;
+        }
+
+        if (auto expr = SelfNew::run(ctx, send.get())) {
             return expr;
         }
 

--- a/test/testdata/desugar/sclass_inheritance.rb.flatten-tree.exp
+++ b/test/testdata/desugar/sclass_inheritance.rb.flatten-tree.exp
@@ -61,7 +61,7 @@ begin
     <emptyTree>
 
     def newer(<blk>)
-      <self>.new()
+      ::<Magic>.<self-new>(<self>)
     end
 
     def self.<static-init>(<blk>)
@@ -74,7 +74,7 @@ begin
     <emptyTree>
 
     def self.newer(<blk>)
-      <self>.new()
+      ::<Magic>.<self-new>(<self>)
     end
 
     def self.<static-init>(<blk>)

--- a/test/testdata/infer/attached_class_factory_example.rb
+++ b/test/testdata/infer/attached_class_factory_example.rb
@@ -1,0 +1,35 @@
+# typed: strict
+
+class Module
+  include(T::Sig)
+end
+
+class Parent
+  private_class_method :new
+
+  sig {returns(T.experimental_attached_class)}
+  def self.make
+    new
+  end
+
+  # Always makes a Parent
+  sig {returns(Parent)}
+  def self.make_parent
+    new
+  end
+end
+class Child < Parent;end
+
+sig {params(child: Child).void}
+def takes_child(child); end
+sig {params(parent: Parent).void}
+def takes_parent(parent); end
+
+# ok to use Child::AttachedClass as a Child
+takes_child(Child.make)
+
+# ok to use Parent::AttachedClass as a Parent
+takes_parent(Parent.make)
+
+# ok to use Child::AttachedClass as a Parent
+takes_parent(Child.make)

--- a/test/testdata/infer/attached_class_self_new.rb
+++ b/test/testdata/infer/attached_class_self_new.rb
@@ -1,0 +1,18 @@
+# typed: true
+
+T.reveal_type(self.new) # error: Revealed type: `T.class_of(<root>)::<AttachedClass>`
+
+class A
+  extend T::Sig
+
+  sig {returns(T.experimental_attached_class)}
+  def self.make_one
+    T.reveal_type(self.new) # error: Revealed type: `T.class_of(A)::<AttachedClass>`
+  end
+
+  sig {returns(A)}
+  def self.make_one2
+    T.reveal_type(new) # error: Revealed type: `A`
+  end
+
+end

--- a/test/testdata/infer/attached_class_self_new.rb
+++ b/test/testdata/infer/attached_class_self_new.rb
@@ -8,6 +8,11 @@ class NoArgs
     T.reveal_type(self.new) # error: Revealed type: `T.class_of(NoArgs)::<AttachedClass>`
   end
 
+  sig {returns(T.experimental_attached_class)}
+  def self.make_implicit_new
+    T.reveal_type(new) # error: Revealed type: `T.class_of(NoArgs)::<AttachedClass>`
+  end
+
 end
 
 class PosArgs

--- a/test/testdata/infer/attached_class_self_new.rb
+++ b/test/testdata/infer/attached_class_self_new.rb
@@ -1,18 +1,91 @@
 # typed: true
 
-T.reveal_type(self.new) # error: Revealed type: `T.class_of(<root>)::<AttachedClass>`
-
-class A
+class NoArgs
   extend T::Sig
 
   sig {returns(T.experimental_attached_class)}
-  def self.make_one
-    T.reveal_type(self.new) # error: Revealed type: `T.class_of(A)::<AttachedClass>`
+  def self.make
+    T.reveal_type(self.new) # error: Revealed type: `T.class_of(NoArgs)::<AttachedClass>`
   end
 
-  sig {returns(A)}
-  def self.make_one2
-    T.reveal_type(new) # error: Revealed type: `A`
+end
+
+class PosArgs
+  extend T::Sig
+
+  sig {params(x: Integer, y: String).void}
+  def initialize(x, y); end
+
+  sig {returns(T.experimental_attached_class)}
+  def self.make
+    T.reveal_type(self.new(10, "foo")) # error: Revealed type: `T.class_of(PosArgs)::<AttachedClass>`
+
+    # Not matching initialize
+    T.reveal_type(self.new())
+                # ^^^^^^^^^^ error: Not enough arguments provided
+  # ^^^^^^^^^^^^^^^^^^^^^^^^^ error: Revealed type: `T.class_of(PosArgs)::<AttachedClass>`
+  end
+end
+
+class NamedArgs
+  extend T::Sig
+
+  sig {params(x: Integer, y: String).void}
+  def initialize(x:, y:); end
+
+  sig {returns(T.experimental_attached_class)}
+  def self.make
+    T.reveal_type(self.new(x: 10, y: "foo")) # error: Revealed type: `T.class_of(NamedArgs)::<AttachedClass>`
+
+    # Not matching initialize
+    T.reveal_type(self.new(x: 10))
+                # ^^^^^^^^^^^^^^^ error: Missing required keyword argument `y`
+  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Revealed type: `T.class_of(NamedArgs)::<AttachedClass>`
+  end
+end
+
+class BlockArg
+  extend T::Sig
+
+  sig {params(blk: T.proc.params(x: Integer).void).void}
+  def initialize(&blk); end
+
+  sig {returns(T.experimental_attached_class)}
+  def self.make
+    T.reveal_type(self.new {|x| x + 1}) # error: Revealed type: `T.class_of(BlockArg)::<AttachedClass>`
+
+    T.reveal_type(self.new)
+                # ^^^^^^^^ error: `initialize` requires a block parameter
+  # ^^^^^^^^^^^^^^^^^^^^^^^ error: Revealed type: `T.class_of(BlockArg)::<AttachedClass>`
+  end
+end
+
+# In this case there is an instance method called new, and the
+# `Magic.<self-new>` intrinsic should handle it.
+class InstNew
+  extend T::Sig
+
+  sig {params(x: Integer).returns(String)}
+  def new(x)
+    x.to_s
   end
 
+  def test
+    T.reveal_type(self.new(10)) # error: Revealed type: `String`
+  end
+end
+
+# In this case there is an instance method called new that takes a block
+# parameter, and the `Magic.<self-new>` intrinsic should handle it.
+class InstNewBlock
+  extend T::Sig
+
+  sig {params(blk: T.proc.params(x: Integer).void).returns(String)}
+  def new(&blk)
+    "foo"
+  end
+
+  def test
+    T.reveal_type(self.new {|x| x + 1}) # error: Revealed type: `String`
+  end
 end

--- a/test/testdata/rewriter/struct.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/struct.rb.rewrite-tree.exp
@@ -209,9 +209,9 @@ class <emptyTree><<C <root>>> < ()
 
       <self>.include(<emptyTree>::<C MyMixin>)
 
-      <self>.new().x()
+      ::<Magic>.<self-new>(<self>).x()
 
-      <self>.new().foo()
+      ::<Magic>.<self-new>(<self>).foo()
 
       ::T::Sig::WithoutRuntime.sig() do ||
         <self>.params({:"x" => ::BasicObject}).void()
@@ -235,13 +235,13 @@ class <emptyTree><<C <root>>> < ()
 
       <self>.include(<emptyTree>::<C MyMixin>)
 
-      <self>.new().x()
+      ::<Magic>.<self-new>(<self>).x()
 
-      <self>.new().foo()
+      ::<Magic>.<self-new>(<self>).foo()
 
-      <self>.new(1, 2)
+      ::<Magic>.<self-new>(<self>, 1, 2)
 
-      <self>.new({:"giberish" => 1})
+      ::<Magic>.<self-new>(<self>, {:"giberish" => 1})
 
       ::T::Sig::WithoutRuntime.sig() do ||
         <self>.params({:"x" => ::BasicObject}).void()

--- a/test/testdata/rewriter/t_enum_snapshot.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_enum_snapshot.rb.rewrite-tree.exp
@@ -34,8 +34,8 @@ class <emptyTree><<C <root>>> < ()
   class <emptyTree>::<C NotAnEnum><<C <todo sym>>> < (::<todo sym>)
     <self>.enums() do ||
       begin
-        <emptyTree>::<C X> = <self>.new()
-        <emptyTree>::<C Y> = <emptyTree>::<C T>.let(<self>.new(), <self>)
+        <emptyTree>::<C X> = ::<Magic>.<self-new>(<self>)
+        <emptyTree>::<C Y> = <emptyTree>::<C T>.let(::<Magic>.<self-new>(<self>), <self>)
       end
     end
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Currently missing from the `T.experimental_attached_class` feature is a way to construct values of that type, without relying on `T.unsafe`. This PR changes the type for `self.new`, having it return `T.experimental_attached_class`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
I've added additional tests for the static and runtime behavior.

See included automated tests.
