### PR TITLE
match this to the spew from bazel

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -85,7 +85,7 @@ def register_sorbet_dependencies():
         remote = "https://github.com/jemalloc/jemalloc.git",
         commit = "ea6b3e973b477b8061e0076bb257dbd7f3faa756",  # 5.2.1
         build_file = "@com_stripe_ruby_typer//third_party:jemalloc.BUILD",
-        shallow_since = "1554252642 -0700",
+        shallow_since = "1565035161 -0700",
     )
 
     new_git_repository(


### PR DESCRIPTION
When compiling this on my new devbox I got this message
```
INFO: Rule 'jemalloc' modified arguments {"shallow_since": "1565035161 -0700"}
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
