### PR TITLE
Handle visibility more fully in rewriter

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -148,8 +148,11 @@ public:
     u4 flags;
 
     enum Flags {
-        SelfMethod = 1,
-        RewriterSynthesized = 2,
+        SelfMethod = 0x01,
+        RewriterSynthesized = 0x02,
+        MethodPrivate = 0x04,
+        MethodProtected = 0x08,
+        MethodPublic = 0x10,
     };
 
     MethodDef(core::Loc loc, core::Loc declLoc, core::SymbolRef symbol, core::NameRef name, ARGS_store args,

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -170,6 +170,18 @@ public:
         return (flags & RewriterSynthesized) != 0;
     }
 
+    bool isPrivate() const {
+        return (flags & MethodPrivate) != 0;
+    }
+
+    bool isProtected() const {
+        return (flags & MethodProtected) != 0;
+    }
+
+    bool isPublic() const {
+        return (flags & MethodPublic) != 0;
+    }
+
     void setIsSelf(bool isSelf) {
         if (isSelf) {
             flags |= SelfMethod;

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -665,7 +665,13 @@ public:
         ENFORCE(method->args.size() == method->symbol.data(ctx)->arguments().size(), "{}: {} != {}",
                 method->name.showRaw(ctx), method->args.size(), method->symbol.data(ctx)->arguments().size());
         // all methods at definition time are public, but their visibility may be changed later
-        method->symbol.data(ctx)->setPublic();
+        if (method->isPrivate()) {
+            method->symbol.data(ctx)->setPrivate();
+        } else if (method->isProtected()) {
+            method->symbol.data(ctx)->setProtected();
+        } else {
+            method->symbol.data(ctx)->setPublic();
+        }
         // Not all information is unfortunately available in the symbol. Original argument names aren't.
         // method->args.clear();
         return method;

--- a/rewriter/Private.cc
+++ b/rewriter/Private.cc
@@ -39,6 +39,17 @@ vector<unique_ptr<ast::Expression>> Private::run(core::MutableContext ctx, ast::
         }
     }
 
+    if (send->fun == core::Names::private_() || send->fun == core::Names::privateClassMethod()) {
+        mdef->flags |= ast::MethodDef::MethodPrivate;
+        empty.emplace_back(move(send->args.front()));
+    } else if (send->fun == core::Names::protected_()) {
+        mdef->flags |= ast::MethodDef::MethodProtected;
+        empty.emplace_back(move(send->args.front()));
+    } else if (send->fun == core::Names::public_()) {
+        mdef->flags |= ast::MethodDef::MethodPublic;
+        empty.emplace_back(move(send->args.front()));
+    }
+
     return empty;
 }
 

--- a/rewriter/module_function.cc
+++ b/rewriter/module_function.cc
@@ -79,11 +79,12 @@ vector<unique_ptr<ast::Expression>> ModuleFunction::rewriteDefn(core::MutableCon
 
     auto sig = ast::cast_tree_const<ast::Send>(prevStat);
     bool hasSig = sig && sig->fun == core::Names::sig();
-    auto loc = expr->loc;
 
     // this creates a private copy of the method
     unique_ptr<ast::Expression> privateCopy = expr->deepCopy();
-    stats.emplace_back(ast::MK::Send1(loc, ast::MK::Self(loc), core::Names::private_(), move(privateCopy)));
+    auto privateDef = ast::cast_tree<ast::MethodDef>(privateCopy.get());
+    privateDef->flags |= ast::MethodDef::MethodPrivate;
+    stats.emplace_back(move(privateCopy));
 
     // as well as a public static copy of the method
     if (hasSig) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
We can't handle 100% of the visibility modifier uses in the rewriter (because we need at least the name for `private :foo` instead of `private def foo; end`) but we can handle a lot of them, and it'll make these rewrites as well as #2171 a lot cleaner.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
