### PR TITLE
Clean up test code, remove some unneeded dependencies from headers...

### DIFF
--- a/main/lsp/LSPConfiguration.h
+++ b/main/lsp/LSPConfiguration.h
@@ -2,11 +2,12 @@
 #define RUBY_TYPER_LSPCONFIGURATION_H
 
 #include "common/concurrency/WorkerPool.h"
-#include "main/lsp/LSPOutput.h"
 #include "main/lsp/json_types.h"
 #include "main/options/options.h"
 
 namespace sorbet::realmain::lsp {
+
+class LSPOutput;
 
 /**
  * Client options sent during initialization.

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -1,6 +1,7 @@
 #include "main/lsp/LSPPreprocessor.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_replace.h"
+#include "main/lsp/LSPOutput.h"
 #include "main/lsp/ShowOperation.h"
 #include "main/lsp/lsp.h"
 #include "main/pipeline/pipeline.h"

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -7,6 +7,7 @@
 #include "core/Unfreeze.h"
 #include "main/lsp/DefLocSaver.h"
 #include "main/lsp/LSPMessage.h"
+#include "main/lsp/LSPOutput.h"
 #include "main/lsp/LocalVarFinder.h"
 #include "main/lsp/LocalVarSaver.h"
 #include "main/lsp/ShowOperation.h"

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -8,7 +8,6 @@
 #include "core/NameHash.h"
 #include "core/core.h"
 #include "main/lsp/LSPConfiguration.h"
-#include "main/lsp/LSPOutput.h"
 
 namespace sorbet::realmain::lsp {
 

--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -1,5 +1,6 @@
 #include "common/Timer.h"
-#include "lsp.h"
+#include "main/lsp/LSPOutput.h"
+#include "main/lsp/lsp.h"
 
 using namespace std;
 

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -1,15 +1,18 @@
 #include "gtest/gtest.h"
 // has to go first as it violates our requirements
 
+#include "main/lsp/LSPOutput.h"
 #include "main/lsp/TimeTravelingGlobalState.h"
 #include "main/lsp/lsp.h"
 #include "payload/payload.h"
 #include "spdlog/sinks/null_sink.h"
 #include "test/helpers/MockFileSystem.h"
+#include "test/helpers/lsp.h"
 #include <climits>
 #include <memory>
 
 using namespace std;
+using namespace sorbet::test;
 
 namespace sorbet::realmain::lsp::test {
 
@@ -23,11 +26,11 @@ options::Options makeOptions(string_view rootPath) {
     return opts;
 }
 
-static auto nullSink = make_shared<spd::sinks::null_sink_mt>();
-static auto logger = make_shared<spd::logger>("console", nullSink);
-static auto typeErrorsConsole = make_shared<spd::logger>("typeDiagnostics", nullSink);
-static auto nullOpts = makeOptions("");
-static auto workers = WorkerPool::create(0, *logger);
+auto nullSink = make_shared<spd::sinks::null_sink_mt>();
+auto logger = make_shared<spd::logger>("console", nullSink);
+auto typeErrorsConsole = make_shared<spd::logger>("typeDiagnostics", nullSink);
+auto nullOpts = makeOptions("");
+auto workers = WorkerPool::create(0, *logger);
 
 shared_ptr<LSPConfiguration> makeConfig(const options::Options &opts = nullOpts, bool enableShowOpNotifs = false,
                                         bool initialize = true) {
@@ -50,7 +53,7 @@ unique_ptr<core::GlobalState> makeGS(const options::Options &opts = nullOpts) {
     return gs;
 }
 
-static auto nullConfig = makeConfig();
+auto nullConfig = makeConfig();
 
 TimeTravelingGlobalState makeTTGS(const shared_ptr<LSPConfiguration> &config = nullConfig, u4 initialVersion = 0) {
     return TimeTravelingGlobalState(config, makeGS(config->opts), initialVersion);
@@ -62,23 +65,6 @@ LSPPreprocessor makePreprocessor(const shared_ptr<LSPConfiguration> &config = nu
 
 bool comesBeforeSymmetric(const TimeTravelingGlobalState &ttgs, u4 a, u4 b) {
     return ttgs.comesBefore(a, b) && !ttgs.comesBefore(b, a);
-}
-
-unique_ptr<LSPMessage> makeOpen(string_view path, u4 version, string_view source) {
-    auto params = make_unique<DidOpenTextDocumentParams>(
-        make_unique<TextDocumentItem>(string(path), "ruby", static_cast<double>(version), string(source)));
-    return make_unique<LSPMessage>(
-        make_unique<NotificationMessage>("2.0", LSPMethod::TextDocumentDidOpen, move(params)));
-}
-
-unique_ptr<LSPMessage> makeChange(string_view path, u4 version, string_view source) {
-    auto contentChange = make_unique<TextDocumentContentChangeEvent>(string(source));
-    vector<unique_ptr<TextDocumentContentChangeEvent>> changes;
-    changes.push_back(move(contentChange));
-    auto params = make_unique<DidChangeTextDocumentParams>(
-        make_unique<VersionedTextDocumentIdentifier>(string(path), static_cast<double>(version)), move(changes));
-    return make_unique<LSPMessage>(
-        make_unique<NotificationMessage>("2.0", LSPMethod::TextDocumentDidChange, move(params)));
 }
 
 unique_ptr<LSPMessage> makeWatchman(vector<string> files) {
@@ -240,7 +226,7 @@ TEST(LSPPreprocessor, IgnoresWatchmanUpdatesFromOpenFiles) { // NOLINT
 
     string fileContents = "# typed: true\n1+1";
     opts.fs->writeFile("foo.rb", "");
-    preprocessor.preprocessAndEnqueue(state, makeOpen("foo.rb", 1, fileContents), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeOpen("foo.rb", fileContents, 1), mtx);
     preprocessor.preprocessAndEnqueue(state, makeWatchman({"foo.rb"}), mtx);
 
     ASSERT_EQ(1, state.pendingRequests.size());
@@ -272,10 +258,10 @@ TEST(LSPPreprocessor, ClonesTypecheckingGSAtCorrectLogicalTime) { // NOLINT
     absl::Mutex mtx;
 
     // Apply one update, slow path.
-    preprocessor.preprocessAndEnqueue(state, makeOpen("foo.rb", 1, fileV1), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeOpen("foo.rb", fileV1, 1), mtx);
     // Pop it off the queue to prevent a merge.
     state.pendingRequests.clear();
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 2, fileV2), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fileV2, 2), mtx);
     {
         const auto updates = getUpdates(state, 0).value();
         ASSERT_FALSE(updates->canTakeFastPath);
@@ -286,7 +272,7 @@ TEST(LSPPreprocessor, ClonesTypecheckingGSAtCorrectLogicalTime) { // NOLINT
     // Append another edit that will get merged with the existing edit.
     // V3 will take the fast path relative to V2, forcing a situation in which a new global state will need to be
     // created.
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 3, fileV3), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fileV3, 3), mtx);
     {
         // Should have the newest version of the update.
         const auto updates = getUpdates(state, 0).value();
@@ -296,7 +282,7 @@ TEST(LSPPreprocessor, ClonesTypecheckingGSAtCorrectLogicalTime) { // NOLINT
 
     // Append another edit that will get merged with the existing edit.
     // V4 will take the slow path relative to V3, and the global state created for it should be re-used.
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 4, fileV4), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fileV4, 4), mtx);
     {
         const auto updates = getUpdates(state, 0).value();
         ASSERT_FALSE(updates->canTakeFastPath);
@@ -380,16 +366,16 @@ TEST(LSPPreprocessor, MergesFileUpdatesProperlyAfterCancelation) { // NOLINT
     int id = 0;
     string barV1 = "2+3+4";
 
-    preprocessor.preprocessAndEnqueue(state, makeOpen("foo.rb", 1, fileV1), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeOpen("foo.rb", fileV1, 1), mtx);
     preprocessor.preprocessAndEnqueue(state, makeHoverReq(id++, "foo.rb", 0, 0), mtx);
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 2, fileV2), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fileV2, 2), mtx);
     preprocessor.preprocessAndEnqueue(state, makeHoverReq(id++, "foo.rb", 0, 0), mtx);
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 3, fileV3), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fileV3, 3), mtx);
     preprocessor.preprocessAndEnqueue(state, makeHoverReq(id++, "foo.rb", 0, 0), mtx);
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 4, fileV4), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fileV4, 4), mtx);
     preprocessor.preprocessAndEnqueue(state, makeHoverReq(id++, "foo.rb", 0, 0), mtx);
     // New file. Should not be present in any cloned global states for earlier edits.
-    preprocessor.preprocessAndEnqueue(state, makeOpen("bar.rb", 1, barV1), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeOpen("bar.rb", barV1, 1), mtx);
 
     vector<pair<int, bool>> fastPathDecisions = {{0, false}, {2, true}, {4, true}, {6, true}};
     for (auto &[messageId, canTakeFastPath] : fastPathDecisions) {
@@ -420,7 +406,7 @@ TEST(LSPPreprocessor, MergesFileUpdatesProperlyAfterCancelation) { // NOLINT
     }
 
     // Push a new edit that takes the slow path.
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 5, fileV5), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fileV5, 5), mtx);
     {
         // Ensure GS for new edit has all previous edits, including the contents of bar.rb.
         const auto updates = getUpdates(state, state.pendingRequests.size() - 1).value();
@@ -442,8 +428,8 @@ TEST(LSPPreprocessor, MakesCorrectFastPathDecisionsOnSimultaneousEdits) { // NOL
     string barV1 = "# typed: true\ndef bar; end";
 
     // Commit new files first. The 'new file flag' is handled specially.
-    preprocessor.preprocessAndEnqueue(state, makeOpen("foo.rb", 1, fooV1), mtx);
-    preprocessor.preprocessAndEnqueue(state, makeOpen("bar.rb", 1, barV1), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeOpen("foo.rb", fooV1, 1), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeOpen("bar.rb", barV1, 1), mtx);
     // Clear out of queue to emulate typechecking thread 'processing' it.
     state.pendingRequests.clear();
 
@@ -456,12 +442,12 @@ TEST(LSPPreprocessor, MakesCorrectFastPathDecisionsOnSimultaneousEdits) { // NOL
     // fooV3 => V4: Fast path
     string fooV4 = "# typed: true\ndef foo; 1 + 4; end";
 
-    preprocessor.preprocessAndEnqueue(state, makeChange("bar.rb", 2, barV2), mtx);
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 2, fooV2), mtx);
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 3, fooV3), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("bar.rb", barV2, 2), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fooV2, 2), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fooV3, 3), mtx);
     // With old buggy logic, preprocessor will 'forget' about the barV2 update, causing it to mistakenly think these
     // four edits can take fast path.
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 4, fooV4), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fooV4, 4), mtx);
 
     const auto updates = getUpdates(state, 0).value();
     EXPECT_FALSE(updates->canTakeFastPath);
@@ -472,7 +458,7 @@ unique_ptr<core::GlobalState> initCancelSlowPathTest(LSPPreprocessor &preprocess
                                                      absl::Mutex &mtx) {
     // New file, slow path. Can't avoid, so emulate processing it.
     string fooV1 = "# typed: true\ndef foo; end";
-    preprocessor.preprocessAndEnqueue(state, makeOpen("foo.rb", 1, fooV1), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeOpen("foo.rb", fooV1, 1), mtx);
 
     // Grab GS.
     unique_ptr<core::GlobalState> gs;
@@ -501,12 +487,12 @@ TEST(SlowPathCancelation, CancelsRunningSlowPathWhenFastPathEditComesIn) { // NO
 
     // Introduce a syntax error, which causes a slow path.
     string fooV2 = "# typed: true\n{def foo; end";
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 2, fooV2), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fooV2, 2), mtx);
     u4 epoch = emulateProcessEditAtHeadOfQueue(state, *gs);
 
     // Introduce a fix to syntax error. Should course-correct to a fast path.
     string fooV3 = "# typed: true\ndef foo; end";
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 3, fooV3), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fooV3, 3), mtx);
     EXPECT_TRUE(gs->wasTypecheckingCanceled());
 
     // Processor thread: Try to typecheck. Should cancel.
@@ -524,12 +510,12 @@ TEST(SlowPathCancelation, CancelsRunningSlowPathWhenSlowPathEditComesIn) { // NO
 
     // Introduce a syntax error, which causes a slow path.
     string fooV2 = "# typed: true\n{def foo; end";
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 2, fooV2), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fooV2, 2), mtx);
     u4 epoch = emulateProcessEditAtHeadOfQueue(state, *gs);
 
     // Introduce another slow path here: new method
     string fooV3 = "# typed: true\ndef foo; end\ndef bar;end";
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 3, fooV3), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fooV3, 3), mtx);
     EXPECT_TRUE(gs->wasTypecheckingCanceled());
 
     // Processor thread: Try to typecheck. Should return false because it has been canceled.
@@ -550,12 +536,12 @@ TEST(SlowPathCancelation, DoesNotCancelRunningSlowPathWhenFastPathEditComesIn) {
 
     // Introduce a new method, which causes a slow path.
     string fooV2 = "# typed: true\ndef foo; end\ndef bar; end";
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 2, fooV2), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fooV2, 2), mtx);
     u4 epoch = emulateProcessEditAtHeadOfQueue(state, *gs);
 
     // Edit the body of the new method which should take the fast path.
     string fooV3 = "# typed: true\ndef foo; end\ndef bar; 1 + 1; end";
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 3, fooV3), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fooV3, 3), mtx);
     EXPECT_FALSE(gs->wasTypecheckingCanceled());
 
     // Processor thread: Try to typecheck. Should return true because typechecking hasn't been canceled.
@@ -570,7 +556,7 @@ TEST(SlowPathCancelation, CancelsRunningSlowPathAfterBlockingRequestGetsCanceled
 
     // Introduce a syntax error, which causes a slow path.
     string fooV2 = "# typed: true\n{def foo; end";
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 2, fooV2), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fooV2, 2), mtx);
     u4 epoch = emulateProcessEditAtHeadOfQueue(state, *gs);
 
     // Blocking hover.
@@ -578,7 +564,7 @@ TEST(SlowPathCancelation, CancelsRunningSlowPathAfterBlockingRequestGetsCanceled
 
     // Fixes parse error, but blocked by hover.
     string fooV3 = "# typed: true\ndef foo; end";
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 3, fooV3), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fooV3, 3), mtx);
     EXPECT_FALSE(gs->wasTypecheckingCanceled());
 
     // Cancel hover, which should cause the slow path to be canceled.
@@ -600,7 +586,7 @@ TEST(SlowPathCancelation, PruneDuringVersionRollover) { // NOLINT
 
     // Edit 0xFFFFFFFF-2 introduces barV1.
     string barV1 = "# typed: true\ndef foo; end";
-    preprocessor.preprocessAndEnqueue(state, makeOpen("bar.rb", 1, barV1), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeOpen("bar.rb", barV1, 1), mtx);
 
     // Emulate typechecker thread: 'process' changes
     emulateProcessEditAtHeadOfQueue(state, *gs);
@@ -611,15 +597,15 @@ TEST(SlowPathCancelation, PruneDuringVersionRollover) { // NOLINT
     string fooV2 = "# typed: true\ndef { foo; end";
     // Edit 0xFFFFFFFF introduces fast path update to bar
     string barV2 = "# typed: true\ndef foo; 1; end";
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 2, fooV2), mtx);
-    preprocessor.preprocessAndEnqueue(state, makeChange("bar.rb", 2, barV2), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fooV2, 2), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("bar.rb", barV2, 2), mtx);
 
     // Emulate typechecker thread: claim that we are actively and concurrently typechecking these changes.
     emulateProcessEditAtHeadOfQueue(state, *gs);
 
     // Edit 0 fixes parse error and cancels slow path from previous bundle.
     string fooV3 = "# typed: true\ndef foo; end";
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 3, fooV3), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fooV3, 3), mtx);
 
     EXPECT_TRUE(gs->wasTypecheckingCanceled());
 
@@ -648,19 +634,19 @@ TEST(SlowPathCancelation, DoesNotIncludeOldEditsInCombinedEdit) { // NOLINT
     // Defines foo.rb.
     unique_ptr<core::GlobalState> gs = initCancelSlowPathTest(preprocessor, state, mtx);
     // Define bar.rb.
-    preprocessor.preprocessAndEnqueue(state, makeOpen("bar.rb", 1, "# typed: true\ndef bar; 99999; end"), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeOpen("bar.rb", "# typed: true\ndef bar; 99999; end", 1), mtx);
     // 'process' those messages.
     state.pendingRequests.clear();
 
     // Fast path bar.rb update.
     string barV2 = "# typed: true\ndef bar; end";
-    preprocessor.preprocessAndEnqueue(state, makeChange("bar.rb", 2, barV2), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("bar.rb", barV2, 2), mtx);
     // Hover request: Blocking.
     preprocessor.preprocessAndEnqueue(state, makeHoverReq(10, "foo.rb"), mtx);
 
     // Slow path foo.rb update (parse error)
     string fooV3 = "# typed: true\ndef {foo; 1; end";
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 3, fooV3), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fooV3, 3), mtx);
 
     // 'process' first two messages
     state.pendingRequests.pop_front();
@@ -670,7 +656,7 @@ TEST(SlowPathCancelation, DoesNotIncludeOldEditsInCombinedEdit) { // NOLINT
 
     // New edit: Fixes parse error, and cancels running slow path.
     string fooV4 = "# typed: true\ndef foo; 1; end";
-    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", 4, fooV4), mtx);
+    preprocessor.preprocessAndEnqueue(state, makeChange("foo.rb", fooV4, 4), mtx);
 
     EXPECT_TRUE(gs->wasTypecheckingCanceled());
 

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -1,5 +1,6 @@
-#include "wrapper.h"
+#include "main/lsp/wrapper.h"
 #include "core/errors/namer.h"
+#include "main/lsp/LSPOutput.h"
 #include "main/pipeline/pipeline.h"
 #include "payload/payload.h"
 #include <regex>
@@ -15,7 +16,7 @@ vector<unique_ptr<LSPMessage>> LSPWrapper::getLSPResponsesFor(unique_ptr<LSPMess
     return output->getOutput();
 }
 
-vector<unique_ptr<LSPMessage>> LSPWrapper::getLSPResponsesFor(vector<unique_ptr<LSPMessage>> &messages) {
+vector<unique_ptr<LSPMessage>> LSPWrapper::getLSPResponsesFor(vector<unique_ptr<LSPMessage>> messages) {
     lspLoop->processRequests(move(messages));
     return output->getOutput();
 }
@@ -29,9 +30,9 @@ void LSPWrapper::instantiate(std::unique_ptr<core::GlobalState> gs, const shared
     output = make_shared<LSPOutputToVector>();
     ENFORCE(gs->errorQueue->ignoreFlushes); // LSP needs this
     workers = WorkerPool::create(0, *logger);
-    config = make_shared<LSPConfiguration>(opts, output, *workers, logger, true, disableFastPath);
+    config_ = make_shared<LSPConfiguration>(opts, output, *workers, logger, true, disableFastPath);
     // Configure LSPLoop to disable configatron.
-    lspLoop = make_unique<LSPLoop>(std::move(gs), config);
+    lspLoop = make_unique<LSPLoop>(std::move(gs), config_);
 }
 
 LSPWrapper::LSPWrapper(options::Options &&options, std::string_view rootPath, bool disableFastPath)
@@ -104,6 +105,10 @@ void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
 
 int LSPWrapper::getTypecheckCount() {
     return lspLoop->getTypecheckCount();
+}
+
+const LSPConfiguration &LSPWrapper::config() const {
+    return *config_;
 }
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -10,7 +10,7 @@
 namespace sorbet::realmain::lsp {
 
 class LSPOutputToVector;
-
+class LSPConfiguration;
 class LSPWrapper final {
     static const std::string EMPTY_STRING;
 
@@ -23,7 +23,7 @@ class LSPWrapper final {
     std::unique_ptr<WorkerPool> workers;
     std::shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink;
     std::shared_ptr<spd::logger> typeErrorsConsole;
-    std::shared_ptr<LSPConfiguration> config;
+    std::shared_ptr<LSPConfiguration> config_;
     std::shared_ptr<LSPOutputToVector> output;
 
     /** Contains shared constructor logic. */
@@ -49,6 +49,8 @@ public:
                const std::shared_ptr<spdlog::logger> &logger, bool disableFastPath);
     ~LSPWrapper();
 
+    const LSPConfiguration &config() const;
+
     /**
      * Send a message to LSP, and returns any responses.
      */
@@ -62,7 +64,7 @@ public:
     /**
      * Sends multiple messages to LSP, and returns any responses.
      */
-    std::vector<std::unique_ptr<LSPMessage>> getLSPResponsesFor(std::vector<std::unique_ptr<LSPMessage>> &messages);
+    std::vector<std::unique_ptr<LSPMessage>> getLSPResponsesFor(std::vector<std::unique_ptr<LSPMessage>> messages);
 
     /**
      * Enable an experimental LSP feature.

--- a/test/helpers/lsp.h
+++ b/test/helpers/lsp.h
@@ -8,11 +8,9 @@
 namespace sorbet::test {
 using namespace sorbet::realmain::lsp;
 
-std::string filePathToUri(std::string_view prefixUrl, std::string_view filePath);
+std::string filePathToUri(const LSPConfiguration &config, std::string_view filePath);
 
-bool isUriATestFile(std::string_view prefixUrl, std::string_view uri);
-
-std::string uriToFilePath(std::string_view prefixUrl, std::string_view uri);
+std::string uriToFilePath(const LSPConfiguration &config, std::string_view uri);
 
 /** Creates the parameters to the `initialize` message, which advertises the client's capabilities. */
 std::unique_ptr<InitializeParams>
@@ -26,8 +24,11 @@ std::unique_ptr<LSPMessage> makeDefinitionRequest(int id, std::string_view uri, 
 /** Create an LSPMessage containing a WorkspaceSymbol request. */
 std::unique_ptr<LSPMessage> makeWorkspaceSymbolRequest(int id, std::string_view query);
 
+/** Create an LSPMessage containing a textDocument/didOpen request. */
+std::unique_ptr<LSPMessage> makeOpen(std::string_view uri, std::string_view contents, int version);
+
 /** Create an LSPMessage containing a textDocument/didChange request. */
-std::unique_ptr<LSPMessage> makeDidChange(std::string_view uri, std::string_view contents, int version);
+std::unique_ptr<LSPMessage> makeChange(std::string_view uri, std::string_view contents, int version);
 
 /** Checks that we are properly advertising Sorbet LSP's capabilities to clients. */
 void checkServerCapabilities(const ServerCapabilities &capabilities);
@@ -40,7 +41,7 @@ void assertResponseMessage(int expectedId, const LSPMessage &response);
 void assertResponseError(int code, std::string_view msg, const LSPMessage &response);
 
 /** Asserts that the LSPMessage is a NotificationMessage with the given method. */
-void assertNotificationMessage(const LSPMethod expectedMethod, const LSPMessage &response);
+void assertNotificationMessage(LSPMethod expectedMethod, const LSPMessage &response);
 
 /** Retrieves the PublishDiagnosticsParam from a publishDiagnostics message, if applicable. Non-fatal fails and returns
  * an empty optional if it cannot be found. */
@@ -49,7 +50,7 @@ std::optional<PublishDiagnosticsParams *> getPublishDiagnosticParams(Notificatio
 /** Use the LSPWrapper to make a textDocument/completion request.
  */
 std::unique_ptr<CompletionList> doTextDocumentCompletion(LSPWrapper &lspWrapper, const Range &range, int &nextId,
-                                                         std::string_view filename, std::string_view uriPrefix);
+                                                         std::string_view filename);
 
 /** Sends boilerplate initialization / initialized messages to start a new LSP session. */
 std::vector<std::unique_ptr<LSPMessage>>

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -33,8 +33,6 @@ protected:
     /** The next ID to use when sending an LSP message. */
     int nextId = 0;
 
-    bool paused = false;
-
     virtual ~ProtocolTest() = default;
 
     void SetUp() override;


### PR DESCRIPTION
Clean up test code, remove some unneeded dependencies from headers, and fixup some clang-tidy warnings.

Most changes are straightforward; I'll add comments where things might be confusing.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Clangd 9.0 now shows me clang-tidy warnings, and it nerdsniped me into making some code changes. I eventually realized that I could remove some redundant test code, so I did.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

There are existing tests that should catch any bugs in this cleanup effort.
