### PR TITLE
VS Code: Disable clangd auto-import, and gitignore cache directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ gems/sorbet-runtime/Gemfile.lock
 
 # To distribute sorbet, we copy the built C++ binary here.
 /gems/sorbet-static/libexec/sorbet
+
+# clangd caches data in this folder.
+/.clangd

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
   // syntax highlighting colors to "bleed" into adjacent lines. Thus, we disable it.
   // We should revisit this option next time we upgrade clang.
   "clangd.semanticHighlighting": false,
+  "clangd.arguments": ["-header-insertion=never"],
   "files.associations": {
     "*.rbi": "ruby",
     "*.rbupdated": "ruby",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,8 @@
   // syntax highlighting colors to "bleed" into adjacent lines. Thus, we disable it.
   // We should revisit this option next time we upgrade clang.
   "clangd.semanticHighlighting": false,
+  // Disable feature where Clangd auto-imports headers for missing references.
+  // It inserts relative paths that we don't want.
   "clangd.arguments": ["-header-insertion=never"],
   "files.associations": {
     "*.rbi": "ruby",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

VS Code: Disable clangd auto-import, and gitignore cache directory.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This "feature" caused a number of relative header import statements to be added to the codebase (e.g., `#include "lsp.h"`).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Manually tested.
