### PR TITLE
Ignore sorbet: URIs in textDocument open/change/close events.

### DIFF
--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -132,7 +132,7 @@ string LSPConfiguration::localName2Remote(string_view filePath) const {
 
 string LSPConfiguration::remoteName2Local(string_view uri) const {
     assertHasClientConfig();
-    if (!isUriInWorkspace(uri)) {
+    if (!isUriInWorkspace(uri) && !isSorbetUri(uri)) {
         logger->error("Unrecognized URI received from client: {}", uri);
         return string(uri);
     }
@@ -161,7 +161,7 @@ string LSPConfiguration::remoteName2Local(string_view uri) const {
 
 core::FileRef LSPConfiguration::uri2FileRef(const core::GlobalState &gs, string_view uri) const {
     assertHasClientConfig();
-    if (!isUriInWorkspace(uri)) {
+    if (!isUriInWorkspace(uri) && !isSorbetUri(uri)) {
         return core::FileRef();
     }
     auto needle = remoteName2Local(uri);
@@ -219,12 +219,13 @@ bool LSPConfiguration::isFileIgnored(string_view filePath) const {
 }
 
 bool LSPConfiguration::isSorbetUri(string_view uri) const {
+    assertHasClientConfig();
     return clientConfig->enableSorbetURIs && absl::StartsWith(uri, sorbetScheme);
 }
 
 bool LSPConfiguration::isUriInWorkspace(string_view uri) const {
     assertHasClientConfig();
-    return absl::StartsWith(uri, clientConfig->rootUri) || isSorbetUri(uri);
+    return absl::StartsWith(uri, clientConfig->rootUri);
 }
 
 void LSPConfiguration::markInitialized() {

--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -7,8 +7,10 @@ using namespace std;
 
 namespace sorbet::realmain::lsp {
 
-constexpr string_view sorbetScheme = "sorbet:";
-constexpr string_view httpsScheme = "https";
+namespace {
+constexpr string_view sorbetScheme = "sorbet:"sv;
+constexpr string_view httpsScheme = "https"sv;
+} // namespace
 
 namespace {
 
@@ -130,12 +132,12 @@ string LSPConfiguration::localName2Remote(string_view filePath) const {
 
 string LSPConfiguration::remoteName2Local(string_view uri) const {
     assertHasClientConfig();
-    const bool isSorbetURI = absl::StartsWith(uri, sorbetScheme);
     if (!isUriInWorkspace(uri)) {
         logger->error("Unrecognized URI received from client: {}", uri);
         return string(uri);
     }
 
+    const bool isSorbetURI = this->isSorbetUri(uri);
     const string_view root = isSorbetURI ? sorbetScheme : clientConfig->rootUri;
     const char *start = uri.data() + root.length();
     if (*start == '/') {
@@ -180,7 +182,7 @@ string LSPConfiguration::fileRef2Uri(const core::GlobalState &gs, core::FileRef 
                 uri = string(messageFile.path());
             }
         } else {
-            uri = localName2Remote(file.data(gs).path());
+            uri = localName2Remote(messageFile.path());
         }
     }
     return uri;
@@ -216,10 +218,13 @@ bool LSPConfiguration::isFileIgnored(string_view filePath) const {
     return FileOps::isFileIgnored(rootPath, filePath, opts.absoluteIgnorePatterns, opts.relativeIgnorePatterns);
 }
 
+bool LSPConfiguration::isSorbetUri(string_view uri) const {
+    return clientConfig->enableSorbetURIs && absl::StartsWith(uri, sorbetScheme);
+}
+
 bool LSPConfiguration::isUriInWorkspace(string_view uri) const {
     assertHasClientConfig();
-    return absl::StartsWith(uri, clientConfig->rootUri) ||
-           (clientConfig->enableSorbetURIs && absl::StartsWith(uri, sorbetScheme));
+    return absl::StartsWith(uri, clientConfig->rootUri) || isSorbetUri(uri);
 }
 
 void LSPConfiguration::markInitialized() {

--- a/main/lsp/LSPConfiguration.h
+++ b/main/lsp/LSPConfiguration.h
@@ -64,6 +64,8 @@ class LSPConfiguration {
     std::atomic<bool> initialized;
     // Throws if clientConfig is not set. Must be called before accessing `clientConfig` in LSPConfiguration methods.
     void assertHasClientConfig() const;
+    // Does the given URI correspond to a `sorbet:` URI?
+    bool isSorbetUri(std::string_view uri) const;
 
 public:
     // The following properties are configured when the language server is created.
@@ -105,8 +107,13 @@ public:
     // returns nullptr if this loc doesn't exist
     std::unique_ptr<Location> loc2Location(const core::GlobalState &gs, core::Loc loc) const;
     bool isFileIgnored(std::string_view filePath) const;
+
+    /**
+     * Returns 'true' if the URI corresponds to a path within the active workspace.
+     * Note: Does *not* return 'true' for URIs corresponding to sorbet: URIs. While these are valid URIs, they are not
+     * actually within the workspace.
+     */
     bool isUriInWorkspace(std::string_view uri) const;
-    bool isSorbetUri(std::string_view uri) const;
 };
 } // namespace sorbet::realmain::lsp
 #endif // RUBY_TYPER_LSPCONFIGURATION_H

--- a/main/lsp/LSPConfiguration.h
+++ b/main/lsp/LSPConfiguration.h
@@ -106,6 +106,7 @@ public:
     std::unique_ptr<Location> loc2Location(const core::GlobalState &gs, core::Loc loc) const;
     bool isFileIgnored(std::string_view filePath) const;
     bool isUriInWorkspace(std::string_view uri) const;
+    bool isSorbetUri(std::string_view uri) const;
 };
 } // namespace sorbet::realmain::lsp
 #endif // RUBY_TYPER_LSPCONFIGURATION_H

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -356,7 +356,7 @@ void LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<DidChangeTextDocumentPa
     updates.versionStart = v;
     updates.versionEnd = v;
     string_view uri = changeParams->textDocument->uri;
-    if (config->isUriInWorkspace(uri) && !config->isSorbetUri(uri)) {
+    if (config->isUriInWorkspace(uri)) {
         string localPath = config->remoteName2Local(uri);
         if (config->isFileIgnored(localPath)) {
             return;
@@ -392,7 +392,7 @@ void LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<DidOpenTextDocumentPara
     updates.versionStart = v;
     updates.versionEnd = v;
     string_view uri = openParams->textDocument->uri;
-    if (config->isUriInWorkspace(uri) && !config->isSorbetUri(uri)) {
+    if (config->isUriInWorkspace(uri)) {
         string localPath = config->remoteName2Local(uri);
         if (!config->isFileIgnored(localPath)) {
             updates.updatedFiles.push_back(make_shared<core::File>(
@@ -406,7 +406,7 @@ void LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<DidCloseTextDocumentPar
     updates.versionStart = v;
     updates.versionEnd = v;
     string_view uri = closeParams->textDocument->uri;
-    if (config->isUriInWorkspace(uri) && !config->isSorbetUri(uri)) {
+    if (config->isUriInWorkspace(uri)) {
         string localPath = config->remoteName2Local(uri);
         if (!config->isFileIgnored(localPath)) {
             // Use contents of file on disk.

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -356,7 +356,7 @@ void LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<DidChangeTextDocumentPa
     updates.versionStart = v;
     updates.versionEnd = v;
     string_view uri = changeParams->textDocument->uri;
-    if (config->isUriInWorkspace(uri)) {
+    if (config->isUriInWorkspace(uri) && !config->isSorbetUri(uri)) {
         string localPath = config->remoteName2Local(uri);
         if (config->isFileIgnored(localPath)) {
             return;
@@ -392,7 +392,7 @@ void LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<DidOpenTextDocumentPara
     updates.versionStart = v;
     updates.versionEnd = v;
     string_view uri = openParams->textDocument->uri;
-    if (config->isUriInWorkspace(uri)) {
+    if (config->isUriInWorkspace(uri) && !config->isSorbetUri(uri)) {
         string localPath = config->remoteName2Local(uri);
         if (!config->isFileIgnored(localPath)) {
             updates.updatedFiles.push_back(make_shared<core::File>(
@@ -406,7 +406,7 @@ void LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<DidCloseTextDocumentPar
     updates.versionStart = v;
     updates.versionEnd = v;
     string_view uri = closeParams->textDocument->uri;
-    if (config->isUriInWorkspace(uri)) {
+    if (config->isUriInWorkspace(uri) && !config->isSorbetUri(uri)) {
         string localPath = config->remoteName2Local(uri);
         if (!config->isFileIgnored(localPath)) {
             // Use contents of file on disk.
@@ -422,7 +422,7 @@ void LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<WatchmanQueryResponse> 
     updates.versionEnd = v;
     for (auto file : queryResponse->files) {
         // Don't append rootPath if it is empty.
-        string localPath = config->rootPath.size() > 0 ? absl::StrCat(config->rootPath, "/", file) : file;
+        string localPath = !config->rootPath.empty() ? absl::StrCat(config->rootPath, "/", file) : file;
         // Editor contents supercede file system updates.
         if (!config->isFileIgnored(localPath) && !openFiles.contains(localPath)) {
             updates.updatedFiles.push_back(make_shared<core::File>(

--- a/test/helpers/lsp.cc
+++ b/test/helpers/lsp.cc
@@ -335,7 +335,7 @@ unique_ptr<LSPMessage> makeOpen(string_view uri, string_view contents, int versi
         make_unique<NotificationMessage>("2.0", LSPMethod::TextDocumentDidOpen, move(params)));
 }
 
-unique_ptr<LSPMessage> makeChange(std::string_view uri, std::string_view contents, int version) {
+unique_ptr<LSPMessage> makeChange(string_view uri, string_view contents, int version) {
     auto textDoc = make_unique<VersionedTextDocumentIdentifier>(string(uri), static_cast<double>(version));
     auto textDocChange = make_unique<TextDocumentContentChangeEvent>(string(contents));
     vector<unique_ptr<TextDocumentContentChangeEvent>> textChanges;
@@ -345,6 +345,12 @@ unique_ptr<LSPMessage> makeChange(std::string_view uri, std::string_view content
     auto didChangeNotif =
         make_unique<NotificationMessage>("2.0", LSPMethod::TextDocumentDidChange, move(didChangeParams));
     return make_unique<LSPMessage>(move(didChangeNotif));
+}
+
+unique_ptr<LSPMessage> makeClose(string_view uri) {
+    auto didCloseParams = make_unique<DidCloseTextDocumentParams>(make_unique<TextDocumentIdentifier>(string(uri)));
+    auto didCloseNotif = make_unique<NotificationMessage>("2.0", LSPMethod::TextDocumentDidClose, move(didCloseParams));
+    return make_unique<LSPMessage>(move(didCloseNotif));
 }
 
 } // namespace sorbet::test

--- a/test/helpers/lsp.h
+++ b/test/helpers/lsp.h
@@ -24,11 +24,14 @@ std::unique_ptr<LSPMessage> makeDefinitionRequest(int id, std::string_view uri, 
 /** Create an LSPMessage containing a WorkspaceSymbol request. */
 std::unique_ptr<LSPMessage> makeWorkspaceSymbolRequest(int id, std::string_view query);
 
-/** Create an LSPMessage containing a textDocument/didOpen request. */
+/** Create an LSPMessage containing a textDocument/didOpen notification. */
 std::unique_ptr<LSPMessage> makeOpen(std::string_view uri, std::string_view contents, int version);
 
-/** Create an LSPMessage containing a textDocument/didChange request. */
+/** Create an LSPMessage containing a textDocument/didChange notification. */
 std::unique_ptr<LSPMessage> makeChange(std::string_view uri, std::string_view contents, int version);
+
+/** Create an LSPMessage containing a textDocument/didClose notification. */
+std::unique_ptr<LSPMessage> makeClose(std::string_view uri);
 
 /** Checks that we are properly advertising Sorbet LSP's capabilities to clients. */
 void checkServerCapabilities(const ServerCapabilities &capabilities);

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -42,11 +42,7 @@ unique_ptr<LSPMessage> ProtocolTest::closeFile(string_view path) {
             sourceFileContents.erase(it);
         }
     }
-
-    auto uri = getUri(path);
-    auto didCloseParams = make_unique<DidCloseTextDocumentParams>(make_unique<TextDocumentIdentifier>(uri));
-    auto didCloseNotif = make_unique<NotificationMessage>("2.0", LSPMethod::TextDocumentDidClose, move(didCloseParams));
-    return make_unique<LSPMessage>(move(didCloseNotif));
+    return makeClose(getUri(path));
 }
 
 unique_ptr<LSPMessage> ProtocolTest::changeFile(string_view path, string_view newContents, int version) {

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -2,12 +2,20 @@
 // ^ Violates linting rules, so include first.
 #include "ProtocolTest.h"
 #include "absl/strings/match.h"
+#include "absl/strings/str_replace.h"
 #include "common/common.h"
 #include "test/helpers/lsp.h"
 
 namespace sorbet::test::lsp {
 using namespace std;
 using namespace sorbet::realmain::lsp;
+
+namespace {
+void assertTookFastPath(const NotificationMessage &notif) {
+    auto &info = get<unique_ptr<SorbetTypecheckRunInfo>>(notif.params);
+    ASSERT_TRUE(info->tookFastPath);
+}
+} // namespace
 
 // Adds two new files that have errors, and asserts that Sorbet returns errors for both of them.
 TEST_F(ProtocolTest, AddFile) {
@@ -445,6 +453,40 @@ TEST_F(ProtocolTest, SorbetURIsWork) {
     auto &myMethodDefLoc = myMethodDefinitions.at(0);
     ASSERT_EQ(myMethodDefLoc->uri, "sorbet:folder/foo.rb");
     ASSERT_EQ(readFile(myMethodDefLoc->uri), fileContents);
+
+    // VS Code replaces : in https with something URL-escaped; test that we handle this use-case.
+    auto arrayRBI = readFile(selectLoc->uri);
+    auto arrayRBIURLEncodeColon =
+        readFile(absl::StrReplaceAll(selectLoc->uri, {{"https://github.com/", "https%3A//github.com/"}}));
+    ASSERT_EQ(arrayRBI, arrayRBIURLEncodeColon);
+}
+
+// Tests that Sorbet URIs don't take the slow path (read: don't define new files!) when opened and closed.
+TEST_F(ProtocolTest, SorbetURIsTakeFastPath) {
+    const bool supportsMarkdown = false;
+    auto initOptions = make_unique<SorbetInitializationOptions>();
+    initOptions->supportsSorbetURIs = true;
+    initOptions->enableTypecheckInfo = true;
+    lspWrapper->opts.lspDirsMissingFromClient.emplace_back("/folder");
+    sorbet::test::initializeLSP(rootPath, rootUri, *lspWrapper, nextId, supportsMarkdown, move(initOptions));
+
+    string fileContents = "# typed: true\n[0,1,2,3].select {|x| x > 0}\ndef myMethod; end;\n";
+    send(*openFile("folder/foo.rb", fileContents));
+
+    auto selectDefinitions = getDefinitions("folder/foo.rb", 1, 11);
+    ASSERT_EQ(selectDefinitions.size(), 1);
+    auto &selectLoc = selectDefinitions.at(0);
+    ASSERT_TRUE(absl::StartsWith(selectLoc->uri, "sorbet:https://github.com/"));
+    auto contents = readFile(selectLoc->uri);
+
+    // Test that opening and closing one of these files doesn't cause a slow path.
+    vector<unique_ptr<LSPMessage>> openClose;
+    openClose.push_back(makeOpen(selectLoc->uri, contents, 1));
+    openClose.push_back(makeClose(selectLoc->uri));
+    auto responses = send(move(openClose));
+    ASSERT_EQ(1, responses.size());
+    ASSERT_NO_FATAL_FAILURE(assertNotificationMessage(LSPMethod::SorbetTypecheckRunInfo, *responses.at(0)));
+    ASSERT_NO_FATAL_FAILURE(assertTookFastPath(responses.at(0)->asNotification()));
 }
 
 // Tests that Sorbet does not crash when a file URI falls outside of the workspace.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Ignore sorbet: URIs in textDocument open/change/close events. `sorbet:` URIs are sent to VS Code for read-only documents (e.g. autogenerated files or rbis in payload).

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes crash. Previously, opening and closing an RBI file would cause Sorbet to commit an empty file with the `sorbet:` URI, and cause all sorts of havoc.

cc @evan-stripe who reported this bug.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
