### PR TITLE
Add autocorrect to delete generated sigs

### DIFF
--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -60,6 +60,7 @@ constexpr ErrorClass InvalidTypeMemberBounds{5052, StrictLevel::False};
 constexpr ErrorClass ParentTypeBoundsMismatch{5053, StrictLevel::False};
 constexpr ErrorClass ImplementationDeprecated{5054, StrictLevel::False};
 constexpr ErrorClass TypeMemberCycle{5055, StrictLevel::False};
+constexpr ErrorClass GeneratedDeprecated{5056, StrictLevel::False};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -341,6 +341,26 @@ ParsedSig TypeSyntax::parseSig(core::MutableContext ctx, ast::Send *sigSend, con
                     break;
                 case core::Names::generated()._id:
                     sig.seen.generated = true;
+
+                    if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::GeneratedDeprecated)) {
+                        e.setHeader("`{}` is deprecated. See docs for alternatives", "generated");
+
+                        auto file = sigSend->loc.file();
+                        auto [sigStart, sigEnd] = sigSend->loc.position(ctx);
+
+                        auto maybeReplaceStart = core::Loc::pos2Offset(file.data(ctx), {sigStart.line, 1});
+                        ENFORCE(maybeReplaceStart.has_value());
+                        auto replaceStart = maybeReplaceStart.value();
+
+                        auto replaceEnd = sigSend->loc.endPos();
+                        if (auto nextLine = core::Loc::pos2Offset(file.data(ctx), {sigEnd.line + 1, 1})) {
+                            replaceEnd = nextLine.value();
+                        }
+
+                        auto replacementLoc = core::Loc{file, replaceStart, replaceEnd};
+
+                        e.replaceWith("Delete entire sig", replacementLoc, "");
+                    }
                     break;
                 case core::Names::final_()._id:
                     if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {

--- a/test/cli/suggest-sig-garbage/suggest-sig-garbage.out
+++ b/test/cli/suggest-sig-garbage/suggest-sig-garbage.out
@@ -12,6 +12,35 @@ suggest-sig-garbage.rb:92: Method `with_block` uses `yield` but does not mention
     93 |  yield
           ^^^^^
 
+suggest-sig-garbage.rb:124: `generated` is deprecated. See docs for alternatives https://srb.help/5056
+     124 |sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated} # error: `generated` is deprecated
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    suggest-sig-garbage.rb:124: Deleted
+     124 |sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated} # error: `generated` is deprecated
+     125 |def fooCondGeneratedCurly(a, cond)
+
+suggest-sig-garbage.rb:135: `generated` is deprecated. See docs for alternatives https://srb.help/5056
+     135 |  params(a: T.untyped, cond: T::Boolean). # error: `generated` is deprecated
+     136 |  returns(T.untyped).
+     137 |  generated
+  Autocorrect: Done
+    suggest-sig-garbage.rb:134: Deleted
+     134 |sig do
+     135 |  params(a: T.untyped, cond: T::Boolean). # error: `generated` is deprecated
+     136 |  returns(T.untyped).
+     137 |  generated
+     138 |end
+     139 |def fooCondGeneratedDo(a, cond)
+
+suggest-sig-garbage.rb:147: `generated` is deprecated. See docs for alternatives https://srb.help/5056
+     147 |sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated} # error: `generated` is deprecated
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    suggest-sig-garbage.rb:147: Deleted
+     147 |sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated} # error: `generated` is deprecated
+     148 |def updatesUntypedToProfiled(a, cond)
+
 suggest-sig-garbage.rb:5: This function does not have a `sig` https://srb.help/7017
      5 |def hazTwoArgs(a, b); 1; end;
         ^^^^^^^^^^^^^^^^^^^^
@@ -199,7 +228,7 @@ suggest-sig-garbage.rb:125: This function does not have a `sig` https://srb.help
   Autocorrect: Done
     suggest-sig-garbage.rb:124: Replaced with `sig {params(a: T.any(Integer, String), cond: T::Boolean).returns(::T::Utils::RuntimeProfiled)}
 `
-     124 |sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated}
+     124 |sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated} # error: `generated` is deprecated
      125 |def fooCondGeneratedCurly(a, cond)
 
 suggest-sig-garbage.rb:139: This function does not have a `sig` https://srb.help/7017
@@ -209,7 +238,7 @@ suggest-sig-garbage.rb:139: This function does not have a `sig` https://srb.help
     suggest-sig-garbage.rb:134: Replaced with `sig {params(a: T.any(Integer, String), cond: T::Boolean).returns(::T::Utils::RuntimeProfiled)}
 `
      134 |sig do
-     135 |  params(a: T.untyped, cond: T::Boolean).
+     135 |  params(a: T.untyped, cond: T::Boolean). # error: `generated` is deprecated
      136 |  returns(T.untyped).
      137 |  generated
      138 |end
@@ -221,7 +250,7 @@ suggest-sig-garbage.rb:148: This function does not have a `sig` https://srb.help
   Autocorrect: Done
     suggest-sig-garbage.rb:147: Replaced with `sig {params(a: ::T::Utils::RuntimeProfiled, cond: T::Boolean).returns(::T::Utils::RuntimeProfiled)}
 `
-     147 |sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated}
+     147 |sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated} # error: `generated` is deprecated
      148 |def updatesUntypedToProfiled(a, cond)
 
 suggest-sig-garbage.rb:152: This function does not have a `sig` https://srb.help/7017
@@ -288,7 +317,7 @@ suggest-sig-garbage.rb:108: Method `sig` does not exist on `T.class_of(TestCaras
 suggest-sig-garbage.rb:108: Method `params` does not exist on `T.class_of(TestCarash)` https://srb.help/7003
      108 |  sig {params(merchant: Merchant).void}
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 39
+Errors: 42
 
 --------------------------------------------------------------------------
 
@@ -436,7 +465,6 @@ def cantRun(a)
   1
 end
 
-sig {params(a: T.any(Integer, String), cond: T::Boolean).returns(::T::Utils::RuntimeProfiled)}
 def fooCondGeneratedCurly(a, cond)
   if cond
     takesInt(a)
@@ -446,7 +474,6 @@ def fooCondGeneratedCurly(a, cond)
 end
 
 
-sig {params(a: T.any(Integer, String), cond: T::Boolean).returns(::T::Utils::RuntimeProfiled)}
 def fooCondGeneratedDo(a, cond)
   if cond
     takesInt(a)
@@ -455,7 +482,6 @@ def fooCondGeneratedDo(a, cond)
   end
 end
 
-sig {params(a: ::T::Utils::RuntimeProfiled, cond: T::Boolean).returns(::T::Utils::RuntimeProfiled)}
 def updatesUntypedToProfiled(a, cond)
   a.baz
 end

--- a/test/cli/suggest-sig-garbage/suggest-sig-garbage.rb
+++ b/test/cli/suggest-sig-garbage/suggest-sig-garbage.rb
@@ -121,7 +121,7 @@ def cantRun(a)
   1
 end
 
-sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated}
+sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated} # error: `generated` is deprecated
 def fooCondGeneratedCurly(a, cond)
   if cond
     takesInt(a)
@@ -132,7 +132,7 @@ end
 
 
 sig do
-  params(a: T.untyped, cond: T::Boolean).
+  params(a: T.untyped, cond: T::Boolean). # error: `generated` is deprecated
   returns(T.untyped).
   generated
 end
@@ -144,7 +144,7 @@ def fooCondGeneratedDo(a, cond)
   end
 end
 
-sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated}
+sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated} # error: `generated` is deprecated
 def updatesUntypedToProfiled(a, cond)
   a.baz
 end

--- a/test/cli/suggest-sig/suggest-sig.out
+++ b/test/cli/suggest-sig/suggest-sig.out
@@ -12,6 +12,27 @@ suggest-sig.rb:92: Method `with_block` uses `yield` but does not mention a block
     93 |  yield
           ^^^^^
 
+suggest-sig.rb:124: `generated` is deprecated. See docs for alternatives https://srb.help/5056
+     124 |sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated} # error: `generated` is deprecated
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    suggest-sig.rb:124: Deleted
+     124 |sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated} # error: `generated` is deprecated
+     125 |def fooCondGeneratedCurly(a, cond)
+
+suggest-sig.rb:135: `generated` is deprecated. See docs for alternatives https://srb.help/5056
+     135 |  params(a: T.untyped, cond: T::Boolean). # error: `generated` is deprecated
+     136 |  returns(T.untyped).
+     137 |  generated
+  Autocorrect: Done
+    suggest-sig.rb:134: Deleted
+     134 |sig do
+     135 |  params(a: T.untyped, cond: T::Boolean). # error: `generated` is deprecated
+     136 |  returns(T.untyped).
+     137 |  generated
+     138 |end
+     139 |def fooCondGeneratedDo(a, cond)
+
 suggest-sig.rb:5: This function does not have a `sig` https://srb.help/7017
      5 |def hazTwoArgs(a, b); 1; end;
         ^^^^^^^^^^^^^^^^^^^^
@@ -194,7 +215,7 @@ suggest-sig.rb:125: This function does not have a `sig` https://srb.help/7017
   Autocorrect: Done
     suggest-sig.rb:124: Replaced with `sig {params(a: T.any(Integer, String), cond: T::Boolean).returns(T.untyped)}
 `
-     124 |sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated}
+     124 |sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated} # error: `generated` is deprecated
      125 |def fooCondGeneratedCurly(a, cond)
 
 suggest-sig.rb:139: This function does not have a `sig` https://srb.help/7017
@@ -204,7 +225,7 @@ suggest-sig.rb:139: This function does not have a `sig` https://srb.help/7017
     suggest-sig.rb:134: Replaced with `sig {params(a: T.any(Integer, String), cond: T::Boolean).returns(T.untyped)}
 `
      134 |sig do
-     135 |  params(a: T.untyped, cond: T::Boolean).
+     135 |  params(a: T.untyped, cond: T::Boolean). # error: `generated` is deprecated
      136 |  returns(T.untyped).
      137 |  generated
      138 |end
@@ -274,7 +295,7 @@ suggest-sig.rb:108: Method `sig` does not exist on `T.class_of(TestCarash)` http
 suggest-sig.rb:108: Method `params` does not exist on `T.class_of(TestCarash)` https://srb.help/7003
      108 |  sig {params(merchant: Merchant).void}
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 38
+Errors: 40
 
 --------------------------------------------------------------------------
 
@@ -421,7 +442,6 @@ def cantRun(a)
   1
 end
 
-sig {params(a: T.any(Integer, String), cond: T::Boolean).returns(T.untyped)}
 def fooCondGeneratedCurly(a, cond)
   if cond
     takesInt(a)
@@ -431,7 +451,6 @@ def fooCondGeneratedCurly(a, cond)
 end
 
 
-sig {params(a: T.any(Integer, String), cond: T::Boolean).returns(T.untyped)}
 def fooCondGeneratedDo(a, cond)
   if cond
     takesInt(a)

--- a/test/cli/suggest-sig/suggest-sig.rb
+++ b/test/cli/suggest-sig/suggest-sig.rb
@@ -121,7 +121,7 @@ def cantRun(a)
   1
 end
 
-sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated}
+sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated} # error: `generated` is deprecated
 def fooCondGeneratedCurly(a, cond)
   if cond
     takesInt(a)
@@ -132,7 +132,7 @@ end
 
 
 sig do
-  params(a: T.untyped, cond: T::Boolean).
+  params(a: T.untyped, cond: T::Boolean). # error: `generated` is deprecated
   returns(T.untyped).
   generated
 end

--- a/test/testdata/infer/kwargs_generics.rb
+++ b/test/testdata/infer/kwargs_generics.rb
@@ -1,7 +1,7 @@
 # typed: true
 class S
   extend T::Sig
-  sig {generated.params(value: T.untyped, path: T.untyped).returns(NilClass)}
+  sig {params(value: T.untyped, path: T.untyped).returns(NilClass)}
   def self.has_kwarg(value, path: [])
   end
 end

--- a/test/testdata/lsp/fast_path/method_remove_generated_flag.rb
+++ b/test/testdata/lsp/fast_path/method_remove_generated_flag.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 class A extend T::Sig
-  sig {generated.params(x: Integer).returns(String)}
+  sig {generated.params(x: Integer).returns(String)} # error: `generated` is deprecated
   def bar(x)
     x.to_s
   end

--- a/test/testdata/lsp/hover.rb
+++ b/test/testdata/lsp/hover.rb
@@ -37,7 +37,7 @@ class BigFoo; extend T::Sig
     end
   end
 
-  sig {generated.params(num1: Integer, num2: String).returns(Integer)}
+  sig {generated.params(num1: Integer, num2: String).returns(Integer)} # error: `generated` is deprecated
   def self.bar(num1, num2)
               # ^ hover: Integer
                    # ^ hover: String
@@ -47,7 +47,7 @@ class BigFoo; extend T::Sig
                            # ^^^^^^^^^^^^^^^ hover: String
   end
 
-  sig {generated.void}
+  sig {generated.void} # error: `generated` is deprecated
   def self.baz
   end
 

--- a/test/testdata/resolver/sig_generated.rb
+++ b/test/testdata/resolver/sig_generated.rb
@@ -2,6 +2,6 @@
 
 extend T::Sig
 
-sig {returns(NilClass).generated}
+sig {returns(NilClass).generated} # error: `generated` is deprecated
 def generated
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We used `generated` sigs a year ago for some internal roll-outs of adding sigs to Stripe's codebase in bulk. While they worked ok in the short term, they haven't been particularly useful in the long term. So rather than keep them around, unmaintained and undocumented, we're just going to delete them.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.