### PR TITLE
Enable `workspace/symbol` searches by default in LSP

### DIFF
--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -105,7 +105,7 @@ void LSPLoop::processRequestInternal(LSPMessage &msg) {
             serverCap->definitionProvider = true;
             serverCap->typeDefinitionProvider = true;
             serverCap->documentSymbolProvider = opts.lspDocumentSymbolEnabled;
-            serverCap->workspaceSymbolProvider = opts.lspWorkspaceSymbolsEnabled;
+            serverCap->workspaceSymbolProvider = true;
             serverCap->documentHighlightProvider = opts.lspDocumentHighlightEnabled;
             serverCap->hoverProvider = true;
             serverCap->referencesProvider = true;

--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -272,13 +272,6 @@ unique_ptr<ResponseMessage> LSPLoop::handleWorkspaceSymbols(LSPTypechecker &type
                                                             const WorkspaceSymbolParams &params) const {
     Timer timeit(typechecker.state().tracer(), "LSPLoop::handleWorkspaceSymbols");
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::WorkspaceSymbol);
-    if (!config->opts.lspWorkspaceSymbolsEnabled) {
-        response->error =
-            make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest, "The `Workspace Symbols` LSP feature is "
-                                                                           "experimental and disabled by default.");
-        return response;
-    }
-
     ShowOperation op(*config, "References", "Workspace symbol search...");
     prodCategoryCounterInc("lsp.messages.processed", "workspace.symbols");
     SymbolMatcher matcher(*config, typechecker.state());

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -73,7 +73,6 @@ LSPWrapper::~LSPWrapper() {}
 
 void LSPWrapper::enableAllExperimentalFeatures() {
     enableExperimentalFeature(LSPExperimentalFeature::Autocomplete);
-    enableExperimentalFeature(LSPExperimentalFeature::WorkspaceSymbols);
     enableExperimentalFeature(LSPExperimentalFeature::DocumentHighlight);
     enableExperimentalFeature(LSPExperimentalFeature::DocumentSymbol);
     enableExperimentalFeature(LSPExperimentalFeature::SignatureHelp);
@@ -87,9 +86,6 @@ void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
             break;
         case LSPExperimentalFeature::QuickFix:
             opts.lspQuickFixEnabled = true;
-            break;
-        case LSPExperimentalFeature::WorkspaceSymbols:
-            opts.lspWorkspaceSymbolsEnabled = true;
             break;
         case LSPExperimentalFeature::DocumentHighlight:
             opts.lspDocumentHighlightEnabled = true;

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -33,7 +33,6 @@ class LSPWrapper final {
 public:
     enum class LSPExperimentalFeature {
         Autocomplete = 4,
-        WorkspaceSymbols = 5,
         DocumentSymbol = 6,
         SignatureHelp = 7,
         QuickFix = 8,

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -671,7 +671,7 @@ void readOptions(Options &opts,
                                   opts.inputFileNames.end());
 
         bool enableAllLSPFeatures = raw["enable-all-experimental-lsp-features"].as<bool>();
-        // bool enableBetaLSPFeatures = enableAllLSPFeatures || raw["enable-all-beta-lsp-features"].as<bool>();
+        opts.lspAllBetaFeaturesEnabled = enableAllLSPFeatures || raw["enable-all-beta-lsp-features"].as<bool>();
         opts.lspAutocompleteEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-autocomplete"].as<bool>();
         opts.lspQuickFixEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-quick-fix"].as<bool>();
         opts.lspDocumentSymbolEnabled =

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -342,8 +342,6 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                     cxxopts::value<string>()->default_value(empty.watchmanPath));
     options.add_options("advanced")("enable-experimental-lsp-autocomplete",
                                     "Enable experimental LSP feature: Autocomplete");
-    options.add_options("advanced")("enable-experimental-lsp-workspace-symbols",
-                                    "Enable experimental LSP feature: Workspace Symbols");
     options.add_options("advanced")("enable-experimental-lsp-document-symbol",
                                     "Enable experimental LSP feature: Document Symbol");
     options.add_options("advanced")("enable-experimental-lsp-document-highlight",
@@ -673,11 +671,9 @@ void readOptions(Options &opts,
                                   opts.inputFileNames.end());
 
         bool enableAllLSPFeatures = raw["enable-all-experimental-lsp-features"].as<bool>();
-        bool enableBetaLSPFeatures = enableAllLSPFeatures || raw["enable-all-beta-lsp-features"].as<bool>();
+        // bool enableBetaLSPFeatures = enableAllLSPFeatures || raw["enable-all-beta-lsp-features"].as<bool>();
         opts.lspAutocompleteEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-autocomplete"].as<bool>();
         opts.lspQuickFixEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-quick-fix"].as<bool>();
-        opts.lspWorkspaceSymbolsEnabled =
-            enableBetaLSPFeatures || raw["enable-experimental-lsp-workspace-symbols"].as<bool>();
         opts.lspDocumentSymbolEnabled =
             enableAllLSPFeatures || raw["enable-experimental-lsp-document-symbol"].as<bool>();
         opts.lspDocumentHighlightEnabled =

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -198,7 +198,6 @@ struct Options {
     // Booleans enabling various experimental LSP features. Each will be removed once corresponding feature stabilizes.
     bool lspAutocompleteEnabled = false;
     bool lspQuickFixEnabled = false;
-    bool lspWorkspaceSymbolsEnabled = false;
     bool lspDocumentHighlightEnabled = false;
     bool lspDocumentSymbolEnabled = false;
     bool lspSignatureHelpEnabled = false;

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -195,6 +195,8 @@ struct Options {
     // List of directories not available editor-side. References to files in these directories should be sent via
     // sorbet: URIs to clients that support them.
     std::vector<std::string> lspDirsMissingFromClient;
+    // Enable stable-but-not-yet-shipped features suitable for late-stage beta-testing.
+    bool lspAllBetaFeaturesEnabled = false;
     // Booleans enabling various experimental LSP features. Each will be removed once corresponding feature stabilizes.
     bool lspAutocompleteEnabled = false;
     bool lspQuickFixEnabled = false;

--- a/main/options/test/options_test.cc
+++ b/main/options/test/options_test.cc
@@ -70,7 +70,6 @@ TEST(OptionsTest, DefaultConstructorMatchesReadOptions) {
     EXPECT_EQ(empty.inputFileNames.size(), opts.inputFileNames.size());
     EXPECT_EQ(empty.lspAutocompleteEnabled, opts.lspAutocompleteEnabled);
     EXPECT_EQ(empty.lspQuickFixEnabled, opts.lspQuickFixEnabled);
-    EXPECT_EQ(empty.lspWorkspaceSymbolsEnabled, opts.lspWorkspaceSymbolsEnabled);
     EXPECT_EQ(empty.lspDocumentSymbolEnabled, opts.lspDocumentSymbolEnabled);
     EXPECT_EQ(empty.lspDocumentHighlightEnabled, opts.lspDocumentHighlightEnabled);
     EXPECT_EQ(empty.lspSignatureHelpEnabled, opts.lspSignatureHelpEnabled);

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -76,9 +76,6 @@ Usage:
                                 using `watchman` on your PATH. (default: watchman)
       --enable-experimental-lsp-autocomplete
                                 Enable experimental LSP feature: Autocomplete
-      --enable-experimental-lsp-workspace-symbols
-                                Enable experimental LSP feature: Workspace
-                                Symbols
       --enable-experimental-lsp-document-symbol
                                 Enable experimental LSP feature: Document
                                 Symbol

--- a/test/cli/lsp-common-case-exit/lsp-common-case-exit.out
+++ b/test/cli/lsp-common-case-exit/lsp-common-case-exit.out
@@ -1,5 +1,5 @@
 Content-Length: 351
 
-{"jsonrpc":"2.0","id":0,"requestMethod":"initialize","result":{"capabilities":{"textDocumentSync":1,"hoverProvider":true,"completionProvider":{"triggerCharacters":["."]},"definitionProvider":true,"typeDefinitionProvider":true,"referencesProvider":true,"documentHighlightProvider":false,"documentSymbolProvider":false,"workspaceSymbolProvider":false}}}Content-Length: 65
+{"jsonrpc":"2.0","id":0,"requestMethod":"initialize","result":{"capabilities":{"textDocumentSync":1,"hoverProvider":true,"completionProvider":{"triggerCharacters":["."]},"definitionProvider":true,"typeDefinitionProvider":true,"referencesProvider":true,"documentHighlightProvider":false,"documentSymbolProvider":false,"workspaceSymbolProvider":true}}}Content-Length: 65
 
 {"jsonrpc":"2.0","id":1,"requestMethod":"shutdown","result":null}

--- a/test/cli/lsp-common-case-exit/lsp-common-case-exit.out
+++ b/test/cli/lsp-common-case-exit/lsp-common-case-exit.out
@@ -1,4 +1,4 @@
-Content-Length: 351
+Content-Length: 350
 
 {"jsonrpc":"2.0","id":0,"requestMethod":"initialize","result":{"capabilities":{"textDocumentSync":1,"hoverProvider":true,"completionProvider":{"triggerCharacters":["."]},"definitionProvider":true,"typeDefinitionProvider":true,"referencesProvider":true,"documentHighlightProvider":false,"documentSymbolProvider":false,"workspaceSymbolProvider":true}}}Content-Length: 65
 


### PR DESCRIPTION
### Motivation
Make `workspace/symbol` searches available by default, remove `--enable-experimental-lsp-workspace-symbol` flag.

### Test plan
Automated tests, plus beta-testing.
