### PR TITLE
(LSP) Change input abstractions to not throw exceptions.

### DIFF
--- a/common/FileOps.h
+++ b/common/FileOps.h
@@ -9,6 +9,12 @@ namespace sorbet {
 
 class FileOps final {
 public:
+    enum class ReadResult { Timeout, Success, ErrorOrEof };
+    struct ReadLineOutput {
+        ReadResult result;
+        std::optional<std::string> output = std::nullopt;
+    };
+
     static bool exists(std::string_view filename);
     static bool isFile(std::string_view path, std::string_view ignorePattern, const int pos);
     static bool isFolder(std::string_view path, std::string_view ignorePattern, const int pos);
@@ -43,8 +49,7 @@ public:
      * Returns:
      * - Length of data read if > 0.
      * - 0 if timeout occurs.
-     *
-     * Throws FileReadException on EOF or error.
+     * - <0 if an error or EOF occurs.
      */
     static int readFd(int fd, std::vector<char> &output, int timeoutMs = 100);
     /**
@@ -52,14 +57,8 @@ public:
      * Timeout is specified in milliseconds.
      *
      * Stores any extra bits read into `buffer`.
-     *
-     * Returns:
-     * - nullopt if timeout occurs or read() did not yield a newline.
-     * - string if a line was found. The string does not contain the ending newline character.
-     *
-     * Throws FileReadException on EOF or error.
      */
-    static std::optional<std::string> readLineFromFd(int fd, std::string &buffer, int timeoutMs = 100);
+    static ReadLineOutput readLineFromFd(int fd, std::string &buffer, int timeoutMs = 100);
 };
 
 } // namespace sorbet

--- a/main/lsp/LSPInput.cc
+++ b/main/lsp/LSPInput.cc
@@ -9,7 +9,7 @@ namespace sorbet::realmain::lsp {
 
 LSPFDInput::LSPFDInput(shared_ptr<spdlog::logger> logger, int inputFd) : logger(move(logger)), inputFd(inputFd) {}
 
-ReadOutput LSPFDInput::read(int timeoutMs) {
+LSPInput::ReadOutput LSPFDInput::read(int timeoutMs) {
     int length = -1;
     string allRead;
     {
@@ -66,7 +66,7 @@ ReadOutput LSPFDInput::read(int timeoutMs) {
     return ReadOutput{FileOps::ReadResult::Success, LSPMessage::fromClient(json)};
 }
 
-ReadOutput LSPProgrammaticInput::read(int timeoutMs) {
+LSPInput::ReadOutput LSPProgrammaticInput::read(int timeoutMs) {
     absl::MutexLock lock(&mtx);
     if (closed && available.empty()) {
         return ReadOutput{FileOps::ReadResult::ErrorOrEof};

--- a/main/lsp/LSPInput.cc
+++ b/main/lsp/LSPInput.cc
@@ -1,5 +1,4 @@
 #include "main/lsp/LSPInput.h"
-#include "common/FileOps.h"
 #include "main/lsp/LSPMessage.h"
 #include "spdlog/spdlog.h"
 #include <iterator>
@@ -10,7 +9,7 @@ namespace sorbet::realmain::lsp {
 
 LSPFDInput::LSPFDInput(shared_ptr<spdlog::logger> logger, int inputFd) : logger(move(logger)), inputFd(inputFd) {}
 
-unique_ptr<LSPMessage> LSPFDInput::read(int timeoutMs) {
+ReadOutput LSPFDInput::read(int timeoutMs) {
     int length = -1;
     string allRead;
     {
@@ -18,13 +17,13 @@ unique_ptr<LSPMessage> LSPFDInput::read(int timeoutMs) {
         // lines in a header.
         for (int i = 0; i < 10; i += 1) {
             auto maybeLine = FileOps::readLineFromFd(inputFd, buffer, timeoutMs);
-            if (!maybeLine) {
+            if (maybeLine.result != FileOps::ReadResult::Success) {
                 // Line not read. Abort. Store what was read thus far back into buffer
                 // for use in next call to function.
                 buffer = absl::StrCat(allRead, buffer);
-                return nullptr;
+                return ReadOutput{maybeLine.result};
             }
-            const string &line = *maybeLine;
+            const string &line = *maybeLine.output;
             absl::StrAppend(&allRead, line, "\n");
             if (line == "\r") {
                 // End of headers.
@@ -38,7 +37,7 @@ unique_ptr<LSPMessage> LSPFDInput::read(int timeoutMs) {
     if (length < 0) {
         logger->trace("No \"Content-Length: %i\" header found.");
         // Throw away what we've read and start over.
-        return nullptr;
+        return ReadOutput{FileOps::ReadResult::Timeout};
     }
 
     if (buffer.length() < length) {
@@ -49,13 +48,13 @@ unique_ptr<LSPMessage> LSPFDInput::read(int timeoutMs) {
         if (result > 0) {
             buffer.append(buf.begin(), buf.begin() + result);
         }
-        if (result == -1) {
-            Exception::raise("Error reading file or EOF.");
+        if (result < 0) {
+            return ReadOutput{FileOps::ReadResult::ErrorOrEof};
         }
         if (result != moreNeeded) {
             // Didn't get enough data. Return read data to `buffer`.
             buffer = absl::StrCat(allRead, buffer);
-            return nullptr;
+            return ReadOutput{FileOps::ReadResult::Timeout};
         }
     }
 
@@ -64,13 +63,13 @@ unique_ptr<LSPMessage> LSPFDInput::read(int timeoutMs) {
     string json = buffer.substr(0, length);
     buffer.erase(0, length);
     logger->debug("Read: {}\n", json);
-    return LSPMessage::fromClient(json);
+    return ReadOutput{FileOps::ReadResult::Success, LSPMessage::fromClient(json)};
 }
 
-unique_ptr<LSPMessage> LSPProgrammaticInput::read(int timeoutMs) {
+ReadOutput LSPProgrammaticInput::read(int timeoutMs) {
     absl::MutexLock lock(&mtx);
     if (closed && available.empty()) {
-        throw sorbet::FileReadException("EOF");
+        return ReadOutput{FileOps::ReadResult::ErrorOrEof};
     }
 
     mtx.AwaitWithTimeout(
@@ -79,12 +78,12 @@ unique_ptr<LSPMessage> LSPProgrammaticInput::read(int timeoutMs) {
         absl::Milliseconds(timeoutMs));
 
     if (available.empty()) {
-        return nullptr;
+        return ReadOutput{FileOps::ReadResult::Timeout};
     }
 
     auto msg = move(available.front());
     available.pop_front();
-    return msg;
+    return ReadOutput{FileOps::ReadResult::Success, move(msg)};
 }
 
 void LSPProgrammaticInput::write(unique_ptr<LSPMessage> message) {

--- a/main/lsp/LSPInput.h
+++ b/main/lsp/LSPInput.h
@@ -16,17 +16,17 @@ class LSPMessage;
 class ResponseMessage;
 class NotificationMessage;
 
-struct ReadOutput {
-    FileOps::ReadResult result;
-    std::unique_ptr<LSPMessage> message;
-};
-
 /**
  * Interface for receiving messages from the client. It is _not_ thread safe, and assumes that only one thread will be
  * reading from it at a time.
  */
 class LSPInput {
 public:
+    struct ReadOutput {
+        FileOps::ReadResult result;
+        std::unique_ptr<LSPMessage> message;
+    };
+
     LSPInput() = default;
     virtual ~LSPInput() = default;
     /**

--- a/main/lsp/LSPInput.h
+++ b/main/lsp/LSPInput.h
@@ -2,6 +2,7 @@
 #define RUBY_TYPER_LSP_LSPINPUT_H
 
 #include "absl/synchronization/mutex.h"
+#include "common/FileOps.h"
 #include <deque>
 #include <memory>
 #include <vector>
@@ -15,6 +16,11 @@ class LSPMessage;
 class ResponseMessage;
 class NotificationMessage;
 
+struct ReadOutput {
+    FileOps::ReadResult result;
+    std::unique_ptr<LSPMessage> message;
+};
+
 /**
  * Interface for receiving messages from the client. It is _not_ thread safe, and assumes that only one thread will be
  * reading from it at a time.
@@ -24,12 +30,10 @@ public:
     LSPInput() = default;
     virtual ~LSPInput() = default;
     /**
-     * Blockingly reads the next message from the client with the given timeout (in milliseconds). Returns nullptr if no
-     * message read within timeout.
-     *
-     * Throws a FileReadException on error or EOF.
+     * Blockingly reads the next message from the client with the given timeout (in milliseconds). Returns an output
+     * object that indicates if the read succeeded, timed out, or failed.
      */
-    virtual std::unique_ptr<LSPMessage> read(int timeoutMs = 100) = 0;
+    virtual ReadOutput read(int timeoutMs = 100) = 0;
 };
 
 /**
@@ -47,7 +51,7 @@ public:
     const int inputFd;
     LSPFDInput(std::shared_ptr<spdlog::logger> logger, int inputFd);
 
-    std::unique_ptr<LSPMessage> read(int timeoutMs) override;
+    ReadOutput read(int timeoutMs) override;
 };
 
 /**
@@ -64,7 +68,7 @@ class LSPProgrammaticInput final : public LSPInput {
 public:
     LSPProgrammaticInput() = default;
 
-    std::unique_ptr<LSPMessage> read(int timeoutMs) override;
+    ReadOutput read(int timeoutMs) override;
 
     /** Send the given message to input. */
     void write(std::unique_ptr<LSPMessage> message);

--- a/main/lsp/watchman/WatchmanProcess.cc
+++ b/main/lsp/watchman/WatchmanProcess.cc
@@ -59,9 +59,12 @@ void WatchmanProcess::start() {
 
         while (!isStopped()) {
             auto maybeLine = FileOps::readLineFromFd(fd, buffer);
-            if (maybeLine.result != FileOps::ReadResult::Success) {
+            if (maybeLine.result == FileOps::ReadResult::Timeout) {
                 // Timeout occurred. See if we should abort before reading further.
                 continue;
+            } else if (maybeLine.result == FileOps::ReadResult::ErrorOrEof) {
+                // Exit loop; unable to read from Watchman process.
+                break;
             }
 
             const string &line = *maybeLine.output;

--- a/main/lsp/watchman/WatchmanProcess.cc
+++ b/main/lsp/watchman/WatchmanProcess.cc
@@ -59,12 +59,12 @@ void WatchmanProcess::start() {
 
         while (!isStopped()) {
             auto maybeLine = FileOps::readLineFromFd(fd, buffer);
-            if (!maybeLine) {
+            if (maybeLine.result != FileOps::ReadResult::Success) {
                 // Timeout occurred. See if we should abort before reading further.
                 continue;
             }
 
-            const string &line = *maybeLine;
+            const string &line = *maybeLine.output;
             // Line found!
             rapidjson::MemoryPoolAllocator<> alloc;
             rapidjson::Document d(&alloc);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Changes LSPInput and some FileOps methods to not throw exceptions.

I'm flexible on the names of the structs / enums introduced in this PR.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Not all of Sorbet is compiled with exceptions enabled, and it's good to avoid them when possible. In this case, it actually makes the code cleaner.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Automated tests exist.
