### PR TITLE
Add filter methods that were added in ruby 2.6

### DIFF
--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_3_hidden.rbi.exp
@@ -17,8 +17,6 @@ class Array
 
   def dig(*_); end
 
-  def filter!(); end
-
   def flatten!(*_); end
 
   def pack(*_); end
@@ -3959,8 +3957,6 @@ module Enumerable
   def chunk_while(); end
 
   def each_entry(*_); end
-
-  def filter(); end
 
   def grep_v(_); end
 
@@ -8060,8 +8056,6 @@ class Hash
 
   def fetch_values(*_); end
 
-  def filter!(); end
-
   def flatten(*_); end
 
   def index(_); end
@@ -8621,8 +8615,6 @@ class Set
   def divide(&func); end
 
   def eql?(o); end
-
-  def filter!(&block); end
 
   def flatten_merge(set, seen=T.unsafe(nil)); end
 

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_3_hidden.rbi.exp
@@ -17,8 +17,6 @@ class Array
 
   def dig(*_); end
 
-  def filter!(); end
-
   def flatten!(*_); end
 
   def pack(*_); end
@@ -3971,8 +3969,6 @@ module Enumerable
   def chunk_while(); end
 
   def each_entry(*_); end
-
-  def filter(); end
 
   def grep_v(_); end
 
@@ -8066,8 +8062,6 @@ class Hash
 
   def fetch_values(*_); end
 
-  def filter!(); end
-
   def flatten(*_); end
 
   def index(_); end
@@ -8627,8 +8621,6 @@ class Set
   def divide(&func); end
 
   def eql?(o); end
-
-  def filter!(&block); end
 
   def flatten_merge(set, seen=T.unsafe(nil)); end
 

--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1864,6 +1864,35 @@ class Array < Object
   sig {returns(T::Enumerator[Elem])}
   def select(&blk); end
 
+  # Returns a new array containing all elements of `ary` for which the given
+  # `block` returns a true value.
+  #
+  # If no block is given, an
+  # [`Enumerator`](https://docs.ruby-lang.org/en/2.6.0/Enumerator.html) is
+  # returned instead.
+  #
+  # ```ruby
+  # [1,2,3,4,5].select {|num| num.even? }     #=> [2, 4]
+  #
+  # a = %w[ a b c d e f ]
+  # a.select {|v| v =~ /[aeiou]/ }    #=> ["a", "e"]
+  # ```
+  #
+  # See also
+  # [`Enumerable#select`](https://docs.ruby-lang.org/en/2.6.0/Enumerable.html#method-i-select).
+  #
+  # [`Array#filter`](https://docs.ruby-lang.org/en/2.6.0/Array.html#method-i-filter)
+  # is an alias for
+  # [`Array#select`](https://docs.ruby-lang.org/en/2.6.0/Array.html#method-i-select).
+  sig do
+    params(
+        blk: T.proc.params(arg0: Elem).returns(BasicObject),
+    )
+    .returns(T::Array[Elem])
+  end
+  sig {returns(T::Enumerator[Elem])}
+  def filter(&blk); end
+
   # Invokes the given block passing in successive elements from `self`, deleting
   # elements for which the block returns a `false` value.
   #
@@ -1889,6 +1918,32 @@ class Array < Object
   end
   sig {returns(T::Enumerator[Elem])}
   def select!(&blk); end
+
+  # Invokes the given block passing in successive elements from `self`, deleting
+  # elements for which the block returns a `false` value.
+  #
+  # The array may not be changed instantly every time the block is called.
+  #
+  # If changes were made, it will return `self`, otherwise it returns `nil`.
+  #
+  # If no block is given, an
+  # [`Enumerator`](https://docs.ruby-lang.org/en/2.6.0/Enumerator.html) is
+  # returned instead.
+  #
+  # See also
+  # [`Array#keep_if`](https://docs.ruby-lang.org/en/2.6.0/Array.html#method-i-keep_if).
+  #
+  # [`Array#filter!`](https://docs.ruby-lang.org/en/2.6.0/Array.html#method-i-filter-21)
+  # is an alias for
+  # [`Array#select!`](https://docs.ruby-lang.org/en/2.6.0/Array.html#method-i-select-21).
+  sig do
+    params(
+        blk: T.proc.params(arg0: Elem).returns(BasicObject),
+    )
+    .returns(T.nilable(T::Array[Elem]))
+  end
+  sig {returns(T::Enumerator[Elem])}
+  def filter!(&blk); end
 
   # Removes the first element of `self` and returns it (shifting all other
   # elements down by one). Returns `nil` if the array is empty.

--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -1270,6 +1270,32 @@ module Enumerable
   sig {returns(T::Enumerator[Elem])}
   def select(&blk); end
 
+  # Returns an array containing all elements of `enum` for which the given
+  # `block` returns a true value.
+  #
+  # If no block is given, an
+  # [`Enumerator`](https://docs.ruby-lang.org/en/2.6.0/Enumerator.html) is
+  # returned instead.
+  #
+  # ```ruby
+  # (1..10).find_all { |i|  i % 3 == 0 }   #=> [3, 6, 9]
+  #
+  # [1,2,3,4,5].select { |num|  num.even?  }   #=> [2, 4]
+  #
+  # [:foo, :bar].filter { |x| x == :foo }   #=> [:foo]
+  # ```
+  #
+  # See also
+  # [`Enumerable#reject`](https://docs.ruby-lang.org/en/2.6.0/Enumerable.html#method-i-reject).
+  sig do
+    params(
+        blk: T.proc.params(arg0: Elem).returns(BasicObject),
+    )
+    .returns(T::Array[Elem])
+  end
+  sig {returns(T::Enumerator[Elem])}
+  def filter(&blk); end
+
   # Returns an array containing the items in *enum*.
   #
   # ```ruby

--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -853,6 +853,27 @@ class Hash < Object
   end
   def select(&blk); end
 
+  # Returns a new hash consisting of entries for which the block returns true.
+  #
+  # If no block is given, an enumerator is returned instead.
+  #
+  # ```ruby
+  # h = { "a" => 100, "b" => 200, "c" => 300 }
+  # h.select {|k,v| k > "a"}  #=> {"b" => 200, "c" => 300}
+  # h.select {|k,v| v < 200}  #=> {"a" => 100}
+  # ```
+  #
+  # [`Hash#filter`](https://docs.ruby-lang.org/en/2.6.0/Hash.html#method-i-filter)
+  # is an alias for
+  # [`Hash#select`](https://docs.ruby-lang.org/en/2.6.0/Hash.html#method-i-select).
+  sig do
+    params(
+        blk: T.proc.params(arg0: K, arg1: V).returns(BasicObject),
+    )
+    .returns(T::Hash[K, V])
+  end
+  def filter(&blk); end
+
   # Equivalent to
   # [`Hash#keep_if`](https://docs.ruby-lang.org/en/2.6.0/Hash.html#method-i-keep_if),
   # but returns `nil` if no changes were made.
@@ -867,6 +888,21 @@ class Hash < Object
     .returns(T::Hash[K, V])
   end
   def select!(&blk); end
+
+  # Equivalent to
+  # [`Hash#keep_if`](https://docs.ruby-lang.org/en/2.6.0/Hash.html#method-i-keep_if),
+  # but returns `nil` if no changes were made.
+  #
+  # [`Hash#filter!`](https://docs.ruby-lang.org/en/2.6.0/Hash.html#method-i-filter-21)
+  # is an alias for
+  # [`Hash#select!`](https://docs.ruby-lang.org/en/2.6.0/Hash.html#method-i-select-21).
+  sig do
+    params(
+        blk: T.proc.params(arg0: K, arg1: V).returns(BasicObject),
+    )
+    .returns(T::Hash[K, V])
+  end
+  def filter!(&blk); end
 
   # Removes a key-value pair from *hsh* and returns it as the two-item array `[`
   # *key, value* `]`, or the hash's default value if the hash is empty.

--- a/rbi/stdlib/set.rbi
+++ b/rbi/stdlib/set.rbi
@@ -389,6 +389,16 @@ class Set < Object
   end
   def select!(&blk); end
 
+  # Equivalent to [`Set#select!`](https://docs.ruby-lang.org/en/2.6.0/Set.html#method-i-select-21)
+  # Alias for: [select!](https://docs.ruby-lang.org/en/2.6.0/Set.html#method-i-select-21)
+  sig do
+    params(
+        blk: T.proc.params(arg0: Elem).returns(BasicObject),
+    )
+    .returns(T.nilable(T.self_type))
+  end
+  def filter!(&blk); end
+
   # Returns the number of elements.
   #
   # Also aliased as:


### PR DESCRIPTION
Ruby 2.6 added many `filter` alias to their equivalent `select`. https://github.com/ruby/ruby/commit/b1a8c64483b5ba5e4a391aa68234e7bde6355034 added alias for `Array#filter`, `Array#filter!`, `Enumerable#filter`, `Enumerator::Lazy#filter`, `Hash#filter`, `Hash#filter!` and `Set#filter!`.

This PR copies shims for `select` and renamed them to `filter`. I'm unsure of the state of `Enumerator::Lazy` in sorbet, so I didn't do `Enumerator::Lazy#filter`.

### Motivation

I started to use `Array#filter` and received `Method filter does not exist on T::Array[...]`.