### PR TITLE
Allow srb to check for sorbet on PATH

### DIFF
--- a/gems/sorbet/bin/srb
+++ b/gems/sorbet/bin/srb
@@ -60,6 +60,11 @@ typecheck() {
   if [ -n "$SRB_SORBET_EXE" ]; then
     # shellcheck disable=SC2086
     "$SRB_SORBET_EXE" "${args[@]}"
+  elif command -v sorbet > /dev/null; then
+    # if sorbet has been installed and placed somewhere on the path 
+    # such as from Homebre -- use that.
+    # This is a solution for those who are using platforms such as jruby
+    sorbet "${args[@]}"
   else
     # We're using bash string operations here to avoid forking.
     # Using dirname / basename / etc. would mean ~15ms for each call.

--- a/gems/sorbet/bin/srb
+++ b/gems/sorbet/bin/srb
@@ -62,7 +62,7 @@ typecheck() {
     "$SRB_SORBET_EXE" "${args[@]}"
   elif command -v sorbet > /dev/null; then
     # if sorbet has been installed and placed somewhere on the path 
-    # such as from Homebre -- use that.
+    # such as from Homebrew -- use that.
     # This is a solution for those who are using platforms such as jruby
     sorbet "${args[@]}"
   else


### PR DESCRIPTION
## Motivation
At the moment, those that are using JRuby, sorbet-static can never be installed via gem/bundler.

sorbet-static is platform dependent and has the gem name such as: `sorbet-static-0.4.5055-universal-darwin-19.gem` (darwin being OSX & universal the CPU type)

However when running on JRuby platform the only platforms available are:
```bash
$ gem env
...
  - RUBYGEMS PLATFORMS:
    - ruby
    - universal-java-1.8
```

Whereas on MRI it will list
```bash
$ gem env
  - RUBYGEMS PLATFORMS:
    - ruby
    - universal-darwin-18
```

_Given this dilemma, how can we use sorbet-static on JRuby ?_

## Proposal 
I propose that we leverage platform package managers such as: homebrew
or yum etc.. to deliver sorbet. The `srb` script is changed to check if
sorbet is present on the path.

## Follow Up
1. I will include a Hombrew pull-request as well to include an installable formulae to install sorbet
2. Following the inclusion of (1) I will introduce JRuby.md explaining what should be done