### PR TITLE
Add support for Ruby 2.6's enumerator chains

### DIFF
--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_3_hidden.rbi.exp
@@ -3952,8 +3952,6 @@ class Encoding
 end
 
 module Enumerable
-  def chain(*_); end
-
   def chunk(); end
 
   def chunk_while(); end
@@ -3980,8 +3978,6 @@ module Enumerable
 end
 
 class Enumerator
-  def +(_); end
-
   def each_with_index(); end
 end
 
@@ -4000,12 +3996,6 @@ class Enumerator::ArithmeticSequence
 end
 
 class Enumerator::ArithmeticSequence
-end
-
-class Enumerator::Chain
-end
-
-class Enumerator::Chain
 end
 
 class Enumerator::Generator

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_3_hidden.rbi.exp
@@ -3964,8 +3964,6 @@ class Encoding
 end
 
 module Enumerable
-  def chain(*_); end
-
   def chunk(); end
 
   def chunk_while(); end
@@ -3992,8 +3990,6 @@ module Enumerable
 end
 
 class Enumerator
-  def +(_); end
-
   def each_with_index(); end
 end
 
@@ -4012,12 +4008,6 @@ class Enumerator::ArithmeticSequence
 end
 
 class Enumerator::ArithmeticSequence
-end
-
-class Enumerator::Chain
-end
-
-class Enumerator::Chain
 end
 
 class Enumerator::Generator

--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -76,6 +76,22 @@ module Enumerable
   end
   def any?(&blk); end
 
+  # Returns an enumerator object generated from this enumerator and given
+  # enumerables.
+  #
+  # ```ruby
+  # e = (1..3).chain([4, 5])
+  # e.to_a #=> [1, 2, 3, 4, 5]
+  # ```
+  sig do
+    type_parameters(:T)
+    .params(
+      enums: T::Enumerable[T.type_parameter(:T)],
+    )
+    .returns(T::Enumerator[T.any(Elem, T.type_parameter(:T))])
+  end
+  def chain(*enums); end
+
   # Returns a new array with the results of running *block* once for every
   # element in *enum*.
   #

--- a/rbi/core/enumerator.rbi
+++ b/rbi/core/enumerator.rbi
@@ -200,6 +200,22 @@ class Enumerator < Object
   end
   def initialize(arg0=T.unsafe(nil), &blk); end
 
+  # Returns an enumerator object generated from this enumerator and a given
+  # enumerable.
+  #
+  # ```ruby
+  # e = (1..3).each + [4, 5]
+  # e.to_a #=> [1, 2, 3, 4, 5]
+  # ```
+  sig do
+    type_parameters(:T)
+    .params(
+      other: T::Enumerable[T.type_parameter(:T)],
+    )
+    .returns(T::Enumerator[T.any(Elem, T.type_parameter(:T))])
+  end
+  def +(other); end
+
   # Creates a printable version of *e*.
   sig {returns(String)}
   def inspect(); end
@@ -407,6 +423,64 @@ class Enumerator::Generator < Object
 
   extend T::Generic
   Elem = type_member(:out)
+end
+
+# [`Enumerator::Chain`](https://docs.ruby-lang.org/en/2.6.0/Enumerator/Chain.html)
+# is a subclass of
+# [`Enumerator`](https://docs.ruby-lang.org/en/2.6.0/Enumerator.html), which
+# represents a chain of enumerables that works as a single enumerator.
+#
+# This type of objects can be created by
+# [`Enumerable#chain`](https://docs.ruby-lang.org/en/2.6.0/Enumerable.html#method-i-chain)
+# and
+# [`Enumerator#+`](https://docs.ruby-lang.org/en/2.6.0/Enumerator.html#method-i-2B).
+class Enumerator::Chain < Enumerator
+  sig do
+    type_parameters(:T)
+    .params(
+      args: T::Enumerable[T.type_parameter(:T)],
+    )
+    .returns(T::Enumerator[T.any(Elem, T.type_parameter(:T))])
+  end
+  sig do
+    type_parameters(:T)
+    .params(
+        args: T.any(Integer, T.proc.returns(Integer)),
+        blk: T.proc.params(arg0: Enumerator::Yielder).void,
+    )
+    .void
+  end
+  def initialize(*args, &blk); end
+
+  # Iterates over the elements of the first enumerable by calling the "each"
+  # method on it with the given arguments, then proceeds to the following
+  # enumerables in sequence until all of the enumerables are exhausted.
+  #
+  # If no block is given, returns an enumerator.
+  sig do
+    params(
+        blk: T.proc.params(arg0: Elem).returns(BasicObject),
+    )
+    .returns(T.untyped)
+  end
+  sig {returns(T.self_type)}
+  def each(&blk); end
+
+  # Returns a printable version of the enumerator chain.
+  sig {returns(String)}
+  def inspect(); end
+
+  # Rewinds the enumerator chain by calling the "rewind" method on each
+  # enumerable in reverse order. Each call is performed only if the enumerable
+  # responds to the method.
+  sig {returns(T.self_type)}
+  def rewind(); end
+
+  # Returns the total size of the enumerator chain calculated by summing up the
+  # size of each enumerable in the chain. If any of the enumerables reports its
+  # size as nil or Float::INFINITY, that value is returned as the total size.
+  sig {returns(T.nilable(T.any(Integer, Float)))}
+  def size(); end
 end
 
 # [`Lazy`](https://docs.ruby-lang.org/en/2.6.0/Enumerator/Lazy.html)

--- a/rbi/core/enumerator.rbi
+++ b/rbi/core/enumerator.rbi
@@ -435,6 +435,8 @@ end
 # and
 # [`Enumerator#+`](https://docs.ruby-lang.org/en/2.6.0/Enumerator.html#method-i-2B).
 class Enumerator::Chain < Enumerator
+  Elem = type_member(:out)
+
   sig do
     type_parameters(:T)
     .params(

--- a/test/cli/constant-fuzzy/constant-fuzzy.out
+++ b/test/cli/constant-fuzzy/constant-fuzzy.out
@@ -13,8 +13,8 @@ test/cli/constant-fuzzy/constant-fuzzy.rb:3: Unable to resolve constant `Yieldr`
     test/cli/constant-fuzzy/constant-fuzzy.rb:3: Replace with `Fiber`
      3 |Yieldr.foo(Intege, Int)
         ^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/enumerator.rbi#L660: Did you mean: `Enumerator::Yielder`?
-     660 |class Enumerator::Yielder < Object
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/enumerator.rbi#L736: Did you mean: `Enumerator::Yielder`?
+     736 |class Enumerator::Yielder < Object
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/ripper.rbi#L78: Did you mean: `Ripper`?
     78 |class Ripper

--- a/test/testdata/rbi/enumerator.rb
+++ b/test/testdata/rbi/enumerator.rb
@@ -1,0 +1,17 @@
+# typed: strict
+# frozen_string_literal: true
+
+int_range = (1..3)
+int_array = [4, 5]
+mixed_array = [6.0, 7]
+
+T.assert_type!(int_range.chain(int_array), T::Enumerator[Integer])
+T.assert_type!(
+  int_range.chain(mixed_array),
+  T::Enumerator[T.any(Integer, Float)]
+)
+
+T.assert_type!(
+  int_array.permutation + mixed_array.permutation,
+  T::Array[T.any(Float, Integer)]
+)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Sorbet doesn't correctly handle Enumerator::Chain objects created by `+`ing two enumerators.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
