### PR TITLE
Print T.proc.void

### DIFF
--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -365,7 +365,11 @@ string AppliedType::show(const GlobalState &gs) const {
                 fmt::format_to(buf, ")");
             }
 
-            fmt::format_to(buf, ".returns({})", return_type->show(gs));
+            if (return_type == core::Types::void_()) {
+                fmt::format_to(buf, ".void");
+            } else {
+                fmt::format_to(buf, ".returns({})", return_type->show(gs));
+            }
             return to_string(buf);
         } else {
             fmt::format_to(buf, "{}", this->klass.data(gs)->show(gs));

--- a/test/testdata/lsp/hover_proc_void.rb
+++ b/test/testdata/lsp/hover_proc_void.rb
@@ -4,5 +4,5 @@ extend T::Sig
 
 sig {params(blk: T.proc.void).void}
 def proc_void(&blk)
-  # ^ hover: sig {params(blk: T.proc.returns(Sorbet::Private::Static::Void)).void}
+  # ^ hover: sig {params(blk: T.proc.void).void}
 end

--- a/test/testdata/lsp/hover_proc_void.rb
+++ b/test/testdata/lsp/hover_proc_void.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+extend T::Sig
+
+sig {params(blk: T.proc.void).void}
+def proc_void(&blk)
+  # ^ hover: sig {params(blk: T.proc.returns(Sorbet::Private::Static::Void)).void}
+end

--- a/test/testdata/resolver/bind_class_of.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/bind_class_of.rb.symbol-table-raw.exp
@@ -8,5 +8,5 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     method <S <C <U Test>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/bind_class_of.rb start=3:1 end=9:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/bind_class_of.rb start=??? end=???}
     method <S <C <U Test>> $1><U test> (blk) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/resolver/bind_class_of.rb start=7:3 end=7:22}
-      argument blk<block> -> T.proc.returns(Sorbet::Private::Static::Void) @ Loc {file=test/testdata/resolver/bind_class_of.rb start=6:15 end=6:18} rebindTo ::<Class:Test>
+      argument blk<block> -> T.proc.void @ Loc {file=test/testdata/resolver/bind_class_of.rb start=6:15 end=6:18} rebindTo ::<Class:Test>
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I noticed that in hover / completion items / `T.reveal_type` we were printing
`.returns(Sorbet::Private::Static::Void)` instead of `.void`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Review by commit


- **Add failing test** (e2237571a)


- **Print T.proc.void** (e7bd61c94)

  This mimics the logic that we do in prettySigForMethod (for hover /
  completion). That logic only applied to the top-level method; the proc
  itself is formatted here in core/types/.

- **Update exp files** (62c4ae0ee)