### PR TITLE
Use format_to instead of StrAppend

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -251,13 +251,14 @@ vector<core::LocalVariable> allSimilarLocals(const core::GlobalState &gs, const 
 
 string methodSnippet(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiverType,
                      const core::TypeConstraint *constraint) {
-    auto shortName = method.data(gs)->name.data(gs)->shortName(gs);
+    fmt::memory_buffer result;
+    fmt::format_to(result, "{}", method.data(gs)->name.data(gs)->shortName(gs));
     vector<string> typeAndArgNames;
 
     int i = 1;
     if (method.data(gs)->isMethod()) {
         for (auto &argSym : method.data(gs)->arguments()) {
-            string s;
+            fmt::memory_buffer argBuf;
             if (argSym.flags.isBlock) {
                 continue;
             }
@@ -265,23 +266,24 @@ string methodSnippet(const core::GlobalState &gs, core::SymbolRef method, core::
                 continue;
             }
             if (argSym.flags.isKeyword) {
-                absl::StrAppend(&s, argSym.name.data(gs)->shortName(gs), ": ");
+                fmt::format_to(argBuf, "{}: ", argSym.name.data(gs)->shortName(gs));
             }
             if (argSym.type) {
-                absl::StrAppend(&s, "${", i++, ":",
-                                getResultType(gs, argSym.type, method, receiverType, constraint)->show(gs), "}");
+                auto resultType = getResultType(gs, argSym.type, method, receiverType, constraint)->show(gs);
+                fmt::format_to(argBuf, "${{{}:{}}}", i++, resultType);
             } else {
-                absl::StrAppend(&s, "${", i++, "}");
+                fmt::format_to(argBuf, "${{{}}}", i++);
             }
-            typeAndArgNames.emplace_back(s);
+            typeAndArgNames.emplace_back(to_string(argBuf));
         }
     }
 
-    if (typeAndArgNames.empty()) {
-        return fmt::format("{}{}", shortName, "${0}");
-    } else {
-        return fmt::format("{}({}){}", shortName, fmt::join(typeAndArgNames, ", "), "${0}");
+    if (!typeAndArgNames.empty()) {
+        fmt::format_to(result, "({})", fmt::join(typeAndArgNames, ", "));
     }
+
+    fmt::format_to(result, "${{0}}");
+    return to_string(result);
 }
 
 // This is an approximation. It takes advantage of the fact that nearly all of the time,

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -253,9 +253,9 @@ string methodSnippet(const core::GlobalState &gs, core::SymbolRef method, core::
                      const core::TypeConstraint *constraint) {
     fmt::memory_buffer result;
     fmt::format_to(result, "{}", method.data(gs)->name.data(gs)->shortName(gs));
-    vector<string> typeAndArgNames;
+    auto nextTabstop = 1;
 
-    int i = 1;
+    vector<string> typeAndArgNames;
     if (method.data(gs)->isMethod()) {
         for (auto &argSym : method.data(gs)->arguments()) {
             fmt::memory_buffer argBuf;
@@ -270,9 +270,9 @@ string methodSnippet(const core::GlobalState &gs, core::SymbolRef method, core::
             }
             if (argSym.type) {
                 auto resultType = getResultType(gs, argSym.type, method, receiverType, constraint)->show(gs);
-                fmt::format_to(argBuf, "${{{}:{}}}", i++, resultType);
+                fmt::format_to(argBuf, "${{{}:{}}}", nextTabstop++, resultType);
             } else {
-                fmt::format_to(argBuf, "${{{}}}", i++);
+                fmt::format_to(argBuf, "${{{}}}", nextTabstop++);
             }
             typeAndArgNames.emplace_back(to_string(argBuf));
         }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I was doing some work in this code to insert a snippeted block when a method
must take a block. Landing this refactor as pre-work makes the future change
easier to read.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Review by commit:


- **Use format_to instead of StrAppend** (ff8453142)

  I'm planning to rewrite some of this code in a follow up change. That
  code is easier to write if this uses format_to, so I figured I'd
  refactor it first and change the behavior second.

- **rename local: i -> nextTabstop** (ce68d5474)