### PR TITLE
Re-order array.rbi

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1002,13 +1002,13 @@ class Array < Object
   # ```
   # a -- b -- c --
   # ```
-  sig {returns(T::Enumerator[Elem])}
   sig do
     params(
         blk: T.proc.params(arg0: Elem).returns(BasicObject),
     )
     .returns(T::Array[Elem])
   end
+  sig {returns(T::Enumerator[Elem])}
   def each(&blk); end
 
   # Same as


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I want the oen with the `blk` parameter to be first, because that means
it shows up first in completion results, and I think that calling
`[].each` with block is more common than calling `[].each` to get an
Enumerator over the array.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->