### PR TITLE
Remove redundant isMethod check

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -256,26 +256,25 @@ string methodSnippet(const core::GlobalState &gs, core::SymbolRef method, core::
     auto nextTabstop = 1;
 
     vector<string> typeAndArgNames;
-    if (method.data(gs)->isMethod()) {
-        for (auto &argSym : method.data(gs)->arguments()) {
-            fmt::memory_buffer argBuf;
-            if (argSym.flags.isBlock) {
-                continue;
-            }
-            if (argSym.flags.isDefault) {
-                continue;
-            }
-            if (argSym.flags.isKeyword) {
-                fmt::format_to(argBuf, "{}: ", argSym.name.data(gs)->shortName(gs));
-            }
-            if (argSym.type) {
-                auto resultType = getResultType(gs, argSym.type, method, receiverType, constraint)->show(gs);
-                fmt::format_to(argBuf, "${{{}:{}}}", nextTabstop++, resultType);
-            } else {
-                fmt::format_to(argBuf, "${{{}}}", nextTabstop++);
-            }
-            typeAndArgNames.emplace_back(to_string(argBuf));
+    for (auto &argSym : method.data(gs)->arguments()) {
+        fmt::memory_buffer argBuf;
+        if (argSym.flags.isBlock) {
+            // Blocks are handled below
+            continue;
         }
+        if (argSym.flags.isDefault) {
+            continue;
+        }
+        if (argSym.flags.isKeyword) {
+            fmt::format_to(argBuf, "{}: ", argSym.name.data(gs)->shortName(gs));
+        }
+        if (argSym.type) {
+            auto resultType = getResultType(gs, argSym.type, method, receiverType, constraint)->show(gs);
+            fmt::format_to(argBuf, "${{{}:{}}}", nextTabstop++, resultType);
+        } else {
+            fmt::format_to(argBuf, "${{{}}}", nextTabstop++);
+        }
+        typeAndArgNames.emplace_back(to_string(argBuf));
     }
 
     if (!typeAndArgNames.empty()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We already have this guarantee; methodSnippet is called from one place.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a