### PR TITLE
Automatically insert snippet for required blocks

### DIFF
--- a/test/testdata/lsp/completion/sig_no_defs.A.rbedited
+++ b/test/testdata/lsp/completion/sig_no_defs.A.rbedited
@@ -2,5 +2,7 @@
 
 extend T::Sig
 
-sig${0} # error: no block
+sig do
+  ${1}
+end${0} # error: no block
 #  ^ apply-completion: [A] item: 0

--- a/test/testdata/lsp/completion/sig_no_method.A.rbedited
+++ b/test/testdata/lsp/completion/sig_no_method.A.rbedited
@@ -13,7 +13,9 @@ class Outer
     # Even though there are method defs after this, none are in the right
     # scope, so no suggested sig.
 
-    sig${0} # error: no block
+    sig do
+  ${1}
+end${0} # error: no block
     #  ^ apply-completion: [A] item: 0
   end
 

--- a/test/testdata/lsp/completion/sig_no_method.B.rbedited
+++ b/test/testdata/lsp/completion/sig_no_method.B.rbedited
@@ -23,5 +23,7 @@ end
 def outside_on_root; end
 
 # No method def at all later in the file
-sig${0} # error: no block
+sig do
+  ${1}
+end${0} # error: no block
 #  ^ apply-completion: [B] item: 0

--- a/test/testdata/lsp/completion/snippet_block.A.rbedited
+++ b/test/testdata/lsp/completion/snippet_block.A.rbedited
@@ -1,0 +1,37 @@
+# typed: true
+
+class Module
+  include T::Sig
+end
+
+class A
+  sig {params(blk: T.proc.void).void}
+  def self.required_block(&blk)
+    yield
+  end
+
+  sig {params(blk: T.nilable(T.proc.void)).void}
+  def self.nilable_block(&blk)
+    yield if block_given?
+  end
+
+  sig {params(blk: T.untyped).void}
+  def self.untyped_block(&blk)
+    yield if block_given?
+  end
+
+  def self.unsigged_block(&blk)
+    yield if block_given?
+  end
+end
+
+A.required_block do
+  ${1}
+end${0} # error: does not exist
+#              ^ apply-completion: [A] item: 0
+A.nilable_bloc # error: does not exist
+#             ^ apply-completion: [B] item: 0
+A.untyped_bloc # error: does not exist
+#             ^ apply-completion: [C] item: 0
+A.unsigged_bloc # error: does not exist
+#              ^ apply-completion: [D] item: 0

--- a/test/testdata/lsp/completion/snippet_block.B.rbedited
+++ b/test/testdata/lsp/completion/snippet_block.B.rbedited
@@ -1,0 +1,35 @@
+# typed: true
+
+class Module
+  include T::Sig
+end
+
+class A
+  sig {params(blk: T.proc.void).void}
+  def self.required_block(&blk)
+    yield
+  end
+
+  sig {params(blk: T.nilable(T.proc.void)).void}
+  def self.nilable_block(&blk)
+    yield if block_given?
+  end
+
+  sig {params(blk: T.untyped).void}
+  def self.untyped_block(&blk)
+    yield if block_given?
+  end
+
+  def self.unsigged_block(&blk)
+    yield if block_given?
+  end
+end
+
+A.required_bloc # error: does not exist
+#              ^ apply-completion: [A] item: 0
+A.nilable_block${0} # error: does not exist
+#             ^ apply-completion: [B] item: 0
+A.untyped_bloc # error: does not exist
+#             ^ apply-completion: [C] item: 0
+A.unsigged_bloc # error: does not exist
+#              ^ apply-completion: [D] item: 0

--- a/test/testdata/lsp/completion/snippet_block.C.rbedited
+++ b/test/testdata/lsp/completion/snippet_block.C.rbedited
@@ -1,0 +1,35 @@
+# typed: true
+
+class Module
+  include T::Sig
+end
+
+class A
+  sig {params(blk: T.proc.void).void}
+  def self.required_block(&blk)
+    yield
+  end
+
+  sig {params(blk: T.nilable(T.proc.void)).void}
+  def self.nilable_block(&blk)
+    yield if block_given?
+  end
+
+  sig {params(blk: T.untyped).void}
+  def self.untyped_block(&blk)
+    yield if block_given?
+  end
+
+  def self.unsigged_block(&blk)
+    yield if block_given?
+  end
+end
+
+A.required_bloc # error: does not exist
+#              ^ apply-completion: [A] item: 0
+A.nilable_bloc # error: does not exist
+#             ^ apply-completion: [B] item: 0
+A.untyped_block${0} # error: does not exist
+#             ^ apply-completion: [C] item: 0
+A.unsigged_bloc # error: does not exist
+#              ^ apply-completion: [D] item: 0

--- a/test/testdata/lsp/completion/snippet_block.D.rbedited
+++ b/test/testdata/lsp/completion/snippet_block.D.rbedited
@@ -1,0 +1,35 @@
+# typed: true
+
+class Module
+  include T::Sig
+end
+
+class A
+  sig {params(blk: T.proc.void).void}
+  def self.required_block(&blk)
+    yield
+  end
+
+  sig {params(blk: T.nilable(T.proc.void)).void}
+  def self.nilable_block(&blk)
+    yield if block_given?
+  end
+
+  sig {params(blk: T.untyped).void}
+  def self.untyped_block(&blk)
+    yield if block_given?
+  end
+
+  def self.unsigged_block(&blk)
+    yield if block_given?
+  end
+end
+
+A.required_bloc # error: does not exist
+#              ^ apply-completion: [A] item: 0
+A.nilable_bloc # error: does not exist
+#             ^ apply-completion: [B] item: 0
+A.untyped_bloc # error: does not exist
+#             ^ apply-completion: [C] item: 0
+A.unsigged_block${0} # error: does not exist
+#              ^ apply-completion: [D] item: 0

--- a/test/testdata/lsp/completion/snippet_block.rb
+++ b/test/testdata/lsp/completion/snippet_block.rb
@@ -1,0 +1,35 @@
+# typed: true
+
+class Module
+  include T::Sig
+end
+
+class A
+  sig {params(blk: T.proc.void).void}
+  def self.required_block(&blk)
+    yield
+  end
+
+  sig {params(blk: T.nilable(T.proc.void)).void}
+  def self.nilable_block(&blk)
+    yield if block_given?
+  end
+
+  sig {params(blk: T.untyped).void}
+  def self.untyped_block(&blk)
+    yield if block_given?
+  end
+
+  def self.unsigged_block(&blk)
+    yield if block_given?
+  end
+end
+
+A.required_bloc # error: does not exist
+#              ^ apply-completion: [A] item: 0
+A.nilable_bloc # error: does not exist
+#             ^ apply-completion: [B] item: 0
+A.untyped_bloc # error: does not exist
+#             ^ apply-completion: [C] item: 0
+A.unsigged_bloc # error: does not exist
+#              ^ apply-completion: [D] item: 0

--- a/test/testdata/lsp/completion/snippet_block_arity.A.rbedited
+++ b/test/testdata/lsp/completion/snippet_block_arity.A.rbedited
@@ -1,0 +1,38 @@
+# typed: true
+
+class Module
+  include T::Sig
+end
+
+class A
+  sig {params(blk: T.proc.params(x: Integer).void).void}
+  def self.unary_block(&blk)
+    yield 0
+  end
+
+  sig {params(blk: T.proc.params(x: Integer, y: String).void).void}
+  def self.binary_block(&blk)
+    yield 0, ''
+  end
+
+  sig do
+    params(
+      arg0: Integer,
+      arg1: String,
+      blk: T.proc.params(x: Integer, y: String).void
+    )
+    .void
+  end
+  def self.arg0_arg1_blk(arg0, arg1, &blk)
+    yield arg0, arg1
+  end
+end
+
+A.unary_block do |${1:Integer}|
+  ${2}
+end${0} # error: does not exist
+#           ^ apply-completion: [A] item: 0
+A.binary_bloc # error: does not exist
+#            ^ apply-completion: [B] item: 0
+A.arg0_arg1_bl # error: does not exist
+#             ^ apply-completion: [C] item: 0

--- a/test/testdata/lsp/completion/snippet_block_arity.B.rbedited
+++ b/test/testdata/lsp/completion/snippet_block_arity.B.rbedited
@@ -1,0 +1,38 @@
+# typed: true
+
+class Module
+  include T::Sig
+end
+
+class A
+  sig {params(blk: T.proc.params(x: Integer).void).void}
+  def self.unary_block(&blk)
+    yield 0
+  end
+
+  sig {params(blk: T.proc.params(x: Integer, y: String).void).void}
+  def self.binary_block(&blk)
+    yield 0, ''
+  end
+
+  sig do
+    params(
+      arg0: Integer,
+      arg1: String,
+      blk: T.proc.params(x: Integer, y: String).void
+    )
+    .void
+  end
+  def self.arg0_arg1_blk(arg0, arg1, &blk)
+    yield arg0, arg1
+  end
+end
+
+A.unary_bloc # error: does not exist
+#           ^ apply-completion: [A] item: 0
+A.binary_block do |${1:Integer}, ${2:String}|
+  ${3}
+end${0} # error: does not exist
+#            ^ apply-completion: [B] item: 0
+A.arg0_arg1_bl # error: does not exist
+#             ^ apply-completion: [C] item: 0

--- a/test/testdata/lsp/completion/snippet_block_arity.C.rbedited
+++ b/test/testdata/lsp/completion/snippet_block_arity.C.rbedited
@@ -1,0 +1,38 @@
+# typed: true
+
+class Module
+  include T::Sig
+end
+
+class A
+  sig {params(blk: T.proc.params(x: Integer).void).void}
+  def self.unary_block(&blk)
+    yield 0
+  end
+
+  sig {params(blk: T.proc.params(x: Integer, y: String).void).void}
+  def self.binary_block(&blk)
+    yield 0, ''
+  end
+
+  sig do
+    params(
+      arg0: Integer,
+      arg1: String,
+      blk: T.proc.params(x: Integer, y: String).void
+    )
+    .void
+  end
+  def self.arg0_arg1_blk(arg0, arg1, &blk)
+    yield arg0, arg1
+  end
+end
+
+A.unary_bloc # error: does not exist
+#           ^ apply-completion: [A] item: 0
+A.binary_bloc # error: does not exist
+#            ^ apply-completion: [B] item: 0
+A.arg0_arg1_blk(${1:Integer}, ${2:String}) do |${3:Integer}, ${4:String}|
+  ${5}
+end${0} # error: does not exist
+#             ^ apply-completion: [C] item: 0

--- a/test/testdata/lsp/completion/snippet_block_arity.rb
+++ b/test/testdata/lsp/completion/snippet_block_arity.rb
@@ -1,0 +1,36 @@
+# typed: true
+
+class Module
+  include T::Sig
+end
+
+class A
+  sig {params(blk: T.proc.params(x: Integer).void).void}
+  def self.unary_block(&blk)
+    yield 0
+  end
+
+  sig {params(blk: T.proc.params(x: Integer, y: String).void).void}
+  def self.binary_block(&blk)
+    yield 0, ''
+  end
+
+  sig do
+    params(
+      arg0: Integer,
+      arg1: String,
+      blk: T.proc.params(x: Integer, y: String).void
+    )
+    .void
+  end
+  def self.arg0_arg1_blk(arg0, arg1, &blk)
+    yield arg0, arg1
+  end
+end
+
+A.unary_bloc # error: does not exist
+#           ^ apply-completion: [A] item: 0
+A.binary_bloc # error: does not exist
+#            ^ apply-completion: [B] item: 0
+A.arg0_arg1_bl # error: does not exist
+#             ^ apply-completion: [C] item: 0


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When we can tell from the types that a method must take a block, we can
automatically insert the block snippet.

This snippet unconditionally makes the block snippet multi-line.

Sometimes people might want / need a single line snippet. I suggest that
we merge this as is and if people ask for single line snippets, that we
implement that as a refactoring / code action, or maybe even just revert
this.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.