### PR TITLE
Expose symbol locs in JSON output

### DIFF
--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -103,6 +103,11 @@ public:
 
     Loc loc() const;
     const InlinedVector<Loc, 2> &locs() const;
+    inline InlinedVector<Loc, 2> &locs() {
+        ENFORCE(isClassOrModule());
+        return locs_;
+    }
+
     void addLoc(const core::GlobalState &gs, core::Loc loc);
 
     u4 hash(const GlobalState &gs) const;

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -104,7 +104,6 @@ public:
     Loc loc() const;
     const InlinedVector<Loc, 2> &locs() const;
     inline InlinedVector<Loc, 2> &locs() {
-        ENFORCE(isClassOrModule());
         return locs_;
     }
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -103,10 +103,6 @@ public:
 
     Loc loc() const;
     const InlinedVector<Loc, 2> &locs() const;
-    inline InlinedVector<Loc, 2> &locs() {
-        return locs_;
-    }
-
     void addLoc(const core::GlobalState &gs, core::Loc loc);
 
     u4 hash(const GlobalState &gs) const;

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -128,8 +128,8 @@ com::stripe::rubytyper::Symbol Proto::toProto(const GlobalState &gs, SymbolRef s
             symbolProto.set_resulttype(data->resultType.get()->show(gs));
         }
 
-        for (auto loc : data->locs()) {
-            *symbolProto.add_locs() = toProto(gs, loc);	
+        for (const auto &loc : data->locs()) {
+            *symbolProto.add_locs() = toProto(gs, loc);
         }
     }
 

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -123,6 +123,16 @@ com::stripe::rubytyper::Symbol Proto::toProto(const GlobalState &gs, SymbolRef s
         }
     }
 
+    if (showFull) {
+        if (data->resultType) {
+            symbolProto.set_resulttype(data->resultType.get()->show(gs));
+        }
+
+        for (auto loc : data->locs()) {
+            *symbolProto.add_locs() = toProto(gs, loc);	
+        }
+    }
+
     for (auto pair : data->membersStableOrderSlow(gs)) {
         if (pair.first == Names::singleton() || pair.first == Names::attached() ||
             pair.first == Names::classMethods() || pair.first == Names::Constants::AttachedClass()) {

--- a/proto/Symbol.proto
+++ b/proto/Symbol.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package com.stripe.rubytyper;
 import "proto/Name.proto";
+import "proto/Loc.proto";
 
 message Symbol {
     enum Kind {
@@ -74,7 +75,7 @@ message Symbol {
 //    string resultType = 12;
     // Loc loc = 13; Replaced by locs = 15
     repeated Symbol children = 14;
-//    repeated Loc locs = 15;
+    repeated Loc locs = 15;
 
     int32 aliasTo = 16;
 }

--- a/proto/Symbol.proto
+++ b/proto/Symbol.proto
@@ -72,7 +72,7 @@ message Symbol {
 //    repeated Flag flags = 11;
 
     // ALL
-//    string resultType = 12;
+    string resultType = 12;
     // Loc loc = 13; Replaced by locs = 15
     repeated Symbol children = 14;
     repeated Loc locs = 15;

--- a/test/cli/symbol-table-json-alias/symbol-table-json-alias.sh
+++ b/test/cli/symbol-table-json-alias/symbol-table-json-alias.sh
@@ -1,1 +1,1 @@
-main/sorbet test/cli/symbol-table-json-alias/symbol-table-json-alias.rb -p symbol-table-full-json | grep aliasTo -B 5 | head -n 5
+main/sorbet test/cli/symbol-table-json-alias/symbol-table-json-alias.rb -p symbol-table-full-json | grep aliasTo -B 21 | head -n 5


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
We can leverage Sorbet's LSP to generate documentation, potentially. This PR unblocks a potential avenue for that.

### Test plan
I'll benchmark the Stripe script method that uses the symbol table and make sure there aren't any perf differences