### PR TITLE
Add static error for instantiating an abstract class

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1121,6 +1121,11 @@ public:
                 return;
             }
         }
+        if (attachedClass.data(ctx)->isClassOrModuleAbstract()) {
+            if (auto e = ctx.state.beginError(args.locs.call, errors::Infer::AbstractClassInstantiated)) {
+                e.setHeader("Attempt to instantiate abstract class `{}`", attachedClass.data(ctx)->show(ctx));
+            }
+        }
         auto instanceTy = attachedClass.data(ctx)->externalType(ctx);
         DispatchArgs innerArgs{Names::initialize(), args.locs, args.args, instanceTy, instanceTy, args.block};
         auto dispatched = instanceTy->dispatchCall(ctx, innerArgs);

--- a/test/testdata/infer/instantiate_abstract.rb
+++ b/test/testdata/infer/instantiate_abstract.rb
@@ -1,0 +1,26 @@
+# typed: true
+
+class Abstract
+  extend T::Helpers
+  extend T::Sig
+  abstract!
+
+  sig {abstract.void}
+  def foo; end
+end
+
+class SubclassOfAbstract < Abstract
+  def foo; end
+end
+
+module B
+  extend T::Helpers
+  abstract!
+
+  def self.new
+  end
+end
+
+Abstract.new # error: Attempt to instantiate abstract class `Abstract`
+SubclassOfAbstract.new
+B.new


### PR DESCRIPTION
### Motivation
The runtime has a check for this but it can be defeated if the abstract
class defines `initialize`. Efficently fixing that problem in the
runtime involves using `prepend`, which is risky as it invalidates
assumptions scattered around the codebase.

This only checks calling `new` on a class marked directly with
`abstract!`. Subclasses of abstract classes that are not concrete
already get errors about missing definitions so we should be okay there.

Thanks to @jez for suggesting where to put this check!

Closes #2143

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
