### PR TITLE
Add an ENFORCE to Symbol::arguments

### DIFF
--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -594,10 +594,12 @@ public:
     };
 
     std::vector<ArgInfo> &arguments() {
+        ENFORCE(isMethod());
         return arguments_;
     }
 
     const std::vector<ArgInfo> &arguments() const {
+        ENFORCE(isMethod());
         return arguments_;
     }
 

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -79,10 +79,7 @@ optional<core::AutocorrectSuggestion::Edit> maybeSuggestExtendTSig(core::Context
 }
 
 core::TypePtr extractArgType(core::Context ctx, cfg::Send &send, core::DispatchComponent &component, int argId) {
-    ENFORCE(component.method.exists());
-    if (component.method == core::Symbols::untyped()) {
-        return nullptr;
-    }
+    ENFORCE(component.method.exists() && component.method != core::Symbols::untyped());
     const auto &args = component.method.data(ctx)->arguments();
     if (argId >= args.size()) {
         return nullptr;
@@ -129,7 +126,7 @@ void extractSendArgumentKnowledge(core::Context ctx, core::Loc bindLoc, cfg::Sen
         core::TypePtr thisType;
         auto iter = &dispatchInfo;
         while (iter != nullptr) {
-            if (iter->main.method.exists()) {
+            if (iter->main.method.exists() && iter->main.method != core::Symbols::untyped()) {
                 auto argType = extractArgType(ctx, *snd, iter->main, i);
                 if (argType && !argType->isUntyped()) {
                     if (!thisType) {

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -80,6 +80,9 @@ optional<core::AutocorrectSuggestion::Edit> maybeSuggestExtendTSig(core::Context
 
 core::TypePtr extractArgType(core::Context ctx, cfg::Send &send, core::DispatchComponent &component, int argId) {
     ENFORCE(component.method.exists());
+    if (component.method == core::Symbols::untyped()) {
+        return nullptr;
+    }
     const auto &args = component.method.data(ctx)->arguments();
     if (argId >= args.size()) {
         return nullptr;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This used to be `argumentsOrMixins` but then we refactored the way that mixins
on a class / module worked, and so it became only `arguments`. That means that
it should only be valid to call this on a Method symbol, so we may as well
ENFORCE that.

This uncovered a bit of a wart in SigSuggestion, where we were relying
implicitly on the fact that `core::Symbols::untyped()` has an arguments list of
length 0.

I'm actually not sure why `DispatchComponent` is ever untyped or if we should
check something up higher than `extractArgTypes`, but this fix seems to be good
enough to get the ENFORCE to pass on our test suite.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.