### PR TITLE
Fix bug in sig suggestion with method redefinition

### DIFF
--- a/test/testdata/lsp/completion/sig_redefinition__1.A.rbedited
+++ b/test/testdata/lsp/completion/sig_redefinition__1.A.rbedited
@@ -5,9 +5,7 @@ class Module
 end
 
 class A
-  sig do
-  ${1}
-end${0} # error: no block
+  sig {returns(NilClass)}${0} # error: no block
   #  ^ apply-completion: [A] item: 0
   def foo; end
 

--- a/test/testdata/lsp/completion/sig_redefinition__1.A.rbedited
+++ b/test/testdata/lsp/completion/sig_redefinition__1.A.rbedited
@@ -1,0 +1,15 @@
+# typed: true
+
+class Module
+  include T::Sig
+end
+
+class A
+  sig do
+  ${1}
+end${0} # error: no block
+  #  ^ apply-completion: [A] item: 0
+  def foo; end
+
+  def bar; end
+end

--- a/test/testdata/lsp/completion/sig_redefinition__1.B.rbedited
+++ b/test/testdata/lsp/completion/sig_redefinition__1.B.rbedited
@@ -1,0 +1,13 @@
+# typed: true
+
+class Module
+  include T::Sig
+end
+
+class A
+  sig # error: no block
+  #  ^ apply-completion: [A] item: 0
+  def foo; end
+
+  def bar; end
+end

--- a/test/testdata/lsp/completion/sig_redefinition__1.rb
+++ b/test/testdata/lsp/completion/sig_redefinition__1.rb
@@ -1,0 +1,13 @@
+# typed: true
+
+class Module
+  include T::Sig
+end
+
+class A
+  sig # error: no block
+  #  ^ apply-completion: [A] item: 0
+  def foo; end
+
+  def bar; end
+end

--- a/test/testdata/lsp/completion/sig_redefinition__2.A.rbedited
+++ b/test/testdata/lsp/completion/sig_redefinition__2.A.rbedited
@@ -1,0 +1,9 @@
+# typed: true
+
+class A
+  def foo; end
+
+  sig # error: no block
+  #  ^ apply-completion: [B] item: 0
+  def bar; end
+end

--- a/test/testdata/lsp/completion/sig_redefinition__2.B.rbedited
+++ b/test/testdata/lsp/completion/sig_redefinition__2.B.rbedited
@@ -1,0 +1,9 @@
+# typed: true
+
+class A
+  def foo; end
+
+  sig {returns(NilClass)}${0} # error: no block
+  #  ^ apply-completion: [B] item: 0
+  def bar; end
+end

--- a/test/testdata/lsp/completion/sig_redefinition__2.rb
+++ b/test/testdata/lsp/completion/sig_redefinition__2.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+class A
+  def foo; end
+
+  sig # error: no block
+  #  ^ apply-completion: [B] item: 0
+  def bar; end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This came up a bunch of times when I was was testing sig suggestion locally.
I worked around it but it's easy enough to just fix outright.


- **Add failing (flaky) test** (faf7a719f)

  One of `sig_redefinition__1.rb` or `sig_redefinition__2.rb` would get
  the primary loc for either `foo` or `bar` depending on at random which
  file was processed first.

  Depending on which of the two files became the primary loc, only in that
  file would sig suggestion trigger. I noticed this because when I was
  testing LSP locally I frequently use

    ```ruby
    class A; def foo; end end
    ```

  in small test files. When multiple such test files are in a folder,
  Sorbet sees all the `A#foo` method defs as (compatible) redefinitions of
  each other, and accumulates all their Locs onto one Symbol.

- **Fix failing test** (fd60ceac4)



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.