### PR TITLE
Parse type members as SelfTypeParam, and unwrap them later

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -160,6 +160,9 @@ public:
     static TypePtr widen(Context ctx, const TypePtr &type);
     static std::optional<int> getProcArity(const AppliedType &type);
 
+    /** Unwrap SelfTypeParam instances that belong to the given owner, to a bare LambdaParam */
+    static TypePtr unwrapSkolemVariables(Context ctx, const TypePtr &ty);
+
     // Given a type, return a SymbolRef for the Ruby class that has that type, or no symbol if no such class exists.
     // This is an internal method for implementing intrinsics. In the future we should make all updateKnowledge methods
     // be intrinsics so that this can become an anonymous helper function in calls.cc.
@@ -470,6 +473,7 @@ private:
     friend TypePtr Types::lub(Context ctx, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr Types::glb(Context ctx, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr Types::dropSubtypesOf(Context ctx, const TypePtr &from, SymbolRef klass);
+    friend TypePtr Types::unwrapSkolemVariables(Context ctx, const TypePtr &t1);
     friend class Symbol; // the actual method is `recordSealedSubclass(MutableContext ctx, SymbolRef subclass)`,
                          // but refering to it introduces a cycle
 
@@ -514,6 +518,7 @@ private:
     friend TypePtr glbGround(Context ctx, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr Types::lub(Context ctx, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr Types::glb(Context ctx, const TypePtr &t1, const TypePtr &t2);
+    friend TypePtr Types::unwrapSkolemVariables(Context ctx, const TypePtr &t1);
 
     static TypePtr make_shared(const TypePtr &left, const TypePtr &right);
 };

--- a/core/Types.h
+++ b/core/Types.h
@@ -161,7 +161,7 @@ public:
     static std::optional<int> getProcArity(const AppliedType &type);
 
     /** Unwrap SelfTypeParam instances that belong to the given owner, to a bare LambdaParam */
-    static TypePtr unwrapSkolemVariables(Context ctx, const TypePtr &ty);
+    static TypePtr unwrapSelfTypeParam(Context ctx, const TypePtr &ty);
 
     // Given a type, return a SymbolRef for the Ruby class that has that type, or no symbol if no such class exists.
     // This is an internal method for implementing intrinsics. In the future we should make all updateKnowledge methods
@@ -473,7 +473,7 @@ private:
     friend TypePtr Types::lub(Context ctx, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr Types::glb(Context ctx, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr Types::dropSubtypesOf(Context ctx, const TypePtr &from, SymbolRef klass);
-    friend TypePtr Types::unwrapSkolemVariables(Context ctx, const TypePtr &t1);
+    friend TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &t1);
     friend class Symbol; // the actual method is `recordSealedSubclass(MutableContext ctx, SymbolRef subclass)`,
                          // but refering to it introduces a cycle
 
@@ -518,7 +518,7 @@ private:
     friend TypePtr glbGround(Context ctx, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr Types::lub(Context ctx, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr Types::glb(Context ctx, const TypePtr &t1, const TypePtr &t2);
-    friend TypePtr Types::unwrapSkolemVariables(Context ctx, const TypePtr &t1);
+    friend TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &t1);
 
     static TypePtr make_shared(const TypePtr &left, const TypePtr &right);
 };

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -859,47 +859,48 @@ TypePtr Types::widen(Context ctx, const TypePtr &type) {
     return ret;
 }
 
-TypePtr Types::unwrapSkolemVariables(Context ctx, const TypePtr &type) {
+TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &type) {
     ENFORCE(type != nullptr);
 
     TypePtr ret;
 
     typecase(
-        type.get(),
+        type.get(), [&](ClassType *klass) { ret = type; }, [&](TypeVar *tv) { ret = type; },
+        [&](LambdaParam *tv) { ret = type; }, [&](SelfType *self) { ret = type; },
+        [&](LiteralType *lit) { ret = type; },
         [&](AndType *andType) {
-            ret = AndType::make_shared(unwrapSkolemVariables(ctx, andType->left),
-                                       unwrapSkolemVariables(ctx, andType->right));
+            ret =
+                AndType::make_shared(unwrapSelfTypeParam(ctx, andType->left), unwrapSelfTypeParam(ctx, andType->right));
         },
         [&](OrType *orType) {
-            ret = OrType::make_shared(unwrapSkolemVariables(ctx, orType->left),
-                                      unwrapSkolemVariables(ctx, orType->right));
+            ret = OrType::make_shared(unwrapSelfTypeParam(ctx, orType->left), unwrapSelfTypeParam(ctx, orType->right));
         },
         [&](ShapeType *shape) {
             std::vector<TypePtr> values;
             values.reserve(shape->values.size());
 
             for (auto &value : shape->values) {
-                values.emplace_back(unwrapSkolemVariables(ctx, value));
+                values.emplace_back(unwrapSelfTypeParam(ctx, value));
             }
 
-            ret = make_type<ShapeType>(unwrapSkolemVariables(ctx, shape->underlying_), shape->keys, std::move(values));
+            ret = make_type<ShapeType>(unwrapSelfTypeParam(ctx, shape->underlying_), shape->keys, std::move(values));
         },
         [&](TupleType *tuple) {
             std::vector<TypePtr> elems;
             elems.reserve(tuple->elems.size());
 
             for (auto &value : tuple->elems) {
-                elems.emplace_back(unwrapSkolemVariables(ctx, value));
+                elems.emplace_back(unwrapSelfTypeParam(ctx, value));
             }
 
-            ret = make_type<TupleType>(unwrapSkolemVariables(ctx, tuple->underlying_), std::move(elems));
+            ret = make_type<TupleType>(unwrapSelfTypeParam(ctx, tuple->underlying_), std::move(elems));
         },
-        [&](MetaType *meta) { ret = make_type<MetaType>(unwrapSkolemVariables(ctx, meta->wrapped)); },
+        [&](MetaType *meta) { ret = make_type<MetaType>(unwrapSelfTypeParam(ctx, meta->wrapped)); },
         [&](AppliedType *appliedType) {
             vector<TypePtr> newTargs;
             newTargs.reserve(appliedType->targs.size());
             for (const auto &t : appliedType->targs) {
-                newTargs.emplace_back(unwrapSkolemVariables(ctx, t));
+                newTargs.emplace_back(unwrapSelfTypeParam(ctx, t));
             }
             ret = make_type<AppliedType>(appliedType->klass, newTargs);
         },
@@ -912,7 +913,10 @@ TypePtr Types::unwrapSkolemVariables(Context ctx, const TypePtr &type) {
                 ret = type;
             }
         },
-        [&](Type *tp) { ret = type; });
+        [&](Type *tp) {
+            ENFORCE(false, "Unhandled case: {}", type->toString(ctx));
+            Exception::notImplemented();
+        });
 
     ENFORCE(ret != nullptr);
 

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -28,12 +28,12 @@ ParsedSig TypeSyntax::parseSig(core::MutableContext ctx, ast::Send *sigSend, con
     auto result = parseSigWithSelfTypeParams(ctx, sigSend, parent, args);
 
     for (auto &arg : result.argTypes) {
-        auto type = core::Types::unwrapSelfTypeParam(ctx, arg.type);
-        arg.type = type;
+        arg.type = core::Types::unwrapSelfTypeParam(ctx, arg.type);
     }
 
-    auto returns = core::Types::unwrapSelfTypeParam(ctx, result.returns);
-    result.returns = returns;
+    if (result.returns != nullptr) {
+        result.returns = core::Types::unwrapSelfTypeParam(ctx, result.returns);
+    }
 
     return result;
 }

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -13,14 +13,14 @@ namespace sorbet::resolver {
 // Forward declarations for the local versions of getResultType, getResultTypeAndBind, and parseSig that skolemize type
 // members.
 namespace {
-core::TypePtr getResultTypeWithSelfTypeParams(core::MutableContext ctx, ast::Expression &expr, const ParsedSig &sigBeingParsed,
-                                       TypeSyntaxArgs args);
+core::TypePtr getResultTypeWithSelfTypeParams(core::MutableContext ctx, ast::Expression &expr,
+                                              const ParsedSig &sigBeingParsed, TypeSyntaxArgs args);
 
 TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableContext ctx, ast::Expression &expr,
-                                                       const ParsedSig &sigBeingParsed, TypeSyntaxArgs args);
+                                                              const ParsedSig &sigBeingParsed, TypeSyntaxArgs args);
 
 ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSend, const ParsedSig *parent,
-                              TypeSyntaxArgs args);
+                                     TypeSyntaxArgs args);
 } // namespace
 
 ParsedSig TypeSyntax::parseSig(core::MutableContext ctx, ast::Send *sigSend, const ParsedSig *parent,
@@ -40,8 +40,8 @@ ParsedSig TypeSyntax::parseSig(core::MutableContext ctx, ast::Send *sigSend, con
 
 core::TypePtr TypeSyntax::getResultType(core::MutableContext ctx, ast::Expression &expr,
                                         const ParsedSig &sigBeingParsed, TypeSyntaxArgs args) {
-    return core::Types::unwrapSelfTypeParam(ctx,
-                                            getResultTypeWithSelfTypeParams(ctx, expr, sigBeingParsed, args.withoutRebind()));
+    return core::Types::unwrapSelfTypeParam(
+        ctx, getResultTypeWithSelfTypeParams(ctx, expr, sigBeingParsed, args.withoutRebind()));
 }
 
 TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx, ast::Expression &expr,
@@ -108,7 +108,7 @@ bool TypeSyntax::isSig(core::Context ctx, ast::Send *send) {
 namespace {
 
 ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSend, const ParsedSig *parent,
-                              TypeSyntaxArgs args) {
+                                     TypeSyntaxArgs args) {
     ParsedSig sig;
 
     vector<ast::Send *> sends;
@@ -437,7 +437,8 @@ core::TypePtr interpretTCombinator(core::MutableContext ctx, ast::Send *send, co
             auto result = getResultTypeWithSelfTypeParams(ctx, *(send->args[0]), sig, args);
             int i = 1;
             while (i < send->args.size()) {
-                result = core::Types::all(ctx, result, getResultTypeWithSelfTypeParams(ctx, *(send->args[i]), sig, args));
+                result =
+                    core::Types::all(ctx, result, getResultTypeWithSelfTypeParams(ctx, *(send->args[i]), sig, args));
                 i++;
             }
             return result;
@@ -450,7 +451,8 @@ core::TypePtr interpretTCombinator(core::MutableContext ctx, ast::Send *send, co
             auto result = getResultTypeWithSelfTypeParams(ctx, *(send->args[0]), sig, args);
             int i = 1;
             while (i < send->args.size()) {
-                result = core::Types::any(ctx, result, getResultTypeWithSelfTypeParams(ctx, *(send->args[i]), sig, args));
+                result =
+                    core::Types::any(ctx, result, getResultTypeWithSelfTypeParams(ctx, *(send->args[i]), sig, args));
                 i++;
             }
             return result;
@@ -583,13 +585,13 @@ core::TypePtr interpretTCombinator(core::MutableContext ctx, ast::Send *send, co
     }
 }
 
-core::TypePtr getResultTypeWithSelfTypeParams(core::MutableContext ctx, ast::Expression &expr, const ParsedSig &sigBeingParsed,
-                                       TypeSyntaxArgs args) {
+core::TypePtr getResultTypeWithSelfTypeParams(core::MutableContext ctx, ast::Expression &expr,
+                                              const ParsedSig &sigBeingParsed, TypeSyntaxArgs args) {
     return getResultTypeAndBindWithSelfTypeParams(ctx, expr, sigBeingParsed, args.withoutRebind()).type;
 }
 
 TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableContext ctx, ast::Expression &expr,
-                                                       const ParsedSig &sigBeingParsed, TypeSyntaxArgs args) {
+                                                              const ParsedSig &sigBeingParsed, TypeSyntaxArgs args) {
     // Ensure that we only check types from a class context
     auto ctxOwnerData = ctx.owner.data(ctx);
     ENFORCE(ctxOwnerData->isClassOrModule(), "getResultTypeAndBind wasn't called with a class owner");

--- a/test/testdata/infer/t_all_type_member_bug.rb
+++ b/test/testdata/infer/t_all_type_member_bug.rb
@@ -1,0 +1,13 @@
+# typed: true
+class A
+  extend T::Sig
+  extend T::Generic
+
+  X = type_member
+
+  # This is an example of the bug that caused an enforce failure in:
+  # https://github.com/sorbet/sorbet/issues/206
+  sig {params(x: T.all(X, Integer)).void}
+  def bar(x); end
+end
+

--- a/test/testdata/resolver/self.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/self.rb.symbol-table-raw.exp
@@ -17,7 +17,7 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     method <C <U TestSelfGeneric>><U good1> (s, <blk>) -> AppliedType {
       klass = <C <U TestSelfGeneric>>
       targs = [
-        <C <U Elem>> = SelfTypeParam(<C <U TestSelfGeneric>><C <U Elem>>)
+        <C <U Elem>> = LambdaParam(<C <U TestSelfGeneric>><C <U Elem>>, lower=T.noreturn, upper=<any>)
       ]
     } @ Loc {file=test/testdata/resolver/self.rb start=32:3 end=32:15}
       argument s<> -> TestSelfGeneric[TestSelfGeneric::Elem] @ Loc {file=test/testdata/resolver/self.rb start=29:12 end=29:13}
@@ -25,7 +25,7 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     method <C <U TestSelfGeneric>><U pass> (<blk>) -> AppliedType {
       klass = <C <U TestSelfGeneric>>
       targs = [
-        <C <U Elem>> = SelfTypeParam(<C <U TestSelfGeneric>><C <U Elem>>)
+        <C <U Elem>> = LambdaParam(<C <U TestSelfGeneric>><C <U Elem>>, lower=T.noreturn, upper=<any>)
       ]
     } @ Loc {file=test/testdata/resolver/self.rb start=39:3 end=39:13}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/self.rb start=??? end=???}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
`Types::all` will raise an error in `glbGround` if a bare `LambdaParam` is passed in, which is the case when parsing type member references in a signature. This PR changes the behavior of the signature parser to instead produce a `SelfTypeParam`, avoiding issues with `Types::all`. At the end of type parsing, the type is traversed again, turning `SelfTypeParam` occurrences back into bare `LambdaParams`, so that they will behave as expected during instantiation.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixes #206 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
