### PR TITLE
allow using --typed-override to be used to put the type back 

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -369,7 +369,7 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
     }
     auto fnd = opts.strictnessOverrides.find(filePath);
     if (fnd != opts.strictnessOverrides.end()) {
-        if (fnd->second == fileData.originalSigil) {
+        if (fnd->second == fileData.originalSigil && fnd->second > opts.forceMinStrict && fnd->second < opts.forceMaxStrict) {
             core::ErrorRegion errs(gs, file);
             if (auto e = gs.beginError(sorbet::core::Loc::none(file), core::errors::Parser::ParserError)) {
                 e.setHeader("Useless override of strictness level");

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -367,6 +367,19 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
     if (!absl::StartsWith(filePath, "/") && !absl::StartsWith(filePath, "./")) {
         filePath.insert(0, "./");
     }
+
+    if (fileData.originalSigil == core::StrictLevel::None) {
+        level = core::StrictLevel::False;
+    } else {
+        level = fileData.originalSigil;
+    }
+
+    core::StrictLevel minStrict = opts.forceMinStrict;
+    core::StrictLevel maxStrict = opts.forceMaxStrict;
+    if (level <= core::StrictLevel::Max && level > core::StrictLevel::Ignore) {
+        level = max(min(level, maxStrict), minStrict);
+    }
+
     auto fnd = opts.strictnessOverrides.find(filePath);
     if (fnd != opts.strictnessOverrides.end()) {
         if (fnd->second == fileData.originalSigil && fnd->second > opts.forceMinStrict &&
@@ -377,18 +390,6 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
             }
         }
         level = fnd->second;
-    } else {
-        if (fileData.originalSigil == core::StrictLevel::None) {
-            level = core::StrictLevel::False;
-        } else {
-            level = fileData.originalSigil;
-        }
-    }
-
-    core::StrictLevel minStrict = opts.forceMinStrict;
-    core::StrictLevel maxStrict = opts.forceMaxStrict;
-    if (level <= core::StrictLevel::Max && level > core::StrictLevel::Ignore) {
-        level = max(min(level, maxStrict), minStrict);
     }
 
     if (gs.runningUnderAutogen) {

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -369,7 +369,8 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
     }
     auto fnd = opts.strictnessOverrides.find(filePath);
     if (fnd != opts.strictnessOverrides.end()) {
-        if (fnd->second == fileData.originalSigil && fnd->second > opts.forceMinStrict && fnd->second < opts.forceMaxStrict) {
+        if (fnd->second == fileData.originalSigil && fnd->second > opts.forceMinStrict &&
+            fnd->second < opts.forceMaxStrict) {
             core::ErrorRegion errs(gs, file);
             if (auto e = gs.beginError(sorbet::core::Loc::none(file), core::errors::Parser::ParserError)) {
                 e.setHeader("Useless override of strictness level");

--- a/test/cli/override-typed-bad/override-typed-bad.out
+++ b/test/cli/override-typed-bad/override-typed-bad.out
@@ -12,6 +12,30 @@ test/cli/override-typed-bad/override-typed-bad.rb:2: Expected `Integer` but foun
             ^^^
 Errors: 2
 ----
+test/cli/override-typed-bad/override-typed-bad.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
+     2 |1 + "s"
+        ^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+     148 |        arg0: Integer,
+                  ^^^^
+  Got String("s") originating from:
+    test/cli/override-typed-bad/override-typed-bad.rb:2:
+     2 |1 + "s"
+            ^^^
+Errors: 1
+----
+test/cli/override-typed-bad/override-typed-bad.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
+     2 |1 + "s"
+        ^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+     148 |        arg0: Integer,
+                  ^^^^
+  Got String("s") originating from:
+    test/cli/override-typed-bad/override-typed-bad.rb:2:
+     2 |1 + "s"
+            ^^^
+Errors: 1
+----
 Failed to read strictness override file "file-that-does-not-exist". Does it exist?
 ----
 Cannot parse strictness override format. Map is expected on top level.

--- a/test/cli/override-typed-bad/override-typed-bad.sh
+++ b/test/cli/override-typed-bad/override-typed-bad.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 main/sorbet --silence-dev-message --typed-override=test/cli/override-typed-bad/override-typed-bad.yaml test/cli/override-typed-bad/override-typed-bad.rb 2>&1
 echo ----
+main/sorbet --silence-dev-message --typed=false --typed-override=test/cli/override-typed-bad/override-typed-bad.yaml test/cli/override-typed-bad/override-typed-bad.rb 2>&1
+echo ----
+main/sorbet --silence-dev-message --typed=strong --typed-override=test/cli/override-typed-bad/override-typed-bad.yaml test/cli/override-typed-bad/override-typed-bad.rb 2>&1
+echo ----
 main/sorbet --silence-dev-message --typed-override=file-that-does-not-exist 2>&1 -e ''
 echo ----
 main/sorbet --silence-dev-message --typed-override=test/cli/override-typed-bad/bad-top-level.yaml 2>&1 -e ''


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
If you have a `typed: false` file and do
```
--typed=true
```
and then have a `typed-override` to put the file back to `typed: false` then I think the override should take precedence. What do you think?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
