### PR TITLE
Add RBIs for some URI methods (take two)

### DIFF
--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_3_hidden.rbi.exp
@@ -9132,12 +9132,6 @@ end
 
 module URI
   extend ::URI::Escape
-  def self.decode_www_form(str, enc=T.unsafe(nil), separator: T.unsafe(nil), use__charset_: T.unsafe(nil), isindex: T.unsafe(nil)); end
-
-  def self.encode_www_form(enum, enc=T.unsafe(nil)); end
-
-  def self.encode_www_form_component(str, enc=T.unsafe(nil)); end
-
   def self.get_encoding(label); end
 
 end

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_3_hidden.rbi.exp
@@ -9138,12 +9138,6 @@ end
 
 module URI
   extend ::URI::Escape
-  def self.decode_www_form(str, enc=T.unsafe(nil), separator: T.unsafe(nil), use__charset_: T.unsafe(nil), isindex: T.unsafe(nil)); end
-
-  def self.encode_www_form(enum, enc=T.unsafe(nil)); end
-
-  def self.encode_www_form_component(str, enc=T.unsafe(nil)); end
-
   def self.get_encoding(label); end
 
 end

--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -174,6 +174,35 @@ module URI
   VERSION_CODE = T.let(T.unsafe(nil), String)
   WEB_ENCODINGS_ = T.let(T.unsafe(nil), T::Hash[T.untyped, T.untyped])
 
+  # Decode URL-encoded form data from given `str`.
+  #
+  # This decodes application/x-www-form-urlencoded data and returns array of key-value array.
+  #
+  # This refers [url.spec.whatwg.org/#concept-urlencoded-parser](http://url.spec.whatwg.org/#concept-urlencoded-parser),
+  # so this supports only &-separator, don't support ;-separator.
+  #
+  # ~~~ruby
+  # ary = ::decode_www_form(“a=1&a=2&b=3”)
+  # p ary #=> [['a', '1'], ['a', '2'], ['b', '3']]
+  # p ary.assoc('a').last #=> '1'
+  # p ary.assoc('b').last #=> '3'
+  # p ary.rassoc('a').last #=> '2'
+  # p Hash # => {“a”=>“2”, “b”=>“3”}
+  # ~~~
+  #
+  # See [::decode_www_form_component](https://docs.ruby-lang.org/en/2.6.0/URI.html#method-c-decode_www_form_component),
+  # [::encode_www_form](https://docs.ruby-lang.org/en/2.6.0/URI.html#method-c-encode_www_form)
+  sig do
+    params(
+      str: String,
+      enc: Encoding,
+      separator: String,
+      use__charset_: T::Boolean,
+      isindex: T::Boolean
+    ).returns(T::Array[[String, String]])
+  end
+  def self.decode_www_form(str, enc = Encoding::UTF_8, separator: '&', use__charset_: false, isindex: false); end
+
   # Decodes given `str` of URL-encoded form data.
   #
   # This decodes + to SP.

--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -259,6 +259,26 @@ module URI
   end
   def self.encode_www_form(enum, enc=nil); end
 
+  # Encode given `str` to URL-encoded form data.
+  #
+  # This method doesn't convert *, -, ., 0-9, A-Z, _, a-z, but does convert SP
+  # (ASCII space) to + and converts others to %XX.
+  #
+  # If `enc` is given, convert `str` to the encoding before percent encoding.
+  #
+  # This is an implementation of
+  # [www.w3.org/TR/html5/forms.html#url-encoded-form-data](http://www.w3.org/TR/html5/forms.html#url-encoded-form-data)
+  #
+  # See [::decode_www_form_component](https://docs.ruby-lang.org/en/2.1.0/URI.html#method-c-decode_www_form_component),
+  # [::encode_www_form](https://docs.ruby-lang.org/en/2.1.0/URI.html#method-c-encode_www_form)
+  sig do
+    params(
+      str: Object,
+      enc: T.nilable(Encoding)
+    ).returns(String)
+  end
+  def self.encode_www_form_component(str, enc=nil); end
+
   sig do
     params(
         arg: String,

--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -219,6 +219,46 @@ module URI
   end
   def self.decode_www_form_component(str, enc=Encoding::UTF_8); end
 
+  # Generate URL-encoded form data from given enum.
+  #
+  # This generates application/x-www-form-urlencoded data defined in HTML5 from
+  # given an [Enumerable](https://docs.ruby-lang.org/en/2.6.0/Enumerable.html)
+  # object.
+  #
+  # This internally uses
+  # [::encode_www_form_component](https://docs.ruby-lang.org/en/2.1.0/URI.html#method-c-encode_www_form_component).
+  #
+  # This method doesn't convert the encoding of given items, so convert them
+  # before call this method if you want to send data as other than original
+  # encoding or mixed encoding data. (Strings which are encoded in an HTML5
+  # ASCII incompatible encoding are converted to UTF-8.)
+  #
+  # This method doesn't handle files. When you send a file,
+  # use multipart/form-data.
+  #
+  # This refers [url.spec.whatwg.org/#concept-urlencoded-serializer](http://url.spec.whatwg.org/#concept-urlencoded-serializer)
+  #
+  # ~~~ruby
+  # URI.encode_www_form([["q", "ruby"], ["lang", "en"]])
+  # #=> "q=ruby&lang=en"
+  # URI.encode_www_form("q" => "ruby", "lang" => "en")
+  # #=> "q=ruby&lang=en"
+  # URI.encode_www_form("q" => ["ruby", "perl"], "lang" => "en")
+  # #=> "q=ruby&q=perl&lang=en"
+  # URI.encode_www_form([["q", "ruby"], ["q", "perl"], ["lang", "en"]])
+  # #=> "q=ruby&q=perl&lang=en"
+  # ~~~
+  #
+  # See [::encode_www_form_component](https://docs.ruby-lang.org/en/2.6.0/URI.html#method-c-encode_www_form_component),
+  # [::decode_www_form](https://docs.ruby-lang.org/en/2.6.0/URI.html#method-c-decode_www_form)
+  sig do
+    params(
+      enum: T::Enumerable[Object],
+      enc: T.nilable(Encoding)
+    ).returns(String)
+  end
+  def self.encode_www_form(enum, enc=nil); end
+
   sig do
     params(
         arg: String,


### PR DESCRIPTION
### Motivation

Now version of #2154 with a more permissive signature for `encode_www_form_component`.

The previous PR was suggesting this signature:

```ruby
  sig do
    params(
      str: String,
      enc: T.nilable(Encoding)
    ).returns(String)
  end
  def self.encode_www_form_component(str, enc=nil); end
```

While both the documentation and the parameter name hint for `str` to be a String, the signature was in fact too restrictive for Stripe codebase and got [reverted](#2232).

As discussed with @elliottt, `str` can actually be an `Object` so it accepts `nilable`.
Hence here the new signature:

```ruby
  sig do
    params(
      str: Object, # So we accept things like `URIf.encode_www_form_component(nil)`
      enc: T.nilable(Encoding)
    ).returns(String)
  end
  def self.encode_www_form_component(str, enc=nil); end
```

### Test plan

See included automated tests.
