### PR TITLE
Fix open-ended ranges

### DIFF
--- a/rbi/core/range.rbi
+++ b/rbi/core/range.rbi
@@ -107,7 +107,7 @@ class Range < Object
   # otherwise, it will be excluded.
   sig do
     type_parameters(:U).params(
-      from: T.nilable(T.type_parameter(:U)),
+      from: T.type_parameter(:U),
       to: T.nilable(T.type_parameter(:U)),
       exclude_end: T::Boolean
     ).returns(T::Range[T.type_parameter(:U)])

--- a/rbi/core/range.rbi
+++ b/rbi/core/range.rbi
@@ -107,8 +107,8 @@ class Range < Object
   # otherwise, it will be excluded.
   sig do
     type_parameters(:U).params(
-      from: T.type_parameter(:U),
-      to: T.type_parameter(:U),
+      from: T.nilable(T.type_parameter(:U)),
+      to: T.nilable(T.type_parameter(:U)),
       exclude_end: T::Boolean
     ).returns(T::Range[T.type_parameter(:U)])
   end

--- a/test/testdata/desugar/range.rb
+++ b/test/testdata/desugar/range.rb
@@ -17,6 +17,6 @@ def foo
     # testing for endless ranges
     g = (1..)
     h = Range.new(1, nil)
-    T.reveal_type(g) # error: Revealed type: `T::Range[Integer]`
-    T.reveal_type(h) # error: Revealed type: `T::Range[Integer]`
+    T.reveal_type(g) # error: Revealed type: `T::Range[Integer(1)]`
+    T.reveal_type(h) # error: Revealed type: `T::Range[Integer(1)]`
 end

--- a/test/testdata/desugar/range.rb
+++ b/test/testdata/desugar/range.rb
@@ -13,4 +13,10 @@ def foo
     T.reveal_type(d) # error: Revealed type: `T::Range[Integer]`
     T.reveal_type(e) # error: Revealed type: `Integer`
     T.reveal_type(f) # error: Revealed type: `String`
+
+    # testing for endless ranges
+    g = (1..)
+    h = Range.new(1, nil)
+    T.reveal_type(g) # error: Revealed type: `T::Range[Integer]`
+    T.reveal_type(h) # error: Revealed type: `T::Range[Integer]`
 end

--- a/test/testdata/desugar/range.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/range.rb.desugar-tree-raw.exp
@@ -204,6 +204,70 @@ ClassDef{
               }
             ]
           }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U f>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U g>
+            }
+            rhs = Send{
+              recv = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U Range>>
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+                Literal{ value = 1 }
+                EmptyTree
+              ]
+            }
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U h>
+            }
+            rhs = Send{
+              recv = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U Range>>
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+                Literal{ value = 1 }
+                Literal{ value = nil }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U g>
+              }
+            ]
+          }
         ],
         expr = Send{
           recv = UnresolvedConstantLit{
@@ -215,7 +279,7 @@ ClassDef{
           args = [
             UnresolvedIdent{
               kind = Local
-              name = <U f>
+              name = <U h>
             }
           ]
         }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes #2239; we already parse open-ended ranges correctly, but an open-ended range `(x..)` desugars (correctly) to `Range.new(x, nil)`, and we didn't allow a nilable second argument to `Range.new`, which meant we'd treat `Range.new(5, nil)` as defining a range of nilable integers instead of an range of integers. This makes the RBI change and adds tests, which allows us to support open-ended ranges.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
