### PR TITLE
Replace owner -> enclosingMethod in QueryResponse

### DIFF
--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -23,9 +23,8 @@ public:
 
 class IdentResponse final {
 public:
-    IdentResponse(core::SymbolRef owner, core::Loc termLoc, core::LocalVariable variable, core::TypeAndOrigins retType)
-        : owner(owner), termLoc(termLoc), variable(variable), retType(std::move(retType)){};
-    const core::SymbolRef owner;
+    IdentResponse(core::Loc termLoc, core::LocalVariable variable, core::TypeAndOrigins retType)
+        : termLoc(termLoc), variable(variable), retType(std::move(retType)){};
     const core::Loc termLoc;
     const core::LocalVariable variable;
     const core::TypeAndOrigins retType;
@@ -33,19 +32,16 @@ public:
 
 class LiteralResponse final {
 public:
-    LiteralResponse(core::SymbolRef owner, core::Loc termLoc, core::TypeAndOrigins retType)
-        : owner(owner), termLoc(termLoc), retType(std::move(retType)){};
-    const core::SymbolRef owner;
+    LiteralResponse(core::Loc termLoc, core::TypeAndOrigins retType) : termLoc(termLoc), retType(std::move(retType)){};
     const core::Loc termLoc;
     const core::TypeAndOrigins retType;
 };
 
 class ConstantResponse final {
 public:
-    ConstantResponse(core::SymbolRef owner, core::SymbolRef symbol, core::Loc termLoc, core::NameRef name,
-                     core::TypeAndOrigins receiver, core::TypeAndOrigins retType)
-        : owner(owner), symbol(symbol), termLoc(termLoc), name(name), retType(std::move(retType)){};
-    const core::SymbolRef owner;
+    ConstantResponse(core::SymbolRef symbol, core::Loc termLoc, core::NameRef name, core::TypeAndOrigins receiver,
+                     core::TypeAndOrigins retType)
+        : symbol(symbol), termLoc(termLoc), name(name), retType(std::move(retType)){};
     const core::SymbolRef symbol;
     const core::Loc termLoc;
     const core::NameRef name;

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -23,11 +23,13 @@ public:
 
 class IdentResponse final {
 public:
-    IdentResponse(core::Loc termLoc, core::LocalVariable variable, core::TypeAndOrigins retType)
-        : termLoc(termLoc), variable(variable), retType(std::move(retType)){};
+    IdentResponse(core::Loc termLoc, core::LocalVariable variable, core::TypeAndOrigins retType,
+                  core::SymbolRef enclosingMethod)
+        : termLoc(termLoc), variable(variable), retType(std::move(retType)), enclosingMethod(enclosingMethod){};
     const core::Loc termLoc;
     const core::LocalVariable variable;
     const core::TypeAndOrigins retType;
+    const core::SymbolRef enclosingMethod;
 };
 
 class LiteralResponse final {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -830,7 +830,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                 tp.origins = typeAndOrigin.origins;
 
                 if (lspQueryMatch) {
-                    core::lsp::QueryResponse::pushQueryResponse(ctx, core::lsp::IdentResponse(bind.loc, i->what, tp));
+                    core::lsp::QueryResponse::pushQueryResponse(
+                        ctx, core::lsp::IdentResponse(bind.loc, i->what, tp, ctx.owner));
                 }
 
                 ENFORCE((bind.loc.exists() && bind.loc.file().data(ctx).hasParseErrors) || !tp.origins.empty(),

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -830,8 +830,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                 tp.origins = typeAndOrigin.origins;
 
                 if (lspQueryMatch) {
-                    core::lsp::QueryResponse::pushQueryResponse(
-                        ctx, core::lsp::IdentResponse(ctx.owner, bind.loc, i->what, tp));
+                    core::lsp::QueryResponse::pushQueryResponse(ctx, core::lsp::IdentResponse(bind.loc, i->what, tp));
                 }
 
                 ENFORCE((bind.loc.exists() && bind.loc.file().data(ctx).hasParseErrors) || !tp.origins.empty(),
@@ -1014,8 +1013,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                 tp.origins.emplace_back(bind.loc);
 
                 if (lspQueryMatch) {
-                    core::lsp::QueryResponse::pushQueryResponse(ctx,
-                                                                core::lsp::LiteralResponse(ctx.owner, bind.loc, tp));
+                    core::lsp::QueryResponse::pushQueryResponse(ctx, core::lsp::LiteralResponse(bind.loc, tp));
                 }
             },
             [&](cfg::TAbsurd *i) {

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -31,7 +31,7 @@ unique_ptr<ast::MethodDef> DefLocSaver::postTransformMethodDef(core::Context ctx
                 tp.type = argType.type;
                 tp.origins.emplace_back(localExp->loc);
                 core::lsp::QueryResponse::pushQueryResponse(
-                    ctx, core::lsp::IdentResponse(methodDef->symbol, localExp->loc, localExp->localVariable, tp));
+                    ctx, core::lsp::IdentResponse(localExp->loc, localExp->localVariable, tp));
                 return methodDef;
             }
         }
@@ -67,8 +67,8 @@ unique_ptr<ast::UnresolvedIdent> DefLocSaver::postTransformUnresolvedIdent(core:
             core::TypeAndOrigins tp;
             tp.type = sym.data(ctx.state)->resultType;
             tp.origins.emplace_back(sym.data(ctx.state)->loc());
-            core::lsp::QueryResponse::pushQueryResponse(
-                ctx, core::lsp::ConstantResponse(klass, sym, id->loc, id->name, tp, tp));
+            core::lsp::QueryResponse::pushQueryResponse(ctx,
+                                                        core::lsp::ConstantResponse(sym, id->loc, id->name, tp, tp));
         }
     }
     return id;
@@ -90,7 +90,7 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
             }
 
             core::lsp::QueryResponse::pushQueryResponse(
-                ctx, core::lsp::ConstantResponse(ctx.owner, symbol, lit->loc, symbol.data(ctx)->name, tp, tp));
+                ctx, core::lsp::ConstantResponse(symbol, lit->loc, symbol.data(ctx)->name, tp, tp));
         }
         lit = ast::cast_tree<ast::ConstantLit>(lit->original->scope.get());
         if (lit) {

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -31,7 +31,7 @@ unique_ptr<ast::MethodDef> DefLocSaver::postTransformMethodDef(core::Context ctx
                 tp.type = argType.type;
                 tp.origins.emplace_back(localExp->loc);
                 core::lsp::QueryResponse::pushQueryResponse(
-                    ctx, core::lsp::IdentResponse(localExp->loc, localExp->localVariable, tp));
+                    ctx, core::lsp::IdentResponse(localExp->loc, localExp->localVariable, tp, methodDef->symbol));
                 return methodDef;
             }
         }

--- a/main/lsp/LocalVarSaver.cc
+++ b/main/lsp/LocalVarSaver.cc
@@ -21,8 +21,8 @@ unique_ptr<ast::Local> LocalVarSaver::postTransformLocal(core::Context ctx, uniq
         // No need for type information; this is for a reference request.
         // Let the default constructor make tp.type an empty shared_ptr and tp.origins an empty vector
         core::TypeAndOrigins tp;
-        core::lsp::QueryResponse::pushQueryResponse(
-            ctx, core::lsp::IdentResponse(ctx.owner, local->loc, local->localVariable, tp));
+        core::lsp::QueryResponse::pushQueryResponse(ctx,
+                                                    core::lsp::IdentResponse(local->loc, local->localVariable, tp));
     }
 
     return local;
@@ -39,7 +39,7 @@ unique_ptr<ast::MethodDef> LocalVarSaver::postTransformMethodDef(core::Context c
                 // (Ditto)
                 core::TypeAndOrigins tp;
                 core::lsp::QueryResponse::pushQueryResponse(
-                    ctx, core::lsp::IdentResponse(methodDef->symbol, localExp->loc, localExp->localVariable, tp));
+                    ctx, core::lsp::IdentResponse(localExp->loc, localExp->localVariable, tp));
             }
         }
     }

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -70,10 +70,10 @@ LSPLoop::handleTextDocumentDocumentHighlight(LSPTypechecker &typechecker, const 
                 }
             } else if (fileIsTyped && resp->isIdent()) {
                 auto identResp = resp->isIdent();
-                auto loc = identResp->owner.data(gs)->loc();
+                auto loc = identResp->termLoc;
                 if (loc.exists()) {
                     auto run2 = typechecker.query(
-                        core::lsp::Query::createVarQuery(identResp->owner, identResp->variable), {loc.file()});
+                        core::lsp::Query::createVarQuery(core::Symbols::noSymbol(), identResp->variable), {loc.file()});
                     auto locations = extractLocations(gs, run2.responses);
                     response->result = locationsToDocumentHighlights(move(locations));
                 }

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -73,7 +73,8 @@ LSPLoop::handleTextDocumentDocumentHighlight(LSPTypechecker &typechecker, const 
                 auto loc = identResp->termLoc;
                 if (loc.exists()) {
                     auto run2 = typechecker.query(
-                        core::lsp::Query::createVarQuery(core::Symbols::noSymbol(), identResp->variable), {loc.file()});
+                        core::lsp::Query::createVarQuery(identResp->enclosingMethod, identResp->variable),
+                        {loc.file()});
                     auto locations = extractLocations(gs, run2.responses);
                     response->result = locationsToDocumentHighlights(move(locations));
                 }

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -50,7 +50,8 @@ unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentReferences(LSPTypechecker
                 auto loc = identResp->termLoc;
                 if (loc.exists()) {
                     auto run2 = typechecker.query(
-                        core::lsp::Query::createVarQuery(core::Symbols::noSymbol(), identResp->variable), {loc.file()});
+                        core::lsp::Query::createVarQuery(identResp->enclosingMethod, identResp->variable),
+                        {loc.file()});
                     response->result = extractLocations(gs, run2.responses);
                 }
             } else if (fileIsTyped && resp->isSend()) {

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -47,10 +47,10 @@ unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentReferences(LSPTypechecker
                 }
             } else if (fileIsTyped && resp->isIdent()) {
                 auto identResp = resp->isIdent();
-                auto loc = identResp->owner.data(gs)->loc();
+                auto loc = identResp->termLoc;
                 if (loc.exists()) {
                     auto run2 = typechecker.query(
-                        core::lsp::Query::createVarQuery(identResp->owner, identResp->variable), {loc.file()});
+                        core::lsp::Query::createVarQuery(core::Symbols::noSymbol(), identResp->variable), {loc.file()});
                     response->result = extractLocations(gs, run2.responses);
                 }
             } else if (fileIsTyped && resp->isSend()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

IdentResponse, LiteralResponse, and ConstantResponse all have an `owner`
field on them which doesn't really make sense.

- It's completely unused for ConstantResponse and LiteralResponse.
- For IdentResponse, it's used, but it's kind of strange: when the
  IdentResponse is for an instance variable (which would be a Symbol
  which is "owned" by a class), the `owner` would actually be the method
  that that instance variable was used in (i.e., the lexical scope).

Add into the mix that I want to actually track `owner` on ConstantResponse
in the Symbol sense of the word, and I figure that's enough to get rid of
this.

For the one place where we need it (IdentResponse), I introduced
`SymbolRef enclosingMethod` to track that information.

### Commit summary

I did this in two commits:

- First remove `owner` entirely to find every usage.
- Second add enclosingMethod to support the places that still use it.

Commits:

- **Remove owner from QueryResponse's** (7e6807f90)

- **Add enclosingMethod to IdentResponse** (b2b16d426)



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No change in behavior; covered by existinng tests.