### PR TITLE
Split FieldResponse out from ConstantResponse

### DIFF
--- a/core/lsp/QueryResponse.cc
+++ b/core/lsp/QueryResponse.cc
@@ -29,6 +29,10 @@ const ConstantResponse *QueryResponse::isConstant() const {
     return get_if<ConstantResponse>(&response);
 }
 
+const FieldResponse *QueryResponse::isField() const {
+    return get_if<FieldResponse>(&response);
+}
+
 const DefinitionResponse *QueryResponse::isDefinition() const {
     return get_if<DefinitionResponse>(&response);
 }
@@ -46,6 +50,8 @@ core::Loc QueryResponse::getLoc() const {
         return literal->termLoc;
     } else if (auto constant = isConstant()) {
         return constant->termLoc;
+    } else if (auto field = isField()) {
+        return field->termLoc;
     } else if (auto def = isDefinition()) {
         return def->termLoc;
     } else if (auto edit = isEdit()) {
@@ -64,6 +70,8 @@ core::TypePtr QueryResponse::getRetType() const {
         return literal->retType.type;
     } else if (auto constant = isConstant()) {
         return constant->retType.type;
+    } else if (auto field = isField()) {
+        return field->retType.type;
     } else if (auto def = isDefinition()) {
         return def->retType.type;
     } else {
@@ -79,6 +87,8 @@ const core::TypeAndOrigins &QueryResponse::getTypeAndOrigins() const {
         return literal->retType;
     } else if (auto constant = isConstant()) {
         return constant->retType;
+    } else if (auto field = isField()) {
+        return field->retType;
     } else if (auto def = isDefinition()) {
         return def->retType;
     } else {

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -50,6 +50,16 @@ public:
     const core::TypeAndOrigins retType;
 };
 
+class FieldResponse final {
+public:
+    FieldResponse(core::SymbolRef symbol, core::Loc termLoc, core::NameRef name, core::TypeAndOrigins retType)
+        : symbol(symbol), termLoc(termLoc), name(name), retType(std::move(retType)){};
+    const core::SymbolRef symbol;
+    const core::Loc termLoc;
+    const core::NameRef name;
+    const core::TypeAndOrigins retType;
+};
+
 class DefinitionResponse final {
 public:
     DefinitionResponse(core::SymbolRef symbol, core::Loc termLoc, core::NameRef name, core::TypeAndOrigins retType)
@@ -67,7 +77,8 @@ public:
     const std::string replacement;
 };
 
-typedef std::variant<SendResponse, IdentResponse, LiteralResponse, ConstantResponse, DefinitionResponse, EditResponse>
+typedef std::variant<SendResponse, IdentResponse, LiteralResponse, ConstantResponse, FieldResponse, DefinitionResponse,
+                     EditResponse>
     QueryResponseVariant;
 
 /**
@@ -104,6 +115,11 @@ public:
      * Returns nullptr unless this is a Constant.
      */
     const ConstantResponse *isConstant() const;
+
+    /**
+     * Returns nullptr unless this is a Field.
+     */
+    const FieldResponse *isField() const;
 
     /**
      * Returns nullptr unless this is a Definition.

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -67,8 +67,7 @@ unique_ptr<ast::UnresolvedIdent> DefLocSaver::postTransformUnresolvedIdent(core:
             core::TypeAndOrigins tp;
             tp.type = sym.data(ctx.state)->resultType;
             tp.origins.emplace_back(sym.data(ctx.state)->loc());
-            core::lsp::QueryResponse::pushQueryResponse(ctx,
-                                                        core::lsp::ConstantResponse(sym, id->loc, id->name, tp, tp));
+            core::lsp::QueryResponse::pushQueryResponse(ctx, core::lsp::FieldResponse(sym, id->loc, id->name, tp));
         }
     }
     return id;

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -19,7 +19,7 @@ LSPLoop::extractLocations(const core::GlobalState &gs,
         if (loc.exists() && loc.file().exists()) {
             auto fileIsTyped = loc.file().data(gs).strictLevel >= core::StrictLevel::True;
             // If file is untyped, only support responses involving constants and definitions.
-            if (fileIsTyped || q->isConstant() || q->isDefinition()) {
+            if (fileIsTyped || q->isConstant() || q->isField() || q->isDefinition()) {
                 addLocIfExists(gs, locations, loc);
             }
         }

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -29,8 +29,8 @@ unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentDefinition(LSPTypechecker
                 config->uri2FileRef(gs, params.textDocument->uri).data(gs).strictLevel >= core::StrictLevel::True;
             auto resp = move(queryResponses[0]);
 
-            // Only support go-to-definition on constants in untyped files.
-            if (resp->isConstant() || (fileIsTyped && (resp->isIdent() || resp->isLiteral()))) {
+            // Only support go-to-definition on constants and fields in untyped files.
+            if (resp->isConstant() || resp->isField() || (fileIsTyped && (resp->isIdent() || resp->isLiteral()))) {
                 auto retType = resp->getTypeAndOrigins();
                 for (auto &originLoc : retType.origins) {
                     addLocIfExists(gs, result, originLoc);

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -64,6 +64,8 @@ LSPLoop::handleTextDocumentDocumentHighlight(LSPTypechecker &typechecker, const 
             // If file is untyped, only supports find reference requests from constants and class definitions.
             if (auto constResp = resp->isConstant()) {
                 response->result = getHighlightsToSymbolInFile(typechecker, uri, constResp->symbol);
+            } else if (auto fieldResp = resp->isField()) {
+                response->result = getHighlightsToSymbolInFile(typechecker, uri, fieldResp->symbol);
             } else if (auto defResp = resp->isDefinition()) {
                 if (fileIsTyped || defResp->symbol.data(gs)->isClassOrModule()) {
                     response->result = getHighlightsToSymbolInFile(typechecker, uri, defResp->symbol);

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -48,7 +48,7 @@ unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentHover(LSPTypechecker &typ
         auto resp = move(queryResponses[0]);
 
         optional<string> documentation = nullopt;
-        if (resp->isConstant() || resp->isDefinition()) {
+        if (resp->isConstant() || resp->isField() || resp->isDefinition()) {
             auto origins = resp->getTypeAndOrigins().origins;
             if (!origins.empty()) {
                 auto loc = origins[0];

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -41,6 +41,8 @@ unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentReferences(LSPTypechecker
             // If file is untyped, only supports find reference requests from constants and class definitions.
             if (auto constResp = resp->isConstant()) {
                 response->result = getReferencesToSymbol(typechecker, constResp->symbol);
+            } else if (auto fieldResp = resp->isField()) {
+                response->result = getReferencesToSymbol(typechecker, fieldResp->symbol);
             } else if (auto defResp = resp->isDefinition()) {
                 if (fileIsTyped || defResp->symbol.data(gs)->isClassOrModule()) {
                     response->result = getReferencesToSymbol(typechecker, defResp->symbol);

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -53,8 +53,8 @@ unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentTypeDefinition(LSPTypeche
                 config->uri2FileRef(gs, params.textDocument->uri).data(gs).strictLevel >= core::StrictLevel::True;
             auto resp = move(queryResponses[0]);
 
-            // Only support go-to-type-definition on constants in untyped files.
-            if (resp->isConstant() || (fileIsTyped && (resp->isIdent() || resp->isLiteral()))) {
+            // Only support go-to-type-definition on constants and fields in untyped files.
+            if (resp->isConstant() || resp->isField() || (fileIsTyped && (resp->isIdent() || resp->isLiteral()))) {
                 for (auto loc : locsForType(gs, resp->getRetType())) {
                     addLocIfExists(gs, result, loc);
                 }

--- a/test/testdata/lsp/untyped_field_reference__1.rb
+++ b/test/testdata/lsp/untyped_field_reference__1.rb
@@ -1,0 +1,17 @@
+# typed: false
+
+class X; end
+#     ^ type-def: x-type
+
+class A
+  def initialize
+    @x = T.let(X.new, X)
+    #^ def: x-def
+  end
+
+  def foo
+    @x
+    #^ usage: x-def
+    #^ type: x-type
+  end
+end

--- a/test/testdata/lsp/untyped_field_reference__2.rb
+++ b/test/testdata/lsp/untyped_field_reference__2.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+class A
+  def bar
+    @x
+    #^ usage: x-def
+    #^ type: x-type
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

ConstantResponse previously included things which were instance variables and
class variables. These are not constants. While they were close enough to act
like constants for some operations, for other things they're completely
different (all constants must resolve globally, but instance variables don't
have to be exist, let alone be typed).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.