### PR TITLE
Allow LSP protocol tests to customize initialization options.

### DIFF
--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -22,8 +22,9 @@ void ProtocolTest::SetUp() {
     lspWrapper->enableAllExperimentalFeatures();
 }
 
-vector<unique_ptr<LSPMessage>> ProtocolTest::initializeLSP() {
-    auto responses = sorbet::test::initializeLSP(rootPath, rootUri, *lspWrapper, nextId);
+vector<unique_ptr<LSPMessage>> ProtocolTest::initializeLSP(bool supportsMarkdown,
+                                                           optional<unique_ptr<SorbetInitializationOptions>> opts) {
+    auto responses = sorbet::test::initializeLSP(rootPath, rootUri, *lspWrapper, nextId, supportsMarkdown, move(opts));
     updateDiagnostics(responses);
     return responses;
 }

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -43,7 +43,9 @@ protected:
     /** Get an absolute file URI for the given relative file path. */
     std::string getUri(std::string_view filePath);
 
-    std::vector<std::unique_ptr<LSPMessage>> initializeLSP();
+    std::vector<std::unique_ptr<LSPMessage>>
+    initializeLSP(bool supportsMarkdown = true,
+                  std::optional<std::unique_ptr<SorbetInitializationOptions>> opts = std::nullopt);
 
     std::unique_ptr<LSPMessage> openFile(std::string_view path, std::string_view contents);
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Allow LSP protocol tests to customize initialization options.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Clean up tests that were cargo culting the same logic.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
