### PR TITLE
End-to-end LSP cancellation tests

### DIFF
--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -164,6 +164,7 @@ void LSPPreprocessor::mergeFileChanges(absl::Mutex &mtx, QueueState &state) {
                                 params->updates.versionStart, params->updates.versionEnd);
                             combinedUpdates.updatedGS = getTypecheckingGS();
                         }
+                        combinedUpdates.cancellationExpected = params->updates.cancellationExpected;
                         params->updates = move(combinedUpdates);
                     }
                     break;
@@ -355,6 +356,7 @@ void LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<DidChangeTextDocumentPa
                                         LSPFileUpdates &updates) const {
     updates.versionStart = v;
     updates.versionEnd = v;
+    updates.cancellationExpected = changeParams->sorbetCancellationExpected.value_or(false);
     string_view uri = changeParams->textDocument->uri;
     if (config->isUriInWorkspace(uri)) {
         string localPath = config->remoteName2Local(uri);
@@ -474,6 +476,7 @@ void LSPPreprocessor::mergeEdits(LSPFileUpdates &to, LSPFileUpdates &from) {
         ttgs.travel(from.versionEnd);
         to.updatedGS = getTypecheckingGS();
     }
+    to.cancellationExpected = to.cancellationExpected || from.cancellationExpected;
     ENFORCE(sanityCheckUpdate(ttgs.getGlobalState(), to));
 }
 

--- a/main/lsp/json_types.cc
+++ b/main/lsp/json_types.cc
@@ -156,4 +156,23 @@ unique_ptr<Position> Position::copy() const {
     return make_unique<Position>(line, character);
 }
 
+unique_ptr<DiagnosticRelatedInformation> DiagnosticRelatedInformation::copy() const {
+    return make_unique<DiagnosticRelatedInformation>(location->copy(), message);
+}
+
+unique_ptr<Diagnostic> Diagnostic::copy() const {
+    auto d = make_unique<Diagnostic>(range->copy(), message);
+    d->code = code;
+    d->severity = severity;
+    d->source = source;
+    if (relatedInformation.has_value()) {
+        vector<unique_ptr<DiagnosticRelatedInformation>> cloneRelatedInformation;
+        for (const auto &ri : *relatedInformation) {
+            cloneRelatedInformation.push_back(ri->copy());
+        }
+        d->relatedInformation = move(cloneRelatedInformation);
+    }
+    return d;
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/json_types.h
+++ b/main/lsp/json_types.h
@@ -30,6 +30,8 @@ struct LSPFileUpdates {
     std::vector<ast::ParsedFile> updatedFinalGSFileIndexes;
     // (Optional) Updated global state object to use to typecheck this update.
     std::optional<std::unique_ptr<core::GlobalState>> updatedGS;
+    // (Used in tests) Ensures that a slow path typecheck on these updates waits until it gets cancelled.
+    bool cancellationExpected = false;
 };
 
 class DeserializationError : public std::runtime_error {

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -123,12 +123,13 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                    "std::unique_ptr<Location> copy() const;",
                                });
 
-    auto DiagnosticRelatedInformation = makeObject("DiagnosticRelatedInformation",
-                                                   {
-                                                       makeField("location", Location),
-                                                       makeField("message", JSONString),
-                                                   },
-                                                   classTypes);
+    auto DiagnosticRelatedInformation =
+        makeObject("DiagnosticRelatedInformation",
+                   {
+                       makeField("location", Location),
+                       makeField("message", JSONString),
+                   },
+                   classTypes, {"std::unique_ptr<DiagnosticRelatedInformation> copy() const;"});
 
     auto DiagnosticSeverity =
         makeIntEnum("DiagnosticSeverity", {{"Error", 1}, {"Warning", 2}, {"Information", 3}, {"Hint", 4}}, enumTypes);
@@ -143,7 +144,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                        makeField("message", JSONString),
                        makeField("relatedInformation", makeOptional(makeArray(DiagnosticRelatedInformation))),
                    },
-                   classTypes);
+                   classTypes, {"std::unique_ptr<Diagnostic> copy() const;"});
 
     auto Command = makeObject("Command",
                               {

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -817,6 +817,8 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                    {
                        makeField("textDocument", VersionedTextDocumentIdentifier),
                        makeField("contentChanges", makeArray(TextDocumentContentChangeEvent)),
+                       // Used in tests only.
+                       makeField("sorbetCancellationExpected", makeOptional(JSONBool)),
                    },
                    classTypes);
 
@@ -1279,9 +1281,13 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                        "LSPFileUpdates updates;",
                    });
 
+    auto SorbetTypecheckRunStatus =
+        makeIntEnum("SorbetTypecheckRunStatus", {{"Started", 0}, {"Cancelled", 1}, {"Ended", 2}}, enumTypes);
+
     auto SorbetTypecheckRunInfo = makeObject("SorbetTypecheckRunInfo",
                                              {
-                                                 makeField("tookFastPath", JSONBool),
+                                                 makeField("status", SorbetTypecheckRunStatus),
+                                                 makeField("fastPath", JSONBool),
                                                  makeField("filesTypechecked", makeArray(JSONString)),
                                              },
                                              classTypes);

--- a/test/helpers/lsp.h
+++ b/test/helpers/lsp.h
@@ -29,7 +29,7 @@ std::unique_ptr<LSPMessage> makeOpen(std::string_view uri, std::string_view cont
 
 /** Create an LSPMessage containing a textDocument/didChange notification. */
 std::unique_ptr<LSPMessage> makeChange(std::string_view uri, std::string_view contents, int version,
-                                       bool cancellationExpected);
+                                       bool cancellationExpected = false);
 
 /** Create an LSPMessage containing a textDocument/didClose notification. */
 std::unique_ptr<LSPMessage> makeClose(std::string_view uri);

--- a/test/helpers/lsp.h
+++ b/test/helpers/lsp.h
@@ -28,7 +28,8 @@ std::unique_ptr<LSPMessage> makeWorkspaceSymbolRequest(int id, std::string_view 
 std::unique_ptr<LSPMessage> makeOpen(std::string_view uri, std::string_view contents, int version);
 
 /** Create an LSPMessage containing a textDocument/didChange notification. */
-std::unique_ptr<LSPMessage> makeChange(std::string_view uri, std::string_view contents, int version);
+std::unique_ptr<LSPMessage> makeChange(std::string_view uri, std::string_view contents, int version,
+                                       bool cancellationExpected);
 
 /** Create an LSPMessage containing a textDocument/didClose notification. */
 std::unique_ptr<LSPMessage> makeClose(std::string_view uri);
@@ -48,7 +49,7 @@ void assertNotificationMessage(LSPMethod expectedMethod, const LSPMessage &respo
 
 /** Retrieves the PublishDiagnosticsParam from a publishDiagnostics message, if applicable. Non-fatal fails and returns
  * an empty optional if it cannot be found. */
-std::optional<PublishDiagnosticsParams *> getPublishDiagnosticParams(NotificationMessage &notifMsg);
+std::optional<const PublishDiagnosticsParams *> getPublishDiagnosticParams(const NotificationMessage &notifMsg);
 
 /** Use the LSPWrapper to make a textDocument/completion request.
  */

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -888,7 +888,7 @@ FastPathAssertion::FastPathAssertion(string_view filename, unique_ptr<Range> &ra
 void FastPathAssertion::check(SorbetTypecheckRunInfo &info, string_view folder, int updateVersion,
                               string_view errorPrefix) {
     string updateFile = fmt::format("{}.{}.rbupdate", filename.substr(0, -3), updateVersion);
-    if (!info.tookFastPath) {
+    if (!info.fastPath) {
         ADD_FAILURE_AT(updateFile.c_str(), assertionLine)
             << errorPrefix << "Expected file update to take fast path, but it took the slow path.";
     }

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -162,10 +162,11 @@ void ProtocolTest::updateDiagnostics(const LSPMessage &msg) {
     if (msg.isNotification() && msg.method() == LSPMethod::TextDocumentPublishDiagnostics) {
         if (auto diagnosticParams = getPublishDiagnosticParams(msg.asNotification())) {
             // Will explicitly overwrite older diagnostics that are irrelevant.
-            // TODO: Have a better way of copying.
-            rapidjson::MemoryPoolAllocator<> alloc;
-            diagnostics[uriToFilePath(lspWrapper->config(), (*diagnosticParams)->uri)] =
-                move(PublishDiagnosticsParams::fromJSONValue(*(*diagnosticParams)->toJSONValue(alloc))->diagnostics);
+            vector<unique_ptr<Diagnostic>> diagnostics;
+            for (const auto &d : (*diagnosticParams)->diagnostics) {
+                diagnostics.push_back(d->copy());
+            }
+            this->diagnostics[uriToFilePath(lspWrapper->config(), (*diagnosticParams)->uri)] = move(diagnostics);
         }
     }
 }

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -6,6 +6,16 @@
 namespace sorbet::test::lsp {
 using namespace std;
 
+namespace {
+bool isSorbetFence(const LSPMessage &msg) {
+    return msg.isNotification() && msg.method() == LSPMethod::SorbetFence;
+}
+
+bool isTypecheckRun(const LSPMessage &msg) {
+    return msg.isNotification() && msg.method() == LSPMethod::SorbetTypecheckRunInfo;
+}
+} // namespace
+
 void ProtocolTest::SetUp() {
     rootPath = "/Users/jvilk/stripe/pay-server";
     rootUri = fmt::format("file://{}", rootPath);
@@ -53,10 +63,11 @@ unique_ptr<LSPMessage> ProtocolTest::closeFile(string_view path) {
     return makeClose(getUri(path));
 }
 
-unique_ptr<LSPMessage> ProtocolTest::changeFile(string_view path, string_view newContents, int version) {
+unique_ptr<LSPMessage> ProtocolTest::changeFile(string_view path, string_view newContents, int version,
+                                                bool cancellationExpected) {
     sourceFileContents[string(path)] =
         make_shared<core::File>(string(path), string(newContents), core::File::Type::Normal);
-    return makeChange(getUri(path), newContents, version);
+    return makeChange(getUri(path), newContents, version, cancellationExpected);
 }
 
 unique_ptr<LSPMessage> ProtocolTest::documentSymbol(string_view path) {
@@ -127,17 +138,39 @@ vector<unique_ptr<LSPMessage>> ProtocolTest::send(vector<unique_ptr<LSPMessage>>
     return responses;
 }
 
+void ProtocolTest::sendAsyncRaw(const string &json) {
+    auto &wrapper = dynamic_cast<MultiThreadedLSPWrapper &>(*lspWrapper);
+    wrapper.send(json);
+}
+
+void ProtocolTest::sendAsync(const LSPMessage &message) {
+    sendAsyncRaw(message.toJSON());
+}
+
+unique_ptr<LSPMessage> ProtocolTest::readAsync() {
+    auto &wrapper = dynamic_cast<MultiThreadedLSPWrapper &>(*lspWrapper);
+    auto msg = wrapper.read(20000);
+    if (msg) {
+        updateDiagnostics(*msg);
+    }
+    return msg;
+}
+
+void ProtocolTest::updateDiagnostics(const LSPMessage &msg) {
+    if (msg.isNotification() && msg.method() == LSPMethod::TextDocumentPublishDiagnostics) {
+        if (auto diagnosticParams = getPublishDiagnosticParams(msg.asNotification())) {
+            // Will explicitly overwrite older diagnostics that are irrelevant.
+            // TODO: Have a better way of copying.
+            rapidjson::MemoryPoolAllocator<> alloc;
+            diagnostics[uriToFilePath(lspWrapper->config(), (*diagnosticParams)->uri)] =
+                move(PublishDiagnosticsParams::fromJSONValue(*(*diagnosticParams)->toJSONValue(alloc))->diagnostics);
+        }
+    }
+}
+
 void ProtocolTest::updateDiagnostics(const vector<unique_ptr<LSPMessage>> &messages) {
     for (auto &msg : messages) {
-        if (msg->isNotification() && msg->method() == LSPMethod::TextDocumentPublishDiagnostics) {
-            if (auto diagnosticParams = getPublishDiagnosticParams(msg->asNotification())) {
-                // Will explicitly overwrite older diagnostics that are irrelevant.
-                // TODO: Have a better way of copying.
-                rapidjson::MemoryPoolAllocator<> alloc;
-                diagnostics[uriToFilePath(lspWrapper->config(), (*diagnosticParams)->uri)] = move(
-                    PublishDiagnosticsParams::fromJSONValue(*(*diagnosticParams)->toJSONValue(alloc))->diagnostics);
-            }
-        }
+        updateDiagnostics(*msg);
     }
 }
 
@@ -168,7 +201,10 @@ vector<unique_ptr<Location>> ProtocolTest::getDefinitions(std::string_view uri, 
 
 void ProtocolTest::assertDiagnostics(vector<unique_ptr<LSPMessage>> messages, vector<ExpectedDiagnostic> expected) {
     for (auto &msg : messages) {
-        ASSERT_NO_FATAL_FAILURE(assertNotificationMessage(LSPMethod::TextDocumentPublishDiagnostics, *msg));
+        // Ignore typecheck run and sorbet/fence messages. They do not impact semantics.
+        if (!isTypecheckRun(*msg) && !isSorbetFence(*msg)) {
+            ASSERT_NO_FATAL_FAILURE(assertNotificationMessage(LSPMethod::TextDocumentPublishDiagnostics, *msg));
+        }
     }
 
     // Convert ExpectedDiagnostic into ErrorAssertion objects.

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -152,6 +152,8 @@ unique_ptr<LSPMessage> ProtocolTest::readAsync() {
     auto msg = wrapper.read(20000);
     if (msg) {
         updateDiagnostics(*msg);
+    } else {
+        ADD_FAILURE() << "Timeout waiting for LSP response.";
     }
     return msg;
 }

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -51,7 +51,8 @@ protected:
 
     std::unique_ptr<LSPMessage> closeFile(std::string_view path);
 
-    std::unique_ptr<LSPMessage> changeFile(std::string_view path, std::string_view newContents, int version);
+    std::unique_ptr<LSPMessage> changeFile(std::string_view path, std::string_view newContents, int version,
+                                           bool cancellationExpected = false);
 
     std::unique_ptr<LSPMessage> documentSymbol(std::string_view path);
 
@@ -73,6 +74,12 @@ protected:
 
     std::vector<std::unique_ptr<LSPMessage>> send(std::vector<std::unique_ptr<LSPMessage>> messages);
 
+    void sendAsyncRaw(const std::string &json);
+
+    void sendAsync(const LSPMessage &message);
+
+    std::unique_ptr<LSPMessage> readAsync();
+
     void assertDiagnostics(std::vector<std::unique_ptr<LSPMessage>> messages, std::vector<ExpectedDiagnostic> expected);
 
     std::string readFile(std::string_view uri);
@@ -85,6 +92,7 @@ protected:
      * invokes getLSPResponsesFor on lspWrapper, it should update diagnostics with this function.
      */
     void updateDiagnostics(const std::vector<std::unique_ptr<LSPMessage>> &messages);
+    void updateDiagnostics(const LSPMessage &message);
 };
 
 } // namespace sorbet::test::lsp

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -120,57 +120,6 @@ TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeSlowPath) {
                       });
 }
 
-TEST_P(ProtocolTest, DoesNotCancelSlowPathForFastPathEdits) {
-    auto initOptions = make_unique<SorbetInitializationOptions>();
-    initOptions->enableTypecheckInfo = true;
-    assertDiagnostics(initializeLSP(true /* supportsMarkdown */, move(initOptions)), {});
-
-    // Create three files.
-    assertDiagnostics(send(*openFile("foo.rb", "# typed: true\n\nclass Foo\n\nend\n")), {});
-    assertDiagnostics(
-        send(*openFile(
-            "bar.rb",
-            "# typed: true\n\nclass Bar\nextend T::Sig\n\nsig{returns(String)}\ndef hello\n\"hi\"\nend\nend\n")),
-        {});
-    // baz calls the method defined in bar
-    assertDiagnostics(send(*openFile("baz.rb", "# typed: true\n\nclass Baz\nextend "
-                                               "T::Sig\n\nsig{returns(String)}\ndef hello\nBar.new.hello\nend\nend\n")),
-                      {});
-
-    // Slow path edits two files. One introduces error.
-    sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::PAUSE, nullopt)));
-    // Syntax error in foo.rb.
-    sendAsync(*changeFile("foo.rb", "# typed: true\n\nclass Foo\ndef noend\nend\n", 2, true));
-    // Typechecking error in bar.rb
-    sendAsync(*changeFile(
-        "bar.rb", "# typed: true\n\nclass Bar\nextend T::Sig\n\nsig{returns(Integer)}\ndef hello\n\"hi\"\nend\nend\n",
-        2, true));
-    sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::RESUME, nullopt)));
-    // Wait for typechecking to begin to avoid races.
-    {
-        auto status = getTypecheckRunStatus(*readAsync());
-        ASSERT_TRUE(status.has_value());
-        ASSERT_EQ(*status, SorbetTypecheckRunStatus::Started);
-    }
-
-    // Make another edit that fixes syntax error and should take fast path.
-    sendAsync(*changeFile("foo.rb", "# typed: true\n\nclass Foo\nend\n", 2, false));
-
-    // Wait for first typecheck run to get canceled.
-    {
-        auto status = getTypecheckRunStatus(*readAsync());
-        ASSERT_TRUE(status.has_value());
-        ASSERT_EQ(*status, SorbetTypecheckRunStatus::Cancelled);
-    }
-
-    // Send a no-op to clear out the pipeline. Should have errors in bar and baz, but not foo.
-    assertDiagnostics(send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, 20))),
-                      {
-                          {"bar.rb", 7, "Returning value that does not conform to method result type"},
-                          {"baz.rb", 7, "Returning value that does not conform to method result type"},
-                      });
-}
-
 // Run these tests in multi-threaded mode.
 INSTANTIATE_TEST_SUITE_P(MultithreadedProtocolTests, ProtocolTest, testing::Values(true));
 

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -9,6 +9,14 @@ namespace sorbet::test::lsp {
 using namespace std;
 using namespace sorbet::realmain::lsp;
 
+optional<SorbetTypecheckRunStatus> getTypecheckRunStatus(const LSPMessage &msg) {
+    if (msg.isNotification() && msg.method() == LSPMethod::SorbetTypecheckRunInfo) {
+        auto &typecheckInfo = get<unique_ptr<SorbetTypecheckRunInfo>>(msg.asNotification().params);
+        return typecheckInfo->status;
+    }
+    return nullopt;
+}
+
 TEST_P(ProtocolTest, MultithreadedWrapperWorks) {
     assertDiagnostics(initializeLSP(), {});
     vector<unique_ptr<LSPMessage>> requests;
@@ -17,6 +25,99 @@ TEST_P(ProtocolTest, MultithreadedWrapperWorks) {
     requests.push_back(
         changeFile("yolo1.rb", "# typed: true\nclass Foo1\n  def branch\n    1 + \"bear\"\n  end\nend\n", 3));
     assertDiagnostics(send(move(requests)), {{"yolo1.rb", 3, "bear"}});
+}
+
+TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeFastPath) {
+    auto initOptions = make_unique<SorbetInitializationOptions>();
+    initOptions->enableTypecheckInfo = true;
+    assertDiagnostics(initializeLSP(true /* supportsMarkdown */, move(initOptions)), {});
+
+    // Create three files.
+    assertDiagnostics(send(*openFile("foo.rb", "# typed: true\n\nclass Foo\n\nend\n")), {});
+    assertDiagnostics(
+        send(*openFile(
+            "bar.rb",
+            "# typed: true\n\nclass Bar\nextend T::Sig\n\nsig{returns(String)}\ndef hello\n\"hi\"\nend\nend\n")),
+        {});
+    // baz calls the method defined in bar
+    assertDiagnostics(send(*openFile("baz.rb", "# typed: true\n\nclass Baz\nextend "
+                                               "T::Sig\n\nsig{returns(String)}\ndef hello\nBar.new.hello\nend\nend\n")),
+                      {});
+
+    // Slow path edits two files. One introduces error.
+    sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::PAUSE, nullopt)));
+    // Syntax error in foo.rb.
+    sendAsync(*changeFile("foo.rb", "# typed: true\n\nclass Foo\ndef noend\nend\n", 2, true));
+    // Typechecking error in bar.rb
+    sendAsync(*changeFile(
+        "bar.rb", "# typed: true\n\nclass Bar\nextend T::Sig\n\nsig{returns(Integer)}\ndef hello\n\"hi\"\nend\nend\n",
+        2, true));
+    sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::RESUME, nullopt)));
+    // Wait for typechecking to begin to avoid races.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        ASSERT_TRUE(status.has_value());
+        ASSERT_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // Make another edit that fixes syntax error and should take fast path.
+    sendAsync(*changeFile("foo.rb", "# typed: true\n\nclass Foo\nend\n", 2, false));
+
+    // Wait for first typecheck run to get canceled.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        ASSERT_TRUE(status.has_value());
+        ASSERT_EQ(*status, SorbetTypecheckRunStatus::Cancelled);
+    }
+
+    // Send a no-op to clear out the pipeline. Should have errors in bar and baz, but not foo.
+    assertDiagnostics(send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, 20))),
+                      {
+                          {"bar.rb", 7, "Returning value that does not conform to method result type"},
+                          {"baz.rb", 7, "Returning value that does not conform to method result type"},
+                      });
+}
+
+TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeSlowPath) {
+    auto initOptions = make_unique<SorbetInitializationOptions>();
+    initOptions->enableTypecheckInfo = true;
+    assertDiagnostics(initializeLSP(true /* supportsMarkdown */, move(initOptions)), {});
+
+    // Initial state: Two empty files.
+    assertDiagnostics(send(*openFile("foo.rb", "")), {});
+    assertDiagnostics(send(*openFile("bar.rb", "")), {});
+
+    // Slow path 1: Edit foo to have an error since Bar doesn't exist. Expect a cancelation.
+    sendAsync(*changeFile(
+        "foo.rb", "# typed: true\n\nclass Foo\nextend T::Sig\nsig{returns(Integer)}\ndef foo\nBar.new.bar\nend\nend\n",
+        2, true));
+
+    // Wait for typechecking to begin to avoid races.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        ASSERT_TRUE(status.has_value());
+        ASSERT_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // Slow path 2: Bar defines the expected method, but declared with a non-integer return value (so foo now has a new
+    // error).
+    sendAsync(*changeFile("bar.rb",
+                          "# typed: true\n\nclass Bar\nextend T::Sig\nsig{returns(String)}\ndef bar\n10\nend\nend\n", 2,
+                          false));
+
+    // Wait for first typecheck run to get canceled.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        ASSERT_TRUE(status.has_value());
+        ASSERT_EQ(*status, SorbetTypecheckRunStatus::Cancelled);
+    }
+
+    // Send a no-op to clear out the pipeline. Should have one error per file.
+    assertDiagnostics(send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, 20))),
+                      {
+                          {"foo.rb", 6, "Returning value that does not conform to method result type"},
+                          {"bar.rb", 6, "Returning value that does not conform to method result type"},
+                      });
 }
 
 // Run these tests in multi-threaded mode.

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -481,6 +481,7 @@ TEST_P(ProtocolTest, DoesNotCrashOnNonWorkspaceURIs) {
     auto initOptions = make_unique<SorbetInitializationOptions>();
     initOptions->supportsSorbetURIs = true;
 
+    // Manually invoke to customize rootURI and rootPath.
     auto initializeResponses = sorbet::test::initializeLSP(
         "/Users/jvilk/stripe/areallybigfoldername", "file://Users/jvilk/stripe/areallybigfoldername", *lspWrapper,
         nextId, supportsMarkdown, make_optional(move(initOptions)));

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -1030,14 +1030,17 @@ TEST_P(LSPTest, All) {
             for (auto &r : responses) {
                 if (r->isNotification()) {
                     if (r->method() == LSPMethod::SorbetTypecheckRunInfo) {
-                        foundTypecheckRunInfo = true;
                         auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(r->asNotification().params);
-                        if (assertSlowPath.value_or(false)) {
-                            EXPECT_EQ(params->tookFastPath, false)
-                                << errorPrefix << "Expected Sorbet to take slow path, but it took the fast path.";
-                        }
-                        if (assertFastPath.has_value()) {
-                            (*assertFastPath)->check(*params, test.folder, version, errorPrefix);
+                        // Ignore started messages.
+                        if (params->status == SorbetTypecheckRunStatus::Ended) {
+                            foundTypecheckRunInfo = true;
+                            if (assertSlowPath.value_or(false)) {
+                                EXPECT_EQ(params->tookFastPath, false)
+                                    << errorPrefix << "Expected Sorbet to take slow path, but it took the fast path.";
+                            }
+                            if (assertFastPath.has_value()) {
+                                (*assertFastPath)->check(*params, test.folder, version, errorPrefix);
+                            }
                         }
                     } else if (r->method() != LSPMethod::TextDocumentPublishDiagnostics) {
                         ADD_FAILURE() << errorPrefix

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -640,7 +640,11 @@ void updateDiagnostics(const LSPConfiguration &config, UnorderedMap<string, stri
             << fmt::format("Diagnostic URI is not a test file URI: {}", diagnosticParams->uri);
 
         // Will explicitly overwrite older diagnostics that are irrelevant.
-        diagnostics[filename] = move(diagnosticParams->diagnostics);
+        vector<unique_ptr<Diagnostic>> copiedDiagnostics;
+        for (const auto &d : diagnosticParams->diagnostics) {
+            copiedDiagnostics.push_back(d->copy());
+        }
+        diagnostics[filename] = move(copiedDiagnostics);
     }
 }
 

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -1035,7 +1035,8 @@ TEST_P(LSPTest, All) {
                 if (r->isNotification()) {
                     if (r->method() == LSPMethod::SorbetTypecheckRunInfo) {
                         auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(r->asNotification().params);
-                        // Ignore started messages.
+                        // Ignore started messages. Note that cancelation messages cannot occur in test_corpus since
+                        // test_corpus only runs LSP in single-threaded mode.
                         if (params->status == SorbetTypecheckRunStatus::Ended) {
                             foundTypecheckRunInfo = true;
                             if (assertSlowPath.value_or(false)) {

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -1035,7 +1035,7 @@ TEST_P(LSPTest, All) {
                         if (params->status == SorbetTypecheckRunStatus::Ended) {
                             foundTypecheckRunInfo = true;
                             if (assertSlowPath.value_or(false)) {
-                                EXPECT_EQ(params->tookFastPath, false)
+                                EXPECT_EQ(params->fastPath, false)
                                     << errorPrefix << "Expected Sorbet to take slow path, but it took the fast path.";
                             }
                             if (assertFastPath.has_value()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Adds two end-to-end LSP cancellation tests that run in multithreaded mode. This is in contrast to the existing tests, which are unit tests that do not test the whole cancellation mechanism.

There are two tests:

* That we cancel the slow path when a new edit would take the fast path with the old edits.
* That we cancel the slow path when a new slow path edit comes in.

I add a new field to edit messages, `sorbetCancellationExpected`, which propagates through to slow path typechecking. If it's set, the slow path typechecking routine will block forever (via polling every 1ms if it has been cancelled) until cancellation occurs.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm changing how cancellation is implemented to simplify the mechanism and to make it work better with preemption. However, I'm going to need to land in master at the same time as pre-emption, which will make for a difficult PR review!

To try to lessen the review burden, I broke off these tests into their own PR because they are agnostic to how cancellation is implemented.

These tests are necessary because the old tests will no longer function (and will be deleted) when I change the cancellation implementation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
