### PR TITLE
make SecureRandom.random_number match Random.random_number

### DIFF
--- a/rbi/core/random.rbi
+++ b/rbi/core/random.rbi
@@ -559,8 +559,42 @@ module SecureRandom
   # p SecureRandom.random_number #=> 0.596506046187744
   # p SecureRandom.random_number #=> 0.350621695741409
   # ~~~
+  sig {returns(Float)}
   sig do
-    params(n: Integer).returns(Numeric)
+    params(
+      n: T.nilable(Float)
+    )
+    .returns(Float)
+  end
+  sig do
+    params(
+      n: T.nilable(Integer)
+    )
+    .returns(Integer)
+  end
+  sig do
+    params(
+      n: T.nilable(Numeric)
+    )
+    .returns(Numeric)
+  end
+  sig do
+    params(
+      n: T.nilable(T::Range[Float])
+    )
+    .returns(Float)
+  end
+  sig do
+    params(
+      n: T.nilable(T::Range[Integer])
+    )
+    .returns(Integer)
+  end
+  sig do
+    params(
+      n: T.nilable(T::Range[Numeric])
+    )
+    .returns(Numeric)
   end
   def self.random_number(n=0); end
 


### PR DESCRIPTION
cc @Morriar 

I think these should have the same types so I just copied the once from above.

```
[] main:0> SecureRandom.random_number(3.5)
=> 3.18284671274078
[] main:0> SecureRandom.random_number((1..4))
=> 3
[] main:0> SecureRandom.random_number((1..4.5))
=> 1.1305819645946926
```

### Motivation
https://github.com/sorbet/sorbet/pull/2153

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
