### PR TITLE
Require --enable-experimental-lsp-autocomplete

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -663,6 +663,11 @@ unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentCompletion(LSPTypechecker
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentCompletion);
     auto emptyResult = make_unique<CompletionList>(false, vector<unique_ptr<CompletionItem>>{});
 
+    if (!config->opts.lspAutocompleteEnabled) {
+        response->result = std::move(emptyResult);
+        return response;
+    }
+
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.completion");
 
     const auto &gs = typechecker.state();


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There's a crash with autocompletion that's getting in people's way right
now. While we figure out what's causing it, let's require the
`--enable-experimental-lsp-autocomplete` flag to be passed.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested locally.