### PR TITLE
Fix the tracer to work with JRuby

### DIFF
--- a/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
@@ -215,7 +215,7 @@ module Sorbet::Private
       def gem_from_location(location)
         match =
           location&.match(/^.*\/(ruby)\/([\d.]+)\//) || # ruby stdlib
-          location&.match(/^.*\/(j?ruby)-([\d.]+)\//) || # rvm ruby stdlib
+          location&.match(/^.*\/(j?ruby)-([\d.]+)\//) || # jvm ruby stdlib
           location&.match(/^.*\/(site_ruby)\/([\d.]+)\//) || # rubygems
           location&.match(/^.*\/gems\/(?:j?ruby-)?[\d.]+(?:@[^\/]+)?(?:\/bundler)?\/gems\/([^\/]+)-([^-\/]+)\//i) # gem
         if match.nil?

--- a/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
@@ -215,8 +215,9 @@ module Sorbet::Private
       def gem_from_location(location)
         match =
           location&.match(/^.*\/(ruby)\/([\d.]+)\//) || # ruby stdlib
+          location&.match(/^.*\/(j?ruby)-([\d.]+)\//) || # rvm ruby stdlib
           location&.match(/^.*\/(site_ruby)\/([\d.]+)\//) || # rubygems
-          location&.match(/^.*\/gems\/(?:ruby-)?[\d.]+(?:@[^\/]+)?(?:\/bundler)?\/gems\/([^\/]+)-([^-\/]+)\//i) # gem
+          location&.match(/^.*\/gems\/(?:[j]ruby-)?[\d.]+(?:@[^\/]+)?(?:\/bundler)?\/gems\/([^\/]+)-([^-\/]+)\//i) # gem
         if match.nil?
           # uncomment to generate files for methods outside of gems
           # {

--- a/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
@@ -217,7 +217,7 @@ module Sorbet::Private
           location&.match(/^.*\/(ruby)\/([\d.]+)\//) || # ruby stdlib
           location&.match(/^.*\/(j?ruby)-([\d.]+)\//) || # rvm ruby stdlib
           location&.match(/^.*\/(site_ruby)\/([\d.]+)\//) || # rubygems
-          location&.match(/^.*\/gems\/(?:[j]ruby-)?[\d.]+(?:@[^\/]+)?(?:\/bundler)?\/gems\/([^\/]+)-([^-\/]+)\//i) # gem
+          location&.match(/^.*\/gems\/(?:j?ruby-)?[\d.]+(?:@[^\/]+)?(?:\/bundler)?\/gems\/([^\/]+)-([^-\/]+)\//i) # gem
         if match.nil?
           # uncomment to generate files for methods outside of gems
           # {

--- a/gems/sorbet/lib/gem-generator-tracepoint/tracer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracer.rb
@@ -156,6 +156,7 @@ module Sorbet::Private
               receiver = singleton ? Sorbet::Private::RealStdlib.real_singleton_class(tp.self) : tp.self
 
               # JRuby the main Object is not a module
+              # so lets skip it, otherwise RealStdlib#real_instance_methods raises an exception since it expects one.
               next unless receiver.is_a?(Module)
 
               methods = Sorbet::Private::RealStdlib.real_instance_methods(receiver, false) + Sorbet::Private::RealStdlib.real_private_instance_methods(receiver, false)

--- a/gems/sorbet/lib/gem-generator-tracepoint/tracer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracer.rb
@@ -118,13 +118,18 @@ module Sorbet::Private
           on_module_created(tp.self)
         end
         @c_call_tracepoint = TracePoint.new(:c_call) do |tp|
-          case tp.method_id
+
+          # older version of JRuby unfortunately returned a String
+          case tp.method_id.to_sym
           when :require, :require_relative
             @context_stack << []
           end
         end
         @c_return_tracepoint = TracePoint.new(:c_return) do |tp|
-          case tp.method_id
+
+          # older version of JRuby unfortunately returned a String
+          method_id_sym = tp.method_id.to_sym
+          case method_id_sym
           when :require, :require_relative
             popped = @context_stack.pop
 
@@ -147,8 +152,12 @@ module Sorbet::Private
             begin
               tp.disable
 
-              singleton = tp.method_id == :singleton_method_added
+              singleton = method_id_sym == :singleton_method_added
               receiver = singleton ? Sorbet::Private::RealStdlib.real_singleton_class(tp.self) : tp.self
+
+              # JRuby the main Object is not a module
+              next unless receiver.is_a?(Module)
+
               methods = Sorbet::Private::RealStdlib.real_instance_methods(receiver, false) + Sorbet::Private::RealStdlib.real_private_instance_methods(receiver, false)
               set = @modules[Sorbet::Private::RealStdlib.real_object_id(receiver)] ||= Set.new
               added = methods.find { |m| !set.include?(m) }

--- a/gems/sorbet/lib/gem_loader.rb
+++ b/gems/sorbet/lib/gem_loader.rb
@@ -559,11 +559,7 @@ class Sorbet::Private::GemLoader
         puts "NameError: #{e}"
       end
     else
-      begin
-        require gem # rubocop:disable PrisonGuard/NoDynamicRequire
-      rescue NameError => e
-        puts "NameError: #{e}"
-      end
+      require gem # rubocop:disable PrisonGuard/NoDynamicRequire
     end
   end
 
@@ -584,15 +580,9 @@ class Sorbet::Private::GemLoader
       begin
         require_gem(gemspec.name)
       rescue LoadError
-      rescue NameError => e
-        puts "NameError: #{e}"
       end
     end
-    begin
-      Bundler.require
-    rescue NameError => e
-      puts "NameError: #{e}"
-    end
+    Bundler.require
   end
 end
 # rubocop:enable PrisonGuard/AutogenLoaderPreamble

--- a/gems/sorbet/lib/gem_loader.rb
+++ b/gems/sorbet/lib/gem_loader.rb
@@ -559,7 +559,11 @@ class Sorbet::Private::GemLoader
         puts "NameError: #{e}"
       end
     else
-      require gem # rubocop:disable PrisonGuard/NoDynamicRequire
+      begin
+        require gem # rubocop:disable PrisonGuard/NoDynamicRequire
+      rescue NameError => e
+        puts "NameError: #{e}"
+      end
     end
   end
 
@@ -580,9 +584,15 @@ class Sorbet::Private::GemLoader
       begin
         require_gem(gemspec.name)
       rescue LoadError
+      rescue NameError => e
+        puts "NameError: #{e}"
       end
     end
-    Bundler.require
+    begin
+      Bundler.require
+    rescue NameError => e
+      puts "NameError: #{e}"
+    end
   end
 end
 # rubocop:enable PrisonGuard/AutogenLoaderPreamble


### PR DESCRIPTION
The tracer that is used to analyze Gems needed small tweaking
to be able to work with JRuby.

For instance, `method_id` in earlier versions of JRuby returns
a `String` and not a `Symbol` (it has been fixed in master)
https://github.com/jruby/jruby/blob/jruby-9.1.13.0/core/src/main/java/org/jruby/ext/tracepoint/TracePoint.java#L186

The fix for the above is to just cast the `method_id` to a Symbol using
`to_sym`

Also included is a fix where unfortunately, JRuby's `main` did not
seem to inherit from Module

```
ruby -e 'puts self.is_a?(Module)'
false
```