### PR TITLE
`File.delete` accepts a String or Pathname

### DIFF
--- a/rbi/core/file.rbi
+++ b/rbi/core/file.rbi
@@ -260,7 +260,7 @@ class File < IO
   # See also `Dir::rmdir`.
   sig do
     params(
-        files: String,
+        files: T.any(String, Pathname),
     )
     .returns(Integer)
   end


### PR DESCRIPTION
Similar to https://github.com/sorbet/sorbet/pull/2031

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->



### Test plan
Test case:

```ruby
2.6.3 :008 > path = Pathname.new('.').join('test.txt')
 => #<Pathname:test.txt>
2.6.3 :009 > path.class
 => Pathname
2.6.3 :010 > File.open(path, "wb") {|f| f.write("hi")}
 => 2
2.6.3 :011 > File.read(path)
 => "hi"
2.6.3 :012 > File.delete(path)
 => 1
2.6.3 :013 > File.read(path)
Traceback (most recent call last):
        5: from /Users/alex/.rvm/rubies/ruby-2.6.3/bin/irb:23:in `<main>'
        4: from /Users/alex/.rvm/rubies/ruby-2.6.3/bin/irb:23:in `load'
        3: from /Users/alex/.rvm/rubies/ruby-2.6.3/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        2: from (irb):13
        1: from (irb):13:in `read'
Errno::ENOENT (No such file or directory @ rb_sysopen - test.txt)
```
