### PR TITLE
Revert "Require --enable-experimental-lsp-autocomplete (#2263)"

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -663,11 +663,6 @@ unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentCompletion(LSPTypechecker
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentCompletion);
     auto emptyResult = make_unique<CompletionList>(false, vector<unique_ptr<CompletionItem>>{});
 
-    if (!config->opts.lspAutocompleteEnabled) {
-        response->result = std::move(emptyResult);
-        return response;
-    }
-
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.completion");
 
     const auto &gs = typechecker.state();


### PR DESCRIPTION
This reverts commit a205d8bd9cff319b858257dfede9ca55413bae6e.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We actually think the crash we were seeing in completion was fixed via
dac8c10db.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested in pay-server on a version that included dac8c10db vs one before that.
It reproduced consistently on the one without, and couldn't be reproduced on
the one including dac8c10db.