### PR TITLE
Don't put repeated args in the completion snippet

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -265,6 +265,9 @@ string methodSnippet(const core::GlobalState &gs, core::SymbolRef method, core::
         if (argSym.flags.isDefault) {
             continue;
         }
+        if (argSym.flags.isRepeated) {
+            continue;
+        }
         if (argSym.flags.isKeyword) {
             fmt::format_to(argBuf, "{}: ", argSym.name.data(gs)->shortName(gs));
         }

--- a/test/testdata/lsp/completion/snippet_repeated.A.rbedited
+++ b/test/testdata/lsp/completion/snippet_repeated.A.rbedited
@@ -1,0 +1,18 @@
+# typed: true
+class A
+  extend T::Sig
+
+  sig {params(x: T.untyped).void}
+  def method_using_kwarg(**x)
+  end
+
+  sig {params(x: T.untyped).void}
+  def method_using_rest_arg(*x)
+  end
+end
+
+A.new.method_using_kwarg${0} # error: does not exist
+#                      ^ apply-completion: [A] item: 0
+
+A.new.method_using_rest_ar # error: does not exist
+#                         ^ apply-completion: [B] item: 0

--- a/test/testdata/lsp/completion/snippet_repeated.A.rbedited
+++ b/test/testdata/lsp/completion/snippet_repeated.A.rbedited
@@ -9,6 +9,14 @@ class A
   sig {params(x: T.untyped).void}
   def method_using_rest_arg(*x)
   end
+
+  sig {params(x: Integer, y: T.untyped).void}
+  def positional_then_kwarg(x, *y)
+  end
+
+  sig {params(x: Integer, y: T.untyped).void}
+  def positional_then_rest_arg(x, *y)
+  end
 end
 
 A.new.method_using_kwarg${0} # error: does not exist
@@ -16,3 +24,9 @@ A.new.method_using_kwarg${0} # error: does not exist
 
 A.new.method_using_rest_ar # error: does not exist
 #                         ^ apply-completion: [B] item: 0
+
+A.new.positional_then_kwar # error: does not exist
+#                         ^ apply-completion: [C] item: 0
+
+A.new.positional_then_rest_ar # error: does not exist
+#                            ^ apply-completion: [D] item: 0

--- a/test/testdata/lsp/completion/snippet_repeated.B.rbedited
+++ b/test/testdata/lsp/completion/snippet_repeated.B.rbedited
@@ -1,0 +1,18 @@
+# typed: true
+class A
+  extend T::Sig
+
+  sig {params(x: T.untyped).void}
+  def method_using_kwarg(**x)
+  end
+
+  sig {params(x: T.untyped).void}
+  def method_using_rest_arg(*x)
+  end
+end
+
+A.new.method_using_kwar # error: does not exist
+#                      ^ apply-completion: [A] item: 0
+
+A.new.method_using_rest_arg${0} # error: does not exist
+#                         ^ apply-completion: [B] item: 0

--- a/test/testdata/lsp/completion/snippet_repeated.C.rbedited
+++ b/test/testdata/lsp/completion/snippet_repeated.C.rbedited
@@ -22,10 +22,10 @@ end
 A.new.method_using_kwar # error: does not exist
 #                      ^ apply-completion: [A] item: 0
 
-A.new.method_using_rest_arg${0} # error: does not exist
+A.new.method_using_rest_ar # error: does not exist
 #                         ^ apply-completion: [B] item: 0
 
-A.new.positional_then_kwar # error: does not exist
+A.new.positional_then_kwarg(${1:Integer})${0} # error: does not exist
 #                         ^ apply-completion: [C] item: 0
 
 A.new.positional_then_rest_ar # error: does not exist

--- a/test/testdata/lsp/completion/snippet_repeated.D.rbedited
+++ b/test/testdata/lsp/completion/snippet_repeated.D.rbedited
@@ -22,11 +22,11 @@ end
 A.new.method_using_kwar # error: does not exist
 #                      ^ apply-completion: [A] item: 0
 
-A.new.method_using_rest_arg${0} # error: does not exist
+A.new.method_using_rest_ar # error: does not exist
 #                         ^ apply-completion: [B] item: 0
 
 A.new.positional_then_kwar # error: does not exist
 #                         ^ apply-completion: [C] item: 0
 
-A.new.positional_then_rest_ar # error: does not exist
+A.new.positional_then_rest_arg(${1:Integer})${0} # error: does not exist
 #                            ^ apply-completion: [D] item: 0

--- a/test/testdata/lsp/completion/snippet_repeated.rb
+++ b/test/testdata/lsp/completion/snippet_repeated.rb
@@ -1,0 +1,18 @@
+# typed: true
+class A
+  extend T::Sig
+
+  sig {params(x: T.untyped).void}
+  def method_using_kwarg(**x)
+  end
+
+  sig {params(x: T.untyped).void}
+  def method_using_rest_arg(*x)
+  end
+end
+
+A.new.method_using_kwar # error: does not exist
+#                      ^ apply-completion: [A] item: 0
+
+A.new.method_using_rest_ar # error: does not exist
+#                         ^ apply-completion: [B] item: 0

--- a/test/testdata/lsp/completion/snippet_repeated.rb
+++ b/test/testdata/lsp/completion/snippet_repeated.rb
@@ -9,6 +9,14 @@ class A
   sig {params(x: T.untyped).void}
   def method_using_rest_arg(*x)
   end
+
+  sig {params(x: Integer, y: T.untyped).void}
+  def positional_then_kwarg(x, *y)
+  end
+
+  sig {params(x: Integer, y: T.untyped).void}
+  def positional_then_rest_arg(x, *y)
+  end
 end
 
 A.new.method_using_kwar # error: does not exist
@@ -16,3 +24,9 @@ A.new.method_using_kwar # error: does not exist
 
 A.new.method_using_rest_ar # error: does not exist
 #                         ^ apply-completion: [B] item: 0
+
+A.new.positional_then_kwar # error: does not exist
+#                         ^ apply-completion: [C] item: 0
+
+A.new.positional_then_rest_ar # error: does not exist
+#                            ^ apply-completion: [D] item: 0


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Repeated args aren't required (it's possible to type check without
providing a single one) so we shouldn't require that it be filled out
in the snippet.

For `**x` args in particular it was super annoying, because this shows
up as both `isKeyword` and `isRepeated` so we'd even put an `x: ${1}` in
the snippet, when in fact, that `x` isn't the same as the `x` in `**x`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.