### PR TITLE
Clarify the difference between `abstract!` and `interface!`.

### DIFF
--- a/website/docs/abstract.md
+++ b/website/docs/abstract.md
@@ -6,7 +6,9 @@ sidebar_label: Abstract Classes & Interfaces
 
 Sorbet supports abstract classes, abstract methods, and interfaces. Abstract
 methods ensure that a particular method gets implemented anywhere the class or
-module is inherited, included, or extended.
+module is inherited, included, or extended. An abstract class or module is one
+that contains one or more abstract methods. An interface is a class or module
+that must have only abstract methods.
 
 Keep in mind:
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR adds a few sentences to the opening paragraph of the abstract classes documentation to clarify the difference between an abstract class/module and an interface class/module.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When reading the documentation on abstract classes, the difference between `abstract!` and `interface!` was not clear to me. The details are hidden through the rest of the page but a holistic overview wasn't provided.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This is a documentation change only and does not require tests.
