### PR TITLE
Nesting-aware constant completion

### DIFF
--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -41,10 +41,12 @@ public:
 
 class ConstantResponse final {
 public:
-    ConstantResponse(core::SymbolRef symbol, core::Loc termLoc, core::NameRef name, core::TypeAndOrigins retType)
-        : symbol(symbol), termLoc(termLoc), name(name), retType(std::move(retType)){};
+    ConstantResponse(core::SymbolRef symbol, core::Loc termLoc, core::SymbolRef scope, core::NameRef name,
+                     core::TypeAndOrigins retType)
+        : symbol(symbol), termLoc(termLoc), scope(scope), name(name), retType(std::move(retType)){};
     const core::SymbolRef symbol;
     const core::Loc termLoc;
+    const core::SymbolRef scope;
     const core::NameRef name;
     const core::TypeAndOrigins retType;
 };

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -88,8 +88,16 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
                 tp.type = resultType == nullptr ? core::Types::untyped(ctx, symbol) : resultType;
             }
 
-            core::lsp::QueryResponse::pushQueryResponse(
-                ctx, core::lsp::ConstantResponse(symbol, lit->loc, symbol.data(ctx)->name, tp));
+            core::SymbolRef scope;
+            if (lit->resolutionScope.exists()) {
+                ENFORCE(symbol == core::Symbols::StubModule());
+                scope = lit->resolutionScope;
+            } else {
+                scope = symbol.data(ctx)->owner;
+            }
+
+            auto resp = core::lsp::ConstantResponse(symbol, lit->loc, scope, lit->original->cnst, tp);
+            core::lsp::QueryResponse::pushQueryResponse(ctx, resp);
         }
         lit = ast::cast_tree<ast::ConstantLit>(lit->original->scope.get());
         if (lit) {

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -94,8 +94,8 @@ class LSPLoop {
                                                                const core::TypeConstraint *constraint,
                                                                const core::Loc queryLoc, std::string_view prefix,
                                                                size_t sortIdx) const;
-    void findSimilarConstant(const core::GlobalState &gs, const core::TypePtr receiverType, const core::Loc queryLoc,
-                             std::vector<std::unique_ptr<CompletionItem>> &items) const;
+    void findSimilarConstant(const core::GlobalState &gs, const core::lsp::ConstantResponse &resp,
+                             const core::Loc queryLoc, std::vector<std::unique_ptr<CompletionItem>> &items) const;
     std::unique_ptr<ResponseMessage> handleTextSignatureHelp(LSPTypechecker &typechecker, const MessageId &id,
                                                              const TextDocumentPositionParams &params) const;
 

--- a/test/testdata/lsp/completion/constants.rb
+++ b/test/testdata/lsp/completion/constants.rb
@@ -1,0 +1,17 @@
+# typed: true
+
+class AAA
+  class BBB
+  end
+
+  XXX = 1
+end
+
+p AA # error: Unable to resolve
+#   ^ completion: AAA
+
+p AAA::B # error: Unable to resolve
+#       ^ completion: BBB
+
+p AAA::X # error: Unable to resolve
+#       ^ completion: XXX

--- a/test/testdata/lsp/completion/constants_via_inherit.rb
+++ b/test/testdata/lsp/completion/constants_via_inherit.rb
@@ -1,0 +1,34 @@
+# typed: true
+
+class Parent1
+  XXX = 1
+end
+class Child1 < Parent1
+  XX # error: Unable to resolve
+  # ^ completion: (nothing)
+  # TODO(jez) Should be XXX
+end
+
+class Parent2
+  class ParentInner2
+    YYY = 1
+  end
+end
+class Child2 < Parent2
+  class ChildInner2 < ParentInner2
+    YY # error: Unable to resolve
+    # ^ completion: (nothing)
+    # TODO(jez) Should be YYY
+  end
+end
+
+class OuterParent3
+  ZZZ = nil
+end
+class OuterChild3 < OuterParent3
+  class Inner
+    ZZ # error: Unable to resolve
+    # ^ completion: (nothing)
+    # TODO(jez) This is correct, by accident
+  end
+end

--- a/test/testdata/lsp/completion/constants_via_mixins.rb
+++ b/test/testdata/lsp/completion/constants_via_mixins.rb
@@ -1,0 +1,21 @@
+# typed: true
+
+module MixinA
+  YYY = 1
+end
+
+module MixinB
+  include MixinA
+
+  YY # error: Unable to resolve
+  # ^ completion: (nothing)
+  # TODO(jez) This should be YYY
+end
+
+class Has_YYY_via_B_via_A
+  include MixinB
+
+  YY # error: Unable to resolve
+  # ^ completion: (nothing)
+  # TODO(jez) This should be YYY
+end

--- a/test/testdata/lsp/completion/constants_via_nesting.rb
+++ b/test/testdata/lsp/completion/constants_via_nesting.rb
@@ -1,0 +1,25 @@
+# typed: true
+
+module Outer
+  DefinedInOuter = nil
+
+  module Middle
+    DefinedInMiddle = nil
+
+    module Inner
+      DefinedInInner = nil
+
+      DefinedIn # error: Unable to resolve
+      #        ^ completion: DefinedInInner, DefinedInMiddle, DefinedInOuter
+    end
+
+    DefinedIn # error: Unable to resolve
+    #        ^ completion: DefinedInMiddle, DefinedInOuter
+  end
+
+  DefinedIn # error: Unable to resolve
+  #        ^ completion: DefinedInOuter
+end
+
+p DefinedIn # error: Unable to resolve
+#          ^ completion: (nothing)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Because we never had any tests for constant completion, the code to make it
work atrophied over time.

This change starts to fix the atrophy and add tests.

Not all of the bad things are fixed yet, and not all of the tests exist /
assert the desired behavior. I'll be fixing things in a series of PRs.


### Commit summary

Review by commit. In particular, **ignoring whitespace** is useful.


- **Add scope to ConstantResponse** (27f6d6fe9)

  Threads the `resolutionScope` on the ConstantLit back up.

  `resolutionScope` was added when we made the change to force all missing
  constants to the same constant (`StubModule`) rather than having them
  all get their own special stubbed constant (this makes
  incrementalResolve more predictable).

  The ENFORCE makes it clear what invariants should exist on
  resolutionScope. For more information about correct usage see the
  comment in Trees.h for ConstantLit.

- **Scope-aware completion for constants** (5eb7e4c94)

  The diff ignoring whitespace is actually pretty small (the `cast_type`
  block gets deleted).

  There are two main changes here:

  1.  Make the code work in the current state of the world.

      Constant completion was implemented as a prototype long ago, before
      we changed the way StubConstant / resolutionScope worked.

      We now use the scope on the ConstantResponse to start the search for
      constants, rather than starting from the owner.

  2.  Even before that (back when the prototype actually worked), there
      was a bug where constant resolution would skip searching the first
      level of scope.

      This is fixed by moving the line which updates the scope to after
     searching.

- **Add some tests** (0236a395e)

  Not all of these tests pass yet--suggesting constants that resolve via
  ancestor lookup will come in the next PR.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.