### PR TITLE
Test apply-completion for constants

### DIFF
--- a/test/testdata/lsp/completion/constants.A.rbedited
+++ b/test/testdata/lsp/completion/constants.A.rbedited
@@ -7,7 +7,7 @@ class AAA
   YYY = 1
 end
 
-p AA # error: Unable to resolve
+p AAA${0} # error: Unable to resolve
 #   ^ completion: AAA
 #   ^ apply-completion: [A] item: 0
 

--- a/test/testdata/lsp/completion/constants.B.rbedited
+++ b/test/testdata/lsp/completion/constants.B.rbedited
@@ -11,7 +11,7 @@ p AA # error: Unable to resolve
 #   ^ completion: AAA
 #   ^ apply-completion: [A] item: 0
 
-p AAA::B # error: Unable to resolve
+p AAA::BBB${0} # error: Unable to resolve
 #       ^ completion: BBB
 #       ^ apply-completion: [B] item: 0
 

--- a/test/testdata/lsp/completion/constants.C.rbedited
+++ b/test/testdata/lsp/completion/constants.C.rbedited
@@ -15,6 +15,6 @@ p AAA::B # error: Unable to resolve
 #       ^ completion: BBB
 #       ^ apply-completion: [B] item: 0
 
-p AAA::Y # error: Unable to resolve
+p AAA::YYY${0} # error: Unable to resolve
 #       ^ completion: YYY
 #       ^ apply-completion: [C] item: 0


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The test harness isn't a complete LSP client... It only supports making
edits that use the textEdit property of a CompletionItem. In order to
test `apply-completion`, I needed to change getCompletionItemForConstant
to craft a TextEdit object the same way we do for all other kinds of
completions.

There are good reasons for preferring TextEdit (the default is to use
the CompletionItem label, and VS Code takes a liberty with what edit to
perform in the document). TextEdit gives us complete control.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.