### PR TITLE
Fail Signature#initialize based on check_level

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -258,7 +258,7 @@ module T::Private::Methods
     current_declaration =
       begin
         run_builder(declaration_block)
-      rescue DeclBuilder::BuilderError => e
+      rescue DeclBuilder::BuilderError, Signature::SignatureError => e
         T::Configuration.sig_builder_error_handler(e, declaration_block.loc)
         nil
       end

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -55,11 +55,14 @@ class T::Private::Methods::Signature
     declared_param_names = raw_arg_types.keys
     missing_names = param_names - declared_param_names
     extra_names = declared_param_names - param_names
+
+    should_raise = @check_level == :always || (@check_level == :tests && T::Private::RuntimeLevels.check_tests?)
+
     if !missing_names.empty?
-      raise "The declaration for `#{method.name}` is missing parameter(s): #{missing_names.join(', ')}"
+      raise "The declaration for `#{method.name}` is missing parameter(s): #{missing_names.join(', ')}" if should_raise
     end
     if !extra_names.empty?
-      raise "The declaration for `#{method.name}` has extra parameter(s): #{extra_names.join(', ')}"
+      raise "The declaration for `#{method.name}` has extra parameter(s): #{extra_names.join(', ')}" if should_raise
     end
 
     parameters.zip(raw_arg_types) do |(param_kind, param_name), (type_name, raw_type)|
@@ -87,7 +90,7 @@ class T::Private::Methods::Signature
         if @arg_types.length > @req_arg_count
           # Note that this is actually is supported by Ruby, but it would add complexity to
           # support it here, and I'm happy to discourage its use anyway.
-          raise "Required params after optional params are not supported in method declarations. Method: #{method_desc}"
+          raise "Required params after optional params are not supported in method declarations. Method: #{method_desc}" if should_raise
         end
         @arg_types << [param_name, type]
         @req_arg_count += 1
@@ -110,7 +113,7 @@ class T::Private::Methods::Signature
         @keyrest_name = param_name
         @keyrest_type = type
       else
-        raise "Unexpected param_kind: `#{param_kind}`. Method: #{method_desc}"
+        raise "Unexpected param_kind: `#{param_kind}`. Method: #{method_desc}" if should_raise
       end
     end
   end


### PR DESCRIPTION
### Motivation

As I integrate Sorbet into our codebase it would be great if I don't tarnish/diminish any confidence in type checking by causing outages for our product that are only faced in production.

Unfortunately, I've hit issues where Signature building in production differs from testing or development environment.

```
2019-12-04 01:39:13.972 +0000 [ERROR|00b24|] :: RuntimeError : The declaration for `initialize` has extra parameter(s): dialect
   uri:classloader:/gems/sorbet-runtime-0.4.5045/lib/types/private/methods/signature.rb:68:in `initialize'
   uri:classloader:/gems/sorbet-runtime-0.4.5045/lib/types/private/methods/_methods.rb:295:in `build_sig'
   uri:classloader:/gems/sorbet-runtime-0.4.5045/lib/types/private/methods/_methods.rb:268:in `run_sig'
   uri:classloader:/gems/sorbet-runtime-0.4.5045/lib/types/private/methods/_methods.rb:200:in `block in
```

I had hoped to mitigate this risk with `T::Configuration.default_checked_level = :tests` but the fact that sig building can still fail is cause for concern.

### Implementation

Following the same pattern used in `call_validation.rb`, the raised exceptions in `signature.rb` is only triggered if the checked level of the `sig` is `:always` or `:test` and the test mode has been triggered.