### PR TITLE
Show type-argument symbols in symbol table

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -667,36 +667,35 @@ string Symbol::toStringWithOptions(const GlobalState &gs, int tabs, bool showFul
     }
 
     fmt::format_to(buf, "\n");
-    if (!isMethod()) {
-        for (auto pair : membersStableOrderSlow(gs)) {
-            if (!pair.second.exists()) {
-                ENFORCE(ref(gs) == core::Symbols::root());
-                continue;
-            }
-
-            if (pair.first == Names::singleton() || pair.first == Names::attached() ||
-                pair.first == Names::classMethods()) {
-                continue;
-            }
-
-            if (!showFull && pair.second.data(gs)->isHiddenFromPrinting(gs)) {
-                bool hadPrintableChild = false;
-                for (auto childPair : pair.second.data(gs)->members()) {
-                    if (!childPair.second.data(gs)->isHiddenFromPrinting(gs)) {
-                        hadPrintableChild = true;
-                        break;
-                    }
-                }
-                if (!hadPrintableChild) {
-                    continue;
-                }
-            }
-
-            auto str = pair.second.data(gs)->toStringWithOptions(gs, tabs + 1, showFull, showRaw);
-            ENFORCE(!str.empty());
-            fmt::format_to(buf, "{}", move(str));
+    for (auto pair : membersStableOrderSlow(gs)) {
+        if (!pair.second.exists()) {
+            ENFORCE(ref(gs) == core::Symbols::root());
+            continue;
         }
-    } else {
+
+        if (pair.first == Names::singleton() || pair.first == Names::attached() ||
+            pair.first == Names::classMethods()) {
+            continue;
+        }
+
+        if (!showFull && pair.second.data(gs)->isHiddenFromPrinting(gs)) {
+            bool hadPrintableChild = false;
+            for (auto childPair : pair.second.data(gs)->members()) {
+                if (!childPair.second.data(gs)->isHiddenFromPrinting(gs)) {
+                    hadPrintableChild = true;
+                    break;
+                }
+            }
+            if (!hadPrintableChild) {
+                continue;
+            }
+        }
+
+        auto str = pair.second.data(gs)->toStringWithOptions(gs, tabs + 1, showFull, showRaw);
+        ENFORCE(!str.empty());
+        fmt::format_to(buf, "{}", move(str));
+    }
+    if (isMethod()) {
         for (auto &arg : arguments()) {
             auto str = arg.toString(gs);
             ENFORCE(!str.empty());

--- a/test/testdata/resolver/type_arguments.rb
+++ b/test/testdata/resolver/type_arguments.rb
@@ -1,0 +1,13 @@
+# typed: true
+
+class Func
+  extend T::Sig
+  sig do
+    type_parameters(:U)
+      .params(x: T.type_parameter(:U))
+      .returns(T.type_parameter(:U))
+  end
+  def self.id(x)
+    x
+  end
+end

--- a/test/testdata/resolver/type_arguments.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/type_arguments.rb.symbol-table-raw.exp
@@ -8,6 +8,7 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     method <S <C <U Func>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/type_arguments.rb start=3:1 end=13:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/type_arguments.rb start=??? end=???}
     method <S <C <U Func>> $1><U id>[<T <U U> $1>] (x, <blk>) -> TypeVar(<T <U U> $1>) @ Loc {file=test/testdata/resolver/type_arguments.rb start=10:3 end=10:17}
+      type-argument(+) <S <C <U Func>> $1><U id><T <U U> $1> -> TypeVar(<T <U U> $1>) @ Loc {file=test/testdata/resolver/type_arguments.rb start=6:21 end=6:23}
       argument x<> -> U @ Loc {file=test/testdata/resolver/type_arguments.rb start=7:15 end=7:16}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/type_arguments.rb start=??? end=???}
 

--- a/test/testdata/resolver/type_arguments.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/type_arguments.rb.symbol-table-raw.exp
@@ -1,0 +1,13 @@
+class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4}, Loc {file=test/testdata/resolver/type_arguments.rb start=3:1 end=13:4})
+  class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/type_arguments.rb start=3:1 end=13:4}
+      argument <blk><block> @ Loc {file=test/testdata/resolver/type_arguments.rb start=??? end=???}
+  class <C <U Func>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/type_arguments.rb start=3:1 end=3:11}
+  class <S <C <U Func>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U Sig>>) @ Loc {file=test/testdata/resolver/type_arguments.rb start=3:7 end=3:11}
+    type-member(+) <S <C <U Func>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Func>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Func) @ Loc {file=test/testdata/resolver/type_arguments.rb start=3:7 end=3:11}
+    method <S <C <U Func>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/type_arguments.rb start=3:1 end=13:4}
+      argument <blk><block> @ Loc {file=test/testdata/resolver/type_arguments.rb start=??? end=???}
+    method <S <C <U Func>> $1><U id>[<T <U U> $1>] (x, <blk>) -> TypeVar(<T <U U> $1>) @ Loc {file=test/testdata/resolver/type_arguments.rb start=10:3 end=10:17}
+      argument x<> -> U @ Loc {file=test/testdata/resolver/type_arguments.rb start=7:15 end=7:16}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/type_arguments.rb start=??? end=???}
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Turns out we didn't have any symbol-table-raw tests for files that used
`type_parameters`. We should probably have such a test. We should also probably
print those symbols when requested to print all symbols.

This change is like 2 lines if you ignore whitespace.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See commit log for before/after of new test.