### PR TITLE
Java static release 2

### DIFF
--- a/.buildkite/build-static-release-java.sh
+++ b/.buildkite/build-static-release-java.sh
@@ -5,6 +5,11 @@
 # either linux or mac
 set -o errexit
 
+echo "--- Dowloading artifacts"
+rm -rf release
+rm -rf _out_
+buildkite-agent artifact download "_out_/**/*" .
+
 # Based on the output of build-static-release.sh
 # _out_/gems/ should have the Linux & Mac sorbet-static gem
 mkdir -p gems/sorbet-static/libexec
@@ -21,7 +26,7 @@ do
     x86_64-linux)
         mv sorbet-static-"${release_version}"-${platform}/libexec/sorbet  gems/sorbet-static/libexec/linux.sorbet
     ;;
-
+ine.
     universal-darwin)
         mv sorbet-static-"${release_version}"-${platform}*/libexec/sorbet gems/sorbet-static/libexec/mac.sorbet
     ;;

--- a/.buildkite/build-static-release-java.sh
+++ b/.buildkite/build-static-release-java.sh
@@ -26,7 +26,7 @@ do
     x86_64-linux)
         mv sorbet-static-"${release_version}"-${platform}/libexec/sorbet  gems/sorbet-static/libexec/linux.sorbet
     ;;
-ine.
+
     universal-darwin)
         mv sorbet-static-"${release_version}"-${platform}*/libexec/sorbet gems/sorbet-static/libexec/mac.sorbet
     ;;

--- a/.buildkite/build-static-release-java.sh
+++ b/.buildkite/build-static-release-java.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# exit on the first error
+# this makes sure we don't create a java gem missing
+# either linux or mac
+set -o errexit
+
+# Based on the output of build-static-release.sh
+# _out_/gems/ should have the Linux & Mac sorbet-static gem
+mkdir -p gems/sorbet-static/libexec
+
+git_commit_count=$(git rev-list --count HEAD)
+prefix="0.4"
+release_version="$prefix.${git_commit_count}"
+
+for platform in universal-darwin x86_64-linux
+do
+  gem unpack _out_/gems/sorbet-static-"${release_version}"-${platform}*.gem
+
+  case $platform in
+    x86_64-linux)
+        mv sorbet-static-"${release_version}"-${platform}/libexec/sorbet  gems/sorbet-static/libexec/linux.sorbet
+    ;;
+
+    universal-darwin)
+        mv sorbet-static-"${release_version}"-${platform}*/libexec/sorbet gems/sorbet-static/libexec/mac.sorbet
+    ;;
+  esac
+
+done
+
+pushd gems/sorbet-static
+
+sed -i.bak "s/Gem::Platform::CURRENT/'java'/" sorbet-static.gemspec
+sed -i.bak "s/0\\.0\\.0/${release_version}/" sorbet-static.gemspec
+sed -i.bak "s/'libexec\/sorbet'/'libexec\/mac.sorbet', 'libexec\/linux.sorbet'/" sorbet-static.gemspec
+
+gem build sorbet-static.gemspec
+
+popd
+
+mv gems/sorbet-static/sorbet-static-"${release_version}"-java.gem _out_/gems

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -69,6 +69,14 @@ steps:
     artifact_paths: _out_/**/*
     <<: *elastic
 
+  - label: ":linux: build-static-release-java.sh (master only)"
+    command: .buildkite/build-static-release-java.sh
+    # this needs to be run when both linux & mac build-static-release
+    # are done. at the moment, mac is only done on master branch
+    branches: master
+    artifact_paths: _out_/**/*
+    <<: *elastic
+
   - label: ":linux: build-emscripten.sh"
     command: .buildkite/build-emscripten.sh
     artifact_paths: _out_/**/*

--- a/.buildkite/publish-ruby-gems.sh
+++ b/.buildkite/publish-ruby-gems.sh
@@ -51,15 +51,25 @@ with_backoff() {
 # sorbet-static, but the sorbet-static gem push failed.
 #
 # (By failure here, we mean that RubyGems.org 502'd for some reason.)
-if ! gem list --remote rubygems.org --exact 'sorbet-static' | grep -q "$release_version"; then
-  for gem_archive in "_out_/gems/sorbet-static-$release_version"-*.gem; do
-      with_backoff gem push --verbose "$gem_archive"
-  done
+# Push the linux gem
+if ! gem fetch sorbet-static --platform x86_64-linux --version "$release_version" | grep -q "ERROR"; then
+  with_backoff gem push --verbose "_out_/gems/sorbet-static-$release_version-x86_64-linux.gem"
+fi
+
+# Push the mac gem
+if ! gem fetch sorbet-static --platform universal-darwin --version "$release_version" | grep -q "ERROR"; then
+  with_backoff gem push --verbose "_out_/gems/sorbet-static-$release_version-universal-darwin-"*.gem
+fi
+
+# Push the java gem
+if ! gem fetch sorbet-static --platform java --version "$release_version" | grep -q "ERROR"; then
+  with_backoff gem push --verbose "_out_/gems/sorbet-static-$release_version-java.gem"
 fi
 
 if ! gem list --remote rubygems.org --exact 'sorbet-runtime' | grep -q "$release_version"; then
   with_backoff gem push --verbose "_out_/gems/sorbet-runtime-$release_version.gem"
 fi
+
 if ! gem list --remote rubygems.org --exact 'sorbet' | grep -q "$release_version"; then
   with_backoff gem push --verbose "_out_/gems/sorbet-$release_version.gem"
 fi


### PR DESCRIPTION
re-include 3c508a9c948a3b456cf564a5fb01279da1ffdc44 which introduces a release file for java platform.

The failing part was the script was not downloading previous artifacts.