### PR TITLE
Augment srb so it can leverage new java gem

### DIFF
--- a/gems/sorbet/bin/srb
+++ b/gems/sorbet/bin/srb
@@ -70,6 +70,7 @@ typecheck() {
     version_suffix="${without_bin_srb##*/sorbet}"
     # /path/to/gems
     gems_path="${without_bin_srb%/sorbet*}"
+
     # /path/to/gems/sorbet-static-0.0.1-darwin-17/libexec/sorbet
     # (assumes people only have one platform-depdendent gem installed per version)
     guess_sorbet=("$gems_path/sorbet-static$version_suffix"*/libexec/sorbet)
@@ -81,6 +82,27 @@ typecheck() {
       version="${version_suffix#-}"
       # Resort to locating using the GEM_PATH, this takes ~200ms
       sorbet="$(VISUAL=echo gem open sorbet-static -v "${version}")/libexec/sorbet"
+    fi
+
+    # if we still don't know the sorbet binary
+    # perhaps this is the java platform
+    if ! [[ -f "${sorbet}" ]]; then
+      if gem env platform | grep -q "java"; then
+        # certain platforms (i.e. java) include multiple binaries 
+        # mac.sorbet & linux.sorbet -- since they can't use the host platform (i.e. darwin or linux)
+        # to collect the correct sorbet binary
+        case "$(uname -s)" in
+        Linux*)     prefix="linux.";;
+        Darwin*)    prefix="mac.";;
+        *)          prefix=""
+        esac
+        
+        guess_sorbet=("$gems_path/sorbet-static$version_suffix"*/libexec/"${prefix}sorbet")
+        if [[ -f "${guess_sorbet[0]}" ]]; then
+          sorbet="${guess_sorbet[0]}"
+        fi
+
+      fi
     fi
 
     # shellcheck disable=SC2086


### PR DESCRIPTION
This pull-request augments #2298

Specifically, it augments the `srb` script to do a last-ditch effort to try and match the new `mac.sorbet` or `linux.sorbet` binaries based on the **uname** that are bundled in the java platform gem.

I oped to only do the check at the end since `gem env platform` might incur some cost.

## Testing Plan

I build a local java gem `sorbet-static-0.0.0-java.gem` and installed it.
I then executed `srb tc --help` and _with the changes_ it works!