### PR TITLE
Use richer completion item kinds for constants

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -383,14 +383,28 @@ unique_ptr<CompletionItem> getCompletionItemForConstant(const core::GlobalState 
         resultType = core::Types::untypedUntracked();
     }
 
-    if (what.data(gs)->isStaticField()) {
-        // TODO(jez) Handle isStaticFieldTypeAlias (hover has special handling to show the type for these)
-        item->kind = CompletionItemKind::Constant;
-        item->detail = resultType->show(gs);
+    if (what.data(gs)->isClassOrModule()) {
+        if (what.data(gs)->isClassOrModuleClass()) {
+            if (what.data(gs)->derivesFrom(gs, core::Symbols::T_Enum())) {
+                item->kind = CompletionItemKind::Enum;
+            } else {
+                item->kind = CompletionItemKind::Class;
+            }
+        } else {
+            if (what.data(gs)->isClassOrModuleAbstract() || what.data(gs)->isClassOrModuleInterface()) {
+                item->kind = CompletionItemKind::Interface;
+            } else {
+                item->kind = CompletionItemKind::Module;
+            }
+        }
     } else if (what.data(gs)->isTypeMember()) {
-        item->kind = CompletionItemKind::Constant;
-    } else if (what.data(gs)->isClassOrModule()) {
-        item->kind = CompletionItemKind::Class;
+        item->kind = CompletionItemKind::TypeParameter;
+    } else if (what.data(gs)->isStaticField()) {
+        if (what.data(gs)->isTypeAlias()) {
+            item->kind = CompletionItemKind::TypeParameter;
+        } else {
+            item->kind = CompletionItemKind::Field;
+        }
     } else {
         ENFORCE(false, "Unhandled kind of constant in getCompletionItemForConstant");
     }

--- a/test/testdata/lsp/completion/constants_all_kinds.rb
+++ b/test/testdata/lsp/completion/constants_all_kinds.rb
@@ -1,0 +1,57 @@
+# typed: true
+
+class Box
+  extend T::Generic
+  Elem = type_member
+end
+
+class MyStruct < T::Struct
+  prop :foo, String
+end
+
+class MyEnum < T::Enum
+  enums do
+    Val = new
+  end
+end
+
+module MMM
+  YYY = nil
+  TTT = T.type_alias {Integer}
+end
+
+module Iface
+  extend T::Helpers
+  interface!
+end
+
+# -- isClassOrModule --
+
+p MyEnu # error: Unable to resolve
+#      ^ completion: MyEnum
+p Bo # error: Unable to resolve
+#   ^ completion: Box
+p Ifac # error: Unable to resolve
+#     ^ completion: Iface
+p MM # error: Unable to resolve
+#   ^ completion: MMM
+
+# -- isTypeMember --
+
+p Box::Ele # error: Unable to resolve
+#         ^ completion: Elem
+
+# -- isStaticField --
+
+p MMM::TT # error: Unable to resolve
+#        ^ completion: TTT
+p MMM::YY # error: Unable to resolve
+#        ^ completion: YYY
+
+# -- extras --
+
+# TODO(jez) We show duplicate results because of how the T::Enum DSL pass works
+p MyEnum::Va # error: Unable to resolve
+#           ^ completion: Val, Val
+p MyStruc # error: Unable to resolve
+#        ^ completion: MyStruct


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Note that I removed item->detail—I'm going to roll that into a future
change I'm working on to populate `item-documentation`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

**T::Enum**
<img width="516" alt="Screen Shot 2019-12-05 at 5 34 54 PM" src="https://user-images.githubusercontent.com/5544532/70288050-d2073b80-1785-11ea-865b-c56c26732616.png">

**Class**
<img width="489" alt="Screen Shot 2019-12-05 at 5 35 03 PM" src="https://user-images.githubusercontent.com/5544532/70288049-d2073b80-1785-11ea-9f03-5ad8123b4002.png">

**Interface**
<img width="502" alt="Screen Shot 2019-12-05 at 5 35 12 PM" src="https://user-images.githubusercontent.com/5544532/70288048-d2073b80-1785-11ea-9fa5-4951743d627e.png">

**Module**
<img width="488" alt="Screen Shot 2019-12-05 at 5 35 20 PM" src="https://user-images.githubusercontent.com/5544532/70288047-d2073b80-1785-11ea-996a-e7654b9a2514.png">

**Type Member**
<img width="529" alt="Screen Shot 2019-12-05 at 5 35 30 PM" src="https://user-images.githubusercontent.com/5544532/70288046-d16ea500-1785-11ea-955a-9a2a45c1980d.png">

**Type Alias**
<img width="526" alt="Screen Shot 2019-12-05 at 5 35 37 PM" src="https://user-images.githubusercontent.com/5544532/70288045-d16ea500-1785-11ea-80a9-641f4fa7b7c3.png">

**Static Field**
<img width="524" alt="Screen Shot 2019-12-05 at 5 35 45 PM" src="https://user-images.githubusercontent.com/5544532/70288044-d16ea500-1785-11ea-837e-8c746539cd88.png">

**Value of T::Enum**
<img width="548" alt="Screen Shot 2019-12-05 at 5 35 52 PM" src="https://user-images.githubusercontent.com/5544532/70288043-d16ea500-1785-11ea-835d-2fbe2faabed6.png">

**T::Struct**
<img width="525" alt="Screen Shot 2019-12-05 at 5 35 59 PM" src="https://user-images.githubusercontent.com/5544532/70288042-d0d60e80-1785-11ea-9225-5fc0756790c0.png">

