### PR TITLE
IDE: Cleaner LSPTypechecker::retypecheck() interface.

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -463,7 +463,9 @@ LSPFileUpdates LSPTypechecker::getNoopUpdate(std::vector<core::FileRef> frefs) c
     noop.versionStart = 0;
     noop.versionEnd = 0;
     for (auto fref : frefs) {
-        auto &index = getIndexed(fref);
+        ENFORCE(fref.exists());
+        ENFORCE(fref.id() < indexed.size());
+        auto &index = indexed[fref.id()];
         noop.updatedFileIndexes.push_back({index.tree->deepCopy(), index.file});
         noop.updatedFiles.push_back(gs->getFiles()[fref.id()]);
         noop.updatedFileHashes.push_back(globalStateHashes[fref.id()]);

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -473,7 +473,6 @@ LSPFileUpdates LSPTypechecker::getNoopUpdate(std::vector<core::FileRef> frefs) c
 
 TypecheckRun LSPTypechecker::retypecheck(vector<core::FileRef> frefs) const {
     LSPFileUpdates updates = getNoopUpdate(move(frefs));
-    auto workers = WorkerPool::create(0, *config->logger);
     return runTypechecking(move(updates));
 }
 

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -456,21 +456,24 @@ LSPQueryResult LSPTypechecker::query(const core::lsp::Query &q, const std::vecto
     return LSPQueryResult{move(out.second)};
 }
 
-TypecheckRun LSPTypechecker::retypecheck(LSPFileUpdates updates) const {
-    if (!updates.canTakeFastPath) {
-        Exception::raise("Tried to typecheck slow path updates with retypecheck. Retypecheck can only typecheck the "
-                         "previously typechecked version of a file.");
+LSPFileUpdates LSPTypechecker::getNoopUpdate(std::vector<core::FileRef> frefs) const {
+    LSPFileUpdates noop;
+    noop.canTakeFastPath = true;
+    // Epoch isn't important for this update.
+    noop.versionStart = 0;
+    noop.versionEnd = 0;
+    for (auto fref : frefs) {
+        auto &index = getIndexed(fref);
+        noop.updatedFileIndexes.push_back({index.tree->deepCopy(), index.file});
+        noop.updatedFiles.push_back(gs->getFiles()[fref.id()]);
+        noop.updatedFileHashes.push_back(globalStateHashes[fref.id()]);
     }
+    return noop;
+}
 
-    for (const auto &file : updates.updatedFiles) {
-        auto path = file->path();
-        auto source = file->source();
-        auto fref = gs->findFileByPath(path);
-        if (!fref.exists() || fref.data(*gs).source() != source) {
-            Exception::raise("Retypecheck can only typecheck the previously typechecked version of a file.");
-        }
-    }
-
+TypecheckRun LSPTypechecker::retypecheck(vector<core::FileRef> frefs) const {
+    LSPFileUpdates updates = getNoopUpdate(move(frefs));
+    auto workers = WorkerPool::create(0, *config->logger);
     return runTypechecking(move(updates));
 }
 

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -76,6 +76,12 @@ class LSPTypechecker final {
      * sending diagnostics to the editor. */
     void commitTypecheckRun(TypecheckRun run);
 
+    /**
+     * Get an LSPFileUpdates containing the latest versions of the given files. It's a "no-op" file update because it
+     * doesn't actually change anything.
+     */
+    LSPFileUpdates getNoopUpdate(std::vector<core::FileRef> frefs) const;
+
 public:
     LSPTypechecker(const std::shared_ptr<const LSPConfiguration> &config);
     ~LSPTypechecker() = default;
@@ -95,10 +101,9 @@ public:
     bool typecheck(LSPFileUpdates updates);
 
     /**
-     * Re-typechecks the provided input to re-produce error messages. Input *must* match already committed state!
-     * Provided to facilitate code actions.
+     * Re-typechecks the provided files to re-produce error messages.
      */
-    TypecheckRun retypecheck(LSPFileUpdates updates) const;
+    TypecheckRun retypecheck(std::vector<core::FileRef> frefs) const;
 
     /** Runs the provided query against the given files, and returns matches. */
     LSPQueryResult query(const core::lsp::Query &q, const std::vector<core::FileRef> &filesForQuery) const;

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -29,15 +29,8 @@ unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentCodeAction(LSPTypechecker
         return response;
     }
 
-    LSPFileUpdates updates;
-    updates.canTakeFastPath = true;
-    const auto &globalStateHashes = typechecker.getFileHashes();
-    ENFORCE(file.id() < globalStateHashes.size());
-    updates.updatedFileHashes = {globalStateHashes[file.id()]};
-    updates.updatedFiles.push_back(make_shared<core::File>(string(file.data(gs).path()), string(file.data(gs).source()),
-                                                           core::File::Type::Normal));
     // Simply querying the file in question is insufficient since indexing errors would not be detected.
-    auto run = typechecker.retypecheck(move(updates));
+    auto run = typechecker.retypecheck({file});
     auto loc = params.range->toLoc(gs, file);
     for (auto &error : run.errors) {
         if (!error->isSilenced && !error->autocorrects.empty()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

IDE: Cleaner LSPTypechecker::retypecheck() interface. Code actions use this to get a list of errors from a file and extract autocorrects from those errors.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This implementation bothered me, so I decided to quickly clean it up.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing code_action tests.
