### PR TITLE
Fix publish-ruby-gems.sh

### DIFF
--- a/.buildkite/publish-ruby-gems.sh
+++ b/.buildkite/publish-ruby-gems.sh
@@ -57,9 +57,13 @@ if ! gem fetch sorbet-static --platform x86_64-linux --version "$release_version
 fi
 
 # Push the mac gem
-if ! gem fetch sorbet-static --platform universal-darwin --version "$release_version" | grep -q "ERROR"; then
-  with_backoff gem push --verbose "_out_/gems/sorbet-static-$release_version-universal-darwin-"*.gem
-fi
+# we push 14..19 which is defined in build-static-release.sh
+for i in {14..19}; do
+  if ! gem fetch sorbet-static --platform "universal-darwin-$i" --version "$release_version" | grep -q "ERROR"; then
+    with_backoff gem push --verbose "_out_/gems/sorbet-static-$release_version-universal-darwin-$i.gem"
+  fi
+done
+
 
 # Push the java gem
 if ! gem fetch sorbet-static --platform java --version "$release_version" | grep -q "ERROR"; then


### PR DESCRIPTION
This is a fix ontop of #2298 which changed slightly `publish-ruby-gems.sh`
The Darwin platform is the only gem with multiple files, so changed the
publishing code to be explicit.

The benefit of this approach to the previous glob file approach, is that
the version can be checked for each platform number (i.e.
universal-darwin-18) if it has been published before.