### PR TITLE
standardize on using ENV vars for skipping

### DIFF
--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -euo pipefail
-if [ "schedule" == "${BUILDKITE_SOURCE}" ]; then
+if [ "${CLEAN_BUILD:-}" != "" ] || [ "${PUBLISH_TO_RUBYGEMS:-}" != "" ]; then
   echo "Skipping publish, because this is a scheduled build."
   exit 0
 fi

--- a/.buildkite/tools/setup-bazel.sh
+++ b/.buildkite/tools/setup-bazel.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
+
+set -euo pipefail
+
 echo "--- Pre-setup :bazel:"
 
-if [[ -n "${CLEAN_BUILD-}" ]]; then
+if [ "${CLEAN_BUILD:-}" != "" ]; then
   echo "--- cleanup"
   rm -rf /usr/local/var/bazelcache/*
 fi


### PR DESCRIPTION
https://github.com/sorbet/sorbet/pull/2307 came about because there is no way to practice running a nightly job with the current config. I was surprised by this and I think the benefits of being less surprising out-weight the automatic skipping we would get for all future scheduled jobs. WDYT?

While I was in there I also standardized how we check these vars with `-z` and `-n` and having the `-` after

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
