### PR TITLE
Use RealStdlib for method method in gem generator

### DIFF
--- a/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
@@ -74,7 +74,8 @@ module Sorbet::Private
                     next
                   end
                   begin
-                    method = item[:singleton] ? klass.method(item[:method]) : klass.instance_method(item[:method])
+                    method = item[:singleton] ? Sorbet::Private::RealStdlib.real_method(klass, item[:method]) : klass.instance_method(item[:method])
+
                     "#{generate_method(method, !item[:singleton])}"
                   rescue NameError
                   end

--- a/gems/sorbet/lib/real_stdlib.rb
+++ b/gems/sorbet/lib/real_stdlib.rb
@@ -76,4 +76,9 @@ module Sorbet::Private::RealStdlib
     @real_const_get ||= Object.singleton_class.instance_method(:const_get)
     @real_const_get.bind(obj).call(const, arg)
   end
+
+  def self.real_method(obj, sym)
+    @real_method ||= Object.instance_method(:method)
+    @real_method.bind(obj).call(sym)
+  end
 end

--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_4_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_4_3_hidden.rbi.exp
@@ -3545,6 +3545,8 @@ module Sorbet::Private::RealStdlib
 
   def self.real_is_a?(o, klass); end
 
+  def self.real_method(obj, sym); end
+
   def self.real_name(o); end
 
   def self.real_object_id(o); end

--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_3_hidden.rbi.exp
@@ -8776,6 +8776,8 @@ module Sorbet::Private::RealStdlib
 
   def self.real_is_a?(o, klass); end
 
+  def self.real_method(obj, sym); end
+
   def self.real_name(o); end
 
   def self.real_object_id(o); end

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_4_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_4_3_hidden.rbi.exp
@@ -3551,6 +3551,8 @@ module Sorbet::Private::RealStdlib
 
   def self.real_is_a?(o, klass); end
 
+  def self.real_method(obj, sym); end
+
   def self.real_name(o); end
 
   def self.real_object_id(o); end

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_3_hidden.rbi.exp
@@ -8782,6 +8782,8 @@ module Sorbet::Private::RealStdlib
 
   def self.real_is_a?(o, klass); end
 
+  def self.real_method(obj, sym); end
+
   def self.real_name(o); end
 
   def self.real_object_id(o); end

--- a/gems/sorbet/test/snapshot/partial/local_gem/expected/sorbet/rbi/gems/my_gem.rbi
+++ b/gems/sorbet/test/snapshot/partial/local_gem/expected/sorbet/rbi/gems/my_gem.rbi
@@ -10,4 +10,5 @@
 # my_gem-0.0.0
 class MyGem
   def my_gem_thing; end
+  def self.method; end
 end

--- a/gems/sorbet/test/snapshot/partial/local_gem/gems/0.0.0/gems/my_gem-0.0.0/lib/my_gem.rb
+++ b/gems/sorbet/test/snapshot/partial/local_gem/gems/0.0.0/gems/my_gem-0.0.0/lib/my_gem.rb
@@ -1,6 +1,10 @@
 # frozen_string_literals: true
 
 class MyGem
+  class << self
+    def method; end
+  end
+
   def my_gem_thing
     puts 'hello, world!'
   end


### PR DESCRIPTION
### Motivation
We ran into an issue where a class was overriding the `method` method with one that took no arguments causing the generation of gem RBIs to fail. This just creates a `RealStdlib` version of `method` and uses that.

### Test plan

See included automated tests.
