### PR TITLE
Constant detail + documentation for completion

### DIFF
--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -137,6 +137,7 @@ std::unique_ptr<MarkupContent> formatRubyMarkup(MarkupKind markupKind, std::stri
                                                 std::optional<std::string_view> explanation);
 std::string prettyTypeForMethod(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver,
                                 core::TypePtr retType, const core::TypeConstraint *constraint);
+std::string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef constant, core::TypePtr type);
 core::TypePtr getResultType(const core::GlobalState &gs, core::TypePtr type, core::SymbolRef inWhat,
                             core::TypePtr receiver, const core::TypeConstraint *constr);
 SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef);

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -236,6 +236,15 @@ string prettyTypeForMethod(const core::GlobalState &gs, core::SymbolRef method, 
                        prettyDefForMethod(gs, method));
 }
 
+string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef constant, core::TypePtr type) {
+    core::TypePtr result = type;
+    if (constant.data(gs)->isTypeAlias()) {
+        // By wrapping the type in `MetaType`, it displays as `<Type: Foo>` rather than `Foo`.
+        result = core::make_type<core::MetaType>(type);
+    }
+    return result->showWithMoreInfo(gs);
+}
+
 core::TypePtr getResultType(const core::GlobalState &gs, core::TypePtr type, core::SymbolRef inWhat,
                             core::TypePtr receiver, const core::TypeConstraint *constr) {
     core::Context ctx(gs, inWhat);

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -84,12 +84,7 @@ unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentHover(LSPTypechecker &typ
             string typeString = prettyTypeForMethod(gs, defResp->symbol, nullptr, defResp->retType.type, nullptr);
             response->result = make_unique<Hover>(formatRubyMarkup(clientHoverMarkupKind, typeString, documentation));
         } else if (auto constResp = resp->isConstant()) {
-            auto type = resp->getRetType();
-            if (constResp->symbol.data(gs)->isTypeAlias()) {
-                // By wrapping the type in `MetaType`, it displays as `<Type: Foo>` rather than `Foo`.
-                type = core::make_type<core::MetaType>(type);
-            }
-            auto prettyType = type->showWithMoreInfo(gs);
+            auto prettyType = prettyTypeForConstant(gs, constResp->symbol, resp->getRetType());
             response->result = make_unique<Hover>(formatRubyMarkup(clientHoverMarkupKind, prettyType, documentation));
         } else {
             core::TypePtr retType = resp->getRetType();

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -44,7 +44,8 @@ const UnorderedMap<
 };
 
 // Ignore any comments that have these labels (e.g. `# typed: true`).
-const UnorderedSet<string> ignoredAssertionLabels = {"typed", "TODO", "linearization", "commented-out-error"};
+const UnorderedSet<string> ignoredAssertionLabels = {"typed", "TODO", "linearization", "commented-out-error",
+                                                     "Note",  "See"};
 
 constexpr string_view NOTHING_LABEL = "(nothing)"sv;
 constexpr string_view NULL_LABEL = "null"sv;

--- a/test/testdata/lsp/completion/constants_all_kinds.rb
+++ b/test/testdata/lsp/completion/constants_all_kinds.rb
@@ -1,25 +1,39 @@
 # typed: true
 
+# docs for AAA
+class AAA; end
+
+# docs for Box
 class Box
   extend T::Generic
+  # docs for Box::Elem
   Elem = type_member
 end
 
+# docs for MyStruct
 class MyStruct < T::Struct
   prop :foo, String
 end
 
+# docs for MyEnum
 class MyEnum < T::Enum
   enums do
+    # docs for MyEnum::Val
     Val = new
   end
 end
 
+# docs for MMM
 module MMM
+  # docs for YYY
   YYY = nil
+  # docs for ZZZ
+  ZZZ = AAA
+  # docs for TTT
   TTT = T.type_alias {Integer}
 end
 
+# docs for Iface
 module Iface
   extend T::Helpers
   interface!
@@ -29,6 +43,8 @@ end
 
 p MyEnu # error: Unable to resolve
 #      ^ completion: MyEnum
+p AA # error: Unable to resolve
+#   ^ completion: AAA
 p Bo # error: Unable to resolve
 #   ^ completion: Box
 p Ifac # error: Unable to resolve
@@ -47,6 +63,8 @@ p MMM::TT # error: Unable to resolve
 #        ^ completion: TTT
 p MMM::YY # error: Unable to resolve
 #        ^ completion: YYY
+p MMM::ZZ # error: Unable to resolve
+#        ^ completion: ZZZ
 
 # -- extras --
 

--- a/test/testdata/lsp/hover_constants.rb
+++ b/test/testdata/lsp/hover_constants.rb
@@ -1,0 +1,31 @@
+# typed: true
+
+# This file documents incorrect behavior when we findDocumentation for
+# constants via hover.
+#
+# See: https://github.com/sorbet/sorbet/issues/2311
+#
+# Note: completion also uses this logic for showing documentation.
+# See test/testdata/lsp/completion/constants_all_kinds.rb for a test to look at.
+
+# Docs for AAA
+class AAA; end # right
+#     ^ hover: Docs for AAA
+
+# Docs for BBB
+class BBB # right
+  #   ^ hover: Docs for BBB
+  extend T::Generic
+
+  # Docs for XXX
+  XXX = nil # wrong
+  # ^ hover: Docs for XXX
+
+  # Docs for CCC
+  CCC = AAA # wrong? arguably showing the dealiased docs is fine
+  # ^ hover: Docs for AAA
+
+  # Docs for EEE
+  EEE = type_member # wrong
+  # ^ hover: Docs for XXX
+end

--- a/test/testdata/lsp/hover_constants.rb
+++ b/test/testdata/lsp/hover_constants.rb
@@ -26,6 +26,6 @@ class BBB # right
   # ^ hover: Docs for AAA
 
   # Docs for EEE
-  EEE = type_member # wrong
-  # ^ hover: Docs for XXX
+  EEE = type_member
+  # ^ hover: Docs for EEE
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Feature parity with method completion.

Review by commit:


- **Factor out prettyTypeForConstant** (052ba227a)

  Share more code between hover and completion.

  Completion tests have no way to test that the `documentation` is correct
  on a completion item, but hover tests do. Making completion and hover
  share as much code as possible makes it more likely that we'll catch
  bugs when they come up, and fix bugs everywhere rather than isolated to
  one request kind.

- **Constant detail + documentation for completion** (c95d25ee3)


- **Add docs to constants_all_kinds test** (849b902ea)

  Makes sure that the logic that processes the doc comments doesn't crash
  us.

- **Document incorrect behavior for constants docs** (03459ec3e)




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This is somewhat hard to test, because there's no framework support for testing
the `detail` nor the `documentation` on completion.

My strategy instead has been to re-use as much logic from **hover** as
possible, and to test hover more thoroughly for constants. That surfaced some
bugs in the existing **hover** support for constants. I've added a test + issue
for those. We can fix that separately. In the cases where docs for constants on
hover now work, so do completion docs.

### Screenshots

<img width="744" alt="Screen Shot 2019-12-06 at 1 59 11 PM" src="https://user-images.githubusercontent.com/5544532/70359638-3a5f2700-1831-11ea-8772-00720ffc0df5.png"><img width="712" alt="Screen Shot 2019-12-06 at 1 59 20 PM" src="https://user-images.githubusercontent.com/5544532/70359637-3a5f2700-1831-11ea-8058-e8a838575f39.png">
<img width="713" alt="Screen Shot 2019-12-06 at 1 59 28 PM" src="https://user-images.githubusercontent.com/5544532/70359636-3a5f2700-1831-11ea-821d-dd4f0111ab5a.png">
<img width="729" alt="Screen Shot 2019-12-06 at 1 59 38 PM" src="https://user-images.githubusercontent.com/5544532/70359635-3a5f2700-1831-11ea-9722-ae8674d457f3.png">
<img width="711" alt="Screen Shot 2019-12-06 at 1 59 45 PM" src="https://user-images.githubusercontent.com/5544532/70359634-39c69080-1831-11ea-9cfb-ba5c57a52233.png">
<img width="758" alt="Screen Shot 2019-12-06 at 1 59 54 PM" src="https://user-images.githubusercontent.com/5544532/70359633-39c69080-1831-11ea-823f-96fab085ff26.png">
<img width="753" alt="Screen Shot 2019-12-06 at 2 00 07 PM" src="https://user-images.githubusercontent.com/5544532/70359632-39c69080-1831-11ea-96bc-86a3d6494a09.png">
<img width="754" alt="Screen Shot 2019-12-06 at 2 00 19 PM" src="https://user-images.githubusercontent.com/5544532/70359631-39c69080-1831-11ea-93ba-8e94c8b87099.png">
<img width="753" alt="Screen Shot 2019-12-06 at 2 00 30 PM" src="https://user-images.githubusercontent.com/5544532/70359630-39c69080-1831-11ea-9438-7d7c7755f532.png">
<img width="781" alt="Screen Shot 2019-12-06 at 2 00 39 PM" src="https://user-images.githubusercontent.com/5544532/70359629-392dfa00-1831-11ea-8a93-0d32f9adbc79.png">
<img width="756" alt="Screen Shot 2019-12-06 at 2 00 48 PM" src="https://user-images.githubusercontent.com/5544532/70359628-392dfa00-1831-11ea-90f6-522043a320e8.png">

