### PR TITLE
IDE: Cancel the correct timer when merging updates.

### DIFF
--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -125,7 +125,7 @@ void LSPPreprocessor::mergeFileChanges(absl::Mutex &mtx, QueueState &state) {
             // Merge updates and tracers, and cancel its timer to avoid a distorted latency metric.
             auto &mergeableParams = get<unique_ptr<SorbetWorkspaceEditParams>>(mergeMsg.asNotification().params);
             mergeEdits(msgParams->updates, mergeableParams->updates);
-            cancelTimer(msg.timer);
+            cancelTimer(mergeMsg.timer);
             msg.startTracers.insert(msg.startTracers.end(), mergeMsg.startTracers.begin(), mergeMsg.startTracers.end());
             // Delete the update we just merged and move on to next item.
             it = pendingRequests.erase(it);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

IDE: Cancel the correct timer when merging updates.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

If edit A came in after edit B, and we merged A into B and threw A away, we canceled B's timer rather than A's timer.

As a result, A's timer would report that A completed at the time of merging, and B's timer would never report a metric.

These timers are used to track latency for LSP, so I expect the latency metric to _increase_ after landing this fix.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

N/A
