### PR TITLE
RBIs for `zip` method

### DIFF
--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_4_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_4_3_hidden.rbi.exp
@@ -153,8 +153,6 @@ module Enumerable
   def to_set(klass=T.unsafe(nil), *args, &block); end
 
   def uniq(); end
-
-  def zip(*_); end
 end
 
 class Enumerator

--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_3_hidden.rbi.exp
@@ -3971,8 +3971,6 @@ module Enumerable
   def to_set(klass=T.unsafe(nil), *args, &block); end
 
   def uniq(); end
-
-  def zip(*_); end
 end
 
 class Enumerator

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_4_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_4_3_hidden.rbi.exp
@@ -165,8 +165,6 @@ module Enumerable
   def to_set(klass=T.unsafe(nil), *args, &block); end
 
   def uniq(); end
-
-  def zip(*_); end
 end
 
 class Enumerator

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_3_hidden.rbi.exp
@@ -3983,8 +3983,6 @@ module Enumerable
   def to_set(klass=T.unsafe(nil), *args, &block); end
 
   def uniq(); end
-
-  def zip(*_); end
 end
 
 class Enumerator

--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -2328,8 +2328,7 @@ class Array < Object
   # ```
   sig do
     type_parameters(:U).params(
-        arg: T::Enumerable[T.type_parameter(:U)],
-        blk: NilClass
+        arg: T::Enumerable[T.type_parameter(:U)]
     )
     .returns(T::Array[[Elem, T.nilable(T.type_parameter(:U))]])
   end

--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -2328,14 +2328,14 @@ class Array < Object
   # ```
   sig do
     type_parameters(:U).params(
-        arg: T::Array[T.type_parameter(:U)],
+        arg: T::Enumerable[T.type_parameter(:U)],
         blk: NilClass
     )
     .returns(T::Array[[Elem, T.nilable(T.type_parameter(:U))]])
   end
   sig do
     type_parameters(:U).params(
-        arg: T::Array[T.type_parameter(:U)],
+        arg: T::Enumerable[T.type_parameter(:U)],
         blk: T.proc.params(x: Elem, y: T.nilable(T.type_parameter(:U))).void
     ).void
   end

--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -2328,11 +2328,18 @@ class Array < Object
   # ```
   sig do
     type_parameters(:U).params(
-        arg0: T::Array[T.type_parameter(:U)],
+        arg: T::Array[T.type_parameter(:U)],
+        blk: NilClass
     )
     .returns(T::Array[[Elem, T.nilable(T.type_parameter(:U))]])
   end
-  def zip(*arg0); end
+  sig do
+    type_parameters(:U).params(
+        arg: T::Array[T.type_parameter(:U)],
+        blk: T.proc.params(x: Elem, y: T.nilable(T.type_parameter(:U))).void
+    ).void
+  end
+  def zip(*arg, &blk); end
 
   # [`Set`](https://docs.ruby-lang.org/en/2.6.0/Set.html) Union --- Returns a
   # new array by joining `ary` with `other_ary`, excluding any duplicates and

--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -1342,4 +1342,40 @@ module Enumerable
   # ```
   sig { returns(Enumerator::Lazy[Elem])}
   def lazy(); end
+
+  # Takes one element from *enum* and merges corresponding elements from each
+  # *args*.
+  # This generates a sequence of *n*-element arrays, where *n* is one more than
+  # the count of arguments.
+  # The length of the resulting sequence will be `enum#size`. If the size of
+  # any argument is less than `enum#size`, `nil` values are supplied.
+  # If a block is given, it is invoked for each output array, otherwise an
+  # array of arrays is returned.
+  #
+  # ```ruby
+  # a = [ 4, 5, 6 ]
+  # b = [ 7, 8, 9 ]
+  #
+  # a.zip(b)                 #=> [[4, 7], [5, 8], [6, 9]]
+  # [1, 2, 3].zip(a, b)      #=> [[1, 4, 7], [2, 5, 8], [3, 6, 9]]
+  # [1, 2].zip(a, b)         #=> [[1, 4, 7], [2, 5, 8]]
+  # a.zip([1, 2], [8])       #=> [[4, 1, 8], [5, 2, nil], [6, nil, nil]]
+  #
+  # c = []
+  # a.zip(b) { |x, y| c << x + y }  #=> nil
+  # c                               #=> [11, 13, 15]
+  # ```
+  sig do
+    type_parameters(:U).params(
+        arg: T::Enumerable[T.type_parameter(:U)],
+        blk: NilClass
+    ).returns(T::Array[[Elem, T.nilable(T.type_parameter(:U))]])
+  end
+  sig do
+    type_parameters(:U).params(
+        arg: T::Enumerable[T.type_parameter(:U)],
+        blk: T.proc.params(x: Elem, y: T.nilable(T.type_parameter(:U))).void
+    ).void
+  end
+  def zip(*arg, &blk); end
 end

--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -1367,8 +1367,7 @@ module Enumerable
   # ```
   sig do
     type_parameters(:U).params(
-        arg: T::Enumerable[T.type_parameter(:U)],
-        blk: NilClass
+        arg: T::Enumerable[T.type_parameter(:U)]
     ).returns(T::Array[[Elem, T.nilable(T.type_parameter(:U))]])
   end
   sig do


### PR DESCRIPTION
### Motivation

Re-roll of #2251.

This pull-request makes two changes:
* Add a RBI definition for `Enumerable#zip` (was missing)
* Change the RBI definition for `Array#zip` (was incomplete)

Note that this PR cannot be tested until #2318 is resolved since the overload will not be correctly selected.
