### PR TITLE
[wip] Make clone during deserialize of T::Props::Serializable optional

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -217,6 +217,15 @@ module T::Props::Serializable
         end
 
         if mutation_safety == :freeze
+          case val
+          when Hash
+            val.each do |k,v|
+              k.freeze
+              v.freeze
+            end
+          when Enumerable
+            val.each(&:freeze)
+          end
           val.freeze
         end
 

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -115,8 +115,11 @@ module T::Props::Serializable
   # @param strict [T::Boolean] (false) If true, raise an exception if
   #  the hash contains keys that do not correspond to any known
   #  props on this instance.
+  # @param mutation_safety [Symbol] If :clone (default), clone input
+  #  to ensure mutations do not propagate unexpectedly. If :freeze,
+  #  freeze instead. If :unsafe, do neither.
   # @return [void]
-  def deserialize(hash, strict=false, clone=true)
+  def deserialize(hash, strict=false, mutation_safety=:clone)
     decorator = self.class.decorator
 
     matching_props = 0
@@ -161,7 +164,7 @@ module T::Props::Serializable
               if subtype.is_a?(T::Props::CustomType)
                 val.map {|el| el && subtype.deserialize(el)}
               else
-                val.map {|el| el && subtype.from_hash(el, strict, clone)}
+                val.map {|el| el && subtype.from_hash(el, strict, mutation_safety)}
               end
             elsif rules[:type_is_hash_of_serializable_values] && rules[:type_is_hash_of_custom_type_keys]
               key_subtype = subtype[:keys]
@@ -172,35 +175,54 @@ module T::Props::Serializable
                 end
               else
                 val.each_with_object({}) do |(key, value), result|
-                  result[key_subtype.deserialize(key)] = value && values_subtype.from_hash(value, strict, clone)
+                  result[key_subtype.deserialize(key)] = value && values_subtype.from_hash(value, strict, mutation_safety)
                 end
               end
             elsif rules[:type_is_hash_of_serializable_values]
               if subtype.is_a?(T::Props::CustomType)
                 val.transform_values {|v| v && subtype.deserialize(v)}
               else
-                val.transform_values {|v| v && subtype.from_hash(v, strict, clone)}
+                val.transform_values {|v| v && subtype.from_hash(v, strict, mutation_safety)}
               end
             elsif rules[:type_is_hash_of_custom_type_keys]
               val.map do |key, value|
                 [subtype.deserialize(key), value]
               end.to_h
             else
-              subtype.from_hash(val, strict, clone)
+              subtype.from_hash(val, strict, mutation_safety)
             end
-        elsif clone && (needs_clone = rules[:type_needs_clone])
+        elsif needs_clone = rules[:type_needs_clone]
           val =
-            if needs_clone == :shallow
-              val.dup
+            case mutation_safety
+            when :clone
+              if needs_clone == :shallow
+                val.dup
+              else
+                T::Props::Utils.deep_clone_object(val)
+              end
+            when :freeze
+              if needs_clone == :shallow
+                # Will freeze below
+                val
+              else
+                T::Props::Utils.deep_clone_object(val, freeze: true)
+              end
+            when :unsafe
+              val
             else
-              T::Props::Utils.deep_clone_object(val)
+              raise ArgumentError.new("Unexpected `mutation_safety` strategy: #{mutation_safety}")
             end
         elsif rules[:type_is_custom_type]
           val = rules[:type].deserialize(val)
         end
 
+        if mutation_safety == :freeze
+          val.freeze
+        end
+
         matching_props += 1
       end
+
 
       self.instance_variable_set(rules[:accessor_key], val) # rubocop:disable PrisonGuard/NoLurkyInstanceVariableAccess
     end
@@ -289,11 +311,11 @@ module T::Props::Serializable::DecoratorMethods
   def prop_dont_store?(prop); prop_rules(prop)[:dont_store]; end
   def prop_by_serialized_forms; @class.prop_by_serialized_forms; end
 
-  def from_hash(hash, strict=false, clone=true)
+  def from_hash(hash, strict=false, mutation_safety=:clone)
     raise ArgumentError.new("#{hash.inspect} provided to from_hash") if !(hash && hash.is_a?(Hash))
 
     i = @class.allocate
-    i.deserialize(hash, strict, clone)
+    i.deserialize(hash, strict, mutation_safety)
 
     i
   end
@@ -373,8 +395,8 @@ module T::Props::Serializable::ClassMethods
   # Allocate a new instance and call {#deserialize} to load a new
   # object from a hash.
   # @return [Serializable]
-  def from_hash(hash, strict=false, clone=true)
-    self.decorator.from_hash(hash, strict, clone)
+  def from_hash(hash, strict=false, mutation_safety=:clone)
+    self.decorator.from_hash(hash, strict, mutation_safety)
   end
 
   # Equivalent to {.from_hash} with `strict` set to true.

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -164,7 +164,7 @@ module T::Props::Serializable
               if subtype.is_a?(T::Props::CustomType)
                 val.map {|el| el && subtype.deserialize(el)}
               else
-                val.map {|el| el && subtype.from_hash(el, strict, mutation_safety)}
+                val.map {|el| el && subtype.decorator.from_hash(el, strict, mutation_safety)}
               end
             elsif rules[:type_is_hash_of_serializable_values] && rules[:type_is_hash_of_custom_type_keys]
               key_subtype = subtype[:keys]
@@ -175,21 +175,21 @@ module T::Props::Serializable
                 end
               else
                 val.each_with_object({}) do |(key, value), result|
-                  result[key_subtype.deserialize(key)] = value && values_subtype.from_hash(value, strict, mutation_safety)
+                  result[key_subtype.deserialize(key)] = value && values_subtype.decorator.from_hash(value, strict, mutation_safety)
                 end
               end
             elsif rules[:type_is_hash_of_serializable_values]
               if subtype.is_a?(T::Props::CustomType)
                 val.transform_values {|v| v && subtype.deserialize(v)}
               else
-                val.transform_values {|v| v && subtype.from_hash(v, strict, mutation_safety)}
+                val.transform_values {|v| v && subtype.decorator.from_hash(v, strict, mutation_safety)}
               end
             elsif rules[:type_is_hash_of_custom_type_keys]
               val.map do |key, value|
                 [subtype.deserialize(key), value]
               end.to_h
             else
-              subtype.from_hash(val, strict, mutation_safety)
+              subtype.decorator.from_hash(val, strict, mutation_safety)
             end
         elsif needs_clone = rules[:type_needs_clone]
           val =
@@ -395,8 +395,8 @@ module T::Props::Serializable::ClassMethods
   # Allocate a new instance and call {#deserialize} to load a new
   # object from a hash.
   # @return [Serializable]
-  def from_hash(hash, strict=false, mutation_safety=:clone)
-    self.decorator.from_hash(hash, strict, mutation_safety)
+  def from_hash(hash, strict=false)
+    self.decorator.from_hash(hash, strict)
   end
 
   # Equivalent to {.from_hash} with `strict` set to true.

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -289,11 +289,11 @@ module T::Props::Serializable::DecoratorMethods
   def prop_dont_store?(prop); prop_rules(prop)[:dont_store]; end
   def prop_by_serialized_forms; @class.prop_by_serialized_forms; end
 
-  def from_hash(hash, strict=false)
+  def from_hash(hash, strict=false, clone=true)
     raise ArgumentError.new("#{hash.inspect} provided to from_hash") if !(hash && hash.is_a?(Hash))
 
     i = @class.allocate
-    i.deserialize(hash, strict)
+    i.deserialize(hash, strict, clone)
 
     i
   end

--- a/gems/sorbet-runtime/sorbet-runtime.gemspec
+++ b/gems/sorbet-runtime/sorbet-runtime.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest', '~> 5.11'
   s.add_development_dependency 'mocha', '~> 1.7'
   s.add_development_dependency 'rake'
+  s.add_development_dependency 'pry'
   # for reproducing race conditions in tests
   s.add_development_dependency 'concurrent-ruby', '~> 1.1.5'
 end

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -171,7 +171,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
         'name' => 'hi',
         'foo' => {'hello' => {'world' => 1}},
       }
-      m = MySerializable.from_hash(h, true, :clone)
+      m = MySerializable.decorator.from_hash(h, true, :clone)
       refute_equal(m.foo.object_id, h['foo'].object_id, "`foo` is the same object")
       refute(m.foo.frozen?)
       refute_equal(m.foo['hello'].object_id, h['foo']['hello'].object_id, "`foo.hello` is the same object")
@@ -183,7 +183,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
         'name' => 'hi',
         'foo' => {'hello' => {'world' => 1}},
       }
-      m = MySerializable.from_hash(h, true, :freeze)
+      m = MySerializable.decorator.from_hash(h, true, :freeze)
       assert(m.foo.frozen?)
       assert(m.foo['hello'].frozen?)
 
@@ -200,7 +200,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
         'name' => 'hi',
         'foo' => {'hello' => {'world' => 1}},
       }
-      m = MySerializable.from_hash(h, true, :unsafe)
+      m = MySerializable.decorator.from_hash(h, true, :unsafe)
       assert_equal(m.foo.object_id, h['foo'].object_id, "`foo` is not the same object")
       refute(m.foo.frozen?)
       assert_equal(m.foo['hello'].object_id, h['foo']['hello'].object_id, "`foo.hello` is not the same object")
@@ -223,21 +223,21 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
 
     it 'is not same object and is not frozen on deserialize when mutation_safety is :clone' do
       array = []
-      m = MyArraySerializable.from_hash({'array' => array}, true, :clone)
+      m = MyArraySerializable.decorator.from_hash({'array' => array}, true, :clone)
       refute_equal(array.object_id, m.array.object_id)
       refute(array.frozen?)
     end
 
     it 'is same object and is frozen on deserialize when mutation_safety is :freeze' do
       array = []
-      m = MyArraySerializable.from_hash({'array' => array}, true, :freeze)
+      m = MyArraySerializable.decorator.from_hash({'array' => array}, true, :freeze)
       assert_equal(array.object_id, m.array.object_id)
       assert(array.frozen?)
     end
 
     it 'is same object and is not frozen on deserialize when mutation_safety is :unsafe' do
       array = []
-      m = MyArraySerializable.from_hash({'array' => array}, true, :unsafe)
+      m = MyArraySerializable.decorator.from_hash({'array' => array}, true, :unsafe)
       assert_equal(array.object_id, m.array.object_id)
       refute(array.frozen?)
     end


### PR DESCRIPTION
### Motivation
When using `deserialize` to load a hash that we effectively "own", e.g. something that we just parsed from bytes, cloning is wasteful. And go/profiler-ui samples suggest that the API spends up to 1% of (wall) time doing clones, which I'd guess (though cannot currently prove) are mostly of this unnecessary kind.

To fix this, we provide two new options in a new `mutation_safety` strategy-specification param: `:freeze`, which freezes instead of cloning, and `:unsafe`, which does neither. The main advantage of add a `:freeze` option is that, in cases when we want to freeze (which we do in Chalk::ODM frequently), we can pass the `:freeze` through to the `deep_clone_object` and avoid iterating through everything a second time later in order to do the freeze.

Please note that this change isn't quite a noop for existing callers, because it also has the effect of propagating `strict` to the deserialize calls to substructs. I think this is effectively a bugfix, but there is some potential for unexpected impact if code relies on that bug.

### Test plan
Added unit tests.