### PR TITLE
Pretty-print <AttachedClass> as T.attached_class

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -756,6 +756,12 @@ string Symbol::show(const GlobalState &gs) const {
         return this->name.data(gs)->show(gs);
     }
 
+    if (this->name == core::Names::Constants::AttachedClass()) {
+        auto attached = this->owner.data(gs)->attachedClass(gs);
+        ENFORCE(attached.exists());
+        return fmt::format("T.attached_class (of {})", attached.data(gs)->show(gs));
+    }
+
     if (this->isMethod() && this->owner.data(gs)->isClassOrModule() && this->owner.data(gs)->isSingletonClass(gs)) {
         return fmt::format("{}.{}", this->owner.data(gs)->attachedClass(gs).data(gs)->show(gs),
                            this->name.data(gs)->show(gs));

--- a/test/cli/cache-keeps-print-options/cache-keeps-print-options.out
+++ b/test/cli/cache-keeps-print-options/cache-keeps-print-options.out
@@ -4,7 +4,7 @@ class ::<root> < ::Object () @ (... removed core rbi locs ..., https://github.co
       argument <blk><block> @ Loc {file=test/cli/cache-keeps-print-options/cache-keeps-print-options.rb start=??? end=???}
   class ::CCCCCCCCC < ::Object () @ test/cli/cache-keeps-print-options/cache-keeps-print-options.rb:1
   class ::<Class:CCCCCCCCC>[<AttachedClass>] < ::<Class:Object> () @ test/cli/cache-keeps-print-options/cache-keeps-print-options.rb:1
-    type-member(+) ::<Class:CCCCCCCCC>::<AttachedClass> -> T.class_of(CCCCCCCCC)::<AttachedClass> @ test/cli/cache-keeps-print-options/cache-keeps-print-options.rb:1
+    type-member(+) ::<Class:CCCCCCCCC>::<AttachedClass> -> T.attached_class (of CCCCCCCCC) @ test/cli/cache-keeps-print-options/cache-keeps-print-options.rb:1
     method ::<Class:CCCCCCCCC>#<static-init> (<blk>) @ test/cli/cache-keeps-print-options/cache-keeps-print-options.rb:1
       argument <blk><block> @ Loc {file=test/cli/cache-keeps-print-options/cache-keeps-print-options.rb start=??? end=???}
 
@@ -14,7 +14,7 @@ class ::<root> < ::Object () @ (... removed core rbi locs ..., https://github.co
       argument <blk><block> @ Loc {file=test/cli/cache-keeps-print-options/cache-keeps-print-options.rb start=??? end=???}
   class ::CCCCCCCCC < ::Object () @ test/cli/cache-keeps-print-options/cache-keeps-print-options.rb:1
   class ::<Class:CCCCCCCCC>[<AttachedClass>] < ::<Class:Object> () @ test/cli/cache-keeps-print-options/cache-keeps-print-options.rb:1
-    type-member(+) ::<Class:CCCCCCCCC>::<AttachedClass> -> T.class_of(CCCCCCCCC)::<AttachedClass> @ test/cli/cache-keeps-print-options/cache-keeps-print-options.rb:1
+    type-member(+) ::<Class:CCCCCCCCC>::<AttachedClass> -> T.attached_class (of CCCCCCCCC) @ test/cli/cache-keeps-print-options/cache-keeps-print-options.rb:1
     method ::<Class:CCCCCCCCC>#<static-init> (<blk>) @ test/cli/cache-keeps-print-options/cache-keeps-print-options.rb:1
       argument <blk><block> @ Loc {file=test/cli/cache-keeps-print-options/cache-keeps-print-options.rb start=??? end=???}
 

--- a/test/cli/dash-e/dash-e.out
+++ b/test/cli/dash-e/dash-e.out
@@ -5,7 +5,7 @@ class ::<root> < ::Object () @ (... removed core rbi locs ..., -e:1, https://git
       argument <blk><block> @ Loc {file=-e start=??? end=???}
   class ::Foo < ::Object () @ -e:1
   class ::<Class:Foo>[<AttachedClass>] < ::<Class:Object> () @ -e:1
-    type-member(+) ::<Class:Foo>::<AttachedClass> -> T.class_of(Foo)::<AttachedClass> @ -e:1
+    type-member(+) ::<Class:Foo>::<AttachedClass> -> T.attached_class (of Foo) @ -e:1
     method ::<Class:Foo>#<static-init> (<blk>) @ -e:1
       argument <blk><block> @ Loc {file=-e start=??? end=???}
 

--- a/test/cli/stop-after-namer/stop-after-namer.out
+++ b/test/cli/stop-after-namer/stop-after-namer.out
@@ -8,7 +8,7 @@ class ::<root> < ::<todo sym> () @ test/cli/stop-after-namer/stop-after-namer.rb
       argument method_arg<> @ Loc {file=test/cli/stop-after-namer/stop-after-namer.rb start=4:14 end=4:24}
       argument <blk><block> @ Loc {file=test/cli/stop-after-namer/stop-after-namer.rb start=??? end=???}
   class ::<Class:A>[<AttachedClass>] < ::<todo sym> () @ test/cli/stop-after-namer/stop-after-namer.rb:3
-    type-member(+) ::<Class:A>::<AttachedClass> -> T.class_of(A)::<AttachedClass> @ test/cli/stop-after-namer/stop-after-namer.rb:3
+    type-member(+) ::<Class:A>::<AttachedClass> -> T.attached_class (of A) @ test/cli/stop-after-namer/stop-after-namer.rb:3
     method ::<Class:A>#<static-init> (<blk>) @ test/cli/stop-after-namer/stop-after-namer.rb:3
       argument <blk><block> @ Loc {file=test/cli/stop-after-namer/stop-after-namer.rb start=??? end=???}
     method ::<Class:A>#singleton_method (singleton_method_arg, <blk>) @ test/cli/stop-after-namer/stop-after-namer.rb:10

--- a/test/cli/subprocess-plugin/subprocess-plugin.out
+++ b/test/cli/subprocess-plugin/subprocess-plugin.out
@@ -604,14 +604,14 @@ class ::<root> < ::Object () @ (... removed core rbi locs ..., https://github.co
     method ::Fish#foo (<blk>) @ test/cli/subprocess-plugin/multi2.rb//plugin-generated|0.rbi:2
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi2.rb//plugin-generated|0.rbi start=??? end=???}
   class ::<Class:Fish>[<AttachedClass>] < ::Module () @ (test/cli/subprocess-plugin/multi2.rb:5, test/cli/subprocess-plugin/multi2.rb//plugin-generated|1.rbi:1)
-    type-member(+) ::<Class:Fish>::<AttachedClass> -> T.class_of(Fish)::<AttachedClass> @ test/cli/subprocess-plugin/multi2.rb:3
+    type-member(+) ::<Class:Fish>::<AttachedClass> -> T.attached_class (of Fish) @ test/cli/subprocess-plugin/multi2.rb:3
     method ::<Class:Fish>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi2.rb:3
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi2.rb start=??? end=???}
     static-field ::<Class:Fish>::Fish -> TrueClass @ test/cli/subprocess-plugin/multi2.rb//plugin-generated|1.rbi:3
     method ::<Class:Fish>#fish (<blk>) @ test/cli/subprocess-plugin/multi2.rb//plugin-generated|1.rbi:2
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi2.rb//plugin-generated|1.rbi start=??? end=???}
   class ::<Class:<Class:Fish>>[<AttachedClass>] < ::<Class:Module> () @ test/cli/subprocess-plugin/multi2.rb:5
-    type-member(+) ::<Class:<Class:Fish>>::<AttachedClass> -> T.class_of(T.class_of(Fish))::<AttachedClass> @ test/cli/subprocess-plugin/multi2.rb:5
+    type-member(+) ::<Class:<Class:Fish>>::<AttachedClass> -> T.attached_class (of T.class_of(Fish)) @ test/cli/subprocess-plugin/multi2.rb:5
     method ::<Class:<Class:Fish>>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi2.rb:5
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi2.rb start=??? end=???}
   class ::Haze < ::Object () @ (test/cli/subprocess-plugin/multi4.rb:3, test/cli/subprocess-plugin/multi4.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi4.rb//plugin-generated|1.rbi:1)
@@ -621,7 +621,7 @@ class ::<root> < ::Object () @ (... removed core rbi locs ..., https://github.co
     method ::Haze#lion (<blk>) @ test/cli/subprocess-plugin/multi4.rb//plugin-generated|1.rbi:2
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi4.rb//plugin-generated|1.rbi start=??? end=???}
   class ::<Class:Haze>[<AttachedClass>] < ::<Class:Object> () @ test/cli/subprocess-plugin/multi4.rb:3
-    type-member(+) ::<Class:Haze>::<AttachedClass> -> T.class_of(Haze)::<AttachedClass> @ test/cli/subprocess-plugin/multi4.rb:3
+    type-member(+) ::<Class:Haze>::<AttachedClass> -> T.attached_class (of Haze) @ test/cli/subprocess-plugin/multi4.rb:3
     method ::<Class:Haze>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi4.rb:3
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi4.rb start=??? end=???}
   module ::Hi < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ (test/cli/subprocess-plugin/multi1.rb:15, test/cli/subprocess-plugin/multi1.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|1.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|2.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|3.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|4.rbi:1)
@@ -632,7 +632,7 @@ class ::<root> < ::Object () @ (... removed core rbi locs ..., https://github.co
     method ::Hi#penguin (<blk>) @ test/cli/subprocess-plugin/multi1.rb//plugin-generated|1.rbi:2
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi1.rb//plugin-generated|1.rbi start=??? end=???}
   class ::<Class:Hi>[<AttachedClass>] < ::Module () @ (test/cli/subprocess-plugin/multi1.rb:17, test/cli/subprocess-plugin/multi1.rb//plugin-generated|2.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|3.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|4.rbi:1)
-    type-member(+) ::<Class:Hi>::<AttachedClass> -> T.class_of(Hi)::<AttachedClass> @ test/cli/subprocess-plugin/multi1.rb:15
+    type-member(+) ::<Class:Hi>::<AttachedClass> -> T.attached_class (of Hi) @ test/cli/subprocess-plugin/multi1.rb:15
     method ::<Class:Hi>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi1.rb:15
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi1.rb start=??? end=???}
     static-field ::<Class:Hi>::Cat -> TrueClass @ test/cli/subprocess-plugin/multi1.rb//plugin-generated|3.rbi:3
@@ -642,7 +642,7 @@ class ::<root> < ::Object () @ (... removed core rbi locs ..., https://github.co
       method ::<Class:Hi>::Hello#rabbit (<blk>) @ test/cli/subprocess-plugin/multi1.rb//plugin-generated|4.rbi:2
         argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi1.rb//plugin-generated|4.rbi start=??? end=???}
     class ::<Class:Hi>::<Class:Hello>[<AttachedClass>] < ::<Class:Object> () @ test/cli/subprocess-plugin/multi1.rb:19
-      type-member(+) ::<Class:Hi>::<Class:Hello>::<AttachedClass> -> T.class_of(T.class_of(Hi)::Hello)::<AttachedClass> @ test/cli/subprocess-plugin/multi1.rb:19
+      type-member(+) ::<Class:Hi>::<Class:Hello>::<AttachedClass> -> T.attached_class (of T.class_of(Hi)::Hello) @ test/cli/subprocess-plugin/multi1.rb:19
       method ::<Class:Hi>::<Class:Hello>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi1.rb:19
         argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi1.rb start=??? end=???}
     method ::<Class:Hi>#cat (<blk>) @ test/cli/subprocess-plugin/multi1.rb//plugin-generated|3.rbi:2
@@ -650,7 +650,7 @@ class ::<root> < ::Object () @ (... removed core rbi locs ..., https://github.co
     method ::<Class:Hi>#fish (<blk>) @ test/cli/subprocess-plugin/multi1.rb//plugin-generated|2.rbi:2
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi1.rb//plugin-generated|2.rbi start=??? end=???}
   class ::<Class:<Class:Hi>>[<AttachedClass>] < ::<Class:Module> () @ test/cli/subprocess-plugin/multi1.rb:17
-    type-member(+) ::<Class:<Class:Hi>>::<AttachedClass> -> T.class_of(T.class_of(Hi))::<AttachedClass> @ test/cli/subprocess-plugin/multi1.rb:17
+    type-member(+) ::<Class:<Class:Hi>>::<AttachedClass> -> T.attached_class (of T.class_of(Hi)) @ test/cli/subprocess-plugin/multi1.rb:17
     method ::<Class:<Class:Hi>>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi1.rb:17
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi1.rb start=??? end=???}
   class ::Kick < ::Object () @ (test/cli/subprocess-plugin/multi6.rb:3, test/cli/subprocess-plugin/multi6.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi6.rb//plugin-generated|1.rbi:1)
@@ -659,27 +659,27 @@ class ::<root> < ::Object () @ (... removed core rbi locs ..., https://github.co
       method ::Kick::Down#whale (<blk>) @ test/cli/subprocess-plugin/multi6.rb//plugin-generated|1.rbi:2
         argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi6.rb//plugin-generated|1.rbi start=??? end=???}
     class ::Kick::<Class:Down>[<AttachedClass>] < ::Module () @ test/cli/subprocess-plugin/multi6.rb:4
-      type-member(+) ::Kick::<Class:Down>::<AttachedClass> -> T.class_of(Kick::Down)::<AttachedClass> @ test/cli/subprocess-plugin/multi6.rb:4
+      type-member(+) ::Kick::<Class:Down>::<AttachedClass> -> T.attached_class (of Kick::Down) @ test/cli/subprocess-plugin/multi6.rb:4
       method ::Kick::<Class:Down>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi6.rb:4
         argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi6.rb start=??? end=???}
     method ::Kick#baz (<blk>) -> Integer @ test/cli/subprocess-plugin/multi6.rb//plugin-generated|0.rbi:3
       argument <blk><block> -> T.untyped @ Loc {file=test/cli/subprocess-plugin/multi6.rb//plugin-generated|0.rbi start=??? end=???}
   class ::<Class:Kick>[<AttachedClass>] < ::<Class:Object> () @ test/cli/subprocess-plugin/multi6.rb:3
-    type-member(+) ::<Class:Kick>::<AttachedClass> -> T.class_of(Kick)::<AttachedClass> @ test/cli/subprocess-plugin/multi6.rb:3
+    type-member(+) ::<Class:Kick>::<AttachedClass> -> T.attached_class (of Kick) @ test/cli/subprocess-plugin/multi6.rb:3
     method ::<Class:Kick>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi6.rb:3
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi6.rb start=??? end=???}
   class ::Nope < ::Object () @ (test/cli/subprocess-plugin/multi5.rb:3, test/cli/subprocess-plugin/multi5.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi5.rb//plugin-generated|1.rbi:1)
     method ::Nope#foo (<blk>) @ test/cli/subprocess-plugin/multi5.rb//plugin-generated|0.rbi:2
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi5.rb//plugin-generated|0.rbi start=??? end=???}
   class ::<Class:Nope>[<AttachedClass>] < ::<Class:Object> () @ (test/cli/subprocess-plugin/multi5.rb:4, test/cli/subprocess-plugin/multi5.rb//plugin-generated|1.rbi:1)
-    type-member(+) ::<Class:Nope>::<AttachedClass> -> T.class_of(Nope)::<AttachedClass> @ test/cli/subprocess-plugin/multi5.rb:3
+    type-member(+) ::<Class:Nope>::<AttachedClass> -> T.attached_class (of Nope) @ test/cli/subprocess-plugin/multi5.rb:3
     method ::<Class:Nope>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi5.rb:3
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi5.rb start=??? end=???}
     static-field ::<Class:Nope>::Whale -> TrueClass @ test/cli/subprocess-plugin/multi5.rb//plugin-generated|1.rbi:3
     method ::<Class:Nope>#whale (<blk>) @ test/cli/subprocess-plugin/multi5.rb//plugin-generated|1.rbi:2
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi5.rb//plugin-generated|1.rbi start=??? end=???}
   class ::<Class:<Class:Nope>>[<AttachedClass>] < ::<Class:<Class:Object>> () @ test/cli/subprocess-plugin/multi5.rb:4
-    type-member(+) ::<Class:<Class:Nope>>::<AttachedClass> -> T.class_of(T.class_of(Nope))::<AttachedClass> @ test/cli/subprocess-plugin/multi5.rb:4
+    type-member(+) ::<Class:<Class:Nope>>::<AttachedClass> -> T.attached_class (of T.class_of(Nope)) @ test/cli/subprocess-plugin/multi5.rb:4
     method ::<Class:<Class:Nope>>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi5.rb:4
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi5.rb start=??? end=???}
   class ::Object < ::BasicObject (Kernel) @ https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#L27
@@ -701,7 +701,7 @@ class ::<root> < ::Object () @ (... removed core rbi locs ..., https://github.co
     method ::Something#foo (<blk>) @ test/cli/subprocess-plugin/multi3.rb//plugin-generated|1.rbi:2
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi3.rb//plugin-generated|1.rbi start=??? end=???}
   class ::<Class:Something>[<AttachedClass>] < ::<Class:Object> () @ test/cli/subprocess-plugin/multi3.rb:3
-    type-member(+) ::<Class:Something>::<AttachedClass> -> T.class_of(Something)::<AttachedClass> @ test/cli/subprocess-plugin/multi3.rb:3
+    type-member(+) ::<Class:Something>::<AttachedClass> -> T.attached_class (of Something) @ test/cli/subprocess-plugin/multi3.rb:3
     method ::<Class:Something>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi3.rb:3
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi3.rb start=??? end=???}
 

--- a/test/testdata/infer/attached_class_printing.rb
+++ b/test/testdata/infer/attached_class_printing.rb
@@ -1,8 +1,18 @@
 # typed: true
 
-class Child
-  extend T::Sig
+class Module
+  include T::Sig
+end
 
+class Parent
+  sig {returns(T.experimental_attached_class)}
+  def self.foo
+    # Goal of test: no < ... > in the user-visible type.
+    T.reveal_type(new) # error: Revealed type: `T.attached_class (of Parent)`
+  end
+end
+
+class Child < Parent
   sig {returns(T.experimental_attached_class)}
   def self.foo
     # Goal of test: no < ... > in the user-visible type.

--- a/test/testdata/infer/attached_class_printing.rb
+++ b/test/testdata/infer/attached_class_printing.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+class Child
+  extend T::Sig
+
+  sig {returns(T.experimental_attached_class)}
+  def self.foo
+    # Goal of test: no < ... > in the user-visible type.
+    T.reveal_type(new) # error: Revealed type: `T.attached_class (of Child)`
+  end
+end

--- a/test/testdata/infer/attached_class_self_new.rb
+++ b/test/testdata/infer/attached_class_self_new.rb
@@ -5,12 +5,12 @@ class NoArgs
 
   sig {returns(T.experimental_attached_class)}
   def self.make
-    T.reveal_type(self.new) # error: Revealed type: `T.class_of(NoArgs)::<AttachedClass>`
+    T.reveal_type(self.new) # error: Revealed type: `T.attached_class (of NoArgs)`
   end
 
   sig {returns(T.experimental_attached_class)}
   def self.make_implicit_new
-    T.reveal_type(new) # error: Revealed type: `T.class_of(NoArgs)::<AttachedClass>`
+    T.reveal_type(new) # error: Revealed type: `T.attached_class (of NoArgs)`
   end
 
 end
@@ -23,12 +23,12 @@ class PosArgs
 
   sig {returns(T.experimental_attached_class)}
   def self.make
-    T.reveal_type(self.new(10, "foo")) # error: Revealed type: `T.class_of(PosArgs)::<AttachedClass>`
+    T.reveal_type(self.new(10, "foo")) # error: Revealed type: `T.attached_class (of PosArgs)`
 
     # Not matching initialize
     T.reveal_type(self.new())
                 # ^^^^^^^^^^ error: Not enough arguments provided
-  # ^^^^^^^^^^^^^^^^^^^^^^^^^ error: Revealed type: `T.class_of(PosArgs)::<AttachedClass>`
+  # ^^^^^^^^^^^^^^^^^^^^^^^^^ error: Revealed type: `T.attached_class (of PosArgs)`
   end
 end
 
@@ -40,12 +40,12 @@ class NamedArgs
 
   sig {returns(T.experimental_attached_class)}
   def self.make
-    T.reveal_type(self.new(x: 10, y: "foo")) # error: Revealed type: `T.class_of(NamedArgs)::<AttachedClass>`
+    T.reveal_type(self.new(x: 10, y: "foo")) # error: Revealed type: `T.attached_class (of NamedArgs)`
 
     # Not matching initialize
     T.reveal_type(self.new(x: 10))
                 # ^^^^^^^^^^^^^^^ error: Missing required keyword argument `y`
-  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Revealed type: `T.class_of(NamedArgs)::<AttachedClass>`
+  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Revealed type: `T.attached_class (of NamedArgs)`
   end
 end
 
@@ -57,11 +57,11 @@ class BlockArg
 
   sig {returns(T.experimental_attached_class)}
   def self.make
-    T.reveal_type(self.new {|x| x + 1}) # error: Revealed type: `T.class_of(BlockArg)::<AttachedClass>`
+    T.reveal_type(self.new {|x| x + 1}) # error: Revealed type: `T.attached_class (of BlockArg)`
 
     T.reveal_type(self.new)
                 # ^^^^^^^^ error: `initialize` requires a block parameter
-  # ^^^^^^^^^^^^^^^^^^^^^^^ error: Revealed type: `T.class_of(BlockArg)::<AttachedClass>`
+  # ^^^^^^^^^^^^^^^^^^^^^^^ error: Revealed type: `T.attached_class (of BlockArg)`
   end
 end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This should maybe say `T.experimental_attached_class`.
But either way, it's better than before:

```
T.class_of(Parent)::<AttachedClass>
T.class_of(Child)::<AttachedClass>
```


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.