### PR TITLE
Fix signatures for `open`

### DIFF
--- a/rbi/core/file.rbi
+++ b/rbi/core/file.rbi
@@ -679,7 +679,7 @@ class File < IO
   sig do
     params(
       filename: String,
-      mode: String,
+      mode: T.any(Integer, String),
       perm: T.nilable(Integer),
       opt: T.nilable(T::Hash[Symbol, T.untyped]),
     ).returns(File)
@@ -687,7 +687,7 @@ class File < IO
   sig do
     type_parameters(:U).params(
       filename: String,
-      mode: String,
+      mode: T.any(Integer, String),
       perm: T.nilable(Integer),
       opt: T.nilable(T::Hash[Symbol, T.untyped]),
       blk: T.proc.params(file: File).returns(T.type_parameter(:U))

--- a/rbi/core/file.rbi
+++ b/rbi/core/file.rbi
@@ -662,6 +662,39 @@ class File < IO
   end
   def self.mtime(file); end
 
+  # With no associated block, `File.open` is a synonym for
+  # [`::new`](https://ruby-doc.org/core-2.1.4/File.html#method-c-new).
+  # If the optional code block is given, it will be passed the opened `file` as
+  # an argument and the [`File`](https://ruby-doc.org/core-2.1.4/File.html)
+  # object will automatically be closed when the block terminates.
+  # The value of the block will be returned from `File.open`.
+  #
+  # If a file is being created, its initial permissions may be set using the
+  # `perm` parameter.
+  # See [`::new`](https://ruby-doc.org/core-2.1.4/File.html#method-c-new) for
+  # further discussion.
+  #
+  # See [`IO::new`](https://ruby-doc.org/core-2.6.5/IO.html#method-c-new) for a
+  # description of the `mode` and `opt` parameters.
+  sig do
+    params(
+      filename: String,
+      mode: String,
+      perm: T.nilable(Integer),
+      opt: T.nilable(T::Hash[Symbol, T.untyped]),
+    ).returns(File)
+  end
+  sig do
+    type_parameters(:U).params(
+      filename: String,
+      mode: String,
+      perm: T.nilable(Integer),
+      opt: T.nilable(T::Hash[Symbol, T.untyped]),
+      blk: T.proc.params(file: File).returns(T.type_parameter(:U))
+    ).returns(T.type_parameter(:U))
+  end
+  def self.open(filename, mode='r', perm=nil, opt=nil, &blk); end
+
   # Returns `true` if the named file exists and the effective used id of the
   # calling process is the owner of the file.
   #

--- a/rbi/core/io.rbi
+++ b/rbi/core/io.rbi
@@ -731,6 +731,33 @@ class IO < Object
   end
   def lineno=(arg0); end
 
+  # With no associated block, `IO.open` is a synonym for
+  # [`::new`](https://ruby-doc.org/core-2.6.5/IO.html#method-c-new).
+  # If the optional code block is given, it will be passed io as an argument,
+  # and the [IO](https://ruby-doc.org/core-2.6.5/IO.html) object will
+  # automatically be closed when the block terminates. In this instance,
+  # [`::open`](https://ruby-doc.org/core-2.6.5/IO.html#method-c-open)
+  # returns the value of the block.
+  #
+  # See [`::new`](https://ruby-doc.org/core-2.6.5/IO.html#method-c-new) for a
+  # description of the `fd`, `mode` and `opt` parameters.
+  sig do
+    params(
+      fd: T.any(String, Integer),
+      mode: String,
+      opt: T.nilable(T::Hash[Symbol, T.untyped]),
+    ).returns(IO)
+  end
+  sig do
+    type_parameters(:U).params(
+      fd: T.any(String, Integer),
+      mode: String,
+      opt: T.nilable(T::Hash[Symbol, T.untyped]),
+      blk: T.proc.params(io: IO).returns(T.type_parameter(:U))
+    ).returns(T.type_parameter(:U))
+  end
+  def self.open(fd, mode='r', opt=nil, &blk); end
+
   # Returns the process ID of a child process associated with *ios*. This will
   # be set by `IO.popen`.
   #

--- a/rbi/core/io.rbi
+++ b/rbi/core/io.rbi
@@ -744,14 +744,14 @@ class IO < Object
   sig do
     params(
       fd: T.any(String, Integer),
-      mode: String,
+      mode: T.any(Integer, String),
       opt: T.nilable(T::Hash[Symbol, T.untyped]),
     ).returns(IO)
   end
   sig do
     type_parameters(:U).params(
       fd: T.any(String, Integer),
-      mode: String,
+      mode: T.any(Integer, String),
       opt: T.nilable(T::Hash[Symbol, T.untyped]),
       blk: T.proc.params(io: IO).returns(T.type_parameter(:U))
     ).returns(T.type_parameter(:U))

--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -1644,7 +1644,7 @@ module Kernel
   sig do
     params(
       path: String,
-      mode: String,
+      mode: T.any(Integer, String),
       perm: T.nilable(Integer),
       opt: T.nilable(T::Hash[Symbol, T.untyped]),
     ).returns(T.nilable(IO))
@@ -1652,7 +1652,7 @@ module Kernel
   sig do
     type_parameters(:U).params(
       path: String,
-      mode: String,
+      mode: T.any(Integer, String),
       perm: T.nilable(Integer),
       opt: T.nilable(T::Hash[Symbol, T.untyped]),
       blk: T.proc.params(io: IO).returns(T.type_parameter(:U))

--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -1643,13 +1643,22 @@ module Kernel
   # [`open_uri_original_open`](https://docs.ruby-lang.org/en/2.6.0/Kernel.html#method-i-open_uri_original_open)
   sig do
     params(
-        name: String,
-        rest: T.any(String, Integer),
-        block: String,
-    )
-    .returns(T.nilable(IO))
+      path: String,
+      mode: String,
+      perm: T.nilable(String),
+      opt: T.nilable(T::Hash[Symbol, T.untyped]),
+    ).returns(T.nilable(IO))
   end
-  def open(name, rest=T.unsafe(nil), block=T.unsafe(nil)); end
+  sig do
+    type_parameters(:U).params(
+      path: String,
+      mode: String,
+      perm: T.nilable(String),
+      opt: T.nilable(T::Hash[Symbol, T.untyped]),
+      blk: T.proc.params(io: IO).returns(T.type_parameter(:U))
+    ).returns(T.type_parameter(:U))
+  end
+  def open(path, mode='r', perm=nil, opt=nil, &blk); end
 
   # Prints each object in turn to `$stdout`. If the output field separator
   # (`$,`) is not `nil`, its contents will appear between each field. If the

--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -1645,7 +1645,7 @@ module Kernel
     params(
       path: String,
       mode: String,
-      perm: T.nilable(String),
+      perm: T.nilable(Integer),
       opt: T.nilable(T::Hash[Symbol, T.untyped]),
     ).returns(T.nilable(IO))
   end
@@ -1653,7 +1653,7 @@ module Kernel
     type_parameters(:U).params(
       path: String,
       mode: String,
-      perm: T.nilable(String),
+      perm: T.nilable(Integer),
       opt: T.nilable(T::Hash[Symbol, T.untyped]),
       blk: T.proc.params(io: IO).returns(T.type_parameter(:U))
     ).returns(T.type_parameter(:U))

--- a/rbi/stdlib/socket.rbi
+++ b/rbi/stdlib/socket.rbi
@@ -5039,6 +5039,17 @@ class TCPSocket < IPSocket
   end
   def initialize(host=T.unsafe(nil), port=T.unsafe(nil), local_host=T.unsafe(nil), local_port=T.unsafe(nil)); end
 
+  sig do
+    params(
+      host: String,
+      port: Integer,
+      local_host: T.nilable(String),
+      local_port: T.nilable(Integer),
+    )
+    .returns(::T.untyped)
+  end
+  def self.open(host, port, local_host=nil, local_port=nil); end
+
   sig {returns(::T.untyped)}
   def socks_authenticate(); end
 

--- a/test/cli/cache-dsl/cache-dsl.out
+++ b/test/cli/cache-dsl/cache-dsl.out
@@ -2,8 +2,8 @@ No errors! Great job.
 test/cli/cache-dsl/attr_accessor.rb:7: Method `prop=` does not exist on `A` https://srb.help/7003
      7 |a.prop = 7
         ^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1704: Did you mean: `Kernel#proc`?
-    1704 |  def proc(&blk); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1713: Did you mean: `Kernel#proc`?
+    1713 |  def proc(&blk); end
             ^^^^^^^^^^^^^^
 
 test/cli/cache-dsl/attr_accessor.rb:8: Method `prop` does not exist on `A` https://srb.help/7003
@@ -18,8 +18,8 @@ Errors: 2
 test/cli/cache-dsl/attr_accessor.rb:7: Method `prop=` does not exist on `A` https://srb.help/7003
      7 |a.prop = 7
         ^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1704: Did you mean: `Kernel#proc`?
-    1704 |  def proc(&blk); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1713: Did you mean: `Kernel#proc`?
+    1713 |  def proc(&blk); end
             ^^^^^^^^^^^^^^
 
 test/cli/cache-dsl/attr_accessor.rb:8: Method `prop` does not exist on `A` https://srb.help/7003


### PR DESCRIPTION
### Motivation

All `open` calls were relying on the `Kernel.open` where there are specific definitions for `IO`, `File` and `TCPSocket`.

This PR fixes the existing definition for `Kernel.open` and adds all the specific definitions:
* [`Kernel#open`](https://ruby-doc.org/core-2.6.5/Kernel.html#method-i-open)
* [`IO::open`](https://ruby-doc.org/core-2.5.1/IO.html#method-c-open)
* [`File::open`](https://ruby-doc.org/core-2.6.5/File.html#method-c-open)
* [`TCPSocket::open`](https://ruby-doc.org/stdlib-2.5.1/libdoc/socket/rdoc/TCPSocket.html#method-c-new) (alias to `new`)

One benefit for example is that calling `File.open` will now return a `File` instead of a `T.nilable(IO)`.

Note to reviewer: this PR uses the same overload trick than #2320 which cannot be fully tested until #2318 is resolved.

### Test plan

See included automated tests.