### PR TITLE
Implement each_it for table-driven minitests

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -207,6 +207,7 @@ NameDef names[] = {
 
     {"describe"},
     {"it"},
+    {"eachIt", "each_it"},
     {"before"},
     {"after"},
     {"afterAngles", "<after>"},

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -165,14 +165,15 @@ unique_ptr<ast::Expression> runSingle(core::MutableContext ctx, ast::Send *send)
     }
 
     if (send->args.size() == 2 && send->fun == core::Names::eachIt() && send->block->args.size() == 1) {
-        auto &arg = send->args[1];
+        auto &arg = send->args.front();
         auto argString = to_s(ctx, arg);
 
         ConstantMover constantMover;
         auto body = ast::TreeMap::apply(ctx, constantMover, move(send->block->body));
 
         auto blk = ast::MK::Block1(send->block->loc, move(body), move(send->block->args.front()));
-        auto each = ast::MK::Send0Block(send->loc, move(send->args.front()), core::Names::each(), move(blk));
+        auto each =
+            ast::MK::Send0Block(send->loc, move(send->args[1]), ctx.state.enterNameUTF8("each_value"), move(blk));
 
         auto name = ctx.state.enterNameUTF8("<each_it '" + argString + "'>");
         auto method =

--- a/test/testdata/rewriter/minitest.rb
+++ b/test/testdata/rewriter/minitest.rb
@@ -75,6 +75,10 @@ class MyTest
         end
       end
     end
+
+    each_it([1, 2, 3], "handles each_it") do |x|
+      T.reveal_type(x)  # error: Revealed type: `Integer`
+    end
 end
 
 def junk

--- a/test/testdata/rewriter/minitest.rb
+++ b/test/testdata/rewriter/minitest.rb
@@ -76,8 +76,13 @@ class MyTest
       end
     end
 
-    each_it([1, 2, 3], "handles each_it") do |x|
-      T.reveal_type(x)  # error: Revealed type: `Integer`
+    each_it("handles each_it",{
+      "case one" => 2,
+      "case two" => 3,
+    }) do |x|
+      # we want this to be `Integer` but right now it's not because of reasons
+      # related to our inferred types for hashes
+      T.reveal_type(x)  # error: Revealed type: `T.untyped`
     end
 end
 

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -160,6 +160,17 @@ class <emptyTree><<C <root>>> < ()
         end
       end
     end
+
+    begin
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.params({}).void()
+      end
+      def <each_it 'handles each_it'><<C <todo sym>>>(&<blk>)
+        [1, 2, 3].each() do |x|
+          <emptyTree>::<C T>.reveal_type(x)
+        end
+      end
+    end
   end
 
   def junk<<C <todo sym>>>(&<blk>)

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -166,7 +166,7 @@ class <emptyTree><<C <root>>> < ()
         <self>.params({}).void()
       end
       def <each_it 'handles each_it'><<C <todo sym>>>(&<blk>)
-        [1, 2, 3].each() do |x|
+        {"case one" => 2, "case two" => 3}.each_value() do |x|
           <emptyTree>::<C T>.reveal_type(x)
         end
       end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
We've got a lot of people interested in using table-driven tests but our current DSL for minitest doesn't work with those. This is a compromise that allows table-driven versions of `it` tests at least.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
