### PR TITLE
Improve error message for splats in types

### DIFF
--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -835,7 +835,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
             if (recvi->symbol == core::Symbols::Magic() && s->fun == core::Names::callWithSplat()) {
                 // TODO(pay-server) remove this block
                 if (auto e = ctx.state.beginError(recvi->loc, core::errors::Resolver::InvalidTypeDeclarationTyped)) {
-                    e.setHeader("Splats are unsupported by the static checker and banned in typed code");
+                    e.setHeader("Malformed type declaration: splats cannot be used in types");
                 }
                 result.type = core::Types::untypedUntracked();
                 return;

--- a/test/testdata/resolver/sig_bad.rb
+++ b/test/testdata/resolver/sig_bad.rb
@@ -20,7 +20,7 @@ class A
       d: T.enum([]), # error: enum([]) is invalid
       e: T.enum([unsupported]), # error: Unsupported type literal
       f: 0, # error: Unsupported type syntax
-      g: T.any(*[Integer, String]), # error: Splats are unsupported by the static checker
+      g: T.any(*[Integer, String]), # error: splats cannot be used in types
       h: T.junk, # error: Method `junk` does not exist on `T.class_of(T)`
        # ^^^^^^ error: Unsupported method `T.junk`
       i: T.class_of(T1, T2), # error: Too many arguments provided for method `T.class_of`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
The error message for a type like `T.any(*[xs])` used to be

```
Splats are unsupported by the static checker and banned in typed code
```

which 1. doesn't speak to the exact error (that splats can't be used in a type, whereas this seems to talk about splats in general) and 2. is not longer entirely correct (as we have limited support for splats). This makes the error a bit more specific:

```
Malformed type declaration: splats cannot be used in types
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
