### PR TITLE
Use nilable block args when overloading

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -269,7 +269,8 @@ SymbolRef guessOverload(Context ctx, SymbolRef inClass, SymbolRef primary,
             SymbolRef candidate = *it;
             const auto &args = candidate.data(ctx)->arguments();
             ENFORCE(!args.empty(), "Should at least have a block argument.");
-            auto mentionsBlockArg = !args.back().isSyntheticBlockArgument();
+            auto mentionsBlockArg = !args.back().isSyntheticBlockArgument() &&
+                                    !core::Types::isSubType(ctx, args.back().type, core::Types::nilClass());
             if (mentionsBlockArg != hasBlock) {
                 it = leftCandidates.erase(it);
                 continue;

--- a/test/testdata/infer/overloads_test.rb
+++ b/test/testdata/infer/overloads_test.rb
@@ -57,6 +57,13 @@ class HasOverloads
     #                        ^^ error: Bad parameter ordering for `b`, expected `a` instead
     make_untyped
   end
+
+  sig {params(blk: NilClass).returns(Integer)}
+  sig {params(blk: T.proc.void).returns(Symbol)}
+  def maybe_block(&blk)
+    make_untyped
+  end
+
 end
 
 class OverloadAndGenerics
@@ -82,6 +89,8 @@ class Foo
                     # should ask for string
     h.overloaded("1", 2) # error: Expected `Class` but found `String("1")` for argument `_`
   # ^^^^^^^^^^^^^^^^^^^^ error: Expected `String` but found `Integer(2)` for argument `_1`
+    T.assert_type!(h.maybe_block(), Integer)
+    T.assert_type!(h.maybe_block() {}, Symbol)
 
     g = OverloadAndGenerics[Integer].new
     T.assert_type!(g.overloaded("hi"), String)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fixes #2318; we in theory used the presence or absence of block args in finding overloads, but we treated an overload with a `NilClass`-typed block arg as though it "expected" a block arg. This adds logic to disregard overloads that specify the type of a block arg as `NilClass` if the method invocation does include a block arg.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
