### PR TITLE
`Hash#fetch` sig improvements

### DIFF
--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -520,14 +520,14 @@ class Hash < Object
   end
   sig do
    type_parameters(:X).params(
-      arg0: K,
+      arg0: T.nilable(K),
       arg1: T.type_parameter(:X),
     )
     .returns(T.any(V, T.type_parameter(:X)))
   end
   sig do
    type_parameters(:X).params(
-        arg0: K,
+        arg0: T.nilable(K),
         blk: T.proc.params(arg0: K).returns(T.type_parameter(:X)),
     )
     .returns(T.any(V, T.type_parameter(:X)))

--- a/test/testdata/rbi/hash.rb
+++ b/test/testdata/rbi/hash.rb
@@ -20,12 +20,27 @@ T.assert_type!(
 # defaulting to something of different type should be cool
 my_hash = T.let({}, T::Hash[String, String])
 T.assert_type!(
+  my_hash.fetch("exist"), # will raise if doesn't exist, otherwise return a String
+  String
+)
+
+T.assert_type!(
   my_hash.fetch("doesnt_exist", 5),
   T.any(String, Integer)
 )
 T.assert_type!(
+  my_hash.fetch(nil, 1),
+  T.any(String, Integer)
+)
+
+T.assert_type!(
   my_hash.fetch("doesnt_exist", "foo"),
   String
 )
+T.assert_type!(
+  my_hash.fetch(nil, "foo"),
+  String
+)
+
 
 {a: 1}.merge({b: 2}, {c: 3})


### PR DESCRIPTION
`Hash#fetch` should accept a nilable key if a default value is also given, since a common reason to call `fetch` with a default is in case your key isn't found or doesn't exist. There's some examples in this [sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0A%0Amy_hash%20%3D%20T.let(%7B%7D%2C%20T%3A%3AHash%5BString%2C%20String%5D)%0A%0A%23%20in%20real%20code%20this%20might%20be%20something%20like%20a%20nilable%20DB%20column%0Amy_nilable_prop%20%3D%20T.let(nil%2C%20T.nilable(String))%0A%0AT.assert_type!(my_hash.fetch(my_nilable_prop%2C%20%22foo%22)%2C%20String)%0A%23%20sorbet%20suggests%20using%20%60T.must%60%20but%20this%20would%20fail%0A%23%20if%20the%20prop%20is%20actually%20nil.%20instead%2C%20%60Hash%23fetch%60%20should%20allow%0A%23%20this%20because%20there%20is%20a%20fallback.%0A).
