### PR TITLE
Fix RubyGems publish failures

### DIFF
--- a/.buildkite/publish-ruby-gems.sh
+++ b/.buildkite/publish-ruby-gems.sh
@@ -51,29 +51,15 @@ with_backoff() {
 # sorbet-static, but the sorbet-static gem push failed.
 #
 # (By failure here, we mean that RubyGems.org 502'd for some reason.)
-# Push the linux gem
-if ! gem fetch sorbet-static --platform x86_64-linux --version "$release_version" | grep -q "ERROR"; then
-  with_backoff gem push --verbose "_out_/gems/sorbet-static-$release_version-x86_64-linux.gem"
-fi
-
-# Push the mac gem
-# we push 14..19 which is defined in build-static-release.sh
-for i in {14..19}; do
-  if ! gem fetch sorbet-static --platform "universal-darwin-$i" --version "$release_version" | grep -q "ERROR"; then
-    with_backoff gem push --verbose "_out_/gems/sorbet-static-$release_version-universal-darwin-$i.gem"
+for gem_archive in "_out_/gems/sorbet-static-$release_version"-*.gem; do
+  if ! gem list --remote rubygems.org --exact 'sorbet-static' | grep -q "$release_version"; then
+    with_backoff gem push --verbose "$gem_archive"
   fi
 done
-
-
-# Push the java gem
-if ! gem fetch sorbet-static --platform java --version "$release_version" | grep -q "ERROR"; then
-  with_backoff gem push --verbose "_out_/gems/sorbet-static-$release_version-java.gem"
-fi
 
 if ! gem list --remote rubygems.org --exact 'sorbet-runtime' | grep -q "$release_version"; then
   with_backoff gem push --verbose "_out_/gems/sorbet-runtime-$release_version.gem"
 fi
-
 if ! gem list --remote rubygems.org --exact 'sorbet' | grep -q "$release_version"; then
   with_backoff gem push --verbose "_out_/gems/sorbet-$release_version.gem"
 fi

--- a/.buildkite/publish-ruby-gems.sh
+++ b/.buildkite/publish-ruby-gems.sh
@@ -46,20 +46,27 @@ with_backoff() {
   done
 }
 
-# push the sorbet-static gems first, in case they fail. We don't want to end
+# Push the sorbet-static gems first, in case they fail. We don't want to end
 # up in a weird state where 'sorbet' requires a pinned version of
 # sorbet-static, but the sorbet-static gem push failed.
 #
 # (By failure here, we mean that RubyGems.org 502'd for some reason.)
 for gem_archive in "_out_/gems/sorbet-static-$release_version"-*.gem; do
-  if ! gem list --remote rubygems.org --exact 'sorbet-static' | grep -q "$release_version"; then
-    with_backoff gem push --verbose "$gem_archive"
+  if [[ "$gem_archive" =~ _out_/gems/sorbet-static-([^-]*)-([^.]*).gem ]]; then
+    platform="${BASH_REMATCH[2]}"
+    if ! gem list --remote rubygems.org --exact 'sorbet-static' | grep "$release_version" | grep -q "$platform"; then
+      with_backoff gem push --verbose "$gem_archive"
+    fi
+  else
+    echo "Regex match failed. This should never happen."
+    exit 1
   fi
 done
 
 if ! gem list --remote rubygems.org --exact 'sorbet-runtime' | grep -q "$release_version"; then
   with_backoff gem push --verbose "_out_/gems/sorbet-runtime-$release_version.gem"
 fi
+
 if ! gem list --remote rubygems.org --exact 'sorbet' | grep -q "$release_version"; then
   with_backoff gem push --verbose "_out_/gems/sorbet-$release_version.gem"
 fi


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This fixes a number of issues:

- We should never have had to hard code which platforms `sorbet-static` has been compiled for. That should always have been inferred from the build assets.
- More than that, we should never have had to hard code which platforms we build for darwin.
- This is how we should have fixed the problem when we saw that linux publishing was broken (#2250).
- This fixes the problem from that incorrect fix that the scheduled nightly RubyGems publish fails whenever it's run on two consecutive nights with no new changes.





### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I plan to kick of a build manually with the right environment variables as soon as this lands in master, and then another one for the same SHA, both of which should pass.