### PR TITLE
Add LSP epochs to core::File (currently unused).

### DIFF
--- a/core/Files.cc
+++ b/core/Files.cc
@@ -97,14 +97,14 @@ StrictLevel File::fileSigil(string_view source) {
     }
 }
 
-File::File(string &&path_, string &&source_, Type sourceType)
-    : sourceType(sourceType), path_(path_), source_(source_), originalSigil(fileSigil(this->source_)),
+File::File(string &&path_, string &&source_, Type sourceType, u4 epoch)
+    : epoch(epoch), sourceType(sourceType), path_(path_), source_(source_), originalSigil(fileSigil(this->source_)),
       strictLevel(originalSigil) {}
 
 unique_ptr<File> File::deepCopy(GlobalState &gs) const {
     string sourceCopy = source_;
     string pathCopy = path_;
-    auto ret = make_unique<File>(move(pathCopy), move(sourceCopy), sourceType);
+    auto ret = make_unique<File>(move(pathCopy), move(sourceCopy), sourceType, epoch);
     ret->lineBreaks_ = lineBreaks_;
     ret->minErrorLevel_ = minErrorLevel_;
     ret->strictLevel = strictLevel;

--- a/core/Files.h
+++ b/core/Files.h
@@ -70,6 +70,9 @@ public:
     bool cachedParseTree = false;
     bool hasParseErrors = false; // some reasonable invariants don't hold for invalid files
     bool pluginGenerated = false;
+    // Epoch is _only_ used in LSP mode. Do not depend on it elsewhere.
+    // TODO(jvilk): Delurk epoch usage and use something like pointer equality to check if a file has changed.
+    const u4 epoch;
 
     friend class GlobalState;
     friend class ::sorbet::core::serialize::SerializerImpl;
@@ -84,7 +87,7 @@ public:
     bool isRBI() const;
     bool isStdlib() const;
 
-    File(std::string &&path_, std::string &&source_, Type sourceType);
+    File(std::string &&path_, std::string &&source_, Type sourceType, u4 epoch = 0);
     File(File &&other) = delete;
     File(const File &other) = delete;
     File() = delete;

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -385,7 +385,7 @@ void LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<DidChangeTextDocumentPa
             }
         }
         updates.updatedFiles.push_back(
-            make_shared<core::File>(move(localPath), move(fileContents), core::File::Type::Normal));
+            make_shared<core::File>(move(localPath), move(fileContents), core::File::Type::Normal, v));
     }
 }
 
@@ -398,7 +398,7 @@ void LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<DidOpenTextDocumentPara
         string localPath = config->remoteName2Local(uri);
         if (!config->isFileIgnored(localPath)) {
             updates.updatedFiles.push_back(make_shared<core::File>(
-                move(localPath), move(openParams->textDocument->text), core::File::Type::Normal));
+                move(localPath), move(openParams->textDocument->text), core::File::Type::Normal, v));
         }
     }
 }
@@ -413,7 +413,7 @@ void LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<DidCloseTextDocumentPar
         if (!config->isFileIgnored(localPath)) {
             // Use contents of file on disk.
             updates.updatedFiles.push_back(make_shared<core::File>(
-                move(localPath), readFile(localPath, *config->opts.fs), core::File::Type::Normal));
+                move(localPath), readFile(localPath, *config->opts.fs), core::File::Type::Normal, v));
         }
     }
 }
@@ -428,7 +428,7 @@ void LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<WatchmanQueryResponse> 
         // Editor contents supercede file system updates.
         if (!config->isFileIgnored(localPath) && !openFiles.contains(localPath)) {
             updates.updatedFiles.push_back(make_shared<core::File>(
-                move(localPath), readFile(localPath, *config->opts.fs), core::File::Type::Normal));
+                move(localPath), readFile(localPath, *config->opts.fs), core::File::Type::Normal, v));
         }
     }
 }

--- a/main/lsp/TimeTravelingGlobalState.cc
+++ b/main/lsp/TimeTravelingGlobalState.cc
@@ -208,7 +208,8 @@ void TimeTravelingGlobalState::commitEdits(LSPFileUpdates &update) {
         } else {
             update.hasNewFiles = true;
             // Reversal of a new file is... an empty file...
-            auto emptyFile = make_shared<core::File>(string(file->path()), "", core::File::Type::Normal);
+            auto emptyFile =
+                make_shared<core::File>(string(file->path()), "", core::File::Type::Normal, update.versionStart - 1);
             newUpdate.undoUpdate.hashUpdates.push_back(pipeline::computeFileHash(emptyFile, *config->logger));
             newUpdate.undoUpdate.fileUpdates.push_back(move(emptyFile));
         }

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -101,7 +101,8 @@ LSPFileUpdates makeUpdates(u4 &version, vector<pair<string, string>> files) {
     updates.versionStart = version++;
     updates.versionEnd = updates.versionStart;
     for (auto &[path, contents] : files) {
-        updates.updatedFiles.push_back(make_shared<core::File>(move(path), move(contents), core::File::Type::Normal));
+        updates.updatedFiles.push_back(
+            make_shared<core::File>(move(path), move(contents), core::File::Type::Normal, version));
     }
     return updates;
 }


### PR DESCRIPTION
Add LSP epochs to core::File (currently unused). The "epoch" is an unsigned integer that increases with every edit sent to LSP.

Will be used in preemptive slow path to determine if a file has changed during a slow path. 

For example, let's say a slow path was triggered by edit with epoch 10. At the start of the slow path, all files have an epoch <= 10. Mid-way through the slow path, it is preempted by a fast path edit with epoch 11 that edits `foo.rb`. When the slow path resumes, if it tries to typecheck `foo.rb`, it'll see that it has epoch `11` which is greater than `10`. It then knows that it must have changed mid-typecheck, and so it can _ignore_ `foo.rb` and proceed to typecheck the next file.

The epoch is only relevant in LSP mode, so it would be ideal to refactor this in the future to avoid leaking IDE-specific details into core Sorbet abstractions. One idea is to use the pointer to the file as the file's version; if it changes, then the file must have changed during typechecking. I might make this change after shipping preemption, so I put a TODO into the change.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm breaking off smaller changes from my preemptive slow path branch that are easier to review.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

N/A; field is currently unused.
