### PR TITLE
Fix builder order in sig suggestion (put override first)

### DIFF
--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -368,6 +368,15 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
     bool onlyArgumentIsBlkArg = methodSymbol.data(ctx)->arguments().size() == 1 &&
                                 methodSymbol.data(ctx)->arguments()[0].isSyntheticBlockArgument();
 
+    if (methodSymbol.data(ctx)->name != core::Names::initialize()) {
+        // Only need override / implementation if the parent has a sig
+        if (closestMethod.exists() && closestMethod.data(ctx)->resultType != nullptr) {
+            if (closestMethod.data(ctx)->isAbstract() || childNeedsOverride(ctx, methodSymbol, closestMethod)) {
+                fmt::format_to(ss, "override.");
+            }
+        }
+    }
+
     if (!onlyArgumentIsBlkArg) {
         fmt::format_to(ss, "params(");
 
@@ -411,15 +420,6 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
     }
     if (!guessedSomethingUseful) {
         return nullopt;
-    }
-
-    if (methodSymbol.data(ctx)->name != core::Names::initialize()) {
-        // Only need override / implementation if the parent has a sig
-        if (closestMethod.exists() && closestMethod.data(ctx)->resultType != nullptr) {
-            if (closestMethod.data(ctx)->isAbstract() || childNeedsOverride(ctx, methodSymbol, closestMethod)) {
-                fmt::format_to(ss, "override.");
-            }
-        }
     }
 
     bool suggestsVoid = methodSymbol.data(ctx)->name == core::Names::initialize() ||

--- a/test/cli/suggest-sig-override-edge/suggest-sig-override-edge.out
+++ b/test/cli/suggest-sig-override-edge/suggest-sig-override-edge.out
@@ -12,53 +12,56 @@ class ChildInitialize < ParentInitialize
 end
 
 # Weird edge cases in string parsing for adding 'overridable.'
-class ParentNeedsOverridable
+class ParentIsAbstract
   # Every sig here should have `generated.overridable.` added to it.
   extend T::Sig
+  extend T::Helpers
 
-  sig {override.void}
+  abstract!
+
+  sig {abstract.void}
   def just_void; end
 
-  sig {override.returns(NilClass)}
+  sig {abstract.returns(NilClass)}
   def just_returns; end
 
-  sig {override.params(x: Integer).void}
+  sig {abstract.params(x: Integer).void}
   def x_to_void(x); end
 
-  sig {override.params(x: Integer).returns(NilClass)}
+  sig {abstract.params(x: Integer).returns(NilClass)}
   def x_to_returns(x); end
 
   sig do
-    override
+    abstract
     .params(x: Integer)
     .void
   end
   def multiline_x_to_void(x); end
 
   sig do
-    override
+    abstract
     .params(x: Integer)
     .returns(NilClass)
   end
   def multiline_x_to_returns(x); end
 end
-class ChildForcesOverridable < ParentNeedsOverridable
-  sig {void}
+class ChildNeedsOverride < ParentIsAbstract
+  sig {override.void}
   def just_void; end
 
-  sig {returns(NilClass)}
+  sig {override.returns(NilClass)}
   def just_returns; end
 
-  sig {params(x: Integer).void}
+  sig {params(x: Integer).override.void}
   def x_to_void(x); end
 
-  sig {params(x: Integer).returns(NilClass)}
+  sig {params(x: Integer).override.returns(NilClass)}
   def x_to_returns(x); end
 
-  sig {params(x: Integer).void}
+  sig {params(x: Integer).override.void}
   def multiline_x_to_void(x); end
 
-  sig {params(x: Integer).returns(NilClass)}
+  sig {params(x: Integer).override.returns(NilClass)}
   def multiline_x_to_returns(x); end
 end
 

--- a/test/cli/suggest-sig-override-edge/suggest-sig-override-edge.out
+++ b/test/cli/suggest-sig-override-edge/suggest-sig-override-edge.out
@@ -52,16 +52,16 @@ class ChildNeedsOverride < ParentIsAbstract
   sig {override.returns(NilClass)}
   def just_returns; end
 
-  sig {params(x: Integer).override.void}
+  sig {override.params(x: Integer).void}
   def x_to_void(x); end
 
-  sig {params(x: Integer).override.returns(NilClass)}
+  sig {override.params(x: Integer).returns(NilClass)}
   def x_to_returns(x); end
 
-  sig {params(x: Integer).override.void}
+  sig {override.params(x: Integer).void}
   def multiline_x_to_void(x); end
 
-  sig {params(x: Integer).override.returns(NilClass)}
+  sig {override.params(x: Integer).returns(NilClass)}
   def multiline_x_to_returns(x); end
 end
 

--- a/test/cli/suggest-sig-override-edge/suggest-sig-override-edge.rb
+++ b/test/cli/suggest-sig-override-edge/suggest-sig-override-edge.rb
@@ -11,37 +11,40 @@ class ChildInitialize < ParentInitialize
 end
 
 # Weird edge cases in string parsing for adding 'overridable.'
-class ParentNeedsOverridable
+class ParentIsAbstract
   # Every sig here should have `generated.overridable.` added to it.
   extend T::Sig
+  extend T::Helpers
 
-  sig {implementation.void}
+  abstract!
+
+  sig {abstract.void}
   def just_void; end
 
-  sig {implementation.returns(NilClass)}
+  sig {abstract.returns(NilClass)}
   def just_returns; end
 
-  sig {implementation.params(x: Integer).void}
+  sig {abstract.params(x: Integer).void}
   def x_to_void(x); end
 
-  sig {implementation.params(x: Integer).returns(NilClass)}
+  sig {abstract.params(x: Integer).returns(NilClass)}
   def x_to_returns(x); end
 
   sig do
-    implementation
+    abstract
     .params(x: Integer)
     .void
   end
   def multiline_x_to_void(x); end
 
   sig do
-    implementation
+    abstract
     .params(x: Integer)
     .returns(NilClass)
   end
   def multiline_x_to_returns(x); end
 end
-class ChildForcesOverridable < ParentNeedsOverridable
+class ChildNeedsOverride < ParentIsAbstract
   def just_void; end
 
   def just_returns; end
@@ -69,7 +72,7 @@ end
 
 # Doesn't need generated because parent already has overridable
 class DoesntNeedGenerated
-  sig {implementation.overridable.void}
+  sig {override.overridable.void}
   def already_overridable; end
 end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Feedback from Slack that we were sorting things wrong.

### Commit summary

Review by commit.

At some point, we changed this file to stop testing anything useful.
(My guess is around the time that we removed `implementation` we edited
this test incorrectly.)

The original point of this test was that we needed some way to insert
`generated` up into the parent's sig when suggesting a sig on a child.

We never need to do that anymore because of the changes to `override`
let us simplify some of that logic (so that as long as the parent method
exists at all, it's ok to put `override` on the child).

But as a side effect, it meant that we stopped testing the ordering of
the builders. So this test now tests the order of the builders (which is
wrong; fixed in the next commit).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.