### PR TITLE
Use tasks in LSPTypecheckerCoordinator.

### DIFF
--- a/core/lsp/Task.h
+++ b/core/lsp/Task.h
@@ -1,0 +1,17 @@
+#ifndef SORBET_LSP_TASK_H
+#define SORBET_LSP_TASK_H
+
+namespace sorbet::core::lsp {
+// Generic, multi-use task interface.
+// TODO(jvilk): Will use for tasks that preempt IDE slow path typechecking. It's in core because GlobalState will
+// reference it.
+class Task {
+public:
+    Task() = default;
+    virtual ~Task() = default;
+
+    virtual void run() = 0;
+};
+} // namespace sorbet::core::lsp
+
+#endif

--- a/core/lsp/Task.h
+++ b/core/lsp/Task.h
@@ -11,6 +11,12 @@ public:
     virtual ~Task() = default;
 
     virtual void run() = 0;
+
+    // Delete copy constructor / assignment.
+    Task(Task &) = delete;
+    Task(const Task &) = delete;
+    Task &operator=(Task &&) = delete;
+    Task &operator=(const Task &) = delete;
 };
 } // namespace sorbet::core::lsp
 

--- a/main/lsp/LSPTypecheckerCoordinator.h
+++ b/main/lsp/LSPTypecheckerCoordinator.h
@@ -1,6 +1,7 @@
 #ifndef RUBY_TYPER_LSP_LSPTYPECHECKERCOORDINATOR_H
 #define RUBY_TYPER_LSP_LSPTYPECHECKERCOORDINATOR_H
 
+#include "core/lsp/Task.h"
 #include "main/lsp/LSPTypechecker.h"
 
 namespace sorbet::realmain::lsp {
@@ -10,8 +11,8 @@ namespace sorbet::realmain::lsp {
  * thread).
  */
 class LSPTypecheckerCoordinator final {
-    /** Contains a queue of functions to run on the typechecking thread. */
-    BlockingUnBoundedQueue<std::function<void()>> lambdas;
+    /** Contains a queue of tasks to run on the typechecking thread. */
+    BlockingUnBoundedQueue<std::shared_ptr<core::lsp::Task>> tasks;
     /** If 'true', the coordinator should terminate immediately. */
     bool shouldTerminate;
     /** LSPTypecheckerCoordinator delegates typechecking operations to LSPTypechecker. */
@@ -21,9 +22,9 @@ class LSPTypecheckerCoordinator final {
     bool hasDedicatedThread;
 
     /**
-     * Runs the provided function on the typechecker thread.
+     * Runs the provided task on the typechecker thread.
      */
-    void asyncRunInternal(std::function<void()> &&lambda);
+    void asyncRunInternal(std::shared_ptr<core::lsp::Task> task);
 
 public:
     LSPTypecheckerCoordinator(const std::shared_ptr<const LSPConfiguration> &config);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Use tasks in LSPTypecheckerCoordinator.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Lambdas are annoying and messy to deal with. They can be easily implicitly copied, so if they capture a `unique_ptr` (which cannot be copied) you get messy error messages. Also, they aren't easy to atomically update.

This PR contains a simple `Task` interface, along with an implementation that wraps lambdas. I modified `LSPTypecheckerCoordinator` to pass around `Task` objects internally. In a future PR, I will use the same `Task` interface to schedule work that should preempt slow path typechecking.

After shipping the preemptible slow path, I plan to re-implement most features of LSP as tasks, as they already do not depend on any state within `LSPLoop` (except for `config`, which we can make available to tasks).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
