### PR TITLE
LSP: Move text preprocessing functionality into helper functions.

### DIFF
--- a/main/lsp/json_types.cc
+++ b/main/lsp/json_types.cc
@@ -175,7 +175,7 @@ unique_ptr<Diagnostic> Diagnostic::copy() const {
     return d;
 }
 
-string TextDocumentContentChangeEvent::apply(string oldSource) const {
+string TextDocumentContentChangeEvent::apply(string_view oldSource) const {
     if (range) {
         auto &r = *range;
         // incremental update
@@ -188,7 +188,7 @@ string TextDocumentContentChangeEvent::apply(string oldSource) const {
         // These offsets are non-nullopt assuming the input range is a valid range.
         auto startOffset = core::Loc::pos2Offset(old, start).value();
         auto endOffset = core::Loc::pos2Offset(old, end).value();
-        return oldSource.replace(startOffset, endOffset - startOffset, text);
+        return string(oldSource).replace(startOffset, endOffset - startOffset, text);
     } else {
         return text;
     }
@@ -197,7 +197,7 @@ string TextDocumentContentChangeEvent::apply(string oldSource) const {
 string DidChangeTextDocumentParams::getSource(string_view oldFileContents) const {
     string rv = string(oldFileContents);
     for (auto &change : contentChanges) {
-        rv = change->apply(move(rv));
+        rv = change->apply(rv);
     }
     return rv;
 }

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -811,7 +811,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                                          makeField("rangeLength", makeOptional(JSONInt)),
                                                          makeField("text", JSONString),
                                                      },
-                                                     classTypes);
+                                                     classTypes, {"std::string apply(std::string oldContents) const;"});
 
     auto DidChangeTextDocumentParams =
         makeObject("DidChangeTextDocumentParams",
@@ -821,7 +821,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                        // Used in tests only.
                        makeField("sorbetCancellationExpected", makeOptional(JSONBool)),
                    },
-                   classTypes);
+                   classTypes, {"std::string getSource(std::string_view oldFileContents) const;"});
 
     auto TextDocumentChangeRegistrationOptions =
         makeObject("TextDocumentChangeRegistrationOptions",

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -805,13 +805,14 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                                 },
                                                 classTypes);
 
-    auto TextDocumentContentChangeEvent = makeObject("TextDocumentContentChangeEvent",
-                                                     {
-                                                         makeField("range", makeOptional(Range)),
-                                                         makeField("rangeLength", makeOptional(JSONInt)),
-                                                         makeField("text", JSONString),
-                                                     },
-                                                     classTypes, {"std::string apply(std::string oldContents) const;"});
+    auto TextDocumentContentChangeEvent =
+        makeObject("TextDocumentContentChangeEvent",
+                   {
+                       makeField("range", makeOptional(Range)),
+                       makeField("rangeLength", makeOptional(JSONInt)),
+                       makeField("text", JSONString),
+                   },
+                   classTypes, {"std::string apply(std::string_view oldContents) const;"});
 
     auto DidChangeTextDocumentParams =
         makeObject("DidChangeTextDocumentParams",


### PR DESCRIPTION
LSP: Move text preprocessing functionality into helper functions.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Cleans up preprocessor code.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
