### PR TITLE
Clarify that `T.reveal_type` outputs information during a static type check, not at runtime.

### DIFF
--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -731,8 +731,9 @@ with `T.unsafe(...)`. T.unsafe is one of a handful of
 ## 7014
 
 Sorbet has a special method called `T.reveal_type` which can be useful for
-debugging. `T.reveal_type(expr)` will report an error that shows what the static
-component of Sorbet thinks the result type of `expr` is.
+debugging. `T.reveal_type(expr)` will report an error in the output of `srb tc`
+that shows what the static component of Sorbet thinks the result type of `expr`
+is.
 
 Making this an error is nice for two reasons:
 

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -26,9 +26,9 @@ There are also some tools for helping debug type-related errors:
 ### `T.reveal_type`
 
 If we wrap a variable or method call in `T.reveal_type`, Sorbet will show us
-what type it thinks that variable has. This is a super powerful debugging
-technique! `T.reveal_type` should be **one of the first tools** to reach for
-when debugging a confusing error.
+what type it thinks that variable has in the output of `srb tc`. This is a super
+powerful debugging technique! `T.reveal_type` should be **one of the first
+tools** to reach for when debugging a confusing error.
 
 Try making a hypothesis of what the problem is ("I think the problem is...") and
 then create small examples in <https://sorbet.run> to test the hypothesis with


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR clarifies in two of the places that `T.reveal_type` is documented that its output appears during static type checks rather than at runtime.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When I was first trying `T.reveal_type` for debugging, it wasn't obvious to me from the docs that the output was from `srb tc`. I kept running the program expecting runtime output.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This is just a documentation change and doesn't require testing.
