### PR TITLE
Fix initialize type for Hash.new

### DIFF
--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -574,7 +574,7 @@ class Hash < Object
   sig {params(default: V).void}
   sig do
     params(
-        blk: T.proc.params(hash: T::Hash[K, V], key: K).returns(V)
+        blk: T.proc.params(hash: T::Hash[K, V], key: K).void
     )
     .void
   end

--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -570,16 +570,11 @@ class Hash < Object
   end
   def has_value?(arg0); end
 
-  sig {returns(T::Hash[T.untyped, T.untyped])}
+  sig {void}
+  sig {params(default: V).void}
   sig do
     params(
-        default: BasicObject,
-    )
-    .returns(T::Hash[T.untyped, T.untyped])
-  end
-  sig do
-    params(
-        blk: T.proc.params(hash: T::Hash[T.untyped, T.untyped], key: BasicObject).returns(BasicObject)
+        blk: T.proc.params(hash: T::Hash[K, V], key: K).returns(V)
     )
     .void
   end

--- a/test/testdata/rbi/hash.rb
+++ b/test/testdata/rbi/hash.rb
@@ -29,3 +29,25 @@ T.assert_type!(
 )
 
 {a: 1}.merge({b: 2}, {c: 3})
+
+
+h1 = T::Hash[Integer, String].new
+h1[2] = "foo"
+h1[nil] = "foo" # error: Expected `Integer` but found `NilClass` for argument `arg0`
+h1[3] = nil # error: Expected `String` but found `NilClass` for argument `arg1`
+
+h2 = T::Hash[Integer, String].new("yo")
+h2[2] = "foo"
+h2[nil] = "foo" # error: Expected `Integer` but found `NilClass` for argument `arg0`
+h2[3] = nil # error: Expected `String` but found `NilClass` for argument `arg1`
+
+h3 = T::Hash[Integer, String].new do |h, k|
+  T.assert_type!(h, T::Hash[Integer, String])
+  T.assert_type!(k, Integer)
+  h[k] = "foo"
+  h[nil] = "foo" # error: Expected `Integer` but found `NilClass` for argument `arg0`
+  h[k] = nil # error: Expected `String` but found `NilClass` for argument `arg1`
+end
+h3[2] = "foo"
+h3[nil] = "foo" # error: Expected `Integer` but found `NilClass` for argument `arg0`
+h3[3] = nil # error: Expected `String` but found `NilClass` for argument `arg1`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
The types for `Hash#initialize` in our RBI were looser than they needed to be and also just wrong (as `initialize` shouldn't need a return type); this fixes them and makes them more useful in general.

```ruby
h = T::Hash[Integer, String].new do |h, k|
  T.reveal_type(h)  # T::Hash[Integer, String]
  T.reveal_type(k)  # Integer
  h[k] = k == 0 # error: expected String, found T::Boolean
end
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
