### PR TITLE
Stop using entire asgn tree's loc for Struct args

### DIFF
--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -1,4 +1,5 @@
 #include "rewriter/Struct.h"
+#include "absl/strings/match.h"
 #include "ast/Helpers.h"
 #include "ast/ast.h"
 #include "core/Context.h"
@@ -102,19 +103,23 @@ vector<unique_ptr<ast::Expression>> Struct::run(core::MutableContext ctx, ast::A
             return empty;
         }
         core::NameRef name = sym->asSymbol(ctx);
-
-        sigKeys.emplace_back(ast::MK::Symbol(loc, name));
-        sigValues.emplace_back(ast::MK::Constant(loc, core::Symbols::BasicObject()));
-        auto argName = ast::MK::Local(loc, name);
-        if (keywordInit) {
-            argName = ast::MK::KeywordArg(loc, move(argName));
+        auto symLoc = sym->loc;
+        if (symLoc.exists() && absl::StartsWith(symLoc.source(ctx), ":")) {
+            symLoc = core::Loc{symLoc.file(), symLoc.beginPos() + 1, symLoc.endPos()};
         }
-        newArgs.emplace_back(ast::MK::OptionalArg(loc, move(argName), ast::MK::Nil(loc)));
 
-        body.emplace_back(ast::MK::Method0(loc, loc, name, ast::MK::EmptyTree(), ast::MethodDef::RewriterSynthesized));
-        body.emplace_back(ast::MK::Method1(loc, loc, name.addEq(ctx), ast::MK::Local(loc, core::Names::arg0()),
-                                           ast::MK::Local(loc, core::Names::arg0()),
-                                           ast::MethodDef::RewriterSynthesized));
+        sigKeys.emplace_back(ast::MK::Symbol(symLoc, name));
+        sigValues.emplace_back(ast::MK::Constant(symLoc, core::Symbols::BasicObject()));
+        auto argName = ast::MK::Local(symLoc, name);
+        if (keywordInit) {
+            argName = ast::MK::KeywordArg(symLoc, move(argName));
+        }
+        newArgs.emplace_back(ast::MK::OptionalArg(symLoc, move(argName), ast::MK::Nil(symLoc)));
+
+        body.emplace_back(
+            ast::MK::Method0(symLoc, symLoc, name, ast::MK::EmptyTree(), ast::MethodDef::RewriterSynthesized));
+        body.emplace_back(ast::MK::Method1(symLoc, symLoc, name.addEq(ctx), ast::MK::Local(symLoc, name),
+                                           ast::MK::Local(symLoc, name), ast::MethodDef::RewriterSynthesized));
     }
 
     // Elem = type_member(fixed: T.untyped)

--- a/test/cli/suggest-sig-garbage/suggest-sig-garbage.out
+++ b/test/cli/suggest-sig-garbage/suggest-sig-garbage.out
@@ -271,19 +271,19 @@ suggest-sig-garbage.rb:43: This function does not have a `sig` https://srb.help/
 
 suggest-sig-garbage.rb:102: This function does not have a `sig` https://srb.help/7017
      102 |Foo = Struct.new(:a, :b)
-          ^^^^^^^^^^^^^^^^^^^^^^^^
+                            ^
 
 suggest-sig-garbage.rb:102: This function does not have a `sig` https://srb.help/7017
      102 |Foo = Struct.new(:a, :b)
-          ^^^^^^^^^^^^^^^^^^^^^^^^
+                            ^
 
 suggest-sig-garbage.rb:102: This function does not have a `sig` https://srb.help/7017
      102 |Foo = Struct.new(:a, :b)
-          ^^^^^^^^^^^^^^^^^^^^^^^^
+                                ^
 
 suggest-sig-garbage.rb:102: This function does not have a `sig` https://srb.help/7017
      102 |Foo = Struct.new(:a, :b)
-          ^^^^^^^^^^^^^^^^^^^^^^^^
+                                ^
 
 suggest-sig-garbage.rb:112: This function does not have a `sig` https://srb.help/7017
      112 |  def self.load_account_business_profile(merchant)

--- a/test/cli/suggest-sig/suggest-sig.out
+++ b/test/cli/suggest-sig/suggest-sig.out
@@ -250,19 +250,19 @@ suggest-sig.rb:43: This function does not have a `sig` https://srb.help/7017
 
 suggest-sig.rb:102: This function does not have a `sig` https://srb.help/7017
      102 |Foo = Struct.new(:a, :b)
-          ^^^^^^^^^^^^^^^^^^^^^^^^
+                            ^
 
 suggest-sig.rb:102: This function does not have a `sig` https://srb.help/7017
      102 |Foo = Struct.new(:a, :b)
-          ^^^^^^^^^^^^^^^^^^^^^^^^
+                            ^
 
 suggest-sig.rb:102: This function does not have a `sig` https://srb.help/7017
      102 |Foo = Struct.new(:a, :b)
-          ^^^^^^^^^^^^^^^^^^^^^^^^
+                                ^
 
 suggest-sig.rb:102: This function does not have a `sig` https://srb.help/7017
      102 |Foo = Struct.new(:a, :b)
-          ^^^^^^^^^^^^^^^^^^^^^^^^
+                                ^
 
 suggest-sig.rb:112: This function does not have a `sig` https://srb.help/7017
      112 |  def self.load_account_business_profile(merchant)

--- a/test/testdata/rewriter/struct.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/struct.rb.rewrite-tree.exp
@@ -17,16 +17,16 @@ class <emptyTree><<C <root>>> < ()
         <emptyTree>
       end
 
-      def foo=<<C <todo sym>>>(arg0, &<blk>)
-        arg0
+      def foo=<<C <todo sym>>>(foo, &<blk>)
+        foo
       end
 
       def bar<<C <todo sym>>>(&<blk>)
         <emptyTree>
       end
 
-      def bar=<<C <todo sym>>>(arg0, &<blk>)
-        arg0
+      def bar=<<C <todo sym>>>(bar, &<blk>)
+        bar
       end
 
       <emptyTree>::<C Elem> = <self>.type_member({:"fixed" => ::T.untyped()})
@@ -45,16 +45,16 @@ class <emptyTree><<C <root>>> < ()
         <emptyTree>
       end
 
-      def foo=<<C <todo sym>>>(arg0, &<blk>)
-        arg0
+      def foo=<<C <todo sym>>>(foo, &<blk>)
+        foo
       end
 
       def bar<<C <todo sym>>>(&<blk>)
         <emptyTree>
       end
 
-      def bar=<<C <todo sym>>>(arg0, &<blk>)
-        arg0
+      def bar=<<C <todo sym>>>(bar, &<blk>)
+        bar
       end
 
       <emptyTree>::<C Elem> = <self>.type_member({:"fixed" => ::T.untyped()})
@@ -121,8 +121,8 @@ class <emptyTree><<C <root>>> < ()
         <emptyTree>
       end
 
-      def foo=<<C <todo sym>>>(arg0, &<blk>)
-        arg0
+      def foo=<<C <todo sym>>>(foo, &<blk>)
+        foo
       end
 
       <emptyTree>::<C Elem> = <self>.type_member({:"fixed" => ::T.untyped()})
@@ -141,8 +141,8 @@ class <emptyTree><<C <root>>> < ()
         <emptyTree>
       end
 
-      def foo=<<C <todo sym>>>(arg0, &<blk>)
-        arg0
+      def foo=<<C <todo sym>>>(foo, &<blk>)
+        foo
       end
 
       <emptyTree>::<C Elem> = <self>.type_member({:"fixed" => ::T.untyped()})
@@ -165,16 +165,16 @@ class <emptyTree><<C <root>>> < ()
         <emptyTree>
       end
 
-      def foo=<<C <todo sym>>>(arg0, &<blk>)
-        arg0
+      def foo=<<C <todo sym>>>(foo, &<blk>)
+        foo
       end
 
       def bar<<C <todo sym>>>(&<blk>)
         <emptyTree>
       end
 
-      def bar=<<C <todo sym>>>(arg0, &<blk>)
-        arg0
+      def bar=<<C <todo sym>>>(bar, &<blk>)
+        bar
       end
 
       <emptyTree>::<C Elem> = <self>.type_member({:"fixed" => ::T.untyped()})
@@ -201,8 +201,8 @@ class <emptyTree><<C <root>>> < ()
         <emptyTree>
       end
 
-      def x=<<C <todo sym>>>(arg0, &<blk>)
-        arg0
+      def x=<<C <todo sym>>>(x, &<blk>)
+        x
       end
 
       <emptyTree>::<C Elem> = <self>.type_member({:"fixed" => ::T.untyped()})
@@ -227,8 +227,8 @@ class <emptyTree><<C <root>>> < ()
         <emptyTree>
       end
 
-      def x=<<C <todo sym>>>(arg0, &<blk>)
-        arg0
+      def x=<<C <todo sym>>>(x, &<blk>)
+        x
       end
 
       <emptyTree>::<C Elem> = <self>.type_member({:"fixed" => ::T.untyped()})

--- a/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
@@ -1,0 +1,247 @@
+class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=https://github.com/sorbet/sorbet/tree/master/bazel-out/host/genfiles/rbi/procs.rbi start=1:1 end=252:4}, Loc {file=test/testdata/rewriter/struct.rb start=2:1 end=101:19})
+  class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=2:1 end=101:19}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <C <U AccidentallyStruct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=37:1 end=37:25}
+    class <C <U AccidentallyStruct>><C <U A>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
+      type-member(=) <C <U AccidentallyStruct>><C <U A>><C <U Elem>> -> LambdaParam(<C <U AccidentallyStruct>><C <U A>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
+      method <C <U AccidentallyStruct>><C <U A>><U bar> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U AccidentallyStruct>><C <U A>><U bar=> (A = Struct.new(:foo, :bar), <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
+        argument A = Struct.new(:foo, :bar)<> @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U AccidentallyStruct>><C <U A>><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U AccidentallyStruct>><C <U A>><U foo=> (A = Struct.new(:foo, :bar), <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
+        argument A = Struct.new(:foo, :bar)<> @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U AccidentallyStruct>><C <U A>><U initialize> (A = Struct.new(:foo, :bar), A = Struct.new(:foo, :bar), <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
+        argument A = Struct.new(:foo, :bar)<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
+        argument A = Struct.new(:foo, :bar)<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+    class <C <U AccidentallyStruct>><S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:6}
+      type-member(+) <C <U AccidentallyStruct>><S <C <U A>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U AccidentallyStruct>><S <C <U A>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U AccidentallyStruct>><C <U A>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:6}
+      method <C <U AccidentallyStruct>><S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+    class <C <U AccidentallyStruct>><C <U Struct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=38:5 end=38:17}
+    class <C <U AccidentallyStruct>><S <C <U Struct>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=38:11 end=38:17}
+      type-member(+) <C <U AccidentallyStruct>><S <C <U Struct>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U AccidentallyStruct>><S <C <U Struct>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AccidentallyStruct::Struct) @ Loc {file=test/testdata/rewriter/struct.rb start=38:11 end=38:17}
+      method <C <U AccidentallyStruct>><S <C <U Struct>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=38:5 end=39:8}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <S <C <U AccidentallyStruct>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=37:7 end=37:25}
+    type-member(+) <S <C <U AccidentallyStruct>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U AccidentallyStruct>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AccidentallyStruct) @ Loc {file=test/testdata/rewriter/struct.rb start=37:7 end=37:25}
+    method <S <C <U AccidentallyStruct>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=37:1 end=43:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <C <U BadUsages>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=70:1 end=70:16}
+    static-field <C <U BadUsages>><C <U A>> @ Loc {file=test/testdata/rewriter/struct.rb start=71:3 end=71:4}
+    static-field <C <U BadUsages>><C <U B>> @ Loc {file=test/testdata/rewriter/struct.rb start=72:3 end=72:4}
+    static-field <C <U BadUsages>><C <U C>> @ Loc {file=test/testdata/rewriter/struct.rb start=73:3 end=73:4}
+    static-field <C <U BadUsages>><C <U D>> @ Loc {file=test/testdata/rewriter/struct.rb start=75:3 end=75:4}
+    static-field <C <U BadUsages>><C <U E>> @ Loc {file=test/testdata/rewriter/struct.rb start=76:3 end=76:4}
+  class <S <C <U BadUsages>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=70:7 end=70:16}
+    type-member(+) <S <C <U BadUsages>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U BadUsages>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=BadUsages) @ Loc {file=test/testdata/rewriter/struct.rb start=70:7 end=70:16}
+    method <S <C <U BadUsages>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=70:1 end=77:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  module <C <U Foo>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/rewriter/struct.rb start=4:1 end=4:11}
+    class <C <U Foo>><C <U Struct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=5:5 end=5:17}
+    class <C <U Foo>><S <C <U Struct>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=5:11 end=5:17}
+      type-member(+) <C <U Foo>><S <C <U Struct>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U Foo>><S <C <U Struct>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Foo::Struct) @ Loc {file=test/testdata/rewriter/struct.rb start=5:11 end=5:17}
+      method <C <U Foo>><S <C <U Struct>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=5:5 end=6:8}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <S <C <U Foo>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/rewriter/struct.rb start=4:8 end=4:11}
+    type-member(+) <S <C <U Foo>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Foo>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Foo) @ Loc {file=test/testdata/rewriter/struct.rb start=4:8 end=4:11}
+    method <S <C <U Foo>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=4:1 end=7:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <C <U Main>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=79:1 end=79:11}
+    method <C <U Main>><U main> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=80:5 end=80:13}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <S <C <U Main>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=79:7 end=79:11}
+    type-member(+) <S <C <U Main>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Main>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Main) @ Loc {file=test/testdata/rewriter/struct.rb start=79:7 end=79:11}
+    method <S <C <U Main>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=79:1 end=100:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <C <U MixinStruct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=45:1 end=45:18}
+    class <C <U MixinStruct>><C <U MyKeywordInitStruct>> < <C <U Struct>> (<C <U MyMixin>>) @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
+      type-member(=) <C <U MixinStruct>><C <U MyKeywordInitStruct>><C <U Elem>> -> LambdaParam(<C <U MixinStruct>><C <U MyKeywordInitStruct>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
+      method <C <U MixinStruct>><C <U MyKeywordInitStruct>><U initialize> (x, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
+        argument x<optional, keyword> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U MixinStruct>><C <U MyKeywordInitStruct>><U x> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U MixinStruct>><C <U MyKeywordInitStruct>><U x=> (MyKeywordInitStruct = Struct.new(:x, keyword_init: true) do
+    include MyMixin
+    self.new.x
+    self.new.foo
+    self.new(1, 2) # error: Too many positional arguments provided for method `MixinStruct::MyKeywordInitStruct#initialize`. Expected: `0`, got: `2`
+    self.new(giberish: 1) # error: Unrecognized keyword argument `giberish` passed for method `MixinStruct::MyKeywordInitStruct#initialize`
+  end, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
+        argument MyKeywordInitStruct = Struct.new(:x, keyword_init: true) do
+    include MyMixin
+    self.new.x
+    self.new.foo
+    self.new(1, 2) # error: Too many positional arguments provided for method `MixinStruct::MyKeywordInitStruct#initialize`. Expected: `0`, got: `2`
+    self.new(giberish: 1) # error: Unrecognized keyword argument `giberish` passed for method `MixinStruct::MyKeywordInitStruct#initialize`
+  end<> @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+    class <C <U MixinStruct>><S <C <U MyKeywordInitStruct>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=56:22}
+      type-member(+) <C <U MixinStruct>><S <C <U MyKeywordInitStruct>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U MixinStruct>><S <C <U MyKeywordInitStruct>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U MixinStruct>><C <U MyKeywordInitStruct>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=56:22}
+      method <C <U MixinStruct>><S <C <U MyKeywordInitStruct>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+    module <C <U MixinStruct>><C <U MyMixin>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/rewriter/struct.rb start=46:3 end=46:17}
+      method <C <U MixinStruct>><C <U MyMixin>><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=47:5 end=47:12}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+    class <C <U MixinStruct>><S <C <U MyMixin>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/rewriter/struct.rb start=46:10 end=46:17}
+      type-member(+) <C <U MixinStruct>><S <C <U MyMixin>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U MixinStruct>><S <C <U MyMixin>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=MixinStruct::MyMixin) @ Loc {file=test/testdata/rewriter/struct.rb start=46:10 end=46:17}
+      method <C <U MixinStruct>><S <C <U MyMixin>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=46:3 end=48:6}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+    class <C <U MixinStruct>><C <U MyStruct>> < <C <U Struct>> (<C <U MyMixin>>) @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=54:6}
+      type-member(=) <C <U MixinStruct>><C <U MyStruct>><C <U Elem>> -> LambdaParam(<C <U MixinStruct>><C <U MyStruct>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=54:6}
+      method <C <U MixinStruct>><C <U MyStruct>><U initialize> (MyStruct = Struct.new(:x) do
+    include MyMixin
+    self.new.x
+    self.new.foo
+  end, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=54:6}
+        argument MyStruct = Struct.new(:x) do
+    include MyMixin
+    self.new.x
+    self.new.foo
+  end<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=54:6}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U MixinStruct>><C <U MyStruct>><U x> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=54:6}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U MixinStruct>><C <U MyStruct>><U x=> (MyStruct = Struct.new(:x) do
+    include MyMixin
+    self.new.x
+    self.new.foo
+  end, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=54:6}
+        argument MyStruct = Struct.new(:x) do
+    include MyMixin
+    self.new.x
+    self.new.foo
+  end<> @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=54:6}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+    class <C <U MixinStruct>><S <C <U MyStruct>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=50:11}
+      type-member(+) <C <U MixinStruct>><S <C <U MyStruct>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U MixinStruct>><S <C <U MyStruct>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U MixinStruct>><C <U MyStruct>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=50:11}
+      method <C <U MixinStruct>><S <C <U MyStruct>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=54:6}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <S <C <U MixinStruct>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=45:7 end=45:18}
+    type-member(+) <S <C <U MixinStruct>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U MixinStruct>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=MixinStruct) @ Loc {file=test/testdata/rewriter/struct.rb start=45:7 end=45:18}
+    method <S <C <U MixinStruct>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=45:1 end=68:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <C <U NotStruct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=9:1 end=9:16}
+    static-field <C <U NotStruct>><C <U B>> -> Foo::Struct @ Loc {file=test/testdata/rewriter/struct.rb start=10:5 end=10:6}
+  class <S <C <U NotStruct>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=9:7 end=9:16}
+    type-member(+) <S <C <U NotStruct>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U NotStruct>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=NotStruct) @ Loc {file=test/testdata/rewriter/struct.rb start=9:7 end=9:16}
+    method <S <C <U NotStruct>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=9:1 end=12:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <C <U RealStruct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=14:1 end=14:17}
+    class <C <U RealStruct>><C <U A>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
+      type-member(=) <C <U RealStruct>><C <U A>><C <U Elem>> -> LambdaParam(<C <U RealStruct>><C <U A>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
+      method <C <U RealStruct>><C <U A>><U bar> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U RealStruct>><C <U A>><U bar=> (A = Struct.new(:foo, :bar), <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
+        argument A = Struct.new(:foo, :bar)<> @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U RealStruct>><C <U A>><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U RealStruct>><C <U A>><U foo=> (A = Struct.new(:foo, :bar), <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
+        argument A = Struct.new(:foo, :bar)<> @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U RealStruct>><C <U A>><U initialize> (A = Struct.new(:foo, :bar), A = Struct.new(:foo, :bar), <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
+        argument A = Struct.new(:foo, :bar)<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
+        argument A = Struct.new(:foo, :bar)<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+    class <C <U RealStruct>><S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:6}
+      type-member(+) <C <U RealStruct>><S <C <U A>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U RealStruct>><S <C <U A>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U RealStruct>><C <U A>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:6}
+      method <C <U RealStruct>><S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+    class <C <U RealStruct>><C <U KeywordInit>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
+      type-member(=) <C <U RealStruct>><C <U KeywordInit>><C <U Elem>> -> LambdaParam(<C <U RealStruct>><C <U KeywordInit>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
+      method <C <U RealStruct>><C <U KeywordInit>><U bar> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U RealStruct>><C <U KeywordInit>><U bar=> (KeywordInit = Struct.new(:foo, :bar, keyword_init: true), <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
+        argument KeywordInit = Struct.new(:foo, :bar, keyword_init: true)<> @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U RealStruct>><C <U KeywordInit>><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U RealStruct>><C <U KeywordInit>><U foo=> (KeywordInit = Struct.new(:foo, :bar, keyword_init: true), <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
+        argument KeywordInit = Struct.new(:foo, :bar, keyword_init: true)<> @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U RealStruct>><C <U KeywordInit>><U initialize> (foo, bar, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
+        argument foo<optional, keyword> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
+        argument bar<optional, keyword> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+    class <C <U RealStruct>><S <C <U KeywordInit>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:16}
+      type-member(+) <C <U RealStruct>><S <C <U KeywordInit>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U RealStruct>><S <C <U KeywordInit>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U RealStruct>><C <U KeywordInit>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:16}
+      method <C <U RealStruct>><S <C <U KeywordInit>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <S <C <U RealStruct>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=14:7 end=14:17}
+    type-member(+) <S <C <U RealStruct>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U RealStruct>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=RealStruct) @ Loc {file=test/testdata/rewriter/struct.rb start=14:7 end=14:17}
+    method <S <C <U RealStruct>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=14:1 end=17:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <C <U RealStructDesugar>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=18:1 end=18:24}
+    class <C <U RealStructDesugar>><C <U A>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=19:5 end=19:21}
+      type-member(=) <C <U RealStructDesugar>><C <U A>><C <U Elem>> -> LambdaParam(<C <U RealStructDesugar>><C <U A>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=19:5 end=19:21}
+      method <C <U RealStructDesugar>><C <U A>><U bar> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=22:9 end=22:16}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U RealStructDesugar>><C <U A>><U bar=> (arg0, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=24:9 end=24:23}
+        argument arg0<> @ Loc {file=test/testdata/rewriter/struct.rb start=24:18 end=24:22}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U RealStructDesugar>><C <U A>><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=21:9 end=21:16}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U RealStructDesugar>><C <U A>><U foo=> (arg0, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=23:9 end=23:23}
+        argument arg0<> @ Loc {file=test/testdata/rewriter/struct.rb start=23:18 end=23:22}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+    class <C <U RealStructDesugar>><S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> (<C <U Sig>>) @ Loc {file=test/testdata/rewriter/struct.rb start=19:11 end=19:12}
+      type-member(+) <C <U RealStructDesugar>><S <C <U A>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U RealStructDesugar>><S <C <U A>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U RealStructDesugar>><C <U A>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=19:11 end=19:12}
+      method <C <U RealStructDesugar>><S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=19:5 end=29:8}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U RealStructDesugar>><S <C <U A>> $1><DA <U new> $1> (foo, bar, <blk>) -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=26:26 end=26:29}
+        argument foo<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=25:21 end=25:24}
+        argument bar<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=25:39 end=25:42}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U RealStructDesugar>><S <C <U A>> $1><DA <U new> $2> (foo, bar, <blk>) -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=26:35 end=26:38}
+        argument foo<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=25:21 end=25:24}
+        argument bar<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=25:39 end=25:42}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U RealStructDesugar>><S <C <U A>> $1><U new> (foo, bar, <blk>) -> AppliedType {         klass = <C <U RealStructDesugar>><C <U A>>         targs = [           <C <U Elem>> = T.untyped         ]       } @ Loc {file=test/testdata/rewriter/struct.rb start=26:9 end=26:39}
+        argument foo<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=25:21 end=25:24}
+        argument bar<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=25:39 end=25:42}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <S <C <U RealStructDesugar>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=18:7 end=18:24}
+    type-member(+) <S <C <U RealStructDesugar>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U RealStructDesugar>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=RealStructDesugar) @ Loc {file=test/testdata/rewriter/struct.rb start=18:7 end=18:24}
+    method <S <C <U RealStructDesugar>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=18:1 end=30:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <C <U TwoStructs>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=32:1 end=32:17}
+    class <C <U TwoStructs>><C <U A>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:25}
+      type-member(=) <C <U TwoStructs>><C <U A>><C <U Elem>> -> LambdaParam(<C <U TwoStructs>><C <U A>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:25}
+      method <C <U TwoStructs>><C <U A>><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:25}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U TwoStructs>><C <U A>><U foo=> (A = Struct.new(:foo), <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:25}
+        argument A = Struct.new(:foo)<> @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:25}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U TwoStructs>><C <U A>><U initialize> (A = Struct.new(:foo), <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:25}
+        argument A = Struct.new(:foo)<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:25}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+    class <C <U TwoStructs>><S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:6}
+      type-member(+) <C <U TwoStructs>><S <C <U A>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U TwoStructs>><S <C <U A>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U TwoStructs>><C <U A>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:6}
+      method <C <U TwoStructs>><S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:25}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+    class <C <U TwoStructs>><C <U B>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:25}
+      type-member(=) <C <U TwoStructs>><C <U B>><C <U Elem>> -> LambdaParam(<C <U TwoStructs>><C <U B>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:25}
+      method <C <U TwoStructs>><C <U B>><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:25}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U TwoStructs>><C <U B>><U foo=> (B = Struct.new(:foo), <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:25}
+        argument B = Struct.new(:foo)<> @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:25}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U TwoStructs>><C <U B>><U initialize> (B = Struct.new(:foo), <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:25}
+        argument B = Struct.new(:foo)<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:25}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+    class <C <U TwoStructs>><S <C <U B>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:6}
+      type-member(+) <C <U TwoStructs>><S <C <U B>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U TwoStructs>><S <C <U B>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U TwoStructs>><C <U B>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:6}
+      method <C <U TwoStructs>><S <C <U B>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:25}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <S <C <U TwoStructs>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=32:7 end=32:17}
+    type-member(+) <S <C <U TwoStructs>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U TwoStructs>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=TwoStructs) @ Loc {file=test/testdata/rewriter/struct.rb start=32:7 end=32:17}
+    method <S <C <U TwoStructs>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=32:1 end=35:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+

--- a/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
@@ -5,19 +5,19 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
   class <C <U AccidentallyStruct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=37:1 end=37:25}
     class <C <U AccidentallyStruct>><C <U A>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
       type-member(=) <C <U AccidentallyStruct>><C <U A>><C <U Elem>> -> LambdaParam(<C <U AccidentallyStruct>><C <U A>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
-      method <C <U AccidentallyStruct>><C <U A>><U bar> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
+      method <C <U AccidentallyStruct>><C <U A>><U bar> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=42:27 end=42:30}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U AccidentallyStruct>><C <U A>><U bar=> (A = Struct.new(:foo, :bar), <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
-        argument A = Struct.new(:foo, :bar)<> @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
+      method <C <U AccidentallyStruct>><C <U A>><U bar=> (bar, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=42:27 end=42:30}
+        argument bar<> @ Loc {file=test/testdata/rewriter/struct.rb start=42:27 end=42:30}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U AccidentallyStruct>><C <U A>><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
+      method <C <U AccidentallyStruct>><C <U A>><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=42:21 end=42:24}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U AccidentallyStruct>><C <U A>><U foo=> (A = Struct.new(:foo, :bar), <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
-        argument A = Struct.new(:foo, :bar)<> @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
+      method <C <U AccidentallyStruct>><C <U A>><U foo=> (foo, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=42:21 end=42:24}
+        argument foo<> @ Loc {file=test/testdata/rewriter/struct.rb start=42:21 end=42:24}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U AccidentallyStruct>><C <U A>><U initialize> (A = Struct.new(:foo, :bar), A = Struct.new(:foo, :bar), <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
-        argument A = Struct.new(:foo, :bar)<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
-        argument A = Struct.new(:foo, :bar)<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
+      method <C <U AccidentallyStruct>><C <U A>><U initialize> (foo, bar, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
+        argument foo<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=42:21 end=42:24}
+        argument bar<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=42:27 end=42:30}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
     class <C <U AccidentallyStruct>><S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:6}
       type-member(+) <C <U AccidentallyStruct>><S <C <U A>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U AccidentallyStruct>><S <C <U A>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U AccidentallyStruct>><C <U A>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:6}
@@ -63,24 +63,12 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     class <C <U MixinStruct>><C <U MyKeywordInitStruct>> < <C <U Struct>> (<C <U MyMixin>>) @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
       type-member(=) <C <U MixinStruct>><C <U MyKeywordInitStruct>><C <U Elem>> -> LambdaParam(<C <U MixinStruct>><C <U MyKeywordInitStruct>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
       method <C <U MixinStruct>><C <U MyKeywordInitStruct>><U initialize> (x, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
-        argument x<optional, keyword> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
+        argument x<optional, keyword> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=56:37 end=56:38}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U MixinStruct>><C <U MyKeywordInitStruct>><U x> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
+      method <C <U MixinStruct>><C <U MyKeywordInitStruct>><U x> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=56:37 end=56:38}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U MixinStruct>><C <U MyKeywordInitStruct>><U x=> (MyKeywordInitStruct = Struct.new(:x, keyword_init: true) do
-    include MyMixin
-    self.new.x
-    self.new.foo
-    self.new(1, 2) # error: Too many positional arguments provided for method `MixinStruct::MyKeywordInitStruct#initialize`. Expected: `0`, got: `2`
-    self.new(giberish: 1) # error: Unrecognized keyword argument `giberish` passed for method `MixinStruct::MyKeywordInitStruct#initialize`
-  end, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
-        argument MyKeywordInitStruct = Struct.new(:x, keyword_init: true) do
-    include MyMixin
-    self.new.x
-    self.new.foo
-    self.new(1, 2) # error: Too many positional arguments provided for method `MixinStruct::MyKeywordInitStruct#initialize`. Expected: `0`, got: `2`
-    self.new(giberish: 1) # error: Unrecognized keyword argument `giberish` passed for method `MixinStruct::MyKeywordInitStruct#initialize`
-  end<> @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
+      method <C <U MixinStruct>><C <U MyKeywordInitStruct>><U x=> (x, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=56:37 end=56:38}
+        argument x<> @ Loc {file=test/testdata/rewriter/struct.rb start=56:37 end=56:38}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
     class <C <U MixinStruct>><S <C <U MyKeywordInitStruct>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=56:22}
       type-member(+) <C <U MixinStruct>><S <C <U MyKeywordInitStruct>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U MixinStruct>><S <C <U MyKeywordInitStruct>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U MixinStruct>><C <U MyKeywordInitStruct>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=56:22}
@@ -95,29 +83,13 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
     class <C <U MixinStruct>><C <U MyStruct>> < <C <U Struct>> (<C <U MyMixin>>) @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=54:6}
       type-member(=) <C <U MixinStruct>><C <U MyStruct>><C <U Elem>> -> LambdaParam(<C <U MixinStruct>><C <U MyStruct>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=54:6}
-      method <C <U MixinStruct>><C <U MyStruct>><U initialize> (MyStruct = Struct.new(:x) do
-    include MyMixin
-    self.new.x
-    self.new.foo
-  end, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=54:6}
-        argument MyStruct = Struct.new(:x) do
-    include MyMixin
-    self.new.x
-    self.new.foo
-  end<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=54:6}
+      method <C <U MixinStruct>><C <U MyStruct>><U initialize> (x, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=54:6}
+        argument x<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=50:26 end=50:27}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U MixinStruct>><C <U MyStruct>><U x> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=54:6}
+      method <C <U MixinStruct>><C <U MyStruct>><U x> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=50:26 end=50:27}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U MixinStruct>><C <U MyStruct>><U x=> (MyStruct = Struct.new(:x) do
-    include MyMixin
-    self.new.x
-    self.new.foo
-  end, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=54:6}
-        argument MyStruct = Struct.new(:x) do
-    include MyMixin
-    self.new.x
-    self.new.foo
-  end<> @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=54:6}
+      method <C <U MixinStruct>><C <U MyStruct>><U x=> (x, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=50:26 end=50:27}
+        argument x<> @ Loc {file=test/testdata/rewriter/struct.rb start=50:26 end=50:27}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
     class <C <U MixinStruct>><S <C <U MyStruct>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=50:11}
       type-member(+) <C <U MixinStruct>><S <C <U MyStruct>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U MixinStruct>><S <C <U MyStruct>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U MixinStruct>><C <U MyStruct>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=50:11}
@@ -136,19 +108,19 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
   class <C <U RealStruct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=14:1 end=14:17}
     class <C <U RealStruct>><C <U A>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
       type-member(=) <C <U RealStruct>><C <U A>><C <U Elem>> -> LambdaParam(<C <U RealStruct>><C <U A>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
-      method <C <U RealStruct>><C <U A>><U bar> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
+      method <C <U RealStruct>><C <U A>><U bar> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=15:27 end=15:30}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U RealStruct>><C <U A>><U bar=> (A = Struct.new(:foo, :bar), <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
-        argument A = Struct.new(:foo, :bar)<> @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
+      method <C <U RealStruct>><C <U A>><U bar=> (bar, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=15:27 end=15:30}
+        argument bar<> @ Loc {file=test/testdata/rewriter/struct.rb start=15:27 end=15:30}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U RealStruct>><C <U A>><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
+      method <C <U RealStruct>><C <U A>><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=15:21 end=15:24}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U RealStruct>><C <U A>><U foo=> (A = Struct.new(:foo, :bar), <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
-        argument A = Struct.new(:foo, :bar)<> @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
+      method <C <U RealStruct>><C <U A>><U foo=> (foo, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=15:21 end=15:24}
+        argument foo<> @ Loc {file=test/testdata/rewriter/struct.rb start=15:21 end=15:24}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U RealStruct>><C <U A>><U initialize> (A = Struct.new(:foo, :bar), A = Struct.new(:foo, :bar), <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
-        argument A = Struct.new(:foo, :bar)<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
-        argument A = Struct.new(:foo, :bar)<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
+      method <C <U RealStruct>><C <U A>><U initialize> (foo, bar, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
+        argument foo<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=15:21 end=15:24}
+        argument bar<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=15:27 end=15:30}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
     class <C <U RealStruct>><S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:6}
       type-member(+) <C <U RealStruct>><S <C <U A>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U RealStruct>><S <C <U A>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U RealStruct>><C <U A>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:6}
@@ -156,19 +128,19 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
     class <C <U RealStruct>><C <U KeywordInit>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
       type-member(=) <C <U RealStruct>><C <U KeywordInit>><C <U Elem>> -> LambdaParam(<C <U RealStruct>><C <U KeywordInit>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
-      method <C <U RealStruct>><C <U KeywordInit>><U bar> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
+      method <C <U RealStruct>><C <U KeywordInit>><U bar> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=16:37 end=16:40}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U RealStruct>><C <U KeywordInit>><U bar=> (KeywordInit = Struct.new(:foo, :bar, keyword_init: true), <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
-        argument KeywordInit = Struct.new(:foo, :bar, keyword_init: true)<> @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
+      method <C <U RealStruct>><C <U KeywordInit>><U bar=> (bar, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=16:37 end=16:40}
+        argument bar<> @ Loc {file=test/testdata/rewriter/struct.rb start=16:37 end=16:40}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U RealStruct>><C <U KeywordInit>><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
+      method <C <U RealStruct>><C <U KeywordInit>><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=16:31 end=16:34}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U RealStruct>><C <U KeywordInit>><U foo=> (KeywordInit = Struct.new(:foo, :bar, keyword_init: true), <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
-        argument KeywordInit = Struct.new(:foo, :bar, keyword_init: true)<> @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
+      method <C <U RealStruct>><C <U KeywordInit>><U foo=> (foo, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=16:31 end=16:34}
+        argument foo<> @ Loc {file=test/testdata/rewriter/struct.rb start=16:31 end=16:34}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
       method <C <U RealStruct>><C <U KeywordInit>><U initialize> (foo, bar, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
-        argument foo<optional, keyword> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
-        argument bar<optional, keyword> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
+        argument foo<optional, keyword> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=16:31 end=16:34}
+        argument bar<optional, keyword> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=16:37 end=16:40}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
     class <C <U RealStruct>><S <C <U KeywordInit>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:16}
       type-member(+) <C <U RealStruct>><S <C <U KeywordInit>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U RealStruct>><S <C <U KeywordInit>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U RealStruct>><C <U KeywordInit>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:16}
@@ -214,13 +186,13 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
   class <C <U TwoStructs>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=32:1 end=32:17}
     class <C <U TwoStructs>><C <U A>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:25}
       type-member(=) <C <U TwoStructs>><C <U A>><C <U Elem>> -> LambdaParam(<C <U TwoStructs>><C <U A>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:25}
-      method <C <U TwoStructs>><C <U A>><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:25}
+      method <C <U TwoStructs>><C <U A>><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=33:21 end=33:24}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U TwoStructs>><C <U A>><U foo=> (A = Struct.new(:foo), <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:25}
-        argument A = Struct.new(:foo)<> @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:25}
+      method <C <U TwoStructs>><C <U A>><U foo=> (foo, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=33:21 end=33:24}
+        argument foo<> @ Loc {file=test/testdata/rewriter/struct.rb start=33:21 end=33:24}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U TwoStructs>><C <U A>><U initialize> (A = Struct.new(:foo), <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:25}
-        argument A = Struct.new(:foo)<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:25}
+      method <C <U TwoStructs>><C <U A>><U initialize> (foo, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:25}
+        argument foo<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=33:21 end=33:24}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
     class <C <U TwoStructs>><S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:6}
       type-member(+) <C <U TwoStructs>><S <C <U A>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U TwoStructs>><S <C <U A>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U TwoStructs>><C <U A>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:6}
@@ -228,13 +200,13 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
     class <C <U TwoStructs>><C <U B>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:25}
       type-member(=) <C <U TwoStructs>><C <U B>><C <U Elem>> -> LambdaParam(<C <U TwoStructs>><C <U B>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:25}
-      method <C <U TwoStructs>><C <U B>><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:25}
+      method <C <U TwoStructs>><C <U B>><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=34:21 end=34:24}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U TwoStructs>><C <U B>><U foo=> (B = Struct.new(:foo), <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:25}
-        argument B = Struct.new(:foo)<> @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:25}
+      method <C <U TwoStructs>><C <U B>><U foo=> (foo, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=34:21 end=34:24}
+        argument foo<> @ Loc {file=test/testdata/rewriter/struct.rb start=34:21 end=34:24}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U TwoStructs>><C <U B>><U initialize> (B = Struct.new(:foo), <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:25}
-        argument B = Struct.new(:foo)<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:25}
+      method <C <U TwoStructs>><C <U B>><U initialize> (foo, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:25}
+        argument foo<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=34:21 end=34:24}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
     class <C <U TwoStructs>><S <C <U B>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:6}
       type-member(+) <C <U TwoStructs>><S <C <U B>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U TwoStructs>><S <C <U B>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U TwoStructs>><C <U B>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:6}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Previously, this failed the ENFORCE I added in #2362 to guarantee that each
symbol in the symbol table only takes up one line.

### Commit summary

Review by commit.


- **Add failing test** (33a81ab2d)


- **Fix failing test** (072174f26)




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.