### PR TITLE
Use gem fetch instead of gem list

### DIFF
--- a/.buildkite/publish-ruby-gems.sh
+++ b/.buildkite/publish-ruby-gems.sh
@@ -54,7 +54,7 @@ with_backoff() {
 for gem_archive in "_out_/gems/sorbet-static-$release_version"-*.gem; do
   if [[ "$gem_archive" =~ _out_/gems/sorbet-static-([^-]*)-([^.]*).gem ]]; then
     platform="${BASH_REMATCH[2]}"
-    if ! gem list --remote rubygems.org --exact 'sorbet-static' | grep "$release_version" | grep -q "$platform"; then
+    if ! gem fetch --platform "$platform" --version "$release_version" 'sorbet-static' | grep -q "ERROR"; then
       with_backoff gem push --verbose "$gem_archive"
     else
       echo "$gem_archive already published."
@@ -66,14 +66,14 @@ for gem_archive in "_out_/gems/sorbet-static-$release_version"-*.gem; do
 done
 
 gem_archive="_out_/gems/sorbet-runtime-$release_version.gem"
-if ! gem list --remote rubygems.org --exact 'sorbet-runtime' | grep -q "$release_version"; then
+if ! gem fetch --version "$release_version" 'sorbet-runtime' | grep -q "ERROR"; then
   with_backoff gem push --verbose "$gem_archive"
 else
   echo "$gem_archive already published."
 fi
 
 gem_archive="_out_/gems/sorbet-$release_version.gem"
-if ! gem list --remote rubygems.org --exact 'sorbet' | grep -q "$release_version"; then
+if ! gem fetch --version "$release_version" 'sorbet' | grep -q "ERROR"; then
   with_backoff gem push --verbose "$gem_archive"
 else
   echo "$gem_archive already published."


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I thought we could be clever with two grep's and use `gem list` instead of
`gem fetch` (because gem list is faster), but the output of `gem list`
sometimes looks like this:

```
sorbet-static (0.4.5158 java universal-darwin-14 universal-darwin-15 universal-darwin-16 universal-darwin-17 universal-darwin-18, 0.4.5144 universal-darwin-19 x86_64-linux)
```

We could continue to work around this with regular expressions but I think `gem
fetch` approach is less brittle. We only publish once a night so the perf hit
shouldn't be a big deal.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Test by manually kicking off a build on master.