### PR TITLE
Fix crash in parser for heredocs

### DIFF
--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -39,7 +39,15 @@ string Dedenter::dedent(string_view str) {
                     break;
                 case '\t': {
                     int indent = dedentLevel - spacesToRemove;
-                    spacesToRemove -= (8 - indent % 8);
+                    int delta = 8 - indent % 8;
+                    if (delta > spacesToRemove) {
+                        // Prevent against underflow on unsigned integer.
+                        // In this case, the tab doesn't get chomped.
+                        out.push_back(ch);
+                        spacesToRemove = 0;
+                    } else {
+                        spacesToRemove -= delta;
+                    }
                     break;
                 }
                 default:

--- a/test/testdata/parser/heredoc_chomp.rb
+++ b/test/testdata/parser/heredoc_chomp.rb
@@ -1,0 +1,8 @@
+# typed: true
+x = <<~EOF
+ A
+	Z
+EOF
+
+# Compare desugar output by analogy with VM output:
+p x # => "A\n\tZ\n"

--- a/test/testdata/parser/heredoc_chomp.rb.desugar-tree.exp
+++ b/test/testdata/parser/heredoc_chomp.rb.desugar-tree.exp
@@ -1,0 +1,5 @@
+class <emptyTree><<C <root>>> < ()
+  x = "A\n\tZ\n"
+
+  <self>.p(x)
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In the included test case, Dedenter::dedent starts with `str="\tZ"` and
`spacesToRemove=1`.

The problem is that the case for handling tabs tries to decrement
`spacesToRemove` by 8, which causes unsigned integer underflow, so the
loop guard fails to trip, and we start processing non-whitespace
characters (`Z`) and try to treat them as whitespace to be removed.

The fix is to never underflow the unsigned int, by handling the case
when it would go negative to early exit.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.