### PR TITLE
Switch back to gem list

### DIFF
--- a/.buildkite/publish-ruby-gems.sh
+++ b/.buildkite/publish-ruby-gems.sh
@@ -55,7 +55,8 @@ for gem_archive in "_out_/gems/sorbet-static-$release_version"-*.gem; do
   echo "Attempting to publish $gem_archive"
   if [[ "$gem_archive" =~ _out_/gems/sorbet-static-([^-]*)-([^.]*).gem ]]; then
     platform="${BASH_REMATCH[2]}"
-    if gem fetch --platform "$platform" --version "$release_version" 'sorbet-static' 2>&1 | grep -q "ERROR"; then
+    echo "Attempting to publish $gem_archive"
+    if ! gem list --remote rubygems.org --exact 'sorbet-static' | grep -q "${release_version}[^,]*${platform}"; then
       with_backoff gem push --verbose "$gem_archive"
     else
       echo "$gem_archive already published."
@@ -68,7 +69,7 @@ done
 
 gem_archive="_out_/gems/sorbet-runtime-$release_version.gem"
 echo "Attempting to publish $gem_archive"
-if gem fetch --version "$release_version" 'sorbet-runtime' 2>&1 | grep -q "ERROR"; then
+if ! gem list --remote rubygems.org --exact 'sorbet-runtime' | grep -q "$release_version"; then
   with_backoff gem push --verbose "$gem_archive"
 else
   echo "$gem_archive already published."
@@ -76,7 +77,7 @@ fi
 
 gem_archive="_out_/gems/sorbet-$release_version.gem"
 echo "Attempting to publish $gem_archive"
-if gem fetch --version "$release_version" 'sorbet' 2>&1 | grep -q "ERROR"; then
+if ! gem list --remote rubygems.org --exact 'sorbet' | grep -q "$release_version"; then
   with_backoff gem push --verbose "$gem_archive"
 else
   echo "$gem_archive already published."


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The output of gem fetch was proving to be too hard to work with (it
raised an exit code when the fetch failed, which would have meant
needing to silence the exit code of the `gem fetch` to not cause the
whole pipe to fail, which makes the overall script more brittle because
it could fail for a reason that's not "the gem doesn't exist" but
something else like "the network is down").

Switching back to gem list is also about 15 seconds faster.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.