### PR TITLE
Build `test_each` as a special-case `each` for tests

### DIFF
--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -11,6 +11,6 @@ constexpr ErrorClass BadModuleFunction{3505, StrictLevel::True};
 constexpr ErrorClass TEnumOutsideEnumsDo{3506, StrictLevel::False};
 constexpr ErrorClass TEnumConstNotEnumValue{3506, StrictLevel::False};
 constexpr ErrorClass NonItInTestEach{3507, StrictLevel::True};
-constexpr ErrorClass NonConstantTestEach{3507, StrictLevel::True};
+constexpr ErrorClass NonConstantTestEach{3508, StrictLevel::True};
 } // namespace sorbet::core::errors::Rewriter
 #endif

--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -10,5 +10,6 @@ constexpr ErrorClass BadAttrType{3504, StrictLevel::True};
 constexpr ErrorClass BadModuleFunction{3505, StrictLevel::True};
 constexpr ErrorClass TEnumOutsideEnumsDo{3506, StrictLevel::False};
 constexpr ErrorClass TEnumConstNotEnumValue{3506, StrictLevel::False};
+constexpr ErrorClass NonItInTestEach{3507, StrictLevel::True};
 } // namespace sorbet::core::errors::Rewriter
 #endif

--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -11,6 +11,5 @@ constexpr ErrorClass BadModuleFunction{3505, StrictLevel::True};
 constexpr ErrorClass TEnumOutsideEnumsDo{3506, StrictLevel::False};
 constexpr ErrorClass TEnumConstNotEnumValue{3506, StrictLevel::False};
 constexpr ErrorClass NonItInTestEach{3507, StrictLevel::True};
-constexpr ErrorClass NonConstantTestEach{3508, StrictLevel::True};
 } // namespace sorbet::core::errors::Rewriter
 #endif

--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -11,5 +11,6 @@ constexpr ErrorClass BadModuleFunction{3505, StrictLevel::True};
 constexpr ErrorClass TEnumOutsideEnumsDo{3506, StrictLevel::False};
 constexpr ErrorClass TEnumConstNotEnumValue{3506, StrictLevel::False};
 constexpr ErrorClass NonItInTestEach{3507, StrictLevel::True};
+constexpr ErrorClass NonConstantTestEach{3507, StrictLevel::True};
 } // namespace sorbet::core::errors::Rewriter
 #endif

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -211,6 +211,7 @@ NameDef names[] = {
     {"before"},
     {"after"},
     {"afterAngles", "<after>"},
+    {"testEach", "test_each"},
 
     {"dslOptional", "dsl_optional"},
     {"dslRequired", "dsl_required"},

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -212,7 +212,7 @@ NameDef names[] = {
     {"after"},
     {"afterAngles", "<after>"},
     {"testEach", "test_each"},
-    {"const_set"},
+    {"constSet", "const_set"},
     {"collect"},
 
     {"dslOptional", "dsl_optional"},

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -212,6 +212,7 @@ NameDef names[] = {
     {"after"},
     {"afterAngles", "<after>"},
     {"testEach", "test_each"},
+    {"const_set"},
     {"collect"},
 
     {"dslOptional", "dsl_optional"},

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -212,6 +212,7 @@ NameDef names[] = {
     {"after"},
     {"afterAngles", "<after>"},
     {"testEach", "test_each"},
+    {"collect"},
 
     {"dslOptional", "dsl_optional"},
     {"dslRequired", "dsl_required"},

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -43,7 +43,7 @@ public:
             movedConstants.emplace_back(createConstAssign(*asgn));
 
             auto module = ast::MK::Constant(asgn->loc, core::Symbols::Module());
-            return ast::MK::Send2(asgn->loc, move(module), core::Names::const_set(), move(name), move(asgn->rhs));
+            return ast::MK::Send2(asgn->loc, move(module), core::Names::constSet(), move(name), move(asgn->rhs));
         }
 
         return asgn;

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -43,8 +43,7 @@ public:
             movedConstants.emplace_back(createConstAssign(*asgn));
 
             auto module = ast::MK::Constant(asgn->loc, core::Symbols::Module());
-            auto const_set = ctx.state.enterNameUTF8("const_set");
-            return ast::MK::Send2(asgn->loc, move(module), const_set, move(name), move(asgn->rhs));
+            return ast::MK::Send2(asgn->loc, move(module), core::Names::const_set(), move(name), move(asgn->rhs));
         }
 
         return asgn;

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -254,9 +254,9 @@ unique_ptr<ast::Expression> runSingle(core::MutableContext ctx, ast::Send *send)
         auto name = send->fun == core::Names::after() ? core::Names::afterAngles() : core::Names::initialize();
         ConstantMover constantMover;
         send->block->body = ast::TreeMap::apply(ctx, constantMover, move(send->block->body));
-        unique_ptr<ast::Expression> body = std::move(send->block->body);
-        auto method = addSigVoid(ast::MK::Method0(send->loc, send->loc, name, prepareBody(ctx, std::move(body)),
-                                                  ast::MethodDef::RewriterSynthesized));
+        auto method =
+            addSigVoid(ast::MK::Method0(send->loc, send->loc, name, prepareBody(ctx, std::move(send->block->body)),
+                                        ast::MethodDef::RewriterSynthesized));
         return constantMover.addConstantsToExpression(send->loc, move(method));
     }
 
@@ -270,7 +270,6 @@ unique_ptr<ast::Expression> runSingle(core::MutableContext ctx, ast::Send *send)
         ast::ClassDef::ANCESTORS_store ancestors;
         ancestors.emplace_back(ast::MK::Self(arg->loc));
         ast::ClassDef::RHS_store rhs;
-
         rhs.emplace_back(prepareBody(ctx, std::move(send->block->body)));
         auto name = ast::MK::UnresolvedConstant(arg->loc, ast::MK::EmptyTree(),
                                                 ctx.state.enterNameConstant("<describe '" + argString + "'>"));
@@ -279,10 +278,10 @@ unique_ptr<ast::Expression> runSingle(core::MutableContext ctx, ast::Send *send)
         ConstantMover constantMover;
         send->block->body = ast::TreeMap::apply(ctx, constantMover, move(send->block->body));
         auto name = ctx.state.enterNameUTF8("<it '" + argString + "'>");
-        unique_ptr<ast::Expression> body = std::move(send->block->body);
-        auto method =
-            addSigVoid(ast::MK::Method0(send->loc, send->loc, std::move(name), prepareBody(ctx, std::move(body)),
-                                        ast::MethodDef::RewriterSynthesized));
+        auto method = addSigVoid(ast::MK::Method0(send->loc, send->loc, std::move(name),
+                                                  prepareBody(ctx, std::move(send->block->body)),
+                                                  ast::MethodDef::RewriterSynthesized));
+        method = ast::MK::InsSeq1(send->loc, send->args.front()->deepCopy(), move(method));
         return constantMover.addConstantsToExpression(send->loc, move(method));
     }
 

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -196,8 +196,7 @@ string to_s(core::Context ctx, unique_ptr<ast::Expression> &arg) {
 unique_ptr<ast::Expression> makeContext(core::MutableContext ctx, unique_ptr<ast::Expression> blockArg,
                                         unique_ptr<ast::Expression> &as, optional<ast::Expression *> context) {
     ENFORCE(ast::isa_tree<ast::Array>(as.get()) || ast::isa_tree<ast::UnresolvedConstantLit>(as.get()));
-    auto collect = ctx.state.enterNameUTF8("collect");
-    auto enumToList = ast::MK::Send0(as->loc, as->deepCopy(), collect);
+    auto enumToList = ast::MK::Send0(as->loc, as->deepCopy(), core::Names::collect());
     auto firstOfList = ast::MK::Send0(as->loc, move(enumToList), core::Names::first());
     auto mustOfList =
         ast::MK::Send1(as->loc, ast::MK::UnresolvedConstant(as->loc, ast::MK::EmptyTree(), core::Names::Constants::T()),

--- a/test/testdata/rewriter/minitest_tables.rb
+++ b/test/testdata/rewriter/minitest_tables.rb
@@ -1,0 +1,49 @@
+# typed: true
+
+class A
+  def foo; end
+end
+class B < A
+end
+
+class MyTest
+  def outside_method
+  end
+
+  [A.new, B.new].each do |value|
+    puts value.foo
+    it "works outside" do
+      puts value.foo
+      outside_method
+    end
+  end
+
+  [A.new, B.new].each do |value|
+    puts value.foo
+    describe "some inner tests" do
+      def inside_method
+      end
+
+      it "works inside" do
+        T.reveal_type(value) # error: Revealed type: A
+        puts value.foo
+        outside_method
+        inside_method
+      end
+    end
+  end
+
+  ["foo", 5, {x: false}].each do |v|
+    it "handles lists with several types" do
+      T.reveal_type(v) # error: Revealed type: T.any(String, Integer, T::Hash[T.untyped, T.untyped])
+    end
+  end
+
+  [1, 2].each do |x|
+    [3, 4].each do |y|
+      it "handles nested eaches" do
+        puts (x + y)
+      end
+    end
+  end
+end

--- a/test/testdata/rewriter/minitest_tables.rb
+++ b/test/testdata/rewriter/minitest_tables.rb
@@ -14,10 +14,15 @@ class MyTest
   def self.it(name, &blk); end
 
   test_each [A.new, B.new] do |value|
-    it "works outside" do
+    it "works with instance methods" do
       puts value.foo
       outside_method
     end
+  end
+
+  CONST_LIST = [A.new, B.new]
+  test_each CONST_LIST do |value|
+    puts value
   end
 
   test_each [A.new, B.new] do |x|

--- a/test/testdata/rewriter/minitest_tables.rb
+++ b/test/testdata/rewriter/minitest_tables.rb
@@ -17,6 +17,7 @@ class MyTest
     it "works with instance methods" do
       puts value.foo
       outside_method
+      T.reveal_type(value) # error: type: `A`
     end
   end
 
@@ -24,22 +25,32 @@ class MyTest
   test_each CONST_LIST do |value|
     it "succeeds with a constant list" do
       puts value.foo
+      T.reveal_type(value) # error: type: `T.untyped`
+    end
+  end
+
+  ANOTHER_CONST_LIST = T.let([A.new, B.new], T::Array[A])
+  test_each ANOTHER_CONST_LIST do |value|
+    it "succeeds with a typed constant list" do
+      puts value.foo
+      T.reveal_type(value) # error: type: `A`
     end
   end
 
   local = [A.new, B.new]
-  test_each local do |value| # error: `test_each` can only be used with constants or array literals
-    it "fails with a local variable" do
+  test_each local do |value|
+    it "succeed with a local variable but cannot type it" do
       puts value.foo
+      T.reveal_type(value) # error: type: `T.untyped`
     end
   end
 
   test_each [A.new, B.new] do |x|
-    y = x # error: Only `it` blocks are allowed inside `test_each`
+    y = x # error: Only valid `it`-blocks can appear within `test_each`
   end
 
   test_each [A.new, B.new] do |value|
-    x = value.foo  # error: Only `it` blocks are allowed inside `test_each`
+    x = value.foo  # error: Only valid `it`-blocks can appear within `test_each`
     it "fails with non-it statements" do
       puts x
     end

--- a/test/testdata/rewriter/minitest_tables.rb
+++ b/test/testdata/rewriter/minitest_tables.rb
@@ -22,7 +22,16 @@ class MyTest
 
   CONST_LIST = [A.new, B.new]
   test_each CONST_LIST do |value|
-    puts value
+    it "succeeds with a constant list" do
+      puts value.foo
+    end
+  end
+
+  local = [A.new, B.new]
+  test_each local do |value| # error: `test_each` can only be used with constants or array literals
+    it "fails with a local variable" do
+      puts value.foo
+    end
   end
 
   test_each [A.new, B.new] do |x|

--- a/test/testdata/rewriter/minitest_tables.rb
+++ b/test/testdata/rewriter/minitest_tables.rb
@@ -10,40 +10,30 @@ class MyTest
   def outside_method
   end
 
-  [A.new, B.new].each do |value|
-    puts value.foo
+  def self.test_each(arg, &blk); end
+  def self.it(name, &blk); end
+
+  test_each [A.new, B.new] do |value|
     it "works outside" do
       puts value.foo
       outside_method
     end
   end
 
-  [A.new, B.new].each do |value|
-    puts value.foo
-    describe "some inner tests" do
-      def inside_method
-      end
+  test_each [A.new, B.new] do |x|
+    y = x # error: Only `it` blocks are allowed inside `test_each`
+  end
 
-      it "works inside" do
-        T.reveal_type(value) # error: Revealed type: A
-        puts value.foo
-        outside_method
-        inside_method
-      end
+  test_each [A.new, B.new] do |value|
+    x = value.foo  # error: Only `it` blocks are allowed inside `test_each`
+    it "fails with non-it statements" do
+      puts x
     end
   end
 
-  ["foo", 5, {x: false}].each do |v|
+  test_each ["foo", 5, {x: false}] do |v|
     it "handles lists with several types" do
-      T.reveal_type(v) # error: Revealed type: T.any(String, Integer, T::Hash[T.untyped, T.untyped])
-    end
-  end
-
-  [1, 2].each do |x|
-    [3, 4].each do |y|
-      it "handles nested eaches" do
-        puts (x + y)
-      end
+      T.reveal_type(v) # error: Revealed type: `T.any(String, Integer, T::Hash[T.untyped, T.untyped])`
     end
   end
 end

--- a/test/testdata/rewriter/minitest_tables.rb
+++ b/test/testdata/rewriter/minitest_tables.rb
@@ -1,9 +1,9 @@
 # typed: true
 
-class A
+class Parent
   def foo; end
 end
-class B < A
+class Child < Parent
 end
 
 class MyTest
@@ -13,15 +13,15 @@ class MyTest
   def self.test_each(arg, &blk); end
   def self.it(name, &blk); end
 
-  test_each [A.new, B.new] do |value|
+  test_each [Parent.new, Child.new] do |value|
     it "works with instance methods" do
       puts value.foo
       outside_method
-      T.reveal_type(value) # error: type: `A`
+      T.reveal_type(value) # error: type: `Parent`
     end
   end
 
-  CONST_LIST = [A.new, B.new]
+  CONST_LIST = [Parent.new, Child.new]
   test_each CONST_LIST do |value|
     it "succeeds with a constant list" do
       puts value.foo
@@ -29,15 +29,15 @@ class MyTest
     end
   end
 
-  ANOTHER_CONST_LIST = T.let([A.new, B.new], T::Array[A])
+  ANOTHER_CONST_LIST = T.let([Parent.new, Child.new], T::Array[Parent])
   test_each ANOTHER_CONST_LIST do |value|
     it "succeeds with a typed constant list" do
       puts value.foo
-      T.reveal_type(value) # error: type: `A`
+      T.reveal_type(value) # error: type: `Parent`
     end
   end
 
-  local = [A.new, B.new]
+  local = [Parent.new, Child.new]
   test_each local do |value|
     it "succeed with a local variable but cannot type it" do
       puts value.foo
@@ -45,11 +45,11 @@ class MyTest
     end
   end
 
-  test_each [A.new, B.new] do |x|
+  test_each [Parent.new, Child.new] do |x|
     y = x # error: Only valid `it`-blocks can appear within `test_each`
   end
 
-  test_each [A.new, B.new] do |value|
+  test_each [Parent.new, Child.new] do |value|
     x = value.foo  # error: Only valid `it`-blocks can appear within `test_each`
     it "fails with non-it statements" do
       puts x


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Support table-driven testing: this presupposes a `test_each` method which acts trivially like `each` but which only allows `it`-blocks inside of it, which sidesteps the other problems with desugaring `each` in minitest files. Fixes #1504.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
