### PR TITLE
LSP: Track the epoch at which we last sent diagnostics to the client per-file.

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -42,11 +42,11 @@ LSPTypechecker::LSPTypechecker(std::shared_ptr<const LSPConfiguration> config)
 void LSPTypechecker::initialize(LSPFileUpdates updates) {
     globalStateHashes = move(updates.updatedFileHashes);
     indexed = move(updates.updatedFileIndexes);
+    // Initialize to all zeroes.
+    diagnosticEpochs = vector<u4>(globalStateHashes.size(), 0);
     // Initialization typecheck is not cancelable.
     auto committed = runSlowPath(move(updates), /* cancelable */ false);
     ENFORCE(committed);
-    // Initialize to all zeroes.
-    diagnosticEpochs = vector<u4>(globalStateHashes.size(), 0);
     ENFORCE(globalStateHashes.size() == indexed.size());
 }
 

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -301,7 +301,8 @@ void LSPTypechecker::pushDiagnostics(TypecheckRun run) {
         // TODO(jvilk): When we land preemption, this code will ignore errors from files that have been typechecked on
         // newer versions (e.g. because they preempted the slow path) N.B.: See overflow comment above.
         // Assert that we don't have a weird epoch bug here. We should only have errors for files we typechecked.
-        ENFORCE(diagnosticEpochs[accumulated.first.id()] == epoch);
+        // Note: We can get errors on files that don't exist, and those don't have epochs associated with them.
+        ENFORCE(!accumulated.first.exists() || diagnosticEpochs[accumulated.first.id()] == epoch);
         errorFilesInNewRun.push_back(accumulated.first);
     }
 

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -55,6 +55,9 @@ class LSPTypechecker final {
     UnorderedMap<int, ast::ParsedFile> indexedFinalGS;
     /** Hashes of global states obtained by resolving every file in isolation. Used for fastpath. */
     std::vector<core::FileHash> globalStateHashes;
+    /** Stores the epoch in which we last sent diagnostics to the client for each file. Should be the same length as
+     * globalStateHashes. */
+    std::vector<u4> diagnosticEpochs;
     /** List of files that have had errors in last run*/
     std::vector<core::FileRef> filesThatHaveErrors;
     std::unique_ptr<KeyValueStore> kvstore; // always null for now.

--- a/main/lsp/TimeTravelingGlobalState.cc
+++ b/main/lsp/TimeTravelingGlobalState.cc
@@ -118,6 +118,14 @@ vector<ast::ParsedFile> TimeTravelingGlobalState::indexFromFileSystem() {
         gs->errorQueue->drainWithQueryResponses();
     }
     globalStateHashes = computeStateHashes(gs->getFiles());
+
+    // When inputFileNames is 0 (as in tests), indexed ends up being size 0 because we don't index payload files.
+    // At the same time, we expect indexed to be the same size as GlobalStateHash, which _does_ have payload files.
+    // Resize the indexed array accordingly.
+    if (indexed.size() < gs->getFiles().size()) {
+        indexed.resize(gs->getFiles().size());
+    }
+    ENFORCE(indexed.size() == globalStateHashes.size());
     return indexed;
 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

LSP: Track the epoch at which we last sent diagnostics to the client per-file.

Review commit 1 separately from commit 2. Commit 2 just outdents a loop and adds noise to the diff.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The preemptible slow path uses this information to suppress errors generated for old file versions on the slow path.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I added ENFORCEs that should trigger in tests if we mess this up.
