### PR TITLE
LSP: Delurk WorkerPool from config + abstract away multithreading

### DIFF
--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -32,10 +32,9 @@ MarkupKind getPreferredMarkupKind(vector<MarkupKind> formats) {
 } // namespace
 
 LSPConfiguration::LSPConfiguration(const options::Options &opts, const shared_ptr<LSPOutput> &output,
-                                   WorkerPool &workers, const shared_ptr<spdlog::logger> &logger, bool skipConfigatron,
-                                   bool disableFastPath)
-    : initialized(atomic<bool>(false)), opts(opts), output(output), workers(workers), logger(logger),
-      skipConfigatron(skipConfigatron), disableFastPath(disableFastPath), rootPath(getRootPath(opts, logger)) {}
+                                   const shared_ptr<spdlog::logger> &logger, bool skipConfigatron, bool disableFastPath)
+    : initialized(atomic<bool>(false)), opts(opts), output(output), logger(logger), skipConfigatron(skipConfigatron),
+      disableFastPath(disableFastPath), rootPath(getRootPath(opts, logger)) {}
 
 void LSPConfiguration::assertHasClientConfig() const {
     if (!clientConfig) {

--- a/main/lsp/LSPConfiguration.h
+++ b/main/lsp/LSPConfiguration.h
@@ -1,7 +1,6 @@
 #ifndef RUBY_TYPER_LSPCONFIGURATION_H
 #define RUBY_TYPER_LSPCONFIGURATION_H
 
-#include "common/concurrency/WorkerPool.h"
 #include "main/lsp/json_types.h"
 #include "main/options/options.h"
 
@@ -73,7 +72,6 @@ public:
     /** Command line / startup options. */
     const options::Options &opts;
     const std::shared_ptr<LSPOutput> output;
-    WorkerPool &workers;
     const std::shared_ptr<spdlog::logger> logger;
     /** If true, LSPLoop will skip configatron during type checking */
     const bool skipConfigatron;
@@ -84,7 +82,7 @@ public:
 
     // The following properties are configured during initialization.
 
-    LSPConfiguration(const options::Options &opts, const std::shared_ptr<LSPOutput> &output, WorkerPool &workers,
+    LSPConfiguration(const options::Options &opts, const std::shared_ptr<LSPOutput> &output,
                      const std::shared_ptr<spdlog::logger> &logger, bool skipConfigatron = false,
                      bool disableFastPath = false);
 

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -86,8 +86,8 @@ string_view getFileContents(LSPFileUpdates &updates, const core::GlobalState &in
 } // namespace
 
 LSPPreprocessor::LSPPreprocessor(unique_ptr<core::GlobalState> initialGS, const shared_ptr<LSPConfiguration> &config,
-                                 u4 initialVersion)
-    : ttgs(TimeTravelingGlobalState(config, move(initialGS), initialVersion)), config(config),
+                                 WorkerPool &workers, u4 initialVersion)
+    : ttgs(TimeTravelingGlobalState(config, move(initialGS), workers, initialVersion)), config(config),
       owner(this_thread::get_id()), nextVersion(initialVersion + 1) {}
 
 void LSPPreprocessor::mergeFileChanges(absl::Mutex &mtx, QueueState &state) {

--- a/main/lsp/LSPPreprocessor.h
+++ b/main/lsp/LSPPreprocessor.h
@@ -89,7 +89,7 @@ class LSPPreprocessor final {
 
 public:
     LSPPreprocessor(std::unique_ptr<core::GlobalState> initialGS, const std::shared_ptr<LSPConfiguration> &config,
-                    u4 initialVersion = 0);
+                    WorkerPool &workers, u4 initialVersion = 0);
 
     /**
      * Performs pre-processing on the incoming LSP request and appends it to the queue.

--- a/main/lsp/LSPTypecheckerCoordinator.cc
+++ b/main/lsp/LSPTypecheckerCoordinator.cc
@@ -21,7 +21,8 @@ public:
 
 LSPTypecheckerCoordinator::LSPTypecheckerCoordinator(const shared_ptr<const LSPConfiguration> &config,
                                                      WorkerPool &workers)
-    : shouldTerminate(false), typechecker(config), config(config), hasDedicatedThread(false), workers(workers) {}
+    : shouldTerminate(false), typechecker(config), config(config), hasDedicatedThread(false), workers(workers),
+      emptyWorkers(WorkerPool::create(0, *config->logger)) {}
 
 void LSPTypecheckerCoordinator::asyncRunInternal(shared_ptr<core::lsp::Task> task) {
     if (hasDedicatedThread) {
@@ -31,17 +32,18 @@ void LSPTypecheckerCoordinator::asyncRunInternal(shared_ptr<core::lsp::Task> tas
     }
 }
 
-void LSPTypecheckerCoordinator::syncRun(function<void(LSPTypechecker &)> &&lambda) {
+void LSPTypecheckerCoordinator::syncRun(function<void(LSPTypecheckerDelegate &)> &&lambda, bool multithreaded) {
     absl::Notification notification;
     CounterState typecheckerCounters;
     // If typechecker is running on a dedicated thread, then we need to merge its metrics w/ coordinator thread's so we
     // report them.
     // Note: Capturing notification by reference is safe here, we we wait for the notification to happen prior to
     // returning.
-    asyncRunInternal(
-        make_shared<LambdaTask>([&typechecker = this->typechecker, lambda, &notification, &typecheckerCounters,
-                                 hasDedicatedThread = this->hasDedicatedThread]() -> void {
-            lambda(typechecker);
+    asyncRunInternal(make_shared<LambdaTask>(
+        [&typechecker = this->typechecker, &workers = multithreaded ? workers : *emptyWorkers, lambda, &notification,
+         &typecheckerCounters, hasDedicatedThread = this->hasDedicatedThread]() -> void {
+            LSPTypecheckerDelegate d(workers, typechecker);
+            lambda(d);
             if (hasDedicatedThread) {
                 typecheckerCounters = getAndClearThreadCounters();
             }
@@ -53,31 +55,33 @@ void LSPTypecheckerCoordinator::syncRun(function<void(LSPTypechecker &)> &&lambd
     }
 }
 
-void LSPTypecheckerCoordinator::syncRunMultithreaded(std::function<void(LSPTypechecker &, WorkerPool &)> &&lambda) {
-    absl::Notification notification;
-    CounterState typecheckerCounters;
-    // If typechecker is running on a dedicated thread, then we need to merge its metrics w/ coordinator thread's so we
-    // report them.
-    // Note: Capturing notification by reference is safe here, we we wait for the notification to happen prior to
-    // returning.
-    asyncRunInternal(
-        make_shared<LambdaTask>([&typechecker = this->typechecker, lambda, &notification, &typecheckerCounters,
-                                 hasDedicatedThread = this->hasDedicatedThread, &workers = this->workers]() -> void {
-            lambda(typechecker, workers);
-            if (hasDedicatedThread) {
-                typecheckerCounters = getAndClearThreadCounters();
-            }
-            notification.Notify();
-        }));
-    notification.WaitForNotification();
-    if (hasDedicatedThread) {
-        counterConsume(move(typecheckerCounters));
-    }
+void LSPTypecheckerCoordinator::initialize(unique_ptr<InitializedParams> params) {
+    // TODO: Make async when we land preemptible slow path.
+    syncRun([&typechecker = this->typechecker, &workers = workers, &params = params](auto &tcd) -> void {
+        auto &updates = params->updates;
+        typechecker.initialize(move(updates), workers);
+    });
+}
+
+void LSPTypecheckerCoordinator::typecheckOnSlowPath(LSPFileUpdates updates) {
+    // TODO: Make async when we land preemptible slow path.
+    syncRun([&typechecker = this->typechecker, &workers = workers, &updates = updates](auto &tcd) -> void {
+        const u4 end = updates.versionEnd;
+        const u4 start = updates.versionStart;
+        // Versions are sequential and wrap around. Use them to figure out how many edits are contained
+        // within this update.
+        const u4 merged = min(end - start, 0xFFFFFFFF - start + end);
+        // Only report stats if the edit was committed.
+        if (!typechecker.typecheck(move(updates), workers)) {
+            prodCategoryCounterInc("lsp.messages.processed", "sorbet/workspaceEdit");
+            prodCategoryCounterAdd("lsp.messages.processed", "sorbet/mergedEdits", merged);
+        }
+    });
 }
 
 unique_ptr<core::GlobalState> LSPTypecheckerCoordinator::shutdown() {
     unique_ptr<core::GlobalState> gs;
-    syncRun([&](auto &typechecker) -> void {
+    syncRun([&](auto &tcd) -> void {
         shouldTerminate = true;
         gs = typechecker.destroy();
     });

--- a/main/lsp/LSPTypecheckerCoordinator.h
+++ b/main/lsp/LSPTypecheckerCoordinator.h
@@ -24,6 +24,9 @@ class LSPTypecheckerCoordinator final {
     // A worker pool with typically as many threads as cores. Can only be used during synchronous blocking operations.
     WorkerPool &workers;
 
+    // An empty workerpool with 0 threads. Runs all work on the thread using it.
+    std::unique_ptr<WorkerPool> emptyWorkers;
+
     /**
      * Runs the provided task on the typechecker thread.
      */
@@ -33,17 +36,23 @@ public:
     LSPTypecheckerCoordinator(const std::shared_ptr<const LSPConfiguration> &config, WorkerPool &workers);
 
     /**
-     * Schedules a task on the typechecker thread, and blocks until `lambda` completes.
-     * TODO(jvilk): Make tasks scheduled this way preempt the slow path.
+     * Initializes typechecker and runs typechecking for the first time.
+     * TODO(jvilk): Make the typechecking portion of initialization non-blocking when we implement preemption.
      */
-    void syncRun(std::function<void(LSPTypechecker &)> &&lambda);
+    void initialize(std::unique_ptr<InitializedParams> params);
 
     /**
-     * syncRun, except the function receives direct access to WorkerPool and can perform multithreaded operations.
-     * TODO(jvilk): This method will _wait_ for a running slow path before running, as workers cannot be used
-     * concurrently with a typechecking operation.
+     * Typechecks the given updates on the slow path.
+     * TODO(jvilk): Make this method non-blocking when we implement preemption.
      */
-    void syncRunMultithreaded(std::function<void(LSPTypechecker &, WorkerPool &)> &&lambda);
+    void typecheckOnSlowPath(LSPFileUpdates updates);
+
+    /**
+     * Schedules a task on the typechecker thread, and blocks until `lambda` completes. If "multithreaded" is "true",
+     * then the given task is allowed to use the full threadpool at the cost of not being able to preempt slow paths.
+     * TODO(jvilk): Make single-threaded tasks scheduled this way preempt the slow path.
+     */
+    void syncRun(std::function<void(LSPTypecheckerDelegate &)> &&lambda, bool multithreaded = false);
 
     /**
      * Safely shuts down the typechecker and returns the final GlobalState object. Blocks until typechecker completes

--- a/main/lsp/TimeTravelingGlobalState.h
+++ b/main/lsp/TimeTravelingGlobalState.h
@@ -43,6 +43,9 @@ private:
     std::unique_ptr<KeyValueStore> kvstore; // always null for now.
     std::unique_ptr<core::GlobalState> gs;
 
+    // TODO(jvilk): Delurk when landing preemptible slow path.
+    WorkerPool &workers;
+
     // Indicates the current version of `gs`. May be a version that comes before `latestVersion` if `gs` has traveled
     // back in time.
     u4 activeVersion = 0;
@@ -66,7 +69,7 @@ private:
 
 public:
     TimeTravelingGlobalState(const std::shared_ptr<LSPConfiguration> &config, std::unique_ptr<core::GlobalState> gs,
-                             u4 initialVersion);
+                             WorkerPool &workers, u4 initialVersion);
 
     /**
      * Travels GlobalState forwards and backwards in time. No-op if version == current version.

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -11,8 +11,9 @@ using namespace std;
 
 namespace sorbet::realmain::lsp {
 
-LSPLoop::LSPLoop(std::unique_ptr<core::GlobalState> initialGS, const std::shared_ptr<LSPConfiguration> &config)
-    : config(config), preprocessor(move(initialGS), config), typecheckerCoord(config),
+LSPLoop::LSPLoop(std::unique_ptr<core::GlobalState> initialGS, WorkerPool &workers,
+                 const std::shared_ptr<LSPConfiguration> &config)
+    : config(config), preprocessor(move(initialGS), config, workers), typecheckerCoord(config, workers),
       lastMetricUpdateTime(chrono::steady_clock::now()) {}
 
 LSPQueryResult LSPLoop::queryByLoc(LSPTypechecker &typechecker, string_view uri, const Position &pos,
@@ -37,37 +38,36 @@ LSPQueryResult LSPLoop::queryByLoc(LSPTypechecker &typechecker, string_view uri,
     return typechecker.query(core::lsp::Query::createLocQuery(loc), {fref});
 }
 
-LSPQueryResult LSPLoop::queryBySymbol(LSPTypechecker &typechecker, core::SymbolRef sym,
-                                      optional<string_view> overSingleFile) const {
+LSPQueryResult LSPLoop::queryBySymbolInFiles(LSPTypechecker &typechecker, core::SymbolRef sym,
+                                             vector<core::FileRef> frefs) const {
+    Timer timeit(config->logger, "setupLSPQueryBySymbolInFiles");
+    ENFORCE(sym.exists());
+    return typechecker.query(core::lsp::Query::createSymbolQuery(sym), frefs);
+}
+
+LSPQueryResult LSPLoop::queryBySymbol(LSPTypechecker &typechecker, WorkerPool &workers, core::SymbolRef sym) const {
     Timer timeit(config->logger, "setupLSPQueryBySymbol");
     ENFORCE(sym.exists());
     vector<core::FileRef> frefs;
-    if (overSingleFile.has_value()) {
-        auto fref = config->uri2FileRef(typechecker.state(), overSingleFile.value());
-        if (fref.exists()) {
-            frefs.emplace_back(fref);
-        }
-    } else {
-        const core::GlobalState &gs = typechecker.state();
-        const core::NameHash symNameHash(gs, sym.data(gs)->name.data(gs));
-        // Locate files that contain the same Name as the symbol. Is an overapproximation, but a good first filter.
-        int i = -1;
-        for (auto &hash : typechecker.getFileHashes()) {
-            i++;
-            const auto &usedSends = hash.usages.sends;
-            const auto &usedConstants = hash.usages.constants;
-            auto ref = core::FileRef(i);
+    const core::GlobalState &gs = typechecker.state();
+    const core::NameHash symNameHash(gs, sym.data(gs)->name.data(gs));
+    // Locate files that contain the same Name as the symbol. Is an overapproximation, but a good first filter.
+    int i = -1;
+    for (auto &hash : typechecker.getFileHashes()) {
+        i++;
+        const auto &usedSends = hash.usages.sends;
+        const auto &usedConstants = hash.usages.constants;
+        auto ref = core::FileRef(i);
 
-            const bool fileIsValid = ref.exists() && ref.data(gs).sourceType == core::File::Type::Normal;
-            if (fileIsValid &&
-                (std::find(usedSends.begin(), usedSends.end(), symNameHash) != usedSends.end() ||
-                 std::find(usedConstants.begin(), usedConstants.end(), symNameHash) != usedConstants.end())) {
-                frefs.emplace_back(ref);
-            }
+        const bool fileIsValid = ref.exists() && ref.data(gs).sourceType == core::File::Type::Normal;
+        if (fileIsValid &&
+            (std::find(usedSends.begin(), usedSends.end(), symNameHash) != usedSends.end() ||
+             std::find(usedConstants.begin(), usedConstants.end(), symNameHash) != usedConstants.end())) {
+            frefs.emplace_back(ref);
         }
     }
 
-    return typechecker.query(core::lsp::Query::createSymbolQuery(sym), frefs);
+    return typechecker.queryMultithreaded(core::lsp::Query::createSymbolQuery(sym), frefs, workers);
 }
 
 constexpr chrono::minutes STATSD_INTERVAL = chrono::minutes(5);

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -16,7 +16,7 @@ LSPLoop::LSPLoop(std::unique_ptr<core::GlobalState> initialGS, WorkerPool &worke
     : config(config), preprocessor(move(initialGS), config, workers), typecheckerCoord(config, workers),
       lastMetricUpdateTime(chrono::steady_clock::now()) {}
 
-LSPQueryResult LSPLoop::queryByLoc(LSPTypechecker &typechecker, string_view uri, const Position &pos,
+LSPQueryResult LSPLoop::queryByLoc(LSPTypecheckerDelegate &typechecker, string_view uri, const Position &pos,
                                    const LSPMethod forMethod, bool errorIfFileIsUntyped) const {
     Timer timeit(config->logger, "setupLSPQueryByLoc");
     const core::GlobalState &gs = typechecker.state();
@@ -38,14 +38,14 @@ LSPQueryResult LSPLoop::queryByLoc(LSPTypechecker &typechecker, string_view uri,
     return typechecker.query(core::lsp::Query::createLocQuery(loc), {fref});
 }
 
-LSPQueryResult LSPLoop::queryBySymbolInFiles(LSPTypechecker &typechecker, core::SymbolRef sym,
+LSPQueryResult LSPLoop::queryBySymbolInFiles(LSPTypecheckerDelegate &typechecker, core::SymbolRef sym,
                                              vector<core::FileRef> frefs) const {
     Timer timeit(config->logger, "setupLSPQueryBySymbolInFiles");
     ENFORCE(sym.exists());
     return typechecker.query(core::lsp::Query::createSymbolQuery(sym), frefs);
 }
 
-LSPQueryResult LSPLoop::queryBySymbol(LSPTypechecker &typechecker, WorkerPool &workers, core::SymbolRef sym) const {
+LSPQueryResult LSPLoop::queryBySymbol(LSPTypecheckerDelegate &typechecker, core::SymbolRef sym) const {
     Timer timeit(config->logger, "setupLSPQueryBySymbol");
     ENFORCE(sym.exists());
     vector<core::FileRef> frefs;
@@ -67,7 +67,7 @@ LSPQueryResult LSPLoop::queryBySymbol(LSPTypechecker &typechecker, WorkerPool &w
         }
     }
 
-    return typechecker.queryMultithreaded(core::lsp::Query::createSymbolQuery(sym), frefs, workers);
+    return typechecker.query(core::lsp::Query::createSymbolQuery(sym), frefs);
 }
 
 constexpr chrono::minutes STATSD_INTERVAL = chrono::minutes(5);

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -59,46 +59,51 @@ class LSPLoop {
                      const std::vector<std::unique_ptr<core::lsp::QueryResponse>> &queryResponses,
                      std::vector<std::unique_ptr<Location>> locations = {}) const;
 
-    LSPQueryResult queryByLoc(LSPTypechecker &typechecker, std::string_view uri, const Position &pos,
+    LSPQueryResult queryByLoc(LSPTypecheckerDelegate &typechecker, std::string_view uri, const Position &pos,
                               const LSPMethod forMethod, bool errorIfFileIsUntyped = true) const;
-    LSPQueryResult queryBySymbolInFiles(LSPTypechecker &typechecker, core::SymbolRef symbol,
+    LSPQueryResult queryBySymbolInFiles(LSPTypecheckerDelegate &typechecker, core::SymbolRef symbol,
                                         std::vector<core::FileRef> frefs) const;
-    LSPQueryResult queryBySymbol(LSPTypechecker &typechecker, WorkerPool &workers, core::SymbolRef symbol) const;
+    LSPQueryResult queryBySymbol(LSPTypecheckerDelegate &typechecker, core::SymbolRef symbol) const;
 
     std::unique_ptr<ResponseMessage>
-    handleTextDocumentDocumentHighlight(LSPTypechecker &typechecker, const MessageId &id,
+    handleTextDocumentDocumentHighlight(LSPTypecheckerDelegate &typechecker, const MessageId &id,
                                         const TextDocumentPositionParams &params) const;
-    std::unique_ptr<ResponseMessage> handleTextDocumentHover(LSPTypechecker &typechecker, const MessageId &id,
+    std::unique_ptr<ResponseMessage> handleTextDocumentHover(LSPTypecheckerDelegate &typechecker, const MessageId &id,
                                                              const TextDocumentPositionParams &params) const;
-    std::unique_ptr<ResponseMessage> handleTextDocumentDocumentSymbol(LSPTypechecker &typechecker, const MessageId &id,
+    std::unique_ptr<ResponseMessage> handleTextDocumentDocumentSymbol(LSPTypecheckerDelegate &typechecker,
+                                                                      const MessageId &id,
                                                                       const DocumentSymbolParams &params) const;
-    std::unique_ptr<ResponseMessage> handleWorkspaceSymbols(LSPTypechecker &typechecker, const MessageId &id,
+    std::unique_ptr<ResponseMessage> handleWorkspaceSymbols(LSPTypecheckerDelegate &typechecker, const MessageId &id,
                                                             const WorkspaceSymbolParams &params) const;
     std::vector<std::unique_ptr<Location>>
-    getReferencesToSymbol(LSPTypechecker &typechecker, WorkerPool &workers, core::SymbolRef symbol,
+    getReferencesToSymbol(LSPTypecheckerDelegate &typechecker, core::SymbolRef symbol,
                           std::vector<std::unique_ptr<Location>> locations = {}) const;
     std::vector<std::unique_ptr<DocumentHighlight>>
-    getHighlightsToSymbolInFile(LSPTypechecker &typechecker, std::string_view uri, core::SymbolRef symbol,
+    getHighlightsToSymbolInFile(LSPTypecheckerDelegate &typechecker, std::string_view uri, core::SymbolRef symbol,
                                 std::vector<std::unique_ptr<DocumentHighlight>> highlights = {}) const;
-    std::unique_ptr<ResponseMessage> handleTextDocumentReferences(LSPTypechecker &typechecker, WorkerPool &workers,
+    std::unique_ptr<ResponseMessage> handleTextDocumentReferences(LSPTypecheckerDelegate &typechecker,
                                                                   const MessageId &id,
                                                                   const ReferenceParams &params) const;
-    std::unique_ptr<ResponseMessage> handleTextDocumentDefinition(LSPTypechecker &typechecker, const MessageId &id,
+    std::unique_ptr<ResponseMessage> handleTextDocumentDefinition(LSPTypecheckerDelegate &typechecker,
+                                                                  const MessageId &id,
                                                                   const TextDocumentPositionParams &params) const;
-    std::unique_ptr<ResponseMessage> handleTextDocumentTypeDefinition(LSPTypechecker &typechecker, const MessageId &id,
+    std::unique_ptr<ResponseMessage> handleTextDocumentTypeDefinition(LSPTypecheckerDelegate &typechecker,
+                                                                      const MessageId &id,
                                                                       const TextDocumentPositionParams &params) const;
-    std::unique_ptr<ResponseMessage> handleTextDocumentCompletion(LSPTypechecker &typechecker, const MessageId &id,
+    std::unique_ptr<ResponseMessage> handleTextDocumentCompletion(LSPTypecheckerDelegate &typechecker,
+                                                                  const MessageId &id,
                                                                   const CompletionParams &params) const;
-    std::unique_ptr<ResponseMessage> handleTextDocumentCodeAction(LSPTypechecker &typechecker, const MessageId &id,
+    std::unique_ptr<ResponseMessage> handleTextDocumentCodeAction(LSPTypecheckerDelegate &typechecker,
+                                                                  const MessageId &id,
                                                                   const CodeActionParams &params) const;
-    std::unique_ptr<CompletionItem> getCompletionItemForMethod(LSPTypechecker &typechecker, core::SymbolRef what,
-                                                               core::TypePtr receiverType,
+    std::unique_ptr<CompletionItem> getCompletionItemForMethod(LSPTypecheckerDelegate &typechecker,
+                                                               core::SymbolRef what, core::TypePtr receiverType,
                                                                const core::TypeConstraint *constraint,
                                                                const core::Loc queryLoc, std::string_view prefix,
                                                                size_t sortIdx) const;
     void findSimilarConstant(const core::GlobalState &gs, const core::lsp::ConstantResponse &resp,
                              const core::Loc queryLoc, std::vector<std::unique_ptr<CompletionItem>> &items) const;
-    std::unique_ptr<ResponseMessage> handleTextSignatureHelp(LSPTypechecker &typechecker, const MessageId &id,
+    std::unique_ptr<ResponseMessage> handleTextSignatureHelp(LSPTypecheckerDelegate &typechecker, const MessageId &id,
                                                              const TextDocumentPositionParams &params) const;
 
     void processRequestInternal(LSPMessage &msg);

--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -50,25 +50,26 @@ void LSPLoop::processRequestInternal(LSPMessage &msg) {
             shared_ptr<SorbetWorkspaceEditParams> editParams = move(get<unique_ptr<SorbetWorkspaceEditParams>>(params));
             // Since std::function is copyable, we have to promote captured unique_ptrs into shared_ptrs.
             // TODO(jvilk): Switch to asyncRun once I sort out how this interplays with cancelable slow path.
-            typecheckerCoord.syncRun([editParams](LSPTypechecker &typechecker) -> void {
-                const u4 end = editParams->updates.versionEnd;
-                const u4 start = editParams->updates.versionStart;
-                // Versions are sequential and wrap around. Use them to figure out how many edits are contained
-                // within this update.
-                const u4 merged = min(end - start, 0xFFFFFFFF - start + end);
-                // Only report stats if the edit was committed.
-                if (!typechecker.typecheck(move(editParams->updates))) {
-                    prodCategoryCounterInc("lsp.messages.processed", "sorbet/workspaceEdit");
-                    prodCategoryCounterAdd("lsp.messages.processed", "sorbet/mergedEdits", merged);
-                }
-            });
+            typecheckerCoord.syncRunMultithreaded(
+                [editParams](LSPTypechecker &typechecker, WorkerPool &workers) -> void {
+                    const u4 end = editParams->updates.versionEnd;
+                    const u4 start = editParams->updates.versionStart;
+                    // Versions are sequential and wrap around. Use them to figure out how many edits are contained
+                    // within this update.
+                    const u4 merged = min(end - start, 0xFFFFFFFF - start + end);
+                    // Only report stats if the edit was committed.
+                    if (!typechecker.typecheck(move(editParams->updates), workers)) {
+                        prodCategoryCounterInc("lsp.messages.processed", "sorbet/workspaceEdit");
+                        prodCategoryCounterAdd("lsp.messages.processed", "sorbet/mergedEdits", merged);
+                    }
+                });
         } else if (method == LSPMethod::Initialized) {
             prodCategoryCounterInc("lsp.messages.processed", "initialized");
             auto &initParams = get<unique_ptr<InitializedParams>>(params);
             // TODO: Can we make this asynchronous?
-            typecheckerCoord.syncRun([&](LSPTypechecker &typechecker) -> void {
+            typecheckerCoord.syncRunMultithreaded([&](LSPTypechecker &typechecker, WorkerPool &workers) -> void {
                 auto &updates = initParams->updates;
-                typechecker.initialize(move(updates));
+                typechecker.initialize(move(updates), workers);
             });
         } else if (method == LSPMethod::Exit) {
             prodCategoryCounterInc("lsp.messages.processed", "exit");
@@ -178,8 +179,9 @@ void LSPLoop::processRequestInternal(LSPMessage &msg) {
                 [&](auto &tc) -> void { config->output->write(handleTextSignatureHelp(tc, id, *params)); });
         } else if (method == LSPMethod::TextDocumentReferences) {
             auto &params = get<unique_ptr<ReferenceParams>>(rawParams);
-            typecheckerCoord.syncRun(
-                [&](auto &tc) -> void { config->output->write(handleTextDocumentReferences(tc, id, *params)); });
+            typecheckerCoord.syncRunMultithreaded([&](auto &tc, auto &workers) -> void {
+                config->output->write(handleTextDocumentReferences(tc, workers, id, *params));
+            });
         } else if (method == LSPMethod::SorbetReadFile) {
             auto &params = get<unique_ptr<TextDocumentIdentifier>>(rawParams);
             typecheckerCoord.syncRun([&](auto &tc) -> void {

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -5,7 +5,8 @@
 using namespace std;
 
 namespace sorbet::realmain::lsp {
-unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentCodeAction(LSPTypechecker &typechecker, const MessageId &id,
+unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentCodeAction(LSPTypecheckerDelegate &typechecker,
+                                                                  const MessageId &id,
                                                                   const CodeActionParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentCodeAction);
 

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -463,7 +463,7 @@ unique_ptr<CompletionItem> getCompletionItemForLocal(const core::GlobalState &gs
     return item;
 }
 
-vector<core::LocalVariable> localsForMethod(const core::GlobalState &gs, LSPTypechecker &typechecker,
+vector<core::LocalVariable> localsForMethod(const core::GlobalState &gs, LSPTypecheckerDelegate &typechecker,
                                             const core::SymbolRef method) {
     auto files = vector<core::FileRef>{};
     for (auto loc : method.data(gs)->locs()) {
@@ -494,7 +494,7 @@ vector<core::LocalVariable> localsForMethod(const core::GlobalState &gs, LSPType
     return result;
 }
 
-core::SymbolRef firstMethodAfterQuery(LSPTypechecker &typechecker, const core::Loc queryLoc) {
+core::SymbolRef firstMethodAfterQuery(LSPTypecheckerDelegate &typechecker, const core::Loc queryLoc) {
     const auto &gs = typechecker.state();
     auto files = vector<core::FileRef>{queryLoc.file()};
     auto resolved = typechecker.getResolved(files);
@@ -535,9 +535,10 @@ constexpr string_view suggestSigDocs =
     "Sorbet suggests this signature given the method below. Sorbet's suggested sigs are imperfect. It doesn't always "
     "guess the correct types (or any types at all), but they're usually a good starting point."sv;
 
-unique_ptr<CompletionItem> trySuggestSig(LSPTypechecker &typechecker, const LSPClientConfiguration &clientConfig,
-                                         core::SymbolRef what, core::TypePtr receiverType, const core::Loc queryLoc,
-                                         string_view prefix, size_t sortIdx) {
+unique_ptr<CompletionItem> trySuggestSig(LSPTypecheckerDelegate &typechecker,
+                                         const LSPClientConfiguration &clientConfig, core::SymbolRef what,
+                                         core::TypePtr receiverType, const core::Loc queryLoc, string_view prefix,
+                                         size_t sortIdx) {
     ENFORCE(receiverType != nullptr);
 
     const auto &gs = typechecker.state();
@@ -621,8 +622,8 @@ unique_ptr<CompletionItem> trySuggestSig(LSPTypechecker &typechecker, const LSPC
 
 } // namespace
 
-unique_ptr<CompletionItem> LSPLoop::getCompletionItemForMethod(LSPTypechecker &typechecker, core::SymbolRef maybeAlias,
-                                                               core::TypePtr receiverType,
+unique_ptr<CompletionItem> LSPLoop::getCompletionItemForMethod(LSPTypecheckerDelegate &typechecker,
+                                                               core::SymbolRef maybeAlias, core::TypePtr receiverType,
                                                                const core::TypeConstraint *constraint,
                                                                const core::Loc queryLoc, string_view prefix,
                                                                size_t sortIdx) const {
@@ -722,7 +723,8 @@ void LSPLoop::findSimilarConstant(const core::GlobalState &gs, const core::lsp::
     } while (scope != core::Symbols::root());
 }
 
-unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentCompletion(LSPTypechecker &typechecker, const MessageId &id,
+unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentCompletion(LSPTypecheckerDelegate &typechecker,
+                                                                  const MessageId &id,
                                                                   const CompletionParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentCompletion);
     auto emptyResult = make_unique<CompletionList>(false, vector<unique_ptr<CompletionItem>>{});

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -11,7 +11,8 @@ void LSPLoop::addLocIfExists(const core::GlobalState &gs, vector<unique_ptr<Loca
     }
 }
 
-unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentDefinition(LSPTypechecker &typechecker, const MessageId &id,
+unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentDefinition(LSPTypecheckerDelegate &typechecker,
+                                                                  const MessageId &id,
                                                                   const TextDocumentPositionParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentDefinition);
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.definition");

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -11,11 +11,14 @@ vector<unique_ptr<DocumentHighlight>>
 LSPLoop::getHighlightsToSymbolInFile(LSPTypechecker &typechecker, string_view const uri, core::SymbolRef symbol,
                                      vector<unique_ptr<DocumentHighlight>> highlights) const {
     if (symbol.exists()) {
-        auto run2 = queryBySymbol(typechecker, symbol, uri);
-        auto locations = extractLocations(typechecker.state(), run2.responses);
-        for (auto const &location : locations) {
-            auto highlight = make_unique<DocumentHighlight>(move(location->range));
-            highlights.push_back(move(highlight));
+        auto fref = config->uri2FileRef(typechecker.state(), uri);
+        if (fref.exists()) {
+            auto run2 = queryBySymbolInFiles(typechecker, symbol, {fref});
+            auto locations = extractLocations(typechecker.state(), run2.responses);
+            for (auto const &location : locations) {
+                auto highlight = make_unique<DocumentHighlight>(move(location->range));
+                highlights.push_back(move(highlight));
+            }
         }
     }
     return highlights;

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -8,7 +8,7 @@ using namespace std;
 namespace sorbet::realmain::lsp {
 
 vector<unique_ptr<DocumentHighlight>>
-LSPLoop::getHighlightsToSymbolInFile(LSPTypechecker &typechecker, string_view const uri, core::SymbolRef symbol,
+LSPLoop::getHighlightsToSymbolInFile(LSPTypecheckerDelegate &typechecker, string_view const uri, core::SymbolRef symbol,
                                      vector<unique_ptr<DocumentHighlight>> highlights) const {
     if (symbol.exists()) {
         auto fref = config->uri2FileRef(typechecker.state(), uri);
@@ -34,7 +34,7 @@ vector<unique_ptr<DocumentHighlight>> locationsToDocumentHighlights(vector<uniqu
 }
 
 unique_ptr<ResponseMessage>
-LSPLoop::handleTextDocumentDocumentHighlight(LSPTypechecker &typechecker, const MessageId &id,
+LSPLoop::handleTextDocumentDocumentHighlight(LSPTypecheckerDelegate &typechecker, const MessageId &id,
                                              const TextDocumentPositionParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentDocumentHighlight);
     if (!config->opts.lspDocumentHighlightEnabled) {

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -68,7 +68,8 @@ std::unique_ptr<DocumentSymbol> symbolRef2DocumentSymbol(const core::GlobalState
     return result;
 }
 
-unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentDocumentSymbol(LSPTypechecker &typechecker, const MessageId &id,
+unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentDocumentSymbol(LSPTypecheckerDelegate &typechecker,
+                                                                      const MessageId &id,
                                                                       const DocumentSymbolParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentDocumentSymbol);
     if (!config->opts.lspDocumentSymbolEnabled) {

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -27,7 +27,7 @@ string methodInfoString(const core::GlobalState &gs, const core::TypePtr &retTyp
     return contents;
 }
 
-unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentHover(LSPTypechecker &typechecker, const MessageId &id,
+unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentHover(LSPTypecheckerDelegate &typechecker, const MessageId &id,
                                                              const TextDocumentPositionParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentHover);
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.hover");

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -47,7 +47,7 @@ void addSignatureHelpItem(const core::GlobalState &gs, core::SymbolRef method,
     sigs.push_back(move(sig));
 }
 
-unique_ptr<ResponseMessage> LSPLoop::handleTextSignatureHelp(LSPTypechecker &typechecker, const MessageId &id,
+unique_ptr<ResponseMessage> LSPLoop::handleTextSignatureHelp(LSPTypecheckerDelegate &typechecker, const MessageId &id,
                                                              const TextDocumentPositionParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentSignatureHelp);
     if (!config->opts.lspSignatureHelpEnabled) {

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -35,7 +35,8 @@ vector<core::Loc> locsForType(const core::GlobalState &gs, core::TypePtr type) {
 }
 } // namespace
 
-unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentTypeDefinition(LSPTypechecker &typechecker, const MessageId &id,
+unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentTypeDefinition(LSPTypecheckerDelegate &typechecker,
+                                                                      const MessageId &id,
                                                                       const TextDocumentPositionParams &params) const {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentTypeDefinition);
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.typeDefinition");

--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -268,7 +268,7 @@ vector<unique_ptr<SymbolInformation>> SymbolMatcher::doQuery(string_view query_v
     return results;
 } // namespace sorbet::realmain::lsp
 
-unique_ptr<ResponseMessage> LSPLoop::handleWorkspaceSymbols(LSPTypechecker &typechecker, const MessageId &id,
+unique_ptr<ResponseMessage> LSPLoop::handleWorkspaceSymbols(LSPTypecheckerDelegate &typechecker, const MessageId &id,
                                                             const WorkspaceSymbolParams &params) const {
     Timer timeit(typechecker.state().tracer(), "LSPLoop::handleWorkspaceSymbols");
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::WorkspaceSymbol);

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -34,7 +34,7 @@ auto workers = WorkerPool::create(0, *logger);
 
 shared_ptr<LSPConfiguration> makeConfig(const options::Options &opts = nullOpts, bool enableShowOpNotifs = false,
                                         bool initialize = true) {
-    auto config = make_shared<LSPConfiguration>(opts, make_shared<LSPOutputToVector>(), *workers, logger, true, false);
+    auto config = make_shared<LSPConfiguration>(opts, make_shared<LSPOutputToVector>(), logger, true, false);
     InitializeParams initParams("", "", make_unique<ClientCapabilities>());
     initParams.initializationOptions = make_unique<SorbetInitializationOptions>();
     initParams.initializationOptions.value()->supportsOperationNotifications = enableShowOpNotifs;
@@ -56,11 +56,11 @@ unique_ptr<core::GlobalState> makeGS(const options::Options &opts = nullOpts) {
 auto nullConfig = makeConfig();
 
 TimeTravelingGlobalState makeTTGS(const shared_ptr<LSPConfiguration> &config = nullConfig, u4 initialVersion = 0) {
-    return TimeTravelingGlobalState(config, makeGS(config->opts), initialVersion);
+    return TimeTravelingGlobalState(config, makeGS(config->opts), *workers, initialVersion);
 }
 
 LSPPreprocessor makePreprocessor(const shared_ptr<LSPConfiguration> &config = nullConfig, u4 initialVersion = 0) {
-    return LSPPreprocessor(makeGS(config->opts), config, initialVersion);
+    return LSPPreprocessor(makeGS(config->opts), config, *workers, initialVersion);
 }
 
 bool comesBeforeSymmetric(const TimeTravelingGlobalState &ttgs, u4 a, u4 b) {

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -80,8 +80,8 @@ LSPWrapper::LSPWrapper(unique_ptr<core::GlobalState> gs, shared_ptr<options::Opt
                        shared_ptr<spd::logger> typeErrorsConsole, bool disableFastPath)
     : logger(logger), workers(WorkerPool::create(opts->threads, *logger)), stderrColorSink(move(stderrColorSink)),
       typeErrorsConsole(move(typeErrorsConsole)), output(make_shared<LSPOutputToVector>()),
-      config_(make_shared<LSPConfiguration>(*opts, output, *workers, move(logger), true, disableFastPath)),
-      lspLoop(make_shared<LSPLoop>(std::move(gs), config_)), opts(move(opts)) {}
+      config_(make_shared<LSPConfiguration>(*opts, output, move(logger), true, disableFastPath)),
+      lspLoop(make_shared<LSPLoop>(std::move(gs), *workers, config_)), opts(move(opts)) {}
 
 SingleThreadedLSPWrapper::SingleThreadedLSPWrapper(unique_ptr<core::GlobalState> gs, shared_ptr<options::Options> opts,
                                                    shared_ptr<spd::logger> logger,

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -459,7 +459,7 @@ int realmain(int argc, char *argv[]) {
                       "it will enable outputing the LSP session to stderr(`Write: ` and `Read: ` log lines)",
                       Version::full_version_string);
         auto output = make_shared<lsp::LSPStdout>(logger);
-        lsp::LSPLoop loop(move(gs), make_shared<lsp::LSPConfiguration>(opts, output, *workers, logger));
+        lsp::LSPLoop loop(move(gs), *workers, make_shared<lsp::LSPConfiguration>(opts, output, logger));
         gs = loop.runLSP(make_shared<lsp::LSPFDInput>(logger, STDIN_FILENO)).value_or(nullptr);
 #endif
     } else {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Delurk WorkerPool from config, and create a new `LSPTypecheckerDelegate` that abstracts away multithreading.

`LSPTypecheckerDelegate` only exposes operations that are valid to perform during preemption. It also cleanly abstracts away if the specific task using the delegate requires multithreading or not by storing the `WorkerPool` needed for the typechecker operations (with one that has all worker threads, or one that contains no threads).

I also move the special `initialize` and `typecheckOnSlowPath` logic into `LSPTypecheckerCoord`, as these operations require more direct access to `LSPTypechecker` (and will eventually be made async with the preemption changes). I could have exposed an interface that lets outsiders directly use `LSPTypechecker`, but I think that might be too much of a footgun.

By encapsulating `workers` in `LSPTypecheckerDelegate`, we can pass in different delegates to the same code paths and they can work in both single-threaded and multi-threaded modes.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The primary motivation of this change is to _remove_ WorkerPool from most parts of the LSP codebase, as it cannot be used during preemption; it will cause a deadlock. WorkerPool is now isolated to `LSPTypecheckerCoord` and `TimeTravelingGlobalState`; the latter class will get deleted (as a part to refactoring how cancelation works) before we land preemption.

The only operations that require multithreading are:

* Initialization
* Slow path typechecking
* Find all references (otherwise this operation is terminally slow on large codebases when given a generic symbol name)

The remaining operations/requests can preempt the slow path and use a single thread. Future complex operations like refactoring will also require multithreading to be tractable.

Why can't we use WorkerPool during preemption? All worker threads in a WorkerPool are in use during a slow path. During preemption, all of them are blocked on a mutex until the preemption task exits. Thus, if a preemption task tries to use WorkerPool, Sorbet deadlocks -- worker threads are waiting for the preemption task to complete to resume the slow path, and the preemption task is waiting for the worker threads to become available. This design reduces the chance of WorkerPool getting lurked into places where it could cause a deadlock.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Should be covered by existing tests.
