### PR TITLE
Add a string concatenation primitive

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -109,16 +109,18 @@ unique_ptr<Expression> desugarDString(DesugarContext dctx, core::Loc loc, parser
     }
     auto it = nodes.begin();
     auto end = nodes.end();
-    unique_ptr<Expression> res;
     unique_ptr<Expression> first = node2TreeImpl(dctx, std::move(*it));
     InlinedVector<unique_ptr<Expression>, 4> stringsAccumulated;
+
+    Send::ARGS_store concatArgs;
+
     bool allStringsSoFar;
     if (isStringLit(dctx, first) || isa_tree<EmptyTree>(first.get())) {
         stringsAccumulated.emplace_back(std::move(first));
         allStringsSoFar = true;
     } else {
         auto pieceLoc = first->loc;
-        res = MK::Send0(pieceLoc, std::move(first), core::Names::toS());
+        concatArgs.emplace_back(MK::Send0(pieceLoc, std::move(first), core::Names::toS()));
         allStringsSoFar = false;
     }
     ++it;
@@ -137,15 +139,17 @@ unique_ptr<Expression> desugarDString(DesugarContext dctx, core::Loc loc, parser
         } else {
             if (allStringsSoFar) {
                 allStringsSoFar = false;
-                res = mergeStrings(dctx, loc, std::move(stringsAccumulated));
+                concatArgs.emplace_back(mergeStrings(dctx, loc, std::move(stringsAccumulated)));
             }
-            res = MK::Send1(loc, std::move(res), core::Names::concat(), std::move(narg));
+            concatArgs.emplace_back(std::move(narg));
         }
     };
     if (allStringsSoFar) {
-        res = mergeStrings(dctx, loc, std::move(stringsAccumulated));
+        return mergeStrings(dctx, loc, std::move(stringsAccumulated));
+    } else {
+        auto recv = MK::Constant(loc, core::Symbols::Magic());
+        return MK::Send(loc, std::move(recv), core::Names::concatStrings(), std::move(concatArgs));
     }
-    return res;
 }
 
 bool isIVarAssign(Expression *stat) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -822,26 +822,8 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                     return;
                 }
 
-                auto it = dsymbol->nodes.begin();
-                auto end = dsymbol->nodes.end();
-                unique_ptr<Expression> res;
-                unique_ptr<Expression> first = node2TreeImpl(dctx, std::move(*it));
-                if (isStringLit(dctx, first)) {
-                    res = std::move(first);
-                } else {
-                    res = MK::Send0(loc, std::move(first), core::Names::toS());
-                }
-                ++it;
-                for (; it != end; ++it) {
-                    auto &stat = *it;
-                    unique_ptr<Expression> narg = node2TreeImpl(dctx, std::move(stat));
-                    if (!isStringLit(dctx, narg)) {
-                        narg = MK::Send0(loc, std::move(narg), core::Names::toS());
-                    }
-                    auto n = MK::Send1(loc, std::move(res), core::Names::concat(), std::move(narg));
-                    res.reset(n.release());
-                };
-                res = MK::Send0(loc, std::move(res), core::Names::intern());
+                auto str = desugarDString(dctx, loc, std::move(dsymbol->nodes));
+                unique_ptr<Expression> res = MK::Send0(loc, std::move(str), core::Names::intern());
 
                 result.swap(res);
             },

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -435,6 +435,18 @@ void GlobalState::initEmpty() {
         auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
         arg.flags.isBlock = true;
     }
+    // Synthesize <Magic>#<concat-strings>(arg: *String) => String
+    method = enterMethodSymbol(Loc::none(), Symbols::MagicSingleton(), Names::concatStrings());
+    {
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg0());
+        arg.type = Types::String();
+        arg.flags.isRepeated = true;
+    }
+    method.data(*this)->resultType = Types::String();
+    {
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
+        arg.flags.isBlock = true;
+    }
     // Synthesize <DeclBuilderForProcs>#<params>(args: Hash) => DeclBuilderForProcs
     method = enterMethodSymbol(Loc::none(), Symbols::DeclBuilderForProcsSingleton(), Names::params());
     {

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -339,6 +339,7 @@ NameDef names[] = {
     {"callWithSplatAndBlock", "<call-with-splat-and-block>"},
     {"enumerableToH", "enumerable_to_h"},
     {"selfNew", "<self-new>"},
+    {"concatStrings", "<concat-strings>"},
 
     // GlobalState initEmpty()
     {"Top", "<any>", true},

--- a/test/testdata/desugar/dsymbol.rb.desugar-tree.exp
+++ b/test/testdata/desugar/dsymbol.rb.desugar-tree.exp
@@ -5,5 +5,5 @@ class <emptyTree><<C <root>>> < ()
 
   :""
 
-  "hello_".concat(<self>.name().to_s()).concat("!").intern()
+  ::<Magic>.<concat-strings>("hello_", <self>.name().to_s(), "!").intern()
 end

--- a/test/testdata/desugar/line_literal.rb.desugar-tree.exp
+++ b/test/testdata/desugar/line_literal.rb.desugar-tree.exp
@@ -1,3 +1,3 @@
 class <emptyTree><<C <root>>> < ()
-  <self>.puts("\n".concat(4.to_s()))
+  <self>.puts(::<Magic>.<concat-strings>("\n", 4.to_s()))
 end

--- a/test/testdata/desugar/regexp.rb.desugar-tree.exp
+++ b/test/testdata/desugar/regexp.rb.desugar-tree.exp
@@ -9,7 +9,7 @@ class <emptyTree><<C <root>>> < ()
       <emptyTree>::<C Regexp>.new("abc", 0.|(<emptyTree>::<C Regexp>::<C IGNORECASE>).|(<emptyTree>::<C Regexp>::<C EXTENDED>).|(<emptyTree>::<C Regexp>::<C MULTILINE>))
       a = "a"
       c = "c"
-      ::Regexp.new(a.to_s().concat("b").concat(c.to_s()), 0)
+      ::Regexp.new(::<Magic>.<concat-strings>(a.to_s(), "b", c.to_s()), 0)
       <emptyTree>::<C Regexp>.new(a.+("b").+(c))
       ::Regexp.new("abc", 0)
     end

--- a/test/testdata/desugar/strings.rb.desugar-tree.exp
+++ b/test/testdata/desugar/strings.rb.desugar-tree.exp
@@ -3,7 +3,7 @@ class <emptyTree><<C <root>>> < ()
     begin
       ""
       "foo"
-      "foo".concat(1.to_s())
+      ::<Magic>.<concat-strings>("foo", 1.to_s())
     end
   end
 end

--- a/test/testdata/parser/misc.rb.desugar-tree.exp
+++ b/test/testdata/parser/misc.rb.desugar-tree.exp
@@ -188,7 +188,7 @@ rescue <emptyTree>::<C E> => x
     <assignTemp>$12
   end
 
-  "foo".concat(<self>.bar().to_s()).intern()
+  ::<Magic>.<concat-strings>("foo", <self>.bar().to_s()).intern()
 
   [:"sym"]
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Avoid a string of concatenations for string interpolation by making a new primitive that takes a variable number of strings as an argument.

Instead of desugaring like this:
```ruby
"ab #{10} cd" => "ab ".concat(10.to_s).concat(" cd")
```
We would now desugar like this:
```ruby
"ab #{10} cd" =>  Magic.<concat-strings>("ab ", 10.to_s, " cd")
```

This models the behavior of the `concatstrings` op in the ruby interpreter a bit closer.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
Existing tests.