### PR TITLE
Make release builds smaller

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -64,7 +64,7 @@ build:versioned --workspace_status_command=tools/buildstamp/get_workspace_status
 build:release-common --define release=true
 build:release-common --define jemalloc=true
 build:release-common --compilation_mode=opt
-build:release-common --config=debugsymbols
+build:release-common --config=backtracesymbols
 build:release-common --config=static-libs
 build:release-common --config=versioned
 
@@ -205,6 +205,12 @@ build:debugsymbols --copt=-g3 --copt=-fstandalone-debug --copt=-DDEBUG_SYMBOLS -
 build:debugsymbols --linkopt=-g3 --linkopt=-fstandalone-debug --linkopt=-DDEBUG_SYMBOLS --linkopt=-glldb
 build:debugsymbols --spawn_strategy=standalone
 build:debugsymbols --genrule_strategy=standalone
+
+# simpler & smaller debug symbols. Good enough for backtraces, but not for debugging.
+build:backtracesymbols --copt=-DDEBUG_SYMBOLS --copt=-gline-tables-only
+build:backtracesymbols --linkopt=-DDEBUG_SYMBOLS --linkopt=-gline-tables-only
+build:backtracesymbols --spawn_strategy=standalone
+build:backtracesymbols --genrule_strategy=standalone
 
 build --strip=never
 


### PR DESCRIPTION
### Motivation
Make deployed build at Stripe be >10x smaller than currently without loosing much of functionality.


### Test plan
We already have tests that verify that backtraces work
https://github.com/sorbet/sorbet/blob/9bdc561d9ec79c8fefe0ac0be2435d7ce1e8373b/test/cli/backtrace/backtrace.sh#L20

See included automated tests.
