### PR TITLE
Create simple benchmarks for some hot methods in runtime gem

### DIFF
--- a/gems/sorbet-runtime/Rakefile
+++ b/gems/sorbet-runtime/Rakefile
@@ -3,3 +3,9 @@
 task :test do
   Dir.glob('./test/**/*.rb').reject {|path| path.match(/^.\/test\/types\/fixtures\//)}.each(&method(:require))
 end
+
+begin
+  require './bench/tasks.rb'
+rescue LoadError
+  # Expected when using packaged gem
+end

--- a/gems/sorbet-runtime/bench/constructor.rb
+++ b/gems/sorbet-runtime/bench/constructor.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'benchmark'
+
+require_relative '../lib/sorbet-runtime'
+
+module SorbetBenchmarks
+  module Constructor
+
+    class Example < T::Struct
+      class Subdoc < T::Struct
+        prop :prop, String
+      end
+
+      prop :prop1, T.nilable(Integer)
+      prop :prop2, Integer, default: 0
+      prop :prop3, Integer
+      prop :prop4, T::Array[Integer]
+      prop :prop5, T::Array[Integer], default: []
+      prop :prop6, T::Hash[String, Integer]
+      prop :prop7, T::Hash[String, Integer], default: {}
+      prop :prop8, T.nilable(Subdoc)
+      prop :prop9, T::Array[Subdoc], default: []
+      prop :prop10, T::Hash[String, Subdoc], default: {}
+    end
+
+
+    def self.run
+      input = {
+        prop3: 0,
+        prop4: [],
+        prop6: {},
+      }.freeze
+
+      100_000.times do
+        Example.new(input)
+      end
+
+      result = Benchmark.measure do
+        1_000_000.times do
+          Example.new(input)
+        end
+      end
+
+      puts "T::Props.new, mostly nil input (μs/iter):"
+      puts result
+
+      subdoc = Example::Subdoc.new(prop: '').freeze
+      input = {
+        prop1: 0,
+        prop2: 0,
+        prop3: 0,
+        prop4: [1, 2, 3].freeze,
+        prop5: [1, 2, 3].freeze,
+        prop6: {'foo' => 1, 'bar' => 2}.freeze,
+        prop7: {'foo' => 1, 'bar' => 2}.freeze,
+        prop8: subdoc,
+        prop9: [subdoc, subdoc].freeze,
+        prop10: {'foo' => subdoc, 'bar' => subdoc}.freeze,
+      }.freeze
+
+      100_000.times do
+        Example.new(input)
+      end
+
+      result = Benchmark.measure do
+        1_000_000.times do
+          Example.new(input)
+        end
+      end
+
+      puts "T::Props.new, all props set (μs/iter):"
+      puts result
+    end
+  end
+end
+

--- a/gems/sorbet-runtime/bench/deserialize.rb
+++ b/gems/sorbet-runtime/bench/deserialize.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'benchmark'
+
+require_relative '../lib/sorbet-runtime'
+
+module SorbetBenchmarks
+  module Deserialize
+
+    class Example
+      include T::Props::Serializable
+
+      class Subdoc
+        include T::Props::Serializable
+        prop :prop, String
+      end
+
+      prop :prop1, T.nilable(Integer)
+      prop :prop2, Integer, default: 0
+      prop :prop3, Integer
+      prop :prop4, T::Array[Integer]
+      prop :prop5, T::Array[Integer], default: []
+      prop :prop6, T::Hash[String, Integer]
+      prop :prop7, T::Hash[String, Integer], default: {}
+      prop :prop8, T.nilable(Subdoc)
+      prop :prop9, T::Array[Subdoc], default: []
+      prop :prop10, T::Hash[String, Subdoc], default: {}
+    end
+
+    def self.run
+      input = {
+        'prop3' => 0,
+        'prop4' => [],
+        'prop6' => {},
+      }
+
+      100_000.times do
+        Example.from_hash(input)
+      end
+
+      result = Benchmark.measure do
+        1_000_000.times do
+          Example.from_hash(input)
+        end
+      end
+
+      puts "T::Props.from_hash, mostly nil input (μs/iter):"
+      puts result
+
+      input = {
+        'prop1' => 0,
+        'prop2' => 0,
+        'prop3' => 0,
+        'prop4' => [1, 2, 3],
+        'prop5' => [1, 2, 3],
+        'prop6' => {'foo' => 1, 'bar' => 2},
+        'prop7' => {'foo' => 1, 'bar' => 2},
+        'prop8' => {'prop' => ''},
+        'prop9' => [{'prop' => ''}, {'prop' => ''}],
+        'prop10' => {'foo' => {'prop' => ''}, 'bar' => {'prop' => ''}},
+      }
+
+      100_000.times do
+        Example.from_hash(input)
+      end
+
+      result = Benchmark.measure do
+        1_000_000.times do
+          Example.from_hash(input)
+        end
+      end
+
+      puts "T::Props.from_hash, all props set (μs/iter):"
+      puts result
+    end
+  end
+end

--- a/gems/sorbet-runtime/bench/getters.rb
+++ b/gems/sorbet-runtime/bench/getters.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'benchmark'
+
+require_relative '../lib/sorbet-runtime'
+
+module SorbetBenchmarks
+  module Getters
+
+    class ExamplePoro
+      attr_accessor :attr
+    end
+
+    class ExampleStruct < T::Struct
+      prop :prop, Integer
+      prop :ifunset, T.nilable(Integer), ifunset: 0
+    end
+
+    # Note we manually unroll loops 10x since loop overhead may be non-negligible here
+    def self.run
+      poro = ExamplePoro.new
+      poro.attr = 0
+      10_000.times { poro.attr }
+      result = Benchmark.measure do
+        100_000.times do
+          poro.attr
+          poro.attr
+          poro.attr
+          poro.attr
+          poro.attr
+          poro.attr
+          poro.attr
+          poro.attr
+          poro.attr
+          poro.attr
+        end
+      end
+      puts "Plain Ruby attr_reader, μs/iter:"
+      puts result
+
+      struct = ExampleStruct.new(prop: 0)
+      10_000.times { struct.prop }
+      result = Benchmark.measure do
+        100_000.times do
+          struct.prop
+          struct.prop
+          struct.prop
+          struct.prop
+          struct.prop
+          struct.prop
+          struct.prop
+          struct.prop
+          struct.prop
+          struct.prop
+        end
+      end
+      puts "T::Struct getter, fast path, μs/iter:"
+      puts result
+
+      struct = ExampleStruct.new(prop: 0)
+      10_000.times { struct.ifunset }
+      result = Benchmark.measure do
+        100_000.times do
+          struct.ifunset
+          struct.ifunset
+          struct.ifunset
+          struct.ifunset
+          struct.ifunset
+          struct.ifunset
+          struct.ifunset
+          struct.ifunset
+          struct.ifunset
+          struct.ifunset
+        end
+      end
+      puts "T::Struct getter, with ifunset, μs/iter:"
+      puts result
+    end
+  end
+end

--- a/gems/sorbet-runtime/bench/prop_definition.rb
+++ b/gems/sorbet-runtime/bench/prop_definition.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'benchmark'
+
+require_relative '../lib/sorbet-runtime'
+
+module SorbetBenchmarks
+  module PropDefinition
+
+    class Subdoc < T::Struct
+      prop :prop, String
+    end
+
+    def self.run
+      100.times do
+        cls = Class.new(T::Struct) do
+          prop :prop, String
+        end
+      end
+
+      result = Benchmark.measure do
+        1_000.times do
+          cls = Class.new(T::Struct) do
+            prop :prop, String
+          end
+        end
+      end
+
+      puts "Subclassing T::Struct, with one prop (ms/iter):"
+      puts result
+
+      100.times do
+        cls = Class.new(T::Struct) do
+          prop :prop1, T.nilable(Integer)
+          prop :prop2, Integer, default: 0
+          prop :prop3, Integer
+          prop :prop4, T::Array[Integer]
+          prop :prop5, T::Array[Integer], default: []
+          prop :prop6, T::Hash[String, Integer]
+          prop :prop7, T::Hash[String, Integer], default: {}
+          prop :prop8, T.nilable(Subdoc)
+          prop :prop9, T::Array[Subdoc], default: []
+          prop :prop10, T::Hash[String, Subdoc], default: {}
+        end
+      end
+
+      result = Benchmark.measure do
+        1_000.times do
+          cls = Class.new(T::Struct) do
+            prop :prop1, T.nilable(Integer)
+            prop :prop2, Integer, default: 0
+            prop :prop3, Integer
+            prop :prop4, T::Array[Integer]
+            prop :prop5, T::Array[Integer], default: []
+            prop :prop6, T::Hash[String, Integer]
+            prop :prop7, T::Hash[String, Integer], default: {}
+            prop :prop8, T.nilable(Subdoc)
+            prop :prop9, T::Array[Subdoc], default: []
+            prop :prop10, T::Hash[String, Subdoc], default: {}
+          end
+        end
+      end
+
+      puts "Subclassing T::Struct, with ten props (ms/iter):"
+      puts result
+    end
+  end
+end
+

--- a/gems/sorbet-runtime/bench/setters.rb
+++ b/gems/sorbet-runtime/bench/setters.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'benchmark'
+
+require_relative '../lib/sorbet-runtime'
+
+module SorbetBenchmarks
+  module Setters
+
+    class ExamplePoro
+      attr_accessor :attr
+    end
+
+    class ExampleStruct < T::Struct
+      prop :prop, Integer
+      prop :nilable, T.nilable(Integer), default: 0
+    end
+
+    # Note we manually unroll loops 10x since loop overhead may be non-negligible here
+    def self.run
+      poro = ExamplePoro.new
+
+      10_000.times do
+        poro.attr = 0
+      end
+
+      result = Benchmark.measure do
+        100_000.times do
+          poro.attr = 0
+          poro.attr = 1
+          poro.attr = 2
+          poro.attr = 3
+          poro.attr = 4
+          poro.attr = 5
+          poro.attr = 6
+          poro.attr = 7
+          poro.attr = 8
+          poro.attr = 9
+        end
+      end
+      puts "Plain Ruby attr_writer (μs/iter):"
+      puts result
+
+      struct = ExampleStruct.new(prop: 0)
+
+      10_000.times do
+        struct.prop = 0
+      end
+
+      result = Benchmark.measure do
+        100_000.times do
+          struct.prop = 0
+          struct.prop = 1
+          struct.prop = 2
+          struct.prop = 3
+          struct.prop = 4
+          struct.prop = 5
+          struct.prop = 6
+          struct.prop = 7
+          struct.prop = 8
+          struct.prop = 9
+        end
+      end
+      puts "T::Struct setter, simple type (μs/iter):"
+      puts result
+
+      struct = ExampleStruct.new(prop: 0)
+
+      10_000.times do
+        struct.nilable = 0
+      end
+
+      result = Benchmark.measure do
+        100_000.times do
+          struct.nilable = 0
+          struct.nilable = 1
+          struct.nilable = 2
+          struct.nilable = 3
+          struct.nilable = 4
+          struct.nilable = 5
+          struct.nilable = 6
+          struct.nilable = 7
+          struct.nilable = 8
+          struct.nilable = 9
+        end
+      end
+      puts "T::Struct setter, nilable type (μs/iter):"
+      puts result
+    end
+  end
+end
+

--- a/gems/sorbet-runtime/bench/tasks.rb
+++ b/gems/sorbet-runtime/bench/tasks.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rake/task'
+require_relative 'getters'
+require_relative 'setters'
+require_relative 'constructor'
+require_relative 'deserialize'
+require_relative 'prop_definition'
+
+namespace :bench do
+  task :getters do
+    SorbetBenchmarks::Getters.run
+  end
+
+  task :setters do
+    SorbetBenchmarks::Setters.run
+  end
+
+  task :constructor do
+    SorbetBenchmarks::Constructor.run
+  end
+
+  task :deserialize do
+    SorbetBenchmarks::Deserialize.run
+  end
+
+  task :prop_definition do
+    SorbetBenchmarks::PropDefinition.run
+  end
+
+  task all: [:getters, :setters, :constructor, :deserialize, :prop_definition]
+end


### PR DESCRIPTION
Create some naive benchmarks (using the built-in Benchmark module) for getters, setters, constructors, deserializers, and prop definition

Sample output from `bundle exec rake bench:all`:
```
Plain Ruby attr_reader, μs/iter:
  0.011089   0.000014   0.011103 (  0.011110)
T::Struct getter, fast path, μs/iter:
  0.389369   0.000196   0.389565 (  0.389835)
T::Struct getter, with ifunset, μs/iter:
  0.489488   0.000109   0.489597 (  0.489739)
Plain Ruby attr_writer (μs/iter):
  0.013895   0.000002   0.013897 (  0.013896)
T::Struct setter, simple type (μs/iter):
  0.419869   0.000429   0.420298 (  0.420493)
T::Struct setter, nilable type (μs/iter):
  0.597052   0.000278   0.597330 (  0.597589)
T::Props.new, mostly nil input (μs/iter):
 10.323749   0.004245  10.327994 ( 10.329164)
T::Props.new, all props set (μs/iter):
 11.841947   0.009573  11.851520 ( 11.852694)
T::Props.from_hash, mostly nil input (μs/iter):
  5.712148   0.001558   5.713706 (  5.714530)
T::Props.from_hash, all props set (μs/iter):
  8.476881   0.001475   8.478356 (  8.479198)
Subclassing T::Struct, with one prop (ms/iter):
  0.086425   0.000024   0.086449 (  0.086450)
Subclassing T::Struct, with ten props (ms/iter):
  0.669815   0.000108   0.669923 (  0.669922)
```

### Motivation
These are intended to provide a baseline for optimization. They're certainly not realistic (toy structs, simple call patterns) or scientific (no statistical analysis, no effort at preventing GC from interfering) enough to confidently detect small changes, but my belief is that a ~2x change here should still be a meaningful confidence-booster or warning sign

Generalization of some work in https://github.com/sorbet/sorbet/pull/2336 (meaning moderate conflicts, which I'll resolve in the second PR after whichever is first gets merged)

### Test plan
These tasks have no effect except when run manually in a development environment