### PR TITLE
Convert ClassDefKind to an enum class

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -261,7 +261,7 @@ public:
 
     static std::unique_ptr<ClassDef> Class(core::Loc loc, core::Loc declLoc, std::unique_ptr<Expression> name,
                                            ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs,
-                                           ClassDefKind kind) {
+                                           ClassDef::Kind kind) {
         return std::make_unique<ClassDef>(loc, declLoc, core::Symbols::todo(), std::move(name), std::move(ancestors),
                                           std::move(rhs), kind);
     }

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -80,7 +80,7 @@ Expression::Expression(core::Loc loc) : loc(loc) {}
 Reference::Reference(core::Loc loc) : Expression(loc) {}
 
 ClassDef::ClassDef(core::Loc loc, core::Loc declLoc, core::SymbolRef symbol, unique_ptr<Expression> name,
-                   ANCESTORS_store ancestors, RHS_store rhs, ClassDefKind kind)
+                   ANCESTORS_store ancestors, RHS_store rhs, ClassDef::Kind kind)
     : Declaration(loc, declLoc, symbol), kind(kind), rhs(std::move(rhs)), name(std::move(name)),
       ancestors(std::move(ancestors)) {
     categoryCounterInc("trees", "classdef");
@@ -308,7 +308,7 @@ template <class T> void printArgs(const core::GlobalState &gs, stringstream &buf
 
 string ClassDef::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     stringstream buf;
-    if (kind == ClassDefKind::Module) {
+    if (kind == ClassDef::Kind::Module) {
         buf << "module ";
     } else {
         buf << "class ";
@@ -332,7 +332,7 @@ string ClassDef::showRaw(const core::GlobalState &gs, int tabs) {
     stringstream buf;
     buf << nodeName() << "{" << '\n';
     printTabs(buf, tabs + 1);
-    buf << "kind = " << (kind == ClassDefKind::Module ? "module" : "class") << '\n';
+    buf << "kind = " << (kind == ClassDef::Kind::Module ? "module" : "class") << '\n';
     printTabs(buf, tabs + 1);
     buf << "name = " << name->showRaw(gs, tabs + 1) << "<"
         << this->symbol.dataAllowingNone(gs)->name.data(gs)->showRaw(gs) << ">" << '\n';

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -126,7 +126,7 @@ public:
     ANCESTORS_store singletonAncestors;
 
     ClassDef(core::Loc loc, core::Loc declLoc, core::SymbolRef symbol, std::unique_ptr<Expression> name,
-             ANCESTORS_store ancestors, RHS_store rhs, ClassDefKind kind);
+             ANCESTORS_store ancestors, RHS_store rhs, ClassDef::Kind kind);
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -105,11 +105,13 @@ public:
 };
 // CheckSize(Declaration, 24, 8);
 
-enum ClassDefKind : u1 { Module, Class };
-
 class ClassDef final : public Declaration {
 public:
-    ClassDefKind kind;
+    enum class Kind : u1 {
+        Module,
+        Class,
+    };
+    Kind kind;
     static constexpr int EXPECTED_RHS_COUNT = 4;
     typedef InlinedVector<std::unique_ptr<Expression>, EXPECTED_RHS_COUNT> RHS_store;
 

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -878,7 +878,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 ClassDef::ANCESTORS_store ancestors;
                 unique_ptr<Expression> res =
                     MK::Class(module->loc, module->declLoc, node2TreeImpl(dctx, std::move(module->name)),
-                              std::move(ancestors), std::move(body), ClassDefKind::Module);
+                              std::move(ancestors), std::move(body), ClassDef::Kind::Module);
                 result.swap(res);
             },
             [&](parser::Class *claz) {
@@ -891,7 +891,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 }
                 unique_ptr<Expression> res =
                     MK::Class(claz->loc, claz->declLoc, node2TreeImpl(dctx, std::move(claz->name)),
-                              std::move(ancestors), std::move(body), ClassDefKind::Class);
+                              std::move(ancestors), std::move(body), ClassDef::Kind::Class);
                 result.swap(res);
             },
             [&](parser::Arg *arg) {
@@ -970,7 +970,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 unique_ptr<Expression> res = make_unique<ClassDef>(
                     sclass->loc, sclass->declLoc, core::Symbols::todo(),
                     make_unique<UnresolvedIdent>(sclass->expr->loc, UnresolvedIdent::Class, core::Names::singleton()),
-                    std::move(emptyAncestors), std::move(body), ClassDefKind::Class);
+                    std::move(emptyAncestors), std::move(body), ClassDef::Kind::Class);
                 result.swap(res);
             },
             [&](parser::Block *block) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1747,7 +1747,7 @@ unique_ptr<Expression> liftTopLevel(DesugarContext dctx, core::Loc loc, unique_p
         rhs.emplace_back(std::move(what));
     }
     return make_unique<ClassDef>(loc, loc, core::Symbols::root(), MK::EmptyTree(), ClassDef::ANCESTORS_store(),
-                                 std::move(rhs), Class);
+                                 std::move(rhs), ClassDef::Kind::Class);
 }
 } // namespace
 

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1068,7 +1068,7 @@ unique_ptr<ast::Expression> SerializerImpl::unpickleExpr(serialize::UnPickler &p
                 r = unpickleExpr(p, gs, file);
             }
             auto ret = ast::MK::Class(loc, declLoc, std::move(name), std::move(ancestors), std::move(rhs),
-                                      (ast::ClassDefKind)kind);
+                                      (ast::ClassDef::Kind)kind);
             ret->singletonAncestors = std::move(singletonAncestors);
             ret->symbol = symbol;
             return ret;

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -847,7 +847,7 @@ void SerializerImpl::pickle(Pickler &p, FileRef file, const unique_ptr<ast::Expr
         [&](ast::ClassDef *c) {
             pickleAstHeader(p, 21, c);
             pickle(p, c->declLoc);
-            p.putU1(c->kind);
+            p.putU1(static_cast<u2>(c->kind));
             p.putU4(c->symbol._id);
             p.putU4(c->ancestors.size());
             p.putU4(c->singletonAncestors.size());

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -73,7 +73,7 @@ public:
 
         auto &def = defs.emplace_back();
         def.id = defs.size() - 1;
-        if (original->kind == ast::Class) {
+        if (original->kind == ast::ClassDef::Kind::Class) {
             def.type = Definition::Class;
         } else {
             def.type = Definition::Module;
@@ -92,7 +92,7 @@ public:
         refs[it->second.id()].definitionLoc = original->loc;
 
         auto ait = original->ancestors.begin();
-        if (original->kind == ast::Class && !original->ancestors.empty()) {
+        if (original->kind == ast::ClassDef::Kind::Class && !original->ancestors.empty()) {
             // Handle the superclass at outer scope
             *ait = ast::TreeMap::apply(ctx, *this, move(*ait));
             ++ait;
@@ -118,7 +118,7 @@ public:
             if (it == refMap.end()) {
                 continue;
             }
-            if (original->kind == ast::Class && &ancst == &original->ancestors.front()) {
+            if (original->kind == ast::ClassDef::Kind::Class && &ancst == &original->ancestors.front()) {
                 // superclass
                 def.parent_ref = it->second;
             }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -226,7 +226,7 @@ public:
                 // Nothing else should have been typeAlias by now.
                 ENFORCE(klass->symbol == core::Symbols::root());
             }
-            bool isModule = klass->kind == ast::ClassDefKind::Module;
+            bool isModule = klass->kind == ast::ClassDef::Kind::Module;
             if (!klass->symbol.data(ctx)->isClassOrModule()) {
                 // we might have already mangled the class symbol, so see if we have a symbol that is a class already
                 auto klassSymbol =

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -301,7 +301,7 @@ public:
         }
         if (send->fun == core::Names::declareInterface()) {
             klass->symbol.data(ctx)->setClassInterface();
-            if (klass->kind == ast::Class) {
+            if (klass->kind == ast::ClassDef::Kind::Class) {
                 if (auto e = ctx.state.beginError(send->loc, core::errors::Namer::InterfaceClass)) {
                     e.setHeader("Classes can't be interfaces. Use `abstract!` instead of `interface!`");
                     e.replaceWith("Change `interface!` to `abstract!`", send->loc, "abstract!");
@@ -324,7 +324,7 @@ public:
     }
 
     unique_ptr<ast::Expression> postTransformClassDef(core::MutableContext ctx, unique_ptr<ast::ClassDef> klass) {
-        if (klass->kind == ast::Class && !klass->symbol.data(ctx)->superClass().exists() &&
+        if (klass->kind == ast::ClassDef::Kind::Class && !klass->symbol.data(ctx)->superClass().exists() &&
             klass->symbol != core::Symbols::BasicObject()) {
             klass->symbol.data(ctx)->setSuperClass(core::Symbols::todo());
         }
@@ -358,7 +358,7 @@ public:
         if (ast::isa_tree<ast::ConstantLit>(klass->name.get())) {
             ideSeqs.emplace_back(ast::MK::KeepForIDE(klass->name->deepCopy()));
         }
-        if (klass->kind == ast::Class && !klass->ancestors.empty() &&
+        if (klass->kind == ast::ClassDef::Kind::Class && !klass->ancestors.empty() &&
             shouldLeaveAncestorForIDE(klass->ancestors.front())) {
             ideSeqs.emplace_back(ast::MK::KeepForIDE(klass->ancestors.front()->deepCopy()));
         }

--- a/plugin/SubprocessTextPlugin.cc
+++ b/plugin/SubprocessTextPlugin.cc
@@ -14,7 +14,7 @@ struct Namespace {
     InlinedVector<core::NameRef, 3> components;
 
     Namespace(const unique_ptr<ast::ClassDef> &klass) {
-        type = (klass->kind == ast::ClassDefKind::Module ? Module : Class);
+        type = (klass->kind == ast::ClassDef::Kind::Module ? Module : Class);
         fillComponents(klass->name.get());
     }
     ~Namespace() = default;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -576,8 +576,8 @@ public:
         core::SymbolRef klass = original->symbol;
 
         for (auto &ancst : original->ancestors) {
-            bool isSuperclass = (original->kind == ast::ClassDef::Kind::Class && &ancst == &original->ancestors.front() &&
-                                 !klass.data(ctx)->isSingletonClass(ctx));
+            bool isSuperclass = (original->kind == ast::ClassDef::Kind::Class &&
+                                 &ancst == &original->ancestors.front() && !klass.data(ctx)->isSingletonClass(ctx));
             transformAncestor(isSuperclass ? ctx : ctx.withOwner(klass), klass, ancst, isSuperclass);
         }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -576,7 +576,7 @@ public:
         core::SymbolRef klass = original->symbol;
 
         for (auto &ancst : original->ancestors) {
-            bool isSuperclass = (original->kind == ast::Class && &ancst == &original->ancestors.front() &&
+            bool isSuperclass = (original->kind == ast::ClassDef::Kind::Class && &ancst == &original->ancestors.front() &&
                                  !klass.data(ctx)->isSingletonClass(ctx));
             transformAncestor(isSuperclass ? ctx : ctx.withOwner(klass), klass, ancst, isSuperclass);
         }

--- a/rewriter/ClassNew.cc
+++ b/rewriter/ClassNew.cc
@@ -78,7 +78,7 @@ vector<unique_ptr<ast::Expression>> ClassNew::run(core::MutableContext ctx, ast:
 
     vector<unique_ptr<ast::Expression>> stats;
     stats.emplace_back(make_unique<ast::ClassDef>(loc, loc, core::Symbols::todo(), std::move(asgn->lhs),
-                                                  std::move(ancestors), std::move(body), ast::ClassDefKind::Class));
+                                                  std::move(ancestors), std::move(body), ast::ClassDef::Kind::Class));
     return stats;
 }
 

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -11,7 +11,7 @@ using namespace std;
 namespace sorbet::rewriter {
 
 bool isCommand(core::MutableContext ctx, ast::ClassDef *klass) {
-    if (klass->kind != ast::Class || klass->ancestors.empty()) {
+    if (klass->kind != ast::ClassDef::Kind::Class || klass->ancestors.empty()) {
         return false;
     }
     auto *cnst = ast::cast_tree<ast::UnresolvedConstantLit>(klass->ancestors.front().get());

--- a/rewriter/Flatfiles.cc
+++ b/rewriter/Flatfiles.cc
@@ -59,7 +59,7 @@ void handleFieldDefinition(core::MutableContext ctx, unique_ptr<ast::Expression>
 }
 
 void Flatfiles::run(core::MutableContext ctx, ast::ClassDef *klass) {
-    if (klass->kind != ast::Class || klass->ancestors.empty()) {
+    if (klass->kind != ast::ClassDef::Kind::Class || klass->ancestors.empty()) {
         return;
     }
 

--- a/rewriter/Flatten.cc
+++ b/rewriter/Flatten.cc
@@ -276,7 +276,7 @@ class FlattenWalk {
                 ast::MK::Class(loc, loc,
                                make_unique<ast::UnresolvedIdent>(core::Loc::none(), ast::UnresolvedIdent::Class,
                                                                  core::Names::singleton()),
-                               {}, std::move(body), ast::ClassDefKind::Class);
+                               {}, std::move(body), ast::ClassDef::Kind::Class);
             rhs.emplace_back(std::move(classDef));
         }
 

--- a/rewriter/Mattr.cc
+++ b/rewriter/Mattr.cc
@@ -30,7 +30,7 @@ static void addInstanceCounterPart(vector<unique_ptr<ast::Expression>> &sink, co
 }
 
 vector<unique_ptr<ast::Expression>> Mattr::run(core::MutableContext ctx, const ast::Send *send,
-                                               ast::ClassDefKind classDefKind) {
+                                               ast::ClassDef::Kind classDefKind) {
     vector<unique_ptr<ast::Expression>> empty;
     bool doReaders = false;
     bool doWriters = false;

--- a/rewriter/Mattr.cc
+++ b/rewriter/Mattr.cc
@@ -42,7 +42,7 @@ vector<unique_ptr<ast::Expression>> Mattr::run(core::MutableContext ctx, const a
     } else if (send->fun == core::Names::mattrAccessor() || send->fun == core::Names::cattrAccessor()) {
         doReaders = true;
         doWriters = true;
-    } else if (classDefKind == ast::Class && send->fun == core::Names::classAttribute()) {
+    } else if (classDefKind == ast::ClassDef::Kind::Class && send->fun == core::Names::classAttribute()) {
         doReaders = true;
         doWriters = true;
         doPredicates = true;

--- a/rewriter/Mattr.h
+++ b/rewriter/Mattr.h
@@ -31,7 +31,7 @@ namespace sorbet::rewriter {
 class Mattr final {
 public:
     static std::vector<std::unique_ptr<ast::Expression>> run(core::MutableContext ctx, const ast::Send *send,
-                                                             ast::ClassDefKind classDefKind);
+                                                             ast::ClassDef::Kind classDefKind);
 
     Mattr() = delete;
 };

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -178,7 +178,7 @@ unique_ptr<ast::Expression> runSingle(core::MutableContext ctx, ast::Send *send)
         auto name = ast::MK::UnresolvedConstant(arg->loc, ast::MK::EmptyTree(),
                                                 ctx.state.enterNameConstant("<describe '" + argString + "'>"));
         return ast::MK::Class(send->loc, send->loc, std::move(name), std::move(ancestors), std::move(rhs),
-                              ast::ClassDefKind::Class);
+                              ast::ClassDef::Kind::Class);
     } else if (send->fun == core::Names::it()) {
         ConstantMover constantMover;
         send->block->body = ast::TreeMap::apply(ctx, constantMover, move(send->block->body));

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -344,7 +344,7 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
             auto name = core::Names::Constants::Mutator();
             ret.nodes.emplace_back(ast::MK::Class(loc, loc,
                                                   ast::MK::UnresolvedConstant(loc, ast::MK::EmptyTree(), name),
-                                                  std::move(ancestors), std::move(rhs), ast::ClassDefKind::Class));
+                                                  std::move(ancestors), std::move(rhs), ast::ClassDef::Kind::Class));
         }
     }
 

--- a/rewriter/ProtobufDescriptorPool.cc
+++ b/rewriter/ProtobufDescriptorPool.cc
@@ -16,7 +16,7 @@ vector<unique_ptr<ast::Expression>> ProtobufDescriptorPool::run(core::MutableCon
     if (sendMsgclass->fun != core::Names::msgclass() && sendMsgclass->fun != core::Names::enummodule()) {
         return empty;
     }
-    auto kind = sendMsgclass->fun == core::Names::msgclass() ? ast::ClassDefKind::Class : ast::ClassDefKind::Module;
+    auto kind = sendMsgclass->fun == core::Names::msgclass() ? ast::ClassDef::Kind::Class : ast::ClassDef::Kind::Module;
 
     auto sendLookup = ast::cast_tree<ast::Send>(sendMsgclass->recv.get());
     if (sendLookup == nullptr || sendLookup->fun != core::Names::lookup()) {

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -153,7 +153,7 @@ vector<unique_ptr<ast::Expression>> Struct::run(core::MutableContext ctx, ast::A
 
     vector<unique_ptr<ast::Expression>> stats;
     stats.emplace_back(make_unique<ast::ClassDef>(loc, loc, core::Symbols::todo(), std::move(asgn->lhs),
-                                                  std::move(ancestors), std::move(body), ast::ClassDefKind::Class));
+                                                  std::move(ancestors), std::move(body), ast::ClassDef::Kind::Class));
     return stats;
 }
 

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -133,7 +133,7 @@ vector<unique_ptr<ast::Expression>> processStat(core::MutableContext ctx, ast::C
                                          ast::MK::Constant(stat->loc, core::Symbols::Singleton())));
     classRhs.emplace_back(ast::MK::Send0(stat->loc, ast::MK::Self(stat->loc), core::Names::declareFinal()));
     auto classDef = ast::MK::Class(stat->loc, stat->loc, classCnst->deepCopy(), std::move(parent), std::move(classRhs),
-                                   ast::ClassDefKind::Class);
+                                   ast::ClassDef::Kind::Class);
 
     auto singletonAsgn =
         ast::MK::Assign(stat->loc, std::move(asgn->lhs),

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -19,7 +19,7 @@ enum class FromWhere {
 };
 
 bool isTEnum(core::MutableContext ctx, ast::ClassDef *klass) {
-    if (klass->kind != ast::Class || klass->ancestors.empty()) {
+    if (klass->kind != ast::ClassDef::Kind::Class || klass->ancestors.empty()) {
         return false;
     }
     auto *cnst = ast::cast_tree<ast::UnresolvedConstantLit>(klass->ancestors.front().get());

--- a/test/hello-test.cc
+++ b/test/hello-test.cc
@@ -165,7 +165,7 @@ TEST(PreOrderTreeMap, CountTrees) { // NOLINT
     classrhs.emplace_back(std::move(methodDef));
     unique_ptr<ast::Expression> tree =
         make_unique<ast::ClassDef>(loc, loc, classSym, std::move(cnst), ast::ClassDef::ANCESTORS_store(),
-                                   std::move(classrhs), ast::ClassDefKind::Class);
+                                   std::move(classrhs), ast::ClassDef::Kind::Class);
     Counter c;
 
     auto r = ast::TreeMap::apply(ctx, c, std::move(tree));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`enum class` is better than `enum` (gets it's own namespace, not implicitly
convertible to int).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.