### PR TITLE
Add preemption logic to GlobalState and typecheck

### DIFF
--- a/common/concurrency/WorkerPool.h
+++ b/common/concurrency/WorkerPool.h
@@ -9,7 +9,9 @@ class WorkerPool {
 public:
     inline static constexpr std::chrono::milliseconds BLOCK_INTERVAL() {
         using namespace std::chrono_literals;
-        return 250ms;
+        // NOTE: This value materially impacts IDE responsiveness during typechecking; the typechecking thread wakes up
+        // at this interval and checks if it should do other work.
+        return 20ms;
     }
     using Task = std::function<void()>;
     static std::unique_ptr<WorkerPool> create(int size, spd::logger &logger);

--- a/core/Files.cc
+++ b/core/Files.cc
@@ -169,7 +169,7 @@ vector<int> &File::lineBreaks() const {
     ENFORCE(this->sourceType != File::Type::TombStone);
     ENFORCE(this->sourceType != File::Type::NotYetRead);
     auto ptr = atomic_load(&lineBreaks_);
-    if (ptr) {
+    if (ptr != nullptr) {
         return *ptr;
     } else {
         auto my = make_shared<vector<int>>(findLineBreaks(this->source_));

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -9,6 +9,7 @@
 #include "core/Types.h"
 #include "core/Unfreeze.h"
 #include "core/errors/errors.h"
+#include "core/lsp/Task.h"
 #include <utility>
 
 #include "absl/strings/str_cat.h"
@@ -49,11 +50,11 @@ const int Symbols::MAX_PROC_ARITY;
 
 GlobalState::GlobalState(shared_ptr<ErrorQueue> errorQueue, shared_ptr<absl::Mutex> epochMutex,
                          shared_ptr<atomic<u4>> currentlyProcessingLSPEpoch, shared_ptr<atomic<u4>> lspEpochInvalidator,
-                         shared_ptr<atomic<u4>> lastCommittedLSPEpoch)
+                         shared_ptr<atomic<u4>> lastCommittedLSPEpoch, shared_ptr<shared_ptr<lsp::Task>> preemptTask)
     : globalStateId(globalStateIdCounter.fetch_add(1)), errorQueue(std::move(errorQueue)),
-      lspQuery(lsp::Query::noQuery()), epochMutex(std::move(epochMutex)),
+      lspQuery(lsp::Query::noQuery()), typecheckMutex(make_unique<absl::Mutex>()), epochMutex(std::move(epochMutex)),
       currentlyProcessingLSPEpoch(move(currentlyProcessingLSPEpoch)), lspEpochInvalidator(move(lspEpochInvalidator)),
-      lastCommittedLSPEpoch(move(lastCommittedLSPEpoch)) {
+      lastCommittedLSPEpoch(move(lastCommittedLSPEpoch)), preemptTask(move(preemptTask)) {
     // Empirically determined to be the smallest powers of two larger than the
     // values required by the payload
     unsigned int maxNameCount = 8192;
@@ -1325,7 +1326,7 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     Timer timeit(tracer(), "GlobalState::deepCopy", this->creation);
     this->sanityCheck();
     auto result = make_unique<GlobalState>(this->errorQueue, this->epochMutex, this->currentlyProcessingLSPEpoch,
-                                           this->lspEpochInvalidator, this->lastCommittedLSPEpoch);
+                                           this->lspEpochInvalidator, this->lastCommittedLSPEpoch, this->preemptTask);
 
     result->silenceErrors = this->silenceErrors;
     result->autocorrect = this->autocorrect;
@@ -1492,7 +1493,9 @@ bool GlobalState::wasModified() const {
 }
 
 bool GlobalState::wasTypecheckingCanceled() const {
-    return lspEpochInvalidator->load() != currentlyProcessingLSPEpoch->load();
+    // Can't cancel typechecking if we have a preemption task to run -- we have to make it past resolver at least before
+    // we can cancel.
+    return lspEpochInvalidator->load() != currentlyProcessingLSPEpoch->load() && !atomic_load(preemptTask.get());
 }
 
 void GlobalState::startCommitEpoch(u4 fromEpoch, u4 toEpoch) {
@@ -1537,6 +1540,42 @@ bool GlobalState::tryCancelSlowPath(u4 newEpoch) const {
     return true;
 }
 
+bool GlobalState::tryPreempt(shared_ptr<lsp::Task> task) {
+    // Need to grab epochMutex so we have accurate information w.r.t. if typechecking is happening / if typechecking was
+    // canceled.
+    absl::MutexLock lock(epochMutex.get());
+    const u4 processing = currentlyProcessingLSPEpoch->load();
+    const u4 committed = lastCommittedLSPEpoch->load();
+    const u4 invalidator = lspEpochInvalidator->load();
+    const bool noSlowPathRunning = processing == committed;
+    const bool alreadyCanceled = processing != invalidator;
+
+    // The code should only ever set one preempt function.
+    auto existingTask = atomic_load(preemptTask.get());
+    ENFORCE(!existingTask);
+    if (noSlowPathRunning || alreadyCanceled || existingTask) {
+        // No slow path running, typechecking was canceled so we can't preempt the canceled slow path, or a task is
+        // already scheduled. The latter should _never_ occur, as the scheduled task should _block_ the thread
+        // that scheduled it.
+        return false;
+    }
+
+    return atomic_compare_exchange_strong(preemptTask.get(), &existingTask, move(task));
+}
+
+bool GlobalState::tryRunPreemptionTask() {
+    auto preemptTask = atomic_load(this->preemptTask.get());
+    if (preemptTask) {
+        ENFORCE(lspTypecheckCount > 0); // Resolver needs to have finished running.
+        // Capture with write lock before running task. Ensures that all worker threads park before we proceed.
+        absl::MutexLock lock(typecheckMutex.get());
+        preemptTask->run();
+        atomic_store(this->preemptTask.get(), shared_ptr<lsp::Task>(nullptr));
+        return true;
+    }
+    return false;
+}
+
 bool GlobalState::tryCommitEpoch(u4 epoch, bool isCancelable, function<void()> typecheck) {
     if (!isCancelable) {
         typecheck();
@@ -1567,6 +1606,10 @@ bool GlobalState::tryCommitEpoch(u4 epoch, bool isCancelable, function<void()> t
             lspEpochInvalidator->store(lastCommitted);
         }
     }
+
+    // Now that we are no longer running a slow path, run a preemption task that might have snuck in while we were
+    // finishing up. No others can be scheduled.
+    tryRunPreemptionTask();
     return committed;
 }
 

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -22,6 +22,10 @@ class ErrorRegion;
 class ErrorQueue;
 struct GlobalStateHash;
 
+namespace lsp {
+class Task;
+}
+
 namespace serialize {
 class Serializer;
 class SerializerImpl;
@@ -49,7 +53,9 @@ public:
                 std::shared_ptr<absl::Mutex> epochMutex = std::make_shared<absl::Mutex>(),
                 std::shared_ptr<std::atomic<u4>> currentlyProcessingLSPEpoch = std::make_shared<std::atomic<u4>>(0),
                 std::shared_ptr<std::atomic<u4>> lspEpochInvalidator = std::make_shared<std::atomic<u4>>(0),
-                std::shared_ptr<std::atomic<u4>> lastCommittedLSPEpoch = std::make_shared<std::atomic<u4>>(0));
+                std::shared_ptr<std::atomic<u4>> lastCommittedLSPEpoch = std::make_shared<std::atomic<u4>>(0),
+                std::shared_ptr<std::shared_ptr<lsp::Task>> preemptTask =
+                    std::make_shared<std::shared_ptr<lsp::Task>>(nullptr));
 
     void initEmpty();
     void installIntrinsics();
@@ -209,6 +215,13 @@ public:
     // Tries to cancel a running slow path on this GlobalState or its descendent. Returns true if it succeeded, false if
     // the slow path was unable to be canceled.
     bool tryCancelSlowPath(u4 newEpoch) const;
+    // [LSP] Run only from message processing thread.
+    // Attempts to preempt a running slow path to run the provided task. If it returns true, the task is guaranteed
+    // to run.
+    bool tryPreempt(std::shared_ptr<lsp::Task> task);
+    // [LSP] Run from the typechecker thread during a slow path. Attempts to run the preeemption task, if one is
+    // registered. Returns true if it ran a preemption task.
+    bool tryRunPreemptionTask();
 
     void trace(std::string_view msg) const;
 
@@ -227,6 +240,12 @@ public:
     bool hasAnyDslPlugin() const;
 
     std::vector<std::unique_ptr<pipeline::semantic_extension::SemanticExtension>> semanticExtensions;
+    // In LSP mode: Used to pre-empt typechecking (post-resolver).
+    // - Worker threads grab as a reader lock, and routinely gives up and re-acquire the lock to allow other requests to
+    // pre-empt.
+    // - Typechecking coordinator thread grabs as a writer lock when there's a preemption function, which halts all
+    // worker threads.
+    const std::unique_ptr<absl::Mutex> typecheckMutex;
 
 private:
     bool shouldReportErrorOn(Loc loc, ErrorClass what) const;
@@ -264,6 +283,9 @@ private:
     // If lastCommittedLSPEpoch != currentlyProcessingLSPEpoch, then GlobalState is currently running a slow path
     // containing edits (lastCommittedLSPEpoch, currentlyProcessingLSPEpoch].
     const std::shared_ptr<std::atomic<u4>> lastCommittedLSPEpoch;
+    // Task to run when pre-empting typechecking. Outer shared_ptr is shared amongst all GlobalState instances that
+    // share a common lineage, whereas contents of inner shared_ptr is atomically replaced during preemption.
+    const std::shared_ptr<std::shared_ptr<lsp::Task>> preemptTask;
 
     bool freezeSymbolTable();
     bool freezeNameTable();

--- a/core/lsp/PreemptionTaskManager.cc
+++ b/core/lsp/PreemptionTaskManager.cc
@@ -19,7 +19,7 @@ bool PreemptionTaskManager::trySchedulePreemptionTask(std::shared_ptr<Task> task
         [&preemptTask = this->preemptTask, &task, &success](TypecheckEpochManager::TypecheckingStatus status) -> void {
             // The code should only ever set one preempt function.
             auto existingTask = atomic_load(&preemptTask);
-            ENFORCE(existingTask != nullptr);
+            ENFORCE(existingTask == nullptr);
             if (!status.slowPathRunning || status.slowPathWasCanceled || existingTask != nullptr) {
                 // No slow path running, typechecking was canceled so we can't preempt the canceled slow path, or a task
                 // is already scheduled. The latter should _never_ occur, as the scheduled task should _block_ the

--- a/core/lsp/PreemptionTaskManager.cc
+++ b/core/lsp/PreemptionTaskManager.cc
@@ -1,0 +1,60 @@
+#include "core/lsp/PreemptionTaskManager.h"
+#include "core/lsp/Task.h"
+#include "core/lsp/TypecheckEpochManager.h"
+
+using namespace std;
+
+namespace sorbet::core::lsp {
+
+PreemptionTaskManager::PreemptionTaskManager(shared_ptr<TypecheckEpochManager> epochManager)
+    : epochManager(move(epochManager)) {}
+
+bool PreemptionTaskManager::trySchedulePreemptionTask(std::shared_ptr<Task> task) {
+    TypecheckEpochManager::assertConsistentThread(
+        messageProcessingThreadId, "PreemptionTaskManager::trySchedulePreemptionTask", "message processing thread");
+    bool success = false;
+    // Need to grab epoch lock so we have accurate information w.r.t. if typechecking is happening / if typechecking was
+    // canceled. Avoids races with typechecking thread.
+    this->epochManager->withEpochLock(
+        [&preemptTask = this->preemptTask, &task, &success](TypecheckEpochManager::TypecheckingStatus status) -> void {
+            // The code should only ever set one preempt function.
+            auto existingTask = atomic_load(&preemptTask);
+            ENFORCE(!existingTask);
+            if (!status.slowPathRunning || status.slowPathWasCanceled || existingTask) {
+                // No slow path running, typechecking was canceled so we can't preempt the canceled slow path, or a task
+                // is already scheduled. The latter should _never_ occur, as the scheduled task should _block_ the
+                // thread that scheduled it.
+                return;
+            }
+            success = atomic_compare_exchange_strong(&preemptTask, &existingTask, move(task));
+        });
+
+    return success;
+}
+
+bool PreemptionTaskManager::tryRunScheduledPreemptionTask() {
+    TypecheckEpochManager::assertConsistentThread(
+        typecheckingThreadId, "PreemptionTaskManager::tryRunScheduledPreemptionTask", "typechecking thread");
+    auto preemptTask = atomic_load(&this->preemptTask);
+    if (preemptTask) {
+        // Capture with write lock before running task. Ensures that all worker threads park before we proceed.
+        absl::MutexLock lock(&typecheckMutex);
+        // Invariant: Typechecking _cannot_ be canceled before or during a preemption task.
+        ENFORCE(!epochManager->wasTypecheckingCanceled());
+        preemptTask->run();
+        atomic_store(&this->preemptTask, shared_ptr<lsp::Task>(nullptr));
+        ENFORCE(!epochManager->wasTypecheckingCanceled());
+        return true;
+    }
+    return false;
+}
+
+unique_ptr<absl::ReaderMutexLock> PreemptionTaskManager::lockPreemption() const {
+    return make_unique<absl::ReaderMutexLock>(&typecheckMutex);
+}
+
+void PreemptionTaskManager::assertTypecheckMutexHeld() {
+    typecheckMutex.AssertHeld();
+}
+
+} // namespace sorbet::core::lsp

--- a/core/lsp/PreemptionTaskManager.h
+++ b/core/lsp/PreemptionTaskManager.h
@@ -1,0 +1,41 @@
+#ifndef SORBET_LSP_PREEMPTIONTASKMANAGER_H
+#define SORBET_LSP_PREEMPTIONTASKMANAGER_H
+
+#include "core/core.h"
+#include <memory>
+
+namespace sorbet::core::lsp {
+class Task;
+class TypecheckEpochManager;
+class PreemptionTaskManager final {
+private:
+    // Used to pre-empt typechecking (post-resolver).
+    // - Worker threads grab as a reader lock, and routinely gives up and re-acquire the lock to allow other requests to
+    // pre-empt.
+    // - Typechecking coordinator thread grabs as a writer lock when there's a preemption function, which halts all
+    // worker threads.
+    mutable absl::Mutex typecheckMutex;
+    std::shared_ptr<Task> preemptTask;
+    std::shared_ptr<TypecheckEpochManager> epochManager;
+    // Thread ID of the typechecking thread. Lazily set.
+    std::optional<std::thread::id> typecheckingThreadId;
+    // Thread ID of the message processing thread. Lazily set.
+    std::optional<std::thread::id> messageProcessingThreadId;
+
+public:
+    PreemptionTaskManager(std::shared_ptr<TypecheckEpochManager> epochManager);
+    // Run only from message processing thread.
+    // Attempts to preempt a running slow path to run the provided task. If it returns true, the task is guaranteed
+    // to run.
+    bool trySchedulePreemptionTask(std::shared_ptr<Task> task);
+    // Run only from the typechecking thread.
+    // Runs the scheduled preemption task, if any.
+    bool tryRunScheduledPreemptionTask();
+    // Run only from typechecker worker threads. Prevents preemption from occurring while the ReaderMutexLock is alive.
+    std::unique_ptr<absl::ReaderMutexLock> lockPreemption() const;
+    // (For testing only) Assert that typecheckMutex is held.
+    void assertTypecheckMutexHeld();
+};
+
+} // namespace sorbet::core::lsp
+#endif

--- a/core/lsp/TypecheckEpochManager.cc
+++ b/core/lsp/TypecheckEpochManager.cc
@@ -1,0 +1,118 @@
+#include "core/lsp/TypecheckEpochManager.h"
+#include "core/lsp/PreemptionTaskManager.h"
+
+using namespace std;
+namespace sorbet::core::lsp {
+
+void TypecheckEpochManager::assertConsistentThread(optional<thread::id> &expectedThreadId, string_view method,
+                                                   string_view threadName) {
+    if (!expectedThreadId.has_value()) {
+        expectedThreadId = this_thread::get_id();
+    } else if (*expectedThreadId != this_thread::get_id()) {
+        Exception::raise("{} can only be called by the {} thread.", method, threadName);
+    }
+}
+
+void TypecheckEpochManager::startCommitEpoch(u4 fromEpoch, u4 toEpoch) {
+    assertConsistentThread(typecheckingThreadId, "TypecheckCancellor::startCommitEpoch", "typechecking");
+
+    absl::MutexLock lock(&epochMutex);
+    ENFORCE(fromEpoch != toEpoch);
+    ENFORCE(toEpoch != currentlyProcessingLSPEpoch.load());
+    ENFORCE(toEpoch != lastCommittedLSPEpoch.load());
+    // epoch should be a version 'ahead' of currentlyProcessingLSPEpoch. The distance between the two is the number of
+    // fast path edits that have come in since the last slow path. Since epochs overflow, there's nothing that I can
+    // easily assert here to ensure that we are not moving backward in time.
+    currentlyProcessingLSPEpoch.store(toEpoch);
+    lspEpochInvalidator.store(toEpoch);
+    // lastCommittedLSPEpoch currently contains the epoch of the last slow path we processed. Since then, we may have
+    // committed several fast paths. So, update it to the epoch of the last fast path committed.
+    // We do it this way rather than keep it up-to-date after every fast path to reduce footguns, especially in testing.
+    // With this design, when starting a commit epoch, you have to specify the (from, to] range, and it is compiler
+    // enforced.
+    lastCommittedLSPEpoch.store(fromEpoch);
+}
+
+bool TypecheckEpochManager::wasTypecheckingCanceled() const {
+    // This method is called from many worker threads. Locking isn't required; the result can be slightly out-of-date.
+    return ABSL_TS_UNCHECKED_READ(lspEpochInvalidator).load() !=
+           ABSL_TS_UNCHECKED_READ(currentlyProcessingLSPEpoch).load();
+}
+
+TypecheckEpochManager::TypecheckingStatus TypecheckEpochManager::getStatusInternal() const {
+    const u4 processing = currentlyProcessingLSPEpoch.load();
+    const u4 committed = lastCommittedLSPEpoch.load();
+    const u4 invalidator = lspEpochInvalidator.load();
+    const bool slowPathRunning = processing != committed;
+    const bool slowPathIsCanceled = processing != invalidator;
+    return TypecheckingStatus{slowPathRunning, slowPathIsCanceled, committed, processing};
+}
+
+TypecheckEpochManager::TypecheckingStatus TypecheckEpochManager::getStatus() const {
+    absl::MutexLock lock(&epochMutex);
+    return getStatusInternal();
+}
+
+bool TypecheckEpochManager::tryCancelSlowPath(u4 newEpoch) {
+    assertConsistentThread(preprocessThreadId, "TypecheckEpochManager::tryCancelSlowPath", "preprocessThread");
+    absl::MutexLock lock(&epochMutex);
+    const u4 processing = currentlyProcessingLSPEpoch.load();
+    ENFORCE(newEpoch != processing); // This would prevent a cancelation from happening.
+    const u4 committed = lastCommittedLSPEpoch.load();
+    // The second condition should never happen, but guard against it in production.
+    if (processing == committed || newEpoch == processing) {
+        return false;
+    }
+    // Cancel slow path by bumping invalidator.
+    lspEpochInvalidator.store(newEpoch);
+    return true;
+}
+
+bool TypecheckEpochManager::tryCommitEpoch(u4 epoch, bool isCancelable,
+                                           optional<shared_ptr<PreemptionTaskManager>> preemptionManager,
+                                           function<void()> typecheck) {
+    assertConsistentThread(typecheckingThreadId, "TypecheckEpochManager::tryCommitEpoch", "typechecking");
+    if (!isCancelable) {
+        typecheck();
+        return true;
+    }
+
+    // Should have called "startCommitEpoch" *before* this method.
+    ENFORCE(ABSL_TS_UNCHECKED_READ(currentlyProcessingLSPEpoch).load() == epoch);
+    // Typechecking does not run under the mutex, as it would prevent another thread from running `tryCancelSlowPath`
+    // during typechecking.
+    typecheck();
+
+    bool committed = false;
+    {
+        absl::MutexLock lock(&epochMutex);
+        // Try to commit.
+        const u4 processing = currentlyProcessingLSPEpoch.load();
+        const u4 invalidator = lspEpochInvalidator.load();
+        if (processing == invalidator) {
+            ENFORCE(lastCommittedLSPEpoch.load() != processing, "Trying to commit an already-committed epoch.");
+            // OK to commit!
+            lastCommittedLSPEpoch.store(processing);
+            committed = true;
+        } else {
+            // Typechecking was canceled.
+            const u4 lastCommitted = lastCommittedLSPEpoch.load();
+            currentlyProcessingLSPEpoch.store(lastCommitted);
+            lspEpochInvalidator.store(lastCommitted);
+        }
+    }
+
+    if (preemptionManager.has_value()) {
+        // Now that we are no longer running a slow path, run a preemption task that might have snuck in while we were
+        // finishing up. No others can be scheduled.
+        (*preemptionManager)->tryRunScheduledPreemptionTask();
+    }
+    return committed;
+}
+
+void TypecheckEpochManager::withEpochLock(function<void(TypecheckingStatus)> lambda) const {
+    absl::MutexLock lock(&epochMutex);
+    lambda(getStatusInternal());
+}
+
+} // namespace sorbet::core::lsp

--- a/core/lsp/TypecheckEpochManager.cc
+++ b/core/lsp/TypecheckEpochManager.cc
@@ -14,8 +14,6 @@ void TypecheckEpochManager::assertConsistentThread(optional<thread::id> &expecte
 }
 
 void TypecheckEpochManager::startCommitEpoch(u4 fromEpoch, u4 toEpoch) {
-    assertConsistentThread(typecheckingThreadId, "TypecheckCancellor::startCommitEpoch", "typechecking");
-
     absl::MutexLock lock(&epochMutex);
     ENFORCE(fromEpoch != toEpoch);
     ENFORCE(toEpoch != currentlyProcessingLSPEpoch.load());

--- a/core/lsp/TypecheckEpochManager.h
+++ b/core/lsp/TypecheckEpochManager.h
@@ -40,9 +40,9 @@ private:
 public:
     static void assertConsistentThread(std::optional<std::thread::id> &expectedThreadId, std::string_view method,
                                        std::string_view threadName);
-
-    // Run only from the typechecking thread.
     // Indicates an intent to begin committing a specific epoch.
+    // Run only from the message processing thread.
+    // TODO(jvilk): This responsibility will move to the typechecking thread.
     void startCommitEpoch(u4 fromEpoch, u4 toEpoch);
     // Returns 'true' if the currently running typecheck run has been canceled.
     bool wasTypecheckingCanceled() const;

--- a/core/lsp/TypecheckEpochManager.h
+++ b/core/lsp/TypecheckEpochManager.h
@@ -1,0 +1,66 @@
+#ifndef SORBET_LSP_TYPECHECKEPOCHMANAGER_H
+#define SORBET_LSP_TYPECHECKEPOCHMANAGER_H
+
+#include "core/core.h"
+#include <memory>
+
+namespace sorbet::core::lsp {
+class PreemptionTaskManager;
+class TypecheckEpochManager final {
+public:
+    struct TypecheckingStatus {
+        bool slowPathRunning;
+        bool slowPathWasCanceled;
+        u4 lastCommittedEpoch;
+        u4 epoch;
+    };
+
+private:
+    // Used to linearize operations involving lastCommittedLSPEpoch.
+    mutable absl::Mutex epochMutex;
+    // Contains the current edit version (epoch) that the processing thread is typechecking or has
+    // typechecked last. Is bumped by the typechecking thread.
+    std::atomic<u4> currentlyProcessingLSPEpoch GUARDED_BY(epochMutex);
+    // Should always be `>= currentlyProcessingLSPEpoch` (modulo overflows).
+    // If value in `lspEpochInvalidator` is different from `currentlyProcessingLSPEpoch`, then LSP wants the current
+    // request to be cancelled. Is bumped by the preprocessor thread (which determines cancellations).
+    std::atomic<u4> lspEpochInvalidator GUARDED_BY(epochMutex);
+    // Should always be >= currentlyProcessingLSPEpoch. Is bumped by the typechecking thread.
+    // Contains the versionEnd of the last committed slow path.
+    // If lastCommittedLSPEpoch != currentlyProcessingLSPEpoch, then GlobalState is currently running a slow path
+    // containing edits (lastCommittedLSPEpoch, currentlyProcessingLSPEpoch].
+    std::atomic<u4> lastCommittedLSPEpoch GUARDED_BY(epochMutex);
+    // Thread ID of the typechecking thread. Lazily set.
+    mutable std::optional<std::thread::id> typecheckingThreadId;
+    // Thread ID of the preprocess thread. Lazily set.
+    mutable std::optional<std::thread::id> preprocessThreadId;
+
+    TypecheckingStatus getStatusInternal() const EXCLUSIVE_LOCKS_REQUIRED(epochMutex);
+
+public:
+    static void assertConsistentThread(std::optional<std::thread::id> &expectedThreadId, std::string_view method,
+                                       std::string_view threadName);
+
+    // Run only from the typechecking thread.
+    // Indicates an intent to begin committing a specific epoch.
+    void startCommitEpoch(u4 fromEpoch, u4 toEpoch);
+    // Returns 'true' if the currently running typecheck run has been canceled.
+    bool wasTypecheckingCanceled() const;
+    // Retrieve the status of typechecking.
+    TypecheckingStatus getStatus() const;
+    // Run only from preprocess thread.
+    // Tries to cancel a running slow path on this GlobalState or its descendent. Returns true if it succeeded, false if
+    // the slow path was unable to be canceled.
+    bool tryCancelSlowPath(u4 newEpoch);
+    // Run only from the typechecking thread.
+    // Tries to commit the given epoch. Returns true if the commit succeeeded, or false if it was canceled.
+    // The presence of PreemptionTaskManager determines if this commit is preemptible.
+    bool tryCommitEpoch(u4 epoch, bool isCancelable,
+                        std::optional<std::shared_ptr<PreemptionTaskManager>> preemptionManager,
+                        std::function<void()> typecheck);
+    // Grabs the epoch lock, and calls function with the current typechecking status.
+    void withEpochLock(std::function<void(TypecheckingStatus)> lambda) const;
+};
+
+} // namespace sorbet::core::lsp
+#endif

--- a/core/lsp/TypecheckEpochManager.h
+++ b/core/lsp/TypecheckEpochManager.h
@@ -48,9 +48,10 @@ public:
     bool wasTypecheckingCanceled() const;
     // Retrieve the status of typechecking.
     TypecheckingStatus getStatus() const;
-    // Run only from preprocess thread.
     // Tries to cancel a running slow path on this GlobalState or its descendent. Returns true if it succeeded, false if
     // the slow path was unable to be canceled.
+    // Run only from preprocess thread.
+    // TODO(jvilk): This responsibility will move to message processing thread.
     bool tryCancelSlowPath(u4 newEpoch);
     // Run only from the typechecking thread.
     // Tries to commit the given epoch. Returns true if the commit succeeeded, or false if it was canceled.

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -243,7 +243,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
             return;
         }
 
-        pipeline::typecheck(finalGS, move(resolved), config->opts, workers);
+        pipeline::typecheck(finalGS, move(resolved), config->opts, workers, cancelable);
     });
 
     // Note: This is important to do even if the slow path was canceled. It clears out any typechecking errors from the

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -5,6 +5,8 @@
 #include "common/sort.h"
 #include "common/typecase.h"
 #include "core/Unfreeze.h"
+#include "core/lsp/PreemptionTaskManager.h"
+#include "core/lsp/TypecheckEpochManager.h"
 #include "main/lsp/DefLocSaver.h"
 #include "main/lsp/LSPMessage.h"
 #include "main/lsp/LSPOutput.h"
@@ -184,9 +186,12 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
     // Replace error queue with one that is owned by this thread.
     finalGS->errorQueue = make_shared<core::ErrorQueue>(finalGS->errorQueue->logger, finalGS->errorQueue->tracer);
     finalGS->errorQueue->ignoreFlushes = true;
+    auto &epochManager = *finalGS->epochManager;
+    // TODO: Replace with an actual preemption task manager when we ship preemptible slow path.
+    optional<shared_ptr<core::lsp::PreemptionTaskManager>> preemptManager;
     // Note: Commits can only be canceled if this edit is cancelable, LSP is running across multiple threads, and the
     // cancelation feature is enabled.
-    const bool committed = finalGS->tryCommitEpoch(updates.versionEnd, cancelable, [&]() -> void {
+    const bool committed = epochManager.tryCommitEpoch(updates.versionEnd, cancelable, preemptManager, [&]() -> void {
         UnorderedSet<int> updatedFiles;
         vector<ast::ParsedFile> indexedCopies;
 
@@ -212,7 +217,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
                 indexedCopies.emplace_back(ast::ParsedFile{tree.tree->deepCopy(), tree.file});
             }
         }
-        if (finalGS->wasTypecheckingCanceled()) {
+        if (epochManager.wasTypecheckingCanceled()) {
             return;
         }
 
@@ -237,13 +242,13 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
 
         // [Test only] Wait for a cancellation if one is expected.
         if (updates.cancellationExpected) {
-            while (!gs->wasTypecheckingCanceled()) {
+            while (!epochManager.wasTypecheckingCanceled()) {
                 Timer::timedSleep(1ms, *logger, "slow_path.expected_cancellation.sleep");
             }
             return;
         }
 
-        pipeline::typecheck(finalGS, move(resolved), config->opts, workers, cancelable);
+        pipeline::typecheck(finalGS, move(resolved), config->opts, workers, cancelable, preemptManager);
     });
 
     // Note: This is important to do even if the slow path was canceled. It clears out any typechecking errors from the

--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -2,6 +2,7 @@
 #include "absl/synchronization/notification.h"
 #include "common/Timer.h"
 #include "common/web_tracer_framework/tracing.h"
+#include "core/lsp/TypecheckEpochManager.h"
 #include "lsp.h"
 #include "main/lsp/LSPInput.h"
 #include "main/lsp/LSPPreprocessor.h"
@@ -99,7 +100,7 @@ void LSPLoop::maybeStartCommitSlowPathEdit(const LSPMessage &msg) const {
         const auto &params = get<unique_ptr<SorbetWorkspaceEditParams>>(msg.asNotification().params);
         if (!params->updates.canTakeFastPath && params->updates.updatedGS.has_value()) {
             auto &gs = params->updates.updatedGS.value();
-            gs->startCommitEpoch(params->updates.versionStart - 1, params->updates.versionEnd);
+            gs->epochManager->startCommitEpoch(params->updates.versionStart - 1, params->updates.versionEnd);
         }
     }
 }

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -8,6 +8,10 @@
 #include "core/NameHash.h"
 #include "main/options/options.h"
 
+namespace sorbet::core::lsp {
+class PreemptionTaskManager;
+}
+
 namespace sorbet::realmain::pipeline {
 ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, core::FileRef file,
                          std::unique_ptr<KeyValueStore> &kvstore);
@@ -31,11 +35,11 @@ std::vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, std::vect
 std::vector<ast::ParsedFile> name(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
                                   const options::Options &opts, bool skipConfigatron = false);
 
-// Note: `epoch` parameter is only used in LSP mode when preemptible is true. Do not use it elsewhere.
-// TODO(jvilk): Make this interface cleaner.
-ast::ParsedFilesOrCancelled typecheck(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what,
-                                      const options::Options &opts, WorkerPool &workers, bool cancelable = false,
-                                      bool preemptible = false, u4 epoch = 0);
+// Note: `cancelable` and `preemption task manager` are only applicable to LSP.
+ast::ParsedFilesOrCancelled
+typecheck(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what, const options::Options &opts,
+          WorkerPool &workers, bool cancelable = false,
+          std::optional<std::shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager = std::nullopt);
 
 ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Options &opts);
 

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -31,8 +31,11 @@ std::vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, std::vect
 std::vector<ast::ParsedFile> name(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
                                   const options::Options &opts, bool skipConfigatron = false);
 
+// Note: `epoch` parameter is only used in LSP mode when preemptible is true. Do not use it elsewhere.
+// TODO(jvilk): Make this interface cleaner.
 ast::ParsedFilesOrCancelled typecheck(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what,
-                                      const options::Options &opts, WorkerPool &workers);
+                                      const options::Options &opts, WorkerPool &workers, bool cancelable = false,
+                                      bool preemptible = false, u4 epoch = 0);
 
 ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Options &opts);
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Add preemption logic to GlobalState and typecheck. The new logic is currently unused.

This change introduces two new classes:

* `TypecheckEpochManager`: Contains all of the logic related to slow path cancelation. Previously, all of this lived directly in `GlobalState`.
* `PreemptionTaskManager`: Contains all of the logic related to preemption. Passed into the `typecheck` method.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This logic is needed to enable requests to preempt the slow path. The flow goes like this:

* The _typechecking thread_ is currently running a slow path.
* The _message processing thread_ attempts to preempt the slow path with a task (`trySchedulePreemptionTask`), which succeeds only if the slow path is still happening.
  * N.B.: `withEpochLock` protects against races between the slow path ending and a preemption task getting scheduled.
* The _typechecking thread_, within `pipeline::typecheck`, attempts to run a preemption task with each turn of the coordination loop (it wakes up with maximum latency ~20ms) using `tryRunScheduledPreemptionTask`.
  * If a task is registered, `tryRunScheduledPreemptionTask` grabs `typecheckMutex` as a _write lock_ (exclusive lock). Worker threads that are typechecking individual files conduct their work while holding a _read lock_ (shared lock) on `typecheckMutex` via `lockPreemption`. These threads periodically reacquire the lock, and will block if a thread is attempting to acquire a write lock. Thus, the preemption task only begins once all worker threads are blocked and are not performing any work.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I added automated tests for the core GlobalState logic. There's no easy way to test `typecheck` itself. I intend to add end-to-end tests for this mechanism once I hook up LSP to the preemption logic.
