### PR TITLE
Only handle `params` in props, instead of keyword arguments in general

### DIFF
--- a/test/testdata/rewriter/prop_skipped.rb
+++ b/test/testdata/rewriter/prop_skipped.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+class A < T::Struct
+  # This prop won't be processed by the Prop dsl, as it contains a shape type
+  const :foo, T::Array[{foo: Integer}]
+end
+
+A.new(foo: []) # error: Too many arguments


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Follow up #2406 to restrict the behavior to handling keyword arguments for `T.proc.params` only.

The problem with #2406 is that `Mutator` generation assumes it will never see shape types. The previous implementation would not process props like the following:
```ruby
class A < T::Struct
  prop :foo, T::Array[{foo: Integer}]
end
```
But changing the behavior of `dupType` to handle sends with keyword arguments allowed it through. This results in a segfault when processing the above declaration.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
