### PR TITLE
Rename MK::Class to MK::ClassOrModule

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -259,11 +259,23 @@ public:
         return Method(loc, declLoc, name, std::move(args), std::move(rhs), flags);
     }
 
-    static std::unique_ptr<ClassDef> Class(core::Loc loc, core::Loc declLoc, std::unique_ptr<Expression> name,
-                                           ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs,
-                                           ClassDef::Kind kind) {
+    static std::unique_ptr<ClassDef> ClassOrModule(core::Loc loc, core::Loc declLoc, std::unique_ptr<Expression> name,
+                                                   ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs,
+                                                   ClassDef::Kind kind) {
         return std::make_unique<ClassDef>(loc, declLoc, core::Symbols::todo(), std::move(name), std::move(ancestors),
                                           std::move(rhs), kind);
+    }
+
+    static std::unique_ptr<ClassDef> Class(core::Loc loc, core::Loc declLoc, std::unique_ptr<Expression> name,
+                                           ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs) {
+        return MK::ClassOrModule(loc, declLoc, std::move(name), std::move(ancestors), std::move(rhs),
+                                 ClassDef::Kind::Class);
+    }
+
+    static std::unique_ptr<ClassDef> Module(core::Loc loc, core::Loc declLoc, std::unique_ptr<Expression> name,
+                                            ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs) {
+        return MK::ClassOrModule(loc, declLoc, std::move(name), std::move(ancestors), std::move(rhs),
+                                 ClassDef::Kind::Module);
     }
 
     static std::unique_ptr<Expression> Array(core::Loc loc, Array::ENTRY_store entries) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -953,10 +953,10 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
 
                 ClassDef::RHS_store body = scopeNodeToBody(dctx, std::move(sclass->body));
                 ClassDef::ANCESTORS_store emptyAncestors;
-                unique_ptr<Expression> res = make_unique<ClassDef>(
-                    sclass->loc, sclass->declLoc, core::Symbols::todo(),
+                unique_ptr<Expression> res = MK::Class(
+                    sclass->loc, sclass->declLoc,
                     make_unique<UnresolvedIdent>(sclass->expr->loc, UnresolvedIdent::Class, core::Names::singleton()),
-                    std::move(emptyAncestors), std::move(body), ClassDef::Kind::Class);
+                    std::move(emptyAncestors), std::move(body));
                 result.swap(res);
             },
             [&](parser::Block *block) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -863,8 +863,8 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 ClassDef::RHS_store body = scopeNodeToBody(dctx, std::move(module->body));
                 ClassDef::ANCESTORS_store ancestors;
                 unique_ptr<Expression> res =
-                    MK::Class(module->loc, module->declLoc, node2TreeImpl(dctx, std::move(module->name)),
-                              std::move(ancestors), std::move(body), ClassDef::Kind::Module);
+                    MK::Module(module->loc, module->declLoc, node2TreeImpl(dctx, std::move(module->name)),
+                               std::move(ancestors), std::move(body));
                 result.swap(res);
             },
             [&](parser::Class *claz) {
@@ -877,7 +877,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 }
                 unique_ptr<Expression> res =
                     MK::Class(claz->loc, claz->declLoc, node2TreeImpl(dctx, std::move(claz->name)),
-                              std::move(ancestors), std::move(body), ClassDef::Kind::Class);
+                              std::move(ancestors), std::move(body));
                 result.swap(res);
             },
             [&](parser::Arg *arg) {

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1067,8 +1067,8 @@ unique_ptr<ast::Expression> SerializerImpl::unpickleExpr(serialize::UnPickler &p
             for (auto &r : rhs) {
                 r = unpickleExpr(p, gs, file);
             }
-            auto ret = ast::MK::Class(loc, declLoc, std::move(name), std::move(ancestors), std::move(rhs),
-                                      (ast::ClassDef::Kind)kind);
+            auto ret = ast::MK::ClassOrModule(loc, declLoc, std::move(name), std::move(ancestors), std::move(rhs),
+                                              (ast::ClassDef::Kind)kind);
             ret->singletonAncestors = std::move(singletonAncestors);
             ret->symbol = symbol;
             return ret;

--- a/rewriter/ClassNew.cc
+++ b/rewriter/ClassNew.cc
@@ -77,8 +77,7 @@ vector<unique_ptr<ast::Expression>> ClassNew::run(core::MutableContext ctx, ast:
     }
 
     vector<unique_ptr<ast::Expression>> stats;
-    stats.emplace_back(make_unique<ast::ClassDef>(loc, loc, core::Symbols::todo(), std::move(asgn->lhs),
-                                                  std::move(ancestors), std::move(body), ast::ClassDef::Kind::Class));
+    stats.emplace_back(ast::MK::Class(loc, loc, std::move(asgn->lhs), std::move(ancestors), std::move(body)));
     return stats;
 }
 

--- a/rewriter/Flatten.cc
+++ b/rewriter/Flatten.cc
@@ -275,7 +275,8 @@ class FlattenWalk {
             auto classDef =
                 ast::MK::Class(loc, loc,
                                make_unique<ast::UnresolvedIdent>(core::Loc::none(), ast::UnresolvedIdent::Class,
-                                                                 core::Names::singleton()), {}, std::move(body));
+                                                                 core::Names::singleton()),
+                               {}, std::move(body));
             rhs.emplace_back(std::move(classDef));
         }
 

--- a/rewriter/Flatten.cc
+++ b/rewriter/Flatten.cc
@@ -275,8 +275,7 @@ class FlattenWalk {
             auto classDef =
                 ast::MK::Class(loc, loc,
                                make_unique<ast::UnresolvedIdent>(core::Loc::none(), ast::UnresolvedIdent::Class,
-                                                                 core::Names::singleton()),
-                               {}, std::move(body), ast::ClassDef::Kind::Class);
+                                                                 core::Names::singleton()), {}, std::move(body));
             rhs.emplace_back(std::move(classDef));
         }
 

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -177,8 +177,7 @@ unique_ptr<ast::Expression> runSingle(core::MutableContext ctx, ast::Send *send)
         rhs.emplace_back(prepareBody(ctx, std::move(send->block->body)));
         auto name = ast::MK::UnresolvedConstant(arg->loc, ast::MK::EmptyTree(),
                                                 ctx.state.enterNameConstant("<describe '" + argString + "'>"));
-        return ast::MK::Class(send->loc, send->loc, std::move(name), std::move(ancestors), std::move(rhs),
-                              ast::ClassDef::Kind::Class);
+        return ast::MK::Class(send->loc, send->loc, std::move(name), std::move(ancestors), std::move(rhs));
     } else if (send->fun == core::Names::it()) {
         ConstantMover constantMover;
         send->block->body = ast::TreeMap::apply(ctx, constantMover, move(send->block->body));

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -344,7 +344,7 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
             auto name = core::Names::Constants::Mutator();
             ret.nodes.emplace_back(ast::MK::Class(loc, loc,
                                                   ast::MK::UnresolvedConstant(loc, ast::MK::EmptyTree(), name),
-                                                  std::move(ancestors), std::move(rhs), ast::ClassDef::Kind::Class));
+                                                  std::move(ancestors), std::move(rhs)));
         }
     }
 

--- a/rewriter/ProtobufDescriptorPool.cc
+++ b/rewriter/ProtobufDescriptorPool.cc
@@ -60,7 +60,7 @@ vector<unique_ptr<ast::Expression>> ProtobufDescriptorPool::run(core::MutableCon
     }
 
     vector<unique_ptr<ast::Expression>> res;
-    res.emplace_back(ast::MK::Class(asgn->loc, asgn->loc, asgn->lhs->deepCopy(), {}, std::move(rhs), kind));
+    res.emplace_back(ast::MK::ClassOrModule(asgn->loc, asgn->loc, asgn->lhs->deepCopy(), {}, std::move(rhs), kind));
     return res;
 }
 

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -152,8 +152,7 @@ vector<unique_ptr<ast::Expression>> Struct::run(core::MutableContext ctx, ast::A
                                                        core::Names::Constants::Struct()));
 
     vector<unique_ptr<ast::Expression>> stats;
-    stats.emplace_back(make_unique<ast::ClassDef>(loc, loc, core::Symbols::todo(), std::move(asgn->lhs),
-                                                  std::move(ancestors), std::move(body), ast::ClassDef::Kind::Class));
+    stats.emplace_back(ast::MK::Class(loc, loc, std::move(asgn->lhs), std::move(ancestors), std::move(body)));
     return stats;
 }
 

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -132,8 +132,7 @@ vector<unique_ptr<ast::Expression>> processStat(core::MutableContext ctx, ast::C
     classRhs.emplace_back(ast::MK::Send1(stat->loc, ast::MK::Self(stat->loc), core::Names::include(),
                                          ast::MK::Constant(stat->loc, core::Symbols::Singleton())));
     classRhs.emplace_back(ast::MK::Send0(stat->loc, ast::MK::Self(stat->loc), core::Names::declareFinal()));
-    auto classDef = ast::MK::Class(stat->loc, stat->loc, classCnst->deepCopy(), std::move(parent), std::move(classRhs),
-                                   ast::ClassDef::Kind::Class);
+    auto classDef = ast::MK::Class(stat->loc, stat->loc, classCnst->deepCopy(), std::move(parent), std::move(classRhs));
 
     auto singletonAsgn =
         ast::MK::Assign(stat->loc, std::move(asgn->lhs),


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When I was converting ClassDefKind to an `enum class` in #2403, I realized that
we use `MK::Class` to create classes (not modules) way more frequently. So I
figured I'd make `MK::Class` assume `ClassDef::Kind::Class`, and introduce a
new helper (`MK::ClassOrModule` / `MK::Module`) for the less common cases.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.