### PR TITLE
Stop using `to_s` in string interpolation

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -435,11 +435,11 @@ void GlobalState::initEmpty() {
         auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
         arg.flags.isBlock = true;
     }
-    // Synthesize <Magic>#<concat-strings>(arg: *String) => String
-    method = enterMethodSymbol(Loc::none(), Symbols::MagicSingleton(), Names::concatStrings());
+    // Synthesize <Magic>#<string-interpolate>(arg: *T.untyped) => String
+    method = enterMethodSymbol(Loc::none(), Symbols::MagicSingleton(), Names::stringInterpolate());
     {
         auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg0());
-        arg.type = Types::String();
+        arg.type = Types::untyped(*this, method);
         arg.flags.isRepeated = true;
     }
     method.data(*this)->resultType = Types::String();

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -339,7 +339,7 @@ NameDef names[] = {
     {"callWithSplatAndBlock", "<call-with-splat-and-block>"},
     {"enumerableToH", "enumerable_to_h"},
     {"selfNew", "<self-new>"},
-    {"concatStrings", "<concat-strings>"},
+    {"stringInterpolate", "<string-interpolate>"},
 
     // GlobalState initEmpty()
     {"Top", "<any>", true},

--- a/test/testdata/desugar/dsymbol.rb.desugar-tree.exp
+++ b/test/testdata/desugar/dsymbol.rb.desugar-tree.exp
@@ -5,5 +5,5 @@ class <emptyTree><<C <root>>> < ()
 
   :""
 
-  ::<Magic>.<concat-strings>("hello_", <self>.name().to_s(), "!").intern()
+  ::<Magic>.<string-interpolate>("hello_", <self>.name(), "!").intern()
 end

--- a/test/testdata/desugar/line_literal.rb.desugar-tree.exp
+++ b/test/testdata/desugar/line_literal.rb.desugar-tree.exp
@@ -1,3 +1,3 @@
 class <emptyTree><<C <root>>> < ()
-  <self>.puts(::<Magic>.<concat-strings>("\n", 4.to_s()))
+  <self>.puts(::<Magic>.<string-interpolate>("\n", 4))
 end

--- a/test/testdata/desugar/regexp.rb.desugar-tree.exp
+++ b/test/testdata/desugar/regexp.rb.desugar-tree.exp
@@ -9,7 +9,7 @@ class <emptyTree><<C <root>>> < ()
       <emptyTree>::<C Regexp>.new("abc", 0.|(<emptyTree>::<C Regexp>::<C IGNORECASE>).|(<emptyTree>::<C Regexp>::<C EXTENDED>).|(<emptyTree>::<C Regexp>::<C MULTILINE>))
       a = "a"
       c = "c"
-      ::Regexp.new(::<Magic>.<concat-strings>(a.to_s(), "b", c.to_s()), 0)
+      ::Regexp.new(::<Magic>.<string-interpolate>(a, "b", c), 0)
       <emptyTree>::<C Regexp>.new(a.+("b").+(c))
       ::Regexp.new("abc", 0)
     end

--- a/test/testdata/desugar/strings.rb.desugar-tree.exp
+++ b/test/testdata/desugar/strings.rb.desugar-tree.exp
@@ -3,7 +3,7 @@ class <emptyTree><<C <root>>> < ()
     begin
       ""
       "foo"
-      ::<Magic>.<concat-strings>("foo", 1.to_s())
+      ::<Magic>.<string-interpolate>("foo", 1)
     end
   end
 end

--- a/test/testdata/parser/misc.rb.desugar-tree.exp
+++ b/test/testdata/parser/misc.rb.desugar-tree.exp
@@ -188,7 +188,7 @@ rescue <emptyTree>::<C E> => x
     <assignTemp>$12
   end
 
-  ::<Magic>.<concat-strings>("foo", <self>.bar().to_s()).intern()
+  ::<Magic>.<string-interpolate>("foo", <self>.bar()).intern()
 
   [:"sym"]
 

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -62,12 +62,12 @@ class <emptyTree><<C <root>>> < ()
     end
 
     begin
-      ::<Magic>.<concat-strings>("finds errors in the test name: ", <self>.bad_variable().to_s())
+      ::<Magic>.<string-interpolate>("finds errors in the test name: ", <self>.bad_variable())
       begin
         ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({}).void()
         end
-        def <it '::<Magic>.<concat-strings>("finds errors in the test name: ", <self>.bad_variable().to_s())'><<C <todo sym>>>(&<blk>)
+        def <it '::<Magic>.<string-interpolate>("finds errors in the test name: ", <self>.bad_variable())'><<C <todo sym>>>(&<blk>)
           <emptyTree>
         end
       end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
We don't need to call `to_s` on the spliced expressions during string interpolation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
