### PR TITLE
Convert UnresolvedIdent::VarKind to an enum class

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -100,7 +100,7 @@ public:
     }
 
     static std::unique_ptr<Reference> Local(core::Loc loc, core::NameRef name) {
-        return std::make_unique<UnresolvedIdent>(loc, UnresolvedIdent::Local, name);
+        return std::make_unique<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Local, name);
     }
 
     static std::unique_ptr<Reference> OptionalArg(core::Loc loc, std::unique_ptr<Reference> inner,
@@ -125,7 +125,7 @@ public:
     }
 
     static std::unique_ptr<Reference> Instance(core::Loc loc, core::NameRef name) {
-        return std::make_unique<UnresolvedIdent>(loc, UnresolvedIdent::Instance, name);
+        return std::make_unique<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Instance, name);
     }
 
     static std::unique_ptr<Expression> cpRef(Reference &name) {

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -636,16 +636,16 @@ string UnresolvedIdent::showRaw(const core::GlobalState &gs, int tabs) {
     printTabs(buf, tabs + 1);
     buf << "kind = ";
     switch (this->kind) {
-        case Local:
+        case Kind::Local:
             buf << "Local";
             break;
-        case Instance:
+        case Kind::Instance:
             buf << "Instance";
             break;
-        case Class:
+        case Kind::Class:
             buf << "Class";
             break;
-        case Global:
+        case Kind::Global:
             buf << "Global";
             break;
     }

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -154,7 +154,7 @@ Local::Local(core::Loc loc, core::LocalVariable localVariable1) : Reference(loc)
     _sanityCheck();
 }
 
-UnresolvedIdent::UnresolvedIdent(core::Loc loc, VarKind kind, core::NameRef name)
+UnresolvedIdent::UnresolvedIdent(core::Loc loc, Kind kind, core::NameRef name)
     : Reference(loc), name(name), kind(kind) {
     categoryCounterInc("trees", "unresolvedident");
     _sanityCheck();

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -149,6 +149,7 @@ public:
     core::NameRef name;
     u4 flags;
 
+    // TODO(jez) This uses enum instead of enum class. We should not cargo cult this in new code.
     enum Flags {
         SelfMethod = 1,
         RewriterSynthesized = 2,

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -337,7 +337,7 @@ private:
 
 class UnresolvedIdent final : public Reference {
 public:
-    enum Kind {
+    enum class Kind : u1 {
         Local,
         Instance,
         Class,

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -337,16 +337,16 @@ private:
 
 class UnresolvedIdent final : public Reference {
 public:
-    enum VarKind {
+    enum Kind {
         Local,
         Instance,
         Class,
         Global,
     };
     core::NameRef name;
-    VarKind kind;
+    Kind kind;
 
-    UnresolvedIdent(core::Loc loc, VarKind kind, core::NameRef name);
+    UnresolvedIdent(core::Loc loc, Kind kind, core::NameRef name);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -156,7 +156,7 @@ bool isIVarAssign(Expression *stat) {
     if (!ident) {
         return false;
     }
-    if (ident->kind != UnresolvedIdent::Instance) {
+    if (ident->kind != UnresolvedIdent::Kind::Instance) {
         return false;
     }
     return true;
@@ -948,10 +948,11 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
 
                 ClassDef::RHS_store body = scopeNodeToBody(dctx, std::move(sclass->body));
                 ClassDef::ANCESTORS_store emptyAncestors;
-                unique_ptr<Expression> res = MK::Class(
-                    sclass->loc, sclass->declLoc,
-                    make_unique<UnresolvedIdent>(sclass->expr->loc, UnresolvedIdent::Class, core::Names::singleton()),
-                    std::move(emptyAncestors), std::move(body));
+                unique_ptr<Expression> res =
+                    MK::Class(sclass->loc, sclass->declLoc,
+                              make_unique<UnresolvedIdent>(sclass->expr->loc, UnresolvedIdent::Kind::Class,
+                                                           core::Names::singleton()),
+                              std::move(emptyAncestors), std::move(body));
                 result.swap(res);
             },
             [&](parser::Block *block) {
@@ -1025,15 +1026,17 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 result.swap(res);
             },
             [&](parser::IVar *var) {
-                unique_ptr<Expression> res = make_unique<UnresolvedIdent>(loc, UnresolvedIdent::Instance, var->name);
+                unique_ptr<Expression> res =
+                    make_unique<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Instance, var->name);
                 result.swap(res);
             },
             [&](parser::GVar *var) {
-                unique_ptr<Expression> res = make_unique<UnresolvedIdent>(loc, UnresolvedIdent::Global, var->name);
+                unique_ptr<Expression> res =
+                    make_unique<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Global, var->name);
                 result.swap(res);
             },
             [&](parser::CVar *var) {
-                unique_ptr<Expression> res = make_unique<UnresolvedIdent>(loc, UnresolvedIdent::Class, var->name);
+                unique_ptr<Expression> res = make_unique<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Class, var->name);
                 result.swap(res);
             },
             [&](parser::LVarLhs *var) {
@@ -1041,20 +1044,22 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 result.swap(res);
             },
             [&](parser::GVarLhs *var) {
-                unique_ptr<Expression> res = make_unique<UnresolvedIdent>(loc, UnresolvedIdent::Global, var->name);
+                unique_ptr<Expression> res =
+                    make_unique<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Global, var->name);
                 result.swap(res);
             },
             [&](parser::CVarLhs *var) {
-                unique_ptr<Expression> res = make_unique<UnresolvedIdent>(loc, UnresolvedIdent::Class, var->name);
+                unique_ptr<Expression> res = make_unique<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Class, var->name);
                 result.swap(res);
             },
             [&](parser::IVarLhs *var) {
-                unique_ptr<Expression> res = make_unique<UnresolvedIdent>(loc, UnresolvedIdent::Instance, var->name);
+                unique_ptr<Expression> res =
+                    make_unique<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Instance, var->name);
                 result.swap(res);
             },
             [&](parser::NthRef *var) {
                 unique_ptr<Expression> res = make_unique<UnresolvedIdent>(
-                    loc, UnresolvedIdent::Global, dctx.ctx.state.enterNameUTF8(to_string(var->ref)));
+                    loc, UnresolvedIdent::Kind::Global, dctx.ctx.state.enterNameUTF8(to_string(var->ref)));
                 result.swap(res);
             },
             [&](parser::Assign *asgn) {
@@ -1514,7 +1519,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                 auto varLoc = varExpr->loc;
                 auto var = core::NameRef::noName();
                 if (auto *id = cast_tree<UnresolvedIdent>(varExpr.get())) {
-                    if (id->kind == UnresolvedIdent::Local) {
+                    if (id->kind == UnresolvedIdent::Kind::Local) {
                         var = id->name;
                         varExpr.reset(nullptr);
                     }

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -69,17 +69,17 @@ core::LocalVariable unresolvedIdent2Local(CFGContext cctx, ast::UnresolvedIdent 
     core::SymbolRef klass;
 
     switch (id->kind) {
-        case ast::UnresolvedIdent::Class:
+        case ast::UnresolvedIdent::Kind::Class:
             klass = cctx.ctx.owner.data(cctx.ctx)->enclosingClass(cctx.ctx);
             while (klass.data(cctx.ctx)->attachedClass(cctx.ctx).exists()) {
                 klass = klass.data(cctx.ctx)->attachedClass(cctx.ctx);
             }
             break;
-        case ast::UnresolvedIdent::Instance:
+        case ast::UnresolvedIdent::Kind::Instance:
             ENFORCE(cctx.ctx.owner.data(cctx.ctx)->isMethod());
             klass = cctx.ctx.owner.data(cctx.ctx)->owner;
             break;
-        case ast::UnresolvedIdent::Global:
+        case ast::UnresolvedIdent::Kind::Global:
             klass = core::Symbols::root();
             break;
         default:
@@ -92,7 +92,7 @@ core::LocalVariable unresolvedIdent2Local(CFGContext cctx, ast::UnresolvedIdent 
     if (!sym.exists()) {
         auto fnd = cctx.discoveredUndeclaredFields.find(id->name);
         if (fnd == cctx.discoveredUndeclaredFields.end()) {
-            if (id->kind != ast::UnresolvedIdent::Global) {
+            if (id->kind != ast::UnresolvedIdent::Kind::Global) {
                 if (auto e = cctx.ctx.state.beginError(id->loc, core::errors::CFG::UndeclaredVariable)) {
                     e.setHeader("Use of undeclared variable `{}`", id->name.show(cctx.ctx));
                 }

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1143,7 +1143,7 @@ unique_ptr<ast::Expression> SerializerImpl::unpickleExpr(serialize::UnPickler &p
             return make_unique<ast::ZSuperArgs>(loc);
         }
         case 31: {
-            auto kind = (ast::UnresolvedIdent::VarKind)p.getU1();
+            auto kind = (ast::UnresolvedIdent::Kind)p.getU1();
             NameRef name = unpickleNameRef(p, gs);
             return make_unique<ast::UnresolvedIdent>(loc, kind, name);
         }

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -919,7 +919,7 @@ void SerializerImpl::pickle(Pickler &p, FileRef file, const unique_ptr<ast::Expr
         [&](ast::ZSuperArgs *a) { pickleAstHeader(p, 30, a); },
         [&](ast::UnresolvedIdent *a) {
             pickleAstHeader(p, 31, a);
-            p.putU1((int)a->kind);
+            p.putU1(static_cast<u1>(a->kind));
             p.putU4(a->name._id);
         },
         [&](ast::ConstantLit *a) {

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -246,7 +246,7 @@ public:
 
     unique_ptr<ast::Expression> postTransformUnresolvedIdent(core::MutableContext ctx,
                                                              unique_ptr<ast::UnresolvedIdent> nm) {
-        if (nm->kind == ast::UnresolvedIdent::Local) {
+        if (nm->kind == ast::UnresolvedIdent::Kind::Local) {
             auto &frame = scopeStack.back();
             core::LocalVariable &cur = frame.locals[nm->name];
             if (!cur.exists()) {

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -47,10 +47,10 @@ unique_ptr<ast::MethodDef> DefLocSaver::postTransformMethodDef(core::Context ctx
 
 unique_ptr<ast::UnresolvedIdent> DefLocSaver::postTransformUnresolvedIdent(core::Context ctx,
                                                                            unique_ptr<ast::UnresolvedIdent> id) {
-    if (id->kind == ast::UnresolvedIdent::Instance || id->kind == ast::UnresolvedIdent::Class) {
+    if (id->kind == ast::UnresolvedIdent::Kind::Instance || id->kind == ast::UnresolvedIdent::Kind::Class) {
         core::SymbolRef klass;
         // Logic cargo culted from `global2Local` in `walker_build.cc`.
-        if (id->kind == ast::UnresolvedIdent::Instance) {
+        if (id->kind == ast::UnresolvedIdent::Kind::Instance) {
             ENFORCE(ctx.owner.data(ctx)->isMethod());
             klass = ctx.owner.data(ctx)->owner;
         } else {

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1090,7 +1090,7 @@ public:
 
     unique_ptr<ast::UnresolvedIdent> postTransformUnresolvedIdent(core::Context ctx,
                                                                   unique_ptr<ast::UnresolvedIdent> id) {
-        if (id->kind != ast::UnresolvedIdent::Local) {
+        if (id->kind != ast::UnresolvedIdent::Kind::Local) {
             acc.constants.emplace_back(ctx.state, id->name.data(ctx));
         }
         return id;

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -31,7 +31,7 @@ class NameInserter {
                 return id->symbol.data(ctx)->dealias(ctx);
             }
             if (auto *uid = ast::cast_tree<ast::UnresolvedIdent>(node.get())) {
-                if (uid->kind != ast::UnresolvedIdent::Class || uid->name != core::Names::singleton()) {
+                if (uid->kind != ast::UnresolvedIdent::Kind::Class || uid->name != core::Names::singleton()) {
                     if (auto e = ctx.state.beginError(node->loc, core::errors::Namer::DynamicConstant)) {
                         e.setHeader("Unsupported constant scope");
                     }
@@ -216,7 +216,7 @@ public:
         auto *ident = ast::cast_tree<ast::UnresolvedIdent>(klass->name.get());
 
         if ((ident != nullptr) && ident->name == core::Names::singleton()) {
-            ENFORCE(ident->kind == ast::UnresolvedIdent::Class);
+            ENFORCE(ident->kind == ast::UnresolvedIdent::Kind::Class);
             klass->symbol = ctx.owner.data(ctx)->enclosingClass(ctx).data(ctx)->singletonClass(ctx);
         } else {
             if (klass->symbol == core::Symbols::todo()) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1687,7 +1687,7 @@ private:
             return false;
         }
 
-        if (uid->kind != ast::UnresolvedIdent::Instance && uid->kind != ast::UnresolvedIdent::Class) {
+        if (uid->kind != ast::UnresolvedIdent::Kind::Instance && uid->kind != ast::UnresolvedIdent::Kind::Class) {
             return false;
         }
         ast::Expression *recur = asgn->rhs.get();
@@ -1705,7 +1705,7 @@ private:
         }
 
         core::SymbolRef scope;
-        if (uid->kind == ast::UnresolvedIdent::Class) {
+        if (uid->kind == ast::UnresolvedIdent::Kind::Class) {
             if (!ctx.owner.data(ctx)->isClassOrModule()) {
                 if (auto e = ctx.state.beginError(uid->loc, core::errors::Resolver::InvalidDeclareVariables)) {
                     e.setHeader("The class variable `{}` must be declared at class scope", uid->name.show(ctx));
@@ -1767,7 +1767,7 @@ private:
         }
         core::SymbolRef var;
 
-        if (uid->kind == ast::UnresolvedIdent::Class) {
+        if (uid->kind == ast::UnresolvedIdent::Kind::Class) {
             var = ctx.state.enterStaticFieldSymbol(uid->loc, scope, uid->name);
         } else {
             var = ctx.state.enterFieldSymbol(uid->loc, scope, uid->name);
@@ -2069,7 +2069,7 @@ public:
     }
     unique_ptr<ast::Expression> postTransformUnresolvedIdent(core::MutableContext ctx,
                                                              unique_ptr<ast::UnresolvedIdent> original) {
-        ENFORCE(original->kind != ast::UnresolvedIdent::Local, "{} should have been removed by local_vars",
+        ENFORCE(original->kind != ast::UnresolvedIdent::Kind::Local, "{} should have been removed by local_vars",
                 original->toString(ctx));
         return original;
     }

--- a/rewriter/Flatten.cc
+++ b/rewriter/Flatten.cc
@@ -274,7 +274,7 @@ class FlattenWalk {
         for (auto &body : nestedBlocks) {
             auto classDef =
                 ast::MK::Class(loc, loc,
-                               make_unique<ast::UnresolvedIdent>(core::Loc::none(), ast::UnresolvedIdent::Class,
+                               make_unique<ast::UnresolvedIdent>(core::Loc::none(), ast::UnresolvedIdent::Kind::Class,
                                                                  core::Names::singleton()),
                                {}, std::move(body));
             rhs.emplace_back(std::move(classDef));

--- a/rewriter/Initializer.cc
+++ b/rewriter/Initializer.cc
@@ -30,12 +30,12 @@ void maybeAddLet(core::MutableContext ctx, ast::Expression *expr,
     }
 
     auto lhs = ast::cast_tree<ast::UnresolvedIdent>(assn->lhs.get());
-    if (lhs == nullptr || lhs->kind != ast::UnresolvedIdent::Instance) {
+    if (lhs == nullptr || lhs->kind != ast::UnresolvedIdent::Kind::Instance) {
         return;
     }
 
     auto rhs = ast::cast_tree<ast::UnresolvedIdent>(assn->rhs.get());
-    if (rhs == nullptr || rhs->kind != ast::UnresolvedIdent::Local) {
+    if (rhs == nullptr || rhs->kind != ast::UnresolvedIdent::Kind::Local) {
         return;
     }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is going to be the last one, the only other one is `ast::Send::Flags`, but
those enums are used as bit flags, which involve implicit conversion to ints,
and that makes the code kind of ugly and distracting.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.