### PR TITLE
Remove all runtime typing from T::Props

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/_props.rb
+++ b/gems/sorbet-runtime/lib/types/props/_props.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# typed: false
+# typed: true
 
 # A mixin for defining typed properties (attributes).
 # To get serialization methods (to/from JSON-style hashes), add T::Props::Serializable.
@@ -131,7 +131,7 @@ module T::Props
     sig {params(name: T.any(Symbol, String), cls_or_args: T.untyped, args: T::Hash[Symbol, T.untyped]).void}
     def const(name, cls_or_args, args={})
       if (cls_or_args.is_a?(Hash) && cls_or_args.key?(:immutable)) || args.key?(:immutable)
-        raise ArgumentError.new("Cannot pass 'immutable' argument when using 'const' keyword to define a prop")
+        Kernel.raise ArgumentError.new("Cannot pass 'immutable' argument when using 'const' keyword to define a prop")
       end
 
       if cls_or_args.is_a?(Hash)

--- a/gems/sorbet-runtime/lib/types/props/type_validation.rb
+++ b/gems/sorbet-runtime/lib/types/props/type_validation.rb
@@ -53,7 +53,9 @@ module T::Props::TypeValidation
     # a subtype like the type of the values of a typed hash.
     #
     # If the type is fully valid, returns nil.
-    sig {params(type: T::Types::Base).returns(T.nilable(T::Types::Base))}
+    #
+    # checked(:never) - called potentially many times recursively
+    sig {params(type: T::Types::Base).returns(T.nilable(T::Types::Base)).checked(:never)}
     private def find_invalid_subtype(type)
       case type
       when T::Types::TypedEnumerable

--- a/gems/sorbet-runtime/test/types/props/decorator.rb
+++ b/gems/sorbet-runtime/test/types/props/decorator.rb
@@ -99,7 +99,7 @@ class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest
 
   describe 'When validating prop definitions' do
     it 'Validates prop options are symbols' do
-      assert_prop_error(error: TypeError) do
+      assert_prop_error(error: ArgumentError) do
         prop :foo, String, 'name' => 'mongoprop'
       end
     end


### PR DESCRIPTION
Use `checked(:never)` in a bunch of places during T::Props prop definition, especially where we'd otherwise iterate through the rules hash. Inline comments explain the reasoning.

Also:
- Document the places we already used `checked(:never)` if it was obvious to me why
- Replace uses of WithoutRuntime with `checked(:never)` in T::Props, for consistency
- Remove an unused method

- ~Modify `T::Sig::WithoutRuntime` so it can be `extend`-ed like `T::Sig`~
- ~Use this in all the `T::Props` classes where we formerly used `T::Sig` (and remove the now-redundant `checked: never`)~

### Motivation
Saves ~30~ ~25% of time on `bundle exec rake bench:prop_definition` ~and removes a footgun for potential future regressions~

I'm not sure we really care about prop definition time today, but this makes up for regressions I might otherwise introduce with future optimization PRs 

Note that `decorator.rb` is still `typed: false` so this removes some safety from the build; I think it's worth it for the performance gain, and not a big regression anyway given that we were already heavily using `checked(:never)`

### Test plan
Build still passes