### PR TITLE
Make `Array#sample` work with `SecureRandom`

### DIFF
--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_3_hidden.rbi.exp
@@ -8472,7 +8472,6 @@ module Random::Formatter
 end
 
 class Random
-  extend ::Random::Formatter
   def self.bytes(_); end
 
   def self.urandom(_); end

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_3_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_3_hidden.rbi.exp
@@ -8478,7 +8478,6 @@ module Random::Formatter
 end
 
 class Random
-  extend ::Random::Formatter
   def self.bytes(_); end
 
   def self.urandom(_); end

--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1843,7 +1843,7 @@ class Array < Object
   sig do
     params(
         arg0: Integer,
-        random: Random,
+        random: Random::Formatter,
     )
     .returns(T.any(T.nilable(Elem), T::Array[Elem]))
   end

--- a/rbi/core/random.rbi
+++ b/rbi/core/random.rbi
@@ -30,6 +30,7 @@
 # of 2\*\*19937-1.
 class Random < Object
   include Random::Formatter
+  extend Random::Formatter
 
   # The default Pseudorandom number generator. Used by class methods of
   # [`Random`](https://docs.ruby-lang.org/en/2.6.0/Random.html).
@@ -469,6 +470,8 @@ end
 # p SecureRandom.random_bytes(10) #=> "\323U\030TO\234\357\020\a\337"
 # ~~~
 module SecureRandom
+  extend Random::Formatter
+
   # SecureRandom.base64 generates a random base64 string.
   #
   # The argument _n_ specifies the length, in bytes, of the random number


### PR DESCRIPTION
Make `Array#sample` work with `SecureRandom`, and more generally with any `Random::Formatter`.

Note that:
- `Random` both includes and extends `Random::Formatter` (cf. https://github.com/ruby/ruby/blob/f132825ffa1c225b0055ce6b0aa0d8428fba2623/random.c#L1580-L1582, thanks @jzhou-stripe!)
- `SecureRandom` extends `Random::Formatter` (cf. https://github.com/ruby/ruby/blob/f132825ffa1c225b0055ce6b0aa0d8428fba2623/lib/securerandom.rb#L333)

### Motivation
I want to use `Array#sample` with `SecureRandom`.


### Test plan
Not sure how to write tests for this, but I'm happy to give it a try if you can point me in the right direction.
