### PR TITLE
Avoid allocations in prop rule key validation

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -76,6 +76,7 @@ class T::Props::Decorator
     optional
     _tnilable
   }.to_set.freeze
+  private_constant :VALID_RULE_KEYS
 
   sig {params(key: Symbol).returns(T::Boolean).checked(:never)}
   def valid_rule_key?(key)

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -61,23 +61,32 @@ class T::Props::Decorator
     @props = @props.merge(prop => rules.freeze).freeze
   end
 
-  sig {returns(T::Array[Symbol])}
+  VALID_RULE_KEYS = %i{
+    enum
+    foreign
+    foreign_hint_only
+    ifunset
+    immutable
+    override
+    redaction
+    sensitivity
+    without_accessors
+    clobber_existing_method!
+    extra
+    optional
+    _tnilable
+  }.to_set.freeze
+
+  sig {params(key: Symbol).returns(T::Boolean).checked(:never)}
+  def valid_rule_key?(key)
+    valid_props.include?(key)
+  end
+
+  # Deprecated, kept temporarily to support overrides in pay-server
+  # during the transition to `valid_rule_key?`
+  sig {returns(T::Set[Symbol]).checked(:never)}
   def valid_props
-    %i{
-      enum
-      foreign
-      foreign_hint_only
-      ifunset
-      immutable
-      override
-      redaction
-      sensitivity
-      without_accessors
-      clobber_existing_method!
-      extra
-      optional
-      _tnilable
-    }
+    VALID_RULE_KEYS
   end
 
   sig {returns(DecoratedClass).checked(:never)}
@@ -262,7 +271,7 @@ class T::Props::Decorator
         "to 'sensitivity:' (in prop #{@class.name}.#{name})")
     end
 
-    if !(rules.keys - valid_props).empty?
+    if rules.keys.any? {|k| !valid_rule_key?(k)}
       raise ArgumentError.new("At least one invalid prop arg supplied in #{self}: #{rules.keys.inspect}")
     end
 

--- a/gems/sorbet-runtime/lib/types/props/optional.rb
+++ b/gems/sorbet-runtime/lib/types/props/optional.rb
@@ -21,12 +21,14 @@ module T::Props::Optional::DecoratorMethods
     true,
   ].freeze
 
-  def valid_props
-    super + [
-      :default,
-      :factory,
-      :optional,
-    ]
+  VALID_RULE_KEYS = Set[
+    :default,
+    :factory,
+    :optional,
+  ].freeze
+
+  def valid_rule_key?(key)
+    super || VALID_RULE_KEYS.include?(key)
   end
 
   def prop_optional?(prop); prop_rules(prop)[:fully_optional]; end

--- a/gems/sorbet-runtime/lib/types/props/optional.rb
+++ b/gems/sorbet-runtime/lib/types/props/optional.rb
@@ -26,6 +26,7 @@ module T::Props::Optional::DecoratorMethods
     :factory,
     :optional,
   ].freeze
+  private_constant :VALID_RULE_KEYS
 
   def valid_rule_key?(key)
     super || VALID_RULE_KEYS.include?(key)

--- a/gems/sorbet-runtime/lib/types/props/pretty_printable.rb
+++ b/gems/sorbet-runtime/lib/types/props/pretty_printable.rb
@@ -18,9 +18,9 @@ module T::Props::PrettyPrintable
   module DecoratorMethods
     extend T::Sig
 
-    sig {returns(T::Array[Symbol])}
-    def valid_props
-      super + [:inspect]
+    sig {params(key: Symbol).returns(T::Boolean).checked(:never)}
+    def valid_rule_key?(key)
+      super || key == :inspect
     end
 
     sig do

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -274,12 +274,11 @@ end
 # NB: This must stay in the same file where T::Props::Serializable is defined due to
 # T::Props::Decorator#apply_plugin; see https://git.corp.stripe.com/stripe-internal/pay-server/blob/fc7f15593b49875f2d0499ffecfd19798bac05b3/chalk/odm/lib/chalk-odm/document_decorator.rb#L716-L717
 module T::Props::Serializable::DecoratorMethods
-  def valid_props
-    super + [
-      :dont_store,
-      :name,
-      :raise_on_nil_write,
-    ]
+
+  VALID_RULE_KEYS = Set[:dont_store, :name, :raise_on_nil_write].freeze
+
+  def valid_rule_key?(key)
+    super || VALID_RULE_KEYS.include?(key)
   end
 
   def required_props

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -276,6 +276,7 @@ end
 module T::Props::Serializable::DecoratorMethods
 
   VALID_RULE_KEYS = Set[:dont_store, :name, :raise_on_nil_write].freeze
+  private_constant :VALID_RULE_KEYS
 
   def valid_rule_key?(key)
     super || VALID_RULE_KEYS.include?(key)

--- a/gems/sorbet-runtime/lib/types/props/type_validation.rb
+++ b/gems/sorbet-runtime/lib/types/props/type_validation.rb
@@ -11,9 +11,9 @@ module T::Props::TypeValidation
   module DecoratorMethods
     extend T::Sig
 
-    sig {returns(T::Array[Symbol])}
-    def valid_props
-      super + [:DEPRECATED_underspecified_type]
+    sig {params(key: Symbol).returns(T::Boolean).checked(:never)}
+    def valid_rule_key?(key)
+      super || :DEPRECATED_underspecified_type == key
     end
 
     sig do

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -80,7 +80,8 @@ class T::Props::Decorator
   def set(*args, &blk); end
   def shallow_clone_ok(*args, &blk); end
   def smart_coerce(*args, &blk); end
-  def valid_props(*args, &blk); end
+  def valid_props; end
+  def valid_rule_key?(key); end
   def validate_foreign_option(*args, &blk); end
   def validate_not_missing_sensitivity(*args, &blk); end
   def validate_prop_name(name); end
@@ -123,6 +124,7 @@ module T::Props::Optional::DecoratorMethods
   def prop_optional?(prop); end
   def prop_validate_definition!(name, cls, rules, type); end
   def valid_props; end
+  def valid_rule_key?(key); end
 end
 
 module T::Props::WeakConstructor
@@ -148,7 +150,8 @@ module T::Props::PrettyPrintable::DecoratorMethods
   def join_props_with_pretty_values(pretty_kvs, multiline:, indent: '  ', &blk); end
   def self.method_added(name); end
   def self.singleton_method_added(name); end
-  def valid_props(&blk); end
+  def valid_props; end
+  def valid_rule_key?(key); end
   extend T::Sig
 end
 
@@ -179,6 +182,7 @@ module T::Props::Serializable::DecoratorMethods
   def required_props; end
   def serialized_form_prop(serialized_form); end
   def valid_props; end
+  def valid_rule_key?(key); end
 end
 
 module T::Props::Serializable::ClassMethods
@@ -200,7 +204,8 @@ module T::Props::TypeValidation::DecoratorMethods
   def self.method_added(name); end
   def self.singleton_method_added(name); end
   def type_error_message(*args, &blk); end
-  def valid_props(*args, &blk); end
+  def valid_props; end
+  def valid_rule_key?(key); end
   def validate_type(*args, &blk); end
   extend T::Sig
 end


### PR DESCRIPTION
### Motivation
This saves ~5% on the `prop_definition` benchmark. (It looked a little better earlier and I think the impact will be bigger when we can remove the `valid_props` method entirely, which we can do after updating pay-server to override `valid_rule_key?` instead.)

### Test plan
Passing build