### PR TITLE
Close issue about incorrect docs for constants

### DIFF
--- a/test/testdata/lsp/hover_constants.rb
+++ b/test/testdata/lsp/hover_constants.rb
@@ -1,28 +1,23 @@
 # typed: true
 
-# This file documents incorrect behavior when we findDocumentation for
-# constants via hover.
-#
-# See: https://github.com/sorbet/sorbet/issues/2311
-#
-# Note: completion also uses this logic for showing documentation.
+# Note: completion and hover share logic for showing documentation.
 # See test/testdata/lsp/completion/constants_all_kinds.rb for a test to look at.
 
 # Docs for AAA
-class AAA; end # right
+class AAA; end
 #     ^ hover: Docs for AAA
 
 # Docs for BBB
-class BBB # right
+class BBB
   #   ^ hover: Docs for BBB
   extend T::Generic
 
   # Docs for XXX
-  XXX = nil # wrong
+  XXX = nil
   # ^ hover: Docs for XXX
 
   # Docs for CCC
-  CCC = AAA # wrong? arguably showing the dealiased docs is fine
+  CCC = AAA # Arguably we should show CCC, but this is ~fine.
   # ^ hover: Docs for AAA
 
   # Docs for EEE


### PR DESCRIPTION
Closes #2311




<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The incorrect behavior had to do with the handling of type members. I
thought we were wrong at first. I don't know why I thought that, because
the test passed in CI that I thought would fail, and then I confirmed
that it also worked in the editor manually.

The only thing left that could be construed as "wrong" is that for class
aliases we show the docs for the dealiased symbol, which I think is
actually preferable in some cases, so I'm going to close this.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.