### PR TITLE
Sprinkle some dealiases in constant completion

### DIFF
--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -145,7 +145,7 @@ std::unique_ptr<MarkupContent> formatRubyMarkup(MarkupKind markupKind, std::stri
                                                 std::optional<std::string_view> explanation);
 std::string prettyTypeForMethod(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver,
                                 core::TypePtr retType, const core::TypeConstraint *constraint);
-std::string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef constant, core::TypePtr type);
+std::string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef constant);
 core::TypePtr getResultType(const core::GlobalState &gs, core::TypePtr type, core::SymbolRef inWhat,
                             core::TypePtr receiver, const core::TypeConstraint *constr);
 SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef);

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -236,11 +236,26 @@ string prettyTypeForMethod(const core::GlobalState &gs, core::SymbolRef method, 
                        prettyDefForMethod(gs, method));
 }
 
-string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef constant, core::TypePtr type) {
-    core::TypePtr result = type;
+string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef constant) {
+    // Request that the constant already be dealiased, rather than dealias here to avoid defensively dealiasing.
+    // We should understand where dealias calls go.
+    ENFORCE(constant == constant.data(gs)->dealias(gs));
+
+    core::TypePtr result;
+    if (constant.data(gs)->isClassOrModule()) {
+        auto targetClass = constant;
+        if (!targetClass.data(gs)->attachedClass(gs).exists()) {
+            targetClass = targetClass.data(gs)->lookupSingletonClass(gs);
+        }
+        result = targetClass.data(gs)->externalType(gs);
+    } else {
+        auto resultType = constant.data(gs)->resultType;
+        result = resultType == nullptr ? core::Types::untyped(gs, constant) : resultType;
+    }
+
     if (constant.data(gs)->isTypeAlias()) {
         // By wrapping the type in `MetaType`, it displays as `<Type: Foo>` rather than `Foo`.
-        result = core::make_type<core::MetaType>(type);
+        result = core::make_type<core::MetaType>(result);
     }
     return result->showWithMoreInfo(gs);
 }

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -84,7 +84,7 @@ unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentHover(LSPTypecheckerDeleg
             string typeString = prettyTypeForMethod(gs, defResp->symbol, nullptr, defResp->retType.type, nullptr);
             response->result = make_unique<Hover>(formatRubyMarkup(clientHoverMarkupKind, typeString, documentation));
         } else if (auto constResp = resp->isConstant()) {
-            auto prettyType = prettyTypeForConstant(gs, constResp->symbol, resp->getRetType());
+            auto prettyType = prettyTypeForConstant(gs, constResp->symbol);
             response->result = make_unique<Hover>(formatRubyMarkup(clientHoverMarkupKind, prettyType, documentation));
         } else {
             core::TypePtr retType = resp->getRetType();


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We need to use the source symbol (`maybeAlias`) for anything where the name
of the symbol as typed by the user is important, but the target symbol
(`what`) for anything where the types / arity are important.

In particular, this change should only manifest as a difference in behavior
for what's shown in the `documentation` field, which is currrently untested
(it's tested indirectly by sharing a large portion of code with hover).

### Commit summary


- **Sprinkle some dealiases in constant completion** (1ef177da7)

  We need to use the source symbol (`maybeAlias`) for anything where the
  name of the symbol as typed by the user is important, but the target
  symbol (`what`) for anything where the types / arity are important.

  In particular, this change should only manifest as a difference in
  behavior for what's shown in the `documentation` field, which is
  currrently untested (it's tested indirectly by sharing a large portion
  of code with hover).

- **Consolidate constant type handling in prettyTypeForConstant** (ab8f008a4)

  Turns out, resultType was unused in getCompletionItemForConstant, and
  instead it was exclusively passing its `type` argument forwards to
  prettyTypeForConstant. It would have been nice to get a dead code
  warning there...

  By putting all this logic in prettyTypeForConstant, it meanns that it
  will be shared with hover.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Completion test harness can't test documentation, and completion already showed
the right thing because there was a dealias in a hover-specific location.

Instead of automated tests, here's some screenshots:
 

**Before**

<img width="696" alt="Screen Shot 2020-01-08 at 3 29 22 PM" src="https://user-images.githubusercontent.com/5544532/72025084-e5497300-322b-11ea-8279-cc7aa0d5216c.png">

**After**


<img width="697" alt="Screen Shot 2020-01-08 at 3 28 11 PM" src="https://user-images.githubusercontent.com/5544532/72025085-e5497300-322b-11ea-92ac-a6dc05d9f0e8.png">
