### PR TITLE
Correctly suggest constants that are defined on <root>

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -696,7 +696,7 @@ void LSPLoop::findSimilarConstant(const core::GlobalState &gs, const core::lsp::
     auto prefix = resp.name.data(gs)->shortName(gs);
     config->logger->debug("Looking for constant similar to {}", prefix);
     auto scope = resp.scope;
-    do {
+    while (true) {
         for (auto member : scope.data(gs)->membersStableOrderSlow(gs)) {
             auto sym = member.second;
             if (sym.exists() &&
@@ -719,8 +719,13 @@ void LSPLoop::findSimilarConstant(const core::GlobalState &gs, const core::lsp::
                 items.push_back(getCompletionItemForConstant(gs, *config, sym, type, queryLoc, prefix, items.size()));
             }
         }
+
+        if (scope == core::Symbols::root()) {
+            break;
+        }
+
         scope = scope.data(gs)->owner;
-    } while (scope != core::Symbols::root());
+    }
 }
 
 unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentCompletion(LSPTypecheckerDelegate &typechecker,

--- a/test/testdata/lsp/completion/constants_root.rb
+++ b/test/testdata/lsp/completion/constants_root.rb
@@ -1,0 +1,13 @@
+# typed: true
+
+# Prevents regression against an off-by-one error we used to have that would
+# stop before suggestion similiar constants that existed on <root>
+
+class A
+  extend T::Sig
+  sig {returns(Int)} # error: Unable to resolve
+  #               ^ completion: (nothing)
+  def foo
+    0
+  end
+end

--- a/test/testdata/lsp/completion/constants_root.rb
+++ b/test/testdata/lsp/completion/constants_root.rb
@@ -6,7 +6,7 @@
 class A
   extend T::Sig
   sig {returns(Int)} # error: Unable to resolve
-  #               ^ completion: (nothing)
+  #               ^ completion: Integer, Interrupt
   def foo
     0
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We used to have an off-by-one error suggesting constants that were defined at
the root level if we were nested inside a class (i.e., not at the top level
ourselves).

So this test passed previously:

```ruby
Integ
#    ^ completion: Integer
```

But this test failed:

```ruby
class A
  Integ
  #    ^ completion: Integer
end
```

There was an off-by-one error in the `do ... while`. I fixed it and added a
test.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.