### PR TITLE
Change CompletionItemKind for type members & aliases

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -402,14 +402,8 @@ unique_ptr<CompletionItem> getCompletionItemForConstant(const core::GlobalState 
                 item->kind = CompletionItemKind::Module;
             }
         }
-    } else if (what.data(gs)->isTypeMember()) {
-        item->kind = CompletionItemKind::TypeParameter;
-    } else if (what.data(gs)->isStaticField()) {
-        if (what.data(gs)->isTypeAlias()) {
-            item->kind = CompletionItemKind::TypeParameter;
-        } else {
-            item->kind = CompletionItemKind::Field;
-        }
+    } else if (what.data(gs)->isTypeMember() || what.data(gs)->isStaticField()) {
+        item->kind = CompletionItemKind::Field;
     } else {
         ENFORCE(false, "Unhandled kind of constant in getCompletionItemForConstant");
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I didn't really like the icon that was being used for type members and
type aliases, so I'm replacing it with the icon we use for static fields
(because syntactically, type members & type aliases are static fields).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

**Before**

<img width="449" alt="Screen Shot 2020-01-08 at 4 04 24 PM" src="https://user-images.githubusercontent.com/5544532/72026557-b5509e80-3230-11ea-861a-0a696937bf5b.png">
<img width="482" alt="Screen Shot 2020-01-08 at 4 04 16 PM" src="https://user-images.githubusercontent.com/5544532/72026558-b5509e80-3230-11ea-8723-d564d91e3f0e.png">

**After**

<img width="454" alt="Screen Shot 2020-01-08 at 4 04 58 PM" src="https://user-images.githubusercontent.com/5544532/72026555-b5509e80-3230-11ea-9af4-b92f30cc8ecb.png">
<img width="480" alt="Screen Shot 2020-01-08 at 4 04 52 PM" src="https://user-images.githubusercontent.com/5544532/72026556-b5509e80-3230-11ea-92dd-8271e0ea497c.png">

