### PR TITLE
Signatures for DidYouMean::SpellChecker

### DIFF
--- a/rbi/gems/didyoumean.rbi
+++ b/rbi/gems/didyoumean.rbi
@@ -44,4 +44,11 @@ class DidYouMean::NullChecker < Object
 end
 
 class DidYouMean::SpellChecker < Object
+  sig {params(dictionary: T::Array[T.any(String, Symbol)]).returns(DidYouMean::SpellChecker)}
+  def initialize(dictionary:)
+  end
+
+  sig {params(input: T.any(String, Symbol)).returns(T::Array[T.any(String, Symbol)])}
+  def correct(input)
+  end
 end


### PR DESCRIPTION
Add signatures for `DidYouMean::SpellChecker`.

Definitions:
- `initialize`: https://github.com/ruby/did_you_mean/blob/0da01bcdcc94d5e975d030a6ce60e4cd0a3d7293/lib/did_you_mean/spell_checker.rb#L8
- `correct`: https://github.com/ruby/did_you_mean/blob/0da01bcdcc94d5e975d030a6ce60e4cd0a3d7293/lib/did_you_mean/spell_checker.rb#L12

Example usage: https://github.com/ruby/did_you_mean#using-the-didyoumeanspellchecker


### Motivation
Can't use `DidYouMean::SpellChecker` at the moment: https://sorbet.run/#%23%20typed%3A%20true%0A%0Adef%20main%0A%20%20spell_checker%20%3D%20DidYouMean%3A%3ASpellChecker.new(dictionary%3A%20%5B'email'%2C%20'fail'%2C%20'eval'%5D)%0A%0A%20%20spell_checker.correct('meail')%0A%20%20spell_checker.correct('afil')%0Aend%0A


### Test plan
Not sure how to write tests for this.
