### PR TITLE
Don't show duplicate T::Enum completion results

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -613,6 +613,12 @@ unique_ptr<CompletionItem> trySuggestSig(LSPTypecheckerDelegate &typechecker,
     return item;
 }
 
+bool isTEnumName(const core::GlobalState &gs, core::NameRef name) {
+    auto original = name.data(gs)->cnst.original;
+    return original.data(gs)->kind == core::NameKind::UNIQUE &&
+           original.data(gs)->unique.uniqueNameKind == core::UniqueNameKind::TEnum;
+}
+
 } // namespace
 
 unique_ptr<CompletionItem> LSPLoop::getCompletionItemForMethod(LSPTypecheckerDelegate &typechecker,
@@ -695,6 +701,9 @@ void LSPLoop::findSimilarConstant(const core::GlobalState &gs, const core::lsp::
             if (sym.exists() &&
                 (sym.data(gs)->isClassOrModule() || sym.data(gs)->isStaticField() || sym.data(gs)->isTypeMember()) &&
                 sym.data(gs)->name.data(gs)->kind == core::NameKind::CONSTANT &&
+                // Every T::Enum value gets a class with the ~same name (see rewriter/TEnum.cc for details).
+                // This manifests as showing two completion results when we should only show one, so skip the bad kind.
+                !isTEnumName(gs, sym.data(gs)->name) &&
                 // hide singletons
                 hasSimilarName(gs, sym.data(gs)->name, prefix)) {
                 items.push_back(getCompletionItemForConstant(gs, *config, sym, queryLoc, prefix, items.size()));

--- a/test/testdata/lsp/completion/constants_all_kinds.rb
+++ b/test/testdata/lsp/completion/constants_all_kinds.rb
@@ -68,8 +68,7 @@ p MMM::ZZ # error: Unable to resolve
 
 # -- extras --
 
-# TODO(jez) We show duplicate results because of how the T::Enum DSL pass works
 p MyEnum::Va # error: Unable to resolve
-#           ^ completion: Val, Val
+#           ^ completion: Val
 p MyStruc # error: Unable to resolve
 #        ^ completion: MyStruct


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Every T::Enum value gets a class with the ~same name (see rewriter/TEnum.cc
for details).  This used to manifest as showing two completion results when
we should only show one, so we skip the kind we don't want here.

### Commit summary


- **Don't show duplicate T::Enum completion results** (4cda74c63)

  Every T::Enum value gets a class with the ~same name (see
  rewriter/TEnum.cc for details).  This used to manifest as showing two
  completion results when we should only show one, so we skip the kind we
  don't want here.

- **Rewrite complex if condition** (7464a1e2c)

  I think it's more readable this way.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.