### PR TITLE
Hide constants with angle brackets from completion results

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -706,17 +706,23 @@ void LSPLoop::findSimilarConstant(const core::GlobalState &gs, const core::lsp::
                 continue;
             }
 
-            if (sym.data(gs)->name.data(gs)->kind != core::NameKind::CONSTANT) {
+            auto memberName = sym.data(gs)->name;
+            if (memberName.data(gs)->kind != core::NameKind::CONSTANT) {
                 continue;
             }
 
-            if (isTEnumName(gs, sym.data(gs)->name)) {
+            if (isTEnumName(gs, memberName)) {
                 // Every T::Enum value gets a class with the ~same name (see rewriter/TEnum.cc for details).
                 // This manifests as showing two completion results when we should only show one, so skip the bad kind.
                 continue;
             }
 
-            if (!hasSimilarName(gs, sym.data(gs)->name, prefix)) {
+            if (hasAngleBrackets(memberName.data(gs)->shortName(gs))) {
+                // Gets rid of classes like `<Magic>`; they can't be typed by a user anyways.
+                continue;
+            }
+
+            if (!hasSimilarName(gs, memberName, prefix)) {
                 continue;
             }
 

--- a/test/testdata/lsp/completion/constants_magic.rb
+++ b/test/testdata/lsp/completion/constants_magic.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+# We never want to show constants that have angle brackets in them to the user.
+# Such names aren't human-writable, yet they exist in Sorbet's payload for
+# various reasons.
+
+Magic # error: Unable to resolve
+#    ^ completion: <Magic>

--- a/test/testdata/lsp/completion/constants_magic.rb
+++ b/test/testdata/lsp/completion/constants_magic.rb
@@ -5,4 +5,4 @@
 # various reasons.
 
 Magic # error: Unable to resolve
-#    ^ completion: <Magic>
+#    ^ completion: (nothing)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We do the same thing for methods.

These constants exists solely for internal purposes. It would be a syntax error
for the user to write them in their program.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See commit history to see delta on the test file.