### PR TITLE
Add fast path for T::Props setters

### DIFF
--- a/gems/sorbet-runtime/bench/setters.rb
+++ b/gems/sorbet-runtime/bench/setters.rb
@@ -17,6 +17,20 @@ module SorbetBenchmarks
       prop :nilable, T.nilable(Integer), default: 0
     end
 
+    class OverrideStruct < T::Struct
+      class SetHookDecorator < T::Props::Decorator
+        def prop_set(instance, prop, val, rules=prop_rules())
+          super
+        end
+      end
+
+      def self.decorator_class
+        SetHookDecorator
+      end
+
+      prop :prop, Integer
+    end
+
     # Note we manually unroll loops 10x since loop overhead may be non-negligible here
     def self.run
       poro = ExamplePoro.new
@@ -86,6 +100,29 @@ module SorbetBenchmarks
         end
       end
       puts "T::Struct setter, nilable type (μs/iter):"
+      puts result
+
+      struct = OverrideStruct.new(prop: 0)
+
+      10_000.times do
+        struct.prop = 0
+      end
+
+      result = Benchmark.measure do
+        100_000.times do
+          struct.prop = 0
+          struct.prop = 1
+          struct.prop = 2
+          struct.prop = 3
+          struct.prop = 4
+          struct.prop = 5
+          struct.prop = 6
+          struct.prop = 7
+          struct.prop = 8
+          struct.prop = 9
+        end
+      end
+      puts "T::Struct setter, given prop_set override (μs/iter):"
       puts result
     end
   end

--- a/gems/sorbet-runtime/lib/sorbet-runtime.rb
+++ b/gems/sorbet-runtime/lib/sorbet-runtime.rb
@@ -93,6 +93,7 @@ require_relative 'types/props/errors'
 require_relative 'types/props/plugin'
 require_relative 'types/props/utils'
 # Props that run sigs statically so have to be after all the others :(
+require_relative 'types/props/private/setter_factory'
 require_relative 'types/props/optional'
 require_relative 'types/props/weak_constructor'
 require_relative 'types/props/constructor'

--- a/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
@@ -65,7 +65,7 @@ module T::Props
           type: T.any(T::Types::Base, Module),
           val: T.untyped,
         )
-        .returns(SetterProc)
+        .void
       end
       private_class_method def self.raise_pretty_error(klass, prop, type, val)
         base_message = "Can't set #{klass.name}.#{prop} to #{val.inspect} (instance of #{val.class}) - need a #{type}"

--- a/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+# typed: strict
+
+module T::Props
+  module Private
+    module SetterFactory
+      extend T::Sig
+
+      SetterProc = T.type_alias {T.proc.params(val: T.untyped).void}
+
+      sig do
+        params(
+          klass: T.all(Module, T::Props::ClassMethods),
+          prop: Symbol,
+          rules: T::Hash[Symbol, T.untyped]
+        )
+        .returns(SetterProc)
+        .checked(:never)
+      end
+      def self.build_setter_proc(klass, prop, rules)
+        # Our nil check works differently than a simple T.nilable for various
+        # reasons (including the `raise_on_nil_write` setting, the existence
+        # of defaults & factories, and the fact that we allow `T.nilable(Foo)`
+        # where Foo < T::Props::CustomType as a prop type even though calling
+        # `valid?` on it won't work as expected), so unwrap any T.nilable and
+        # do a check manually. (Note this hack does not fix custom types as
+        # collection elements.)
+        non_nil_type = if rules[:type_is_custom_type]
+          rules.fetch(:type)
+        else
+          T::Utils::Nilable.get_underlying_type_object(rules.fetch(:type_object))
+        end
+        accessor_key = rules.fetch(:accessor_key)
+        raise_error = ->(val) {raise_pretty_error(klass, prop, non_nil_type, val)}
+
+        # It seems like a bug that this affects the behavior of setters, but
+        # some existing code relies on this behavior
+        has_explicit_nil_default = rules.key?(:default) && rules.fetch(:default).nil?
+
+        if !T::Props::Utils.need_nil_write_check?(rules) || has_explicit_nil_default
+          proc do |val|
+            if val.nil?
+              instance_variable_set(accessor_key, nil)
+            elsif non_nil_type.valid?(val)
+              instance_variable_set(accessor_key, val)
+            else
+              raise_error.call(val)
+            end
+          end
+        else
+          proc do |val|
+            if non_nil_type.valid?(val)
+              instance_variable_set(accessor_key, val)
+            else
+              raise_error.call(val)
+            end
+          end
+        end
+      end
+
+      sig do
+        params(
+          klass: T.all(Module, T::Props::ClassMethods),
+          prop: Symbol,
+          type: T.any(T::Types::Base, Module),
+          val: T.untyped,
+        )
+        .returns(SetterProc)
+      end
+      private_class_method def self.raise_pretty_error(klass, prop, type, val)
+        base_message = "Can't set #{klass.name}.#{prop} to #{val.inspect} (instance of #{val.class}) - need a #{type}"
+
+        pretty_message = "Parameter '#{prop}': #{base_message}\n"
+        caller_loc = caller_locations&.find {|l| !l.to_s.include?('sorbet-runtime/lib/types/props')}
+        if caller_loc
+          pretty_message += "Caller: #{caller_loc.path}:#{caller_loc.lineno}\n"
+        end
+
+        T::Configuration.call_validation_error_handler(
+          nil,
+          message: base_message,
+          pretty_message: pretty_message,
+          kind: 'Parameter',
+          name: prop,
+          type: type,
+          value: val,
+          location: caller_loc,
+        )
+      end
+    end
+  end
+end

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -52,7 +52,6 @@ class T::Props::Decorator
   def add_prop_definition(*args, &blk); end
   def all_props(*args, &blk); end
   def array_subdoc_type(*args, &blk); end
-  def check_prop_type(*args, &blk); end
   def convert_type_to_class(*args, &blk); end
   def decorated_class; end
   def define_foreign_method(*args, &blk); end


### PR DESCRIPTION
Instead of figuring out what kind of type check we need to do for each setter at each invocation at runtime, we figure it out at prop definition time, and create an appropriate proc. We then use that proc with `define_method` to define a setter that doesn't need to go through the decorator, if there are no `prop_set` hooks (for which we check by the same mechanism we're now using for `prop_get`.)

To minimize divergent code paths, we still use this proc even when going through `prop_set`, via `instance_exec`. A new benchmark shows that this slow path is still marginally faster than the old implementation (~10%, but plausibly within the margin of error when generalizing past my laptop).

### Motivation
A ~4x improvement in the fast path

Unfortunately neither models nor Chalk::ODM::Document can take advantage of this in pay-server currently because the implementation of `soft_freeze` relies on a `prop_set` hook, but at least this will help T::Struct users

This is also a building block for optimizations to constructors (in a later PR)

### Test plan
Passing tests here plus in pay-server via https://git.corp.stripe.com/stripe-internal/pay-server/compare/djudd/t-props-setter-fast-path

(Note that there are still a couple cases I need to fix there, but I'm opening this for comment)