### PR TITLE
Clean up T::Props#valid_props

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -76,19 +76,12 @@ class T::Props::Decorator
     extra
     optional
     _tnilable
-  }.to_set.freeze
+  }.map {|k| [k, true]}.to_h.freeze
   private_constant :VALID_RULE_KEYS
 
   sig {params(key: Symbol).returns(T::Boolean).checked(:never)}
   def valid_rule_key?(key)
-    valid_props.include?(key)
-  end
-
-  # Deprecated, kept temporarily to support overrides in pay-server
-  # during the transition to `valid_rule_key?`
-  sig {returns(T::Set[Symbol]).checked(:never)}
-  def valid_props
-    VALID_RULE_KEYS
+    VALID_RULE_KEYS[key]
   end
 
   # checked(:never) - O(prop accesses)

--- a/gems/sorbet-runtime/lib/types/props/optional.rb
+++ b/gems/sorbet-runtime/lib/types/props/optional.rb
@@ -21,15 +21,15 @@ module T::Props::Optional::DecoratorMethods
     true,
   ].freeze
 
-  VALID_RULE_KEYS = Set[
-    :default,
-    :factory,
-    :optional,
-  ].freeze
+  VALID_RULE_KEYS = {
+    default: true,
+    factory: true,
+    optional: true,
+  }.freeze
   private_constant :VALID_RULE_KEYS
 
   def valid_rule_key?(key)
-    super || VALID_RULE_KEYS.include?(key)
+    super || VALID_RULE_KEYS[key]
   end
 
   def prop_optional?(prop); prop_rules(prop)[:fully_optional]; end

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -275,11 +275,11 @@ end
 # T::Props::Decorator#apply_plugin; see https://git.corp.stripe.com/stripe-internal/pay-server/blob/fc7f15593b49875f2d0499ffecfd19798bac05b3/chalk/odm/lib/chalk-odm/document_decorator.rb#L716-L717
 module T::Props::Serializable::DecoratorMethods
 
-  VALID_RULE_KEYS = Set[:dont_store, :name, :raise_on_nil_write].freeze
+  VALID_RULE_KEYS = {dont_store: true, name: true, raise_on_nil_write: true}.freeze
   private_constant :VALID_RULE_KEYS
 
   def valid_rule_key?(key)
-    super || VALID_RULE_KEYS.include?(key)
+    super || VALID_RULE_KEYS[key]
   end
 
   def required_props

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -80,7 +80,6 @@ class T::Props::Decorator
   def set(*args, &blk); end
   def shallow_clone_ok(*args, &blk); end
   def smart_coerce(*args, &blk); end
-  def valid_props; end
   def valid_rule_key?(key); end
   def validate_foreign_option(*args, &blk); end
   def validate_not_missing_sensitivity(*args, &blk); end
@@ -123,7 +122,6 @@ module T::Props::Optional::DecoratorMethods
   def mutate_prop_backdoor!(prop, key, value); end
   def prop_optional?(prop); end
   def prop_validate_definition!(name, cls, rules, type); end
-  def valid_props; end
   def valid_rule_key?(key); end
 end
 
@@ -150,7 +148,6 @@ module T::Props::PrettyPrintable::DecoratorMethods
   def join_props_with_pretty_values(pretty_kvs, multiline:, indent: '  ', &blk); end
   def self.method_added(name); end
   def self.singleton_method_added(name); end
-  def valid_props; end
   def valid_rule_key?(key); end
   extend T::Sig
 end
@@ -181,7 +178,6 @@ module T::Props::Serializable::DecoratorMethods
   def prop_validate_definition!(name, cls, rules, type); end
   def required_props; end
   def serialized_form_prop(serialized_form); end
-  def valid_props; end
   def valid_rule_key?(key); end
 end
 
@@ -204,7 +200,6 @@ module T::Props::TypeValidation::DecoratorMethods
   def self.method_added(name); end
   def self.singleton_method_added(name); end
   def type_error_message(*args, &blk); end
-  def valid_props; end
   def valid_rule_key?(key); end
   def validate_type(*args, &blk); end
   extend T::Sig


### PR DESCRIPTION
- Remove deprecated `valid_props` method
- Switch from sets to hashes for marginal increase in performance (`Hash#[]` seems to have special treatment)

### Motivation
Cleanup now that pay-server no longer depends on `valid_props` (https://git.corp.stripe.com/stripe-internal/pay-server/pull/199193)

### Test plan
Passing build
