### PR TITLE
Fix test that runs su when it's not root

### DIFF
--- a/test/cli/bad-perm/bad-perm.sh
+++ b/test/cli/bad-perm/bad-perm.sh
@@ -5,7 +5,7 @@ echo "parse_fail +" > "$dir/file.rb"
 mkdir "$dir/no-read"
 chmod 000 "$dir/no-read"
 cmd="main/sorbet --silence-dev-message $dir"
-if [ $UID == 0 ]; then
+if [ "$(id -u)" = 0 ]; then
     su -s /bin/bash nobody -c "$cmd" 2>&1 | sed "s,$dir,dir,"
 else
     $cmd 2>&1 | sed "s,$dir,dir,"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
It was failing & logging failures in syslog


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
