### PR TITLE
Add `test_each_hash`

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -212,6 +212,7 @@ NameDef names[] = {
     {"after"},
     {"afterAngles", "<after>"},
     {"testEach", "test_each"},
+    {"testEachHash", "test_each_hash"},
     {"constSet", "const_set"},
     {"collect"},
 

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -176,7 +176,7 @@ unique_ptr<ast::Expression> getIteratee(unique_ptr<ast::Expression> &exp) {
 // this applies to each statement contained within a `test_each`: if it's an `it`-block, then convert it appropriately,
 // otherwise flag an error about it
 unique_ptr<ast::Expression> runUnderEach(core::MutableContext ctx, unique_ptr<ast::Expression> stmt,
-                                         unique_ptr<ast::Expression> &arg, unique_ptr<ast::Expression> &iteratee) {
+                                         ast::MethodDef::ARGS_store &args, unique_ptr<ast::Expression> &iteratee) {
     // this statement must be a send
     if (auto send = ast::cast_tree<ast::Send>(stmt.get())) {
         // the send must be a call to `it` with a single argument (the test name) and a block with no arguments
@@ -192,7 +192,11 @@ unique_ptr<ast::Expression> runUnderEach(core::MutableContext ctx, unique_ptr<as
             body = ast::TreeMap::apply(ctx, constantMover, move(body));
 
             // pull the arg and the iteratee in and synthesize `iterate.each { |arg| body }`
-            auto blk = ast::MK::Block1(send->loc, move(body), arg->deepCopy());
+            ast::MethodDef::ARGS_store new_args;
+            for (auto &arg : args) {
+                new_args.emplace_back(arg->deepCopy());
+            }
+            auto blk = ast::MK::Block(send->loc, move(body), std::move(new_args));
             auto each = ast::MK::Send0Block(send->loc, iteratee->deepCopy(), core::Names::each(), move(blk));
             // put that into a method def named the appropriate thing
             auto method = addSigVoid(
@@ -211,17 +215,17 @@ unique_ptr<ast::Expression> runUnderEach(core::MutableContext ctx, unique_ptr<as
 
 // this just walks the body of a `test_each` and tries to transform every statement
 unique_ptr<ast::Expression> prepareTestEachBody(core::MutableContext ctx, unique_ptr<ast::Expression> body,
-                                                unique_ptr<ast::Expression> &arg,
+                                                ast::MethodDef::ARGS_store &args,
                                                 unique_ptr<ast::Expression> &iteratee) {
     auto bodySeq = ast::cast_tree<ast::InsSeq>(body.get());
     if (bodySeq) {
         for (auto &exp : bodySeq->stats) {
-            exp = runUnderEach(ctx, std::move(exp), arg, iteratee);
+            exp = runUnderEach(ctx, std::move(exp), args, iteratee);
         }
 
-        bodySeq->expr = runUnderEach(ctx, std::move(bodySeq->expr), arg, iteratee);
+        bodySeq->expr = runUnderEach(ctx, std::move(bodySeq->expr), args, iteratee);
     } else {
-        body = runUnderEach(ctx, std::move(body), arg, iteratee);
+        body = runUnderEach(ctx, std::move(body), args, iteratee);
     }
 
     return body;
@@ -236,11 +240,13 @@ unique_ptr<ast::Expression> runSingle(core::MutableContext ctx, ast::Send *send)
         return nullptr;
     }
 
-    if (send->fun == core::Names::testEach() && send->args.size() == 1 && send->block != nullptr) {
-        if (send->block->args.size() != 1) {
+    if ((send->fun == core::Names::testEach() || send->fun == core::Names::testEachHash()) && send->args.size() == 1 &&
+        send->block != nullptr) {
+        if ((send->fun == core::Names::testEach() && send->block->args.size() != 1) ||
+            (send->fun == core::Names::testEachHash() && send->block->args.size() != 2)) {
             if (auto e = ctx.state.beginError(send->block->loc, core::errors::Rewriter::BadTestEach)) {
-                e.setHeader("Wrong number of parameters for `{}` block: expected `{}`, got `{}`", "test_each", 1,
-                            send->block->args.size());
+                e.setHeader("Wrong number of parameters for `{}` block: expected `{}`, got `{}`", send->fun.show(ctx),
+                            1, send->block->args.size());
             }
             return nullptr;
         }
@@ -253,7 +259,7 @@ unique_ptr<ast::Expression> runSingle(core::MutableContext ctx, ast::Send *send)
         return ast::MK::Send(
             send->loc, ast::MK::Self(send->loc), send->fun, std::move(args), send->flags,
             ast::MK::Block(send->block->loc,
-                           prepareTestEachBody(ctx, std::move(send->block->body), send->block->args.front(), iteratee),
+                           prepareTestEachBody(ctx, std::move(send->block->body), send->block->args, iteratee),
                            std::move(send->block->args)));
     }
 

--- a/test/testdata/rewriter/minitest_tables.rb
+++ b/test/testdata/rewriter/minitest_tables.rb
@@ -3,14 +3,33 @@
 class Parent
   def foo; end
 end
+
 class Child < Parent
 end
 
 class MyTest
+  extend T::Sig
+
   def outside_method
   end
 
+  sig do
+    type_parameters(:U)
+    .params(arg: T::Enumerable[T.type_parameter(:U)], blk: T.proc.params(arg0: T.type_parameter(:U)).void)
+    .void
+  end
   def self.test_each(arg, &blk); end
+
+  sig do
+    type_parameters(:K, :V)
+    .params(
+      arg: T::Hash[T.type_parameter(:K), T.type_parameter(:V)],
+      blk: T.proc.params(arg0: T.type_parameter(:K), arg1: T.type_parameter(:V)).void,
+    ).void
+  end
+  def self.test_each_hash(arg, &blk); end
+
+  sig {params(name: String, blk: T.proc.void).void}
   def self.it(name, &blk); end
 
   test_each [Parent.new, Child.new] do |value|
@@ -49,7 +68,7 @@ class MyTest
     y = x # error: Only valid `it`-blocks can appear within `test_each`
   end
 
-  test_each [Parent.new, Child.new] do |value|
+  test_each CONST_LIST do |value|
     x = value.foo  # error: Only valid `it`-blocks can appear within `test_each`
     it "fails with non-it statements" do
       puts x
@@ -62,6 +81,7 @@ class MyTest
     end
   end
 
+
   test_each [1, 2, 3] do |k, v| # error: Wrong number of parameters for `test_each` block
     it "does not handle more than one argument" do
     end
@@ -71,4 +91,25 @@ class MyTest
     it "does not handle more than one argument" do
     end
   end
+
+  test_each_hash({foo: 1, bar: 2, baz: 3}) do |k, v|
+    it "handles lists with several types" do
+      # we don't decay literal hash types like we do for arrays, so
+      # these will still be untyped here
+      T.reveal_type(k) # error: Revealed type: `T.untyped`
+      T.reveal_type(v) # error: Revealed type: `T.untyped`
+    end
+  end
+
+  test_each_hash([1, 2, 3]) do |k, v| # error: Expected `T::Hash[K, V]`
+    it "fails to typecheck with non-hash arguments to `test_each-hash`" do
+      puts k, v
+    end
+  end
+
+  test_each_hash({foo: 1, bar: 2}) do |x| # error: Wrong number of parameters for `test_each_hash` block
+    it "does not handle more than one argument" do
+    end
+  end
+
 end

--- a/test/testdata/rewriter/minitest_tables.rb
+++ b/test/testdata/rewriter/minitest_tables.rb
@@ -68,6 +68,10 @@ class MyTest
     y = x # error: Only valid `it`-blocks can appear within `test_each`
   end
 
+  test_each_hash({}) do |k, v|
+    y = k + v # error: Only valid `it`-blocks can appear within `test_each_hash`
+  end
+
   test_each CONST_LIST do |value|
     x = value.foo  # error: Only valid `it`-blocks can appear within `test_each`
     it "fails with non-it statements" do

--- a/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
@@ -1,0 +1,196 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Parent><<C <todo sym>>> < (::<todo sym>)
+    def foo<<C <todo sym>>>(&<blk>)
+      <emptyTree>
+    end
+  end
+
+  class <emptyTree>::<C Child><<C <todo sym>>> < (<emptyTree>::<C Parent>)  end
+
+  class <emptyTree>::<C MyTest><<C <todo sym>>> < (::<todo sym>)
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    def outside_method<<C <todo sym>>>(&<blk>)
+      <emptyTree>
+    end
+
+    <self>.sig() do ||
+      <self>.type_parameters(:"U").params({:"arg" => <emptyTree>::<C T>::<C Enumerable>.[](<emptyTree>::<C T>.type_parameter(:"U")), :"blk" => <emptyTree>::<C T>.proc().params({:"arg0" => <emptyTree>::<C T>.type_parameter(:"U")}).void()}).void()
+    end
+
+    def self.test_each<<C <todo sym>>>(arg, &blk)
+      <emptyTree>
+    end
+
+    <self>.sig() do ||
+      <self>.type_parameters(:"K", :"V").params({:"arg" => <emptyTree>::<C T>::<C Hash>.[](<emptyTree>::<C T>.type_parameter(:"K"), <emptyTree>::<C T>.type_parameter(:"V")), :"blk" => <emptyTree>::<C T>.proc().params({:"arg0" => <emptyTree>::<C T>.type_parameter(:"K"), :"arg1" => <emptyTree>::<C T>.type_parameter(:"V")}).void()}).void()
+    end
+
+    def self.test_each_hash<<C <todo sym>>>(arg, &blk)
+      <emptyTree>
+    end
+
+    <self>.sig() do ||
+      <self>.params({:"name" => <emptyTree>::<C String>, :"blk" => <emptyTree>::<C T>.proc().void()}).void()
+    end
+
+    def self.it<<C <todo sym>>>(name, &blk)
+      <emptyTree>
+    end
+
+    <self>.test_each([<emptyTree>::<C Parent>.new(), <emptyTree>::<C Child>.new()]) do |value|
+      begin
+        ::T::Sig::WithoutRuntime.sig() do ||
+          <self>.params({}).void()
+        end
+        def <it 'works with instance methods'><<C <todo sym>>>(&<blk>)
+          [<emptyTree>::<C Parent>.new(), <emptyTree>::<C Child>.new()].each() do |value|
+            begin
+              <self>.puts(value.foo())
+              <self>.outside_method()
+              <emptyTree>::<C T>.reveal_type(value)
+            end
+          end
+        end
+      end
+    end
+
+    <emptyTree>::<C CONST_LIST> = [<emptyTree>::<C Parent>.new(), <emptyTree>::<C Child>.new()]
+
+    <self>.test_each(<emptyTree>::<C CONST_LIST>) do |value|
+      begin
+        ::T::Sig::WithoutRuntime.sig() do ||
+          <self>.params({}).void()
+        end
+        def <it 'succeeds with a constant list'><<C <todo sym>>>(&<blk>)
+          <emptyTree>::<C CONST_LIST>.each() do |value|
+            begin
+              <self>.puts(value.foo())
+              <emptyTree>::<C T>.reveal_type(value)
+            end
+          end
+        end
+      end
+    end
+
+    <emptyTree>::<C ANOTHER_CONST_LIST> = <emptyTree>::<C T>.let([<emptyTree>::<C Parent>.new(), <emptyTree>::<C Child>.new()], <emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C Parent>))
+
+    <self>.test_each(<emptyTree>::<C ANOTHER_CONST_LIST>) do |value|
+      begin
+        ::T::Sig::WithoutRuntime.sig() do ||
+          <self>.params({}).void()
+        end
+        def <it 'succeeds with a typed constant list'><<C <todo sym>>>(&<blk>)
+          <emptyTree>::<C ANOTHER_CONST_LIST>.each() do |value|
+            begin
+              <self>.puts(value.foo())
+              <emptyTree>::<C T>.reveal_type(value)
+            end
+          end
+        end
+      end
+    end
+
+    local = [<emptyTree>::<C Parent>.new(), <emptyTree>::<C Child>.new()]
+
+    <self>.test_each(local) do |value|
+      begin
+        ::T::Sig::WithoutRuntime.sig() do ||
+          <self>.params({}).void()
+        end
+        def <it 'succeed with a local variable but cannot type it'><<C <todo sym>>>(&<blk>)
+          ::T.unsafe(nil).each() do |value|
+            begin
+              <self>.puts(value.foo())
+              <emptyTree>::<C T>.reveal_type(value)
+            end
+          end
+        end
+      end
+    end
+
+    <self>.test_each([<emptyTree>::<C Parent>.new(), <emptyTree>::<C Child>.new()]) do |x|
+      y = x
+    end
+
+    <self>.test_each_hash({}) do |k, v|
+      y = k.+(v)
+    end
+
+    <self>.test_each(<emptyTree>::<C CONST_LIST>) do |value|
+      begin
+        x = value.foo()
+        begin
+          ::T::Sig::WithoutRuntime.sig() do ||
+            <self>.params({}).void()
+          end
+          def <it 'fails with non-it statements'><<C <todo sym>>>(&<blk>)
+            <emptyTree>::<C CONST_LIST>.each() do |value|
+              <self>.puts(x)
+            end
+          end
+        end
+      end
+    end
+
+    <self>.test_each(["foo", 5, {:"x" => false}]) do |v|
+      begin
+        ::T::Sig::WithoutRuntime.sig() do ||
+          <self>.params({}).void()
+        end
+        def <it 'handles lists with several types'><<C <todo sym>>>(&<blk>)
+          ["foo", 5, {:"x" => false}].each() do |v|
+            <emptyTree>::<C T>.reveal_type(v)
+          end
+        end
+      end
+    end
+
+    <self>.test_each([1, 2, 3]) do |k, v|
+      <self>.it("does not handle more than one argument") do ||
+        <emptyTree>
+      end
+    end
+
+    <self>.test_each([1, 2, 3]) do ||
+      <self>.it("does not handle more than one argument") do ||
+        <emptyTree>
+      end
+    end
+
+    <self>.test_each_hash({:"foo" => 1, :"bar" => 2, :"baz" => 3}) do |k, v|
+      begin
+        ::T::Sig::WithoutRuntime.sig() do ||
+          <self>.params({}).void()
+        end
+        def <it 'handles lists with several types'><<C <todo sym>>>(&<blk>)
+          {:"foo" => 1, :"bar" => 2, :"baz" => 3}.each() do |k, v|
+            begin
+              <emptyTree>::<C T>.reveal_type(k)
+              <emptyTree>::<C T>.reveal_type(v)
+            end
+          end
+        end
+      end
+    end
+
+    <self>.test_each_hash([1, 2, 3]) do |k, v|
+      begin
+        ::T::Sig::WithoutRuntime.sig() do ||
+          <self>.params({}).void()
+        end
+        def <it 'fails to typecheck with non-hash arguments to `test_each-hash`'><<C <todo sym>>>(&<blk>)
+          [1, 2, 3].each() do |k, v|
+            <self>.puts(k, v)
+          end
+        end
+      end
+    end
+
+    <self>.test_each_hash({:"foo" => 1, :"bar" => 2}) do |x|
+      <self>.it("does not handle more than one argument") do ||
+        <emptyTree>
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
User request: using `test_each` with a hash. As per offline conversation, we felt it would be better to have a hash-specific helper method for this rather than rely on Ruby's multiple-block-argument behavior.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
