### PR TITLE
Constant completion via ancestors

### DIFF
--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -101,8 +101,8 @@ class LSPLoop {
                                                                const core::TypeConstraint *constraint,
                                                                const core::Loc queryLoc, std::string_view prefix,
                                                                size_t sortIdx) const;
-    void findSimilarConstant(const core::GlobalState &gs, const core::lsp::ConstantResponse &resp,
-                             const core::Loc queryLoc, std::vector<std::unique_ptr<CompletionItem>> &items) const;
+    void findSimilarConstants(const core::GlobalState &gs, const core::lsp::ConstantResponse &resp,
+                              const core::Loc queryLoc, std::vector<std::unique_ptr<CompletionItem>> &items) const;
     std::unique_ptr<ResponseMessage> handleTextSignatureHelp(LSPTypecheckerDelegate &typechecker, const MessageId &id,
                                                              const TextDocumentPositionParams &params) const;
 

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -619,6 +619,34 @@ bool isTEnumName(const core::GlobalState &gs, core::NameRef name) {
            original.data(gs)->unique.uniqueNameKind == core::UniqueNameKind::TEnum;
 }
 
+bool isSimilarConstant(const core::GlobalState &gs, string_view prefix, core::SymbolRef sym) {
+    if (!sym.exists()) {
+        return false;
+    }
+
+    if (!(sym.data(gs)->isClassOrModule() || sym.data(gs)->isStaticField() || sym.data(gs)->isTypeMember())) {
+        return false;
+    }
+
+    auto name = sym.data(gs)->name;
+    if (name.data(gs)->kind != core::NameKind::CONSTANT) {
+        return false;
+    }
+
+    if (isTEnumName(gs, name)) {
+        // Every T::Enum value gets a class with the ~same name (see rewriter/TEnum.cc for details).
+        // This manifests as showing two completion results when we should only show one, so skip the bad kind.
+        return false;
+    }
+
+    if (hasAngleBrackets(name.data(gs)->shortName(gs))) {
+        // Gets rid of classes like `<Magic>`; they can't be typed by a user anyways.
+        return false;
+    }
+
+    return hasSimilarName(gs, name, prefix);
+}
+
 } // namespace
 
 unique_ptr<CompletionItem> LSPLoop::getCompletionItemForMethod(LSPTypecheckerDelegate &typechecker,
@@ -685,45 +713,18 @@ unique_ptr<CompletionItem> LSPLoop::getCompletionItemForMethod(LSPTypecheckerDel
     return item;
 }
 
-void LSPLoop::findSimilarConstant(const core::GlobalState &gs, const core::lsp::ConstantResponse &resp,
-                                  const core::Loc queryLoc, vector<unique_ptr<CompletionItem>> &items) const {
+void LSPLoop::findSimilarConstants(const core::GlobalState &gs, const core::lsp::ConstantResponse &resp,
+                                   const core::Loc queryLoc, vector<unique_ptr<CompletionItem>> &items) const {
     auto prefix = resp.name.data(gs)->shortName(gs);
     config->logger->debug("Looking for constant similar to {}", prefix);
     ENFORCE(!resp.scopes.empty());
     for (auto scope : resp.scopes) {
         // TODO(jez) This membersStableOrderSlow is the only ordering we have on constant items right now.
         // We should probably at least sort by whether the prefix of the suggested constant matches.
-        for (auto member : scope.data(gs)->membersStableOrderSlow(gs)) {
-            auto sym = member.second;
-            if (!sym.exists()) {
-                continue;
+        for (auto [_name, sym] : scope.data(gs)->membersStableOrderSlow(gs)) {
+            if (isSimilarConstant(gs, prefix, sym)) {
+                items.push_back(getCompletionItemForConstant(gs, *config, sym, queryLoc, prefix, items.size()));
             }
-
-            if (!(sym.data(gs)->isClassOrModule() || sym.data(gs)->isStaticField() || sym.data(gs)->isTypeMember())) {
-                continue;
-            }
-
-            auto memberName = sym.data(gs)->name;
-            if (memberName.data(gs)->kind != core::NameKind::CONSTANT) {
-                continue;
-            }
-
-            if (isTEnumName(gs, memberName)) {
-                // Every T::Enum value gets a class with the ~same name (see rewriter/TEnum.cc for details).
-                // This manifests as showing two completion results when we should only show one, so skip the bad kind.
-                continue;
-            }
-
-            if (hasAngleBrackets(memberName.data(gs)->shortName(gs))) {
-                // Gets rid of classes like `<Magic>`; they can't be typed by a user anyways.
-                continue;
-            }
-
-            if (!hasSimilarName(gs, memberName, prefix)) {
-                continue;
-            }
-
-            items.push_back(getCompletionItemForConstant(gs, *config, sym, queryLoc, prefix, items.size()));
         }
     }
 }
@@ -845,7 +846,7 @@ unique_ptr<ResponseMessage> LSPLoop::handleTextDocumentCompletion(LSPTypechecker
             response->result = std::move(emptyResult);
             return response;
         }
-        findSimilarConstant(gs, *constantResp, queryLoc, items);
+        findSimilarConstants(gs, *constantResp, queryLoc, items);
     }
 
     response->result = make_unique<CompletionList>(false, move(items));

--- a/test/testdata/lsp/completion/constants_via_inherit.rb
+++ b/test/testdata/lsp/completion/constants_via_inherit.rb
@@ -5,8 +5,7 @@ class Parent1
 end
 class Child1 < Parent1
   XX # error: Unable to resolve
-  # ^ completion: (nothing)
-  # TODO(jez) Should be XXX
+  # ^ completion: XXX
 end
 
 class Parent2
@@ -17,8 +16,7 @@ end
 class Child2 < Parent2
   class ChildInner2 < ParentInner2
     YY # error: Unable to resolve
-    # ^ completion: (nothing)
-    # TODO(jez) Should be YYY
+    # ^ completion: YYY
   end
 end
 
@@ -29,6 +27,8 @@ class OuterChild3 < OuterParent3
   class Inner
     ZZ # error: Unable to resolve
     # ^ completion: (nothing)
-    # TODO(jez) This is correct, by accident
+
+    OuterParent3::ZZ # error: Unable to resolve constant
+    #               ^ completion: ZZZ
   end
 end

--- a/test/testdata/lsp/completion/constants_via_mixins.rb
+++ b/test/testdata/lsp/completion/constants_via_mixins.rb
@@ -8,14 +8,12 @@ module MixinB
   include MixinA
 
   YY # error: Unable to resolve
-  # ^ completion: (nothing)
-  # TODO(jez) This should be YYY
+  # ^ completion: YYY
 end
 
 class Has_Result_via_B_via_A
   include MixinB
 
   YY # error: Unable to resolve
-  # ^ completion: (nothing)
-  # TODO(jez) This should be YYY
+  # ^ completion: YYY
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In addition to via nesting scope, constants can be resolved via ancestor
resolution.

These two strategies don't compose. Ruby looks through your ancestors or your
nesting scopes, but not all the ancestors of all your nesting scopes.


### Commit summary


- **prework: Factor out a function** (fef11ce55)


- **Constant completion via ancestors** (c161b2078)





### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.