### PR TITLE
Ignore Sqreen ruby gem

### DIFF
--- a/gems/sorbet/lib/gem_loader.rb
+++ b/gems/sorbet/lib/gem_loader.rb
@@ -148,6 +148,9 @@ class Sorbet::Private::GemLoader
       my_require 'sinatra/multi_route'
       my_require 'sinatra/contrib/version'
     end,
+    'sqreen' => proc do
+      puts "Sqreen is incompatible with Sorbet"
+    end,
     'thin-attach_socket' => proc do
       my_require 'thin'
       my_require 'thin/attach_socket'


### PR DESCRIPTION
When running commands such as `srb rbi hidden-definitions` it seems to choke with [sqreen's gem](https://rubygems.org/gems/sqreen/versions/0.1.0.pre). Since this is just a middleware for security I think we can safely ignore it: our code is not going to depend on sqreen's API.

```
/srv/app/shared/bundle/ruby/2.4.0/gems/actionpack-5.2.3/lib/action_dispatch/middleware/stack.rb:76:in `insert': can't modify frozen Array (RuntimeError)
	from /srv/app/shared/bundle/ruby/2.4.0/gems/actionpack-5.2.3/lib/action_dispatch/middleware/stack.rb:76:in `insert'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/actionpack-5.2.3/lib/action_dispatch/middleware/stack.rb:83:in `insert_after'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/sqreen-1.18.3/lib/sqreen/dependency/rails.rb:30:in `insert_sqreen_middlewares'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/sqreen-1.18.3/lib/sqreen/dependency/detector.rb:32:in `block in hook'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/activesupport-5.2.3/lib/active_support/lazy_load_hooks.rb:69:in `block in execute_hook'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/activesupport-5.2.3/lib/active_support/lazy_load_hooks.rb:62:in `with_execution_control'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/activesupport-5.2.3/lib/active_support/lazy_load_hooks.rb:67:in `execute_hook'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/activesupport-5.2.3/lib/active_support/lazy_load_hooks.rb:43:in `block in on_load'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/activesupport-5.2.3/lib/active_support/lazy_load_hooks.rb:42:in `each'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/activesupport-5.2.3/lib/active_support/lazy_load_hooks.rb:42:in `on_load'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/sqreen-1.18.3/lib/sqreen/dependency/detector.rb:31:in `hook'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/sqreen-1.18.3/lib/sqreen/agent.rb:28:in `start'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/sqreen-1.18.3/lib/sqreen.rb:7:in `<top (required)>'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `block in require'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/sorbet-0.4.5049/lib/gem_loader.rb:562:in `require_gem'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/sorbet-0.4.5049/lib/gem_loader.rb:581:in `block in require_all_gems'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/sorbet-0.4.5049/lib/gem_loader.rb:579:in `each'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/sorbet-0.4.5049/lib/gem_loader.rb:579:in `require_all_gems'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/sorbet-0.4.5049/lib/require_everything.rb:39:in `load_bundler'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/sorbet-0.4.5049/lib/require_everything.rb:19:in `require_everything'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/sorbet-0.4.5049/lib/hidden-definition-finder.rb:64:in `require_everything'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/sorbet-0.4.5049/lib/hidden-definition-finder.rb:43:in `main'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/sorbet-0.4.5049/lib/hidden-definition-finder.rb:38:in `main'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/sorbet-0.4.5049/bin/srb-rbi:232:in `block in make_step'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/sorbet-0.4.5049/bin/srb-rbi:224:in `main'
	from /srv/app/shared/bundle/ruby/2.4.0/gems/sorbet-0.4.5049/bin/srb-rbi:237:in `<main>'
```

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
