### PR TITLE
File.open takes a String or Pathname

### DIFF
--- a/rbi/core/file.rbi
+++ b/rbi/core/file.rbi
@@ -678,7 +678,7 @@ class File < IO
   # description of the `mode` and `opt` parameters.
   sig do
     params(
-      filename: String,
+      filename: T.any(String, Pathname),
       mode: T.any(Integer, String),
       perm: T.nilable(Integer),
       opt: T.nilable(T::Hash[Symbol, T.untyped]),
@@ -686,7 +686,7 @@ class File < IO
   end
   sig do
     type_parameters(:U).params(
-      filename: String,
+      filename: T.any(String, Pathname),
       mode: T.any(Integer, String),
       perm: T.nilable(Integer),
       opt: T.nilable(T::Hash[Symbol, T.untyped]),


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation

Allow this:

```ruby
File.open(Pathname.new("foo"))
```

Which currently gets error "Expected String but found Pathname for argument filename", but works as expected.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
