### PR TITLE
Show defaulted positional args in hover

### DIFF
--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -193,18 +193,22 @@ string prettyDefForMethod(const core::GlobalState &gs, core::SymbolRef method) {
         }
         string prefix = "";
         string suffix = "";
-        if (argSym.flags.isKeyword) {
-            if (argSym.flags.isRepeated) {
+        if (argSym.flags.isRepeated) {
+            if (argSym.flags.isKeyword) {
                 prefix = "**"; // variadic keyword args
-            } else if (argSym.flags.isDefault) {
+            } else {
+                prefix = "*"; // rest args
+            }
+        } else if (argSym.flags.isKeyword) {
+            if (argSym.flags.isDefault) {
                 suffix = ": …"; // optional keyword (has a default value)
             } else {
                 suffix = ":"; // required keyword
             }
-        } else if (argSym.flags.isRepeated) {
-            prefix = "*";
         } else if (argSym.flags.isBlock) {
             prefix = "&";
+        } else if (argSym.flags.isDefault) {
+            suffix = "=…";
         }
         prettyArgs.emplace_back(fmt::format("{}{}{}", prefix, argSym.argumentName(gs), suffix));
     }

--- a/test/testdata/lsp/hover_method_includes_defs.rb
+++ b/test/testdata/lsp/hover_method_includes_defs.rb
@@ -59,6 +59,12 @@ module OuterModule
     end
 
     sig {params(fname: String, lname: String).returns(String)}
+    def positional_args_with_defaults(fname='Jane', lname='Doe')
+      # ^ hover: def positional_args_with_defaults(fname=…, lname=…); end
+      "#{fname}:#{lname}"
+    end
+
+    sig {params(fname: String, lname: String).returns(String)}
     def keyword_args_no_defaults(fname:, lname:)
       "#{fname}:#{lname}"
     end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We were previously only showing `x: …` in hover for methods with keyword args.
Positional args can have defaults too.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.