### PR TITLE
Mark methods on root private

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -456,6 +456,7 @@ public:
             } else {
                 return original;
             }
+
             switch (original->fun._id) {
                 case core::Names::private_()._id:
                 case core::Names::privateClassMethod()._id:
@@ -646,8 +647,16 @@ public:
         ENFORCE(method->args.size() == method->symbol.data(ctx)->arguments().size());
         ENFORCE(method->args.size() == method->symbol.data(ctx)->arguments().size(), "{}: {} != {}",
                 method->name.showRaw(ctx), method->args.size(), method->symbol.data(ctx)->arguments().size());
-        // all methods at definition time are public, but their visibility may be changed later
-        method->symbol.data(ctx)->setPublic();
+
+        auto implicitlyPrivate = ctx.owner.data(ctx)->enclosingClass(ctx) == core::Symbols::root();
+        if (implicitlyPrivate) {
+            // Methods defined at the top level default to private (on Object)
+            method->symbol.data(ctx)->setPrivate();
+        } else {
+            // All other methods default to public (their visibility might be changed later)
+            method->symbol.data(ctx)->setPublic();
+        }
+
         // Not all information is unfortunately available in the symbol. Original argument names aren't.
         // method->args.clear();
         return method;

--- a/test/cli/subprocess-plugin/subprocess-plugin.out
+++ b/test/cli/subprocess-plugin/subprocess-plugin.out
@@ -683,13 +683,13 @@ class ::<root> < ::Object () @ (... removed core rbi locs ..., test/cli/subproce
     method ::<Class:<Class:Nope>>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi5.rb:4
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi5.rb start=??? end=???}
   class ::Object < ::BasicObject (Kernel) @ https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#L27
-    method ::Object#bar_gen (<blk>) @ test/cli/subprocess-plugin/multi1.rb:9
+    method ::Object#bar_gen : private (<blk>) @ test/cli/subprocess-plugin/multi1.rb:9
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi1.rb start=??? end=???}
-    method ::Object#baz_gen (<blk>) @ test/cli/subprocess-plugin/multi1.rb:12
+    method ::Object#baz_gen : private (<blk>) @ test/cli/subprocess-plugin/multi1.rb:12
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi1.rb start=??? end=???}
-    method ::Object#foo_gen (<blk>) @ test/cli/subprocess-plugin/multi1.rb:6
+    method ::Object#foo_gen : private (<blk>) @ test/cli/subprocess-plugin/multi1.rb:6
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi1.rb start=??? end=???}
-    method ::Object#gen (_arg, <blk>) @ test/cli/subprocess-plugin/multi1.rb:3
+    method ::Object#gen : private (_arg, <blk>) @ test/cli/subprocess-plugin/multi1.rb:3
       argument _arg<> @ Loc {file=test/cli/subprocess-plugin/multi1.rb start=3:9 end=3:13}
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi1.rb start=??? end=???}
   class ::Something < ::Object () @ (test/cli/subprocess-plugin/multi3.rb:3, test/cli/subprocess-plugin/multi3.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi3.rb//plugin-generated|1.rbi:1, test/cli/subprocess-plugin/multi3.rb//plugin-generated|2.rbi:1)

--- a/test/testdata/cfg/singleton_lazy.rb.symbol-table-raw.exp
+++ b/test/testdata/cfg/singleton_lazy.rb.symbol-table-raw.exp
@@ -8,6 +8,6 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     method <S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/cfg/singleton_lazy.rb start=2:1 end=3:4}
       argument <blk><block> @ Loc {file=test/testdata/cfg/singleton_lazy.rb start=??? end=???}
   class <C <U Object>> < <C <U BasicObject>> (<C <U Kernel>>) @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed}
-    method <C <U Object>><U main> (<blk>) @ Loc {file=test/testdata/cfg/singleton_lazy.rb start=4:1 end=4:9}
+    method <C <U Object>><U main> : private (<blk>) @ Loc {file=test/testdata/cfg/singleton_lazy.rb start=4:1 end=4:9}
       argument <blk><block> @ Loc {file=test/testdata/cfg/singleton_lazy.rb start=??? end=???}
 

--- a/test/testdata/desugar/sclass.rb.symbol-table-raw.exp
+++ b/test/testdata/desugar/sclass.rb.symbol-table-raw.exp
@@ -93,6 +93,6 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     method <S <S <C <U H>> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=77:5 end=83:8}
       argument <blk><block> @ Loc {file=test/testdata/desugar/sclass.rb start=??? end=???}
   class <C <U Object>> < <C <U BasicObject>> (<C <U Kernel>>) @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed}
-    method <C <U Object>><U main> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=86:1 end=86:9}
+    method <C <U Object>><U main> : private (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=86:1 end=86:9}
       argument <blk><block> @ Loc {file=test/testdata/desugar/sclass.rb start=??? end=???}
 

--- a/test/testdata/desugar/sclass_inheritance.rb.symbol-table-raw.exp
+++ b/test/testdata/desugar/sclass_inheritance.rb.symbol-table-raw.exp
@@ -37,6 +37,6 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     method <S <C <U MM>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/desugar/sclass_inheritance.rb start=2:1 end=2:15}
       argument <blk><block> @ Loc {file=test/testdata/desugar/sclass_inheritance.rb start=??? end=???}
   class <C <U Object>> < <C <U BasicObject>> (<C <U Kernel>>) @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed}
-    method <C <U Object>><U main> (<blk>) @ Loc {file=test/testdata/desugar/sclass_inheritance.rb start=30:1 end=30:9}
+    method <C <U Object>><U main> : private (<blk>) @ Loc {file=test/testdata/desugar/sclass_inheritance.rb start=30:1 end=30:9}
       argument <blk><block> @ Loc {file=test/testdata/desugar/sclass_inheritance.rb start=??? end=???}
 

--- a/test/testdata/infer/infer1.rb.symbol-table-raw.exp
+++ b/test/testdata/infer/infer1.rb.symbol-table-raw.exp
@@ -3,23 +3,23 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/infer/infer1.rb start=2:1 end=50:4}
       argument <blk><block> @ Loc {file=test/testdata/infer/infer1.rb start=??? end=???}
   class <C <U Object>> < <C <U BasicObject>> (<C <U Kernel>>) @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed}
-    method <C <U Object>><U baz1> (<blk>) @ Loc {file=test/testdata/infer/infer1.rb start=2:1 end=2:9}
+    method <C <U Object>><U baz1> : private (<blk>) @ Loc {file=test/testdata/infer/infer1.rb start=2:1 end=2:9}
       argument <blk><block> @ Loc {file=test/testdata/infer/infer1.rb start=??? end=???}
-    method <C <U Object>><U baz2> (<blk>) @ Loc {file=test/testdata/infer/infer1.rb start=7:1 end=7:9}
+    method <C <U Object>><U baz2> : private (<blk>) @ Loc {file=test/testdata/infer/infer1.rb start=7:1 end=7:9}
       argument <blk><block> @ Loc {file=test/testdata/infer/infer1.rb start=??? end=???}
-    method <C <U Object>><U baz3> (<blk>) @ Loc {file=test/testdata/infer/infer1.rb start=12:1 end=12:9}
+    method <C <U Object>><U baz3> : private (<blk>) @ Loc {file=test/testdata/infer/infer1.rb start=12:1 end=12:9}
       argument <blk><block> @ Loc {file=test/testdata/infer/infer1.rb start=??? end=???}
-    method <C <U Object>><U baz4> (<blk>) @ Loc {file=test/testdata/infer/infer1.rb start=16:1 end=16:9}
+    method <C <U Object>><U baz4> : private (<blk>) @ Loc {file=test/testdata/infer/infer1.rb start=16:1 end=16:9}
       argument <blk><block> @ Loc {file=test/testdata/infer/infer1.rb start=??? end=???}
-    method <C <U Object>><U baz5> (cond, <blk>) @ Loc {file=test/testdata/infer/infer1.rb start=20:1 end=20:15}
+    method <C <U Object>><U baz5> : private (cond, <blk>) @ Loc {file=test/testdata/infer/infer1.rb start=20:1 end=20:15}
       argument cond<> @ Loc {file=test/testdata/infer/infer1.rb start=20:10 end=20:14}
       argument <blk><block> @ Loc {file=test/testdata/infer/infer1.rb start=??? end=???}
-    method <C <U Object>><U baz6> (cond, <blk>) @ Loc {file=test/testdata/infer/infer1.rb start=29:1 end=29:15}
+    method <C <U Object>><U baz6> : private (cond, <blk>) @ Loc {file=test/testdata/infer/infer1.rb start=29:1 end=29:15}
       argument cond<> @ Loc {file=test/testdata/infer/infer1.rb start=29:10 end=29:14}
       argument <blk><block> @ Loc {file=test/testdata/infer/infer1.rb start=??? end=???}
-    method <C <U Object>><U baz7> (cond, <blk>) @ Loc {file=test/testdata/infer/infer1.rb start=38:1 end=38:15}
+    method <C <U Object>><U baz7> : private (cond, <blk>) @ Loc {file=test/testdata/infer/infer1.rb start=38:1 end=38:15}
       argument cond<> @ Loc {file=test/testdata/infer/infer1.rb start=38:10 end=38:14}
       argument <blk><block> @ Loc {file=test/testdata/infer/infer1.rb start=??? end=???}
-    method <C <U Object>><U baz8> (<blk>) @ Loc {file=test/testdata/infer/infer1.rb start=46:1 end=46:9}
+    method <C <U Object>><U baz8> : private (<blk>) @ Loc {file=test/testdata/infer/infer1.rb start=46:1 end=46:9}
       argument <blk><block> @ Loc {file=test/testdata/infer/infer1.rb start=??? end=???}
 

--- a/test/testdata/lsp/hover_proc_void.rb
+++ b/test/testdata/lsp/hover_proc_void.rb
@@ -4,5 +4,5 @@ extend T::Sig
 
 sig {params(blk: T.proc.void).void}
 def proc_void(&blk)
-  # ^ hover: sig {params(blk: T.proc.void).void}
+  # ^ hover: private sig {params(blk: T.proc.void).void}
 end

--- a/test/testdata/namer/defs_in_blocks.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/defs_in_blocks.rb.symbol-table-raw.exp
@@ -3,6 +3,6 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/defs_in_blocks.rb start=2:1 end=13:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/defs_in_blocks.rb start=??? end=???}
   class <C <U Object>> < <C <U BasicObject>> (<C <U Kernel>>) @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed}
-    method <C <U Object>><U a_method> (<blk>) @ Loc {file=test/testdata/namer/defs_in_blocks.rb start=5:3 end=5:15}
+    method <C <U Object>><U a_method> : private (<blk>) @ Loc {file=test/testdata/namer/defs_in_blocks.rb start=5:3 end=5:15}
       argument <blk><block> @ Loc {file=test/testdata/namer/defs_in_blocks.rb start=??? end=???}
 

--- a/test/testdata/namer/root_private.rb
+++ b/test/testdata/namer/root_private.rb
@@ -14,4 +14,4 @@ class A
 end
 
 A.new.foo_method_ # error: does not exist
-#                ^ completion: foo_method_inner_public, foo_method_root
+#                ^ completion: foo_method_inner_public

--- a/test/testdata/namer/root_private.rb
+++ b/test/testdata/namer/root_private.rb
@@ -1,0 +1,17 @@
+# typed: true
+
+# Only way to observe that a method is private right now is via completion.
+
+def foo_method_root; end
+
+foo_method_ # error: does not exist
+#          ^ completion: foo_method_root
+
+class A
+  def foo_method_inner_public; end
+
+  private def foo_method_inner_private; end
+end
+
+A.new.foo_method_ # error: does not exist
+#                ^ completion: foo_method_inner_public, foo_method_root

--- a/test/testdata/namer/root_private.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/root_private.rb.symbol-table-raw.exp
@@ -1,0 +1,17 @@
+class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/root_private.rb start=5:1 end=16:18})
+  class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/root_private.rb start=5:1 end=16:18}
+      argument <blk><block> @ Loc {file=test/testdata/namer/root_private.rb start=??? end=???}
+  class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/namer/root_private.rb start=10:1 end=10:8}
+    method <C <U A>><U foo_method_inner_private> : private (<blk>) @ Loc {file=test/testdata/namer/root_private.rb start=13:11 end=13:39}
+      argument <blk><block> @ Loc {file=test/testdata/namer/root_private.rb start=??? end=???}
+    method <C <U A>><U foo_method_inner_public> (<blk>) @ Loc {file=test/testdata/namer/root_private.rb start=11:3 end=11:30}
+      argument <blk><block> @ Loc {file=test/testdata/namer/root_private.rb start=??? end=???}
+  class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/root_private.rb start=10:7 end=10:8}
+    type-member(+) <S <C <U A>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/namer/root_private.rb start=10:7 end=10:8}
+    method <S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/root_private.rb start=10:1 end=14:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/root_private.rb start=??? end=???}
+  class <C <U Object>> < <C <U BasicObject>> (<C <U Kernel>>) @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed}
+    method <C <U Object>><U foo_method_root> : private (<blk>) @ Loc {file=test/testdata/namer/root_private.rb start=5:1 end=5:20}
+      argument <blk><block> @ Loc {file=test/testdata/namer/root_private.rb start=??? end=???}
+

--- a/test/testdata/namer/singleton_class.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/singleton_class.rb.symbol-table-raw.exp
@@ -14,6 +14,6 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
   class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/namer/singleton_class.rb start=2:7 end=2:8}
     type-member(+) <S <C <U A>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/namer/singleton_class.rb start=2:7 end=2:8}
   class <C <U Object>> < <C <U BasicObject>> (<C <U Kernel>>) @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed}
-    method <C <U Object>><U main> (<blk>) @ Loc {file=test/testdata/namer/singleton_class.rb start=5:1 end=5:9}
+    method <C <U Object>><U main> : private (<blk>) @ Loc {file=test/testdata/namer/singleton_class.rb start=5:1 end=5:9}
       argument <blk><block> @ Loc {file=test/testdata/namer/singleton_class.rb start=??? end=???}
 

--- a/test/testdata/resolver/invalid_alias.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/invalid_alias.rb.symbol-table-raw.exp
@@ -14,6 +14,6 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     method <S <S <C <U BadAliasingClassMethod1>> $1> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/invalid_alias.rb start=4:3 end=10:6}
       argument <blk><block> @ Loc {file=test/testdata/resolver/invalid_alias.rb start=??? end=???}
   class <C <U Object>> < <C <U BasicObject>> (<C <U Kernel>>) @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed}
-    method <C <U Object>><U main> (<blk>) @ Loc {file=test/testdata/resolver/invalid_alias.rb start=13:1 end=13:9}
+    method <C <U Object>><U main> : private (<blk>) @ Loc {file=test/testdata/resolver/invalid_alias.rb start=13:1 end=13:9}
       argument <blk><block> @ Loc {file=test/testdata/resolver/invalid_alias.rb start=??? end=???}
 

--- a/test/testdata/resolver/recover_from_bad_superclass.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/recover_from_bad_superclass.rb.symbol-table-raw.exp
@@ -35,6 +35,6 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     method <S <C <U G>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=29:1 end=30:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=??? end=???}
   class <C <U Object>> < <C <U BasicObject>> (<C <U Kernel>>) @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed}
-    method <C <U Object>><U make_a_class> (<blk>) @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=3:1 end=3:17}
+    method <C <U Object>><U make_a_class> : private (<blk>) @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=3:1 end=3:17}
       argument <blk><block> @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=??? end=???}
 

--- a/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
@@ -177,7 +177,7 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
       argument args<repeated> @ Loc {file=test/testdata/rewriter/prop.rb start=3:20 end=3:24}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U Object>> < <C <U BasicObject>> (<C <U Kernel>>) @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed}
-    method <C <U Object>><U main> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=84:1 end=84:9}
+    method <C <U Object>><U main> : private (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=84:1 end=84:9}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U PropHelpers>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=65:1 end=65:18}
     method <C <U PropHelpers>><U created> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=67:3 end=67:15}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

```ruby
def foo; end
class A; end

A.new.foo
```

```
❯ ruby foo.rb
Traceback (most recent call last):
foo.rb:4:in `<main>': private method `foo' called for #<A:0x00007fc22a04edd8> (NoMethodError)
Did you mean?  for
```

Stripe's codebase has a lot of methods defined on root. These show up as
completion results for nearly every method completion, because nearly everthing
is an Object.

One day, this will also help us properly support raising an error when trying
to call a private method when not allowed.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.