### PR TITLE
Revert "We're no longer using pull-panda(it was integrated in github)"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,6 @@
 # It uses the same pattern rule for gitignore file
 # https://git-scm.com/docs/gitignore#_pattern_format
 
-**/*                  @sorbet/sorbet-on-call
+**/*                  @sorbet/sorbet-reviewer-roundrobin
+
+# This group actually forwards to @sorbet/core reviewers via https://github.com/marketplace/pull-panda

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,6 @@
 # It uses the same pattern rule for gitignore file
 # https://git-scm.com/docs/gitignore#_pattern_format
 
-**/*                  @sorbet/sorbet-reviewer-roundrobin
+**/*                  @sorbet/sorbet-reviewer-assigner
 
 # This group actually forwards to @sorbet/core reviewers via https://github.com/marketplace/pull-panda


### PR DESCRIPTION
Reverts sorbet/sorbet#2480

Github doesn't support all of prior functionality.
In particular, it doesn't support not assigning a review automatically if manual reviewer was selected.