### PR TITLE
Small T::Props API simplifications

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -32,15 +32,6 @@ class T::Props::Decorator
     @props ||= {}.freeze
   end
 
-  # Try to avoid using this; post-definition mutation of prop rules is
-  # surprising and hard to reason about.
-  sig {params(prop: Symbol, key: Symbol, value: T.untyped).void}
-  def mutate_prop_backdoor!(prop, key, value)
-    @props = props.merge(
-      prop => props.fetch(prop).merge(key => value).freeze
-    ).freeze
-  end
-
   sig {returns(T::Array[Symbol])}
   def all_props; props.keys; end
 

--- a/gems/sorbet-runtime/lib/types/props/optional.rb
+++ b/gems/sorbet-runtime/lib/types/props/optional.rb
@@ -34,13 +34,6 @@ module T::Props::Optional::DecoratorMethods
 
   def prop_optional?(prop); prop_rules(prop)[:fully_optional]; end
 
-  def mutate_prop_backdoor!(prop, key, value)
-    rules = props.fetch(prop)
-    rules = rules.merge(key => value)
-    compute_derived_rules(rules)
-    @props = props.merge(prop => rules.freeze).freeze
-  end
-
   def compute_derived_rules(rules)
     rules[:fully_optional] = !T::Props::Utils.need_nil_write_check?(rules)
     rules[:need_nil_read_check] = T::Props::Utils.need_nil_read_check?(rules)

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -335,7 +335,7 @@ module T::Props::Serializable::DecoratorMethods
   private_constant :EMPTY_EXTRA_PROPS
 
   def extra_props(instance)
-    get(instance, '_extra_props') || EMPTY_EXTRA_PROPS
+    instance.instance_variable_get(:@_extra_props) || EMPTY_EXTRA_PROPS
   end
 
   # @override T::Props::PrettyPrintable
@@ -383,6 +383,6 @@ module T::Props::Serializable::ClassMethods
     if !(extra_props = decorator.extra_props(result)).empty?
       raise "Unknown properties for #{name}: #{extra_props.keys.inspect}"
     end
-    self.decorator.from_hash(hash, true)
+    result
   end
 end

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -114,6 +114,25 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     end
   end
 
+  describe 'extra_props' do
+    it 'are set by from_hash' do
+      m = MySerializable.from_hash({'not_a_prop' => 1})
+      assert_equal({'not_a_prop' => 1}, m.class.decorator.extra_props(m))
+    end
+
+    it 'round trip to serialize' do
+      m = MySerializable.from_hash({'not_a_prop' => 1})
+      assert_equal({'not_a_prop' => 1}, m.serialize)
+    end
+
+    it 'produce error with from_hash!' do
+      e = assert_raises(RuntimeError) do
+        MySerializable.from_hash!({'not_a_prop' => 1})
+      end
+      assert_match(/Unknown properties.*not_a_prop/, e.message)
+    end
+  end
+
   describe 'hash props' do
     it 'does not share structure on serialize' do
       m = MySerializable.new

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -67,7 +67,6 @@ class T::Props::Decorator
   def initialize(klass); end
   def is_nilable?(*args, &blk); end
   def model_inherited(child); end
-  def mutate_prop_backdoor!(*args, &blk); end
   def plugin(mod); end
   def prop_defined(*args, &blk); end
   def prop_get(*args, &blk); end
@@ -119,7 +118,6 @@ module T::Props::Optional::DecoratorMethods
   def compute_derived_rules(rules); end
   def get_default(rules, instance_class); end
   def has_default?(rules); end
-  def mutate_prop_backdoor!(prop, key, value); end
   def prop_optional?(prop); end
   def prop_validate_definition!(name, cls, rules, type); end
   def valid_rule_key?(key); end


### PR DESCRIPTION
Two changes:
1. Remove `mutate_prop_backdoor!`
2. Remove the `strict` option from `deserialize`/`from_hash`

### Motivation
A smaller API is nicer where we can get away with it, but more specifically:
1. This was always a hack, and it's not used in pay-server anymore
2. Strict deserialization is ~buggy in that strictness doesn't propagate recursively to deserializing subdocs. Since the `strict` parameter for serialization _does_ propagate recursively, there's a misleading false parallelism. This change removes that, enabled by https://git.corp.stripe.com/stripe-internal/pay-server/pull/200014

### Test plan
Primarily, a passing pay-server build

There was no test coverage here so I added very basic tests