### PR TITLE
Add sealed_violation_whitelist to RBI payload

### DIFF
--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -127,6 +127,8 @@ module T::Configuration
   def self.log_info_handler=(value); end
   def self.scalar_types; end
   def self.scalar_types=(values); end
+  def self.sealed_violation_whitelist; end
+  def self.sealed_violation_whitelist=(sealed_violation_whitelist); end
   def self.sig_builder_error_handler(error, location); end
   def self.sig_builder_error_handler=(value); end
   def self.sig_validation_error_handler(error, opts); end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sorbet gave me type errors when I tried to use this function when bumping the
version of sorbet-runtime in pay-server. See #2486 which added this function.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.