### PR TITLE
Raise errors about bad `test_each` arity

### DIFF
--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -10,6 +10,6 @@ constexpr ErrorClass BadAttrType{3504, StrictLevel::True};
 constexpr ErrorClass BadModuleFunction{3505, StrictLevel::True};
 constexpr ErrorClass TEnumOutsideEnumsDo{3506, StrictLevel::False};
 constexpr ErrorClass TEnumConstNotEnumValue{3506, StrictLevel::False};
-constexpr ErrorClass NonItInTestEach{3507, StrictLevel::True};
+constexpr ErrorClass BadTestEach{3507, StrictLevel::True};
 } // namespace sorbet::core::errors::Rewriter
 #endif

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -236,8 +236,14 @@ unique_ptr<ast::Expression> runSingle(core::MutableContext ctx, ast::Send *send)
         return nullptr;
     }
 
-    if (send->fun == core::Names::testEach() && send->args.size() == 1 && send->block != nullptr &&
-        send->block->args.size() == 1) {
+    if (send->fun == core::Names::testEach() && send->args.size() == 1 && send->block != nullptr) {
+        if (send->block->args.size() != 1) {
+            if (auto e = ctx.state.beginError(send->block->loc, core::errors::Rewriter::BadTestEach)) {
+                e.setHeader("Wrong number of parameters for `{}` block: expected `{}`, got `{}`", "test_each", 1,
+                            send->block->args.size());
+            }
+            return nullptr;
+        }
         // if this has the form `test_each(expr) { |arg | .. }`, then start by trying to convert `expr` into a thing we
         // can freely copy into methoddef scope
         auto iteratee = getIteratee(send->args.front());

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -202,7 +202,7 @@ unique_ptr<ast::Expression> runUnderEach(core::MutableContext ctx, unique_ptr<as
         }
     }
     // if any of the above tests were not satisfied, then mark this statement as being invalid here
-    if (auto e = ctx.state.beginError(stmt->loc, core::errors::Rewriter::NonItInTestEach)) {
+    if (auto e = ctx.state.beginError(stmt->loc, core::errors::Rewriter::BadTestEach)) {
         e.setHeader("Only valid `{}`-blocks can appear within `{}`", "it", "test_each");
     }
 

--- a/test/testdata/rewriter/minitest_tables.rb
+++ b/test/testdata/rewriter/minitest_tables.rb
@@ -61,4 +61,14 @@ class MyTest
       T.reveal_type(v) # error: Revealed type: `T.any(String, Integer, T::Hash[T.untyped, T.untyped])`
     end
   end
+
+  test_each [1, 2, 3] do |k, v| # error: Wrong number of parameters for `test_each` block
+    it "does not handle more than one argument" do
+    end
+  end
+
+  test_each [1, 2, 3] do # error: Wrong number of parameters for `test_each` block
+    it "does not handle more than one argument" do
+    end
+  end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This would just confusingly not work before, but now this produces an error when you use `test_each` with more than one parameter to the proc.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
