### PR TITLE
IDE: Operation-specific metrics and small improvements

### DIFF
--- a/main/lsp/LSPMessage.cc
+++ b/main/lsp/LSPMessage.cc
@@ -120,7 +120,7 @@ bool LSPMessage::isCanceled() const {
 void LSPMessage::cancel() {
     if (!canceled) {
         canceled = true;
-        // Protect against nullptrs.
+        // Timers are optional, and may not be specified (e.g., they will be nullptr). Guard against that possibility.
         if (timer) {
             timer->cancel();
         }

--- a/main/lsp/LSPMessage.cc
+++ b/main/lsp/LSPMessage.cc
@@ -113,6 +113,23 @@ LSPMessage::LSPMessage(rapidjson::Document &d) : LSPMessage::LSPMessage(fromJSON
 
 LSPMessage::LSPMessage(const std::string &json) : LSPMessage::LSPMessage(fromJSON(json)) {}
 
+bool LSPMessage::isCanceled() const {
+    return canceled;
+}
+
+void LSPMessage::cancel() {
+    if (!canceled) {
+        canceled = true;
+        // Protect against nullptrs.
+        if (timer) {
+            timer->cancel();
+        }
+        if (methodTimer) {
+            methodTimer->cancel();
+        }
+    }
+}
+
 optional<MessageId> LSPMessage::id() const {
     if (isRequest()) {
         return asRequest().id;

--- a/main/lsp/LSPMessage.h
+++ b/main/lsp/LSPMessage.h
@@ -40,6 +40,7 @@ public:
 
 private:
     RawLSPMessage msg;
+    bool canceled = false;
 
 public:
     /**
@@ -60,9 +61,14 @@ public:
     /** Used to calculate latency of message processing. If this message represents multiple edits, it contains the
      * oldest timer.*/
     std::unique_ptr<Timer> timer;
+    /** A more specific timer for the given method. Used to track latency for specific types of requests. */
+    std::unique_ptr<Timer> methodTimer;
 
     /** If `true`, then this LSPMessage contains a canceled LSP request. */
-    bool canceled = false;
+    bool isCanceled() const;
+
+    /** Cancels this message. */
+    void cancel();
 
     /**
      * Returns an ID if the message has one. Otherwise, returns nullopt.

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -5,9 +5,11 @@
 namespace sorbet::realmain::lsp {
 using namespace std;
 
-LSPTask::LSPTask(const LSPConfiguration &config) : config(config) {}
+LSPTask::LSPTask(const LSPConfiguration &config, bool enableMultithreading)
+    : config(config), enableMultithreading(enableMultithreading) {}
 
-LSPRequestTask::LSPRequestTask(const LSPConfiguration &config, MessageId id) : LSPTask(config), id(move(id)) {}
+LSPRequestTask::LSPRequestTask(const LSPConfiguration &config, MessageId id, bool enableMultithreading)
+    : LSPTask(config, enableMultithreading), id(move(id)) {}
 
 void LSPRequestTask::run(LSPTypecheckerDelegate &typechecker) {
     auto response = runRequest(typechecker);

--- a/main/lsp/LSPTask.h
+++ b/main/lsp/LSPTask.h
@@ -8,6 +8,8 @@ namespace sorbet::realmain::lsp {
 /**
  * A work unit that needs to execute on the typechecker thread. Subclasses implement `run`.
  * Contains miscellaneous helper methods that are useful in multiple tasks.
+ *
+ * NOTE: If `enableMultithreading` is set to `true`, then this task cannot preempt slow path typechecking.
  */
 class LSPTask {
 protected:
@@ -33,9 +35,11 @@ protected:
                                         std::vector<core::FileRef> frefs) const;
     LSPQueryResult queryBySymbol(LSPTypecheckerDelegate &typechecker, core::SymbolRef symbol) const;
 
-    LSPTask(const LSPConfiguration &config);
+    LSPTask(const LSPConfiguration &config, bool enableMultithreading);
 
 public:
+    const bool enableMultithreading;
+
     virtual ~LSPTask() = default;
 
     // Runs the task. Is only ever invoked from the typechecker thread.
@@ -49,7 +53,7 @@ class LSPRequestTask : public LSPTask {
 protected:
     const MessageId id;
 
-    LSPRequestTask(const LSPConfiguration &config, MessageId id);
+    LSPRequestTask(const LSPConfiguration &config, MessageId id, bool enableMultithreading = false);
 
     virtual std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) = 0;
 

--- a/main/lsp/LSPTypecheckerCoordinator.h
+++ b/main/lsp/LSPTypecheckerCoordinator.h
@@ -49,11 +49,12 @@ public:
     void typecheckOnSlowPath(LSPFileUpdates updates);
 
     /**
-     * Schedules a task on the typechecker thread, and blocks until `lambda` completes. If "multithreaded" is "true",
-     * then the given task is allowed to use the full threadpool at the cost of not being able to preempt slow paths.
+     * Schedules a task on the typechecker thread, and blocks until `lambda` completes. If the task has
+     * `enableMultithreaded` set to "true", then the given task is allowed to use the full threadpool at the cost of not
+     * being able to preempt slow path typechecking.
      * TODO(jvilk): Make single-threaded tasks scheduled this way preempt the slow path.
      */
-    void syncRun(std::unique_ptr<LSPTask> task, bool multithreaded = false);
+    void syncRun(std::unique_ptr<LSPTask> task);
 
     /**
      * Safely shuts down the typechecker and returns the final GlobalState object. Blocks until typechecker completes

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -45,7 +45,7 @@ class TypecheckCountTask : public LSPTask {
     int &count;
 
 public:
-    TypecheckCountTask(const LSPConfiguration &config, int &count) : LSPTask(config), count(count) {}
+    TypecheckCountTask(const LSPConfiguration &config, int &count) : LSPTask(config, true), count(count) {}
 
     void run(LSPTypecheckerDelegate &tc) override {
         count = tc.state().lspTypecheckCount;

--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -89,7 +89,7 @@ void LSPLoop::processRequestInternal(LSPMessage &msg) {
         // asRequest() should guarantee the presence of an ID.
         ENFORCE(msg.id());
         auto id = *msg.id();
-        if (msg.canceled) {
+        if (msg.isCanceled()) {
             auto response = make_unique<ResponseMessage>("2.0", id, method);
             prodCounterInc("lsp.messages.canceled");
             response->error = make_unique<ResponseError>((int)LSPErrorCodes::RequestCancelled, "Request was canceled");

--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -159,7 +159,7 @@ void LSPLoop::processRequestInternal(LSPMessage &msg) {
             typecheckerCoord.syncRun(make_unique<SignatureHelpTask>(*config, id, move(params)));
         } else if (method == LSPMethod::TextDocumentReferences) {
             auto &params = get<unique_ptr<ReferenceParams>>(rawParams);
-            typecheckerCoord.syncRun(make_unique<ReferencesTask>(*config, id, move(params)), /* multithreaded */ true);
+            typecheckerCoord.syncRun(make_unique<ReferencesTask>(*config, id, move(params)));
         } else if (method == LSPMethod::SorbetReadFile) {
             auto &params = get<unique_ptr<TextDocumentIdentifier>>(rawParams);
             typecheckerCoord.syncRun(make_unique<SorbetReadFileTask>(*config, id, move(params)));

--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -12,7 +12,7 @@ class SorbetFenceTask final : public LSPTask {
     int id;
 
 public:
-    SorbetFenceTask(const LSPConfiguration &config, int id) : LSPTask(config), id(id) {}
+    SorbetFenceTask(const LSPConfiguration &config, int id) : LSPTask(config, true), id(id) {}
     void run(LSPTypecheckerDelegate &tc) override {
         // Send the same fence back to acknowledge the fence.
         // NOTE: Fence is a notification rather than a request so that we don't have to worry about clashes with

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -9,7 +9,7 @@ using namespace std;
 namespace sorbet::realmain::lsp {
 
 ReferencesTask::ReferencesTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<ReferenceParams> params)
-    : LSPRequestTask(config, move(id)), params(move(params)) {}
+    : LSPRequestTask(config, move(id), true), params(move(params)) {}
 
 unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentReferences);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

IDE: Operation-specific metrics and small improvements

Specific changes:

* `LSPMessage`s now have a second optional timer that tracks the latency of specific methods.
* `LSPMessage` now contains message (and timer) cancelation logic.
* `enableMultithreading` is now a property of `LSPTask` rather than a parameter to `TypecheckerCoordinator::syncRun`.
* Renamed the confusing `TypecheckerTask::hasDedicatedThread` to `TypecheckerTask::collectCounters`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We have no way to check the latency of specific operations in SignalFX, as all operations are grouped together 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
