### PR TITLE
Report class/module for autogen

### DIFF
--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -182,7 +182,7 @@ public:
         // `ancestors` or `singletonAncestors` values. Otherwise, (at least for the parent relationships we care about)
         // we're looking at the first `class Child < Parent` relationship, so we change `is_subclassing` to true.
         if (!defs.empty() && !nesting.empty() && defs.back().id._id != nesting.back()._id) {
-            ref.is_subclassing = true;
+            ref.parentKind = ClassKind::Class;
         }
         refMap[original.get()] = ref.id;
         return original;

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -178,6 +178,12 @@ public:
         }
         ref.is_resolved_statically = true;
         ref.is_defining_ref = false;
+        // if we're already in the scope of the class (which will be the newest-created one) then we're looking at the
+        // `ancestors` or `singletonAncestors` values. Otherwise, (at least for the parent relationships we care about)
+        // we're looking at the first `class Child < Parent` relationship, so we change `is_subclassing` to true.
+        if (!defs.empty() && !nesting.empty() && defs.back().id._id != nesting.back()._id) {
+            ref.is_subclassing = true;
+        }
         refMap[original.get()] = ref.id;
         return original;
     }

--- a/main/autogen/autogen.h
+++ b/main/autogen/autogen.h
@@ -75,6 +75,7 @@ struct Reference {
     core::Loc definitionLoc;
     bool is_resolved_statically;
     bool is_defining_ref;
+    bool is_subclassing;
 
     DefinitionRef parent_of;
 };

--- a/main/autogen/autogen.h
+++ b/main/autogen/autogen.h
@@ -16,6 +16,8 @@ struct AutoloaderConfig;
 struct NamedDefinition;
 class DefTree;
 
+enum class ClassKind { Class, Module };
+
 struct DefinitionRef {
     u4 _id;
 
@@ -75,7 +77,8 @@ struct Reference {
     core::Loc definitionLoc;
     bool is_resolved_statically;
     bool is_defining_ref;
-    bool is_subclassing;
+
+    ClassKind parentKind = ClassKind::Module;
 
     DefinitionRef parent_of;
 };

--- a/main/autogen/subclasses.cc
+++ b/main/autogen/subclasses.cc
@@ -63,7 +63,8 @@ optional<Subclasses::Map> Subclasses::listAllSubclasses(core::Context ctx, Parse
             "{}", fmt::map_join(pf.showFullName(ctx, defn),
                                 "::", [&ctx](const core::NameRef &nm) -> string { return nm.data(ctx)->show(ctx); }));
 
-        out[parentName].insert(make_pair(childName, defn.data(pf).type));
+        out[parentName].entries.insert(make_pair(childName, defn.data(pf).type));
+        out[parentName].isClass = ref.is_subclassing;
     }
 
     return out;
@@ -71,30 +72,31 @@ optional<Subclasses::Map> Subclasses::listAllSubclasses(core::Context ctx, Parse
 
 // Generate all descendants of a parent class
 // Recursively walks `childMap`, which stores the IMMEDIATE children of subclassed class.
-optional<Subclasses::Entries> Subclasses::descendantsOf(const Subclasses::Map &childMap, const string &parentName) {
+optional<Subclasses::SubclassInfo> Subclasses::descendantsOf(const Subclasses::Map &childMap,
+                                                             const string &parentName) {
     auto fnd = childMap.find(parentName);
     if (fnd == childMap.end()) {
         return nullopt;
     }
-    const Subclasses::Entries children = fnd->second;
+    const Subclasses::Entries children = fnd->second.entries;
 
     Subclasses::Entries out;
     out.insert(children.begin(), children.end());
     for (const auto &[name, _type] : children) {
         auto descendants = Subclasses::descendantsOf(childMap, name);
         if (descendants) {
-            out.insert(descendants->begin(), descendants->end());
+            out.insert(descendants->entries.begin(), descendants->entries.end());
         }
     }
 
-    return out;
+    return SubclassInfo(fnd->second.isClass, out);
 }
 
 // Manually patch the child map to account for inheritance that happens at runtime `self.included`
 // Please do not add to this list.
 void Subclasses::patchChildMap(Subclasses::Map &childMap) {
-    childMap["Opus::SafeMachine"].insert(childMap["Opus::Risk::Model::Mixins::RiskSafeMachine"].begin(),
-                                         childMap["Opus::Risk::Model::Mixins::RiskSafeMachine"].end());
+    childMap["Opus::SafeMachine"].entries.insert(childMap["Opus::Risk::Model::Mixins::RiskSafeMachine"].entries.begin(),
+                                                 childMap["Opus::Risk::Model::Mixins::RiskSafeMachine"].entries.end());
 }
 
 vector<string> Subclasses::serializeSubclassMap(const Subclasses::Map &descendantsMap,
@@ -106,12 +108,13 @@ vector<string> Subclasses::serializeSubclassMap(const Subclasses::Map &descendan
         if (fnd == descendantsMap.end()) {
             continue;
         }
-        const Subclasses::Entries children = fnd->second;
+        const Subclasses::SubclassInfo &children = fnd->second;
 
-        descendantsMapSerialized.emplace_back(parentName);
+        auto type = children.isClass ? "class" : "module";
+        descendantsMapSerialized.emplace_back(fmt::format("{} {}", type, parentName));
 
         vector<string> serializedChildren;
-        for (const auto &[name, type] : children) {
+        for (const auto &[name, type] : children.entries) {
             // Ignore Modules
             if (type != autogen::Definition::Type::Class) {
                 continue;

--- a/main/autogen/subclasses.cc
+++ b/main/autogen/subclasses.cc
@@ -64,7 +64,7 @@ optional<Subclasses::Map> Subclasses::listAllSubclasses(core::Context ctx, Parse
                                 "::", [&ctx](const core::NameRef &nm) -> string { return nm.data(ctx)->show(ctx); }));
 
         out[parentName].entries.insert(make_pair(childName, defn.data(pf).type));
-        out[parentName].isClass = ref.is_subclassing;
+        out[parentName].classKind = ref.parentKind;
     }
 
     return out;
@@ -89,7 +89,7 @@ optional<Subclasses::SubclassInfo> Subclasses::descendantsOf(const Subclasses::M
         }
     }
 
-    return SubclassInfo(fnd->second.isClass, out);
+    return SubclassInfo(fnd->second.classKind, out);
 }
 
 // Manually patch the child map to account for inheritance that happens at runtime `self.included`
@@ -110,7 +110,7 @@ vector<string> Subclasses::serializeSubclassMap(const Subclasses::Map &descendan
         }
         const Subclasses::SubclassInfo &children = fnd->second;
 
-        auto type = children.isClass ? "class" : "module";
+        auto type = children.classKind == ClassKind::Class ? "class" : "module";
         descendantsMapSerialized.emplace_back(fmt::format("{} {}", type, parentName));
 
         vector<string> serializedChildren;

--- a/main/autogen/subclasses.h
+++ b/main/autogen/subclasses.h
@@ -10,11 +10,11 @@ public:
     using Entry = std::pair<std::string, Definition::Type>;
     using Entries = UnorderedSet<Entry>;
     struct SubclassInfo {
-        bool isClass = false;
+        ClassKind classKind = ClassKind::Module;
         Entries entries;
 
         SubclassInfo() = default;
-        SubclassInfo(bool isClass, Entries entries) : isClass(isClass), entries(entries){};
+        SubclassInfo(ClassKind classKind, Entries entries) : classKind(classKind), entries(entries){};
     };
     using Map = UnorderedMap<std::string, SubclassInfo>;
 

--- a/main/autogen/subclasses.h
+++ b/main/autogen/subclasses.h
@@ -9,7 +9,14 @@ class Subclasses final {
 public:
     using Entry = std::pair<std::string, Definition::Type>;
     using Entries = UnorderedSet<Entry>;
-    using Map = UnorderedMap<std::string, Entries>;
+    struct SubclassInfo {
+        bool isClass = false;
+        Entries entries;
+
+        SubclassInfo() = default;
+        SubclassInfo(bool isClass, Entries entries) : isClass(isClass), entries(entries){};
+    };
+    using Map = UnorderedMap<std::string, SubclassInfo>;
 
     static std::optional<Subclasses::Map> listAllSubclasses(core::Context ctx, ParsedFile &pf,
                                                             const std::vector<std::string> &absoluteIgnorePatterns,
@@ -20,7 +27,7 @@ private:
     static void patchChildMap(Subclasses::Map &childMap);
     static bool isFileIgnored(const std::string &path, const std::vector<std::string> &absoluteIgnorePatterns,
                               const std::vector<std::string> &relativeIgnorePatterns);
-    static std::optional<Entries> descendantsOf(const Subclasses::Map &childMap, const std::string &parents);
+    static std::optional<SubclassInfo> descendantsOf(const Subclasses::Map &childMap, const std::string &parents);
     static std::vector<std::string> serializeSubclassMap(const Subclasses::Map &descendantsMap,
                                                          const std::vector<std::string> &parentNames);
 };

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -298,7 +298,7 @@ void runAutogen(core::Context ctx, options::Options &opts, const autogen::Autolo
             for (const auto &[parentName, children] : *el.second.subclasses) {
                 if (!parentName.empty()) {
                     childMap[parentName].entries.insert(children.entries.begin(), children.entries.end());
-                    childMap[parentName].isClass = children.isClass;
+                    childMap[parentName].classKind = children.classKind;
                 }
             }
         }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -297,7 +297,8 @@ void runAutogen(core::Context ctx, options::Options &opts, const autogen::Autolo
 
             for (const auto &[parentName, children] : *el.second.subclasses) {
                 if (!parentName.empty()) {
-                    childMap[parentName].insert(children.begin(), children.end());
+                    childMap[parentName].entries.insert(children.entries.begin(), children.entries.end());
+                    childMap[parentName].isClass = children.isClass;
                 }
             }
         }

--- a/test/cli/autogen-subclasses-ignore/autogen-subclasses-ignore.out
+++ b/test/cli/autogen-subclasses-ignore/autogen-subclasses-ignore.out
@@ -1,5 +1,5 @@
 --- autogen-subclasses-ignore-absolute ---
 
 --- autogen-subclasses-ignore-relative ---
-Opus::Parent
+class Opus::Parent
  Opus::Child

--- a/test/cli/autogen-subclasses/autogen-subclasses.out
+++ b/test/cli/autogen-subclasses/autogen-subclasses.out
@@ -1,7 +1,7 @@
 --- autogen-subclasses ---
-Opus::Mixin
+module Opus::Mixin
  Opus::Mixed
  Opus::MixedDescendant
-Opus::Parent
+class Opus::Parent
  Opus::Child
  Opus::DupChild


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This changes the autogen output to indicate whether the parent classes for printed subclasses are classes or modules. This information needed to be plumbed through some of the autogen paths.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
