### PR TITLE
Optimize T::Props constructors and default-setting

### DIFF
--- a/gems/sorbet-runtime/lib/sorbet-runtime.rb
+++ b/gems/sorbet-runtime/lib/sorbet-runtime.rb
@@ -92,8 +92,10 @@ require_relative 'types/props/decorator'
 require_relative 'types/props/errors'
 require_relative 'types/props/plugin'
 require_relative 'types/props/utils'
+require_relative 'types/enum'
 # Props that run sigs statically so have to be after all the others :(
 require_relative 'types/props/private/setter_factory'
+require_relative 'types/props/private/apply_default'
 require_relative 'types/props/optional'
 require_relative 'types/props/weak_constructor'
 require_relative 'types/props/constructor'
@@ -102,6 +104,5 @@ require_relative 'types/props/serializable'
 require_relative 'types/props/type_validation'
 
 require_relative 'types/struct'
-require_relative 'types/enum'
 
 require_relative 'types/compatibility_patches'

--- a/gems/sorbet-runtime/lib/types/props/constructor.rb
+++ b/gems/sorbet-runtime/lib/types/props/constructor.rb
@@ -8,6 +8,12 @@ end
 module T::Props::Constructor::DecoratorMethods
   extend T::Sig
 
+  # Set values for all props that have no defaults. Override what `WeakConstructor`
+  # does in order to raise errors on nils instead of ignoring them.
+  #
+  # @return [Integer] A count of props that we successfully initialized (which
+  # we'll use to check for any unrecognized input.)
+  #
   # checked(:never) - O(runtime object construction)
   sig {params(instance: T::Props::Constructor, hash: T::Hash[Symbol, T.untyped]).returns(Integer).checked(:never)}
   def construct_props_without_defaults(instance, hash)
@@ -17,7 +23,7 @@ module T::Props::Constructor::DecoratorMethods
         instance.instance_exec(val, &setter_proc)
         val || hash.key?(p)
       rescue TypeError, T::Props::InvalidValueError
-        if val.nil?
+        if !hash.key?(p)
           raise ArgumentError.new("Missing required prop `#{p}` for class `#{instance.class.name}`")
         else
           raise

--- a/gems/sorbet-runtime/lib/types/props/optional.rb
+++ b/gems/sorbet-runtime/lib/types/props/optional.rb
@@ -12,6 +12,8 @@ end
 # NB: This must stay in the same file where T::Props::Optional is defined due to
 # T::Props::Decorator#apply_plugin; see https://git.corp.stripe.com/stripe-internal/pay-server/blob/fc7f15593b49875f2d0499ffecfd19798bac05b3/chalk/odm/lib/chalk-odm/document_decorator.rb#L716-L717
 module T::Props::Optional::DecoratorMethods
+  extend T::Sig
+
   # TODO: clean this up. This set of options is confusing, and some of them are not universally
   # applicable (e.g., :on_load only applies when using T::Serializable).
   VALID_OPTIONAL_RULES = Set[
@@ -27,6 +29,9 @@ module T::Props::Optional::DecoratorMethods
     optional: true,
   }.freeze
   private_constant :VALID_RULE_KEYS
+
+  DEFAULT_SETTER_RULE_KEY = :_t_props_private_apply_default
+  private_constant :DEFAULT_SETTER_RULE_KEY
 
   def valid_rule_key?(key)
     super || VALID_RULE_KEYS[key]
@@ -46,8 +51,30 @@ module T::Props::Optional::DecoratorMethods
     rules[:need_nil_read_check] = T::Props::Utils.need_nil_read_check?(rules)
   end
 
+  # checked(:never) - O(runtime object construction)
+  sig {returns(T::Hash[Symbol, T::Props::Private::ApplyDefault]).checked(:never)}
+  attr_reader :props_with_defaults
+
+  # checked(:never) - O(runtime object construction)
+  sig {returns(T::Hash[Symbol, T::Props::Private::SetterFactory::SetterProc]).checked(:never)}
+  attr_reader :props_without_defaults
+
   def add_prop_definition(prop, rules)
     compute_derived_rules(rules)
+
+    default_setter = T::Props::Private::ApplyDefault.for(decorated_class, rules)
+    if default_setter
+      @props_with_defaults ||= {}
+      @props_with_defaults[prop] = default_setter
+      @props_without_defaults&.delete(prop) # Handle potential override
+
+      rules[DEFAULT_SETTER_RULE_KEY] = default_setter
+    else
+      @props_without_defaults ||= {}
+      @props_without_defaults[prop] = rules.fetch(:setter_proc)
+      @props_with_defaults&.delete(prop) # Handle potential override
+    end
+
     super
   end
 
@@ -68,21 +95,10 @@ module T::Props::Optional::DecoratorMethods
   end
 
   def has_default?(rules)
-    rules.include?(:default) || rules.include?(:factory)
+    rules.include?(DEFAULT_SETTER_RULE_KEY)
   end
 
   def get_default(rules, instance_class)
-    if rules.include?(:default)
-      default = rules[:default]
-      T::Props::Utils.deep_clone_object(default)
-    elsif rules.include?(:factory)
-      # Factory should never be nil if the key is specified, but
-      # we do this rather than 'elsif rules[:factory]' for
-      # consistency with :default.
-      factory = rules[:factory]
-      instance_class.class_exec(&factory)
-    else
-      nil
-    end
+    rules[DEFAULT_SETTER_RULE_KEY]&.default
   end
 end

--- a/gems/sorbet-runtime/lib/types/props/private/apply_default.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/apply_default.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+# typed: strict
+
+module T::Props
+  module Private
+    class ApplyDefault
+      extend T::Sig
+      extend T::Helpers
+      abstract!
+
+      # checked(:never) - O(object construction x prop count)
+      sig {returns(SetterFactory::SetterProc).checked(:never)}
+      attr_reader :setter_proc
+
+      # checked(:never) - We do this with `T.let` instead
+      sig {params(accessor_key: Symbol, setter_proc: SetterFactory::SetterProc).void.checked(:never)}
+      def initialize(accessor_key, setter_proc)
+        @accessor_key = T.let(accessor_key, Symbol)
+        @setter_proc = T.let(setter_proc, SetterFactory::SetterProc)
+      end
+
+      # checked(:never) - O(object construction x prop count)
+      sig {abstract.returns(T.untyped).checked(:never)}
+      def default; end
+
+      # checked(:never) - O(object construction x prop count)
+      sig {abstract.params(instance: T.all(T::Props::Optional, Object)).void.checked(:never)}
+      def set_default(instance); end
+
+      NO_CLONE_TYPES = T.let([TrueClass, FalseClass, NilClass, Symbol, Numeric, T::Enum].freeze, T::Array[Module])
+
+      # checked(:never) - Rules hash is expensive to check
+      sig {params(cls: Module, rules: T::Hash[Symbol, T.untyped]).returns(T.nilable(ApplyDefault)).checked(:never)}
+      def self.for(cls, rules)
+        accessor_key = rules.fetch(:accessor_key)
+        setter = rules.fetch(:setter_proc)
+
+        if rules.key?(:factory)
+          ApplyDefaultFactory.new(cls, rules.fetch(:factory), accessor_key, setter)
+        elsif rules.key?(:default)
+          default = rules.fetch(:default)
+          case default
+          when *NO_CLONE_TYPES
+            return ApplyPrimitiveDefault.new(default, accessor_key, setter)
+          when String
+            if default.frozen?
+              return ApplyPrimitiveDefault.new(default, accessor_key, setter)
+            end
+          when Array
+            if default.empty? && default.class == Array
+              return ApplyEmptyArrayDefault.new(accessor_key, setter)
+            end
+          when Hash
+            if default.empty? && default.default.nil? && T.unsafe(default).default_proc.nil? && default.class == Hash
+              return ApplyEmptyHashDefault.new(accessor_key, setter)
+            end
+          end
+
+          ApplyComplexDefault.new(default, accessor_key, setter)
+        else
+          nil
+        end
+      end
+    end
+
+    class ApplyFixedDefault < ApplyDefault
+      abstract!
+
+      # checked(:never) - We do this with `T.let` instead
+      sig {params(default: BasicObject, accessor_key: Symbol, setter_proc: SetterFactory::SetterProc).void.checked(:never)}
+      def initialize(default, accessor_key, setter_proc)
+        # FIXME: Ideally we'd check here that the default is actually a valid
+        # value for this field, but existing code relies on the fact that we don't.
+        #
+        # :(
+        #
+        # setter_proc.call(default)
+        @default = T.let(default, BasicObject)
+        super(accessor_key, setter_proc)
+      end
+
+      # checked(:never) - O(object construction x prop count)
+      sig {override.params(instance: T.all(T::Props::Optional, Object)).void.checked(:never)}
+      def set_default(instance)
+        instance.instance_variable_set(@accessor_key, default)
+      end
+    end
+
+    class ApplyPrimitiveDefault < ApplyFixedDefault
+      # checked(:never) - O(object construction x prop count)
+      sig {override.returns(T.untyped).checked(:never)}
+      attr_reader :default
+    end
+
+    class ApplyComplexDefault < ApplyFixedDefault
+      # checked(:never) - O(object construction x prop count)
+      sig {override.returns(T.untyped).checked(:never)}
+      def default
+        T::Props::Utils.deep_clone_object(@default)
+      end
+    end
+
+    # Special case since it's so common, and a literal `[]` is meaningfully
+    # faster than falling back to ApplyComplexDefault or even calling
+    # `some_empty_array.dup`
+    class ApplyEmptyArrayDefault < ApplyDefault
+      # checked(:never) - O(object construction x prop count)
+      sig {override.params(instance: T.all(T::Props::Optional, Object)).void.checked(:never)}
+      def set_default(instance)
+        instance.instance_variable_set(@accessor_key, [])
+      end
+
+      # checked(:never) - O(object construction x prop count)
+      sig {override.returns(T::Array[T.untyped]).checked(:never)}
+      def default
+        []
+      end
+    end
+
+    # Special case since it's so common, and a literal `{}` is meaningfully
+    # faster than falling back to ApplyComplexDefault or even calling
+    # `some_empty_hash.dup`
+    class ApplyEmptyHashDefault < ApplyDefault
+      # checked(:never) - O(object construction x prop count)
+      sig {override.params(instance: T.all(T::Props::Optional, Object)).void.checked(:never)}
+      def set_default(instance)
+        instance.instance_variable_set(@accessor_key, {})
+      end
+
+      # checked(:never) - O(object construction x prop count)
+      sig {override.returns(T::Hash[T.untyped, T.untyped]).checked(:never)}
+      def default
+        {}
+      end
+    end
+
+    class ApplyDefaultFactory < ApplyDefault
+      # checked(:never) - We do this with `T.let` instead
+      sig do
+        params(
+          cls: Module,
+          factory: T.any(Proc, Method),
+          accessor_key: Symbol,
+          setter_proc: SetterFactory::SetterProc,
+        )
+        .void
+        .checked(:never)
+      end
+      def initialize(cls, factory, accessor_key, setter_proc)
+        @class = T.let(cls, Module)
+        @factory = T.let(factory, T.any(Proc, Method))
+        super(accessor_key, setter_proc)
+      end
+
+      # checked(:never) - O(object construction x prop count)
+      sig {override.params(instance: T.all(T::Props::Optional, Object)).void.checked(:never)}
+      def set_default(instance)
+        # Use the actual setter to validate the factory returns a legitimate
+        # value every time
+        instance.instance_exec(default, &@setter_proc)
+      end
+
+      # checked(:never) - O(object construction x prop count)
+      sig {override.returns(T.untyped).checked(:never)}
+      def default
+        @class.class_exec(&@factory)
+      end
+    end
+  end
+end

--- a/gems/sorbet-runtime/lib/types/props/weak_constructor.rb
+++ b/gems/sorbet-runtime/lib/types/props/weak_constructor.rb
@@ -22,6 +22,11 @@ end
 module T::Props::WeakConstructor::DecoratorMethods
   extend T::Sig
 
+  # Set values for all props that have no defaults. Ignore any not present.
+  #
+  # @return [Integer] A count of props that we successfully initialized (which
+  # we'll use to check for any unrecognized input.)
+  #
   # checked(:never) - O(runtime object construction)
   sig {params(instance: T::Props::WeakConstructor, hash: T::Hash[Symbol, T.untyped]).returns(Integer).checked(:never)}
   def construct_props_without_defaults(instance, hash)
@@ -35,6 +40,12 @@ module T::Props::WeakConstructor::DecoratorMethods
     end || 0
   end
 
+  # Set values for all props that have defaults. Use the default if and only if
+  # the prop key isn't in the input.
+  #
+  # @return [Integer] A count of props that we successfully initialized (which
+  # we'll use to check for any unrecognized input.)
+  #
   # checked(:never) - O(runtime object construction)
   sig {params(instance: T::Props::WeakConstructor, hash: T::Hash[Symbol, T.untyped]).returns(Integer).checked(:never)}
   def construct_props_with_defaults(instance, hash)

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -78,6 +78,18 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     )
   end
 
+  class ParentWithNoDefault < T::InexactStruct
+    prop :prop, String
+  end
+
+  class ChildWithDefault < ParentWithNoDefault
+    prop :prop, String, default: '', override: true
+  end
+
+  it 'uses default set on child in constructor' do
+    assert_equal('', ChildWithDefault.new.prop)
+  end
+
   it 'serializes' do
     m = a_serializable
 
@@ -209,13 +221,11 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_includes(ex.message, "Can't set Opus::Types::Test::Props::SerializableTest::NilFieldStruct.bar to nil (instance of NilClass) - need a String")
     end
 
-    # Is this intended? It seems like the behavior you'd want with T::Props::WeakConstructor,
-    # or perhaps with `default: nil`, but not T::Props::Constructor / T::Struct
-    it 'allows implicit but forbids explicit nil in constructor' do
-      struct = NilFieldStruct.new
-      assert_nil(struct.foo)
-      assert_nil(struct.bar)
-      assert_raises(TypeError) do
+    it 'forbids nil in constructor' do
+      assert_raises(ArgumentError) do
+        NilFieldStruct.new
+      end
+      assert_raises(ArgumentError) do
         NilFieldStruct.new(foo: nil, bar: nil)
       end
     end

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -225,7 +225,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_raises(ArgumentError) do
         NilFieldStruct.new
       end
-      assert_raises(ArgumentError) do
+      assert_raises(TypeError) do
         NilFieldStruct.new(foo: nil, bar: nil)
       end
     end


### PR DESCRIPTION
Building on #2448, this speeds up T::Struct#new, and also T::Props::Serializable#deserialize for cases where we are mostly using defaults.

Most of the meat of the optimization is in re-implementing/replacing `get_default` by creating a  specialized `ApplyDefault` instance at prop definition time based on the type of any `:default` and/or `:factory` option. This lets us optimize the common-case fast paths (a primitive default or an empty-collection default) a lot, while also removing a branch & hash lookup or two even in the slow path.

Specifically for constructors, we also reduce the redundancy between WeakConstructor and (strict) Constructor, as well as runtime branching, by splitting up props into "with default" and "without default", and handling each collection separately. WeakConstructor and Constructor can handle props with defaults identically, while splitting on their handling of props without.

### Motivation
On my laptop, produces a ~2x improvement in the benchmark for constructing an instance mostly with defaults, and a ~1.3x improvement for constructing with all props set explicitly.

Also produces a ~1.2x improvement in deserialization with mostly defaults (with no effect on deserialization with props set explicitly).

### Test plan
Added tests here plus ~passing build in pay-server

(Note: a pay-server build currently fails but all errors are ~trivial changes in error messages. If this approach looks good, I'll go ahead and relax the relevant tests to make them pass before we actually merge this.)