### PR TITLE
Use .send to access private attr_reader in ruby 2.3, 2.4

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -529,7 +529,7 @@ class T::Props::Decorator
         end
       else
         # Fast path (~30x faster as of Ruby 2.6)
-        @class.attr_reader(name)
+        @class.send(:attr_reader, name)
       end
     end
   end

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -529,7 +529,7 @@ class T::Props::Decorator
         end
       else
         # Fast path (~30x faster as of Ruby 2.6)
-        @class.send(:attr_reader, name)
+        @class.send(:attr_reader, name) # send is used because `attr_reader` is private in 2.4
       end
     end
   end


### PR DESCRIPTION
This fixes issue https://github.com/sorbet/sorbet/issues/2487

### Motivation

### Test plan
Run tests on Ruby 2.4.3 and it works

```
ruby ./test/types/props/decorator.rb
```

Without this PR, get the expected error
```
/home/dev/sorbet/gems/sorbet-runtime/lib/types/props/decorator.rb:532:in `block in define_getter_and_setter': private method `attr_reader' called for Opus::Types::Test::Props::DecoratorTest::StringArrayAndHashStruct:Class (NoMethodError)
```