### PR TITLE
Correct sig for Kernel#eval

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -223,9 +223,9 @@ module Kernel
   sig do
     params(
         arg0: String,
-        arg1: Binding,
-        filename: String,
-        lineno: Integer,
+        arg1: T.nilable(Binding),
+        filename: T.nilable(String),
+        lineno: T.nilable(Integer),
     )
     .returns(T.untyped)
   end


### PR DESCRIPTION
### Motivation

The following is legal Ruby code:

```
eval "1", nil, "filename", 1
```
However, the Sorbet sig for Kernel#eval specifies arguments 2 to 4 as mandatory, while the official Ruby docs (https://ruby-doc.org/core-2.7.0/Kernel.html#method-i-eval) say they are optional. For that reason, the above legal Ruby code is rejected by Sorbet.

### Test plan

Have not looked into test plans for core api calls.
