### PR TITLE
Bug report: T::Props::Plugin steps on mixes_in_class_methods

### DIFF
--- a/diff-false-true.diff
+++ b/diff-false-true.diff
@@ -1,0 +1,30 @@
+--- false.out	2020-01-22 14:22:47.000000000 -0800
++++ true.out	2020-01-22 14:21:54.000000000 -0800
+@@ -68,10 +68,10 @@
+ │ self:  GrandParent
+ │
+ │ other.extend(mod)
+-│ Parent.extend(GrandParent::CMs)
++│ Parent.extend(GrandParent::ClassMethods)
+ └────────────────────────────
+ ┌─── self.extend(other) ─────
+-│ Parent.extend(GrandParent::CMs)
++│ Parent.extend(GrandParent::ClassMethods)
+ │
+ │ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/private/mixins/mixins.rb:16:in `included'
+ │ include-true.rb:13:in `include'
+@@ -88,7 +88,7 @@
+ │ include-true.rb:16:in `<main>'
+ └────────────────────────────
+ ┌─── self.extend(other) ─────
+-│ Child.extend(T::Props::Plugin::ClassMethods)
++│ Child.extend(GrandParent::ClassMethods)
+ │
+ │ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/decorator.rb:829:in `apply_class_methods'
+ │ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/decorator.rb:818:in `plugin'
+@@ -100,4 +100,4 @@
+ │ include-true.rb:16:in `<main>'
+ └────────────────────────────
+ true
+-false
++true

--- a/false.out
+++ b/false.out
@@ -1,0 +1,103 @@
+┌─── MixesInClassMethods ────
+│ self:  T::Props
+│
+│ other.extend(mod)
+│ T::Props::Plugin.extend(T::Props::ClassMethods)
+└────────────────────────────
+┌─── MixesInClassMethods ────
+│ self:  T::Props::Plugin
+│
+│ other.extend(mod)
+│ T::Props::Optional.extend(T::Props::Plugin::ClassMethods)
+└────────────────────────────
+┌─── MixesInClassMethods ────
+│ self:  T::Props::Plugin
+│
+│ other.extend(mod)
+│ T::Props::PrettyPrintable.extend(T::Props::Plugin::ClassMethods)
+└────────────────────────────
+┌─── MixesInClassMethods ────
+│ self:  T::Props::Plugin
+│
+│ other.extend(mod)
+│ T::Props::Serializable.extend(T::Props::Plugin::ClassMethods)
+└────────────────────────────
+┌─── MixesInClassMethods ────
+│ self:  T::Props::Plugin
+│
+│ other.extend(mod)
+│ T::Props::TypeValidation.extend(T::Props::Plugin::ClassMethods)
+└────────────────────────────
+┌─── MixesInClassMethods ────
+│ self:  T::Props
+│
+│ other.extend(mod)
+│ T::InexactStruct.extend(T::Props::ClassMethods)
+└────────────────────────────
+┌─── self.extend(other) ─────
+│ GrandParent.extend(T::Helpers)
+│
+│ include-true.rb:6:in `<module:GrandParent>'
+│ include-true.rb:5:in `<main>'
+└────────────────────────────
+┌─── MixesInClassMethods ────
+│ self:  T::Props::Plugin
+│
+│ other.extend(mod)
+│ Parent.extend(T::Props::Plugin::ClassMethods)
+└────────────────────────────
+┌─── self.extend(other) ─────
+│ Parent.extend(T::Props::Plugin::ClassMethods)
+│
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/private/mixins/mixins.rb:16:in `included'
+│ include-true.rb:12:in `include'
+│ include-true.rb:12:in `<module:Parent>'
+│ include-true.rb:11:in `<main>'
+└────────────────────────────
+┌─── self.extend(other) ─────
+│ Parent.extend(T::Props::ClassMethods)
+│
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/decorator.rb:770:in `model_inherited'
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/_props.rb:145:in `included'
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/private/mixins/mixins.rb:17:in `included'
+│ include-true.rb:12:in `include'
+│ include-true.rb:12:in `<module:Parent>'
+│ include-true.rb:11:in `<main>'
+└────────────────────────────
+┌─── MixesInClassMethods ────
+│ self:  GrandParent
+│
+│ other.extend(mod)
+│ Parent.extend(GrandParent::CMs)
+└────────────────────────────
+┌─── self.extend(other) ─────
+│ Parent.extend(GrandParent::CMs)
+│
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/private/mixins/mixins.rb:16:in `included'
+│ include-true.rb:13:in `include'
+│ include-true.rb:13:in `<module:Parent>'
+│ include-true.rb:11:in `<main>'
+└────────────────────────────
+┌─── self.extend(other) ─────
+│ Child.extend(T::Props::ClassMethods)
+│
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/decorator.rb:770:in `model_inherited'
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/_props.rb:145:in `included'
+│ include-true.rb:17:in `include'
+│ include-true.rb:17:in `<class:Child>'
+│ include-true.rb:16:in `<main>'
+└────────────────────────────
+┌─── self.extend(other) ─────
+│ Child.extend(T::Props::Plugin::ClassMethods)
+│
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/decorator.rb:829:in `apply_class_methods'
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/decorator.rb:818:in `plugin'
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/_props.rb:127:in `plugin'
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/plugin.rb:11:in `included'
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/_props.rb:146:in `included'
+│ include-true.rb:17:in `include'
+│ include-true.rb:17:in `<class:Child>'
+│ include-true.rb:16:in `<main>'
+└────────────────────────────
+true
+false

--- a/gems/sorbet-runtime/lib/types/private/mixins/mixins.rb
+++ b/gems/sorbet-runtime/lib/types/private/mixins/mixins.rb
@@ -5,6 +5,14 @@ module T::Private
   module MixesInClassMethods
     def included(other)
       mod = Abstract::Data.get(self, :class_methods_mixin)
+
+      Kernel.puts "┌─── MixesInClassMethods ────"
+      Kernel.puts "│ self:  #{self}"
+      Kernel.puts "│"
+      Kernel.puts "│ other.extend(mod)"
+      Kernel.puts "│ #{other}.extend(#{mod})"
+      Kernel.puts "└────────────────────────────"
+
       other.extend(mod)
       super
     end

--- a/include-false-1.rb
+++ b/include-false-1.rb
@@ -1,0 +1,21 @@
+# typed: true
+require_relative './gems/sorbet-runtime/lib/sorbet-runtime'
+require_relative './patch-extend'
+
+module GrandParent
+  extend T::Helpers
+  module CMs; end
+  mixes_in_class_methods(CMs)
+end
+
+module Parent
+  include T::Props::Plugin
+  include GrandParent
+end
+
+class Child
+  include Parent
+end
+
+p Parent.singleton_class.ancestors.include?(GrandParent::CMs)
+p Child.singleton_class.ancestors.include?(GrandParent::CMs)

--- a/include-false-2.rb
+++ b/include-false-2.rb
@@ -1,0 +1,21 @@
+# typed: true
+require_relative './gems/sorbet-runtime/lib/sorbet-runtime'
+require_relative './patch-extend'
+
+module GrandParent
+  extend T::Helpers
+  module ClassMethods; end
+  mixes_in_class_methods(ClassMethods)
+end
+
+module Parent
+  include GrandParent
+  include T::Props::Plugin
+end
+
+class Child
+  include Parent
+end
+
+p Parent.singleton_class.ancestors.include?(GrandParent::ClassMethods)
+p Child.singleton_class.ancestors.include?(GrandParent::ClassMethods)

--- a/include-true.rb
+++ b/include-true.rb
@@ -1,0 +1,21 @@
+# typed: true
+require_relative './gems/sorbet-runtime/lib/sorbet-runtime'
+require_relative './patch-extend'
+
+module GrandParent
+  extend T::Helpers
+  module ClassMethods; end
+  mixes_in_class_methods(ClassMethods)
+end
+
+module Parent
+  include T::Props::Plugin
+  include GrandParent
+end
+
+class Child
+  include Parent
+end
+
+p Parent.singleton_class.ancestors.include?(GrandParent::ClassMethods)
+p Child.singleton_class.ancestors.include?(GrandParent::ClassMethods)

--- a/patch-extend.rb
+++ b/patch-extend.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+class Module
+  def extend(other)
+      Kernel.puts "┌─── self.extend(other) ─────"
+      Kernel.puts "│ #{self}.extend(#{other})"
+      Kernel.puts "│"
+      Kernel.puts caller.map {|line| "│ #{line}"}
+      Kernel.puts "└────────────────────────────"
+      super
+  end
+end

--- a/true.out
+++ b/true.out
@@ -1,0 +1,103 @@
+┌─── MixesInClassMethods ────
+│ self:  T::Props
+│
+│ other.extend(mod)
+│ T::Props::Plugin.extend(T::Props::ClassMethods)
+└────────────────────────────
+┌─── MixesInClassMethods ────
+│ self:  T::Props::Plugin
+│
+│ other.extend(mod)
+│ T::Props::Optional.extend(T::Props::Plugin::ClassMethods)
+└────────────────────────────
+┌─── MixesInClassMethods ────
+│ self:  T::Props::Plugin
+│
+│ other.extend(mod)
+│ T::Props::PrettyPrintable.extend(T::Props::Plugin::ClassMethods)
+└────────────────────────────
+┌─── MixesInClassMethods ────
+│ self:  T::Props::Plugin
+│
+│ other.extend(mod)
+│ T::Props::Serializable.extend(T::Props::Plugin::ClassMethods)
+└────────────────────────────
+┌─── MixesInClassMethods ────
+│ self:  T::Props::Plugin
+│
+│ other.extend(mod)
+│ T::Props::TypeValidation.extend(T::Props::Plugin::ClassMethods)
+└────────────────────────────
+┌─── MixesInClassMethods ────
+│ self:  T::Props
+│
+│ other.extend(mod)
+│ T::InexactStruct.extend(T::Props::ClassMethods)
+└────────────────────────────
+┌─── self.extend(other) ─────
+│ GrandParent.extend(T::Helpers)
+│
+│ include-true.rb:6:in `<module:GrandParent>'
+│ include-true.rb:5:in `<main>'
+└────────────────────────────
+┌─── MixesInClassMethods ────
+│ self:  T::Props::Plugin
+│
+│ other.extend(mod)
+│ Parent.extend(T::Props::Plugin::ClassMethods)
+└────────────────────────────
+┌─── self.extend(other) ─────
+│ Parent.extend(T::Props::Plugin::ClassMethods)
+│
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/private/mixins/mixins.rb:16:in `included'
+│ include-true.rb:12:in `include'
+│ include-true.rb:12:in `<module:Parent>'
+│ include-true.rb:11:in `<main>'
+└────────────────────────────
+┌─── self.extend(other) ─────
+│ Parent.extend(T::Props::ClassMethods)
+│
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/decorator.rb:770:in `model_inherited'
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/_props.rb:145:in `included'
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/private/mixins/mixins.rb:17:in `included'
+│ include-true.rb:12:in `include'
+│ include-true.rb:12:in `<module:Parent>'
+│ include-true.rb:11:in `<main>'
+└────────────────────────────
+┌─── MixesInClassMethods ────
+│ self:  GrandParent
+│
+│ other.extend(mod)
+│ Parent.extend(GrandParent::ClassMethods)
+└────────────────────────────
+┌─── self.extend(other) ─────
+│ Parent.extend(GrandParent::ClassMethods)
+│
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/private/mixins/mixins.rb:16:in `included'
+│ include-true.rb:13:in `include'
+│ include-true.rb:13:in `<module:Parent>'
+│ include-true.rb:11:in `<main>'
+└────────────────────────────
+┌─── self.extend(other) ─────
+│ Child.extend(T::Props::ClassMethods)
+│
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/decorator.rb:770:in `model_inherited'
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/_props.rb:145:in `included'
+│ include-true.rb:17:in `include'
+│ include-true.rb:17:in `<class:Child>'
+│ include-true.rb:16:in `<main>'
+└────────────────────────────
+┌─── self.extend(other) ─────
+│ Child.extend(GrandParent::ClassMethods)
+│
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/decorator.rb:829:in `apply_class_methods'
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/decorator.rb:818:in `plugin'
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/_props.rb:127:in `plugin'
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/plugin.rb:11:in `included'
+│ /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/_props.rb:146:in `included'
+│ include-true.rb:17:in `include'
+│ include-true.rb:17:in `<class:Child>'
+│ include-true.rb:16:in `<main>'
+└────────────────────────────
+true
+true


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

> For purpose of reporting a bug only.

We expect `Child.singleton_class.ancestors.include?(GrandParent::ClassMethods)`
to be false (because there's no `include GrandParent` in `Child`). But in
certain circumstances, putting `T::Props::Plugin` (or something else like
`T::Props::Serializable` which includes `Plugin` transitively) can cause
`GrandParent::ClassMethods` to show up in the runtime because there's a dynamic
constant access in the implementation of `decorator.rb`:

https://github.com/sorbet/sorbet/blob/b5a4436d9e94bfdbce1f0cf9291924cdfc8e87d4/gems/sorbet-runtime/lib/types/props/decorator.rb#L829

I've included three ruby files, `include-true.rb`, `include-false-1.rb`, and
`include-false-2.rb` which cause the `Child.singleton_class.ancestors.include?`
line to print `true`, `false`, and `false` respectively.

I've also patched `Module#extend` and `MixesInClassMethods` with some print
statements that I found useful while debugging this.