### PR TITLE
Add special casing in runtime for writer methods

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -51,8 +51,14 @@ class T::Private::Methods::Signature
     @on_failure = on_failure
     @override_allow_incompatible = override_allow_incompatible
 
-    param_names = parameters.map {|_, name| name}
     declared_param_names = raw_arg_types.keys
+    # If sig params are declared but there is a single parameter with a missing name
+    # **and** the method ends with a "=", assume it is a writer method generated
+    # by attr_writer or attr_accessor
+    writer_method = declared_param_names != [nil] && parameters == [[:req]] && method_name[-1] == "="
+    # For writer methods, map the single parameter to the method name without the "=" at the end
+    parameters = [[:req, method_name[0...-1].to_sym]] if writer_method
+    param_names = parameters.map {|_, name| name}
     missing_names = param_names - declared_param_names
     extra_names = declared_param_names - param_names
     if !missing_names.empty?

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -15,6 +15,20 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     assert_equal(klass.new, klass.new)
   end
 
+  it 'handles attr_writer and attr_accessor generated writers' do
+    klass = Class.new do
+      extend T::Sig
+      extend T::Helpers
+      sig { params(foo: String).returns(String) }
+      attr_writer :foo
+      sig { params(bar: Integer).returns(Integer) }
+      attr_accessor :bar
+    end
+
+    assert_equal("foo", klass.new.foo = "foo")
+    assert_equal(42, klass.new.bar = 42)
+  end
+
   it 'handles aliased methods' do
     klass = Class.new do
       extend T::Sig


### PR DESCRIPTION
This PR tries to identify writer methods generated by `attr_writer` or `attr_accessor` methods properly so that type-checking can be performed at runtime without errors.

Since writer methods have a single parameter with a declared name, currently the runtime fails matching the parameter to the one declared in the signature.

The fix uses heuristics to try to identify which methods are writer methods with a supplied signature and modifies the parameter list so that runtime type-checking can be performed.

More details on the strategy can be found here: https://github.com/sorbet/sorbet/issues/1239#issuecomment-577382200

### Motivation

Fixes #1239 

### Test plan

Added an edge-case test that explicitly calls the writer methods generated by an `attr_writer` and an `attr_accessor`.
