### PR TITLE
Allow Array#sample to have more sensitive types when not passing in any parameters

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1847,6 +1847,8 @@ class Array < Object
     )
     .returns(T.any(T.nilable(Elem), T::Array[Elem]))
   end
+  sig { returns(Elem) }
+  sig { params(random: Random::Formatter).returns(Elem) }
   def sample(arg0=T.unsafe(nil), random: T.unsafe(nil)); end
 
   # Returns a new array containing all elements of `ary` for which the given

--- a/test/testdata/rbi/array.rb
+++ b/test/testdata/rbi/array.rb
@@ -38,6 +38,6 @@ T::Array[Float].new.sum.nan? # error: Method `nan?` does not exist on `Integer` 
 
 # Sample
 T.assert_type!([1, 2].sample, Integer)
-T.assert_type!([1, 2].sample, random: Random.new, Integer)
+T.assert_type!([1, 2].sample(random: Random.new), Integer)
 T.assert_type!([1, 2].sample(2), T::Array[Integer])
 T.assert_type!([1, 2].sample(2), random: Random.new, T::Array[Integer])

--- a/test/testdata/rbi/array.rb
+++ b/test/testdata/rbi/array.rb
@@ -40,4 +40,4 @@ T::Array[Float].new.sum.nan? # error: Method `nan?` does not exist on `Integer` 
 T.assert_type!([1, 2].sample, Integer)
 T.assert_type!([1, 2].sample(random: Random.new), Integer)
 T.assert_type!([1, 2].sample(2), T::Array[Integer])
-T.assert_type!([1, 2].sample(2), random: Random.new, T::Array[Integer])
+T.assert_type!([1, 2].sample(2, random: Random.new), T::Array[Integer])

--- a/test/testdata/rbi/array.rb
+++ b/test/testdata/rbi/array.rb
@@ -35,3 +35,9 @@ T.assert_type!([1,2].repeated_combination(1) {}, T::Array[Integer])
 # errors
 
 T::Array[Float].new.sum.nan? # error: Method `nan?` does not exist on `Integer` component of `T.any(Integer, Float)`
+
+# Sample
+T.assert_type!([1, 2].sample, Integer)
+T.assert_type!([1, 2].sample, random: Random.new, Integer)
+T.assert_type!([1, 2].sample(2), T::Array[Integer])
+T.assert_type!([1, 2].sample(2), random: Random.new, T::Array[Integer])


### PR DESCRIPTION
`Array#sample` could return an array of things if an integer is passed in. It returns a single element if no parameter is passed in:
https://ruby-doc.org/core-2.4.1/Array.html#method-i-sample

### Motivation
This allows us to use `.sample` and have more constrained types.

This sorbet.run illustrates the issue: https://sorbet.run/#%23%20typed%3A%20true%0Aclass%20A%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7B%20returns(Integer)%20%7D%0A%20%20def%20bar%0A%20%20%20%5B1%2C%202%5D.sample%0A%20%20end%0Aend%0A%0Adef%20main%0A%20%20A.new.bar%0Aend

### Test plan
See included automated tests.
