### PR TITLE
Speed up CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -119,18 +119,6 @@ test:travis --ram_utilization_factor=10
 test:travis --test_strategy=standalone
 test:travis --test_output=errors
 
-# this is a variant of buildfarm that doen't specify -Os or any sanitizer flags
-build:buildfarm-ruby --define jemalloc=false
-build:buildfarm-ruby --copt=-O2
-# this includes --spawn_strategy=standalone --genrule_strategy=standalone, which
-# seems to break the snapshot tests
-# build:buildfarm-ruby --config=dbg 
-build:buildfarm-ruby --nostamp
-build:buildfarm-ruby --define release=false
-build:buildfarm-ruby --config=forcedebug
-build:buildfarm-ruby --config=reduce-intermediate-file-size-base
-test:buildfarm-ruby --test_output=errors
-
 ##
 ## Shared fragments of configuration
 ##

--- a/.buildkite/test-static-sanitized.sh
+++ b/.buildkite/test-static-sanitized.sh
@@ -28,11 +28,11 @@ echo will run with $CONFIG_OPTS
 
 err=0
 
-# NOTE: running ruby/gem/srb testing without the sanitized flags
-./bazel test @ruby_2_6//... @ruby_2_4//... @gems//... //gems/sorbet/test/snapshot \
-  //gems/sorbet/test/hidden-method-finder --config=buildfarm-ruby || err=$?
-
-./bazel test //... $CONFIG_OPTS --test_summary=terse || err=$?
+./bazel test \
+  @gems//... \
+  //gems/sorbet/test/snapshot \
+  //gems/sorbet/test/hidden-method-finder \
+  //... $CONFIG_OPTS --test_summary=terse || err=$?
 
 echo "--- uploading test results"
 

--- a/gems/sorbet/test/snapshot/check_one.sh
+++ b/gems/sorbet/test/snapshot/check_one.sh
@@ -16,7 +16,7 @@ setup_validate_env "$@"
 
 info "Checking output log"
 if [ "$is_partial" = "" ] || [ -f "expected/out.log" ]; then
-  if ! diff -u "expected/out.log" "actual/out.log"; then
+  if ! diff -u "expected/out.log" "$actual/out.log"; then
     error "├─ expected out.log did not match actual out.log"
     error "└─ see output above."
     exit 1
@@ -26,7 +26,7 @@ fi
 # ----- Check err.log -----
 
 if [ "$is_partial" = "" ] || [ -f "expected/err.log" ]; then
-  if ! diff -u "expected/err.log" "actual/err.log"; then
+  if ! diff -u "expected/err.log" "$actual/err.log"; then
     error "├─ expected err.log did not match actual err.log"
     error "└─ see output above."
     exit 1
@@ -37,7 +37,7 @@ fi
 
 diff_total() {
   info "├─ checking for total match"
-  if ! diff -ur "expected/sorbet" "actual/sorbet"; then
+  if ! diff -ur "expected/sorbet" "$actual/sorbet"; then
     error "├─ expected sorbet/ folder did not match actual sorbet/ folder"
     error "└─ see output above."
     exit 1
@@ -48,8 +48,8 @@ diff_partial() {
   info "├─ checking for partial match"
 
   set +e
-  diff -ur "expected/sorbet" "actual/sorbet" | \
-    grep -vF "Only in actual" > "partial-diff.log"
+  diff -ur "expected/sorbet" "$actual/sorbet" | \
+    grep -vF "Only in $actual" > "partial-diff.log"
   set -e
 
   # File exists and is non-empty

--- a/gems/sorbet/test/snapshot/update_one.sh
+++ b/gems/sorbet/test/snapshot/update_one.sh
@@ -12,28 +12,28 @@ setup_validate_env "$@"
 # ----- Update sorbet/ -----
 
 diff_total() {
-  if ! diff -ur "expected/sorbet" "actual/sorbet"; then
+  if ! diff -ur "expected/sorbet" "$actual/sorbet"; then
     attn "├─ updating expected/sorbet (total):"
     rm -rf "$test_dir/expected/sorbet"
     mkdir -p "$test_dir/expected"
-    cp -r "actual/sorbet" "$test_dir/expected"
+    cp -r "$actual/sorbet" "$test_dir/expected"
   fi
 }
 
 diff_partial() {
   set +e
-  diff -ur "expected" "actual" | \
+  diff -ur "expected" "$actual" | \
     grep -vF "Only in actual" \
-    > "actual/partial-diff.log"
+    > "$actual/partial-diff.log"
   set -e
 
   # File exists and is non-empty
-  if [ -s "actual/partial-diff.log" ]; then
+  if [ -s "$actual/partial-diff.log" ]; then
     attn "├─ updating expected/sorbet (partial):"
 
     find "$test_dir/expected/sorbet" -print0 | while IFS= read -r -d '' expected_path; do
       path_suffix="${expected_path#$test_dir/expected/sorbet}"
-      actual_path="actual/sorbet$path_suffix"
+      actual_path="$actual/sorbet$path_suffix"
 
       # Only ever update existing files, never grow this partial snapshot.
       if [ -d "$expected_path" ]; then
@@ -72,12 +72,12 @@ fi
 # ----- Update logs -----
 if [ -f "expected/err.log" ]; then
   info "├─ updating err.log"
-  cp actual/err.log expected/err.log
+  cp "$actual/err.log" expected/err.log
 fi
 
 if [ -f "expected/out.log" ]; then
   info "├─ updating out.log"
-  cp actual/out.log expected/out.log
+  cp "$actual/out.log" expected/out.log
 fi
 
 cleanup_validation

--- a/gems/sorbet/test/snapshot/validate_utils.sh
+++ b/gems/sorbet/test/snapshot/validate_utils.sh
@@ -37,8 +37,13 @@ setup_validate_env() {
 
   pushd "$test_dir" || fatal "Unable to change to test_dir"
 
+  actual="$(mktemp -d)"
+
   info "├─ Extracting test artifacts"
-  tar -xvf "$(basename "${archive_path}")"
+  attn "├─ $actual"
+  tar -xvf "$(basename "${archive_path}")" -C "$actual"
+
+  export actual
 }
 
 # Leave the test directory that was setup by setup_validate_env, and print a
@@ -46,7 +51,7 @@ setup_validate_env() {
 cleanup_validation() {
 
   # Cleanup the extracted run results
-  rm -rf actual
+  rm -rf "$actual"
 
   popd || fatal "Unable to leave test_dir"
   success "└─ test passed."

--- a/third_party/gems/bundle.sh
+++ b/third_party/gems/bundle.sh
@@ -3,14 +3,21 @@
 # A templated wrapper for the `bundle` command that will work with `bazel run`
 # and as an `sh_binary` source.
 
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck disable=SC1090
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
 
-# was this invoked via bazel run?
-RUNFILES="${BASH_SOURCE[0]}.runfiles"
-if [ -d "${RUNFILES}" ]; then
-  base_dir="${RUNFILES}/{{workspace}}/{{bundler}}"
-else
-  base_dir="$(dirname "${BASH_SOURCE[0]}")"
-fi
+BUNDLE="$(rlocation "{{workspace}}/bundler/{{site_bin}}/bundle")"
+
+base_dir="$(dirname "$BUNDLE")/.."
 
 RUBY_VERSION=$(ruby -e 'require "rbconfig"; puts RbConfig::CONFIG["ruby_version"]')
 
@@ -20,4 +27,4 @@ export BUNDLER_ROOT
 RUBYLIB="${BUNDLER_ROOT}${RUBYLIB:+:}${RUBYLIB:-}"
 export RUBYLIB
 
-exec "${base_dir}/{{site_bin}}/bundle" "$@"
+exec "$BUNDLE" "$@"

--- a/third_party/gems/bundler.BUILD
+++ b/third_party/gems/bundler.BUILD
@@ -12,6 +12,7 @@ sh_binary(
     srcs = ["bundle.sh"],
     data = [":runtime_deps"],
     visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 sh_binary(
@@ -19,4 +20,5 @@ sh_binary(
     srcs = ["bundle.sh"],
     data = [":runtime_deps"],
     visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/third_party/gems/gems.BUILD
+++ b/third_party/gems/gems.BUILD
@@ -1,6 +1,5 @@
 # This is a templated build file that will export all downloaded gems in the
 # "//gems" package. The `quoted_gems` template variable is supplied by `rules.bzl`.
-exports_files([{{quoted_gems}}])
 
 # This is so that depending on `@gems//gems` will bring in all gemfiles.
 filegroup(

--- a/third_party/ruby/build-ruby.bzl
+++ b/third_party/ruby/build-ruby.bzl
@@ -134,8 +134,13 @@ def _build_ruby_impl(ctx):
     # -Werror breaks configure, so we strip out all flags with a leading -W
     flags = []
     for flag in ctx.fragments.cpp.copts + ctx.fragments.cpp.conlyopts:
-        if not flag.startswith("-W"):
-            flags.append(flag)
+        if flag.startswith("-W"):
+            continue
+
+        if flag.startswith("-fsanitize"):
+            continue
+
+        flags.append(flag)
 
     # Outputs
     binaries = [

--- a/third_party/ruby/build-ruby.bzl
+++ b/third_party/ruby/build-ruby.bzl
@@ -96,6 +96,15 @@ rm -rf "$build_dir"
 
 RubyInfo = provider()
 
+def _is_sanitizer_flag(flag):
+    return flag.startswith("-fsanitize") or \
+           flag.startswith("-fno-sanitize") or \
+           flag == "-DHAS_SANITIZER" or \
+           flag == "-DADDRESS_SANITIZER" or \
+           flag.endswith("asan_cxx-x86_64.a") or \
+           flag.endswith("ubsan_standalone_cxx-x86_64.a") or \
+           flag.endswith("ubsan_standalone-x86_64.a")
+
 def _build_ruby_impl(ctx):
     # Discover the path to the source by finding ruby.c
     src_dir = None
@@ -132,15 +141,23 @@ def _build_ruby_impl(ctx):
     )
 
     # -Werror breaks configure, so we strip out all flags with a leading -W
+    # ruby doesn't work with asan or ubsan
     flags = []
     for flag in ctx.fragments.cpp.copts + ctx.fragments.cpp.conlyopts:
-        if flag.startswith("-W"):
-            continue
-
-        if flag.startswith("-fsanitize"):
+        if flag.startswith("-W") or \
+           flag == "-DHAS_SANITIZER" or \
+           flag == "-DADDRESS_SANITIZER" or \
+           _is_sanitizer_flag(flag):
             continue
 
         flags.append(flag)
+
+    ldflags = []
+    for flag in ctx.fragments.cpp.linkopts:
+        if _is_sanitizer_flag(flag):
+            continue
+
+        ldflags.append(flag)
 
     # Outputs
     binaries = [
@@ -164,7 +181,7 @@ def _build_ruby_impl(ctx):
         command = ctx.expand_location(_BUILD_RUBY.format(
             cc = cc,
             copts = " ".join(cmdline + flags),
-            linkopts = " ".join(ctx.fragments.cpp.linkopts),
+            linkopts = " ".join(ldflags),
             toolchain = libdir.dirname,
             src_dir = src_dir,
             internal_incdir = internal_incdir.path,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
There were two main problems:
* The ruby build didn't work with `--config=sanitize`
* The snapshot and hidden-method-finder tests didn't work outside of the sandbox

Fixing those issues lets us run the snapshot and hidden-method-finder tests at the same time as  the other tests, and allows for reuse of build artifacts.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
CI has been pretty slow recently, and we don't reuse build artifacts between buildfarm-ruby and buildfarm-sanitized-{mac,linux}.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
CI