### PR TITLE
Fix type for mode argument to FileUtils.mkdir_p

### DIFF
--- a/rbi/stdlib/fileutils.rbi
+++ b/rbi/stdlib/fileutils.rbi
@@ -187,7 +187,7 @@ module FileUtils
   sig do
     params(
       list: T.any(String, Pathname),
-      mode: T.nilable(T::Hash[Symbol, T::Boolean]),
+      mode: T.nilable(Integer),
       noop: T.nilable(T::Boolean),
       verbose: T.nilable(T::Boolean)
     ).returns(T::Array[String])
@@ -199,7 +199,7 @@ module FileUtils
   sig do
     params(
       list: T.any(String, Pathname),
-      mode: T.nilable(T::Hash[Symbol, T::Boolean]),
+      mode: T.nilable(Integer),
       noop: T.nilable(T::Boolean),
       verbose: T.nilable(T::Boolean)
     ).returns(T::Array[String])
@@ -211,7 +211,7 @@ module FileUtils
   sig do
     params(
       list: T.any(String, Pathname),
-      mode: T.nilable(T::Hash[Symbol, T::Boolean]),
+      mode: T.nilable(Integer),
       noop: T.nilable(T::Boolean),
       verbose: T.nilable(T::Boolean)
     ).returns(T::Array[String])


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Fix type for mode argument to FileUtils.mkdir_p

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It's a bug, and code using this option has to hack around the bug with T.unsafe currently.

Fixes https://github.com/sorbet/sorbet/issues/2537

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

