### PR TITLE
Fix type for Date#-

### DIFF
--- a/rbi/stdlib/date.rbi
+++ b/rbi/stdlib/date.rbi
@@ -368,7 +368,8 @@ class Date
   # DateTime.new(2001,2,3) - DateTime.new(2001,2,2,12)
   #                          #=> (1/2)
   # ```
-  sig {params(arg0: T.untyped).returns(Date)}
+  sig {params(arg0: Date).returns(Rational)}
+  sig {params(arg0: Numeric).returns(Date)}
   def -(arg0); end
 
   # Returns the day of the month (1-31).


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
#2514 treated `Date#-` as always returning a `Date`, but that's not the case: if you subtract two dates, instead you get a `Rational`. This adds the appropriate overloads.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
