### PR TITLE
Support openssl in ruby_2_4 and ruby_2_6

### DIFF
--- a/gems/sorbet/test/snapshot/BUILD
+++ b/gems/sorbet/test/snapshot/BUILD
@@ -39,16 +39,6 @@ snapshot_tests(
             "total/*",
         ],
         exclude = [
-            # These tests can't currently run under bazel,
-            # and can't be written another way.
-
-            # Requires openssl, which doesn't work in bazel.
-            # Can't be rewritten because it's testing gem_loader.
-            "partial/webmock",
-
-            # Requires native extensions. Tests gem_loader for codecov.
-            "partial/codecov",
-
             # Requires native extensions.
             # Can't be rewritten, because it's essentially an integration test
             # that a certain private Rails API gives us back absolute vs
@@ -72,16 +62,6 @@ snapshot_tests(
             "total/*",
         ],
         exclude = [
-            # These tests can't currently run under bazel,
-            # and can't be written another way.
-
-            # Requires openssl, which doesn't work in bazel.
-            # Can't be rewritten because it's testing gem_loader.
-            "partial/webmock",
-
-            # Requires native extensions. Tests gem_loader for codecov.
-            "partial/codecov",
-
             # Requires native extensions.
             # Can't be rewritten, because it's essentially an integration test
             # that a certain private Rails API gives us back absolute vs

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -270,3 +270,15 @@ package(default_visibility = ["//visibility:public"])
         strip_prefix = "zlib-1.2.11",
         build_file = "@com_stripe_ruby_typer//third_party:zlib.BUILD",
     )
+
+    native.new_local_repository(
+        name = "system_ssl_darwin",
+        path = "/usr/local/opt/openssl",
+        build_file = "@com_stripe_ruby_typer//third_party/openssl:darwin.BUILD",
+    )
+
+    native.new_local_repository(
+        name = "system_ssl_linux",
+        path = "/usr",
+        build_file = "@com_stripe_ruby_typer//third_party/openssl:linux.BUILD",
+    )

--- a/third_party/openssl/darwin.BUILD
+++ b/third_party/openssl/darwin.BUILD
@@ -1,0 +1,14 @@
+
+cc_import(
+    name = "ssl",
+    hdrs = glob(["include/**/*.h"]),
+    shared_library = "lib/libssl.dylib",
+    visibility = ["//visibility:public"],
+)
+
+cc_import(
+    name = "crypto",
+    hdrs = glob(["include/**/*.h"]),
+    shared_library = "lib/libcrypto.dylib",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/openssl/darwin.BUILD
+++ b/third_party/openssl/darwin.BUILD
@@ -1,4 +1,3 @@
-
 cc_import(
     name = "ssl",
     hdrs = glob(["include/**/*.h"]),

--- a/third_party/openssl/linux.BUILD
+++ b/third_party/openssl/linux.BUILD
@@ -1,12 +1,14 @@
 
 cc_import(
     name = "ssl",
-    hdrs = glob(["include/**/*"]),
+    hdrs = glob(["include/openssl/**/*.h"]),
     shared_library = "lib/x86_64-linux-gnu/libssl.so",
+    visibility = ["//visibility:public"],
 )
 
 cc_import(
     name = "crypto",
-    hdrs = glob(["include/**/*"]),
+    hdrs = glob(["include/openssl/**/*.h"]),
     shared_library = "lib/x86_64-linux-gnu/libcrypto.so",
+    visibility = ["//visibility:public"],
 )

--- a/third_party/openssl/linux.BUILD
+++ b/third_party/openssl/linux.BUILD
@@ -1,4 +1,3 @@
-
 cc_import(
     name = "ssl",
     hdrs = glob(["include/openssl/**/*.h"]),

--- a/third_party/openssl/linux.BULID
+++ b/third_party/openssl/linux.BULID
@@ -1,0 +1,12 @@
+
+cc_import(
+    name = "ssl",
+    hdrs = glob(["include/**/*"]),
+    shared_library = "lib/x86_64-linux-gnu/libssl.so",
+)
+
+cc_import(
+    name = "crypto",
+    hdrs = glob(["include/**/*"]),
+    shared_library = "lib/x86_64-linux-gnu/libcrypto.so",
+)

--- a/third_party/ruby/ruby.BUILD
+++ b/third_party/ruby/ruby.BUILD
@@ -11,13 +11,13 @@ filegroup(
 build_ruby(
     name = "ruby-dist",
     src = ":source",
-    ssl = select({
-        "@com_stripe_ruby_typer//tools/config:darwin": "@system_ssl_darwin//:ssl",
-        "@com_stripe_ruby_typer//tools/config:linux": "@system_ssl_linux//:ssl",
-    }),
     crypto = select({
         "@com_stripe_ruby_typer//tools/config:darwin": "@system_ssl_darwin//:crypto",
         "@com_stripe_ruby_typer//tools/config:linux": "@system_ssl_linux//:crypto",
+    }),
+    ssl = select({
+        "@com_stripe_ruby_typer//tools/config:darwin": "@system_ssl_darwin//:ssl",
+        "@com_stripe_ruby_typer//tools/config:linux": "@system_ssl_linux//:ssl",
     }),
     visibility = ["//visibility:private"],
 )

--- a/third_party/ruby/ruby.BUILD
+++ b/third_party/ruby/ruby.BUILD
@@ -11,6 +11,14 @@ filegroup(
 build_ruby(
     name = "ruby-dist",
     src = ":source",
+    ssl = select({
+        "@com_stripe_ruby_typer//tools/config:darwin": "@system_ssl_darwin//:ssl",
+        "@com_stripe_ruby_typer//tools/config:linux": "@system_ssl_linux//:ssl",
+    }),
+    crypto = select({
+        "@com_stripe_ruby_typer//tools/config:darwin": "@system_ssl_darwin//:crypto",
+        "@com_stripe_ruby_typer//tools/config:linux": "@system_ssl_linux//:crypto",
+    }),
     visibility = ["//visibility:private"],
 )
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
LInk against the system openssl when building ruby_2_4 and ruby_2_6.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This allows a few more snapshot tests to run.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
Uncommented snapshot tests that rely on native extensions and openssl.