### PR TITLE
Leave behind Symbol when flattening methods

### DIFF
--- a/flattener/flatten.cc
+++ b/flattener/flatten.cc
@@ -118,7 +118,7 @@ public:
         ENFORCE(classes.size() > classStack.back());
         ENFORCE(classes[classStack.back()] == nullptr);
 
-        classDef->rhs = addMethods(ctx, std::move(classDef->rhs));
+        classDef->rhs = addMethodsFromRHS(ctx, std::move(classDef->rhs));
         classes[classStack.back()] = std::move(classDef);
         classStack.pop_back();
         return ast::MK::EmptyTree();
@@ -160,7 +160,7 @@ public:
         return tree;
     }
 
-    unique_ptr<ast::Expression> addMethods(core::Context ctx, unique_ptr<ast::Expression> tree) {
+    unique_ptr<ast::Expression> addMethodsFromTree(core::Context ctx, unique_ptr<ast::Expression> tree) {
         auto &methods = curMethodSet().methods;
         if (methods.empty()) {
             ENFORCE(popCurMethodDefs().empty());
@@ -176,7 +176,7 @@ public:
         if (insSeq == nullptr) {
             ast::InsSeq::STATS_store stats;
             tree = ast::MK::InsSeq(tree->loc, std::move(stats), std::move(tree));
-            return addMethods(ctx, std::move(tree));
+            return addMethodsFromTree(ctx, std::move(tree));
         }
 
         for (auto &method : popCurMethodDefs()) {
@@ -194,7 +194,7 @@ private:
         return ret;
     }
 
-    ast::ClassDef::RHS_store addMethods(core::Context ctx, ast::ClassDef::RHS_store rhs) {
+    ast::ClassDef::RHS_store addMethodsFromRHS(core::Context ctx, ast::ClassDef::RHS_store rhs) {
         if (curMethodSet().methods.size() == 1 && rhs.size() == 1 &&
             (ast::cast_tree<ast::EmptyTree>(rhs[0].get()) != nullptr)) {
             // It was only 1 method to begin with, put it back
@@ -253,7 +253,7 @@ ast::ParsedFile runOne(core::Context ctx, ast::ParsedFile tree) {
     FlattenWalk flatten;
     tree.tree = ast::TreeMap::apply(ctx, flatten, std::move(tree.tree));
     tree.tree = flatten.addClasses(ctx, std::move(tree.tree));
-    tree.tree = flatten.addMethods(ctx, std::move(tree.tree));
+    tree.tree = flatten.addMethodsFromTree(ctx, std::move(tree.tree));
 
     return tree;
 }

--- a/flattener/flatten.cc
+++ b/flattener/flatten.cc
@@ -130,9 +130,11 @@ public:
         ENFORCE(methods.methods.size() > methods.stack.back());
         ENFORCE(methods.methods[methods.stack.back()] == nullptr);
 
+        auto loc = methodDef->loc;
+        auto name = methodDef->name;
         methods.methods[methods.stack.back()] = std::move(methodDef);
         methods.stack.pop_back();
-        return ast::MK::EmptyTree();
+        return ast::MK::Symbol(loc, name);
     };
 
     unique_ptr<ast::Expression> addClasses(core::Context ctx, unique_ptr<ast::Expression> tree) {

--- a/test/testdata/infer/flatten_methods.rb
+++ b/test/testdata/infer/flatten_methods.rb
@@ -1,0 +1,20 @@
+# typed: true
+
+class Parent
+  extend T::Sig
+  sig {params(x: Integer).void}
+  def self.takes_integer_static(x); end
+
+  sig {params(x: Integer).void}
+  def takes_integer_instance(x); end
+end
+
+class Child < Parent
+  takes_integer_static def self.outer_static # error: Expected `Integer` but found `Symbol(:"outer_static")` for argument `x`
+    takes_integer_static def self.inner_static; end # error: Expected `Integer` but found `Symbol(:"inner_static")` for argument `x`
+  end
+
+  takes_integer_static def outer_instance # error: Expected `Integer` but found `Symbol(:"outer_instance")` for argument `x`
+    takes_integer_instance def inner_instance; end # error: Expected `Integer` but found `Symbol(:"inner_instance")` for argument `x`
+  end
+end

--- a/test/testdata/infer/flatten_methods.rb.flatten-tree.exp
+++ b/test/testdata/infer/flatten_methods.rb.flatten-tree.exp
@@ -1,0 +1,83 @@
+begin
+  <emptyTree>
+  class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
+    def self.<static-init><<static-init>$CENSORED>(<blk>)
+      begin
+        begin
+          <emptyTree>
+          ::Sorbet::Private::Static.keep_for_ide(::Parent)
+          <emptyTree>
+        end
+        begin
+          <emptyTree>
+          ::Sorbet::Private::Static.keep_for_ide(::Child)
+          ::Sorbet::Private::Static.keep_for_ide(::Parent)
+          <emptyTree>
+        end
+        <emptyTree>
+      end
+    end
+  end
+  class ::Parent<<C Parent>> < (::<todo sym>)
+    :"takes_integer_static"
+
+    :"takes_integer_instance"
+
+    :"<static-init>"
+
+    def self.takes_integer_static(x, <blk>)
+      <emptyTree>
+    end
+
+    def takes_integer_instance(x, <blk>)
+      <emptyTree>
+    end
+
+    def self.<static-init>(<blk>)
+      begin
+        <self>.extend(::T::Sig)
+        <self>.sig() do ||
+          <self>.params({:"x" => ::Integer}).void()
+        end
+        <self>.sig() do ||
+          <self>.params({:"x" => ::Integer}).void()
+        end
+        <emptyTree>
+      end
+    end
+  end
+  class ::Child<<C Child>> < (::Parent)
+    :"inner_static"
+
+    :"inner_instance"
+
+    :"<static-init>"
+
+    def self.inner_static(<blk>)
+      <emptyTree>
+    end
+
+    def inner_instance(<blk>)
+      <emptyTree>
+    end
+
+    def self.<static-init>(<blk>)
+      begin
+        <self>.takes_integer_static(:"outer_static")
+        <self>.takes_integer_static(:"outer_instance")
+        <emptyTree>
+      end
+    end
+
+    def self.outer_static(<blk>)
+      <self>.takes_integer_static(:"inner_static")
+    end
+
+    def outer_instance(<blk>)
+      <self>.takes_integer_instance(:"inner_instance")
+    end
+  end
+  <emptyTree>
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

A method definition evaluates to a Symbol corresponding to it's name. We should
model this more accurately.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.