### PR TITLE
Swap this_file & decl_file in sealed_violation_whitelist

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/sealed.rb
+++ b/gems/sorbet-runtime/lib/types/private/sealed.rb
@@ -55,7 +55,7 @@ module T::Private::Sealed
 
     if !this_file.start_with?(decl_file)
       whitelist = T::Configuration.sealed_violation_whitelist
-      if whitelist != nil && whitelist.any? {|pattern| decl_file =~ pattern}
+      if whitelist != nil && whitelist.any? {|pattern| this_file =~ pattern}
         return
       end
 

--- a/gems/sorbet-runtime/test/types/fixtures/sealed_module/whitelist_violation__1.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/sealed_module/whitelist_violation__1.rb
@@ -1,5 +1,5 @@
 module Opus::Types::Test::SealedModuleSandbox
-  T::Configuration.sealed_violation_whitelist = [/whitelist_violation__1\.rb/]
+  T::Configuration.sealed_violation_whitelist = [/whitelist_violation__2\.rb/]
 
   class SealedParent
     extend T::Helpers


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The whole point of this regex was to be able to opt entire swaths of a
project (like, various folders) into skipping the sealed definition
checks. For that purpose, it was implemented backwards... whoops.

The bug was masked by the fact that I also swapped the regex in the test
I wrote.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.