### PR TITLE
Revert "Small T::Props API simplifications (#2485)"

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -33,6 +33,15 @@ class T::Props::Decorator
   sig {returns(T::Hash[Symbol, Rules]).checked(:never)}
   attr_reader :props
 
+  # Try to avoid using this; post-definition mutation of prop rules is
+  # surprising and hard to reason about.
+  sig {params(prop: Symbol, key: Symbol, value: T.untyped).void}
+  def mutate_prop_backdoor!(prop, key, value)
+    @props = props.merge(
+      prop => props.fetch(prop).merge(key => value).freeze
+    ).freeze
+  end
+
   sig {returns(T::Array[Symbol])}
   def all_props; props.keys; end
 

--- a/gems/sorbet-runtime/lib/types/props/optional.rb
+++ b/gems/sorbet-runtime/lib/types/props/optional.rb
@@ -34,6 +34,13 @@ module T::Props::Optional::DecoratorMethods
 
   def prop_optional?(prop); prop_rules(prop)[:fully_optional]; end
 
+  def mutate_prop_backdoor!(prop, key, value)
+    rules = props.fetch(prop)
+    rules = rules.merge(key => value)
+    compute_derived_rules(rules)
+    @props = props.merge(prop => rules.freeze).freeze
+  end
+
   def compute_derived_rules(rules)
     rules[:fully_optional] = !T::Props::Utils.need_nil_write_check?(rules)
     rules[:need_nil_read_check] = T::Props::Utils.need_nil_read_check?(rules)

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -114,25 +114,6 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     end
   end
 
-  describe 'extra_props' do
-    it 'are set by from_hash' do
-      m = MySerializable.from_hash({'not_a_prop' => 1})
-      assert_equal({'not_a_prop' => 1}, m.class.decorator.extra_props(m))
-    end
-
-    it 'round trip to serialize' do
-      m = MySerializable.from_hash({'not_a_prop' => 1})
-      assert_equal({'not_a_prop' => 1}, m.serialize)
-    end
-
-    it 'produce error with from_hash!' do
-      e = assert_raises(RuntimeError) do
-        MySerializable.from_hash!({'not_a_prop' => 1})
-      end
-      assert_match(/Unknown properties.*not_a_prop/, e.message)
-    end
-  end
-
   describe 'hash props' do
     it 'does not share structure on serialize' do
       m = MySerializable.new

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -102,6 +102,7 @@ module T::Props::Optional::DecoratorMethods
   def compute_derived_rules(rules); end
   def get_default(rules, instance_class); end
   def has_default?(rules); end
+  def mutate_prop_backdoor!(prop, key, value); end
   def prop_optional?(prop); end
   def prop_validate_definition!(name, cls, rules, type); end
   def valid_rule_key?(key); end


### PR DESCRIPTION
This reverts commit 35f56220ddc189f92fd284768c6fb85a019c8e35.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This change was causing a bunch of test failures when we tried to bump
sorbet-runtime in pay-server. We'll need to fix pay-server before we can
un-revert this change.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a

http://go/builds/bui_Gcw6Ow9KkT4ale