### PR TITLE
Revert "Stop supporting non-props with `T::Props::Decorator#get`"

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -91,6 +91,25 @@ class T::Props::Decorator
 
   # Accessors
 
+  # For performance, don't use named params here.
+  # Passing in rules here is purely a performance optimization.
+  #
+  # checked(:never) - O(prop accesses)
+  sig do
+    params(
+      instance: DecoratedInstance,
+      prop: T.any(String, Symbol),
+      rules: T.nilable(Rules)
+    )
+    .returns(T.untyped)
+    .checked(:never)
+  end
+  def get(instance, prop, rules=props[prop.to_sym])
+    # For backwards compatibility, fall back to reconstructing the accessor key
+    # (though it would probably make more sense to raise in that case).
+    instance.instance_variable_get(rules ? rules[:accessor_key] : '@' + prop.to_s) # rubocop:disable PrisonGuard/NoLurkyInstanceVariableAccess
+  end
+
   # Use this to validate that a value will validate for a given prop. Useful for knowing whether a value can be set on a model without setting it.
   #
   # checked(:never) - potentially O(prop accesses) depending on usage pattern
@@ -138,37 +157,26 @@ class T::Props::Decorator
     params(
       instance: DecoratedInstance,
       prop: T.any(String, Symbol),
-      rules: Rules
+      rules: T.nilable(Rules)
     )
     .returns(T.untyped)
     .checked(:never)
   end
-  def prop_get(instance, prop, rules=prop_rules(prop))
-    val = instance.instance_variable_get(rules[:accessor_key])
+  def prop_get(instance, prop, rules=props[prop.to_sym])
+    val = get(instance, prop, rules)
+
     if !val.nil?
       val
     else
-      if (d = rules[:ifunset])
+      raise NoRulesError.new if !rules
+      d = rules[:ifunset]
+      if d
         T::Props::Utils.deep_clone_object(d)
       else
         nil
       end
     end
   end
-
-  sig do
-    params(
-      instance: DecoratedInstance,
-      prop: T.any(String, Symbol),
-      rules: Rules
-    )
-    .returns(T.untyped)
-    .checked(:never)
-  end
-  def prop_get_if_set(instance, prop, rules=prop_rules(prop))
-    instance.instance_variable_get(rules[:accessor_key])
-  end
-  alias_method :get, :prop_get_if_set # Alias for backwards compatibility
 
   # checked(:never) - O(prop accesses)
   sig do

--- a/gems/sorbet-runtime/test/types/props/_props.rb
+++ b/gems/sorbet-runtime/test/types/props/_props.rb
@@ -140,26 +140,6 @@ class Opus::Types::Test::Props::PropsTest < Critic::Unit::UnitTest
     end
   end
 
-  describe 'ifunset' do
-    before do
-      @doc = SubProps.new
-    end
-
-    it 'is used by getter' do
-      assert_equal(42, @doc.prop2)
-    end
-
-    it 'is used by decorator#prop_get' do
-      assert_equal(42, @doc.class.decorator.prop_get(@doc, :prop2))
-    end
-
-    # This distinction seems subtle and, given that it has no relationship
-    # to the method names, pretty confusing. But code relies on it.
-    it 'is not used by decorator#get' do
-      assert_nil(@doc.class.decorator.get(@doc, :prop2))
-    end
-  end
-
   class TestRedactedProps
     include T::Props
 

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -52,13 +52,13 @@ class T::Props::Decorator
   def all_props; end
   def decorated_class; end
   def foreign_prop_get(instance, prop, foreign_class, rules = {}, opts = {}); end
+  def get(instance, prop, rules = {}); end
   def initialize(klass); end
+  def is_nilable?(*args, &blk); end
   def model_inherited(child); end
   def plugin(mod); end
   def prop_defined(name, cls, rules = {}); end
   def prop_get(instance, prop, rules = {}); end
-  def prop_get_if_set(instance, prop, rules = {}); end
-  alias_method :get, :prop_get_if_set
   def prop_rules(prop); end
   def prop_set(instance, prop, value, rules = {}); end
   alias_method :set, :prop_set


### PR DESCRIPTION
Reverts sorbet/sorbet#2494

Tests failed on master.

cc @djudd-stripe 