### PR TITLE
Allow autogen to include modules in subclasses output

### DIFF
--- a/main/autogen/subclasses.cc
+++ b/main/autogen/subclasses.cc
@@ -116,10 +116,11 @@ vector<string> Subclasses::serializeSubclassMap(const Subclasses::Map &descendan
         vector<string> serializedChildren;
         for (const auto &[name, type] : children.entries) {
             // Ignore Modules
-            if (type != autogen::Definition::Type::Class) {
-                continue;
+            if (type == autogen::Definition::Type::Class) {
+                serializedChildren.emplace_back(fmt::format(" class {}", name));
+            } else {
+                serializedChildren.emplace_back(fmt::format(" module {}", name));
             }
-            serializedChildren.emplace_back(fmt::format(" {}", name));
         }
 
         fast_sort(serializedChildren);

--- a/test/cli/autogen-subclasses-ignore/autogen-subclasses-ignore.out
+++ b/test/cli/autogen-subclasses-ignore/autogen-subclasses-ignore.out
@@ -2,4 +2,4 @@
 
 --- autogen-subclasses-ignore-relative ---
 class Opus::Parent
- Opus::Child
+ class Opus::Child

--- a/test/cli/autogen-subclasses/autogen-subclasses.out
+++ b/test/cli/autogen-subclasses/autogen-subclasses.out
@@ -1,7 +1,8 @@
 --- autogen-subclasses ---
 module Opus::Mixin
- Opus::Mixed
- Opus::MixedDescendant
+ class Opus::Mixed
+ class Opus::MixedDescendant
+ module Opus::MixedModule
 class Opus::Parent
- Opus::Child
- Opus::DupChild
+ class Opus::Child
+ class Opus::DupChild


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
A request from ruby-infra: there are some places where it'd be nice to list modules that include a given module, as well. This modifies the `subclasses` output to not omit modules, but also to indicate them: this allows us to retain the old behavior by only looking for children prefixed with `class`, but also gives us information on `module`s we can use as well.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
