### PR TITLE
Dmitry's theory: we use database to store _two_ modes, autogen and normal typechech run.

### DIFF
--- a/common/kvstore/BUILD
+++ b/common/kvstore/BUILD
@@ -1,14 +1,9 @@
 cc_library(
     name = "kvstore",
-    srcs = glob(
-        [
-            "*.cc",
-            "*.h",
-        ],
-
-        # workaround https://github.com/flycheck/flycheck/issues/248 in emacs
-        exclude = ["flycheck_*"],
-    ),
+    srcs = select({
+        "//tools/config:webasm": ["KeyValueStore-emscripten.cc"],
+        "//conditions:default": ["KeyValueStore.cc"],
+    }),
     hdrs = [
         "KeyValueStore.h",
     ],
@@ -25,6 +20,8 @@ cc_library(
         "//common",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
-        "@lmdb",
-    ],
+    ] + select({
+        "//tools/config:webasm": [],
+        "//conditions:default": ["@lmdb"],
+    }),
 )

--- a/common/kvstore/KeyValueStore-emscripten.cc
+++ b/common/kvstore/KeyValueStore-emscripten.cc
@@ -4,8 +4,7 @@
 
 using namespace std;
 namespace sorbet {
-struct KeyValueStore::DBState {
-};
+struct KeyValueStore::DBState {};
 
 [[noreturn]] static void throw_mdb_error(string_view what, int err) {
     fmt::print(stderr, "mdb error: {}: {}\n", what, "");
@@ -18,34 +17,34 @@ KeyValueStore::KeyValueStore(string version, string path, string flavor)
 }
 KeyValueStore::~KeyValueStore() noexcept(false) {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
-   }
+}
 
 void KeyValueStore::write(string_view key, const vector<u1> &value) {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
-   }
+}
 
 u1 *KeyValueStore::read(string_view key) {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
-    }
+}
 
 void KeyValueStore::clear() {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
-    }
+}
 
 string_view KeyValueStore::readString(string_view key) {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
-    }
+}
 
 void KeyValueStore::writeString(string_view key, string_view value) {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
-    }
+}
 
 void KeyValueStore::refreshMainTransaction() {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
-    }
+}
 
 bool KeyValueStore::commit(unique_ptr<KeyValueStore> k) {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
-   }
+}
 
 } // namespace sorbet

--- a/common/kvstore/KeyValueStore-emscripten.cc
+++ b/common/kvstore/KeyValueStore-emscripten.cc
@@ -1,0 +1,51 @@
+#include "common/kvstore/KeyValueStore.h"
+
+#include <utility>
+
+using namespace std;
+namespace sorbet {
+struct KeyValueStore::DBState {
+};
+
+[[noreturn]] static void throw_mdb_error(string_view what, int err) {
+    fmt::print(stderr, "mdb error: {}: {}\n", what, "");
+    throw invalid_argument(string(what));
+}
+
+KeyValueStore::KeyValueStore(string version, string path, string flavor)
+    : path(move(path)), flavor(move(flavor)), writerId(this_thread::get_id()), dbState(make_unique<DBState>()) {
+    throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
+}
+KeyValueStore::~KeyValueStore() noexcept(false) {
+    throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
+   }
+
+void KeyValueStore::write(string_view key, const vector<u1> &value) {
+    throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
+   }
+
+u1 *KeyValueStore::read(string_view key) {
+    throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
+    }
+
+void KeyValueStore::clear() {
+    throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
+    }
+
+string_view KeyValueStore::readString(string_view key) {
+    throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
+    }
+
+void KeyValueStore::writeString(string_view key, string_view value) {
+    throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
+    }
+
+void KeyValueStore::refreshMainTransaction() {
+    throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
+    }
+
+bool KeyValueStore::commit(unique_ptr<KeyValueStore> k) {
+    throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
+   }
+
+} // namespace sorbet

--- a/common/kvstore/KeyValueStore.cc
+++ b/common/kvstore/KeyValueStore.cc
@@ -7,7 +7,7 @@ namespace sorbet {
 constexpr string_view OLD_VERSION_KEY = "VERSION"sv;
 constexpr string_view VERSION_KEY = "DB_FORMAT_VERSION"sv;
 constexpr size_t MAX_DB_SIZE_BYTES =
-    1L * 1024 * 1024 * 1024; // 1G. This is both maximum fs db size and max virtual memory usage.
+    2L * 1024 * 1024 * 1024; // 2G. This is both maximum fs db size and max virtual memory usage.
 
 static void throw_mdb_error(string_view what, int err) {
     fmt::print(stderr, "mdb error: {}: {}\n", what, mdb_strerror(err));

--- a/common/kvstore/KeyValueStore.cc
+++ b/common/kvstore/KeyValueStore.cc
@@ -1,4 +1,5 @@
 #include "common/kvstore/KeyValueStore.h"
+#include "lmdb.h"
 
 #include <utility>
 
@@ -8,6 +9,12 @@ constexpr string_view OLD_VERSION_KEY = "VERSION"sv;
 constexpr string_view VERSION_KEY = "DB_FORMAT_VERSION"sv;
 constexpr size_t MAX_DB_SIZE_BYTES =
     2L * 1024 * 1024 * 1024; // 2G. This is both maximum fs db size and max virtual memory usage.
+struct KeyValueStore::DBState {
+    MDB_env *env;
+    MDB_dbi dbi;
+    MDB_txn *txn;
+    UnorderedMap<std::thread::id, MDB_txn *> readers;
+};
 
 static void throw_mdb_error(string_view what, int err) {
     fmt::print(stderr, "mdb error: {}: {}\n", what, mdb_strerror(err));
@@ -15,21 +22,21 @@ static void throw_mdb_error(string_view what, int err) {
 }
 
 KeyValueStore::KeyValueStore(string version, string path, string flavor)
-    : path(move(path)), flavor(move(flavor)), writerId(this_thread::get_id()) {
+    : path(move(path)), flavor(move(flavor)), writerId(this_thread::get_id()), dbState(make_unique<DBState>()) {
     int rc;
-    rc = mdb_env_create(&env);
+    rc = mdb_env_create(&dbState->env);
     if (rc != 0) {
         goto fail;
     }
-    rc = mdb_env_set_mapsize(env, MAX_DB_SIZE_BYTES);
+    rc = mdb_env_set_mapsize(dbState->env, MAX_DB_SIZE_BYTES);
     if (rc != 0) {
         goto fail;
     }
-    rc = mdb_env_set_maxdbs(env, 3);
+    rc = mdb_env_set_maxdbs(dbState->env, 3);
     if (rc != 0) {
         goto fail;
     }
-    rc = mdb_env_open(env, this->path.c_str(), 0, 0664);
+    rc = mdb_env_open(dbState->env, this->path.c_str(), 0, 0664);
     if (rc != 0) {
         goto fail;
     }
@@ -53,9 +60,9 @@ KeyValueStore::~KeyValueStore() noexcept(false) {
         return;
     }
 
-    mdb_txn_abort(txn);
-    mdb_close(env, dbi);
-    mdb_env_close(env);
+    mdb_txn_abort(dbState->txn);
+    mdb_close(dbState->env, dbState->dbi);
+    mdb_env_close(dbState->env);
 }
 
 void KeyValueStore::write(string_view key, const vector<u1> &value) {
@@ -70,7 +77,7 @@ void KeyValueStore::write(string_view key, const vector<u1> &value) {
     dv.mv_data = (void *)value.data();
 
     int rc;
-    rc = mdb_put(txn, dbi, &kv, &dv, 0);
+    rc = mdb_put(dbState->txn, dbState->dbi, &kv, &dv, 0);
     if (rc != 0) {
         throw_mdb_error("failed write into database"sv, rc);
     }
@@ -81,17 +88,17 @@ u1 *KeyValueStore::read(string_view key) {
     int rc = 0;
     {
         absl::ReaderMutexLock lk(&readers_mtx);
-        auto fnd = readers.find(this_thread::get_id());
-        if (fnd != readers.end()) {
+        auto fnd = dbState->readers.find(this_thread::get_id());
+        if (fnd != dbState->readers.end()) {
             txn = fnd->second;
             ENFORCE(txn != nullptr);
         }
     }
     if (txn == nullptr) {
         absl::WriterMutexLock lk(&readers_mtx);
-        auto &txn_store = readers[this_thread::get_id()];
+        auto &txn_store = dbState->readers[this_thread::get_id()];
         ENFORCE(txn_store == nullptr);
-        rc = mdb_txn_begin(env, nullptr, MDB_RDONLY, &txn_store);
+        rc = mdb_txn_begin(dbState->env, nullptr, MDB_RDONLY, &txn_store);
         txn = txn_store;
     }
     if (rc != 0) {
@@ -102,7 +109,7 @@ u1 *KeyValueStore::read(string_view key) {
     kv.mv_size = key.size();
     kv.mv_data = (void *)key.data();
     MDB_val data;
-    rc = mdb_get(txn, dbi, &kv, &data);
+    rc = mdb_get(txn, dbState->dbi, &kv, &data);
     if (rc != 0) {
         if (rc == MDB_NOTFOUND) {
             return nullptr;
@@ -116,11 +123,11 @@ void KeyValueStore::clear() {
     if (writerId != this_thread::get_id()) {
         throw_mdb_error("KeyValueStore can only write from thread that created it"sv, 0);
     }
-    int rc = mdb_drop(txn, dbi, 0);
+    int rc = mdb_drop(dbState->txn, dbState->dbi, 0);
     if (rc != 0) {
         goto fail;
     }
-    rc = mdb_txn_commit(txn);
+    rc = mdb_txn_commit(dbState->txn);
     if (rc != 0) {
         goto fail;
     }
@@ -153,11 +160,11 @@ void KeyValueStore::refreshMainTransaction() {
     if (writerId != this_thread::get_id()) {
         throw_mdb_error("KeyValueStore can only write from thread that created it"sv, 0);
     }
-    auto rc = mdb_txn_begin(env, nullptr, 0, &txn);
+    auto rc = mdb_txn_begin(dbState->env, nullptr, 0, &dbState->txn);
     if (rc != 0) {
         goto fail;
     }
-    rc = mdb_dbi_open(txn, flavor.c_str(), MDB_CREATE, &dbi);
+    rc = mdb_dbi_open(dbState->txn, flavor.c_str(), MDB_CREATE, &dbState->dbi);
     if (rc != 0) {
         goto fail;
     }
@@ -173,17 +180,17 @@ void KeyValueStore::refreshMainTransaction() {
     // So we commit immediately to force the dbi into the shared space
     // so that readers can use it, and then re-open the transaction
     // for future writes.
-    rc = mdb_txn_commit(txn);
+    rc = mdb_txn_commit(dbState->txn);
     if (rc != 0) {
         goto fail;
     }
-    rc = mdb_txn_begin(env, nullptr, 0, &txn);
+    rc = mdb_txn_begin(dbState->env, nullptr, 0, &dbState->txn);
     if (rc != 0) {
         goto fail;
     }
     {
         absl::WriterMutexLock lk(&readers_mtx);
-        readers[writerId] = txn;
+        dbState->readers[writerId] = dbState->txn;
     }
     return;
 fail:
@@ -193,13 +200,13 @@ fail:
 bool KeyValueStore::commit(unique_ptr<KeyValueStore> k) {
     int rc;
     k->commited = true;
-    rc = mdb_txn_commit(k->txn);
+    rc = mdb_txn_commit(k->dbState->txn);
 
     if (rc != 0) {
         return false;
     }
-    mdb_close(k->env, k->dbi);
-    mdb_env_close(k->env);
+    mdb_close(k->dbState->env, k->dbState->dbi);
+    mdb_env_close(k->dbState->env);
     return true;
 }
 

--- a/common/kvstore/KeyValueStore.h
+++ b/common/kvstore/KeyValueStore.h
@@ -2,7 +2,6 @@
 #define SORBET_KEYVALUESTORE_H
 #include "absl/synchronization/mutex.h"
 #include "common/common.h"
-#include "lmdb.h"
 #include <thread>
 namespace sorbet {
 
@@ -12,13 +11,11 @@ namespace sorbet {
  * Creating KeyValueStore grabs a lock and allows to have consistent view over database.
  */
 class KeyValueStore {
-    MDB_env *env;
-    MDB_dbi dbi;
-    MDB_txn *txn;
     const std::string path;
     const std::string flavor;
     const std::thread::id writerId;
-    UnorderedMap<std::thread::id, MDB_txn *> readers;
+    struct DBState;
+    std::unique_ptr<DBState> dbState;
     absl::Mutex readers_mtx;
     bool commited = false;
 


### PR DESCRIPTION
…

The global state isn't yet big enough to hit the 1G compressed limit, but _two_ of them could be hitting it very close.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
