### PR TITLE
Rename addMethods in flatten to avoid overload

### DIFF
--- a/flattener/flatten.cc
+++ b/flattener/flatten.cc
@@ -118,7 +118,7 @@ public:
         ENFORCE(classes.size() > classStack.back());
         ENFORCE(classes[classStack.back()] == nullptr);
 
-        classDef->rhs = addMethods(ctx, std::move(classDef->rhs));
+        classDef->rhs = addMethodsFromRHS(ctx, std::move(classDef->rhs));
         classes[classStack.back()] = std::move(classDef);
         classStack.pop_back();
         return ast::MK::EmptyTree();
@@ -160,7 +160,7 @@ public:
         return tree;
     }
 
-    unique_ptr<ast::Expression> addMethods(core::Context ctx, unique_ptr<ast::Expression> tree) {
+    unique_ptr<ast::Expression> addMethodsFromTree(core::Context ctx, unique_ptr<ast::Expression> tree) {
         auto &methods = curMethodSet().methods;
         if (methods.empty()) {
             ENFORCE(popCurMethodDefs().empty());
@@ -176,7 +176,7 @@ public:
         if (insSeq == nullptr) {
             ast::InsSeq::STATS_store stats;
             tree = ast::MK::InsSeq(tree->loc, std::move(stats), std::move(tree));
-            return addMethods(ctx, std::move(tree));
+            return addMethodsFromTree(ctx, std::move(tree));
         }
 
         for (auto &method : popCurMethodDefs()) {
@@ -194,7 +194,7 @@ private:
         return ret;
     }
 
-    ast::ClassDef::RHS_store addMethods(core::Context ctx, ast::ClassDef::RHS_store rhs) {
+    ast::ClassDef::RHS_store addMethodsFromRHS(core::Context ctx, ast::ClassDef::RHS_store rhs) {
         if (curMethodSet().methods.size() == 1 && rhs.size() == 1 &&
             (ast::cast_tree<ast::EmptyTree>(rhs[0].get()) != nullptr)) {
             // It was only 1 method to begin with, put it back
@@ -253,7 +253,7 @@ ast::ParsedFile runOne(core::Context ctx, ast::ParsedFile tree) {
     FlattenWalk flatten;
     tree.tree = ast::TreeMap::apply(ctx, flatten, std::move(tree.tree));
     tree.tree = flatten.addClasses(ctx, std::move(tree.tree));
-    tree.tree = flatten.addMethods(ctx, std::move(tree.tree));
+    tree.tree = flatten.addMethodsFromTree(ctx, std::move(tree.tree));
 
     return tree;
 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When I was first reading this, I was really confused, because we're overloading
this method, and one of them is public and one of them is private. They're
nominally doing similar things, but each takes a different argument, and I'd
rather just have unique names.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.