### PR TITLE
Stop supporting non-props with T::Props::Decorator#get, take 2

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -344,7 +344,7 @@ module T::Props::Serializable::DecoratorMethods
   private_constant :EMPTY_EXTRA_PROPS
 
   def extra_props(instance)
-    get(instance, '_extra_props') || EMPTY_EXTRA_PROPS
+    instance.instance_variable_get(:@_extra_props) || EMPTY_EXTRA_PROPS
   end
 
   # @override T::Props::PrettyPrintable

--- a/gems/sorbet-runtime/test/types/props/_props.rb
+++ b/gems/sorbet-runtime/test/types/props/_props.rb
@@ -140,6 +140,26 @@ class Opus::Types::Test::Props::PropsTest < Critic::Unit::UnitTest
     end
   end
 
+  describe 'ifunset' do
+    before do
+      @doc = SubProps.new
+    end
+
+    it 'is used by getter' do
+      assert_equal(42, @doc.prop2)
+    end
+
+    it 'is used by decorator#prop_get' do
+      assert_equal(42, @doc.class.decorator.prop_get(@doc, :prop2))
+    end
+
+    # This distinction seems subtle and, given that it has no relationship
+    # to the method names, pretty confusing. But code relies on it.
+    it 'is not used by decorator#get' do
+      assert_nil(@doc.class.decorator.get(@doc, :prop2))
+    end
+  end
+
   class TestRedactedProps
     include T::Props
 

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -52,13 +52,13 @@ class T::Props::Decorator
   def all_props; end
   def decorated_class; end
   def foreign_prop_get(instance, prop, foreign_class, rules = {}, opts = {}); end
-  def get(instance, prop, rules = {}); end
   def initialize(klass); end
-  def is_nilable?(*args, &blk); end
   def model_inherited(child); end
   def plugin(mod); end
   def prop_defined(name, cls, rules = {}); end
   def prop_get(instance, prop, rules = {}); end
+  def prop_get_if_set(instance, prop, rules = {}); end
+  alias_method :get, :prop_get_if_set
   def prop_rules(prop); end
   def prop_set(instance, prop, value, rules = {}); end
   alias_method :set, :prop_set


### PR DESCRIPTION
### Motivation
Same as https://github.com/sorbet/sorbet/pull/2494 but with fix for a merge conflict

### Test plan
Passing build + pay-server build where the only failure comes from a disallowed gem source: https://git.corp.stripe.com/stripe-internal/pay-server/compare/djudd/nonprops-get-take-2