### PR TITLE
Remove mutate_prop_backdoor, take 2

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -33,15 +33,6 @@ class T::Props::Decorator
   sig {returns(T::Hash[Symbol, Rules]).checked(:never)}
   attr_reader :props
 
-  # Try to avoid using this; post-definition mutation of prop rules is
-  # surprising and hard to reason about.
-  sig {params(prop: Symbol, key: Symbol, value: T.untyped).void}
-  def mutate_prop_backdoor!(prop, key, value)
-    @props = props.merge(
-      prop => props.fetch(prop).merge(key => value).freeze
-    ).freeze
-  end
-
   sig {returns(T::Array[Symbol])}
   def all_props; props.keys; end
 

--- a/gems/sorbet-runtime/lib/types/props/optional.rb
+++ b/gems/sorbet-runtime/lib/types/props/optional.rb
@@ -34,13 +34,6 @@ module T::Props::Optional::DecoratorMethods
 
   def prop_optional?(prop); prop_rules(prop)[:fully_optional]; end
 
-  def mutate_prop_backdoor!(prop, key, value)
-    rules = props.fetch(prop)
-    rules = rules.merge(key => value)
-    compute_derived_rules(rules)
-    @props = props.merge(prop => rules.freeze).freeze
-  end
-
   def compute_derived_rules(rules)
     rules[:fully_optional] = !T::Props::Utils.need_nil_write_check?(rules)
     rules[:need_nil_read_check] = T::Props::Utils.need_nil_read_check?(rules)

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -102,7 +102,6 @@ module T::Props::Optional::DecoratorMethods
   def compute_derived_rules(rules); end
   def get_default(rules, instance_class); end
   def has_default?(rules); end
-  def mutate_prop_backdoor!(prop, key, value); end
   def prop_optional?(prop); end
   def prop_validate_definition!(name, cls, rules, type); end
   def valid_rule_key?(key); end


### PR DESCRIPTION
### Motivation
Low risk part of the change that was reverted in https://github.com/sorbet/sorbet/pull/2550

The signature change to `from_hash` broke due to incompatible changes in pay-server, so that'll require more work to retry

### Test plan
Passing build plus grepped to verify that mutate_prop_backdoor is still unused in pay-server