### PR TITLE
Fix `Date#-`

### DIFF
--- a/rbi/stdlib/date.rbi
+++ b/rbi/stdlib/date.rbi
@@ -368,8 +368,8 @@ class Date
   # DateTime.new(2001,2,3) - DateTime.new(2001,2,2,12)
   #                          #=> (1/2)
   # ```
-  sig {params(arg0: Date).returns(Rational)}
-  sig {params(arg0: Numeric).returns(Date)}
+  sig {params(arg0: Numeric).returns(T.self_type)}
+  sig {params(arg0: T.self_type).returns(Rational)}
   def -(arg0); end
 
   # Returns the day of the month (1-31).

--- a/test/testdata/rbi/date.rb
+++ b/test/testdata/rbi/date.rb
@@ -4,3 +4,19 @@ require "date"
 
 T.assert_type!(Date.today, Date)
 T.assert_type!(Date.today + 1, Date)
+
+class Test
+  extend T::Sig
+
+  sig {params(x: Date).void}
+  def test_date(x)
+    T.reveal_type(x -  x) # error: Revealed type: `Rational`
+    T.reveal_type(x - 10) # error: Revealed type: `Date`
+  end
+
+  sig {params(x: DateTime).void}
+  def test_datetime(x)
+    T.reveal_type(x - x) # error: Revealed type: `Rational`
+    T.reveal_type(x - 10) # error: Revealed type: `DateTime`
+  end
+end


### PR DESCRIPTION
As DateTime inherits from Date, this method needs to use `T.self_type` in place of `Date`.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The previous rbi change raised about 13 errors on the stripe monorepo related to uses of `DateTime#-`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
