### PR TITLE
Don't steal private et al. in namer

### DIFF
--- a/flattener/flatten.cc
+++ b/flattener/flatten.cc
@@ -128,9 +128,11 @@ public:
         ENFORCE(methods.methods.size() > methods.stack.back());
         ENFORCE(methods.methods[methods.stack.back()] == nullptr);
 
+        auto loc = methodDef->declLoc;
+        auto name = methodDef->name;
         methods.methods[methods.stack.back()] = std::move(methodDef);
         methods.stack.pop_back();
-        return ast::MK::EmptyTree();
+        return ast::MK::Symbol(loc, name);
     };
 
     unique_ptr<ast::Expression> addClasses(core::Context ctx, unique_ptr<ast::Expression> tree) {

--- a/main/autogen/subclasses.cc
+++ b/main/autogen/subclasses.cc
@@ -116,10 +116,11 @@ vector<string> Subclasses::serializeSubclassMap(const Subclasses::Map &descendan
         vector<string> serializedChildren;
         for (const auto &[name, type] : children.entries) {
             // Ignore Modules
-            if (type != autogen::Definition::Type::Class) {
-                continue;
+            if (type == autogen::Definition::Type::Class) {
+                serializedChildren.emplace_back(fmt::format(" class {}", name));
+            } else {
+                serializedChildren.emplace_back(fmt::format(" module {}", name));
             }
-            serializedChildren.emplace_back(fmt::format(" {}", name));
         }
 
         fast_sort(serializedChildren);

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -477,9 +477,6 @@ public:
                 default:
                     return original;
             }
-            if (ast::isa_tree<ast::MethodDef>(original->args[0].get())) {
-                return std::move(original->args[0]);
-            }
         }
         return original;
     }

--- a/rbi/stdlib/date.rbi
+++ b/rbi/stdlib/date.rbi
@@ -369,7 +369,7 @@ class Date
   #                          #=> (1/2)
   # ```
   sig {params(arg0: Numeric).returns(T.self_type)}
-  sig {params(arg0: T.self_type).returns(Rational)}
+  sig {params(arg0: Date).returns(Rational)}
   def -(arg0); end
 
   # Returns the day of the month (1-31).

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1551,6 +1551,13 @@ private:
                     lastSigs.emplace_back(send);
                     return;
                 }
+
+                if (send->args.size() == 1 &&
+                    (send->fun == core::Names::public_() || send->fun == core::Names::private_() ||
+                     send->fun == core::Names::privateClassMethod() || send->fun == core::Names::protected_())) {
+                    processStatement(ctx, send->args[0], lastSigs);
+                    return;
+                }
             },
 
             [&](ast::MethodDef *mdef) {

--- a/test/cli/autogen-subclasses-ignore/autogen-subclasses-ignore.out
+++ b/test/cli/autogen-subclasses-ignore/autogen-subclasses-ignore.out
@@ -2,4 +2,4 @@
 
 --- autogen-subclasses-ignore-relative ---
 class Opus::Parent
- Opus::Child
+ class Opus::Child

--- a/test/cli/autogen-subclasses/autogen-subclasses.out
+++ b/test/cli/autogen-subclasses/autogen-subclasses.out
@@ -1,7 +1,8 @@
 --- autogen-subclasses ---
 module Opus::Mixin
- Opus::Mixed
- Opus::MixedDescendant
+ class Opus::Mixed
+ class Opus::MixedDescendant
+ module Opus::MixedModule
 class Opus::Parent
- Opus::Child
- Opus::DupChild
+ class Opus::Child
+ class Opus::DupChild

--- a/test/cli/phases/phases.out
+++ b/test/cli/phases/phases.out
@@ -119,6 +119,8 @@ InsSeq{
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       1
     end
@@ -138,6 +140,8 @@ InsSeq{
           symbol = ::<todo sym>
         }]
       rhs = [
+        Literal{ value = :"<static-init>" }
+
         MethodDef{
           flags = self
           name = <U <static-init>><<N <U <static-init>> $CENSORED>>
@@ -156,6 +160,8 @@ InsSeq{
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       1
     end
@@ -175,6 +181,8 @@ InsSeq{
           symbol = ::<todo sym>
         }]
       rhs = [
+        Literal{ value = :"<static-init>" }
+
         MethodDef{
           flags = self
           name = <U <static-init>><<N <U <static-init>> $CENSORED>>
@@ -253,8 +261,10 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
 
 --- symbol-table-raw end ---
 --- checking diff ---
-1,24d0
-1,9d0
+1,11d0
+1,26d0
+< 
+< 
 <               localVariable = <U <blk>>
 <             }]
 <           args = [Local{
@@ -263,6 +273,7 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
 <           orig = nullptr
 <           rhs = Literal{ value = 1 }
 <           symbol = ::<todo sym>
+<         Literal{ value = :"<static-init>" }
 <         MethodDef{
 <         }
 <         }]
@@ -272,6 +283,7 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
 <       kind = class
 <       name = EmptyTree<<C <U <root>>>>
 <       rhs = [
+<     :"<static-init>"
 <     ClassDef{
 <     EmptyTree
 <     def self.<static-init><<static-init>$CENSORED>(<blk>)

--- a/test/testdata/cfg/block_in_deadcode.rb.cfg.exp
+++ b/test/testdata/cfg/block_in_deadcode.rb.cfg.exp
@@ -6,7 +6,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"foo\") = :\"foo\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"foo\")\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];

--- a/test/testdata/cfg/blocks.rb.cfg.exp
+++ b/test/testdata/cfg/blocks.rb.cfg.exp
@@ -24,7 +24,7 @@ subgraph "cluster_::<Class:BlockTest>#<static-init>" {
     "bb::<Class:BlockTest>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:BlockTest>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(BlockTest) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U BlockTest>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U BlockTest>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(BlockTest) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U BlockTest>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U BlockTest>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"blockPass\") = :\"blockPass\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"blockPass\")\l<unconditional>\l"
     ];
 
     "bb::<Class:BlockTest>#<static-init>_0" -> "bb::<Class:BlockTest>#<static-init>_1" [style="bold"];

--- a/test/testdata/cfg/break_in_junk.rb.cfg.exp
+++ b/test/testdata/cfg/break_in_junk.rb.cfg.exp
@@ -6,7 +6,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"foo\") = :\"foo\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"foo\")\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];

--- a/test/testdata/cfg/dealias_with_return.rb.cfg.exp
+++ b/test/testdata/cfg/dealias_with_return.rb.cfg.exp
@@ -6,7 +6,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"a\") = :\"a\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"a\")\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];

--- a/test/testdata/cfg/examples.rb.flatten-tree.exp
+++ b/test/testdata/cfg/examples.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         <emptyTree>
@@ -10,18 +12,18 @@ begin
     end
   end
   class ::Examples<<C Examples>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
+        :"i_like_ifs"
+        :"i_like_exps"
+        :"return_in_one_branch1"
+        :"return_in_one_branch2"
+        :"variables"
+        :"variables_and_loop"
+        :"variables_loop_if"
+        :"take_arguments"
         <emptyTree>
       end
     end

--- a/test/testdata/cfg/extra_bb_args.rb.cfg.exp
+++ b/test/testdata/cfg/extra_bb_args.rb.cfg.exp
@@ -6,7 +6,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"main\") = :\"main\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"main\")\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];

--- a/test/testdata/cfg/floats.rb.cfg.exp
+++ b/test/testdata/cfg/floats.rb.cfg.exp
@@ -6,7 +6,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"test_large_float\") = :\"test_large_float\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"test_large_float\")\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];

--- a/test/testdata/cfg/next.rb.cfg.exp
+++ b/test/testdata/cfg/next.rb.cfg.exp
@@ -6,7 +6,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"foo\") = :\"foo\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"foo\")\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];

--- a/test/testdata/cfg/next_in_junk.rb.cfg.exp
+++ b/test/testdata/cfg/next_in_junk.rb.cfg.exp
@@ -6,7 +6,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"foo\") = :\"foo\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"foo\")\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];

--- a/test/testdata/cfg/next_in_while.rb.cfg.exp
+++ b/test/testdata/cfg/next_in_while.rb.cfg.exp
@@ -6,7 +6,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"foo\") = :\"foo\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"foo\")\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];

--- a/test/testdata/cfg/rescue_bad_class.rb.flatten-tree.exp
+++ b/test/testdata/cfg/rescue_bad_class.rb.flatten-tree.exp
@@ -1,10 +1,10 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init><<static-init>$CENSORED>(<blk>)
-      <emptyTree>
+      :"foo"
     end
 
     def foo(<blk>)

--- a/test/testdata/cfg/rescue_else_block.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_else_block.rb.cfg.exp
@@ -6,7 +6,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"foo\") = :\"foo\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"foo\")\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];

--- a/test/testdata/cfg/rescue_two_return.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_two_return.rb.cfg.exp
@@ -6,7 +6,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"foo\") = :\"foo\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"foo\")\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];

--- a/test/testdata/cfg/rescue_var_expression.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_var_expression.rb.cfg.exp
@@ -84,7 +84,7 @@ subgraph "cluster_::<Class:MyClass>#<static-init>" {
     "bb::<Class:MyClass>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:MyClass>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(MyClass) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U MyClass>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U MyClass>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(MyClass) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U MyClass>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U MyClass>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"foo=\") = :\"foo=\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"foo=\")\l<unconditional>\l"
     ];
 
     "bb::<Class:MyClass>#<static-init>_0" -> "bb::<Class:MyClass>#<static-init>_1" [style="bold"];

--- a/test/testdata/cfg/rescue_with_return.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_with_return.rb.cfg.exp
@@ -6,7 +6,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"a\") = :\"a\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"a\")\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];

--- a/test/testdata/cfg/side_effects.rb.cfg.exp
+++ b/test/testdata/cfg/side_effects.rb.cfg.exp
@@ -24,7 +24,7 @@ subgraph "cluster_::<Class:Side>#<static-init>" {
     "bb::<Class:Side>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Side>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Side) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Side>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Side>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Side) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Side>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Side>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"foo\") = :\"foo\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"foo\")\l<unconditional>\l"
     ];
 
     "bb::<Class:Side>#<static-init>_0" -> "bb::<Class:Side>#<static-init>_1" [style="bold"];

--- a/test/testdata/cfg/uaf1.rb.cfg.exp
+++ b/test/testdata/cfg/uaf1.rb.cfg.exp
@@ -24,7 +24,7 @@ subgraph "cluster_::<Class:A>#<static-init>" {
     "bb::<Class:A>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:A>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"initialize\") = :\"initialize\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"initialize\")\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_0" -> "bb::<Class:A>#<static-init>_1" [style="bold"];

--- a/test/testdata/desugar/destructure.rb.flatten-tree.exp
+++ b/test/testdata/desugar/destructure.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         <emptyTree>
@@ -10,10 +12,10 @@ begin
     end
   end
   class ::Destructure<<C Destructure>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
-      <emptyTree>
+      :"f"
     end
 
     def f((x,y), z, <blk>)

--- a/test/testdata/desugar/for.rb.cfg.exp
+++ b/test/testdata/desugar/for.rb.cfg.exp
@@ -24,7 +24,7 @@ subgraph "cluster_::<Class:A>#<static-init>" {
     "bb::<Class:A>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:A>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"each\") = :\"each\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"each\")\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_0" -> "bb::<Class:A>#<static-init>_1" [style="bold"];
@@ -114,7 +114,7 @@ subgraph "cluster_::<Class:Main>#<static-init>" {
     "bb::<Class:Main>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Main>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Main) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Main>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Main>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Main) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Main>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Main>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"main\") = :\"main\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"main\")\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#<static-init>_0" -> "bb::<Class:Main>#<static-init>_1" [style="bold"];

--- a/test/testdata/desugar/op_eq.rb.flatten-tree.exp
+++ b/test/testdata/desugar/op_eq.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         <emptyTree>
@@ -10,15 +12,15 @@ begin
     end
   end
   class ::OpEq<<C OpEq>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
+        :"b"
+        :"b="
+        :"y"
+        :"z"
+        :"example"
         <emptyTree>
       end
     end

--- a/test/testdata/desugar/sclass.rb.flatten-tree.exp
+++ b/test/testdata/desugar/sclass.rb.flatten-tree.exp
@@ -1,7 +1,7 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
@@ -41,7 +41,7 @@ begin
           ::Sorbet::Private::Static.keep_for_ide(::H)
           <emptyTree>
         end
-        <emptyTree>
+        :"main"
         <self>.main()
         <emptyTree>
       end
@@ -61,11 +61,15 @@ begin
     end
   end
   class ::A<<C A>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end
   end
   class ::B<<C B>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       begin
         <emptyTree>
@@ -74,10 +78,10 @@ begin
     end
   end
   class <singleton class><<Class:B>> < ()
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
-      <emptyTree>
+      :"b"
     end
 
     def b(<blk>)
@@ -85,6 +89,8 @@ begin
     end
   end
   class ::D<<C D>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       begin
         <emptyTree>
@@ -93,6 +99,8 @@ begin
     end
   end
   class <singleton class><<Class:D>> < ()
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       begin
         <emptyTree>
@@ -101,10 +109,10 @@ begin
     end
   end
   class <singleton class><<Class:<Class:D>>> < ()
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
-      <emptyTree>
+      :"d"
     end
 
     def d(<blk>)
@@ -112,7 +120,7 @@ begin
     end
   end
   class ::E<<C E>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
@@ -121,7 +129,7 @@ begin
           <emptyTree>
         end
         <self>.wrapper()
-        <emptyTree>
+        :"e"
         <emptyTree>
       end
     end
@@ -131,10 +139,10 @@ begin
     end
   end
   class <singleton class><<Class:E>> < ()
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
-      <emptyTree>
+      :"wrapper"
     end
 
     def wrapper(<blk>)
@@ -142,6 +150,8 @@ begin
     end
   end
   class ::F<<C F>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       begin
         <emptyTree>
@@ -150,16 +160,16 @@ begin
     end
   end
   class <singleton class><<Class:F>> < ()
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
-        <emptyTree>
+        :"initialize"
         <self>.extend(::T::Sig)
         <self>.sig() do ||
           <self>.params({:"f" => ::Integer}).returns(::Integer)
         end
-        <emptyTree>
+        :"f="
         <emptyTree>
       end
     end
@@ -176,17 +186,17 @@ begin
     end
   end
   class ::G<<C G>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
-        <emptyTree>
-        <emptyTree>
+        :"wrapper"
+        :"g"
         begin
           <emptyTree>
           <emptyTree>
         end
-        <emptyTree>
+        :"inner"
         <emptyTree>
       end
     end
@@ -204,11 +214,15 @@ begin
     end
   end
   class <singleton class><<Class:G>> < ()
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       :"inner"
     end
   end
   class ::H<<C H>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       begin
         <emptyTree>
@@ -217,6 +231,8 @@ begin
     end
   end
   class <singleton class><<Class:H>> < ()
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       begin
         <emptyTree>
@@ -226,10 +242,10 @@ begin
     end
   end
   class ::<Class:H>::H2<<C H2>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
-      <emptyTree>
+      :"h"
     end
 
     def self.h(<blk>)

--- a/test/testdata/desugar/sclass_inheritance.rb.flatten-tree.exp
+++ b/test/testdata/desugar/sclass_inheritance.rb.flatten-tree.exp
@@ -1,7 +1,7 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
@@ -26,7 +26,7 @@ begin
           ::Sorbet::Private::Static.keep_for_ide(::A)
           <emptyTree>
         end
-        <emptyTree>
+        :"main"
         <self>.main()
         <emptyTree>
       end
@@ -41,11 +41,15 @@ begin
     end
   end
   module ::MM<<C MM>> < ()
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end
   end
   class ::A<<C A>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       begin
         <emptyTree>
@@ -55,12 +59,12 @@ begin
     end
   end
   class <singleton class><<Class:A>> < (::MM)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
         <self>.include(::MM)
-        <emptyTree>
+        :"newer"
         <emptyTree>
       end
     end
@@ -70,12 +74,12 @@ begin
     end
   end
   class ::B<<C B>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
         <self>.extend(::MM)
-        <emptyTree>
+        :"newer"
         <emptyTree>
       end
     end
@@ -85,6 +89,8 @@ begin
     end
   end
   class ::C<<C C>> < (::A)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       begin
         <emptyTree>
@@ -93,10 +99,10 @@ begin
     end
   end
   class <singleton class><<Class:C>> < ()
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
-      <emptyTree>
+      :"newerer"
     end
 
     def newerer(<blk>)

--- a/test/testdata/deviations/non_ruby_names.rb.flatten-tree.exp
+++ b/test/testdata/deviations/non_ruby_names.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         begin
@@ -18,11 +20,15 @@ begin
     end
   end
   module ::B<<C B>> < ()
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end
   end
   module ::A<<C A>> < ()
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       begin
         <emptyTree>
@@ -32,6 +38,8 @@ begin
     end
   end
   class ::A::B::C<<C C>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end

--- a/test/testdata/infer/casts.rb.flatten-tree.exp
+++ b/test/testdata/infer/casts.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         <emptyTree>
@@ -10,12 +12,12 @@ begin
     end
   end
   class ::TestCasts<<C TestCasts>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
-        <emptyTree>
-        <emptyTree>
+        :"untyped"
+        :"test_casts"
         <emptyTree>
       end
     end

--- a/test/testdata/infer/control_flow/complex_implication_1.rb.cfg.exp
+++ b/test/testdata/infer/control_flow/complex_implication_1.rb.cfg.exp
@@ -24,7 +24,7 @@ subgraph "cluster_::<Class:ModuleMethods>#<static-init>" {
     "bb::<Class:ModuleMethods>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:ModuleMethods>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(ModuleMethods) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U ModuleMethods>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U ModuleMethods>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(ModuleMethods) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U ModuleMethods>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U ModuleMethods>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"instrumented_request\") = :\"instrumented_request\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"instrumented_request\")\l<unconditional>\l"
     ];
 
     "bb::<Class:ModuleMethods>#<static-init>_0" -> "bb::<Class:ModuleMethods>#<static-init>_1" [style="bold"];

--- a/test/testdata/infer/control_flow/complex_implications_2.rb.cfg.exp
+++ b/test/testdata/infer/control_flow/complex_implications_2.rb.cfg.exp
@@ -6,7 +6,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"foo\") = :\"foo\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"foo\")\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];

--- a/test/testdata/infer/control_flow/normalize_params.rb.cfg.exp
+++ b/test/testdata/infer/control_flow/normalize_params.rb.cfg.exp
@@ -24,7 +24,7 @@ subgraph "cluster_::<Class:Test>#<static-init>" {
     "bb::<Class:Test>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Test>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Test) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Test>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Test>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Test) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Test>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Test>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"normalize_params\") = :\"normalize_params\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"normalize_params\")\l<unconditional>\l"
     ];
 
     "bb::<Class:Test>#<static-init>_0" -> "bb::<Class:Test>#<static-init>_1" [style="bold"];

--- a/test/testdata/infer/flatten_methods.rb
+++ b/test/testdata/infer/flatten_methods.rb
@@ -10,11 +10,11 @@ class Parent
 end
 
 class Child < Parent
-  takes_integer_static def self.outer_static # error: Expected `Integer` but found `NilClass` for argument `x`
+  takes_integer_static def self.outer_static # error: Expected `Integer` but found `Symbol(:"outer_static")` for argument `x`
     takes_integer_static def self.inner_static; end # error: Expected `Integer` but found `Symbol(:"inner_static")` for argument `x`
   end
 
-  takes_integer_static def outer_instance # error: Expected `Integer` but found `NilClass` for argument `x`
+  takes_integer_static def outer_instance # error: Expected `Integer` but found `Symbol(:"outer_instance")` for argument `x`
     takes_integer_instance def inner_instance; end # error: Expected `Integer` but found `Symbol(:"inner_instance")` for argument `x`
   end
 end

--- a/test/testdata/infer/flatten_methods.rb.flatten-tree.exp
+++ b/test/testdata/infer/flatten_methods.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         begin
@@ -19,7 +21,7 @@ begin
     end
   end
   class ::Parent<<C Parent>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
@@ -27,11 +29,11 @@ begin
         <self>.sig() do ||
           <self>.params({:"x" => ::Integer}).void()
         end
-        <emptyTree>
+        :"takes_integer_static"
         <self>.sig() do ||
           <self>.params({:"x" => ::Integer}).void()
         end
-        <emptyTree>
+        :"takes_integer_instance"
         <emptyTree>
       end
     end
@@ -45,14 +47,14 @@ begin
     end
   end
   class ::Child<<C Child>> < (::Parent)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
-        <self>.takes_integer_static(<emptyTree>)
-        <self>.takes_integer_static(<emptyTree>)
-        <emptyTree>
-        <emptyTree>
+        <self>.takes_integer_static(:"outer_static")
+        <self>.takes_integer_static(:"outer_instance")
+        :"inner_static"
+        :"inner_instance"
         <emptyTree>
       end
     end

--- a/test/testdata/infer/flatten_private.rb
+++ b/test/testdata/infer/flatten_private.rb
@@ -11,11 +11,11 @@ class A
   sig {params(arg0: Integer).void}
   def self.private_class_method(arg0); end
 
-  private_class_method def self.outer_static
+  private_class_method def self.outer_static # error: Expected `Integer` but found `Symbol(:"outer_static")` for argument `arg0`
     private_class_method def self.inner_static; end # error: Expected `Integer` but found `Symbol(:"inner_static")` for argument `arg0`
   end
 
-  private def outer_instance
+  private def outer_instance # error: Expected `Integer` but found `Symbol(:"outer_instance")` for argument `arg0`
     self.class.private def inner_instance; end # error: Expected `Integer` but found `Symbol(:"inner_instance")` for argument `arg0`
   end
 end

--- a/test/testdata/infer/flatten_private.rb.flatten-tree.exp
+++ b/test/testdata/infer/flatten_private.rb.flatten-tree.exp
@@ -25,8 +25,8 @@ begin
           <self>.params({:"arg0" => ::Integer}).void()
         end
         :"private_class_method"
-        :"outer_static"
-        :"outer_instance"
+        <self>.private_class_method(:"outer_static")
+        <self>.private(:"outer_instance")
         :"inner_static"
         :"inner_instance"
         <emptyTree>

--- a/test/testdata/infer/flatten_private.rb.flatten-tree.exp
+++ b/test/testdata/infer/flatten_private.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         <emptyTree>
@@ -10,7 +12,7 @@ begin
     end
   end
   class ::A<<C A>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
@@ -18,15 +20,15 @@ begin
         <self>.sig() do ||
           <self>.params({:"arg0" => ::Integer}).void()
         end
-        <emptyTree>
+        :"private"
         <self>.sig() do ||
           <self>.params({:"arg0" => ::Integer}).void()
         end
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
+        :"private_class_method"
+        :"outer_static"
+        :"outer_instance"
+        :"inner_static"
+        :"inner_instance"
         <emptyTree>
       end
     end

--- a/test/testdata/infer/hashes.rb.cfg.exp
+++ b/test/testdata/infer/hashes.rb.cfg.exp
@@ -24,7 +24,7 @@ subgraph "cluster_::<Class:Foo>#<static-init>" {
     "bb::<Class:Foo>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Foo>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Foo) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Foo>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Foo>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Foo) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Foo>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Foo>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"bar\") = :\"bar\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"bar\")\l<unconditional>\l"
     ];
 
     "bb::<Class:Foo>#<static-init>_0" -> "bb::<Class:Foo>#<static-init>_1" [style="bold"];

--- a/test/testdata/infer/huge_unions.rb.cfg.exp
+++ b/test/testdata/infer/huge_unions.rb.cfg.exp
@@ -492,7 +492,7 @@ subgraph "cluster_::<Class:A>#<static-init>" {
     "bb::<Class:A>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:A>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"send_beta_invitation\") = :\"send_beta_invitation\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"send_beta_invitation\")\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_0" -> "bb::<Class:A>#<static-init>_1" [style="bold"];

--- a/test/testdata/infer/infer1.rb.flatten-tree.exp
+++ b/test/testdata/infer/infer1.rb.flatten-tree.exp
@@ -1,18 +1,18 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
+        :"baz1"
+        :"baz2"
+        :"baz3"
+        :"baz4"
+        :"baz5"
+        :"baz6"
+        :"baz7"
+        :"baz8"
         <emptyTree>
       end
     end

--- a/test/testdata/infer/rebind.rb.cfg.exp
+++ b/test/testdata/infer/rebind.rb.cfg.exp
@@ -24,7 +24,7 @@ subgraph "cluster_::<Class:C>#<static-init>" {
     "bb::<Class:C>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"only_on_C\") = :\"only_on_C\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"only_on_C\")\l<unconditional>\l"
     ];
 
     "bb::<Class:C>#<static-init>_0" -> "bb::<Class:C>#<static-init>_1" [style="bold"];

--- a/test/testdata/infer/sigil.rb.cfg.exp
+++ b/test/testdata/infer/sigil.rb.cfg.exp
@@ -6,7 +6,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"foo\") = :\"foo\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"foo\")\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];

--- a/test/testdata/infer/singleton_methods.rb.cfg.exp
+++ b/test/testdata/infer/singleton_methods.rb.cfg.exp
@@ -24,7 +24,7 @@ subgraph "cluster_::<Class:Foo>#<static-init>" {
     "bb::<Class:Foo>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Foo>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Foo) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Foo>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Foo>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Foo) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Foo>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Foo>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"bar\") = :\"bar\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"bar\")\l<unconditional>\l"
     ];
 
     "bb::<Class:Foo>#<static-init>_0" -> "bb::<Class:Foo>#<static-init>_1" [style="bold"];
@@ -60,7 +60,7 @@ subgraph "cluster_::<Class:Bar>#<static-init>" {
     "bb::<Class:Bar>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Bar>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Bar) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Bar>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Bar>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Bar) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Bar>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Bar>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"baz\") = :\"baz\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"baz\")\l<unconditional>\l"
     ];
 
     "bb::<Class:Bar>#<static-init>_0" -> "bb::<Class:Bar>#<static-init>_1" [style="bold"];

--- a/test/testdata/infer/toplevel.rb.flatten-tree.exp
+++ b/test/testdata/infer/toplevel.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       1.+("hi")
     end

--- a/test/testdata/infer/zsuper.rb.cfg.exp
+++ b/test/testdata/infer/zsuper.rb.cfg.exp
@@ -24,7 +24,7 @@ subgraph "cluster_::<Class:Foo>#<static-init>" {
     "bb::<Class:Foo>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Foo>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Foo) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Foo>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Foo>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Foo) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Foo>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Foo>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"baz\") = :\"baz\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"baz\")\l<unconditional>\l"
     ];
 
     "bb::<Class:Foo>#<static-init>_0" -> "bb::<Class:Foo>#<static-init>_1" [style="bold"];
@@ -60,7 +60,7 @@ subgraph "cluster_::<Class:Bar>#<static-init>" {
     "bb::<Class:Bar>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Bar>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Bar) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Bar>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Bar>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Bar) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Bar>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Bar>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"baz\") = :\"baz\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"baz\")\l<unconditional>\l"
     ];
 
     "bb::<Class:Bar>#<static-init>_0" -> "bb::<Class:Bar>#<static-init>_1" [style="bold"];

--- a/test/testdata/namer/alias_cross_file.flatten-tree.exp
+++ b/test/testdata/namer/alias_cross_file.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         <emptyTree>
@@ -10,14 +12,14 @@ begin
     end
   end
   class ::TestSig<<C TestSig>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
         <self>.sig() do ||
           <self>.returns(::T2)
         end
-        <emptyTree>
+        :"test_resolve"
         <emptyTree>
       end
     end
@@ -31,6 +33,8 @@ end
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         begin
@@ -44,6 +48,8 @@ begin
     end
   end
   class ::T1<<C T1>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end

--- a/test/testdata/namer/ancestors.rb.flatten-tree.exp
+++ b/test/testdata/namer/ancestors.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         begin
@@ -34,26 +36,36 @@ begin
     end
   end
   module ::Mixin1<<C Mixin1>> < ()
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end
   end
   module ::Mixin2<<C Mixin2>> < ()
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end
   end
   class ::Parent<<C Parent>> < (::<todo sym>, ::Mixin1)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <self>.include(::Mixin1)
     end
   end
   class ::Child<<C Child>> < (::Parent, ::Mixin2)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <self>.include(::Mixin2)
     end
   end
   class ::MultipleInclude<<C MultipleInclude>> < (::<todo sym>, ::Mixin2, ::Mixin1)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <self>.include(::Mixin1, ::Mixin2)
     end

--- a/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
+++ b/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
@@ -9,6 +9,8 @@ InsSeq{
           symbol = ::<todo sym>
         }]
       rhs = [
+        Literal{ value = :"<static-init>" }
+
         MethodDef{
           flags = self
           name = <U <static-init>><<N <U <static-init>> $CENSORED>>
@@ -55,7 +57,7 @@ InsSeq{
           symbol = ::<todo sym>
         }]
       rhs = [
-        EmptyTree
+        Literal{ value = :"<static-init>" }
 
         MethodDef{
           flags = self
@@ -65,9 +67,9 @@ InsSeq{
             }]
           rhs = InsSeq{
             stats = [
-              EmptyTree
-              EmptyTree
-              EmptyTree
+              Literal{ value = :"take_arguments" }
+              Literal{ value = :"take_arguments<defaultArg>1" }
+              Literal{ value = :"take_arguments<defaultArg>2" }
             ],
             expr = EmptyTree
           }

--- a/test/testdata/namer/arguments.rb.flatten-tree.exp
+++ b/test/testdata/namer/arguments.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         <emptyTree>
@@ -10,13 +12,13 @@ begin
     end
   end
   class ::A<<C A>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
+        :"take_arguments"
+        :"take_arguments<defaultArg>1"
+        :"take_arguments<defaultArg>2"
         <emptyTree>
       end
     end

--- a/test/testdata/namer/class_and_alias.rb.flatten-tree.exp
+++ b/test/testdata/namer/class_and_alias.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         ::A = 91
@@ -20,11 +22,15 @@ begin
     end
   end
   class ::A<<C A>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end
   end
   class ::B<B$1> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end

--- a/test/testdata/namer/conflicting_names.rb.flatten-tree.exp
+++ b/test/testdata/namer/conflicting_names.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         <emptyTree>
@@ -10,11 +12,11 @@ begin
     end
   end
   module ::A<<C A>> < ()
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
-        <emptyTree>
+        :"Foo"
         begin
           <emptyTree>
           ::Sorbet::Private::Static.keep_for_ide(::A::Foo)
@@ -29,6 +31,8 @@ begin
     end
   end
   class ::A::Foo<<C Foo>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end

--- a/test/testdata/namer/constants.rb.flatten-tree.exp
+++ b/test/testdata/namer/constants.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         begin
@@ -16,6 +18,8 @@ begin
     end
   end
   module ::A<<C A>> < ()
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       begin
         ::A::B::C = 1
@@ -29,6 +33,8 @@ begin
     end
   end
   module ::A::B<<C B>> < ()
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       begin
         ::A::B::C

--- a/test/testdata/namer/defs_in_blocks.rb.flatten-tree.exp
+++ b/test/testdata/namer/defs_in_blocks.rb.flatten-tree.exp
@@ -1,11 +1,11 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       <self>.foobar() do ||
-        <emptyTree>
+        :"a_method"
       end
     end
 

--- a/test/testdata/namer/gvar.rb.flatten-tree.exp
+++ b/test/testdata/namer/gvar.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         $a = 1
@@ -14,13 +16,13 @@ begin
     end
   end
   class ::A<<C A>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
         $b = 2
         $a
-        <emptyTree>
+        :"meth"
         <emptyTree>
       end
     end

--- a/test/testdata/namer/locals.rb.flatten-tree.exp
+++ b/test/testdata/namer/locals.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         <emptyTree>
@@ -10,10 +12,10 @@ begin
     end
   end
   class ::TestLocals<<C TestLocals>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
-      <emptyTree>
+      :"method"
     end
 
     def method(<blk>)

--- a/test/testdata/namer/module_function.rb.cfg.exp
+++ b/test/testdata/namer/module_function.rb.cfg.exp
@@ -58,7 +58,7 @@ subgraph "cluster_::<Class:Funcs>#<static-init>" {
     "bb::<Class:Funcs>#<static-init>_6" -> "bb::<Class:Funcs>#<static-init>_7" [style="tapered"];
 
     "bb::<Class:Funcs>#<static-init>_7" [
-        label = "block[id=7, rubyBlockId=0](<selfRestore>$30: T.class_of(Funcs), <block-pre-call-temp>$29: Sorbet::Private::Static::Void)\l<statTemp>$27: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$29, sig>\l<self>: T.class_of(Funcs) = <selfRestore>$30\l<block-pre-call-temp>$45: Sorbet::Private::Static::Void = <self>: T.class_of(Funcs).sig()\l<selfRestore>$46: T.class_of(Funcs) = <self>\l<unconditional>\l"
+        label = "block[id=7, rubyBlockId=0](<selfRestore>$30: T.class_of(Funcs), <block-pre-call-temp>$29: Sorbet::Private::Static::Void)\l<statTemp>$27: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$29, sig>\l<self>: T.class_of(Funcs) = <selfRestore>$30\l<statTemp>$44: Symbol(:\"g\") = :\"g\"\l<statTemp>$42: T.class_of(Funcs) = <self>: T.class_of(Funcs).private(<statTemp>$44: Symbol(:\"g\"))\l<block-pre-call-temp>$47: Sorbet::Private::Static::Void = <self>: T.class_of(Funcs).sig()\l<selfRestore>$48: T.class_of(Funcs) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_7" -> "bb::<Class:Funcs>#<static-init>_10" [style="bold"];
@@ -68,53 +68,53 @@ subgraph "cluster_::<Class:Funcs>#<static-init>" {
 
     "bb::<Class:Funcs>#<static-init>_9" -> "bb::<Class:Funcs>#<static-init>_6" [style="bold"];
     "bb::<Class:Funcs>#<static-init>_10" [
-        label = "block[id=10, rubyBlockId=3](<self>: T.class_of(Funcs), <selfRestore>$46: T.class_of(Funcs), <block-pre-call-temp>$45: Sorbet::Private::Static::Void)\louterLoops: 1\l<block-call>: NilClass\l"
+        label = "block[id=10, rubyBlockId=3](<self>: T.class_of(Funcs), <selfRestore>$48: T.class_of(Funcs), <block-pre-call-temp>$47: Sorbet::Private::Static::Void)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_10" -> "bb::<Class:Funcs>#<static-init>_13" [style="bold"];
     "bb::<Class:Funcs>#<static-init>_10" -> "bb::<Class:Funcs>#<static-init>_11" [style="tapered"];
 
     "bb::<Class:Funcs>#<static-init>_11" [
-        label = "block[id=11, rubyBlockId=0](<selfRestore>$46: T.class_of(Funcs), <block-pre-call-temp>$45: Sorbet::Private::Static::Void)\l<statTemp>$43: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$45, sig>\l<self>: T.class_of(Funcs) = <selfRestore>$46\l<block-pre-call-temp>$61: Sorbet::Private::Static::Void = <self>: T.class_of(Funcs).sig()\l<selfRestore>$62: T.class_of(Funcs) = <self>\l<unconditional>\l"
+        label = "block[id=11, rubyBlockId=0](<selfRestore>$48: T.class_of(Funcs), <block-pre-call-temp>$47: Sorbet::Private::Static::Void)\l<statTemp>$45: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$47, sig>\l<self>: T.class_of(Funcs) = <selfRestore>$48\l<block-pre-call-temp>$63: Sorbet::Private::Static::Void = <self>: T.class_of(Funcs).sig()\l<selfRestore>$64: T.class_of(Funcs) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_11" -> "bb::<Class:Funcs>#<static-init>_14" [style="bold"];
     "bb::<Class:Funcs>#<static-init>_13" [
-        label = "block[id=13, rubyBlockId=3](<self>: T.class_of(Funcs), <selfRestore>$46: T.class_of(Funcs), <block-pre-call-temp>$45: Sorbet::Private::Static::Void)\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$53: Symbol(:\"s\") = :\"s\"\l<hashTemp>$54: T.class_of(Symbol) = alias <C Symbol>\l<magic>$55: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$52: {s: T.class_of(Symbol)} = <magic>$55: T.class_of(<Magic>).<build-hash>(<hashTemp>$53: Symbol(:\"s\"), <hashTemp>$54: T.class_of(Symbol))\l<statTemp>$50: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<statTemp>$52: {s: T.class_of(Symbol)})\l<statTemp>$56: T.class_of(Symbol) = alias <C Symbol>\l<blockReturnTemp>$49: T::Private::Methods::DeclBuilder = <statTemp>$50: T::Private::Methods::DeclBuilder.returns(<statTemp>$56: T.class_of(Symbol))\l<blockReturnTemp>$57: T.noreturn = blockreturn<sig> <blockReturnTemp>$49: T::Private::Methods::DeclBuilder\l<unconditional>\l"
+        label = "block[id=13, rubyBlockId=3](<self>: T.class_of(Funcs), <selfRestore>$48: T.class_of(Funcs), <block-pre-call-temp>$47: Sorbet::Private::Static::Void)\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$55: Symbol(:\"s\") = :\"s\"\l<hashTemp>$56: T.class_of(Symbol) = alias <C Symbol>\l<magic>$57: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$54: {s: T.class_of(Symbol)} = <magic>$57: T.class_of(<Magic>).<build-hash>(<hashTemp>$55: Symbol(:\"s\"), <hashTemp>$56: T.class_of(Symbol))\l<statTemp>$52: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<statTemp>$54: {s: T.class_of(Symbol)})\l<statTemp>$58: T.class_of(Symbol) = alias <C Symbol>\l<blockReturnTemp>$51: T::Private::Methods::DeclBuilder = <statTemp>$52: T::Private::Methods::DeclBuilder.returns(<statTemp>$58: T.class_of(Symbol))\l<blockReturnTemp>$59: T.noreturn = blockreturn<sig> <blockReturnTemp>$51: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_13" -> "bb::<Class:Funcs>#<static-init>_10" [style="bold"];
     "bb::<Class:Funcs>#<static-init>_14" [
-        label = "block[id=14, rubyBlockId=4](<self>: T.class_of(Funcs), <selfRestore>$62: T.class_of(Funcs), <block-pre-call-temp>$61: Sorbet::Private::Static::Void)\louterLoops: 1\l<block-call>: NilClass\l"
+        label = "block[id=14, rubyBlockId=4](<self>: T.class_of(Funcs), <selfRestore>$64: T.class_of(Funcs), <block-pre-call-temp>$63: Sorbet::Private::Static::Void)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_14" -> "bb::<Class:Funcs>#<static-init>_17" [style="bold"];
     "bb::<Class:Funcs>#<static-init>_14" -> "bb::<Class:Funcs>#<static-init>_15" [style="tapered"];
 
     "bb::<Class:Funcs>#<static-init>_15" [
-        label = "block[id=15, rubyBlockId=0](<selfRestore>$62: T.class_of(Funcs), <block-pre-call-temp>$61: Sorbet::Private::Static::Void)\l<statTemp>$59: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$61, sig>\l<self>: T.class_of(Funcs) = <selfRestore>$62\l<block-pre-call-temp>$77: Sorbet::Private::Static::Void = <self>: T.class_of(Funcs).sig()\l<selfRestore>$78: T.class_of(Funcs) = <self>\l<unconditional>\l"
+        label = "block[id=15, rubyBlockId=0](<selfRestore>$64: T.class_of(Funcs), <block-pre-call-temp>$63: Sorbet::Private::Static::Void)\l<statTemp>$61: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$63, sig>\l<self>: T.class_of(Funcs) = <selfRestore>$64\l<statTemp>$78: Symbol(:\"h\") = :\"h\"\l<statTemp>$76: T.class_of(Funcs) = <self>: T.class_of(Funcs).private(<statTemp>$78: Symbol(:\"h\"))\l<block-pre-call-temp>$81: Sorbet::Private::Static::Void = <self>: T.class_of(Funcs).sig()\l<selfRestore>$82: T.class_of(Funcs) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_15" -> "bb::<Class:Funcs>#<static-init>_18" [style="bold"];
     "bb::<Class:Funcs>#<static-init>_17" [
-        label = "block[id=17, rubyBlockId=4](<self>: T.class_of(Funcs), <selfRestore>$62: T.class_of(Funcs), <block-pre-call-temp>$61: Sorbet::Private::Static::Void)\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$69: Symbol(:\"s\") = :\"s\"\l<hashTemp>$70: T.class_of(String) = alias <C String>\l<magic>$71: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$68: {s: T.class_of(String)} = <magic>$71: T.class_of(<Magic>).<build-hash>(<hashTemp>$69: Symbol(:\"s\"), <hashTemp>$70: T.class_of(String))\l<statTemp>$66: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<statTemp>$68: {s: T.class_of(String)})\l<statTemp>$72: T.class_of(String) = alias <C String>\l<blockReturnTemp>$65: T::Private::Methods::DeclBuilder = <statTemp>$66: T::Private::Methods::DeclBuilder.returns(<statTemp>$72: T.class_of(String))\l<blockReturnTemp>$73: T.noreturn = blockreturn<sig> <blockReturnTemp>$65: T::Private::Methods::DeclBuilder\l<unconditional>\l"
+        label = "block[id=17, rubyBlockId=4](<self>: T.class_of(Funcs), <selfRestore>$64: T.class_of(Funcs), <block-pre-call-temp>$63: Sorbet::Private::Static::Void)\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$71: Symbol(:\"s\") = :\"s\"\l<hashTemp>$72: T.class_of(String) = alias <C String>\l<magic>$73: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$70: {s: T.class_of(String)} = <magic>$73: T.class_of(<Magic>).<build-hash>(<hashTemp>$71: Symbol(:\"s\"), <hashTemp>$72: T.class_of(String))\l<statTemp>$68: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<statTemp>$70: {s: T.class_of(String)})\l<statTemp>$74: T.class_of(String) = alias <C String>\l<blockReturnTemp>$67: T::Private::Methods::DeclBuilder = <statTemp>$68: T::Private::Methods::DeclBuilder.returns(<statTemp>$74: T.class_of(String))\l<blockReturnTemp>$75: T.noreturn = blockreturn<sig> <blockReturnTemp>$67: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_17" -> "bb::<Class:Funcs>#<static-init>_14" [style="bold"];
     "bb::<Class:Funcs>#<static-init>_18" [
-        label = "block[id=18, rubyBlockId=5](<self>: T.class_of(Funcs), <selfRestore>$78: T.class_of(Funcs), <block-pre-call-temp>$77: Sorbet::Private::Static::Void)\louterLoops: 1\l<block-call>: NilClass\l"
+        label = "block[id=18, rubyBlockId=5](<self>: T.class_of(Funcs), <selfRestore>$82: T.class_of(Funcs), <block-pre-call-temp>$81: Sorbet::Private::Static::Void)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_18" -> "bb::<Class:Funcs>#<static-init>_21" [style="bold"];
     "bb::<Class:Funcs>#<static-init>_18" -> "bb::<Class:Funcs>#<static-init>_19" [style="tapered"];
 
     "bb::<Class:Funcs>#<static-init>_19" [
-        label = "block[id=19, rubyBlockId=0](<selfRestore>$78: T.class_of(Funcs), <block-pre-call-temp>$77: Sorbet::Private::Static::Void)\l<statTemp>$75: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$77, sig>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=19, rubyBlockId=0](<selfRestore>$82: T.class_of(Funcs), <block-pre-call-temp>$81: Sorbet::Private::Static::Void)\l<statTemp>$79: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$81, sig>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_19" -> "bb::<Class:Funcs>#<static-init>_1" [style="bold"];
     "bb::<Class:Funcs>#<static-init>_21" [
-        label = "block[id=21, rubyBlockId=5](<self>: T.class_of(Funcs), <selfRestore>$78: T.class_of(Funcs), <block-pre-call-temp>$77: Sorbet::Private::Static::Void)\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$85: Symbol(:\"s\") = :\"s\"\l<hashTemp>$86: T.class_of(String) = alias <C String>\l<magic>$87: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$84: {s: T.class_of(String)} = <magic>$87: T.class_of(<Magic>).<build-hash>(<hashTemp>$85: Symbol(:\"s\"), <hashTemp>$86: T.class_of(String))\l<statTemp>$82: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<statTemp>$84: {s: T.class_of(String)})\l<statTemp>$88: T.class_of(String) = alias <C String>\l<blockReturnTemp>$81: T::Private::Methods::DeclBuilder = <statTemp>$82: T::Private::Methods::DeclBuilder.returns(<statTemp>$88: T.class_of(String))\l<blockReturnTemp>$89: T.noreturn = blockreturn<sig> <blockReturnTemp>$81: T::Private::Methods::DeclBuilder\l<unconditional>\l"
+        label = "block[id=21, rubyBlockId=5](<self>: T.class_of(Funcs), <selfRestore>$82: T.class_of(Funcs), <block-pre-call-temp>$81: Sorbet::Private::Static::Void)\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$89: Symbol(:\"s\") = :\"s\"\l<hashTemp>$90: T.class_of(String) = alias <C String>\l<magic>$91: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$88: {s: T.class_of(String)} = <magic>$91: T.class_of(<Magic>).<build-hash>(<hashTemp>$89: Symbol(:\"s\"), <hashTemp>$90: T.class_of(String))\l<statTemp>$86: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<statTemp>$88: {s: T.class_of(String)})\l<statTemp>$92: T.class_of(String) = alias <C String>\l<blockReturnTemp>$85: T::Private::Methods::DeclBuilder = <statTemp>$86: T::Private::Methods::DeclBuilder.returns(<statTemp>$92: T.class_of(String))\l<blockReturnTemp>$93: T.noreturn = blockreturn<sig> <blockReturnTemp>$85: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_21" -> "bb::<Class:Funcs>#<static-init>_18" [style="bold"];

--- a/test/testdata/namer/multiple_stubs.rb.flatten-tree.exp
+++ b/test/testdata/namer/multiple_stubs.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         Unresolved: Unresolved: <emptyTree>::<C Foo>::<C Bar>.baz(1)

--- a/test/testdata/namer/nested_class.rb.flatten-tree.exp
+++ b/test/testdata/namer/nested_class.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         begin
@@ -18,6 +20,8 @@ begin
     end
   end
   module ::A<<C A>> < ()
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       begin
         <emptyTree>
@@ -27,11 +31,15 @@ begin
     end
   end
   class ::A::B<<C B>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end
   end
   class ::C<<C C>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end

--- a/test/testdata/namer/next_break.rb.flatten-tree.exp
+++ b/test/testdata/namer/next_break.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         <emptyTree>
@@ -10,10 +12,10 @@ begin
     end
   end
   class ::Test<<C Test>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
-      <emptyTree>
+      :"test_next_break"
     end
 
     def test_next_break(<blk>)

--- a/test/testdata/namer/redefines_object.rb.cfg.exp
+++ b/test/testdata/namer/redefines_object.rb.cfg.exp
@@ -42,7 +42,7 @@ subgraph "cluster_::<Class:Trigger>#<static-init>" {
     "bb::<Class:Trigger>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Trigger>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Trigger) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Trigger>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Trigger>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Trigger) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Trigger>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Trigger>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Symbol(:\"trigger\") = :\"trigger\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:\"trigger\")\l<unconditional>\l"
     ];
 
     "bb::<Class:Trigger>#<static-init>_0" -> "bb::<Class:Trigger>#<static-init>_1" [style="bold"];

--- a/test/testdata/namer/redefinition_method.rb.flatten-tree.exp
+++ b/test/testdata/namer/redefinition_method.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         <emptyTree>
@@ -10,7 +12,7 @@ begin
     end
   end
   class ::Main<<C Main>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
@@ -18,9 +20,9 @@ begin
         <self>.sig() do ||
           <self>.params({:"a" => ::Integer}).returns(::Integer)
         end
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
+        :"foo"
+        :"foo"
+        :"foo"
         <emptyTree>
       end
     end

--- a/test/testdata/namer/simple.rb.flatten-tree.exp
+++ b/test/testdata/namer/simple.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         begin
@@ -44,12 +46,12 @@ begin
     end
   end
   class ::NormalClass<<C NormalClass>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
-        <emptyTree>
-        <emptyTree>
+        :"normal_method"
+        :"normal_static_method"
         begin
           <emptyTree>
           ::Sorbet::Private::Static.keep_for_ide(::NormalClass::InnerClass)
@@ -73,16 +75,22 @@ begin
     end
   end
   class ::NormalClass::InnerClass<<C InnerClass>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end
   end
   module ::NormalClass::InnerModule<<C InnerModule>> < ()
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end
   end
   module ::ANamespace<<C ANamespace>> < ()
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       begin
         <emptyTree>
@@ -92,31 +100,43 @@ begin
     end
   end
   class ::ANamespace::ObviousChild<<C ObviousChild>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end
   end
   class ::ANamespace::ClassInNamespace<<C ClassInNamespace>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end
   end
   class ::Parent<<C Parent>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end
   end
   module ::Mixin<<C Mixin>> < ()
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end
   end
   module ::OtherMixin<<C OtherMixin>> < ()
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end
   end
   class ::Child<<C Child>> < (::Parent, ::Mixin)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       begin
         <self>.include(::Mixin)

--- a/test/testdata/namer/yield.rb.flatten-tree.exp
+++ b/test/testdata/namer/yield.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         begin
@@ -14,15 +16,15 @@ begin
     end
   end
   class ::Main<<C Main>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
+        :"yielder"
+        :"blockpass"
+        :"mixed"
+        :"blockyield"
+        :"main"
         <emptyTree>
       end
     end

--- a/test/testdata/rbi/date.rb
+++ b/test/testdata/rbi/date.rb
@@ -8,15 +8,15 @@ T.assert_type!(Date.today + 1, Date)
 class Test
   extend T::Sig
 
-  sig {params(x: Date).void}
-  def test_date(x)
+  sig {params(x: Date, y: DateTime).void}
+  def test_date(x, y)
     T.reveal_type(x -  x) # error: Revealed type: `Rational`
     T.reveal_type(x - 10) # error: Revealed type: `Date`
-  end
 
-  sig {params(x: DateTime).void}
-  def test_datetime(x)
-    T.reveal_type(x - x) # error: Revealed type: `Rational`
-    T.reveal_type(x - 10) # error: Revealed type: `DateTime`
+    T.reveal_type(y - y) # error: Revealed type: `Rational`
+    T.reveal_type(y - 10) # error: Revealed type: `DateTime`
+
+    T.reveal_type(y - x) # error: Revealed type: `Rational`
+    T.reveal_type(x - y) # error: Revealed type: `Rational`
   end
 end

--- a/test/testdata/resolver/ancestor_scope.rb.flatten-tree.exp
+++ b/test/testdata/resolver/ancestor_scope.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         begin
@@ -31,11 +33,15 @@ begin
     end
   end
   class ::Other<<C Other>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end
   end
   class ::Test<<C Test>> < (::Other, ::Test::Mixin, ::Test::Other)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       begin
         begin
@@ -55,11 +61,15 @@ begin
     end
   end
   module ::Test::Mixin<<C Mixin>> < ()
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end
   end
   module ::Test::Other<<C Other>> < ()
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end

--- a/test/testdata/resolver/class_instance_vars.rb.flatten-tree.exp
+++ b/test/testdata/resolver/class_instance_vars.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         begin
@@ -31,16 +33,16 @@ begin
     end
   end
   class ::Parent<<C Parent>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
-        <emptyTree>
+        :"initialize"
         @@class_var = begin
           ::Sorbet::Private::Static.keep_for_typechecking(::String)
           T.let("hi", String)
         end
-        <emptyTree>
+        :"hi"
         <emptyTree>
       end
     end
@@ -66,6 +68,8 @@ begin
     end
   end
   module ::Mixin<<C Mixin>> < ()
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       begin
         @@mixin_cvar = begin
@@ -78,7 +82,7 @@ begin
     end
   end
   class ::Child<<C Child>> < (::Parent, ::Mixin)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
@@ -86,7 +90,7 @@ begin
         @@class_var
         @@mixin_cvar
         @@undefined_cvar
-        <emptyTree>
+        :"child_method"
         <emptyTree>
       end
     end
@@ -101,6 +105,8 @@ begin
     end
   end
   class ::Child1<<C Child1>> < (::Alias)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       @@class_var
     end

--- a/test/testdata/resolver/field.rb.flatten-tree-raw.exp
+++ b/test/testdata/resolver/field.rb.flatten-tree-raw.exp
@@ -9,7 +9,7 @@ InsSeq{
           symbol = ::<todo sym>
         }]
       rhs = [
-        EmptyTree
+        Literal{ value = :"<static-init>" }
 
         MethodDef{
           flags = self
@@ -17,7 +17,7 @@ InsSeq{
           args = [Local{
               localVariable = <U <blk>>
             }]
-          rhs = EmptyTree
+          rhs = Literal{ value = :"foo" }
         }
 
         MethodDef{

--- a/test/testdata/resolver/flatten.rb.flatten-tree.exp
+++ b/test/testdata/resolver/flatten.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         begin
@@ -25,16 +27,16 @@ begin
     end
   end
   class ::A<<C A>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
+        :"foo"
+        :"sfoo"
+        :"food"
+        :"foos"
+        :"sfood"
+        :"sfoos"
         <emptyTree>
       end
     end

--- a/test/testdata/resolver/missing_type_combinator_args.rb.flatten-tree.exp
+++ b/test/testdata/resolver/missing_type_combinator_args.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         begin

--- a/test/testdata/resolver/optional_nil.rb.flatten-tree.exp
+++ b/test/testdata/resolver/optional_nil.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         <emptyTree>
@@ -10,7 +12,7 @@ begin
     end
   end
   class ::Test<<C Test>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
@@ -18,35 +20,35 @@ begin
         <self>.sig() do ||
           <self>.params({:"x" => ::String}).returns(::String)
         end
-        <emptyTree>
+        :"foo"
         <self>.sig() do ||
           <self>.params({:"y" => ::String}).returns(::String)
         end
-        <emptyTree>
+        :"bar"
         <self>.sig() do ||
           <self>.params({:"z" => ::String}).returns(::String)
         end
-        <emptyTree>
+        :"qux"
         <self>.sig() do ||
           <self>.params({:"w" => ::String}).returns(::String)
         end
-        <emptyTree>
+        :"baz"
         <self>.sig() do ||
           <self>.params({:"x" => ::String}).returns(::String)
         end
-        <emptyTree>
+        :"foo<defaultArg>1"
         <self>.sig() do ||
           <self>.params({:"y" => ::String}).returns(::String)
         end
-        <emptyTree>
+        :"bar<defaultArg>1"
         <self>.sig() do ||
           <self>.params({:"z" => ::String}).returns(::String)
         end
-        <emptyTree>
+        :"qux<defaultArg>1"
         <self>.sig() do ||
           <self>.params({:"w" => ::String}).returns(::String)
         end
-        <emptyTree>
+        :"baz<defaultArg>1"
         <emptyTree>
       end
     end

--- a/test/testdata/resolver/resolve_tree_printing.rb.flatten-tree-raw.exp
+++ b/test/testdata/resolver/resolve_tree_printing.rb.flatten-tree-raw.exp
@@ -9,6 +9,8 @@ InsSeq{
           symbol = ::<todo sym>
         }]
       rhs = [
+        Literal{ value = :"<static-init>" }
+
         MethodDef{
           flags = self
           name = <U <static-init>><<N <U <static-init>> $CENSORED>>
@@ -55,7 +57,7 @@ InsSeq{
           symbol = ::<todo sym>
         }]
       rhs = [
-        EmptyTree
+        Literal{ value = :"<static-init>" }
 
         MethodDef{
           flags = self
@@ -65,14 +67,14 @@ InsSeq{
             }]
           rhs = InsSeq{
             stats = [
-              EmptyTree
-              EmptyTree
-              EmptyTree
-              EmptyTree
-              EmptyTree
-              EmptyTree
-              EmptyTree
-              EmptyTree
+              Literal{ value = :"has_while" }
+              Literal{ value = :"has_constant_with_resolution_scope" }
+              Literal{ value = :"has_global_field" }
+              Literal{ value = :"has_class_field" }
+              Literal{ value = :"has_next" }
+              Literal{ value = :"has_break" }
+              Literal{ value = :"has_return" }
+              Literal{ value = :"has_cast" }
             ],
             expr = EmptyTree
           }

--- a/test/testdata/resolver/simple.rb.flatten-tree.exp
+++ b/test/testdata/resolver/simple.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         begin
@@ -18,11 +20,15 @@ begin
     end
   end
   class ::Outer1<<C Outer1>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end
   end
   class ::Outer2<<C Outer2>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       begin
         begin
@@ -51,11 +57,15 @@ begin
     end
   end
   class ::Outer2::C<<C C>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end
   end
   class ::Outer2::Inner1<<C Inner1>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       begin
         begin
@@ -73,11 +83,15 @@ begin
     end
   end
   class ::Outer2::Inner1::A<<C A>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end
   end
   class ::Outer2::Inner1::Inner2<<C Inner2>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       begin
         ::Outer2::Inner1::A
@@ -89,6 +103,8 @@ begin
     end
   end
   class ::Outer2::Inner1::Inner2<<C Inner2>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       begin
         ::Outer2::C
@@ -98,6 +114,8 @@ begin
     end
   end
   class ::Outer2::Other<<C Other>> < (::Outer2::Inner1::Inner2)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end

--- a/test/testdata/resolver/stubs_typed_untyped.flatten-tree.exp
+++ b/test/testdata/resolver/stubs_typed_untyped.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         begin
@@ -15,6 +17,8 @@ begin
     end
   end
   module ::Foo<<C Foo>> < ()
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       <emptyTree>
     end
@@ -24,6 +28,8 @@ end
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         Unresolved: <emptyTree>::<C Bar>

--- a/test/testdata/rewriter/attr.rb.flatten-tree.exp
+++ b/test/testdata/rewriter/attr.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         <emptyTree>
@@ -10,7 +12,7 @@ begin
     end
   end
   class ::TestAttr<<C TestAttr>> < (::<todo sym>)
-    <emptyTree>
+    :"<static-init>"
 
     def self.<static-init>(<blk>)
       begin
@@ -18,29 +20,29 @@ begin
         <self>.sig() do ||
           <self>.void()
         end
-        <emptyTree>
+        :"initialize"
         <self>.sig() do ||
           <self>.returns(::Integer)
         end
-        <emptyTree>
+        :"v1"
         <self>.sig() do ||
           <self>.params({:"v1" => ::Integer}).returns(::Integer)
         end
-        <emptyTree>
+        :"v1="
         <self>.sig() do ||
           <self>.returns(::String)
         end
-        <emptyTree>
+        :"v2"
         <self>.sig() do ||
           <self>.params({:"v2" => ::String}).returns(::String)
         end
-        <emptyTree>
+        :"v2="
         <self>.sig() do ||
           <self>.returns(::String)
         end
-        <emptyTree>
-        <emptyTree>
-        <emptyTree>
+        :"v3"
+        :"v4="
+        :"v5="
         <emptyTree>
       end
     end

--- a/test/testdata/todo/block_in_class.rb.flatten-tree.exp
+++ b/test/testdata/todo/block_in_class.rb.flatten-tree.exp
@@ -1,6 +1,8 @@
 begin
   <emptyTree>
   class <emptyTree><<C <root>>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
         <emptyTree>
@@ -10,6 +12,8 @@ begin
     end
   end
   class ::C<<C C>> < (::<todo sym>)
+    :"<static-init>"
+
     def self.<static-init>(<blk>)
       ::C::L = begin
         ::Sorbet::Private::Static.keep_for_typechecking(::T.proc().params({:"x" => ::Integer}).returns(::Integer))


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Now that MethodDefs are replaced with `Symbol`s, it became apparent that we
weren't also keeping `private` and friends in the tree.

For accuracy's sake, we want to keep these method calls in the tree. (Notably,
all other method calls work fine; see `test/testdata/infer/flatten_methods.rb`,
not changed in this PR).


### Commit summary


- **Don't steal private et al. in namer** (1dfbfbc4c)

  We need to keep `private` and friends in the tree so that we can thread 
  them all the way through to the flatten after resolver.

- **Fix failing test** (46bb88a0d)


- **tools/scripts/update_testdata_exp.sh** (a2bc79a0d)




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.