### PR TITLE
Fix `Date#-` Again

### DIFF
--- a/rbi/stdlib/date.rbi
+++ b/rbi/stdlib/date.rbi
@@ -369,7 +369,7 @@ class Date
   #                          #=> (1/2)
   # ```
   sig {params(arg0: Numeric).returns(T.self_type)}
-  sig {params(arg0: T.self_type).returns(Rational)}
+  sig {params(arg0: Date).returns(Rational)}
   def -(arg0); end
 
   # Returns the day of the month (1-31).

--- a/test/testdata/rbi/date.rb
+++ b/test/testdata/rbi/date.rb
@@ -8,15 +8,15 @@ T.assert_type!(Date.today + 1, Date)
 class Test
   extend T::Sig
 
-  sig {params(x: Date).void}
-  def test_date(x)
+  sig {params(x: Date, y: DateTime).void}
+  def test_date(x, y)
     T.reveal_type(x -  x) # error: Revealed type: `Rational`
     T.reveal_type(x - 10) # error: Revealed type: `Date`
-  end
 
-  sig {params(x: DateTime).void}
-  def test_datetime(x)
-    T.reveal_type(x - x) # error: Revealed type: `Rational`
-    T.reveal_type(x - 10) # error: Revealed type: `DateTime`
+    T.reveal_type(y - y) # error: Revealed type: `Rational`
+    T.reveal_type(y - 10) # error: Revealed type: `DateTime`
+
+    T.reveal_type(y - x) # error: Revealed type: `Rational`
+    T.reveal_type(x - y) # error: Revealed type: `Rational`
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The `Date#-` case where a subclass of `Date` is provided as the argument should not use `T.self_type`, as that would rule out `DateTime.new - Date.new`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixing the date rbi again.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
