### PR TITLE
Better sigs for `Date` and `DateTime`

### DIFF
--- a/rbi/stdlib/date.rbi
+++ b/rbi/stdlib/date.rbi
@@ -923,9 +923,6 @@ class Date
   def to_datetime(); end
 
   sig {params(arg0: T.untyped).returns(T.untyped)}
-  def self.new(*arg0); end
-
-  sig {params(arg0: T.untyped).returns(T.untyped)}
   def self._load(arg0); end
 
   # Creates a date object denoting the present day.

--- a/rbi/stdlib/date_time.rbi
+++ b/rbi/stdlib/date_time.rbi
@@ -510,25 +510,12 @@ class DateTime < Date
   def localize(locale=T.unsafe(nil), options=T.unsafe(nil)); end
 
   # Creates a [`DateTime`](https://docs.ruby-lang.org/en/2.6.0/DateTime.html)
-  # object denoting the given calendar date.
-  #
-  # ```ruby
-  # DateTime.new(2001,2,3)    #=> #<DateTime: 2001-02-03T00:00:00+00:00 ...>
-  # DateTime.new(2001,2,3,4,5,6,'+7')
-  #                           #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
-  # DateTime.new(2001,-11,-26,-20,-55,-54,'+7')
-  #                           #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
-  # ```
-  sig {params(arg0: T.untyped).returns(T.untyped)}
-  def self.new(*arg0); end
-
-  # Creates a [`DateTime`](https://docs.ruby-lang.org/en/2.6.0/DateTime.html)
   # object denoting the present time.
   #
   # ```ruby
   # DateTime.now              #=> #<DateTime: 2011-06-11T21:20:44+09:00 ...>
   # ```
-  sig {params(arg0: T.untyped).returns(T.untyped)}
+  sig {params(arg0: T.untyped).returns(DateTime)}
   def self.now(*arg0); end
 
   # Parses the given representation of date and time, and creates a

--- a/test/testdata/rbi/date.rb
+++ b/test/testdata/rbi/date.rb
@@ -2,6 +2,9 @@
 
 require "date"
 
+T.assert_type!(Date.new, Date)
+T.assert_type!(DateTime.new, DateTime)
+T.assert_type!(DateTime.now, DateTime)
 T.assert_type!(Date.today, Date)
 T.assert_type!(Date.today + 1, Date)
 


### PR DESCRIPTION
- `Date.new` should be a `Date`
- `DateTime.new` should be a `DateTime`
- `DateTime.now` should be a `DateTime`

Fixes #2574