### PR TITLE
Upgrade the version of concurrentqueue we're using

### DIFF
--- a/third_party/concurrentqueue.BUILD
+++ b/third_party/concurrentqueue.BUILD
@@ -2,9 +2,9 @@ cc_library(
     name = "concurrentqueue",
     srcs = [],
     hdrs = [
-        "lightweightsemaphore.h",
         "blockingconcurrentqueue.h",
         "concurrentqueue.h",
+        "lightweightsemaphore.h",
     ],
     linkstatic = select({
         "@com_stripe_ruby_typer//tools/config:linkshared": 0,

--- a/third_party/concurrentqueue.BUILD
+++ b/third_party/concurrentqueue.BUILD
@@ -2,6 +2,7 @@ cc_library(
     name = "concurrentqueue",
     srcs = [],
     hdrs = [
+        "lightweightsemaphore.h",
         "blockingconcurrentqueue.h",
         "concurrentqueue.h",
     ],

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -91,9 +91,9 @@ def register_sorbet_dependencies():
     new_git_repository(
         name = "concurrentqueue",
         remote = "https://github.com/cameron314/concurrentqueue.git",
-        commit = "7e3ad876fcca2e44e17528a51865ab2420afb238",
+        commit = "79cec4c3bf1ca23ea4a03adfcd3c2c3659684dd2",
         build_file = "@com_stripe_ruby_typer//third_party:concurrentqueue.BUILD",
-        shallow_since = "1564683624 -0400",
+        shallow_since = "1580387311 -0500",
     )
 
     new_git_repository(


### PR DESCRIPTION
This fixes CI, as there seems to be something wrong with
new_git_repository, shallow_since, and the specific revision of
concurrentqueue we depend on.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fix the build.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
