### PR TITLE
Enter T::Private::Types::Void::VOID as a class symbol

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -309,7 +309,7 @@ void GlobalState::initEmpty() {
     id = enterClassSymbol(Loc::none(), Symbols::T_Private_Types(), Names::Constants::Void());
     id.data(*this)->setIsModule(false);
     ENFORCE(id == Symbols::T_Private_Types_Void());
-    id = enterStaticFieldSymbol(Loc::none(), Symbols::T_Private_Types_Void(), Names::Constants::VOID());
+    id = enterClassSymbol(Loc::none(), Symbols::T_Private_Types_Void(), Names::Constants::VOID());
     ENFORCE(id == Symbols::T_Private_Types_Void_VOID());
 
     // Root members

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -311,6 +311,8 @@ void GlobalState::initEmpty() {
     ENFORCE(id == Symbols::T_Private_Types_Void());
     id = enterClassSymbol(Loc::none(), Symbols::T_Private_Types_Void(), Names::Constants::VOID());
     ENFORCE(id == Symbols::T_Private_Types_Void_VOID());
+    id = id.data(*this)->singletonClass(*this);
+    ENFORCE(id == Symbols::T_Private_Types_Void_VOIDSingleton());
 
     // Root members
     Symbols::root().dataAllowingNone(*this)->members()[core::Names::Constants::NoSymbol()] = Symbols::noSymbol();

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -413,6 +413,10 @@ public:
         return SymbolRef(nullptr, 87);
     }
 
+    static SymbolRef T_Private_Types_Void_VOIDSingleton() {
+        return SymbolRef(nullptr, 88);
+    }
+
     static constexpr int MAX_PROC_ARITY = 10;
     static SymbolRef Proc0() {
         return SymbolRef(nullptr, MAX_SYNTHETIC_SYMBOLS - MAX_PROC_ARITY * 3 - 3);

--- a/gems/sorbet-runtime/lib/types/private/types/void.rb
+++ b/gems/sorbet-runtime/lib/types/private/types/void.rb
@@ -8,13 +8,14 @@ class T::Private::Types::Void < T::Types::Base
 
   # The actual return value of `.void` methods.
   #
-  # Uses `Module.new` because in Ruby an anonymous module will inherit the name
-  # of the constant it's assigned to. This gives it a readable name someone
+  # Uses `module VOID` because this gives it a readable name when someone
   # examines it in Pry or with `#inspect` like:
   #
   #     T::Private::Types::Void::VOID
   #
-  VOID = Module.new.freeze
+  module VOID
+    freeze
+  end
 
   # @override Base
   def name

--- a/test/testdata/resolver/void.rb
+++ b/test/testdata/resolver/void.rb
@@ -1,3 +1,6 @@
 # typed: true
 
 puts T::Private::Types::Void::VOID
+
+# Ensures that VOID gets entered as a class symbol (can be used in type position)
+T.cast(nil, T::Private::Types::Void::VOID)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This matches what reflection sees. Even though it would look like a static
field to sorbet-static, that doesn't matter because Sorbet never sees
sorbet-runtime.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.