### PR TITLE
LSP: When ordering QueryResponses, break location ties by response type.

### DIFF
--- a/test/testdata/lsp/hover_method.rb
+++ b/test/testdata/lsp/hover_method.rb
@@ -64,7 +64,7 @@ class Foo
   sig {params(blk: T.proc.params(arg0: Integer, arg1: String).returns(String)).returns(String)}
   def self.blk_arg(&blk)
     yield(1, "hello")
-  # ^ hover: T.proc.params(arg0: Integer, arg1: String).returns(String)
+  # ^ hover: sig {params(arg0: Integer, arg1: String).returns(String)}
   end
 
   sig {params(a: String, x: String).returns(T::Array[String])}


### PR DESCRIPTION
LSP: When ordering QueryResponses, break location ties by response type.

As a side effect, the hover text for `yield` now displays the hover for a call to `Proc.call` rather than the type of the proc called, e.g.:

```ruby
sig {params(arg0: Integer, arg1: String).returns(String)}
def call(arg0, arg1); end
```

instead of

```ruby
T.proc.params(arg0: Integer, arg1: String).returns(String)
```

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When LSP features ask Sorbet "what's in file foo.rb line 10 column 8", they may get back multiple answers. They take the first item in the list, which we try to order to be the most specific thing by location, and assume that's the best answer.

A recent change caused each method definition site to report a Symbol (LiteralResponse) and a Definition (DefinitionResponse) with the same location. DefinitionResponse is what we want; selecting the LiteralResponse breaks many LSP features (like Find All References, hover...) as literals don't have a definition location. When LiteralResponse is selected, hovering over method "foo" may show "Symbol(:foo)". Due to the tie, which response chosen seems nondeterministic without this change, so the tests in CI pass (because they see DefinitionResponse) while running Sorbet on Stripe code tends to show Symbol(:foo).

This change disambiguates this tie. Ties can still happen if a query reports two responses of the same type with the same location, but I would expect that, should that happen, that the responses would be identical and equivalent.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
