### PR TITLE
Add SPARQL classes to gem loader.

### DIFF
--- a/gems/sorbet/lib/gem_loader.rb
+++ b/gems/sorbet/lib/gem_loader.rb
@@ -538,6 +538,24 @@ class Sorbet::Private::GemLoader
       my_require 'simplecov'
       my_require 'codecov'
     end,
+    'sparql' => proc do
+      my_require 'sparql'
+      [
+        SPARQL::Algebra,
+        SPARQL::Algebra::Aggregate,
+        SPARQL::Algebra::Evaluatable,
+        SPARQL::Algebra::Expression,
+        SPARQL::Algebra::Operator,
+        SPARQL::Algebra::Query,
+        SPARQL::Algebra::Update,
+        SPARQL::Client,
+        SPARQL::Grammar,
+        SPARQL::Grammar::Parser,
+        SPARQL::Grammar::Terminals,
+        SPARQL::Results,
+        SPARQL::VERSION,
+      ]
+    end,
   }
 
   # This is so that the autoloader doesn't treat these as manditory requires


### PR DESCRIPTION
Adds the classes from these autoloads:

- [SPARQL subclass autoloads](https://github.com/ruby-rdf/sparql/blob/a17ed9a6c0a831850fb948419eb692e8db26bd99/lib/sparql.rb#L8-L11)
- [Algebra subclass autoloads](https://github.com/ruby-rdf/sparql/blob/a17ed9a6c0a831850fb948419eb692e8db26bd99/lib/sparql/algebra.rb#L355-L360)
- [Grammar subclass autoloads](https://github.com/ruby-rdf/sparql/blob/a17ed9a6c0a831850fb948419eb692e8db26bd99/lib/sparql/grammar.rb#L160-L161)

There are also all of [these](https://github.com/ruby-rdf/sparql/blob/9abb130008e9763209a3b2c6c80cfd745ea6e0e7/lib/sparql/algebra/operator.rb#L10-L147) on `Operator`, but I didn't include them because there are so many and I haven't needed any of them.

### Motivation

I use the sparql gem for querying [Wikidata](https://www.wikidata.org/wiki/Wikidata:Main_Page) and wanted its types to actually load properly.

### Test plan

See included automated tests. You could also compare the before/after of a basic Ruby project where you use SPARQL and Sorbet, but that's not really necessary.