### PR TITLE
DateTime.new accepts numeric params

### DIFF
--- a/rbi/stdlib/date_time.rbi
+++ b/rbi/stdlib/date_time.rbi
@@ -177,14 +177,14 @@ class DateTime < Date
   # ```
   sig do
     params(
-      year: Integer,
-      month: Integer,
-      mday: Integer,
-      hour: Integer,
-      minute: Integer,
-      second: Integer,
-      offset: T.any(Integer, String),
-      start: T.any(Integer, Float)
+      year: Numeric,
+      month: Numeric,
+      mday: Numeric,
+      hour: Numeric,
+      minute: Numeric,
+      second: Numeric,
+      offset: T.any(Numeric, String),
+      start: Numeric
     )
     .void
   end


### PR DESCRIPTION
### Motivation

To my surprise it also accepts Numeric parameters:

```
$ irb
irb(main):0> DateTime.new(1.1)
=> #<DateTime: 0001-01-01T00:00:00+00:00 ((1721424j,0s,0n),+0s,2299161j)>
irb(main):0> DateTime.new(1, 1.1)
=> #<DateTime: 0001-01-01T00:00:00+00:00 ((1721424j,0s,0n),+0s,2299161j)>
irb(main):0> DateTime.new(1, 1, 1.1)
=> #<DateTime: 0001-01-01T02:24:00+00:00 ((1721424j,8640s,0n),+0s,2299161j)>
irb(main):0> DateTime.new(1, 1, 1, 1.1)
=> #<DateTime: 0001-01-01T01:06:00+00:00 ((1721424j,3960s,0n),+0s,2299161j)>
irb(main):0> DateTime.new(1, 1, 1, 1, 1.1)
=> #<DateTime: 0001-01-01T01:01:06+00:00 ((1721424j,3666s,0n),+0s,2299161j)>
irb(main):0> DateTime.new(1, 1, 1, 1, 1, 1.1)
=> #<DateTime: 0001-01-01T01:01:01+00:00 ((1721424j,3661s,100000000n),+0s,2299161j)>
irb(main):0> DateTime.new(1, 1, 1, 1, 1, 1, 1.1)
=> #<DateTime: 0001-01-01T01:01:01+00:00 ((1721424j,3661s,0n),+0s,2299161j)>
irb(main):0> DateTime.new(1, 1, 1, 1, 1, 1, 1, 1.1)
=> #<DateTime: 0001-01-01T01:01:01+24:00 ((1721423j,3661s,0n),+86400s,2299161j)>
```

### Test plan

See included automated tests.
