### PR TITLE
Absurd can never be checked in typed: false files

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1927,15 +1927,18 @@ public:
                                             make_unique<ast::Cast>(send->loc, type, std::move(expr), send->fun));
                 }
                 case core::Names::revealType()._id:
-                    // This error does not match up with our "upper error levels are super sets
+                case core::Names::absurd()._id: {
+                    // These errors do not match up with our "upper error levels are super sets
                     // of errors from lower levels" claim. This is ONLY an error in lower levels.
+                    auto doWhat = send->fun == core::Names::revealType() ? "reveal types" : "check exhaustiveness";
+                    auto fun = fmt::format("T.{}", send->fun.data(ctx)->show(ctx));
                     if (send->loc.file().data(ctx).strictLevel <= core::StrictLevel::False) {
                         if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::RevealTypeInUntypedFile)) {
-                            e.setHeader("`{}` can only reveal types in `{}` files (or higher)", "T.reveal_type",
-                                        "# typed: true");
+                            e.setHeader("`{}` can only {} in `{}` files (or higher)", fun, doWhat, "# typed: true");
                         }
                     }
                     return send;
+                }
                 default:
                     return send;
             }

--- a/test/testdata/infer/absurd_false.rb
+++ b/test/testdata/infer/absurd_false.rb
@@ -1,0 +1,3 @@
+# typed: false
+
+T.absurd(nil) # error: `T.absurd` can only check exhaustiveness in `# typed: true` files (or higher)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

From Slack:

> I've noticed that `T.absurd` isn't checked in `typed: false` mode. This makes
> using it with enums a bit risky, because if you add a new enum option, sorbet
> can only guarantee that you are using it correctly everywhere if all the
> files you use it in are `typed: true` or higher.
>
> Would it be worth considering making `T.absurd` raise an error when in
> `typed: false` warning the programmer of this? There is precedent in that
> `T.reveal_type` also doesn't work in false, and has errors saying so.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.