### PR TITLE
Support rbenv generated gem paths

### DIFF
--- a/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
@@ -218,7 +218,7 @@ module Sorbet::Private
           location&.match(/^.*\/(ruby)\/([\d.]+)\//) || # ruby stdlib
           location&.match(/^.*\/(j?ruby)-([\d.]+)\//) || # jvm ruby stdlib
           location&.match(/^.*\/(site_ruby)\/([\d.]+)\//) || # rubygems
-          location&.match(/^.*\/gems\/(?:j?ruby-)?[\d.]+(?:@[^\/]+)?(?:\/bundler)?\/gems\/([^\/]+)-([^-\/]+)\//i) # gem
+          location&.match(/^.*\/gems\/(?:(?:j?ruby-)?[\d.]+(?:@[^\/]+)?(?:\/bundler)?\/)?gems\/([^\/]+)-([^-\/]+)\//i) # gem
         if match.nil?
           # uncomment to generate files for methods outside of gems
           # {


### PR DESCRIPTION
Update the regular expression in TracepointSerializer to account for a gem path created by rbenv. Specifically, we should support the following path:

`/mnt/rbenv/versions/2.3.1/gems/gems/mygem-0.2/lib/mygem.rb`

Note the `/gems/gems/` in the middle of this path where the old regular expression assumes a ruby version (but rbenv puts the ruby version at the beginning of the folder structure).

### Motivation

Sorbet could not find our gems due to the rbenv gem path

### Test plan

Simple backwards-compatible regular expression where one segment within the middle of the regular expression is now completely optional
