### PR TITLE
Add the the sample code when using attr_*

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -79,6 +79,7 @@ class A
   sig {returns(Integer)}
   attr_accessor :accessor
   
+  sig {void}
   def initialize
     reader = T.let(0, Integer)
     writer = T.let(0, Integer)

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -78,7 +78,7 @@ class A
   # (Sorbet will use that to write the sig for the writer portion.)
   sig {returns(Integer)}
   attr_accessor :accessor
-  
+
   sig {void}
   def initialize
     reader = T.let(0, Integer)

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -78,6 +78,12 @@ class A
   # (Sorbet will use that to write the sig for the writer portion.)
   sig {returns(Integer)}
   attr_accessor :accessor
+  
+  def initialize
+    reader = T.let(0, Integer)
+    writer = T.let(0, Integer)
+    accessor = T.let(0, Integer)
+  end
 end
 ```
 


### PR DESCRIPTION
Because it's very easy to miss the warning on the constructor part. Having the example in the code is clearer.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
