### PR TITLE
Fix RBI for Process.spawn

### DIFF
--- a/rbi/core/process.rbi
+++ b/rbi/core/process.rbi
@@ -833,6 +833,18 @@ module Process
   sig {returns(Integer)}
   def self.setsid(); end
 
+  # spawn executes specified command and return its pid.
+  # spawn([env,] command... [,options]) → pid
+  sig do
+    params(
+      args: T.any(
+        String,
+        T::Hash[T.any(Symbol, String), T.untyped]
+      )
+    ).returns(Integer)
+  end
+  def self.spawn(*args); end
+
   # Returns a `Tms` structure (see `Process::Tms`) that contains user and system
   # CPU times for this process, and also for children processes.
   #

--- a/test/testdata/rbi/process.rb
+++ b/test/testdata/rbi/process.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+pid = Process.spawn('ls -al')
+Process.wait pid


### PR DESCRIPTION
[Fixes #1671], in which Harry suggested:

```ruby
sig { params(args: T.untyped).returns(Integer) }
```

The sig in this PR is only slightly more accurate, but I don't know how to make it any better. I don't think splat `*args` can be defined as a tuple, and tuples are experimental anyway.

### Motivation

At least now it won't produce error: `Method spawn does not exist`

### Test plan

See included automated tests.
