### PR TITLE
Maintain code definition order in T::Enum

### DIFF
--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -150,11 +150,6 @@ class T::Enum
   sig {returns(SerializedVal).checked(:never)}
   def serialize
     assert_bound!
-    _serialized_val
-  end
-
-  sig {returns(SerializedVal).checked(:never)}
-  def _serialized_val
     @serialized_val
   end
 
@@ -266,7 +261,7 @@ class T::Enum
     serialized_val = serialized_val.frozen? ? serialized_val : serialized_val.dup.freeze
     @serialized_val = T.let(serialized_val, T.nilable(SerializedVal))
     @const_name = T.let(nil, T.nilable(Symbol))
-    self.class._add_instance(self)
+    self.class._register_instance(self)
   end
 
   sig {returns(NilClass).checked(:never)}
@@ -306,7 +301,7 @@ class T::Enum
 
   # Maintains the order in which values are defined
   sig {params(instance: T.untyped).void}
-  def self._add_instance(instance)
+  def self._register_instance(instance)
     @values ||= []
     @values << T.cast(instance, T.attached_class)
   end
@@ -348,7 +343,7 @@ class T::Enum
 
     orphaned_instances = T.must(@values) - @mapping.values
     if !orphaned_instances.empty?
-      raise "Enum values must be assigned to constants: #{orphaned_instances.map(&:_serialized_val)}"
+      raise "Enum values must be assigned to constants: #{orphaned_instances.map {|v| v.instance_variable_get('@serialized_val')}}"
     end
 
     @fully_initialized = true

--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -329,7 +329,7 @@ class T::Enum
       end
       @mapping[serialized] = instance
     end
-    @values = @mapping.values.sort.freeze
+    @values = @mapping.values.freeze
     @mapping.freeze
     @fully_initialized = true
   end

--- a/gems/sorbet-runtime/sorbet-runtime.gemspec
+++ b/gems/sorbet-runtime/sorbet-runtime.gemspec
@@ -18,4 +18,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   # for reproducing race conditions in tests
   s.add_development_dependency 'concurrent-ruby', '~> 1.1.5'
+  s.add_development_dependency 'pry'
+  s.add_development_dependency 'pry-byebug'
 end

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -67,13 +67,6 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
     end
   end
 
-  describe 'sorting' do
-    it 'sorts according to serialized_val' do
-      assert_equal(CardSuit::CLUB, CardSuit.values.min) # 'c' is first alphabetically
-      assert_equal(CardSuit::SPADE, CardSuit.values.max)
-    end
-  end
-
   describe 'to_s' do
     it 'prints the full constant name' do
       assert_equal('#<T::Enum::Test::EnumTest::CardSuit::SPADE>', CardSuit::SPADE.to_s)
@@ -81,9 +74,10 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
   end
 
   describe 'values' do
-    it 'returns an array of enum instances' do
+    it 'returns an array of enum instances, sorted by code order' do
+      # note this is *not* alphabetical order (S before D)
       assert_equal(
-        [CardSuit::CLUB, CardSuit::DIAMOND, CardSuit::HEART, CardSuit::SPADE],
+        [CardSuit::CLUB, CardSuit::SPADE, CardSuit::DIAMOND, CardSuit::HEART],
         CardSuit.values
       )
     end

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -259,6 +259,13 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
       )
     end
 
+    it 'does not allow `_add_instance` after enum has been defined' do
+      ex = assert_raises(RuntimeError) do
+        CardSuit._add_instance(CardSuit::HEART)
+      end
+      assert_match(/can't modify frozen Array/, ex.message)
+    end
+
     it 'returns the same object for #dup and #clone' do
       assert_equal(CardSuit::DIAMOND.object_id, CardSuit::DIAMOND.dup.object_id)
       assert_equal(CardSuit::DIAMOND.object_id, CardSuit::DIAMOND.clone.object_id)
@@ -297,6 +304,17 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
         /Attempting to access Enum value on #<.*> before it has been initialized/,
         ex.message
       )
+    end
+
+    it 'does not allow instance without assigning to constant' do
+      ex = assert_raises(RuntimeError) do
+        Class.new(T::Enum) do
+          enums do
+            new('foo')
+          end
+        end
+      end
+      assert_equal('Enum values must be assigned to constants: ["foo"]', ex.message)
     end
   end
 

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -315,7 +315,7 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
           end
         end
       end
-      assert_equal('Enum values must be assigned to constants: ["foo"]', ex.message)
+      assert_equal('Enum values must be assigned to constants: ["foo", nil]', ex.message)
     end
   end
 

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -259,9 +259,9 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
       )
     end
 
-    it 'does not allow `_add_instance` after enum has been defined' do
+    it 'does not allow `_register_instance` after enum has been defined' do
       ex = assert_raises(RuntimeError) do
-        CardSuit._add_instance(CardSuit::HEART)
+        CardSuit._register_instance(CardSuit::HEART)
       end
       assert_match(/can't modify frozen Array/, ex.message)
     end
@@ -311,6 +311,7 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
         Class.new(T::Enum) do
           enums do
             new('foo')
+            new
           end
         end
       end


### PR DESCRIPTION
### Summary
The ordering of enums can be important. Enums are often naively implemented as arrays which make this easy. But with `T::Enum`, the definition order is lost – `values` are currently [sorted alphabetically](https://github.com/sorbet/sorbet/blob/be978ff1699c36791866272a0c3c5e4f1918c128/gems/sorbet-runtime/lib/types/enum.rb#L332). This requires, for example, duplicate code to maintain an array of the desired order alongside the instances. 

I don't think this `sort` is necessary – I think the definition order should be maintained. This will make migrating code from other styles of (Array-based) enums to `T::Enum` easier.

Also addressed a bug in which a `T::Enum` value can be `new`'d without being assigned to a constant, which effectively orphans it.

### Test plan
Added and modified unit tests
