### PR TITLE
Fix source of untypedness in Array#flatten intrinsic

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1982,7 +1982,7 @@ public:
             ENFORCE(false, "Array#flatten on unexpected type: {}", args.selfType->show(ctx));
         }
 
-        int64_t depth = INT64_MAX;
+        int64_t depth;
         if (args.args.size() == 1) {
             auto argTyp = args.args[0]->type;
             ENFORCE(args.locs.args.size() == 1, "Mismatch between args.size() and args.locs.args.size(): {}",
@@ -2004,6 +2004,8 @@ public:
                 // Negative values behave like no depth was given
                 depth = INT64_MAX;
             }
+        } else if (args.args.size() == 0) {
+            depth = INT64_MAX;
         } else {
             // If our arity is off, then calls.cc will report an error due to mismatch with the RBI elsewhere, so we
             // don't need to do anything special here

--- a/test/testdata/infer/flatten.rb
+++ b/test/testdata/infer/flatten.rb
@@ -22,20 +22,20 @@ xsss = T.let(
   T::Array[T::Array[T::Array[Integer]]],
 )
 
-T.assert_type!(flat_tuple.flatten, T::Array[Integer]);
-T.assert_type!(nested_tuple.flatten, T::Array[Integer])
+T.reveal_type(flat_tuple.flatten) # error: Revealed type: `T::Array[Integer]`
+T.reveal_type(nested_tuple.flatten) # error: Revealed type: `T::Array[Integer]`
 
-T.assert_type!(xs.flatten, T::Array[Integer])
-T.assert_type!(xss.flatten, T::Array[Integer])
+T.reveal_type(xs.flatten) # error: Revealed type: `T::Array[Integer]`
+T.reveal_type(xss.flatten) # error: Revealed type: `T::Array[Integer]`
 
-T.assert_type!(xss.flatten(0), T::Array[T::Array[Integer]])
-T.assert_type!(xss.flatten(1), T::Array[Integer])
-T.assert_type!(xss.flatten(2), T::Array[Integer])
+T.reveal_type(xss.flatten(0)) # error: Revealed type: `T::Array[T::Array[Integer]]`
+T.reveal_type(xss.flatten(1)) # error: Revealed type: `T::Array[Integer]`
+T.reveal_type(xss.flatten(2)) # error: Revealed type: `T::Array[Integer]`
 
-T.assert_type!(xsss.flatten(-1), T::Array[Integer])
-T.assert_type!(xsss.flatten(0), T::Array[T::Array[T::Array[Integer]]])
-T.assert_type!(xsss.flatten(1), T::Array[T::Array[Integer]])
-T.assert_type!(xsss.flatten(2), T::Array[Integer])
+T.reveal_type(xsss.flatten(-1)) # error: Revealed type: `T::Array[Integer]`
+T.reveal_type(xsss.flatten(0)) # error: Revealed type: `T::Array[T::Array[T::Array[Integer]]]`
+T.reveal_type(xsss.flatten(1)) # error: Revealed type: `T::Array[T::Array[Integer]]`
+T.reveal_type(xsss.flatten(2)) # error: Revealed type: `T::Array[Integer]`
 
 xs.flatten(1 + 1) # error: You must pass an Integer literal to specify a depth
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I found that we were accidentally returning `T::Array[T.untyped]` while adding
types to a small Ruby script at work.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.