### PR TITLE
Fix ruby build for GCC

### DIFF
--- a/third_party/ruby/build-ruby.bzl
+++ b/third_party/ruby/build-ruby.bzl
@@ -109,7 +109,7 @@ cp "$base/{bundler}" bundler.gem
 # --local to avoid going to rubygmes for the gem
 # --env-shebang to not hardcode the path to ruby in the sandbox
 # --force because bundler is packaged with ruby starting with 2.6
-"$out_dir/bin/gem" install --local --env-shebang --force bundler.gem
+run_cmd "$out_dir/bin/gem" install --local --env-shebang --force bundler.gem
 
 popd > /dev/null
 

--- a/third_party/ruby/build-ruby.bzl
+++ b/third_party/ruby/build-ruby.bzl
@@ -54,6 +54,9 @@ done
 
 build_dir="$(mktemp -d)"
 
+# Add the compiler's directory the PATH, as this fixes builds with gcc
+export PATH="$(dirname "{cc}"):$PATH"
+
 # Copy everything to a separate directory to get rid of symlinks:
 # tool/rbinstall.rb will explicitly ignore symlinks when installing files,
 # and this feels more maintainable than patching it.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Building ruby with GCC fails when it tries to find `ld`, if the directory that contains `gcc` isn't in the PATH.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
