### PR TITLE
Fix a typo in website/docs/metrics.md

### DIFF
--- a/website/docs/metrics.md
+++ b/website/docs/metrics.md
@@ -1,7 +1,7 @@
 ---
 id: metrics
 title: Tracking Adoption with Metrics
-sidebar_label: Tracking Adopption
+sidebar_label: Tracking Adoption
 ---
 
 There are two primary metrics that we recommend to track adoption of Sorbet in a


### PR DESCRIPTION
Fixes this:

<img width="226" alt="Screen Shot 2020-02-07 at 9 38 13 AM" src="https://user-images.githubusercontent.com/548/74047459-a07d3d00-498d-11ea-80da-e052b8be7429.png">

<img width="172" alt="Screen Shot 2020-02-07 at 9 38 18 AM" src="https://user-images.githubusercontent.com/548/74047465-a115d380-498d-11ea-9990-28a2cffb2619.png">
