### PR TITLE
Expose additional configure arguments to ruby

### DIFF
--- a/third_party/ruby/build-ruby.bzl
+++ b/third_party/ruby/build-ruby.bzl
@@ -79,6 +79,7 @@ run_cmd ./configure \
         CPPFLAGS="${{inc_path[*]}} {copts}" \
         LDFLAGS="${{lib_path[*]}} {linkopts}" \
         OUTFLAG="-fvisibility=default -o" \
+        {configure_flags} \
         --enable-load-relative \
         --with-destdir="$out_dir" \
         --with-rubyhdrdir='${{includedir}}' \
@@ -227,6 +228,7 @@ def _build_ruby_impl(ctx):
             hdrs = " ".join(hdrs),
             libs = " ".join(libs),
             bundler = ctx.files.bundler[0].path,
+            configure_flags = " ".join(ctx.attr.configure_flags),
         )),
     )
 
@@ -251,6 +253,9 @@ build_ruby = rule(
         "bundler": attr.label(
             mandatory = True,
             doc = "The bundler gem to install",
+        ),
+        "configure_flags": attr.string_list(
+            doc = "Additional arguments to configure",
         ),
         "copts": attr.string_list(
             doc = "Additional copts for the ruby build",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Adds the `configure_flags` attribute to the ruby internal build rules.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
