### PR TITLE
Add a newline after the header for gem RBIs.

### DIFF
--- a/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
@@ -55,7 +55,7 @@ module Sorbet::Private
 #   https://github.com/sorbet/sorbet-typed/new/master?filename=lib/#{gem[:gem]}/all/#{gem[:gem]}.rbi
 #
 ")
-            f.write("# #{gem[:gem]}-#{gem[:version]}\n")
+            f.write("# #{gem[:gem]}-#{gem[:version]}\n\n")
             klass_ids.each do |klass_id, class_def|
               klass = class_def.klass
 

--- a/gems/sorbet/test/snapshot/partial/local_gem/expected/sorbet/rbi/gems/my_gem.rbi
+++ b/gems/sorbet/test/snapshot/partial/local_gem/expected/sorbet/rbi/gems/my_gem.rbi
@@ -8,6 +8,7 @@
 #   https://github.com/sorbet/sorbet-typed/new/master?filename=lib/my_gem/all/my_gem.rbi
 #
 # my_gem-0.0.0
+
 class MyGem
   def my_gem_thing; end
   def self.method; end

--- a/gems/sorbet/test/snapshot/partial/local_rvm_gemset_gem/expected/sorbet/rbi/gems/my_gem.rbi
+++ b/gems/sorbet/test/snapshot/partial/local_rvm_gemset_gem/expected/sorbet/rbi/gems/my_gem.rbi
@@ -8,6 +8,7 @@
 #   https://github.com/sorbet/sorbet-typed/new/master?filename=lib/my_gem/all/my_gem.rbi
 #
 # my_gem-0.0.0
+
 class MyGem
   def my_gem_thing; end
 end


### PR DESCRIPTION
This prevents the LSP from picking the header up as a comment on the gem's first class/module.

Before:

<img width="619" alt="Screen Shot 2020-02-09 at 2 49 06 PM" src="https://user-images.githubusercontent.com/2977353/74110733-378ff380-4b4c-11ea-938b-4302309fda5c.png">

After:

<img width="296" alt="Screen Shot 2020-02-09 at 2 54 21 PM" src="https://user-images.githubusercontent.com/2977353/74110730-3363d600-4b4c-11ea-97cf-cc5be781e7fd.png">

### Motivation

Just a minor nitpick that bothered me.

### Test plan

See included automated tests.