### PR TITLE
Add FriendlyId to gem_loader.rb

### DIFF
--- a/gems/sorbet/lib/gem_loader.rb
+++ b/gems/sorbet/lib/gem_loader.rb
@@ -592,6 +592,19 @@ class Sorbet::Private::GemLoader
         Selenium::WebDriver::Support,
       ]
     end,
+    'friendly_id' => proc do
+      my_require 'friendly_id'
+      [
+        FriendlyId::History,
+        FriendlyId::Slug,
+        FriendlyId::SimpleI18n,
+        FriendlyId::Reserved,
+        FriendlyId::Scoped,
+        FriendlyId::Slugged,
+        FriendlyId::Finders,
+        FriendlyId::SequentiallySlugged
+      ]
+    end,
   }
 
   # This is so that the autoloader doesn't treat these as manditory requires


### PR DESCRIPTION
These are some autoloads from friendly_id.

https://github.com/norman/friendly_id/blob/9cd4ce2b5d0425aa704872e1334b442cab03c29c/lib/friendly_id.rb#L46-L53

### Motivation

These classes/modules weren't being loaded before this change, so they ended up in hidden.rbi.

### Test plan

See included automated tests.