### PR TITLE
Prevent Sqreen from attempting to boot

### DIFF
--- a/gems/sorbet/lib/gem_loader.rb
+++ b/gems/sorbet/lib/gem_loader.rb
@@ -148,6 +148,10 @@ class Sorbet::Private::GemLoader
       my_require 'sinatra/multi_route'
       my_require 'sinatra/contrib/version'
     end,
+    'sqreen' => proc do
+      ENV['SQREEN_DISABLE'] = 'true'
+      my_require 'sqreen'
+    end,
     'thin-attach_socket' => proc do
       my_require 'thin'
       my_require 'thin/attach_socket'


### PR DESCRIPTION
### Motivation

Follow-up to https://github.com/sorbet/sorbet/pull/2461

Prevents Sqreen from attempting to boot on `load_bundler`:

```
class Sorbet::Private::RequireEverything
    # ...
    load_rails # does Bundler.require(*Rails.groups)
    load_bundler # does Sorbet::Private::GemLoader.require_all_gems
```

This is achieved by using Sqreen's agent feature of early disabling its side-effectful boot via `SQREEN_DISABLE` environment variable.

Note: this does not disable Sqreen if it is required by `load_rails`. Sqreen has facilities to handle that case but there may be bugs in older versions. A counter to that would be to define `SQREEN_DISABLE` before `load_rails`.

In any case, improvements to Sqreen code itself will be made in upcoming versions as support for Sorbet is further integrated.

### Test plan

I don't think this area is covered by tests.
