### PR TITLE
Attached class param docs

### DIFF
--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -63,6 +63,7 @@ constexpr ErrorClass TypeMemberCycle{5055, StrictLevel::False};
 constexpr ErrorClass ExperimentalAttachedClass{5056, StrictLevel::False};
 // constexpr ErrorClass GeneratedDeprecated{5056, StrictLevel::False};
 constexpr ErrorClass StaticAbstractModuleMethod{5057, StrictLevel::False};
+constexpr ErrorClass AttachedClassAsParam{5058, StrictLevel::False};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -144,17 +144,24 @@ private:
                 auto paramVariance = paramData->variance();
 
                 if (!hasCompatibleVariance(polarity, paramVariance)) {
-                    if (auto e = ctx.state.beginError(this->loc, core::errors::Resolver::InvalidVariance)) {
-                        auto flavor =
-                            paramData->owner.data(ctx)->isSingletonClass(ctx) ? "type_template" : "type_member";
+                    if (paramData->name == core::Names::Constants::AttachedClass()) {
+                        if (auto e = ctx.state.beginError(this->loc, core::errors::Resolver::AttachedClassAsParam)) {
+                            e.setHeader("`{}` may only be used in an `{}` context, like `{}`", "T.attached_class",
+                                        ":out", "returns");
+                        }
+                    } else {
+                        if (auto e = ctx.state.beginError(this->loc, core::errors::Resolver::InvalidVariance)) {
+                            auto flavor =
+                                paramData->owner.data(ctx)->isSingletonClass(ctx) ? "type_template" : "type_member";
 
-                        auto paramName = paramData->name.data(ctx)->show(ctx);
+                            auto paramName = paramData->name.data(ctx)->show(ctx);
 
-                        e.setHeader("`{}` `{}` was defined as `{}` but is used in an `{}` context", flavor, paramName,
-                                    showVariance(paramVariance), showPolarity(polarity));
+                            e.setHeader("`{}` `{}` was defined as `{}` but is used in an `{}` context", flavor,
+                                        paramName, showVariance(paramVariance), showPolarity(polarity));
 
-                        e.addErrorLine(paramData->loc(), "`{}` `{}` defined here as `{}`", flavor, paramName,
-                                       showVariance(paramVariance));
+                            e.addErrorLine(paramData->loc(), "`{}` `{}` defined here as `{}`", flavor, paramName,
+                                           showVariance(paramVariance));
+                        }
                     }
                 }
             },

--- a/test/testdata/infer/attached_class_params.rb
+++ b/test/testdata/infer/attached_class_params.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+class A
+  extend T::Sig
+
+  sig {params(x: T.attached_class).void}
+            # ^ error: `T.attached_class` may only be used in an `:out` context
+  def self.test(x); end
+end

--- a/website/docs/attached-class.md
+++ b/website/docs/attached-class.md
@@ -160,9 +160,11 @@ calls to `A.consume_parent`:
     and thus will raise an error when `say_hi` is called on the instance
     produced by `Parent.make`
 
-Because of this problem, `T.attached_class` is only allowed to show up in the
-`returns` part of a signature, and if it does show up in the `params` of a
-signature, you'll get an error:
+As these two cases show, Sorbet can't know whether the body of
+`A.consume_parent` type checks or not without knowledge about what type `cls` is
+at runtime. Because of this problem, `T.attached_class` is only allowed to show
+up in the `returns` part of a signature, and if it does show up in the `params`
+of a signature, you'll get an error:
 
 ```ruby
 class Parent

--- a/website/docs/attached-class.md
+++ b/website/docs/attached-class.md
@@ -171,8 +171,7 @@ class Parent
   extend T::Sig
 
   sig {params(x: T.attached_class).void}
-            # ^: error: type_template <AttachedClass> was defined as :out but is
-            # used in an :in context
+            # ^: T.attached_class may only be used in an :out context, like returns
   def self.problem(x); end
 end
 ```

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -518,6 +518,12 @@ Some alternatives:
   references to inherit from this class instead of including the original
   module.
 
+## 5058
+
+It's an error to use `T.attached_class` to describe the type of method
+parameters. See the [T.attached_class](attached-class.md) documentation for a
+more thorough description of why this is.
+
 ## 6002
 
 In `# typed: strict` files, Sorbet requires that all instance and class

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -521,8 +521,9 @@ Some alternatives:
 ## 5058
 
 It's an error to use `T.attached_class` to describe the type of method
-parameters. See the [T.attached_class](attached-class.md) documentation for a
-more thorough description of why this is.
+parameters. See the
+[T.attached_class](attached-class.md#tattached_class-as-an-argument)
+documentation for a more thorough description of why this is.
 
 ## 6002
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Explain why `T.attached_class` is not allowed to show up as the type of a parameter in a self method.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
