### PR TITLE
Load more gems in gem loader

### DIFF
--- a/gems/sorbet/lib/gem_loader.rb
+++ b/gems/sorbet/lib/gem_loader.rb
@@ -647,9 +647,12 @@ class Sorbet::Private::GemLoader
     # Do not load gems in Gemfile where require is false
     dependencies = lockfile_parser.dependencies.reject { |name, dep| dep.autorequire && dep.autorequire.empty? }
     required_dependency_names = dependencies.values.map(&:name)
-    # Only include the spec for a gem if it's autorequired.
     lockfile_parser.specs.each do |spec|
-      specs << spec.dependencies if required_dependency_names.include?(spec.name)
+      # Only include the spec for a gem and it's dependencies if it's autorequired.
+      if required_dependency_names.include?(spec.name)
+        specs << spec
+        specs << spec.dependencies
+      end
     end
     specs.flatten!
     specs.uniq! { |spec| spec.name }


### PR DESCRIPTION
This loads _all_ gems (those that are autorequired, at least) when requiring gems in gem_loader.rb.

### Motivation

I was adding new gems to the gem autoload map in gem_loader.rb, but it wasn't having any effect. `gem_loader.rb` wasn't picking up the subdependencies of my gems, which meant that any classes/modules from those gems that needed to be autoloaded were left undetected by Sorbet. 

### Test plan

See included automated tests. Run this on your own Ruby projects to make sure it works properly. It should increase the amount of modules/classes that are detected by Sorbet.

You can see how this change effected my Rails app with [this commit](https://github.com/connorshea/VideoGameList/commit/3ebdcff16426f11f1299c3c0bf093be724509673), which adds ~7000 lines of RBIs and adds RBIs for more than a dozen gems that were previously missing. (It oddly seems to get rid of 2, I'm not really sure why).