### PR TITLE
Support canceling the slow path while copying ParsedFiles

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -239,10 +239,13 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
         // We use `gs` rather than the moved `finalGS` from this point forward.
 
         // Copy the indexes of unchanged files.
-        for (const auto &tree : indexed) {
-            // Note: indexed entries for payload files don't have any contents.
-            if (tree.tree && !updatedFiles.contains(tree.file.id())) {
-                indexedCopies.emplace_back(ast::ParsedFile{tree.tree->deepCopy(), tree.file});
+        {
+            Timer timeit(logger, "slow_path.copy_indexes");
+            for (const auto &tree : indexed) {
+                // Note: indexed entries for payload files don't have any contents.
+                if (tree.tree && !updatedFiles.contains(tree.file.id())) {
+                    indexedCopies.emplace_back(ast::ParsedFile{tree.tree->deepCopy(), tree.file});
+                }
             }
         }
         if (epochManager.wasTypecheckingCanceled()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Support canceling the slow path while copying ParsedFiles

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Copying ParsedFiles can take over a second, so this change improves latency.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
