### PR TITLE
Parallelize copying indexes on slow path.

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -2,6 +2,7 @@
 #include "absl/synchronization/mutex.h"
 #include "absl/synchronization/notification.h"
 #include "ast/treemap/treemap.h"
+#include "common/concurrency/ConcurrentQueue.h"
 #include "common/sort.h"
 #include "common/typecase.h"
 #include "core/ErrorQueue.h"
@@ -233,6 +234,53 @@ updateFile(unique_ptr<core::GlobalState> gs, const shared_ptr<core::File> &file,
 }
 } // namespace
 
+void LSPTypechecker::copyIndexed(WorkerPool &workers, const UnorderedSet<int> &ignore,
+                                 vector<ast::ParsedFile> &out) const {
+    auto &logger = *config->logger;
+    Timer timeit(logger, "slow_path.copy_indexes");
+    shared_ptr<ConcurrentBoundedQueue<int>> fileq = make_shared<ConcurrentBoundedQueue<int>>(indexed.size());
+    for (int i = 0; i < indexed.size(); i++) {
+        auto copy = i;
+        fileq->push(move(copy), 1);
+    }
+
+    shared_ptr<BlockingBoundedQueue<vector<ast::ParsedFile>>> resultq =
+        make_shared<BlockingBoundedQueue<vector<ast::ParsedFile>>>(indexed.size());
+    workers.multiplexJob("copyParsedFiles", [fileq, resultq, &indexed = this->indexed, &ignore]() {
+        vector<ast::ParsedFile> threadResult;
+        int processedByThread = 0;
+        int job;
+        {
+            for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
+                if (result.gotItem()) {
+                    processedByThread++;
+
+                    const auto &tree = indexed[job];
+                    // Note: indexed entries for payload files don't have any contents.
+                    if (tree.tree && !ignore.contains(tree.file.id())) {
+                        threadResult.emplace_back(ast::ParsedFile{tree.tree->deepCopy(), tree.file});
+                    }
+                }
+            }
+        }
+
+        if (processedByThread > 0) {
+            resultq->push(move(threadResult), processedByThread);
+        }
+    });
+    {
+        vector<ast::ParsedFile> threadResult;
+        for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger); !result.done();
+             result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger)) {
+            if (result.gotItem()) {
+                for (auto &copy : threadResult) {
+                    out.push_back(move(copy));
+                }
+            }
+        }
+    }
+}
+
 bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bool cancelable) {
     ENFORCE(this_thread::get_id() == typecheckerThreadId,
             "runSlowPath can only be called from the typechecker thread.");
@@ -282,26 +330,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
         // We use `gs` rather than the moved `finalGS` from this point forward.
 
         // Copy the indexes of unchanged files.
-        {
-            Timer timeit(logger, "slow_path.copy_indexes");
-            u4 count = 0;
-            for (const auto &tree : indexed) {
-                // Note: indexed entries for payload files don't have any contents.
-                if (tree.tree && !updatedFiles.contains(tree.file.id())) {
-                    indexedCopies.emplace_back(ast::ParsedFile{tree.tree->deepCopy(), tree.file});
-
-                    // Copying index trees is fast, but if you're in a huge project it can still take enough time to
-                    // warrant checking if you should cancel typechecking.
-                    // Assuming 0.04 ms per file, this will check every ~10ms.
-                    if (count % 250 == 0 && epochManager.wasTypecheckingCanceled()) {
-                        timeit.cancel();
-                        return;
-                    }
-                    // Explicitly deferred to after check so that we check once at start of indexing.
-                    count++;
-                }
-            }
-        }
+        copyIndexed(workers, updatedFiles, indexedCopies);
         if (epochManager.wasTypecheckingCanceled()) {
             return;
         }

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -99,6 +99,9 @@ class LSPTypechecker final {
      */
     LSPFileUpdates getNoopUpdate(std::vector<core::FileRef> frefs) const;
 
+    /** Deep copy all entries in `indexed` that contain ASTs, except for those with IDs in the ignore set. */
+    void copyIndexed(WorkerPool &workers, const UnorderedSet<int> &ignore, std::vector<ast::ParsedFile> &out) const;
+
 public:
     LSPTypechecker(std::shared_ptr<const LSPConfiguration> config,
                    std::shared_ptr<core::lsp::PreemptionTaskManager> preemptionTaskManager);

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -99,8 +99,9 @@ class LSPTypechecker final {
      */
     LSPFileUpdates getNoopUpdate(std::vector<core::FileRef> frefs) const;
 
-    /** Deep copy all entries in `indexed` that contain ASTs, except for those with IDs in the ignore set. */
-    void copyIndexed(WorkerPool &workers, const UnorderedSet<int> &ignore, std::vector<ast::ParsedFile> &out) const;
+    /** Deep copy all entries in `indexed` that contain ASTs, except for those with IDs in the ignore set. Returns true
+     * on success, false if the operation was canceled. */
+    bool copyIndexed(WorkerPool &workers, const UnorderedSet<int> &ignore, std::vector<ast::ParsedFile> &out) const;
 
 public:
     LSPTypechecker(std::shared_ptr<const LSPConfiguration> config,

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1004,7 +1004,6 @@ ast::ParsedFilesOrCancelled typecheck(unique_ptr<core::GlobalState> &gs, vector<
                 });
 
             typecheck_thread_result threadResult;
-            const auto &epochManager = ctx.state.epochManager;
             {
                 for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs->tracer());
                      !result.done();
@@ -1020,7 +1019,7 @@ ast::ParsedFilesOrCancelled typecheck(unique_ptr<core::GlobalState> &gs, vector<
                         (*preemptionManager)->tryRunScheduledPreemptionTask(*gs);
                     }
                 }
-                if (cancelable && epochManager->wasTypecheckingCanceled()) {
+                if (cancelable && epochManager.wasTypecheckingCanceled()) {
                     return ast::ParsedFilesOrCancelled();
                 }
             }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Parallelize copying indexes on slow path.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed up slow path. It significantly speeds up copying indexed ASTs on very large projects.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
