### PR TITLE
Reimplement ast::Send flags with bit fields

### DIFF
--- a/ast/Helpers.cc
+++ b/ast/Helpers.cc
@@ -41,7 +41,7 @@ bool definesBehavior(const unique_ptr<ast::Expression> &expr) {
         },
 
         // Ignore code synthesized by Rewriter pass.
-        [&](ast::Send *send) { result = !send->isRewriterSynthesized(); },
+        [&](ast::Send *send) { result = !send->flags.isRewriterSynthesized; },
         [&](ast::MethodDef *methodDef) { result = !methodDef->isRewriterSynthesized(); },
         [&](ast::Literal *methodDef) { result = false; },
 

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -308,7 +308,7 @@ public:
         auto sig = Send0(loc, Constant(loc, core::Symbols::T_Sig_WithoutRuntime()), core::Names::sig());
         auto sigSend = ast::cast_tree<ast::Send>(sig.get());
         sigSend->block = Block0(loc, std::move(returns));
-        sigSend->flags |= ast::Send::REWRITER_SYNTHESIZED;
+        sigSend->flags.isRewriterSynthesized = true;
         return sig;
     }
 
@@ -318,7 +318,7 @@ public:
         auto sig = Send0(loc, Constant(loc, core::Symbols::T_Sig_WithoutRuntime()), core::Names::sig());
         auto sigSend = ast::cast_tree<ast::Send>(sig.get());
         sigSend->block = Block0(loc, std::move(void_));
-        sigSend->flags |= ast::Send::REWRITER_SYNTHESIZED;
+        sigSend->flags.isRewriterSynthesized = true;
         return sig;
     }
 
@@ -327,7 +327,7 @@ public:
         auto sig = Send0(loc, Constant(loc, core::Symbols::T_Sig_WithoutRuntime()), core::Names::sig());
         auto sigSend = ast::cast_tree<ast::Send>(sig.get());
         sigSend->block = Block0(loc, std::move(returns));
-        sigSend->flags |= ast::Send::REWRITER_SYNTHESIZED;
+        sigSend->flags.isRewriterSynthesized = true;
         return sig;
     }
 

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -31,10 +31,9 @@ public:
     }
 
     static std::unique_ptr<Expression> Send(core::Loc loc, std::unique_ptr<Expression> recv, core::NameRef fun,
-                                            Send::ARGS_store args, u4 flags = 0,
+                                            Send::ARGS_store args, Send::Flags flags = {},
                                             std::unique_ptr<ast::Block> blk = nullptr) {
-        auto send = std::make_unique<ast::Send>(loc, std::move(recv), fun, std::move(args), std::move(blk));
-        send->flags = flags;
+        auto send = std::make_unique<ast::Send>(loc, std::move(recv), fun, std::move(args), std::move(blk), flags);
         return send;
     }
 
@@ -46,7 +45,7 @@ public:
     static std::unique_ptr<Expression> Send0Block(core::Loc loc, std::unique_ptr<Expression> recv, core::NameRef fun,
                                                   std::unique_ptr<ast::Block> blk) {
         Send::ARGS_store nargs;
-        return Send(loc, std::move(recv), fun, std::move(nargs), 0, std::move(blk));
+        return Send(loc, std::move(recv), fun, std::move(nargs), {}, std::move(blk));
     }
 
     static std::unique_ptr<Expression> Send1(core::Loc loc, std::unique_ptr<Expression> recv, core::NameRef fun,
@@ -383,7 +382,7 @@ public:
                      std::move(arg));
     }
 
-    static std::unique_ptr<Expression> SelfNew(core::Loc loc, ast::Send::ARGS_store args, u4 flags = 0,
+    static std::unique_ptr<Expression> SelfNew(core::Loc loc, ast::Send::ARGS_store args, Send::Flags flags = {},
                                                std::unique_ptr<ast::Block> block = nullptr) {
         auto magic = Constant(loc, core::Symbols::Magic());
         return Send(loc, std::move(magic), core::Names::selfNew(), std::move(args), flags, std::move(block));

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -169,7 +169,7 @@ Assign::Assign(core::Loc loc, unique_ptr<Expression> lhs, unique_ptr<Expression>
 }
 
 Send::Send(core::Loc loc, unique_ptr<Expression> recv, core::NameRef fun, Send::ARGS_store args,
-           unique_ptr<Block> block, u4 flags)
+           unique_ptr<Block> block, Flags flags)
     : Expression(loc), fun(fun), flags(flags), recv(std::move(recv)), args(std::move(args)), block(std::move(block)) {
     categoryCounterInc("trees", "send");
     if (block) {

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -456,9 +456,16 @@ class Send final : public Expression {
 public:
     core::NameRef fun;
 
-    static const int PRIVATE_OK = 1 << 0;
-    static const int REWRITER_SYNTHESIZED = 1 << 1;
-    u4 flags;
+    struct __attribute__((packed, aligned(1))) Flags {
+        bool isPrivateOk : 1;
+        bool isRewriterSynthesized : 1;
+
+        // In C++20 we can replace this with bit field initialzers
+        Flags() : isPrivateOk(false), isRewriterSynthesized(false) {}
+    };
+    CheckSize(Flags, 1, 1);
+
+    Flags flags;
 
     std::unique_ptr<Expression> recv;
 
@@ -468,19 +475,11 @@ public:
     std::unique_ptr<Block> block; // null if no block passed
 
     Send(core::Loc loc, std::unique_ptr<Expression> recv, core::NameRef fun, ARGS_store args,
-         std::unique_ptr<Block> block = nullptr, u4 flags = 0);
+         std::unique_ptr<Block> block = nullptr, Flags flags = {});
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
     virtual std::unique_ptr<Expression> _deepCopy(const Expression *avoid, bool root = false) const;
-
-    bool isRewriterSynthesized() const {
-        return (flags & REWRITER_SYNTHESIZED) != 0;
-    }
-
-    bool isPrivateOk() const {
-        return (flags & PRIVATE_OK) != 0;
-    }
 
 private:
     virtual void _sanityCheck();

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -456,7 +456,7 @@ class Send final : public Expression {
 public:
     core::NameRef fun;
 
-    struct __attribute__((packed, aligned(1))) Flags {
+    struct Flags {
         bool isPrivateOk : 1;
         bool isRewriterSynthesized : 1;
 

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -459,17 +459,17 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                     unique_ptr<Expression> res;
                     if (block == nullptr) {
                         res = MK::Send(loc, MK::Constant(loc, core::Symbols::Magic()), core::Names::callWithSplat(),
-                                       std::move(sendargs), 0);
+                                       std::move(sendargs), {});
                     } else {
                         auto convertedBlock = node2TreeImpl(dctx, std::move(block));
                         Literal *lit;
                         if ((lit = cast_tree<Literal>(convertedBlock.get())) && lit->isSymbol(dctx.ctx)) {
                             res = MK::Send(loc, MK::Constant(loc, core::Symbols::Magic()), core::Names::callWithSplat(),
-                                           std::move(sendargs), 0, symbol2Proc(dctx, std::move(convertedBlock)));
+                                           std::move(sendargs), {}, symbol2Proc(dctx, std::move(convertedBlock)));
                         } else {
                             sendargs.emplace_back(std::move(convertedBlock));
                             res = MK::Send(loc, MK::Constant(loc, core::Symbols::Magic()),
-                                           core::Names::callWithSplatAndBlock(), std::move(sendargs), 0);
+                                           core::Names::callWithSplatAndBlock(), std::move(sendargs), {});
                         }
                     }
                     result.swap(res);
@@ -507,7 +507,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
                             }
 
                             res = MK::Send(loc, MK::Constant(loc, core::Symbols::Magic()), core::Names::callWithBlock(),
-                                           std::move(sendargs), 0);
+                                           std::move(sendargs), {});
                         }
                     }
 
@@ -1128,7 +1128,7 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
 
                 Send::ARGS_store noargs;
                 auto res = MK::Send(loc, node2TreeImpl(dctx, std::move(for_->expr)), core::Names::each(),
-                                    std::move(noargs), 0, std::move(block));
+                                    std::move(noargs), {}, std::move(block));
                 result.swap(res);
             },
             [&](parser::Integer *integer) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -423,12 +423,12 @@ unique_ptr<Expression> node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Nod
             // add entries here, without consulting the "node.*" counters from a
             // run over a representative code base.
             [&](parser::Send *send) {
-                u4 flags = 0;
+                Send::Flags flags;
                 auto rec = node2TreeImpl(dctx, std::move(send->receiver));
                 if (isa_tree<EmptyTree>(rec.get())) {
                     // 0-sized Loc, since `self.` doesn't appear in the original file.
                     rec = MK::Self(loc.copyWithZeroLength());
-                    flags |= Send::PRIVATE_OK;
+                    flags.isPrivateOk = true;
                 }
                 if (absl::c_any_of(send->args, [](auto &arg) { return parser::isa_node<parser::Splat>(arg.get()); })) {
                     // If we have a splat anywhere in the argument list, desugar

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -320,7 +320,8 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::Expression *what, BasicBlock 
                         target.isShadow = e.shadow;
                     }
                     auto link = make_shared<core::SendAndBlockLink>(s->fun, move(argFlags), newRubyBlockId);
-                    auto send = make_unique<Send>(recv, s->fun, s->recv->loc, args, argLocs, s->isPrivateOk(), link);
+                    auto send =
+                        make_unique<Send>(recv, s->fun, s->recv->loc, args, argLocs, !!s->flags.isPrivateOk, link);
                     core::LocalVariable sendTemp = cctx.newTemporary(core::Names::blockPreCallTemp());
                     auto solveConstraint = make_unique<SolveConstraint>(link, sendTemp);
                     current->exprs.emplace_back(sendTemp, s->loc, move(send));
@@ -418,7 +419,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::Expression *what, BasicBlock 
                 } else {
                     current->exprs.emplace_back(
                         cctx.target, s->loc,
-                        make_unique<Send>(recv, s->fun, s->recv->loc, args, argLocs, s->isPrivateOk()));
+                        make_unique<Send>(recv, s->fun, s->recv->loc, args, argLocs, !!s->flags.isPrivateOk));
                 }
 
                 ret = current;

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -221,7 +221,7 @@ public:
             original->fun == core::Names::extend()) {
             ignoring.emplace_back(original.get());
         }
-        if (original->isPrivateOk() && original->fun == core::Names::require() && original->args.size() == 1) {
+        if (original->flags.isPrivateOk && original->fun == core::Names::require() && original->args.size() == 1) {
             auto *lit = ast::cast_tree<ast::Literal>(original->args.front().get());
             if (lit && lit->isString(ctx)) {
                 requires.emplace_back(lit->asString(ctx));

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1590,7 +1590,7 @@ private:
 
                     auto loc = lastSigs[0]->loc;
                     if (loc.file().data(ctx).originalSigil == core::StrictLevel::None &&
-                        !lastSigs.front()->isRewriterSynthesized()) {
+                        !lastSigs.front()->flags.isRewriterSynthesized) {
                         if (auto e = ctx.state.beginError(loc, core::errors::Resolver::SigInFileWithoutSigil)) {
                             e.setHeader("To use `{}`, this file must declare an explicit `{}` sigil (found: "
                                         "none). If you're not sure which one to use, start with `{}`",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I think the code is cleaner this way. It's also more type safe (people can't
accidentally use `flags` interchangeably with a `u4` anymore) and harder to
misuse (the compiler computes bit offsets).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.