### PR TITLE
allow Time#round to accept no arguments

### DIFF
--- a/rbi/core/time.rbi
+++ b/rbi/core/time.rbi
@@ -856,7 +856,7 @@ class Time < Object
     )
     .returns(Time)
   end
-  def round(arg0); end
+  def round(arg0 = 0); end
 
   # Returns `true` if *time* represents Saturday.
   #


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Using `Time#round` without any arguments results in an error. The examples sitting right above the `libdef` show that it can be used with 0 arguments, so I've added the default (which the docs mention is `0`).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
