### PR TITLE
Make ast::MK::Method assumes RewriterSynthesized

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -240,20 +240,28 @@ public:
             args.emplace_back(std::make_unique<ast::BlockArg>(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
         }
         return std::make_unique<MethodDef>(loc, declLoc, core::Symbols::todo(), name, std::move(args), std::move(rhs),
-                                           ast::MethodDef::Flags::RewriterSynthesized);
+                                           0);
     }
 
-    static std::unique_ptr<MethodDef> Method0(core::Loc loc, core::Loc declLoc, core::NameRef name,
-                                              std::unique_ptr<Expression> rhs) {
+    static std::unique_ptr<MethodDef> SyntheticMethod(core::Loc loc, core::Loc declLoc, core::NameRef name,
+                                                      MethodDef::ARGS_store args, std::unique_ptr<Expression> rhs) {
+        auto mdef = Method(loc, declLoc, name, std::move(args), std::move(rhs));
+        mdef->flags |= ast::MethodDef::Flags::RewriterSynthesized;
+        return mdef;
+    }
+
+    static std::unique_ptr<MethodDef> SyntheticMethod0(core::Loc loc, core::Loc declLoc, core::NameRef name,
+                                                       std::unique_ptr<Expression> rhs) {
         MethodDef::ARGS_store args;
-        return Method(loc, declLoc, name, std::move(args), std::move(rhs));
+        return SyntheticMethod(loc, declLoc, name, std::move(args), std::move(rhs));
     }
 
-    static std::unique_ptr<MethodDef> Method1(core::Loc loc, core::Loc declLoc, core::NameRef name,
-                                              std::unique_ptr<Expression> arg0, std::unique_ptr<Expression> rhs) {
+    static std::unique_ptr<MethodDef> SyntheticMethod1(core::Loc loc, core::Loc declLoc, core::NameRef name,
+                                                       std::unique_ptr<Expression> arg0,
+                                                       std::unique_ptr<Expression> rhs) {
         MethodDef::ARGS_store args;
         args.emplace_back(std::move(arg0));
-        return Method(loc, declLoc, name, std::move(args), std::move(rhs));
+        return SyntheticMethod(loc, declLoc, name, std::move(args), std::move(rhs));
     }
 
     static std::unique_ptr<ClassDef> ClassOrModule(core::Loc loc, core::Loc declLoc, std::unique_ptr<Expression> name,

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -244,15 +244,15 @@ public:
                                            flags);
     }
 
-    static std::unique_ptr<Expression> Method0(core::Loc loc, core::Loc declLoc, core::NameRef name,
-                                               std::unique_ptr<Expression> rhs, u4 flags = 0) {
+    static std::unique_ptr<MethodDef> Method0(core::Loc loc, core::Loc declLoc, core::NameRef name,
+                                              std::unique_ptr<Expression> rhs, u4 flags = 0) {
         MethodDef::ARGS_store args;
         return Method(loc, declLoc, name, std::move(args), std::move(rhs), flags);
     }
 
-    static std::unique_ptr<Expression> Method1(core::Loc loc, core::Loc declLoc, core::NameRef name,
-                                               std::unique_ptr<Expression> arg0, std::unique_ptr<Expression> rhs,
-                                               u4 flags = 0) {
+    static std::unique_ptr<MethodDef> Method1(core::Loc loc, core::Loc declLoc, core::NameRef name,
+                                              std::unique_ptr<Expression> arg0, std::unique_ptr<Expression> rhs,
+                                              u4 flags = 0) {
         MethodDef::ARGS_store args;
         args.emplace_back(std::move(arg0));
         return Method(loc, declLoc, name, std::move(args), std::move(rhs), flags);

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -234,28 +234,26 @@ public:
     }
 
     static std::unique_ptr<MethodDef> Method(core::Loc loc, core::Loc declLoc, core::NameRef name,
-                                             MethodDef::ARGS_store args, std::unique_ptr<Expression> rhs,
-                                             u4 flags = 0) {
+                                             MethodDef::ARGS_store args, std::unique_ptr<Expression> rhs) {
         if (args.empty() || (!isa_tree<ast::Local>(args.back().get()) && !isa_tree<ast::BlockArg>(args.back().get()))) {
             auto blkLoc = core::Loc::none(declLoc.file());
             args.emplace_back(std::make_unique<ast::BlockArg>(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
         }
         return std::make_unique<MethodDef>(loc, declLoc, core::Symbols::todo(), name, std::move(args), std::move(rhs),
-                                           flags);
+                                           ast::MethodDef::Flags::RewriterSynthesized);
     }
 
     static std::unique_ptr<MethodDef> Method0(core::Loc loc, core::Loc declLoc, core::NameRef name,
-                                              std::unique_ptr<Expression> rhs, u4 flags = 0) {
+                                              std::unique_ptr<Expression> rhs) {
         MethodDef::ARGS_store args;
-        return Method(loc, declLoc, name, std::move(args), std::move(rhs), flags);
+        return Method(loc, declLoc, name, std::move(args), std::move(rhs));
     }
 
     static std::unique_ptr<MethodDef> Method1(core::Loc loc, core::Loc declLoc, core::NameRef name,
-                                              std::unique_ptr<Expression> arg0, std::unique_ptr<Expression> rhs,
-                                              u4 flags = 0) {
+                                              std::unique_ptr<Expression> arg0, std::unique_ptr<Expression> rhs) {
         MethodDef::ARGS_store args;
         args.emplace_back(std::move(arg0));
-        return Method(loc, declLoc, name, std::move(args), std::move(rhs), flags);
+        return Method(loc, declLoc, name, std::move(args), std::move(rhs));
     }
 
     static std::unique_ptr<ClassDef> ClassOrModule(core::Loc loc, core::Loc declLoc, std::unique_ptr<Expression> name,

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -223,7 +223,6 @@ unique_ptr<MethodDef> buildMethod(DesugarContext dctx, core::Loc loc, core::Loc 
     desugaredBody = validateRBIBody(dctx, move(desugaredBody));
 
     auto mdef = MK::Method(loc, declLoc, name, std::move(args), std::move(desugaredBody));
-    mdef->flags &= ~ast::MethodDef::Flags::RewriterSynthesized;
     mdef->setIsSelf(isSelf);
     return mdef;
 }

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -223,9 +223,8 @@ unique_ptr<MethodDef> buildMethod(DesugarContext dctx, core::Loc loc, core::Loc 
     desugaredBody = validateRBIBody(dctx, move(desugaredBody));
 
     auto mdef = MK::Method(loc, declLoc, name, std::move(args), std::move(desugaredBody));
-    if (isSelf) {
-        mdef->flags |= MethodDef::SelfMethod;
-    }
+    mdef->flags &= ~ast::MethodDef::Flags::RewriterSynthesized;
+    mdef->setIsSelf(isSelf);
     return mdef;
 }
 

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1093,7 +1093,7 @@ unique_ptr<ast::Expression> SerializerImpl::unpickleExpr(serialize::UnPickler &p
             for (auto &arg : args) {
                 arg = unpickleExpr(p, gs, file);
             }
-            auto ret = ast::MK::Method(loc, declLoc, name, std::move(args), std::move(rhs));
+            auto ret = ast::MK::SyntheticMethod(loc, declLoc, name, std::move(args), std::move(rhs));
             ret->flags = flags;
             ret->symbol = symbol;
             return ret;

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -233,7 +233,7 @@ vector<unique_ptr<ast::Expression>> AttrReader::run(core::MutableContext ctx, as
                 }
             }
 
-            stats.emplace_back(ast::MK::Method0(loc, loc, name, ast::MK::Instance(argLoc, varName)));
+            stats.emplace_back(ast::MK::SyntheticMethod0(loc, loc, name, ast::MK::Instance(argLoc, varName)));
         }
     }
 
@@ -266,7 +266,7 @@ vector<unique_ptr<ast::Expression>> AttrReader::run(core::MutableContext ctx, as
             } else {
                 body = ast::MK::Assign(loc, ast::MK::Instance(argLoc, varName), ast::MK::Local(loc, name));
             }
-            stats.emplace_back(ast::MK::Method1(loc, loc, setName, ast::MK::Local(argLoc, name), move(body)));
+            stats.emplace_back(ast::MK::SyntheticMethod1(loc, loc, setName, ast::MK::Local(argLoc, name), move(body)));
         }
     }
 

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -233,8 +233,7 @@ vector<unique_ptr<ast::Expression>> AttrReader::run(core::MutableContext ctx, as
                 }
             }
 
-            stats.emplace_back(ast::MK::Method0(loc, loc, name, ast::MK::Instance(argLoc, varName),
-                                                ast::MethodDef::RewriterSynthesized));
+            stats.emplace_back(ast::MK::Method0(loc, loc, name, ast::MK::Instance(argLoc, varName)));
         }
     }
 
@@ -267,8 +266,7 @@ vector<unique_ptr<ast::Expression>> AttrReader::run(core::MutableContext ctx, as
             } else {
                 body = ast::MK::Assign(loc, ast::MK::Instance(argLoc, varName), ast::MK::Local(loc, name));
             }
-            stats.emplace_back(ast::MK::Method1(loc, loc, setName, ast::MK::Local(argLoc, name), move(body),
-                                                ast::MethodDef::RewriterSynthesized));
+            stats.emplace_back(ast::MK::Method1(loc, loc, setName, ast::MK::Local(argLoc, name), move(body)));
         }
     }
 

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -87,7 +87,6 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
     }
 
     auto selfCall = ast::MK::Method(call->loc, call->loc, call->name, std::move(newArgs), ast::MK::Untyped(call->loc));
-    selfCall->flags &= ~ast::MethodDef::Flags::RewriterSynthesized;
     selfCall->flags |= ast::MethodDef::Flags::SelfMethod;
 
     klass->rhs.insert(klass->rhs.begin() + i + 1, sig->deepCopy());

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -86,7 +86,8 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
         newArgs.emplace_back(arg->deepCopy());
     }
 
-    auto selfCall = ast::MK::Method(call->loc, call->loc, call->name, std::move(newArgs), ast::MK::Untyped(call->loc));
+    auto selfCall =
+        ast::MK::SyntheticMethod(call->loc, call->loc, call->name, std::move(newArgs), ast::MK::Untyped(call->loc));
     selfCall->flags |= ast::MethodDef::Flags::SelfMethod;
 
     klass->rhs.insert(klass->rhs.begin() + i + 1, sig->deepCopy());

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -86,8 +86,9 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
         newArgs.emplace_back(arg->deepCopy());
     }
 
-    auto selfCall = ast::MK::Method(call->loc, call->loc, call->name, std::move(newArgs), ast::MK::Untyped(call->loc),
-                                    ast::MethodDef::SelfMethod);
+    auto selfCall = ast::MK::Method(call->loc, call->loc, call->name, std::move(newArgs), ast::MK::Untyped(call->loc));
+    selfCall->flags &= ~ast::MethodDef::Flags::RewriterSynthesized;
+    selfCall->flags |= ast::MethodDef::Flags::SelfMethod;
 
     klass->rhs.insert(klass->rhs.begin() + i + 1, sig->deepCopy());
     klass->rhs.insert(klass->rhs.begin() + i + 2, std::move(selfCall));

--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -88,8 +88,9 @@ vector<unique_ptr<ast::Expression>> DSLBuilder::run(core::MutableContext ctx, as
             auto default_ = ast::MK::Send0(loc, ast::MK::T(loc), core::Names::untyped());
             arg = ast::MK::OptionalArg(loc, move(arg), move(default_));
         }
-        stats.emplace_back(ast::MK::Method1(loc, loc, name, move(arg), ast::MK::EmptyTree(),
-                                            ast::MethodDef::SelfMethod | ast::MethodDef::RewriterSynthesized));
+        auto defSelfProp = ast::MK::Method1(loc, loc, name, move(arg), ast::MK::EmptyTree());
+        defSelfProp->flags |= ast::MethodDef::Flags::SelfMethod;
+        stats.emplace_back(move(defSelfProp));
     }
 
     if (!skipGetter) {
@@ -100,13 +101,13 @@ vector<unique_ptr<ast::Expression>> DSLBuilder::run(core::MutableContext ctx, as
         // def self.get_<prop>
         core::NameRef getName = ctx.state.enterNameUTF8("get_" + name.data(ctx)->show(ctx));
         stats.emplace_back(ast::MK::Sig0(loc, ASTUtil::dupType(type.get())));
-        stats.emplace_back(ast::MK::Method(loc, loc, getName, {}, ast::MK::Unsafe(loc, ast::MK::Nil(loc)),
-                                           ast::MethodDef::SelfMethod | ast::MethodDef::RewriterSynthesized));
+        auto defSelfGetProp = ast::MK::Method(loc, loc, getName, {}, ast::MK::Unsafe(loc, ast::MK::Nil(loc)));
+        defSelfGetProp->flags |= ast::MethodDef::Flags::SelfMethod;
+        stats.emplace_back(move(defSelfGetProp));
 
         // def <prop>()
         stats.emplace_back(ast::MK::Sig0(loc, ASTUtil::dupType(type.get())));
-        stats.emplace_back(ast::MK::Method(loc, loc, name, {}, ast::MK::Unsafe(loc, ast::MK::Nil(loc)),
-                                           ast::MethodDef::RewriterSynthesized));
+        stats.emplace_back(ast::MK::Method(loc, loc, name, {}, ast::MK::Unsafe(loc, ast::MK::Nil(loc))));
     }
 
     return stats;

--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -88,7 +88,7 @@ vector<unique_ptr<ast::Expression>> DSLBuilder::run(core::MutableContext ctx, as
             auto default_ = ast::MK::Send0(loc, ast::MK::T(loc), core::Names::untyped());
             arg = ast::MK::OptionalArg(loc, move(arg), move(default_));
         }
-        auto defSelfProp = ast::MK::Method1(loc, loc, name, move(arg), ast::MK::EmptyTree());
+        auto defSelfProp = ast::MK::SyntheticMethod1(loc, loc, name, move(arg), ast::MK::EmptyTree());
         defSelfProp->flags |= ast::MethodDef::Flags::SelfMethod;
         stats.emplace_back(move(defSelfProp));
     }
@@ -101,13 +101,13 @@ vector<unique_ptr<ast::Expression>> DSLBuilder::run(core::MutableContext ctx, as
         // def self.get_<prop>
         core::NameRef getName = ctx.state.enterNameUTF8("get_" + name.data(ctx)->show(ctx));
         stats.emplace_back(ast::MK::Sig0(loc, ASTUtil::dupType(type.get())));
-        auto defSelfGetProp = ast::MK::Method(loc, loc, getName, {}, ast::MK::Unsafe(loc, ast::MK::Nil(loc)));
+        auto defSelfGetProp = ast::MK::SyntheticMethod(loc, loc, getName, {}, ast::MK::Unsafe(loc, ast::MK::Nil(loc)));
         defSelfGetProp->flags |= ast::MethodDef::Flags::SelfMethod;
         stats.emplace_back(move(defSelfGetProp));
 
         // def <prop>()
         stats.emplace_back(ast::MK::Sig0(loc, ASTUtil::dupType(type.get())));
-        stats.emplace_back(ast::MK::Method(loc, loc, name, {}, ast::MK::Unsafe(loc, ast::MK::Nil(loc))));
+        stats.emplace_back(ast::MK::SyntheticMethod(loc, loc, name, {}, ast::MK::Unsafe(loc, ast::MK::Nil(loc))));
     }
 
     return stats;

--- a/rewriter/DefaultArgs.cc
+++ b/rewriter/DefaultArgs.cc
@@ -172,8 +172,9 @@ void DefaultArgs::run(core::MutableContext ctx, ast::ClassDef *klass) {
                         }
                         newMethods.emplace_back(move(sig));
                     }
-                    newMethods.emplace_back(ast::MK::Method(loc, loc, name, std::move(args), std::move(rhs),
-                                                            mdef->flags | ast::MethodDef::RewriterSynthesized));
+                    auto defaultArgDef = ast::MK::Method(loc, loc, name, std::move(args), std::move(rhs));
+                    defaultArgDef->setIsSelf(mdef->isSelf());
+                    newMethods.emplace_back(move(defaultArgDef));
                 }
                 lastSig = nullptr;
             },

--- a/rewriter/DefaultArgs.cc
+++ b/rewriter/DefaultArgs.cc
@@ -172,7 +172,7 @@ void DefaultArgs::run(core::MutableContext ctx, ast::ClassDef *klass) {
                         }
                         newMethods.emplace_back(move(sig));
                     }
-                    auto defaultArgDef = ast::MK::Method(loc, loc, name, std::move(args), std::move(rhs));
+                    auto defaultArgDef = ast::MK::SyntheticMethod(loc, loc, name, std::move(args), std::move(rhs));
                     defaultArgDef->setIsSelf(mdef->isSelf());
                     newMethods.emplace_back(move(defaultArgDef));
                 }

--- a/rewriter/Delegate.cc
+++ b/rewriter/Delegate.cc
@@ -124,8 +124,7 @@ vector<unique_ptr<ast::Expression>> Delegate::run(core::MutableContext ctx, cons
         args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
         args.emplace_back(std::make_unique<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
 
-        methodStubs.push_back(ast::MK::Method(loc, loc, methodName, std::move(args), ast::MK::EmptyTree(),
-                                              ast::MethodDef::RewriterSynthesized));
+        methodStubs.push_back(ast::MK::Method(loc, loc, methodName, std::move(args), ast::MK::EmptyTree()));
     }
 
     return methodStubs;

--- a/rewriter/Delegate.cc
+++ b/rewriter/Delegate.cc
@@ -124,7 +124,7 @@ vector<unique_ptr<ast::Expression>> Delegate::run(core::MutableContext ctx, cons
         args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
         args.emplace_back(std::make_unique<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
 
-        methodStubs.push_back(ast::MK::Method(loc, loc, methodName, std::move(args), ast::MK::EmptyTree()));
+        methodStubs.push_back(ast::MK::SyntheticMethod(loc, loc, methodName, std::move(args), ast::MK::EmptyTree()));
     }
 
     return methodStubs;

--- a/rewriter/Flatfiles.cc
+++ b/rewriter/Flatfiles.cc
@@ -49,12 +49,13 @@ void handleFieldDefinition(core::MutableContext ctx, unique_ptr<ast::Expression>
         }
 
         methods.emplace_back(ast::MK::Sig0(send->loc, ast::MK::Untyped(send->loc)));
-        methods.emplace_back(ast::MK::Method0(send->loc, send->loc, *name, ast::MK::Nil(send->loc)));
+        methods.emplace_back(ast::MK::SyntheticMethod0(send->loc, send->loc, *name, ast::MK::Nil(send->loc)));
         auto var = ast::MK::Local(send->loc, core::Names::arg0());
         auto setName = name->addEq(ctx);
         methods.emplace_back(ast::MK::Sig1(send->loc, ast::MK::Symbol(send->loc, core::Names::arg0()),
                                            ast::MK::Untyped(send->loc), ast::MK::Untyped(send->loc)));
-        methods.emplace_back(ast::MK::Method1(send->loc, send->loc, setName, move(var), ast::MK::Nil(send->loc)));
+        methods.emplace_back(
+            ast::MK::SyntheticMethod1(send->loc, send->loc, setName, move(var), ast::MK::Nil(send->loc)));
     }
 }
 

--- a/rewriter/Mattr.cc
+++ b/rewriter/Mattr.cc
@@ -92,7 +92,7 @@ vector<unique_ptr<ast::Expression>> Mattr::run(core::MutableContext ctx, const a
         auto loc = lit->loc;
         if (doReaders) {
             auto sig = ast::MK::Sig0(loc, ast::MK::Untyped(loc));
-            auto def = ast::MK::Method0(loc, loc, lit->asSymbol(ctx), ast::MK::EmptyTree());
+            auto def = ast::MK::SyntheticMethod0(loc, loc, lit->asSymbol(ctx), ast::MK::EmptyTree());
             def->flags |= ast::MethodDef::Flags::SelfMethod;
             if (instanceReader) {
                 addInstanceCounterPart(result, sig, def);
@@ -103,8 +103,8 @@ vector<unique_ptr<ast::Expression>> Mattr::run(core::MutableContext ctx, const a
         if (doWriters) {
             auto sig = ast::MK::Sig1(loc, ast::MK::Symbol(loc, core::Names::arg0()), ast::MK::Untyped(loc),
                                      ast::MK::Untyped(loc));
-            auto def = ast::MK::Method1(loc, loc, lit->asSymbol(ctx).addEq(ctx),
-                                        ast::MK::Local(loc, core::Names::arg0()), ast::MK::EmptyTree());
+            auto def = ast::MK::SyntheticMethod1(loc, loc, lit->asSymbol(ctx).addEq(ctx),
+                                                 ast::MK::Local(loc, core::Names::arg0()), ast::MK::EmptyTree());
             def->flags |= ast::MethodDef::Flags::SelfMethod;
             if (instanceWriter) {
                 addInstanceCounterPart(result, sig, def);
@@ -117,7 +117,7 @@ vector<unique_ptr<ast::Expression>> Mattr::run(core::MutableContext ctx, const a
             // from being generated.
             auto sig = ast::MK::Sig0(
                 loc, ast::MK::UnresolvedConstant(loc, ast::MK::T(loc), core::Names::Constants::Boolean()));
-            auto def = ast::MK::Method0(loc, loc, lit->asSymbol(ctx).addQuestion(ctx), ast::MK::False(loc));
+            auto def = ast::MK::SyntheticMethod0(loc, loc, lit->asSymbol(ctx).addQuestion(ctx), ast::MK::False(loc));
             def->flags |= ast::MethodDef::Flags::SelfMethod;
             if (instanceReader && instancePredicate) {
                 addInstanceCounterPart(result, sig, def);

--- a/rewriter/Mattr.cc
+++ b/rewriter/Mattr.cc
@@ -21,7 +21,7 @@ static bool isLiteralFalse(const core::GlobalState &gs, ast::Expression *node) {
 }
 
 static void addInstanceCounterPart(vector<unique_ptr<ast::Expression>> &sink, const unique_ptr<ast::Expression> &sig,
-                                   const unique_ptr<ast::Expression> &def) {
+                                   const unique_ptr<ast::MethodDef> &def) {
     sink.emplace_back(sig->deepCopy());
     auto instanceDef = def->deepCopy();
     ENFORCE(ast::isa_tree<ast::MethodDef>(def.get()));

--- a/rewriter/Mattr.cc
+++ b/rewriter/Mattr.cc
@@ -92,8 +92,8 @@ vector<unique_ptr<ast::Expression>> Mattr::run(core::MutableContext ctx, const a
         auto loc = lit->loc;
         if (doReaders) {
             auto sig = ast::MK::Sig0(loc, ast::MK::Untyped(loc));
-            auto def = ast::MK::Method0(loc, loc, lit->asSymbol(ctx), ast::MK::EmptyTree(),
-                                        ast::MethodDef::Flags::SelfMethod | ast::MethodDef::Flags::RewriterSynthesized);
+            auto def = ast::MK::Method0(loc, loc, lit->asSymbol(ctx), ast::MK::EmptyTree());
+            def->flags |= ast::MethodDef::Flags::SelfMethod;
             if (instanceReader) {
                 addInstanceCounterPart(result, sig, def);
             }
@@ -104,8 +104,8 @@ vector<unique_ptr<ast::Expression>> Mattr::run(core::MutableContext ctx, const a
             auto sig = ast::MK::Sig1(loc, ast::MK::Symbol(loc, core::Names::arg0()), ast::MK::Untyped(loc),
                                      ast::MK::Untyped(loc));
             auto def = ast::MK::Method1(loc, loc, lit->asSymbol(ctx).addEq(ctx),
-                                        ast::MK::Local(loc, core::Names::arg0()), ast::MK::EmptyTree(),
-                                        ast::MethodDef::Flags::SelfMethod | ast::MethodDef::Flags::RewriterSynthesized);
+                                        ast::MK::Local(loc, core::Names::arg0()), ast::MK::EmptyTree());
+            def->flags |= ast::MethodDef::Flags::SelfMethod;
             if (instanceWriter) {
                 addInstanceCounterPart(result, sig, def);
             }
@@ -117,8 +117,8 @@ vector<unique_ptr<ast::Expression>> Mattr::run(core::MutableContext ctx, const a
             // from being generated.
             auto sig = ast::MK::Sig0(
                 loc, ast::MK::UnresolvedConstant(loc, ast::MK::T(loc), core::Names::Constants::Boolean()));
-            auto def = ast::MK::Method0(loc, loc, lit->asSymbol(ctx).addQuestion(ctx), ast::MK::False(loc),
-                                        ast::MethodDef::Flags::SelfMethod | ast::MethodDef::Flags::RewriterSynthesized);
+            auto def = ast::MK::Method0(loc, loc, lit->asSymbol(ctx).addQuestion(ctx), ast::MK::False(loc));
+            def->flags |= ast::MethodDef::Flags::SelfMethod;
             if (instanceReader && instancePredicate) {
                 addInstanceCounterPart(result, sig, def);
             }

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -200,7 +200,7 @@ unique_ptr<ast::Expression> runUnderEach(core::MutableContext ctx, core::NameRef
             auto blk = ast::MK::Block(send->loc, move(body), std::move(new_args));
             auto each = ast::MK::Send0Block(send->loc, iteratee->deepCopy(), core::Names::each(), move(blk));
             // put that into a method def named the appropriate thing
-            auto method = addSigVoid(ast::MK::Method0(send->loc, send->loc, move(name), move(each)));
+            auto method = addSigVoid(ast::MK::SyntheticMethod0(send->loc, send->loc, move(name), move(each)));
             // add back any moved constants
             return constantMover.addConstantsToExpression(send->loc, move(method));
         }
@@ -267,8 +267,8 @@ unique_ptr<ast::Expression> runSingle(core::MutableContext ctx, ast::Send *send)
         auto name = send->fun == core::Names::after() ? core::Names::afterAngles() : core::Names::initialize();
         ConstantMover constantMover;
         send->block->body = ast::TreeMap::apply(ctx, constantMover, move(send->block->body));
-        auto method =
-            addSigVoid(ast::MK::Method0(send->loc, send->loc, name, prepareBody(ctx, std::move(send->block->body))));
+        auto method = addSigVoid(
+            ast::MK::SyntheticMethod0(send->loc, send->loc, name, prepareBody(ctx, std::move(send->block->body))));
         return constantMover.addConstantsToExpression(send->loc, move(method));
     }
 
@@ -290,8 +290,8 @@ unique_ptr<ast::Expression> runSingle(core::MutableContext ctx, ast::Send *send)
         ConstantMover constantMover;
         send->block->body = ast::TreeMap::apply(ctx, constantMover, move(send->block->body));
         auto name = ctx.state.enterNameUTF8("<it '" + argString + "'>");
-        auto method = addSigVoid(
-            ast::MK::Method0(send->loc, send->loc, std::move(name), prepareBody(ctx, std::move(send->block->body))));
+        auto method = addSigVoid(ast::MK::SyntheticMethod0(send->loc, send->loc, std::move(name),
+                                                           prepareBody(ctx, std::move(send->block->body))));
         method = ast::MK::InsSeq1(send->loc, send->args.front()->deepCopy(), move(method));
         return constantMover.addConstantsToExpression(send->loc, move(method));
     }

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -200,8 +200,7 @@ unique_ptr<ast::Expression> runUnderEach(core::MutableContext ctx, core::NameRef
             auto blk = ast::MK::Block(send->loc, move(body), std::move(new_args));
             auto each = ast::MK::Send0Block(send->loc, iteratee->deepCopy(), core::Names::each(), move(blk));
             // put that into a method def named the appropriate thing
-            auto method = addSigVoid(
-                ast::MK::Method0(send->loc, send->loc, move(name), move(each), ast::MethodDef::RewriterSynthesized));
+            auto method = addSigVoid(ast::MK::Method0(send->loc, send->loc, move(name), move(each)));
             // add back any moved constants
             return constantMover.addConstantsToExpression(send->loc, move(method));
         }
@@ -269,8 +268,7 @@ unique_ptr<ast::Expression> runSingle(core::MutableContext ctx, ast::Send *send)
         ConstantMover constantMover;
         send->block->body = ast::TreeMap::apply(ctx, constantMover, move(send->block->body));
         auto method =
-            addSigVoid(ast::MK::Method0(send->loc, send->loc, name, prepareBody(ctx, std::move(send->block->body)),
-                                        ast::MethodDef::RewriterSynthesized));
+            addSigVoid(ast::MK::Method0(send->loc, send->loc, name, prepareBody(ctx, std::move(send->block->body))));
         return constantMover.addConstantsToExpression(send->loc, move(method));
     }
 
@@ -292,9 +290,8 @@ unique_ptr<ast::Expression> runSingle(core::MutableContext ctx, ast::Send *send)
         ConstantMover constantMover;
         send->block->body = ast::TreeMap::apply(ctx, constantMover, move(send->block->body));
         auto name = ctx.state.enterNameUTF8("<it '" + argString + "'>");
-        auto method = addSigVoid(ast::MK::Method0(send->loc, send->loc, std::move(name),
-                                                  prepareBody(ctx, std::move(send->block->body)),
-                                                  ast::MethodDef::RewriterSynthesized));
+        auto method = addSigVoid(
+            ast::MK::Method0(send->loc, send->loc, std::move(name), prepareBody(ctx, std::move(send->block->body))));
         method = ast::MK::InsSeq1(send->loc, send->args.front()->deepCopy(), move(method));
         return constantMover.addConstantsToExpression(send->loc, move(method));
     }

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -132,7 +132,7 @@ vector<unique_ptr<ast::Expression>> ModuleFunction::run(core::MutableContext ctx
             ast::MethodDef::ARGS_store args;
             args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
             args.emplace_back(std::make_unique<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
-            auto methodDef = ast::MK::Method(loc, loc, methodName, std::move(args), ast::MK::EmptyTree());
+            auto methodDef = ast::MK::SyntheticMethod(loc, loc, methodName, std::move(args), ast::MK::EmptyTree());
             methodDef->flags |= ast::MethodDef::Flags::SelfMethod;
             stats.emplace_back(std::move(methodDef));
         } else {

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -132,8 +132,9 @@ vector<unique_ptr<ast::Expression>> ModuleFunction::run(core::MutableContext ctx
             ast::MethodDef::ARGS_store args;
             args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
             args.emplace_back(std::make_unique<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
-            stats.emplace_back(ast::MK::Method(loc, loc, methodName, std::move(args), ast::MK::EmptyTree(),
-                                               ast::MethodDef::SelfMethod | ast::MethodDef::RewriterSynthesized));
+            auto methodDef = ast::MK::Method(loc, loc, methodName, std::move(args), ast::MK::EmptyTree());
+            methodDef->flags |= ast::MethodDef::Flags::SelfMethod;
+            stats.emplace_back(std::move(methodDef));
         } else {
             if (auto e = ctx.state.beginError(arg->loc, core::errors::Rewriter::BadModuleFunction)) {
                 e.setHeader("Bad argument to `{}`: must be a symbol, string, method definition, or nothing",

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -279,9 +279,8 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
 
         unique_ptr<ast::Expression> arg =
             ast::MK::RestArg(nameLoc, ast::MK::KeywordArg(nameLoc, ast::MK::Local(nameLoc, core::Names::opts())));
-        ret.nodes.emplace_back(ast::MK::Method1(loc, loc, fkMethod, std::move(arg),
-                                                ast::MK::Unsafe(loc, ast::MK::Nil(loc)),
-                                                ast::MethodDef::RewriterSynthesized));
+        ret.nodes.emplace_back(
+            ast::MK::Method1(loc, loc, fkMethod, std::move(arg), ast::MK::Unsafe(loc, ast::MK::Nil(loc))));
 
         // sig {params(opts: T.untyped).returns($foreign)}
         ret.nodes.emplace_back(ast::MK::Sig1(loc, ast::MK::Symbol(nameLoc, core::Names::opts()), ast::MK::Untyped(loc),
@@ -294,9 +293,8 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
         auto fkMethodBang = ctx.state.enterNameUTF8(name.data(ctx)->show(ctx) + "_!");
         unique_ptr<ast::Expression> arg2 =
             ast::MK::RestArg(nameLoc, ast::MK::KeywordArg(nameLoc, ast::MK::Local(nameLoc, core::Names::opts())));
-        ret.nodes.emplace_back(ast::MK::Method1(loc, loc, fkMethodBang, std::move(arg2),
-                                                ast::MK::Unsafe(loc, ast::MK::Nil(loc)),
-                                                ast::MethodDef::RewriterSynthesized));
+        ret.nodes.emplace_back(
+            ast::MK::Method1(loc, loc, fkMethodBang, std::move(arg2), ast::MK::Unsafe(loc, ast::MK::Nil(loc))));
     }
 
     // Compute the Mutator
@@ -412,8 +410,8 @@ void Prop::run(core::MutableContext ctx, ast::ClassDef *klass) {
         }
         auto loc = klass->loc;
         klass->rhs.emplace_back(ast::MK::SigVoid(loc, ast::MK::Hash(loc, std::move(sigKeys), std::move(sigVals))));
-        klass->rhs.emplace_back(ast::MK::Method(loc, loc, core::Names::initialize(), std::move(args),
-                                                ast::MK::EmptyTree(), ast::MethodDef::RewriterSynthesized));
+        klass->rhs.emplace_back(
+            ast::MK::Method(loc, loc, core::Names::initialize(), std::move(args), ast::MK::EmptyTree()));
     }
     // this is cargo-culted from rewriter.cc.
     for (auto &stat : oldRHS) {

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -280,7 +280,7 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
         unique_ptr<ast::Expression> arg =
             ast::MK::RestArg(nameLoc, ast::MK::KeywordArg(nameLoc, ast::MK::Local(nameLoc, core::Names::opts())));
         ret.nodes.emplace_back(
-            ast::MK::Method1(loc, loc, fkMethod, std::move(arg), ast::MK::Unsafe(loc, ast::MK::Nil(loc))));
+            ast::MK::SyntheticMethod1(loc, loc, fkMethod, std::move(arg), ast::MK::Unsafe(loc, ast::MK::Nil(loc))));
 
         // sig {params(opts: T.untyped).returns($foreign)}
         ret.nodes.emplace_back(ast::MK::Sig1(loc, ast::MK::Symbol(nameLoc, core::Names::opts()), ast::MK::Untyped(loc),
@@ -293,8 +293,8 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
         auto fkMethodBang = ctx.state.enterNameUTF8(name.data(ctx)->show(ctx) + "_!");
         unique_ptr<ast::Expression> arg2 =
             ast::MK::RestArg(nameLoc, ast::MK::KeywordArg(nameLoc, ast::MK::Local(nameLoc, core::Names::opts())));
-        ret.nodes.emplace_back(
-            ast::MK::Method1(loc, loc, fkMethodBang, std::move(arg2), ast::MK::Unsafe(loc, ast::MK::Nil(loc))));
+        ret.nodes.emplace_back(ast::MK::SyntheticMethod1(loc, loc, fkMethodBang, std::move(arg2),
+                                                         ast::MK::Unsafe(loc, ast::MK::Nil(loc))));
     }
 
     // Compute the Mutator
@@ -411,7 +411,7 @@ void Prop::run(core::MutableContext ctx, ast::ClassDef *klass) {
         auto loc = klass->loc;
         klass->rhs.emplace_back(ast::MK::SigVoid(loc, ast::MK::Hash(loc, std::move(sigKeys), std::move(sigVals))));
         klass->rhs.emplace_back(
-            ast::MK::Method(loc, loc, core::Names::initialize(), std::move(args), ast::MK::EmptyTree()));
+            ast::MK::SyntheticMethod(loc, loc, core::Names::initialize(), std::move(args), ast::MK::EmptyTree()));
     }
     // this is cargo-culted from rewriter.cc.
     for (auto &stat : oldRHS) {

--- a/rewriter/ProtobufDescriptorPool.cc
+++ b/rewriter/ProtobufDescriptorPool.cc
@@ -55,8 +55,8 @@ vector<unique_ptr<ast::Expression>> ProtobufDescriptorPool::run(core::MutableCon
     if (sendMsgclass->fun == core::Names::msgclass()) {
         auto arg0 = ast::MK::Local(asgn->loc, core::Names::arg0());
         auto arg = ast::MK::OptionalArg(asgn->loc, std::move(arg0), ast::MK::Hash0(asgn->loc));
-        rhs.emplace_back(
-            ast::MK::Method1(asgn->loc, asgn->loc, core::Names::initialize(), std::move(arg), ast::MK::EmptyTree()));
+        rhs.emplace_back(ast::MK::SyntheticMethod1(asgn->loc, asgn->loc, core::Names::initialize(), std::move(arg),
+                                                   ast::MK::EmptyTree()));
     }
 
     vector<unique_ptr<ast::Expression>> res;

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -116,10 +116,9 @@ vector<unique_ptr<ast::Expression>> Struct::run(core::MutableContext ctx, ast::A
         }
         newArgs.emplace_back(ast::MK::OptionalArg(symLoc, move(argName), ast::MK::Nil(symLoc)));
 
-        body.emplace_back(
-            ast::MK::Method0(symLoc, symLoc, name, ast::MK::EmptyTree(), ast::MethodDef::RewriterSynthesized));
+        body.emplace_back(ast::MK::Method0(symLoc, symLoc, name, ast::MK::EmptyTree()));
         body.emplace_back(ast::MK::Method1(symLoc, symLoc, name.addEq(ctx), ast::MK::Local(symLoc, name),
-                                           ast::MK::Local(symLoc, name), ast::MethodDef::RewriterSynthesized));
+                                           ast::MK::Local(symLoc, name)));
     }
 
     // Elem = type_member(fixed: T.untyped)
@@ -144,8 +143,7 @@ vector<unique_ptr<ast::Expression>> Struct::run(core::MutableContext ctx, ast::A
 
     body.emplace_back(ast::MK::SigVoid(loc, ast::MK::Hash(loc, std::move(sigKeys), std::move(sigValues))));
     body.emplace_back(ast::MK::Method(loc, loc, core::Names::initialize(), std::move(newArgs),
-                                      ast::MK::Cast(loc, dupName(asgn->lhs.get())),
-                                      ast::MethodDef::RewriterSynthesized));
+                                      ast::MK::Cast(loc, dupName(asgn->lhs.get()))));
 
     ast::ClassDef::ANCESTORS_store ancestors;
     ancestors.emplace_back(ast::MK::UnresolvedConstant(loc, ast::MK::Constant(loc, core::Symbols::root()),

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -116,9 +116,9 @@ vector<unique_ptr<ast::Expression>> Struct::run(core::MutableContext ctx, ast::A
         }
         newArgs.emplace_back(ast::MK::OptionalArg(symLoc, move(argName), ast::MK::Nil(symLoc)));
 
-        body.emplace_back(ast::MK::Method0(symLoc, symLoc, name, ast::MK::EmptyTree()));
-        body.emplace_back(ast::MK::Method1(symLoc, symLoc, name.addEq(ctx), ast::MK::Local(symLoc, name),
-                                           ast::MK::Local(symLoc, name)));
+        body.emplace_back(ast::MK::SyntheticMethod0(symLoc, symLoc, name, ast::MK::EmptyTree()));
+        body.emplace_back(ast::MK::SyntheticMethod1(symLoc, symLoc, name.addEq(ctx), ast::MK::Local(symLoc, name),
+                                                    ast::MK::Local(symLoc, name)));
     }
 
     // Elem = type_member(fixed: T.untyped)
@@ -142,8 +142,8 @@ vector<unique_ptr<ast::Expression>> Struct::run(core::MutableContext ctx, ast::A
     }
 
     body.emplace_back(ast::MK::SigVoid(loc, ast::MK::Hash(loc, std::move(sigKeys), std::move(sigValues))));
-    body.emplace_back(ast::MK::Method(loc, loc, core::Names::initialize(), std::move(newArgs),
-                                      ast::MK::Cast(loc, dupName(asgn->lhs.get()))));
+    body.emplace_back(ast::MK::SyntheticMethod(loc, loc, core::Names::initialize(), std::move(newArgs),
+                                               ast::MK::Cast(loc, dupName(asgn->lhs.get()))));
 
     ast::ClassDef::ANCESTORS_store ancestors;
     ancestors.emplace_back(ast::MK::UnresolvedConstant(loc, ast::MK::Constant(loc, core::Symbols::root()),

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -179,12 +179,12 @@ const ast::Send *ASTUtil::castSig(const ast::Expression *expr, core::NameRef ret
 }
 
 unique_ptr<ast::Expression> ASTUtil::mkGet(core::Loc loc, core::NameRef name, unique_ptr<ast::Expression> rhs) {
-    return ast::MK::Method0(loc, loc, name, move(rhs));
+    return ast::MK::SyntheticMethod0(loc, loc, name, move(rhs));
 }
 
 unique_ptr<ast::Expression> ASTUtil::mkSet(core::Loc loc, core::NameRef name, core::Loc argLoc,
                                            unique_ptr<ast::Expression> rhs) {
-    return ast::MK::Method1(loc, loc, name, ast::MK::Local(argLoc, core::Names::arg0()), move(rhs));
+    return ast::MK::SyntheticMethod1(loc, loc, name, ast::MK::Local(argLoc, core::Names::arg0()), move(rhs));
 }
 
 unique_ptr<ast::Expression> ASTUtil::mkNilable(core::Loc loc, unique_ptr<ast::Expression> type) {

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -179,13 +179,12 @@ const ast::Send *ASTUtil::castSig(const ast::Expression *expr, core::NameRef ret
 }
 
 unique_ptr<ast::Expression> ASTUtil::mkGet(core::Loc loc, core::NameRef name, unique_ptr<ast::Expression> rhs) {
-    return ast::MK::Method0(loc, loc, name, move(rhs), ast::MethodDef::RewriterSynthesized);
+    return ast::MK::Method0(loc, loc, name, move(rhs));
 }
 
 unique_ptr<ast::Expression> ASTUtil::mkSet(core::Loc loc, core::NameRef name, core::Loc argLoc,
                                            unique_ptr<ast::Expression> rhs) {
-    return ast::MK::Method1(loc, loc, name, ast::MK::Local(argLoc, core::Names::arg0()), move(rhs),
-                            ast::MethodDef::RewriterSynthesized);
+    return ast::MK::Method1(loc, loc, name, ast::MK::Local(argLoc, core::Names::arg0()), move(rhs));
 }
 
 unique_ptr<ast::Expression> ASTUtil::mkNilable(core::Loc loc, unique_ptr<ast::Expression> type) {


### PR DESCRIPTION
### Motivation

This is by far the common case; only Desugar.cc creates non-rewriter
synthesized method defs.

RewriterSynthesized on a method def determines whether a class defines behavior
(aka, whether we need to register the enclosing class with the autoloader).

This is pre-work for a change I made over the weekend to convert the flags
on a MethodDef from a u4 to use bit fields, similar to #2657.


### Test plan

I tested this on Stripe's codebase and determined that there were no new
errors.