### PR TITLE
Reimplement ast::MethodDef flags with bit fields

### DIFF
--- a/ast/Helpers.cc
+++ b/ast/Helpers.cc
@@ -42,7 +42,7 @@ bool definesBehavior(const unique_ptr<ast::Expression> &expr) {
 
         // Ignore code synthesized by Rewriter pass.
         [&](ast::Send *send) { result = !send->flags.isRewriterSynthesized; },
-        [&](ast::MethodDef *methodDef) { result = !methodDef->isRewriterSynthesized(); },
+        [&](ast::MethodDef *methodDef) { result = !methodDef->flags.isRewriterSynthesized; },
         [&](ast::Literal *methodDef) { result = false; },
 
         [&](ast::Expression *klass) { result = true; });

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -246,7 +246,7 @@ public:
     static std::unique_ptr<MethodDef> SyntheticMethod(core::Loc loc, core::Loc declLoc, core::NameRef name,
                                                       MethodDef::ARGS_store args, std::unique_ptr<Expression> rhs) {
         auto mdef = Method(loc, declLoc, name, std::move(args), std::move(rhs));
-        mdef->flags |= ast::MethodDef::Flags::RewriterSynthesized;
+        mdef->flags.isRewriterSynthesized = true;
         return mdef;
     }
 

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -239,8 +239,9 @@ public:
             auto blkLoc = core::Loc::none(declLoc.file());
             args.emplace_back(std::make_unique<ast::BlockArg>(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
         }
+        MethodDef::Flags flags;
         return std::make_unique<MethodDef>(loc, declLoc, core::Symbols::todo(), name, std::move(args), std::move(rhs),
-                                           0);
+                                           flags);
     }
 
     static std::unique_ptr<MethodDef> SyntheticMethod(core::Loc loc, core::Loc declLoc, core::NameRef name,

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -406,7 +406,7 @@ string InsSeq::showRaw(const core::GlobalState &gs, int tabs) {
 string MethodDef::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     stringstream buf;
 
-    if (isSelf()) {
+    if (this->flags.isSelfMethod) {
         buf << "def self.";
     } else {
         buf << "def ";

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -449,16 +449,14 @@ string MethodDef::showRaw(const core::GlobalState &gs, int tabs) {
     printTabs(buf, tabs + 1);
 
     buf << "flags =";
-    const pair<int, string_view> flags[] = {
-        {SelfMethod, "self"sv},
-        {RewriterSynthesized, "rewriter"sv},
-    };
-    for (auto &ent : flags) {
-        if ((this->flags & ent.first) != 0) {
-            buf << " " << ent.second;
-        }
+    // TODO(jez) Change this to show a list or something
+    if (this->flags.isSelfMethod) {
+        buf << " self";
     }
-    if (this->flags == 0) {
+    if (this->flags.isRewriterSynthesized) {
+        buf << " rewriter";
+    }
+    if (!this->flags.isSelfMethod && !this->flags.isRewriterSynthesized) {
         buf << " 0";
     }
     buf << '\n';

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -91,7 +91,7 @@ ClassDef::ClassDef(core::Loc loc, core::Loc declLoc, core::SymbolRef symbol, uni
 }
 
 MethodDef::MethodDef(core::Loc loc, core::Loc declLoc, core::SymbolRef symbol, core::NameRef name, ARGS_store args,
-                     unique_ptr<Expression> rhs, u4 flags)
+                     unique_ptr<Expression> rhs, Flags flags)
     : Declaration(loc, declLoc, symbol), rhs(std::move(rhs)), args(std::move(args)), name(name), flags(flags) {
     categoryCounterInc("trees", "methoddef");
     histogramInc("trees.methodDef.args", this->args.size());

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -147,36 +147,24 @@ public:
     ARGS_store args;
 
     core::NameRef name;
-    u4 flags;
 
-    // TODO(jez) This uses enum instead of enum class. We should not cargo cult this in new code.
-    enum Flags {
-        SelfMethod = 1,
-        RewriterSynthesized = 2,
+    struct Flags {
+        bool isSelfMethod : 1;
+        bool isRewriterSynthesized : 1;
+
+        // In C++20 we can replace this with bit field initialzers
+        Flags() : isSelfMethod(false), isRewriterSynthesized(false) {}
     };
+    CheckSize(Flags, 1, 1);
+
+    Flags flags;
 
     MethodDef(core::Loc loc, core::Loc declLoc, core::SymbolRef symbol, core::NameRef name, ARGS_store args,
-              std::unique_ptr<Expression> rhs, u4 flags);
+              std::unique_ptr<Expression> rhs, Flags flags);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
     virtual std::unique_ptr<Expression> _deepCopy(const Expression *avoid, bool root = false) const;
-
-    bool isSelf() const {
-        return (flags & SelfMethod) != 0;
-    }
-
-    bool isRewriterSynthesized() const {
-        return (flags & RewriterSynthesized) != 0;
-    }
-
-    void setIsSelf(bool isSelf) {
-        if (isSelf) {
-            flags |= SelfMethod;
-        } else {
-            flags &= ~SelfMethod;
-        }
-    }
 
 private:
     virtual void _sanityCheck();

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -223,7 +223,7 @@ unique_ptr<MethodDef> buildMethod(DesugarContext dctx, core::Loc loc, core::Loc 
     desugaredBody = validateRBIBody(dctx, move(desugaredBody));
 
     auto mdef = MK::Method(loc, declLoc, name, std::move(args), std::move(desugaredBody));
-    mdef->setIsSelf(isSelf);
+    mdef->flags.isSelfMethod = isSelf;
     return mdef;
 }
 

--- a/class_flatten/class_flatten.cc
+++ b/class_flatten/class_flatten.cc
@@ -93,7 +93,9 @@ public:
         args.emplace_back(make_unique<ast::Local>(blkLoc, blkLocalVar));
 
         auto init = make_unique<ast::MethodDef>(loc, loc, sym, core::Names::staticInit(), std::move(args),
-                                                std::move(inits), true);
+                                                std::move(inits), ast::MethodDef::Flags());
+        init->flags.isRewriterSynthesized = false;
+        init->flags.isSelfMethod = true;
 
         classDef->rhs.emplace_back(std::move(init));
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -602,7 +602,7 @@ public:
     unique_ptr<ast::MethodDef> preTransformMethodDef(core::MutableContext ctx, unique_ptr<ast::MethodDef> method) {
         core::SymbolRef owner = methodOwner(ctx);
 
-        if (method->isSelf()) {
+        if (method->flags.isSelfMethod) {
             if (owner.data(ctx)->isClassOrModule()) {
                 owner = owner.data(ctx)->singletonClass(ctx);
             }
@@ -661,7 +661,7 @@ public:
         method->symbol = ctx.state.enterMethodSymbol(method->declLoc, owner, method->name);
         method->args = fillInArgs(ctx.withOwner(method->symbol), move(parsedArgs));
         method->symbol.data(ctx)->addLoc(ctx, method->declLoc);
-        if (method->isRewriterSynthesized()) {
+        if (method->flags.isRewriterSynthesized) {
             method->symbol.data(ctx)->setRewriterSynthesized();
         }
         return method;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1563,7 +1563,7 @@ private:
             [&](ast::MethodDef *mdef) {
                 if (debug_mode) {
                     bool hasSig = !lastSigs.empty();
-                    bool rewriten = mdef->isRewriterSynthesized();
+                    bool rewriten = mdef->flags.isRewriterSynthesized;
                     bool isRBI = mdef->loc.file().data(ctx).isRBI();
                     if (hasSig) {
                         categoryCounterInc("method.sig", "true");
@@ -1609,7 +1609,7 @@ private:
                     // class, or the current singleton class, depending on if
                     // the current method is a self method.
                     core::SymbolRef sigOwner;
-                    if (mdef->isSelf()) {
+                    if (mdef->flags.isSelfMethod) {
                         sigOwner = ctx.owner.data(ctx)->singletonClass(ctx);
                     } else {
                         sigOwner = ctx.owner;

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -88,7 +88,7 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
 
     auto selfCall =
         ast::MK::SyntheticMethod(call->loc, call->loc, call->name, std::move(newArgs), ast::MK::Untyped(call->loc));
-    selfCall->flags |= ast::MethodDef::Flags::SelfMethod;
+    selfCall->flags.isSelfMethod = true;
 
     klass->rhs.insert(klass->rhs.begin() + i + 1, sig->deepCopy());
     klass->rhs.insert(klass->rhs.begin() + i + 2, std::move(selfCall));

--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -89,7 +89,7 @@ vector<unique_ptr<ast::Expression>> DSLBuilder::run(core::MutableContext ctx, as
             arg = ast::MK::OptionalArg(loc, move(arg), move(default_));
         }
         auto defSelfProp = ast::MK::SyntheticMethod1(loc, loc, name, move(arg), ast::MK::EmptyTree());
-        defSelfProp->flags |= ast::MethodDef::Flags::SelfMethod;
+        defSelfProp->flags.isSelfMethod = true;
         stats.emplace_back(move(defSelfProp));
     }
 
@@ -102,7 +102,7 @@ vector<unique_ptr<ast::Expression>> DSLBuilder::run(core::MutableContext ctx, as
         core::NameRef getName = ctx.state.enterNameUTF8("get_" + name.data(ctx)->show(ctx));
         stats.emplace_back(ast::MK::Sig0(loc, ASTUtil::dupType(type.get())));
         auto defSelfGetProp = ast::MK::SyntheticMethod(loc, loc, getName, {}, ast::MK::Unsafe(loc, ast::MK::Nil(loc)));
-        defSelfGetProp->flags |= ast::MethodDef::Flags::SelfMethod;
+        defSelfGetProp->flags.isSelfMethod = true;
         stats.emplace_back(move(defSelfGetProp));
 
         // def <prop>()

--- a/rewriter/DefaultArgs.cc
+++ b/rewriter/DefaultArgs.cc
@@ -173,7 +173,7 @@ void DefaultArgs::run(core::MutableContext ctx, ast::ClassDef *klass) {
                         newMethods.emplace_back(move(sig));
                     }
                     auto defaultArgDef = ast::MK::SyntheticMethod(loc, loc, name, std::move(args), std::move(rhs));
-                    defaultArgDef->setIsSelf(mdef->isSelf());
+                    defaultArgDef->flags.isSelfMethod = mdef->flags.isSelfMethod;
                     newMethods.emplace_back(move(defaultArgDef));
                 }
                 lastSig = nullptr;

--- a/rewriter/Mattr.cc
+++ b/rewriter/Mattr.cc
@@ -25,7 +25,8 @@ static void addInstanceCounterPart(vector<unique_ptr<ast::Expression>> &sink, co
     sink.emplace_back(sig->deepCopy());
     auto instanceDef = def->deepCopy();
     ENFORCE(ast::isa_tree<ast::MethodDef>(def.get()));
-    ast::cast_tree<ast::MethodDef>(instanceDef.get())->flags = ast::MethodDef::Flags::RewriterSynthesized;
+    ast::cast_tree<ast::MethodDef>(instanceDef.get())->flags.isSelfMethod = false;
+    ast::cast_tree<ast::MethodDef>(instanceDef.get())->flags.isRewriterSynthesized = true;
     sink.emplace_back(move(instanceDef));
 }
 
@@ -93,7 +94,7 @@ vector<unique_ptr<ast::Expression>> Mattr::run(core::MutableContext ctx, const a
         if (doReaders) {
             auto sig = ast::MK::Sig0(loc, ast::MK::Untyped(loc));
             auto def = ast::MK::SyntheticMethod0(loc, loc, lit->asSymbol(ctx), ast::MK::EmptyTree());
-            def->flags |= ast::MethodDef::Flags::SelfMethod;
+            def->flags.isSelfMethod = true;
             if (instanceReader) {
                 addInstanceCounterPart(result, sig, def);
             }
@@ -105,7 +106,7 @@ vector<unique_ptr<ast::Expression>> Mattr::run(core::MutableContext ctx, const a
                                      ast::MK::Untyped(loc));
             auto def = ast::MK::SyntheticMethod1(loc, loc, lit->asSymbol(ctx).addEq(ctx),
                                                  ast::MK::Local(loc, core::Names::arg0()), ast::MK::EmptyTree());
-            def->flags |= ast::MethodDef::Flags::SelfMethod;
+            def->flags.isSelfMethod = true;
             if (instanceWriter) {
                 addInstanceCounterPart(result, sig, def);
             }
@@ -118,7 +119,7 @@ vector<unique_ptr<ast::Expression>> Mattr::run(core::MutableContext ctx, const a
             auto sig = ast::MK::Sig0(
                 loc, ast::MK::UnresolvedConstant(loc, ast::MK::T(loc), core::Names::Constants::Boolean()));
             auto def = ast::MK::SyntheticMethod0(loc, loc, lit->asSymbol(ctx).addQuestion(ctx), ast::MK::False(loc));
-            def->flags |= ast::MethodDef::Flags::SelfMethod;
+            def->flags.isSelfMethod = true;
             if (instanceReader && instancePredicate) {
                 addInstanceCounterPart(result, sig, def);
             }

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -92,7 +92,8 @@ vector<unique_ptr<ast::Expression>> ModuleFunction::rewriteDefn(core::MutableCon
     unique_ptr<ast::Expression> moduleCopy = expr->deepCopy();
     ENFORCE(moduleCopy, "Should be non-nil.");
     auto newDefn = ast::cast_tree<ast::MethodDef>(moduleCopy.get());
-    newDefn->flags |= ast::MethodDef::SelfMethod | ast::MethodDef::RewriterSynthesized;
+    newDefn->flags.isSelfMethod = true;
+    newDefn->flags.isRewriterSynthesized = true;
     stats.emplace_back(move(moduleCopy));
 
     return stats;
@@ -133,7 +134,7 @@ vector<unique_ptr<ast::Expression>> ModuleFunction::run(core::MutableContext ctx
             args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
             args.emplace_back(std::make_unique<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
             auto methodDef = ast::MK::SyntheticMethod(loc, loc, methodName, std::move(args), ast::MK::EmptyTree());
-            methodDef->flags |= ast::MethodDef::Flags::SelfMethod;
+            methodDef->flags.isSelfMethod = true;
             stats.emplace_back(std::move(methodDef));
         } else {
             if (auto e = ctx.state.beginError(arg->loc, core::errors::Rewriter::BadModuleFunction)) {

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -72,7 +72,7 @@ vector<unique_ptr<ast::Expression>> ModuleFunction::rewriteDefn(core::MutableCon
     vector<unique_ptr<ast::Expression>> stats;
     auto mdef = ast::cast_tree_const<ast::MethodDef>(expr);
     // only do this rewrite to method defs that aren't self methods
-    if (mdef == nullptr || (mdef->flags & ast::MethodDef::SelfMethod) != 0) {
+    if (mdef == nullptr || mdef->flags.isSelfMethod) {
         stats.emplace_back(expr->deepCopy());
         return stats;
     }

--- a/rewriter/Private.cc
+++ b/rewriter/Private.cc
@@ -23,14 +23,14 @@ vector<unique_ptr<ast::Expression>> Private::run(core::MutableContext ctx, ast::
         return empty;
     }
 
-    if (send->fun == core::Names::private_() && mdef->isSelf()) {
+    if (send->fun == core::Names::private_() && mdef->flags.isSelfMethod) {
         if (auto e = ctx.state.beginError(send->loc, core::errors::Rewriter::PrivateMethodMismatch)) {
             e.setHeader("Use `{}` to define private class methods", "private_class_method");
             auto beginPos = send->loc.beginPos();
             auto replacementLoc = core::Loc{send->loc.file(), beginPos, beginPos + 7};
             e.replaceWith("Replace with `private_class_method`", replacementLoc, "private_class_method");
         }
-    } else if (send->fun == core::Names::privateClassMethod() && !mdef->isSelf()) {
+    } else if (send->fun == core::Names::privateClassMethod() && !mdef->flags.isSelfMethod) {
         if (auto e = ctx.state.beginError(send->loc, core::errors::Rewriter::PrivateMethodMismatch)) {
             e.setHeader("Use `{}` to define private instance methods", "private");
             auto beginPos = send->loc.beginPos();

--- a/test/hello-test.cc
+++ b/test/hello-test.cc
@@ -156,8 +156,9 @@ TEST(PreOrderTreeMap, CountTrees) { // NOLINT
     ast::MethodDef::ARGS_store args;
     args.emplace_back(std::move(arg));
 
+    ast::MethodDef::Flags flags;
     unique_ptr<ast::Expression> methodDef =
-        make_unique<ast::MethodDef>(loc, loc, methodSym, name, std::move(args), std::move(rhs), false);
+        make_unique<ast::MethodDef>(loc, loc, methodSym, name, std::move(args), std::move(rhs), flags);
     unique_ptr<ast::Expression> emptyTree = ast::MK::EmptyTree();
     unique_ptr<ast::Expression> cnst = make_unique<ast::UnresolvedConstantLit>(loc, std::move(emptyTree), name);
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Similar to #2657

I think the code is cleaner this way. It's also more type safe (people can't
accidentally use flags interchangeably with a u4 anymore) and harder to
misuse (the compiler computes bit offsets).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.