### PR TITLE
Give the lsp protocol corpus more time

### DIFF
--- a/test/lsp/BUILD
+++ b/test/lsp/BUILD
@@ -8,7 +8,7 @@ sh_binary(
 
 cc_test(
     name = "protocol_test_corpus",
-    size = "medium",
+    timeout = "long",
     srcs = [
         "ProtocolTest.cc",
         "ProtocolTest.h",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The lsp_protocol_corpus test keeps failing on the mac because it takes too long. This bumps its timeout to 15 minutes (`timeout = "large"`).

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Get master passing again.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
