### PR TITLE
VS Code: Use clangd executable from bazel.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,8 @@
   "clangd.semanticHighlighting": false,
   // Disable feature where Clangd auto-imports headers for missing references.
   // It inserts relative paths that we don't want.
-  "clangd.arguments": ["-header-insertion=never"],
+  "clangd.arguments": ["--header-insertion=never"],
+  "clangd.path": "bazel-sorbet/external/llvm_toolchain/bin/clangd",
   "files.associations": {
     "*.rbi": "ruby",
     "*.rbupdated": "ruby",

--- a/README.md
+++ b/README.md
@@ -758,16 +758,14 @@ You are encouraged to play around with various clang-based tools which use the
 
 -   [clangd] -- Clang-based language server implementation
 
-    ```shell
-    brew install llvm@8
-
-    # => /usr/local/opt/llvm/bin/clangd
-    # You might need to put this on your PATH to tell your editor about it.
-    ```
-
     `clangd` supports more features than `rtags` (specifically, reporting
     Diagnostics), but can be somewhat slower at times because it does not
     pre-index all your code like rtags does.
+
+
+    After successfully compiling Sorbet, point your editor to use the
+    `clangd` executable located in
+    `bazel-sorbet/external/llvm_toolchain/bin/clangd`.
 
 -   [clang-format] -- Clang-based source code formatter
 
@@ -808,8 +806,9 @@ You are encouraged to play around with various clang-based tools which use the
     run `clang-format` whenever you save. **Note: Microsoft's C/C++ extension
     does *not* work properly with Sorbet's `compile_commands.json`.**
 
-    clangd will need to be on your path, or you will need to change the
-    "clangd.path" setting.
+    The settings for this repository automatically configure vscode-clangd to
+    run the clangd executable in the `bazel-sorbet` directory. Note that you
+    will need to compile Sorbet once before it will work.
 
     clangd operates on `compile_commands.json`, so make sure you run the
     `./tools/scripts/build_compilation_db.sh` script.

--- a/README.md
+++ b/README.md
@@ -762,7 +762,6 @@ You are encouraged to play around with various clang-based tools which use the
     Diagnostics), but can be somewhat slower at times because it does not
     pre-index all your code like rtags does.
 
-
     After successfully compiling Sorbet, point your editor to use the
     `clangd` executable located in
     `bazel-sorbet/external/llvm_toolchain/bin/clangd`.


### PR DESCRIPTION
Use clangd executable from bazel in VS Code.
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes issue where clangd fails to include stdint.h properly.

The problem is that using system clangd causes clangd to pass the `--resource-dir` argument to clang set to the include directory for the system clang rather than the bazel clang.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Manually tested.
