### PR TITLE
add ratchet for non-proc foreign usage

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -629,6 +629,14 @@ class T::Props::Decorator
       )
     end
 
+    unless foreign.is_a?(Proc)
+      T::Configuration.soft_assert_handler(<<~MESSAGE, storytime: {option_sym: option_sym})
+        Please use a Proc that returns a model class instead of the model class itself as the argument to `foreign`. In other words:
+          instead of `prop :foo, String, foreign: FooModel`
+          use `prop :foo, String, foreign: -> {FooModel}`
+      MESSAGE
+    end
+
     if !foreign.is_a?(Proc) && !foreign.is_a?(Array) && !foreign.respond_to?(:load)
       raise ArgumentError.new("The `#{option_sym}` option must be #{valid_type_msg}")
     end

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -630,7 +630,7 @@ class T::Props::Decorator
     end
 
     unless foreign.is_a?(Proc)
-      T::Configuration.soft_assert_handler(<<~MESSAGE, storytime: {option_sym: option_sym})
+      T::Configuration.soft_assert_handler(<<~MESSAGE, storytime: {option_sym: option_sym}, notify: 'jerry')
         Please use a Proc that returns a model class instead of the model class itself as the argument to `foreign`. In other words:
           instead of `prop :foo, String, foreign: FooModel`
           use `prop :foo, String, foreign: -> {FooModel}`

--- a/gems/sorbet-runtime/test/types/props/_props.rb
+++ b/gems/sorbet-runtime/test/types/props/_props.rb
@@ -229,6 +229,16 @@ class Opus::Types::Test::Props::PropsTest < Critic::Unit::UnitTest
       assert(test_model)
       assert_equal(obj.foreign2, test_model.id)
     end
+
+    it 'disallows non-proc arguments' do
+      T::Configuration.expects(:soft_assert_handler).with do |msg, _|
+        msg =~ /Please use a Proc that returns a model class instead/
+      end
+
+      Class.new(TestForeignProps) do
+        prop :foreign3, String, foreign: MyTestModel
+      end
+    end
   end
 
   class MyCustomType


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Forcing lazy evaluation gives us some small selective test execution wins. It seems that there was a codemod started to make this required across pay-server, but we never put in place a ratchet, so this does that.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

- See included automated tests.
- Tested [against pay-server](https://git.corp.stripe.com/stripe-internal/pay-server/compare/jerry-ratchet-non-proc-foreign?expand=1). The only test failure is in a test case that I can remove in the same PR that I bump the sorbet gem.