### PR TITLE
Add support for tags in core/Timer, and use them for some LSP metrics

### DIFF
--- a/common/Counters.cc
+++ b/common/Counters.cc
@@ -190,16 +190,31 @@ vector<pair<const char *, string>> givenArgs2StoredArgs(vector<pair<ConstExprStr
     return stored;
 }
 
+vector<pair<const char *, const char *>> givenTags2StoredTags(vector<pair<ConstExprStr, ConstExprStr>> given) {
+    vector<pair<const char *, const char *>> stored;
+    for (auto &e : given) {
+        stored.emplace_back(e.first.str, e.second.str);
+    }
+    return stored;
+}
+
 void timingAdd(ConstExprStr measure, std::chrono::time_point<std::chrono::steady_clock> start,
                std::chrono::time_point<std::chrono::steady_clock> end, vector<pair<ConstExprStr, string>> args,
-               FlowId self, FlowId previous) {
+               vector<pair<ConstExprStr, ConstExprStr>> tags, FlowId self, FlowId previous) {
     ENFORCE(
         (self.id == 0) || (previous.id == 0),
         "format doesn't support chaining"); // see "case 1" in
                                             // https://docs.google.com/document/d/1La_0PPfsTqHJihazYhff96thhjPtvq1KjAUOJu0dvEg/edit?pli=1#
                                             // for workaround
-    CounterImpl::Timing tim{0,    measure.str, start, end, getThreadId(), givenArgs2StoredArgs(move(args)),
-                            self, previous};
+    CounterImpl::Timing tim{0,
+                            measure.str,
+                            start,
+                            end,
+                            getThreadId(),
+                            givenArgs2StoredArgs(move(args)),
+                            givenTags2StoredTags(move(tags)),
+                            self,
+                            previous};
     counterState.timingAdd(tim);
 }
 

--- a/common/Counters.h
+++ b/common/Counters.h
@@ -89,7 +89,8 @@ struct FlowId {
 
 void timingAdd(ConstExprStr measure, std::chrono::time_point<std::chrono::steady_clock> start,
                std::chrono::time_point<std::chrono::steady_clock> end,
-               std::vector<std::pair<ConstExprStr, std::string>> args, FlowId self, FlowId previous);
+               std::vector<std::pair<ConstExprStr, std::string>> args,
+               std::vector<std::pair<ConstExprStr, ConstExprStr>> tags, FlowId self, FlowId previous);
 
 UnorderedMap<long, long> getAndClearHistogram(ConstExprStr histogram);
 std::string getCounterStatistics(std::vector<std::string> names);

--- a/common/Counters_impl.h
+++ b/common/Counters_impl.h
@@ -38,6 +38,7 @@ struct CounterImpl {
         std::chrono::time_point<std::chrono::steady_clock> start, end;
         int threadId;
         std::vector<std::pair<char const *, std::string>> args;
+        std::vector<std::pair<char const *, char const *>> tags;
         FlowId self;
         FlowId prev;
     };

--- a/common/Timer.cc
+++ b/common/Timer.cc
@@ -57,6 +57,19 @@ Timer Timer::clone(ConstExprStr name) {
     return forked;
 }
 
+void Timer::setTag(ConstExprStr name, ConstExprStr value) {
+    // Check if tag is already set; if so, update value.
+    for (auto &tag : tags) {
+        const auto tagName = tag.first;
+        if (tagName.size == name.size && strncmp(tagName.str, name.str, tagName.size) == 0) {
+            tag.second = value;
+            return;
+        }
+    }
+    // Add new tag.
+    tags.push_back(make_pair(name, value));
+}
+
 Timer::~Timer() {
     auto clock = chrono::steady_clock::now();
     auto dur = clock - start;

--- a/common/Timer.cc
+++ b/common/Timer.cc
@@ -42,7 +42,7 @@ void Timer::cancel() {
     this->canceled = true;
 }
 
-Timer Timer::fork(ConstExprStr name) {
+Timer Timer::clone(ConstExprStr name) {
     Timer forked(log, name, prev, {}, start);
     forked.args = args;
     forked.canceled = canceled;

--- a/common/Timer.cc
+++ b/common/Timer.cc
@@ -20,14 +20,11 @@ Timer::Timer(const shared_ptr<spdlog::logger> &log, ConstExprStr name,
              initializer_list<pair<ConstExprStr, string>> args)
     : Timer(*log, name, args){};
 
-Timer::Timer(const shared_ptr<spdlog::logger> &log, ConstExprStr name)
-    : Timer(*log, name, initializer_list<pair<ConstExprStr, string>>()){};
+Timer::Timer(const shared_ptr<spdlog::logger> &log, ConstExprStr name) : Timer(*log, name, {}){};
 Timer::Timer(const shared_ptr<spdlog::logger> &log, ConstExprStr name, FlowId prev) : Timer(*log, name, prev, {}){};
 
-Timer::Timer(spdlog::logger &log, ConstExprStr name)
-    : Timer(log, name, initializer_list<pair<ConstExprStr, string>>()){};
-Timer::Timer(spdlog::logger &log, ConstExprStr name, FlowId prev)
-    : Timer(log, name, prev, initializer_list<pair<ConstExprStr, string>>()){};
+Timer::Timer(spdlog::logger &log, ConstExprStr name) : Timer(log, name, {}){};
+Timer::Timer(spdlog::logger &log, ConstExprStr name, FlowId prev) : Timer(log, name, prev, {}){};
 
 int getGlobalTimingId() {
     static atomic<int> counter = 1;

--- a/common/Timer.cc
+++ b/common/Timer.cc
@@ -3,15 +3,11 @@ using namespace std;
 namespace sorbet {
 
 Timer::Timer(spdlog::logger &log, ConstExprStr name, FlowId prev, initializer_list<pair<ConstExprStr, string>> args,
-             std::initializer_list<std::pair<ConstExprStr, ConstExprStr>> tags,
              chrono::time_point<chrono::steady_clock> start)
-    : log(log), name(name), prev(prev), self{0}, args(args), tags(tags), start(start) {}
+    : log(log), name(name), prev(prev), self{0}, args(args), start(start) {}
 
 Timer::Timer(spdlog::logger &log, ConstExprStr name, FlowId prev, initializer_list<pair<ConstExprStr, string>> args)
-    : Timer(log, name, prev, args, {}, chrono::steady_clock::now()){};
-
-Timer::Timer(spdlog::logger &log, ConstExprStr name, initializer_list<pair<ConstExprStr, ConstExprStr>> tags)
-    : Timer(log, name, FlowId{0}, initializer_list<pair<ConstExprStr, string>>(), tags, chrono::steady_clock::now()){};
+    : Timer(log, name, prev, args, chrono::steady_clock::now()){};
 
 Timer::Timer(spdlog::logger &log, ConstExprStr name, initializer_list<pair<ConstExprStr, string>> args)
     : Timer(log, name, FlowId{0}, args){};
@@ -50,7 +46,7 @@ void Timer::cancel() {
 }
 
 Timer Timer::clone(ConstExprStr name) {
-    Timer forked(log, name, prev, {}, {}, start);
+    Timer forked(log, name, prev, {}, start);
     forked.args = args;
     forked.tags = tags;
     forked.canceled = canceled;

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -32,6 +32,8 @@ public:
     // Don't report timer when it gets destructed.
     void cancel();
 
+    void setTag(ConstExprStr name, ConstExprStr value);
+
     // Creates a new timer with the same start time and args but a different name.
     Timer clone(ConstExprStr name);
 

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -10,12 +10,14 @@ namespace sorbet {
 class Timer {
     Timer(spdlog::logger &log, ConstExprStr name, FlowId prev,
           std::initializer_list<std::pair<ConstExprStr, std::string>> args,
+          std::initializer_list<std::pair<ConstExprStr, ConstExprStr>> tags,
           std::chrono::time_point<std::chrono::steady_clock> start);
 
 public:
     Timer(spdlog::logger &log, ConstExprStr name);
     Timer(spdlog::logger &log, ConstExprStr name, FlowId prev);
     Timer(spdlog::logger &log, ConstExprStr name, std::initializer_list<std::pair<ConstExprStr, std::string>> args);
+    Timer(spdlog::logger &log, ConstExprStr name, std::initializer_list<std::pair<ConstExprStr, ConstExprStr>> tags);
     Timer(spdlog::logger &log, ConstExprStr name, FlowId prev,
           std::initializer_list<std::pair<ConstExprStr, std::string>> args);
     Timer(const std::shared_ptr<spdlog::logger> &log, ConstExprStr name, FlowId prev);
@@ -48,6 +50,7 @@ private:
     FlowId prev;
     FlowId self;
     std::vector<std::pair<ConstExprStr, std::string>> args;
+    std::vector<std::pair<ConstExprStr, ConstExprStr>> tags;
     const std::chrono::time_point<std::chrono::steady_clock> start;
     bool canceled = false;
 };

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -31,7 +31,7 @@ public:
     void cancel();
 
     // Creates a new timer with the same start time and args but a different name.
-    Timer fork(ConstExprStr name);
+    Timer clone(ConstExprStr name);
 
     // TODO We could add more overloads for this if we need them (to create other kinds of Timers)
     // We could also make this more generic to allow more sleep duration types.

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -30,6 +30,7 @@ public:
     // Don't report timer when it gets destructed.
     void cancel();
 
+    // Add a tag to the statsd metrics for this timer. Will not appear in traces.
     void setTag(ConstExprStr name, ConstExprStr value);
 
     // Creates a new timer with the same start time and args but a different name.
@@ -49,7 +50,9 @@ private:
     ConstExprStr name;
     FlowId prev;
     FlowId self;
+    // 'args' appear in traces, but not in statsd metrics because they can cause an explosion in cardinality
     std::vector<std::pair<ConstExprStr, std::string>> args;
+    // 'tags' appear in statsd metrics but not in traces. They are ConstExprStr to limit cardinality.
     std::vector<std::pair<ConstExprStr, ConstExprStr>> tags;
     const std::chrono::time_point<std::chrono::steady_clock> start;
     bool canceled = false;

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -10,14 +10,12 @@ namespace sorbet {
 class Timer {
     Timer(spdlog::logger &log, ConstExprStr name, FlowId prev,
           std::initializer_list<std::pair<ConstExprStr, std::string>> args,
-          std::initializer_list<std::pair<ConstExprStr, ConstExprStr>> tags,
           std::chrono::time_point<std::chrono::steady_clock> start);
 
 public:
     Timer(spdlog::logger &log, ConstExprStr name);
     Timer(spdlog::logger &log, ConstExprStr name, FlowId prev);
     Timer(spdlog::logger &log, ConstExprStr name, std::initializer_list<std::pair<ConstExprStr, std::string>> args);
-    Timer(spdlog::logger &log, ConstExprStr name, std::initializer_list<std::pair<ConstExprStr, ConstExprStr>> tags);
     Timer(spdlog::logger &log, ConstExprStr name, FlowId prev,
           std::initializer_list<std::pair<ConstExprStr, std::string>> args);
     Timer(const std::shared_ptr<spdlog::logger> &log, ConstExprStr name, FlowId prev);

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -272,6 +272,8 @@ void LSPPreprocessor::preprocessAndEnqueue(unique_ptr<LSPMessage> msg) {
             // Only edits can be merged; avoid looping over the queue on every request.
             mergeFileChanges();
         }
+    } else {
+        categoryCounterInc("lsp.messages.processed", task->methodString());
     }
 }
 

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -97,9 +97,8 @@ LSPTask::Phase LSPRequestTask::finalPhase() const {
 
 bool LSPRequestTask::cancel(const MessageId &id) {
     if (this->id.equals(id)) {
-        // Don't report a latency metric for canceled requests.
         if (latencyTimer) {
-            latencyTimer->cancel();
+            latencyTimer->setTag("canceled", "true");
         }
         auto response = make_unique<ResponseMessage>("2.0", id, method);
         prodCounterInc("lsp.messages.canceled");

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -28,53 +28,53 @@ LSPTask::~LSPTask() {
         case LSPMethod::TextDocumentPublishDiagnostics:
         case LSPMethod::WindowShowMessage:
             // Not a request we care about. Bucket it in case it gets large.
-            latencyTimer->fork("latency.other");
+            latencyTimer->clone("latency.other");
             break;
         case LSPMethod::Initialize:
-            latencyTimer->fork("latency.initialize");
+            latencyTimer->clone("latency.initialize");
             break;
         case LSPMethod::Initialized:
-            latencyTimer->fork("latency.initialized");
+            latencyTimer->clone("latency.initialized");
             break;
         case LSPMethod::SorbetReadFile:
-            latencyTimer->fork("latency.sorbetreadfile");
+            latencyTimer->clone("latency.sorbetreadfile");
             break;
         case LSPMethod::SorbetWatchmanFileChange:
         case LSPMethod::SorbetWorkspaceEdit:
         case LSPMethod::TextDocumentDidChange:
         case LSPMethod::TextDocumentDidClose:
         case LSPMethod::TextDocumentDidOpen:
-            latencyTimer->fork("latency.fileedit");
+            latencyTimer->clone("latency.fileedit");
             break;
         case LSPMethod::TextDocumentCodeAction:
-            latencyTimer->fork("latency.codeaction");
+            latencyTimer->clone("latency.codeaction");
             break;
         case LSPMethod::TextDocumentCompletion:
-            latencyTimer->fork("latency.completion");
+            latencyTimer->clone("latency.completion");
             break;
         case LSPMethod::TextDocumentDefinition:
-            latencyTimer->fork("latency.definition");
+            latencyTimer->clone("latency.definition");
             break;
         case LSPMethod::TextDocumentDocumentHighlight:
-            latencyTimer->fork("latency.documenthighlight");
+            latencyTimer->clone("latency.documenthighlight");
             break;
         case LSPMethod::TextDocumentDocumentSymbol:
-            latencyTimer->fork("latency.documentsymbol");
+            latencyTimer->clone("latency.documentsymbol");
             break;
         case LSPMethod::TextDocumentHover:
-            latencyTimer->fork("latency.hover");
+            latencyTimer->clone("latency.hover");
             break;
         case LSPMethod::TextDocumentReferences:
-            latencyTimer->fork("latency.references");
+            latencyTimer->clone("latency.references");
             break;
         case LSPMethod::TextDocumentSignatureHelp:
-            latencyTimer->fork("latency.signaturehelp");
+            latencyTimer->clone("latency.signaturehelp");
             break;
         case LSPMethod::TextDocumentTypeDefinition:
-            latencyTimer->fork("latency.typedefinition");
+            latencyTimer->clone("latency.typedefinition");
             break;
         case LSPMethod::WorkspaceSymbol:
-            latencyTimer->fork("latency.workspacesymbol");
+            latencyTimer->clone("latency.workspacesymbol");
             break;
     }
 }

--- a/main/lsp/LSPTask.h
+++ b/main/lsp/LSPTask.h
@@ -58,6 +58,9 @@ public:
         RUN = 3,
     };
 
+    // Get this task's method as a string.
+    ConstExprStr methodString() const;
+
     /**
      * If `true`, this task can be delayed in favor of processing other tasks sooner. Defaults to `false`.
      */

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -291,7 +291,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
             slowPathOp = make_unique<ShowOperation>(*config, "SlowPathNonBlocking", "Typechecking in background");
         }
         // Report how long the slow path blocks preemption.
-        timeit.fork("slow_path.blocking_time");
+        timeit.clone("slow_path.blocking_time");
 
         // [Test only] Wait for a preemption if one is expected.
         while (updates.preemptionsExpected > 0) {

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -320,6 +320,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
 
     if (committed) {
         prodCategoryCounterInc("lsp.updates", "slowpath");
+        timeit.setTag("canceled", "false");
         // No need to keep around cancelation state!
         cancellationUndoState = nullptr;
         // Send diagnostics to client (we already committed file updates earlier).
@@ -327,8 +328,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
         logger->debug("[Typechecker] Typecheck run for epoch {} successfully finished.", updates.epoch);
     } else {
         prodCategoryCounterInc("lsp.updates", "slowpath_canceled");
-        // Don't report the runtime of a canceled slow path.
-        timeit.cancel();
+        timeit.setTag("canceled", "true");
         // Update responsible will use state in `cancellationUndoState` to restore typechecker to the point before
         // this slow path.
         ENFORCE(cancelable);

--- a/main/lsp/notifications/cancel_request.cc
+++ b/main/lsp/notifications/cancel_request.cc
@@ -12,7 +12,6 @@ LSPTask::Phase CancelRequestTask::finalPhase() const {
 }
 
 void CancelRequestTask::preprocess(LSPPreprocessor &preprocessor) {
-    prodCategoryCounterInc("lsp.messages.processed", "cancelRequest");
     preprocessor.cancelRequest(*params);
 }
 

--- a/main/lsp/notifications/exit.cc
+++ b/main/lsp/notifications/exit.cc
@@ -13,7 +13,6 @@ LSPTask::Phase ExitTask::finalPhase() const {
 }
 
 void ExitTask::preprocess(LSPPreprocessor &preprocessor) {
-    prodCategoryCounterInc("lsp.messages.processed", "exit");
     preprocessor.exit(exitCode);
 }
 

--- a/main/lsp/notifications/initialized.cc
+++ b/main/lsp/notifications/initialized.cc
@@ -19,7 +19,6 @@ void InitializedTask::index(LSPIndexer &indexer) {
 }
 
 void InitializedTask::runSpecial(LSPTypechecker &typechecker, WorkerPool &workers) {
-    prodCategoryCounterInc("lsp.messages.processed", "initialized");
     ENFORCE(this->indexer != nullptr);
     indexer->initialize(updates, workers);
     typechecker.initialize(move(updates), workers);

--- a/main/lsp/notifications/sorbet_workspace_edit.cc
+++ b/main/lsp/notifications/sorbet_workspace_edit.cc
@@ -61,8 +61,7 @@ void SorbetWorkspaceEditTask::run(LSPTypecheckerDelegate &typechecker) {
         Exception::raise("Attempted to run a slow path update on the fast path!");
     }
     typechecker.typecheckOnFastPath(move(*updates));
-    prodCategoryCounterInc("lsp.messages.processed", "sorbet/workspaceEdit");
-    prodCategoryCounterAdd("lsp.messages.processed", "sorbet/mergedEdits", updates->editCount - 1);
+    prodCategoryCounterAdd("lsp.messages.processed", "sorbet.mergedEdits", updates->editCount - 1);
 }
 
 void SorbetWorkspaceEditTask::runSpecial(LSPTypechecker &typechecker, WorkerPool &workers) {
@@ -77,8 +76,7 @@ void SorbetWorkspaceEditTask::runSpecial(LSPTypechecker &typechecker, WorkerPool
     startedNotification.Notify();
     // Only report stats if the edit was committed.
     if (!typechecker.typecheck(move(*updates), workers)) {
-        prodCategoryCounterInc("lsp.messages.processed", "sorbet/workspaceEdit");
-        prodCategoryCounterAdd("lsp.messages.processed", "sorbet/mergedEdits", updates->editCount - 1);
+        prodCategoryCounterAdd("lsp.messages.processed", "sorbet.mergedEdits", updates->editCount - 1);
     }
 }
 

--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -48,8 +48,7 @@ CounterState mergeCounters(CounterState counters) {
 }
 
 void tagNewRequest(spd::logger &logger, LSPMessage &msg) {
-    // TODO(jvilk): This should actually be named latency...
-    msg.latencyTimer = make_unique<Timer>(logger, "processing_time");
+    msg.latencyTimer = make_unique<Timer>(logger, "task_latency");
 }
 } // namespace
 

--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -49,6 +49,7 @@ CounterState mergeCounters(CounterState counters) {
 
 void tagNewRequest(spd::logger &logger, LSPMessage &msg) {
     msg.latencyTimer = make_unique<Timer>(logger, "task_latency");
+    msg.latencyTimer->setTag("canceled", "false");
 }
 } // namespace
 

--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -37,6 +37,7 @@ void LSPLoop::processRequests(vector<unique_ptr<LSPMessage>> messages) {
 }
 
 void LSPLoop::runTask(unique_ptr<LSPTask> task) {
+    categoryCounterInc("lsp.messages.processed", task->methodString());
     task->index(indexer);
     if (task->finalPhase() == LSPTask::Phase::INDEX) {
         // Task doesn't need the typechecker.

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -20,8 +20,6 @@ unique_ptr<ResponseMessage> CodeActionTask::runRequest(LSPTypecheckerDelegate &t
 
     vector<unique_ptr<CodeAction>> result;
 
-    prodCategoryCounterInc("lsp.messages.processed", "textDocument.codeAction");
-
     const core::GlobalState &gs = typechecker.state();
     core::FileRef file = config.uri2FileRef(gs, params->textDocument->uri);
     if (!file.exists()) {

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -764,8 +764,6 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentCompletion);
     auto emptyResult = make_unique<CompletionList>(false, vector<unique_ptr<CompletionItem>>{});
 
-    prodCategoryCounterInc("lsp.messages.processed", "textDocument.completion");
-
     const auto &gs = typechecker.state();
     auto uri = params->textDocument->uri;
     auto fref = config.uri2FileRef(gs, uri);

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -11,7 +11,6 @@ DefinitionTask::DefinitionTask(const LSPConfiguration &config, MessageId id,
 
 unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentDefinition);
-    prodCategoryCounterInc("lsp.messages.processed", "textDocument.definition");
     const core::GlobalState &gs = typechecker.state();
     auto result =
         queryByLoc(typechecker, params->textDocument->uri, *params->position, LSPMethod::TextDocumentDefinition, false);

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -28,7 +28,6 @@ unique_ptr<ResponseMessage> DocumentHighlightTask::runRequest(LSPTypecheckerDele
         return response;
     }
 
-    prodCategoryCounterInc("lsp.messages.processed", "textDocument.documentHighlight");
     const core::GlobalState &gs = typechecker.state();
     auto uri = params->textDocument->uri;
     auto result = queryByLoc(typechecker, params->textDocument->uri, *params->position,

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -87,7 +87,6 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerDelegat
     }
 
     const core::GlobalState &gs = typechecker.state();
-    prodCategoryCounterInc("lsp.messages.processed", "textDocument.documentSymbol");
     vector<unique_ptr<DocumentSymbol>> result;
     string_view uri = params->textDocument->uri;
     auto fref = config.uri2FileRef(gs, uri);

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -33,7 +33,6 @@ HoverTask::HoverTask(const LSPConfiguration &config, MessageId id, std::unique_p
 
 unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentHover);
-    prodCategoryCounterInc("lsp.messages.processed", "textDocument.hover");
 
     const core::GlobalState &gs = typechecker.state();
     auto result = queryByLoc(typechecker, params->textDocument->uri, *params->position, LSPMethod::TextDocumentHover);

--- a/main/lsp/requests/initialize.cc
+++ b/main/lsp/requests/initialize.cc
@@ -15,7 +15,6 @@ void InitializeTask::preprocess(LSPPreprocessor &preprocessor) {
 }
 
 unique_ptr<ResponseMessage> InitializeTask::runRequest(LSPTypecheckerDelegate &ts) {
-    prodCategoryCounterInc("lsp.messages.processed", "initialize");
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::Initialize);
     const auto &opts = config.opts;
     auto serverCap = make_unique<ServerCapabilities>();

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -18,7 +18,6 @@ bool ReferencesTask::needsMultithreading(const LSPIndexer &indexer) const {
 unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentReferences);
     ShowOperation op(config, "References", "Finding all references...");
-    prodCategoryCounterInc("lsp.messages.processed", "textDocument.references");
 
     const core::GlobalState &gs = typechecker.state();
     auto result =

--- a/main/lsp/requests/shutdown.cc
+++ b/main/lsp/requests/shutdown.cc
@@ -11,7 +11,6 @@ bool ShutdownTask::canPreempt(const LSPIndexer &indexer) const {
 }
 
 unique_ptr<ResponseMessage> ShutdownTask::runRequest(LSPTypecheckerDelegate &ts) {
-    prodCategoryCounterInc("lsp.messages.processed", "shutdown");
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::Shutdown);
     response->result = JSONNullObject();
     return response;

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -61,8 +61,6 @@ unique_ptr<ResponseMessage> SignatureHelpTask::runRequest(LSPTypecheckerDelegate
         return response;
     }
 
-    prodCategoryCounterInc("lsp.messages.processed", "textDocument.signatureHelp");
-
     const core::GlobalState &gs = typechecker.state();
     auto result =
         queryByLoc(typechecker, params->textDocument->uri, *params->position, LSPMethod::TextDocumentSignatureHelp);

--- a/main/lsp/requests/sorbet_error.cc
+++ b/main/lsp/requests/sorbet_error.cc
@@ -14,7 +14,6 @@ LSPTask::Phase SorbetErrorTask::finalPhase() const {
 }
 
 void SorbetErrorTask::preprocess(LSPPreprocessor &preprocessor) {
-    prodCategoryCounterInc("lsp.messages.processed", "sorbet.error");
     // Don't bother the main thread with these. Quickly handle.
     if (id.has_value()) {
         auto response = make_unique<ResponseMessage>("2.0", id.value(), LSPMethod::SorbetError);

--- a/main/lsp/requests/sorbet_read_file.cc
+++ b/main/lsp/requests/sorbet_read_file.cc
@@ -9,7 +9,6 @@ SorbetReadFileTask::SorbetReadFileTask(const LSPConfiguration &config, MessageId
     : LSPRequestTask(config, move(id), LSPMethod::SorbetReadFile), params(move(params)) {}
 
 unique_ptr<ResponseMessage> SorbetReadFileTask::runRequest(LSPTypecheckerDelegate &typechecker) {
-    prodCategoryCounterInc("lsp.messages.processed", "sorbet.readFile");
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::SorbetReadFile);
     auto fref = config.uri2FileRef(typechecker.state(), params->uri);
     if (fref.exists()) {

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -42,7 +42,6 @@ TypeDefinitionTask::TypeDefinitionTask(const LSPConfiguration &config, MessageId
 
 unique_ptr<ResponseMessage> TypeDefinitionTask::runRequest(LSPTypecheckerDelegate &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentTypeDefinition);
-    prodCategoryCounterInc("lsp.messages.processed", "textDocument.typeDefinition");
     const core::GlobalState &gs = typechecker.state();
     auto result = queryByLoc(typechecker, params->textDocument->uri, *params->position,
                              LSPMethod::TextDocumentTypeDefinition, false);

--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -281,7 +281,6 @@ unique_ptr<ResponseMessage> WorkspaceSymbolsTask::runRequest(LSPTypecheckerDeleg
     Timer timeit(typechecker.state().tracer(), "LSPLoop::handleWorkspaceSymbols");
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::WorkspaceSymbol);
     ShowOperation op(config, "References", "Workspace symbol search...");
-    prodCategoryCounterInc("lsp.messages.processed", "workspace.symbols");
     SymbolMatcher matcher(config, typechecker.state());
     response->result = matcher.doQuery(params->query);
     return response;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Add support for tags in core/Timer, and use them for some LSP metrics.

In the process, I combined `processing_time` and `latency.[method]` into `task_latency` which has a `method` and a `canceled` tag.

While I was at it, I renamed `Timer::fork` => `Timer::clone`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Improve metrics collection for Sorbet in the editor setting.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I manually tested this change, and verified that the stats appeared with the proper tags in SignalFX.
