### PR TITLE
Include CASGN name in for_autoload output

### DIFF
--- a/test/cli/autogen-autoloader/autogen-autoloader.out
+++ b/test/cli/autogen-autoloader/autogen-autoloader.out
@@ -11,6 +11,7 @@ end
 
 Opus::Require.autoload_map(Foo, {
   Bar: "autoloader/Foo/Bar.rb",
+  Dabba: "autoloader/Foo/Dabba.rb",
   Errors: "autoloader/Foo/Errors.rb",
   TOP_LEVEL_CONST: "autoloader/Foo/TOP_LEVEL_CONST.rb",
 })
@@ -56,6 +57,16 @@ class Foo::Bar::Quuz
 end
 
 Opus::Require.for_autoload(Foo::Bar::Quuz, "test/cli/autogen-autoloader/foo.rb")
+
+--- output/Foo/Dabba.rb
+# frozen_string_literal: true
+# typed: true
+
+require 'in_class'
+require 'in_method'
+require 'my_gem'
+
+Opus::Require.for_autoload(nil, "test/cli/autogen-autoloader/foo.rb", [Foo, :Dabba])
 
 --- output/Foo/Errors.rb
 # frozen_string_literal: true

--- a/test/cli/autogen-autoloader/autogen-autoloader.out
+++ b/test/cli/autogen-autoloader/autogen-autoloader.out
@@ -12,6 +12,7 @@ end
 Opus::Require.autoload_map(Foo, {
   Bar: "autoloader/Foo/Bar.rb",
   Errors: "autoloader/Foo/Errors.rb",
+  TOP_LEVEL_CONST: "autoloader/Foo/TOP_LEVEL_CONST.rb",
 })
 
 --- output/Foo/Bar.rb
@@ -103,6 +104,16 @@ class Foo::Errors::MyError2 < Foo::Errors::BaseError
 end
 
 Opus::Require.for_autoload(Foo::Errors::MyError2, "test/cli/autogen-autoloader/errors.rb")
+
+--- output/Foo/TOP_LEVEL_CONST.rb
+# frozen_string_literal: true
+# typed: true
+
+require 'in_class'
+require 'in_method'
+require 'my_gem'
+
+Opus::Require.for_autoload(nil, "test/cli/autogen-autoloader/foo.rb", [Foo, :TOP_LEVEL_CONST])
 
 --- output/Yabba.rb
 # frozen_string_literal: true

--- a/test/cli/autogen-autoloader/foo.rb
+++ b/test/cli/autogen-autoloader/foo.rb
@@ -4,6 +4,11 @@ require 'byebug'
 require 'my_gem'
 
 module Foo
+
+  # :Foo doesn't define behavior therefore this constant should get its own
+  # autoloader file.
+  TOP_LEVEL_CONST = some_method
+
   module Bar
     class Quuz
       p 'x'

--- a/test/cli/autogen-autoloader/foo.rb
+++ b/test/cli/autogen-autoloader/foo.rb
@@ -8,6 +8,8 @@ module Foo
   # :Foo doesn't define behavior therefore this constant should get its own
   # autoloader file.
   TOP_LEVEL_CONST = some_method
+  # This should also happen for aliases.
+  Dabba = Yabba::Dabba
 
   module Bar
     class Quuz


### PR DESCRIPTION
Only affects users of autoloader.

For constant assignments and aliases in autoloader output include a 3rd argument to `Opus::Require.for_autoload(nil, "test/cli/autogen-autoloader/foo.rb", [Foo, :TOP_LEVEL_CONST])` that includes an array with module and constant name.


### Motivation
Autoloader changes need ability to force the constant (lazy-consts).


### Test plan
See included automated tests.
