### PR TITLE
Add method and sig for `respond_to?`

### DIFF
--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_4_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_4_hidden.rbi.exp
@@ -9077,8 +9077,6 @@ module Kernel
   def itself(); end
 
   def object_id(); end
-
-  def respond_to?(*_); end
 end
 
 module Kernel

--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_hidden.rbi.exp
@@ -9385,8 +9385,6 @@ module Kernel
 
   def object_id(); end
 
-  def respond_to?(*_); end
-
   def then(); end
 
   def yield_self(); end

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_4_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_4_hidden.rbi.exp
@@ -9083,8 +9083,6 @@ module Kernel
   def itself(); end
 
   def object_id(); end
-
-  def respond_to?(*_); end
 end
 
 module Kernel

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_hidden.rbi.exp
@@ -9391,8 +9391,6 @@ module Kernel
 
   def object_id(); end
 
-  def respond_to?(*_); end
-
   def then(); end
 
   def yield_self(); end

--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -530,6 +530,15 @@ module Kernel
   sig do
     params(
         arg0: T.any(String, Symbol),
+        include_all: T.untyped,
+    )
+    .returns(T::Boolean)
+  end
+  def respond_to?(arg0,include_all=false); end
+
+  sig do
+    params(
+        arg0: T.any(String, Symbol),
         arg1: BasicObject,
     )
     .returns(T.untyped)

--- a/test/cli/cache-dsl/cache-dsl.out
+++ b/test/cli/cache-dsl/cache-dsl.out
@@ -2,8 +2,8 @@ No errors! Great job.
 test/cli/cache-dsl/attr_accessor.rb:7: Method `prop=` does not exist on `A` https://srb.help/7003
      7 |a.prop = 7
         ^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1713: Did you mean: `Kernel#proc`?
-    1713 |  def proc(&blk); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1722: Did you mean: `Kernel#proc`?
+    1722 |  def proc(&blk); end
             ^^^^^^^^^^^^^^
 
 test/cli/cache-dsl/attr_accessor.rb:8: Method `prop` does not exist on `A` https://srb.help/7003
@@ -18,8 +18,8 @@ Errors: 2
 test/cli/cache-dsl/attr_accessor.rb:7: Method `prop=` does not exist on `A` https://srb.help/7003
      7 |a.prop = 7
         ^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1713: Did you mean: `Kernel#proc`?
-    1713 |  def proc(&blk); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1722: Did you mean: `Kernel#proc`?
+    1722 |  def proc(&blk); end
             ^^^^^^^^^^^^^^
 
 test/cli/cache-dsl/attr_accessor.rb:8: Method `prop` does not exist on `A` https://srb.help/7003

--- a/test/cli/incremental-resolver/incremental-resolver.out
+++ b/test/cli/incremental-resolver/incremental-resolver.out
@@ -114,8 +114,8 @@ test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:68: Method `sig` 
 test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:68: Method `void` does not exist on `T.class_of(<root>)` https://srb.help/7003
     68 |  sig {void}
                ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1491: Did you mean: `Kernel#load`?
-    1491 |  def load(filename, arg0=T.unsafe(nil)); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1500: Did you mean: `Kernel#load`?
+    1500 |  def load(filename, arg0=T.unsafe(nil)); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:69: Method `sig` does not exist on `T.class_of(<root>)` https://srb.help/7003
@@ -125,7 +125,7 @@ test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:69: Method `sig` 
 test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:69: Method `void` does not exist on `T.class_of(<root>)` https://srb.help/7003
     69 |  sig {void}
                ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1491: Did you mean: `Kernel#load`?
-    1491 |  def load(filename, arg0=T.unsafe(nil)); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1500: Did you mean: `Kernel#load`?
+    1500 |  def load(filename, arg0=T.unsafe(nil)); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 10


### PR DESCRIPTION
Fixes #2268.

### Motivation
We have this manually typed in our repo but figured it would be better to up-stream it. 

### Test plan
This is an instance method on `Object` that's included via `Kernel` so I wasn't sure exactly where to put the test since I didn't see others. I took this from my repo's manually curated rbi file which has been working as expected so I'm reasonably confident this will work. Happy to add tests if necessary.
