### PR TITLE
Revert "add ratchet for non-proc foreign usage"

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -629,14 +629,6 @@ class T::Props::Decorator
       )
     end
 
-    unless foreign.is_a?(Proc)
-      T::Configuration.soft_assert_handler(<<~MESSAGE, storytime: {option_sym: option_sym}, notify: 'jerry')
-        Please use a Proc that returns a model class instead of the model class itself as the argument to `foreign`. In other words:
-          instead of `prop :foo, String, foreign: FooModel`
-          use `prop :foo, String, foreign: -> {FooModel}`
-      MESSAGE
-    end
-
     if !foreign.is_a?(Proc) && !foreign.is_a?(Array) && !foreign.respond_to?(:load)
       raise ArgumentError.new("The `#{option_sym}` option must be #{valid_type_msg}")
     end

--- a/gems/sorbet-runtime/test/types/props/_props.rb
+++ b/gems/sorbet-runtime/test/types/props/_props.rb
@@ -229,16 +229,6 @@ class Opus::Types::Test::Props::PropsTest < Critic::Unit::UnitTest
       assert(test_model)
       assert_equal(obj.foreign2, test_model.id)
     end
-
-    it 'disallows non-proc arguments' do
-      T::Configuration.expects(:soft_assert_handler).with do |msg, _|
-        msg =~ /Please use a Proc that returns a model class instead/
-      end
-
-      Class.new(TestForeignProps) do
-        prop :foreign3, String, foreign: MyTestModel
-      end
-    end
   end
 
   class MyCustomType


### PR DESCRIPTION
Reverts sorbet/sorbet#2682

This produced some subtle test failures that we'll need to work through.