### PR TITLE
Add support for histograms to Timers

### DIFF
--- a/common/Counters.h
+++ b/common/Counters.h
@@ -90,7 +90,8 @@ struct FlowId {
 void timingAdd(ConstExprStr measure, std::chrono::time_point<std::chrono::steady_clock> start,
                std::chrono::time_point<std::chrono::steady_clock> end,
                std::vector<std::pair<ConstExprStr, std::string>> args,
-               std::vector<std::pair<ConstExprStr, ConstExprStr>> tags, FlowId self, FlowId previous);
+               std::vector<std::pair<ConstExprStr, ConstExprStr>> tags, FlowId self, FlowId previous,
+               std::vector<int> histogramBuckets);
 
 UnorderedMap<long, long> getAndClearHistogram(ConstExprStr histogram);
 std::string getCounterStatistics(std::vector<std::string> names);

--- a/common/Timer.cc
+++ b/common/Timer.cc
@@ -1,30 +1,46 @@
 #include "common/Timer.h"
+#include "common/sort.h"
 using namespace std;
 namespace sorbet {
+namespace {
+vector<int> ensureSorted(initializer_list<int> input) {
+    vector<int> output(input);
+    output.push_back(INT_MAX);
+    fast_sort(output);
+    return output;
+}
+} // namespace
 
 Timer::Timer(spdlog::logger &log, ConstExprStr name, FlowId prev, initializer_list<pair<ConstExprStr, string>> args,
-             chrono::time_point<chrono::steady_clock> start)
-    : log(log), name(name), prev(prev), self{0}, args(args), start(start) {}
+             chrono::time_point<chrono::steady_clock> start, initializer_list<int> histogramBuckets)
+    : log(log), name(name), prev(prev), self{0}, args(args), start(start),
+      histogramBuckets(ensureSorted(histogramBuckets)) {}
 
-Timer::Timer(spdlog::logger &log, ConstExprStr name, FlowId prev, initializer_list<pair<ConstExprStr, string>> args)
-    : Timer(log, name, prev, args, chrono::steady_clock::now()){};
+Timer::Timer(spdlog::logger &log, ConstExprStr name, FlowId prev, initializer_list<pair<ConstExprStr, string>> args,
+             initializer_list<int> histogramBuckets)
+    : Timer(log, name, prev, args, chrono::steady_clock::now(), histogramBuckets){};
 
 Timer::Timer(spdlog::logger &log, ConstExprStr name, initializer_list<pair<ConstExprStr, string>> args)
-    : Timer(log, name, FlowId{0}, args){};
+    : Timer(log, name, FlowId{0}, args, {}){};
+
+Timer::Timer(spdlog::logger &log, ConstExprStr name, initializer_list<int> histogramBuckets)
+    : Timer(log, name, FlowId{0}, {}, histogramBuckets) {}
 
 Timer::Timer(const shared_ptr<spdlog::logger> &log, ConstExprStr name, FlowId prev,
              initializer_list<pair<ConstExprStr, string>> args)
-    : Timer(*log, name, prev, args){};
+    : Timer(*log, name, prev, args, {}){};
 
 Timer::Timer(const shared_ptr<spdlog::logger> &log, ConstExprStr name,
              initializer_list<pair<ConstExprStr, string>> args)
     : Timer(*log, name, args){};
 
-Timer::Timer(const shared_ptr<spdlog::logger> &log, ConstExprStr name) : Timer(*log, name, {}){};
-Timer::Timer(const shared_ptr<spdlog::logger> &log, ConstExprStr name, FlowId prev) : Timer(*log, name, prev, {}){};
+Timer::Timer(const shared_ptr<spdlog::logger> &log, ConstExprStr name)
+    : Timer(*log, name, initializer_list<pair<ConstExprStr, string>>{}){};
+Timer::Timer(const shared_ptr<spdlog::logger> &log, ConstExprStr name, FlowId prev) : Timer(*log, name, prev, {}, {}){};
 
-Timer::Timer(spdlog::logger &log, ConstExprStr name) : Timer(log, name, {}){};
-Timer::Timer(spdlog::logger &log, ConstExprStr name, FlowId prev) : Timer(log, name, prev, {}){};
+Timer::Timer(spdlog::logger &log, ConstExprStr name)
+    : Timer(log, name, initializer_list<pair<ConstExprStr, string>>{}){};
+Timer::Timer(spdlog::logger &log, ConstExprStr name, FlowId prev) : Timer(log, name, prev, {}, {}){};
 
 int getGlobalTimingId() {
     static atomic<int> counter = 1;
@@ -43,10 +59,11 @@ void Timer::cancel() {
 }
 
 Timer Timer::clone(ConstExprStr name) {
-    Timer forked(log, name, prev, {}, start);
+    Timer forked(log, name, prev, {}, start, {});
     forked.args = args;
     forked.tags = tags;
     forked.canceled = canceled;
+    forked.histogramBuckets = histogramBuckets;
     return forked;
 }
 
@@ -69,8 +86,19 @@ Timer::~Timer() {
     if (!canceled && dur > std::chrono::milliseconds(1)) {
         // the trick ^^^ is to skip double comparison in the common case and use the most efficient representation.
         auto dur = std::chrono::duration<double, std::milli>(clock - start);
-        log.debug("{}: {}ms", this->name.str, dur.count());
+        const auto msCount = dur.count();
+        log.debug("{}: {}ms", this->name.str, msCount);
         sorbet::timingAdd(this->name, start, clock, move(args), move(tags), self, prev);
+
+        if (!histogramBuckets.empty()) {
+            // Find the bucket for this value. The last bucket is INT_MAX, so it's guaranteed to pick one.
+            for (const auto bucket : histogramBuckets) {
+                if (msCount < bucket) {
+                    prodHistogramInc(name, bucket);
+                    break;
+                }
+            }
+        }
     }
 }
 

--- a/common/Timer.cc
+++ b/common/Timer.cc
@@ -94,13 +94,12 @@ Timer::~Timer() {
         log.debug("{}: {}ms", this->name.str, msCount);
         sorbet::timingAdd(this->name, start, clock, move(args), move(tags), self, prev);
 
-        if (!histogramBuckets.empty()) {
-            // Find the bucket for this value. The last bucket is INT_MAX, so it's guaranteed to pick one.
-            for (const auto bucket : histogramBuckets) {
-                if (msCount < bucket) {
-                    prodHistogramInc(name, bucket);
-                    break;
-                }
+        // Find the bucket for this value. The last bucket is INT_MAX, so it's guaranteed to pick one if a histogram
+        // is set. If histogramBuckets is empty (which is the common case), then nothing happens.
+        for (const auto bucket : histogramBuckets) {
+            if (msCount < bucket) {
+                prodHistogramInc(name, bucket);
+                break;
             }
         }
     }

--- a/common/Timer.cc
+++ b/common/Timer.cc
@@ -5,8 +5,12 @@ namespace sorbet {
 namespace {
 vector<int> ensureSorted(initializer_list<int> input) {
     vector<int> output(input);
-    output.push_back(INT_MAX);
-    fast_sort(output);
+    // Keep empty output empty; that means that there is no histogram.
+    if (!output.empty()) {
+        // Append a catch-all bucket.
+        output.push_back(INT_MAX);
+        fast_sort(output);
+    }
     return output;
 }
 } // namespace

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -10,14 +10,16 @@ namespace sorbet {
 class Timer {
     Timer(spdlog::logger &log, ConstExprStr name, FlowId prev,
           std::initializer_list<std::pair<ConstExprStr, std::string>> args,
-          std::chrono::time_point<std::chrono::steady_clock> start);
+          std::chrono::time_point<std::chrono::steady_clock> start, std::initializer_list<int> histogramBuckets);
 
 public:
     Timer(spdlog::logger &log, ConstExprStr name);
+    Timer(spdlog::logger &log, ConstExprStr name, std::initializer_list<int> histogramBuckets);
     Timer(spdlog::logger &log, ConstExprStr name, FlowId prev);
     Timer(spdlog::logger &log, ConstExprStr name, std::initializer_list<std::pair<ConstExprStr, std::string>> args);
     Timer(spdlog::logger &log, ConstExprStr name, FlowId prev,
-          std::initializer_list<std::pair<ConstExprStr, std::string>> args);
+          std::initializer_list<std::pair<ConstExprStr, std::string>> args,
+          std::initializer_list<int> histogramBuckets);
     Timer(const std::shared_ptr<spdlog::logger> &log, ConstExprStr name, FlowId prev);
     Timer(const std::shared_ptr<spdlog::logger> &log, ConstExprStr name);
     Timer(const std::shared_ptr<spdlog::logger> &log, ConstExprStr name, FlowId prev,
@@ -55,6 +57,9 @@ private:
     // 'tags' appear in statsd metrics but not in traces. They are ConstExprStr to limit cardinality.
     std::vector<std::pair<ConstExprStr, ConstExprStr>> tags;
     const std::chrono::time_point<std::chrono::steady_clock> start;
+    // If not empty, report the time for this timer in the given histogram, where each entry forms an upper bound
+    // on a bucket. Is sorted from smallest to largest upper bound, and contains MAX_INT at the end as a catch-all.
+    std::vector<int> histogramBuckets;
     bool canceled = false;
 };
 } // namespace sorbet

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -58,7 +58,7 @@ private:
     std::vector<std::pair<ConstExprStr, ConstExprStr>> tags;
     const std::chrono::time_point<std::chrono::steady_clock> start;
     // If not empty, report the time for this timer in the given histogram, where each entry forms an upper bound
-    // on a bucket. Is sorted from smallest to largest upper bound, and contains MAX_INT at the end as a catch-all.
+    // on a bucket.
     std::vector<int> histogramBuckets;
     bool canceled = false;
 };

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -98,7 +98,8 @@ LSPTask::Phase LSPRequestTask::finalPhase() const {
 bool LSPRequestTask::cancel(const MessageId &id) {
     if (this->id.equals(id)) {
         if (latencyTimer) {
-            latencyTimer->setTag("canceled", "true");
+            latencyTimer->cancel();
+            latencyTimer = nullptr;
         }
         auto response = make_unique<ResponseMessage>("2.0", id, method);
         prodCounterInc("lsp.messages.canceled");

--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -48,8 +48,10 @@ CounterState mergeCounters(CounterState counters) {
 }
 
 void tagNewRequest(spd::logger &logger, LSPMessage &msg) {
-    msg.latencyTimer = make_unique<Timer>(logger, "task_latency");
-    msg.latencyTimer->setTag("canceled", "false");
+    // apparently make_unique doesn't like initializer lists, so I'm passing it a Timer object directly.
+    msg.latencyTimer = make_unique<Timer>(
+        Timer(logger, "task_latency",
+              {50, 100, 250, 500, 1000, 1500, 2000, 2500, 5000, 10000, 15000, 20000, 25000, 30000, 35000, 40000}));
 }
 } // namespace
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Add support for histograms to Timers.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It would be useful to see a histogram of the Sorbet language server's latency on various requests.

As a corollary, I removed the 'canceled' tag from requests as 1) histograms don't support tags right now, and 2) I don't want canceled request latency in the histogram.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested manually and verified that metrics appeared in SignalFX.
