### PR TITLE
Add additional metrics to language server

### DIFF
--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -262,6 +262,9 @@ void LSPPreprocessor::preprocessAndEnqueue(unique_ptr<LSPMessage> msg) {
 
     auto task = getTaskForMessage(*msg);
     task->latencyTimer = move(msg->latencyTimer);
+
+    Timer timeit(config->logger, "task_preprocess");
+    timeit.setTag("method", task->methodString());
     task->preprocess(*this);
     if (task->finalPhase() != LSPTask::Phase::PREPROCESS) {
         // Enqueue task to be processed on processing thread.

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -278,7 +278,7 @@ void LSPPreprocessor::preprocessAndEnqueue(unique_ptr<LSPMessage> msg) {
             mergeFileChanges();
         }
     } else {
-        categoryCounterInc("lsp.messages.processed", task->methodString());
+        prodCategoryCounterInc("lsp.messages.processed", task->methodString());
     }
 }
 

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -263,9 +263,11 @@ void LSPPreprocessor::preprocessAndEnqueue(unique_ptr<LSPMessage> msg) {
     auto task = getTaskForMessage(*msg);
     task->latencyTimer = move(msg->latencyTimer);
 
-    Timer timeit(config->logger, "task_preprocess");
-    timeit.setTag("method", task->methodString());
-    task->preprocess(*this);
+    {
+        Timer timeit(config->logger, "LSPTask::Preprocess");
+        timeit.setTag("method", task->methodString());
+        task->preprocess(*this);
+    }
     if (task->finalPhase() != LSPTask::Phase::PREPROCESS) {
         // Enqueue task to be processed on processing thread.
         absl::MutexLock lock(taskQueueMutex.get());

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -256,7 +256,7 @@ void LSPQueuePreemptionTask::run(LSPTypecheckerDelegate &tc) {
             taskQueue.pendingTasks.pop_front();
 
             {
-                Timer timeit(config.logger, "task_index");
+                Timer timeit(config.logger, "LSPTask::index");
                 timeit.setTag("method", task->methodString());
                 // Index while holding lock to prevent races with processing thread.
                 task->index(indexer);
@@ -268,7 +268,7 @@ void LSPQueuePreemptionTask::run(LSPTypecheckerDelegate &tc) {
         if (task->finalPhase() == Phase::INDEX) {
             continue;
         }
-        Timer timeit(config.logger, "task_run");
+        Timer timeit(config.logger, "LSPTask::run");
         timeit.setTag("method", task->methodString());
         task->run(tc);
     }

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -102,7 +102,7 @@ bool LSPRequestTask::cancel(const MessageId &id) {
             latencyTimer = nullptr;
         }
         auto response = make_unique<ResponseMessage>("2.0", id, method);
-        prodCounterInc("lsp.messages.canceled");
+        prodCategoryCounterInc("lsp.messages.canceled", methodString());
         response->error = make_unique<ResponseError>((int)LSPErrorCodes::RequestCancelled, "Request was canceled");
         config.output->write(move(response));
         return true;
@@ -262,8 +262,7 @@ void LSPQueuePreemptionTask::run(LSPTypecheckerDelegate &tc) {
                 task->index(indexer);
             }
         }
-        prodCounterInc("lsp.messages.received");
-        categoryCounterInc("lsp.messages.processed", task->methodString());
+        prodCategoryCounterInc("lsp.messages.processed", task->methodString());
 
         if (task->finalPhase() == Phase::INDEX) {
             continue;

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -79,6 +79,7 @@ bool LSPTypechecker::typecheck(LSPFileUpdates updates, WorkerPool &workers) {
     sendTypecheckInfo(*config, *gs, SorbetTypecheckRunStatus::Started, isFastPath, {});
     if (isFastPath) {
         auto run = runFastPath(move(updates), workers);
+        prodCategoryCounterInc("lsp.updates", "fastpath");
         filesTypechecked = run.filesTypechecked;
         commitTypecheckRun(move(run));
     } else {
@@ -153,7 +154,6 @@ TypecheckRun LSPTypechecker::runFastPath(LSPFileUpdates updates, WorkerPool &wor
     fast_sort(subset);
     subset.resize(std::distance(subset.begin(), std::unique(subset.begin(), subset.end())));
 
-    prodCategoryCounterInc("lsp.updates", "fastpath");
     config->logger->debug("Taking fast path");
     ENFORCE(gs->errorQueue->isEmpty());
     vector<ast::ParsedFile> updatedIndexed;

--- a/main/lsp/notifications/sorbet_workspace_edit.cc
+++ b/main/lsp/notifications/sorbet_workspace_edit.cc
@@ -49,7 +49,9 @@ void SorbetWorkspaceEditTask::index(LSPIndexer &indexer) {
 }
 
 void SorbetWorkspaceEditTask::run(LSPTypecheckerDelegate &typechecker) {
-    latencyTimer->setTag("path", "fast");
+    if (latencyTimer != nullptr) {
+        latencyTimer->setTag("path", "fast");
+    }
     ENFORCE(updates != nullptr);
     if (!updates->canceledSlowPath) {
         latencyCancelSlowPath->cancel();
@@ -62,13 +64,17 @@ void SorbetWorkspaceEditTask::run(LSPTypecheckerDelegate &typechecker) {
         Exception::raise("Attempted to run a slow path update on the fast path!");
     }
     typechecker.typecheckOnFastPath(move(*updates));
-    // TODO: Move into pushDiagnostics once we have fast feedback.
-    latencyTimer->clone("last_diagnostic_latency");
+    if (latencyTimer != nullptr) {
+        // TODO: Move into pushDiagnostics once we have fast feedback.
+        latencyTimer->clone("last_diagnostic_latency");
+    }
     prodCategoryCounterAdd("lsp.messages.processed", "sorbet.mergedEdits", updates->editCount - 1);
 }
 
 void SorbetWorkspaceEditTask::runSpecial(LSPTypechecker &typechecker, WorkerPool &workers) {
-    latencyTimer->setTag("path", "slow");
+    if (latencyTimer != nullptr) {
+        latencyTimer->setTag("path", "slow");
+    }
     if (!updates->canceledSlowPath) {
         latencyCancelSlowPath->cancel();
     }
@@ -80,8 +86,10 @@ void SorbetWorkspaceEditTask::runSpecial(LSPTypechecker &typechecker, WorkerPool
     startedNotification.Notify();
     // Only report stats if the edit was committed.
     if (!typechecker.typecheck(move(*updates), workers)) {
-        // TODO: Move into pushDiagnostics once we have fast feedback.
-        latencyTimer->clone("last_diagnostic_latency");
+        if (latencyTimer != nullptr) {
+            // TODO: Move into pushDiagnostics once we have fast feedback.
+            latencyTimer->clone("last_diagnostic_latency");
+        }
         prodCategoryCounterAdd("lsp.messages.processed", "sorbet.mergedEdits", updates->editCount - 1);
     }
 }

--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -270,7 +270,6 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(shared_ptr<LSPInput> inp
                 task = move(taskQueue->pendingTasks.front());
                 taskQueue->pendingTasks.pop_front();
             }
-            prodCounterInc("lsp.messages.received");
 
             logger->debug("[Processing] Running task {} normally", convertLSPMethodToString(task->method));
             runTask(move(task));

--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -37,6 +37,8 @@ void LSPLoop::processRequests(vector<unique_ptr<LSPMessage>> messages) {
 }
 
 void LSPLoop::runTask(unique_ptr<LSPTask> task) {
+    Timer timeit(config->logger, "task_run_blocking");
+    timeit.setTag("method", task->methodString());
     categoryCounterInc("lsp.messages.processed", task->methodString());
     task->index(indexer);
     if (task->finalPhase() == LSPTask::Phase::INDEX) {

--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -37,7 +37,7 @@ void LSPLoop::processRequests(vector<unique_ptr<LSPMessage>> messages) {
 }
 
 void LSPLoop::runTask(unique_ptr<LSPTask> task) {
-    categoryCounterInc("lsp.messages.processed", task->methodString());
+    prodCategoryCounterInc("lsp.messages.processed", task->methodString());
     {
         Timer timeit(config->logger, "LSPTask::index");
         timeit.setTag("method", task->methodString());

--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -39,7 +39,7 @@ void LSPLoop::processRequests(vector<unique_ptr<LSPMessage>> messages) {
 void LSPLoop::runTask(unique_ptr<LSPTask> task) {
     categoryCounterInc("lsp.messages.processed", task->methodString());
     {
-        Timer timeit(config->logger, "task_index");
+        Timer timeit(config->logger, "LSPTask::index");
         timeit.setTag("method", task->methodString());
         task->index(indexer);
     }
@@ -47,9 +47,6 @@ void LSPLoop::runTask(unique_ptr<LSPTask> task) {
         // Task doesn't need the typechecker.
         return;
     }
-
-    Timer timeit(config->logger, "task_run");
-    timeit.setTag("method", task->methodString());
 
     // Check if the task is a dangerous task, as those are scheduled specially.
     if (auto *dangerousTask = dynamic_cast<LSPDangerousTypecheckerTask *>(task.get())) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Adds the following metrics to the language server:

* Runtime of the three core `LSPTask` phases (preprocess, index, and run) tagged by LSP method.
* Runtime of `LSPLoop::sendCountersToStatsd`
* Runtime of `LSPDangerousTypecheckerTask::runSpecial` (which is used for slow path, initialization, etc).
* `last_diagnostic_latency`, which is meant to capture the latency between making an edit and receiving all errors for that edit.
* `lsp.messages.canceled` is now parameterized by the method of the message.

Fixes the following metrics:

* Does not credit calls to `LSPTypechecker::retypecheck` as a fast path typecheck. Prevents code actions from artificially inflating the % of edits that take fast/slow path.
* Tags `SorbetWorkspaceEdit` latency with the path the edit took.

Removes the following metrics:

* `lsp.messages.received`, as it basically mirrors the `processed` metric now.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Improving metrics for the language server.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

N/A
