### PR TITLE
Fix error handling of T::Struct with T.untyped props

### DIFF
--- a/gems/sorbet-runtime/test/types/props/constructor.rb
+++ b/gems/sorbet-runtime/test/types/props/constructor.rb
@@ -16,6 +16,10 @@ class Opus::Types::Test::Props::ConstructorTest < Critic::Unit::UnitTest
     prop :objs, T::Array[Inner]
   end
 
+  class StructWithUntypedProp < T::Struct
+    prop :bar, T.untyped
+  end
+
   it "raises when omitting a required prop" do
     err = assert_raises(ArgumentError) do
       MyStruct.new(foo: 'foo')
@@ -23,10 +27,22 @@ class Opus::Types::Test::Props::ConstructorTest < Critic::Unit::UnitTest
     assert_equal("Missing required prop `name` for class `Opus::Types::Test::Props::ConstructorTest::MyStruct`", err.message)
   end
 
+  it "raises when omitting a required untyped prop" do
+    err = assert_raises(ArgumentError) do
+      StructWithUntypedProp.new
+    end
+    assert_equal("Missing required prop `bar` for class `Opus::Types::Test::Props::ConstructorTest::StructWithUntypedProp`", err.message)
+  end
+
   it 'allows required props to be omitted if they have a default value' do
     m = MyStruct.new(name: "Alex",
                      foo: {color: :red})
     assert_equal("Hi", m.greeting)
+  end
+
+  it 'allows props to be omitted if they are nilable' do
+    m = MyStruct.new(name: "Alex")
+    assert_equal("Alex", m.name)
   end
 
   it 'populates props' do
@@ -38,9 +54,10 @@ class Opus::Types::Test::Props::ConstructorTest < Critic::Unit::UnitTest
   end
 
   it 'raises on unknown props' do
-    assert_raises(ArgumentError) do
-      MyStruct.new(notathing: 4)
+    err = assert_raises(ArgumentError) do
+      MyStruct.new(name: "Alex", notathing: 4)
     end
+    assert_equal("Opus::Types::Test::Props::ConstructorTest::MyStruct: Unrecognized properties: notathing", err.message)
   end
 
   it 'checks types' do

--- a/gems/sorbet-runtime/test/types/props/struct.rb
+++ b/gems/sorbet-runtime/test/types/props/struct.rb
@@ -77,6 +77,11 @@ class Opus::Types::Test::Props::StructTest < Critic::Unit::UnitTest
     prop :foo5, T.nilable(T::Array[SubStruct])
   end
 
+  class StructWithUntypedField < T::Struct
+    prop :foo0, T.untyped
+    prop :foo1, T.nilable(T.untyped)
+  end
+
   class StructWithReqiredField < T::Struct
     prop :foo1, Integer
     prop :foo2, Integer
@@ -101,6 +106,12 @@ class Opus::Types::Test::Props::StructTest < Critic::Unit::UnitTest
 
       assert_equal(true, T::Props::Utils.optional_prop?(TestStruct.props[:foo5]))
       assert_nil(TestStruct.props[:foo5][:optional])
+
+      assert_equal(true, T::Props::Utils.required_prop?(StructWithUntypedField.props[:foo0]))
+      assert_nil(StructWithUntypedField.props[:foo0][:optional])
+
+      assert_equal(true, T::Props::Utils.optional_prop?(StructWithUntypedField.props[:foo1]))
+      assert_nil(StructWithUntypedField.props[:foo1][:optional])
     end
 
     it 'tstruct tnilable field type_object' do


### PR DESCRIPTION
### Motivation

A recent PR (#2506) changed how `T::Struct` initialization works and changed behavior related to props defined as `T.untyped`.

**Before**

If a field was "required" (i.e. non-nilable) AND there was no default AND you didn't pass in a key then you'd get a `Missing required prop` argument error. See: https://github.com/sorbet/sorbet/pull/2506/files#diff-2149460b596c7795d2e75fd56b5efda8L13

**After**

We're now implicitly casting a missing key to `nil` and relying on the raising of a `TypeError` or `T::Props::InvalidValueError` to re-raise a `Missing required prop` argument error. See: https://github.com/sorbet/sorbet/pull/2506/files#diff-2149460b596c7795d2e75fd56b5efda8R25. This breaks when a prop is typed as `T.untyped` since `nil` passes the type check so the missing key does not raise an exception even though `T::Props::Utils.required_prop?` would say it's a required prop.

Here's the sorbet.run showing that the "before" behavior is the behavior that the static type checker enforces:

https://sorbet.run/#%23%20typed%3A%20true%0Aclass%20A%20%3C%20T%3A%3AStruct%0A%20%20const%20%3Aa%2C%20String%0A%20%20const%20%3Ab%2C%20T.nilable(String)%0A%20%20const%20%3Ac%2C%20T.untyped%0A%20%20const%20%3Ad%2C%20T.nilable(T.untyped)%0Aend%0A%0AA.new(a%3A%20''%2C%20b%3A%20''%2C%20c%3A%20''%2C%20d%3A%20'')%20%23%20All%20there%0AA.new(a%3A%20''%2C%20c%3A%20'')%20%23%20Missing%20nilable%0AA.new(a%3A%20'')%20%23%20Missing%20T.untyped%0A

**Approach**

I don't actually know the best way to fix this so I'd defer to you all. I figured I'd open a PR instead of simply an issue so that I could add failing test cases. Feel free to provide guidance on how to fix it or if you have bandwidth and agree it needs fixing add to this PR.

### Test plan

See included automated tests.
