### PR TITLE
Reduce enclosed variables for setter procs in T::Props

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
@@ -49,7 +49,7 @@ module T::Props
         params(
           prop: Symbol,
           accessor_key: Symbol,
-          non_nil_type: T.any(T::Types::Base, Module),
+          non_nil_type: T.any(T::Types::Base, T.all(T::Props::CustomType, Module)),
         )
         .returns(SetterProc)
       end
@@ -59,7 +59,7 @@ module T::Props
             instance_variable_set(accessor_key, val)
           else
             T::Props::Private::SetterFactory.raise_pretty_error(
-              self.class,
+              T.unsafe(self.class),
               prop,
               non_nil_type,
               val,
@@ -72,7 +72,7 @@ module T::Props
         params(
           prop: Symbol,
           accessor_key: Symbol,
-          non_nil_type: T.any(T::Types::Base, Module),
+          non_nil_type: T.any(T::Types::Base, T.all(T::Props::CustomType, Module)),
         )
         .returns(SetterProc)
       end
@@ -84,7 +84,7 @@ module T::Props
             instance_variable_set(accessor_key, val)
           else
             T::Props::Private::SetterFactory.raise_pretty_error(
-              self.class,
+              T.unsafe(self.class),
               prop,
               non_nil_type,
               val,


### PR DESCRIPTION
### Motivation
Something @dmitry-stripe pointed out to me in an over-the-shoulder code review a couple weeks ago

Has no impact on microbenchmarks, but seems reasonable as cleanup anyway

### Test plan
Passing build