### PR TITLE
Tests for foundational language server metrics

### DIFF
--- a/common/Counters.h
+++ b/common/Counters.h
@@ -40,6 +40,11 @@ class Proto;
 namespace web_tracer_framework {
 class Tracing;
 }
+
+namespace test::lsp {
+class CounterStateDatabase;
+}
+
 struct CounterState {
     CounterState();
     ~CounterState();
@@ -57,6 +62,7 @@ private:
     friend class core::Proto;
     friend class StatsD;
     friend class sorbet::web_tracer_framework::Tracing;
+    friend class sorbet::test::lsp::CounterStateDatabase;
 
     CounterState(std::unique_ptr<CounterImpl> counters);
     std::unique_ptr<CounterImpl> counters;

--- a/common/Timer.cc
+++ b/common/Timer.cc
@@ -47,7 +47,11 @@ void Timer::cancel() {
     this->canceled = true;
 }
 
-Timer Timer::clone(ConstExprStr name) {
+Timer Timer::clone() const {
+    return clone(name);
+}
+
+Timer Timer::clone(ConstExprStr name) const {
     Timer forked(log, name, prev, {}, start, {});
     forked.args = args;
     forked.tags = tags;

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -35,8 +35,11 @@ public:
     // Add a tag to the statsd metrics for this timer. Will not appear in traces.
     void setTag(ConstExprStr name, ConstExprStr value);
 
-    // Creates a new timer with the same start time and args but a different name.
-    Timer clone(ConstExprStr name);
+    // Creates a new timer with the same start time, tags, args, and name.
+    Timer clone() const;
+
+    // Creates a new timer with the same start time, tags, and args but a different name.
+    Timer clone(ConstExprStr name) const;
 
     // TODO We could add more overloads for this if we need them (to create other kinds of Timers)
     // We could also make this more generic to allow more sleep duration types.

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -194,6 +194,8 @@ unique_ptr<LSPTask> LSPPreprocessor::getTaskForMessage(LSPMessage &msg) {
                 return make_unique<ShutdownTask>(*config, id);
             case LSPMethod::SorbetError:
                 return make_unique<SorbetErrorTask>(*config, move(get<unique_ptr<SorbetErrorParams>>(rawParams)), id);
+            case LSPMethod::GETCOUNTERS:
+                return make_unique<GetCountersTask>(*config, id);
             default:
                 return make_unique<SorbetErrorTask>(
                     *config,

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -266,7 +266,7 @@ void LSPPreprocessor::preprocessAndEnqueue(unique_ptr<LSPMessage> msg) {
     task->latencyTimer = move(msg->latencyTimer);
 
     {
-        Timer timeit(config->logger, "LSPTask::Preprocess");
+        Timer timeit(config->logger, "LSPTask::preprocess");
         timeit.setTag("method", task->methodString());
         task->preprocess(*this);
     }

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -26,6 +26,8 @@ ConstExprStr LSPTask::methodString() const {
             return "PAUSE";
         case LSPMethod::RESUME:
             return "RESUME";
+        case LSPMethod::GETCOUNTERS:
+            return "GETCOUNTERS";
         case LSPMethod::Shutdown:
             return "shutdown";
         case LSPMethod::SorbetError:

--- a/main/lsp/LSPTypecheckerCoordinator.cc
+++ b/main/lsp/LSPTypecheckerCoordinator.cc
@@ -141,7 +141,7 @@ shared_ptr<core::lsp::Task>
 LSPTypecheckerCoordinator::trySchedulePreemption(std::unique_ptr<LSPQueuePreemptionTask> preemptTask) {
     auto wrappedTask = make_shared<TypecheckerTask>(*config, move(preemptTask),
                                                     make_unique<LSPTypecheckerDelegate>(*emptyWorkers, typechecker),
-                                                    hasDedicatedThread);
+                                                    /* collectCounters */ false);
     // Plant this timer before scheduling task to preempt, as task could run before we plant the timer!
     wrappedTask->timeLatencyUntilRun(make_unique<Timer>(*config->logger, "latency.preempt_slow_path"));
     if (hasDedicatedThread && preemptionTaskManager->trySchedulePreemptionTask(wrappedTask)) {

--- a/main/lsp/notifications/sorbet_workspace_edit.cc
+++ b/main/lsp/notifications/sorbet_workspace_edit.cc
@@ -91,7 +91,7 @@ void SorbetWorkspaceEditTask::runSpecial(LSPTypechecker &typechecker, WorkerPool
             latencyTimer->clone("last_diagnostic_latency");
         }
         prodCategoryCounterAdd("lsp.messages.processed", "sorbet.mergedEdits", updates->editCount - 1);
-    } else if (latencyTimer) {
+    } else if (latencyTimer != nullptr) {
         // Don't report a latency value for canceled slow paths.
         latencyTimer->cancel();
     }

--- a/main/lsp/notifications/sorbet_workspace_edit.cc
+++ b/main/lsp/notifications/sorbet_workspace_edit.cc
@@ -45,7 +45,7 @@ void SorbetWorkspaceEditTask::mergeNewer(SorbetWorkspaceEditTask &task) {
 }
 
 void SorbetWorkspaceEditTask::index(LSPIndexer &indexer) {
-    updates = make_unique<LSPFileUpdates>(indexer.commitEdit(*params, cachedFileHashesOrEmpty));
+    updates = make_unique<LSPFileUpdates>(indexer.commitEdit(latencyTimer, *params, cachedFileHashesOrEmpty));
 }
 
 void SorbetWorkspaceEditTask::run(LSPTypecheckerDelegate &typechecker) {

--- a/main/lsp/requests/get_counters.cc
+++ b/main/lsp/requests/get_counters.cc
@@ -1,18 +1,30 @@
 #include "main/lsp/requests/get_counters.h"
+#include "main/lsp/LSPOutput.h"
 #include "main/lsp/lsp.h"
 
 using namespace std;
 
 namespace sorbet::realmain::lsp {
 GetCountersTask::GetCountersTask(const LSPConfiguration &config, MessageId id)
-    : LSPRequestTask(config, move(id), LSPMethod::GETCOUNTERS) {}
+    : LSPTask(config, LSPMethod::GETCOUNTERS), id(move(id)) {}
 
-std::unique_ptr<ResponseMessage> GetCountersTask::runRequest(LSPTypecheckerDelegate &typechecker) {
+LSPTask::Phase GetCountersTask::finalPhase() const {
+    return LSPTask::Phase::INDEX;
+}
+
+bool GetCountersTask::canPreempt(const LSPIndexer &) const {
+    return false;
+}
+
+// Has to run on indexing thread, which is what coordinates all threads and collects all of the statistics.
+void GetCountersTask::index(LSPIndexer &indexer) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::GETCOUNTERS);
     unique_ptr<SorbetCounters> counters = make_unique<SorbetCounters>();
     counters->counters = getAndClearThreadCounters();
     response->result = move(counters);
-    return response;
+    config.output->write(move(response));
 }
+
+void GetCountersTask::run(LSPTypecheckerDelegate &typechecker) {}
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/get_counters.cc
+++ b/main/lsp/requests/get_counters.cc
@@ -1,0 +1,18 @@
+#include "main/lsp/requests/get_counters.h"
+#include "main/lsp/lsp.h"
+
+using namespace std;
+
+namespace sorbet::realmain::lsp {
+GetCountersTask::GetCountersTask(const LSPConfiguration &config, MessageId id)
+    : LSPRequestTask(config, move(id), LSPMethod::GETCOUNTERS) {}
+
+std::unique_ptr<ResponseMessage> GetCountersTask::runRequest(LSPTypecheckerDelegate &typechecker) {
+    auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::GETCOUNTERS);
+    unique_ptr<SorbetCounters> counters = make_unique<SorbetCounters>();
+    counters->counters = getAndClearThreadCounters();
+    response->result = move(counters);
+    return response;
+}
+
+} // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/get_counters.cc
+++ b/main/lsp/requests/get_counters.cc
@@ -16,7 +16,7 @@ bool GetCountersTask::canPreempt(const LSPIndexer &) const {
     return false;
 }
 
-// Has to run on indexing thread, which is what coordinates all threads and collects all of the statistics.
+// Has to run on indexing thread, which is what coordinates all threads and collects all of the metrics.
 void GetCountersTask::index(LSPIndexer &indexer) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::GETCOUNTERS);
     unique_ptr<SorbetCounters> counters = make_unique<SorbetCounters>();

--- a/main/lsp/requests/get_counters.h
+++ b/main/lsp/requests/get_counters.h
@@ -4,11 +4,19 @@
 #include "main/lsp/LSPTask.h"
 
 namespace sorbet::realmain::lsp {
-class GetCountersTask final : public LSPRequestTask {
+class GetCountersTask final : public LSPTask {
+    MessageId id;
+
 public:
     GetCountersTask(const LSPConfiguration &config, MessageId id);
 
-    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+    bool canPreempt(const LSPIndexer &) const override;
+
+    LSPTask::Phase finalPhase() const override;
+
+    void index(LSPIndexer &indexer) override;
+
+    void run(LSPTypecheckerDelegate &typechecker) override;
 };
 } // namespace sorbet::realmain::lsp
 

--- a/main/lsp/requests/get_counters.h
+++ b/main/lsp/requests/get_counters.h
@@ -1,0 +1,15 @@
+#ifndef RUBY_TYPER_LSP_REQUESTS_GET_COUNTERS_H
+#define RUBY_TYPER_LSP_REQUESTS_GET_COUNTERS_H
+
+#include "main/lsp/LSPTask.h"
+
+namespace sorbet::realmain::lsp {
+class GetCountersTask final : public LSPRequestTask {
+public:
+    GetCountersTask(const LSPConfiguration &config, MessageId id);
+
+    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+};
+} // namespace sorbet::realmain::lsp
+
+#endif

--- a/main/lsp/requests/requests.h
+++ b/main/lsp/requests/requests.h
@@ -6,6 +6,7 @@
 #include "main/lsp/requests/definition.h"
 #include "main/lsp/requests/document_highlight.h"
 #include "main/lsp/requests/document_symbol.h"
+#include "main/lsp/requests/get_counters.h"
 #include "main/lsp/requests/hover.h"
 #include "main/lsp/requests/initialize.h"
 #include "main/lsp/requests/references.h"

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -1300,11 +1300,14 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                              },
                                              classTypes);
 
+    auto SorbetCounters = makeObject("SorbetCounters", {}, classTypes, {"CounterState counters;"});
+
     /* Core LSPMessage objects */
     // N.B.: Only contains LSP methods that Sorbet actually cares about.
     // All others are ignored.
     auto LSPMethod = makeStrEnum("LSPMethod",
                                  {
+                                     "__GETCOUNTERS__",
                                      "__PAUSE__",
                                      "__RESUME__",
                                      "$/cancelRequest",
@@ -1340,6 +1343,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
     auto methodField = makeField("method", LSPMethod);
     auto RequestMessageParamsType =
         makeDiscriminatedUnion(methodField, {
+                                                {"__GETCOUNTERS__", makeOptional(JSONNull)},
                                                 {"initialize", InitializeParams},
                                                 {"shutdown", makeOptional(JSONNull)},
                                                 {"textDocument/documentHighlight", TextDocumentPositionParams},
@@ -1365,6 +1369,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
     auto ResponseMessageResultType = makeDiscriminatedUnion(
         requestMethodField,
         {
+            {"__GETCOUNTERS__", SorbetCounters},
             {"initialize", InitializeResult},
             {"shutdown", JSONNull},
             // DocumentHighlight[] | null

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -18,6 +18,8 @@ bool isTypecheckRun(const LSPMessage &msg) {
 
 CounterStateDatabase::CounterStateDatabase(CounterState counters) : counters(move(counters)) {
     EXPECT_FALSE(this->counters.hasNullCounters());
+    // Combines counters with the same name but different char* pointers.
+    this->counters.counters->canonicalize();
 }
 
 // Get counter value or 0.

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -16,6 +16,90 @@ bool isTypecheckRun(const LSPMessage &msg) {
 }
 } // namespace
 
+CounterStateDatabase::CounterStateDatabase(CounterState counters) : counters(move(counters)) {
+    EXPECT_FALSE(this->counters.hasNullCounters());
+}
+
+// Get counter value or 0.
+CounterImpl::CounterType CounterStateDatabase::getCounter(ConstExprStr counter) const {
+    auto internedCounter = counters.counters->internKey(counter.str);
+    const auto &it = counters.counters->counters.find(internedCounter);
+    if (it != counters.counters->counters.end()) {
+        return it->second;
+    }
+    return 0;
+}
+
+CounterImpl::CounterType CounterStateDatabase::getCategoryCounter(ConstExprStr counter, ConstExprStr category) const {
+    auto internedCounter = counters.counters->internKey(counter.str);
+    const auto &it = counters.counters->countersByCategory.find(internedCounter);
+    if (it == counters.counters->countersByCategory.end()) {
+        return 0;
+    }
+    auto internedCategory = counters.counters->internKey(category.str);
+    const auto &catIt = it->second.find(internedCategory);
+    if (catIt == it->second.end()) {
+        return 0;
+    }
+    return catIt->second;
+}
+
+CounterImpl::CounterType CounterStateDatabase::getCategoryCounterSum(ConstExprStr counter) const {
+    auto internedCounter = counters.counters->internKey(counter.str);
+    const auto &it = counters.counters->countersByCategory.find(internedCounter);
+    CounterImpl::CounterType total = 0;
+    if (it != counters.counters->countersByCategory.end()) {
+        for (const auto &catIt : it->second) {
+            total += catIt.second;
+        }
+    }
+    return total;
+}
+
+CounterImpl::CounterType CounterStateDatabase::getHistogramCount(ConstExprStr histogram) const {
+    auto internedHistogram = counters.counters->internKey(histogram.str);
+    CounterImpl::CounterType rv = 0;
+    const auto &it = counters.counters->histograms.find(internedHistogram);
+    if (it != counters.counters->histograms.end()) {
+        const auto &map = it->second;
+        for (const auto &entry : map) {
+            rv += entry.second;
+        }
+    }
+    return rv;
+}
+
+vector<CounterImpl::Timing> CounterStateDatabase::getTimings(ConstExprStr counter,
+                                                             vector<pair<ConstExprStr, ConstExprStr>> tags) const {
+    // Note: Timers don't have interned names.
+    vector<CounterImpl::Timing> rv;
+    for (const auto &timing : counters.counters->timings) {
+        if (strncmp(timing.measure, counter.str, counter.size + 1) == 0 && timing.tags.size() >= tags.size()) {
+            UnorderedMap<std::string, const char *> timingTags;
+            for (const auto &tag : timing.tags) {
+                timingTags[tag.first] = tag.second;
+            }
+
+            int tagsMatched = 0;
+            for (const auto &tag : tags) {
+                auto it = timingTags.find(tag.first.str);
+                if (it == timingTags.end()) {
+                    break;
+                }
+                if (strncmp(it->second, tag.second.str, tag.second.size + 1) != 0) {
+                    break;
+                }
+                tagsMatched++;
+            }
+
+            if (tagsMatched == tags.size()) {
+                rv.push_back(timing);
+            }
+        }
+    }
+    return rv;
+}
+
 void ProtocolTest::SetUp() {
     rootPath = "/Users/jvilk/stripe/pay-server";
     rootUri = fmt::format("file://{}", rootPath);
@@ -223,6 +307,17 @@ void ProtocolTest::assertDiagnostics(vector<unique_ptr<LSPMessage>> messages, ve
 
     // Use same logic as main test runner.
     ErrorAssertion::checkAll(sourceFileContents, errorAssertions, diagnostics);
+}
+
+const CounterStateDatabase ProtocolTest::getCounters() {
+    auto results = getLSPResponsesFor(*lspWrapper, make_unique<LSPMessage>(make_unique<RequestMessage>(
+                                                       "2.0", nextId++, LSPMethod::GETCOUNTERS, nullopt)));
+    EXPECT_EQ(results.size(), 1);
+    auto &result = results.at(0);
+    EXPECT_TRUE(result->isResponse());
+    auto &response = result->asResponse();
+    auto &counters = get<unique_ptr<SorbetCounters>>(response.result.value());
+    return CounterStateDatabase(move(counters->counters));
 }
 
 } // namespace sorbet::test::lsp

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -3,6 +3,8 @@
 
 #include "gtest/gtest.h"
 // ^ Violates linting rules, so include first.
+#include "common/Counters.h"
+#include "common/Counters_impl.h"
 #include "main/lsp/wrapper.h"
 #include "test/helpers/MockFileSystem.h"
 
@@ -13,6 +15,25 @@ struct ExpectedDiagnostic {
     std::string path;
     int line;
     std::string message;
+};
+
+class CounterStateDatabase final {
+    const CounterState counters;
+
+public:
+    CounterStateDatabase(CounterState counters);
+
+    // Get counter value or 0.
+    CounterImpl::CounterType getCounter(ConstExprStr counter) const;
+
+    CounterImpl::CounterType getCategoryCounter(ConstExprStr counter, ConstExprStr category) const;
+
+    CounterImpl::CounterType getCategoryCounterSum(ConstExprStr counter) const;
+
+    CounterImpl::CounterType getHistogramCount(ConstExprStr histogram) const;
+
+    std::vector<CounterImpl::Timing> getTimings(ConstExprStr counter,
+                                                std::vector<std::pair<ConstExprStr, ConstExprStr>> tags = {}) const;
 };
 
 /**
@@ -95,6 +116,11 @@ protected:
      */
     void updateDiagnostics(const std::vector<std::unique_ptr<LSPMessage>> &messages);
     void updateDiagnostics(const LSPMessage &message);
+
+    /**
+     * Request all counter metrics from the server. Used to assert that metrics are reporting correctly.
+     */
+    const CounterStateDatabase getCounters();
 };
 
 } // namespace sorbet::test::lsp

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -45,6 +45,7 @@ TEST_P(ProtocolTest, MultithreadedWrapperWorks) {
     auto counters = getCounters();
     EXPECT_EQ(counters.getCategoryCounter("lsp.messages.processed", "sorbet.workspaceEdit"), 1);
     EXPECT_EQ(counters.getTimings("task_latency", {{"method", "sorbet.workspaceEdit"}}).size(), 1);
+    EXPECT_EQ(counters.getTimings("task_latency").size(), counters.getHistogramCount("task_latency"));
     EXPECT_EQ(counters.getCategoryCounterSum("lsp.messages.canceled"), 0);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 1);
     EXPECT_EQ(counters.getCategoryCounterSum("lsp.updates"), 1);

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -48,6 +48,7 @@ TEST_P(ProtocolTest, MultithreadedWrapperWorks) {
     EXPECT_EQ(counters.getCategoryCounterSum("lsp.messages.canceled"), 0);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 1);
     EXPECT_EQ(counters.getCategoryCounterSum("lsp.updates"), 1);
+    EXPECT_EQ(counters.getTimings("last_diagnostic_latency").size(), 1);
 }
 
 TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeFastPathWithOldEdits) {
@@ -119,6 +120,7 @@ TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeFastPathWithOldEdits) {
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 0);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath_canceled"), 1);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "query"), 0);
+    EXPECT_EQ(counters.getTimings("last_diagnostic_latency").size(), 1);
 }
 
 TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeSlowPath) {
@@ -180,6 +182,7 @@ TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeSlowPath) {
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 1);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath_canceled"), 1);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "query"), 0);
+    EXPECT_EQ(counters.getTimings("last_diagnostic_latency").size(), 1);
 }
 
 TEST_P(ProtocolTest, CanPreemptSlowPathWithHover) {
@@ -239,6 +242,7 @@ TEST_P(ProtocolTest, CanPreemptSlowPathWithHover) {
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 1);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath_canceled"), 0);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "query"), 1);
+    EXPECT_EQ(counters.getTimings("last_diagnostic_latency").size(), 1);
 }
 
 TEST_P(ProtocolTest, CanPreemptSlowPathWithHoverAndReturnsErrors) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Adds tests for foundational language server metrics and fixes a few bugs:

* If an edit comes in and cancels the slow path, we now calculate latency using the timer from the canceled slow path.
* When a slow path gets canceled, we properly emit `last_diagnostic_latency` and `sorbet.mergedEdits` metrics. (The conditional was flipped before.)
* When a slow path gets canceled, we do not emit a latency metric for it.

Includes a new test-only LSP method for getting counters out of the language server.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These metrics are hard to get right because they are asynchronous and have a few notable corner cases. It's easy to introduce regressions in them. The tests should break if we introduce bugs in these timers in the future.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
