### PR TITLE
Add `Regexp#match?` sig

### DIFF
--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_4_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_4_hidden.rbi.exp
@@ -9280,10 +9280,6 @@ module RbConfig
   def self.ruby(); end
 end
 
-class Regexp
-  def match?(*_); end
-end
-
 class RubyVM::InstructionSequence
   def absolute_path(); end
 

--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_hidden.rbi.exp
@@ -9632,10 +9632,6 @@ module RbConfig
   def self.ruby(); end
 end
 
-class Regexp
-  def match?(*_); end
-end
-
 module RubyVM::AbstractSyntaxTree
 end
 

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_4_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_4_hidden.rbi.exp
@@ -9286,10 +9286,6 @@ module RbConfig
   def self.ruby(); end
 end
 
-class Regexp
-  def match?(*_); end
-end
-
 class RubyVM::InstructionSequence
   def absolute_path(); end
 

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_hidden.rbi.exp
@@ -9638,10 +9638,6 @@ module RbConfig
   def self.ruby(); end
 end
 
-class Regexp
-  def match?(*_); end
-end
-
 module RubyVM::AbstractSyntaxTree
 end
 

--- a/rbi/core/regexp.rbi
+++ b/rbi/core/regexp.rbi
@@ -1129,6 +1129,20 @@ class Regexp < Object
   end
   def match(arg0, arg1=T.unsafe(nil), &blk); end
 
+  # Returns a true or false indicates whether the regexp is matched or
+  # not without updating $~ and other related variables. If the second
+  # parameter is present, it specifies the position in the string to
+  # begin the search.
+  # https://ruby-doc.org/core-2.7.0/Regexp.html#method-i-match-3F
+  sig do
+    params(
+        arg0: String,
+        arg1: T.nilable(Integer),
+    )
+    .returns(T::Boolean)
+  end
+  def match?(arg0, arg1=T.unsafe(nil)); end
+
   # Returns a hash representing information about named captures of *rxp*.
   #
   # A key of the hash is a name of the named captures. A value of the hash is an

--- a/rbi/core/regexp.rbi
+++ b/rbi/core/regexp.rbi
@@ -1136,7 +1136,7 @@ class Regexp < Object
   # https://ruby-doc.org/core-2.7.0/Regexp.html#method-i-match-3F
   sig do
     params(
-        arg0: String,
+        arg0: T.nilable(T.any(String, Symbol)),
         arg1: T.nilable(Integer),
     )
     .returns(T::Boolean)

--- a/test/testdata/rbi/regexp.rb
+++ b/test/testdata/rbi/regexp.rb
@@ -6,3 +6,6 @@ T.reveal_type(maybe_match) # error: type: `T.nilable(MatchData)`
 /foo/.match('foo') do |m|
   T.reveal_type(m) # error: type: `MatchData`
 end
+
+T.reveal_type(/foo/.match?('foo'))  # error: type: `T::Boolean`
+T.reveal_type(/foo/.match?('foo', 1))  # error: type: `T::Boolean`


### PR DESCRIPTION
https://ruby-doc.org/core-2.7.0/Regexp.html#method-i-match-3F

Fixes [this sorbet.run error](https://sorbet.run/#%23%20typed%3A%20true%0A%2Ffoo%2F.match%3F(%22foo%22)).