### PR TITLE
add ratchet for non-proc foreign usage

### DIFF
--- a/gems/sorbet-runtime/test/types/props/_props.rb
+++ b/gems/sorbet-runtime/test/types/props/_props.rb
@@ -233,6 +233,24 @@ class Opus::Types::Test::Props::PropsTest < Critic::Unit::UnitTest
       assert(test_model)
       assert_equal(obj.foreign2, test_model.id)
     end
+
+    it 'disallows non-proc arguments' do
+      T::Configuration.expects(:soft_assert_handler).with do |msg, _|
+        msg =~ /Please use a Proc that returns a model class instead/
+      end.times(3)
+
+      Class.new(TestForeignProps) do
+        prop :foreign3, String, foreign: MyTestModel
+      end
+
+      Class.new(TestForeignProps) do
+        prop :foreign3, String, foreign_hint_only: MyTestModel
+      end
+
+      Class.new(TestForeignProps) do
+        prop :foreign3, String, foreign_hint_only: [MyTestModel]
+      end
+    end
   end
 
   class MyCustomType


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Take 2 of https://github.com/sorbet/sorbet/pull/2682. This adds soft assertions against passing in non-proc values to the `foreign` and `foreign_hint_only` prop DSLs.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Forcing lazy evaluation gives us some small selective test execution wins. It seems that there was a codemod started to make this required across pay-server, but we never put in place a ratchet, so this does that.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

- See included automated tests.
- [Tested this change against pay-server and fixed the CI failures.](https://git.corp.stripe.com/stripe-internal/pay-server/pull/211118)
