### PR TITLE
Add RSpec, sparql-client and Kaminari to gem_loader.rb

### DIFF
--- a/gems/sorbet/lib/gem_loader.rb
+++ b/gems/sorbet/lib/gem_loader.rb
@@ -803,6 +803,15 @@ class Sorbet::Private::GemLoader
     'rspec-expectations' => proc do
       my_require 'rspec/expectations'
     end,
+    'kaminari-core' => proc do
+      my_require 'kaminari/core'
+    end,
+    'kaminari-activerecord' => proc do
+      my_require 'kaminari/activerecord'
+    end,
+    'kaminari-actionview' => proc do
+      my_require 'kaminari/actionview'
+    end,
   }
 
   # This is so that the autoloader doesn't treat these as manditory requires

--- a/gems/sorbet/lib/gem_loader.rb
+++ b/gems/sorbet/lib/gem_loader.rb
@@ -690,6 +690,9 @@ class Sorbet::Private::GemLoader
         SPARQL::VERSION,
       ]
     end,
+    'sparql-client' => proc do
+      my_require 'sparql/client'
+    end,
     'selenium-webdriver' => proc do
       my_require 'selenium/webdriver'
       [

--- a/gems/sorbet/lib/gem_loader.rb
+++ b/gems/sorbet/lib/gem_loader.rb
@@ -791,6 +791,18 @@ class Sorbet::Private::GemLoader
         RDF::Util::Coercions,
       ]
     end,
+    'rspec-core' => proc do
+      my_require 'rspec/core'
+    end,
+    'rspec-mocks' => proc do
+      my_require 'rspec/mocks'
+    end,
+    'rspec-support' => proc do
+      my_require 'rspec/support'
+    end,
+    'rspec-expectations' => proc do
+      my_require 'rspec/expectations'
+    end,
   }
 
   # This is so that the autoloader doesn't treat these as manditory requires

--- a/gems/sorbet/lib/gem_loader.rb
+++ b/gems/sorbet/lib/gem_loader.rb
@@ -801,6 +801,15 @@ class Sorbet::Private::GemLoader
         RSpec::Core::ExampleStatusPersister,
         RSpec::Core::Profiler,
         RSpec::Core::DidYouMean,
+        RSpec::Core::Formatters::DocumentationFormatter,
+        RSpec::Core::Formatters::HtmlFormatter,
+        RSpec::Core::Formatters::FallbackMessageFormatter,
+        RSpec::Core::Formatters::ProgressFormatter,
+        RSpec::Core::Formatters::ProfileFormatter,
+        RSpec::Core::Formatters::JsonFormatter,
+        RSpec::Core::Formatters::BisectDRbFormatter,
+        RSpec::Core::Formatters::ExceptionPresenter,
+        RSpec::Core::Formatters::FailureListFormatter,
       ]
     end,
     'rspec-mocks' => proc do

--- a/gems/sorbet/lib/gem_loader.rb
+++ b/gems/sorbet/lib/gem_loader.rb
@@ -796,15 +796,75 @@ class Sorbet::Private::GemLoader
     end,
     'rspec-core' => proc do
       my_require 'rspec/core'
+      [
+        RSpec::SharedContext,
+        RSpec::Core::ExampleStatusPersister,
+        RSpec::Core::Profiler,
+        RSpec::Core::DidYouMean,
+      ]
     end,
     'rspec-mocks' => proc do
       my_require 'rspec/mocks'
+      [
+        RSpec::Mocks::AnyInstance,
+        RSpec::Mocks::ExpectChain,
+        RSpec::Mocks::StubChain,
+        RSpec::Mocks::MarshalExtension,
+        RSpec::Mocks::Matchers::HaveReceived,
+        RSpec::Mocks::Matchers::Receive,
+        RSpec::Mocks::Matchers::ReceiveMessageChain,
+        RSpec::Mocks::Matchers::ReceiveMessages,
+      ]
     end,
     'rspec-support' => proc do
       my_require 'rspec/support'
+      [
+        RSpec::Support::Differ,
+      ]
     end,
     'rspec-expectations' => proc do
       my_require 'rspec/expectations'
+      [
+        RSpec::Expectations::BlockSnippetExtractor,
+        RSpec::Expectations::FailureAggregator,
+        RSpec::Matchers::BuiltIn::BeAKindOf,
+        RSpec::Matchers::BuiltIn::BeAnInstanceOf,
+        RSpec::Matchers::BuiltIn::BeBetween,
+        RSpec::Matchers::BuiltIn::Be,
+        RSpec::Matchers::BuiltIn::BeComparedTo,
+        RSpec::Matchers::BuiltIn::BeFalsey,
+        RSpec::Matchers::BuiltIn::BeNil,
+        RSpec::Matchers::BuiltIn::BePredicate,
+        RSpec::Matchers::BuiltIn::BeTruthy,
+        RSpec::Matchers::BuiltIn::BeWithin,
+        RSpec::Matchers::BuiltIn::Change,
+        RSpec::Matchers::BuiltIn::Compound,
+        RSpec::Matchers::BuiltIn::ContainExactly,
+        RSpec::Matchers::BuiltIn::Cover,
+        RSpec::Matchers::BuiltIn::EndWith,
+        RSpec::Matchers::BuiltIn::Eq,
+        RSpec::Matchers::BuiltIn::Eql,
+        RSpec::Matchers::BuiltIn::Equal,
+        RSpec::Matchers::BuiltIn::Exist,
+        RSpec::Matchers::BuiltIn::Has,
+        RSpec::Matchers::BuiltIn::HaveAttributes,
+        RSpec::Matchers::BuiltIn::Include,
+        RSpec::Matchers::BuiltIn::All,
+        RSpec::Matchers::BuiltIn::Match,
+        RSpec::Matchers::BuiltIn::NegativeOperatorMatcher,
+        RSpec::Matchers::BuiltIn::OperatorMatcher,
+        RSpec::Matchers::BuiltIn::Output,
+        RSpec::Matchers::BuiltIn::PositiveOperatorMatcher,
+        RSpec::Matchers::BuiltIn::RaiseError,
+        RSpec::Matchers::BuiltIn::RespondTo,
+        RSpec::Matchers::BuiltIn::Satisfy,
+        RSpec::Matchers::BuiltIn::StartWith,
+        RSpec::Matchers::BuiltIn::ThrowSymbol,
+        RSpec::Matchers::BuiltIn::YieldControl,
+        RSpec::Matchers::BuiltIn::YieldSuccessiveArgs,
+        RSpec::Matchers::BuiltIn::YieldWithArgs,
+        RSpec::Matchers::BuiltIn::YieldWithNoArgs,
+      ]
     end,
     'kaminari-core' => proc do
       my_require 'kaminari/core'


### PR DESCRIPTION
# Motivation

I was getting errors like this when generating rbis with Sorbet:

```
LoadError: cannot load such file -- rspec-core
```

So I wanted to fix the ones I could determine the correct `require`s for. I also added the specific classes that RSpec gems have as autoloading.

I figure this is easier to do in groups rather than one-at-a-time like I've done before.

### Test plan

See included automated tests.
