### PR TITLE
WIP: Store FileHash in File

### DIFF
--- a/core/Files.cc
+++ b/core/Files.cc
@@ -111,6 +111,14 @@ unique_ptr<File> File::deepCopy(GlobalState &gs) const {
     return ret;
 }
 
+void File::setFileHash(shared_ptr<FileHash> hash) {
+    hash_ = move(hash);
+}
+
+const shared_ptr<FileHash> &File::getFileHash() const {
+    return hash_;
+}
+
 FileRef::FileRef(unsigned int id) : _id(id) {
     ENFORCE(((u2)id) == id, "FileRef overflow. Do you have 2^16 files?");
 }

--- a/core/Files.h
+++ b/core/Files.h
@@ -9,6 +9,7 @@ namespace sorbet::core {
 class GlobalState;
 class File;
 struct GlobalStateHash;
+struct FileHash;
 namespace serialize {
 class SerializerImpl;
 }
@@ -99,11 +100,15 @@ public:
     /** Given a 1-based line number, returns a string view of the line. */
     std::string_view getLine(int i);
 
+    void setFileHash(std::shared_ptr<FileHash> hash);
+    const std::shared_ptr<FileHash> &getFileHash() const;
+
 private:
     const std::string path_;
     const std::string source_;
     mutable std::shared_ptr<std::vector<int>> lineBreaks_;
     mutable StrictLevel minErrorLevel_ = StrictLevel::Max;
+    std::shared_ptr<FileHash> hash_;
 
 public:
     const StrictLevel originalSigil;

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -291,7 +291,7 @@ LSPFileUpdates LSPIndexer::commitEdit(unique_ptr<Timer> &latencyTimer, SorbetWor
             initialGS->epochManager->tryCancelSlowPath(update.epoch)) {
             // Cancelation succeeded! Merge with the pending update.
             update.mergeOlder(pendingTypecheckUpdates);
-            update.fastPathDecision = makeFastPathDecision(update);
+            update.fastPathDecision = makeFastPathDecision(update, true);
             update.canceledSlowPath = true;
             mergeEvictedFiles(evictedFiles, newlyEvictedFiles);
         }

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -12,7 +12,7 @@ using namespace std;
 namespace sorbet::realmain::lsp {
 namespace {
 const core::File &getOldFile(core::FileRef fref, const core::GlobalState &gs,
-                             const UnorderedMap<int, shared_ptr<core::File>> evictedFiles) {
+                             const UnorderedMap<int, shared_ptr<core::File>> &evictedFiles) {
     const auto &it = evictedFiles.find(fref.id());
     if (it != evictedFiles.end()) {
         return *it->second;

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -106,8 +106,8 @@ void LSPIndexer::computeFileHashes(const vector<shared_ptr<core::File>> &files) 
     computeFileHashes(files, *emptyWorkers);
 }
 
-FastPathDecision LSPIndexer::canTakeFastPath(const std::vector<std::shared_ptr<core::File>> &changedFiles,
-                                             bool containsPendingTypecheckUpdates) const {
+FastPathDecision LSPIndexer::makeFastPathDecision(const std::vector<std::shared_ptr<core::File>> &changedFiles,
+                                                  bool containsPendingTypecheckUpdates) const {
     Timer timeit(config->logger, "fast_path_decision");
     auto &logger = *config->logger;
     logger.debug("Trying to see if fast path is available after {} file changes", changedFiles.size());
@@ -150,7 +150,8 @@ FastPathDecision LSPIndexer::canTakeFastPath(const std::vector<std::shared_ptr<c
     return FastPathDecision::FAST;
 }
 
-FastPathDecision LSPIndexer::canTakeFastPath(const LSPFileUpdates &edit, bool containsPendingTypecheckUpdates) const {
+FastPathDecision LSPIndexer::makeFastPathDecision(const LSPFileUpdates &edit,
+                                                  bool containsPendingTypecheckUpdates) const {
     auto &logger = *config->logger;
     // Path taken after the first time an update has been encountered. Hack since we can't roll back new files just yet.
     if (edit.hasNewFiles) {
@@ -158,7 +159,7 @@ FastPathDecision LSPIndexer::canTakeFastPath(const LSPFileUpdates &edit, bool co
         prodCategoryCounterInc("lsp.slow_path_reason", "new_file");
         return FastPathDecision::SLOW;
     }
-    return canTakeFastPath(edit.updatedFiles, containsPendingTypecheckUpdates);
+    return makeFastPathDecision(edit.updatedFiles, containsPendingTypecheckUpdates);
 }
 
 void LSPIndexer::initialize(LSPFileUpdates &updates, WorkerPool &workers) {
@@ -200,7 +201,7 @@ void LSPIndexer::initialize(LSPFileUpdates &updates, WorkerPool &workers) {
     computeFileHashes(initialGS->getFiles(), workers);
 
     updates.epoch = 0;
-    updates.canTakeFastPath = FastPathDecision::NOT_DETERMINED;
+    updates.fastPathDecision = FastPathDecision::SLOW;
     updates.updatedFileIndexes = move(indexed);
     updates.updatedGS = initialGS->deepCopy();
 
@@ -218,9 +219,9 @@ LSPFileUpdates LSPIndexer::commitEdit(unique_ptr<Timer> &latencyTimer, SorbetWor
     computeFileHashes(edit.updates, *emptyWorkers);
 
     update.updatedFiles = move(edit.updates);
-    update.canTakeFastPath = cachedFastPathDecision;
-    if (update.canTakeFastPath == FastPathDecision::NOT_DETERMINED) {
-        update.canTakeFastPath = canTakeFastPath(update);
+    update.fastPathDecision = cachedFastPathDecision;
+    if (update.fastPathDecision == FastPathDecision::NOT_DETERMINED) {
+        update.fastPathDecision = makeFastPathDecision(update);
     }
     update.cancellationExpected = edit.sorbetCancellationExpected;
     update.preemptionsExpected = edit.sorbetPreemptionsExpected;
@@ -286,11 +287,11 @@ LSPFileUpdates LSPIndexer::commitEdit(unique_ptr<Timer> &latencyTimer, SorbetWor
         ENFORCE(runningSlowPath.epoch > (pendingTypecheckUpdates.epoch - pendingTypecheckUpdates.editCount));
 
         // Cancel if the new update cannot take the fast path.
-        if (update.canTakeFastPath == FastPathDecision::SLOW &&
+        if (update.fastPathDecision == FastPathDecision::SLOW &&
             initialGS->epochManager->tryCancelSlowPath(update.epoch)) {
             // Cancelation succeeded! Merge with the pending update.
             update.mergeOlder(pendingTypecheckUpdates);
-            update.canTakeFastPath = canTakeFastPath(update);
+            update.fastPathDecision = makeFastPathDecision(update);
             update.canceledSlowPath = true;
             mergeEvictedFiles(evictedFiles, newlyEvictedFiles);
         }
@@ -298,8 +299,8 @@ LSPFileUpdates LSPIndexer::commitEdit(unique_ptr<Timer> &latencyTimer, SorbetWor
 
     ENFORCE(update.updatedFiles.size() == update.updatedFileIndexes.size());
 
-    ENFORCE(update.canTakeFastPath != FastPathDecision::NOT_DETERMINED);
-    if (update.canTakeFastPath == FastPathDecision::FAST) {
+    ENFORCE(update.fastPathDecision != FastPathDecision::NOT_DETERMINED);
+    if (update.fastPathDecision == FastPathDecision::FAST) {
         // Edit takes the fast path. Merge with this edit so we can reverse it if the slow path gets canceled.
         auto merged = update.copy();
         merged.mergeOlder(pendingTypecheckUpdates);

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -45,9 +45,10 @@ public:
     /** Determines if the given edit can take the fast path relative to the most recently committed edit. If
      * `containsPendingTypecheckUpdates` is `true`, it will make the determination in the immediate past using
      * `evictedFiles`. */
-    FastPathDecision canTakeFastPath(const LSPFileUpdates &edit, bool containsPendingTypecheckUpdates = false) const;
-    FastPathDecision canTakeFastPath(const std::vector<std::shared_ptr<core::File>> &changedFiles,
-                                     bool containsPendingTypecheckUpdates = false) const;
+    FastPathDecision makeFastPathDecision(const LSPFileUpdates &edit,
+                                          bool containsPendingTypecheckUpdates = false) const;
+    FastPathDecision makeFastPathDecision(const std::vector<std::shared_ptr<core::File>> &changedFiles,
+                                          bool containsPendingTypecheckUpdates = false) const;
 
     /**
      * Computes state hashes for the given set of files. Is a no-op if the provided files all have hashes.

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -36,8 +36,7 @@ class LSPIndexer final {
     /** A WorkerPool with 0 workers. */
     std::unique_ptr<WorkerPool> emptyWorkers;
 
-    std::vector<core::FileHash> computeFileHashes(const std::vector<std::shared_ptr<core::File>> &files,
-                                                  WorkerPool &workers) const;
+    void computeFileHashes(const std::vector<std::shared_ptr<core::File>> &files, WorkerPool &workers) const;
 
 public:
     LSPIndexer(std::shared_ptr<const LSPConfiguration> config, std::unique_ptr<core::GlobalState> initialGS);

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -149,8 +149,10 @@ LSPQueryResult LSPTask::queryBySymbol(LSPTypecheckerDelegate &typechecker, core:
     const core::NameHash symNameHash(gs, sym.data(gs)->name.data(gs));
     // Locate files that contain the same Name as the symbol. Is an overapproximation, but a good first filter.
     int i = -1;
-    for (auto &hash : typechecker.getFileHashes()) {
+    for (auto &file : typechecker.state().getFiles()) {
         i++;
+        ENFORCE(file->getFileHash() != nullptr);
+        const auto &hash = *file->getFileHash();
         const auto &usedSends = hash.usages.sends;
         const auto &usedConstants = hash.usages.constants;
         auto ref = core::FileRef(i);

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -151,6 +151,10 @@ LSPQueryResult LSPTask::queryBySymbol(LSPTypecheckerDelegate &typechecker, core:
     int i = -1;
     for (auto &file : typechecker.state().getFiles()) {
         i++;
+        if (file == nullptr) {
+            continue;
+        }
+
         ENFORCE(file->getFileHash() != nullptr);
         const auto &hash = *file->getFileHash();
         const auto &usedSends = hash.usages.sends;

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -135,6 +135,10 @@ TypecheckRun LSPTypechecker::runFastPath(LSPFileUpdates updates, WorkerPool &wor
     // N.B.: We'll iterate over the changed files, too, but it's benign if we re-add them since we dedupe `subset`.
     for (auto &oldFile : gs->getFiles()) {
         i++;
+        if (oldFile == nullptr) {
+            continue;
+        }
+
         ENFORCE(oldFile->getFileHash() != nullptr);
         const auto &oldHash = *oldFile->getFileHash();
         vector<core::NameHash> intersection;

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -54,10 +54,7 @@ class LSPTypechecker final {
     std::vector<ast::ParsedFile> indexed;
     /** Trees that have been indexed (with finalGS) and can be reused between different runs */
     UnorderedMap<int, ast::ParsedFile> indexedFinalGS;
-    /** Hashes of global states obtained by resolving every file in isolation. Used for fastpath. */
-    std::vector<core::FileHash> globalStateHashes;
-    /** Stores the epoch in which we last sent diagnostics to the client for each file. Should be the same length as
-     * globalStateHashes. */
+    /** Stores the epoch in which we last sent diagnostics to the client for each file. */
     std::vector<u4> diagnosticEpochs;
     /** List of files that have had errors in last run*/
     std::vector<core::FileRef> filesThatHaveErrors;
@@ -106,7 +103,7 @@ public:
     ~LSPTypechecker();
 
     /**
-     * Conducts the first typechecking pass of the session, and initializes `gs`, `index`, and `globalStateHashes`
+     * Conducts the first typechecking pass of the session, and initializes `gs` and `index`
      * variables. Must be called before typecheck and other functions work.
      *
      * Writes all diagnostic messages to LSPOutput.
@@ -137,11 +134,6 @@ public:
      * Returns the parsed files for the given files, including resolver.
      */
     std::vector<ast::ParsedFile> getResolved(const std::vector<core::FileRef> &frefs) const;
-
-    /**
-     * Returns the hashes of all committed files.
-     */
-    const std::vector<core::FileHash> &getFileHashes() const;
 
     /**
      * Returns the currently active GlobalState.
@@ -203,11 +195,6 @@ public:
      * Returns the parsed files for the given files, including resolver.
      */
     std::vector<ast::ParsedFile> getResolved(const std::vector<core::FileRef> &frefs) const;
-
-    /**
-     * Returns the hashes of all committed files.
-     */
-    const std::vector<core::FileHash> &getFileHashes() const;
 
     /**
      * Returns the currently active GlobalState.

--- a/main/lsp/UndoState.cc
+++ b/main/lsp/UndoState.cc
@@ -13,28 +13,22 @@ UndoState::UndoState(const LSPConfiguration &config, unique_ptr<core::GlobalStat
     : config(config), evictedGs(move(evictedGs)), evictedIndexedFinalGS(std::move(evictedIndexedFinalGS)),
       evictedFilesThatHaveErrors(move(evictedFilesThatHaveErrors)) {}
 
-void UndoState::recordEvictedState(ast::ParsedFile evictedIndexTree, core::FileHash evictedFileHash) {
+void UndoState::recordEvictedState(ast::ParsedFile evictedIndexTree) {
     const auto id = evictedIndexTree.file.id();
     // The first time a file gets evicted, it's an index tree from the old global state.
     // Subsequent times it is evicting old index trees from the new global state, and we don't care.
     // Also, ignore updates to new files (id >= size of file table)
     if (id < evictedGs->getFiles().size() && !evictedIndexed.contains(id)) {
         evictedIndexed[id] = move(evictedIndexTree);
-        // file hashes should be kept in-sync with indexed.
-        ENFORCE(!evictedFileHashes.contains(id));
-        evictedFileHashes[id] = move(evictedFileHash);
     }
 }
 
 vector<core::FileRef> UndoState::restore(unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> &indexed,
                                          UnorderedMap<int, ast::ParsedFile> &indexedFinalGS,
-                                         vector<core::FileHash> &globalStateHashes,
                                          std::vector<core::FileRef> &filesThatHaveErrors) {
     // Replace evicted index trees and file hashes.
     for (auto &entry : evictedIndexed) {
         indexed[entry.first] = move(entry.second);
-        ENFORCE(evictedFileHashes.contains(entry.first));
-        globalStateHashes[entry.first] = move(evictedFileHashes[entry.first]);
     }
     indexedFinalGS = std::move(evictedIndexedFinalGS);
 

--- a/main/lsp/UndoState.h
+++ b/main/lsp/UndoState.h
@@ -17,8 +17,6 @@ class UndoState final {
     std::unique_ptr<core::GlobalState> evictedGs;
     // Stores index trees containing data stored in `gs` that have been evicted during the slow path operation.
     UnorderedMap<int, ast::ParsedFile> evictedIndexed;
-    // Stores file hashes that have been evicted during the slow path operation.
-    UnorderedMap<int, core::FileHash> evictedFileHashes;
     // Stores the index trees stored in `gs` that were evicted because the slow path operation replaced `gs`.
     UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS;
     // Stores the list of files that had errors before the slow path began.
@@ -32,7 +30,7 @@ public:
     /**
      * Records that the given items were evicted from LSPTypechecker following a typecheck run.
      */
-    void recordEvictedState(ast::ParsedFile evictedIndexTree, core::FileHash evictedStateHash);
+    void recordEvictedState(ast::ParsedFile evictedIndexTree);
 
     /**
      * Undoes the slow path changes represented by this class. and clears the client's error list for any files that
@@ -41,7 +39,6 @@ public:
      */
     std::vector<core::FileRef> restore(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> &indexed,
                                        UnorderedMap<int, ast::ParsedFile> &indexedFinalGS,
-                                       std::vector<core::FileHash> &globalStateHashes,
                                        std::vector<core::FileRef> &filesThatHaveErrors);
 };
 

--- a/main/lsp/json_types.cc
+++ b/main/lsp/json_types.cc
@@ -208,9 +208,7 @@ void LSPFileUpdates::mergeOlder(const LSPFileUpdates &older) {
     cancellationExpected = cancellationExpected || older.cancellationExpected;
     preemptionsExpected += older.preemptionsExpected;
 
-    ENFORCE(updatedFiles.size() == updatedFileHashes.size());
     ENFORCE(updatedFiles.size() == updatedFileIndexes.size());
-    ENFORCE(older.updatedFiles.size() == older.updatedFileHashes.size());
     ENFORCE(older.updatedFiles.size() == older.updatedFileIndexes.size());
 
     // For updates, we prioritize _newer_ updates.
@@ -227,10 +225,10 @@ void LSPFileUpdates::mergeOlder(const LSPFileUpdates &older) {
         }
         encountered.emplace(f->path());
         updatedFiles.push_back(f);
-        updatedFileHashes.push_back(older.updatedFileHashes[i]);
         auto &ast = older.updatedFileIndexes[i];
         updatedFileIndexes.push_back(ast::ParsedFile{ast.tree->deepCopy(), ast.file});
     }
+    canTakeFastPath = FastPathDecision::NOT_DETERMINED;
 }
 
 LSPFileUpdates LSPFileUpdates::copy() const {
@@ -240,7 +238,6 @@ LSPFileUpdates LSPFileUpdates::copy() const {
     copy.canTakeFastPath = canTakeFastPath;
     copy.hasNewFiles = hasNewFiles;
     copy.updatedFiles = updatedFiles;
-    copy.updatedFileHashes = updatedFileHashes;
     copy.cancellationExpected = cancellationExpected;
     copy.preemptionsExpected = preemptionsExpected;
     for (auto &ast : updatedFileIndexes) {

--- a/main/lsp/json_types.cc
+++ b/main/lsp/json_types.cc
@@ -228,14 +228,14 @@ void LSPFileUpdates::mergeOlder(const LSPFileUpdates &older) {
         auto &ast = older.updatedFileIndexes[i];
         updatedFileIndexes.push_back(ast::ParsedFile{ast.tree->deepCopy(), ast.file});
     }
-    canTakeFastPath = FastPathDecision::NOT_DETERMINED;
+    fastPathDecision = FastPathDecision::NOT_DETERMINED;
 }
 
 LSPFileUpdates LSPFileUpdates::copy() const {
     LSPFileUpdates copy;
     copy.epoch = epoch;
     copy.editCount = editCount;
-    copy.canTakeFastPath = canTakeFastPath;
+    copy.fastPathDecision = fastPathDecision;
     copy.hasNewFiles = hasNewFiles;
     copy.updatedFiles = updatedFiles;
     copy.cancellationExpected = cancellationExpected;

--- a/main/lsp/json_types.h
+++ b/main/lsp/json_types.h
@@ -32,7 +32,7 @@ public:
     std::vector<std::shared_ptr<core::File>> updatedFiles;
     std::vector<ast::ParsedFile> updatedFileIndexes;
 
-    FastPathDecision canTakeFastPath = FastPathDecision::NOT_DETERMINED;
+    FastPathDecision fastPathDecision = FastPathDecision::NOT_DETERMINED;
     // Indicates that this update contains a new file. Is a hack for determining if combining two updates can take the
     // fast path.
     bool hasNewFiles = false;
@@ -50,7 +50,7 @@ public:
     /**
      * Merges the given (and older) LSPFileUpdates object into this LSPFileUpdates object.
      *
-     * Does not handle updating `canTakeFastPath`.
+     * Resets `fastPathDecision`.
      */
     void mergeOlder(const LSPFileUpdates &older);
 

--- a/main/lsp/json_types.h
+++ b/main/lsp/json_types.h
@@ -12,6 +12,12 @@
 
 namespace sorbet::realmain::lsp {
 
+enum class FastPathDecision {
+    NOT_DETERMINED = 1,
+    FAST = 2,
+    SLOW = 3,
+};
+
 /**
  * Encapsulates an update to LSP's file state in a compact form.
  * Placed into json_types.h because it is referenced from InitializedParams.
@@ -24,10 +30,9 @@ public:
     u4 editCount = 0;
 
     std::vector<std::shared_ptr<core::File>> updatedFiles;
-    std::vector<core::FileHash> updatedFileHashes;
     std::vector<ast::ParsedFile> updatedFileIndexes;
 
-    bool canTakeFastPath = false;
+    FastPathDecision canTakeFastPath = FastPathDecision::NOT_DETERMINED;
     // Indicates that this update contains a new file. Is a hack for determining if combining two updates can take the
     // fast path.
     bool hasNewFiles = false;

--- a/main/lsp/notifications/sorbet_workspace_edit.cc
+++ b/main/lsp/notifications/sorbet_workspace_edit.cc
@@ -57,7 +57,7 @@ void SorbetWorkspaceEditTask::run(LSPTypecheckerDelegate &typechecker) {
     latencyCancelSlowPath = nullptr;
     // For consistency; I don't expect this notification to be used for fast path edits.
     startedNotification.Notify();
-    if (updates->canTakeFastPath != FastPathDecision::FAST) {
+    if (updates->fastPathDecision != FastPathDecision::FAST) {
         Exception::raise("Attempted to run a slow path update on the fast path!");
     }
     typechecker.typecheckOnFastPath(move(*updates));
@@ -100,11 +100,11 @@ void SorbetWorkspaceEditTask::schedulerWaitUntilReady() {
 
 bool SorbetWorkspaceEditTask::canTakeFastPath(const LSPIndexer &index) const {
     if (updates != nullptr) {
-        return updates->canTakeFastPath == FastPathDecision::FAST;
+        return updates->fastPathDecision == FastPathDecision::FAST;
     }
     if (cachedFastPathDecision == FastPathDecision::NOT_DETERMINED) {
         index.computeFileHashes(params->updates);
-        cachedFastPathDecision = index.canTakeFastPath(params->updates);
+        cachedFastPathDecision = index.makeFastPathDecision(params->updates);
     }
     return cachedFastPathDecision == FastPathDecision::FAST;
 }

--- a/main/lsp/notifications/sorbet_workspace_edit.h
+++ b/main/lsp/notifications/sorbet_workspace_edit.h
@@ -10,11 +10,8 @@ class SorbetWorkspaceEditTask final : public LSPDangerousTypecheckerTask {
     absl::Notification startedNotification;
     std::unique_ptr<Timer> latencyCancelSlowPath;
     std::unique_ptr<SorbetWorkspaceEditParams> params;
-    // Caches the file hashes computed for `canPreempt` to avoid recomputing them later.
-    mutable std::vector<core::FileHash> cachedFileHashesOrEmpty;
-    // Caches the fast path decision made with cachedFileHashesOrEmpty.
-    // Is only valid if `cachedFileHashesOrEmpty` is not empty.
-    mutable bool cachedFastPathDecision = false;
+    // Caches the fast path decision for the provided update. Becomes invalidated when the update changes.
+    mutable FastPathDecision cachedFastPathDecision = FastPathDecision::NOT_DETERMINED;
 
 public:
     SorbetWorkspaceEditTask(const LSPConfiguration &config, std::unique_ptr<SorbetWorkspaceEditParams> params);

--- a/main/lsp/test/lsp_file_updates_test.cc
+++ b/main/lsp/test/lsp_file_updates_test.cc
@@ -13,9 +13,9 @@ using namespace sorbet::realmain::lsp;
 
 namespace {
 u4 nextHash = 0;
-core::FileHash getFileHash() {
-    core::FileHash hash;
-    hash.definitions.hierarchyHash = nextHash++;
+shared_ptr<core::FileHash> getFileHash() {
+    auto hash = make_shared<core::FileHash>();
+    hash->definitions.hierarchyHash = nextHash++;
     return hash;
 }
 
@@ -25,13 +25,14 @@ ast::ParsedFile getParsedFile(core::FileRef fref) {
 }
 
 shared_ptr<core::File> makeFile(std::string path, std::string contents) {
-    return make_shared<core::File>(move(path), move(contents), core::File::Type::Normal);
+    auto file = make_shared<core::File>(move(path), move(contents), core::File::Type::Normal);
+    file->setFileHash(getFileHash());
+    return file;
 }
 
 void addFile(LSPFileUpdates &updates, core::FileRef fref, std::string path, std::string contents) {
     updates.updatedFiles.push_back(makeFile(move(path), move(contents)));
     updates.updatedFileIndexes.push_back(getParsedFile(fref));
-    updates.updatedFileHashes.push_back(getFileHash());
 }
 
 } // namespace
@@ -105,7 +106,6 @@ TEST(LSPFileUpdatesTest, MergeUpdatedFiles) {
     newUpdates.mergeOlder(oldUpdates);
     ASSERT_EQ(3, newUpdates.updatedFiles.size());
     ASSERT_EQ(3, newUpdates.updatedFileIndexes.size());
-    ASSERT_EQ(3, newUpdates.updatedFileHashes.size());
 
     UnorderedMap<string, int> fileIndexes;
     int i = -1;
@@ -120,8 +120,8 @@ TEST(LSPFileUpdatesTest, MergeUpdatedFiles) {
         int i = fileIndexes["bar.rb"];
         EXPECT_EQ("newcontents", newUpdates.updatedFiles[i]->source());
         EXPECT_EQ(2, newUpdates.updatedFileIndexes[i].file.id());
-        EXPECT_NE(oldUpdates.updatedFileHashes[1].definitions.hierarchyHash,
-                  newUpdates.updatedFileHashes[i].definitions.hierarchyHash);
+        EXPECT_NE(oldUpdates.updatedFiles[1]->getFileHash()->definitions.hierarchyHash,
+                  newUpdates.updatedFiles[i]->getFileHash()->definitions.hierarchyHash);
     }
 
     {
@@ -129,8 +129,8 @@ TEST(LSPFileUpdatesTest, MergeUpdatedFiles) {
         int i = fileIndexes["foo.rb"];
         EXPECT_EQ("foo", newUpdates.updatedFiles[i]->source());
         EXPECT_EQ(1, newUpdates.updatedFileIndexes[i].file.id());
-        EXPECT_EQ(oldUpdates.updatedFileHashes[0].definitions.hierarchyHash,
-                  newUpdates.updatedFileHashes[i].definitions.hierarchyHash);
+        EXPECT_EQ(oldUpdates.updatedFiles[0]->getFileHash()->definitions.hierarchyHash,
+                  newUpdates.updatedFiles[i]->getFileHash()->definitions.hierarchyHash);
     }
 
     {

--- a/main/lsp/test/lsp_file_updates_test.cc
+++ b/main/lsp/test/lsp_file_updates_test.cc
@@ -144,7 +144,7 @@ TEST(LSPFileUpdatesTest, Copy) {
     updates.editCount = 10;
     updates.epoch = 10;
     updates.cancellationExpected = true;
-    updates.canTakeFastPath = true;
+    updates.fastPathDecision = FastPathDecision::FAST;
     updates.hasNewFiles = true;
     updates.updatedGS = unique_ptr<core::GlobalState>(nullptr);
     addFile(updates, core::FileRef(1), "foo.rb", "foo");
@@ -154,12 +154,11 @@ TEST(LSPFileUpdatesTest, Copy) {
     EXPECT_EQ(10, copy.epoch);
     EXPECT_EQ(10, copy.editCount);
     EXPECT_TRUE(copy.cancellationExpected);
-    EXPECT_TRUE(copy.canTakeFastPath);
+    EXPECT_EQ(copy.fastPathDecision, FastPathDecision::FAST);
     EXPECT_TRUE(copy.hasNewFiles);
     EXPECT_FALSE(copy.updatedGS.has_value());
 
     ASSERT_EQ(2, copy.updatedFiles.size());
-    ASSERT_EQ(2, copy.updatedFileHashes.size());
     ASSERT_EQ(2, copy.updatedFileIndexes.size());
 
     EXPECT_EQ("foo.rb", copy.updatedFiles[0]->path());
@@ -170,10 +169,10 @@ TEST(LSPFileUpdatesTest, Copy) {
     EXPECT_EQ(1, copy.updatedFileIndexes[0].file.id());
     EXPECT_EQ(2, copy.updatedFileIndexes[1].file.id());
 
-    EXPECT_EQ(updates.updatedFileHashes[0].definitions.hierarchyHash,
-              copy.updatedFileHashes[0].definitions.hierarchyHash);
-    EXPECT_EQ(updates.updatedFileHashes[1].definitions.hierarchyHash,
-              copy.updatedFileHashes[1].definitions.hierarchyHash);
+    EXPECT_EQ(updates.updatedFiles[0]->getFileHash()->definitions.hierarchyHash,
+              copy.updatedFiles[0]->getFileHash()->definitions.hierarchyHash);
+    EXPECT_EQ(updates.updatedFiles[1]->getFileHash()->definitions.hierarchyHash,
+              copy.updatedFiles[1]->getFileHash()->definitions.hierarchyHash);
 }
 
 TEST(LSPFileUpdatesTest, MergeOlderPreemptionExpected) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This change stores core::FileHash inside of core::File, which ends up simplifying LSP logic.

Previously, LSP had to maintain track a vector of file hashes, and keep it up-to-date when it processed edits or canceled slow paths (rolled back edits temporarily). It was messy.

With FileHashes stored in Files, LSP no longer has to do that. Simply reinstating the old version of a file is sufficient to also reinstate its old hash, since the two are coupled together.

Along the way, I made a few other simplifying changes:

* **LSP only cancels the slow path if a new edit will take the slow path.** LSP previously checked if a new edit would take the fast path with the currently typechecking slow path, but that new edit would always take the slow path in isolation, so the check was redundant.
  * This is a remnant of the first ship of the cancelable slow path, which _only_ canceled a slow path if a new edit would take the fast path with the currently typechecking edits. It didn't cancel the slow path for a new slow path until a later change.
* **The "can run fast path" property of updates is now a trinary enum rather than a boolean.** I wanted to track the value "NOT_DECIDED" as the initial value to catch (in ENFORCEs) if we ever forgot to make a fast path decision on an edit.

WIP since I hacked this on the plane to Massachusetts and haven't manually tested yet. It seems to pass our tests, though, which is very promising. :) 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This change is required before we can {de}serialize file hashes to speed up initialization.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
