### PR TITLE
Remove a bad class from the ActionCable class list.

### DIFF
--- a/gems/sorbet/lib/gem_loader.rb
+++ b/gems/sorbet/lib/gem_loader.rb
@@ -599,7 +599,6 @@ class Sorbet::Private::GemLoader
         ActionCable::Server::Connections,
         ActionCable::Server::Configuration,
         ActionCable::Server::Worker,
-        ActionCable::Server::ActiveRecordConnectionManagement,
         ActionCable::Connection,
         ActionCable::Connection::Authorization,
         ActionCable::Connection::Base,


### PR DESCRIPTION
### Motivation

I somehow missed that this class was causing problems when running srb init. It doesn't exist until Rails 6.1.

### Test plan

See included automated tests.
