### PR TITLE
Fix Sorbet's LSP failing when using a gem with an rbi/ directory

### DIFF
--- a/gems/sorbet/README.md
+++ b/gems/sorbet/README.md
@@ -62,9 +62,10 @@ behavior:
 
 - `XDG_CACHE_HOME`
 
-  The `srb` command keeps a cache of `sorbet-typed` on disk. Setting
-  `XDG_CACHE_HOME` will change the folder where the `sorbet-typed` cache will
-  be. (The default when this is unset is to use `$HOME/.cache/`.)
+  The `srb` command keeps a cache of `sorbet-typed` and RBIs from gems with
+  `rbi/` directories on disk. Setting `XDG_CACHE_HOME` will change the folder
+  where the cache will be. (The default when this is unset is to use
+  `$HOME/.cache/`.)
 
 - `SRB_SORBET_TYPED_REVISION`
 

--- a/gems/sorbet/bin/srb-rbi
+++ b/gems/sorbet/bin/srb-rbi
@@ -210,10 +210,8 @@ If instead you want to explore your files locally, here are some things to try:
       make_step(Sorbet::Private::TodoRBI)
     when 'suggest-typed'
       make_step(Sorbet::Private::SuggestTyped)
-
-    when 'find-gem-rbis', "#{ENV['HOME']}/.cache/sorbet/gem-rbis", "#{ENV['HOME']}/.cache/sorbet/gem-rbis/"
+    when 'find-gem-rbis', "#{ENV['HOME']}/.cache/sorbet/gem-rbis/", "#{ENV['HOME']}/.cache/sorbet/gem-rbis/"
       make_step(Sorbet::Private::FindGemRBIs)
-
     else
       puts "Unknown command: #{argv[0]}"
       puts self.usage

--- a/gems/sorbet/bin/srb-rbi
+++ b/gems/sorbet/bin/srb-rbi
@@ -188,8 +188,6 @@ If instead you want to explore your files locally, here are some things to try:
       exit(1)
     end
 
-    XDG_CACHE_HOME = ENV['XDG_CACHE_HOME'] || "#{ENV['HOME']}/.cache"
-
     command = case (argv[0])
     when 'help', '--help'
       puts self.usage
@@ -212,7 +210,7 @@ If instead you want to explore your files locally, here are some things to try:
       make_step(Sorbet::Private::TodoRBI)
     when 'suggest-typed'
       make_step(Sorbet::Private::SuggestTyped)
-    when 'find-gem-rbis', "#{ENV['XDG_CACHE_HOME']}/sorbet/gem-rbis/"
+    when 'find-gem-rbis', Sorbet::Private::FindGemRBIs.cache_dir
       make_step(Sorbet::Private::FindGemRBIs)
     else
       puts "Unknown command: #{argv[0]}"

--- a/gems/sorbet/bin/srb-rbi
+++ b/gems/sorbet/bin/srb-rbi
@@ -188,6 +188,8 @@ If instead you want to explore your files locally, here are some things to try:
       exit(1)
     end
 
+    XDG_CACHE_HOME = ENV['XDG_CACHE_HOME'] || "#{ENV['HOME']}/.cache"
+
     command = case (argv[0])
     when 'help', '--help'
       puts self.usage
@@ -210,7 +212,7 @@ If instead you want to explore your files locally, here are some things to try:
       make_step(Sorbet::Private::TodoRBI)
     when 'suggest-typed'
       make_step(Sorbet::Private::SuggestTyped)
-    when 'find-gem-rbis', "#{ENV['HOME']}/.cache/sorbet/gem-rbis/", "#{ENV['HOME']}/.cache/sorbet/gem-rbis/"
+    when 'find-gem-rbis', "#{ENV['XDG_CACHE_HOME']}/sorbet/gem-rbis/"
       make_step(Sorbet::Private::FindGemRBIs)
     else
       puts "Unknown command: #{argv[0]}"

--- a/gems/sorbet/lib/find-gem-rbis.rb
+++ b/gems/sorbet/lib/find-gem-rbis.rb
@@ -45,6 +45,10 @@ class Sorbet::Private::FindGemRBIs
   def self.output_file
     nil
   end
+
+  def self.cache_dir
+    RBI_CACHE_DIR
+  end
 end
 
 if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
### Motivation

When I added the sorbet-coerce gem to my project, Sorbet's LSP started failing because of the `rbi/` directory in sorbet-coerce.

`bundle exec srb tc --lsp` was returning an error: "Sorbet's language server requires a single input directory."

With this change, it no longer errors, and also respects the XDG_CACHE_HOME environment variable if it exists.

The issue was discussed a bit in Slack w/ Harry: https://sorbet-ruby.slack.com/archives/CJL5B3CEN/p1583017631039900

### Test plan

See included automated tests.

To reproduce the issue:

- `git clone https://github.com/connorshea/sorbet-gem-rbis-example` ([repo](https://github.com/connorshea/sorbet-gem-rbis-example))
- `cd sorbet-gem-rbis-example`
- `bundle install`
- `bundle exec srb tc --lsp`
- See that it errors.

Then you can use `bundle open sorbet` and apply the changes from this PR. Then, when you re-run `bundle exec srb tc --lsp` it should work correctly.