### PR TITLE
Run a :setter_validate proc when setting props

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -67,6 +67,7 @@ class T::Props::Decorator
     clobber_existing_method!
     extra
     optional
+    setter_validate
     _tnilable
   }.map {|k| [k, true]}.to_h.freeze, T::Hash[Symbol, T::Boolean])
   private_constant :VALID_RULE_KEYS

--- a/gems/sorbet-runtime/test/test_helper.rb
+++ b/gems/sorbet-runtime/test/test_helper.rb
@@ -64,3 +64,4 @@ module Opus::Types; end
 module Opus::Types::Test; end
 class Opus::Types::Test::TypesTest < Critic::Unit::UnitTest; end
 module Opus::Types::Test::Props; end
+module Opus::Types::Test::Props::Private; end

--- a/gems/sorbet-runtime/test/types/props/private/setter_factory.rb
+++ b/gems/sorbet-runtime/test/types/props/private/setter_factory.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require_relative '../../../test_helper'
+
+class Opus::Types::Test::Props::Private::SetterFactoryTest < Critic::Unit::UnitTest
+  class TestSetValidate
+    include T::Props
+    include T::Props::WeakConstructor
+
+    prop :validated, T.untyped, setter_validate: -> (prop, value) { raise Error.new 'invalid' }
+    prop :nilable_validated, T.nilable(Integer), setter_validate: -> (prop, value) { raise Error.new 'invalid' }
+
+    def some_method; end
+  end
+
+  describe 'setter_validate' do
+    it 'runs when setting' do
+      obj = TestSetValidate.new
+      ex = assert_raises { obj.validated = 5 }
+      assert_equal('invalid', ex.message)
+    end
+
+    it 'runs when constructing' do
+      ex = assert_raises { TestSetValidate.new(validated: 5) }
+      assert_equal('invalid', ex.message)
+    end
+
+    it 'does not run when a nilable is nil' do
+      TestSetValidate.new(nilable_validated: nil)
+    end
+
+    it 'runs when a nilable is non-nil' do
+      ex = assert_raises { TestSetValidate.new(nilable_validated: 5) }
+      assert_equal('invalid', ex.message)
+    end
+
+    it 'runs when validate_prop_value is called' do
+      ex = assert_raises { TestSetValidate.validate_prop_value(:validated, 5) }
+      assert_equal('invalid', ex.message)
+    end
+
+    it 'does not run when validate_prop_value is called when a nilable is nil' do
+      TestSetValidate.validate_prop_value(:nilable_validated, nil)
+    end
+  end
+
+end

--- a/gems/sorbet-runtime/test/types/props/private/setter_factory.rb
+++ b/gems/sorbet-runtime/test/types/props/private/setter_factory.rb
@@ -8,8 +8,8 @@ class Opus::Types::Test::Props::Private::SetterFactoryTest < Critic::Unit::UnitT
 
     prop :validated, T.untyped, setter_validate: -> (prop, value) { raise Error.new 'invalid' }
     prop :nilable_validated, T.nilable(Integer), setter_validate: -> (prop, value) { raise Error.new 'invalid' }
+    prop :unvalidated, T.untyped, setter_validate: -> (prop, value) { raise Error.new 'bad prop' unless prop == :unvalidated }
 
-    def some_method; end
   end
 
   describe 'setter_validate' do
@@ -17,6 +17,11 @@ class Opus::Types::Test::Props::Private::SetterFactoryTest < Critic::Unit::UnitT
       obj = TestSetValidate.new
       ex = assert_raises { obj.validated = 5 }
       assert_equal('invalid', ex.message)
+    end
+
+    it "doesn't break set" do
+      obj = TestSetValidate.new(unvalidated: 3)
+      assert_equal(3, obj.unvalidated)
     end
 
     it 'runs when constructing' do


### PR DESCRIPTION
This adds a `:setter_validate` option to props definitions.  The value is a `proc` which has `prop_symbol, prop_value` as parameters.

### Motivation
This is to support making `model_prop` fully lazy while preserving safety.  See pay-server#212513.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
