### PR TITLE
Collect RSS stats _before_ clearing thread counters.

### DIFF
--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -32,10 +32,10 @@ void LSPLoop::sendCountersToStatsd(chrono::time_point<chrono::steady_clock> curr
     Timer timeit(config->logger, "LSPLoop::sendCountersToStatsd");
     ENFORCE(this_thread::get_id() == mainThreadId, "sendCounterToStatsd can only be called from the main LSP thread.");
     const auto &opts = config->opts;
+    // Record process and version stats. Do this BEFORE clearing the thread counters!
+    StatsD::addStandardMetrics();
     auto counters = getAndClearThreadCounters();
     if (!opts.statsdHost.empty()) {
-        // Record process and version stats.
-        StatsD::addStandardMetrics();
         lastMetricUpdateTime = currentTime;
         auto prefix = fmt::format("{}.lsp.counters", opts.statsdPrefix);
         StatsD::submitCounters(counters, opts.statsdHost, opts.statsdPort, prefix);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Collect RSS stats _before_ clearing thread counters.

Fixes a bug where we report 2X the RSS when Sorbet shuts down.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

If we run `addStandardMetrics` twice before reporting to SFX, the counters are added together.

We were doing exactly that at shutdown, distorting RSS metrics.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
