### PR TITLE
WIP: experiment - see what latency histogram looks like when weighting by # of edits

### DIFF
--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -364,7 +364,7 @@ LSPFileUpdates LSPIndexer::commitEdit(unique_ptr<Timer> &latencyTimer, SorbetWor
         pendingTypecheckEvictedStateHashes = std::move(mergedEvictions);
         if (!update.canceledSlowPath) {
             // This update preempted.
-            pendingTypecheckUpdates.committedEditCount++;
+            pendingTypecheckUpdates.committedEditCount += update.editCount;
         }
     }
     // Don't copy over these (test-only) properties, as they only apply to the original request.

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -33,6 +33,7 @@ class LSPIndexer final {
     /** Contains a clone of the latency timer for the pending typecheck operation. Is used to ensure that we correctly
      * track the latency of canceled & rescheduled typechecking operations. */
     std::unique_ptr<Timer> pendingTypecheckLatencyTimer;
+    std::vector<std::unique_ptr<Timer>> pendingTypecheckDiagnosticLatencyTimers;
     /** Contains globalStateHashes evicted with `pendingTypecheckUpdates`. Used in slow path cancelation logic. */
     UnorderedMap<int, core::FileHash> pendingTypecheckEvictedStateHashes;
     std::unique_ptr<KeyValueStore> kvstore; // always null for now.

--- a/main/lsp/json_types.cc
+++ b/main/lsp/json_types.cc
@@ -205,6 +205,7 @@ string DidChangeTextDocumentParams::getSource(string_view oldFileContents) const
 
 void LSPFileUpdates::mergeOlder(const LSPFileUpdates &older) {
     editCount += older.editCount;
+    committedEditCount += older.committedEditCount;
     hasNewFiles = hasNewFiles || older.hasNewFiles;
     cancellationExpected = cancellationExpected || older.cancellationExpected;
     preemptionsExpected += older.preemptionsExpected;
@@ -238,6 +239,7 @@ LSPFileUpdates LSPFileUpdates::copy() const {
     LSPFileUpdates copy;
     copy.epoch = epoch;
     copy.editCount = editCount;
+    copy.committedEditCount = committedEditCount;
     copy.canTakeFastPath = canTakeFastPath;
     copy.hasNewFiles = hasNewFiles;
     copy.updatedFiles = updatedFiles;

--- a/main/lsp/json_types.cc
+++ b/main/lsp/json_types.cc
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include "common/Timer.h"
 #include "rapidjson/prettywriter.h"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
@@ -270,6 +271,10 @@ void SorbetWorkspaceEditParams::merge(SorbetWorkspaceEditParams &newerParams) {
     mergeCount += newerParams.mergeCount + 1;
     sorbetCancellationExpected = sorbetCancellationExpected || newerParams.sorbetCancellationExpected;
     sorbetPreemptionsExpected += newerParams.sorbetPreemptionsExpected;
+    // Consume newerParams' diagnostic latency timers.
+    diagnosticLatencyTimers.insert(diagnosticLatencyTimers.end(),
+                                   make_move_iterator(newerParams.diagnosticLatencyTimers.begin()),
+                                   make_move_iterator(newerParams.diagnosticLatencyTimers.end()));
 }
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/json_types.h
+++ b/main/lsp/json_types.h
@@ -27,6 +27,8 @@ public:
     u4 epoch = 0;
     // The total number of edits that this update represents. Used for stats.
     u4 editCount = 0;
+    // The total number of edits in this update that are already committed (via preemption). Used for assertions.
+    u4 committedEditCount = 0;
     std::vector<std::shared_ptr<core::File>> updatedFiles;
     std::vector<core::FileHash> updatedFileHashes;
     std::vector<ast::ParsedFile> updatedFileIndexes;

--- a/main/lsp/json_types.h
+++ b/main/lsp/json_types.h
@@ -2,6 +2,7 @@
 #define RUBY_TYPER_LSP_JSON_TYPES_H
 
 #include "ast/ast.h"
+#include "common/Timer.h"
 #include "common/common.h"
 #include "core/NameHash.h"
 #include "core/core.h"
@@ -9,6 +10,10 @@
 
 #include <optional>
 #include <variant>
+
+namespace sorbet {
+class Timer;
+}
 
 namespace sorbet::realmain::lsp {
 
@@ -22,7 +27,6 @@ public:
     u4 epoch = 0;
     // The total number of edits that this update represents. Used for stats.
     u4 editCount = 0;
-
     std::vector<std::shared_ptr<core::File>> updatedFiles;
     std::vector<core::FileHash> updatedFileHashes;
     std::vector<ast::ParsedFile> updatedFileIndexes;

--- a/main/lsp/notifications/sorbet_workspace_edit.cc
+++ b/main/lsp/notifications/sorbet_workspace_edit.cc
@@ -67,6 +67,10 @@ void SorbetWorkspaceEditTask::run(LSPTypecheckerDelegate &typechecker) {
     if (latencyTimer != nullptr) {
         // TODO: Move into pushDiagnostics once we have fast feedback.
         latencyTimer->clone("last_diagnostic_latency");
+        // Experiment: Weight by number of edits.
+        for (u4 i = 0; i < updates->editCount; i++) {
+            latencyTimer->clone("last_diagnostic_latency_weighted");
+        }
     }
     prodCategoryCounterAdd("lsp.messages.processed", "sorbet.mergedEdits", updates->editCount - 1);
 }
@@ -89,6 +93,10 @@ void SorbetWorkspaceEditTask::runSpecial(LSPTypechecker &typechecker, WorkerPool
         if (latencyTimer != nullptr) {
             // TODO: Move into pushDiagnostics once we have fast feedback.
             latencyTimer->clone("last_diagnostic_latency");
+            // Experiment: Weight by number of edits.
+            for (u4 i = 0; i < updates->editCount; i++) {
+                latencyTimer->clone("last_diagnostic_latency_weighted");
+            }
         }
         prodCategoryCounterAdd("lsp.messages.processed", "sorbet.mergedEdits", updates->editCount - 1);
     } else if (latencyTimer != nullptr) {

--- a/main/lsp/notifications/sorbet_workspace_edit.h
+++ b/main/lsp/notifications/sorbet_workspace_edit.h
@@ -25,6 +25,7 @@ public:
     const SorbetWorkspaceEditParams &getParams() const;
 
     void mergeNewer(SorbetWorkspaceEditTask &task);
+    void preprocess(LSPPreprocessor &preprocess) override;
     void index(LSPIndexer &indexer) override;
     void run(LSPTypecheckerDelegate &typechecker) override;
     void runSpecial(LSPTypechecker &typechecker, WorkerPool &workers) override;

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -1283,6 +1283,8 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                        "bool sorbetCancellationExpected = false;"
                        "// Used in multithreaded tests to wait for a preemption to occur when processing this edit.",
                        "int sorbetPreemptionsExpected = 0;",
+                       "// For each edit rolled up into update, contains a timer used to report diagnostic latency.",
+                       "std::vector<std::unique_ptr<Timer>> diagnosticLatencyTimers;",
                        "// File updates contained in this edit.",
                        "std::vector<std::shared_ptr<core::File>> updates;",
                        "// Merge newerParams into this object, which mutates `epoch` and `updates`",


### PR DESCRIPTION
WIP: experiment - see what latency histogram looks like when weighting by # of edits. Pushing so I can test before deciding if it is a good change.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Goal: Surface user pain more clearly. Without this change, 50 edits that dogpile after a slow path are only counted with 1 data point.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

N/A
