### PR TITLE
Allow `describe` under `test_each`

### DIFF
--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -228,7 +228,7 @@ unique_ptr<ast::Expression> runUnderEach(core::MutableContext ctx, core::NameRef
         e.setHeader("Only valid `{}`-blocks can appear within `{}`", "it", eachName.show(ctx));
     }
 
-    return ast::MK::EmptyTree();
+    return stmt;
 }
 
 // this just walks the body of a `test_each` and tries to transform every statement

--- a/test/testdata/rewriter/minitest_tables.rb
+++ b/test/testdata/rewriter/minitest_tables.rb
@@ -122,7 +122,7 @@ class MyTest
   describe "foo" do
     test_each([1, 2, 3]) do |x|
       describe("bar: #{x}") do
-        it "does a thing" do
+        it "does a thing with #{x}" do
           T.reveal_type(x) # error: Revealed type: `Integer`
         end
       end

--- a/test/testdata/rewriter/minitest_tables.rb
+++ b/test/testdata/rewriter/minitest_tables.rb
@@ -32,6 +32,9 @@ class MyTest
   sig {params(name: String, blk: T.proc.void).void}
   def self.it(name, &blk); end
 
+  sig {params(name: String, blk: T.proc.void).void}
+  def self.describe(name, &blk); end
+
   test_each [Parent.new, Child.new] do |value|
     it "works with instance methods" do
       puts value.foo
@@ -113,6 +116,16 @@ class MyTest
 
   test_each_hash({foo: 1, bar: 2}) do |x| # error: Wrong number of parameters for `test_each_hash` block
     it "does not handle more than one argument" do
+    end
+  end
+
+  describe "foo" do
+    test_each([1, 2, 3]) do |x|
+      describe("bar: #{x}") do
+        it "does a thing" do
+          
+        end
+      end
     end
   end
 

--- a/test/testdata/rewriter/minitest_tables.rb
+++ b/test/testdata/rewriter/minitest_tables.rb
@@ -123,7 +123,7 @@ class MyTest
     test_each([1, 2, 3]) do |x|
       describe("bar: #{x}") do
         it "does a thing" do
-          
+          T.reveal_type(x) # error: Revealed type: `Integer`
         end
       end
     end

--- a/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
@@ -177,15 +177,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     <self>.test_each([<emptyTree>::<C Parent>.new(), <emptyTree>::<C Child>.new()]) do |x|
-      <emptyTree>
+      y = x
     end
 
     <self>.test_each_hash({}) do |k, v|
-      <emptyTree>
+      y = k.+(v)
     end
 
     <self>.test_each(<emptyTree>::<C CONST_LIST>) do |value|
-      ::Sorbet::Private::Static.keep_def(<self>, :"<it \'fails with non-it statements\'>")
+      begin
+        x = value.foo()
+        ::Sorbet::Private::Static.keep_def(<self>, :"<it \'fails with non-it statements\'>")
+      end
     end
 
     <self>.test_each(["foo", 5, {:"x" => false}]) do |v|
@@ -225,13 +228,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
             <self>.params({}).void()
           end
 
-          def <it 'does a thing'><<C <todo sym>>>(&<blk>)
+          def <it '::<Magic>.<string-interpolate>("bar: ", x)/::<Magic>.<string-interpolate>("does a thing with ", x)'><<C <todo sym>>>(&<blk>)
             [1, 2, 3].each() do |x|
               <emptyTree>::<C T>.reveal_type(x)
             end
           end
 
-          ::Sorbet::Private::Static.keep_def(<self>, :"<it \'does a thing\'>")
+          ::Sorbet::Private::Static.keep_def(<self>, :"<it \'::<Magic>.<string-interpolate>(\"bar: \", x)/::<Magic>.<string-interpolate>(\"does a thing with \", x)\'>")
         end
       end
     end

--- a/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
@@ -227,7 +227,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
           def <it 'does a thing'><<C <todo sym>>>(&<blk>)
             [1, 2, 3].each() do |x|
-              <emptyTree>
+              <emptyTree>::<C T>.reveal_type(x)
             end
           end
 

--- a/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
@@ -38,6 +38,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
+    <self>.sig() do ||
+      <self>.params({:"name" => <emptyTree>::<C String>, :"blk" => <emptyTree>::<C T>.proc().void()}).void()
+    end
+
+    def self.describe<<C <todo sym>>>(name, &blk)
+      <emptyTree>
+    end
+
     ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({}).void()
     end
@@ -144,6 +152,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     ::Sorbet::Private::Static.keep_self_def(<self>, :"it")
 
+    ::Sorbet::Private::Static.keep_self_def(<self>, :"describe")
+
     <self>.test_each([<emptyTree>::<C Parent>.new(), <emptyTree>::<C Child>.new()]) do |value|
       ::Sorbet::Private::Static.keep_def(<self>, :"<it \'works with instance methods\'>")
     end
@@ -167,18 +177,15 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     <self>.test_each([<emptyTree>::<C Parent>.new(), <emptyTree>::<C Child>.new()]) do |x|
-      y = x
+      <emptyTree>
     end
 
     <self>.test_each_hash({}) do |k, v|
-      y = k.+(v)
+      <emptyTree>
     end
 
     <self>.test_each(<emptyTree>::<C CONST_LIST>) do |value|
-      begin
-        x = value.foo()
-        ::Sorbet::Private::Static.keep_def(<self>, :"<it \'fails with non-it statements\'>")
-      end
+      ::Sorbet::Private::Static.keep_def(<self>, :"<it \'fails with non-it statements\'>")
     end
 
     <self>.test_each(["foo", 5, {:"x" => false}]) do |v|
@@ -208,6 +215,24 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.test_each_hash({:"foo" => 1, :"bar" => 2}) do |x|
       <self>.it("does not handle more than one argument") do ||
         <emptyTree>
+      end
+    end
+
+    class <emptyTree>::<C <describe 'foo'>><<C <todo sym>>> < (<self>)
+      <self>.test_each([1, 2, 3]) do |x|
+        class <emptyTree>::<C <describe '::<Magic>.<string-interpolate>("bar: ", x)'>><<C <todo sym>>> < (<self>)
+          ::T::Sig::WithoutRuntime.sig() do ||
+            <self>.params({}).void()
+          end
+
+          def <it 'does a thing'><<C <todo sym>>>(&<blk>)
+            [1, 2, 3].each() do |x|
+              <emptyTree>
+            end
+          end
+
+          ::Sorbet::Private::Static.keep_def(<self>, :"<it \'does a thing\'>")
+        end
       end
     end
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Right now, `test_each` _only_ allows `it` blocks underneath it, but we've had multiple requests that it also allow a nested `describe` block, e.g. in #2694. This PR extends `test_each` just a bit to allow this by desugaring it in the same way that `describe` blocks are usually desugared.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
