### PR TITLE
Don't check sig of `Decorator#initialize`

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -20,7 +20,7 @@ class T::Props::Decorator
   EMPTY_PROPS = T.let({}.freeze, T::Hash[Symbol, Rules])
   private_constant :EMPTY_PROPS
 
-  sig {params(klass: T.untyped).void}
+  sig {params(klass: T.untyped).void.checked(:never)}
   def initialize(klass)
     @class = T.let(klass, T.all(Module, T::Props::ClassMethods))
     @class.plugins.each do |mod|


### PR DESCRIPTION
`Decorator.new` is being called as part of the initialization of `sorbet-runtime` library, which in turn loads the signature for `Decorator#initialize` and sets the internal `@has_read_default_checked_level` to `true` before the library consumer even has a chance to set it. Thus, setting  `T::Configuration.default_checked_level` always fails after doing a `require 'sorbet-runtime'`.

By changing the signature on `Decorator#initialize` to be never checked, we still protect the static checks on the method but make sure the runtime library does not get initialized too early.

### Motivation

Fixes: #2717

As can be seen on the stack-trace posted on that issue and the minimal repro case in another comment, this is a problem preventing the library from behaving as intended.

### Test plan

No tests. But the minimal repro from https://github.com/sorbet/sorbet/issues/2717#issuecomment-593436262 _could be_ added as a test.
