### PR TITLE
Allow explicit eval of lazily-defined methods even after disabling lazy auto-eval

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
+++ b/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
@@ -27,6 +27,9 @@ module T::Props
     #
     # This is intended to be called after startup but before interacting with
     # the outside world, to limit attack surface for our `class_eval` use.
+    #
+    # Note it does _not_ prevent explicit calls to `eagerly_define_lazy_methods!`
+    # from working.
     sig {void}
     def self.disable_lazy_evaluation!
       @lazy_evaluation_disabled ||= true
@@ -72,11 +75,7 @@ module T::Props
 
       sig {void}
       def eagerly_define_lazy_methods!
-        if !HasLazilySpecializedMethods.lazy_evaluation_enabled?
-          raise SourceEvaluationDisabled.new
-        elsif lazily_defined_methods.empty?
-          return
-        end
+        return if lazily_defined_methods.empty?
 
         source = lazily_defined_methods.values.map(&:call).map(&:to_s).join("\n\n")
 

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -643,10 +643,8 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
           m.new.serialize
         end
 
-        assert_raises(T::Props::HasLazilySpecializedMethods::SourceEvaluationDisabled) do
-          m.decorator.eagerly_define_lazy_methods!
-        end
-
+        # Explicit call is still ok
+        m.decorator.eagerly_define_lazy_methods!
       end
 
       after do


### PR DESCRIPTION
### Motivation
We can't fully disable lazy auto-load in production, so we need to be able to explicitly eager-eval when we are autoloading something lazily. We'll still disable transparent lazy-eval, so the eval will happen only when we know we are autoloading a particular file.

See http://go/jeoiwj2j223f

### Test plan
Passing build