### PR TITLE
Fix `sorbet-runtime` early initialization

### DIFF
--- a/gems/sorbet-runtime/Rakefile
+++ b/gems/sorbet-runtime/Rakefile
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# Make sure that sorbet-runtime does not do any early
+# initialization that would affect the ability to change
+# the checked level default value
+require "./lib/sorbet-runtime"
+T::Configuration.default_checked_level = :always
+
 task :test do
   Dir.glob('./test/**/*.rb').reject {|path| path.match(/^.\/test\/types\/fixtures\//)}.each(&method(:require))
 end

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -20,7 +20,7 @@ class T::Props::Decorator
   EMPTY_PROPS = T.let({}.freeze, T::Hash[Symbol, Rules])
   private_constant :EMPTY_PROPS
 
-  sig {params(klass: T.untyped).void}
+  sig {params(klass: T.untyped).void.checked(:never)}
   def initialize(klass)
     @class = T.let(klass, T.all(Module, T::Props::ClassMethods))
     @class.plugins.each do |mod|


### PR DESCRIPTION
There were a few places loading `sig`s during `sorbet-runtime` initialization, thus preventing `T::Configuration.default_checked_level` from being changed by application code:

1. `Decorator#initialize` had a checked signature.
2. `SerdeTransform` was declaring a `T::Enum` type that was triggering various `sig`s

The fix for (1) was simple enough, I just made the signature not-checked.

The fix for (2) while still keeping exhaustiveness checking was non-trivial. I was able to declare private classes that `Mode` constants are instances of and then made a union type for the `mode` parameter. This keeps the public interface the same, preserves exhaustiveness checking while not relying on `T::Enum` for these benefits. I am not sure if this is the best solution, though. Open to trying different approaches here. /cc @djudd-stripe 

### Motivation

Fixes: #2717

As can be seen on the stack-trace posted on that issue and the minimal repro case in another comment, this is a problem preventing the library from behaving as intended.

### Test plan

It is hard to add an isolated test for `T::Configuration.default_checked_level=` since depending on the order of tests, sigs could be (and mostly are) legitimately loaded before setting this config.

I chose to fail the Rake task completely by trying an early use of this config setter, in a way that does not change the value of it.
