### PR TITLE
Report per-edit (from the client) diagnostic latency

### DIFF
--- a/common/Timer.cc
+++ b/common/Timer.cc
@@ -47,18 +47,17 @@ void Timer::cancel() {
     this->canceled = true;
 }
 
-unique_ptr<Timer> Timer::clone() const {
+Timer Timer::clone() const {
     return clone(name);
 }
 
-unique_ptr<Timer> Timer::clone(ConstExprStr name) const {
-    // Using new to access private constructor.
-    auto forked = unique_ptr<Timer>(new Timer(log, name, prev, {}, start, {}));
-    forked->args = args;
-    forked->tags = tags;
-    forked->canceled = canceled;
-    forked->histogramBuckets = histogramBuckets;
-    return forked;
+Timer Timer::clone(ConstExprStr name) const {
+    Timer forked(log, name, prev, {}, start, {});
+    forked.args = args;
+    forked.tags = tags;
+    forked.canceled = canceled;
+    forked.histogramBuckets = histogramBuckets;
+    return move(forked);
 }
 
 void Timer::setTag(ConstExprStr name, ConstExprStr value) {

--- a/common/Timer.cc
+++ b/common/Timer.cc
@@ -81,9 +81,6 @@ Timer::~Timer() {
         // the trick ^^^ is to skip double comparison in the common case and use the most efficient representation.
         auto dur = std::chrono::duration<double, std::milli>(clock - start);
         log.debug("{}: {}ms", this->name.str, dur.count());
-        if (strncmp(this->name.str, "last_diagnostic_latency", 30) == 0) {
-            log.debug("latency");
-        }
         sorbet::timingAdd(this->name, start, clock, move(args), move(tags), self, prev, move(histogramBuckets));
     }
 }

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -27,6 +27,7 @@ public:
     Timer(const std::shared_ptr<spdlog::logger> &log, ConstExprStr name,
           std::initializer_list<std::pair<ConstExprStr, std::string>> args);
     Timer(const Timer &) = delete;
+    Timer(Timer &&);
     ~Timer();
     FlowId getFlowEdge();
 

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -26,6 +26,7 @@ public:
           std::initializer_list<std::pair<ConstExprStr, std::string>> args);
     Timer(const std::shared_ptr<spdlog::logger> &log, ConstExprStr name,
           std::initializer_list<std::pair<ConstExprStr, std::string>> args);
+    Timer(const Timer &) = delete;
     ~Timer();
     FlowId getFlowEdge();
 
@@ -36,10 +37,10 @@ public:
     void setTag(ConstExprStr name, ConstExprStr value);
 
     // Creates a new timer with the same start time, tags, args, and name.
-    Timer clone() const;
+    std::unique_ptr<Timer> clone() const;
 
     // Creates a new timer with the same start time, tags, and args but a different name.
-    Timer clone(ConstExprStr name) const;
+    std::unique_ptr<Timer> clone(ConstExprStr name) const;
 
     // TODO We could add more overloads for this if we need them (to create other kinds of Timers)
     // We could also make this more generic to allow more sleep duration types.

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -37,10 +37,10 @@ public:
     void setTag(ConstExprStr name, ConstExprStr value);
 
     // Creates a new timer with the same start time, tags, args, and name.
-    std::unique_ptr<Timer> clone() const;
+    Timer clone() const;
 
     // Creates a new timer with the same start time, tags, and args but a different name.
-    std::unique_ptr<Timer> clone(ConstExprStr name) const;
+    Timer clone(ConstExprStr name) const;
 
     // TODO We could add more overloads for this if we need them (to create other kinds of Timers)
     // We could also make this more generic to allow more sleep duration types.

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -26,9 +26,13 @@ public:
           std::initializer_list<std::pair<ConstExprStr, std::string>> args);
     Timer(const std::shared_ptr<spdlog::logger> &log, ConstExprStr name,
           std::initializer_list<std::pair<ConstExprStr, std::string>> args);
+    // Delete copy constructor to avoid accidentally copying and reporting a timer twice.
     Timer(const Timer &) = delete;
+    // Define custom move constructor to avoid reporting moved timers.
     Timer(Timer &&);
+
     ~Timer();
+
     FlowId getFlowEdge();
 
     // Don't report timer when it gets destructed.

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -40,7 +40,7 @@ void clearAndReplaceTimers(vector<unique_ptr<Timer>> &timers, const vector<uniqu
     timers.clear();
     timers.reserve(newTimers.size());
     for (auto &timer : newTimers) {
-        timers.push_back(timer->clone());
+        timers.push_back(make_unique<Timer>(timer->clone()));
     }
 }
 } // namespace

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -29,14 +29,28 @@ void mergeEvictedFiles(const UnorderedMap<int, shared_ptr<core::File>> &oldEvict
         newlyEvictedFiles[entry.first] = move(entry.second);
     }
 }
+
+// Cancels all timers in timers and clears the vector, and replaces with clones of newTimers.
+void clearAndReplaceTimers(vector<unique_ptr<Timer>> &timers, const vector<unique_ptr<Timer>> &newTimers) {
+    for (auto &timer : timers) {
+        if (timer != nullptr) {
+            timer->cancel();
+        }
+    }
+    timers.clear();
+    timers.reserve(newTimers.size());
+    for (auto &timer : newTimers) {
+        timers.push_back(timer->clone());
+    }
+}
 } // namespace
 
 LSPIndexer::LSPIndexer(shared_ptr<const LSPConfiguration> config, unique_ptr<core::GlobalState> initialGS)
     : config(config), initialGS(move(initialGS)), emptyWorkers(WorkerPool::create(0, *config->logger)) {}
 
 LSPIndexer::~LSPIndexer() {
-    if (pendingTypecheckLatencyTimer != nullptr) {
-        pendingTypecheckLatencyTimer->cancel();
+    for (auto &timer : pendingTypecheckDiagnosticLatencyTimers) {
+        timer->cancel();
     }
 }
 
@@ -212,7 +226,7 @@ void LSPIndexer::initialize(LSPFileUpdates &updates, WorkerPool &workers) {
     initialGS->errorQueue = move(savedErrorQueue);
 }
 
-LSPFileUpdates LSPIndexer::commitEdit(unique_ptr<Timer> &latencyTimer, SorbetWorkspaceEditParams &edit) {
+LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit) {
     Timer timeit(config->logger, "LSPIndexer::commitEdit");
     LSPFileUpdates update;
     update.epoch = edit.epoch;
@@ -300,29 +314,31 @@ LSPFileUpdates LSPIndexer::commitEdit(unique_ptr<Timer> &latencyTimer, SorbetWor
 
     ENFORCE(update.updatedFiles.size() == update.updatedFileIndexes.size());
 
+    if (update.canceledSlowPath) {
+        // Merge diagnostic latency timers; this edit contains the previous slow path.
+        edit.diagnosticLatencyTimers.insert(edit.diagnosticLatencyTimers.end(),
+                                            make_move_iterator(pendingTypecheckDiagnosticLatencyTimers.begin()),
+                                            make_move_iterator(pendingTypecheckDiagnosticLatencyTimers.end()));
+        clearAndReplaceTimers(pendingTypecheckDiagnosticLatencyTimers, edit.diagnosticLatencyTimers);
+    } else if (!update.canTakeFastPath) {
+        // Replace diagnostic latency timers; this is a new slow path that did not cancel the previous slow path.
+        clearAndReplaceTimers(pendingTypecheckDiagnosticLatencyTimers, edit.diagnosticLatencyTimers);
+    }
+
     if (update.canTakeFastPath) {
         // Edit takes the fast path. Merge with this edit so we can reverse it if the slow path gets canceled.
         auto merged = update.copy();
         merged.mergeOlder(pendingTypecheckUpdates);
         pendingTypecheckUpdates = move(merged);
-        if (update.canceledSlowPath && pendingTypecheckLatencyTimer != nullptr) {
-            // Replace edit's latencyTimer with that of the running slow path.
-            if (latencyTimer != nullptr) {
-                latencyTimer->cancel();
-            }
-            latencyTimer = make_unique<Timer>(pendingTypecheckLatencyTimer->clone());
+        if (!update.canceledSlowPath) {
+            // If a slow path is running, this update preempted.
+            pendingTypecheckUpdates.committedEditCount += update.editCount;
         }
         mergeEvictedFiles(evictedFiles, newlyEvictedFiles);
     } else {
         // Completely replace `pendingTypecheckUpdates` if this was a slow path update.
         update.updatedGS = initialGS->deepCopy();
         pendingTypecheckUpdates = update.copy();
-        if (pendingTypecheckLatencyTimer != nullptr) {
-            pendingTypecheckLatencyTimer->cancel();
-        }
-        if (latencyTimer != nullptr) {
-            pendingTypecheckLatencyTimer = make_unique<Timer>(latencyTimer->clone());
-        }
     }
 
     // newlyEvictedFiles contains the changes from this edit + changes from the pending typecheck, if applicable.

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -27,9 +27,9 @@ class LSPIndexer final {
     std::unique_ptr<core::GlobalState> initialGS;
     /** Contains a copy of the last edit committed on the slow path. Used in slow path cancelation logic. */
     LSPFileUpdates pendingTypecheckUpdates;
-    /** Contains a clone of the latency timer for the pending typecheck operation. Is used to ensure that we correctly
-     * track the latency of canceled & rescheduled typechecking operations. */
-    std::unique_ptr<Timer> pendingTypecheckLatencyTimer;
+    /** Contains a clone of the latency timers for each new edit in the pending typecheck operation. Is used to ensure
+     * that we correctly track the latency of canceled & rescheduled typechecking operations. */
+    std::vector<std::unique_ptr<Timer>> pendingTypecheckDiagnosticLatencyTimers;
     /** Contains files evicted by `pendingTypecheckUpdates`. Used to make fast path decisions in the immediate past. */
     UnorderedMap<int, std::shared_ptr<core::File>> evictedFiles;
     std::unique_ptr<KeyValueStore> kvstore; // always null for now.
@@ -67,7 +67,7 @@ public:
      * Commits the given edit to `initialGS`, and returns a canonical LSPFileUpdates object containing indexed trees
      * and file hashes. Also handles canceling the running slow path.
      */
-    LSPFileUpdates commitEdit(std::unique_ptr<Timer> &latencyTimer, SorbetWorkspaceEditParams &edit);
+    LSPFileUpdates commitEdit(SorbetWorkspaceEditParams &edit);
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/json_types.cc
+++ b/main/lsp/json_types.cc
@@ -204,6 +204,7 @@ string DidChangeTextDocumentParams::getSource(string_view oldFileContents) const
 
 void LSPFileUpdates::mergeOlder(const LSPFileUpdates &older) {
     editCount += older.editCount;
+    committedEditCount += older.committedEditCount;
     hasNewFiles = hasNewFiles || older.hasNewFiles;
     cancellationExpected = cancellationExpected || older.cancellationExpected;
     preemptionsExpected += older.preemptionsExpected;
@@ -235,6 +236,7 @@ LSPFileUpdates LSPFileUpdates::copy() const {
     LSPFileUpdates copy;
     copy.epoch = epoch;
     copy.editCount = editCount;
+    copy.committedEditCount = committedEditCount;
     copy.canTakeFastPath = canTakeFastPath;
     copy.hasNewFiles = hasNewFiles;
     copy.updatedFiles = updatedFiles;
@@ -267,6 +269,10 @@ void SorbetWorkspaceEditParams::merge(SorbetWorkspaceEditParams &newerParams) {
     mergeCount += newerParams.mergeCount + 1;
     sorbetCancellationExpected = sorbetCancellationExpected || newerParams.sorbetCancellationExpected;
     sorbetPreemptionsExpected += newerParams.sorbetPreemptionsExpected;
+    // Consume newerParams' diagnostic latency timers.
+    diagnosticLatencyTimers.insert(diagnosticLatencyTimers.end(),
+                                   make_move_iterator(newerParams.diagnosticLatencyTimers.begin()),
+                                   make_move_iterator(newerParams.diagnosticLatencyTimers.end()));
 }
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/json_types.h
+++ b/main/lsp/json_types.h
@@ -2,6 +2,7 @@
 #define RUBY_TYPER_LSP_JSON_TYPES_H
 
 #include "ast/ast.h"
+#include "common/Timer.h"
 #include "common/common.h"
 #include "core/NameHash.h"
 #include "core/core.h"
@@ -19,8 +20,11 @@ class LSPFileUpdates final {
 public:
     // This specific update contains edits with the given epoch
     u4 epoch = 0;
-    // The total number of edits that this update represents. Used for stats.
+    // The total number of edits that this update represents. Used for stats and assertions.
     u4 editCount = 0;
+    // The total number of edits in this update that are already committed & had diagnostics sent out (via preemption).
+    // Used for stats and assertions.
+    u4 committedEditCount = 0;
 
     std::vector<std::shared_ptr<core::File>> updatedFiles;
     std::vector<ast::ParsedFile> updatedFileIndexes;

--- a/main/lsp/notifications/sorbet_workspace_edit.cc
+++ b/main/lsp/notifications/sorbet_workspace_edit.cc
@@ -43,8 +43,15 @@ void SorbetWorkspaceEditTask::mergeNewer(SorbetWorkspaceEditTask &task) {
     cachedFastPathDecision = false;
 }
 
+void SorbetWorkspaceEditTask::preprocess(LSPPreprocessor &preprocessor) {
+    // latencyTimer is assigned prior to preprocess.
+    if (this->latencyTimer != nullptr && !params->updates.empty()) {
+        params->diagnosticLatencyTimers.push_back(this->latencyTimer->clone("last_diagnostic_latency"));
+    }
+}
+
 void SorbetWorkspaceEditTask::index(LSPIndexer &indexer) {
-    updates = make_unique<LSPFileUpdates>(indexer.commitEdit(latencyTimer, *params));
+    updates = make_unique<LSPFileUpdates>(indexer.commitEdit(*params));
 }
 
 void SorbetWorkspaceEditTask::run(LSPTypecheckerDelegate &typechecker) {
@@ -62,12 +69,14 @@ void SorbetWorkspaceEditTask::run(LSPTypecheckerDelegate &typechecker) {
     if (!updates->canTakeFastPath) {
         Exception::raise("Attempted to run a slow path update on the fast path!");
     }
+    const auto newEditCount = updates->editCount - updates->committedEditCount;
     typechecker.typecheckOnFastPath(move(*updates));
     if (latencyTimer != nullptr) {
+        ENFORCE(newEditCount == params->diagnosticLatencyTimers.size());
         // TODO: Move into pushDiagnostics once we have fast feedback.
-        latencyTimer->clone("last_diagnostic_latency");
+        params->diagnosticLatencyTimers.clear();
     }
-    prodCategoryCounterAdd("lsp.messages.processed", "sorbet.mergedEdits", updates->editCount - 1);
+    prodCategoryCounterAdd("lsp.messages.processed", "sorbet.mergedEdits", newEditCount - 1);
 }
 
 void SorbetWorkspaceEditTask::runSpecial(LSPTypechecker &typechecker, WorkerPool &workers) {
@@ -83,16 +92,22 @@ void SorbetWorkspaceEditTask::runSpecial(LSPTypechecker &typechecker, WorkerPool
     // processing thread that it's safe to move on.
     typechecker.state().epochManager->startCommitEpoch(updates->epoch);
     startedNotification.Notify();
+    const auto newEditCount = updates->editCount - updates->committedEditCount;
     // Only report stats if the edit was committed.
     if (typechecker.typecheck(move(*updates), workers)) {
         if (latencyTimer != nullptr) {
+            ENFORCE(newEditCount == params->diagnosticLatencyTimers.size());
             // TODO: Move into pushDiagnostics once we have fast feedback.
-            latencyTimer->clone("last_diagnostic_latency");
+            params->diagnosticLatencyTimers.clear();
         }
-        prodCategoryCounterAdd("lsp.messages.processed", "sorbet.mergedEdits", updates->editCount - 1);
+        prodCategoryCounterAdd("lsp.messages.processed", "sorbet.mergedEdits", newEditCount - 1);
     } else if (latencyTimer != nullptr) {
         // Don't report a latency value for canceled slow paths.
         latencyTimer->cancel();
+        for (auto &timer : params->diagnosticLatencyTimers) {
+            timer->cancel();
+        }
+        params->diagnosticLatencyTimers.clear();
     }
 }
 

--- a/main/lsp/notifications/sorbet_workspace_edit.cc
+++ b/main/lsp/notifications/sorbet_workspace_edit.cc
@@ -46,7 +46,8 @@ void SorbetWorkspaceEditTask::mergeNewer(SorbetWorkspaceEditTask &task) {
 void SorbetWorkspaceEditTask::preprocess(LSPPreprocessor &preprocessor) {
     // latencyTimer is assigned prior to preprocess.
     if (this->latencyTimer != nullptr && !params->updates.empty()) {
-        params->diagnosticLatencyTimers.push_back(this->latencyTimer->clone("last_diagnostic_latency"));
+        params->diagnosticLatencyTimers.push_back(
+            make_unique<Timer>(this->latencyTimer->clone("last_diagnostic_latency")));
     }
 }
 

--- a/main/lsp/notifications/sorbet_workspace_edit.h
+++ b/main/lsp/notifications/sorbet_workspace_edit.h
@@ -23,6 +23,7 @@ public:
     const SorbetWorkspaceEditParams &getParams() const;
 
     void mergeNewer(SorbetWorkspaceEditTask &task);
+    void preprocess(LSPPreprocessor &preprocess) override;
     void index(LSPIndexer &indexer) override;
     void run(LSPTypecheckerDelegate &typechecker) override;
     void runSpecial(LSPTypechecker &typechecker, WorkerPool &workers) override;

--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -48,10 +48,9 @@ CounterState mergeCounters(CounterState counters) {
 }
 
 void tagNewRequest(spd::logger &logger, LSPMessage &msg) {
-    // apparently make_unique doesn't like initializer lists, so I'm passing it a Timer object directly.
-    msg.latencyTimer = make_unique<Timer>(
-        Timer(logger, "task_latency",
-              {50, 100, 250, 500, 1000, 1500, 2000, 2500, 5000, 10000, 15000, 20000, 25000, 30000, 35000, 40000}));
+    msg.latencyTimer = make_unique<Timer>(logger, "task_latency",
+                                          initializer_list<int>{50, 100, 250, 500, 1000, 1500, 2000, 2500, 5000, 10000,
+                                                                15000, 20000, 25000, 30000, 35000, 40000});
 }
 } // namespace
 

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -1283,6 +1283,8 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                        "bool sorbetCancellationExpected = false;"
                        "// Used in multithreaded tests to wait for a preemption to occur when processing this edit.",
                        "int sorbetPreemptionsExpected = 0;",
+                       "// For each edit rolled up into update, contains a timer used to report diagnostic latency.",
+                       "std::vector<std::unique_ptr<Timer>> diagnosticLatencyTimers;",
                        "// File updates contained in this edit.",
                        "std::vector<std::shared_ptr<core::File>> updates;",
                        "// Merge newerParams into this object, which mutates `epoch` and `updates`",

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -443,7 +443,14 @@ TEST_P(ProtocolTest, CanPreemptSlowPathWithFastPathAndThenCancelBoth) {
                           {"bar.rb", 5, "Returning value that does not conform to method result type"},
                           {"baz.rb", 5, "Returning value that does not conform to method result type"},
                       });
-    checkDiagnosticTimes(getCounters().getTimings("last_diagnostic_latency"), 6);
+
+    auto counters = getCounters();
+    checkDiagnosticTimes(counters.getTimings("last_diagnostic_latency"), 6);
+
+    // N.B.: This counter contains canceled edits.
+    EXPECT_EQ(counters.getCategoryCounter("lsp.messages.processed", "sorbet.workspaceEdit"), 6);
+    // mergedEdits should not count the preempted fast path, but should count the canceled slow path.
+    EXPECT_EQ(counters.getCategoryCounter("lsp.messages.processed", "sorbet.mergedEdits"), 1);
 }
 
 TEST_P(ProtocolTest, CanPreemptSlowPathWithFastPathAndBothErrorsAreReported) {

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -49,7 +49,7 @@ TEST_P(ProtocolTest, MultithreadedWrapperWorks) {
     EXPECT_EQ(counters.getCategoryCounterSum("lsp.messages.canceled"), 0);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 1);
     EXPECT_EQ(counters.getCategoryCounterSum("lsp.updates"), 1);
-    EXPECT_EQ(counters.getTimings("last_diagnostic_latency").size(), 1);
+    EXPECT_EQ(counters.getTimings("last_diagnostic_latency").size(), 2);
 }
 
 TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeFastPathWithOldEdits) {
@@ -124,7 +124,7 @@ TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeFastPathWithOldEdits) {
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath_canceled"), 1);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "query"), 0);
     auto lastDiagnosticLatency = counters.getTimings("last_diagnostic_latency");
-    EXPECT_EQ(lastDiagnosticLatency.size(), 1);
+    EXPECT_EQ(lastDiagnosticLatency.size(), 3);
     EXPECT_GE(lastDiagnosticLatency[0].end - lastDiagnosticLatency[0].start, chrono::milliseconds(5));
 }
 
@@ -187,7 +187,7 @@ TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeSlowPath) {
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 1);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath_canceled"), 1);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "query"), 0);
-    EXPECT_EQ(counters.getTimings("last_diagnostic_latency").size(), 1);
+    EXPECT_EQ(counters.getTimings("last_diagnostic_latency").size(), 2);
 }
 
 TEST_P(ProtocolTest, CanPreemptSlowPathWithHover) {

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -2,6 +2,7 @@
 // ^ Violates linting rules, so include first.
 #include "absl/strings/match.h"
 #include "common/common.h"
+#include "common/sort.h"
 #include "test/helpers/lsp.h"
 #include "test/lsp/ProtocolTest.h"
 
@@ -17,6 +18,22 @@ optional<SorbetTypecheckRunStatus> getTypecheckRunStatus(const LSPMessage &msg) 
     }
     return nullopt;
 }
+
+void sortTimersByStartTime(vector<CounterImpl::Timing> &times) {
+    fast_sort(times,
+              [](const CounterImpl::Timing &a, const CounterImpl::Timing &b) -> bool { return a.start < b.start; });
+}
+
+void checkDiagnosticTimes(vector<CounterImpl::Timing> times, size_t expectedSize) {
+    EXPECT_EQ(times.size(), expectedSize);
+    sortTimersByStartTime(times);
+
+    // No two diagnostic latency timers should have the same start timestamp.
+    for (size_t i = 1; i < times.size(); i++) {
+        EXPECT_LT(times[i - 1].start, times[i].start);
+    }
+}
+
 } // namespace
 
 TEST_P(ProtocolTest, MultithreadedWrapperWorks) {
@@ -34,6 +51,8 @@ TEST_P(ProtocolTest, MultithreadedWrapperWorks) {
 
     sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::PAUSE, nullopt)));
     sendAsync(*openFile("yolo1.rb", "# typed: true\nclass Foo2\n  def branch\n    2 + \"dog\"\n  end\nend\n"));
+    // Pause to differentiate message times
+    this_thread::sleep_for(chrono::microseconds(100));
     sendAsync(*changeFile("yolo1.rb", "# typed: true\nclass Foo1\n  def branch\n    1 + \"bear\"\n  end\nend\n", 3));
 
     // Pause so that all latency timers for the above operations get reported.
@@ -49,7 +68,8 @@ TEST_P(ProtocolTest, MultithreadedWrapperWorks) {
     EXPECT_EQ(counters.getCategoryCounterSum("lsp.messages.canceled"), 0);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 1);
     EXPECT_EQ(counters.getCategoryCounterSum("lsp.updates"), 1);
-    EXPECT_EQ(counters.getTimings("last_diagnostic_latency").size(), 2);
+    // 1 per edit
+    checkDiagnosticTimes(counters.getTimings("last_diagnostic_latency"), 2);
 }
 
 TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeFastPathWithOldEdits) {
@@ -76,6 +96,8 @@ TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeFastPathWithOldEdits) {
     sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::PAUSE, nullopt)));
     // Syntax error in foo.rb.
     sendAsync(*changeFile("foo.rb", "# typed: true\n\nclass Foo\ndef noend\nend\n", 2, true));
+    // Pause to differentiate message times
+    this_thread::sleep_for(chrono::microseconds(100));
     // Typechecking error in bar.rb
     sendAsync(*changeFile(
         "bar.rb", "# typed: true\n\nclass Bar\nextend T::Sig\n\nsig{returns(Integer)}\ndef hello\n\"hi\"\nend\nend\n",
@@ -88,7 +110,7 @@ TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeFastPathWithOldEdits) {
         ASSERT_EQ(*status, SorbetTypecheckRunStatus::Started);
     }
 
-    // Pause for a moderate amount of time so that we can check that the subsequent fast path uses the latency timer
+    // Pause for a moderate amount of time so that we can check that the subsequent fast path includes the latency timer
     // from the initial slow path.
     this_thread::sleep_for(chrono::milliseconds(5));
 
@@ -123,9 +145,13 @@ TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeFastPathWithOldEdits) {
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 0);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath_canceled"), 1);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "query"), 0);
+
     auto lastDiagnosticLatency = counters.getTimings("last_diagnostic_latency");
-    EXPECT_EQ(lastDiagnosticLatency.size(), 3);
+    sortTimersByStartTime(lastDiagnosticLatency);
     EXPECT_GE(lastDiagnosticLatency[0].end - lastDiagnosticLatency[0].start, chrono::milliseconds(5));
+    EXPECT_GE(lastDiagnosticLatency[1].end - lastDiagnosticLatency[1].start, chrono::milliseconds(5));
+    // 1 per edit
+    checkDiagnosticTimes(lastDiagnosticLatency, 3);
 }
 
 TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeSlowPath) {
@@ -187,7 +213,8 @@ TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeSlowPath) {
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 1);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath_canceled"), 1);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "query"), 0);
-    EXPECT_EQ(counters.getTimings("last_diagnostic_latency").size(), 2);
+    // 1 per edit
+    checkDiagnosticTimes(counters.getTimings("last_diagnostic_latency"), 2);
 }
 
 TEST_P(ProtocolTest, CanPreemptSlowPathWithHover) {
@@ -247,7 +274,8 @@ TEST_P(ProtocolTest, CanPreemptSlowPathWithHover) {
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 1);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath_canceled"), 0);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "query"), 1);
-    EXPECT_EQ(counters.getTimings("last_diagnostic_latency").size(), 1);
+    // 1 per edit
+    checkDiagnosticTimes(counters.getTimings("last_diagnostic_latency"), 1);
 }
 
 TEST_P(ProtocolTest, CanPreemptSlowPathWithHoverAndReturnsErrors) {
@@ -288,6 +316,7 @@ TEST_P(ProtocolTest, CanPreemptSlowPathWithHoverAndReturnsErrors) {
                       {
                           {"foo.rb", 6, "Returning value that does not conform to method result type"},
                       });
+    checkDiagnosticTimes(getCounters().getTimings("last_diagnostic_latency"), 2);
 }
 
 TEST_P(ProtocolTest, CanPreemptSlowPathWithFastPath) {
@@ -329,6 +358,7 @@ TEST_P(ProtocolTest, CanPreemptSlowPathWithFastPath) {
                           {"foo.rb", 9, "Returning value that does not conform to method result type"},
                           {"bar.rb", 5, "Returning value that does not conform to method result type"},
                       });
+    checkDiagnosticTimes(getCounters().getTimings("last_diagnostic_latency"), 5);
 }
 
 TEST_P(ProtocolTest, CanPreemptSlowPathWithFastPathThatFixesAllErrors) {
@@ -366,6 +396,7 @@ TEST_P(ProtocolTest, CanPreemptSlowPathWithFastPathThatFixesAllErrors) {
 
     // Send a no-op to clear out the pipeline. Should have no errors at end of both typechecking runs.
     assertDiagnostics(send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, 20))), {});
+    checkDiagnosticTimes(getCounters().getTimings("last_diagnostic_latency"), 5);
 }
 
 TEST_P(ProtocolTest, CanPreemptSlowPathWithFastPathAndThenCancelBoth) {
@@ -412,6 +443,7 @@ TEST_P(ProtocolTest, CanPreemptSlowPathWithFastPathAndThenCancelBoth) {
                           {"bar.rb", 5, "Returning value that does not conform to method result type"},
                           {"baz.rb", 5, "Returning value that does not conform to method result type"},
                       });
+    checkDiagnosticTimes(getCounters().getTimings("last_diagnostic_latency"), 6);
 }
 
 TEST_P(ProtocolTest, CanPreemptSlowPathWithFastPathAndBothErrorsAreReported) {
@@ -453,6 +485,7 @@ TEST_P(ProtocolTest, CanPreemptSlowPathWithFastPathAndBothErrorsAreReported) {
                           {"bar.rb", 5, "Returning value that does not conform to method result type"},
                           {"baz.rb", 5, "Returning value that does not conform to method result type"},
                       });
+    checkDiagnosticTimes(getCounters().getTimings("last_diagnostic_latency"), 5);
 }
 
 TEST_P(ProtocolTest, CanCancelSlowPathWithFastPathThatReintroducesOldError) {
@@ -499,6 +532,7 @@ TEST_P(ProtocolTest, CanCancelSlowPathWithFastPathThatReintroducesOldError) {
     // Send a no-op to clear out the pipeline. Should have one error on baz.rb.
     assertDiagnostics(send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, 20))),
                       {{"baz.rb", 5, "Returning value that does not conform to method result type"}});
+    checkDiagnosticTimes(getCounters().getTimings("last_diagnostic_latency"), 7);
 }
 
 TEST_P(ProtocolTest, CanCancelSlowPathEvenIfAddsFile) {
@@ -546,6 +580,7 @@ TEST_P(ProtocolTest, CanCancelSlowPathEvenIfAddsFile) {
     assertDiagnostics(
         send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, 20))),
         {{"foo.rb", 5, "Returning value that does not conform to method result type"}, {"bar.rb", 6, "unexpected"}});
+    checkDiagnosticTimes(getCounters().getTimings("last_diagnostic_latency"), 5);
 }
 
 TEST_P(ProtocolTest, CanceledRequestsDontReportLatencyMetrics) {
@@ -573,6 +608,7 @@ TEST_P(ProtocolTest, CanceledRequestsDontReportLatencyMetrics) {
     EXPECT_EQ(counters.getCategoryCounter("lsp.messages.processed", "textDocument.hover"), 0);
     EXPECT_EQ(counters.getCategoryCounter("lsp.messages.canceled", "textDocument.hover"), 1);
     EXPECT_EQ(counters.getTimings("task_latency", {{"method", "textDocument.hover"}}).size(), 0);
+    checkDiagnosticTimes(getCounters().getTimings("last_diagnostic_latency"), 0);
 }
 
 // Run these tests in multi-threaded mode.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Report per-edit (from the client) diagnostic latency.

Also forbids the Timer copy constructor; I was accidentally doubly reporting some times. 🤦‍♂

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Create a more representative latency metric for Sorbet. For every edit (even if combined!), this will report how long it takes to provide a diagnostics update containing that edit.

The start time for this metric is when the editor sends an edit to Sorbet. The end time is when Sorbet completes typechecking the combined LSPFileUpdates containing that edit.

When we switch to streaming out diagnostics per-file, we will likely change the logic to send the metric when Sorbet sends the last diagnostic update from those edits. (Since we can't know this apriori without an oracle, at that time we'll have to figure out a mechanism for reporting timers that ended in the past -- perhaps in a new timer-like class for async timers.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
