### PR TITLE
Simplify LSP cancelation decision.

### DIFF
--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -291,8 +291,7 @@ LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit) {
 
     auto runningSlowPath = initialGS->epochManager->getStatus();
     if (runningSlowPath.slowPathRunning) {
-        // A cancelable slow path is currently running. Before running deepCopy(), check if we can cancel -- we might be
-        // able to avoid it.
+        // A cancelable slow path is currently running. Check if we can cancel.
         // Invariant: `pendingTypecheckUpdates` should contain the edits currently being typechecked on the slow path.
         // runningSlowPath.epoch should be in the interval (pendingTypecheckUpdates.epoch - editCount,
         // pendingTypecheckUpdates.epoch]
@@ -301,7 +300,7 @@ LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit) {
 
         // Cancel if the new update will take the slow path anyway.
         if (!update.canTakeFastPath && initialGS->epochManager->tryCancelSlowPath(update.epoch)) {
-            // Cancelation succeeded! Use merged as the update.
+            // Cancelation succeeded! Merge the updates from the cancelled run into the current update.
             update.mergeOlder(pendingTypecheckUpdates);
             // The two updates together could end up taking the fast path.
             update.canTakeFastPath = canTakeFastPath(update, true);

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -301,7 +301,7 @@ LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit) {
 
         // Cancel if the new update will take the slow path anyway.
         if (!update.canTakeFastPath && initialGS->epochManager->tryCancelSlowPath(update.epoch)) {
-            // Cancelation succeeded! Use `merged` as the update.
+            // Cancelation succeeded! Use merged as the update.
             update.mergeOlder(pendingTypecheckUpdates);
             // The two updates together could end up taking the fast path.
             update.canTakeFastPath = canTakeFastPath(update, true);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Simplify LSP cancelation decision.

If a new edit comes in and it will take the slow path relative to the last committed update, it should cancel the currently running slow path.

There's no need to check if it would take the fast path with the currently running slow path, since there exists no update such that it takes the fast path relative to the last edit AND takes the fast path with the currently running slow path.

We initially had this check because the first implementation of cancelable slow path did not cancel the slow path unless the edit took the fast path with the slow path. I later changed the code to always cancel the slow path when a new slow path edit came in, and never thought to simplify the check.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Simpler code is better code.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See existing automated tests.
