### PR TITLE
Fix enqueue_lazy_method_definition! on Ruby <2.5

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
+++ b/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
@@ -63,7 +63,7 @@ module T::Props
         lazily_defined_methods[name] = blk
 
         cls = decorated_class
-        cls.define_method(name) do |*args|
+        cls.send(:define_method, name) do |*args|
           self.class.decorator.send(:eval_lazily_defined_method!, name)
           send(name, *args)
         end


### PR DESCRIPTION
The `enqueue_lazy_method_definition!` method in `HasLazilySpecializedMethods` calls `define_method` directly, rather than using `send` to call it.

This means that the method doesn't work on any Ruby version prior to 2.5, which consequently breaks `T::Struct`.

### Motivation
Fixes #2743 

### Test plan
As this is specific to a particular Ruby version, this could be tested by extending the Buildkite sorbet-runtime tests to run on 2.4 as well as 2.6.3. 