### PR TITLE
Add rbis for Env filter/select methods

### DIFF
--- a/rbi/sorbet/sorbet.rbi
+++ b/rbi/sorbet/sorbet.rbi
@@ -161,6 +161,24 @@ class Sorbet::Private::Static::ENVClass
     params(
         blk: T.proc.params(name: String, value: String).returns(BasicObject),
     )
+    .returns(T::Hash[String, String])
+  end
+  sig {returns(T::Enumerator[Elem])}
+  def filter(&blk); end
+
+  sig do
+    params(
+        blk: T.proc.params(name: String, value: String).returns(BasicObject),
+    )
+    .returns(T.nilable(Sorbet::Private::Static::ENVClass))
+  end
+  sig {returns(T::Enumerator[Elem])}
+  def filter!(&blk); end
+
+  sig do
+    params(
+        blk: T.proc.params(name: String, value: String).returns(BasicObject),
+    )
     .returns(Sorbet::Private::Static::ENVClass)
   end
   sig {returns(T::Enumerator[Elem])}
@@ -210,6 +228,24 @@ class Sorbet::Private::Static::ENVClass
   end
   sig {returns(T::Enumerator[Elem])}
   def reject!(&blk); end
+
+  sig do
+    params(
+        blk: T.proc.params(name: String, value: String).returns(BasicObject),
+    )
+    .returns(T::Hash[String, String])
+  end
+  sig {returns(T::Enumerator[Elem])}
+  def select(&blk); end
+
+  sig do
+    params(
+        blk: T.proc.params(name: String, value: String).returns(BasicObject),
+    )
+    .returns(T.nilable(Sorbet::Private::Static::ENVClass))
+  end
+  sig {returns(T::Enumerator[Elem])}
+  def select!(&blk); end
 
   sig do
     params(


### PR DESCRIPTION
Fixes https://github.com/sorbet/sorbet/issues/2547

These signatures were previously incorrect as they were returning Arrays, instead of hashes.

I based these off of the existing `reject` and `reject!` signatures respectively. 

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation

Increases the accuracy of sorbet type signatures.

### Test plan

I couldn't find any for ENV specifically, though I be happy to add some!


![image](https://user-images.githubusercontent.com/1909544/76169844-b6c81580-6152-11ea-80b3-e259889a9f3b.png)

