### PR TITLE
VS Code: restrict format-on-save to C++.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,4 @@
 {
-  // Runs clang-format when you save (provided by vscode-clangd).
-  "editor.formatOnSave": true,
   "editor.insertSpaces": true,
   "editor.rulers": [120],
   // Clangd 9.0 has a new semantic highlighting feature, but it's buggy and causes
@@ -17,6 +15,9 @@
     "*.rbedited": "ruby"
   },
   "[cpp]": {
+    // Runs clang-format when you save (provided by vscode-clangd).
+    // We do not enable this globally as our RBIs and Markdown don't conform to a specific style.
+    "editor.formatOnSave": true,
     "editor.tabSize": 4,
     "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
   },


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

VS Code: restrict format-on-save to C++.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Our RBI and Markdown files don't conform to Rubocop/Prettier conventions. Disabling this option reduces the chance of new contributors hitting a rough edge where VS Code creates a huge diff.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

N/A
