### PR TITLE
Delurk `json_types.h` from ~every header file

### DIFF
--- a/main/lsp/BUILD
+++ b/main/lsp/BUILD
@@ -17,6 +17,7 @@ cc_library(
         "watchman/WatchmanProcess.h",
         "NextMethodFinder.h",
         "LocalVarFinder.h",
+        "json_enums.h",
         "LocalVarSaver.h",
         "ShowOperation.h",
         "lsp_messages_gen_helpers.h",

--- a/main/lsp/BUILD
+++ b/main/lsp/BUILD
@@ -12,6 +12,7 @@ cc_library(
         "lsp_messages_gen.cc",
         "lsp_messages_enums_gen.h",
         "lsp_messages_enums_gen.cc",
+        "LSPFileUpdates.h",
         "DefLocSaver.h",
         "watchman/WatchmanProcess.h",
         "NextMethodFinder.h",

--- a/main/lsp/BUILD
+++ b/main/lsp/BUILD
@@ -8,7 +8,10 @@ cc_library(
         "notifications/*.cc",
         "watchman/*.cc",
     ]) + [
+        "lsp_messages_gen.h",
         "lsp_messages_gen.cc",
+        "lsp_messages_enums_gen.h",
+        "lsp_messages_enums_gen.cc",
         "DefLocSaver.h",
         "watchman/WatchmanProcess.h",
         "NextMethodFinder.h",
@@ -30,7 +33,6 @@ cc_library(
         "LSPPreprocessor.h",
         "json_types.h",
         "lsp.h",
-        "lsp_messages_gen.h",
         "wrapper.h",
     ],
     linkstatic = select({
@@ -79,9 +81,13 @@ genrule(
     outs = [
         "lsp_messages_gen.h",
         "lsp_messages_gen.cc",
+        "lsp_messages_enums_gen.h",
+        "lsp_messages_enums_gen.cc",
     ],
-    cmd = "$(location :generate_lsp_messages) $(location lsp_messages_gen.h) $(location lsp_messages_gen.cc) && \
-             $(location //tools:clang-format) -i $(location lsp_messages_gen.h) $(location lsp_messages_gen.cc)",
+    cmd = "$(location :generate_lsp_messages) $(location lsp_messages_gen.h) $(location lsp_messages_gen.cc) \
+             $(location lsp_messages_enums_gen.h) $(location lsp_messages_enums_gen.cc) && \
+             $(location //tools:clang-format) -i $(location lsp_messages_gen.h) $(location lsp_messages_gen.cc) \
+             $(location lsp_messages_enums_gen.h) $(location lsp_messages_enums_gen.cc)",
     tools = [
         ":generate_lsp_messages",
         "//tools:clang-format",

--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -2,6 +2,7 @@
 #include "absl/strings/match.h"
 #include "absl/strings/str_replace.h"
 #include "common/FileOps.h"
+#include "main/lsp/json_types.h"
 
 using namespace std;
 

--- a/main/lsp/LSPConfiguration.h
+++ b/main/lsp/LSPConfiguration.h
@@ -1,12 +1,16 @@
 #ifndef RUBY_TYPER_LSPCONFIGURATION_H
 #define RUBY_TYPER_LSPCONFIGURATION_H
 
-#include "main/lsp/json_types.h"
+#include "core/Loc.h"
+#include "main/lsp/json_enums.h"
 #include "main/options/options.h"
 
 namespace sorbet::realmain::lsp {
 
 class LSPOutput;
+class InitializeParams;
+class Position;
+class Location;
 
 /**
  * Client options sent during initialization.

--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -1,0 +1,52 @@
+#include "main/lsp/LSPFileUpdates.h"
+#include "core/core.h"
+
+using namespace std;
+
+namespace sorbet::realmain::lsp {
+void LSPFileUpdates::mergeOlder(const LSPFileUpdates &older) {
+    editCount += older.editCount;
+    committedEditCount += older.committedEditCount;
+    hasNewFiles = hasNewFiles || older.hasNewFiles;
+    cancellationExpected = cancellationExpected || older.cancellationExpected;
+    preemptionsExpected += older.preemptionsExpected;
+
+    ENFORCE(updatedFiles.size() == updatedFileIndexes.size());
+    ENFORCE(older.updatedFiles.size() == older.updatedFileIndexes.size());
+
+    // For updates, we prioritize _newer_ updates.
+    UnorderedSet<string> encountered;
+    for (auto &f : updatedFiles) {
+        encountered.emplace(f->path());
+    }
+
+    int i = -1;
+    for (auto &f : older.updatedFiles) {
+        i++;
+        if (encountered.contains(f->path())) {
+            continue;
+        }
+        encountered.emplace(f->path());
+        updatedFiles.push_back(f);
+        auto &ast = older.updatedFileIndexes[i];
+        updatedFileIndexes.push_back(ast::ParsedFile{ast.tree->deepCopy(), ast.file});
+    }
+    canTakeFastPath = false;
+}
+
+LSPFileUpdates LSPFileUpdates::copy() const {
+    LSPFileUpdates copy;
+    copy.epoch = epoch;
+    copy.editCount = editCount;
+    copy.committedEditCount = committedEditCount;
+    copy.canTakeFastPath = canTakeFastPath;
+    copy.hasNewFiles = hasNewFiles;
+    copy.updatedFiles = updatedFiles;
+    copy.cancellationExpected = cancellationExpected;
+    copy.preemptionsExpected = preemptionsExpected;
+    for (auto &ast : updatedFileIndexes) {
+        copy.updatedFileIndexes.push_back(ast::ParsedFile{ast.tree->deepCopy(), ast.file});
+    }
+    return copy;
+}
+} // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPFileUpdates.h
+++ b/main/lsp/LSPFileUpdates.h
@@ -1,0 +1,54 @@
+#ifndef RUBY_TYPER_LSP_LSPFILEUPDATES_H
+#define RUBY_TYPER_LSP_LSPFILEUPDATES_H
+
+#include "ast/ast.h"
+#include "common/common.h"
+
+namespace sorbet::realmain::lsp {
+/**
+ * Encapsulates an update to LSP's file state in a compact form.
+ * Placed into json_types.h because it is referenced from InitializedParams.
+ */
+class LSPFileUpdates final {
+public:
+    // This specific update contains edits with the given epoch
+    u4 epoch = 0;
+    // The total number of edits that this update represents. Used for stats and assertions.
+    u4 editCount = 0;
+    // The total number of edits in this update that are already committed & had diagnostics sent out (via preemption).
+    // Used for stats and assertions.
+    u4 committedEditCount = 0;
+
+    std::vector<std::shared_ptr<core::File>> updatedFiles;
+    std::vector<ast::ParsedFile> updatedFileIndexes;
+
+    bool canTakeFastPath = false;
+    // Indicates that this update contains a new file. Is a hack for determining if combining two updates can take the
+    // fast path.
+    bool hasNewFiles = false;
+    // If true, this update caused a slow path to be canceled.
+    bool canceledSlowPath = false;
+    // Updated on typechecking thread. Contains indexes processed with typechecking global state.
+    std::vector<ast::ParsedFile> updatedFinalGSFileIndexes;
+    // (Optional) Updated global state object to use to typecheck this update.
+    std::optional<std::unique_ptr<core::GlobalState>> updatedGS;
+    // (Used in tests) Ensures that a slow path typecheck on these updates waits until it gets cancelled.
+    bool cancellationExpected = false;
+    // (Used in tests) Ensures that a slow path typecheck waits until this number of preemption occurs before finishing.
+    int preemptionsExpected = 0;
+
+    /**
+     * Merges the given (and older) LSPFileUpdates object into this LSPFileUpdates object.
+     *
+     * Resets `fastPathDecision`.
+     */
+    void mergeOlder(const LSPFileUpdates &older);
+
+    /**
+     * Returns a copy of this LSPFileUpdates object. Does not handle deepCopying `updatedGS`.
+     */
+    LSPFileUpdates copy() const;
+};
+} // namespace sorbet::realmain::lsp
+
+#endif

--- a/main/lsp/LSPFileUpdates.h
+++ b/main/lsp/LSPFileUpdates.h
@@ -7,7 +7,6 @@
 namespace sorbet::realmain::lsp {
 /**
  * Encapsulates an update to LSP's file state in a compact form.
- * Placed into json_types.h because it is referenced from InitializedParams.
  */
 class LSPFileUpdates final {
 public:

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -5,6 +5,7 @@
 #include "core/lsp/TypecheckEpochManager.h"
 #include "main/lsp/LSPConfiguration.h"
 #include "main/lsp/ShowOperation.h"
+#include "main/lsp/json_types.h"
 #include "main/pipeline/pipeline.h"
 
 using namespace std;

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -1,11 +1,14 @@
 #ifndef RUBY_TYPER_LSP_LSPINDEXER_H
 #define RUBY_TYPER_LSP_LSPINDEXER_H
 
-#include "common/concurrency/WorkerPool.h"
-#include "common/kvstore/KeyValueStore.h"
-#include "core/NameHash.h"
 #include "core/core.h"
+#include "main/lsp/LSPFileUpdates.h"
 #include "main/lsp/LSPMessage.h"
+
+namespace sorbet {
+class WorkerPool;
+class KeyValueStore;
+} // namespace sorbet
 
 namespace sorbet::realmain::lsp {
 

--- a/main/lsp/LSPMessage.cc
+++ b/main/lsp/LSPMessage.cc
@@ -1,4 +1,5 @@
 #include "LSPMessage.h"
+#include "json_types.h"
 
 using namespace std;
 
@@ -125,6 +126,8 @@ LSPMessage::LSPMessage(RawLSPMessage msg) : msg(move(msg)) {}
 LSPMessage::LSPMessage(rapidjson::Document &d) : LSPMessage::LSPMessage(fromJSONValue(d)) {}
 
 LSPMessage::LSPMessage(const std::string &json) : LSPMessage::LSPMessage(fromJSON(json)) {}
+
+LSPMessage::~LSPMessage() = default;
 
 optional<MessageId> LSPMessage::id() const {
     if (isRequest()) {

--- a/main/lsp/LSPMessage.h
+++ b/main/lsp/LSPMessage.h
@@ -2,10 +2,15 @@
 #define RUBY_TYPER_LSP_LSPMESSAGE_H
 
 #include "common/Timer.h"
-#include "main/lsp/json_types.h"
+#include "main/lsp/json_enums.h"
+#include "rapidjson/document.h"
 #include <variant>
 
 namespace sorbet::realmain::lsp {
+
+class RequestMessage;
+class ResponseMessage;
+class NotificationMessage;
 
 /**
  * Represents the ID on an LSP message.
@@ -52,6 +57,7 @@ public:
     LSPMessage(RawLSPMessage msg);
     LSPMessage(rapidjson::Document &d);
     LSPMessage(const std::string &json);
+    ~LSPMessage();
 
     /**
      * Tracks the latency of this specific message.

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -2,7 +2,7 @@
 #include "absl/strings/match.h"
 #include "absl/strings/str_replace.h"
 #include "main/lsp/LSPOutput.h"
-#include "main/lsp/lsp.h"
+#include "main/lsp/json_types.h"
 #include "main/lsp/notifications/notifications.h"
 #include "main/lsp/requests/requests.h"
 

--- a/main/lsp/LSPPreprocessor.h
+++ b/main/lsp/LSPPreprocessor.h
@@ -8,6 +8,12 @@
 namespace sorbet::realmain::lsp {
 
 class LSPTask;
+class SorbetWorkspaceEditParams;
+class DidChangeTextDocumentParams;
+class DidCloseTextDocumentParams;
+class DidOpenTextDocumentParams;
+class WatchmanQueryResponse;
+class CancelParams;
 
 struct MessageQueueState {
     std::deque<std::unique_ptr<LSPMessage>> pendingRequests;

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -1,6 +1,8 @@
 #include "main/lsp/LSPTask.h"
 #include "absl/synchronization/notification.h"
 #include "common/sort.h"
+#include "core/NameHash.h"
+#include "core/lsp/QueryResponse.h"
 #include "main/lsp/LSPOutput.h"
 #include "main/lsp/lsp.h"
 

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -4,6 +4,7 @@
 #include "core/NameHash.h"
 #include "core/lsp/QueryResponse.h"
 #include "main/lsp/LSPOutput.h"
+#include "main/lsp/json_types.h"
 #include "main/lsp/lsp.h"
 
 namespace sorbet::realmain::lsp {

--- a/main/lsp/LSPTask.h
+++ b/main/lsp/LSPTask.h
@@ -11,6 +11,7 @@ class Notification;
 namespace sorbet::realmain::lsp {
 class LSPIndexer;
 class LSPPreprocessor;
+class DocumentHighlight;
 /**
  * A work unit that needs to execute on the typechecker thread. Subclasses implement `run`.
  * Contains miscellaneous helper methods that are useful in multiple tasks.

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -4,6 +4,7 @@
 #include "ast/treemap/treemap.h"
 #include "common/sort.h"
 #include "common/typecase.h"
+#include "core/ErrorQueue.h"
 #include "core/Unfreeze.h"
 #include "core/lsp/PreemptionTaskManager.h"
 #include "core/lsp/TypecheckEpochManager.h"

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -15,6 +15,7 @@
 #include "main/lsp/LocalVarSaver.h"
 #include "main/lsp/ShowOperation.h"
 #include "main/lsp/UndoState.h"
+#include "main/lsp/json_types.h"
 #include "main/pipeline/pipeline.h"
 
 namespace sorbet::realmain::lsp {

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -2,16 +2,19 @@
 #define RUBY_TYPER_LSP_LSPTYPECHECKER_H
 
 #include "ast/ast.h"
-#include "common/concurrency/WorkerPool.h"
-#include "common/kvstore/KeyValueStore.h"
-#include "core/ErrorQueue.h"
-#include "core/NameHash.h"
 #include "core/core.h"
 #include "main/lsp/LSPConfiguration.h"
+#include "main/lsp/LSPFileUpdates.h"
+
+namespace sorbet {
+class WorkerPool;
+class KeyValueStore;
+} // namespace sorbet
 
 namespace sorbet::core::lsp {
 class PreemptionTaskManager;
-}
+class QueryResponse;
+} // namespace sorbet::core::lsp
 
 namespace sorbet::realmain::lsp {
 

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -17,6 +17,7 @@ class QueryResponse;
 } // namespace sorbet::core::lsp
 
 namespace sorbet::realmain::lsp {
+class ResponseError;
 
 struct LSPQueryResult {
     std::vector<std::unique_ptr<core::lsp::QueryResponse>> responses;

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -22,7 +22,7 @@ class ResponseError;
 struct LSPQueryResult {
     std::vector<std::unique_ptr<core::lsp::QueryResponse>> responses;
     // (Optional) Error that occurred during the query that you can pass on to the client.
-    std::unique_ptr<ResponseError> error = nullptr;
+    std::unique_ptr<ResponseError> error;
 };
 
 class TypecheckRun final {

--- a/main/lsp/LSPTypecheckerCoordinator.cc
+++ b/main/lsp/LSPTypecheckerCoordinator.cc
@@ -1,5 +1,6 @@
 #include "main/lsp/LSPTypecheckerCoordinator.h"
 #include "absl/synchronization/notification.h"
+#include "common/concurrency/WorkerPool.h"
 #include "core/lsp/PreemptionTaskManager.h"
 #include "core/lsp/Task.h"
 #include "core/lsp/TypecheckEpochManager.h"

--- a/main/lsp/LSPTypecheckerCoordinator.h
+++ b/main/lsp/LSPTypecheckerCoordinator.h
@@ -1,6 +1,7 @@
 #ifndef RUBY_TYPER_LSP_LSPTYPECHECKERCOORDINATOR_H
 #define RUBY_TYPER_LSP_LSPTYPECHECKERCOORDINATOR_H
 
+#include "common/concurrency/ConcurrentQueue.h"
 #include "main/lsp/LSPTypechecker.h"
 
 namespace sorbet::core::lsp {

--- a/main/lsp/ShowOperation.cc
+++ b/main/lsp/ShowOperation.cc
@@ -2,16 +2,19 @@
 #include "main/lsp/LSPConfiguration.h"
 #include "main/lsp/LSPMessage.h"
 #include "main/lsp/LSPOutput.h"
+#include "main/lsp/json_types.h"
 
 namespace sorbet::realmain::lsp {
 using namespace std;
 
+namespace {
 unique_ptr<LSPMessage> makeShowOperation(std::string operationName, std::string description,
                                          SorbetOperationStatus status) {
     return make_unique<LSPMessage>(make_unique<NotificationMessage>(
         "2.0", LSPMethod::SorbetShowOperation,
         make_unique<SorbetShowOperationParams>(move(operationName), move(description), status)));
 }
+} // namespace
 
 ShowOperation::ShowOperation(const LSPConfiguration &config, std::string operationName, std::string description)
     : config(config), operationName(move(operationName)), description(move(description)) {

--- a/main/lsp/UndoState.cc
+++ b/main/lsp/UndoState.cc
@@ -3,6 +3,7 @@
 #include "main/lsp/LSPConfiguration.h"
 #include "main/lsp/LSPMessage.h"
 #include "main/lsp/LSPOutput.h"
+#include "main/lsp/json_types.h"
 
 using namespace std;
 

--- a/main/lsp/json_enums.h
+++ b/main/lsp/json_enums.h
@@ -1,0 +1,10 @@
+#ifndef RUBY_TYPER_LSP_JSON_ENUMS_H
+#define RUBY_TYPER_LSP_JSON_ENUMS_H
+
+#include <string>
+
+namespace sorbet::realmain::lsp {
+#include "main/lsp/lsp_messages_enums_gen.h"
+}
+
+#endif

--- a/main/lsp/json_enums.h
+++ b/main/lsp/json_enums.h
@@ -4,7 +4,26 @@
 #include <string>
 
 namespace sorbet::realmain::lsp {
+enum class LSPErrorCodes {
+    // Defined by JSON RPC
+    ParseError = -32700,
+    InvalidRequest = -32600,
+    MethodNotFound = -32601,
+    InvalidParams = -32602, // todo
+    InternalError = -32603,
+    ServerErrorStart = -32099,
+    ServerErrorEnd = -32000,
+    ServerNotInitialized = -32002,
+    UnknownErrorCode = -32001,
+
+    // Defined by the LSP
+    RequestCancelled = -32800,
+};
+
+// Is not an enum, but is as simple as one. Putting it here reduces dependencies on json_types.h.
+class JSONNullObject final {};
+
 #include "main/lsp/lsp_messages_enums_gen.h"
-}
+} // namespace sorbet::realmain::lsp
 
 #endif

--- a/main/lsp/json_types.cc
+++ b/main/lsp/json_types.cc
@@ -202,52 +202,6 @@ string DidChangeTextDocumentParams::getSource(string_view oldFileContents) const
     return rv;
 }
 
-void LSPFileUpdates::mergeOlder(const LSPFileUpdates &older) {
-    editCount += older.editCount;
-    committedEditCount += older.committedEditCount;
-    hasNewFiles = hasNewFiles || older.hasNewFiles;
-    cancellationExpected = cancellationExpected || older.cancellationExpected;
-    preemptionsExpected += older.preemptionsExpected;
-
-    ENFORCE(updatedFiles.size() == updatedFileIndexes.size());
-    ENFORCE(older.updatedFiles.size() == older.updatedFileIndexes.size());
-
-    // For updates, we prioritize _newer_ updates.
-    UnorderedSet<string> encountered;
-    for (auto &f : updatedFiles) {
-        encountered.emplace(f->path());
-    }
-
-    int i = -1;
-    for (auto &f : older.updatedFiles) {
-        i++;
-        if (encountered.contains(f->path())) {
-            continue;
-        }
-        encountered.emplace(f->path());
-        updatedFiles.push_back(f);
-        auto &ast = older.updatedFileIndexes[i];
-        updatedFileIndexes.push_back(ast::ParsedFile{ast.tree->deepCopy(), ast.file});
-    }
-    canTakeFastPath = false;
-}
-
-LSPFileUpdates LSPFileUpdates::copy() const {
-    LSPFileUpdates copy;
-    copy.epoch = epoch;
-    copy.editCount = editCount;
-    copy.committedEditCount = committedEditCount;
-    copy.canTakeFastPath = canTakeFastPath;
-    copy.hasNewFiles = hasNewFiles;
-    copy.updatedFiles = updatedFiles;
-    copy.cancellationExpected = cancellationExpected;
-    copy.preemptionsExpected = preemptionsExpected;
-    for (auto &ast : updatedFileIndexes) {
-        copy.updatedFileIndexes.push_back(ast::ParsedFile{ast.tree->deepCopy(), ast.file});
-    }
-    return copy;
-}
-
 void SorbetWorkspaceEditParams::merge(SorbetWorkspaceEditParams &newerParams) {
     // 'newerParams' has newer updates, so merge its contents into this object.
     epoch = newerParams.epoch;

--- a/main/lsp/json_types.h
+++ b/main/lsp/json_types.h
@@ -11,21 +11,6 @@
 #include <variant>
 
 namespace sorbet::realmain::lsp {
-enum class LSPErrorCodes {
-    // Defined by JSON RPC
-    ParseError = -32700,
-    InvalidRequest = -32600,
-    MethodNotFound = -32601,
-    InvalidParams = -32602, // todo
-    InternalError = -32603,
-    ServerErrorStart = -32099,
-    ServerErrorEnd = -32000,
-    ServerNotInitialized = -32002,
-    UnknownErrorCode = -32001,
-
-    // Defined by the LSP
-    RequestCancelled = -32800,
-};
 
 class DeserializationError : public std::runtime_error {
 public:
@@ -101,8 +86,6 @@ public:
     InvalidTypeError(std::string_view fieldName, std::string_view expectedType,
                      const std::unique_ptr<rapidjson::Value> &found);
 };
-
-class JSONNullObject final {};
 
 class JSONBaseType {
 public:

--- a/main/lsp/json_types.h
+++ b/main/lsp/json_types.h
@@ -4,6 +4,7 @@
 #include "common/Timer.h"
 #include "common/common.h"
 #include "core/core.h"
+#include "main/lsp/json_enums.h"
 #include "rapidjson/document.h"
 
 #include <optional>

--- a/main/lsp/json_types.h
+++ b/main/lsp/json_types.h
@@ -1,10 +1,8 @@
 #ifndef RUBY_TYPER_LSP_JSON_TYPES_H
 #define RUBY_TYPER_LSP_JSON_TYPES_H
 
-#include "ast/ast.h"
 #include "common/Timer.h"
 #include "common/common.h"
-#include "core/NameHash.h"
 #include "core/core.h"
 #include "rapidjson/document.h"
 
@@ -12,51 +10,6 @@
 #include <variant>
 
 namespace sorbet::realmain::lsp {
-/**
- * Encapsulates an update to LSP's file state in a compact form.
- * Placed into json_types.h because it is referenced from InitializedParams.
- */
-class LSPFileUpdates final {
-public:
-    // This specific update contains edits with the given epoch
-    u4 epoch = 0;
-    // The total number of edits that this update represents. Used for stats and assertions.
-    u4 editCount = 0;
-    // The total number of edits in this update that are already committed & had diagnostics sent out (via preemption).
-    // Used for stats and assertions.
-    u4 committedEditCount = 0;
-
-    std::vector<std::shared_ptr<core::File>> updatedFiles;
-    std::vector<ast::ParsedFile> updatedFileIndexes;
-
-    bool canTakeFastPath = false;
-    // Indicates that this update contains a new file. Is a hack for determining if combining two updates can take the
-    // fast path.
-    bool hasNewFiles = false;
-    // If true, this update caused a slow path to be canceled.
-    bool canceledSlowPath = false;
-    // Updated on typechecking thread. Contains indexes processed with typechecking global state.
-    std::vector<ast::ParsedFile> updatedFinalGSFileIndexes;
-    // (Optional) Updated global state object to use to typecheck this update.
-    std::optional<std::unique_ptr<core::GlobalState>> updatedGS;
-    // (Used in tests) Ensures that a slow path typecheck on these updates waits until it gets cancelled.
-    bool cancellationExpected = false;
-    // (Used in tests) Ensures that a slow path typecheck waits until this number of preemption occurs before finishing.
-    int preemptionsExpected = 0;
-
-    /**
-     * Merges the given (and older) LSPFileUpdates object into this LSPFileUpdates object.
-     *
-     * Resets `fastPathDecision`.
-     */
-    void mergeOlder(const LSPFileUpdates &older);
-
-    /**
-     * Returns a copy of this LSPFileUpdates object. Does not handle deepCopying `updatedGS`.
-     */
-    LSPFileUpdates copy() const;
-};
-
 enum class LSPErrorCodes {
     // Defined by JSON RPC
     ParseError = -32700,

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -1,5 +1,6 @@
 #include "main/lsp/lsp.h"
 #include "common/Timer.h"
+#include "common/concurrency/WorkerPool.h"
 #include "common/statsd/statsd.h"
 #include "common/typecase.h"
 #include "common/web_tracer_framework/tracing.h"

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -19,6 +19,7 @@
 // This is an implementation of LSP protocol (version 3.13) for Sorbet
 namespace sorbet::realmain::lsp {
 
+class MarkupContent;
 class LSPInput;
 class LSPConfiguration;
 class LSPQueuePreemptionTask;

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -5,6 +5,7 @@
 #include "common/FileOps.h"
 #include "common/sort.h"
 #include "lsp.h"
+#include "main/lsp/json_types.h"
 
 using namespace std;
 

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -4,8 +4,8 @@
 #include "absl/strings/str_split.h"
 #include "common/FileOps.h"
 #include "common/sort.h"
-#include "lsp.h"
 #include "main/lsp/json_types.h"
+#include "main/lsp/lsp.h"
 
 using namespace std;
 

--- a/main/lsp/lsp_messages_gen_helpers.cc
+++ b/main/lsp/lsp_messages_gen_helpers.cc
@@ -1,4 +1,5 @@
 #include "main/lsp/lsp_messages_gen_helpers.h"
+#include "main/lsp/json_types.h"
 
 using namespace std;
 

--- a/main/lsp/lsp_messages_gen_helpers.h
+++ b/main/lsp/lsp_messages_gen_helpers.h
@@ -1,7 +1,9 @@
 #ifndef LSP_MESSAGES_GEN_HELPERS_H
 #define LSP_MESSAGES_GEN_HELPERS_H
 
-#include "main/lsp/json_types.h"
+#include "common/common.h"
+#include "main/lsp/json_enums.h"
+#include "rapidjson/document.h"
 
 namespace sorbet::realmain::lsp {
 

--- a/main/lsp/notifications/cancel_request.cc
+++ b/main/lsp/notifications/cancel_request.cc
@@ -1,5 +1,6 @@
 #include "main/lsp/notifications/cancel_request.h"
 #include "main/lsp/LSPPreprocessor.h"
+#include "main/lsp/json_types.h"
 
 using namespace std;
 namespace sorbet::realmain::lsp {

--- a/main/lsp/notifications/cancel_request.h
+++ b/main/lsp/notifications/cancel_request.h
@@ -4,6 +4,7 @@
 #include "main/lsp/LSPTask.h"
 
 namespace sorbet::realmain::lsp {
+class CancelParams;
 class CancelRequestTask final : public LSPTask {
     const std::unique_ptr<CancelParams> params;
 

--- a/main/lsp/notifications/initialized.h
+++ b/main/lsp/notifications/initialized.h
@@ -2,6 +2,7 @@
 #define RUBY_TYPER_LSP_NOTIFICATIONS_INITIALIZED_H
 
 #include "absl/synchronization/notification.h"
+#include "main/lsp/LSPFileUpdates.h"
 #include "main/lsp/LSPTask.h"
 
 namespace sorbet::realmain::lsp {

--- a/main/lsp/notifications/sorbet_fence.cc
+++ b/main/lsp/notifications/sorbet_fence.cc
@@ -1,5 +1,6 @@
 #include "main/lsp/notifications/sorbet_fence.h"
 #include "main/lsp/LSPOutput.h"
+#include "main/lsp/json_types.h"
 
 using namespace std;
 

--- a/main/lsp/notifications/sorbet_workspace_edit.cc
+++ b/main/lsp/notifications/sorbet_workspace_edit.cc
@@ -2,6 +2,7 @@
 #include "core/lsp/TypecheckEpochManager.h"
 #include "main/lsp/LSPFileUpdates.h"
 #include "main/lsp/LSPIndexer.h"
+#include "main/lsp/json_types.h"
 
 using namespace std;
 
@@ -14,6 +15,8 @@ SorbetWorkspaceEditTask::SorbetWorkspaceEditTask(const LSPConfiguration &config,
         latencyCancelSlowPath->cancel();
     }
 };
+
+SorbetWorkspaceEditTask::~SorbetWorkspaceEditTask() = default;
 
 LSPTask::Phase SorbetWorkspaceEditTask::finalPhase() const {
     if (params->updates.empty()) {

--- a/main/lsp/notifications/sorbet_workspace_edit.cc
+++ b/main/lsp/notifications/sorbet_workspace_edit.cc
@@ -1,5 +1,6 @@
 #include "main/lsp/notifications/sorbet_workspace_edit.h"
 #include "core/lsp/TypecheckEpochManager.h"
+#include "main/lsp/LSPFileUpdates.h"
 #include "main/lsp/LSPIndexer.h"
 
 using namespace std;

--- a/main/lsp/notifications/sorbet_workspace_edit.h
+++ b/main/lsp/notifications/sorbet_workspace_edit.h
@@ -6,6 +6,7 @@
 
 namespace sorbet::realmain::lsp {
 class LSPFileUpdates;
+class SorbetWorkspaceEditParams;
 class SorbetWorkspaceEditTask final : public LSPDangerousTypecheckerTask {
     std::unique_ptr<LSPFileUpdates> updates;
     absl::Notification startedNotification;
@@ -17,6 +18,7 @@ class SorbetWorkspaceEditTask final : public LSPDangerousTypecheckerTask {
 
 public:
     SorbetWorkspaceEditTask(const LSPConfiguration &config, std::unique_ptr<SorbetWorkspaceEditParams> params);
+    ~SorbetWorkspaceEditTask();
 
     LSPTask::Phase finalPhase() const override;
 

--- a/main/lsp/notifications/sorbet_workspace_edit.h
+++ b/main/lsp/notifications/sorbet_workspace_edit.h
@@ -5,6 +5,7 @@
 #include "main/lsp/LSPTask.h"
 
 namespace sorbet::realmain::lsp {
+class LSPFileUpdates;
 class SorbetWorkspaceEditTask final : public LSPDangerousTypecheckerTask {
     std::unique_ptr<LSPFileUpdates> updates;
     absl::Notification startedNotification;

--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -12,6 +12,7 @@
 #include <iostream>
 
 using namespace std;
+namespace spd = spdlog;
 
 namespace sorbet::realmain::lsp {
 

--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -3,13 +3,13 @@
 #include "common/Timer.h"
 #include "common/web_tracer_framework/tracing.h"
 #include "core/lsp/TypecheckEpochManager.h"
-#include "lsp.h"
 #include "main/lsp/LSPInput.h"
 #include "main/lsp/LSPPreprocessor.h"
 #include "main/lsp/LSPTask.h"
+#include "main/lsp/json_types.h"
+#include "main/lsp/lsp.h"
 #include "main/lsp/watchman/WatchmanProcess.h"
 #include "main/options/options.h" // For EarlyReturnWithCode.
-#include <iostream>
 
 using namespace std;
 namespace spd = spdlog;

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -1,6 +1,7 @@
 #include "main/lsp/requests/code_action.h"
 #include "common/sort.h"
 #include "core/lsp/QueryResponse.h"
+#include "main/lsp/json_types.h"
 #include "main/lsp/lsp.h"
 
 using namespace std;

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -2,7 +2,6 @@
 #include "common/sort.h"
 #include "core/lsp/QueryResponse.h"
 #include "main/lsp/json_types.h"
-#include "main/lsp/lsp.h"
 
 using namespace std;
 

--- a/main/lsp/requests/code_action.h
+++ b/main/lsp/requests/code_action.h
@@ -4,6 +4,7 @@
 #include "main/lsp/LSPTask.h"
 
 namespace sorbet::realmain::lsp {
+class CodeActionParams;
 class CodeActionTask final : public LSPRequestTask {
     std::unique_ptr<CodeActionParams> params;
 

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -10,6 +10,7 @@
 #include "core/lsp/QueryResponse.h"
 #include "main/lsp/LocalVarFinder.h"
 #include "main/lsp/NextMethodFinder.h"
+#include "main/lsp/json_types.h"
 #include "main/lsp/lsp.h"
 
 using namespace std;

--- a/main/lsp/requests/completion.h
+++ b/main/lsp/requests/completion.h
@@ -5,6 +5,8 @@
 #include "main/lsp/LSPTask.h"
 
 namespace sorbet::realmain::lsp {
+class CompletionParams;
+class CompletionItem;
 class CompletionTask final : public LSPRequestTask {
     std::unique_ptr<CompletionParams> params;
 

--- a/main/lsp/requests/completion.h
+++ b/main/lsp/requests/completion.h
@@ -1,6 +1,7 @@
 #ifndef RUBY_TYPER_LSP_REQUESTS_COMPLETION_H
 #define RUBY_TYPER_LSP_REQUESTS_COMPLETION_H
 
+#include "core/lsp/QueryResponse.h"
 #include "main/lsp/LSPTask.h"
 
 namespace sorbet::realmain::lsp {

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -1,7 +1,6 @@
 #include "main/lsp/requests/definition.h"
 #include "core/lsp/QueryResponse.h"
 #include "main/lsp/json_types.h"
-#include "main/lsp/lsp.h"
 
 using namespace std;
 

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -1,5 +1,6 @@
 #include "main/lsp/requests/definition.h"
 #include "core/lsp/QueryResponse.h"
+#include "main/lsp/json_types.h"
 #include "main/lsp/lsp.h"
 
 using namespace std;

--- a/main/lsp/requests/definition.h
+++ b/main/lsp/requests/definition.h
@@ -4,6 +4,7 @@
 #include "main/lsp/LSPTask.h"
 
 namespace sorbet::realmain::lsp {
+class TextDocumentPositionParams;
 class DefinitionTask final : public LSPRequestTask {
     std::unique_ptr<TextDocumentPositionParams> params;
 

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -1,6 +1,7 @@
 #include "main/lsp/requests/document_highlight.h"
 #include "absl/strings/match.h"
 #include "core/lsp/QueryResponse.h"
+#include "main/lsp/json_types.h"
 #include "main/lsp/lsp.h"
 
 using namespace std;

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -2,7 +2,6 @@
 #include "absl/strings/match.h"
 #include "core/lsp/QueryResponse.h"
 #include "main/lsp/json_types.h"
-#include "main/lsp/lsp.h"
 
 using namespace std;
 

--- a/main/lsp/requests/document_highlight.h
+++ b/main/lsp/requests/document_highlight.h
@@ -4,6 +4,7 @@
 #include "main/lsp/LSPTask.h"
 
 namespace sorbet::realmain::lsp {
+class TextDocumentPositionParams;
 class DocumentHighlightTask final : public LSPRequestTask {
     std::unique_ptr<TextDocumentPositionParams> params;
 

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -1,5 +1,6 @@
 #include "main/lsp/requests/document_symbol.h"
 #include "core/lsp/QueryResponse.h"
+#include "main/lsp/json_types.h"
 #include "main/lsp/lsp.h"
 
 using namespace std;

--- a/main/lsp/requests/document_symbol.h
+++ b/main/lsp/requests/document_symbol.h
@@ -4,6 +4,7 @@
 #include "main/lsp/LSPTask.h"
 
 namespace sorbet::realmain::lsp {
+class DocumentSymbolParams;
 class DocumentSymbolTask final : public LSPRequestTask {
     std::unique_ptr<DocumentSymbolParams> params;
 

--- a/main/lsp/requests/get_counters.cc
+++ b/main/lsp/requests/get_counters.cc
@@ -1,7 +1,6 @@
 #include "main/lsp/requests/get_counters.h"
 #include "main/lsp/LSPOutput.h"
 #include "main/lsp/json_types.h"
-#include "main/lsp/lsp.h"
 
 using namespace std;
 

--- a/main/lsp/requests/get_counters.cc
+++ b/main/lsp/requests/get_counters.cc
@@ -1,5 +1,6 @@
 #include "main/lsp/requests/get_counters.h"
 #include "main/lsp/LSPOutput.h"
+#include "main/lsp/json_types.h"
 #include "main/lsp/lsp.h"
 
 using namespace std;

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -1,6 +1,7 @@
 #include "main/lsp/requests/hover.h"
 #include "absl/strings/ascii.h"
 #include "core/lsp/QueryResponse.h"
+#include "main/lsp/json_types.h"
 #include "main/lsp/lsp.h"
 
 using namespace std;

--- a/main/lsp/requests/hover.h
+++ b/main/lsp/requests/hover.h
@@ -4,6 +4,7 @@
 #include "main/lsp/LSPTask.h"
 
 namespace sorbet::realmain::lsp {
+class TextDocumentPositionParams;
 class HoverTask final : public LSPRequestTask {
     std::unique_ptr<TextDocumentPositionParams> params;
 

--- a/main/lsp/requests/initialize.cc
+++ b/main/lsp/requests/initialize.cc
@@ -1,4 +1,5 @@
 #include "main/lsp/requests/initialize.h"
+#include "main/lsp/json_types.h"
 
 using namespace std;
 

--- a/main/lsp/requests/initialize.h
+++ b/main/lsp/requests/initialize.h
@@ -4,6 +4,7 @@
 #include "main/lsp/LSPTask.h"
 
 namespace sorbet::realmain::lsp {
+class InitializeParams;
 class InitializeTask final : public LSPRequestTask {
     LSPConfiguration &mutableConfig;
     std::unique_ptr<InitializeParams> params;

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -2,6 +2,7 @@
 #include "absl/strings/match.h"
 #include "core/lsp/QueryResponse.h"
 #include "main/lsp/ShowOperation.h"
+#include "main/lsp/json_types.h"
 #include "main/lsp/lsp.h"
 
 using namespace std;

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -3,7 +3,6 @@
 #include "core/lsp/QueryResponse.h"
 #include "main/lsp/ShowOperation.h"
 #include "main/lsp/json_types.h"
-#include "main/lsp/lsp.h"
 
 using namespace std;
 

--- a/main/lsp/requests/references.h
+++ b/main/lsp/requests/references.h
@@ -4,6 +4,7 @@
 #include "main/lsp/LSPTask.h"
 
 namespace sorbet::realmain::lsp {
+class ReferenceParams;
 class ReferencesTask final : public LSPRequestTask {
     std::unique_ptr<ReferenceParams> params;
 

--- a/main/lsp/requests/shutdown.cc
+++ b/main/lsp/requests/shutdown.cc
@@ -1,4 +1,5 @@
 #include "main/lsp/requests/shutdown.h"
+#include "main/lsp/json_types.h"
 
 using namespace std;
 

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -1,5 +1,6 @@
 #include "main/lsp/requests/signature_help.h"
 #include "core/lsp/QueryResponse.h"
+#include "main/lsp/json_types.h"
 #include "main/lsp/lsp.h"
 
 using namespace std;

--- a/main/lsp/requests/signature_help.h
+++ b/main/lsp/requests/signature_help.h
@@ -4,6 +4,7 @@
 #include "main/lsp/LSPTask.h"
 
 namespace sorbet::realmain::lsp {
+class TextDocumentPositionParams;
 class SignatureHelpTask final : public LSPRequestTask {
     std::unique_ptr<TextDocumentPositionParams> params;
 

--- a/main/lsp/requests/sorbet_error.cc
+++ b/main/lsp/requests/sorbet_error.cc
@@ -1,5 +1,6 @@
 #include "main/lsp/requests/sorbet_error.h"
 #include "main/lsp/LSPOutput.h"
+#include "main/lsp/json_types.h"
 #include "main/lsp/lsp.h"
 
 using namespace std;

--- a/main/lsp/requests/sorbet_error.cc
+++ b/main/lsp/requests/sorbet_error.cc
@@ -1,7 +1,6 @@
 #include "main/lsp/requests/sorbet_error.h"
 #include "main/lsp/LSPOutput.h"
 #include "main/lsp/json_types.h"
-#include "main/lsp/lsp.h"
 
 using namespace std;
 

--- a/main/lsp/requests/sorbet_error.h
+++ b/main/lsp/requests/sorbet_error.h
@@ -4,6 +4,7 @@
 #include "main/lsp/LSPTask.h"
 
 namespace sorbet::realmain::lsp {
+class SorbetErrorParams;
 class SorbetErrorTask final : public LSPTask {
     std::unique_ptr<SorbetErrorParams> params;
     std::optional<MessageId> id;

--- a/main/lsp/requests/sorbet_read_file.cc
+++ b/main/lsp/requests/sorbet_read_file.cc
@@ -1,4 +1,5 @@
 #include "main/lsp/requests/sorbet_read_file.h"
+#include "main/lsp/json_types.h"
 
 using namespace std;
 

--- a/main/lsp/requests/sorbet_read_file.h
+++ b/main/lsp/requests/sorbet_read_file.h
@@ -4,6 +4,7 @@
 #include "main/lsp/LSPTask.h"
 
 namespace sorbet::realmain::lsp {
+class TextDocumentIdentifier;
 class SorbetReadFileTask final : public LSPRequestTask {
     std::unique_ptr<TextDocumentIdentifier> params;
 

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -1,6 +1,7 @@
 #include "main/lsp/requests/type_definition.h"
 #include "common/typecase.h"
 #include "core/lsp/QueryResponse.h"
+#include "main/lsp/json_types.h"
 #include "main/lsp/lsp.h"
 
 using namespace std;

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -2,7 +2,6 @@
 #include "common/typecase.h"
 #include "core/lsp/QueryResponse.h"
 #include "main/lsp/json_types.h"
-#include "main/lsp/lsp.h"
 
 using namespace std;
 

--- a/main/lsp/requests/type_definition.h
+++ b/main/lsp/requests/type_definition.h
@@ -4,6 +4,7 @@
 #include "main/lsp/LSPTask.h"
 
 namespace sorbet::realmain::lsp {
+class TextDocumentPositionParams;
 class TypeDefinitionTask final : public LSPRequestTask {
     std::unique_ptr<TextDocumentPositionParams> params;
 

--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -2,6 +2,7 @@
 #include "common/sort.h"
 #include "core/lsp/QueryResponse.h"
 #include "main/lsp/ShowOperation.h"
+#include "main/lsp/json_types.h"
 #include "main/lsp/lsp.h"
 #include <algorithm>
 #include <cctype>

--- a/main/lsp/requests/workspace_symbols.h
+++ b/main/lsp/requests/workspace_symbols.h
@@ -4,6 +4,7 @@
 #include "main/lsp/LSPTask.h"
 
 namespace sorbet::realmain::lsp {
+class WorkspaceSymbolParams;
 class WorkspaceSymbolsTask final : public LSPRequestTask {
     std::unique_ptr<WorkspaceSymbolParams> params;
 

--- a/main/lsp/test/lsp_file_updates_test.cc
+++ b/main/lsp/test/lsp_file_updates_test.cc
@@ -4,6 +4,7 @@
 #include "ast/ast.h"
 #include "core/NameHash.h"
 #include "core/core.h"
+#include "main/lsp/LSPFileUpdates.h"
 #include "main/lsp/json_types.h"
 
 namespace sorbet::realmain::lsp::test {

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -1,8 +1,10 @@
 #include "gtest/gtest.h"
 // has to go first as it violates our requirements
 
+#include "common/concurrency/WorkerPool.h"
 #include "common/sort.h"
 #include "core/Error.h"
+#include "core/ErrorQueue.h"
 #include "core/lsp/PreemptionTaskManager.h"
 #include "core/lsp/Task.h"
 #include "core/lsp/TypecheckEpochManager.h"

--- a/main/lsp/tools/generate_lsp_messages.cc
+++ b/main/lsp/tools/generate_lsp_messages.cc
@@ -26,6 +26,7 @@ int main(int argc, char **argv) {
     fmt::memory_buffer enumHeaderBuffer;
     fmt::memory_buffer enumClassFileBuffer;
 
+    fmt::format_to(enumClassFileBuffer, "#include \"main/lsp/json_types.h\"\n");
     fmt::format_to(enumClassFileBuffer, "#include \"main/lsp/lsp_messages_gen_helpers.h\"\n");
     fmt::format_to(enumClassFileBuffer, "namespace sorbet::realmain::lsp {{\n");
 

--- a/main/lsp/tools/generate_lsp_messages.cc
+++ b/main/lsp/tools/generate_lsp_messages.cc
@@ -33,8 +33,6 @@ int main(int argc, char **argv) {
     fmt::format_to(classFileBuffer, "#include \"main/lsp/lsp_messages_gen_helpers.h\"\n");
     fmt::format_to(classFileBuffer, "namespace sorbet::realmain::lsp {{\n");
 
-    fmt::format_to(headerBuffer, "#include \"main/lsp/lsp_messages_enums_gen.h\"\n");
-
     vector<std::shared_ptr<JSONClassType>> enumTypes;
     vector<std::shared_ptr<JSONObjectType>> classTypes;
     makeLSPTypes(enumTypes, classTypes);

--- a/main/lsp/tools/generate_lsp_messages.cc
+++ b/main/lsp/tools/generate_lsp_messages.cc
@@ -5,13 +5,35 @@ using namespace std;
 
 const string JSONArrayType::arrayVar = "a";
 
+bool writeFile(char *path, fmt::memory_buffer &buffer) {
+    ofstream stream(path, ios::trunc);
+    if (!stream.good()) {
+        cerr << "unable to open " << path << '\n';
+        return false;
+    }
+    stream << to_string(buffer);
+    return true;
+}
+
 int main(int argc, char **argv) {
+    if (argc < 5) {
+        cerr << "Error: Expected 4 input files\n";
+        return 1;
+    }
+
     fmt::memory_buffer headerBuffer;
     fmt::memory_buffer classFileBuffer;
+    fmt::memory_buffer enumHeaderBuffer;
+    fmt::memory_buffer enumClassFileBuffer;
+
+    fmt::format_to(enumClassFileBuffer, "#include \"main/lsp/lsp_messages_gen_helpers.h\"\n");
+    fmt::format_to(enumClassFileBuffer, "namespace sorbet::realmain::lsp {{\n");
 
     fmt::format_to(classFileBuffer, "#include \"main/lsp/json_types.h\"\n");
     fmt::format_to(classFileBuffer, "#include \"main/lsp/lsp_messages_gen_helpers.h\"\n");
     fmt::format_to(classFileBuffer, "namespace sorbet::realmain::lsp {{\n");
+
+    fmt::format_to(headerBuffer, "#include \"main/lsp/lsp_messages_enums_gen.h\"\n");
 
     vector<std::shared_ptr<JSONClassType>> enumTypes;
     vector<std::shared_ptr<JSONObjectType>> classTypes;
@@ -19,26 +41,30 @@ int main(int argc, char **argv) {
 
     // Emits enums before class definitions themselves.
     for (auto &enumType : enumTypes) {
-        enumType->emit(headerBuffer, classFileBuffer);
+        enumType->emit(enumHeaderBuffer, enumClassFileBuffer);
     }
     for (auto &classType : classTypes) {
         classType->emit(headerBuffer, classFileBuffer);
     }
     fmt::format_to(classFileBuffer, "}}\n");
+    fmt::format_to(enumClassFileBuffer, "}}\n");
 
     // Output buffers to files.
-    ofstream header(argv[1], ios::trunc);
-    if (!header.good()) {
-        cerr << "unable to open " << argv[1] << '\n';
+    if (!writeFile(argv[1], headerBuffer)) {
         return 1;
     }
-    header << to_string(headerBuffer);
 
-    ofstream classfile(argv[2], ios::trunc);
-    if (!classfile.good()) {
-        cerr << "unable to open " << argv[2] << '\n';
+    if (!writeFile(argv[2], classFileBuffer)) {
         return 1;
     }
-    classfile << to_string(classFileBuffer);
+
+    if (!writeFile(argv[3], enumHeaderBuffer)) {
+        return 1;
+    }
+
+    if (!writeFile(argv[4], enumClassFileBuffer)) {
+        return 1;
+    }
+
     return 0;
 }

--- a/main/lsp/tools/generate_lsp_messages.cc
+++ b/main/lsp/tools/generate_lsp_messages.cc
@@ -21,48 +21,56 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    fmt::memory_buffer headerBuffer;
-    fmt::memory_buffer classFileBuffer;
-    fmt::memory_buffer enumHeaderBuffer;
-    fmt::memory_buffer enumClassFileBuffer;
-
-    fmt::format_to(enumClassFileBuffer, "#include \"main/lsp/json_types.h\"\n");
-    fmt::format_to(enumClassFileBuffer, "#include \"main/lsp/lsp_messages_gen_helpers.h\"\n");
-    fmt::format_to(enumClassFileBuffer, "namespace sorbet::realmain::lsp {{\n");
-
-    fmt::format_to(classFileBuffer, "#include \"main/lsp/json_types.h\"\n");
-    fmt::format_to(classFileBuffer, "#include \"main/lsp/lsp_messages_gen_helpers.h\"\n");
-    fmt::format_to(classFileBuffer, "namespace sorbet::realmain::lsp {{\n");
-
     vector<std::shared_ptr<JSONClassType>> enumTypes;
     vector<std::shared_ptr<JSONObjectType>> classTypes;
     makeLSPTypes(enumTypes, classTypes);
 
-    // Emits enums before class definitions themselves.
-    for (auto &enumType : enumTypes) {
-        enumType->emit(enumHeaderBuffer, enumClassFileBuffer);
-    }
-    for (auto &classType : classTypes) {
-        classType->emit(headerBuffer, classFileBuffer);
-    }
-    fmt::format_to(classFileBuffer, "}}\n");
-    fmt::format_to(enumClassFileBuffer, "}}\n");
+    // Emit enums.
+    {
+        fmt::memory_buffer enumHeaderBuffer;
+        fmt::memory_buffer enumClassFileBuffer;
 
-    // Output buffers to files.
-    if (!writeFile(argv[1], headerBuffer)) {
-        return 1;
+        fmt::format_to(enumClassFileBuffer, "#include \"main/lsp/json_types.h\"\n");
+        fmt::format_to(enumClassFileBuffer, "#include \"main/lsp/lsp_messages_gen_helpers.h\"\n");
+        fmt::format_to(enumClassFileBuffer, "namespace sorbet::realmain::lsp {{\n");
+
+        // Emits enums before class definitions themselves.
+        for (auto &enumType : enumTypes) {
+            enumType->emit(enumHeaderBuffer, enumClassFileBuffer);
+        }
+        fmt::format_to(enumClassFileBuffer, "}}\n");
+
+        if (!writeFile(argv[3], enumHeaderBuffer)) {
+            return 1;
+        }
+
+        if (!writeFile(argv[4], enumClassFileBuffer)) {
+            return 1;
+        }
     }
 
-    if (!writeFile(argv[2], classFileBuffer)) {
-        return 1;
-    }
+    // Emit classes.
+    {
+        fmt::memory_buffer headerBuffer;
+        fmt::memory_buffer classFileBuffer;
 
-    if (!writeFile(argv[3], enumHeaderBuffer)) {
-        return 1;
-    }
+        fmt::format_to(classFileBuffer, "#include \"main/lsp/json_types.h\"\n");
+        fmt::format_to(classFileBuffer, "#include \"main/lsp/lsp_messages_gen_helpers.h\"\n");
+        fmt::format_to(classFileBuffer, "namespace sorbet::realmain::lsp {{\n");
 
-    if (!writeFile(argv[4], enumClassFileBuffer)) {
-        return 1;
+        for (auto &classType : classTypes) {
+            classType->emit(headerBuffer, classFileBuffer);
+        }
+        fmt::format_to(classFileBuffer, "}}\n");
+
+        // Output buffers to files.
+        if (!writeFile(argv[1], headerBuffer)) {
+            return 1;
+        }
+
+        if (!writeFile(argv[2], classFileBuffer)) {
+            return 1;
+        }
     }
 
     return 0;

--- a/main/lsp/watchman/WatchmanProcess.cc
+++ b/main/lsp/watchman/WatchmanProcess.cc
@@ -1,6 +1,7 @@
 #include "WatchmanProcess.h"
 #include "common/FileOps.h"
 #include "common/formatting.h"
+#include "main/lsp/json_types.h"
 #include "rapidjson/document.h"
 #include "subprocess.hpp"
 

--- a/main/lsp/watchman/WatchmanProcess.cc
+++ b/main/lsp/watchman/WatchmanProcess.cc
@@ -1,5 +1,6 @@
 #include "WatchmanProcess.h"
 #include "common/FileOps.h"
+#include "common/common.h"
 #include "common/formatting.h"
 #include "main/lsp/json_types.h"
 #include "rapidjson/document.h"

--- a/main/lsp/watchman/WatchmanProcess.h
+++ b/main/lsp/watchman/WatchmanProcess.h
@@ -4,8 +4,11 @@
 #include "absl/synchronization/mutex.h"
 #include "common/common.h"
 #include "core/core.h"
-#include "main/lsp/json_types.h"
 #include "spdlog/spdlog.h"
+
+namespace sorbet::realmain::lsp {
+class WatchmanQueryResponse;
+}
 
 namespace sorbet::realmain::lsp::watchman {
 class WatchmanProcess {

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -3,6 +3,7 @@
 #include "core/errors/namer.h"
 #include "main/lsp/LSPInput.h"
 #include "main/lsp/LSPOutput.h"
+#include "main/lsp/lsp.h"
 #include "main/pipeline/pipeline.h"
 #include "payload/payload.h"
 #include <memory>

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -3,7 +3,6 @@
 #include "core/errors/namer.h"
 #include "main/lsp/LSPInput.h"
 #include "main/lsp/LSPOutput.h"
-#include "main/lsp/json_types.h"
 #include "main/pipeline/pipeline.h"
 #include "payload/payload.h"
 #include <memory>

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -1,4 +1,5 @@
 #include "main/lsp/wrapper.h"
+#include "core/ErrorQueue.h"
 #include "core/errors/namer.h"
 #include "main/lsp/LSPInput.h"
 #include "main/lsp/LSPOutput.h"

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -83,6 +83,8 @@ LSPWrapper::LSPWrapper(unique_ptr<core::GlobalState> gs, shared_ptr<options::Opt
       config_(make_shared<LSPConfiguration>(*opts, output, move(logger), true, disableFastPath)),
       lspLoop(make_shared<LSPLoop>(std::move(gs), *workers, config_)), opts(move(opts)) {}
 
+LSPWrapper::~LSPWrapper() = default;
+
 SingleThreadedLSPWrapper::SingleThreadedLSPWrapper(unique_ptr<core::GlobalState> gs, shared_ptr<options::Options> opts,
                                                    shared_ptr<spd::logger> logger,
                                                    shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink,

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -3,15 +3,21 @@
 
 #include "spdlog/spdlog.h"
 // has to come before the next spdlog include. This comment stops formatter from reordering them
+#include "core/core.h"
 #include "main/lsp/LSPMessage.h"
-#include "main/lsp/lsp.h"
+#include "main/options/options.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include <string_view>
 
 namespace spd = spdlog;
 
+namespace sorbet {
+class WorkerPool;
+}
+
 namespace sorbet::realmain::lsp {
 
+class LSPLoop;
 class LSPOutputToVector;
 class LSPProgrammaticInput;
 class LSPConfiguration;

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -49,7 +49,7 @@ public:
     // N.B.: Sorbet assumes we 'own' this object; keep it alive to avoid memory errors.
     const std::shared_ptr<options::Options> opts;
 
-    virtual ~LSPWrapper() = default;
+    virtual ~LSPWrapper();
 
     const LSPConfiguration &config() const;
 

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -7,6 +7,9 @@
 #include "main/lsp/lsp.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include <string_view>
+
+namespace spd = spdlog;
+
 namespace sorbet::realmain::lsp {
 
 class LSPOutputToVector;

--- a/test/LSPTest.cc
+++ b/test/LSPTest.cc
@@ -1,7 +1,6 @@
 #include "test/LSPTest.h"
 
-#include <csignal>
-
+#include "common/concurrency/WorkerPool.h"
 #include "main/lsp/json_types.h"
 #include "payload/payload.h"
 

--- a/test/helpers/lsp.cc
+++ b/test/helpers/lsp.cc
@@ -5,6 +5,7 @@
 #include "absl/strings/match.h"
 #include "common/common.h"
 #include "common/sort.h"
+#include "main/lsp/LSPConfiguration.h"
 #include "test/helpers/lsp.h"
 
 namespace sorbet::test {

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -6,6 +6,7 @@
 #include "common/FileOps.h"
 #include "common/formatting.h"
 #include "common/sort.h"
+#include "main/lsp/LSPConfiguration.h"
 #include "test/helpers/lsp.h"
 #include "test/helpers/position_assertions.h"
 #include <iterator>

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -2,7 +2,6 @@
 #define TEST_HELPERS_POSITION_ASSERTIONS_H
 
 #include "main/lsp/json_types.h"
-#include "main/lsp/lsp.h"
 #include "main/lsp/wrapper.h"
 #include "test/helpers/expectations.h"
 #include <regex>

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -5,6 +5,7 @@
 // ^ Violates linting rules, so include first.
 #include "common/Counters.h"
 #include "common/Counters_impl.h"
+#include "main/lsp/json_types.h"
 #include "main/lsp/wrapper.h"
 #include "test/helpers/MockFileSystem.h"
 

--- a/test/print_document_symbols.cc
+++ b/test/print_document_symbols.cc
@@ -1,6 +1,5 @@
 #include "common/FileSystem.h"
 #include "main/lsp/LSPMessage.h"
-#include "main/lsp/lsp.h"
 #include "main/lsp/wrapper.h"
 #include "test/helpers/lsp.h"
 #include <iostream>

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -18,6 +18,7 @@
 #include "common/formatting.h"
 #include "common/sort.h"
 #include "core/Error.h"
+#include "core/ErrorQueue.h"
 #include "core/Unfreeze.h"
 #include "core/serialize/serialize.h"
 #include "definition_validator/validator.h"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Delurk `json_types.h` from ~every header file.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`json_types.h` is a large header file (since it includes all generated types) and was getting included into more locations than needed.

I was able to delurk it from everywhere with the following changes:

* Forward-declaring classes.
* Separating generated enums from generated classes.
  * There's now a `json_enums.h` and `lsp_messages_enums_gen.{h,cc}`.
* Moving destructor definitions to *.cc files.
* Removing redundant explicit field initializations in header files.
* Moved `LSPFileUpdates` from `json_types.h` into its own dedicated `.h` and `.cc` files.

While I was at it, I also delurked `lsp.h` and a few other now-unused header file imports that were leftover from some previous restructurings.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
