### PR TITLE
Fix props factory hover and go to definition behavior

### DIFF
--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -233,7 +233,10 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
             }
         }
 
-        ret.nodes.emplace_back(ast::MK::Unsafe(send->loc, rules->deepCopy()));
+        // Keep around keyword args for IDE
+        if (!rules->keys.empty()) {
+            ret.nodes.emplace_back(ast::MK::Unsafe(send->loc, rules->deepCopy()));
+        }
     }
 
     ret.nodes.emplace_back(ast::MK::Sig(loc, ast::MK::Hash0(loc), ASTUtil::dupType(getType.get())));

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -232,6 +232,8 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
                 }
             }
         }
+
+        ret.nodes.emplace_back(ast::MK::Unsafe(send->loc, rules->deepCopy()));
     }
 
     ret.nodes.emplace_back(ast::MK::Sig(loc, ast::MK::Hash0(loc), ASTUtil::dupType(getType.get())));

--- a/test/testdata/lsp/props.rb
+++ b/test/testdata/lsp/props.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# typed: true
+
+class Foo
+  extend T::Sig
+  prop :bar, String, factory: -> { Bar.new }
+# ^^^^ hover: sig {returns(String)}
+#                    ^^^^^^^ hover: Symbol(:"factory")
+#                                  ^^^ hover: T.class_of(Foo::Bar)
+#                                  ^^^ usage: bar_class
+#                                      ^^^ hover: def initialize; end
+#                                      ^^^ usage: bar_class_initialize
+
+  class Bar
+#       ^^^ def: bar_class
+    def initialize
+#       ^^^^^^^^^^ def: bar_class_initialize
+    end
+  end
+end

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -5671,6 +5671,28 @@ ClassDef{
         Send{
           recv = ConstantLit{
             orig = nullptr
+            symbol = ::T
+          }
+          fun = <U unsafe>
+          block = nullptr
+          args = [
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"array" }
+                  value = UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U String>>
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
             symbol = ::Sorbet::Private::Static
           }
           fun = <U keep_def>
@@ -6567,6 +6589,25 @@ ClassDef{
         Send{
           recv = ConstantLit{
             orig = nullptr
+            symbol = ::T
+          }
+          fun = <U unsafe>
+          block = nullptr
+          args = [
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"immutable" }
+                  value = Literal{ value = true }
+                ]
+              ]
+            }
+          ]
+        }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
             symbol = ::Sorbet::Private::Static
           }
           fun = <U keep_def>
@@ -6591,6 +6632,32 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :"const" }
+          ]
+        }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = ::T
+          }
+          fun = <U unsafe>
+          block = nullptr
+          args = [
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"immutable" }
+                  value = Literal{ value = true }
+                ]
+                [
+                  key = Literal{ value = :"array" }
+                  value = UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U String>>
+                  }
+                ]
+              ]
+            }
           ]
         }
 
@@ -6856,6 +6923,30 @@ ClassDef{
         Send{
           recv = ConstantLit{
             orig = nullptr
+            symbol = ::T
+          }
+          fun = <U unsafe>
+          block = nullptr
+          args = [
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"enum" }
+                  value = Array{
+                    elems = [
+                      Literal{ value = "hello" }
+                      Literal{ value = "goodbye" }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
             symbol = ::Sorbet::Private::Static
           }
           fun = <U keep_def>
@@ -7111,6 +7202,25 @@ ClassDef{
         Send{
           recv = ConstantLit{
             orig = nullptr
+            symbol = ::T
+          }
+          fun = <U unsafe>
+          block = nullptr
+          args = [
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"ifunset" }
+                  value = Literal{ value = "" }
+                ]
+              ]
+            }
+          ]
+        }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
             symbol = ::Sorbet::Private::Static
           }
           fun = <U keep_def>
@@ -7135,6 +7245,25 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :"ifunset=" }
+          ]
+        }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = ::T
+          }
+          fun = <U unsafe>
+          block = nullptr
+          args = [
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"ifunset" }
+                  value = Literal{ value = "" }
+                ]
+              ]
+            }
           ]
         }
 
@@ -7808,6 +7937,25 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :"token=" }
+          ]
+        }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = ::T
+          }
+          fun = <U unsafe>
+          block = nullptr
+          args = [
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"immutable" }
+                  value = Literal{ value = true }
+                ]
+              ]
+            }
           ]
         }
 

--- a/test/testdata/rewriter/prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree.exp
@@ -508,6 +508,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :"array_of=")
 
+    ::T.unsafe({:"array" => <emptyTree>::<C String>})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"array_of_explicit")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"array_of_explicit=")
@@ -586,9 +588,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::Sorbet::Private::Static.keep_def(<self>, :"hash_of")
     end
 
+    ::T.unsafe({:"immutable" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"const_explicit")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"const")
+
+    ::T.unsafe({:"immutable" => true, :"array" => <emptyTree>::<C String>})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"no_class_arg")
 
@@ -613,6 +619,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
       ::Sorbet::Private::Static.keep_def(<self>, :"no_class_arg")
     end
+
+    ::T.unsafe({:"enum" => ["hello", "goodbye"]})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"enum_prop")
 
@@ -648,9 +656,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foreign_invalid_!")
 
+    ::T.unsafe({:"ifunset" => ""})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"ifunset")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"ifunset=")
+
+    ::T.unsafe({:"ifunset" => ""})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"ifunset_nilable")
 
@@ -727,6 +739,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     ::Sorbet::Private::Static.keep_def(<self>, :"token")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"token=")
+
+    ::T.unsafe({:"immutable" => true})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"created")
   end


### PR DESCRIPTION
### Motivation
Hover and go to definition for `factory` in `prop` would send user to the beginning of the `prop` line. Fixes https://github.com/sorbet/sorbet/issues/2188


### Test plan
See included automated tests.
