### PR TITLE
Add compatibility patch for `Method` methods

### DIFF
--- a/gems/sorbet-runtime/test/types/method_patches.rb
+++ b/gems/sorbet-runtime/test/types/method_patches.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+module Opus::Types::Test
+  class MethodPatchesTest < Critic::Unit::UnitTest
+    module MethodRefinement
+      refine Method do
+        prepend(T::CompatibilityPatches::MethodExtensions)
+      end
+    end
+
+    using MethodRefinement
+
+    before do
+      @mod = Module.new do
+        extend T::Sig
+        # Make it public for testing only
+        public_class_method :sig
+      end
+    end
+
+    it "return the same result for simple methods with and without signature" do
+      def @mod.no_sig(bar)
+        :foo
+      end
+
+      @mod.sig {params(bar: T.untyped).returns(T.untyped)}
+      def @mod.with_sig(bar)
+        :foo
+      end
+
+      method_no_sig = @mod.method(:no_sig)
+      method_with_sig = @mod.method(:with_sig)
+
+      assert_equal(method_no_sig.arity, method_with_sig.arity)
+      assert_equal(method_no_sig.parameters, method_with_sig.parameters)
+      # file names from source_location should match
+      assert_equal(method_no_sig.source_location.first, method_with_sig.source_location.first)
+      # line numbers from source_location should differ by 5 lines
+      assert_equal(method_no_sig.source_location.last + 5, method_with_sig.source_location.last)
+    end
+
+    it "return the same result for rest arg methods with and without signature" do
+      def @mod.no_sig(*bar)
+        :foo
+      end
+
+      @mod.sig {params(bar: T.untyped).returns(T.untyped)}
+      def @mod.with_sig(*bar)
+        :foo
+      end
+
+      method_no_sig = @mod.method(:no_sig)
+      method_with_sig = @mod.method(:with_sig)
+
+      assert_equal(method_no_sig.arity, method_with_sig.arity)
+      assert_equal(method_no_sig.parameters, method_with_sig.parameters)
+      # file names from source_location should match
+      assert_equal(method_no_sig.source_location.first, method_with_sig.source_location.first)
+      # line numbers from source_location should differ by 5 lines
+      assert_equal(method_no_sig.source_location.last + 5, method_with_sig.source_location.last)
+    end
+
+    it "return the same result for complex methods with and without signature" do
+      def @mod.no_sig(a, b = nil, *c, d:, e: nil, **f, &blk)
+        :foo
+      end
+
+      @mod.sig {params(a: T.untyped, b: T.untyped, c: T.untyped, d: T.untyped, e: T.untyped, f: T.untyped, blk: T.untyped).void}
+      def @mod.with_sig(a, b = nil, *c, d:, e: nil, **f, &blk)
+        :foo
+      end
+
+      method_no_sig = @mod.method(:no_sig)
+      method_with_sig = @mod.method(:with_sig)
+
+      assert_equal(method_no_sig.arity, method_with_sig.arity)
+      assert_equal(method_no_sig.parameters, method_with_sig.parameters)
+      # file names from source_location should match
+      assert_equal(method_no_sig.source_location.first, method_with_sig.source_location.first)
+      # line numbers from source_location should differ by 5 lines
+      assert_equal(method_no_sig.source_location.last + 5, method_with_sig.source_location.last)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2643 

### Motivation

Since Sorbet runtime wraps methods with a signature breaks the return values of some `Method` methods, namely: `arity`, `parameters` and `source_location`.

This PR adds a compatibility patch to `Method` to fix these methods when the original method has a signature wrapper.

The automatic patching of `Method` might not be desirable for all users of the library, so I am open to adding a `T::Config` method to do the patching when asked for it.

### Test plan

See included automated tests.
