### PR TITLE
Store FileHashes in payload

### DIFF
--- a/core/Files.cc
+++ b/core/Files.cc
@@ -113,7 +113,9 @@ unique_ptr<File> File::deepCopy(GlobalState &gs) const {
 }
 
 void File::setFileHash(unique_ptr<const FileHash> hash) {
-    hash_ = move(hash);
+    if (hash_ == nullptr) {
+        hash_ = move(hash);
+    }
 }
 
 const shared_ptr<const FileHash> &File::getFileHash() const {

--- a/core/Files.cc
+++ b/core/Files.cc
@@ -113,6 +113,8 @@ unique_ptr<File> File::deepCopy(GlobalState &gs) const {
 }
 
 void File::setFileHash(unique_ptr<const FileHash> hash) {
+    // If hash_ != nullptr, then the contents of hash_ and hash should be identical.
+    // Avoid needlessly invalidating references to *hash_.
     if (hash_ == nullptr) {
         hash_ = move(hash);
     }

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1,6 +1,7 @@
 #include "GlobalState.h"
 
 #include "common/Timer.h"
+#include "common/sort.h"
 #include "core/Error.h"
 #include "core/Hashing.h"
 #include "core/NameHash.h"
@@ -1573,8 +1574,11 @@ unique_ptr<GlobalStateHash> GlobalState::hash() const {
     }
     unique_ptr<GlobalStateHash> result = make_unique<GlobalStateHash>();
     for (const auto &e : methodHashes) {
-        result->methodHashes[e.first] = patchHash(e.second);
+        result->methodHashes.emplace_back(e.first, patchHash(e.second));
     }
+    // Sort the hashes. Semantically important for quickly diffing hashes.
+    fast_sort(result->methodHashes);
+
     result->hierarchyHash = patchHash(hierarchyHash);
     return result;
 }

--- a/core/NameHash.h
+++ b/core/NameHash.h
@@ -44,7 +44,8 @@ struct GlobalStateHash {
     static constexpr int HASH_STATE_INVALID = 2;
     static constexpr int HASH_STATE_INVALID_COLLISION_AVOID = 3;
     u4 hierarchyHash = HASH_STATE_NOT_COMPUTED;
-    UnorderedMap<NameHash, u4> methodHashes;
+    // N.B.: methodHashes is sorted by NameHash.
+    std::vector<std::pair<NameHash, u4>> methodHashes;
 };
 
 struct UsageHash {

--- a/core/NameHash.h
+++ b/core/NameHash.h
@@ -44,7 +44,7 @@ struct GlobalStateHash {
     static constexpr int HASH_STATE_INVALID = 2;
     static constexpr int HASH_STATE_INVALID_COLLISION_AVOID = 3;
     u4 hierarchyHash = HASH_STATE_NOT_COMPUTED;
-    // N.B.: methodHashes is sorted by NameHash.
+    // N.B.: methodHashes is sorted.
     std::vector<std::pair<NameHash, u4>> methodHashes;
 };
 

--- a/core/NameHash.h
+++ b/core/NameHash.h
@@ -44,7 +44,6 @@ struct GlobalStateHash {
     static constexpr int HASH_STATE_INVALID = 2;
     static constexpr int HASH_STATE_INVALID_COLLISION_AVOID = 3;
     u4 hierarchyHash = HASH_STATE_NOT_COMPUTED;
-    // N.B.: methodHashes is sorted.
     std::vector<std::pair<NameHash, u4>> methodHashes;
 };
 

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -262,7 +262,7 @@ unique_ptr<const FileHash> SerializerImpl::unpickleFileHash(UnPickler &p) {
     for (int it = 0; it < methodHashSize; it++) {
         NameHash key;
         key._hashValue = p.getU4();
-        ret.definitions.methodHashes[key] = p.getU4();
+        ret.definitions.methodHashes.emplace_back(key, p.getU4());
     }
     auto constantsSize = p.getU4();
     ret.usages.constants.reserve(constantsSize);

--- a/core/serialize/serialize.h
+++ b/core/serialize/serialize.h
@@ -6,7 +6,7 @@
 namespace sorbet::core::serialize {
 class Serializer {
 public:
-    static const u4 VERSION = 4;
+    static const u4 VERSION = 5;
     static const u1 GLOBAL_STATE_COMPRESSION_DEGREE =
         10; // >20 introduce decompression slowdown, >10 introduces compression slowdown
     static const u1 FILE_COMPRESSION_DEGREE =

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -31,6 +31,23 @@ void sendTypecheckInfo(const LSPConfiguration &config, const core::GlobalState &
             make_unique<NotificationMessage>("2.0", LSPMethod::SorbetTypecheckRunInfo, move(sorbetTypecheckInfo))));
     }
 }
+
+// In debug builds, used to assert that we have not accidentally taken the fast path after a change to the set of
+// methods in a file.
+bool validateMethodHashesHaveSameMethods(const std::vector<std::pair<core::NameHash, u4>> &a,
+                                         const std::vector<std::pair<core::NameHash, u4>> &b) {
+    // Should be sorted.
+    auto bIt = b.begin();
+    for (const auto &methodA : a) {
+        const auto &methodB = *bIt;
+        if (methodA.first != methodB.first) {
+            return false;
+        }
+        bIt++;
+    }
+    return true;
+}
+
 } // namespace
 
 LSPTypechecker::LSPTypechecker(std::shared_ptr<const LSPConfiguration> config,
@@ -111,6 +128,7 @@ TypecheckRun LSPTypechecker::runFastPath(LSPFileUpdates updates, WorkerPool &wor
     vector<core::FileRef> subset;
     vector<core::NameHash> changedHashes;
     {
+        vector<pair<core::NameHash, u4>> changedMethodHashes;
         for (auto &f : updates.updatedFiles) {
             auto fref = gs->findFileByPath(f->path());
             // We don't support new files on the fast path. This enforce failing indicates a bug in our fast/slow
@@ -120,19 +138,29 @@ TypecheckRun LSPTypechecker::runFastPath(LSPFileUpdates updates, WorkerPool &wor
             if (fref.exists()) {
                 // Update to existing file on fast path
                 ENFORCE(fref.data(*gs).getFileHash() != nullptr);
-                auto &oldHash = *fref.data(*gs).getFileHash();
-                for (auto &p : f->getFileHash()->definitions.methodHashes) {
-                    auto fnd = oldHash.definitions.methodHashes.find(p.first);
-                    ENFORCE(fnd != oldHash.definitions.methodHashes.end(), "definitionHash should have failed");
-                    if (fnd->second != p.second) {
-                        changedHashes.emplace_back(p.first);
-                    }
-                }
+                const auto &oldMethodHashes = fref.data(*gs).getFileHash()->definitions.methodHashes;
+                const auto &newMethodHashes = f->getFileHash()->definitions.methodHashes;
+
+                // Both oldHash and newHash should have the same methods, since this is the fast path!
+                ENFORCE(oldMethodHashes.size() != newMethodHashes.size(), "definitionHash should have failed");
+                ENFORCE(validateMethodHashesHaveSameMethods(oldMethodHashes, newMethodHashes));
+
+                // Find which hashes changed. Note: methodHashes are sorted, so set_difference should work.
+                // This will insert two entries into `changedMethodHashes` for each changed method, but they will get
+                // deduped later.
+                set_difference(oldMethodHashes.begin(), oldMethodHashes.end(), newMethodHashes.begin(),
+                               newMethodHashes.end(), inserter(changedMethodHashes, changedMethodHashes.begin()));
+
                 gs = core::GlobalState::replaceFile(move(gs), fref, f);
                 // If file doesn't have a typed: sigil, then we need to ensure it's typechecked using typed: false.
                 fref.data(*gs).strictLevel = pipeline::decideStrictLevel(*gs, fref, config->opts);
                 subset.emplace_back(fref);
             }
+        }
+
+        changedHashes.reserve(changedMethodHashes.size());
+        for (auto &changedMethodHash : changedMethodHashes) {
+            changedHashes.push_back(changedMethodHash.first);
         }
         core::NameHash::sortAndDedupe(changedHashes);
     }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -40,15 +40,23 @@ bool validateMethodHashesHaveSameMethods(const std::vector<std::pair<core::NameH
         return false;
     }
 
-    // Should be sorted.
+    pair<core::NameHash, u4> previousHash; // Initializes to <0, 0>.
     auto bIt = b.begin();
     for (const auto &methodA : a) {
         const auto &methodB = *bIt;
         if (methodA.first != methodB.first) {
             return false;
         }
+
+        // Enforce that hashes are sorted in ascending order.
+        if (methodA < previousHash) {
+            return false;
+        }
+
+        previousHash = methodA;
         bIt++;
     }
+
     return true;
 }
 

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -36,6 +36,10 @@ void sendTypecheckInfo(const LSPConfiguration &config, const core::GlobalState &
 // methods in a file.
 bool validateMethodHashesHaveSameMethods(const std::vector<std::pair<core::NameHash, u4>> &a,
                                          const std::vector<std::pair<core::NameHash, u4>> &b) {
+    if (a.size() != b.size()) {
+        return false;
+    }
+
     // Should be sorted.
     auto bIt = b.begin();
     for (const auto &methodA : a) {
@@ -142,8 +146,8 @@ TypecheckRun LSPTypechecker::runFastPath(LSPFileUpdates updates, WorkerPool &wor
                 const auto &newMethodHashes = f->getFileHash()->definitions.methodHashes;
 
                 // Both oldHash and newHash should have the same methods, since this is the fast path!
-                ENFORCE(oldMethodHashes.size() != newMethodHashes.size(), "definitionHash should have failed");
-                ENFORCE(validateMethodHashesHaveSameMethods(oldMethodHashes, newMethodHashes));
+                ENFORCE(validateMethodHashesHaveSameMethods(oldMethodHashes, newMethodHashes),
+                        "definitionHash should have failed");
 
                 // Find which hashes changed. Note: methodHashes are sorted, so set_difference should work.
                 // This will insert two entries into `changedMethodHashes` for each changed method, but they will get

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -32,7 +32,7 @@ void sendTypecheckInfo(const LSPConfiguration &config, const core::GlobalState &
     }
 }
 
-// In debug builds, used to assert that we have not accidentally taken the fast path after a change to the set of
+// In debug builds, asserts that we have not accidentally taken the fast path after a change to the set of
 // methods in a file.
 bool validateMethodHashesHaveSameMethods(const std::vector<std::pair<core::NameHash, u4>> &a,
                                          const std::vector<std::pair<core::NameHash, u4>> &b) {

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -5,7 +5,6 @@
 #include "common/common.h"
 #include "common/concurrency/WorkerPool.h"
 #include "common/kvstore/KeyValueStore.h"
-#include "core/NameHash.h"
 #include "main/options/options.h"
 
 namespace sorbet::core::lsp {
@@ -43,7 +42,9 @@ typecheck(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> w
 
 ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Options &opts);
 
-core::FileHash computeFileHash(std::shared_ptr<core::File> forWhat, spdlog::logger &logger);
+// Computes file hashes for the given files, and stores them in the files.
+void computeFileHashes(const std::vector<std::shared_ptr<core::File>> files, spdlog::logger &logger,
+                       WorkerPool &workers);
 
 core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::FileRef file,
                                     const options::Options &opts);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -547,6 +547,7 @@ int realmain(int argc, char *argv[]) {
 
         if (!opts.storeState.empty()) {
             gs->markAsPayload();
+            // Store file hashes for LSP.
             pipeline::computeFileHashes(gs->getFiles(), *logger, *workers);
             FileOps::write(opts.storeState.c_str(), core::serialize::Serializer::store(*gs));
         }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -547,6 +547,7 @@ int realmain(int argc, char *argv[]) {
 
         if (!opts.storeState.empty()) {
             gs->markAsPayload();
+            pipeline::computeFileHashes(gs->getFiles(), *logger, *workers);
             FileOps::write(opts.storeState.c_str(), core::serialize::Serializer::store(*gs));
         }
 

--- a/test/lsp/BUILD
+++ b/test/lsp/BUILD
@@ -8,7 +8,7 @@ sh_binary(
 
 cc_test(
     name = "protocol_test_corpus",
-    timeout = "long",
+    size = "medium",
     srcs = [
         "ProtocolTest.cc",
         "ProtocolTest.h",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Serialize FileHashes into cache, and store FileHashes in payload.

Does not yet modify LSP to use cache. I have those changes locally, but I'm landing that as a follow-on change to de-risk it.

There's currently a mystery failure; the store-state test fails because the cached state changes between runs. It's possible that NameHashes have some nondeterminism. I'm looking into it now.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The biggest win from this PR alone is significantly speeding up LSP-based tests (order of magnitude speedup):

Before on my mac:

```
$ bazel test //test/lsp:protocol_test_corpus --config=dbg 
//test/lsp:protocol_test_corpus                                          PASSED in 118.9s
```

After: 

```
$ bazel test //test/lsp:protocol_test_corpus --config=dbg 
//test/lsp:protocol_test_corpus                                          PASSED in 13.1s
```

There are big savings on test corpus LSP tests, too, which spent most of their time hashing.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Automated tests already exist.
