### PR TITLE
Update T::Struct#serialize doc snippet

### DIFF
--- a/website/docs/tstruct.md
+++ b/website/docs/tstruct.md
@@ -61,5 +61,5 @@ A particularly common case is to convert an struct to a Hash. Because this is so
 common, this conversion has been built in (it still must be explicitly called):
 
 ```ruby
-my_struct.serialize # => '{ x: 3 }'
+my_struct.serialize # => { "x": 3 }
 ```


### PR DESCRIPTION
The existing documentation mischaracterizes the output. The existing text implies that you get back a string, or possibly a hash with symbol keys. It should be clear that what you get back is a hash with string keys.

```
irb(main):007:0> class X < T::Struct
irb(main):008:1>   prop :x, Integer
irb(main):009:1>   prop :y, String
irb(main):010:1> end
=> nil
irb(main):011:0> x = X.new({ x: 1, y: 'hi' })
=> <X x=1, y="hi">

irb(main):014:0> x.serialize
=> {"x"=>1, "y"=>"hi"}
```

### Motivation
I noticed this ambiguity while I was evaluating Sorbet for use at work. I was excited by the possibility of using structs to represent typed objects, but was worried about the ergonomics. Having had a chance to install sorbet in our code base and try it out, I am relieved to note that this method doesn't return some kind of string.


### Test plan
Just docs, no tests :)
