### PR TITLE
Use kvstore in LSP to optimize startup performance.

### DIFF
--- a/common/kvstore/BUILD
+++ b/common/kvstore/BUILD
@@ -25,3 +25,22 @@ cc_library(
         "//conditions:default": ["@lmdb"],
     }),
 )
+
+cc_test(
+    name = "kvstore_test",
+    size = "small",
+    srcs = glob([
+        "test/*.cc",
+    ]),
+    copts = ["-Iexternal/gtest/include"],
+    linkstatic = select({
+        "//tools/config:linkshared": 0,
+        "//conditions:default": 1,
+    }),
+    visibility = ["//tools:__pkg__"],
+    deps = [
+        "kvstore",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/common/kvstore/KeyValueStore-emscripten.cc
+++ b/common/kvstore/KeyValueStore-emscripten.cc
@@ -28,7 +28,11 @@ OwnedKeyValueStore::~OwnedKeyValueStore() {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
-int OwnedKeyValueStore::commitOrAbortTransactions(bool commit) {
+bool OwnedKeyValueStore::commit() {
+    throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
+}
+
+void OwnedKeyValueStore::abort() {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
@@ -56,11 +60,11 @@ void OwnedKeyValueStore::refreshMainTransaction() {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
-bool OwnedKeyValueStore::commitAndClose(unique_ptr<OwnedKeyValueStore> k) {
+unique_ptr<KeyValueStore> OwnedKeyValueStore::commit(spdlog::logger &logger, unique_ptr<OwnedKeyValueStore> k) {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
-unique_ptr<KeyValueStore> OwnedKeyValueStore::disown(unique_ptr<OwnedKeyValueStore> ownedKvstore, bool commitChanges) {
+unique_ptr<KeyValueStore> OwnedKeyValueStore::abort(unique_ptr<OwnedKeyValueStore> ownedKvstore) {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 

--- a/common/kvstore/KeyValueStore-emscripten.cc
+++ b/common/kvstore/KeyValueStore-emscripten.cc
@@ -28,7 +28,7 @@ OwnedKeyValueStore::~OwnedKeyValueStore() {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
-bool OwnedKeyValueStore::commit() {
+int OwnedKeyValueStore::commit() {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
@@ -60,7 +60,8 @@ void OwnedKeyValueStore::refreshMainTransaction() {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
-unique_ptr<KeyValueStore> OwnedKeyValueStore::commit(spdlog::logger &logger, unique_ptr<OwnedKeyValueStore> k) {
+unique_ptr<KeyValueStore> OwnedKeyValueStore::bestEffortCommit(spdlog::logger &logger,
+                                                               unique_ptr<OwnedKeyValueStore> k) {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 

--- a/common/kvstore/KeyValueStore-emscripten.cc
+++ b/common/kvstore/KeyValueStore-emscripten.cc
@@ -5,6 +5,7 @@
 using namespace std;
 namespace sorbet {
 struct KeyValueStore::DBState {};
+struct OwnedKeyValueStore::TxnState {};
 
 [[noreturn]] static void throw_mdb_error(string_view what, int err) {
     fmt::print(stderr, "mdb error: {}: {}\n", what, "");
@@ -12,38 +13,54 @@ struct KeyValueStore::DBState {};
 }
 
 KeyValueStore::KeyValueStore(string version, string path, string flavor)
-    : path(move(path)), flavor(move(flavor)), writerId(this_thread::get_id()), dbState(make_unique<DBState>()) {
+    : version(move(version)), path(move(path)), flavor(move(flavor)), dbState(make_unique<DBState>()) {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 KeyValueStore::~KeyValueStore() noexcept(false) {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
-void KeyValueStore::write(string_view key, const vector<u1> &value) {
+OwnedKeyValueStore::OwnedKeyValueStore(unique_ptr<KeyValueStore> kvstore) : kvstore(move(kvstore)) {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
-u1 *KeyValueStore::read(string_view key) {
+OwnedKeyValueStore::~OwnedKeyValueStore() {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
-void KeyValueStore::clear() {
+int OwnedKeyValueStore::commitOrAbortTransactions(bool commit) {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
-string_view KeyValueStore::readString(string_view key) {
+void OwnedKeyValueStore::write(string_view key, const vector<u1> &value) {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
-void KeyValueStore::writeString(string_view key, string_view value) {
+u1 *OwnedKeyValueStore::read(string_view key) {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
-void KeyValueStore::refreshMainTransaction() {
+void OwnedKeyValueStore::clear() {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
-bool KeyValueStore::commit(unique_ptr<KeyValueStore> k) {
+string_view OwnedKeyValueStore::readString(string_view key) {
+    throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
+}
+
+void OwnedKeyValueStore::writeString(string_view key, string_view value) {
+    throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
+}
+
+void OwnedKeyValueStore::refreshMainTransaction() {
+    throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
+}
+
+bool OwnedKeyValueStore::commitAndClose(unique_ptr<OwnedKeyValueStore> k) {
+    throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
+}
+
+unique_ptr<KeyValueStore> OwnedKeyValueStore::disown(unique_ptr<OwnedKeyValueStore> ownedKvstore, bool commitChanges) {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 

--- a/common/kvstore/KeyValueStore.cc
+++ b/common/kvstore/KeyValueStore.cc
@@ -246,7 +246,7 @@ unique_ptr<KeyValueStore> OwnedKeyValueStore::abort(unique_ptr<OwnedKeyValueStor
 
 unique_ptr<KeyValueStore> OwnedKeyValueStore::bestEffortCommit(spdlog::logger &logger,
                                                                unique_ptr<OwnedKeyValueStore> ownedKvstore) {
-    Timer timeit(logger, "kvstore.commit");
+    Timer timeit(logger, "kvstore.bestEffortCommit");
     ownedKvstore->commit();
     return move(ownedKvstore->kvstore);
 }

--- a/common/kvstore/KeyValueStore.cc
+++ b/common/kvstore/KeyValueStore.cc
@@ -240,12 +240,18 @@ fail:
 }
 
 unique_ptr<KeyValueStore> OwnedKeyValueStore::abort(unique_ptr<OwnedKeyValueStore> ownedKvstore) {
+    if (ownedKvstore == nullptr) {
+        return nullptr;
+    }
     ownedKvstore->abort();
     return move(ownedKvstore->kvstore);
 }
 
 unique_ptr<KeyValueStore> OwnedKeyValueStore::bestEffortCommit(spdlog::logger &logger,
                                                                unique_ptr<OwnedKeyValueStore> ownedKvstore) {
+    if (ownedKvstore == nullptr) {
+        return nullptr;
+    }
     Timer timeit(logger, "kvstore.bestEffortCommit");
     ownedKvstore->commit();
     return move(ownedKvstore->kvstore);

--- a/common/kvstore/KeyValueStore.cc
+++ b/common/kvstore/KeyValueStore.cc
@@ -84,7 +84,7 @@ void OwnedKeyValueStore::abort() {
     mdb_close(kvstore->dbState->env, txnState->dbi);
 }
 
-bool OwnedKeyValueStore::commit() {
+int OwnedKeyValueStore::commit() {
     // Note: txn being null indicates that the transaction has already ended, perhaps due to a commit.
     if (txnState->txn == nullptr) {
         return 0;
@@ -97,7 +97,7 @@ bool OwnedKeyValueStore::commit() {
     txnState->txn = nullptr;
     ENFORCE(kvstore != nullptr);
     mdb_close(kvstore->dbState->env, txnState->dbi);
-    return rc == 0;
+    return rc;
 }
 
 OwnedKeyValueStore::~OwnedKeyValueStore() {
@@ -244,8 +244,8 @@ unique_ptr<KeyValueStore> OwnedKeyValueStore::abort(unique_ptr<OwnedKeyValueStor
     return move(ownedKvstore->kvstore);
 }
 
-unique_ptr<KeyValueStore> OwnedKeyValueStore::commit(spdlog::logger &logger,
-                                                     unique_ptr<OwnedKeyValueStore> ownedKvstore) {
+unique_ptr<KeyValueStore> OwnedKeyValueStore::bestEffortCommit(spdlog::logger &logger,
+                                                               unique_ptr<OwnedKeyValueStore> ownedKvstore) {
     Timer timeit(logger, "kvstore.commit");
     ownedKvstore->commit();
     return move(ownedKvstore->kvstore);

--- a/common/kvstore/KeyValueStore.h
+++ b/common/kvstore/KeyValueStore.h
@@ -58,7 +58,8 @@ class OwnedKeyValueStore final {
 
     void clear();
     void refreshMainTransaction();
-    int commitOrAbortTransactions(bool commit);
+    bool commit();
+    void abort();
 
 public:
     OwnedKeyValueStore(std::unique_ptr<KeyValueStore> kvstore);
@@ -71,12 +72,14 @@ public:
     /** can only be called from owning thread */
     void write(std::string_view key, const std::vector<u1> &value);
 
-    /** Convert an owned key value store into an unowned key value store. If `commitChanges` is `true`, writes are
-     * committed to disk. */
-    static std::unique_ptr<KeyValueStore> disown(std::unique_ptr<OwnedKeyValueStore> ownedKvstore, bool commitChanges);
+    /** Aborts all changes without writing them to disk. Returns an unowned kvstore that can be re-owned if more writes
+     * are desired. */
+    static std::unique_ptr<KeyValueStore> abort(std::unique_ptr<OwnedKeyValueStore> ownedKvstore);
 
-    /** Commits all changes to disk and closes the database. */
-    static bool commitAndClose(std::unique_ptr<OwnedKeyValueStore> kvstore);
+    /** Attempts to commit all changes to disk. Returns an unowned kvstore that can be re-owned if more writes are
+     * desired. */
+    static std::unique_ptr<KeyValueStore> commit(spdlog::logger &logger,
+                                                 std::unique_ptr<OwnedKeyValueStore> ownedKvstore);
 };
 
 } // namespace sorbet

--- a/common/kvstore/KeyValueStore.h
+++ b/common/kvstore/KeyValueStore.h
@@ -58,7 +58,7 @@ class OwnedKeyValueStore final {
 
     void clear();
     void refreshMainTransaction();
-    bool commit();
+    int commit();
     void abort();
 
 public:
@@ -76,10 +76,10 @@ public:
      * are desired. If not explicitly called, OwnedKeyValueStore will implicitly abort everything in the destructor. */
     static std::unique_ptr<KeyValueStore> abort(std::unique_ptr<OwnedKeyValueStore> ownedKvstore);
 
-    /** Attempts to commit all changes to disk. Returns an unowned kvstore that can be re-owned if more writes are
-     * desired. */
-    static std::unique_ptr<KeyValueStore> commit(spdlog::logger &logger,
-                                                 std::unique_ptr<OwnedKeyValueStore> ownedKvstore);
+    /** Attempts to commit all changes to disk. Can fail to commit changes silently. Returns an unowned kvstore that can
+     * be re-owned if more writes are desired. */
+    static std::unique_ptr<KeyValueStore> bestEffortCommit(spdlog::logger &logger,
+                                                           std::unique_ptr<OwnedKeyValueStore> ownedKvstore);
 };
 
 } // namespace sorbet

--- a/common/kvstore/test/kvstore_test.cc
+++ b/common/kvstore/test/kvstore_test.cc
@@ -1,0 +1,110 @@
+#include "gtest/gtest.h"
+// has to go first as it violates our requirements
+#include "spdlog/spdlog.h"
+// has to go above null_sink.h; this comment prevents reordering.
+#include "absl/strings/str_split.h"
+#include "common/FileOps.h"
+#include "common/common.h"
+#include "common/kvstore/KeyValueStore.h"
+#include "spdlog/sinks/null_sink.h"
+
+using namespace std;
+using namespace sorbet;
+
+string exec(string cmd);
+
+namespace {
+class KeyValueStoreTest : public ::testing::Test {
+protected:
+    const string directory;
+    const shared_ptr<spdlog::sinks::null_sink_mt> sink;
+    const shared_ptr<spdlog::logger> logger;
+
+    KeyValueStoreTest()
+        : directory(string(absl::StripAsciiWhitespace(exec("mktemp -d")))),
+          sink(make_shared<spdlog::sinks::null_sink_mt>()), logger(make_shared<spdlog::logger>("null", sink)) {}
+
+    void TearDown() override {
+        exec(fmt::format("rm -r {}", directory));
+    }
+};
+} // namespace
+
+TEST_F(KeyValueStoreTest, CommitsChangesToDisk) {
+    {
+        auto kvstore = make_unique<KeyValueStore>("1", directory, "vanilla");
+        auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
+        owned->writeString("hello", "testing");
+        EXPECT_EQ(owned->readString("hello"), "testing");
+        OwnedKeyValueStore::bestEffortCommit(*logger, move(owned));
+    }
+    {
+        auto kvstore = make_unique<KeyValueStore>("1", directory, "vanilla");
+        auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
+        EXPECT_EQ(owned->readString("hello"), "testing");
+    }
+}
+
+TEST_F(KeyValueStoreTest, AbortsChangesByDefault) {
+    {
+        auto kvstore = make_unique<KeyValueStore>("1", directory, "vanilla");
+        auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
+        owned->writeString("hello", "testing");
+        EXPECT_EQ(owned->readString("hello"), "testing");
+    }
+    {
+        auto kvstore = make_unique<KeyValueStore>("1", directory, "vanilla");
+        auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
+        EXPECT_EQ(owned->readString("hello"), "");
+    }
+}
+
+TEST_F(KeyValueStoreTest, CanBeReowned) {
+    auto kvstore = make_unique<KeyValueStore>("1", directory, "vanilla");
+    auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
+    owned->writeString("hello", "testing");
+    EXPECT_EQ(owned->readString("hello"), "testing");
+    kvstore = OwnedKeyValueStore::bestEffortCommit(*logger, move(owned));
+    owned = make_unique<OwnedKeyValueStore>(move(kvstore));
+    EXPECT_EQ(owned->readString("hello"), "testing");
+}
+
+TEST_F(KeyValueStoreTest, AbortsChangesWhenAborted) {
+    auto kvstore = make_unique<KeyValueStore>("1", directory, "vanilla");
+    auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
+    owned->writeString("hello", "testing");
+    EXPECT_EQ(owned->readString("hello"), "testing");
+    kvstore = OwnedKeyValueStore::abort(move(owned));
+    owned = make_unique<OwnedKeyValueStore>(move(kvstore));
+    EXPECT_EQ(owned->readString("hello"), "");
+}
+
+TEST_F(KeyValueStoreTest, ClearsChangesOnVersionChange) {
+    {
+        auto kvstore = make_unique<KeyValueStore>("1", directory, "vanilla");
+        auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
+        owned->writeString("hello", "testing");
+        EXPECT_EQ(owned->readString("hello"), "testing");
+        OwnedKeyValueStore::bestEffortCommit(*logger, move(owned));
+    }
+    {
+        auto kvstore = make_unique<KeyValueStore>("2", directory, "vanilla");
+        auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
+        EXPECT_EQ(owned->readString("hello"), "");
+    }
+}
+
+TEST_F(KeyValueStoreTest, FlavorsHaveDifferentContents) {
+    {
+        auto kvstore = make_unique<KeyValueStore>("1", directory, "vanilla");
+        auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
+        owned->writeString("hello", "testing");
+        EXPECT_EQ(owned->readString("hello"), "testing");
+        OwnedKeyValueStore::bestEffortCommit(*logger, move(owned));
+    }
+    {
+        auto kvstore = make_unique<KeyValueStore>("1", directory, "coldbrewcoffeewithchocolateflakes");
+        auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
+        EXPECT_EQ(owned->readString("hello"), "");
+    }
+}

--- a/common/kvstore/test/kvstore_test.cc
+++ b/common/kvstore/test/kvstore_test.cc
@@ -2,7 +2,7 @@
 // has to go first as it violates our requirements
 #include "spdlog/spdlog.h"
 // has to go above null_sink.h; this comment prevents reordering.
-#include "absl/strings/str_split.h"
+#include "absl/strings/str_split.h" // For StripAsciiWhitespace
 #include "common/FileOps.h"
 #include "common/common.h"
 #include "common/kvstore/KeyValueStore.h"

--- a/core/Files.cc
+++ b/core/Files.cc
@@ -116,6 +116,7 @@ void File::setFileHash(unique_ptr<const FileHash> hash) {
     // If hash_ != nullptr, then the contents of hash_ and hash should be identical.
     // Avoid needlessly invalidating references to *hash_.
     if (hash_ == nullptr) {
+        cached = false;
         hash_ = move(hash);
     }
 }

--- a/core/Files.h
+++ b/core/Files.h
@@ -68,8 +68,7 @@ public:
         TombStone,
     };
 
-    bool cachedParseTree = false;
-    bool cachedFileHash = false;
+    bool cached = false;         // If 'true', file is completely cached in kvstore.
     bool hasParseErrors = false; // some reasonable invariants don't hold for invalid files
     bool pluginGenerated = false;
     // Epoch is _only_ used in LSP mode. Do not depend on it elsewhere.

--- a/core/Files.h
+++ b/core/Files.h
@@ -69,6 +69,7 @@ public:
     };
 
     bool cachedParseTree = false;
+    bool cachedFileHash = false;
     bool hasParseErrors = false; // some reasonable invariants don't hold for invalid files
     bool pluginGenerated = false;
     // Epoch is _only_ used in LSP mode. Do not depend on it elsewhere.

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1247,6 +1247,17 @@ vector<u1> Serializer::storeExpression(GlobalState &gs, unique_ptr<ast::Expressi
     return pickler.result(FILE_COMPRESSION_DEGREE);
 }
 
+unique_ptr<const core::FileHash> Serializer::loadFileHash(spdlog::logger &logger, const u1 *const data) {
+    serialize::UnPickler up(data, logger);
+    return SerializerImpl::unpickleFileHash(up);
+}
+
+vector<u1> Serializer::storeFileHash(shared_ptr<const core::FileHash> fh) {
+    serialize::Pickler pickler;
+    SerializerImpl::pickle(pickler, move(fh));
+    return pickler.result(FILE_COMPRESSION_DEGREE);
+}
+
 NameRef SerializerImpl::unpickleNameRef(UnPickler &p, GlobalState &gs) {
     NameRef name(NameRef::WellKnown{}, p.getU4());
     ENFORCE(name.data(gs)->ref(gs) == name);

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -41,13 +41,13 @@ public:
 
     static shared_ptr<File> unpickleFile(UnPickler &p);
     static Name unpickleName(UnPickler &p, GlobalState &gs);
-    static TypePtr unpickleType(UnPickler &p, GlobalState *gs);
-    static ArgInfo unpickleArgInfo(UnPickler &p, GlobalState *gs);
-    static Symbol unpickleSymbol(UnPickler &p, GlobalState *gs);
+    static TypePtr unpickleType(UnPickler &p, const GlobalState *gs);
+    static ArgInfo unpickleArgInfo(UnPickler &p, const GlobalState *gs);
+    static Symbol unpickleSymbol(UnPickler &p, const GlobalState *gs);
     static void unpickleGS(UnPickler &p, GlobalState &result);
     static Loc unpickleLoc(UnPickler &p, FileRef file);
-    static unique_ptr<ast::Expression> unpickleExpr(UnPickler &p, GlobalState &, FileRef file);
-    static NameRef unpickleNameRef(UnPickler &p, GlobalState &);
+    static unique_ptr<ast::Expression> unpickleExpr(UnPickler &p, const GlobalState &, FileRef file);
+    static NameRef unpickleNameRef(UnPickler &p, const GlobalState &);
     static unique_ptr<const FileHash> unpickleFileHash(UnPickler &p);
 
     SerializerImpl() = delete;
@@ -398,7 +398,7 @@ void SerializerImpl::pickle(Pickler &p, Type *what) {
     }
 }
 
-TypePtr SerializerImpl::unpickleType(UnPickler &p, GlobalState *gs) {
+TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
     auto tag = p.getU4(); // though we formally need only u1 here, benchmarks suggest that size difference after
                           // compression is small and u4 is 10% faster
     switch (tag) {
@@ -491,7 +491,7 @@ void SerializerImpl::pickle(Pickler &p, const ArgInfo &a) {
     pickle(p, a.type.get());
 }
 
-ArgInfo SerializerImpl::unpickleArgInfo(UnPickler &p, GlobalState *gs) {
+ArgInfo SerializerImpl::unpickleArgInfo(UnPickler &p, const GlobalState *gs) {
     ArgInfo result;
     result.name = core::NameRef(*gs, p.getU4());
     result.rebind = core::SymbolRef(gs, p.getU4());
@@ -552,7 +552,7 @@ void SerializerImpl::pickle(Pickler &p, const Symbol &what) {
     }
 }
 
-Symbol SerializerImpl::unpickleSymbol(UnPickler &p, GlobalState *gs) {
+Symbol SerializerImpl::unpickleSymbol(UnPickler &p, const GlobalState *gs) {
     Symbol result;
     result.owner = SymbolRef(gs, p.getU4());
     result.name = NameRef(*gs, p.getU4());
@@ -766,7 +766,7 @@ vector<u1> Serializer::store(GlobalState &gs) {
     return p.result(GLOBAL_STATE_COMPRESSION_DEGREE);
 }
 
-vector<u1> Serializer::storePayloadAndNameTable(GlobalState &gs) {
+std::vector<u1> Serializer::storePayloadAndNameTable(GlobalState &gs) {
     Timer timeit(gs.tracer(), "Serializer::storePayloadAndNameTable");
     Pickler p = SerializerImpl::pickle(gs, true);
     return p.result(GLOBAL_STATE_COMPRESSION_DEGREE);
@@ -777,6 +777,21 @@ void Serializer::loadGlobalState(GlobalState &gs, const u1 *const data) {
     UnPickler p(data, gs.tracer());
     SerializerImpl::unpickleGS(p, gs);
     gs.installIntrinsics();
+}
+
+vector<u1> Serializer::storeFile(const core::File &file, ast::ParsedFile &tree) {
+    Pickler p;
+    SerializerImpl::pickle(p, file);
+    SerializerImpl::pickleTree(p, tree.file, tree.tree);
+    return p.result(FILE_COMPRESSION_DEGREE);
+}
+
+CachedFile Serializer::loadFile(const core::GlobalState &gs, core::FileRef fref, const u1 *const data) {
+    UnPickler p(data, gs.tracer());
+    auto file = SerializerImpl::unpickleFile(p);
+    file->cached = true;
+    auto tree = SerializerImpl::unpickleExpr(p, gs, fref);
+    return CachedFile{move(file), move(tree)};
 }
 
 template <class T> void SerializerImpl::pickleTree(Pickler &p, FileRef file, unique_ptr<T> &t) {
@@ -999,7 +1014,7 @@ void SerializerImpl::pickle(Pickler &p, FileRef file, const unique_ptr<ast::Expr
         [&](ast::Expression *n) { Exception::raise("Unimplemented AST Node: {}", n->nodeName()); });
 }
 
-unique_ptr<ast::Expression> SerializerImpl::unpickleExpr(serialize::UnPickler &p, GlobalState &gs, FileRef file) {
+unique_ptr<ast::Expression> SerializerImpl::unpickleExpr(serialize::UnPickler &p, const GlobalState &gs, FileRef file) {
     u1 kind = p.getU1();
     if (kind == 1) {
         return nullptr;
@@ -1233,32 +1248,7 @@ unique_ptr<ast::Expression> SerializerImpl::unpickleExpr(serialize::UnPickler &p
     Exception::raise("Not handled {}", kind);
 }
 
-unique_ptr<ast::Expression> Serializer::loadExpression(GlobalState &gs, const u1 *const p, u4 forceId) {
-    serialize::UnPickler up(p, gs.tracer());
-    u4 loaded = up.getU4();
-    FileRef fileId(forceId > 0 ? forceId : loaded);
-    return SerializerImpl::unpickleExpr(up, gs, fileId);
-}
-
-vector<u1> Serializer::storeExpression(GlobalState &gs, unique_ptr<ast::Expression> &e) {
-    serialize::Pickler pickler;
-    pickler.putU4(e->loc.file().id());
-    SerializerImpl::pickle(pickler, e->loc.file(), e);
-    return pickler.result(FILE_COMPRESSION_DEGREE);
-}
-
-unique_ptr<const core::FileHash> Serializer::loadFileHash(spdlog::logger &logger, const u1 *const data) {
-    serialize::UnPickler up(data, logger);
-    return SerializerImpl::unpickleFileHash(up);
-}
-
-vector<u1> Serializer::storeFileHash(shared_ptr<const core::FileHash> fh) {
-    serialize::Pickler pickler;
-    SerializerImpl::pickle(pickler, move(fh));
-    return pickler.result(FILE_COMPRESSION_DEGREE);
-}
-
-NameRef SerializerImpl::unpickleNameRef(UnPickler &p, GlobalState &gs) {
+NameRef SerializerImpl::unpickleNameRef(UnPickler &p, const GlobalState &gs) {
     NameRef name(NameRef::WellKnown{}, p.getU4());
     ENFORCE(name.data(gs)->ref(gs) == name);
     return name;

--- a/core/serialize/serialize.h
+++ b/core/serialize/serialize.h
@@ -21,11 +21,13 @@ public:
     // individual cached files, which can be loaded independently.
     static std::vector<u1> storePayloadAndNameTable(GlobalState &gs);
     static std::vector<u1> storeExpression(GlobalState &gs, std::unique_ptr<ast::Expression> &e);
+    static std::vector<u1> storeFileHash(std::shared_ptr<const core::FileHash> fh);
 
     // Loads an ast::Expression saved by storeExpression. Optionally overrides
     // the saved file ID to the caller-specified ID.
     static std::unique_ptr<ast::Expression> loadExpression(GlobalState &gs, const u1 *const p, u4 forceId = 0);
     static void loadGlobalState(GlobalState &gs, const u1 *const data);
+    static std::unique_ptr<const core::FileHash> loadFileHash(spdlog::logger &logger, const u1 *const data);
 };
 }; // namespace sorbet::core::serialize
 

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -185,7 +185,7 @@ void LSPIndexer::initialize(LSPFileUpdates &updates, WorkerPool &workers) {
 
     if (shouldCommit) {
         // We should only commit if we wrote new hashes or global state changed.
-        OwnedKeyValueStore::commit(*config->logger, move(kvstore));
+        OwnedKeyValueStore::bestEffortCommit(*config->logger, move(kvstore));
     }
 
     updates.epoch = 0;

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -174,7 +174,7 @@ void LSPIndexer::initialize(LSPFileUpdates &updates, WorkerPool &workers) {
 
     pipeline::computeFileHashes(initialGS->getFiles(), *config->logger, workers);
     bool wroteGlobalState = payload::retainGlobalState(initialGS, config->opts, kvstore);
-    auto wroteFiles = pipeline::cacheTreesAndFiles(*initialGS, inputFiles, indexed, kvstore);
+    auto wroteFiles = pipeline::cacheTreesAndFiles(*initialGS, indexed, kvstore);
     if (wroteGlobalState || wroteFiles) {
         // Only write changes to disk if GlobalState changed since the last time.
         OwnedKeyValueStore::bestEffortCommit(*config->logger, move(kvstore));

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -28,6 +28,8 @@ class LSPIndexer final {
     /** Global state that we keep up-to-date with file edits. We do _not_ typecheck using this global state! We clone
      * this global state every time we need to perform a slow path typechecking operation. */
     std::unique_ptr<core::GlobalState> initialGS;
+    /** Key-value store used during initialization. */
+    std::unique_ptr<KeyValueStore> kvstore;
     /** Contains a copy of the last edit committed on the slow path. Used in slow path cancelation logic. */
     LSPFileUpdates pendingTypecheckUpdates;
     /** Contains a clone of the latency timers for each new edit in the pending typecheck operation. Is used to ensure
@@ -35,7 +37,6 @@ class LSPIndexer final {
     std::vector<std::unique_ptr<Timer>> pendingTypecheckDiagnosticLatencyTimers;
     /** Contains files evicted by `pendingTypecheckUpdates`. Used to make fast path decisions in the immediate past. */
     UnorderedMap<int, std::shared_ptr<core::File>> evictedFiles;
-    std::unique_ptr<KeyValueStore> kvstore; // always null for now.
     /** A WorkerPool with 0 workers. */
     std::unique_ptr<WorkerPool> emptyWorkers;
 
@@ -49,7 +50,8 @@ class LSPIndexer final {
                          bool containsPendingTypecheckUpdates) const;
 
 public:
-    LSPIndexer(std::shared_ptr<const LSPConfiguration> config, std::unique_ptr<core::GlobalState> initialGS);
+    LSPIndexer(std::shared_ptr<const LSPConfiguration> config, std::unique_ptr<core::GlobalState> initialGS,
+               std::unique_ptr<KeyValueStore> kvstore);
     ~LSPIndexer();
 
     /**

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -206,8 +206,7 @@ TypecheckRun LSPTypechecker::runFastPath(LSPFileUpdates updates, WorkerPool &wor
     vector<ast::ParsedFile> updatedIndexed;
     for (auto &f : subset) {
         // TODO(jvilk): We don't need to re-index files that didn't change.
-        unique_ptr<OwnedKeyValueStore> kvstore; // Use a null kvstore since this is likely a short-lived editor edit.
-        auto t = pipeline::indexOne(config->opts, *gs, f, kvstore);
+        auto t = pipeline::indexOne(config->opts, *gs, f);
         updatedIndexed.emplace_back(ast::ParsedFile{t.tree->deepCopy(), t.file});
         updates.updatedFinalGSFileIndexes.push_back(move(t));
     }
@@ -229,10 +228,8 @@ updateFile(unique_ptr<core::GlobalState> gs, const shared_ptr<core::File> &file,
     } else {
         fref = gs->enterFile(file);
     }
-    // Use a null kvstore since this is likely a short-lived editor edit.
-    unique_ptr<OwnedKeyValueStore> kvstore;
     fref.data(*gs).strictLevel = pipeline::decideStrictLevel(*gs, fref, opts);
-    return make_pair(move(gs), pipeline::indexOne(opts, *gs, fref, kvstore));
+    return make_pair(move(gs), pipeline::indexOne(opts, *gs, fref));
 }
 } // namespace
 

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -205,10 +205,8 @@ TypecheckRun LSPTypechecker::runFastPath(LSPFileUpdates updates, WorkerPool &wor
     ENFORCE(gs->errorQueue->isEmpty());
     vector<ast::ParsedFile> updatedIndexed;
     for (auto &f : subset) {
-        unique_ptr<KeyValueStore> kvstore; // nullptr
-        // TODO: Thread through kvstore.
-        ENFORCE(this->kvstore == nullptr);
         // TODO(jvilk): We don't need to re-index files that didn't change.
+        unique_ptr<OwnedKeyValueStore> kvstore; // Use a null kvstore since this is likely a short-lived editor edit.
         auto t = pipeline::indexOne(config->opts, *gs, f, kvstore);
         updatedIndexed.emplace_back(ast::ParsedFile{t.tree->deepCopy(), t.file});
         updates.updatedFinalGSFileIndexes.push_back(move(t));
@@ -231,8 +229,9 @@ updateFile(unique_ptr<core::GlobalState> gs, const shared_ptr<core::File> &file,
     } else {
         fref = gs->enterFile(file);
     }
+    // Use a null kvstore since this is likely a short-lived editor edit.
+    unique_ptr<OwnedKeyValueStore> kvstore;
     fref.data(*gs).strictLevel = pipeline::decideStrictLevel(*gs, fref, opts);
-    std::unique_ptr<KeyValueStore> kvstore; // nullptr
     return make_pair(move(gs), pipeline::indexOne(opts, *gs, fref, kvstore));
 }
 } // namespace

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -8,7 +8,6 @@
 
 namespace sorbet {
 class WorkerPool;
-class KeyValueStore;
 } // namespace sorbet
 
 namespace sorbet::core::lsp {
@@ -62,7 +61,6 @@ class LSPTypechecker final {
     std::vector<u4> diagnosticEpochs;
     /** List of files that have had errors in last run*/
     std::vector<core::FileRef> filesThatHaveErrors;
-    std::unique_ptr<KeyValueStore> kvstore; // always null for now.
     /** Set only when typechecking is happening on the slow path. Contains all of the state needed to restore
      * LSPTypechecker to its pre-slow-path state. Can be null, which indicates that no slow path is currently running */
     std::unique_ptr<UndoState> cancellationUndoState;

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -1,6 +1,7 @@
 #include "main/lsp/lsp.h"
 #include "common/Timer.h"
 #include "common/concurrency/WorkerPool.h"
+#include "common/kvstore/KeyValueStore.h"
 #include "common/statsd/statsd.h"
 #include "common/typecase.h"
 #include "common/web_tracer_framework/tracing.h"
@@ -16,11 +17,11 @@ using namespace std;
 namespace sorbet::realmain::lsp {
 
 LSPLoop::LSPLoop(std::unique_ptr<core::GlobalState> initialGS, WorkerPool &workers,
-                 const std::shared_ptr<LSPConfiguration> &config)
+                 const std::shared_ptr<LSPConfiguration> &config, std::unique_ptr<KeyValueStore> kvstore)
     : config(config), taskQueueMutex(make_shared<absl::Mutex>()), taskQueue(make_shared<TaskQueueState>()),
       epochManager(initialGS->epochManager), preprocessor(config, taskQueueMutex, taskQueue),
       typecheckerCoord(config, make_shared<core::lsp::PreemptionTaskManager>(initialGS->epochManager), workers),
-      indexer(config, move(initialGS)), emptyWorkers(WorkerPool::create(0, *config->logger)),
+      indexer(config, move(initialGS), move(kvstore)), emptyWorkers(WorkerPool::create(0, *config->logger)),
       lastMetricUpdateTime(chrono::steady_clock::now()) {}
 
 constexpr chrono::minutes STATSD_INTERVAL = chrono::minutes(5);

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -63,7 +63,7 @@ class LSPLoop {
 
 public:
     LSPLoop(std::unique_ptr<core::GlobalState> initialGS, WorkerPool &workers,
-            const std::shared_ptr<LSPConfiguration> &config);
+            const std::shared_ptr<LSPConfiguration> &config, std::unique_ptr<KeyValueStore> kvstore);
     /**
      * Runs the language server on a dedicated thread. Returns the final global state if it exits cleanly, or nullopt
      * on error.

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -56,7 +56,7 @@ shared_ptr<LSPConfiguration> makeConfig(const options::Options &opts = nullOpts,
 
 unique_ptr<core::GlobalState> makeGS(const options::Options &opts = nullOpts) {
     auto gs = make_unique<core::GlobalState>((make_shared<core::ErrorQueue>(*typeErrorsConsole, *logger)));
-    unique_ptr<KeyValueStore> kvstore;
+    unique_ptr<OwnedKeyValueStore> kvstore;
     payload::createInitialGlobalState(gs, opts, kvstore);
     gs->errorQueue->ignoreFlushes = true;
     return gs;

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -40,8 +40,7 @@ createGlobalStateAndOtherObjects(string_view rootPath, options::Options &options
     typeErrorsConsoleOut = make_shared<spd::logger>("typeDiagnostics", stderrColorSinkOut);
     typeErrorsConsoleOut->set_pattern("%v");
     auto gs = make_unique<core::GlobalState>((make_shared<core::ErrorQueue>(*typeErrorsConsoleOut, *loggerOut)));
-    // TODO: Thread kvstore through.
-    unique_ptr<KeyValueStore> kvstore;
+    unique_ptr<OwnedKeyValueStore> kvstore;
     payload::createInitialGlobalState(gs, options, kvstore);
     setRequiredLSPOptions(*gs, options);
     return gs;
@@ -82,7 +81,7 @@ LSPWrapper::LSPWrapper(unique_ptr<core::GlobalState> gs, shared_ptr<options::Opt
     : logger(logger), workers(WorkerPool::create(opts->threads, *logger)), stderrColorSink(move(stderrColorSink)),
       typeErrorsConsole(move(typeErrorsConsole)), output(make_shared<LSPOutputToVector>()),
       config_(make_shared<LSPConfiguration>(*opts, output, move(logger), true, disableFastPath)),
-      lspLoop(make_shared<LSPLoop>(std::move(gs), *workers, config_)), opts(move(opts)) {}
+      lspLoop(make_shared<LSPLoop>(std::move(gs), *workers, config_, nullptr)), opts(move(opts)) {}
 
 LSPWrapper::~LSPWrapper() = default;
 

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -13,7 +13,7 @@ namespace spd = spdlog;
 
 namespace sorbet {
 class WorkerPool;
-}
+} // namespace sorbet
 
 namespace sorbet::realmain::lsp {
 

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -13,6 +13,7 @@ namespace spd = spdlog;
 
 namespace sorbet {
 class WorkerPool;
+class KeyValueStore;
 } // namespace sorbet
 
 namespace sorbet::realmain::lsp {
@@ -42,7 +43,8 @@ protected:
     LSPWrapper(std::unique_ptr<core::GlobalState> gs, std::shared_ptr<options::Options> opts,
                std::shared_ptr<spd::logger> logger,
                std::shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
-               std::shared_ptr<spd::logger> typeErrorsConsole, bool disableFastPath);
+               std::shared_ptr<spd::logger> typeErrorsConsole, std::unique_ptr<KeyValueStore> kvstore,
+               bool disableFastPath);
 
 public:
     enum class LSPExperimentalFeature {
@@ -82,12 +84,14 @@ class SingleThreadedLSPWrapper final : public LSPWrapper {
     SingleThreadedLSPWrapper(std::unique_ptr<core::GlobalState> gs, std::shared_ptr<options::Options> opts,
                              std::shared_ptr<spd::logger> logger,
                              std::shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
-                             std::shared_ptr<spd::logger> typeErrorsConsole, bool disableFastPath);
+                             std::shared_ptr<spd::logger> typeErrorsConsole, std::unique_ptr<KeyValueStore> kvstore,
+                             bool disableFastPath);
 
 public:
     static std::unique_ptr<SingleThreadedLSPWrapper> createWithGlobalState(std::unique_ptr<core::GlobalState> gs,
                                                                            std::shared_ptr<options::Options> options,
                                                                            std::shared_ptr<spdlog::logger> logger,
+                                                                           std::unique_ptr<KeyValueStore> kvstore,
                                                                            bool disableFastPath = false);
 
     static std::unique_ptr<SingleThreadedLSPWrapper>
@@ -121,7 +125,8 @@ class MultiThreadedLSPWrapper final : public LSPWrapper {
     MultiThreadedLSPWrapper(std::unique_ptr<core::GlobalState> gs, std::shared_ptr<options::Options> opts,
                             std::shared_ptr<spd::logger> logger,
                             std::shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
-                            std::shared_ptr<spd::logger> typeErrorsConsole, bool disableFastPath);
+                            std::shared_ptr<spd::logger> typeErrorsConsole, std::unique_ptr<KeyValueStore> kvstore,
+                            bool disableFastPath);
 
 public:
     static std::unique_ptr<MultiThreadedLSPWrapper>

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -714,10 +714,6 @@ void readOptions(Options &opts,
         }
 
         opts.runLSP = raw["lsp"].as<bool>();
-        if (opts.runLSP && !opts.cacheDir.empty()) {
-            logger->error("lsp mode does not yet support caching.");
-            throw EarlyReturnWithCode(1);
-        }
         opts.disableWatchman = raw["disable-watchman"].as<bool>();
         opts.watchmanPath = raw["watchman-path"].as<string>();
         // Certain features only need certain passes

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1229,7 +1229,7 @@ bool cacheTreesAndFiles(const core::GlobalState &gs, vector<ast::ParsedFile> &pa
         }
 
         auto &file = pfile.file.data(gs);
-        if (!file.cached) {
+        if (!file.cached && !file.hasParseErrors) {
             kvstore->write(fileKey(file), core::serialize::Serializer::storeFile(file, pfile));
             written = true;
         }

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -13,11 +13,11 @@ class PreemptionTaskManager;
 
 namespace sorbet::realmain::pipeline {
 ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, core::FileRef file,
-                         const std::unique_ptr<OwnedKeyValueStore> &kvstore);
+                         std::unique_ptr<ast::Expression> cachedTree = nullptr);
 
 std::pair<ast::ParsedFile, std::vector<std::shared_ptr<core::File>>>
 indexOneWithPlugins(const options::Options &opts, core::GlobalState &lgs, core::FileRef file,
-                    const std::unique_ptr<OwnedKeyValueStore> &kvstore);
+                    std::unique_ptr<ast::Expression> cachedTree = nullptr);
 
 std::vector<core::FileRef> reserveFiles(std::unique_ptr<core::GlobalState> &gs, const std::vector<std::string> &files);
 
@@ -44,11 +44,15 @@ ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const 
 
 // Computes file hashes for the given files, and stores them in the files. If supplied, attempts to retrieve hashes from
 // the key-value store. Returns 'true' if it had to compute any file hashes.
-bool computeFileHashes(const std::vector<std::shared_ptr<core::File>> files, spdlog::logger &logger,
-                       WorkerPool &workers, const std::unique_ptr<OwnedKeyValueStore> &kvstore);
+void computeFileHashes(const std::vector<std::shared_ptr<core::File>> files, spdlog::logger &logger,
+                       WorkerPool &workers);
 
 core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::FileRef file,
                                     const options::Options &opts);
+
+// Caches any uncached trees and files. Returns true if it modifies kvstore.
+bool cacheTreesAndFiles(const core::GlobalState &gs, const std::vector<core::FileRef> &frefs,
+                        std::vector<ast::ParsedFile> &parsedFiles, const std::unique_ptr<OwnedKeyValueStore> &kvstore);
 
 } // namespace sorbet::realmain::pipeline
 #endif // RUBY_TYPER_PIPELINE_H

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -51,8 +51,8 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
                                     const options::Options &opts);
 
 // Caches any uncached trees and files. Returns true if it modifies kvstore.
-bool cacheTreesAndFiles(const core::GlobalState &gs, const std::vector<core::FileRef> &frefs,
-                        std::vector<ast::ParsedFile> &parsedFiles, const std::unique_ptr<OwnedKeyValueStore> &kvstore);
+bool cacheTreesAndFiles(const core::GlobalState &gs, std::vector<ast::ParsedFile> &parsedFiles,
+                        const std::unique_ptr<OwnedKeyValueStore> &kvstore);
 
 } // namespace sorbet::realmain::pipeline
 #endif // RUBY_TYPER_PIPELINE_H

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -54,5 +54,8 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
 bool cacheTreesAndFiles(const core::GlobalState &gs, std::vector<ast::ParsedFile> &parsedFiles,
                         const std::unique_ptr<OwnedKeyValueStore> &kvstore);
 
+// Exported for tests only.
+std::string fileKey(const core::File &file);
+
 } // namespace sorbet::realmain::pipeline
 #endif // RUBY_TYPER_PIPELINE_H

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -42,9 +42,10 @@ typecheck(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> w
 
 ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Options &opts);
 
-// Computes file hashes for the given files, and stores them in the files.
-void computeFileHashes(const std::vector<std::shared_ptr<core::File>> files, spdlog::logger &logger,
-                       WorkerPool &workers);
+// Computes file hashes for the given files, and stores them in the files. If supplied, attempts to retrieve hashes from
+// the key-value store. Returns 'true' if it had to compute any file hashes.
+bool computeFileHashes(const std::vector<std::shared_ptr<core::File>> files, spdlog::logger &logger,
+                       WorkerPool &workers, const std::unique_ptr<OwnedKeyValueStore> &kvstore);
 
 core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::FileRef file,
                                     const options::Options &opts);

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -13,17 +13,17 @@ class PreemptionTaskManager;
 
 namespace sorbet::realmain::pipeline {
 ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, core::FileRef file,
-                         std::unique_ptr<KeyValueStore> &kvstore);
+                         const std::unique_ptr<OwnedKeyValueStore> &kvstore);
 
 std::pair<ast::ParsedFile, std::vector<std::shared_ptr<core::File>>>
 indexOneWithPlugins(const options::Options &opts, core::GlobalState &lgs, core::FileRef file,
-                    std::unique_ptr<KeyValueStore> &kvstore);
+                    const std::unique_ptr<OwnedKeyValueStore> &kvstore);
 
 std::vector<core::FileRef> reserveFiles(std::unique_ptr<core::GlobalState> &gs, const std::vector<std::string> &files);
 
 std::vector<ast::ParsedFile> index(std::unique_ptr<core::GlobalState> &gs, std::vector<core::FileRef> files,
                                    const options::Options &opts, WorkerPool &workers,
-                                   std::unique_ptr<KeyValueStore> &kvstore);
+                                   const std::unique_ptr<OwnedKeyValueStore> &kvstore);
 
 ast::ParsedFilesOrCancelled resolve(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what,
                                     const options::Options &opts, WorkerPool &workers, bool skipConfigatron = false);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -556,7 +556,7 @@ int realmain(int argc, char *argv[]) {
         if (!opts.storeState.empty()) {
             gs->markAsPayload();
             // Store file hashes for LSP.
-            pipeline::computeFileHashes(gs->getFiles(), *logger, *workers);
+            pipeline::computeFileHashes(gs->getFiles(), *logger, *workers, /* kvstore; not relevant here */ nullptr);
             FileOps::write(opts.storeState.c_str(), core::serialize::Serializer::store(*gs));
         }
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -452,11 +452,8 @@ int realmain(int argc, char *argv[]) {
                       "it will enable outputing the LSP session to stderr(`Write: ` and `Read: ` log lines)",
                       Version::full_version_string);
 
-        unique_ptr<KeyValueStore> unownedKvstore;
-        if (kvstore) {
-            // There should not have been any writes to the kvstore, so no need to commit changes to disk.
-            unownedKvstore = OwnedKeyValueStore::abort(move(kvstore));
-        }
+        // There should not have been any writes to the kvstore, so no need to commit changes to disk.
+        unique_ptr<KeyValueStore> unownedKvstore = OwnedKeyValueStore::abort(move(kvstore));
 
         auto output = make_shared<lsp::LSPStdout>(logger);
         lsp::LSPLoop loop(move(gs), *workers, make_shared<lsp::LSPConfiguration>(opts, output, logger),

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -489,7 +489,7 @@ int realmain(int argc, char *argv[]) {
         { indexed = pipeline::index(gs, inputFiles, opts, *workers, kvstore); }
 
         auto wroteGlobalState = payload::retainGlobalState(gs, opts, kvstore);
-        auto wroteFiles = pipeline::cacheTreesAndFiles(*gs, inputFiles, indexed, kvstore);
+        auto wroteFiles = pipeline::cacheTreesAndFiles(*gs, indexed, kvstore);
         if (wroteGlobalState || wroteFiles) {
             // Only write changes to disk if GlobalState changed since the last time.
             OwnedKeyValueStore::bestEffortCommit(*logger, move(kvstore));

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -394,10 +394,11 @@ int realmain(int argc, char *argv[]) {
     vector<ast::ParsedFile> indexed;
 
     logger->trace("building initial global state");
-    unique_ptr<KeyValueStore> kvstore;
+    unique_ptr<OwnedKeyValueStore> kvstore;
     if (!opts.cacheDir.empty()) {
-        kvstore = make_unique<KeyValueStore>(Version::full_version_string, opts.cacheDir,
-                                             opts.skipRewriterPasses ? "nodsl" : "default");
+        auto unownedKvstore = make_unique<KeyValueStore>(Version::full_version_string, opts.cacheDir,
+                                                         opts.skipRewriterPasses ? "nodsl" : "default");
+        kvstore = make_unique<OwnedKeyValueStore>(move(unownedKvstore));
     }
     payload::createInitialGlobalState(gs, opts, kvstore);
     if (opts.silenceErrors) {
@@ -450,8 +451,15 @@ int realmain(int argc, char *argv[]) {
                       "If you're developing an LSP extension to some editor, make sure to run sorbet with `-v` flag,"
                       "it will enable outputing the LSP session to stderr(`Write: ` and `Read: ` log lines)",
                       Version::full_version_string);
+
+        unique_ptr<KeyValueStore> unownedKvstore;
+        if (kvstore) {
+            unownedKvstore = OwnedKeyValueStore::disown(move(kvstore), /* commit */ true);
+        }
+
         auto output = make_shared<lsp::LSPStdout>(logger);
-        lsp::LSPLoop loop(move(gs), *workers, make_shared<lsp::LSPConfiguration>(opts, output, logger));
+        lsp::LSPLoop loop(move(gs), *workers, make_shared<lsp::LSPConfiguration>(opts, output, logger),
+                          move(unownedKvstore));
         gs = loop.runLSP(make_shared<lsp::LSPFDInput>(logger, STDIN_FILENO)).value_or(nullptr);
 #endif
     } else {
@@ -479,7 +487,7 @@ int realmain(int argc, char *argv[]) {
 
         { indexed = pipeline::index(gs, inputFiles, opts, *workers, kvstore); }
 
-        payload::retainGlobalState(gs, opts, kvstore);
+        payload::retainGlobalState(gs, opts, move(kvstore));
 
         if (gs->runningUnderAutogen) {
 #ifndef SORBET_REALMAIN_MIN

--- a/payload/payload.cc
+++ b/payload/payload.cc
@@ -42,10 +42,12 @@ void createInitialGlobalState(unique_ptr<core::GlobalState> &gs, const realmain:
 }
 
 void retainGlobalState(unique_ptr<core::GlobalState> &gs, const realmain::options::Options &options,
-                       unique_ptr<OwnedKeyValueStore> kvstore) {
+                       unique_ptr<OwnedKeyValueStore> kvstore, bool forceCommit) {
     if (kvstore && gs->wasModified() && !gs->hadCriticalError()) {
         Timer timeit(gs->tracer(), "write_global_state.kvstore");
         kvstore->write(GLOBAL_STATE_KEY, core::serialize::Serializer::storePayloadAndNameTable(*gs));
+        OwnedKeyValueStore::commitAndClose(move(kvstore));
+    } else if (forceCommit) {
         OwnedKeyValueStore::commitAndClose(move(kvstore));
     }
 }

--- a/payload/payload.cc
+++ b/payload/payload.cc
@@ -11,7 +11,7 @@ namespace sorbet::payload {
 constexpr string_view GLOBAL_STATE_KEY = "GlobalState"sv;
 
 void createInitialGlobalState(unique_ptr<core::GlobalState> &gs, const realmain::options::Options &options,
-                              unique_ptr<KeyValueStore> &kvstore) {
+                              const unique_ptr<OwnedKeyValueStore> &kvstore) {
     if (kvstore) {
         auto maybeGsBytes = kvstore->read(GLOBAL_STATE_KEY);
         if (maybeGsBytes) {
@@ -42,11 +42,11 @@ void createInitialGlobalState(unique_ptr<core::GlobalState> &gs, const realmain:
 }
 
 void retainGlobalState(unique_ptr<core::GlobalState> &gs, const realmain::options::Options &options,
-                       unique_ptr<KeyValueStore> &kvstore) {
+                       unique_ptr<OwnedKeyValueStore> kvstore) {
     if (kvstore && gs->wasModified() && !gs->hadCriticalError()) {
         Timer timeit(gs->tracer(), "write_global_state.kvstore");
         kvstore->write(GLOBAL_STATE_KEY, core::serialize::Serializer::storePayloadAndNameTable(*gs));
-        KeyValueStore::commit(move(kvstore));
+        OwnedKeyValueStore::commitAndClose(move(kvstore));
     }
 }
 } // namespace sorbet::payload

--- a/payload/payload.cc
+++ b/payload/payload.cc
@@ -41,14 +41,13 @@ void createInitialGlobalState(unique_ptr<core::GlobalState> &gs, const realmain:
     }
 }
 
-void retainGlobalState(unique_ptr<core::GlobalState> &gs, const realmain::options::Options &options,
-                       unique_ptr<OwnedKeyValueStore> kvstore, bool forceCommit) {
+bool retainGlobalState(unique_ptr<core::GlobalState> &gs, const realmain::options::Options &options,
+                       const unique_ptr<OwnedKeyValueStore> &kvstore) {
     if (kvstore && gs->wasModified() && !gs->hadCriticalError()) {
         Timer timeit(gs->tracer(), "write_global_state.kvstore");
         kvstore->write(GLOBAL_STATE_KEY, core::serialize::Serializer::storePayloadAndNameTable(*gs));
-        OwnedKeyValueStore::commitAndClose(move(kvstore));
-    } else if (forceCommit) {
-        OwnedKeyValueStore::commitAndClose(move(kvstore));
+        return true;
     }
+    return false;
 }
 } // namespace sorbet::payload

--- a/payload/payload.h
+++ b/payload/payload.h
@@ -10,7 +10,7 @@ namespace sorbet::payload {
 void createInitialGlobalState(std::unique_ptr<core::GlobalState> &gs, const realmain::options::Options &options,
                               const std::unique_ptr<OwnedKeyValueStore> &kvstore);
 void retainGlobalState(std::unique_ptr<core::GlobalState> &gs, const realmain::options::Options &options,
-                       std::unique_ptr<OwnedKeyValueStore> kvstore);
+                       std::unique_ptr<OwnedKeyValueStore> kvstore, bool forceCommit = false);
 
 } // namespace sorbet::payload
 #endif // RUBY_TYPER_PAYLOAD_H

--- a/payload/payload.h
+++ b/payload/payload.h
@@ -8,9 +8,9 @@
 namespace sorbet::payload {
 
 void createInitialGlobalState(std::unique_ptr<core::GlobalState> &gs, const realmain::options::Options &options,
-                              std::unique_ptr<KeyValueStore> &kvstore);
+                              const std::unique_ptr<OwnedKeyValueStore> &kvstore);
 void retainGlobalState(std::unique_ptr<core::GlobalState> &gs, const realmain::options::Options &options,
-                       std::unique_ptr<KeyValueStore> &kvstore);
+                       std::unique_ptr<OwnedKeyValueStore> kvstore);
 
 } // namespace sorbet::payload
 #endif // RUBY_TYPER_PAYLOAD_H

--- a/payload/payload.h
+++ b/payload/payload.h
@@ -9,8 +9,10 @@ namespace sorbet::payload {
 
 void createInitialGlobalState(std::unique_ptr<core::GlobalState> &gs, const realmain::options::Options &options,
                               const std::unique_ptr<OwnedKeyValueStore> &kvstore);
-void retainGlobalState(std::unique_ptr<core::GlobalState> &gs, const realmain::options::Options &options,
-                       std::unique_ptr<OwnedKeyValueStore> kvstore, bool forceCommit = false);
+
+/** Writes the GlobalState to kvstore, but only if it was modified. Returns 'true' if a write happens. */
+bool retainGlobalState(std::unique_ptr<core::GlobalState> &gs, const realmain::options::Options &options,
+                       const std::unique_ptr<OwnedKeyValueStore> &kvstore);
 
 } // namespace sorbet::payload
 #endif // RUBY_TYPER_PAYLOAD_H

--- a/payload/text/populate.cc
+++ b/payload/text/populate.cc
@@ -20,7 +20,7 @@ void polulateRBIsInto(unique_ptr<core::GlobalState> &gs) {
         }
     }
     realmain::options::Options emptyOpts;
-    unique_ptr<KeyValueStore> kvstore;
+    unique_ptr<OwnedKeyValueStore> kvstore;
     auto workers = WorkerPool::create(emptyOpts.threads, gs->tracer());
     auto indexed = realmain::pipeline::index(gs, payloadFiles, emptyOpts, *workers, kvstore);
     realmain::pipeline::resolve(gs, move(indexed), emptyOpts, *workers); // result is thrown away

--- a/test/fuzz/fuzz_dash_e.cc
+++ b/test/fuzz/fuzz_dash_e.cc
@@ -23,7 +23,7 @@ realmain::options::Options createDefaultOptions(bool stressIncrementalResolver) 
 unique_ptr<const realmain::options::Options> opts =
     make_unique<const realmain::options::Options>(createDefaultOptions(false));
 
-unique_ptr<KeyValueStore> kvstore;
+unique_ptr<OwnedKeyValueStore> kvstore;
 
 unique_ptr<core::GlobalState> buildInitialGlobalState() {
     typeErrorsConsole->set_level(spd::level::critical);

--- a/test/lsp/BUILD
+++ b/test/lsp/BUILD
@@ -31,6 +31,30 @@ cc_test(
 )
 
 cc_test(
+    name = "cache_protocol_test_corpus",
+    size = "medium",
+    srcs = [
+        "ProtocolTest.cc",
+        "ProtocolTest.h",
+        "cache_protocol_test_corpus.cc",
+    ],
+    copts = ["-Iexternal/gtest/include"],
+    linkstatic = select({
+        "//tools/config:linkshared": 0,
+        "//conditions:default": 1,
+    }),
+    visibility = ["//tools:__pkg__"],
+    deps = [
+        "//core",
+        "//main/lsp",
+        "//payload",
+        "//test/helpers",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "multithreaded_protocol_test_corpus",
     size = "medium",
     srcs = [

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -37,19 +37,25 @@ public:
                                                 std::vector<std::pair<ConstExprStr, ConstExprStr>> tags = {}) const;
 };
 
+struct ProtocolTestConfig {
+    bool useMultithreading = false;
+    // Should the test use kvstore?
+    bool useCache = false;
+};
+
 /**
  * If parameter is 'true', LSP is configured in multithreaded mode.
  */
-class ProtocolTest : public testing::TestWithParam<bool> {
+class ProtocolTest : public testing::TestWithParam<ProtocolTestConfig> {
 protected:
     std::unique_ptr<LSPWrapper> lspWrapper;
     std::string rootPath;
     std::string rootUri;
+    std::string cacheDir;
     // Contains the current source file contents. Used to print pretty error messages.
     // TODO(jvilk): Remove and instead get state from Sorbet directly. Will be hard to maintain
     // once we test incremental diffs.
     UnorderedMap<std::string, std::shared_ptr<core::File>> sourceFileContents;
-    std::vector<std::unique_ptr<LSPMessage>> pendingRequests;
     // Currently active diagnostics, specifically using map to enforce sort order on filename.
     std::map<std::string, std::vector<std::unique_ptr<Diagnostic>>> diagnostics;
     // Emulated file system.
@@ -61,6 +67,11 @@ protected:
     ~ProtocolTest() override = default;
 
     void SetUp() override;
+
+    void TearDown() override;
+
+    /** Reset lspWrapper and other internal state. */
+    void resetState();
 
     /** Get an absolute file URI for the given relative file path. */
     std::string getUri(std::string_view filePath);

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -1,0 +1,126 @@
+#include "gtest/gtest.h"
+// ^ Violates linting rules, so include first.
+#include "ProtocolTest.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_replace.h"
+#include "common/common.h"
+#include "common/kvstore/KeyValueStore.h"
+#include "core/ErrorQueue.h"
+#include "core/serialize/serialize.h"
+#include "main/pipeline/pipeline.h"
+#include "payload/payload.h"
+#include "spdlog/sinks/null_sink.h"
+#include "test/helpers/lsp.h"
+#include "version/version.h"
+
+namespace sorbet::test::lsp {
+using namespace std;
+using namespace sorbet::realmain::lsp;
+
+TEST_P(ProtocolTest, LSPUsesCache) {
+    // Write a file to disk.
+    auto relativeFilepath = "test.rb";
+    auto filePath = fmt::format("{}/{}", rootPath, relativeFilepath);
+    // This file has an error to indirectly assert that LSP is actually typechecking the file during initialization.
+    auto fileContents = "# typed: true\nclass Foo extend T::Sig\nsig {returns(Integer)}\ndef bar\n'hello'\nend\nend\n";
+    auto key =
+        realmain::pipeline::fileKey(core::File(string(filePath), string(fileContents), core::File::Type::Normal, 0));
+
+    auto updatedFileContents = "# typed: true\n";
+    auto updatedKey = realmain::pipeline::fileKey(
+        core::File(string(filePath), string(updatedFileContents), core::File::Type::Normal, 0));
+
+    // LSP should write a cache to disk corresponding to initialization state.
+    {
+        writeFilesToFS({{relativeFilepath, fileContents}});
+
+        lspWrapper->opts->inputFileNames.push_back(filePath);
+        assertDiagnostics(initializeLSP(),
+                          {{relativeFilepath, 4, "Returning value that does not conform to method result type"}});
+
+        // Update the file on disk to a different version. This change should not be synced to disk.
+        assertDiagnostics(send(*openFile(relativeFilepath, updatedFileContents)), {});
+    }
+
+    // LSP should have written cache to disk with file hashes from initialization.
+    // It should not include data from file updates made during the editor session.
+    {
+        auto opts = lspWrapper->opts;
+
+        // Release cache lock.
+        lspWrapper = nullptr;
+
+        auto kvstore = make_unique<OwnedKeyValueStore>(
+            make_unique<KeyValueStore>(Version::full_version_string, cacheDir, "default"));
+        EXPECT_EQ(kvstore->read(updatedKey), nullptr);
+
+        auto contents = kvstore->read(key);
+        ASSERT_NE(contents, nullptr);
+
+        auto sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+        auto logger = std::make_shared<spdlog::logger>("null", sink);
+        auto gs = make_unique<core::GlobalState>((make_shared<core::ErrorQueue>(*logger, *logger)));
+        payload::createInitialGlobalState(gs, *opts, kvstore);
+
+        // If caching fails, gs gets modified during payload creation.
+        EXPECT_FALSE(gs->wasModified());
+
+        auto cachedFile = core::serialize::Serializer::loadFile(*gs, core::FileRef{10}, contents);
+        EXPECT_TRUE(cachedFile.file->cached);
+        EXPECT_EQ(cachedFile.file->path(), filePath);
+        EXPECT_EQ(cachedFile.file->source(), fileContents);
+        EXPECT_NE(cachedFile.file->getFileHash(), nullptr);
+    }
+
+    // LSP should read from the cache when files on disk match. There should be no cache misses this time since disk
+    // state has not changed.
+    {
+        resetState();
+        lspWrapper->opts->inputFileNames.push_back(filePath);
+        writeFilesToFS({{relativeFilepath, fileContents}});
+        assertDiagnostics(initializeLSP(),
+                          {{relativeFilepath, 4, "Returning value that does not conform to method result type"}});
+
+        auto counters = getCounters();
+        EXPECT_EQ(counters.getCounter("types.input.files.kvstore.miss"), 0);
+        EXPECT_GT(counters.getCounter("types.input.files.kvstore.hit"), 0);
+    }
+
+    // LSP should not use the cached file when a file on disk changes.
+    {
+        resetState();
+        lspWrapper->opts->inputFileNames.push_back(filePath);
+        writeFilesToFS({{relativeFilepath, updatedFileContents}});
+        assertDiagnostics(initializeLSP(), {});
+
+        auto counters = getCounters();
+        EXPECT_EQ(counters.getCounter("types.input.files.kvstore.miss"), 1);
+    }
+
+    // LSP should update the cache when seeing an updated file during initialization.
+    {
+        auto opts = lspWrapper->opts;
+
+        // Release cache lock.
+        lspWrapper = nullptr;
+        auto kvstore = make_unique<OwnedKeyValueStore>(
+            make_unique<KeyValueStore>(Version::full_version_string, cacheDir, "default"));
+        auto updatedFileData = kvstore->read(updatedKey);
+        ASSERT_NE(updatedFileData, nullptr);
+
+        auto sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+        auto logger = std::make_shared<spdlog::logger>("null", sink);
+        auto gs = make_unique<core::GlobalState>(make_shared<core::ErrorQueue>(*logger, *logger));
+        payload::createInitialGlobalState(gs, *opts, kvstore);
+
+        auto cachedFile = core::serialize::Serializer::loadFile(*gs, core::FileRef{10}, updatedFileData);
+        EXPECT_TRUE(cachedFile.file->cached);
+        EXPECT_EQ(cachedFile.file->path(), filePath);
+        EXPECT_EQ(cachedFile.file->source(), updatedFileContents);
+        EXPECT_NE(cachedFile.file->getFileHash(), nullptr);
+    }
+}
+
+// Run these tests in multi-threaded mode with caching
+INSTANTIATE_TEST_SUITE_P(MultithreadedProtocolTests, ProtocolTest, testing::Values(ProtocolTestConfig{true, true}));
+} // namespace sorbet::test::lsp

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -619,6 +619,6 @@ TEST_P(ProtocolTest, CanceledRequestsDontReportLatencyMetrics) {
 }
 
 // Run these tests in multi-threaded mode.
-INSTANTIATE_TEST_SUITE_P(MultithreadedProtocolTests, ProtocolTest, testing::Values(true));
+INSTANTIATE_TEST_SUITE_P(MultithreadedProtocolTests, ProtocolTest, testing::Values(ProtocolTestConfig{true}));
 
 } // namespace sorbet::test::lsp

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -527,6 +527,6 @@ TEST_P(ProtocolTest, DoesNotCrashOnNonWorkspaceURIs) {
 }
 
 // Run these tests in single-threaded mode.
-INSTANTIATE_TEST_SUITE_P(SingleThreadedProtocolTests, ProtocolTest, testing::Values(false));
+INSTANTIATE_TEST_SUITE_P(SingleThreadedProtocolTests, ProtocolTest, testing::Values(ProtocolTestConfig{false}));
 
 } // namespace sorbet::test::lsp

--- a/test/lsp/watchman_test_corpus.cc
+++ b/test/lsp/watchman_test_corpus.cc
@@ -121,6 +121,6 @@ TEST_P(ProtocolTest, MergesMultipleWatchmanUpdates) {
 }
 
 // Run these tests in single-threaded mode.
-INSTANTIATE_TEST_SUITE_P(SingleThreadedProtocolTests, ProtocolTest, testing::Values(false));
+INSTANTIATE_TEST_SUITE_P(SingleThreadedProtocolTests, ProtocolTest, testing::Values(ProtocolTestConfig{false}));
 
 } // namespace sorbet::test::lsp

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -122,9 +122,10 @@ UnorderedSet<string> knownExpectations = {
     "document-symbols"};
 
 ast::ParsedFile testSerialize(core::GlobalState &gs, ast::ParsedFile expr) {
-    auto saved = core::serialize::Serializer::storeExpression(gs, expr.tree);
-    auto restored = core::serialize::Serializer::loadExpression(gs, saved.data());
-    return {move(restored), expr.file};
+    auto &savedFile = expr.file.data(gs);
+    auto saved = core::serialize::Serializer::storeFile(savedFile, expr);
+    auto restored = core::serialize::Serializer::loadFile(gs, expr.file, saved.data());
+    return {move(restored.tree), expr.file};
 }
 
 /** Converts a Sorbet Error object into an equivalent LSP Diagnostic object. */

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -76,6 +76,7 @@ compilation_database(
         "//common/web_tracer_framework:tracing",
         "//common/statsd:statsd",
         "//version:version",
+        "//common/kvstore:kvstore_test",
         "//common/kvstore:kvstore",
         "//common/crypto_hashing:crypto_hashing",
         "//common:common_test",

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -14,6 +14,7 @@ compilation_database(
         "//test/lsp:watchman_test_corpus",
         "//test/lsp:protocol_test_corpus",
         "//test/lsp:multithreaded_protocol_test_corpus",
+        "//test/lsp:cache_protocol_test_corpus",
         "//test/fuzz:fuzz_hover",
         "//test/fuzz:proto",
         "//test/fuzz:fuzz_doc_symbols",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Use kvstore in LSP to optimize startup performance. When LSP starts up, it has to parse and hash every file in the project. This cost currently dominates startup time on large projects.

With this change, when --cache-dir and --lsp are supplied to Sorbet, Sorbet will store the following on disk in the kvstore immediately after initialization:

* The same contents as the CLI version (parsed ASTs and GlobalState).
* Hashes for files

Sorbet does not touch the cache-dir for the rest of execution.

LSP is compatible with the CLI's kvstore, so the same --cache-dir can be supplied to both LSP and CLI modes. The extra hashes are stored in keys that are uniquely used only in LSP mode.

The implementation involved changing KeyValueStore so that it's possible to transfer ownership between threads, which is necessary to support kvstore interactions in `realmain` and `LSPIndexer`. Specifically:

* All access to `KeyValueStore` must be mediated via an `OwnedKeyValueStore`.
* `OwnedKeyValueStore` can be downgraded (via `commit` or `abort`) to a `KeyValueStore`, which also serves to explicitly commit or abort writes made to the store.

The end result of this optimization: A huge decrease in startup latency for Sorbet LSP (an order of magnitude decrease) when the project is cached on disk.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Mainly, to speed up LSP initialization!

Sorbet's CLI supports caching ASTs on disk with --cache-dir, and earlier today I landed logic for also serializing hashes for files. It made sense to connect this logic with LSP when --cache-dir is supplied.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.