### PR TITLE
Avoid clone for T::Configuration.scalar_types and T::Boolean in serde

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/private/serde_transform.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/serde_transform.rb
@@ -69,6 +69,16 @@ module T::Props
             handle_serializable_subtype(varname, raw, mode)
           elsif raw.singleton_class < T::Props::CustomType
             handle_custom_type(varname, T.unsafe(raw), mode)
+          elsif T::Configuration.scalar_types.include?(raw.name)
+            # It's a bit of a hack that this is separate from NO_TRANSFORM_TYPES
+            # and doesn't check inheritance (like `T::Props::CustomType.scalar_type?`
+            # does), but it covers the main use case (pay-server's custom `Boolean`
+            # module) without either requiring `T::Configuration.scalar_types` to
+            # accept modules instead of strings (which produces load-order issues
+            # and subtle behavior changes) or eating the performance cost of doing
+            # an inheritance check by manually crawling a class hierarchy and doing
+            # string comparisons.
+            nil
           else
             "T::Props::Utils.deep_clone_object(#{varname})"
           end

--- a/gems/sorbet-runtime/lib/types/props/private/serde_transform.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/serde_transform.rb
@@ -82,7 +82,12 @@ module T::Props
               "#{varname}.nil? ? nil : #{inner}"
             end
           else
-            "T::Props::Utils.deep_clone_object(#{varname})"
+            # Handle, e.g., T::Boolean
+            if type.types.all? {|t| generate(t, mode, varname).nil?}
+              nil
+            else
+              "T::Props::Utils.deep_clone_object(#{varname})"
+            end
           end
         when T::Types::Enum
           generate(T::Utils.lift_enum(type), mode, varname)


### PR DESCRIPTION
Use `T::Configuration.scalar_types` to check if cloning is unnecessary in the serde code generator, instead of only using a hardcoded list; also improve our `T.any` handling so that we don't generate a clone for `T::Boolean` props.

### Motivation
The hardcoded list doesn't (and can't really) include pay-server's Boolean class, so we call `T::Props::Utils.deep_clone_object` a lot more than we need to in, e.g., `Charge#deserialize`. `T::Props::Utils.deep_clone_object` should noop out, but it's better to skip the extra method calls and type checks in the first place.

And while I was fixing that, I realized we didn't even handle T::Boolean as intended!

### Test plan
Passing build here (with added tests) & in pay-server, plus inspected the generated deserializer for Charge in `pay console` and it does fewer unnecessary clones