### PR TITLE
Remove Stripe internal type from signature

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -602,7 +602,7 @@ class T::Props::Decorator
   sig do
     params(
       prop_name: Symbol,
-      redaction: Chalk::Tools::RedactionUtils::RedactionDirectiveSpec,
+      redaction: T.untyped,
     )
     .void
   end


### PR DESCRIPTION
Replacing `Chalk::Tools::RedactionUtils::RedactionDirectiveSpec` with `T.untyped` in the signature of `T::Props::Decorator#handle_redaction_option`.

### Motivation
Currently `T::Utils.run_all_sig_blocks` method call fails for every codebase other than Stripe's due to the `Chalk::Tools::RedactionUtils::RedactionDirectiveSpec` type in one of the signatures in `sorbet-runtime`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No tests, do you want me to add one?
