### PR TITLE
No longer store FileRefs in most of trees, keep them in MethodDef and ClassDefs

### DIFF
--- a/ast/ArgParsing.h
+++ b/ast/ArgParsing.h
@@ -3,7 +3,7 @@
 #include "ast/ast.h"
 namespace sorbet::ast {
 struct ParsedArg {
-    core::Loc loc;
+    core::LocOffsets loc;
     core::LocalVariable local;
     std::unique_ptr<ast::Expression> default_;
     bool keyword = false;

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -13,49 +13,51 @@ public:
         return std::make_unique<ast::EmptyTree>();
     }
 
-    static std::unique_ptr<Block> Block(core::Loc loc, std::unique_ptr<Expression> body, MethodDef::ARGS_store args) {
+    static std::unique_ptr<Block> Block(core::LocOffsets loc, std::unique_ptr<Expression> body,
+                                        MethodDef::ARGS_store args) {
         auto blk = std::make_unique<ast::Block>(loc, std::move(args), std::move(body));
         return blk;
     }
 
-    static std::unique_ptr<ast::Block> Block0(core::Loc loc, std::unique_ptr<Expression> body) {
+    static std::unique_ptr<ast::Block> Block0(core::LocOffsets loc, std::unique_ptr<Expression> body) {
         MethodDef::ARGS_store args;
         return Block(loc, std::move(body), std::move(args));
     }
 
-    static std::unique_ptr<ast::Block> Block1(core::Loc loc, std::unique_ptr<Expression> body,
+    static std::unique_ptr<ast::Block> Block1(core::LocOffsets loc, std::unique_ptr<Expression> body,
                                               std::unique_ptr<Expression> arg1) {
         MethodDef::ARGS_store args;
         args.emplace_back(move(arg1));
         return Block(loc, std::move(body), std::move(args));
     }
 
-    static std::unique_ptr<Expression> Send(core::Loc loc, std::unique_ptr<Expression> recv, core::NameRef fun,
+    static std::unique_ptr<Expression> Send(core::LocOffsets loc, std::unique_ptr<Expression> recv, core::NameRef fun,
                                             Send::ARGS_store args, Send::Flags flags = {},
                                             std::unique_ptr<ast::Block> blk = nullptr) {
         auto send = std::make_unique<ast::Send>(loc, std::move(recv), fun, std::move(args), std::move(blk), flags);
         return send;
     }
 
-    static std::unique_ptr<Expression> Send0(core::Loc loc, std::unique_ptr<Expression> recv, core::NameRef fun) {
+    static std::unique_ptr<Expression> Send0(core::LocOffsets loc, std::unique_ptr<Expression> recv,
+                                             core::NameRef fun) {
         Send::ARGS_store nargs;
         return Send(loc, std::move(recv), fun, std::move(nargs));
     }
 
-    static std::unique_ptr<Expression> Send0Block(core::Loc loc, std::unique_ptr<Expression> recv, core::NameRef fun,
-                                                  std::unique_ptr<ast::Block> blk) {
+    static std::unique_ptr<Expression> Send0Block(core::LocOffsets loc, std::unique_ptr<Expression> recv,
+                                                  core::NameRef fun, std::unique_ptr<ast::Block> blk) {
         Send::ARGS_store nargs;
         return Send(loc, std::move(recv), fun, std::move(nargs), {}, std::move(blk));
     }
 
-    static std::unique_ptr<Expression> Send1(core::Loc loc, std::unique_ptr<Expression> recv, core::NameRef fun,
+    static std::unique_ptr<Expression> Send1(core::LocOffsets loc, std::unique_ptr<Expression> recv, core::NameRef fun,
                                              std::unique_ptr<Expression> arg1) {
         Send::ARGS_store nargs;
         nargs.emplace_back(std::move(arg1));
         return Send(loc, std::move(recv), fun, std::move(nargs));
     }
 
-    static std::unique_ptr<Expression> Send2(core::Loc loc, std::unique_ptr<Expression> recv, core::NameRef fun,
+    static std::unique_ptr<Expression> Send2(core::LocOffsets loc, std::unique_ptr<Expression> recv, core::NameRef fun,
                                              std::unique_ptr<Expression> arg1, std::unique_ptr<Expression> arg2) {
         Send::ARGS_store nargs;
         nargs.emplace_back(std::move(arg1));
@@ -63,7 +65,7 @@ public:
         return Send(loc, std::move(recv), fun, std::move(nargs));
     }
 
-    static std::unique_ptr<Expression> Send3(core::Loc loc, std::unique_ptr<Expression> recv, core::NameRef fun,
+    static std::unique_ptr<Expression> Send3(core::LocOffsets loc, std::unique_ptr<Expression> recv, core::NameRef fun,
                                              std::unique_ptr<Expression> arg1, std::unique_ptr<Expression> arg2,
                                              std::unique_ptr<Expression> arg3) {
         Send::ARGS_store nargs;
@@ -73,57 +75,57 @@ public:
         return Send(loc, std::move(recv), fun, std::move(nargs));
     }
 
-    static std::unique_ptr<Literal> Literal(core::Loc loc, const core::TypePtr &tpe) {
+    static std::unique_ptr<Literal> Literal(core::LocOffsets loc, const core::TypePtr &tpe) {
         return std::make_unique<ast::Literal>(loc, tpe);
     }
 
-    static std::unique_ptr<Expression> Return(core::Loc loc, std::unique_ptr<Expression> expr) {
+    static std::unique_ptr<Expression> Return(core::LocOffsets loc, std::unique_ptr<Expression> expr) {
         return std::make_unique<ast::Return>(loc, std::move(expr));
     }
 
-    static std::unique_ptr<Expression> Next(core::Loc loc, std::unique_ptr<Expression> expr) {
+    static std::unique_ptr<Expression> Next(core::LocOffsets loc, std::unique_ptr<Expression> expr) {
         return std::make_unique<ast::Next>(loc, std::move(expr));
     }
 
-    static std::unique_ptr<Expression> Break(core::Loc loc, std::unique_ptr<Expression> expr) {
+    static std::unique_ptr<Expression> Break(core::LocOffsets loc, std::unique_ptr<Expression> expr) {
         return std::make_unique<ast::Break>(loc, std::move(expr));
     }
 
-    static std::unique_ptr<Expression> Nil(core::Loc loc) {
+    static std::unique_ptr<Expression> Nil(core::LocOffsets loc) {
         return std::make_unique<ast::Literal>(loc, core::Types::nilClass());
     }
 
-    static std::unique_ptr<ConstantLit> Constant(core::Loc loc, core::SymbolRef symbol) {
+    static std::unique_ptr<ConstantLit> Constant(core::LocOffsets loc, core::SymbolRef symbol) {
         ENFORCE(symbol.exists());
         return std::make_unique<ConstantLit>(loc, symbol, nullptr);
     }
 
-    static std::unique_ptr<Reference> Local(core::Loc loc, core::NameRef name) {
+    static std::unique_ptr<Reference> Local(core::LocOffsets loc, core::NameRef name) {
         return std::make_unique<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Local, name);
     }
 
-    static std::unique_ptr<Reference> OptionalArg(core::Loc loc, std::unique_ptr<Reference> inner,
+    static std::unique_ptr<Reference> OptionalArg(core::LocOffsets loc, std::unique_ptr<Reference> inner,
                                                   std::unique_ptr<Expression> default_) {
         return std::make_unique<ast::OptionalArg>(loc, std::move(inner), std::move(default_));
     }
 
-    static std::unique_ptr<Reference> KeywordArg(core::Loc loc, std::unique_ptr<Reference> inner) {
+    static std::unique_ptr<Reference> KeywordArg(core::LocOffsets loc, std::unique_ptr<Reference> inner) {
         return std::make_unique<ast::KeywordArg>(loc, std::move(inner));
     }
 
-    static std::unique_ptr<Reference> RestArg(core::Loc loc, std::unique_ptr<Reference> inner) {
+    static std::unique_ptr<Reference> RestArg(core::LocOffsets loc, std::unique_ptr<Reference> inner) {
         return std::make_unique<ast::RestArg>(loc, std::move(inner));
     }
 
-    static std::unique_ptr<Reference> BlockArg(core::Loc loc, std::unique_ptr<Reference> inner) {
+    static std::unique_ptr<Reference> BlockArg(core::LocOffsets loc, std::unique_ptr<Reference> inner) {
         return std::make_unique<ast::BlockArg>(loc, std::move(inner));
     }
 
-    static std::unique_ptr<Reference> ShadowArg(core::Loc loc, std::unique_ptr<Reference> inner) {
+    static std::unique_ptr<Reference> ShadowArg(core::LocOffsets loc, std::unique_ptr<Reference> inner) {
         return std::make_unique<ast::ShadowArg>(loc, std::move(inner));
     }
 
-    static std::unique_ptr<Reference> Instance(core::Loc loc, core::NameRef name) {
+    static std::unique_ptr<Reference> Instance(core::LocOffsets loc, core::NameRef name) {
         return std::make_unique<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Instance, name);
     }
 
@@ -136,7 +138,7 @@ public:
         Exception::notImplemented();
     }
 
-    static std::unique_ptr<Expression> Assign(core::Loc loc, std::unique_ptr<Expression> lhs,
+    static std::unique_ptr<Expression> Assign(core::LocOffsets loc, std::unique_ptr<Expression> lhs,
                                               std::unique_ptr<Expression> rhs) {
         if (auto *s = cast_tree<ast::Send>(lhs.get())) {
             // the LHS might be a send of the form x.y=(), in which case we add the RHS to the arguments list and get
@@ -160,25 +162,26 @@ public:
         return std::make_unique<ast::Assign>(loc, std::move(lhs), std::move(rhs));
     }
 
-    static std::unique_ptr<Expression> Assign(core::Loc loc, core::NameRef name, std::unique_ptr<Expression> rhs) {
+    static std::unique_ptr<Expression> Assign(core::LocOffsets loc, core::NameRef name,
+                                              std::unique_ptr<Expression> rhs) {
         return Assign(loc, Local(loc, name), std::move(rhs));
     }
 
-    static std::unique_ptr<Expression> If(core::Loc loc, std::unique_ptr<Expression> cond,
+    static std::unique_ptr<Expression> If(core::LocOffsets loc, std::unique_ptr<Expression> cond,
                                           std::unique_ptr<Expression> thenp, std::unique_ptr<Expression> elsep) {
         return std::make_unique<ast::If>(loc, std::move(cond), std::move(thenp), std::move(elsep));
     }
 
-    static std::unique_ptr<Expression> While(core::Loc loc, std::unique_ptr<Expression> cond,
+    static std::unique_ptr<Expression> While(core::LocOffsets loc, std::unique_ptr<Expression> cond,
                                              std::unique_ptr<Expression> body) {
         return std::make_unique<ast::While>(loc, std::move(cond), std::move(body));
     }
 
-    static std::unique_ptr<Expression> Self(core::Loc loc) {
+    static std::unique_ptr<Expression> Self(core::LocOffsets loc) {
         return std::make_unique<ast::Local>(loc, core::LocalVariable::selfVariable());
     }
 
-    static std::unique_ptr<Expression> InsSeq(core::Loc loc, InsSeq::STATS_store stats,
+    static std::unique_ptr<Expression> InsSeq(core::LocOffsets loc, InsSeq::STATS_store stats,
                                               std::unique_ptr<Expression> expr) {
         if (!stats.empty()) {
             return std::make_unique<ast::InsSeq>(loc, std::move(stats), std::move(expr));
@@ -186,57 +189,57 @@ public:
         return expr;
     }
 
-    static std::unique_ptr<Expression> Splat(core::Loc loc, std::unique_ptr<Expression> arg) {
+    static std::unique_ptr<Expression> Splat(core::LocOffsets loc, std::unique_ptr<Expression> arg) {
         auto to_a = Send0(loc, std::move(arg), core::Names::toA());
         return Send1(loc, Constant(loc, core::Symbols::Magic()), core::Names::splat(), std::move(to_a));
     }
 
-    static std::unique_ptr<Expression> CallWithSplat(core::Loc loc, std::unique_ptr<Expression> recv,
+    static std::unique_ptr<Expression> CallWithSplat(core::LocOffsets loc, std::unique_ptr<Expression> recv,
                                                      core::NameRef name, std::unique_ptr<Expression> args) {
         return Send3(loc, Constant(loc, core::Symbols::Magic()), core::Names::callWithSplat(), std::move(recv),
                      MK::Symbol(loc, name), std::move(args));
     }
 
-    static std::unique_ptr<Expression> InsSeq1(core::Loc loc, std::unique_ptr<Expression> stat,
+    static std::unique_ptr<Expression> InsSeq1(core::LocOffsets loc, std::unique_ptr<Expression> stat,
                                                std::unique_ptr<Expression> expr) {
         InsSeq::STATS_store stats;
         stats.emplace_back(std::move(stat));
         return InsSeq(loc, std::move(stats), std::move(expr));
     }
 
-    static std::unique_ptr<Expression> True(core::Loc loc) {
+    static std::unique_ptr<Expression> True(core::LocOffsets loc) {
         return std::make_unique<ast::Literal>(loc, core::Types::trueClass());
     }
 
-    static std::unique_ptr<Expression> False(core::Loc loc) {
+    static std::unique_ptr<Expression> False(core::LocOffsets loc) {
         return std::make_unique<ast::Literal>(loc, core::Types::falseClass());
     }
 
-    static std::unique_ptr<UnresolvedConstantLit> UnresolvedConstant(core::Loc loc, std::unique_ptr<Expression> scope,
-                                                                     core::NameRef name) {
+    static std::unique_ptr<UnresolvedConstantLit>
+    UnresolvedConstant(core::LocOffsets loc, std::unique_ptr<Expression> scope, core::NameRef name) {
         return std::make_unique<UnresolvedConstantLit>(loc, std::move(scope), name);
     }
 
-    static std::unique_ptr<Expression> Int(core::Loc loc, int64_t val) {
+    static std::unique_ptr<Expression> Int(core::LocOffsets loc, int64_t val) {
         return std::make_unique<ast::Literal>(loc, core::make_type<core::LiteralType>(val));
     }
 
-    static std::unique_ptr<Expression> Float(core::Loc loc, double val) {
+    static std::unique_ptr<Expression> Float(core::LocOffsets loc, double val) {
         return std::make_unique<ast::Literal>(loc, core::make_type<core::LiteralType>(val));
     }
 
-    static std::unique_ptr<Expression> Symbol(core::Loc loc, core::NameRef name) {
+    static std::unique_ptr<Expression> Symbol(core::LocOffsets loc, core::NameRef name) {
         return std::make_unique<ast::Literal>(loc, core::make_type<core::LiteralType>(core::Symbols::Symbol(), name));
     }
 
-    static std::unique_ptr<Expression> String(core::Loc loc, core::NameRef value) {
+    static std::unique_ptr<Expression> String(core::LocOffsets loc, core::NameRef value) {
         return std::make_unique<ast::Literal>(loc, core::make_type<core::LiteralType>(core::Symbols::String(), value));
     }
 
-    static std::unique_ptr<MethodDef> Method(core::Loc loc, core::Loc declLoc, core::NameRef name,
+    static std::unique_ptr<MethodDef> Method(core::LocOffsets loc, core::Loc declLoc, core::NameRef name,
                                              MethodDef::ARGS_store args, std::unique_ptr<Expression> rhs) {
         if (args.empty() || (!isa_tree<ast::Local>(args.back().get()) && !isa_tree<ast::BlockArg>(args.back().get()))) {
-            auto blkLoc = core::Loc::none(declLoc.file());
+            auto blkLoc = core::LocOffsets::none();
             args.emplace_back(std::make_unique<ast::BlockArg>(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
         }
         MethodDef::Flags flags;
@@ -244,20 +247,20 @@ public:
                                            flags);
     }
 
-    static std::unique_ptr<MethodDef> SyntheticMethod(core::Loc loc, core::Loc declLoc, core::NameRef name,
+    static std::unique_ptr<MethodDef> SyntheticMethod(core::LocOffsets loc, core::Loc declLoc, core::NameRef name,
                                                       MethodDef::ARGS_store args, std::unique_ptr<Expression> rhs) {
         auto mdef = Method(loc, declLoc, name, std::move(args), std::move(rhs));
         mdef->flags.isRewriterSynthesized = true;
         return mdef;
     }
 
-    static std::unique_ptr<MethodDef> SyntheticMethod0(core::Loc loc, core::Loc declLoc, core::NameRef name,
+    static std::unique_ptr<MethodDef> SyntheticMethod0(core::LocOffsets loc, core::Loc declLoc, core::NameRef name,
                                                        std::unique_ptr<Expression> rhs) {
         MethodDef::ARGS_store args;
         return SyntheticMethod(loc, declLoc, name, std::move(args), std::move(rhs));
     }
 
-    static std::unique_ptr<MethodDef> SyntheticMethod1(core::Loc loc, core::Loc declLoc, core::NameRef name,
+    static std::unique_ptr<MethodDef> SyntheticMethod1(core::LocOffsets loc, core::Loc declLoc, core::NameRef name,
                                                        std::unique_ptr<Expression> arg0,
                                                        std::unique_ptr<Expression> rhs) {
         MethodDef::ARGS_store args;
@@ -265,40 +268,41 @@ public:
         return SyntheticMethod(loc, declLoc, name, std::move(args), std::move(rhs));
     }
 
-    static std::unique_ptr<ClassDef> ClassOrModule(core::Loc loc, core::Loc declLoc, std::unique_ptr<Expression> name,
+    static std::unique_ptr<ClassDef> ClassOrModule(core::LocOffsets loc, core::Loc declLoc,
+                                                   std::unique_ptr<Expression> name,
                                                    ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs,
                                                    ClassDef::Kind kind) {
         return std::make_unique<ClassDef>(loc, declLoc, core::Symbols::todo(), std::move(name), std::move(ancestors),
                                           std::move(rhs), kind);
     }
 
-    static std::unique_ptr<ClassDef> Class(core::Loc loc, core::Loc declLoc, std::unique_ptr<Expression> name,
+    static std::unique_ptr<ClassDef> Class(core::LocOffsets loc, core::Loc declLoc, std::unique_ptr<Expression> name,
                                            ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs) {
         return MK::ClassOrModule(loc, declLoc, std::move(name), std::move(ancestors), std::move(rhs),
                                  ClassDef::Kind::Class);
     }
 
-    static std::unique_ptr<ClassDef> Module(core::Loc loc, core::Loc declLoc, std::unique_ptr<Expression> name,
+    static std::unique_ptr<ClassDef> Module(core::LocOffsets loc, core::Loc declLoc, std::unique_ptr<Expression> name,
                                             ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs) {
         return MK::ClassOrModule(loc, declLoc, std::move(name), std::move(ancestors), std::move(rhs),
                                  ClassDef::Kind::Module);
     }
 
-    static std::unique_ptr<Expression> Array(core::Loc loc, Array::ENTRY_store entries) {
+    static std::unique_ptr<Expression> Array(core::LocOffsets loc, Array::ENTRY_store entries) {
         return std::make_unique<ast::Array>(loc, std::move(entries));
     }
 
-    static std::unique_ptr<Expression> Hash(core::Loc loc, Hash::ENTRY_store keys, Hash::ENTRY_store values) {
+    static std::unique_ptr<Expression> Hash(core::LocOffsets loc, Hash::ENTRY_store keys, Hash::ENTRY_store values) {
         return std::make_unique<ast::Hash>(loc, std::move(keys), std::move(values));
     }
 
-    static std::unique_ptr<Expression> Hash0(core::Loc loc) {
+    static std::unique_ptr<Expression> Hash0(core::LocOffsets loc) {
         Hash::ENTRY_store keys;
         Hash::ENTRY_store values;
         return Hash(loc, std::move(keys), std::move(values));
     }
 
-    static std::unique_ptr<Expression> Hash1(core::Loc loc, std::unique_ptr<Expression> key,
+    static std::unique_ptr<Expression> Hash1(core::LocOffsets loc, std::unique_ptr<Expression> key,
                                              std::unique_ptr<Expression> value) {
         Hash::ENTRY_store keys;
         Hash::ENTRY_store values;
@@ -307,7 +311,7 @@ public:
         return Hash(loc, std::move(keys), std::move(values));
     }
 
-    static std::unique_ptr<Expression> Sig(core::Loc loc, std::unique_ptr<Expression> hash,
+    static std::unique_ptr<Expression> Sig(core::LocOffsets loc, std::unique_ptr<Expression> hash,
                                            std::unique_ptr<Expression> ret) {
         auto params = Send1(loc, Self(loc), core::Names::params(), std::move(hash));
         auto returns = Send1(loc, std::move(params), core::Names::returns(), std::move(ret));
@@ -318,7 +322,7 @@ public:
         return sig;
     }
 
-    static std::unique_ptr<Expression> SigVoid(core::Loc loc, std::unique_ptr<Expression> hash) {
+    static std::unique_ptr<Expression> SigVoid(core::LocOffsets loc, std::unique_ptr<Expression> hash) {
         auto params = Send1(loc, Self(loc), core::Names::params(), std::move(hash));
         auto void_ = Send0(loc, std::move(params), core::Names::void_());
         auto sig = Send0(loc, Constant(loc, core::Symbols::T_Sig_WithoutRuntime()), core::Names::sig());
@@ -328,7 +332,7 @@ public:
         return sig;
     }
 
-    static std::unique_ptr<Expression> Sig0(core::Loc loc, std::unique_ptr<Expression> ret) {
+    static std::unique_ptr<Expression> Sig0(core::LocOffsets loc, std::unique_ptr<Expression> ret) {
         auto returns = Send1(loc, Self(loc), core::Names::returns(), std::move(ret));
         auto sig = Send0(loc, Constant(loc, core::Symbols::T_Sig_WithoutRuntime()), core::Names::sig());
         auto sigSend = ast::cast_tree<ast::Send>(sig.get());
@@ -337,12 +341,12 @@ public:
         return sig;
     }
 
-    static std::unique_ptr<Expression> Sig1(core::Loc loc, std::unique_ptr<Expression> key,
+    static std::unique_ptr<Expression> Sig1(core::LocOffsets loc, std::unique_ptr<Expression> key,
                                             std::unique_ptr<Expression> value, std::unique_ptr<Expression> ret) {
         return Sig(loc, Hash1(loc, std::move(key), std::move(value)), std::move(ret));
     }
 
-    static std::unique_ptr<Expression> Cast(core::Loc loc, std::unique_ptr<Expression> type) {
+    static std::unique_ptr<Expression> Cast(core::LocOffsets loc, std::unique_ptr<Expression> type) {
         if (auto *send = cast_tree<ast::Send>(type.get())) {
             if (send->fun == core::Names::untyped()) {
                 return Unsafe(loc, Nil(loc));
@@ -351,45 +355,45 @@ public:
         return Send2(loc, T(loc), core::Names::cast(), Unsafe(loc, Nil(loc)), std::move(type));
     }
 
-    static std::unique_ptr<Expression> T(core::Loc loc) {
+    static std::unique_ptr<Expression> T(core::LocOffsets loc) {
         return Constant(loc, core::Symbols::T());
     }
 
-    static std::unique_ptr<Expression> Let(core::Loc loc, std::unique_ptr<Expression> value,
+    static std::unique_ptr<Expression> Let(core::LocOffsets loc, std::unique_ptr<Expression> value,
                                            std::unique_ptr<Expression> type) {
         return Send2(loc, T(loc), core::Names::let(), std::move(value), std::move(type));
     }
 
-    static std::unique_ptr<Expression> AssertType(core::Loc loc, std::unique_ptr<Expression> value,
+    static std::unique_ptr<Expression> AssertType(core::LocOffsets loc, std::unique_ptr<Expression> value,
                                                   std::unique_ptr<Expression> type) {
         return Send2(loc, T(loc), core::Names::assertType(), std::move(value), std::move(type));
     }
 
-    static std::unique_ptr<Expression> Unsafe(core::Loc loc, std::unique_ptr<Expression> inner) {
+    static std::unique_ptr<Expression> Unsafe(core::LocOffsets loc, std::unique_ptr<Expression> inner) {
         return Send1(loc, T(loc), core::Names::unsafe(), std::move(inner));
     }
 
-    static std::unique_ptr<Expression> Untyped(core::Loc loc) {
+    static std::unique_ptr<Expression> Untyped(core::LocOffsets loc) {
         return Send0(loc, T(loc), core::Names::untyped());
     }
 
-    static std::unique_ptr<Expression> Nilable(core::Loc loc, std::unique_ptr<Expression> arg) {
+    static std::unique_ptr<Expression> Nilable(core::LocOffsets loc, std::unique_ptr<Expression> arg) {
         return Send1(loc, T(loc), core::Names::nilable(), std::move(arg));
     }
 
     static std::unique_ptr<Expression> KeepForIDE(std::unique_ptr<Expression> arg) {
-        auto loc = core::Loc::none(arg->loc.file());
+        auto loc = core::LocOffsets::none();
         return Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::keepForIde(),
                      std::move(arg));
     }
 
     static std::unique_ptr<Expression> KeepForTypechecking(std::unique_ptr<Expression> arg) {
-        auto loc = core::Loc::none(arg->loc.file());
+        auto loc = core::LocOffsets::none();
         return Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::keepForTypechecking(),
                      std::move(arg));
     }
 
-    static std::unique_ptr<Expression> SelfNew(core::Loc loc, ast::Send::ARGS_store args, Send::Flags flags = {},
+    static std::unique_ptr<Expression> SelfNew(core::LocOffsets loc, ast::Send::ARGS_store args, Send::Flags flags = {},
                                                std::unique_ptr<ast::Block> block = nullptr) {
         auto magic = Constant(loc, core::Symbols::Magic());
         return Send(loc, std::move(magic), core::Names::selfNew(), std::move(args), flags, std::move(block));

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -76,11 +76,11 @@ void printTabs(stringstream &to, int count) {
     }
 }
 
-Expression::Expression(core::Loc loc) : loc(loc) {}
+Expression::Expression(core::LocOffsets loc) : loc(loc) {}
 
-Reference::Reference(core::Loc loc) : Expression(loc) {}
+Reference::Reference(core::LocOffsets loc) : Expression(loc) {}
 
-ClassDef::ClassDef(core::Loc loc, core::Loc declLoc, core::SymbolRef symbol, unique_ptr<Expression> name,
+ClassDef::ClassDef(core::LocOffsets loc, core::Loc declLoc, core::SymbolRef symbol, unique_ptr<Expression> name,
                    ANCESTORS_store ancestors, RHS_store rhs, ClassDef::Kind kind)
     : Declaration(loc, declLoc, symbol), kind(kind), rhs(std::move(rhs)), name(std::move(name)),
       ancestors(std::move(ancestors)) {
@@ -90,50 +90,50 @@ ClassDef::ClassDef(core::Loc loc, core::Loc declLoc, core::SymbolRef symbol, uni
     _sanityCheck();
 }
 
-MethodDef::MethodDef(core::Loc loc, core::Loc declLoc, core::SymbolRef symbol, core::NameRef name, ARGS_store args,
-                     unique_ptr<Expression> rhs, Flags flags)
+MethodDef::MethodDef(core::LocOffsets loc, core::Loc declLoc, core::SymbolRef symbol, core::NameRef name,
+                     ARGS_store args, unique_ptr<Expression> rhs, Flags flags)
     : Declaration(loc, declLoc, symbol), rhs(std::move(rhs)), args(std::move(args)), name(name), flags(flags) {
     categoryCounterInc("trees", "methoddef");
     histogramInc("trees.methodDef.args", this->args.size());
     _sanityCheck();
 }
 
-Declaration::Declaration(core::Loc loc, core::Loc declLoc, core::SymbolRef symbol)
+Declaration::Declaration(core::LocOffsets loc, core::Loc declLoc, core::SymbolRef symbol)
     : Expression(loc), declLoc(declLoc), symbol(symbol) {}
 
-If::If(core::Loc loc, unique_ptr<Expression> cond, unique_ptr<Expression> thenp, unique_ptr<Expression> elsep)
+If::If(core::LocOffsets loc, unique_ptr<Expression> cond, unique_ptr<Expression> thenp, unique_ptr<Expression> elsep)
     : Expression(loc), cond(std::move(cond)), thenp(std::move(thenp)), elsep(std::move(elsep)) {
     categoryCounterInc("trees", "if");
     _sanityCheck();
 }
 
-While::While(core::Loc loc, unique_ptr<Expression> cond, unique_ptr<Expression> body)
+While::While(core::LocOffsets loc, unique_ptr<Expression> cond, unique_ptr<Expression> body)
     : Expression(loc), cond(std::move(cond)), body(std::move(body)) {
     categoryCounterInc("trees", "while");
     _sanityCheck();
 }
 
-Break::Break(core::Loc loc, unique_ptr<Expression> expr) : Expression(loc), expr(std::move(expr)) {
+Break::Break(core::LocOffsets loc, unique_ptr<Expression> expr) : Expression(loc), expr(std::move(expr)) {
     categoryCounterInc("trees", "break");
     _sanityCheck();
 }
 
-Retry::Retry(core::Loc loc) : Expression(loc) {
+Retry::Retry(core::LocOffsets loc) : Expression(loc) {
     categoryCounterInc("trees", "retry");
     _sanityCheck();
 }
 
-Next::Next(core::Loc loc, unique_ptr<Expression> expr) : Expression(loc), expr(std::move(expr)) {
+Next::Next(core::LocOffsets loc, unique_ptr<Expression> expr) : Expression(loc), expr(std::move(expr)) {
     categoryCounterInc("trees", "next");
     _sanityCheck();
 }
 
-Return::Return(core::Loc loc, unique_ptr<Expression> expr) : Expression(loc), expr(std::move(expr)) {
+Return::Return(core::LocOffsets loc, unique_ptr<Expression> expr) : Expression(loc), expr(std::move(expr)) {
     categoryCounterInc("trees", "return");
     _sanityCheck();
 }
 
-RescueCase::RescueCase(core::Loc loc, EXCEPTION_store exceptions, unique_ptr<Expression> var,
+RescueCase::RescueCase(core::LocOffsets loc, EXCEPTION_store exceptions, unique_ptr<Expression> var,
                        unique_ptr<Expression> body)
     : Expression(loc), exceptions(std::move(exceptions)), var(std::move(var)), body(std::move(body)) {
     categoryCounterInc("trees", "rescuecase");
@@ -141,8 +141,8 @@ RescueCase::RescueCase(core::Loc loc, EXCEPTION_store exceptions, unique_ptr<Exp
     _sanityCheck();
 }
 
-Rescue::Rescue(core::Loc loc, unique_ptr<Expression> body, RESCUE_CASE_store rescueCases, unique_ptr<Expression> else_,
-               unique_ptr<Expression> ensure)
+Rescue::Rescue(core::LocOffsets loc, unique_ptr<Expression> body, RESCUE_CASE_store rescueCases,
+               unique_ptr<Expression> else_, unique_ptr<Expression> ensure)
     : Expression(loc), body(std::move(body)), rescueCases(std::move(rescueCases)), else_(std::move(else_)),
       ensure(std::move(ensure)) {
     categoryCounterInc("trees", "rescue");
@@ -150,25 +150,25 @@ Rescue::Rescue(core::Loc loc, unique_ptr<Expression> body, RESCUE_CASE_store res
     _sanityCheck();
 }
 
-Local::Local(core::Loc loc, core::LocalVariable localVariable1) : Reference(loc), localVariable(localVariable1) {
+Local::Local(core::LocOffsets loc, core::LocalVariable localVariable1) : Reference(loc), localVariable(localVariable1) {
     categoryCounterInc("trees", "local");
     _sanityCheck();
 }
 
-UnresolvedIdent::UnresolvedIdent(core::Loc loc, Kind kind, core::NameRef name)
+UnresolvedIdent::UnresolvedIdent(core::LocOffsets loc, Kind kind, core::NameRef name)
     : Reference(loc), name(name), kind(kind) {
     categoryCounterInc("trees", "unresolvedident");
     _sanityCheck();
     _sanityCheck();
 }
 
-Assign::Assign(core::Loc loc, unique_ptr<Expression> lhs, unique_ptr<Expression> rhs)
+Assign::Assign(core::LocOffsets loc, unique_ptr<Expression> lhs, unique_ptr<Expression> rhs)
     : Expression(loc), lhs(std::move(lhs)), rhs(std::move(rhs)) {
     categoryCounterInc("trees", "assign");
     _sanityCheck();
 }
 
-Send::Send(core::Loc loc, unique_ptr<Expression> recv, core::NameRef fun, Send::ARGS_store args,
+Send::Send(core::LocOffsets loc, unique_ptr<Expression> recv, core::NameRef fun, Send::ARGS_store args,
            unique_ptr<Block> block, Flags flags)
     : Expression(loc), fun(fun), flags(flags), recv(std::move(recv)), args(std::move(args)), block(std::move(block)) {
     categoryCounterInc("trees", "send");
@@ -179,55 +179,55 @@ Send::Send(core::Loc loc, unique_ptr<Expression> recv, core::NameRef fun, Send::
     _sanityCheck();
 }
 
-Cast::Cast(core::Loc loc, core::TypePtr ty, unique_ptr<Expression> arg, core::NameRef cast)
+Cast::Cast(core::LocOffsets loc, core::TypePtr ty, unique_ptr<Expression> arg, core::NameRef cast)
     : Expression(loc), cast(cast), type(std::move(ty)), arg(std::move(arg)) {
     categoryCounterInc("trees", "cast");
     _sanityCheck();
 }
 
-ZSuperArgs::ZSuperArgs(core::Loc loc) : Expression(loc) {
+ZSuperArgs::ZSuperArgs(core::LocOffsets loc) : Expression(loc) {
     categoryCounterInc("trees", "zsuper");
     _sanityCheck();
 }
 
-RestArg::RestArg(core::Loc loc, unique_ptr<Reference> arg) : Reference(loc), expr(std::move(arg)) {
+RestArg::RestArg(core::LocOffsets loc, unique_ptr<Reference> arg) : Reference(loc), expr(std::move(arg)) {
     categoryCounterInc("trees", "restarg");
     _sanityCheck();
 }
 
-KeywordArg::KeywordArg(core::Loc loc, unique_ptr<Reference> expr) : Reference(loc), expr(std::move(expr)) {
+KeywordArg::KeywordArg(core::LocOffsets loc, unique_ptr<Reference> expr) : Reference(loc), expr(std::move(expr)) {
     categoryCounterInc("trees", "keywordarg");
     _sanityCheck();
 }
 
-OptionalArg::OptionalArg(core::Loc loc, unique_ptr<Reference> expr, unique_ptr<Expression> default_)
+OptionalArg::OptionalArg(core::LocOffsets loc, unique_ptr<Reference> expr, unique_ptr<Expression> default_)
     : Reference(loc), expr(std::move(expr)), default_(std::move(default_)) {
     categoryCounterInc("trees", "optionalarg");
     _sanityCheck();
 }
 
-ShadowArg::ShadowArg(core::Loc loc, unique_ptr<Reference> expr) : Reference(loc), expr(std::move(expr)) {
+ShadowArg::ShadowArg(core::LocOffsets loc, unique_ptr<Reference> expr) : Reference(loc), expr(std::move(expr)) {
     categoryCounterInc("trees", "shadowarg");
     _sanityCheck();
 }
 
-BlockArg::BlockArg(core::Loc loc, unique_ptr<Reference> expr) : Reference(loc), expr(std::move(expr)) {
+BlockArg::BlockArg(core::LocOffsets loc, unique_ptr<Reference> expr) : Reference(loc), expr(std::move(expr)) {
     categoryCounterInc("trees", "blockarg");
     _sanityCheck();
 }
 
-Literal::Literal(core::Loc loc, const core::TypePtr &value) : Expression(loc), value(std::move(value)) {
+Literal::Literal(core::LocOffsets loc, const core::TypePtr &value) : Expression(loc), value(std::move(value)) {
     categoryCounterInc("trees", "literal");
     _sanityCheck();
 }
 
-UnresolvedConstantLit::UnresolvedConstantLit(core::Loc loc, unique_ptr<Expression> scope, core::NameRef cnst)
+UnresolvedConstantLit::UnresolvedConstantLit(core::LocOffsets loc, unique_ptr<Expression> scope, core::NameRef cnst)
     : Expression(loc), cnst(cnst), scope(std::move(scope)) {
     categoryCounterInc("trees", "constantlit");
     _sanityCheck();
 }
 
-ConstantLit::ConstantLit(core::Loc loc, core::SymbolRef symbol, unique_ptr<UnresolvedConstantLit> original)
+ConstantLit::ConstantLit(core::LocOffsets loc, core::SymbolRef symbol, unique_ptr<UnresolvedConstantLit> original)
     : Expression(loc), symbol(symbol), original(std::move(original)) {
     categoryCounterInc("trees", "resolvedconstantlit");
     _sanityCheck();
@@ -256,33 +256,33 @@ ConstantLit::fullUnresolvedPath(const core::GlobalState &gs) const {
     return make_pair(prefix, move(namesFailedToResolve));
 }
 
-Block::Block(core::Loc loc, MethodDef::ARGS_store args, unique_ptr<Expression> body)
+Block::Block(core::LocOffsets loc, MethodDef::ARGS_store args, unique_ptr<Expression> body)
     : Expression(loc), args(std::move(args)), body(std::move(body)) {
     categoryCounterInc("trees", "block");
     _sanityCheck();
 };
 
-Hash::Hash(core::Loc loc, ENTRY_store keys, ENTRY_store values)
+Hash::Hash(core::LocOffsets loc, ENTRY_store keys, ENTRY_store values)
     : Expression(loc), keys(std::move(keys)), values(std::move(values)) {
     categoryCounterInc("trees", "hash");
     histogramInc("trees.hash.entries", this->keys.size());
     _sanityCheck();
 }
 
-Array::Array(core::Loc loc, ENTRY_store elems) : Expression(loc), elems(std::move(elems)) {
+Array::Array(core::LocOffsets loc, ENTRY_store elems) : Expression(loc), elems(std::move(elems)) {
     categoryCounterInc("trees", "array");
     histogramInc("trees.array.elems", this->elems.size());
     _sanityCheck();
 }
 
-InsSeq::InsSeq(core::Loc loc, STATS_store stats, unique_ptr<Expression> expr)
+InsSeq::InsSeq(core::LocOffsets loc, STATS_store stats, unique_ptr<Expression> expr)
     : Expression(loc), stats(std::move(stats)), expr(std::move(expr)) {
     categoryCounterInc("trees", "insseq");
     histogramInc("trees.insseq.stats", this->stats.size());
     _sanityCheck();
 }
 
-EmptyTree::EmptyTree() : Expression(core::Loc::none()) {
+EmptyTree::EmptyTree() : Expression(core::LocOffsets::none()) {
     categoryCounterInc("trees", "emptytree");
     _sanityCheck();
 }

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -49,7 +49,7 @@ public:
 
     bool isSelfReference() const;
 };
-CheckSize(Expression, 24, 8);
+CheckSize(Expression, 16, 8);
 
 struct ParsedFile {
     std::unique_ptr<ast::Expression> tree;
@@ -94,7 +94,7 @@ class Reference : public Expression {
 public:
     Reference(core::LocOffsets loc);
 };
-CheckSize(Reference, 24, 8);
+CheckSize(Reference, 16, 8);
 
 class Declaration : public Expression {
 public:
@@ -103,7 +103,7 @@ public:
 
     Declaration(core::LocOffsets loc, core::Loc declLoc, core::SymbolRef symbol);
 };
-CheckSize(Declaration, 48, 8);
+CheckSize(Declaration, 32, 8);
 
 class ClassDef final : public Declaration {
 public:
@@ -136,7 +136,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(ClassDef, 144, 8);
+CheckSize(ClassDef, 136, 8);
 
 class MethodDef final : public Declaration {
 public:
@@ -169,7 +169,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(MethodDef, 88, 8);
+CheckSize(MethodDef, 72, 8);
 
 class If final : public Expression {
 public:
@@ -187,7 +187,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(If, 48, 8);
+CheckSize(If, 40, 8);
 
 class While final : public Expression {
 public:
@@ -203,7 +203,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(While, 40, 8);
+CheckSize(While, 32, 8);
 
 class Break final : public Expression {
 public:
@@ -218,7 +218,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(Break, 32, 8);
+CheckSize(Break, 24, 8);
 
 class Retry final : public Expression {
 public:
@@ -231,7 +231,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(Retry, 24, 8);
+CheckSize(Retry, 16, 8);
 
 class Next final : public Expression {
 public:
@@ -246,7 +246,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(Next, 32, 8);
+CheckSize(Next, 24, 8);
 
 class Return final : public Expression {
 public:
@@ -261,7 +261,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(Return, 32, 8);
+CheckSize(Return, 24, 8);
 
 class RescueCase final : public Expression {
 public:
@@ -285,7 +285,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(RescueCase, 64, 8);
+CheckSize(RescueCase, 56, 8);
 
 class Rescue final : public Expression {
 public:
@@ -307,7 +307,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(Rescue, 72, 8);
+CheckSize(Rescue, 64, 8);
 
 class Local final : public Reference {
 public:
@@ -322,7 +322,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(Local, 32, 8);
+CheckSize(Local, 24, 8);
 
 class UnresolvedIdent final : public Reference {
 public:
@@ -344,7 +344,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(UnresolvedIdent, 32, 8);
+CheckSize(UnresolvedIdent, 24, 8);
 
 class RestArg final : public Reference {
 public:
@@ -359,7 +359,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(RestArg, 32, 8);
+CheckSize(RestArg, 24, 8);
 
 class KeywordArg final : public Reference {
 public:
@@ -374,7 +374,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(KeywordArg, 32, 8);
+CheckSize(KeywordArg, 24, 8);
 
 class OptionalArg final : public Reference {
 public:
@@ -390,7 +390,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(OptionalArg, 40, 8);
+CheckSize(OptionalArg, 32, 8);
 
 class BlockArg final : public Reference {
 public:
@@ -405,7 +405,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(BlockArg, 32, 8);
+CheckSize(BlockArg, 24, 8);
 
 class ShadowArg final : public Reference {
 public:
@@ -420,7 +420,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(ShadowArg, 32, 8);
+CheckSize(ShadowArg, 24, 8);
 
 class Assign final : public Expression {
 public:
@@ -436,7 +436,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(Assign, 40, 8);
+CheckSize(Assign, 32, 8);
 
 class Block;
 
@@ -472,7 +472,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-// CheckSize(Send, 64, 8);
+CheckSize(Send, 64, 8);
 
 class Cast final : public Expression {
 public:
@@ -491,7 +491,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(Cast, 56, 8);
+CheckSize(Cast, 48, 8);
 
 class Hash final : public Expression {
 public:
@@ -511,7 +511,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(Hash, 72, 8);
+CheckSize(Hash, 64, 8);
 
 class Array final : public Expression {
 public:
@@ -530,7 +530,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(Array, 64, 8);
+CheckSize(Array, 56, 8);
 
 class Literal final : public Expression {
 public:
@@ -552,7 +552,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(Literal, 40, 8);
+CheckSize(Literal, 32, 8);
 
 class UnresolvedConstantLit final : public Expression {
 public:
@@ -568,7 +568,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(UnresolvedConstantLit, 40, 8);
+CheckSize(UnresolvedConstantLit, 32, 8);
 
 class ConstantLit final : public Expression {
 public:
@@ -590,7 +590,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(ConstantLit, 64, 8);
+CheckSize(ConstantLit, 56, 8);
 
 class ZSuperArgs final : public Expression {
 public:
@@ -604,7 +604,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(ZSuperArgs, 24, 8);
+CheckSize(ZSuperArgs, 16, 8);
 
 class Block final : public Expression {
 public:
@@ -618,7 +618,7 @@ public:
     virtual std::unique_ptr<Expression> _deepCopy(const Expression *avoid, bool root = false) const;
     virtual void _sanityCheck();
 };
-CheckSize(Block, 56, 8);
+CheckSize(Block, 48, 8);
 
 class InsSeq final : public Expression {
 public:
@@ -639,7 +639,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(InsSeq, 72, 8);
+CheckSize(InsSeq, 64, 8);
 
 class EmptyTree final : public Expression {
 public:
@@ -652,7 +652,7 @@ public:
 private:
     virtual void _sanityCheck();
 };
-CheckSize(EmptyTree, 24, 8);
+CheckSize(EmptyTree, 16, 8);
 
 /** https://git.corp.stripe.com/gist/nelhage/51564501674174da24822e60ad770f64
  *

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -30,7 +30,7 @@ namespace sorbet::ast {
 
 class Expression {
 public:
-    Expression(core::Loc loc);
+    Expression(core::LocOffsets loc);
     virtual ~Expression() = default;
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const = 0;
     std::string toString(const core::GlobalState &gs) const {
@@ -40,7 +40,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) = 0;
     std::unique_ptr<Expression> deepCopy() const;
     virtual void _sanityCheck() = 0;
-    const core::Loc loc;
+    const core::LocOffsets loc;
 
     class DeepCopyError {};
 
@@ -92,7 +92,7 @@ template <class To> bool isa_tree(Expression *what) {
 
 class Reference : public Expression {
 public:
-    Reference(core::Loc loc);
+    Reference(core::LocOffsets loc);
 };
 CheckSize(Reference, 24, 8);
 
@@ -101,7 +101,7 @@ public:
     core::Loc declLoc;
     core::SymbolRef symbol;
 
-    Declaration(core::Loc loc, core::Loc declLoc, core::SymbolRef symbol);
+    Declaration(core::LocOffsets loc, core::Loc declLoc, core::SymbolRef symbol);
 };
 CheckSize(Declaration, 48, 8);
 
@@ -125,7 +125,7 @@ public:
     ANCESTORS_store ancestors;
     ANCESTORS_store singletonAncestors;
 
-    ClassDef(core::Loc loc, core::Loc declLoc, core::SymbolRef symbol, std::unique_ptr<Expression> name,
+    ClassDef(core::LocOffsets loc, core::Loc declLoc, core::SymbolRef symbol, std::unique_ptr<Expression> name,
              ANCESTORS_store ancestors, RHS_store rhs, ClassDef::Kind kind);
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
@@ -159,7 +159,7 @@ public:
 
     Flags flags;
 
-    MethodDef(core::Loc loc, core::Loc declLoc, core::SymbolRef symbol, core::NameRef name, ARGS_store args,
+    MethodDef(core::LocOffsets loc, core::Loc declLoc, core::SymbolRef symbol, core::NameRef name, ARGS_store args,
               std::unique_ptr<Expression> rhs, Flags flags);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
@@ -177,7 +177,7 @@ public:
     std::unique_ptr<Expression> thenp;
     std::unique_ptr<Expression> elsep;
 
-    If(core::Loc loc, std::unique_ptr<Expression> cond, std::unique_ptr<Expression> thenp,
+    If(core::LocOffsets loc, std::unique_ptr<Expression> cond, std::unique_ptr<Expression> thenp,
        std::unique_ptr<Expression> elsep);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
@@ -194,7 +194,7 @@ public:
     std::unique_ptr<Expression> cond;
     std::unique_ptr<Expression> body;
 
-    While(core::Loc loc, std::unique_ptr<Expression> cond, std::unique_ptr<Expression> body);
+    While(core::LocOffsets loc, std::unique_ptr<Expression> cond, std::unique_ptr<Expression> body);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
@@ -209,7 +209,7 @@ class Break final : public Expression {
 public:
     std::unique_ptr<Expression> expr;
 
-    Break(core::Loc loc, std::unique_ptr<Expression> expr);
+    Break(core::LocOffsets loc, std::unique_ptr<Expression> expr);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
@@ -222,7 +222,7 @@ CheckSize(Break, 32, 8);
 
 class Retry final : public Expression {
 public:
-    Retry(core::Loc loc);
+    Retry(core::LocOffsets loc);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
@@ -237,7 +237,7 @@ class Next final : public Expression {
 public:
     std::unique_ptr<Expression> expr;
 
-    Next(core::Loc loc, std::unique_ptr<Expression> expr);
+    Next(core::LocOffsets loc, std::unique_ptr<Expression> expr);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
@@ -252,7 +252,7 @@ class Return final : public Expression {
 public:
     std::unique_ptr<Expression> expr;
 
-    Return(core::Loc loc, std::unique_ptr<Expression> expr);
+    Return(core::LocOffsets loc, std::unique_ptr<Expression> expr);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
@@ -275,7 +275,7 @@ public:
     std::unique_ptr<Expression> var;
     std::unique_ptr<Expression> body;
 
-    RescueCase(core::Loc loc, EXCEPTION_store exceptions, std::unique_ptr<Expression> var,
+    RescueCase(core::LocOffsets loc, EXCEPTION_store exceptions, std::unique_ptr<Expression> var,
                std::unique_ptr<Expression> body);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
@@ -297,7 +297,7 @@ public:
     std::unique_ptr<Expression> else_;
     std::unique_ptr<Expression> ensure;
 
-    Rescue(core::Loc loc, std::unique_ptr<Expression> body, RESCUE_CASE_store rescueCases,
+    Rescue(core::LocOffsets loc, std::unique_ptr<Expression> body, RESCUE_CASE_store rescueCases,
            std::unique_ptr<Expression> else_, std::unique_ptr<Expression> ensure);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
@@ -313,7 +313,7 @@ class Local final : public Reference {
 public:
     core::LocalVariable localVariable;
 
-    Local(core::Loc loc, core::LocalVariable localVariable1);
+    Local(core::LocOffsets loc, core::LocalVariable localVariable1);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
@@ -335,7 +335,7 @@ public:
     core::NameRef name;
     Kind kind;
 
-    UnresolvedIdent(core::Loc loc, Kind kind, core::NameRef name);
+    UnresolvedIdent(core::LocOffsets loc, Kind kind, core::NameRef name);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
@@ -350,7 +350,7 @@ class RestArg final : public Reference {
 public:
     std::unique_ptr<Reference> expr;
 
-    RestArg(core::Loc loc, std::unique_ptr<Reference> arg);
+    RestArg(core::LocOffsets loc, std::unique_ptr<Reference> arg);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
@@ -365,7 +365,7 @@ class KeywordArg final : public Reference {
 public:
     std::unique_ptr<Reference> expr;
 
-    KeywordArg(core::Loc loc, std::unique_ptr<Reference> expr);
+    KeywordArg(core::LocOffsets loc, std::unique_ptr<Reference> expr);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
@@ -381,7 +381,7 @@ public:
     std::unique_ptr<Reference> expr;
     std::unique_ptr<Expression> default_;
 
-    OptionalArg(core::Loc loc, std::unique_ptr<Reference> expr, std::unique_ptr<Expression> default_);
+    OptionalArg(core::LocOffsets loc, std::unique_ptr<Reference> expr, std::unique_ptr<Expression> default_);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
@@ -396,7 +396,7 @@ class BlockArg final : public Reference {
 public:
     std::unique_ptr<Reference> expr;
 
-    BlockArg(core::Loc loc, std::unique_ptr<Reference> expr);
+    BlockArg(core::LocOffsets loc, std::unique_ptr<Reference> expr);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
@@ -411,7 +411,7 @@ class ShadowArg final : public Reference {
 public:
     std::unique_ptr<Reference> expr;
 
-    ShadowArg(core::Loc loc, std::unique_ptr<Reference> expr);
+    ShadowArg(core::LocOffsets loc, std::unique_ptr<Reference> expr);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
@@ -427,7 +427,7 @@ public:
     std::unique_ptr<Expression> lhs;
     std::unique_ptr<Expression> rhs;
 
-    Assign(core::Loc loc, std::unique_ptr<Expression> lhs, std::unique_ptr<Expression> rhs);
+    Assign(core::LocOffsets loc, std::unique_ptr<Expression> lhs, std::unique_ptr<Expression> rhs);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
@@ -462,7 +462,7 @@ public:
     ARGS_store args;
     std::unique_ptr<Block> block; // null if no block passed
 
-    Send(core::Loc loc, std::unique_ptr<Expression> recv, core::NameRef fun, ARGS_store args,
+    Send(core::LocOffsets loc, std::unique_ptr<Expression> recv, core::NameRef fun, ARGS_store args,
          std::unique_ptr<Block> block = nullptr, Flags flags = {});
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
@@ -482,7 +482,7 @@ public:
     core::TypePtr type;
     std::unique_ptr<Expression> arg;
 
-    Cast(core::Loc loc, core::TypePtr ty, std::unique_ptr<Expression> arg, core::NameRef cast);
+    Cast(core::LocOffsets loc, core::TypePtr ty, std::unique_ptr<Expression> arg, core::NameRef cast);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
@@ -501,7 +501,7 @@ public:
     ENTRY_store keys;
     ENTRY_store values;
 
-    Hash(core::Loc loc, ENTRY_store keys, ENTRY_store values);
+    Hash(core::LocOffsets loc, ENTRY_store keys, ENTRY_store values);
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
@@ -520,7 +520,7 @@ public:
 
     ENTRY_store elems;
 
-    Array(core::Loc loc, ENTRY_store elems);
+    Array(core::LocOffsets loc, ENTRY_store elems);
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
@@ -536,7 +536,7 @@ class Literal final : public Expression {
 public:
     core::TypePtr value;
 
-    Literal(core::Loc loc, const core::TypePtr &value);
+    Literal(core::LocOffsets loc, const core::TypePtr &value);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
@@ -559,7 +559,7 @@ public:
     core::NameRef cnst;
     std::unique_ptr<Expression> scope;
 
-    UnresolvedConstantLit(core::Loc loc, std::unique_ptr<Expression> scope, core::NameRef cnst);
+    UnresolvedConstantLit(core::LocOffsets loc, std::unique_ptr<Expression> scope, core::NameRef cnst);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
@@ -579,7 +579,7 @@ public:
     ResolutionScopes resolutionScopes;
     std::unique_ptr<UnresolvedConstantLit> original;
 
-    ConstantLit(core::Loc loc, core::SymbolRef symbol, std::unique_ptr<UnresolvedConstantLit> original);
+    ConstantLit(core::LocOffsets loc, core::SymbolRef symbol, std::unique_ptr<UnresolvedConstantLit> original);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
@@ -595,7 +595,7 @@ CheckSize(ConstantLit, 64, 8);
 class ZSuperArgs final : public Expression {
 public:
     // null if no block passed
-    ZSuperArgs(core::Loc loc);
+    ZSuperArgs(core::LocOffsets loc);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
@@ -611,7 +611,7 @@ public:
     MethodDef::ARGS_store args;
     std::unique_ptr<Expression> body;
 
-    Block(core::Loc loc, MethodDef::ARGS_store args, std::unique_ptr<Expression> body);
+    Block(core::LocOffsets loc, MethodDef::ARGS_store args, std::unique_ptr<Expression> body);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
@@ -630,7 +630,7 @@ public:
     // The distinguished final expression (determines return value)
     std::unique_ptr<Expression> expr;
 
-    InsSeq(core::Loc loc, STATS_store stats, std::unique_ptr<Expression> expr);
+    InsSeq(core::LocOffsets locOffsets, STATS_store stats, std::unique_ptr<Expression> expr);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -166,8 +166,7 @@ unique_ptr<Expression> validateRBIBody(DesugarContext dctx, unique_ptr<Expressio
     if (!body->loc.exists()) {
         return body;
     }
-    auto loc = core::Loc(dctx.enclosingMethodLoc.file(), body->loc);
-    if (!loc.file().data(dctx.ctx).isRBI()) {
+    if (!dctx.enclosingMethodLoc.file().data(dctx.ctx).isRBI()) {
         return body;
     }
     if (isa_tree<EmptyTree>(body.get())) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -163,12 +163,14 @@ bool isIVarAssign(Expression *stat) {
 }
 
 unique_ptr<Expression> validateRBIBody(DesugarContext dctx, unique_ptr<Expression> body) {
-    if (!body->loc.exists()) {
-        return body;
-    }
     if (!dctx.enclosingMethodLoc.file().data(dctx.ctx).isRBI()) {
         return body;
     }
+    if (!body->loc.exists()) {
+        return body;
+    }
+
+    auto loc = core::Loc(dctx.enclosingMethodLoc.file(), body->loc);
     if (isa_tree<EmptyTree>(body.get())) {
         return body;
     } else if (isa_tree<Assign>(body.get())) {

--- a/ast/desugar/test/desugar_test.cc
+++ b/ast/desugar/test/desugar_test.cc
@@ -27,7 +27,8 @@ TEST(DesugarTest, SimpleDesugar) { // NOLINT
     sorbet::core::UnfreezeNameTable nameTableAccess(gs);
     sorbet::core::UnfreezeFileTable ft(gs);
 
-    auto ast = sorbet::parser::Parser::run(gs, "<test>", "def hello_world; p :hello; end");
-    sorbet::core::MutableContext ctx(gs, sorbet::core::Symbols::root());
+    sorbet::core::FileRef fileId = gs.enterFile("<test>", "def hello_world; p :hello; end");
+    auto ast = sorbet::parser::Parser::run(gs, fileId);
+    sorbet::core::MutableContext ctx(gs, sorbet::core::Symbols::root(), fileId);
     auto o1 = sorbet::ast::desugar::node2Tree(ctx, move(ast));
 }

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -273,7 +273,7 @@ private:
         // We intentionally do not walk v->ancestors nor v->singletonAncestors.
         // They are guaranteed to be simple trees in the desugarer.
         for (auto &def : v->rhs) {
-            def = mapIt(move(def), ctx.withOwner(v->symbol));
+            def = mapIt(move(def), ctx.withOwner(v->symbol).withFile(v->declLoc.file()));
         }
 
         if constexpr (HAS_MEMBER_postTransformClassDef<FUNC>::value) {
@@ -295,7 +295,7 @@ private:
                 optArg->default_ = mapIt(move(optArg->default_), ctx.withOwner(v->symbol));
             }
         }
-        v->rhs = mapIt(move(v->rhs), ctx.withOwner(v->symbol));
+        v->rhs = mapIt(move(v->rhs), ctx.withOwner(v->symbol).withFile(v->declLoc.file()));
 
         if constexpr (HAS_MEMBER_postTransformMethodDef<FUNC>::value) {
             return PostPonePostTransform_MethodDef<FUNC, CTX, HAS_MEMBER_postTransformMethodDef<FUNC>::value>::call(
@@ -683,7 +683,7 @@ private:
         } catch (SorbetException &e) {
             Exception::failInFuzzer();
 
-            throw ReportedRubyException{e, loc};
+            throw ReportedRubyException{e, core::Loc(ctx.file, loc)};
         }
     }
 };
@@ -1144,7 +1144,7 @@ private:
         } catch (SorbetException &e) {
             Exception::failInFuzzer();
 
-            throw ReportedRubyException{e, loc};
+            throw ReportedRubyException{e, core::Loc(ctx.file, loc)};
         }
     }
 };

--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -251,7 +251,7 @@ string BasicBlock::showRaw(core::Context ctx) const {
     return to_string(buf);
 }
 
-Binding::Binding(core::LocalVariable bind, core::Loc loc, unique_ptr<Instruction> value)
+Binding::Binding(core::LocalVariable bind, core::LocOffsets loc, unique_ptr<Instruction> value)
     : bind(bind), loc(loc), value(std::move(value)) {}
 
 } // namespace sorbet::cfg

--- a/cfg/CFG.h
+++ b/cfg/CFG.h
@@ -27,7 +27,7 @@ public:
     VariableUseSite cond;
     BasicBlock *thenb;
     BasicBlock *elseb;
-    core::Loc loc;
+    core::LocOffsets loc;
     bool isCondSet() {
         return cond.variable._name.id() >= 0;
     }
@@ -37,11 +37,11 @@ public:
 class Binding final {
 public:
     VariableUseSite bind;
-    core::Loc loc;
+    core::LocOffsets loc;
 
     std::unique_ptr<Instruction> value;
 
-    Binding(core::LocalVariable bind, core::Loc loc, std::unique_ptr<Instruction> value);
+    Binding(core::LocalVariable bind, core::LocOffsets loc, std::unique_ptr<Instruction> value);
     Binding(Binding &&other) = default;
     Binding() = default;
 
@@ -84,6 +84,7 @@ public:
     core::SymbolRef symbol;
     int maxBasicBlockId = 0;
     int maxRubyBlockId = 0;
+    core::FileRef file;
     std::vector<std::unique_ptr<BasicBlock>> basicBlocks;
     /** Blocks in topoligical sort. All parent blocks are earlier than child blocks
      *

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -70,9 +70,9 @@ string LoadSelf::showRaw(const core::GlobalState &gs, int tabs) const {
     return fmt::format("LoadSelf {{}}", spacesForTabLevel(tabs));
 }
 
-Send::Send(core::LocalVariable recv, core::NameRef fun, core::Loc receiverLoc,
-           const InlinedVector<core::LocalVariable, 2> &args, InlinedVector<core::Loc, 2> argLocs, bool isPrivateOk,
-           const shared_ptr<core::SendAndBlockLink> &link)
+Send::Send(core::LocalVariable recv, core::NameRef fun, core::LocOffsets receiverLoc,
+           const InlinedVector<core::LocalVariable, 2> &args, InlinedVector<core::LocOffsets, 2> argLocs,
+           bool isPrivateOk, const shared_ptr<core::SendAndBlockLink> &link)
     : recv(recv), fun(fun), receiverLoc(receiverLoc), argLocs(std::move(argLocs)), isPrivateOk(isPrivateOk),
       link(move(link)) {
     this->args.resize(args.size());

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -86,14 +86,14 @@ class Send final : public Instruction {
 public:
     VariableUseSite recv;
     core::NameRef fun;
-    core::Loc receiverLoc;
+    core::LocOffsets receiverLoc;
     InlinedVector<VariableUseSite, 2> args;
-    InlinedVector<core::Loc, 2> argLocs;
+    InlinedVector<core::LocOffsets, 2> argLocs;
     bool isPrivateOk;
     std::shared_ptr<core::SendAndBlockLink> link;
 
-    Send(core::LocalVariable recv, core::NameRef fun, core::Loc receiverLoc,
-         const InlinedVector<core::LocalVariable, 2> &args, InlinedVector<core::Loc, 2> argLocs,
+    Send(core::LocalVariable recv, core::NameRef fun, core::LocOffsets receiverLoc,
+         const InlinedVector<core::LocalVariable, 2> &args, InlinedVector<core::LocOffsets, 2> argLocs,
          bool isPrivateOk = false, const std::shared_ptr<core::SendAndBlockLink> &link = nullptr);
 
     virtual std::string toString(const core::GlobalState &gs) const;

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -99,7 +99,7 @@ public:
     virtual std::string toString(const core::GlobalState &gs) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
 };
-CheckSize(Send, 184, 8);
+CheckSize(Send, 160, 8);
 
 class Return final : public Instruction {
 public:

--- a/cfg/builder/builder.h
+++ b/cfg/builder/builder.h
@@ -20,7 +20,7 @@ private:
     static void removeDeadAssigns(core::Context ctx, const CFG::ReadsAndWrites &RnW, CFG &cfg);
     static void markLoopHeaders(core::Context ctx, CFG &cfg);
     static int topoSortFwd(std::vector<BasicBlock *> &target, int nextFree, BasicBlock *currentBB);
-    static void synthesizeExpr(BasicBlock *bb, core::LocalVariable var, core::Loc loc,
+    static void synthesizeExpr(BasicBlock *bb, core::LocalVariable var, core::LocOffsets loc,
                                std::unique_ptr<Instruction> inst);
 };
 

--- a/class_flatten/class_flatten.cc
+++ b/class_flatten/class_flatten.cc
@@ -50,7 +50,7 @@ unique_ptr<ast::Expression> extractClassInit(core::Context ctx, unique_ptr<ast::
     if (inits.size() == 1) {
         return std::move(inits.front());
     }
-    return ast::MK::InsSeq(klass->declLoc, std::move(inits), ast::MK::EmptyTree());
+    return ast::MK::InsSeq(klass->declLoc.offsets(), std::move(inits), ast::MK::EmptyTree());
 }
 
 class ClassFlattenWalk {
@@ -87,12 +87,12 @@ public:
         // Synthesize a block argument for this <static-init> block. This is rather fiddly,
         // because we have to know exactly what invariants desugar and namer set up about
         // methods and block arguments before us.
-        auto blkLoc = core::Loc::none(loc.file());
+        auto blkLoc = core::LocOffsets::none();
         core::LocalVariable blkLocalVar(core::Names::blkArg(), 0);
         ast::MethodDef::ARGS_store args;
         args.emplace_back(make_unique<ast::Local>(blkLoc, blkLocalVar));
 
-        auto init = make_unique<ast::MethodDef>(loc, loc, sym, core::Names::staticInit(), std::move(args),
+        auto init = make_unique<ast::MethodDef>(loc.offsets(), loc, sym, core::Names::staticInit(), std::move(args),
                                                 std::move(inits), ast::MethodDef::Flags());
         init->flags.isRewriterSynthesized = false;
         init->flags.isSelfMethod = true;

--- a/core/Context.cc
+++ b/core/Context.cc
@@ -46,7 +46,7 @@ bool MutableContext::permitOverloadDefinitions(FileRef sigLoc) const {
     return Context::permitOverloadDefinitions(state, sigLoc, owner);
 }
 
-Context::Context(const MutableContext &other) noexcept : state(other.state), owner(other.owner) {}
+Context::Context(const MutableContext &other) noexcept : state(other.state), owner(other.owner), file(other.file) {}
 
 void Context::trace(string_view msg) const {
     state.trace(msg);
@@ -56,8 +56,20 @@ void MutableContext::trace(string_view msg) const {
     state.trace(msg);
 }
 
+Context Context::withFile(FileRef file) const {
+    return Context(state, owner, file);
+}
+
 Context Context::withOwner(SymbolRef sym) const {
-    return Context(state, sym);
+    return Context(state, sym, file);
+}
+
+MutableContext MutableContext::withFile(FileRef file) const {
+    return MutableContext(state, owner, file);
+}
+
+MutableContext MutableContext::withOwner(SymbolRef sym) const {
+    return MutableContext(state, sym, file);
 }
 
 GlobalSubstitution::GlobalSubstitution(const GlobalState &from, GlobalState &to,
@@ -144,4 +156,10 @@ bool GlobalSubstitution::useFastPath() const {
     return fastPath;
 }
 
+ErrorBuilder MutableContext::beginError(LocOffsets loc, ErrorClass what) const {
+    return state.beginError(Loc(file, loc), what);
+}
+ErrorBuilder Context::beginError(LocOffsets loc, ErrorClass what) const {
+    return state.beginError(Loc(file, loc), what);
+}
 } // namespace sorbet::core

--- a/core/Context.h
+++ b/core/Context.h
@@ -2,6 +2,9 @@
 #define SORBET_CONTEXT_H
 
 #include "common/common.h"
+#include "core/Error.h"
+#include "core/Files.h"
+#include "core/Loc.h"
 #include "core/NameRef.h"
 #include "core/SymbolRef.h"
 
@@ -9,32 +12,38 @@ namespace sorbet::core {
 class GlobalState;
 class FileRef;
 class MutableContext;
+class ErrorBuilder;
 
 class Context {
 public:
     const GlobalState &state;
     const SymbolRef owner;
+    const FileRef file;
 
     operator const GlobalState &() const noexcept {
         return state;
     }
 
-    Context(const GlobalState &state, SymbolRef owner) noexcept : state(state), owner(owner) {}
-    Context(const Context &other) noexcept : state(other.state), owner(other.owner) {}
+    Context(const GlobalState &state, SymbolRef owner, FileRef file) noexcept
+        : state(state), owner(owner), file(file) {}
+    Context(const Context &other) noexcept : state(other.state), owner(other.owner), file(other.file) {}
     Context(const MutableContext &other) noexcept;
 
+    ErrorBuilder beginError(LocOffsets loc, ErrorClass what) const;
     static bool permitOverloadDefinitions(const core::GlobalState &gs, FileRef sigLoc, core::SymbolRef owner);
 
     Context withOwner(SymbolRef sym) const;
+    Context withFile(FileRef file) const;
 
     void trace(std::string_view msg) const;
 };
-CheckSize(Context, 16, 8);
+CheckSize(Context, 24, 8);
 
 class MutableContext final {
 public:
     GlobalState &state;
     const SymbolRef owner;
+    const FileRef file;
     operator GlobalState &() {
         return state;
     }
@@ -44,8 +53,9 @@ public:
     }
 
     // 👋 Stepped here in the debugger? Type 'finish' to step back out.
-    MutableContext(GlobalState &state, SymbolRef owner) noexcept : state(state), owner(owner) {}
-    MutableContext(const MutableContext &other) noexcept : state(other.state), owner(other.owner) {}
+    MutableContext(GlobalState &state, SymbolRef owner, FileRef file) noexcept
+        : state(state), owner(owner), file(file) {}
+    MutableContext(const MutableContext &other) noexcept : state(other.state), owner(other.owner), file(other.file) {}
 
     // Returns a SymbolRef corresponding to the class `self.class` for code
     // executed in this MutableContext, or, if `self` is a class,
@@ -55,13 +65,13 @@ public:
 
     bool permitOverloadDefinitions(FileRef sigLoc) const;
 
-    MutableContext withOwner(SymbolRef sym) const {
-        return MutableContext(state, sym);
-    }
+    MutableContext withOwner(SymbolRef sym) const;
+    MutableContext withFile(FileRef file) const;
+    ErrorBuilder beginError(LocOffsets loc, ErrorClass what) const;
 
     void trace(std::string_view msg) const;
 };
-CheckSize(MutableContext, 16, 8);
+CheckSize(MutableContext, 24, 8);
 
 } // namespace sorbet::core
 

--- a/core/Context.h
+++ b/core/Context.h
@@ -37,7 +37,7 @@ public:
 
     void trace(std::string_view msg) const;
 };
-CheckSize(Context, 24, 8);
+CheckSize(Context, 16, 8);
 
 class MutableContext final {
 public:
@@ -71,7 +71,7 @@ public:
 
     void trace(std::string_view msg) const;
 };
-CheckSize(MutableContext, 24, 8);
+CheckSize(MutableContext, 16, 8);
 
 } // namespace sorbet::core
 

--- a/core/Files.cc
+++ b/core/Files.cc
@@ -125,9 +125,7 @@ const shared_ptr<const FileHash> &File::getFileHash() const {
     return hash_;
 }
 
-FileRef::FileRef(unsigned int id) : _id(id) {
-    ENFORCE(((u2)id) == id, "FileRef overflow. Do you have 2^16 files?");
-}
+FileRef::FileRef(unsigned int id) : _id(id) {}
 
 const File &FileRef::data(const GlobalState &gs) const {
     ENFORCE(gs.files[_id]);

--- a/core/Files.h
+++ b/core/Files.h
@@ -54,7 +54,7 @@ public:
     File &dataAllowingUnsafe(GlobalState &gs) const;
 
 private:
-    unsigned int _id : 24;
+    u4 _id;
 };
 CheckSize(FileRef, 4, 4);
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -320,7 +320,6 @@ void GlobalState::initEmpty() {
     Symbols::root().dataAllowingNone(*this)->members()[core::Names::Constants::NoSymbol()] = Symbols::noSymbol();
     Symbols::root().dataAllowingNone(*this)->members()[core::Names::Constants::Top()] = Symbols::top();
     Symbols::root().dataAllowingNone(*this)->members()[core::Names::Constants::Bottom()] = Symbols::bottom();
-    Context ctx(*this, Symbols::root());
 
     // Synthesize <Magic>#<build-hash>(*vs : T.untyped) => Hash
     SymbolRef method = enterMethodSymbol(Loc::none(), Symbols::MagicSingleton(), Names::buildHash());
@@ -366,7 +365,7 @@ void GlobalState::initEmpty() {
         arg.flags.isRepeated = true;
         arg.type = Types::String();
     }
-    method.data(*this)->resultType = Types::any(ctx, Types::nilClass(), Types::String());
+    method.data(*this)->resultType = Types::any(*this, Types::nilClass(), Types::String());
     {
         auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
         arg.flags.isBlock = true;

--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -11,6 +11,15 @@
 namespace sorbet::core {
 
 using namespace std;
+LocOffsets LocOffsets::join(LocOffsets other) const {
+    if (!this->exists()) {
+        return other;
+    }
+    if (!other.exists()) {
+        return *this;
+    }
+    return LocOffsets{min(this->beginPos(), other.beginPos()), max(this->endPos(), other.endPos())};
+}
 
 Loc Loc::join(Loc other) const {
     if (!this->exists()) {

--- a/core/Loc.h
+++ b/core/Loc.h
@@ -11,8 +11,8 @@ class GlobalState;
 
 constexpr int INVALID_POS_LOC = 0xffffff;
 struct LocOffsets {
-    unsigned int beginLoc : 24;
-    unsigned int endLoc : 24;
+    u4 beginLoc;
+    u4 endLoc;
     u4 beginPos() const {
         return beginLoc;
     };

--- a/core/Loc.h
+++ b/core/Loc.h
@@ -32,7 +32,7 @@ struct LocOffsets {
         return LocOffsets{beginPos(), beginPos()};
     }
 };
-CheckSize(LocOffsets, 8, 8);
+CheckSize(LocOffsets, 8, 4);
 
 class Loc final {
     struct {
@@ -124,7 +124,7 @@ public:
     //
     std::pair<Loc, u4> findStartOfLine(const GlobalState &gs) const;
 };
-CheckSize(Loc, 16, 8);
+CheckSize(Loc, 12, 4);
 
 template <typename H> H AbslHashValue(H h, const Loc &m) {
     return H::combine(std::move(h), m.storage.offsets.beginLoc, m.storage.offsets.endLoc, m.storage.fileRef.id());

--- a/core/Loc.h
+++ b/core/Loc.h
@@ -23,24 +23,32 @@ struct LocOffsets {
     bool exists() const {
         return endLoc != INVALID_POS_LOC && beginLoc != INVALID_POS_LOC;
     }
-} __attribute__((packed, aligned(1)));
-CheckSize(LocOffsets, 6, 1);
+    static LocOffsets none() {
+        return LocOffsets{INVALID_POS_LOC, INVALID_POS_LOC};
+    }
+    LocOffsets join(LocOffsets other) const;
+    // For a given Loc, returns a zero-length version that starts at the same location.
+    LocOffsets copyWithZeroLength() const {
+        return LocOffsets{beginPos(), beginPos()};
+    }
+};
+CheckSize(LocOffsets, 8, 8);
 
 class Loc final {
     struct {
         LocOffsets offsets;
-        unsigned int fileRef : 24;
-    } __attribute__((packed, aligned(8))) storage;
+        core::FileRef fileRef;
+    } storage;
     template <typename H> friend H AbslHashValue(H h, const Loc &m);
     friend class sorbet::core::serialize::SerializerImpl;
 
     void setFile(core::FileRef file) {
-        storage.fileRef = file.id();
+        storage.fileRef = file;
     }
 
 public:
     static Loc none(FileRef file = FileRef()) {
-        return Loc{file, INVALID_POS_LOC, INVALID_POS_LOC};
+        return Loc{file, LocOffsets::none()};
     }
 
     bool exists() const {
@@ -56,9 +64,12 @@ public:
     u4 endPos() const {
         return storage.offsets.endLoc;
     }
+    const LocOffsets &offsets() const {
+        return storage.offsets;
+    }
 
     FileRef file() const {
-        return FileRef(storage.fileRef);
+        return storage.fileRef;
     }
 
     bool isTombStoned(const GlobalState &gs) const {
@@ -70,13 +81,15 @@ public:
         }
     }
 
-    inline Loc(FileRef file, u4 begin, u4 end) : storage{{begin, end}, file.id()} {
+    inline Loc(FileRef file, u4 begin, u4 end) : storage{{begin, end}, file} {
         ENFORCE(begin <= INVALID_POS_LOC);
         ENFORCE(end <= INVALID_POS_LOC);
         ENFORCE(begin <= end);
     }
 
-    Loc() : Loc(0, INVALID_POS_LOC, INVALID_POS_LOC){};
+    inline Loc(FileRef file, LocOffsets offsets) : Loc(file, offsets.beginPos(), offsets.endPos()){};
+
+    Loc() : Loc(0, LocOffsets::none()){};
 
     Loc &operator=(const Loc &rhs) = default;
     Loc &operator=(Loc &&rhs) = default;
@@ -103,18 +116,6 @@ public:
     static std::optional<u4> pos2Offset(const File &file, Detail pos);
     static Detail offset2Pos(const File &file, u4 off);
     static std::optional<Loc> fromDetails(const GlobalState &gs, FileRef fileRef, Detail begin, Detail end);
-    std::pair<u4, u4> getAs2u4() const {
-        auto low = (((u4)storage.offsets.beginLoc) << 8) + ((((u4)storage.fileRef) >> 8) & ((1 << 8) - 1));
-        auto high = (((u4)storage.offsets.endLoc) << 8) + ((((u4)storage.fileRef)) & ((1 << 8) - 1));
-        return {low, high};
-    };
-
-    // Intentionally not a constructor because we don't want to ever be able to call it unintentionally
-    void setFrom2u4(u4 low, u4 high) {
-        storage.fileRef = (high & ((1 << 8) - 1)) + ((low & ((1 << 8) - 1)) << 8);
-        storage.offsets.endLoc = high >> 8;
-        storage.offsets.beginLoc = low >> 8;
-    }
 
     // For a given Loc, returns
     //
@@ -122,16 +123,11 @@ public:
     // - how many characters of the start of this line are whitespace.
     //
     std::pair<Loc, u4> findStartOfLine(const GlobalState &gs) const;
-
-    // For a given Loc, returns a zero-length version that starts at the same location.
-    Loc copyWithZeroLength() const {
-        return Loc(file(), beginPos(), beginPos());
-    }
 };
 CheckSize(Loc, 16, 8);
 
 template <typename H> H AbslHashValue(H h, const Loc &m) {
-    return H::combine(std::move(h), m.storage.offsets.beginLoc, m.storage.offsets.endLoc, m.storage.fileRef);
+    return H::combine(std::move(h), m.storage.offsets.beginLoc, m.storage.offsets.endLoc, m.storage.fileRef.id());
 }
 } // namespace sorbet::core
 

--- a/core/Types.h
+++ b/core/Types.h
@@ -670,9 +670,10 @@ public:
 CheckSize(TypeAndOrigins, 40, 8);
 
 struct CallLocs final {
-    Loc call;
-    Loc receiver;
-    InlinedVector<Loc, 2> &args;
+    FileRef file;
+    LocOffsets call;
+    LocOffsets receiver;
+    InlinedVector<LocOffsets, 2> &args;
 };
 
 struct DispatchArgs {

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -33,11 +33,13 @@ public:
     static void pickle(Pickler &p, Type *what);
     static void pickle(Pickler &p, const ArgInfo &a);
     static void pickle(Pickler &p, const Symbol &what);
-    static void pickle(Pickler &p, FileRef file, const unique_ptr<ast::Expression> &what);
-    static void pickle(Pickler &p, core::Loc loc);
+    static void pickle(Pickler &p, const unique_ptr<ast::Expression> &what);
+    static void pickle(Pickler &p, core::LocOffsets loc);
+    static void pickleWithFile(Pickler &p, core::Loc loc);
+    static void pickleWithoutFile(Pickler &p, core::Loc loc);
     static void pickle(Pickler &p, shared_ptr<const FileHash> fh);
 
-    template <class T> static void pickleTree(Pickler &p, FileRef file, unique_ptr<T> &t);
+    template <class T> static void pickleTree(Pickler &p, unique_ptr<T> &t);
 
     static shared_ptr<File> unpickleFile(UnPickler &p);
     static Name unpickleName(UnPickler &p, GlobalState &gs);
@@ -46,9 +48,12 @@ public:
     static Symbol unpickleSymbol(UnPickler &p, const GlobalState *gs);
     static void unpickleGS(UnPickler &p, GlobalState &result);
     static u4 unpickleGSUUID(UnPickler &p);
-    static Loc unpickleLoc(UnPickler &p, FileRef file);
+    static Loc unpickleLocInFile(UnPickler &p, FileRef file);
+    static LocOffsets unpickleLocOffsets(UnPickler &p);
+    static Loc unpickleLoc(UnPickler &p);
     static unique_ptr<ast::Expression> unpickleExpr(UnPickler &p, const GlobalState &, FileRef file);
     static NameRef unpickleNameRef(UnPickler &p, const GlobalState &);
+    static NameRef unpickleNameRef(UnPickler &p, GlobalState &);
     static unique_ptr<const FileHash> unpickleFileHash(UnPickler &p);
 
     SerializerImpl() = delete;
@@ -487,7 +492,7 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
 void SerializerImpl::pickle(Pickler &p, const ArgInfo &a) {
     p.putU4(a.name._id);
     p.putU4(a.rebind._id);
-    pickle(p, a.loc);
+    pickleWithFile(p, a.loc);
     p.putU1(a.flags.toU1());
     pickle(p, a.type.get());
 }
@@ -496,13 +501,7 @@ ArgInfo SerializerImpl::unpickleArgInfo(UnPickler &p, const GlobalState *gs) {
     ArgInfo result;
     result.name = core::NameRef(*gs, p.getU4());
     result.rebind = core::SymbolRef(gs, p.getU4());
-    {
-        core::Loc loc;
-        auto low = p.getU4();
-        auto high = p.getU4();
-        loc.setFrom2u4(low, high);
-        result.loc = loc;
-    }
+    result.loc = unpickleLoc(p);
     {
         u1 flags = p.getU1();
         result.flags.setFromU1(flags);
@@ -549,7 +548,7 @@ void SerializerImpl::pickle(Pickler &p, const Symbol &what) {
     pickle(p, what.resultType.get());
     p.putU4(what.locs().size());
     for (auto &loc : what.locs()) {
-        pickle(p, loc);
+        pickleWithFile(p, loc);
     }
 }
 
@@ -594,11 +593,7 @@ Symbol SerializerImpl::unpickleSymbol(UnPickler &p, const GlobalState *gs) {
     result.resultType = unpickleType(p, gs);
     auto locCount = p.getU4();
     for (int i = 0; i < locCount; i++) {
-        core::Loc loc;
-        auto low = p.getU4();
-        auto high = p.getU4();
-        loc.setFrom2u4(low, high);
-        result.locs_.emplace_back(loc);
+        result.locs_.emplace_back(unpickleLoc(p));
     }
     return result;
 }
@@ -757,19 +752,35 @@ void SerializerImpl::unpickleGS(UnPickler &p, GlobalState &result) {
     result.sanityCheck();
 }
 
-void SerializerImpl::pickle(Pickler &p, Loc loc) {
-    auto [low, high] = loc.getAs2u4();
-    p.putU4(low);
-    p.putU4(high);
+void SerializerImpl::pickle(Pickler &p, LocOffsets loc) {
+    p.putU4(loc.beginLoc);
+    p.putU4(loc.endLoc);
 }
 
-Loc SerializerImpl::unpickleLoc(UnPickler &p, FileRef file) {
+void SerializerImpl::pickleWithFile(Pickler &p, Loc loc) {
+    p.putU4(loc.file().id());
+    pickle(p, loc.storage.offsets);
+}
+void SerializerImpl::pickleWithoutFile(Pickler &p, Loc loc) {
+    pickle(p, loc.storage.offsets);
+}
+
+Loc SerializerImpl::unpickleLoc(UnPickler &p) {
+    FileRef file(p.getU4());
+    auto offsets = unpickleLocOffsets(p);
+    return Loc(file, offsets);
+}
+
+Loc SerializerImpl::unpickleLocInFile(UnPickler &p, FileRef file) {
     Loc loc;
-    auto low = p.getU4();
-    auto high = p.getU4();
-    loc.setFrom2u4(low, high);
+    LocOffsets offsets = unpickleLocOffsets(p);
     loc.setFile(file);
+    loc.storage.offsets = offsets;
     return loc;
+}
+
+LocOffsets SerializerImpl::unpickleLocOffsets(UnPickler &p) {
+    return LocOffsets{p.getU4(), p.getU4()};
 }
 
 vector<u1> Serializer::store(GlobalState &gs) {
@@ -798,7 +809,7 @@ u4 Serializer::loadGlobalStateUUID(const GlobalState &gs, const u1 *const data) 
 vector<u1> Serializer::storeFile(const core::File &file, ast::ParsedFile &tree) {
     Pickler p;
     SerializerImpl::pickle(p, file);
-    SerializerImpl::pickleTree(p, tree.file, tree.tree);
+    SerializerImpl::pickleTree(p, tree.tree);
     return p.result(FILE_COMPRESSION_DEGREE);
 }
 
@@ -810,10 +821,10 @@ CachedFile Serializer::loadFile(const core::GlobalState &gs, core::FileRef fref,
     return CachedFile{move(file), move(tree)};
 }
 
-template <class T> void SerializerImpl::pickleTree(Pickler &p, FileRef file, unique_ptr<T> &t) {
+template <class T> void SerializerImpl::pickleTree(Pickler &p, unique_ptr<T> &t) {
     T *raw = t.get();
     unique_ptr<ast::Expression> tmp(t.release());
-    pickle(p, file, tmp);
+    pickle(p, tmp);
     t.reset(raw);
     tmp.release();
 }
@@ -823,13 +834,11 @@ void SerializerImpl::pickleAstHeader(Pickler &p, u1 tag, ast::Expression *tree) 
     pickle(p, tree->loc);
 }
 
-void SerializerImpl::pickle(Pickler &p, FileRef file, const unique_ptr<ast::Expression> &what) {
+void SerializerImpl::pickle(Pickler &p, const unique_ptr<ast::Expression> &what) {
     if (what == nullptr) {
         p.putU1(1);
         return;
     }
-    ENFORCE(!what->loc.exists() || file == what->loc.file(), "Pickling a tree from file ", what->loc.file().id(),
-            " inside a tree from ", file.id());
 
     typecase(
         what.get(),
@@ -842,18 +851,18 @@ void SerializerImpl::pickle(Pickler &p, FileRef file, const unique_ptr<ast::Expr
             memcpy(&flags, &s->flags, sizeof(flags));
             p.putU1(flags);
             p.putU4(s->args.size());
-            pickle(p, file, s->recv);
-            pickleTree(p, file, s->block);
+            pickle(p, s->recv);
+            pickleTree(p, s->block);
             for (auto &arg : s->args) {
-                pickle(p, file, arg);
+                pickle(p, arg);
             }
         },
         [&](ast::Block *a) {
             pickleAstHeader(p, 3, a);
             p.putU4(a->args.size());
-            pickle(p, file, a->body);
+            pickle(p, a->body);
             for (auto &arg : a->args) {
-                pickle(p, file, arg);
+                pickle(p, arg);
             };
         },
         [&](ast::Literal *a) {
@@ -862,24 +871,24 @@ void SerializerImpl::pickle(Pickler &p, FileRef file, const unique_ptr<ast::Expr
         },
         [&](ast::While *a) {
             pickleAstHeader(p, 5, a);
-            pickle(p, file, a->cond);
-            pickle(p, file, a->body);
+            pickle(p, a->cond);
+            pickle(p, a->body);
         },
         [&](ast::Return *a) {
             pickleAstHeader(p, 6, a);
-            pickle(p, file, a->expr);
+            pickle(p, a->expr);
         },
         [&](ast::If *a) {
             pickleAstHeader(p, 7, a);
-            pickle(p, file, a->cond);
-            pickle(p, file, a->thenp);
-            pickle(p, file, a->elsep);
+            pickle(p, a->cond);
+            pickle(p, a->thenp);
+            pickle(p, a->elsep);
         },
 
         [&](ast::UnresolvedConstantLit *a) {
             pickleAstHeader(p, 8, a);
             p.putU4(a->cnst._id);
-            pickle(p, file, a->scope);
+            pickle(p, a->scope);
         },
         [&](ast::Local *a) {
             pickleAstHeader(p, 10, a);
@@ -888,26 +897,26 @@ void SerializerImpl::pickle(Pickler &p, FileRef file, const unique_ptr<ast::Expr
         },
         [&](ast::Assign *a) {
             pickleAstHeader(p, 12, a);
-            pickle(p, file, a->lhs);
-            pickle(p, file, a->rhs);
+            pickle(p, a->lhs);
+            pickle(p, a->rhs);
         },
         [&](ast::InsSeq *a) {
             pickleAstHeader(p, 13, a);
             p.putU4(a->stats.size());
-            pickle(p, file, a->expr);
+            pickle(p, a->expr);
             for (auto &st : a->stats) {
-                pickle(p, file, st);
+                pickle(p, st);
             }
         },
 
         [&](ast::Next *a) {
             pickleAstHeader(p, 14, a);
-            pickle(p, file, a->expr);
+            pickle(p, a->expr);
         },
 
         [&](ast::Break *a) {
             pickleAstHeader(p, 15, a);
-            pickle(p, file, a->expr);
+            pickle(p, a->expr);
         },
 
         [&](ast::Retry *a) { pickleAstHeader(p, 16, a); },
@@ -917,10 +926,10 @@ void SerializerImpl::pickle(Pickler &p, FileRef file, const unique_ptr<ast::Expr
             ENFORCE(h->values.size() == h->keys.size());
             p.putU4(h->values.size());
             for (auto &v : h->values) {
-                pickle(p, file, v);
+                pickle(p, v);
             }
             for (auto &k : h->keys) {
-                pickle(p, file, k);
+                pickle(p, k);
             }
         },
 
@@ -928,7 +937,7 @@ void SerializerImpl::pickle(Pickler &p, FileRef file, const unique_ptr<ast::Expr
             pickleAstHeader(p, 18, a);
             p.putU4(a->elems.size());
             for (auto &e : a->elems) {
-                pickle(p, file, e);
+                pickle(p, e);
             }
         },
 
@@ -936,32 +945,32 @@ void SerializerImpl::pickle(Pickler &p, FileRef file, const unique_ptr<ast::Expr
             pickleAstHeader(p, 19, c);
             p.putU4(c->cast._id);
             pickle(p, c->type.get());
-            pickle(p, file, c->arg);
+            pickle(p, c->arg);
         },
 
         [&](ast::EmptyTree *n) { pickleAstHeader(p, 20, n); },
         [&](ast::ClassDef *c) {
             pickleAstHeader(p, 21, c);
-            pickle(p, c->declLoc);
+            pickleWithoutFile(p, c->declLoc);
             p.putU1(static_cast<u2>(c->kind));
             p.putU4(c->symbol._id);
             p.putU4(c->ancestors.size());
             p.putU4(c->singletonAncestors.size());
             p.putU4(c->rhs.size());
-            pickle(p, file, c->name);
+            pickle(p, c->name);
             for (auto &anc : c->ancestors) {
-                pickle(p, file, anc);
+                pickle(p, anc);
             }
             for (auto &anc : c->singletonAncestors) {
-                pickle(p, file, anc);
+                pickle(p, anc);
             }
             for (auto &anc : c->rhs) {
-                pickle(p, file, anc);
+                pickle(p, anc);
             }
         },
         [&](ast::MethodDef *c) {
             pickleAstHeader(p, 22, c);
-            pickle(p, c->declLoc);
+            pickleWithoutFile(p, c->declLoc);
             u1 flags;
             static_assert(sizeof(flags) == sizeof(c->flags));
             // Can replace this with std::bit_cast in C++20
@@ -970,50 +979,50 @@ void SerializerImpl::pickle(Pickler &p, FileRef file, const unique_ptr<ast::Expr
             p.putU4(c->name._id);
             p.putU4(c->symbol._id);
             p.putU4(c->args.size());
-            pickle(p, file, c->rhs);
+            pickle(p, c->rhs);
             for (auto &a : c->args) {
-                pickle(p, file, a);
+                pickle(p, a);
             }
         },
         [&](ast::Rescue *a) {
             pickleAstHeader(p, 23, a);
             p.putU4(a->rescueCases.size());
-            pickle(p, file, a->ensure);
-            pickle(p, file, a->else_);
-            pickle(p, file, a->body);
+            pickle(p, a->ensure);
+            pickle(p, a->else_);
+            pickle(p, a->body);
             for (auto &rc : a->rescueCases) {
-                pickleTree(p, file, rc);
+                pickleTree(p, rc);
             }
         },
         [&](ast::RescueCase *a) {
             pickleAstHeader(p, 24, a);
             p.putU4(a->exceptions.size());
-            pickle(p, file, a->var);
-            pickle(p, file, a->body);
+            pickle(p, a->var);
+            pickle(p, a->body);
             for (auto &ex : a->exceptions) {
-                pickle(p, file, ex);
+                pickle(p, ex);
             }
         },
         [&](ast::RestArg *a) {
             pickleAstHeader(p, 25, a);
-            pickleTree(p, file, a->expr);
+            pickleTree(p, a->expr);
         },
         [&](ast::KeywordArg *a) {
             pickleAstHeader(p, 26, a);
-            pickleTree(p, file, a->expr);
+            pickleTree(p, a->expr);
         },
         [&](ast::ShadowArg *a) {
             pickleAstHeader(p, 27, a);
-            pickleTree(p, file, a->expr);
+            pickleTree(p, a->expr);
         },
         [&](ast::BlockArg *a) {
             pickleAstHeader(p, 28, a);
-            pickleTree(p, file, a->expr);
+            pickleTree(p, a->expr);
         },
         [&](ast::OptionalArg *a) {
             pickleAstHeader(p, 29, a);
-            pickleTree(p, file, a->expr);
-            pickle(p, file, a->default_);
+            pickleTree(p, a->expr);
+            pickle(p, a->default_);
         },
         [&](ast::ZSuperArgs *a) { pickleAstHeader(p, 30, a); },
         [&](ast::UnresolvedIdent *a) {
@@ -1024,7 +1033,7 @@ void SerializerImpl::pickle(Pickler &p, FileRef file, const unique_ptr<ast::Expr
         [&](ast::ConstantLit *a) {
             pickleAstHeader(p, 32, a);
             p.putU4(a->symbol._id);
-            pickleTree(p, file, a->original);
+            pickleTree(p, a->original);
         },
 
         [&](ast::Expression *n) { Exception::raise("Unimplemented AST Node: {}", n->nodeName()); });
@@ -1035,7 +1044,7 @@ unique_ptr<ast::Expression> SerializerImpl::unpickleExpr(serialize::UnPickler &p
     if (kind == 1) {
         return nullptr;
     }
-    Loc loc = unpickleLoc(p, file);
+    LocOffsets loc = unpickleLocOffsets(p);
 
     switch (kind) {
         case 2: {
@@ -1152,7 +1161,7 @@ unique_ptr<ast::Expression> SerializerImpl::unpickleExpr(serialize::UnPickler &p
             return ast::MK::EmptyTree();
         }
         case 21: {
-            auto declLoc = unpickleLoc(p, file);
+            auto declLoc = unpickleLocInFile(p, file);
             auto kind = p.getU1();
             SymbolRef symbol(gs, p.getU4());
             auto ancestorsSize = p.getU4();
@@ -1178,7 +1187,7 @@ unique_ptr<ast::Expression> SerializerImpl::unpickleExpr(serialize::UnPickler &p
             return ret;
         }
         case 22: {
-            auto declLoc = unpickleLoc(p, file);
+            auto declLoc = unpickleLocInFile(p, file);
             auto flagsU1 = p.getU1();
             ast::MethodDef::Flags flags;
             static_assert(sizeof(flags) == sizeof(flagsU1));

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -132,33 +132,4 @@ TEST(CoreTest, Substitute) { // NOLINT
     ASSERT_TRUE(other2.data(gs2)->kind == NameKind::UTF8);
     ASSERT_EQ("<U other>", other2.showRaw(gs2));
 }
-
-TEST(CoreTest, LocTest) { // NOLINT
-    constexpr auto maxFileId = 0xffff - 1;
-    constexpr auto maxOffset = 0xffffff - 1;
-    for (auto fileRef = 0; fileRef < maxFileId; fileRef = fileRef * 2 + 1) {
-        for (auto beginPos = 0; beginPos < maxOffset; beginPos = beginPos * 2 + 1) {
-            for (auto endPos = beginPos; endPos < maxOffset; endPos = endPos * 2 + 1) {
-                Loc loc(core::FileRef(fileRef), beginPos, endPos);
-                EXPECT_EQ(loc.file().id(), fileRef);
-                EXPECT_EQ(loc.beginPos(), beginPos);
-                EXPECT_EQ(loc.endPos(), endPos);
-            }
-        }
-    }
-    for (auto fileRef = 0; fileRef < maxFileId; fileRef = fileRef * 2 + 1) {
-        for (auto beginPos = 0; beginPos < maxOffset; beginPos = beginPos * 2 + 1) {
-            for (auto endPos = beginPos; endPos < maxOffset; endPos = endPos * 2 + 1) {
-                Loc loc(core::FileRef(fileRef), beginPos, endPos);
-                auto [low, high] = loc.getAs2u4();
-                Loc loc2;
-                loc2.setFrom2u4(low, high);
-                EXPECT_EQ(loc.file().id(), loc2.file().id());
-                EXPECT_EQ(loc.beginPos(), loc2.beginPos());
-                EXPECT_EQ(loc.endPos(), loc2.endPos());
-            }
-        }
-    }
-}
-
 } // namespace sorbet::core

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -472,7 +472,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
         return DispatchResult(Types::untyped(gs, thisType->untypedBlame()), std::move(args.selfType),
                               Symbols::untyped());
     } else if (symbol == Symbols::void_()) {
-        if (auto e = gs.beginError(args.locs.call, errors::Infer::UnknownMethod)) {
+        if (auto e = gs.beginError(core::Loc(args.locs.file, args.locs.call), errors::Infer::UnknownMethod)) {
             e.setHeader("Can not call method `{}` on void type", args.name.data(gs)->show(gs));
         }
         return DispatchResult(Types::untypedUntracked(), std::move(args.selfType), Symbols::noSymbol());
@@ -488,7 +488,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
             // some cases, so we special-case it here as a last resort.
             auto result = DispatchResult(Types::untypedUntracked(), std::move(args.selfType), Symbols::noSymbol());
             if (!args.args.empty()) {
-                if (auto e = gs.beginError(args.locs.call, errors::Infer::MethodArgumentCountMismatch)) {
+                if (auto e = gs.beginError(core::Loc(args.locs.file, args.locs.call),
+                                           errors::Infer::MethodArgumentCountMismatch)) {
                     e.setHeader("Wrong number of arguments for constructor. Expected: `{}`, got: `{}`", 0,
                                 args.args.size());
                     result.main.errors.emplace_back(e.build());
@@ -504,7 +505,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
         // and recorded.
         // Instead, the error always should get queued up in the
         // errors list of the result so that the caller can deal with the error.
-        auto e = gs.beginError(args.locs.call, errors::Infer::UnknownMethod);
+        auto e = gs.beginError(core::Loc(args.locs.file, args.locs.call), errors::Infer::UnknownMethod);
         if (e) {
             string thisStr = thisType->show(gs);
             if (args.fullType.get() != thisType) {
@@ -517,13 +518,15 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
                 // suggest adding `extend T::Helpers`.
                 if (args.name == core::Names::declareInterface() || args.name == core::Names::declareAbstract() ||
                     args.name == core::Names::declareFinal() || args.name == core::Names::declareSealed()) {
-                    if (auto suggestion = maybeSuggestExtendTHelpers(gs, thisType, args.locs.call)) {
+                    if (auto suggestion =
+                            maybeSuggestExtendTHelpers(gs, thisType, core::Loc(args.locs.file, args.locs.call))) {
                         e.addAutocorrect(std::move(*suggestion));
                     }
                 }
             }
             if (args.fullType.get() != thisType && symbol == Symbols::NilClass()) {
-                e.replaceWith("Wrap in `T.must`", args.locs.receiver, "T.must({})", args.locs.receiver.source(gs));
+                e.replaceWith("Wrap in `T.must`", core::Loc(args.locs.file, args.locs.receiver), "T.must({})",
+                              core::Loc(args.locs.file, args.locs.receiver).source(gs));
             } else {
                 if (symbol.data(gs)->isClassOrModuleModule()) {
                     auto objMeth = core::Symbols::Object().data(gs)->findMemberTransitive(gs, args.name);
@@ -549,7 +552,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
                         bool addedAutocorrect = false;
                         if (possibleSymbol->isClassOrModule()) {
                             const auto replacement = possibleSymbol->name.show(gs);
-                            const auto loc = args.locs.call;
+                            const auto loc = core::Loc(args.locs.file, args.locs.call);
                             const auto toReplace = args.name.toString(gs);
                             // This is a bit hacky but the loc corresponding to the send isn't available here and until
                             // it is, this verifies that the methodLoc below exists.
@@ -564,9 +567,9 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
                             const auto replacement = possibleSymbol->name.toString(gs);
                             const auto toReplace = args.name.toString(gs);
                             if (replacement != toReplace) {
-                                const auto loc = args.locs.receiver;
+                                const auto loc = core::Loc(args.locs.file, args.locs.receiver);
                                 // See comment above.
-                                if (absl::StartsWith(args.locs.call.source(gs),
+                                if (absl::StartsWith(core::Loc(args.locs.file, args.locs.call).source(gs),
                                                      fmt::format("{}.{}", loc.source(gs), toReplace))) {
                                     const auto methodLoc =
                                         Loc{loc.file(), loc.endPos() + 1, (u4)(loc.endPos() + 1 + toReplace.length())};
@@ -649,8 +652,10 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
         }
 
         auto offset = ait - args.args.begin();
-        if (auto e = matchArgType(gs, *constr, args.locs.call, args.locs.receiver, symbol, method, *arg, spec,
-                                  args.selfType, targs, args.locs.args[offset], args.args.size() == 1)) {
+        if (auto e =
+                matchArgType(gs, *constr, core::Loc(args.locs.file, args.locs.call),
+                             core::Loc(args.locs.file, args.locs.receiver), symbol, method, *arg, spec, args.selfType,
+                             targs, core::Loc(args.locs.file, args.locs.args[offset]), args.args.size() == 1)) {
             result.main.errors.emplace_back(std::move(e));
         }
 
@@ -662,7 +667,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
 
     if (pit != pend) {
         if (!(pit->flags.isKeyword || pit->flags.isDefault || pit->flags.isRepeated || pit->flags.isBlock)) {
-            if (auto e = gs.beginError(args.locs.call, errors::Infer::MethodArgumentCountMismatch)) {
+            if (auto e = gs.beginError(core::Loc(args.locs.file, args.locs.call),
+                                       errors::Infer::MethodArgumentCountMismatch)) {
                 if (args.fullType.get() != thisType) {
                     e.setHeader(
                         "Not enough arguments provided for method `{}` on `{}` component of `{}`. Expected: `{}`, got: "
@@ -728,7 +734,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
                         tpe.origins = args.args.back()->origins;
                         auto offset = it - hash->keys.begin();
                         tpe.type = hash->values[offset];
-                        if (auto e = matchArgType(gs, *constr, args.locs.call, args.locs.receiver, symbol, method, tpe,
+                        if (auto e = matchArgType(gs, *constr, core::Loc(args.locs.file, args.locs.call),
+                                                  core::Loc(args.locs.file, args.locs.receiver), symbol, method, tpe,
                                                   spec, args.selfType, targs, Loc::none())) {
                             result.main.errors.emplace_back(std::move(e));
                         }
@@ -744,7 +751,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
                 });
                 if (arg == hash->keys.end()) {
                     if (!spec.flags.isDefault) {
-                        if (auto e = missingArg(gs, args.locs.call, args.locs.receiver, method, spec)) {
+                        if (auto e = missingArg(gs, core::Loc(args.locs.file, args.locs.call),
+                                                core::Loc(args.locs.file, args.locs.receiver), method, spec)) {
                             result.main.errors.emplace_back(std::move(e));
                         }
                     }
@@ -755,7 +763,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
                 tpe.origins = args.args.back()->origins;
                 auto offset = arg - hash->keys.begin();
                 tpe.type = hash->values[offset];
-                if (auto e = matchArgType(gs, *constr, args.locs.call, args.locs.receiver, symbol, method, tpe, spec,
+                if (auto e = matchArgType(gs, *constr, core::Loc(args.locs.file, args.locs.call),
+                                          core::Loc(args.locs.file, args.locs.receiver), symbol, method, tpe, spec,
                                           args.selfType, targs, Loc::none())) {
                     result.main.errors.emplace_back(std::move(e));
                 }
@@ -768,7 +777,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
                 }
                 NameRef arg(gs, key->value);
 
-                if (auto e = gs.beginError(args.locs.call, errors::Infer::MethodArgumentCountMismatch)) {
+                if (auto e = gs.beginError(core::Loc(args.locs.file, args.locs.call),
+                                           errors::Infer::MethodArgumentCountMismatch)) {
                     e.setHeader("Unrecognized keyword argument `{}` passed for method `{}`", arg.show(gs),
                                 data->show(gs));
                     result.main.errors.emplace_back(e.build());
@@ -776,7 +786,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
             }
         } else if (hashArgType->derivesFrom(gs, Symbols::Hash())) {
             --aend;
-            if (auto e = gs.beginError(args.locs.call, errors::Infer::UntypedSplat)) {
+            if (auto e = gs.beginError(core::Loc(args.locs.file, args.locs.call), errors::Infer::UntypedSplat)) {
                 e.setHeader("Passing a hash where the specific keys are unknown to a method taking keyword arguments");
                 e.addErrorSection(ErrorSection("Got " + hashArgType->show(gs) + " originating from:",
                                                hashArg->origins2Explanations(gs)));
@@ -791,14 +801,16 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
             if (!spec.flags.isKeyword || spec.flags.isDefault || spec.flags.isRepeated) {
                 continue;
             }
-            if (auto e = missingArg(gs, args.locs.call, args.locs.receiver, method, spec)) {
+            if (auto e = missingArg(gs, core::Loc(args.locs.file, args.locs.call),
+                                    core::Loc(args.locs.file, args.locs.receiver), method, spec)) {
                 result.main.errors.emplace_back(std::move(e));
             }
         }
     }
 
     if (ait != aend) {
-        if (auto e = gs.beginError(args.locs.call, errors::Infer::MethodArgumentCountMismatch)) {
+        if (auto e =
+                gs.beginError(core::Loc(args.locs.file, args.locs.call), errors::Infer::MethodArgumentCountMismatch)) {
             if (!hasKwargs) {
                 e.setHeader("Too many arguments provided for method `{}`. Expected: `{}`, got: `{}`", data->show(gs),
                             prettyArity(gs, method), args.args.size());
@@ -825,7 +837,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
                     return arg.flags.isKeyword && arg.flags.isDefault && consumed.count(arg.name) == 0;
                 });
                 if (firstKeyword != data->arguments().end()) {
-                    e.addErrorLine(args.locs.call,
+                    e.addErrorLine(core::Loc(args.locs.file, args.locs.call),
                                    "`{}` has optional keyword arguments. Did you mean to provide a value for `{}`?",
                                    data->show(gs), firstKeyword->argumentName(gs));
                 }
@@ -879,7 +891,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
         // if block is there we do not attempt to solve the constaint. CFG adds an explicit solve
         // node that triggers constraint solving
         if (!constr->solve(gs)) {
-            if (auto e = gs.beginError(args.locs.call, errors::Infer::GenericMethodConstaintUnsolved)) {
+            if (auto e = gs.beginError(core::Loc(args.locs.file, args.locs.call),
+                                       errors::Infer::GenericMethodConstaintUnsolved)) {
                 e.setHeader("Could not find valid instantiation of type parameters");
                 result.main.errors.emplace_back(e.build());
             }
@@ -888,7 +901,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
         ENFORCE(data->arguments().back().flags.isBlock, "The last arg should be the block arg.");
         auto blockType = data->arguments().back().type;
         if (blockType && !core::Types::isSubType(gs, core::Types::nilClass(), blockType)) {
-            if (auto e = gs.beginError(args.locs.call, errors::Infer::BlockNotPassed)) {
+            if (auto e = gs.beginError(core::Loc(args.locs.file, args.locs.call), errors::Infer::BlockNotPassed)) {
                 e.setHeader("`{}` requires a block parameter, but no block was passed", args.name.show(gs));
                 e.addErrorLine(method.data(gs)->loc(), "defined here");
                 result.main.errors.emplace_back(e.build());
@@ -1009,7 +1022,7 @@ public:
         if (args.args.empty()) {
             return;
         }
-        const auto loc = args.locs.call;
+        const auto loc = core::Loc(args.locs.file, args.locs.call);
         if (!args.args[0]->type->isFullyDefined()) {
             if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
                 e.setHeader("T.must() applied to incomplete type `{}`", args.args[0]->type->show(gs));
@@ -1039,7 +1052,7 @@ public:
         auto i = -1;
         for (auto &arg : args.args) {
             i++;
-            auto ty = unwrapType(gs, args.locs.args[i], arg->type);
+            auto ty = unwrapType(gs, core::Loc(args.locs.file, args.locs.args[i]), arg->type);
             ret = Types::any(gs, ret, ty);
         }
 
@@ -1058,7 +1071,7 @@ public:
         auto i = -1;
         for (auto &arg : args.args) {
             i++;
-            auto ty = unwrapType(gs, args.locs.args[i], arg->type);
+            auto ty = unwrapType(gs, core::Loc(args.locs.file, args.locs.args[i]), arg->type);
             ret = Types::all(gs, ret, ty);
         }
 
@@ -1073,7 +1086,7 @@ public:
             return;
         }
 
-        if (auto e = gs.beginError(args.locs.call, errors::Infer::RevealType)) {
+        if (auto e = gs.beginError(core::Loc(args.locs.file, args.locs.call), errors::Infer::RevealType)) {
             e.setHeader("Revealed type: `{}`", args.args[0]->type->showWithMoreInfo(gs));
             e.addErrorSection(ErrorSection("From:", args.args[0]->origins2Explanations(gs)));
         }
@@ -1088,8 +1101,8 @@ public:
             return;
         }
 
-        res.returnType = make_type<MetaType>(
-            Types::any(gs, unwrapType(gs, args.locs.args[0], args.args[0]->type), Types::nilClass()));
+        res.returnType = make_type<MetaType>(Types::any(
+            gs, unwrapType(gs, core::Loc(args.locs.file, args.locs.args[0]), args.args[0]->type), Types::nilClass()));
     }
 } T_nilable;
 
@@ -1178,7 +1191,8 @@ public:
         }
 
         if (args.args.size() != arity) {
-            if (auto e = gs.beginError(args.locs.call, errors::Infer::GenericArgumentCountMismatch)) {
+            if (auto e = gs.beginError(core::Loc(args.locs.file, args.locs.call),
+                                       errors::Infer::GenericArgumentCountMismatch)) {
                 e.setHeader("Wrong number of type parameters for `{}`. Expected: `{}`, got: `{}`",
                             attachedClass.data(gs)->show(gs), arity, args.args.size());
             }
@@ -1201,7 +1215,7 @@ public:
                 // arguments from the list that's supplied.
                 targs.emplace_back(memType->upperBound);
             } else if (it != args.args.end()) {
-                auto loc = args.locs.args[it - args.args.begin()];
+                auto loc = core::Loc(args.locs.file, args.locs.args[it - args.args.begin()]);
                 auto argType = unwrapType(gs, loc, (*it)->type);
                 bool validBounds = true;
 
@@ -1281,7 +1295,7 @@ public:
         for (auto &elem : args.args) {
             ++i;
             if (isType) {
-                elems.emplace_back(unwrapType(gs, args.locs.args[i], elem->type));
+                elems.emplace_back(unwrapType(gs, core::Loc(args.locs.file, args.locs.args[i]), elem->type));
             } else {
                 elems.emplace_back(elem->type);
             }
@@ -1389,7 +1403,8 @@ public:
         }
         auto *tuple = cast_type<TupleType>(args.args[2]->type.get());
         if (tuple == nullptr) {
-            if (auto e = gs.beginError(args.locs.args[2], core::errors::Infer::UntypedSplat)) {
+            if (auto e =
+                    gs.beginError(core::Loc(args.locs.file, args.locs.args[2]), core::errors::Infer::UntypedSplat)) {
                 e.setHeader("Splats are only supported where the size of the array is known statically");
             }
             return;
@@ -1397,9 +1412,9 @@ public:
 
         InlinedVector<TypeAndOrigins, 2> sendArgStore;
         InlinedVector<const TypeAndOrigins *, 2> sendArgs =
-            Magic_callWithSplat::generateSendArgs(tuple, sendArgStore, args.locs.args[2]);
-        InlinedVector<Loc, 2> sendArgLocs(tuple->elems.size(), args.locs.args[2]);
-        CallLocs sendLocs{args.locs.call, args.locs.args[0], sendArgLocs};
+            Magic_callWithSplat::generateSendArgs(tuple, sendArgStore, core::Loc(args.locs.file, args.locs.args[2]));
+        InlinedVector<LocOffsets, 2> sendArgLocs(tuple->elems.size(), args.locs.args[2]);
+        CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], sendArgLocs};
         DispatchArgs innerArgs{fn, sendLocs, sendArgs, receiver->type, receiver->type, args.block};
         auto dispatched = receiver->type->dispatchCall(gs, innerArgs);
         for (auto &err : dispatched.main.errors) {
@@ -1422,7 +1437,8 @@ class Magic_callWithBlock : public IntrinsicMethod {
     friend class Magic_callWithSplatAndBlock;
 
 private:
-    static TypePtr typeToProc(const GlobalState &gs, TypePtr blockType, Loc callLoc, Loc receiverLoc) {
+    static TypePtr typeToProc(const GlobalState &gs, TypePtr blockType, core::FileRef file, LocOffsets callLoc,
+                              LocOffsets receiverLoc) {
         auto nonNilBlockType = blockType;
         auto typeIsNilable = false;
         if (Types::isSubType(gs, Types::nilClass(), blockType)) {
@@ -1436,8 +1452,8 @@ private:
 
         NameRef to_proc = core::Names::toProc();
         InlinedVector<const TypeAndOrigins *, 2> sendArgs;
-        InlinedVector<Loc, 2> sendArgLocs;
-        CallLocs sendLocs{callLoc, receiverLoc, sendArgLocs};
+        InlinedVector<LocOffsets, 2> sendArgLocs;
+        CallLocs sendLocs{file, callLoc, receiverLoc, sendArgLocs};
         DispatchArgs innerArgs{to_proc, sendLocs, sendArgs, nonNilBlockType, nonNilBlockType, nullptr};
         auto dispatched = nonNilBlockType->dispatchCall(gs, innerArgs);
         for (auto &err : dispatched.main.errors) {
@@ -1592,7 +1608,8 @@ public:
         }
 
         if (core::cast_type<core::TypeVar>(args.args[2]->type.get())) {
-            if (auto e = gs.beginError(args.locs.args[2], core::errors::Infer::GenericPassedAsBlock)) {
+            if (auto e = gs.beginError(core::Loc(args.locs.file, args.locs.args[2]),
+                                       core::errors::Infer::GenericPassedAsBlock)) {
                 e.setHeader("Passing generics as block arguments is not supported");
             }
             return;
@@ -1605,7 +1622,7 @@ public:
         NameRef fn(gs, (u4)lit->value);
 
         InlinedVector<TypeAndOrigins, 2> sendArgStore;
-        InlinedVector<Loc, 2> sendArgLocs;
+        InlinedVector<LocOffsets, 2> sendArgLocs;
         for (int i = 3; i < args.args.size(); i++) {
             sendArgStore.emplace_back(*args.args[i]);
             sendArgLocs.emplace_back(args.locs.args[i]);
@@ -1615,18 +1632,19 @@ public:
         for (auto &arg : sendArgStore) {
             sendArgs.emplace_back(&arg);
         }
-        CallLocs sendLocs{args.locs.call, args.locs.args[0], sendArgLocs};
+        CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], sendArgLocs};
 
         TypePtr finalBlockType =
-            Magic_callWithBlock::typeToProc(gs, args.args[2]->type, args.locs.call, args.locs.args[2]);
+            Magic_callWithBlock::typeToProc(gs, args.args[2]->type, args.locs.file, args.locs.call, args.locs.args[2]);
         std::optional<int> blockArity = Magic_callWithBlock::getArityForBlock(finalBlockType);
         auto link = make_shared<core::SendAndBlockLink>(fn, Magic_callWithBlock::argInfoByArity(blockArity), -1);
         res.main.constr = make_unique<TypeConstraint>();
 
         DispatchArgs innerArgs{fn, sendLocs, sendArgs, receiver->type, receiver->type, link};
 
-        Magic_callWithBlock::simulateCall(gs, receiver, innerArgs, link, finalBlockType, args.locs.args[2],
-                                          args.locs.call, res);
+        Magic_callWithBlock::simulateCall(gs, receiver, innerArgs, link, finalBlockType,
+                                          core::Loc(args.locs.file, args.locs.args[2]),
+                                          core::Loc(args.locs.file, args.locs.call), res);
     }
 } Magic_callWithBlock;
 
@@ -1663,14 +1681,16 @@ public:
         }
         auto *tuple = cast_type<TupleType>(args.args[2]->type.get());
         if (tuple == nullptr) {
-            if (auto e = gs.beginError(args.locs.args[2], core::errors::Infer::UntypedSplat)) {
+            if (auto e =
+                    gs.beginError(core::Loc(args.locs.file, args.locs.args[2]), core::errors::Infer::UntypedSplat)) {
                 e.setHeader("Splats are only supported where the size of the array is known statically");
             }
             return;
         }
 
         if (core::cast_type<core::TypeVar>(args.args[3]->type.get())) {
-            if (auto e = gs.beginError(args.locs.args[3], core::errors::Infer::GenericPassedAsBlock)) {
+            if (auto e = gs.beginError(core::Loc(args.locs.file, args.locs.args[3]),
+                                       core::errors::Infer::GenericPassedAsBlock)) {
                 e.setHeader("Passing generics as block arguments is not supported");
             }
             return;
@@ -1678,20 +1698,21 @@ public:
 
         InlinedVector<TypeAndOrigins, 2> sendArgStore;
         InlinedVector<const TypeAndOrigins *, 2> sendArgs =
-            Magic_callWithSplat::generateSendArgs(tuple, sendArgStore, args.locs.args[2]);
-        InlinedVector<Loc, 2> sendArgLocs(tuple->elems.size(), args.locs.args[2]);
-        CallLocs sendLocs{args.locs.call, args.locs.args[0], sendArgLocs};
+            Magic_callWithSplat::generateSendArgs(tuple, sendArgStore, core::Loc(args.locs.file, args.locs.args[2]));
+        InlinedVector<LocOffsets, 2> sendArgLocs(tuple->elems.size(), args.locs.args[2]);
+        CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], sendArgLocs};
 
         TypePtr finalBlockType =
-            Magic_callWithBlock::typeToProc(gs, args.args[3]->type, args.locs.call, args.locs.args[3]);
+            Magic_callWithBlock::typeToProc(gs, args.args[3]->type, args.locs.file, args.locs.call, args.locs.args[3]);
         std::optional<int> blockArity = Magic_callWithBlock::getArityForBlock(finalBlockType);
         auto link = make_shared<core::SendAndBlockLink>(fn, Magic_callWithBlock::argInfoByArity(blockArity), -1);
         res.main.constr = make_unique<TypeConstraint>();
 
         DispatchArgs innerArgs{fn, sendLocs, sendArgs, receiver->type, receiver->type, link};
 
-        Magic_callWithBlock::simulateCall(gs, receiver, innerArgs, link, finalBlockType, args.locs.args[3],
-                                          args.locs.call, res);
+        Magic_callWithBlock::simulateCall(gs, receiver, innerArgs, link, finalBlockType,
+                                          core::Loc(args.locs.file, args.locs.args[3]),
+                                          core::Loc(args.locs.file, args.locs.call), res);
     }
 } Magic_callWithSplatAndBlock;
 
@@ -1700,7 +1721,7 @@ public:
     void apply(const GlobalState &gs, DispatchArgs args, const Type *thisType, DispatchResult &res) const override {
         ENFORCE(args.args.size() == 1);
         auto ty = core::Types::widen(gs, args.args.front()->type);
-        auto loc = args.locs.args[0];
+        auto loc = core::Loc(args.locs.file, args.locs.args[0]);
         if (auto e = gs.beginError(loc, core::errors::Infer::UntypedConstantSuggestion)) {
             e.setHeader("Constants must have type annotations with `{}` when specifying `{}`", "T.let",
                         "# typed: strict");
@@ -1732,12 +1753,12 @@ public:
         SymbolRef self = unwrapSymbol(selfTy.get());
 
         InlinedVector<const TypeAndOrigins *, 2> sendArgStore;
-        InlinedVector<Loc, 2> sendArgLocs;
+        InlinedVector<LocOffsets, 2> sendArgLocs;
         for (int i = 1; i < args.args.size(); ++i) {
             sendArgStore.emplace_back(args.args[i]);
             sendArgLocs.emplace_back(args.locs.args[i]);
         }
-        CallLocs sendLocs{args.locs.call, args.locs.args[0], sendArgLocs};
+        CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], sendArgLocs};
 
         TypePtr returnTy;
         DispatchResult dispatched;
@@ -1999,7 +2020,8 @@ public:
 
             auto lt = cast_type<LiteralType>(argTyp.get());
             if (!lt) {
-                if (auto e = gs.beginError(argLoc, core::errors::Infer::ExpectedLiteralType)) {
+                if (auto e =
+                        gs.beginError(core::Loc(args.locs.file, argLoc), core::errors::Infer::ExpectedLiteralType)) {
                     e.setHeader("You must pass an Integer literal to specify a depth with Array#flatten");
                 }
                 return;
@@ -2104,13 +2126,14 @@ public:
     // Forward Enumerable.to_h to RubyType.enumerable_to_h[self]
     void apply(const GlobalState &gs, DispatchArgs args, const Type *thisType, DispatchResult &res) const override {
         auto hash = make_type<ClassType>(core::Symbols::Sorbet_Private_Static().data(gs)->lookupSingletonClass(gs));
-        InlinedVector<Loc, 2> argLocs{args.locs.receiver};
+        InlinedVector<LocOffsets, 2> argLocs{args.locs.receiver};
         CallLocs locs{
+            args.locs.file,
             args.locs.call,
             args.locs.call,
             argLocs,
         };
-        TypeAndOrigins myType{args.selfType, {args.locs.receiver}};
+        TypeAndOrigins myType{args.selfType, {core::Loc(args.locs.file, args.locs.receiver)}};
         InlinedVector<const TypeAndOrigins *, 2> innerArgs{&myType};
 
         DispatchArgs dispatch{

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -69,7 +69,7 @@ core::TypePtr extractArgType(core::Context ctx, cfg::Send &send, core::DispatchC
     return to;
 }
 
-void extractSendArgumentKnowledge(core::Context ctx, core::Loc bindLoc, cfg::Send *snd,
+void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, cfg::Send *snd,
                                   const UnorderedMap<core::LocalVariable, InlinedVector<core::NameRef, 1>> &blockLocals,
                                   UnorderedMap<core::NameRef, core::TypePtr> &blockArgRequirements) {
     InlinedVector<unique_ptr<core::TypeAndOrigins>, 2> typeAndOriginsOwner;
@@ -84,6 +84,7 @@ void extractSendArgumentKnowledge(core::Context ctx, core::Loc bindLoc, cfg::Sen
     }
 
     core::CallLocs locs{
+        ctx.file,
         bindLoc,
         snd->receiverLoc,
         snd->argLocs,

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -510,7 +510,7 @@ const Environment &Environment::withCond(core::Context ctx, const Environment &e
         return env;
     }
     copy.cloneFrom(env);
-    copy.assumeKnowledge(ctx, isTrue, env.bb->bexit.cond.variable, env.bb->bexit.loc, filter);
+    copy.assumeKnowledge(ctx, isTrue, env.bb->bexit.cond.variable, core::Loc(ctx.file, env.bb->bexit.loc), filter);
     return copy;
 }
 
@@ -763,7 +763,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
 
         bool checkFullyDefined = true;
         const core::lsp::Query &lspQuery = ctx.state.lspQuery;
-        bool lspQueryMatch = lspQuery.matchesLoc(bind.loc);
+        bool lspQueryMatch = lspQuery.matchesLoc(core::Loc(ctx.file, bind.loc));
 
         typecase(
             bind.value.get(),
@@ -780,6 +780,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                     checkFullyDefined = false;
                 }
                 core::CallLocs locs{
+                    ctx.file,
                     bind.loc,
                     send->receiverLoc,
                     send->argLocs,
@@ -807,8 +808,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                 }
                 if (lspQueryMatch) {
                     core::lsp::QueryResponse::pushQueryResponse(
-                        ctx,
-                        core::lsp::SendResponse(bind.loc, retainedResult, send->fun, send->isPrivateOk, ctx.owner));
+                        ctx, core::lsp::SendResponse(core::Loc(ctx.file, bind.loc), retainedResult, send->fun,
+                                                     send->isPrivateOk, ctx.owner));
                 }
                 if (send->link) {
                     // This should eventually become ENFORCEs but currently they are wrong
@@ -822,7 +823,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
 
                     send->link->result = move(retainedResult);
                 }
-                tp.origins.emplace_back(bind.loc);
+                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
             },
             [&](cfg::Ident *i) {
                 const core::TypeAndOrigins &typeAndOrigin = getTypeAndOrigin(ctx, i->what);
@@ -831,11 +832,10 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
 
                 if (lspQueryMatch) {
                     core::lsp::QueryResponse::pushQueryResponse(
-                        ctx, core::lsp::IdentResponse(bind.loc, i->what, tp, ctx.owner));
+                        ctx, core::lsp::IdentResponse(core::Loc(ctx.file, bind.loc), i->what, tp, ctx.owner));
                 }
 
-                ENFORCE((bind.loc.exists() && bind.loc.file().data(ctx).hasParseErrors) || !tp.origins.empty(),
-                        "Inferencer did not assign location");
+                ENFORCE(ctx.file.data(ctx).hasParseErrors || !tp.origins.empty(), "Inferencer did not assign location");
             },
             [&](cfg::Alias *a) {
                 core::SymbolRef symbol = a->what.data(ctx)->dealias(ctx);
@@ -882,7 +882,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
             },
             [&](cfg::SolveConstraint *i) {
                 if (i->link->result->main.constr && !i->link->result->main.constr->solve(ctx)) {
-                    if (auto e = ctx.state.beginError(bind.loc, core::errors::Infer::GenericMethodConstaintUnsolved)) {
+                    if (auto e = ctx.beginError(bind.loc, core::errors::Infer::GenericMethodConstaintUnsolved)) {
                         e.setHeader("Could not find valid instantiation of type parameters");
                     }
                 }
@@ -896,7 +896,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                 }
                 type = flatmapHack(ctx, i->link->result->main.receiver, type, i->link->fun);
                 tp.type = std::move(type);
-                tp.origins.emplace_back(bind.loc);
+                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
             },
             [&](cfg::LoadArg *i) {
                 /* read type from info filled by define_method */
@@ -914,7 +914,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
 
                 auto argType = i->argument(ctx).argumentTypeAsSeenByImplementation(ctx, constr);
                 tp.type = std::move(argType);
-                tp.origins.emplace_back(bind.loc);
+                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
             },
             [&](cfg::LoadYieldParams *insn) {
                 ENFORCE(insn->link);
@@ -939,11 +939,11 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                 } else {
                     tp.type = params;
                 }
-                tp.origins.emplace_back(bind.loc);
+                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
             },
             [&](cfg::Return *i) {
                 tp.type = core::Types::bottom();
-                tp.origins.emplace_back(bind.loc);
+                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
 
                 const core::TypeAndOrigins &typeAndOrigin = getAndFillTypeAndOrigin(ctx, i->what);
                 if (core::Types::isSubType(ctx, core::Types::void_(), methodReturnType)) {
@@ -951,7 +951,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                 }
                 if (!core::Types::isSubTypeUnderConstraint(ctx, constr, typeAndOrigin.type, methodReturnType,
                                                            core::UntypedMode::AlwaysCompatible)) {
-                    if (auto e = ctx.state.beginError(bind.loc, core::errors::Infer::ReturnTypeMismatch)) {
+                    if (auto e = ctx.beginError(bind.loc, core::errors::Infer::ReturnTypeMismatch)) {
                         auto ownerData = ctx.owner.data(ctx);
                         if (ownerData->name.data(ctx)->kind == core::NameKind::UNIQUE &&
                             ownerData->name.data(ctx)->unique.uniqueNameKind == core::UniqueNameKind::DefaultArg) {
@@ -997,7 +997,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                     // information about the `send` and/or the
                     // definition of the block type
 
-                    if (auto e = ctx.state.beginError(bind.loc, core::errors::Infer::ReturnTypeMismatch)) {
+                    if (auto e = ctx.beginError(bind.loc, core::errors::Infer::ReturnTypeMismatch)) {
                         e.setHeader("Returning value that does not conform to block result type");
                         e.addErrorSection(core::ErrorSection("Expected " + expectedType->show(ctx)));
                         e.addErrorSection(
@@ -1007,20 +1007,21 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                 }
 
                 tp.type = core::Types::bottom();
-                tp.origins.emplace_back(bind.loc);
+                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
             },
             [&](cfg::Literal *i) {
                 tp.type = i->value;
-                tp.origins.emplace_back(bind.loc);
+                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
 
                 if (lspQueryMatch) {
-                    core::lsp::QueryResponse::pushQueryResponse(ctx, core::lsp::LiteralResponse(bind.loc, tp));
+                    core::lsp::QueryResponse::pushQueryResponse(
+                        ctx, core::lsp::LiteralResponse(core::Loc(ctx.file, bind.loc), tp));
                 }
             },
             [&](cfg::TAbsurd *i) {
                 const core::TypeAndOrigins &typeAndOrigin = getTypeAndOrigin(ctx, i->what.variable);
 
-                if (auto e = ctx.state.beginError(bind.loc, core::errors::Infer::NotExhaustive)) {
+                if (auto e = ctx.beginError(bind.loc, core::errors::Infer::NotExhaustive)) {
                     if (typeAndOrigin.type->isUntyped()) {
                         e.setHeader("Control flow could reach `{}` because argument was `{}`", "T.absurd", "T.untyped");
                     } else {
@@ -1031,17 +1032,17 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                 }
 
                 tp.type = core::Types::bottom();
-                tp.origins.emplace_back(bind.loc);
+                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
             },
             [&](cfg::Unanalyzable *i) {
                 tp.type = core::Types::untypedUntracked();
-                tp.origins.emplace_back(bind.loc);
+                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
             },
             [&](cfg::LoadSelf *l) {
                 ENFORCE(l->link);
                 if (l->link->result->main.blockSpec.rebind.exists()) {
                     tp.type = l->link->result->main.blockSpec.rebind.data(ctx)->externalType(ctx);
-                    tp.origins.emplace_back(bind.loc);
+                    tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
 
                 } else {
                     tp = getTypeAndOrigin(ctx, l->fallback);
@@ -1053,7 +1054,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                                                          klass.data(ctx)->selfTypeArgs(ctx));
 
                 tp.type = castType;
-                tp.origins.emplace_back(bind.loc);
+                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
 
                 if (!hasType(ctx, bind.bind.variable)) {
                     noLoopChecking = true;
@@ -1062,14 +1063,14 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                 const core::TypeAndOrigins &ty = getAndFillTypeAndOrigin(ctx, c->value);
                 if (c->cast != core::Names::cast()) {
                     if (c->cast == core::Names::assertType() && ty.type->isUntyped()) {
-                        if (auto e = ctx.state.beginError(bind.loc, core::errors::Infer::CastTypeMismatch)) {
+                        if (auto e = ctx.beginError(bind.loc, core::errors::Infer::CastTypeMismatch)) {
                             e.setHeader("The typechecker was unable to infer the type of the asserted value");
                             e.addErrorSection(core::ErrorSection("Got " + ty.type->show(ctx) + " originating from:",
                                                                  ty.origins2Explanations(ctx)));
                             e.addErrorSection(core::ErrorSection("You may need to add additional `sig` annotations"));
                         }
                     } else if (!core::Types::isSubType(ctx, ty.type, castType)) {
-                        if (auto e = ctx.state.beginError(bind.loc, core::errors::Infer::CastTypeMismatch)) {
+                        if (auto e = ctx.beginError(bind.loc, core::errors::Infer::CastTypeMismatch)) {
                             e.setHeader("Argument does not have asserted type `{}`", castType->show(ctx));
                             e.addErrorSection(core::ErrorSection("Got " + ty.type->show(ctx) + " originating from:",
                                                                  ty.origins2Explanations(ctx)));
@@ -1077,11 +1078,11 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                     }
                 } else if (!c->isSynthetic) {
                     if (castType->isUntyped()) {
-                        if (auto e = ctx.state.beginError(bind.loc, core::errors::Infer::InvalidCast)) {
+                        if (auto e = ctx.beginError(bind.loc, core::errors::Infer::InvalidCast)) {
                             e.setHeader("Please use `T.unsafe(...)` to cast to T.untyped");
                         }
                     } else if (!ty.type->isUntyped() && core::Types::isSubType(ctx, ty.type, castType)) {
-                        if (auto e = ctx.state.beginError(bind.loc, core::errors::Infer::InvalidCast)) {
+                        if (auto e = ctx.beginError(bind.loc, core::errors::Infer::InvalidCast)) {
                             e.setHeader("Useless cast: inferred type `{}` is already a subtype of `{}`",
                                         ty.type->show(ctx), castType->show(ctx));
                         }
@@ -1096,14 +1097,13 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
         tp.type->sanityCheck(ctx);
 
         if (checkFullyDefined && !tp.type->isFullyDefined()) {
-            if (auto e = ctx.state.beginError(bind.loc, core::errors::Infer::IncompleteType)) {
+            if (auto e = ctx.beginError(bind.loc, core::errors::Infer::IncompleteType)) {
                 e.setHeader("Expression does not have a fully-defined type (Did you reference another class's type "
                             "members?)");
             }
             tp.type = core::Types::untypedUntracked();
         }
-        ENFORCE((bind.loc.exists() && bind.loc.file().data(ctx).hasParseErrors) || !tp.origins.empty(),
-                "Inferencer did not assign location");
+        ENFORCE(ctx.file.data(ctx).hasParseErrors || !tp.origins.empty(), "Inferencer did not assign location");
 
         if (!noLoopChecking && loopCount != bindMinLoops) {
             auto pin = pinnedTypes.find(bind.bind.variable);
@@ -1117,8 +1117,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                 switch (bindMinLoops) {
                     case cfg::CFG::MIN_LOOP_FIELD:
                         if (!asGoodAs) {
-                            if (auto e = ctx.state.beginError(bind.loc,
-                                                              core::errors::Infer::FieldReassignmentTypeMismatch)) {
+                            if (auto e = ctx.beginError(bind.loc, core::errors::Infer::FieldReassignmentTypeMismatch)) {
                                 e.setHeader(
                                     "Reassigning field with a value of wrong type: `{}` is not a subtype of `{}`",
                                     tp.type->show(ctx), cur.type->show(ctx));
@@ -1128,8 +1127,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                         break;
                     case cfg::CFG::MIN_LOOP_GLOBAL:
                         if (!asGoodAs) {
-                            if (auto e = ctx.state.beginError(bind.loc,
-                                                              core::errors::Infer::GlobalReassignmentTypeMismatch)) {
+                            if (auto e =
+                                    ctx.beginError(bind.loc, core::errors::Infer::GlobalReassignmentTypeMismatch)) {
                                 e.setHeader(
                                     "Reassigning global with a value of wrong type: `{}` is not a subtype of `{}`",
                                     tp.type->show(ctx), cur.type->show(ctx));
@@ -1139,7 +1138,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                         break;
                     case cfg::CFG::MIN_LOOP_LET:
                         if (!asGoodAs) {
-                            if (auto e = ctx.state.beginError(bind.loc, core::errors::Infer::PinnedVariableMismatch)) {
+                            if (auto e = ctx.beginError(bind.loc, core::errors::Infer::PinnedVariableMismatch)) {
                                 e.setHeader("Incompatible assignment to variable declared via `{}`: `{}` is not a "
                                             "subtype of `{}`",
                                             "let", tp.type->show(ctx), cur.type->show(ctx));
@@ -1164,7 +1163,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
                                     break;
                                 }
                             }
-                            if (auto e = ctx.state.beginError(bind.loc, core::errors::Infer::PinnedVariableMismatch)) {
+                            if (auto e = ctx.beginError(bind.loc, core::errors::Infer::PinnedVariableMismatch)) {
                                 e.setHeader("Changing the type of a variable in a loop is not permitted");
                                 e.addErrorSection(core::ErrorSection(core::ErrorColors::format(
                                     "Existing variable has type: `{}`", cur.type->show(ctx))));
@@ -1199,7 +1198,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
 
         clearKnowledge(ctx, bind.bind.variable, knowledgeFilter);
         if (auto *send = cfg::cast_instruction<cfg::Send>(bind.value.get())) {
-            updateKnowledge(ctx, bind.bind.variable, bind.loc, send, knowledgeFilter);
+            updateKnowledge(ctx, bind.bind.variable, core::Loc(ctx.file, bind.loc), send, knowledgeFilter);
         } else if (auto *i = cfg::cast_instruction<cfg::Ident>(bind.value.get())) {
             propagateKnowledge(ctx, bind.bind.variable, i->what, knowledgeFilter);
         }
@@ -1207,7 +1206,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, cfg::Binding &bind,
         return move(tp.type);
     } catch (SorbetException &) {
         Exception::failInFuzzer();
-        if (auto e = ctx.state.beginError(bind.loc, core::errors::Internal::InternalError)) {
+        if (auto e = ctx.beginError(bind.loc, core::errors::Internal::InternalError)) {
             e.setHeader("Failed to type (backtrace is above)");
         }
         throw;

--- a/infer/test/infer_test.cc
+++ b/infer/test/infer_test.cc
@@ -30,39 +30,40 @@ auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger);
 class InferFixture : public ::testing::Test {
 public:
     void SetUp() override {
-        ctxPtr = make_unique<core::GlobalState>(errorQueue);
-        ctxPtr->initEmpty();
+        gsPtr = make_unique<core::GlobalState>(errorQueue);
+        gsPtr->initEmpty();
     }
-    core::MutableContext getCtx() {
-        return core::MutableContext(*ctxPtr, core::Symbols::root());
+    core::GlobalState &getGs() {
+        return *gsPtr;
     }
 
 private:
-    unique_ptr<core::GlobalState> ctxPtr;
+    unique_ptr<core::GlobalState> gsPtr;
 };
 
 void processSource(core::GlobalState &cb, string str) {
     sorbet::core::UnfreezeNameTable nt(cb);
     sorbet::core::UnfreezeSymbolTable st(cb);
     sorbet::core::UnfreezeFileTable ft(cb);
-    auto ast = parser::Parser::run(cb, "<test>", str);
-    sorbet::core::MutableContext ctx(cb, core::Symbols::root());
-    auto fileId = ast->loc.file();
+    core::FileRef fileId = cb.enterFile("<test>", str);
+    auto ast = parser::Parser::run(cb, fileId);
+    sorbet::core::MutableContext ctx(cb, core::Symbols::root(), fileId);
     auto tree = ast::ParsedFile{ast::desugar::node2Tree(ctx, move(ast)), fileId};
     tree.tree = rewriter::Rewriter::run(ctx, move(tree.tree));
     tree = local_vars::LocalVars::run(ctx, move(tree));
     vector<ast::ParsedFile> trees;
     trees.emplace_back(move(tree));
-    trees = namer::Namer::run(ctx, move(trees));
+    trees = namer::Namer::run(cb, move(trees));
     auto workers = WorkerPool::create(0, *logger);
-    resolver::Resolver::run(ctx, move(trees), *workers);
-    for (auto &tree : trees) {
+    auto resolved = resolver::Resolver::run(cb, move(trees), *workers);
+    for (auto &tree : resolved.result()) {
+        sorbet::core::MutableContext ctx(cb, core::Symbols::root(), tree.file);
         tree = class_flatten::runOne(ctx, move(tree));
     }
 }
 
 TEST_F(InferFixture, LiteralsSubtyping) { // NOLINT
-    auto ctx = getCtx();
+    auto &gs = getGs();
     auto intLit = core::make_type<core::LiteralType>(int64_t(1));
     auto intClass = core::make_type<core::ClassType>(core::Symbols::Integer());
     auto floatLit = core::make_type<core::LiteralType>(1.0f);
@@ -71,129 +72,129 @@ TEST_F(InferFixture, LiteralsSubtyping) { // NOLINT
     auto trueClass = core::make_type<core::ClassType>(core::Symbols::TrueClass());
     auto stringLit = core::make_type<core::LiteralType>(core::Symbols::String(), core::Names::assignTemp());
     auto stringClass = core::make_type<core::ClassType>(core::Symbols::String());
-    EXPECT_TRUE(core::Types::isSubType(ctx, intLit, intClass));
-    EXPECT_TRUE(core::Types::isSubType(ctx, floatLit, floatClass));
-    EXPECT_TRUE(core::Types::isSubType(ctx, trueLit, trueClass));
-    EXPECT_TRUE(core::Types::isSubType(ctx, stringLit, stringClass));
+    EXPECT_TRUE(core::Types::isSubType(gs, intLit, intClass));
+    EXPECT_TRUE(core::Types::isSubType(gs, floatLit, floatClass));
+    EXPECT_TRUE(core::Types::isSubType(gs, trueLit, trueClass));
+    EXPECT_TRUE(core::Types::isSubType(gs, stringLit, stringClass));
 
-    EXPECT_TRUE(core::Types::isSubType(ctx, intLit, intLit));
-    EXPECT_TRUE(core::Types::isSubType(ctx, floatLit, floatLit));
-    EXPECT_TRUE(core::Types::isSubType(ctx, trueLit, trueLit));
-    EXPECT_TRUE(core::Types::isSubType(ctx, stringLit, stringLit));
+    EXPECT_TRUE(core::Types::isSubType(gs, intLit, intLit));
+    EXPECT_TRUE(core::Types::isSubType(gs, floatLit, floatLit));
+    EXPECT_TRUE(core::Types::isSubType(gs, trueLit, trueLit));
+    EXPECT_TRUE(core::Types::isSubType(gs, stringLit, stringLit));
 
-    EXPECT_FALSE(core::Types::isSubType(ctx, intClass, intLit));
-    EXPECT_TRUE(core::Types::isSubType(ctx, core::Types::top(), core::Types::untypedUntracked()));
-    EXPECT_TRUE(core::Types::isSubType(ctx, core::Types::untypedUntracked(), core::Types::top()));
+    EXPECT_FALSE(core::Types::isSubType(gs, intClass, intLit));
+    EXPECT_TRUE(core::Types::isSubType(gs, core::Types::top(), core::Types::untypedUntracked()));
+    EXPECT_TRUE(core::Types::isSubType(gs, core::Types::untypedUntracked(), core::Types::top()));
 }
 
 TEST_F(InferFixture, ClassesSubtyping) { // NOLINT
-    auto ctx = getCtx();
-    processSource(ctx, "class Bar; end; class Foo < Bar; end");
-    const auto &rootScope = core::Symbols::root().data(ctx);
+    auto &gs = getGs();
+    processSource(gs, "class Bar; end; class Foo < Bar; end");
+    const auto &rootScope = core::Symbols::root().data(gs);
 
-    auto barSymbol = rootScope->findMember(ctx, ctx.state.enterNameConstant("Bar"));
-    auto fooSymbol = rootScope->findMember(ctx, ctx.state.enterNameConstant("Foo"));
-    ASSERT_EQ("<C <U Bar>>", barSymbol.data(ctx)->name.data(ctx)->showRaw(ctx));
-    ASSERT_EQ("<C <U Foo>>", fooSymbol.data(ctx)->name.data(ctx)->showRaw(ctx));
+    auto barSymbol = rootScope->findMember(gs, gs.enterNameConstant("Bar"));
+    auto fooSymbol = rootScope->findMember(gs, gs.enterNameConstant("Foo"));
+    ASSERT_EQ("<C <U Bar>>", barSymbol.data(gs)->name.data(gs)->showRaw(gs));
+    ASSERT_EQ("<C <U Foo>>", fooSymbol.data(gs)->name.data(gs)->showRaw(gs));
 
     auto barType = core::make_type<core::ClassType>(barSymbol);
     auto fooType = core::make_type<core::ClassType>(fooSymbol);
 
-    ASSERT_TRUE(core::Types::isSubType(ctx, fooType, barType));
-    ASSERT_TRUE(core::Types::isSubType(ctx, fooType, fooType));
-    ASSERT_TRUE(core::Types::isSubType(ctx, barType, barType));
-    ASSERT_FALSE(core::Types::isSubType(ctx, barType, fooType));
+    ASSERT_TRUE(core::Types::isSubType(gs, fooType, barType));
+    ASSERT_TRUE(core::Types::isSubType(gs, fooType, fooType));
+    ASSERT_TRUE(core::Types::isSubType(gs, barType, barType));
+    ASSERT_FALSE(core::Types::isSubType(gs, barType, fooType));
 }
 
 TEST_F(InferFixture, ClassesLubs) { // NOLINT
-    auto ctx = getCtx();
-    processSource(ctx, "class Bar; end; class Foo1 < Bar; end; class Foo2 < Bar;  end");
-    const auto &rootScope = core::Symbols::root().data(ctx);
+    auto &gs = getGs();
+    processSource(gs, "class Bar; end; class Foo1 < Bar; end; class Foo2 < Bar;  end");
+    const auto &rootScope = core::Symbols::root().data(gs);
 
-    auto barSymbol = rootScope->findMember(ctx, ctx.state.enterNameConstant("Bar"));
-    auto foo1Symbol = rootScope->findMember(ctx, ctx.state.enterNameConstant("Foo1"));
-    auto foo2Symbol = rootScope->findMember(ctx, ctx.state.enterNameConstant("Foo2"));
-    ASSERT_EQ("<C <U Bar>>", barSymbol.data(ctx)->name.data(ctx)->showRaw(ctx));
-    ASSERT_EQ("<C <U Foo1>>", foo1Symbol.data(ctx)->name.data(ctx)->showRaw(ctx));
-    ASSERT_EQ("<C <U Foo2>>", foo2Symbol.data(ctx)->name.data(ctx)->showRaw(ctx));
+    auto barSymbol = rootScope->findMember(gs, gs.enterNameConstant("Bar"));
+    auto foo1Symbol = rootScope->findMember(gs, gs.enterNameConstant("Foo1"));
+    auto foo2Symbol = rootScope->findMember(gs, gs.enterNameConstant("Foo2"));
+    ASSERT_EQ("<C <U Bar>>", barSymbol.data(gs)->name.data(gs)->showRaw(gs));
+    ASSERT_EQ("<C <U Foo1>>", foo1Symbol.data(gs)->name.data(gs)->showRaw(gs));
+    ASSERT_EQ("<C <U Foo2>>", foo2Symbol.data(gs)->name.data(gs)->showRaw(gs));
 
     auto barType = core::make_type<core::ClassType>(barSymbol);
     auto foo1Type = core::make_type<core::ClassType>(foo1Symbol);
     auto foo2Type = core::make_type<core::ClassType>(foo2Symbol);
 
-    auto barNfoo1 = core::Types::any(ctx, barType, foo1Type);
-    auto foo1Nbar = core::Types::any(ctx, foo1Type, barType);
-    auto barNfoo2 = core::Types::any(ctx, barType, foo2Type);
-    auto foo2Nbar = core::Types::any(ctx, foo2Type, barType);
-    auto foo1Nfoo2 = core::Types::any(ctx, foo1Type, foo2Type);
-    auto foo2Nfoo1 = core::Types::any(ctx, foo2Type, foo1Type);
+    auto barNfoo1 = core::Types::any(gs, barType, foo1Type);
+    auto foo1Nbar = core::Types::any(gs, foo1Type, barType);
+    auto barNfoo2 = core::Types::any(gs, barType, foo2Type);
+    auto foo2Nbar = core::Types::any(gs, foo2Type, barType);
+    auto foo1Nfoo2 = core::Types::any(gs, foo1Type, foo2Type);
+    auto foo2Nfoo1 = core::Types::any(gs, foo2Type, foo1Type);
 
     ASSERT_EQ("ClassType", barNfoo1->typeName());
-    ASSERT_TRUE(core::Types::isSubType(ctx, barType, barNfoo1));
-    ASSERT_TRUE(core::Types::isSubType(ctx, foo1Type, barNfoo1));
+    ASSERT_TRUE(core::Types::isSubType(gs, barType, barNfoo1));
+    ASSERT_TRUE(core::Types::isSubType(gs, foo1Type, barNfoo1));
     ASSERT_EQ("ClassType", barNfoo2->typeName());
-    ASSERT_TRUE(core::Types::isSubType(ctx, barType, barNfoo2));
-    ASSERT_TRUE(core::Types::isSubType(ctx, foo2Type, barNfoo2));
+    ASSERT_TRUE(core::Types::isSubType(gs, barType, barNfoo2));
+    ASSERT_TRUE(core::Types::isSubType(gs, foo2Type, barNfoo2));
     ASSERT_EQ("ClassType", foo1Nbar->typeName());
-    ASSERT_TRUE(core::Types::isSubType(ctx, barType, foo1Nbar));
-    ASSERT_TRUE(core::Types::isSubType(ctx, foo1Type, foo1Nbar));
+    ASSERT_TRUE(core::Types::isSubType(gs, barType, foo1Nbar));
+    ASSERT_TRUE(core::Types::isSubType(gs, foo1Type, foo1Nbar));
     ASSERT_EQ("ClassType", foo2Nbar->typeName());
-    ASSERT_TRUE(core::Types::isSubType(ctx, barType, foo2Nbar));
-    ASSERT_TRUE(core::Types::isSubType(ctx, foo2Type, foo2Nbar));
+    ASSERT_TRUE(core::Types::isSubType(gs, barType, foo2Nbar));
+    ASSERT_TRUE(core::Types::isSubType(gs, foo2Type, foo2Nbar));
 
-    ASSERT_TRUE(core::Types::equiv(ctx, barNfoo2, foo2Nbar));
-    ASSERT_TRUE(core::Types::equiv(ctx, barNfoo1, foo1Nbar));
-    ASSERT_TRUE(core::Types::equiv(ctx, foo1Nfoo2, foo2Nfoo1));
+    ASSERT_TRUE(core::Types::equiv(gs, barNfoo2, foo2Nbar));
+    ASSERT_TRUE(core::Types::equiv(gs, barNfoo1, foo1Nbar));
+    ASSERT_TRUE(core::Types::equiv(gs, foo1Nfoo2, foo2Nfoo1));
 
     auto intType = core::make_type<core::ClassType>(core::Symbols::Integer());
-    auto intNfoo1 = core::Types::any(ctx, foo1Type, intType);
-    auto intNbar = core::Types::any(ctx, barType, intType);
-    auto intNfoo1Nbar = core::Types::any(ctx, intNfoo1, barType);
-    ASSERT_TRUE(core::Types::equiv(ctx, intNfoo1Nbar, intNbar));
-    auto intNfoo1Nfoo2 = core::Types::any(ctx, intNfoo1, foo2Type);
-    auto intNfoo1Nfoo2Nbar = core::Types::any(ctx, intNfoo1Nfoo2, barType);
-    ASSERT_TRUE(core::Types::equiv(ctx, intNfoo1Nfoo2Nbar, intNbar));
+    auto intNfoo1 = core::Types::any(gs, foo1Type, intType);
+    auto intNbar = core::Types::any(gs, barType, intType);
+    auto intNfoo1Nbar = core::Types::any(gs, intNfoo1, barType);
+    ASSERT_TRUE(core::Types::equiv(gs, intNfoo1Nbar, intNbar));
+    auto intNfoo1Nfoo2 = core::Types::any(gs, intNfoo1, foo2Type);
+    auto intNfoo1Nfoo2Nbar = core::Types::any(gs, intNfoo1Nfoo2, barType);
+    ASSERT_TRUE(core::Types::equiv(gs, intNfoo1Nfoo2Nbar, intNbar));
 }
 
 TEST_F(InferFixture, ClassesGlbs) { // NOLINT
-    auto ctx = getCtx();
-    processSource(ctx, "class Bar; end; class Foo1 < Bar; end; class Foo2 < Bar;  end");
-    const auto &rootScope = core::Symbols::root().data(ctx);
+    auto &gs = getGs();
+    processSource(gs, "class Bar; end; class Foo1 < Bar; end; class Foo2 < Bar;  end");
+    const auto &rootScope = core::Symbols::root().data(gs);
 
-    auto barSymbol = rootScope->findMember(ctx, ctx.state.enterNameConstant("Bar"));
-    auto foo1Symbol = rootScope->findMember(ctx, ctx.state.enterNameConstant("Foo1"));
-    auto foo2Symbol = rootScope->findMember(ctx, ctx.state.enterNameConstant("Foo2"));
-    ASSERT_EQ("<C <U Bar>>", barSymbol.data(ctx)->name.data(ctx)->showRaw(ctx));
-    ASSERT_EQ("<C <U Foo1>>", foo1Symbol.data(ctx)->name.data(ctx)->showRaw(ctx));
-    ASSERT_EQ("<C <U Foo2>>", foo2Symbol.data(ctx)->name.data(ctx)->showRaw(ctx));
+    auto barSymbol = rootScope->findMember(gs, gs.enterNameConstant("Bar"));
+    auto foo1Symbol = rootScope->findMember(gs, gs.enterNameConstant("Foo1"));
+    auto foo2Symbol = rootScope->findMember(gs, gs.enterNameConstant("Foo2"));
+    ASSERT_EQ("<C <U Bar>>", barSymbol.data(gs)->name.data(gs)->showRaw(gs));
+    ASSERT_EQ("<C <U Foo1>>", foo1Symbol.data(gs)->name.data(gs)->showRaw(gs));
+    ASSERT_EQ("<C <U Foo2>>", foo2Symbol.data(gs)->name.data(gs)->showRaw(gs));
 
     auto barType = core::make_type<core::ClassType>(barSymbol);
     auto foo1Type = core::make_type<core::ClassType>(foo1Symbol);
     auto foo2Type = core::make_type<core::ClassType>(foo2Symbol);
 
-    auto barOrfoo1 = core::Types::all(ctx, barType, foo1Type);
-    auto foo1Orbar = core::Types::all(ctx, foo1Type, barType);
-    auto barOrfoo2 = core::Types::all(ctx, barType, foo2Type);
-    auto foo2Orbar = core::Types::all(ctx, foo2Type, barType);
-    auto foo1Orfoo2 = core::Types::all(ctx, foo1Type, foo2Type);
-    auto foo2Orfoo1 = core::Types::all(ctx, foo2Type, foo1Type);
+    auto barOrfoo1 = core::Types::all(gs, barType, foo1Type);
+    auto foo1Orbar = core::Types::all(gs, foo1Type, barType);
+    auto barOrfoo2 = core::Types::all(gs, barType, foo2Type);
+    auto foo2Orbar = core::Types::all(gs, foo2Type, barType);
+    auto foo1Orfoo2 = core::Types::all(gs, foo1Type, foo2Type);
+    auto foo2Orfoo1 = core::Types::all(gs, foo2Type, foo1Type);
 
     ASSERT_EQ("ClassType", barOrfoo1->typeName());
-    ASSERT_TRUE(core::Types::isSubType(ctx, barOrfoo1, barType));
-    ASSERT_TRUE(core::Types::isSubType(ctx, barOrfoo1, foo1Type));
+    ASSERT_TRUE(core::Types::isSubType(gs, barOrfoo1, barType));
+    ASSERT_TRUE(core::Types::isSubType(gs, barOrfoo1, foo1Type));
     ASSERT_EQ("ClassType", barOrfoo2->typeName());
-    ASSERT_TRUE(core::Types::isSubType(ctx, barOrfoo2, barType));
-    ASSERT_TRUE(core::Types::isSubType(ctx, barOrfoo2, foo2Type));
+    ASSERT_TRUE(core::Types::isSubType(gs, barOrfoo2, barType));
+    ASSERT_TRUE(core::Types::isSubType(gs, barOrfoo2, foo2Type));
     ASSERT_EQ("ClassType", foo1Orbar->typeName());
-    ASSERT_TRUE(core::Types::isSubType(ctx, foo1Orbar, barType));
-    ASSERT_TRUE(core::Types::isSubType(ctx, foo1Orbar, foo1Type));
+    ASSERT_TRUE(core::Types::isSubType(gs, foo1Orbar, barType));
+    ASSERT_TRUE(core::Types::isSubType(gs, foo1Orbar, foo1Type));
     ASSERT_EQ("ClassType", foo2Orbar->typeName());
-    ASSERT_TRUE(core::Types::isSubType(ctx, foo2Orbar, barType));
-    ASSERT_TRUE(core::Types::isSubType(ctx, foo2Orbar, foo2Type));
+    ASSERT_TRUE(core::Types::isSubType(gs, foo2Orbar, barType));
+    ASSERT_TRUE(core::Types::isSubType(gs, foo2Orbar, foo2Type));
 
-    ASSERT_TRUE(core::Types::equiv(ctx, barOrfoo2, foo2Orbar));
-    ASSERT_TRUE(core::Types::equiv(ctx, barOrfoo1, foo1Orbar));
-    ASSERT_TRUE(core::Types::equiv(ctx, foo1Orfoo2, foo2Orfoo1));
+    ASSERT_TRUE(core::Types::equiv(gs, barOrfoo2, foo2Orbar));
+    ASSERT_TRUE(core::Types::equiv(gs, barOrfoo1, foo1Orbar));
+    ASSERT_TRUE(core::Types::equiv(gs, foo1Orfoo2, foo2Orfoo1));
 }
 
 } // namespace sorbet::infer::test

--- a/local_vars/local_vars.h
+++ b/local_vars/local_vars.h
@@ -7,7 +7,7 @@ namespace sorbet::local_vars {
 
 class LocalVars final {
 public:
-    static ast::ParsedFile run(core::MutableContext ctx, ast::ParsedFile tree);
+    static ast::ParsedFile run(core::GlobalState &gs, ast::ParsedFile tree);
 
     LocalVars() = delete;
 };

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -89,7 +89,7 @@ public:
         ENFORCE(it != refMap.end());
         def.defining_ref = it->second;
         refs[it->second.id()].is_defining_ref = true;
-        refs[it->second.id()].definitionLoc = original->loc;
+        refs[it->second.id()].definitionLoc = core::Loc(ctx.file, original->loc);
 
         auto ait = original->ancestors.begin();
         if (original->kind == ast::ClassDef::Kind::Class && !original->ancestors.empty()) {
@@ -166,11 +166,11 @@ public:
             ref.nesting.pop_back();
             ref.scope = nesting.back();
         }
-        ref.loc = original->loc;
+        ref.loc = core::Loc(ctx.file, original->loc);
 
         // This will get overridden if this loc is_defining_ref at the point
         // where we set that flag.
-        ref.definitionLoc = original->loc;
+        ref.definitionLoc = core::Loc(ctx.file, original->loc);
         ref.name = constantName(ctx, original.get());
         auto sym = original->symbol;
         if (!sym.data(ctx)->isClassOrModule() || sym != core::Symbols::StubModule()) {
@@ -208,7 +208,7 @@ public:
         auto &ref = refs[refMap[lhs].id()];
         def.defining_ref = ref.id;
         ref.is_defining_ref = true;
-        ref.definitionLoc = original->loc;
+        ref.definitionLoc = core::Loc(ctx.file, original->loc);
 
         def.defines_behavior = true;
         def.is_empty = false;

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -28,8 +28,8 @@ bool AutoloaderConfig::sameFileCollapsable(const vector<core::NameRef> &module) 
     return nonCollapsableModuleNames.find(module) == nonCollapsableModuleNames.end();
 }
 
-string_view AutoloaderConfig::normalizePath(core::Context ctx, core::FileRef file) const {
-    auto path = file.data(ctx).path();
+string_view AutoloaderConfig::normalizePath(const core::GlobalState &gs, core::FileRef file) const {
+    auto path = file.data(gs).path();
     for (const auto &prefix : stripPrefixes) {
         if (absl::StartsWith(path, prefix)) {
             return path.substr(prefix.size());
@@ -61,7 +61,7 @@ AutoloaderConfig AutoloaderConfig::enterConfig(core::GlobalState &gs, const real
     return out;
 }
 
-NamedDefinition NamedDefinition::fromDef(const core::Context ctx, ParsedFile &parsedFile, DefinitionRef def) {
+NamedDefinition NamedDefinition::fromDef(const core::GlobalState &gs, ParsedFile &parsedFile, DefinitionRef def) {
     vector<core::NameRef> parentName;
     if (def.data(parsedFile).parent_ref.exists()) {
         auto parentRef = def.data(parsedFile).parent_ref.data(parsedFile);
@@ -71,14 +71,14 @@ NamedDefinition NamedDefinition::fromDef(const core::Context ctx, ParsedFile &pa
             parentName = parentRef.name;
         }
     }
-    const auto &pathStr = parsedFile.tree.file.data(ctx).path();
+    const auto &pathStr = parsedFile.tree.file.data(gs).path();
     u4 pathDepth = count(pathStr.begin(), pathStr.end(), '/'); // Pre-compute for comparison
-    return {def.data(parsedFile), parsedFile.showFullName(ctx, def),
+    return {def.data(parsedFile), parsedFile.showFullName(gs, def),
             parentName,           parsedFile.requires,
             parsedFile.tree.file, pathDepth};
 }
 
-bool NamedDefinition::preferredTo(core::Context ctx, const NamedDefinition &lhs, const NamedDefinition &rhs) {
+bool NamedDefinition::preferredTo(const core::GlobalState &gs, const NamedDefinition &lhs, const NamedDefinition &rhs) {
     ENFORCE(lhs.nameParts == rhs.nameParts, "Can only compare definitions with same name");
     // Load defs with a parent name first since others will tend to depend on them.
     // Secondarily, the same idea for defs with less nesting in their path.
@@ -89,30 +89,30 @@ bool NamedDefinition::preferredTo(core::Context ctx, const NamedDefinition &lhs,
     if (lhs.pathDepth != rhs.pathDepth) {
         return lhs.pathDepth < rhs.pathDepth;
     }
-    return lhs.fileRef.data(ctx).path() < rhs.fileRef.data(ctx).path();
+    return lhs.fileRef.data(gs).path() < rhs.fileRef.data(gs).path();
 }
 
-void showHelper(core::Context ctx, fmt::memory_buffer &buf, const DefTree &node, int level) {
-    auto fileRefToString = [&](const NamedDefinition &nd) -> string_view { return nd.fileRef.data(ctx).path(); };
-    fmt::format_to(buf, "{} [{}]\n", node.root() ? "<ROOT>" : node.name().show(ctx),
+void showHelper(const core::GlobalState &gs, fmt::memory_buffer &buf, const DefTree &node, int level) {
+    auto fileRefToString = [&](const NamedDefinition &nd) -> string_view { return nd.fileRef.data(gs).path(); };
+    fmt::format_to(buf, "{} [{}]\n", node.root() ? "<ROOT>" : node.name().show(gs),
                    fmt::map_join(node.namedDefs, ", ", fileRefToString));
     for (const auto &[name, tree] : node.children) {
         for (int i = 0; i < level; ++i) {
             fmt::format_to(buf, "  ");
         }
-        showHelper(ctx, buf, *tree, level + 1);
+        showHelper(gs, buf, *tree, level + 1);
     }
 }
 
-string DefTree::show(core::Context ctx, int level) const {
+string DefTree::show(const core::GlobalState &gs, int level) const {
     fmt::memory_buffer buf;
-    showHelper(ctx, buf, *this, 0);
+    showHelper(gs, buf, *this, 0);
     return to_string(buf);
 }
 
-string DefTree::fullName(core::Context ctx) const {
+string DefTree::fullName(const core::GlobalState &gs) const {
     return fmt::format("{}",
-                       fmt::map_join(nameParts, "::", [&](core::NameRef nr) -> string_view { return nr.show(ctx); }));
+                       fmt::map_join(nameParts, "::", [&](core::NameRef nr) -> string_view { return nr.show(gs); }));
 }
 
 string join(string path, string file) {
@@ -170,7 +170,7 @@ core::NameRef DefTree::name() const {
     return nameParts.back();
 }
 
-string DefTree::renderAutoloadSrc(core::Context ctx, const AutoloaderConfig &alCfg) const {
+string DefTree::renderAutoloadSrc(const core::GlobalState &gs, const AutoloaderConfig &alCfg) const {
     fmt::memory_buffer buf;
     fmt::format_to(buf, "{}\n", alCfg.preamble);
 
@@ -181,29 +181,29 @@ string DefTree::renderAutoloadSrc(core::Context ctx, const AutoloaderConfig &alC
         definingFile = file();
     }
     if (definingFile.exists()) {
-        requires(ctx, alCfg, buf);
+        requires(gs, alCfg, buf);
     }
 
     string fullName = "nil";
     string casgnArg;
-    auto type = definitionType(ctx);
+    auto type = definitionType(gs);
     if (type == Definition::Type::Module || type == Definition::Type::Class) {
         fullName = root() ? "Object" : fmt::format("{}", fmt::map_join(nameParts, "::", [&](const auto &nr) -> string {
-                                                       return nr.show(ctx);
+                                                       return nr.show(gs);
                                                    }));
         if (!root()) {
             fmt::format_to(buf, "Opus::Require.on_autoload('{}')\n", fullName);
-            predeclare(ctx, fullName, buf);
+            predeclare(gs, fullName, buf);
         }
         if (!children.empty()) {
             fmt::format_to(buf, "\nOpus::Require.autoload_map({}, {{\n", fullName);
             vector<pair<core::NameRef, string>> childNames;
             std::transform(children.begin(), children.end(), back_inserter(childNames),
-                           [ctx](const auto &pair) { return make_pair(pair.first, pair.first.show(ctx)); });
+                           [&gs](const auto &pair) { return make_pair(pair.first, pair.first.show(gs)); });
             fast_sort(childNames, [](const auto &lhs, const auto &rhs) -> bool { return lhs.second < rhs.second; });
             for (const auto &pair : childNames) {
                 fmt::format_to(buf, "  {}: \"{}/{}\",\n", pair.second, alCfg.rootDir,
-                               children.at(pair.first)->path(ctx));
+                               children.at(pair.first)->path(gs));
             }
             fmt::format_to(buf, "}})\n", fullName);
         }
@@ -211,26 +211,26 @@ string DefTree::renderAutoloadSrc(core::Context ctx, const AutoloaderConfig &alC
         ENFORCE(nameParts.size() > 1);
         casgnArg = fmt::format(", [{}, :{}]",
                                fmt::map_join(nameParts.begin(), --nameParts.end(),
-                                             "::", [&](const auto &nr) -> string { return nr.show(ctx); }),
-                               nameParts.back().show(ctx));
+                                             "::", [&](const auto &nr) -> string { return nr.show(gs); }),
+                               nameParts.back().show(gs));
     }
 
     if (definingFile.exists()) {
         fmt::format_to(buf, "\nOpus::Require.for_autoload({}, \"{}\"{})\n", fullName,
-                       alCfg.normalizePath(ctx, definingFile), casgnArg);
+                       alCfg.normalizePath(gs, definingFile), casgnArg);
     }
     return to_string(buf);
 }
 
-void DefTree::requires(core::Context ctx, const AutoloaderConfig &alCfg, fmt::memory_buffer &buf) const {
+void DefTree::requires(const core::GlobalState &gs, const AutoloaderConfig &alCfg, fmt::memory_buffer &buf) const {
     if (root() || !hasDef()) {
         return;
     }
-    auto &ndef = definition(ctx);
+    auto &ndef = definition(gs);
     vector<string> reqs;
     for (auto reqRef : ndef.requires) {
         if (alCfg.includeRequire(reqRef)) {
-            string req = reqRef.show(ctx);
+            string req = reqRef.show(gs);
             reqs.emplace_back(req);
         }
     }
@@ -241,13 +241,13 @@ void DefTree::requires(core::Context ctx, const AutoloaderConfig &alCfg, fmt::me
     }
 }
 
-void DefTree::predeclare(core::Context ctx, string_view fullName, fmt::memory_buffer &buf) const {
-    if (hasDef() && definitionType(ctx) == Definition::Type::Class) {
+void DefTree::predeclare(const core::GlobalState &gs, string_view fullName, fmt::memory_buffer &buf) const {
+    if (hasDef() && definitionType(gs) == Definition::Type::Class) {
         fmt::format_to(buf, "\nclass {}", fullName);
-        auto &def = definition(ctx);
+        auto &def = definition(gs);
         if (!def.parentName.empty()) {
             fmt::format_to(buf, " < {}",
-                           fmt::map_join(def.parentName, "::", [&](const auto &nr) -> string { return nr.show(ctx); }));
+                           fmt::map_join(def.parentName, "::", [&](const auto &nr) -> string { return nr.show(gs); }));
         }
     } else {
         fmt::format_to(buf, "\nmodule {}", fullName);
@@ -256,34 +256,34 @@ void DefTree::predeclare(core::Context ctx, string_view fullName, fmt::memory_bu
     fmt::format_to(buf, "\nend\n");
 }
 
-string DefTree::path(core::Context ctx) const {
-    auto toPath = [&](const auto &fr) -> string { return fr.show(ctx); };
+string DefTree::path(const core::GlobalState &gs) const {
+    auto toPath = [&](const auto &fr) -> string { return fr.show(gs); };
     return fmt::format("{}.rb", fmt::map_join(nameParts, "/", toPath));
 }
 
-Definition::Type DefTree::definitionType(core::Context ctx) const {
+Definition::Type DefTree::definitionType(const core::GlobalState &gs) const {
     if (!hasDef()) {
         return Definition::Type::Module;
     }
-    return definition(ctx).def.type;
+    return definition(gs).def.type;
 }
 
 bool DefTree::hasDef() const {
     return (nonBehaviorDef != nullptr) || !namedDefs.empty();
 }
 
-const NamedDefinition &DefTree::definition(core::Context ctx) const {
+const NamedDefinition &DefTree::definition(const core::GlobalState &gs) const {
     if (!namedDefs.empty()) {
-        ENFORCE(namedDefs.size() == 1, "Cannot determine definitions for '{}' (size={})", fullName(ctx),
+        ENFORCE(namedDefs.size() == 1, "Cannot determine definitions for '{}' (size={})", fullName(gs),
                 namedDefs.size());
         return namedDefs[0];
     } else {
-        ENFORCE(nonBehaviorDef != nullptr, "Could not find any definitions for '{}'", fullName(ctx));
+        ENFORCE(nonBehaviorDef != nullptr, "Could not find any definitions for '{}'", fullName(gs));
         return *nonBehaviorDef;
     }
 }
 
-void DefTreeBuilder::addParsedFileDefinitions(core::Context ctx, const AutoloaderConfig &alConfig,
+void DefTreeBuilder::addParsedFileDefinitions(const core::GlobalState &gs, const AutoloaderConfig &alConfig,
                                               std::unique_ptr<DefTree> &root, ParsedFile &pf) {
     ENFORCE(root->root());
     if (!alConfig.includePath(pf.path)) {
@@ -293,12 +293,12 @@ void DefTreeBuilder::addParsedFileDefinitions(core::Context ctx, const Autoloade
         if (def.id.id() == 0) {
             continue;
         }
-        addSingleDef(ctx, alConfig, root, NamedDefinition::fromDef(ctx, pf, def.id));
+        addSingleDef(gs, alConfig, root, NamedDefinition::fromDef(gs, pf, def.id));
     }
 }
 
-void DefTreeBuilder::addSingleDef(core::Context ctx, const AutoloaderConfig &alCfg, std::unique_ptr<DefTree> &root,
-                                  NamedDefinition ndef) {
+void DefTreeBuilder::addSingleDef(const core::GlobalState &gs, const AutoloaderConfig &alCfg,
+                                  std::unique_ptr<DefTree> &root, NamedDefinition ndef) {
     if (!alCfg.include(ndef)) {
         return;
     }
@@ -315,40 +315,40 @@ void DefTreeBuilder::addSingleDef(core::Context ctx, const AutoloaderConfig &alC
     if (ndef.def.defines_behavior) {
         node->namedDefs.emplace_back(move(ndef));
     } else {
-        updateNonBehaviorDef(ctx, *node, move(ndef));
+        updateNonBehaviorDef(gs, *node, move(ndef));
     }
 }
 
-DefTree DefTreeBuilder::merge(core::Context ctx, DefTree lhs, DefTree rhs) {
+DefTree DefTreeBuilder::merge(const core::GlobalState &gs, DefTree lhs, DefTree rhs) {
     ENFORCE(lhs.nameParts == rhs.nameParts, "Name mismatch for DefTreeBuilder::merge");
     lhs.namedDefs.insert(lhs.namedDefs.end(), make_move_iterator(rhs.namedDefs.begin()),
                          make_move_iterator(rhs.namedDefs.end()));
     if (rhs.nonBehaviorDef) {
-        updateNonBehaviorDef(ctx, lhs, move(*rhs.nonBehaviorDef.get()));
+        updateNonBehaviorDef(gs, lhs, move(*rhs.nonBehaviorDef.get()));
     }
     for (auto &[rname, rchild] : rhs.children) {
         auto lchild = lhs.children.find(rname);
         if (lchild == lhs.children.end()) {
             lhs.children[rname] = move(rchild);
         } else {
-            lhs.children[rname] = make_unique<DefTree>(merge(ctx, move(*lchild->second), move(*rchild)));
+            lhs.children[rname] = make_unique<DefTree>(merge(gs, move(*lchild->second), move(*rchild)));
         }
     }
     return lhs;
 }
 
-void DefTreeBuilder::updateNonBehaviorDef(core::Context ctx, DefTree &node, NamedDefinition ndef) {
+void DefTreeBuilder::updateNonBehaviorDef(const core::GlobalState &gs, DefTree &node, NamedDefinition ndef) {
     if (!node.namedDefs.empty()) {
         // Non behavior-defining definitions do not matter for nodes that have behavior. There is no
         // need to continue tracking it.
         return;
     }
-    if ((node.nonBehaviorDef == nullptr) || NamedDefinition::preferredTo(ctx, ndef, *node.nonBehaviorDef)) {
+    if ((node.nonBehaviorDef == nullptr) || NamedDefinition::preferredTo(gs, ndef, *node.nonBehaviorDef)) {
         node.nonBehaviorDef = make_unique<NamedDefinition>(move(ndef));
     }
 }
 
-void DefTreeBuilder::collapseSameFileDefs(core::Context ctx, const AutoloaderConfig &alCfg, DefTree &root) {
+void DefTreeBuilder::collapseSameFileDefs(const core::GlobalState &gs, const AutoloaderConfig &alCfg, DefTree &root) {
     core::FileRef definingFile;
     if (!root.namedDefs.empty()) {
         definingFile = root.file();
@@ -360,31 +360,31 @@ void DefTreeBuilder::collapseSameFileDefs(core::Context ctx, const AutoloaderCon
     for (auto it = root.children.begin(); it != root.children.end(); ++it) {
         auto &child = it->second;
         if (child->hasDifferentFile(definingFile)) {
-            collapseSameFileDefs(ctx, alCfg, *child);
+            collapseSameFileDefs(gs, alCfg, *child);
         } else {
             root.children.erase(it);
         }
     }
 }
 
-void AutoloadWriter::writeAutoloads(core::Context ctx, const AutoloaderConfig &alCfg, const std::string &path,
+void AutoloadWriter::writeAutoloads(const core::GlobalState &gs, const AutoloaderConfig &alCfg, const std::string &path,
                                     const DefTree &root) {
     UnorderedSet<string> toDelete; // Remove from this set as we write files
     if (FileOps::exists(path)) {
         vector<string> existingFiles = FileOps::listFilesInDir(path, {".rb"}, true, {}, {});
         toDelete.insert(make_move_iterator(existingFiles.begin()), make_move_iterator(existingFiles.end()));
     }
-    write(ctx, alCfg, path, toDelete, root);
+    write(gs, alCfg, path, toDelete, root);
     for (const auto &file : toDelete) {
         FileOps::removeFile(file);
     }
 }
 
-void AutoloadWriter::write(core::Context ctx, const AutoloaderConfig &alCfg, const std::string &path,
+void AutoloadWriter::write(const core::GlobalState &gs, const AutoloaderConfig &alCfg, const std::string &path,
                            UnorderedSet<std::string> &toDelete, const DefTree &node) {
-    string name = node.root() ? "root" : node.name().show(ctx);
+    string name = node.root() ? "root" : node.name().show(gs);
     string filePath = join(path, fmt::format("{}.rb", name));
-    FileOps::writeIfDifferent(filePath, node.renderAutoloadSrc(ctx, alCfg));
+    FileOps::writeIfDifferent(filePath, node.renderAutoloadSrc(gs, alCfg));
     toDelete.erase(filePath);
     if (!node.children.empty()) {
         auto subdir = join(path, node.root() ? "" : name);
@@ -392,7 +392,7 @@ void AutoloadWriter::write(core::Context ctx, const AutoloaderConfig &alCfg, con
             FileOps::createDir(subdir);
         }
         for (auto &[_, child] : node.children) {
-            write(ctx, alCfg, subdir, toDelete, *child);
+            write(gs, alCfg, subdir, toDelete, *child);
         }
     }
 }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -594,7 +594,7 @@ void tryApplyLocalVarSaver(const core::GlobalState &gs, vector<ast::ParsedFile> 
     }
     for (auto &t : indexedCopies) {
         LocalVarSaver localVarSaver;
-        core::Context ctx(gs, core::Symbols::root());
+        core::Context ctx(gs, core::Symbols::root(), t.file);
         t.tree = ast::TreeMap::apply(ctx, localVarSaver, move(t.tree));
     }
 }
@@ -605,7 +605,7 @@ void tryApplyDefLocSaver(const core::GlobalState &gs, vector<ast::ParsedFile> &i
     }
     for (auto &t : indexedCopies) {
         DefLocSaver defLocSaver;
-        core::Context ctx(gs, core::Symbols::root());
+        core::Context ctx(gs, core::Symbols::root(), t.file);
         t.tree = ast::TreeMap::apply(ctx, defLocSaver, move(t.tree));
     }
 }

--- a/main/lsp/LocalVarFinder.cc
+++ b/main/lsp/LocalVarFinder.cc
@@ -51,7 +51,7 @@ unique_ptr<ast::ClassDef> LocalVarFinder::preTransformClassDef(core::Context ctx
     ENFORCE(classDef->symbol != core::Symbols::todo());
 
     auto currentMethod = classDef->symbol == core::Symbols::root()
-                             ? ctx.state.lookupStaticInitForFile(classDef->loc)
+                             ? ctx.state.lookupStaticInitForFile(classDef->declLoc)
                              : ctx.state.lookupStaticInitForClass(classDef->symbol);
 
     this->methodStack.emplace_back(currentMethod);

--- a/main/lsp/LocalVarSaver.cc
+++ b/main/lsp/LocalVarSaver.cc
@@ -10,7 +10,7 @@ unique_ptr<ast::Local> LocalVarSaver::postTransformLocal(core::Context ctx, uniq
     if (ctx.owner.data(ctx)->isMethod()) {
         owner = ctx.owner;
     } else if (ctx.owner == core::Symbols::root()) {
-        owner = ctx.state.lookupStaticInitForFile(local->loc);
+        owner = ctx.state.lookupStaticInitForFile(core::Loc(ctx.file, local->loc));
     } else {
         ENFORCE(ctx.owner.data(ctx)->isClassOrModule());
         owner = ctx.state.lookupStaticInitForClass(ctx.owner);
@@ -24,12 +24,13 @@ unique_ptr<ast::Local> LocalVarSaver::postTransformLocal(core::Context ctx, uniq
 
         auto enclosingMethod = ctx.owner;
         if (enclosingMethod.data(ctx)->isClassOrModule()) {
-            enclosingMethod = ctx.owner == core::Symbols::root() ? ctx.state.lookupStaticInitForFile(local->loc)
-                                                                 : ctx.state.lookupStaticInitForClass(ctx.owner);
+            enclosingMethod = ctx.owner == core::Symbols::root()
+                                  ? ctx.state.lookupStaticInitForFile(core::Loc(ctx.file, local->loc))
+                                  : ctx.state.lookupStaticInitForClass(ctx.owner);
         }
 
         core::lsp::QueryResponse::pushQueryResponse(
-            ctx, core::lsp::IdentResponse(local->loc, local->localVariable, tp, enclosingMethod));
+            ctx, core::lsp::IdentResponse(core::Loc(ctx.file, local->loc), local->localVariable, tp, enclosingMethod));
     }
 
     return local;
@@ -46,7 +47,8 @@ unique_ptr<ast::MethodDef> LocalVarSaver::postTransformMethodDef(core::Context c
                 // (Ditto)
                 core::TypeAndOrigins tp;
                 core::lsp::QueryResponse::pushQueryResponse(
-                    ctx, core::lsp::IdentResponse(localExp->loc, localExp->localVariable, tp, methodDef->symbol));
+                    ctx, core::lsp::IdentResponse(core::Loc(ctx.file, localExp->loc), localExp->localVariable, tp,
+                                                  methodDef->symbol));
             }
         }
     }

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -242,24 +242,23 @@ string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef consta
 
 core::TypePtr getResultType(const core::GlobalState &gs, core::TypePtr type, core::SymbolRef inWhat,
                             core::TypePtr receiver, const core::TypeConstraint *constr) {
-    core::Context ctx(gs, inWhat);
     auto resultType = type;
     if (auto *proxy = core::cast_type<core::ProxyType>(receiver.get())) {
         receiver = proxy->underlying();
     }
     if (auto *applied = core::cast_type<core::AppliedType>(receiver.get())) {
         /* instantiate generic classes */
-        resultType = core::Types::resultTypeAsSeenFrom(ctx, resultType, inWhat.data(ctx)->enclosingClass(ctx),
+        resultType = core::Types::resultTypeAsSeenFrom(gs, resultType, inWhat.data(gs)->enclosingClass(gs),
                                                        applied->klass, applied->targs);
     }
     if (!resultType) {
         resultType = core::Types::untypedUntracked();
     }
     if (receiver) {
-        resultType = core::Types::replaceSelfType(ctx, resultType, receiver); // instantiate self types
+        resultType = core::Types::replaceSelfType(gs, resultType, receiver); // instantiate self types
     }
     if (constr) {
-        resultType = core::Types::instantiate(ctx, resultType, *constr); // instantiate generic methods
+        resultType = core::Types::instantiate(gs, resultType, *constr); // instantiate generic methods
     }
     return resultType;
 }

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -289,9 +289,8 @@ string methodSnippet(const core::GlobalState &gs, core::SymbolRef method, core::
     auto &blkArg = method.data(gs)->arguments().back();
     ENFORCE(blkArg.flags.isBlock);
 
-    auto ctx = core::Context{gs, core::Symbols::root()};
     auto hasBlockType = blkArg.type != nullptr && !blkArg.type->isUntyped();
-    if (hasBlockType && !core::Types::isSubType(ctx, core::Types::nilClass(), blkArg.type)) {
+    if (hasBlockType && !core::Types::isSubType(gs, core::Types::nilClass(), blkArg.type)) {
         string blkArgs;
         if (auto *appliedType = core::cast_type<core::AppliedType>(blkArg.type.get())) {
             if (appliedType->targs.size() >= 2) {
@@ -466,8 +465,8 @@ vector<core::LocalVariable> localsForMethod(const core::GlobalState &gs, LSPType
 
     // Instantiate localVarFinder outside loop so that result accumualates over every time we TreeMap::apply
     LocalVarFinder localVarFinder(method);
-    auto ctx = core::Context{gs, core::Symbols::root()};
     for (auto &t : resolved) {
+        auto ctx = core::Context(gs, core::Symbols::root(), t.file);
         t.tree = ast::TreeMap::apply(ctx, localVarFinder, move(t.tree));
     }
 
@@ -493,8 +492,8 @@ core::SymbolRef firstMethodAfterQuery(LSPTypecheckerDelegate &typechecker, const
     auto resolved = typechecker.getResolved(files);
 
     NextMethodFinder nextMethodFinder(queryLoc);
-    auto ctx = core::Context{gs, core::Symbols::root()};
     for (auto &t : resolved) {
+        auto ctx = core::Context(gs, core::Symbols::root(), t.file);
         t.tree = ast::TreeMap::apply(ctx, nextMethodFinder, move(t.tree));
     }
 

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -73,7 +73,7 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
             }
             auto &constraint = sendResp->dispatchResult->main.constr;
             if (constraint) {
-                retType = core::Types::instantiate(core::Context(gs, core::Symbols::root()), retType, *constraint);
+                retType = core::Types::instantiate(gs, retType, *constraint);
             }
             string typeString;
             if (sendResp->dispatchResult->main.method.exists() && sendResp->dispatchResult->main.method.isSynthetic()) {

--- a/main/lsp/test/lsp_file_updates_test.cc
+++ b/main/lsp/test/lsp_file_updates_test.cc
@@ -21,7 +21,7 @@ unique_ptr<core::FileHash> getFileHash() {
 }
 
 ast::ParsedFile getParsedFile(core::FileRef fref) {
-    auto lit = make_unique<ast::Literal>(core::Loc(fref, 0, 1), core::Types::Integer());
+    auto lit = make_unique<ast::Literal>(core::LocOffsets{0, 1}, core::Types::Integer());
     return ast::ParsedFile{move(lit), fref};
 }
 

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -53,7 +53,7 @@ public:
     CFGCollectorAndTyper(const options::Options &opts) : opts(opts){};
 
     unique_ptr<ast::MethodDef> preTransformMethodDef(core::Context ctx, unique_ptr<ast::MethodDef> m) {
-        if (m->loc.file().data(ctx).strictLevel < core::StrictLevel::True || m->symbol.data(ctx)->isOverloaded()) {
+        if (ctx.file.data(ctx).strictLevel < core::StrictLevel::True || m->symbol.data(ctx)->isOverloaded()) {
             return m;
         }
         auto &print = opts.print;
@@ -96,7 +96,6 @@ unique_ptr<core::serialize::CachedFile> fetchFileFromCache(core::GlobalState &gs
         if (maybeCached) {
             prodCounterInc("types.input.files.kvstore.hit");
             auto cachedTree = core::serialize::Serializer::loadFile(gs, fref, maybeCached);
-            ENFORCE(cachedTree.tree->loc.file() == fref);
             // Ensure that the trees were read in the same session that read GlobalState -- otherwise, it may reference
             // a name not in the name table!
             ENFORCE(kvstore->sessionId() == gs.kvstoreSessionId);
@@ -140,7 +139,7 @@ unique_ptr<ast::Expression> runDesugar(core::GlobalState &gs, core::FileRef file
                                        const options::Printers &print) {
     Timer timeit(gs.tracer(), "runDesugar", {{"file", (string)file.data(gs).path()}});
     unique_ptr<ast::Expression> ast;
-    core::MutableContext ctx(gs, core::Symbols::root());
+    core::MutableContext ctx(gs, core::Symbols::root(), file);
     {
         core::ErrorRegion errs(gs, file);
         core::UnfreezeNameTable nameTableAccess(gs); // creates temporaries during desugaring
@@ -156,7 +155,7 @@ unique_ptr<ast::Expression> runDesugar(core::GlobalState &gs, core::FileRef file
 }
 
 unique_ptr<ast::Expression> runRewriter(core::GlobalState &gs, core::FileRef file, unique_ptr<ast::Expression> ast) {
-    core::MutableContext ctx(gs, core::Symbols::root());
+    core::MutableContext ctx(gs, core::Symbols::root(), file);
     Timer timeit(gs.tracer(), "runRewriter", {{"file", (string)file.data(gs).path()}});
     core::UnfreezeNameTable nameTableAccess(gs); // creates temporaries during desugaring
     core::ErrorRegion errs(gs, file);
@@ -165,7 +164,7 @@ unique_ptr<ast::Expression> runRewriter(core::GlobalState &gs, core::FileRef fil
 
 ast::ParsedFile runLocalVars(core::GlobalState &gs, ast::ParsedFile tree) {
     Timer timeit(gs.tracer(), "runLocalVars", {{"file", (string)tree.file.data(gs).path()}});
-    core::MutableContext ctx(gs, core::Symbols::root());
+    core::MutableContext ctx(gs, core::Symbols::root(), tree.file);
     return sorbet::local_vars::LocalVars::run(ctx, move(tree));
 }
 
@@ -213,7 +212,6 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
         }
 
         rewriten.tree = move(tree);
-        ENFORCE(rewriten.tree->loc.file() == file);
         return rewriten;
     } catch (SorbetException &) {
         Exception::failInFuzzer();
@@ -254,7 +252,7 @@ pair<ast::ParsedFile, vector<shared_ptr<core::File>>> indexOneWithPlugins(const 
 #ifndef SORBET_REALMAIN_MIN
             {
                 Timer timeit(gs.tracer(), "plugins_text");
-                core::MutableContext ctx(gs, core::Symbols::root());
+                core::MutableContext ctx(gs, core::Symbols::root(), file);
                 core::ErrorRegion errs(gs, file);
 
                 auto [pluginTree, pluginFiles] = plugin::SubprocessTextPlugin::run(ctx, move(tree));
@@ -288,7 +286,6 @@ pair<ast::ParsedFile, vector<shared_ptr<core::File>>> indexOneWithPlugins(const 
         }
 
         rewriten.tree = move(tree);
-        ENFORCE(rewriten.tree->loc.file() == file);
         return {move(rewriten), resultPluginFiles};
     } catch (SorbetException &) {
         Exception::failInFuzzer();
@@ -302,13 +299,12 @@ pair<ast::ParsedFile, vector<shared_ptr<core::File>>> indexOneWithPlugins(const 
 vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
                                            const options::Options &opts) {
     try {
-        core::MutableContext ctx(gs, core::Symbols::root());
         {
             Timer timeit(gs.tracer(), "incremental_naming");
             core::UnfreezeSymbolTable symbolTable(gs);
             core::UnfreezeNameTable nameTable(gs);
 
-            what = sorbet::namer::Namer::run(ctx, move(what));
+            what = sorbet::namer::Namer::run(gs, move(what));
         }
 
         {
@@ -318,7 +314,7 @@ vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, vector<ast::Pa
             core::UnfreezeSymbolTable symbolTable(gs);
             core::UnfreezeNameTable nameTable(gs);
 
-            what = sorbet::resolver::Resolver::runTreePasses(ctx, move(what));
+            what = sorbet::resolver::Resolver::runTreePasses(gs, move(what));
         }
     } catch (SorbetException &) {
         if (auto e = gs.beginError(sorbet::core::Loc::none(), sorbet::core::errors::Internal::InternalError)) {
@@ -507,13 +503,13 @@ IndexResult mergeIndexResults(const shared_ptr<core::GlobalState> cgs, const opt
                 ret.pluginGeneratedFiles = move(threadResult.res.pluginGeneratedFiles);
             } else {
                 core::GlobalSubstitution substitution(*threadResult.res.gs, *ret.gs, cgs.get());
-                core::MutableContext ctx(*ret.gs, core::Symbols::root());
                 {
                     Timer timeit(cgs->tracer(), "substituteTrees");
                     for (auto &tree : threadResult.res.trees) {
                         auto file = tree.file;
                         core::ErrorRegion errs(*ret.gs, file);
                         if (!file.data(*ret.gs).cached) {
+                            core::MutableContext ctx(*ret.gs, core::Symbols::root(), file);
                             tree.tree = ast::Substitute::run(ctx, substitution, move(tree.tree));
                         }
                     }
@@ -621,9 +617,9 @@ IndexResult indexPluginFiles(IndexResult firstPass, const options::Options &opts
     {
         Timer timeit(suppliedFilesAndPluginFiles.gs->tracer(), "incremental_resolve");
         core::GlobalSubstitution substitution(*protoGs, *suppliedFilesAndPluginFiles.gs, protoGs.get());
-        core::MutableContext ctx(*suppliedFilesAndPluginFiles.gs, core::Symbols::root());
         for (auto &tree : firstPass.trees) {
             auto file = tree.file;
+            core::MutableContext ctx(*suppliedFilesAndPluginFiles.gs, core::Symbols::root(), file);
             core::ErrorRegion errs(*suppliedFilesAndPluginFiles.gs, file);
             tree.tree = ast::Substitute::run(ctx, substitution, move(tree.tree));
         }
@@ -752,10 +748,9 @@ vector<ast::ParsedFile> name(core::GlobalState &gs, vector<ast::ParsedFile> what
     }
 
     {
-        core::MutableContext ctx(gs, core::Symbols::root());
         core::UnfreezeNameTable nameTableAccess(gs);     // creates singletons and class names
         core::UnfreezeSymbolTable symbolTableAccess(gs); // enters symbols
-        what = namer::Namer::run(ctx, move(what));
+        what = namer::Namer::run(gs, move(what));
         gs.errorQueue->flushErrors();
     }
     return what;
@@ -780,9 +775,9 @@ public:
 vector<ast::ParsedFile> printMissingConstants(core::GlobalState &gs, const options::Options &opts,
                                               vector<ast::ParsedFile> what) {
     Timer timeit(gs.tracer(), "printMissingConstants");
-    core::MutableContext ctx(gs, core::Symbols::root());
     GatherUnresolvedConstantsWalk walk;
     for (auto &resolved : what) {
+        core::MutableContext ctx(gs, core::Symbols::root(), resolved.file);
         resolved.tree = ast::TreeMap::apply(ctx, walk, move(resolved.tree));
     }
     auto &missing = walk.unresolvedConstants;
@@ -839,7 +834,7 @@ public:
 ast::ParsedFile checkNoDefinitionsInsideProhibitedLines(core::GlobalState &gs, ast::ParsedFile what,
                                                         int prohibitedLinesStart, int prohibitedLinesEnd) {
     DefinitionLinesBlacklistEnforcer enforcer(what.file, prohibitedLinesStart, prohibitedLinesEnd);
-    what.tree = ast::TreeMap::apply(core::Context(gs, core::Symbols::root()), enforcer, move(what.tree));
+    what.tree = ast::TreeMap::apply(core::Context(gs, core::Symbols::root(), what.file), enforcer, move(what.tree));
     return what;
 }
 
@@ -864,7 +859,6 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
             return ast::ParsedFilesOrCancelled(move(what));
         }
 
-        core::MutableContext ctx(*gs, core::Symbols::root());
         ProgressIndicator namingProgress(opts.showProgress, "Resolving", 1);
         {
             Timer timeit(gs->tracer(), "resolving");
@@ -875,7 +869,7 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
             }
             core::UnfreezeNameTable nameTableAccess(*gs);     // Resolver::defineAttr
             core::UnfreezeSymbolTable symbolTableAccess(*gs); // enters stubs
-            auto maybeResult = resolver::Resolver::run(ctx, move(what), workers);
+            auto maybeResult = resolver::Resolver::run(*gs, move(what), workers);
             if (!maybeResult.hasResult()) {
                 return maybeResult;
             }
@@ -950,7 +944,7 @@ ast::ParsedFilesOrCancelled typecheck(unique_ptr<core::GlobalState> &gs, vector<
             resultq = make_shared<BlockingBoundedQueue<typecheck_thread_result>>(what.size());
         }
 
-        core::Context ctx(*gs, core::Symbols::root());
+        const core::GlobalState &igs = *gs;
 
         // We want to start typeckecking big files first because it helps with better work distribution
         fast_sort(what, [&](const auto &lhs, const auto &rhs) -> bool {
@@ -963,7 +957,7 @@ ast::ParsedFilesOrCancelled typecheck(unique_ptr<core::GlobalState> &gs, vector<
         {
             ProgressIndicator cfgInferProgress(opts.showProgress, "CFG+Inference", what.size());
             workers.multiplexJob(
-                "typecheck", [ctx, &opts, epoch, &epochManager, &preemptionManager, fileq, resultq, cancelable]() {
+                "typecheck", [&igs, &opts, epoch, &epochManager, &preemptionManager, fileq, resultq, cancelable]() {
                     typecheck_thread_result threadResult;
                     ast::ParsedFile job;
                     int processedByThread = 0;
@@ -983,15 +977,16 @@ ast::ParsedFilesOrCancelled typecheck(unique_ptr<core::GlobalState> &gs, vector<
                                 // [IDE] Also, don't do work if the file has changed under us since we began
                                 // typechecking!
                                 // TODO(jvilk): epoch is unlikely to overflow, but it is theoretically possible.
-                                const bool fileWasChanged = preemptionManager && job.file.data(ctx).epoch > epoch;
+                                const bool fileWasChanged = preemptionManager && job.file.data(igs).epoch > epoch;
                                 if (!isCanceled && !fileWasChanged) {
                                     core::FileRef file = job.file;
                                     try {
+                                        core::Context ctx(igs, core::Symbols::root(), file);
                                         threadResult.trees.emplace_back(typecheckOne(ctx, move(job), opts));
                                     } catch (SorbetException &) {
                                         Exception::failInFuzzer();
-                                        ctx.state.tracer().error("Exception typing file: {} (backtrace is above)",
-                                                                 file.data(ctx).path());
+                                        igs.tracer().error("Exception typing file: {} (backtrace is above)",
+                                                           file.data(igs).path());
                                     }
                                 }
                             }
@@ -1133,9 +1128,9 @@ public:
     }
 };
 
-core::UsageHash getAllNames(const core::GlobalState &gs, unique_ptr<ast::Expression> &tree) {
+core::UsageHash getAllNames(core::Context ctx, unique_ptr<ast::Expression> &tree) {
     AllNamesCollector collector;
-    tree = ast::TreeMap::apply(core::Context(gs, core::Symbols::root()), collector, move(tree));
+    tree = ast::TreeMap::apply(ctx, collector, move(tree));
     core::NameHash::sortAndDedupe(collector.acc.sends);
     core::NameHash::sortAndDedupe(collector.acc.constants);
     return move(collector.acc);
@@ -1159,7 +1154,8 @@ core::FileHash computeFileHash(shared_ptr<core::File> forWhat, spdlog::logger &l
 
     single.emplace_back(pipeline::indexOne(emptyOpts, *lgs, fref));
     auto errs = lgs->errorQueue->drainAllErrors();
-    auto allNames = getAllNames(*lgs, single[0].tree);
+    core::Context ctx(*lgs, core::Symbols::root(), single[0].file);
+    auto allNames = getAllNames(ctx, single[0].tree);
     auto workers = WorkerPool::create(0, lgs->tracer());
     pipeline::resolve(lgs, move(single), emptyOpts, *workers, true);
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -171,7 +171,7 @@ struct AutogenResult {
     unique_ptr<autogen::DefTree> defTree = make_unique<autogen::DefTree>();
 };
 
-void runAutogen(core::Context ctx, options::Options &opts, const autogen::AutoloaderConfig &autoloaderCfg,
+void runAutogen(const core::GlobalState &gs, options::Options &opts, const autogen::AutoloaderConfig &autoloaderCfg,
                 WorkerPool &workers, vector<ast::ParsedFile> &indexed) {
     Timer timeit(logger, "autogen");
 
@@ -181,7 +181,7 @@ void runAutogen(core::Context ctx, options::Options &opts, const autogen::Autolo
         fileq->push(move(i), 1);
     }
 
-    workers.multiplexJob("runAutogen", [&ctx, &opts, &indexed, &autoloaderCfg, fileq, resultq]() {
+    workers.multiplexJob("runAutogen", [&gs, &opts, &indexed, &autoloaderCfg, fileq, resultq]() {
         AutogenResult out;
         int n = 0;
         {
@@ -191,9 +191,11 @@ void runAutogen(core::Context ctx, options::Options &opts, const autogen::Autolo
             for (auto result = fileq->try_pop(idx); !result.done(); result = fileq->try_pop(idx)) {
                 ++n;
                 auto &tree = indexed[idx];
-                if (tree.file.data(ctx).isRBI()) {
+                if (tree.file.data(gs).isRBI()) {
                     continue;
                 }
+
+                core::Context ctx(gs, core::Symbols::root(), tree.file);
                 auto pf = autogen::Autogen::generate(ctx, move(tree));
                 tree = move(pf.tree);
 
@@ -241,7 +243,7 @@ void runAutogen(core::Context ctx, options::Options &opts, const autogen::Autolo
         merged.insert(merged.end(), make_move_iterator(out.prints.begin()), make_move_iterator(out.prints.end()));
         if (opts.print.AutogenAutoloader.enabled) {
             Timer timeit(logger, "autogenAutoloaderDefTreeMerge");
-            root = autogen::DefTreeBuilder::merge(ctx, move(root), move(*out.defTree));
+            root = autogen::DefTreeBuilder::merge(gs, move(root), move(*out.defTree));
         }
     }
     fast_sort(merged, [](const auto &lhs, const auto &rhs) -> bool { return lhs.first < rhs.first; });
@@ -257,11 +259,11 @@ void runAutogen(core::Context ctx, options::Options &opts, const autogen::Autolo
     if (opts.print.AutogenAutoloader.enabled) {
         {
             Timer timeit(logger, "autogenAutoloaderPrune");
-            autogen::DefTreeBuilder::collapseSameFileDefs(ctx, autoloaderCfg, root);
+            autogen::DefTreeBuilder::collapseSameFileDefs(gs, autoloaderCfg, root);
         }
         {
             Timer timeit(logger, "autogenAutoloaderWrite");
-            autogen::AutoloadWriter::writeAutoloads(ctx, autoloaderCfg, opts.print.AutogenAutoloader.outputPath, root);
+            autogen::AutoloadWriter::writeAutoloads(gs, autoloaderCfg, opts.print.AutogenAutoloader.outputPath, root);
         }
     }
 
@@ -503,8 +505,6 @@ int realmain(int argc, char *argv[]) {
             gs->suppressErrorClass(core::errors::Namer::ModuleKindRedefinition.code);
             gs->suppressErrorClass(core::errors::Resolver::StubConstant.code);
 
-            core::MutableContext ctx(*gs, core::Symbols::root());
-
             indexed = pipeline::name(*gs, move(indexed), opts);
             autogen::AutoloaderConfig autoloaderCfg;
             {
@@ -516,11 +516,11 @@ int realmain(int argc, char *argv[]) {
                     auto file = tree.file;
                     errs.emplace_back(*gs, file);
                 }
-                indexed = resolver::Resolver::runConstantResolution(ctx, move(indexed), *workers);
+                indexed = resolver::Resolver::runConstantResolution(*gs, move(indexed), *workers);
                 autoloaderCfg = autogen::AutoloaderConfig::enterConfig(*gs, opts.autoloaderConfig);
             }
 
-            runAutogen(ctx, opts, autoloaderCfg, *workers, indexed);
+            runAutogen(*gs, opts, autoloaderCfg, *workers, indexed);
 #endif
         } else {
             indexed = move(pipeline::resolve(gs, move(indexed), opts, *workers).result());

--- a/namer/configatron/configatron.cc
+++ b/namer/configatron/configatron.cc
@@ -99,7 +99,7 @@ struct Path {
 
     void setType(core::GlobalState &gs, core::TypePtr tp) {
         if (myType) {
-            myType = core::Types::any(core::MutableContext(gs, core::Symbols::root()), myType, tp);
+            myType = core::Types::any(gs, myType, tp);
         } else {
             myType = tp;
         }
@@ -145,8 +145,7 @@ void recurse(core::GlobalState &gs, const YAML::Node &node, shared_ptr<Path> pre
             for (const auto &child : node) {
                 auto thisElemType = child.IsScalar() ? getType(gs, child) : core::Types::untypedUntracked();
                 if (elemType) {
-                    elemType =
-                        core::Types::any(core::MutableContext(gs, core::Symbols::root()), elemType, thisElemType);
+                    elemType = core::Types::any(gs, elemType, thisElemType);
                 } else {
                     elemType = thisElemType;
                 }

--- a/namer/namer.h
+++ b/namer/namer.h
@@ -7,7 +7,7 @@ namespace sorbet::namer {
 
 class Namer final {
 public:
-    static std::vector<ast::ParsedFile> run(core::MutableContext ctx, std::vector<ast::ParsedFile> trees);
+    static std::vector<ast::ParsedFile> run(core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
 
     Namer() = delete;
 };

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -65,14 +65,13 @@ string Dedenter::dedent(string_view str) {
 
 class Builder::Impl {
 public:
-    Impl(GlobalState &gs, core::FileRef file) : gs_(gs), file_(file) {
+    Impl(GlobalState &gs, core::FileRef file) : gs_(gs) {
         this->maxOff_ = file.data(gs).source().size();
         foreignNodes_.emplace_back();
     }
 
     GlobalState &gs_;
-    u4 uniqueCounter_ = 1;
-    core::FileRef file_;
+    u2 uniqueCounter_ = 1;
     u4 maxOff_;
     ruby_parser::base_driver *driver_;
 
@@ -82,34 +81,34 @@ public:
         return std::min(off, maxOff_);
     }
 
-    core::Loc tokLoc(const token *tok) {
-        return core::Loc{file_, clamp((u4)tok->start()), clamp((u4)tok->end())};
+    core::LocOffsets tokLoc(const token *tok) {
+        return core::LocOffsets{clamp((u4)tok->start()), clamp((u4)tok->end())};
     }
 
-    core::Loc maybe_loc(unique_ptr<Node> &node) {
+    core::LocOffsets maybe_loc(unique_ptr<Node> &node) {
         if (node == nullptr) {
-            return core::Loc::none(file_);
+            return core::LocOffsets::none();
         }
         return node->loc;
     }
 
-    core::Loc tokLoc(const token *begin, const token *end) {
-        return core::Loc{file_, clamp((u4)begin->start()), clamp((u4)end->end())};
+    core::LocOffsets tokLoc(const token *begin, const token *end) {
+        return core::LocOffsets{clamp((u4)begin->start()), clamp((u4)end->end())};
     }
 
-    core::Loc collectionLoc(const token *begin, sorbet::parser::NodeVec &elts, const token *end) {
+    core::LocOffsets collectionLoc(const token *begin, sorbet::parser::NodeVec &elts, const token *end) {
         if (begin != nullptr) {
             ENFORCE(end != nullptr);
             return tokLoc(begin, end);
         }
         ENFORCE(end == nullptr);
         if (elts.empty()) {
-            return core::Loc::none(file_);
+            return core::LocOffsets::none();
         }
         return elts.front()->loc.join(elts.back()->loc);
     }
 
-    core::Loc collectionLoc(sorbet::parser::NodeVec &elts) {
+    core::LocOffsets collectionLoc(sorbet::parser::NodeVec &elts) {
         return collectionLoc(nullptr, elts, nullptr);
     }
 
@@ -136,7 +135,7 @@ public:
         return cond;
     }
 
-    void error(ruby_parser::dclass err, core::Loc loc, std::string data = "") {
+    void error(ruby_parser::dclass err, core::LocOffsets loc, std::string data = "") {
         driver_->external_diagnostic(ruby_parser::dlevel::ERROR, err, loc.beginPos(), loc.endPos(), data);
     }
 
@@ -165,7 +164,7 @@ public:
 
     unique_ptr<Node> args(const token *begin, sorbet::parser::NodeVec args, const token *end, bool check_args) {
         if (check_args) {
-            UnorderedMap<std::string, core::Loc> map;
+            UnorderedMap<std::string, core::LocOffsets> map;
             checkDuplicateArgs(args, map);
         }
 
@@ -180,7 +179,7 @@ public:
     }
 
     unique_ptr<Node> assign(unique_ptr<Node> lhs, const token *eql, unique_ptr<Node> rhs) {
-        core::Loc loc = lhs->loc.join(rhs->loc);
+        core::LocOffsets loc = lhs->loc.join(rhs->loc);
 
         if (auto *s = parser::cast_node<Send>(lhs.get())) {
             s->args.emplace_back(std::move(rhs));
@@ -224,7 +223,7 @@ public:
 
     unique_ptr<Node> attrAsgn(unique_ptr<Node> receiver, const token *dot, const token *selector) {
         core::NameRef method = gs_.enterNameUTF8(selector->string() + "=");
-        core::Loc loc = receiver->loc.join(tokLoc(selector));
+        core::LocOffsets loc = receiver->loc.join(tokLoc(selector));
         if ((dot != nullptr) && dot->string() == "&.") {
             return make_unique<CSend>(loc, std::move(receiver), method, sorbet::parser::NodeVec());
         }
@@ -236,7 +235,7 @@ public:
     }
 
     unique_ptr<Node> begin(const token *begin, unique_ptr<Node> body, const token *end) {
-        core::Loc loc;
+        core::LocOffsets loc;
         if (begin != nullptr) {
             loc = tokLoc(begin).join(tokLoc(end));
         } else {
@@ -289,7 +288,7 @@ public:
         }
 
         if (ensure_tok != nullptr) {
-            core::Loc loc;
+            core::LocOffsets loc;
             if (body != nullptr) {
                 loc = body->loc;
             } else {
@@ -303,7 +302,7 @@ public:
     }
 
     unique_ptr<Node> beginKeyword(const token *begin, unique_ptr<Node> body, const token *end) {
-        core::Loc loc = tokLoc(begin).join(tokLoc(end));
+        core::LocOffsets loc = tokLoc(begin).join(tokLoc(end));
         if (body != nullptr) {
             if (auto *b = parser::cast_node<Begin>(body.get())) {
                 return make_unique<Kwbegin>(loc, std::move(b->stmts));
@@ -317,7 +316,7 @@ public:
     }
 
     unique_ptr<Node> binaryOp(unique_ptr<Node> receiver, const token *oper, unique_ptr<Node> arg) {
-        core::Loc loc = receiver->loc.join(arg->loc);
+        core::LocOffsets loc = receiver->loc.join(arg->loc);
 
         sorbet::parser::NodeVec args;
         args.emplace_back(std::move(arg));
@@ -366,7 +365,7 @@ public:
             [&](Node *n) { Exception::raise("Unexpected send node: {}", n->nodeName()); });
 
         auto &send = exprs->front();
-        core::Loc blockLoc = send->loc.join(tokLoc(end));
+        core::LocOffsets blockLoc = send->loc.join(tokLoc(end));
         unique_ptr<Node> block = make_unique<Block>(blockLoc, std::move(send), std::move(args), std::move(body));
         exprs->front().swap(block);
         return methodCall;
@@ -377,7 +376,7 @@ public:
     }
 
     unique_ptr<Node> blockarg(const token *amper, const token *name) {
-        core::Loc loc;
+        core::LocOffsets loc;
         core::NameRef nm;
 
         if (name != nullptr) {
@@ -396,7 +395,7 @@ public:
 
     unique_ptr<Node> call_method(unique_ptr<Node> receiver, const token *dot, const token *selector,
                                  const token *lparen, sorbet::parser::NodeVec args, const token *rparen) {
-        core::Loc selectorLoc, startLoc;
+        core::LocOffsets selectorLoc, startLoc;
         if (selector != nullptr) {
             selectorLoc = tokLoc(selector);
         } else {
@@ -408,7 +407,7 @@ public:
             startLoc = receiver->loc;
         }
 
-        core::Loc loc;
+        core::LocOffsets loc;
         if (rparen != nullptr) {
             loc = startLoc.join(tokLoc(rparen));
         } else if (!args.empty()) {
@@ -459,7 +458,7 @@ public:
 
     unique_ptr<Node> condition(const token *cond_tok, unique_ptr<Node> cond, const token *then, unique_ptr<Node> ifTrue,
                                const token *else_, unique_ptr<Node> ifFalse, const token *end) {
-        core::Loc loc = tokLoc(cond_tok).join(cond->loc);
+        core::LocOffsets loc = tokLoc(cond_tok).join(cond->loc);
         if (then != nullptr) {
             loc = loc.join(tokLoc(then));
         }
@@ -479,7 +478,7 @@ public:
     }
 
     unique_ptr<Node> conditionMod(unique_ptr<Node> ifTrue, unique_ptr<Node> ifFalse, unique_ptr<Node> cond) {
-        core::Loc loc = cond->loc;
+        core::LocOffsets loc = cond->loc;
         if (ifTrue != nullptr) {
             loc = loc.join(ifTrue->loc);
         } else {
@@ -548,38 +547,38 @@ public:
 
     unique_ptr<Node> def_class(const token *class_, unique_ptr<Node> name, const token *lt_,
                                unique_ptr<Node> superclass, unique_ptr<Node> body, const token *end_) {
-        core::Loc declLoc = tokLoc(class_).join(maybe_loc(name)).join(maybe_loc(superclass));
-        core::Loc loc = tokLoc(class_, end_);
+        core::LocOffsets declLoc = tokLoc(class_).join(maybe_loc(name)).join(maybe_loc(superclass));
+        core::LocOffsets loc = tokLoc(class_, end_);
 
         return make_unique<Class>(loc, declLoc, std::move(name), std::move(superclass), std::move(body));
     }
 
     unique_ptr<Node> defMethod(const token *def, const token *name, unique_ptr<Node> args, unique_ptr<Node> body,
                                const token *end) {
-        core::Loc declLoc = tokLoc(def, name).join(maybe_loc(args));
-        core::Loc loc = tokLoc(def, end);
+        core::LocOffsets declLoc = tokLoc(def, name).join(maybe_loc(args));
+        core::LocOffsets loc = tokLoc(def, end);
 
         return make_unique<DefMethod>(loc, declLoc, gs_.enterNameUTF8(name->string()), std::move(args),
                                       std::move(body));
     }
 
     unique_ptr<Node> defModule(const token *module, unique_ptr<Node> name, unique_ptr<Node> body, const token *end_) {
-        core::Loc declLoc = tokLoc(module).join(maybe_loc(name));
-        core::Loc loc = tokLoc(module, end_);
+        core::LocOffsets declLoc = tokLoc(module).join(maybe_loc(name));
+        core::LocOffsets loc = tokLoc(module, end_);
         return make_unique<Module>(loc, declLoc, std::move(name), std::move(body));
     }
 
     unique_ptr<Node> def_sclass(const token *class_, const token *lshft_, unique_ptr<Node> expr, unique_ptr<Node> body,
                                 const token *end_) {
-        core::Loc declLoc = tokLoc(class_);
-        core::Loc loc = tokLoc(class_, end_);
+        core::LocOffsets declLoc = tokLoc(class_);
+        core::LocOffsets loc = tokLoc(class_, end_);
         return make_unique<SClass>(loc, declLoc, std::move(expr), std::move(body));
     }
 
     unique_ptr<Node> defSingleton(const token *def, unique_ptr<Node> definee, const token *dot, const token *name,
                                   unique_ptr<Node> args, unique_ptr<Node> body, const token *end) {
-        core::Loc declLoc = tokLoc(def, name).join(maybe_loc(args));
-        core::Loc loc = tokLoc(def, end);
+        core::LocOffsets declLoc = tokLoc(def, name).join(maybe_loc(args));
+        core::LocOffsets loc = tokLoc(def, end);
 
         if (isLiteralNode(*(definee.get()))) {
             error(ruby_parser::dclass::SingletonLiteral, definee->loc);
@@ -645,7 +644,7 @@ public:
 
     unique_ptr<Node> keywordBreak(const token *keyword, const token *lparen, sorbet::parser::NodeVec args,
                                   const token *rparen) {
-        core::Loc loc = tokLoc(keyword).join(collectionLoc(lparen, args, rparen));
+        core::LocOffsets loc = tokLoc(keyword).join(collectionLoc(lparen, args, rparen));
         return make_unique<Break>(loc, std::move(args));
     }
 
@@ -668,14 +667,14 @@ public:
 
     unique_ptr<Node> keywordReturn(const token *keyword, const token *lparen, sorbet::parser::NodeVec args,
                                    const token *rparen) {
-        core::Loc loc = tokLoc(keyword).join(collectionLoc(lparen, args, rparen));
+        core::LocOffsets loc = tokLoc(keyword).join(collectionLoc(lparen, args, rparen));
         return make_unique<Return>(loc, std::move(args));
     }
 
     unique_ptr<Node> keywordSuper(const token *keyword, const token *lparen, sorbet::parser::NodeVec args,
                                   const token *rparen) {
-        core::Loc loc = tokLoc(keyword);
-        core::Loc argloc = collectionLoc(lparen, args, rparen);
+        core::LocOffsets loc = tokLoc(keyword);
+        core::LocOffsets argloc = collectionLoc(lparen, args, rparen);
         if (argloc.exists()) {
             loc = loc.join(argloc);
         }
@@ -684,7 +683,7 @@ public:
 
     unique_ptr<Node> keywordYield(const token *keyword, const token *lparen, sorbet::parser::NodeVec args,
                                   const token *rparen) {
-        core::Loc loc = tokLoc(keyword).join(collectionLoc(lparen, args, rparen));
+        core::LocOffsets loc = tokLoc(keyword).join(collectionLoc(lparen, args, rparen));
         if (!args.empty() && parser::isa_node<BlockPass>(args.back().get())) {
             error(ruby_parser::dclass::BlockGivenToYield, loc);
         }
@@ -705,7 +704,7 @@ public:
     }
 
     unique_ptr<Node> kwrestarg(const token *dstar, const token *name) {
-        core::Loc loc = tokLoc(dstar);
+        core::LocOffsets loc = tokLoc(dstar);
         core::NameRef nm;
 
         if (name != nullptr) {
@@ -764,7 +763,7 @@ public:
         // groups, Ruby will autovivify the match groups as locals. If we were
         // to support that, we'd need to analyze that here and call
         // `driver_->lex.declare`.
-        core::Loc loc = receiver->loc.join(arg->loc);
+        core::LocOffsets loc = receiver->loc.join(arg->loc);
         sorbet::parser::NodeVec args;
         args.emplace_back(std::move(arg));
         return make_unique<Send>(loc, std::move(receiver), gs_.enterNameUTF8(oper->string()), std::move(args));
@@ -793,7 +792,7 @@ public:
 
     unique_ptr<Node> not_op(const token *not_, const token *begin, unique_ptr<Node> receiver, const token *end) {
         if (receiver != nullptr) {
-            core::Loc loc;
+            core::LocOffsets loc;
             if (end != nullptr) {
                 loc = tokLoc(not_).join(tokLoc(end));
             } else {
@@ -838,7 +837,7 @@ public:
     }
 
     unique_ptr<Node> pair_keyword(const token *key, unique_ptr<Node> value) {
-        auto keyLoc = core::Loc{file_, clamp((u4)key->start()), clamp((u4)key->end() - 1)}; // drop the trailing :
+        auto keyLoc = core::LocOffsets{clamp((u4)key->start()), clamp((u4)key->end() - 1)}; // drop the trailing :
 
         return make_unique<Pair>(tokLoc(key).join(value->loc),
                                  make_unique<Symbol>(keyLoc, gs_.enterNameUTF8(key->string())), std::move(value));
@@ -863,12 +862,12 @@ public:
     }
 
     unique_ptr<Node> range_exclusive(unique_ptr<Node> lhs, const token *oper, unique_ptr<Node> rhs) {
-        core::Loc loc = lhs->loc.join(tokLoc(oper)).join(maybe_loc(rhs));
+        core::LocOffsets loc = lhs->loc.join(tokLoc(oper)).join(maybe_loc(rhs));
         return make_unique<ERange>(loc, std::move(lhs), std::move(rhs));
     }
 
     unique_ptr<Node> range_inclusive(unique_ptr<Node> lhs, const token *oper, unique_ptr<Node> rhs) {
-        core::Loc loc = lhs->loc.join(tokLoc(oper)).join(maybe_loc(rhs));
+        core::LocOffsets loc = lhs->loc.join(tokLoc(oper)).join(maybe_loc(rhs));
         return make_unique<IRange>(loc, std::move(lhs), std::move(rhs));
     }
 
@@ -884,7 +883,7 @@ public:
 
     unique_ptr<Node> regexp_compose(const token *begin, sorbet::parser::NodeVec parts, const token *end,
                                     unique_ptr<Node> options) {
-        core::Loc loc = tokLoc(begin).join(tokLoc(end)).join(maybe_loc(options));
+        core::LocOffsets loc = tokLoc(begin).join(tokLoc(end)).join(maybe_loc(options));
         return make_unique<Regexp>(loc, std::move(parts), std::move(options));
     }
 
@@ -894,7 +893,7 @@ public:
 
     unique_ptr<Node> rescue_body(const token *rescue, unique_ptr<Node> excList, const token *assoc,
                                  unique_ptr<Node> excVar, const token *then, unique_ptr<Node> body) {
-        core::Loc loc = tokLoc(rescue);
+        core::LocOffsets loc = tokLoc(rescue);
         if (excList != nullptr) {
             loc = loc.join(excList->loc);
         }
@@ -908,9 +907,9 @@ public:
     }
 
     unique_ptr<Node> restarg(const token *star, const token *name) {
-        core::Loc loc = tokLoc(star);
+        core::LocOffsets loc = tokLoc(star);
         core::NameRef nm;
-        core::Loc nameLoc = loc;
+        core::LocOffsets nameLoc = loc;
 
         if (name != nullptr) {
             nameLoc = tokLoc(name);
@@ -936,7 +935,7 @@ public:
     }
 
     unique_ptr<Node> splat_mlhs(const token *star, unique_ptr<Node> arg) {
-        core::Loc loc = tokLoc(star).join(maybe_loc(arg));
+        core::LocOffsets loc = tokLoc(star).join(maybe_loc(arg));
         return make_unique<SplatLhs>(loc, std::move(arg));
     }
 
@@ -962,7 +961,7 @@ public:
                 return make_unique<String>(s->loc, s->val);
             }
         } else {
-            core::Loc loc = collectionLoc(begin, parts, end);
+            core::LocOffsets loc = collectionLoc(begin, parts, end);
             return make_unique<DString>(loc, std::move(parts));
         }
     }
@@ -994,7 +993,7 @@ public:
     }
 
     unique_ptr<Node> symbols_compose(const token *begin, sorbet::parser::NodeVec parts, const token *end) {
-        core::Loc loc = collectionLoc(begin, parts, end);
+        core::LocOffsets loc = collectionLoc(begin, parts, end);
         sorbet::parser::NodeVec outParts;
         outParts.reserve(parts.size());
         for (auto &p : parts) {
@@ -1011,7 +1010,7 @@ public:
 
     unique_ptr<Node> ternary(unique_ptr<Node> cond, const token *question, unique_ptr<Node> ifTrue, const token *colon,
                              unique_ptr<Node> ifFalse) {
-        core::Loc loc = cond->loc.join(ifFalse->loc);
+        core::LocOffsets loc = cond->loc.join(ifFalse->loc);
         return make_unique<If>(loc, transformCondition(std::move(cond)), std::move(ifTrue), std::move(ifFalse));
     }
 
@@ -1020,7 +1019,7 @@ public:
     }
 
     unique_ptr<Node> unary_op(const token *oper, unique_ptr<Node> receiver) {
-        core::Loc loc = tokLoc(oper).join(receiver->loc);
+        core::LocOffsets loc = tokLoc(oper).join(receiver->loc);
 
         if (auto *num = parser::cast_node<Integer>(receiver.get())) {
             return make_unique<Integer>(loc, oper->string() + num->val);
@@ -1048,7 +1047,7 @@ public:
     }
 
     unique_ptr<Node> undefMethod(const token *undef, sorbet::parser::NodeVec name_list) {
-        core::Loc loc = tokLoc(undef);
+        core::LocOffsets loc = tokLoc(undef);
         if (!name_list.empty()) {
             loc = loc.join(name_list.back()->loc);
         }
@@ -1057,7 +1056,7 @@ public:
 
     unique_ptr<Node> when(const token *when, sorbet::parser::NodeVec patterns, const token *then,
                           unique_ptr<Node> body) {
-        core::Loc loc = tokLoc(when);
+        core::LocOffsets loc = tokLoc(when);
         if (body != nullptr) {
             loc = loc.join(body->loc);
         } else if (then != nullptr) {
@@ -1069,7 +1068,7 @@ public:
     }
 
     unique_ptr<Node> word(sorbet::parser::NodeVec parts) {
-        core::Loc loc = collectionLoc(parts);
+        core::LocOffsets loc = collectionLoc(parts);
         if (collapseStringParts(parts)) {
             // a single String child
             auto firstPart = parts.front().get();
@@ -1138,7 +1137,7 @@ public:
         return parser::isa_node<String>(firstPart) || parser::isa_node<DString>(firstPart);
     }
 
-    void checkDuplicateArgs(sorbet::parser::NodeVec &args, UnorderedMap<std::string, core::Loc> &map) {
+    void checkDuplicateArgs(sorbet::parser::NodeVec &args, UnorderedMap<std::string, core::LocOffsets> &map) {
         for (auto &this_arg : args) {
             if (auto *arg = parser::cast_node<Arg>(this_arg.get())) {
                 checkDuplicateArg(arg->name.toString(gs_), arg->loc, map);
@@ -1162,7 +1161,8 @@ public:
         }
     }
 
-    void checkDuplicateArg(std::string this_name, core::Loc this_loc, UnorderedMap<std::string, core::Loc> &map) {
+    void checkDuplicateArg(std::string this_name, core::LocOffsets this_loc,
+                           UnorderedMap<std::string, core::LocOffsets> &map) {
         auto that_arg_loc_it = map.find(this_name);
 
         if (that_arg_loc_it == map.end()) {

--- a/parser/Node.h
+++ b/parser/Node.h
@@ -7,7 +7,7 @@ namespace sorbet::parser {
 
 class Node {
 public:
-    Node(core::Loc loc) : loc(loc) {
+    Node(core::LocOffsets loc) : loc(loc) {
         ENFORCE(loc.exists(), "Location of parser node is none");
     }
     virtual ~Node() = default;
@@ -18,7 +18,7 @@ public:
     virtual std::string toJSON(const core::GlobalState &gs, int tabs = 0) = 0;
     virtual std::string toWhitequark(const core::GlobalState &gs, int tabs = 0) = 0;
     virtual std::string nodeName() = 0;
-    core::Loc loc;
+    core::LocOffsets loc;
 
 protected:
     void printTabs(fmt::memory_buffer &to, int count) const;

--- a/parser/Parser.cc
+++ b/parser/Parser.cc
@@ -62,18 +62,11 @@ unique_ptr<Node> Parser::run(sorbet::core::GlobalState &gs, core::FileRef file,
     ErrorToError::run(gs, file, driver.diagnostics);
 
     if (!ast) {
-        core::Loc loc(file, 0, 0);
+        core::LocOffsets loc{0, 0};
         NodeVec empty;
         return make_unique<Begin>(loc, std::move(empty));
     }
 
     return ast;
 }
-
-unique_ptr<Node> Parser::run(sorbet::core::GlobalState &gs, string_view path, string_view src,
-                             std::vector<std::string> initialLocals) {
-    core::FileRef file = gs.enterFile(path, src);
-    return run(gs, file, initialLocals);
-}
-
 }; // namespace sorbet::parser

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -9,8 +9,6 @@ class Parser final {
 public:
     static std::unique_ptr<Node> run(core::GlobalState &gs, core::FileRef file,
                                      std::vector<std::string> initialLocals = {});
-    static std::unique_ptr<Node> run(core::GlobalState &gs, std::string_view path, std::string_view src,
-                                     std::vector<std::string> initialLocals = {});
 };
 
 } // namespace sorbet::parser

--- a/parser/test/parser_test.cc
+++ b/parser/test/parser_test.cc
@@ -25,9 +25,12 @@ TEST(ParserTest, SimpleParse) { // NOLINT
     gs.initEmpty();
     sorbet::core::UnfreezeNameTable nameTableAccess(gs);
     sorbet::core::UnfreezeFileTable ft(gs);
-    sorbet::parser::Parser::run(gs, "<test1>", "def hello_world; p :hello; end");
-    sorbet::parser::Parser::run(gs, "<test2>", "class A; class B; end; end");
-    sorbet::parser::Parser::run(gs, "<test3>", "class A::B; module B; end; end");
+    sorbet::core::FileRef fileId1 = gs.enterFile("<test1>", "def hello_world; p :hello; end");
+    sorbet::parser::Parser::run(gs, fileId1);
+    sorbet::core::FileRef fileId2 = gs.enterFile("<test2>", "class A; class B; end; end");
+    sorbet::parser::Parser::run(gs, fileId2);
+    sorbet::core::FileRef fileId3 = gs.enterFile("<test3>", "class A::B; module B; end; end");
+    sorbet::parser::Parser::run(gs, fileId3);
 }
 
 struct DedentTest {

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -621,7 +621,7 @@ string fieldType(FieldType arg) {
         case FieldType::Uint:
             return "u4";
         case FieldType::Loc:
-            return "core::Loc";
+            return "core::LocOffsets";
     }
 }
 
@@ -630,7 +630,7 @@ void emitNodeHeader(ostream &out, NodeDef &node) {
     out << "public:" << '\n';
 
     // generate constructor
-    out << "    " << node.name << "(core::Loc loc";
+    out << "    " << node.name << "(core::LocOffsets loc";
     for (auto &arg : node.fields) {
         out << ", " << fieldType(arg.type) << " " << arg.name;
     }

--- a/plugin/SubprocessTextPlugin.cc
+++ b/plugin/SubprocessTextPlugin.cc
@@ -64,9 +64,9 @@ struct SpawningWalker {
 
             optional<string> output;
             {
-                string className = klass->name->loc.source(ctx);
+                string className = core::Loc(ctx.file, klass->name->loc).source(ctx);
                 string_view shortName = send->fun.data(ctx)->shortName(ctx);
-                string sendSource = send->loc.source(ctx);
+                string sendSource = core::Loc(ctx.file, send->loc).source(ctx);
 
                 vector<string> args(ctx.state.dslRubyExtraArgs);
                 args.emplace_back(*command);
@@ -105,14 +105,14 @@ struct SpawningWalker {
                     format_to(generatedSource, "{}", "end;");
                 }
 
-                auto path = fmt::format("{}//plugin-generated|{}.rbi", klass->loc.file().data(ctx).path(),
-                                        subprocessResults.size());
+                auto path =
+                    fmt::format("{}//plugin-generated|{}.rbi", ctx.file.data(ctx).path(), subprocessResults.size());
                 auto file =
                     make_shared<core::File>(move(path), fmt::to_string(generatedSource), core::File::Type::Normal);
                 file->pluginGenerated = true;
                 subprocessResults.emplace_back(move(file));
             } else {
-                if (auto e = ctx.state.beginError(send->loc, core::errors::Plugin::SubProcessError)) {
+                if (auto e = ctx.beginError(send->loc, core::errors::Plugin::SubProcessError)) {
                     e.setHeader("Error while executing subprocess plugin `{}`", *command);
                 }
             }

--- a/resolver/resolver.h
+++ b/resolver/resolver.h
@@ -9,27 +9,27 @@ namespace sorbet::resolver {
 
 class Resolver final {
 public:
-    static ast::ParsedFilesOrCancelled run(core::MutableContext ctx, std::vector<ast::ParsedFile> trees,
+    static ast::ParsedFilesOrCancelled run(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
                                            WorkerPool &workers);
     Resolver() = delete;
 
     /** Only runs tree passes, used for incremental changes that do not affect global state. Assumes that `run` was
      * called on a tree that contains same definitions before (LSP uses heuristics that should only have false negatives
      * to find this) */
-    static std::vector<ast::ParsedFile> runTreePasses(core::MutableContext ctx, std::vector<ast::ParsedFile> trees);
+    static std::vector<ast::ParsedFile> runTreePasses(core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
 
     // used by autogen only
-    static std::vector<ast::ParsedFile> runConstantResolution(core::MutableContext ctx,
-                                                              std::vector<ast::ParsedFile> trees, WorkerPool &workers);
+    static std::vector<ast::ParsedFile> runConstantResolution(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
+                                                              WorkerPool &workers);
 
 private:
     static void finalizeAncestors(core::GlobalState &gs);
     static void finalizeSymbols(core::GlobalState &gs);
     static void computeLinearization(core::GlobalState &gs);
-    static std::vector<ast::ParsedFile> resolveSigs(core::MutableContext ctx, std::vector<ast::ParsedFile> trees);
-    static std::vector<ast::ParsedFile> resolveMixesInClassMethods(core::MutableContext ctx,
+    static std::vector<ast::ParsedFile> resolveSigs(core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
+    static std::vector<ast::ParsedFile> resolveMixesInClassMethods(core::GlobalState &gs,
                                                                    std::vector<ast::ParsedFile> trees);
-    static void sanityCheck(core::MutableContext ctx, std::vector<ast::ParsedFile> &trees);
+    static void sanityCheck(core::GlobalState &gs, std::vector<ast::ParsedFile> &trees);
 };
 
 } // namespace sorbet::resolver

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -56,7 +56,7 @@ core::TypePtr getResultLiteral(core::Context ctx, unique_ptr<ast::Expression> &e
     typecase(
         expr.get(), [&](ast::Literal *lit) { result = lit->value; },
         [&](ast::Expression *expr) {
-            if (auto e = ctx.state.beginError(expr->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+            if (auto e = ctx.beginError(expr->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                 e.setHeader("Unsupported type literal");
             }
             result = core::Types::untypedUntracked();
@@ -158,7 +158,7 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
         while (tsend != nullptr) {
             if (tsend->fun == core::Names::typeParameters()) {
                 if (parent != nullptr) {
-                    if (auto e = ctx.state.beginError(tsend->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                    if (auto e = ctx.beginError(tsend->loc, core::errors::Resolver::InvalidMethodSignature)) {
                         e.setHeader("Malformed signature; Type parameters can only be specified in outer sig");
                     }
                     break;
@@ -169,22 +169,20 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
                             auto name = c->asSymbol(ctx);
                             auto &typeArgSpec = sig.enterTypeArgByName(name);
                             if (typeArgSpec.type) {
-                                if (auto e = ctx.state.beginError(arg->loc,
-                                                                  core::errors::Resolver::InvalidMethodSignature)) {
+                                if (auto e = ctx.beginError(arg->loc, core::errors::Resolver::InvalidMethodSignature)) {
                                     e.setHeader("Malformed signature; Type argument `{}` was specified twice",
                                                 name.show(ctx));
                                 }
                             }
                             typeArgSpec.type = core::make_type<core::TypeVar>(core::Symbols::todo());
-                            typeArgSpec.loc = arg->loc;
+                            typeArgSpec.loc = core::Loc(ctx.file, arg->loc);
                         } else {
-                            if (auto e =
-                                    ctx.state.beginError(arg->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                            if (auto e = ctx.beginError(arg->loc, core::errors::Resolver::InvalidMethodSignature)) {
                                 e.setHeader("Malformed signature; Type parameters are specified with symbols");
                             }
                         }
                     } else {
-                        if (auto e = ctx.state.beginError(arg->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                        if (auto e = ctx.beginError(arg->loc, core::errors::Resolver::InvalidMethodSignature)) {
                             e.setHeader("Malformed signature; Type parameters are specified with symbols");
                         }
                     }
@@ -207,7 +205,7 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
                     break;
                 case core::Names::bind()._id: {
                     if (sig.seen.bind) {
-                        if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                        if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
                             e.setHeader("Malformed `{}`: Multiple calls to `.bind`", send->fun.show(ctx));
                         }
                         sig.bind = core::SymbolRef();
@@ -215,7 +213,7 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
                     sig.seen.bind = true;
 
                     if (send->args.size() != 1) {
-                        if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                        if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
                             e.setHeader("Wrong number of args to `{}`. Expected: `{}`, got: `{}`", "bind", 1,
                                         send->args.size());
                         }
@@ -239,7 +237,7 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
                     }
 
                     if (!validBind) {
-                        if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                        if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
                             e.setHeader("Malformed `{}`: Can only bind to simple class names", send->fun.show(ctx));
                         }
                     }
@@ -248,7 +246,7 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
                 }
                 case core::Names::params()._id: {
                     if (sig.seen.params) {
-                        if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                        if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
                             e.setHeader("Malformed `{}`: Multiple calls to `.params`", send->fun.show(ctx));
                         }
                         sig.argTypes.clear();
@@ -260,7 +258,7 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
                     }
 
                     if (send->args.size() > 1) {
-                        if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                        if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
                             e.setHeader("Wrong number of args to `{}`. Expected: `{}`, got: `{}`", send->fun.show(ctx),
                                         "0-1", send->args.size());
                         }
@@ -268,7 +266,7 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
 
                     auto *hash = ast::cast_tree<ast::Hash>(send->args[0].get());
                     if (hash == nullptr) {
-                        if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                        if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
                             auto paramsStr = send->fun.show(ctx);
                             e.setHeader("`{}` expects keyword arguments", paramsStr);
                             e.addErrorSection(core::ErrorSection(core::ErrorColors::format(
@@ -285,8 +283,8 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
                             core::NameRef name = lit->asSymbol(ctx);
                             auto resultAndBind =
                                 getResultTypeAndBindWithSelfTypeParams(ctx, *value, *parent, args.withRebind());
-                            sig.argTypes.emplace_back(
-                                ParsedSig::ArgSpec{key->loc, name, resultAndBind.type, resultAndBind.rebind});
+                            sig.argTypes.emplace_back(ParsedSig::ArgSpec{core::Loc(ctx.file, key->loc), name,
+                                                                         resultAndBind.type, resultAndBind.rebind});
                         }
                     }
                     break;
@@ -301,7 +299,7 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
                     sig.seen.override_ = true;
 
                     if (send->args.size() > 1) {
-                        if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                        if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
                             e.setHeader("Wrong number of args to `{}`. Expected: `{}`, got: `{}`", send->fun.show(ctx),
                                         "0-1", send->args.size());
                         }
@@ -310,8 +308,7 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
                     if (send->args.size() == 1) {
                         auto *hash = ast::cast_tree<ast::Hash>(send->args[0].get());
                         if (hash == nullptr) {
-                            if (auto e =
-                                    ctx.state.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                            if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
                                 auto paramsStr = send->fun.show(ctx);
                                 e.setHeader("`{}` expects keyword arguments", send->fun.show(ctx));
                             }
@@ -336,13 +333,13 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
                     break;
                 }
                 case core::Names::implementation()._id:
-                    if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::ImplementationDeprecated)) {
+                    if (auto e = ctx.beginError(send->loc, core::errors::Resolver::ImplementationDeprecated)) {
                         e.setHeader("Use of `{}` has been replaced by `{}`", "implementation", "override");
                         if (send->recv->isSelfReference()) {
-                            e.replaceWith("Replace with `override`", send->loc, "override");
+                            e.replaceWith("Replace with `override`", core::Loc(ctx.file, send->loc), "override");
                         } else {
-                            e.replaceWith("Replace with `override`", send->loc, "{}.override",
-                                          send->recv->loc.source(ctx));
+                            e.replaceWith("Replace with `override`", core::Loc(ctx.file, send->loc), "{}.override",
+                                          core::Loc(ctx.file, send->recv->loc).source(ctx));
                         }
                     }
                     break;
@@ -352,7 +349,7 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
                 case core::Names::returns()._id: {
                     sig.seen.returns = true;
                     if (send->args.size() != 1) {
-                        if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                        if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
                             e.setHeader("Wrong number of args to `{}`. Expected: `{}`, got: `{}`", "returns", 1,
                                         send->args.size());
                         }
@@ -361,7 +358,7 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
 
                     auto nil = ast::cast_tree<ast::Literal>(send->args[0].get());
                     if (nil && nil->isNil(ctx)) {
-                        const auto loc = send->args[0]->loc;
+                        const auto loc = core::Loc(ctx.file, send->args[0]->loc);
                         if (auto e = ctx.state.beginError(loc, core::errors::Resolver::InvalidMethodSignature)) {
                             e.setHeader("You probably meant `.returns(NilClass)`");
                             e.replaceWith("Replace with `NilClass`", loc, "NilClass");
@@ -384,17 +381,18 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
                 case core::Names::onFailure()._id:
                     break;
                 case core::Names::final_()._id:
-                    if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                    if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
                         reportedInvalidMethod = true;
                         e.setHeader("The syntax for declaring a method final is `sig(:final) {{...}}`, not `sig "
                                     "{{final. ...}}`");
                     }
                     break;
                 default:
-                    if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                    if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
                         reportedInvalidMethod = true;
                         e.setHeader("Malformed signature: `{}` is invalid in this context", send->fun.show(ctx));
-                        e.addErrorLine(send->loc, "Consult https://sorbet.org/docs/sigs for signature syntax");
+                        e.addErrorLine(core::Loc(ctx.file, send->loc),
+                                       "Consult https://sorbet.org/docs/sigs for signature syntax");
                     }
             }
             auto recv = ast::cast_tree<ast::Send>(send->recv.get());
@@ -403,7 +401,7 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
             if (!recv && !reportedInvalidMethod) {
                 if (!send->recv->isSelfReference()) {
                     if (!sig.seen.proc) {
-                        if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                        if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
                             e.setHeader("Malformed signature: `{}` being invoked on an invalid receiver",
                                         send->fun.show(ctx));
                         }
@@ -464,14 +462,14 @@ core::TypePtr interpretTCombinator(core::MutableContext ctx, ast::Send *send, co
             }
             auto arr = ast::cast_tree<ast::Literal>(send->args[0].get());
             if (!arr || !arr->isSymbol(ctx)) {
-                if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("type_parameter requires a symbol");
                 }
                 return core::Types::untypedUntracked();
             }
             auto fnd = sig.findTypeArgByName(arr->asSymbol(ctx));
             if (!fnd.type) {
-                if (auto e = ctx.state.beginError(arr->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                if (auto e = ctx.beginError(arr->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("Unspecified type parameter");
                 }
                 return core::Types::untypedUntracked();
@@ -487,13 +485,13 @@ core::TypePtr interpretTCombinator(core::MutableContext ctx, ast::Send *send, co
             if (arr == nullptr) {
                 // TODO(pay-server) unsilence this error and support enums from pay-server
                 { return core::Types::Object(); }
-                if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("enum must be passed a literal array. e.g. enum([1,\"foo\",MyClass])");
                 }
                 return core::Types::untypedUntracked();
             }
             if (arr->elems.empty()) {
-                if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("enum([]) is invalid");
                 }
                 return core::Types::untypedUntracked();
@@ -516,27 +514,27 @@ core::TypePtr interpretTCombinator(core::MutableContext ctx, ast::Send *send, co
 
             auto *obj = ast::cast_tree<ast::ConstantLit>(arg);
             if (!obj) {
-                if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("T.class_of needs a Class as its argument");
                 }
                 return core::Types::untypedUntracked();
             }
             auto maybeAliased = obj->symbol;
             if (maybeAliased.data(ctx)->isTypeAlias()) {
-                if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("T.class_of can't be used with a T.type_alias");
                 }
                 return core::Types::untypedUntracked();
             }
             if (maybeAliased.data(ctx)->isTypeMember()) {
-                if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("T.class_of can't be used with a T.type_member");
                 }
                 return core::Types::untypedUntracked();
             }
             auto sym = maybeAliased.data(ctx)->dealias(ctx);
             if (sym.data(ctx)->isStaticField()) {
-                if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("T.class_of can't be used with a constant field");
                 }
                 return core::Types::untypedUntracked();
@@ -544,7 +542,7 @@ core::TypePtr interpretTCombinator(core::MutableContext ctx, ast::Send *send, co
 
             auto singleton = sym.data(ctx)->singletonClass(ctx);
             if (!singleton.exists()) {
-                if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("Unknown class");
                 }
                 return core::Types::untypedUntracked();
@@ -557,22 +555,23 @@ core::TypePtr interpretTCombinator(core::MutableContext ctx, ast::Send *send, co
             if (args.allowSelfType) {
                 return core::make_type<core::SelfType>();
             }
-            if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+            if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                 e.setHeader("Only top-level T.self_type is supported");
             }
             return core::Types::untypedUntracked();
         case core::Names::experimentalAttachedClass()._id:
         case core::Names::attachedClass()._id:
             if (send->fun == core::Names::experimentalAttachedClass()) {
-                if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::ExperimentalAttachedClass)) {
+                if (auto e = ctx.beginError(send->loc, core::errors::Resolver::ExperimentalAttachedClass)) {
                     e.setHeader("`{}` has been stabilized and is no longer experimental",
                                 "T.experimental_attached_class");
-                    e.replaceWith("Replace with `T.attached_class`", send->loc, "T.attached_class");
+                    e.replaceWith("Replace with `T.attached_class`", core::Loc(ctx.file, send->loc),
+                                  "T.attached_class");
                 }
             }
 
             if (!ctx.owner.data(ctx)->isSingletonClass(ctx)) {
-                if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("`T.{}` may only be used in a singleton class method context",
                                 core::Names::attachedClass().show(ctx));
                 }
@@ -587,7 +586,7 @@ core::TypePtr interpretTCombinator(core::MutableContext ctx, ast::Send *send, co
             return core::Types::bottom();
 
         default:
-            if (auto e = ctx.state.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+            if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                 e.setHeader("Unsupported method `{}`", "T." + send->fun.show(ctx));
             }
             return core::Types::untypedUntracked();
@@ -628,7 +627,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                     keys.emplace_back(lit->value);
                     values.emplace_back(val);
                 } else {
-                    if (auto e = ctx.state.beginError(ktree->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                    if (auto e = ctx.beginError(ktree->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                         e.setHeader("Malformed type declaration. Shape keys must be literals");
                     }
                 }
@@ -675,7 +674,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                                                sym == core::Symbols::Enumerable() || sym == core::Symbols::Enumerator();
                     auto level = isStdlibWhitelisted ? core::errors::Resolver::GenericClassWithoutTypeArgsStdlib
                                                      : core::errors::Resolver::GenericClassWithoutTypeArgs;
-                    if (auto e = ctx.state.beginError(i->loc, level)) {
+                    if (auto e = ctx.beginError(i->loc, level)) {
                         e.setHeader("Malformed type declaration. Generic class without type arguments `{}`",
                                     sym.show(ctx));
                         // if we're looking at `Array`, we want the autocorrect to include `T::`, but we don't need to
@@ -683,8 +682,9 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                         auto typePrefix = isBuiltinGeneric ? "" : "T::";
                         if (sym == core::Symbols::Hash() || sym == core::Symbols::T_Hash()) {
                             // Hash is special because it has arity 3 but you're only supposed to write the first 2
-                            e.replaceWith("Add type arguments", i->loc, "{}{}[T.untyped, T.untyped]", typePrefix,
-                                          i->loc.source(ctx));
+                            e.replaceWith("Add type arguments", core::Loc(ctx.file, i->loc),
+                                          "{}{}[T.untyped, T.untyped]", typePrefix,
+                                          core::Loc(ctx.file, i->loc).source(ctx));
                         } else if (isStdlibWhitelisted || isBuiltinGeneric) {
                             // the default provided here for builtin generic types is 1, and that might need to change
                             // if we add other builtin generics (but ideally we should never need to do so!)
@@ -693,8 +693,8 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                             for (int i = 0; i < numTypeArgs; i++) {
                                 untypeds.emplace_back("T.untyped");
                             }
-                            e.replaceWith("Add type arguments", i->loc, "{}{}[{}]", typePrefix, i->loc.source(ctx),
-                                          absl::StrJoin(untypeds, ", "));
+                            e.replaceWith("Add type arguments", core::Loc(ctx.file, i->loc), "{}{}[{}]", typePrefix,
+                                          core::Loc(ctx.file, i->loc).source(ctx), absl::StrJoin(untypeds, ", "));
                         }
                     }
                 }
@@ -743,8 +743,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                         // constructors like `Types::any` do not expect to see bound variables, and will panic.
                         result.type = core::make_type<core::SelfTypeParam>(sym);
                     } else {
-                        if (auto e =
-                                ctx.state.beginError(i->loc, core::errors::Resolver::InvalidTypeDeclarationTyped)) {
+                        if (auto e = ctx.beginError(i->loc, core::errors::Resolver::InvalidTypeDeclarationTyped)) {
                             string typeSource = isTypeTemplate ? "type_template" : "type_member";
                             string typeStr = sym.show(ctx);
 
@@ -764,14 +763,14 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                     }
                 } else {
                     // a type member has occurred in a context that doesn't allow them
-                    if (auto e = ctx.state.beginError(i->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                    if (auto e = ctx.beginError(i->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                         auto flavor = isTypeTemplate ? "type_template"sv : "type_member"sv;
                         e.setHeader("`{}` `{}` is not allowed in this context", flavor, sym.show(ctx));
                     }
                     result.type = core::Types::untypedUntracked();
                 }
             } else if (sym.data(ctx)->isStaticField()) {
-                if (auto e = ctx.state.beginError(i->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                if (auto e = ctx.beginError(i->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("Constant `{}` is not a class or type alias", maybeAliased.show(ctx));
                     e.addErrorLine(sym.data(ctx)->loc(),
                                    "If you are trying to define a type alias, you should use `{}` here",
@@ -779,7 +778,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                 }
                 result.type = core::Types::untypedUntracked();
             } else {
-                if (auto e = ctx.state.beginError(i->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                if (auto e = ctx.beginError(i->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("Malformed type declaration. Not a class type `{}`", maybeAliased.show(ctx));
                 }
                 result.type = core::Types::untypedUntracked();
@@ -790,7 +789,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                 auto sig = parseSigWithSelfTypeParams(ctx, s, &sigBeingParsed, args.withoutSelfType());
                 if (sig.bind.exists()) {
                     if (!args.allowRebind) {
-                        if (auto e = ctx.state.beginError(s->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                        if (auto e = ctx.beginError(s->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                             e.setHeader("Using `{}` is not permitted here", "bind");
                         }
                     } else {
@@ -801,7 +800,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                 vector<core::TypePtr> targs;
 
                 if (sig.returns == nullptr) {
-                    if (auto e = ctx.state.beginError(s->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                    if (auto e = ctx.beginError(s->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                         e.setHeader("Malformed T.proc: You must specify a return type");
                     }
                     targs.emplace_back(core::Types::untypedUntracked());
@@ -815,7 +814,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
 
                 auto arity = targs.size() - 1;
                 if (arity > core::Symbols::MAX_PROC_ARITY) {
-                    if (auto e = ctx.state.beginError(s->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                    if (auto e = ctx.beginError(s->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                         e.setHeader("Malformed T.proc: Too many arguments (max `{}`)", core::Symbols::MAX_PROC_ARITY);
                     }
                     result.type = core::Types::untypedUntracked();
@@ -830,7 +829,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
 
             auto *recvi = ast::cast_tree<ast::ConstantLit>(recv);
             if (recvi == nullptr) {
-                if (auto e = ctx.state.beginError(s->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                if (auto e = ctx.beginError(s->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("Malformed type declaration. Unknown type syntax. Expected a ClassName or T.<func>");
                 }
                 result.type = core::Types::untypedUntracked();
@@ -843,7 +842,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
 
             if (recvi->symbol == core::Symbols::Magic() && s->fun == core::Names::callWithSplat()) {
                 // TODO(pay-server) remove this block
-                if (auto e = ctx.state.beginError(recvi->loc, core::errors::Resolver::InvalidTypeDeclarationTyped)) {
+                if (auto e = ctx.beginError(recvi->loc, core::errors::Resolver::InvalidTypeDeclarationTyped)) {
                     e.setHeader("Malformed type declaration: splats cannot be used in types");
                 }
                 result.type = core::Types::untypedUntracked();
@@ -851,7 +850,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
             }
 
             if (s->fun != core::Names::squareBrackets()) {
-                if (auto e = ctx.state.beginError(s->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                if (auto e = ctx.beginError(s->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("Malformed type declaration. Unknown type syntax. Expected a ClassName or T.<func>");
                 }
                 result.type = core::Types::untypedUntracked();
@@ -860,13 +859,13 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
 
             InlinedVector<unique_ptr<core::TypeAndOrigins>, 2> holders;
             InlinedVector<const core::TypeAndOrigins *, 2> targs;
-            InlinedVector<core::Loc, 2> argLocs;
+            InlinedVector<core::LocOffsets, 2> argLocs;
             targs.reserve(s->args.size());
             argLocs.reserve(s->args.size());
             holders.reserve(s->args.size());
             for (auto &arg : s->args) {
                 core::TypeAndOrigins ty;
-                ty.origins.emplace_back(arg->loc);
+                ty.origins.emplace_back(core::Loc(ctx.file, arg->loc));
                 ty.type = core::make_type<core::MetaType>(
                     getResultTypeWithSelfTypeParams(ctx, *arg, sigBeingParsed, args.withoutSelfType()));
                 holders.emplace_back(make_unique<core::TypeAndOrigins>(move(ty)));
@@ -889,7 +888,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                 corrected = core::Symbols::T_Set();
             }
             if (corrected.exists()) {
-                if (auto e = ctx.state.beginError(s->loc, core::errors::Resolver::BadStdlibGeneric)) {
+                if (auto e = ctx.beginError(s->loc, core::errors::Resolver::BadStdlibGeneric)) {
                     e.setHeader("Use `{}`, not `{}` to declare a typed `{}`", corrected.data(ctx)->show(ctx) + "[...]",
                                 recvi->symbol.data(ctx)->show(ctx) + "[...]", recvi->symbol.data(ctx)->show(ctx));
                     e.addErrorSection(
@@ -897,7 +896,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                                                                      recvi->symbol.data(ctx)->show(ctx) + "[...]")));
                     e.replaceWith(fmt::format("Change `{}` to `{}`", recvi->symbol.data(ctx)->show(ctx),
                                               corrected.data(ctx)->show(ctx)),
-                                  recvi->loc, "{}", corrected.data(ctx)->show(ctx));
+                                  core::Loc(ctx.file, recvi->loc), "{}", corrected.data(ctx)->show(ctx));
                 }
                 result.type = core::Types::untypedUntracked();
                 return;
@@ -907,7 +906,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
             corrected = corrected.data(ctx)->dealias(ctx);
 
             if (!corrected.data(ctx)->isClassOrModule()) {
-                if (auto e = ctx.state.beginError(s->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                if (auto e = ctx.beginError(s->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("Expected a class or module");
                 }
                 result.type = core::Types::untypedUntracked();
@@ -917,6 +916,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
             auto correctedSingleton = corrected.data(ctx)->singletonClass(ctx);
             auto ctype = core::make_type<core::ClassType>(correctedSingleton);
             core::CallLocs locs{
+                ctx.file,
                 s->loc,
                 recvi->loc,
                 argLocs,
@@ -942,7 +942,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                 return;
             }
 
-            if (auto e = ctx.state.beginError(s->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+            if (auto e = ctx.beginError(s->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                 e.setHeader("Malformed type declaration. Unknown type syntax. Expected a ClassName or T.<func>");
             }
             result.type = core::Types::untypedUntracked();
@@ -951,14 +951,14 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
             if (slf->isSelfReference()) {
                 result.type = ctxOwnerData->selfType(ctx);
             } else {
-                if (auto e = ctx.state.beginError(slf->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                if (auto e = ctx.beginError(slf->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("Unsupported type syntax");
                 }
                 result.type = core::Types::untypedUntracked();
             }
         },
         [&](ast::Expression *expr) {
-            if (auto e = ctx.state.beginError(expr->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+            if (auto e = ctx.beginError(expr->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                 e.setHeader("Unsupported type syntax");
             }
             result.type = core::Types::untypedUntracked();

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -15,15 +15,15 @@ namespace sorbet::rewriter {
 
 namespace {
 
-pair<core::NameRef, core::Loc> getName(core::MutableContext ctx, ast::Expression *name) {
-    core::Loc loc;
+pair<core::NameRef, core::LocOffsets> getName(core::MutableContext ctx, ast::Expression *name) {
+    core::LocOffsets loc;
     core::NameRef res = core::NameRef::noName();
     if (auto lit = ast::cast_tree<ast::Literal>(name)) {
         if (lit->isSymbol(ctx)) {
             res = lit->asSymbol(ctx);
             loc = lit->loc;
-            ENFORCE(loc.source(ctx).size() > 1 && loc.source(ctx)[0] == ':');
-            loc = core::Loc(loc.file(), loc.beginPos() + 1, loc.endPos());
+            ENFORCE(core::Loc(ctx.file, loc).source(ctx).size() > 1 && core::Loc(ctx.file, loc).source(ctx)[0] == ':');
+            loc = core::LocOffsets{loc.beginPos() + 1, loc.endPos()};
         } else if (lit->isString(ctx)) {
             core::NameRef nameRef = lit->asString(ctx);
             auto shortName = nameRef.data(ctx)->shortName(ctx);
@@ -32,7 +32,7 @@ pair<core::NameRef, core::Loc> getName(core::MutableContext ctx, ast::Expression
             if (validAttr) {
                 res = nameRef;
             } else {
-                if (auto e = ctx.state.beginError(name->loc, core::errors::Rewriter::BadAttrArg)) {
+                if (auto e = ctx.beginError(name->loc, core::errors::Rewriter::BadAttrArg)) {
                     e.setHeader("Bad attribute name \"{}\"", absl::CEscape(shortName));
                 }
                 res = core::Names::empty();
@@ -41,7 +41,7 @@ pair<core::NameRef, core::Loc> getName(core::MutableContext ctx, ast::Expression
         }
     }
     if (!res.exists()) {
-        if (auto e = ctx.state.beginError(name->loc, core::errors::Rewriter::BadAttrArg)) {
+        if (auto e = ctx.beginError(name->loc, core::errors::Rewriter::BadAttrArg)) {
             e.setHeader("arg must be a Symbol or String");
         }
     }
@@ -105,7 +105,7 @@ void ensureSafeSig(core::MutableContext ctx, const core::NameRef attrFun, const 
     ast::Send *cur = body;
     while (cur != nullptr) {
         if (cur->fun == core::Names::typeParameters()) {
-            if (auto e = ctx.state.beginError(sig->loc, core::errors::Rewriter::BadAttrType)) {
+            if (auto e = ctx.beginError(sig->loc, core::errors::Rewriter::BadAttrType)) {
                 e.setHeader("The type for an `{}` cannot contain `{}`", attrFun.show(ctx), "type_parameters");
             }
             body->args[0] = ast::MK::Untyped(body->args[0]->loc);
@@ -117,7 +117,7 @@ void ensureSafeSig(core::MutableContext ctx, const core::NameRef attrFun, const 
 // To convert a sig into a writer sig with argument `name`, we copy the `returns(...)`
 // value into the `sig {params(...)}` using whatever name we have for the setter.
 unique_ptr<ast::Expression> toWriterSigForName(core::MutableContext ctx, const ast::Send *sharedSig,
-                                               const core::NameRef name, core::Loc nameLoc) {
+                                               const core::NameRef name, core::LocOffsets nameLoc) {
     ENFORCE(ASTUtil::castSig(sharedSig, core::Names::returns()),
             "We weren't given a send node that's a valid signature");
 
@@ -233,7 +233,8 @@ vector<unique_ptr<ast::Expression>> AttrReader::run(core::MutableContext ctx, as
                 }
             }
 
-            stats.emplace_back(ast::MK::SyntheticMethod0(loc, loc, name, ast::MK::Instance(argLoc, varName)));
+            stats.emplace_back(
+                ast::MK::SyntheticMethod0(loc, core::Loc(ctx.file, loc), name, ast::MK::Instance(argLoc, varName)));
         }
     }
 
@@ -266,7 +267,8 @@ vector<unique_ptr<ast::Expression>> AttrReader::run(core::MutableContext ctx, as
             } else {
                 body = ast::MK::Assign(loc, ast::MK::Instance(argLoc, varName), ast::MK::Local(loc, name));
             }
-            stats.emplace_back(ast::MK::SyntheticMethod1(loc, loc, setName, ast::MK::Local(argLoc, name), move(body)));
+            stats.emplace_back(ast::MK::SyntheticMethod1(loc, core::Loc(ctx.file, loc), setName,
+                                                         ast::MK::Local(argLoc, name), move(body)));
         }
     }
 

--- a/rewriter/ClassNew.cc
+++ b/rewriter/ClassNew.cc
@@ -12,7 +12,7 @@ namespace sorbet::rewriter {
 
 vector<unique_ptr<ast::Expression>> ClassNew::run(core::MutableContext ctx, ast::Assign *asgn) {
     vector<unique_ptr<ast::Expression>> empty;
-    core::Loc loc = asgn->loc;
+    auto loc = asgn->loc;
 
     if (ctx.state.runningUnderAutogen) {
         // This is not safe to run under autogen, because we'd be outputing
@@ -77,7 +77,8 @@ vector<unique_ptr<ast::Expression>> ClassNew::run(core::MutableContext ctx, ast:
     }
 
     vector<unique_ptr<ast::Expression>> stats;
-    stats.emplace_back(ast::MK::Class(loc, loc, std::move(asgn->lhs), std::move(ancestors), std::move(body)));
+    stats.emplace_back(
+        ast::MK::Class(loc, core::Loc(ctx.file, loc), std::move(asgn->lhs), std::move(ancestors), std::move(body)));
     return stats;
 }
 

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -86,8 +86,8 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
         newArgs.emplace_back(arg->deepCopy());
     }
 
-    auto selfCall =
-        ast::MK::SyntheticMethod(call->loc, call->loc, call->name, std::move(newArgs), ast::MK::Untyped(call->loc));
+    auto selfCall = ast::MK::SyntheticMethod(call->loc, core::Loc(ctx.file, call->loc), call->name, std::move(newArgs),
+                                             ast::MK::Untyped(call->loc));
     selfCall->flags.isSelfMethod = true;
 
     klass->rhs.insert(klass->rhs.begin() + i + 1, sig->deepCopy());

--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -48,8 +48,8 @@ vector<unique_ptr<ast::Expression>> DSLBuilder::run(core::MutableContext ctx, as
     }
     name = sym->asSymbol(ctx);
 
-    ENFORCE(!sym->loc.source(ctx).empty() && sym->loc.source(ctx)[0] == ':');
-    auto nameLoc = core::Loc(sym->loc.file(), sym->loc.beginPos() + 1, sym->loc.endPos());
+    ENFORCE(!core::Loc(ctx.file, sym->loc).source(ctx).empty() && core::Loc(ctx.file, sym->loc).source(ctx)[0] == ':');
+    auto nameLoc = core::LocOffsets{sym->loc.beginPos() + 1, sym->loc.endPos()};
 
     type = ASTUtil::dupType(send->args[1].get());
     if (!type) {
@@ -88,7 +88,8 @@ vector<unique_ptr<ast::Expression>> DSLBuilder::run(core::MutableContext ctx, as
             auto default_ = ast::MK::Send0(loc, ast::MK::T(loc), core::Names::untyped());
             arg = ast::MK::OptionalArg(loc, move(arg), move(default_));
         }
-        auto defSelfProp = ast::MK::SyntheticMethod1(loc, loc, name, move(arg), ast::MK::EmptyTree());
+        auto defSelfProp =
+            ast::MK::SyntheticMethod1(loc, core::Loc(ctx.file, loc), name, move(arg), ast::MK::EmptyTree());
         defSelfProp->flags.isSelfMethod = true;
         stats.emplace_back(move(defSelfProp));
     }
@@ -101,13 +102,15 @@ vector<unique_ptr<ast::Expression>> DSLBuilder::run(core::MutableContext ctx, as
         // def self.get_<prop>
         core::NameRef getName = ctx.state.enterNameUTF8("get_" + name.data(ctx)->show(ctx));
         stats.emplace_back(ast::MK::Sig0(loc, ASTUtil::dupType(type.get())));
-        auto defSelfGetProp = ast::MK::SyntheticMethod(loc, loc, getName, {}, ast::MK::Unsafe(loc, ast::MK::Nil(loc)));
+        auto defSelfGetProp = ast::MK::SyntheticMethod(loc, core::Loc(ctx.file, loc), getName, {},
+                                                       ast::MK::Unsafe(loc, ast::MK::Nil(loc)));
         defSelfGetProp->flags.isSelfMethod = true;
         stats.emplace_back(move(defSelfGetProp));
 
         // def <prop>()
         stats.emplace_back(ast::MK::Sig0(loc, ASTUtil::dupType(type.get())));
-        stats.emplace_back(ast::MK::SyntheticMethod(loc, loc, name, {}, ast::MK::Unsafe(loc, ast::MK::Nil(loc))));
+        stats.emplace_back(
+            ast::MK::SyntheticMethod(loc, core::Loc(ctx.file, loc), name, {}, ast::MK::Unsafe(loc, ast::MK::Nil(loc))));
     }
 
     return stats;

--- a/rewriter/DefaultArgs.cc
+++ b/rewriter/DefaultArgs.cc
@@ -172,7 +172,8 @@ void DefaultArgs::run(core::MutableContext ctx, ast::ClassDef *klass) {
                         }
                         newMethods.emplace_back(move(sig));
                     }
-                    auto defaultArgDef = ast::MK::SyntheticMethod(loc, loc, name, std::move(args), std::move(rhs));
+                    auto defaultArgDef =
+                        ast::MK::SyntheticMethod(loc, core::Loc(ctx.file, loc), name, std::move(args), std::move(rhs));
                     defaultArgDef->flags.isSelfMethod = mdef->flags.isSelfMethod;
                     newMethods.emplace_back(move(defaultArgDef));
                 }

--- a/rewriter/Delegate.cc
+++ b/rewriter/Delegate.cc
@@ -124,7 +124,8 @@ vector<unique_ptr<ast::Expression>> Delegate::run(core::MutableContext ctx, cons
         args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
         args.emplace_back(std::make_unique<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
 
-        methodStubs.push_back(ast::MK::SyntheticMethod(loc, loc, methodName, std::move(args), ast::MK::EmptyTree()));
+        methodStubs.push_back(
+            ast::MK::SyntheticMethod(loc, core::Loc(ctx.file, loc), methodName, std::move(args), ast::MK::EmptyTree()));
     }
 
     return methodStubs;

--- a/rewriter/Flatfiles.cc
+++ b/rewriter/Flatfiles.cc
@@ -49,13 +49,14 @@ void handleFieldDefinition(core::MutableContext ctx, unique_ptr<ast::Expression>
         }
 
         methods.emplace_back(ast::MK::Sig0(send->loc, ast::MK::Untyped(send->loc)));
-        methods.emplace_back(ast::MK::SyntheticMethod0(send->loc, send->loc, *name, ast::MK::Nil(send->loc)));
+        methods.emplace_back(
+            ast::MK::SyntheticMethod0(send->loc, core::Loc(ctx.file, send->loc), *name, ast::MK::Nil(send->loc)));
         auto var = ast::MK::Local(send->loc, core::Names::arg0());
         auto setName = name->addEq(ctx);
         methods.emplace_back(ast::MK::Sig1(send->loc, ast::MK::Symbol(send->loc, core::Names::arg0()),
                                            ast::MK::Untyped(send->loc), ast::MK::Untyped(send->loc)));
-        methods.emplace_back(
-            ast::MK::SyntheticMethod1(send->loc, send->loc, setName, move(var), ast::MK::Nil(send->loc)));
+        methods.emplace_back(ast::MK::SyntheticMethod1(send->loc, core::Loc(ctx.file, send->loc), setName, move(var),
+                                                       ast::MK::Nil(send->loc)));
     }
 }
 

--- a/rewriter/Flatten.cc
+++ b/rewriter/Flatten.cc
@@ -279,11 +279,11 @@ class FlattenWalk {
 
         // generate the nested `class << self` blocks as needed and add them to the class
         for (auto &body : nestedClassBodies) {
-            auto classDef =
-                ast::MK::Class(loc, loc,
-                               make_unique<ast::UnresolvedIdent>(core::Loc::none(), ast::UnresolvedIdent::Kind::Class,
-                                                                 core::Names::singleton()),
-                               {}, std::move(body));
+            auto classDef = ast::MK::Class(loc.offsets(), loc,
+                                           make_unique<ast::UnresolvedIdent>(core::LocOffsets::none(),
+                                                                             ast::UnresolvedIdent::Kind::Class,
+                                                                             core::Names::singleton()),
+                                           {}, std::move(body));
             rhs.emplace_back(std::move(classDef));
         }
 
@@ -307,7 +307,8 @@ public:
     }
 
     unique_ptr<ast::Expression> postTransformClassDef(core::Context ctx, unique_ptr<ast::ClassDef> classDef) {
-        classDef->rhs = addClassDefMethods(ctx, std::move(classDef->rhs), classDef->loc);
+        classDef->rhs =
+            addClassDefMethods(ctx, std::move(classDef->rhs), core::Loc(classDef->declLoc.file(), classDef->loc));
         auto &methods = curMethodSet();
         if (curMethodSet().stack.empty()) {
             return classDef;
@@ -365,8 +366,8 @@ public:
 
         methods.addExpr(*md, move(methodDef));
 
-        return ast::MK::Send2(loc, ast::MK::Constant(loc, core::Symbols::Sorbet_Private_Static()), keepName,
-                              ast::MK::Self(loc), ast::MK::Symbol(loc, name));
+        return ast::MK::Send2(loc.offsets(), ast::MK::Constant(loc.offsets(), core::Symbols::Sorbet_Private_Static()),
+                              keepName, ast::MK::Self(loc.offsets()), ast::MK::Symbol(loc.offsets(), name));
     };
 
     unique_ptr<ast::Expression> addTopLevelMethods(core::Context ctx, unique_ptr<ast::Expression> tree) {

--- a/rewriter/InterfaceWrapper.cc
+++ b/rewriter/InterfaceWrapper.cc
@@ -21,14 +21,14 @@ unique_ptr<ast::Expression> InterfaceWrapper::run(core::MutableContext ctx, ast:
     }
 
     if (!ast::isa_tree<ast::UnresolvedConstantLit>(send->recv.get())) {
-        if (auto e = ctx.state.beginError(send->recv->loc, core::errors::Rewriter::BadWrapInstance)) {
+        if (auto e = ctx.beginError(send->recv->loc, core::errors::Rewriter::BadWrapInstance)) {
             e.setHeader("Unsupported wrap_instance() on a non-constant-literal");
         }
         return nullptr;
     }
 
     if (send->args.size() != 1) {
-        if (auto e = ctx.state.beginError(send->loc, core::errors::Rewriter::BadWrapInstance)) {
+        if (auto e = ctx.beginError(send->loc, core::errors::Rewriter::BadWrapInstance)) {
             e.setHeader("Wrong number of arguments to `{}`. Expected: `{}`, got: `{}`", "wrap_instance", 0,
                         send->args.size());
         }

--- a/rewriter/Mattr.cc
+++ b/rewriter/Mattr.cc
@@ -93,7 +93,8 @@ vector<unique_ptr<ast::Expression>> Mattr::run(core::MutableContext ctx, const a
         auto loc = lit->loc;
         if (doReaders) {
             auto sig = ast::MK::Sig0(loc, ast::MK::Untyped(loc));
-            auto def = ast::MK::SyntheticMethod0(loc, loc, lit->asSymbol(ctx), ast::MK::EmptyTree());
+            auto def =
+                ast::MK::SyntheticMethod0(loc, core::Loc(ctx.file, loc), lit->asSymbol(ctx), ast::MK::EmptyTree());
             def->flags.isSelfMethod = true;
             if (instanceReader) {
                 addInstanceCounterPart(result, sig, def);
@@ -104,7 +105,7 @@ vector<unique_ptr<ast::Expression>> Mattr::run(core::MutableContext ctx, const a
         if (doWriters) {
             auto sig = ast::MK::Sig1(loc, ast::MK::Symbol(loc, core::Names::arg0()), ast::MK::Untyped(loc),
                                      ast::MK::Untyped(loc));
-            auto def = ast::MK::SyntheticMethod1(loc, loc, lit->asSymbol(ctx).addEq(ctx),
+            auto def = ast::MK::SyntheticMethod1(loc, core::Loc(ctx.file, loc), lit->asSymbol(ctx).addEq(ctx),
                                                  ast::MK::Local(loc, core::Names::arg0()), ast::MK::EmptyTree());
             def->flags.isSelfMethod = true;
             if (instanceWriter) {
@@ -118,7 +119,8 @@ vector<unique_ptr<ast::Expression>> Mattr::run(core::MutableContext ctx, const a
             // from being generated.
             auto sig = ast::MK::Sig0(
                 loc, ast::MK::UnresolvedConstant(loc, ast::MK::T(loc), core::Names::Constants::Boolean()));
-            auto def = ast::MK::SyntheticMethod0(loc, loc, lit->asSymbol(ctx).addQuestion(ctx), ast::MK::False(loc));
+            auto def = ast::MK::SyntheticMethod0(loc, core::Loc(ctx.file, loc), lit->asSymbol(ctx).addQuestion(ctx),
+                                                 ast::MK::False(loc));
             def->flags.isSelfMethod = true;
             if (instanceReader && instancePredicate) {
                 addInstanceCounterPart(result, sig, def);

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -89,7 +89,7 @@ public:
         return move(movedConstants);
     }
 
-    unique_ptr<ast::Expression> addConstantsToExpression(core::Loc loc, unique_ptr<ast::Expression> expr) {
+    unique_ptr<ast::Expression> addConstantsToExpression(core::LocOffsets loc, unique_ptr<ast::Expression> expr) {
         auto consts = getMovedConstants();
 
         if (consts.empty()) {
@@ -200,13 +200,14 @@ unique_ptr<ast::Expression> runUnderEach(core::MutableContext ctx, core::NameRef
             auto blk = ast::MK::Block(send->loc, move(body), std::move(new_args));
             auto each = ast::MK::Send0Block(send->loc, iteratee->deepCopy(), core::Names::each(), move(blk));
             // put that into a method def named the appropriate thing
-            auto method = addSigVoid(ast::MK::SyntheticMethod0(send->loc, send->loc, move(name), move(each)));
+            auto method = addSigVoid(
+                ast::MK::SyntheticMethod0(send->loc, core::Loc(ctx.file, send->loc), move(name), move(each)));
             // add back any moved constants
             return constantMover.addConstantsToExpression(send->loc, move(method));
         }
     }
     // if any of the above tests were not satisfied, then mark this statement as being invalid here
-    if (auto e = ctx.state.beginError(stmt->loc, core::errors::Rewriter::BadTestEach)) {
+    if (auto e = ctx.beginError(stmt->loc, core::errors::Rewriter::BadTestEach)) {
         e.setHeader("Only valid `{}`-blocks can appear within `{}`", "it", eachName.show(ctx));
     }
 
@@ -244,7 +245,7 @@ unique_ptr<ast::Expression> runSingle(core::MutableContext ctx, ast::Send *send)
         send->block != nullptr) {
         if ((send->fun == core::Names::testEach() && send->block->args.size() != 1) ||
             (send->fun == core::Names::testEachHash() && send->block->args.size() != 2)) {
-            if (auto e = ctx.state.beginError(send->block->loc, core::errors::Rewriter::BadTestEach)) {
+            if (auto e = ctx.beginError(send->block->loc, core::errors::Rewriter::BadTestEach)) {
                 e.setHeader("Wrong number of parameters for `{}` block: expected `{}`, got `{}`", send->fun.show(ctx),
                             1, send->block->args.size());
             }
@@ -267,8 +268,8 @@ unique_ptr<ast::Expression> runSingle(core::MutableContext ctx, ast::Send *send)
         auto name = send->fun == core::Names::after() ? core::Names::afterAngles() : core::Names::initialize();
         ConstantMover constantMover;
         send->block->body = ast::TreeMap::apply(ctx, constantMover, move(send->block->body));
-        auto method = addSigVoid(
-            ast::MK::SyntheticMethod0(send->loc, send->loc, name, prepareBody(ctx, std::move(send->block->body))));
+        auto method = addSigVoid(ast::MK::SyntheticMethod0(send->loc, core::Loc(ctx.file, send->loc), name,
+                                                           prepareBody(ctx, std::move(send->block->body))));
         return constantMover.addConstantsToExpression(send->loc, move(method));
     }
 
@@ -285,12 +286,13 @@ unique_ptr<ast::Expression> runSingle(core::MutableContext ctx, ast::Send *send)
         rhs.emplace_back(prepareBody(ctx, std::move(send->block->body)));
         auto name = ast::MK::UnresolvedConstant(arg->loc, ast::MK::EmptyTree(),
                                                 ctx.state.enterNameConstant("<describe '" + argString + "'>"));
-        return ast::MK::Class(send->loc, send->loc, std::move(name), std::move(ancestors), std::move(rhs));
+        return ast::MK::Class(send->loc, core::Loc(ctx.file, send->loc), std::move(name), std::move(ancestors),
+                              std::move(rhs));
     } else if (send->fun == core::Names::it()) {
         ConstantMover constantMover;
         send->block->body = ast::TreeMap::apply(ctx, constantMover, move(send->block->body));
         auto name = ctx.state.enterNameUTF8("<it '" + argString + "'>");
-        auto method = addSigVoid(ast::MK::SyntheticMethod0(send->loc, send->loc, std::move(name),
+        auto method = addSigVoid(ast::MK::SyntheticMethod0(send->loc, core::Loc(ctx.file, send->loc), std::move(name),
                                                            prepareBody(ctx, std::move(send->block->body))));
         method = ast::MK::InsSeq1(send->loc, send->args.front()->deepCopy(), move(method));
         return constantMover.addConstantsToExpression(send->loc, move(method));

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -123,7 +123,7 @@ vector<unique_ptr<ast::Expression>> ModuleFunction::run(core::MutableContext ctx
                 if (validAttr) {
                     methodName = nameRef;
                 } else {
-                    if (auto e = ctx.state.beginError(lit->loc, core::errors::Rewriter::BadModuleFunction)) {
+                    if (auto e = ctx.beginError(lit->loc, core::errors::Rewriter::BadModuleFunction)) {
                         e.setHeader("Bad attribute name \"{}\"", absl::CEscape(shortName));
                     }
                 }
@@ -133,11 +133,12 @@ vector<unique_ptr<ast::Expression>> ModuleFunction::run(core::MutableContext ctx
             ast::MethodDef::ARGS_store args;
             args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
             args.emplace_back(std::make_unique<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
-            auto methodDef = ast::MK::SyntheticMethod(loc, loc, methodName, std::move(args), ast::MK::EmptyTree());
+            auto methodDef = ast::MK::SyntheticMethod(loc, core::Loc(ctx.file, loc), methodName, std::move(args),
+                                                      ast::MK::EmptyTree());
             methodDef->flags.isSelfMethod = true;
             stats.emplace_back(std::move(methodDef));
         } else {
-            if (auto e = ctx.state.beginError(arg->loc, core::errors::Rewriter::BadModuleFunction)) {
+            if (auto e = ctx.beginError(arg->loc, core::errors::Rewriter::BadModuleFunction)) {
                 e.setHeader("Bad argument to `{}`: must be a symbol, string, method definition, or nothing",
                             "module_function");
             }

--- a/rewriter/Private.cc
+++ b/rewriter/Private.cc
@@ -24,17 +24,17 @@ vector<unique_ptr<ast::Expression>> Private::run(core::MutableContext ctx, ast::
     }
 
     if (send->fun == core::Names::private_() && mdef->flags.isSelfMethod) {
-        if (auto e = ctx.state.beginError(send->loc, core::errors::Rewriter::PrivateMethodMismatch)) {
+        if (auto e = ctx.beginError(send->loc, core::errors::Rewriter::PrivateMethodMismatch)) {
             e.setHeader("Use `{}` to define private class methods", "private_class_method");
             auto beginPos = send->loc.beginPos();
-            auto replacementLoc = core::Loc{send->loc.file(), beginPos, beginPos + 7};
+            auto replacementLoc = core::Loc{ctx.file, beginPos, beginPos + 7};
             e.replaceWith("Replace with `private_class_method`", replacementLoc, "private_class_method");
         }
     } else if (send->fun == core::Names::privateClassMethod() && !mdef->flags.isSelfMethod) {
-        if (auto e = ctx.state.beginError(send->loc, core::errors::Rewriter::PrivateMethodMismatch)) {
+        if (auto e = ctx.beginError(send->loc, core::errors::Rewriter::PrivateMethodMismatch)) {
             e.setHeader("Use `{}` to define private instance methods", "private");
             auto beginPos = send->loc.beginPos();
-            auto replacementLoc = core::Loc{send->loc.file(), beginPos, beginPos + 20};
+            auto replacementLoc = core::Loc{ctx.file, beginPos, beginPos + 20};
             e.replaceWith("Replace with `private`", replacementLoc, "private");
         }
     }

--- a/rewriter/ProtobufDescriptorPool.cc
+++ b/rewriter/ProtobufDescriptorPool.cc
@@ -55,12 +55,13 @@ vector<unique_ptr<ast::Expression>> ProtobufDescriptorPool::run(core::MutableCon
     if (sendMsgclass->fun == core::Names::msgclass()) {
         auto arg0 = ast::MK::Local(asgn->loc, core::Names::arg0());
         auto arg = ast::MK::OptionalArg(asgn->loc, std::move(arg0), ast::MK::Hash0(asgn->loc));
-        rhs.emplace_back(ast::MK::SyntheticMethod1(asgn->loc, asgn->loc, core::Names::initialize(), std::move(arg),
-                                                   ast::MK::EmptyTree()));
+        rhs.emplace_back(ast::MK::SyntheticMethod1(asgn->loc, core::Loc(ctx.file, asgn->loc), core::Names::initialize(),
+                                                   std::move(arg), ast::MK::EmptyTree()));
     }
 
     vector<unique_ptr<ast::Expression>> res;
-    res.emplace_back(ast::MK::ClassOrModule(asgn->loc, asgn->loc, asgn->lhs->deepCopy(), {}, std::move(rhs), kind));
+    res.emplace_back(ast::MK::ClassOrModule(asgn->loc, core::Loc(ctx.file, asgn->loc), asgn->lhs->deepCopy(), {},
+                                            std::move(rhs), kind));
     return res;
 }
 

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -73,7 +73,7 @@ vector<unique_ptr<ast::Expression>> Struct::run(core::MutableContext ctx, ast::A
         return empty;
     }
 
-    core::Loc loc = asgn->loc;
+    auto loc = asgn->loc;
 
     ast::MethodDef::ARGS_store newArgs;
     ast::Hash::ENTRY_store sigKeys;
@@ -104,8 +104,8 @@ vector<unique_ptr<ast::Expression>> Struct::run(core::MutableContext ctx, ast::A
         }
         core::NameRef name = sym->asSymbol(ctx);
         auto symLoc = sym->loc;
-        if (symLoc.exists() && absl::StartsWith(symLoc.source(ctx), ":")) {
-            symLoc = core::Loc{symLoc.file(), symLoc.beginPos() + 1, symLoc.endPos()};
+        if (symLoc.exists() && absl::StartsWith(core::Loc(ctx.file, symLoc).source(ctx), ":")) {
+            symLoc = core::LocOffsets{symLoc.beginPos() + 1, symLoc.endPos()};
         }
 
         sigKeys.emplace_back(ast::MK::Symbol(symLoc, name));
@@ -116,9 +116,9 @@ vector<unique_ptr<ast::Expression>> Struct::run(core::MutableContext ctx, ast::A
         }
         newArgs.emplace_back(ast::MK::OptionalArg(symLoc, move(argName), ast::MK::Nil(symLoc)));
 
-        body.emplace_back(ast::MK::SyntheticMethod0(symLoc, symLoc, name, ast::MK::EmptyTree()));
-        body.emplace_back(ast::MK::SyntheticMethod1(symLoc, symLoc, name.addEq(ctx), ast::MK::Local(symLoc, name),
-                                                    ast::MK::Local(symLoc, name)));
+        body.emplace_back(ast::MK::SyntheticMethod0(symLoc, core::Loc(ctx.file, symLoc), name, ast::MK::EmptyTree()));
+        body.emplace_back(ast::MK::SyntheticMethod1(symLoc, core::Loc(ctx.file, symLoc), name.addEq(ctx),
+                                                    ast::MK::Local(symLoc, name), ast::MK::Local(symLoc, name)));
     }
 
     // Elem = type_member(fixed: T.untyped)
@@ -142,15 +142,16 @@ vector<unique_ptr<ast::Expression>> Struct::run(core::MutableContext ctx, ast::A
     }
 
     body.emplace_back(ast::MK::SigVoid(loc, ast::MK::Hash(loc, std::move(sigKeys), std::move(sigValues))));
-    body.emplace_back(ast::MK::SyntheticMethod(loc, loc, core::Names::initialize(), std::move(newArgs),
-                                               ast::MK::Cast(loc, dupName(asgn->lhs.get()))));
+    body.emplace_back(ast::MK::SyntheticMethod(loc, core::Loc(ctx.file, loc), core::Names::initialize(),
+                                               std::move(newArgs), ast::MK::Cast(loc, dupName(asgn->lhs.get()))));
 
     ast::ClassDef::ANCESTORS_store ancestors;
     ancestors.emplace_back(ast::MK::UnresolvedConstant(loc, ast::MK::Constant(loc, core::Symbols::root()),
                                                        core::Names::Constants::Struct()));
 
     vector<unique_ptr<ast::Expression>> stats;
-    stats.emplace_back(ast::MK::Class(loc, loc, std::move(asgn->lhs), std::move(ancestors), std::move(body)));
+    stats.emplace_back(
+        ast::MK::Class(loc, core::Loc(ctx.file, loc), std::move(asgn->lhs), std::move(ancestors), std::move(body)));
     return stats;
 }
 

--- a/rewriter/TypeMembers.cc
+++ b/rewriter/TypeMembers.cc
@@ -30,7 +30,7 @@ void TypeMembers::run(core::MutableContext ctx, ast::ClassDef *cdef) {
         }
 
         if (typeMembers.contains(lhs->cnst)) {
-            if (auto e = ctx.state.beginError(lhs->loc, core::errors::Namer::InvalidTypeDefinition)) {
+            if (auto e = ctx.beginError(lhs->loc, core::errors::Namer::InvalidTypeDefinition)) {
                 e.setHeader("Duplicate type member `{}`", lhs->cnst.data(ctx)->show(ctx));
             }
             auto empty = ast::MK::EmptyTree();

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -179,19 +179,20 @@ const ast::Send *ASTUtil::castSig(const ast::Expression *expr, core::NameRef ret
 }
 
 unique_ptr<ast::Expression> ASTUtil::mkGet(core::Loc loc, core::NameRef name, unique_ptr<ast::Expression> rhs) {
-    return ast::MK::SyntheticMethod0(loc, loc, name, move(rhs));
+    return ast::MK::SyntheticMethod0(loc.offsets(), loc, name, move(rhs));
 }
 
-unique_ptr<ast::Expression> ASTUtil::mkSet(core::Loc loc, core::NameRef name, core::Loc argLoc,
+unique_ptr<ast::Expression> ASTUtil::mkSet(core::Loc loc, core::NameRef name, core::LocOffsets argLoc,
                                            unique_ptr<ast::Expression> rhs) {
-    return ast::MK::SyntheticMethod1(loc, loc, name, ast::MK::Local(argLoc, core::Names::arg0()), move(rhs));
+    return ast::MK::SyntheticMethod1(loc.offsets(), loc, name, ast::MK::Local(argLoc, core::Names::arg0()), move(rhs));
 }
 
-unique_ptr<ast::Expression> ASTUtil::mkNilable(core::Loc loc, unique_ptr<ast::Expression> type) {
+unique_ptr<ast::Expression> ASTUtil::mkNilable(core::LocOffsets loc, unique_ptr<ast::Expression> type) {
     return ast::MK::Send1(loc, ast::MK::T(loc), core::Names::nilable(), move(type));
 }
 
-unique_ptr<ast::Expression> ASTUtil::mkMutator(core::MutableContext ctx, core::Loc loc, core::NameRef className) {
+unique_ptr<ast::Expression> ASTUtil::mkMutator(core::MutableContext ctx, core::LocOffsets loc,
+                                               core::NameRef className) {
     auto chalk = ast::MK::UnresolvedConstant(loc, ast::MK::Constant(loc, core::Symbols::root()),
                                              core::Names::Constants::Chalk());
     auto odm = ast::MK::UnresolvedConstant(loc, move(chalk), core::Names::Constants::ODM());

--- a/rewriter/Util.h
+++ b/rewriter/Util.h
@@ -23,12 +23,13 @@ public:
     static std::unique_ptr<ast::Expression> mkGet(core::Loc loc, core::NameRef name,
                                                   std::unique_ptr<ast::Expression> rhs);
 
-    static std::unique_ptr<ast::Expression> mkSet(core::Loc loc, core::NameRef name, core::Loc argLoc,
+    static std::unique_ptr<ast::Expression> mkSet(core::Loc loc, core::NameRef name, core::LocOffsets argLoc,
                                                   std::unique_ptr<ast::Expression> rhs);
 
-    static std::unique_ptr<ast::Expression> mkNilable(core::Loc loc, std::unique_ptr<ast::Expression> type);
+    static std::unique_ptr<ast::Expression> mkNilable(core::LocOffsets loc, std::unique_ptr<ast::Expression> type);
 
-    static std::unique_ptr<ast::Expression> mkMutator(core::MutableContext ctx, core::Loc loc, core::NameRef className);
+    static std::unique_ptr<ast::Expression> mkMutator(core::MutableContext ctx, core::LocOffsets loc,
+                                                      core::NameRef className);
 
     static std::unique_ptr<ast::Expression> thunkBody(core::MutableContext ctx, ast::Expression *node);
 

--- a/test/error-check-test.cc
+++ b/test/error-check-test.cc
@@ -33,10 +33,12 @@ TEST(ErrorTest, ParserCheck) { // NOLINT
     sorbet::core::UnfreezeNameTable nt(gs);
     sorbet::core::UnfreezeSymbolTable st(gs);
     sorbet::core::UnfreezeFileTable ft(gs);
-    sorbet::core::MutableContext ctx(gs, core::Symbols::root());
-    auto ast = sorbet::parser::Parser::run(gs, "<test input>", "a");
+
+    core::FileRef fileId = gs.enterFile("<test input>", "a");
+    auto ast = sorbet::parser::Parser::run(gs, fileId);
 
     try {
+        sorbet::core::MutableContext ctx(gs, core::Symbols::root(), fileId);
         auto desugared = sorbet::ast::desugar::node2Tree(ctx, move(ast));
     } catch (SorbetException &) {
     }

--- a/test/hello-test.cc
+++ b/test/hello-test.cc
@@ -133,41 +133,42 @@ TEST(PreOrderTreeMap, CountTrees) { // NOLINT
 
     sorbet::core::GlobalState cb(errorQueue);
     cb.initEmpty();
-    sorbet::core::MutableContext ctx(cb, core::Symbols::root());
     static constexpr string_view foo_str = "Foo"sv;
     sorbet::core::Loc loc(sorbet::core::FileRef(), 42, 91);
-    sorbet::core::UnfreezeNameTable nt(ctx);
-    sorbet::core::UnfreezeSymbolTable st(ctx);
+    sorbet::core::UnfreezeNameTable nt(cb);
+    sorbet::core::UnfreezeSymbolTable st(cb);
 
-    auto name = ctx.state.enterNameUTF8(foo_str);
-    auto classSym = ctx.state.enterClassSymbol(loc, sorbet::core::Symbols::root(), ctx.state.enterNameConstant(name));
-
-    // see if it crashes via failed ENFORCE
-    ctx.state.enterTypeMember(loc, classSym, ctx.state.enterNameConstant(name), sorbet::core::Variance::CoVariant);
-    auto methodSym = ctx.state.enterMethodSymbol(loc, classSym, name);
+    auto name = cb.enterNameUTF8(foo_str);
+    auto classSym = cb.enterClassSymbol(loc, sorbet::core::Symbols::root(), cb.enterNameConstant(name));
 
     // see if it crashes via failed ENFORCE
-    ctx.state.enterTypeArgument(loc, methodSym, ctx.state.enterNameConstant(name), sorbet::core::Variance::CoVariant);
+    cb.enterTypeMember(loc, classSym, cb.enterNameConstant(name), sorbet::core::Variance::CoVariant);
+    auto methodSym = cb.enterMethodSymbol(loc, classSym, name);
+
+    // see if it crashes via failed ENFORCE
+    cb.enterTypeArgument(loc, methodSym, cb.enterNameConstant(name), sorbet::core::Variance::CoVariant);
 
     auto empty = vector<core::SymbolRef>();
     auto argumentSym = core::LocalVariable(name, 0);
-    unique_ptr<ast::Expression> rhs(ast::MK::Int(loc, 5));
-    unique_ptr<ast::Expression> arg = make_unique<ast::Local>(loc, argumentSym);
+    unique_ptr<ast::Expression> rhs(ast::MK::Int(loc.offsets(), 5));
+    unique_ptr<ast::Expression> arg = make_unique<ast::Local>(loc.offsets(), argumentSym);
     ast::MethodDef::ARGS_store args;
     args.emplace_back(std::move(arg));
 
     ast::MethodDef::Flags flags;
     unique_ptr<ast::Expression> methodDef =
-        make_unique<ast::MethodDef>(loc, loc, methodSym, name, std::move(args), std::move(rhs), flags);
+        make_unique<ast::MethodDef>(loc.offsets(), loc, methodSym, name, std::move(args), std::move(rhs), flags);
     unique_ptr<ast::Expression> emptyTree = ast::MK::EmptyTree();
-    unique_ptr<ast::Expression> cnst = make_unique<ast::UnresolvedConstantLit>(loc, std::move(emptyTree), name);
+    unique_ptr<ast::Expression> cnst =
+        make_unique<ast::UnresolvedConstantLit>(loc.offsets(), std::move(emptyTree), name);
 
     ast::ClassDef::RHS_store classrhs;
     classrhs.emplace_back(std::move(methodDef));
     unique_ptr<ast::Expression> tree =
-        make_unique<ast::ClassDef>(loc, loc, classSym, std::move(cnst), ast::ClassDef::ANCESTORS_store(),
+        make_unique<ast::ClassDef>(loc.offsets(), loc, classSym, std::move(cnst), ast::ClassDef::ANCESTORS_store(),
                                    std::move(classrhs), ast::ClassDef::Kind::Class);
     Counter c;
+    sorbet::core::MutableContext ctx(cb, core::Symbols::root(), loc.file());
 
     auto r = ast::TreeMap::apply(ctx, c, std::move(tree));
     EXPECT_EQ(c.count, 3);


### PR DESCRIPTION
### Motivation
We want to allow more bits in FileRefs and this means that Loc's will no longer fit in 64 bits. This has substantial performance impact so, we're moving most code _away_ from storing locs to only store LocOffsets

### Test plan

See included automated tests.
