### PR TITLE
Fix method parameter serialization for delegation in Ruby 2.7

### DIFF
--- a/gems/sorbet/lib/serialize.rb
+++ b/gems/sorbet/lib/serialize.rb
@@ -328,6 +328,8 @@ class Sorbet::Private::Serialize
   def from_method(method)
     uniq = 0
     method.parameters.map.with_index do |(kind, name), index|
+      name = :args if kind == :rest && name == :*
+      name = :blk if kind == :block && name == :&
       if !name
         arg_name = method.name.to_s[0...-1]
         if (!KEYWORDS.include?(arg_name.to_sym)) && method.name.to_s.end_with?('=') && arg_name =~ /\A[a-z_][a-z0-9A-Z_]*\Z/ && index == 0


### PR DESCRIPTION
Technically, this should probably generate the method signature as `foo(...)`, but Sorbet doesn't know how to parse that properly. Instead, it replaces it with `foo(*args, &blk)`.

This is mostly just a workaround to make the `hidden.rbi` generator work. I'm not 100% sure what happens if you actually use a method with these type signatures.

### Motivation

I wanted to fix #2771 since it prevents me from using Sorbet on Ruby 2.7.

This was a problem because `hidden.rbi` would fail on a method like `def foo(...)`. Ruby's `Method#parameters` method returns `[[:rest, :*], [:block, :&]]` which Sorbet previously interpreted as `foo(**, &&)`. This code turns that into `foo(*args, &blk)`.

A better fix for this would be to make Sorbet understand how to handle `...`, then detect methods that have parameters like `[[:rest, :*], [:block, :&]]` and set the method to use `...`.

### Test plan

See included automated tests. The tests aren't currently run on Ruby 2.7 so I'm not sure how to write a test for this functionality.

You can test this by following the reproduction instructions in #2771 and seeing that it no longer crashes if you use this patch.