### PR TITLE
Add methods on Benchmark::Report and Benchmark::Job.

### DIFF
--- a/rbi/stdlib/benchmark.rbi
+++ b/rbi/stdlib/benchmark.rbi
@@ -323,10 +323,66 @@ module Benchmark
   def self.realtime(&blk); end
 end
 
-class Benchmark::Job < Object
+class Benchmark::Job
+  # Registers the given label and block pair in the job list.
+  sig do
+    params(
+        label: String,
+        blk: T.proc.void
+    )
+    .returns(T.self_type)
+  end
+  def item(label=T.unsafe(nil), &blk); end
+
+  # An array of 2-element arrays, consisting of label and block pairs.
+  sig {returns(T::Array[T.untyped])}
+  def list; end
+
+  # Registers the given label and block pair in the job list.
+  sig do
+    params(
+        label: String,
+        blk: T.proc.void
+    )
+    .returns(T.self_type)
+  end
+  def report(label=T.unsafe(nil), &blk); end
+
+  # Length of the widest label in the #list.
+  sig {returns(Integer)}
+  def width; end
 end
 
-class Benchmark::Report < Object
+class Benchmark::Report
+  # Prints the `label` and measured time for the block,
+  # formatted by `format`. See Tms#format for the
+  # formatting rules.
+  sig do
+    params(
+        label: String,
+        format: T.untyped,
+        blk: T.proc.void
+    )
+    .returns(T.self_type)
+  end
+  def item(label=T.unsafe(nil), *format, &blk); end
+
+  # An array of Benchmark::Tms objects representing each item.
+  sig {returns(T::Array[Benchmark::Tms])}
+  def list; end
+
+  # Prints the `label` and measured time for the block,
+  # formatted by `format`. See Tms#format for the
+  # formatting rules.
+  sig do
+    params(
+        label: String,
+        format: T.untyped,
+        blk: T.proc.void
+    )
+    .returns(T.self_type)
+  end
+  def report(label=T.unsafe(nil), *format, &blk); end
 end
 
 # A data object, representing the times associated with a benchmark measurement.


### PR DESCRIPTION
### Motivation

These methods were missing, which made it hard to use the benchmarker with Sorbet enabled.

The methods and docs are based on [`benchmark.rb`](https://github.com/ruby/ruby/blob/v2_7_0/lib/benchmark.rb).

I wanted to make this code typecheck-able:

```ruby
# typed: true

require 'benchmark'

array = (1..1000000).map { rand }

Benchmark.bmbm do |x|
  x.report("sort!") { array.dup.sort! }
  x.report("sort")  { array.dup.sort  }
end

n = 5

Benchmark.bm(7) do |x|
  x.report("for:")   { for i in 1..n; a = "1"; end }
  x.report("times:") { n.times do   ; a = "1"; end }
  x.report("upto:")  { 1.upto(n) do ; a = "1"; end }
end
```

As you can see on [sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0A%0Arequire%20'benchmark'%0A%0Aarray%20%3D%20(1..1000000).map%20%7B%20rand%20%7D%0A%0ABenchmark.bmbm%20do%20%7Cx%7C%0A%20%20x.report(%22sort!%22)%20%7B%20array.dup.sort!%20%7D%0A%20%20x.report(%22sort%22)%20%20%7B%20array.dup.sort%20%20%7D%0Aend%0A%0An%20%3D%205%0A%0ABenchmark.bm(7)%20do%20%7Cx%7C%0A%20%20x.report(%22for%3A%22)%20%20%20%7B%20for%20i%20in%201..n%3B%20a%20%3D%20%221%22%3B%20end%20%7D%0A%20%20x.report(%22times%3A%22)%20%7B%20n.times%20do%20%20%20%3B%20a%20%3D%20%221%22%3B%20end%20%7D%0A%20%20x.report(%22upto%3A%22)%20%20%7B%201.upto(n)%20do%20%3B%20a%20%3D%20%221%22%3B%20end%20%7D%0Aend%0A), it currently errors because the methods for Benchmark::Job and Benchmark::Report weren't included in the gem. With this change, it works fine.

### Test plan
I'm not sure if I should add tests for the Benchmark classes somewhere? There aren't any right now.