### PR TITLE
Surround ternary with parens to ensure correct operator precedence

### DIFF
--- a/gems/sorbet/lib/hidden-definition-finder.rb
+++ b/gems/sorbet/lib/hidden-definition-finder.rb
@@ -329,9 +329,9 @@ class Sorbet::Private::HiddenMethodFinder
       end
       next if Sorbet::Private::RealStdlib.real_is_a?(my_value, Class) || Sorbet::Private::RealStdlib.real_is_a?(my_value, Module)
       if defined?(T::Types) && Sorbet::Private::RealStdlib.real_is_a?(my_value, T::Types::TypeMember)
-        ret << my_value.variance == :invariant ? "  #{name} = type_member" : "  #{name} = type_member(#{my_value.variance.inspect})"
+        ret << (my_value.variance == :invariant ? "  #{name} = type_member" : "  #{name} = type_member(#{my_value.variance.inspect})")
       elsif defined?(T::Types) && Sorbet::Private::RealStdlib.real_is_a?(my_value, T::Types::TypeTemplate)
-        ret << my_value.variance == :invariant ? "  #{name} = type_template" : "  #{name} = type_template(#{my_value.variance.inspect})"
+        ret << (my_value.variance == :invariant ? "  #{name} = type_template" : "  #{name} = type_template(#{my_value.variance.inspect})")
       else
         ret << "  #{name} = ::T.let(nil, ::T.untyped)"
       end


### PR DESCRIPTION
Without the parentheses, `my_value.variance` was being appended to `ret` instead
of the entire conditional.

### Motivation

Fixes #2693, which caused `srb rbi` to fail for gems with a bundled .rbi that contained type members (namely, `sorbet-rails` - see related issue https://github.com/chanzuckerberg/sorbet-rails/issues/275 ).

### Test plan

No tests written. I would appreciate guidance as to how to test this - I'm new to this code base and I'm applying a very tactical "fix" to a large piece of code that I do not pretend to understand.
