### PR TITLE
Improve error messages coming from generated serde code

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -223,7 +223,7 @@ module T::Props::Serializable::DecoratorMethods
     next_blank = line_num + (source_lines[line_num..-1].find_index(&:empty?) || 0)
     context = "  " + source_lines[(previous_blank + 1)...(next_blank)].join("\n  ")
     <<~MSG
-      Error in #{generated_method}: #{error.message}
+      Error in #{decorated_class.name}##{generated_method}: #{error.message}
       at line #{line_num-previous_blank-1} in:
       #{context}
     MSG

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -16,7 +16,23 @@ module T::Props::Serializable
   #   values.
   # @return [Hash] A serialization of this object.
   def serialize(strict=true)
-    h = __t_props_generated_serialize(strict)
+    begin
+      h = __t_props_generated_serialize(strict)
+    rescue T::Props::InvalidValueError
+      raise
+    rescue => e
+      msg = self.class.decorator.message_with_generated_source_context(
+        e,
+        :__t_props_generated_serialize,
+        :generate_serialize_source
+      )
+      if msg
+        raise msg
+      else
+        raise
+      end
+    end
+
     h.merge!(@_extra_props) if @_extra_props
     h
   end
@@ -39,7 +55,21 @@ module T::Props::Serializable
   #  props on this instance.
   # @return [void]
   def deserialize(hash, strict=false)
-    hash_keys_matching_props = __t_props_generated_deserialize(hash)
+    begin
+      hash_keys_matching_props = __t_props_generated_deserialize(hash)
+    rescue => e
+      msg = self.class.decorator.message_with_generated_source_context(
+        e,
+        :__t_props_generated_deserialize,
+        :generate_deserialize_source
+      )
+      if msg
+        raise msg
+      else
+        raise
+      end
+    end
+
     if hash.size > hash_keys_matching_props
       serialized_forms = self.class.decorator.prop_by_serialized_forms
       extra = hash.reject {|k, _| serialized_forms.key?(k)}
@@ -179,6 +209,24 @@ module T::Props::Serializable::DecoratorMethods
       props,
       props_with_defaults || {},
     )
+  end
+
+  def message_with_generated_source_context(error, generated_method, generate_source_method)
+    line_label = error.backtrace.find {|l| l.end_with?("in `#{generated_method}'")}
+    return unless line_label
+
+    line_num = line_label.split(':')[1]&.to_i
+    return unless line_num
+
+    source_lines = self.send(generate_source_method).split("\n")
+    previous_blank = source_lines[0...line_num].rindex(&:empty?) || 0
+    next_blank = line_num + (source_lines[line_num..-1].find_index(&:empty?) || 0)
+    context = "  " + source_lines[(previous_blank + 1)...(next_blank)].join("\n  ")
+    <<~MSG
+      Error in #{generated_method}: #{error.message}
+      at line #{line_num-previous_blank-1} in:
+      #{context}
+    MSG
   end
 
   def raise_nil_deserialize_error(hkey)

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -134,6 +134,29 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     end
   end
 
+  describe 'error message' do
+    it 'includes relevant generated code on deserialize' do
+      e = assert_raises(RuntimeError) do
+        MySerializable.from_hash({'foo' => "Won't respond like hash"})
+      end
+
+      assert_includes(e.message, "undefined method `each_with_object'")
+      assert_includes(e.message, "foo")
+      assert_includes(e.message, "val.each_with_object({}) {|(k,v),h| h[T::Props::Utils.deep_clone_object(k)] = T::Props::Utils.deep_clone_object(v)}")
+    end
+
+    it 'includes relevant generated code on serialize' do
+      m = a_serializable
+      m.instance_variable_set(:@foo, "Won't respond like hash")
+      e = assert_raises(RuntimeError) do
+        m.serialize
+      end
+
+      assert_includes(e.message, "undefined method `each_with_object'")
+      assert_includes(e.message, 'h["foo"] = @foo.each_with_object({}) {|(k,v),h| h[T::Props::Utils.deep_clone_object(k)] = T::Props::Utils.deep_clone_object(v)}')
+    end
+  end
+
   class HasUnstoredProp < T::Struct
     prop :stored, String
     prop :not_stored, String, dont_store: true


### PR DESCRIPTION
### Motivation
Occasionally bad data can show up as a RuntimeError in serde, and the autogenerated backtrace doesn't make it easy to figure out which prop is at fault

### Test plan
See included automated tests.
