### PR TITLE
Make //version not depend on anything.

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -33,8 +33,8 @@ cc_library(
     }),
     visibility = ["//visibility:public"],
     deps = [
-        "//version",
         "//third_party/progressbar",
+        "//version",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",

--- a/common/BUILD
+++ b/common/BUILD
@@ -33,6 +33,7 @@ cc_library(
     }),
     visibility = ["//visibility:public"],
     deps = [
+        "//version",
         "//third_party/progressbar",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/common/common.h
+++ b/common/common.h
@@ -12,6 +12,7 @@ static_assert(false, "Need c++14 to compile this codebase");
 #include "absl/container/flat_hash_set.h"
 #include "absl/container/inlined_vector.h"
 #include "spdlog/spdlog.h"
+#include "version/version.h"
 #include <stdint.h>
 #include <string>
 #include <string_view>
@@ -31,11 +32,9 @@ template <class E> using UnorderedSet = absl::flat_hash_set<E>;
 // Uncomment to make vectors debuggable
 // template <class T, size_t N> using InlinedVector = std::vector<T>;
 
-#if defined(NDEBUG) && !defined(FORCE_DEBUG)
+#ifdef DEBUG_MODE
 constexpr bool debug_mode = false;
-#undef DEBUG_MODE
 #else
-#define DEBUG_MODE
 constexpr bool debug_mode = true;
 #endif
 

--- a/common/statsd/statsd.cc
+++ b/common/statsd/statsd.cc
@@ -123,9 +123,8 @@ void StatsD::addStandardMetrics() {
         prodCounterAdd("run.utilization.context_switch.voluntary", usage.ru_nvcsw);
         prodCounterAdd("run.utilization.context_switch.involuntary", usage.ru_nivcsw);
     }
-    prodCounterAdd("release.build_scm_commit_count", Version::build_scm_commit_count);
-    prodCounterAdd("release.build_timestamp",
-                   chrono::duration_cast<std::chrono::seconds>(Version::build_timestamp.time_since_epoch()).count());
+    prodCounterAdd("release.build_scm_commit_count", sorbet_build_scm_commit_count);
+    prodCounterAdd("release.build_timestamp", sorbet_build_timestamp);
 }
 
 } // namespace sorbet

--- a/common/web_tracer_framework/tracing.cc
+++ b/common/web_tracer_framework/tracing.cc
@@ -24,7 +24,7 @@ bool Tracing::storeTraces(const CounterState &counters, string_view fileName) {
     auto pid = getpid();
     fmt::format_to(result,
                    "{{\"name\":\"process_name\",\"ph\":\"M\",\"pid\":{},\"args\":{{\"name\":\"Sorbet v{}\"}}}},\n", pid,
-                   Version::full_version_string);
+                   sorbet_full_version_string);
     counters.counters->canonicalize();
 
     for (auto &cat : counters.counters->countersByCategory) {

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -30,7 +30,7 @@ void setRequiredLSPOptions(core::GlobalState &gs, options::Options &options) {
 
 unique_ptr<KeyValueStore> getCache(const options::Options &options) {
     if (!options.cacheDir.empty()) {
-        return make_unique<KeyValueStore>(Version::full_version_string, options.cacheDir,
+        return make_unique<KeyValueStore>(sorbet_full_version_string, options.cacheDir,
                                           options.skipRewriterPasses ? "nodsl" : "default");
     }
     return nullptr;

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -761,7 +761,7 @@ void readOptions(Options &opts,
             throw EarlyReturnWithCode(0);
         }
         if (raw["version"].as<bool>()) {
-            fmt::print("Sorbet typechecker {}\n", Version::full_version_string);
+            fmt::print("Sorbet typechecker {}\n", sorbet_full_version_string);
             throw EarlyReturnWithCode(0);
         }
         if (raw["license"].as<bool>()) {

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -374,9 +374,8 @@ int realmain(int argc, char *argv[]) {
         for (int i = 1; i < argc; i++) {
             absl::StrAppend(&argsConcat, " ", argv[i]);
         }
-        logger->debug("Running sorbet version {} with arguments: {}", Version::full_version_string, argsConcat);
-        if (!Version::isReleaseBuild && !opts.silenceDevMessage &&
-            std::getenv("SORBET_SILENCE_DEV_MESSAGE") == nullptr) {
+        logger->debug("Running sorbet version {} with arguments: {}", sorbet_full_version_string, argsConcat);
+        if (!sorbet_isReleaseBuild && !opts.silenceDevMessage && std::getenv("SORBET_SILENCE_DEV_MESSAGE") == nullptr) {
             logger->info("👋 Hey there! Heads up that this is not a release build of sorbet.\n"
                          "Release builds are faster and more well-supported by the Sorbet team.\n"
                          "Check out the README to learn how to build Sorbet in release mode.\n"
@@ -396,7 +395,7 @@ int realmain(int argc, char *argv[]) {
     logger->trace("building initial global state");
     unique_ptr<OwnedKeyValueStore> kvstore;
     if (!opts.cacheDir.empty()) {
-        auto unownedKvstore = make_unique<KeyValueStore>(Version::full_version_string, opts.cacheDir,
+        auto unownedKvstore = make_unique<KeyValueStore>(sorbet_full_version_string, opts.cacheDir,
                                                          opts.skipRewriterPasses ? "nodsl" : "default");
         kvstore = make_unique<OwnedKeyValueStore>(move(unownedKvstore));
     }
@@ -450,7 +449,7 @@ int realmain(int argc, char *argv[]) {
                       "More details at https://microsoft.github.io/language-server-protocol/specification."
                       "If you're developing an LSP extension to some editor, make sure to run sorbet with `-v` flag,"
                       "it will enable outputing the LSP session to stderr(`Write: ` and `Read: ` log lines)",
-                      Version::full_version_string);
+                      sorbet_full_version_string);
 
         // There should not have been any writes to the kvstore, so no need to commit changes to disk.
         unique_ptr<KeyValueStore> unownedKvstore = OwnedKeyValueStore::abort(move(kvstore));

--- a/payload/text/tools/generate_payload.cc
+++ b/payload/text/tools/generate_payload.cc
@@ -33,8 +33,8 @@ void emit_classfile(vector<string> sourceFiles, ostream &out) {
     out << "#include<string_view>" << '\n' << "#include<vector>\nusing namespace std;\n";
     out << "namespace sorbet{" << '\n' << "namespace rbi{" << '\n';
     string version;
-    if (sorbet::Version::isReleaseBuild) {
-        version = sorbet::Version::build_scm_revision;
+    if (sorbet_isReleaseBuild) {
+        version = sorbet_build_scm_revision;
     } else {
         version = "master";
     }

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -51,7 +51,7 @@ TEST_P(ProtocolTest, LSPUsesCache) {
         lspWrapper = nullptr;
 
         auto kvstore = make_unique<OwnedKeyValueStore>(
-            make_unique<KeyValueStore>(Version::full_version_string, cacheDir, "default"));
+            make_unique<KeyValueStore>(sorbet_full_version_string, cacheDir, "default"));
         EXPECT_EQ(kvstore->read(updatedKey), nullptr);
 
         auto contents = kvstore->read(key);
@@ -104,7 +104,7 @@ TEST_P(ProtocolTest, LSPUsesCache) {
         // Release cache lock.
         lspWrapper = nullptr;
         auto kvstore = make_unique<OwnedKeyValueStore>(
-            make_unique<KeyValueStore>(Version::full_version_string, cacheDir, "default"));
+            make_unique<KeyValueStore>(sorbet_full_version_string, cacheDir, "default"));
         auto updatedFileData = kvstore->read(updatedKey);
         ASSERT_NE(updatedFileData, nullptr);
 

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -76,7 +76,6 @@ compilation_database(
         "//core:core_test",
         "//common/web_tracer_framework:tracing",
         "//common/statsd:statsd",
-        "//version:version",
         "//common/kvstore:kvstore_test",
         "//common/kvstore:kvstore",
         "//common/crypto_hashing:crypto_hashing",
@@ -97,6 +96,7 @@ compilation_database(
         "//main/pipeline/semantic_extension:interface",
         "//common/concurrency:concurrency",
         "//common:common",
+        "//version:version",
         "//third_party/progressbar:progressbar",
         # END compile_commands targets
     ],

--- a/version/BUILD
+++ b/version/BUILD
@@ -10,7 +10,7 @@ cc_library(
         "//conditions:default": 1,
     }),
     visibility = ["//visibility:public"],
-    deps = [ ],# this should have _no_ dependencies, we want it to be very light and not impose stuff
+    deps = [],  # this should have _no_ dependencies, we want it to be very light and not impose stuff
 )
 
 config_setting(

--- a/version/BUILD
+++ b/version/BUILD
@@ -10,9 +10,7 @@ cc_library(
         "//conditions:default": 1,
     }),
     visibility = ["//visibility:public"],
-    deps = [
-        "//common",
-    ],
+    deps = [ ],# this should have _no_ dependencies, we want it to be very light and not impose stuff
 )
 
 config_setting(

--- a/version/version.h
+++ b/version/version.h
@@ -1,23 +1,29 @@
 #ifndef SORBET_VERSION_H
 #define SORBET_VERSION_H
 
-#include <chrono>
-#include <string>
+// We want this header to be both a C++ and a C header, so that it can be depended on by very
+// low-level things
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if defined(NDEBUG) && !defined(FORCE_DEBUG)
+#define DEBUG_MODE
+#else
+#undef DEBUG_MODE
+#endif
 
-namespace sorbet {
-class Version {
-public:
-    static const std::string version;
-    static const std::string codename;
-    static const std::string build_scm_revision;
-    static const int build_scm_commit_count;
-    static const std::string build_scm_status;
-    static const std::chrono::system_clock::time_point build_timestamp;
-    static const std::string build_timestamp_string;
-    static const std::string full_version_string;
-    static const bool isReleaseBuild;
-    static const bool withDebugSymbols;
-};
-} // namespace sorbet
+extern const char *sorbet_version;
+extern const char *sorbet_codename;
+extern const char *sorbet_build_scm_revision;
+extern const int sorbet_build_scm_commit_count;
+extern const char *sorbet_build_scm_status;
+extern const long sorbet_build_timestamp;
+extern const char *sorbet_full_version_string;
+extern const int sorbet_isReleaseBuild;
+extern const int sorbet_isWithDebugSymbols;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // SORBET_VERSION_H


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
We plan to depend on it using non-C++ languages and want it to have a
more stable ABI



### Test plan

Existing tests