### PR TITLE
More Specifically Match JRuby Gems

### DIFF
--- a/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
@@ -216,7 +216,7 @@ module Sorbet::Private
       def gem_from_location(location)
         match =
           location&.match(/^.*\/(ruby)\/([\d.]+)\//) || # ruby stdlib
-          location&.match(/^.*\/(j?ruby)-([\d.]+)\//) || # jvm ruby stdlib
+          location&.match(/^.*\/(jruby)-([\d.]+)\//) || # jvm ruby stdlib
           location&.match(/^.*\/(site_ruby)\/([\d.]+)\//) || # rubygems
           location&.match(/^.*\/gems\/(?:(?:j?ruby-)?[\d.]+(?:@[^\/]+)?(?:\/bundler)?\/)?gems\/([^\/]+)-([^-\/]+)\//i) # gem
         if match.nil?


### PR DESCRIPTION
Fixes the issue [here](https://github.com/sorbet/sorbet/issues/2558) which I have also run into.

The regular expression added in [this PR](https://github.com/sorbet/sorbet/pull/2266) to ignore `JRuby` standard Gems was too broad and so matches `rvm` Gem paths IE `/Users/williampride/.rvm/gems/ruby-2.6.2/gems/sorbet-0.5.5449` - inadvertently undoing the fix [here](https://github.com/sorbet/sorbet/pull/1082).

Seems like the simple and ideal fix is making this regular expression more precise.

### Test plan
Made change and ran locally on my project, confirming this works. 
