### PR TITLE
Add `BigDecimal::SIGN_NaN` definition.

### DIFF
--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_4_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_4_hidden.rbi.exp
@@ -32,7 +32,6 @@ BasicObject::BasicObject = BasicObject
 
 class BigDecimal
   EXCEPTION_NaN = ::T.let(nil, ::T.untyped)
-  SIGN_NaN = ::T.let(nil, ::T.untyped)
 end
 
 class BigDecimal

--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_hidden.rbi.exp
@@ -37,7 +37,6 @@ BasicObject::BasicObject = BasicObject
 class BigDecimal
   def clone(); end
   EXCEPTION_NaN = ::T.let(nil, ::T.untyped)
-  SIGN_NaN = ::T.let(nil, ::T.untyped)
   VERSION = ::T.let(nil, ::T.untyped)
 end
 

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_4_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_4_hidden.rbi.exp
@@ -32,7 +32,6 @@ BasicObject::BasicObject = BasicObject
 
 class BigDecimal
   EXCEPTION_NaN = ::T.let(nil, ::T.untyped)
-  SIGN_NaN = ::T.let(nil, ::T.untyped)
 end
 
 class BigDecimal

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_hidden.rbi.exp
@@ -37,7 +37,6 @@ BasicObject::BasicObject = BasicObject
 class BigDecimal
   def clone(); end
   EXCEPTION_NaN = ::T.let(nil, ::T.untyped)
-  SIGN_NaN = ::T.let(nil, ::T.untyped)
   VERSION = ::T.let(nil, ::T.untyped)
 end
 

--- a/rbi/stdlib/bigdecimal.rbi
+++ b/rbi/stdlib/bigdecimal.rbi
@@ -226,6 +226,9 @@ class BigDecimal < Numeric
   # Indicates that a value is +0. See
   # [`BigDecimal.sign`](https://docs.ruby-lang.org/en/2.6.0/BigDecimal.html#method-i-sign).
   SIGN_POSITIVE_ZERO = T.let(T.unsafe(nil), Integer)
+  # Indicates that a value is Not a Number. See
+  # [`BigDecimal::SIGN_NaN`](https://docs.ruby-lang.org/en/2.6.0/BigDecimal.html#SIGN_NaN)
+  SIGN_NaN = T.let(T.unsafe(nil), Integer)
 
   ### internal method, here for completeness
   # Internal method used to provide marshalling support. See the

--- a/test/testdata/rbi/bigdecimal.rb
+++ b/test/testdata/rbi/bigdecimal.rb
@@ -7,6 +7,7 @@ BigDecimal.new(100, 2)
 BigDecimal('123')
 BigDecimal(999)
 BigDecimal('123', 4)
+BigDecimal::SIGN_NaN
 
 BigDecimal('0.5').round
 BigDecimal('0.5').round(1)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Sorbet generates an error if you use this constant.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
