### PR TITLE
Fix `prop` and `const` desugaring

### DIFF
--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -20,6 +20,7 @@ end
 module T::Props::ClassMethods
   sig {params(name: T.any(Symbol, String), cls_or_args: T.untyped, args: T::Hash[Symbol, T.untyped]).void}
   def const(name, cls_or_args, args={}, &blk); end
+  sig {params(name: T.any(Symbol, String), cls: T.untyped, rules: T.untyped).void}
   def prop(name, cls, rules = nil); end
   def decorator; end
   def decorator_class; end

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -111,7 +111,7 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
 
     if (type == nullptr) {
         if (send->args.size() == 1) {
-            type = ast::MK::Constant(send->loc, core::Symbols::Object());
+            return nullopt;
         } else {
             type = ASTUtil::dupType(send->args[1].get());
         }

--- a/test/testdata/rewriter/prop.rb
+++ b/test/testdata/rewriter/prop.rb
@@ -39,7 +39,7 @@ class AdvancedODM
     prop :t_nilable, T.nilable(String)
 
     prop :type, type: String
-    prop :object
+    prop :object  # error: Method `prop` does not exist on `T.class_of(AdvancedODM)`
     prop :array, Array
     prop :array_of, array: String
     prop :array_of_explicit, Array, array: String
@@ -91,7 +91,8 @@ def main
     T.reveal_type(AdvancedODM.new.t_nilable) # error: Revealed type: `T.nilable(String)`
 
     T.reveal_type(AdvancedODM.new.type) # error: Revealed type: `String`
-    T.reveal_type(AdvancedODM.new.object) # error: Revealed type: `Object`
+    T.reveal_type(AdvancedODM.new.object) # error: Revealed type: `T.untyped`
+                # ^^^^^^^^^^^^^^^^^^^^^^ error: Method `object` does not exist on `AdvancedODM`
     T.reveal_type(AdvancedODM.new.array) # error: Revealed type: `T::Array[T.untyped]`
     T.reveal_type(AdvancedODM.new.array_of) # error: Revealed type: `T::Array[String]`
     T.reveal_type(AdvancedODM.new.array_of_explicit) # error: Revealed type: `T::Array[T.untyped]`

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -2294,158 +2294,6 @@ ClassDef{
               fun = <U returns>
               block = nullptr
               args = [
-                ConstantLit{
-                  orig = nullptr
-                  symbol = ::Object
-                }
-              ]
-            }
-          }
-          args = [
-          ]
-        }
-
-        MethodDef{
-          flags = {rewriter}
-          name = <U object><<C <U <todo sym>>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
-              kind = Local
-              name = <U <blk>>
-            } }]
-          rhs = Send{
-            recv = ConstantLit{
-              orig = nullptr
-              symbol = ::T
-            }
-            fun = <U cast>
-            block = nullptr
-            args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              ConstantLit{
-                orig = nullptr
-                symbol = ::Object
-              }
-            ]
-          }
-        }
-
-        Send{
-          recv = ConstantLit{
-            orig = nullptr
-            symbol = ::T::Sig::WithoutRuntime
-          }
-          fun = <U sig>
-          block = Block {
-            args = [
-            ]
-            body = Send{
-              recv = Send{
-                recv = Local{
-                  localVariable = <U <self>>
-                }
-                fun = <U params>
-                block = nullptr
-                args = [
-                  Hash{
-                    pairs = [
-                      [
-                        key = Literal{ value = :"arg0" }
-                        value = ConstantLit{
-                          orig = nullptr
-                          symbol = ::Object
-                        }
-                      ]
-                    ]
-                  }
-                ]
-              }
-              fun = <U returns>
-              block = nullptr
-              args = [
-                ConstantLit{
-                  orig = nullptr
-                  symbol = ::Object
-                }
-              ]
-            }
-          }
-          args = [
-          ]
-        }
-
-        MethodDef{
-          flags = {rewriter}
-          name = <U object=><<C <U <todo sym>>>>
-          args = [UnresolvedIdent{
-              kind = Local
-              name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
-              kind = Local
-              name = <U <blk>>
-            } }]
-          rhs = Send{
-            recv = ConstantLit{
-              orig = nullptr
-              symbol = ::T
-            }
-            fun = <U cast>
-            block = nullptr
-            args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              ConstantLit{
-                orig = nullptr
-                symbol = ::Object
-              }
-            ]
-          }
-        }
-
-        Send{
-          recv = ConstantLit{
-            orig = nullptr
-            symbol = ::T::Sig::WithoutRuntime
-          }
-          fun = <U sig>
-          block = Block {
-            args = [
-            ]
-            body = Send{
-              recv = Send{
-                recv = Local{
-                  localVariable = <U <self>>
-                }
-                fun = <U params>
-                block = nullptr
-                args = [
-                  Hash{
-                    pairs = [
-                    ]
-                  }
-                ]
-              }
-              fun = <U returns>
-              block = nullptr
-              args = [
                 UnresolvedConstantLit{
                   scope = EmptyTree
                   cnst = <C <U Array>>
@@ -5335,32 +5183,13 @@ ClassDef{
         }
 
         Send{
-          recv = ConstantLit{
-            orig = nullptr
-            symbol = ::Sorbet::Private::Static
+          recv = Local{
+            localVariable = <U <self>>
           }
-          fun = <U keep_def>
+          fun = <U prop>
           block = nullptr
           args = [
-            Local{
-              localVariable = <U <self>>
-            }
             Literal{ value = :"object" }
-          ]
-        }
-
-        Send{
-          recv = ConstantLit{
-            orig = nullptr
-            symbol = ::Sorbet::Private::Static
-          }
-          fun = <U keep_def>
-          block = nullptr
-          args = [
-            Local{
-              localVariable = <U <self>>
-            }
-            Literal{ value = :"object=" }
           ]
         }
 

--- a/test/testdata/rewriter/prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree.exp
@@ -175,22 +175,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
-      <self>.params({}).returns(::Object)
-    end
-
-    def object<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), ::Object)
-    end
-
-    ::T::Sig::WithoutRuntime.sig() do ||
-      <self>.params({:"arg0" => ::Object}).returns(::Object)
-    end
-
-    def object=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), ::Object)
-    end
-
-    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({}).returns(<emptyTree>::<C Array>)
     end
 
@@ -474,9 +458,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :"type=")
 
-    ::Sorbet::Private::Static.keep_def(<self>, :"object")
-
-    ::Sorbet::Private::Static.keep_def(<self>, :"object=")
+    <self>.prop(:"object")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"array")
 

--- a/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=147:4})
+class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=148:4})
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=147:4}
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=148:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U AdvancedODM>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=37:1 end=37:18}
     class <C <U AdvancedODM>><C <U Mutator>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:68}
@@ -119,11 +119,6 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
       argument ifunset_nilable<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=62:11 end=62:26}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>><U no_class_arg> (<blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:68}
-      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U object> (<blk>) -> Object @ Loc {file=test/testdata/rewriter/prop.rb start=42:5 end=42:17}
-      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U object=> (object, <blk>) -> Object @ Loc {file=test/testdata/rewriter/prop.rb start=42:5 end=42:17}
-      argument object<> -> Object @ Loc {file=test/testdata/rewriter/prop.rb start=42:11 end=42:17}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>><U t_array> (<blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = String       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=46:5 end=46:36}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}

--- a/test/testdata/rewriter/t_struct/default.rb
+++ b/test/testdata/rewriter/t_struct/default.rb
@@ -8,3 +8,8 @@ T.reveal_type(Default.new.foo) # error: Revealed type: `Integer`
 Default.new(foo: "no") # error: Expected `Integer` but found `String("no")` for argument `foo`
 Default.new(foo: 3, bar: 4) # error: Unrecognized keyword argument `bar` passed for method `Default#initialize`
 T.reveal_type(Default.new(foo: 3).foo) # error: Revealed type: `Integer`
+
+class Bad < T::Struct
+  prop :no_type_on_prop  # error: Not enough arguments provided for method `T::Props::ClassMethods#prop`
+  const :no_type_on_const  # error: Not enough arguments provided for method `T::Props::ClassMethods#const`
+end

--- a/test/testdata/rewriter/t_struct/default.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/default.rb.rewrite-tree.exp
@@ -48,4 +48,20 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C Default>.new({:"foo" => 3, :"bar" => 4})
 
   <emptyTree>::<C T>.reveal_type(<emptyTree>::<C Default>.new({:"foo" => 3}).foo())
+
+  class <emptyTree>::<C Bad><<C <todo sym>>> < (<emptyTree>::<C T>::<C Struct>)
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({}).void()
+    end
+
+    def initialize<<C <todo sym>>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"initialize")
+
+    <self>.prop(:"no_type_on_prop")
+
+    <self>.const(:"no_type_on_const")
+  end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Our runtime system for `prop` and `const` on things like `T::Struct` has never supported invocations without explicit types, but we would allow this statically (c.f. #2790.) By refusing to desugar those, we leave the original calls to `prop` and `const` in place, which means that the errors we get are the result of us attempting to type the calls to `prop` and `const` instead, like:

```ruby
class Bad < T::Struct
  prop :no_type_on_prop  # error: Not enough arguments provided for method `T::Props::ClassMethods#prop`
  const :no_type_on_const  # error: Not enough arguments provided for method `T::Props::ClassMethods#const`
end
```


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
