### PR TITLE
Pass :storytime hash to soft_assert_handler

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
@@ -59,10 +59,12 @@ module T::Props
               rescue NoMethodError => e
                 T::Configuration.soft_assert_handler(
                   'Deserialization error (probably unexpected stored type)',
-                  klass: self.class,
-                  prop: #{prop.inspect},
-                  value: val,
-                  error: e.message
+                  storytime: {
+                    klass: self.class,
+                    prop: #{prop.inspect},
+                    value: val,
+                    error: e.message
+                  }
                 )
                 val
               end

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -148,9 +148,10 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
 
       refute_nil(msg_string)
       refute_nil(extra_hash)
-      assert_equal(MySerializable, extra_hash[:klass])
-      assert_equal(:foo, extra_hash[:prop])
-      assert_equal("Won't respond like hash", extra_hash[:value])
+      storytime = extra_hash[:storytime]
+      assert_equal(MySerializable, storytime[:klass])
+      assert_equal(:foo, storytime[:prop])
+      assert_equal("Won't respond like hash", storytime[:value])
     end
 
     it 'includes relevant generated code on deserialize when we raise' do


### PR DESCRIPTION
pay-server takes a storytime hash rather than an arbitrary set of keys

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
We need to pass `:storytime` in for pay-server

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
