### PR TITLE
Don't use sha.html when detecting changes to sorbet.org

### DIFF
--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -61,6 +61,7 @@ git rm -rf '*'
 tar -xjf _out_/website/website.tar.bz2 .
 git add .
 git reset HEAD _out_
+git reset HEAD sha.html
 dirty=
 git diff-index --quiet HEAD -- || dirty=1
 if [ "$dirty" != "" ]; then


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We'd gotten two page build failures for sorbet.org in the last week. My guess
is that it's one of two reasons:

- our jekyll build is getting rate limited somehow?
- our jekyll build is timing out somehow?

We previously had the same problem with sorbet.run, and we solved this by
adding a `.nojekyll` file to the repo to request that GitHub not treat our site
as a Jekyll site and instead just copy the files to their CDN verbatim.

<https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/>

I was also curious if maybe it was the rate limit thing anyways, and I noticed
that every time we publish the website, we commit a new sha.html, even if there
were otherwise no changes to the website.

The reason why that was happening was because we `git rm -rf '*'` to delete all
tracked files, and then add everything back. That was making it seem like
`sha.html` was getting deleted each time we went to publish the site, which
looked like some change that needed to be published, so then the publish script
would add back a new `sha.html` file, and the cycle would continue.

By unstaging sha.html for the purpose of computing whether the website needs to
be published, we'll get fewer pushes to the gh-pages and maybe not hit the rate
limit or whatever we were hitting so frequently.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I verified my assumptions with a throwaway build that had some extra print
information:

https://buildkite.com/sorbet/sorbet/builds/9583#bea7b62d-1bfa-42a1-b351-11deff938a12/94-256

Only way to know for sure whether this works will be to see if we still getting
page build failures after merging.