### PR TITLE
Fix a typo in sorbet-runtime lib/types/configuration.rb

### DIFF
--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -336,7 +336,7 @@ module T::Configuration
   #   T::Configuration.scalar_types = ["NilClass", "TrueClass", "FalseClass", ...]
   def self.scalar_types=(values)
     if values.nil?
-      @scalar_tyeps = values
+      @scalar_types = values
     else
       bad_values = values.select {|v| v.class != String}
       unless bad_values.empty?


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes a typo in an instance variable name.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Have not included tests. Not sure whether the behaviour it fixes is significant. Maybe the current behaviour is desirable and the `if values.nil?` branch should just be deleted.