### PR TITLE
Add to RSpec compatibility patch to handle and_call_original

### DIFF
--- a/gems/sorbet-runtime/lib/types/compatibility_patches.rb
+++ b/gems/sorbet-runtime/lib/types/compatibility_patches.rb
@@ -26,7 +26,7 @@ require_relative 'private/methods/_methods'
 if defined? ::RSpec::Mocks
   module T
     module CompatibilityPatches
-      module RSpec
+      module RSpecCompatibility
         module RecorderExtensions
           def observe!(method_name)
             method = @klass.instance_method(method_name.to_sym)
@@ -38,8 +38,10 @@ if defined? ::RSpec::Mocks
 
         module MethodDoubleExtensions
           def initialize(object, method_name, proxy)
-            method = object.method(method_name)
-            T::Private::Methods.maybe_run_sig_block_for_method(method)
+            if ::Kernel.instance_method(:respond_to?).bind(object).call(method_name, true)
+              method = ::RSpec::Support.method_handle_for(object, method_name)
+              T::Private::Methods.maybe_run_sig_block_for_method(method)
+            end
             super(object, method_name, proxy)
           end
         end


### PR DESCRIPTION
I was investigating an issue my team has bumped into a few times and I've seen others run into on the sorbet slack channel with `RSpec::Mocks` and `and_call_original`. I found a solution and realized there was already a very similar compatibility patch for RSpec::Mocks: the existing solution was for `(expect|allow)_any_instance_of` and `and_call_original` whereas my issue and solution was for `(expect|allow)` and `and_call_original`. I updated the existing compatibility patch to include both fixes and moved them both into a `RSpec` namespace.

### Motivation

My team has run into this issue a few times and we have 420 instances of `and_call_original` in our codebase so changing our code to workaround this issue would be tough. Also it seems like this has bitten some other folks as well (see threads):
- https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1583535733132200
- https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1582929135070500
- https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1582747292039700

### Test plan

I didn't include any tests but I inlined the code into my codebase where I had the issue repro'd and it fixed it. I also pushed it up to CI (63k rspec examples) and ~will open for review once I confirm a green build~ confirmed a green build ✅.