### PR TITLE
Make sorbet_version.{c,h} into a filegroup

### DIFF
--- a/sorbet_version/BUILD
+++ b/sorbet_version/BUILD
@@ -1,9 +1,17 @@
-cc_library(
-    name = "sorbet_version",
-    srcs = select({
+filegroup(
+    name = "sorbet_version_srcs",
+    srcs = [
+        "sorbet_version.h",
+    ] + select({
         "be-versioned": ["sorbet_version_gen.c"],
         "//conditions:default": ["sorbet_version.c"],
     }),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "sorbet_version",
+    srcs = [":sorbet_version_srcs"],
     hdrs = ["sorbet_version.h"],
     linkstatic = select({
         "//tools/config:linkshared": 0,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This lets other people depend on sorbet_version.c and sorbet_version.h
directly as source files, instead of just on the object and header files
of the library.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.