### PR TITLE
Make sig for Random.rand match Random#rand

### DIFF
--- a/rbi/core/random.rbi
+++ b/rbi/core/random.rbi
@@ -123,6 +123,7 @@ class Random < Object
   # Both the beginning and ending values of the range must respond to subtract
   # (`-`) and add (`+`)methods, or rand will raise an
   # [`ArgumentError`](https://docs.ruby-lang.org/en/2.6.0/ArgumentError.html).
+  sig {returns(Float)}
   sig do
     params(
         max: T.any(Integer, T::Range[Integer]),
@@ -163,6 +164,7 @@ class Random < Object
   def self.new_seed(); end
 
   # Alias of Random::DEFAULT.rand.
+  sig {returns(Float)}
   sig do
     params(
         max: T.any(Integer, T::Range[Integer]),

--- a/rbi/core/random.rbi
+++ b/rbi/core/random.rbi
@@ -165,9 +165,15 @@ class Random < Object
   # Alias of Random::DEFAULT.rand.
   sig do
     params(
-        max: Integer,
+        max: T.any(Integer, T::Range[Integer]),
     )
-    .returns(Numeric)
+    .returns(Integer)
+  end
+  sig do
+    params(
+        max: T.any(Float, T::Range[Float]),
+    )
+    .returns(Float)
   end
   def self.rand(max=T.unsafe(nil)); end
 

--- a/test/testdata/rbi/random.rb
+++ b/test/testdata/rbi/random.rb
@@ -1,0 +1,14 @@
+# typed: true
+
+r = Random.new
+T.assert_type!(r.rand, Float)
+T.assert_type!(r.rand(1), Integer)
+T.assert_type!(r.rand(1.0), Float)
+T.assert_type!(r.rand(1..1), Integer)
+T.assert_type!(r.rand(1.0..1.0), Float)
+
+T.assert_type!(Random.rand, Float)
+T.assert_type!(Random.rand(1), Integer)
+T.assert_type!(Random.rand(1.0), Float)
+T.assert_type!(Random.rand(1..1), Integer)
+T.assert_type!(Random.rand(1.0..1.0), Float)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Since `Random.rand` is an alias for `Random::DEFAULT.rand`, its sig should match `Random#rand`, so copy the overloads from

https://github.com/sorbet/sorbet/blob/aad48ab2cc39c8f30237f63af147393d10cd243f/rbi/core/random.rbi#L126-L138

Also fixed `Random.rand` and `Random.new.rand` without any arguments.

The runtime behavior looks like this:

```
[1] pry(main)> r = Random.new
=> #<Random:0x00007ff6a131f750>
[2] pry(main)> r.rand.class
=> Float
[3] pry(main)> r.rand(1).class
=> Integer
[4] pry(main)> r.rand(1.0).class
=> Float
[5] pry(main)> r.rand(1..1).class
=> Integer
[6] pry(main)> r.rand(1.0..1.0).class
=> Float
[7] pry(main)> Random.rand.class
=> Float
[8] pry(main)> Random.rand(1).class
=> Integer
[9] pry(main)> Random.rand(1.0).class
=> Float
[10] pry(main)> Random.rand(1..1).class
=> Integer
[11] pry(main)> Random.rand(1.0..1.0).class
=> Float
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Can't use `Random.rand(1...1000)`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
Added a test file and ran `./bazel run //main:sorbet -- $PWD/test/testdata/rbi/random.rb`.

See included automated tests.