### PR TITLE
Fix `--suggest-typed` errors

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1415,7 +1415,8 @@ void GlobalState::_error(unique_ptr<Error> error) const {
     }
     auto loc = error->loc;
     if (loc.file().exists() && error->what != errors::Infer::SuggestTyped &&
-        error->what != core::errors::Resolver::SigInFileWithoutSigil) {
+        error->what != core::errors::Resolver::SigInFileWithoutSigil &&
+        error->what != core::errors::Namer::MultipleBehaviorDefs) {
         loc.file().data(*this).minErrorLevel_ = min(loc.file().data(*this).minErrorLevel_, error->what.minLevel);
     }
 

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -213,6 +213,7 @@ public:
     // Contains a string to be used as the base of the error URL.
     // The error code is appended to this string.
     std::string errorUrlBase;
+    void ignoreErrorClassForSuggestTyped(int code);
     void suppressErrorClass(int code);
     void onlyShowErrorClass(int code);
 
@@ -240,6 +241,7 @@ private:
     std::vector<Symbol> symbols;
     std::vector<std::pair<unsigned int, unsigned int>> namesByHash;
     std::vector<std::shared_ptr<File>> files;
+    UnorderedSet<int> ignoredForSuggestTypedErrorClasses;
     UnorderedSet<int> suppressedErrorClasses;
     UnorderedSet<int> onlyErrorClasses;
     UnorderedMap<NameRef, std::string> dslPlugins;

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -441,6 +441,13 @@ int realmain(int argc, char *argv[]) {
             gs->suppressErrorClass(core::errors::Namer::MultipleBehaviorDefs.code);
         }
     }
+    if (opts.suggestTyped) {
+        gs->ignoreErrorClassForSuggestTyped(core::errors::Infer::SuggestTyped.code);
+        gs->ignoreErrorClassForSuggestTyped(core::errors::Resolver::SigInFileWithoutSigil.code);
+        if (!opts.stripeMode) {
+            gs->ignoreErrorClassForSuggestTyped(core::errors::Namer::MultipleBehaviorDefs.code);
+        }
+    }
 
     logger->trace("done building initial global state");
 

--- a/test/cli/suggest-typed-true/suggest-typed-and-type.rb
+++ b/test/cli/suggest-typed-true/suggest-typed-and-type.rb
@@ -1,0 +1,19 @@
+# typed: strong
+module I1
+  extend T::Sig
+  sig {void}
+  def i1; end
+end
+
+module I2
+  extend T::Sig
+  sig {void}
+  def i2; end
+end
+
+extend T::Sig
+sig {params(x: T.all(I1, I2)).void}
+def foo(x)
+  x.i1
+  x.i2
+end

--- a/test/cli/suggest-typed-true/suggest-typed-behaviour-over-multiple-1.rb
+++ b/test/cli/suggest-typed-true/suggest-typed-behaviour-over-multiple-1.rb
@@ -1,0 +1,6 @@
+# typed: true
+class Foo
+  def initialize
+    @bar = 1
+  end
+end

--- a/test/cli/suggest-typed-true/suggest-typed-behaviour-over-multiple-2.rb
+++ b/test/cli/suggest-typed-true/suggest-typed-behaviour-over-multiple-2.rb
@@ -1,0 +1,6 @@
+# typed: true
+class Foo
+  def bar
+    @bar
+  end
+end

--- a/test/cli/suggest-typed-true/suggest-typed-true.out
+++ b/test/cli/suggest-typed-true/suggest-typed-true.out
@@ -157,3 +157,25 @@ class Foo
 end
 No errors! Great job.
 -------------------------
+No errors! Great job.
+# typed: strong
+module I1
+  extend T::Sig
+  sig {void}
+  def i1; end
+end
+
+module I2
+  extend T::Sig
+  sig {void}
+  def i2; end
+end
+
+extend T::Sig
+sig {params(x: T.all(I1, I2)).void}
+def foo(x)
+  x.i1
+  x.i2
+end
+No errors! Great job.
+-------------------------

--- a/test/cli/suggest-typed-true/suggest-typed-true.out
+++ b/test/cli/suggest-typed-true/suggest-typed-true.out
@@ -142,3 +142,18 @@ def true_func
 end
 No errors! Great job.
 -------------------------
+No errors! Great job.
+# typed: true
+class Foo
+  def initialize
+    @bar = 1
+  end
+end
+# typed: true
+class Foo
+  def bar
+    @bar
+  end
+end
+No errors! Great job.
+-------------------------

--- a/test/cli/suggest-typed-true/suggest-typed-true.sh
+++ b/test/cli/suggest-typed-true/suggest-typed-true.sh
@@ -74,4 +74,10 @@ cat suggest-typed-shabang.rb
 "$cwd/main/sorbet" --silence-dev-message --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-shabang.rb 2>&1
 separator
 
+"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-behaviour-over-multiple-1.rb suggest-typed-behaviour-over-multiple-2.rb 2>&1
+cat suggest-typed-behaviour-over-multiple-1.rb
+cat suggest-typed-behaviour-over-multiple-2.rb
+"$cwd/main/sorbet" --silence-dev-message --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-behaviour-over-multiple-1.rb suggest-typed-behaviour-over-multiple-2.rb 2>&1
+separator
+
 rm -r "$tmp"

--- a/test/cli/suggest-typed-true/suggest-typed-true.sh
+++ b/test/cli/suggest-typed-true/suggest-typed-true.sh
@@ -80,4 +80,9 @@ cat suggest-typed-behaviour-over-multiple-2.rb
 "$cwd/main/sorbet" --silence-dev-message --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-behaviour-over-multiple-1.rb suggest-typed-behaviour-over-multiple-2.rb 2>&1
 separator
 
+"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-and-type.rb 2>&1
+cat suggest-typed-and-type.rb
+"$cwd/main/sorbet" --silence-dev-message --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-and-type.rb 2>&1
+separator
+
 rm -r "$tmp"


### PR DESCRIPTION
There are two problems with the way `--suggest-typed` is working:

1. `MultipleBehaviourDefs` error seems to be an internal Stripe-only error that is raised for when a type has behaviour coming from multiple files.

	Under normal circumstances, that error is never visible for end-users unless `--stripe-mode` flag is enabled. However, the error is still being considered for setting the minimum error level of each file, and is thus breaking the behaviour of `--suggest-typed`. As a result many files that are passing type checking with strictness levels `false` or above are being suggested `ignore` instead.

	This PR fixes the problem by ignoring `MultipleBehaviorDefs` when setting the minimum error level of a file.

2. `T.all` check for existence of methods in all the components of the `AndType`. However, that means that an `UnknownMethod` error is being raised each time one of the method existence checks fails for one of the components in a `T.all`, even though the method would be found in another component. This, again, means that files that pass type checking with strictness levels `true` or above are now being suggested `false` instead.

	This PR fixes the problem by making sure the error gets properly queued in the result from the method existence check so that the call can properly register the final error, if it exists, when it has to.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #1951
Fixes #2426

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
