### PR TITLE
Add missing methods and parameters on Coverage.

### DIFF
--- a/rbi/stdlib/coverage.rbi
+++ b/rbi/stdlib/coverage.rbi
@@ -39,13 +39,50 @@
 # p Coverage.result  #=> {"foo.rb"=>[1, 1, 10, nil, nil, 1, 1, nil, 0, nil]}
 # ```
 module Coverage
+  sig {returns(T.untyped)}
+  def self.line_stub(); end
+
+  # Returns a hash that contains filename as key and coverage array as value.
+  # This is the same as `Coverage.result(stop: false, clear: false)`.
+  #
+  # ```
+  # {
+  #   "file.rb" => [1, 2, nil],
+  #   ...
+  # }
+  # ```
+  sig {returns(T::Hash[String, T::Array[T.nilable(Integer)]])}
+  def self.peek_result(); end
+
   # Returns a hash that contains filename as key and coverage array as value. If
   # `clear` is true, it clears the counters to zero. If `stop` is true, it
   # disables coverage measurement.
-  sig {returns(T::Hash[String, T::Array[T.nilable(Integer)]])}
-  def self.result(); end
+  sig do
+    params(
+        stop: T::Boolean,
+        clear: T::Boolean
+    )
+    .returns(T::Hash[String, T::Array[T.nilable(Integer)]])
+  end
+  def self.result(stop: T.unsafe(nil), clear: T.unsafe(nil)); end
+
+  # Returns true if coverage stats are currently being collected (after
+  # [`Coverage.start`](https://docs.ruby-lang.org/en/2.6.0/Coverage.html#method-c-start)
+  # call, but before
+  # [`Coverage.result`](https://docs.ruby-lang.org/en/2.6.0/Coverage.html#method-c-result)
+  # call)
+  sig {returns(T::Boolean)}
+  def self.running?(); end
 
   # Enables coverage measurement.
-  sig {returns(NilClass)}
-  def self.start(); end
+  sig do
+    params(
+        lines: T::Boolean,
+        branches: T::Boolean,
+        methods: T::Boolean,
+        oneshot_lines: T::Boolean
+    )
+    .returns(NilClass)
+  end
+  def self.start(lines: T.unsafe(nil), branches: T.unsafe(nil), methods: T.unsafe(nil), oneshot_lines: T.unsafe(nil)); end
 end


### PR DESCRIPTION
### Motivation
Ruby 2.5 and 2.6 added some new methods to the Coverage module and updated some existing methods. This adds those and updates the docs.

See https://github.com/ruby/ruby/blob/db166290088fb7d39d01f68b9860253893d4f1a7/doc/NEWS-2.6.0 and https://github.com/ruby/ruby/blob/db166290088fb7d39d01f68b9860253893d4f1a7/doc/NEWS-2.5.0.

### Test plan

See included automated tests.
