### PR TITLE
Update kvstore to open / close transactions on the same thread.

### DIFF
--- a/common/kvstore/KeyValueStore-emscripten.cc
+++ b/common/kvstore/KeyValueStore-emscripten.cc
@@ -32,7 +32,7 @@ int OwnedKeyValueStore::commit() {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
-void OwnedKeyValueStore::abort() {
+void OwnedKeyValueStore::abort() const {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
@@ -60,17 +60,13 @@ void OwnedKeyValueStore::refreshMainTransaction() {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
-u4 OwnedKeyValueStore::sessionId() const {
-    return 0;
-}
-
 unique_ptr<KeyValueStore> OwnedKeyValueStore::bestEffortCommit(spdlog::logger &logger,
                                                                unique_ptr<OwnedKeyValueStore> k) {
-    throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
+    return nullptr;
 }
 
-unique_ptr<KeyValueStore> OwnedKeyValueStore::abort(unique_ptr<OwnedKeyValueStore> ownedKvstore) {
-    throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
+unique_ptr<KeyValueStore> OwnedKeyValueStore::abort(unique_ptr<const OwnedKeyValueStore> ownedKvstore) {
+    return nullptr;
 }
 
 } // namespace sorbet

--- a/common/kvstore/KeyValueStore.h
+++ b/common/kvstore/KeyValueStore.h
@@ -51,7 +51,7 @@ public:
  */
 class OwnedKeyValueStore final {
     const std::thread::id writerId;
-    // Mutable so that abort() can be const.
+    // Mutable so that private method abort() can be const.
     mutable std::unique_ptr<KeyValueStore> kvstore;
     struct TxnState;
     const std::unique_ptr<TxnState> txnState;

--- a/common/kvstore/test/kvstore_test.cc
+++ b/common/kvstore/test/kvstore_test.cc
@@ -108,3 +108,8 @@ TEST_F(KeyValueStoreTest, FlavorsHaveDifferentContents) {
         EXPECT_EQ(owned->readString("hello"), "");
     }
 }
+
+TEST_F(KeyValueStoreTest, CannotCreateTwoKvstores) {
+    auto kvstore1 = make_unique<KeyValueStore>("1", directory, "vanilla");
+    EXPECT_THROW(make_unique<KeyValueStore>("1", directory, "vanilla"), invalid_argument);
+}

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1371,7 +1371,6 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     result->files = this->files;
     result->fileRefByPath = this->fileRefByPath;
     result->lspQuery = this->lspQuery;
-    result->kvstoreSessionId = this->kvstoreSessionId;
     result->kvstoreUuid = this->kvstoreUuid;
     result->lspTypecheckCount = this->lspTypecheckCount;
     result->errorUrlBase = this->errorUrlBase;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -191,9 +191,6 @@ public:
     // See ErrorQueue#queryResponse
     lsp::Query lspQuery;
 
-    // Stores the ID of the kvstore session that created this GlobalState (if any). Is used in debug assertions.
-    u4 kvstoreSessionId = 0;
-
     // Stores a UUID that uniquely identifies this GlobalState in kvstore.
     u4 kvstoreUuid = 0;
 

--- a/main/cache/cache-orig.cc
+++ b/main/cache/cache-orig.cc
@@ -3,11 +3,15 @@
 using namespace std;
 
 namespace sorbet::realmain::cache {
-unique_ptr<KeyValueStore> maybeCreateKeyValueStore(const options::Options &opts) {
+unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(const options::Options &opts) {
     return nullptr;
 }
 
-void maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore> &kvstore, const options::Options &opts,
+unique_ptr<OwnedKeyValueStore> ownIfUnchanged(const core::GlobalState &gs, unique_ptr<KeyValueStore> kvstore) {
+    return nullptr;
+}
+
+void maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore> kvstore, const options::Options &opts,
                                    core::GlobalState &gs, vector<ast::ParsedFile> &indexed) {
     return;
 }

--- a/main/cache/cache.h
+++ b/main/cache/cache.h
@@ -5,6 +5,7 @@
 
 namespace sorbet {
 class KeyValueStore;
+class OwnedKeyValueStore;
 namespace ast {
 struct ParsedFile;
 }
@@ -18,11 +19,14 @@ struct Options;
 
 namespace sorbet::realmain::cache {
 // If cacheDir is specified, creates a KeyValueStore. Otherwise, returns nullptr.
-std::unique_ptr<KeyValueStore> maybeCreateKeyValueStore(const options::Options &opts);
+std::unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(const options::Options &opts);
+
+// Returns an owned key value store if kvstore is unchanged since gs was created, or false otherwise.
+std::unique_ptr<OwnedKeyValueStore> ownIfUnchanged(const core::GlobalState &gs, std::unique_ptr<KeyValueStore> kvstore);
 
 // If kvstore is not null, caches global state and the given files to disk if they have changed. Can silently fail to
 // cache
-void maybeCacheGlobalStateAndFiles(std::unique_ptr<KeyValueStore> &kvstore, const options::Options &opts,
+void maybeCacheGlobalStateAndFiles(std::unique_ptr<KeyValueStore> kvstore, const options::Options &opts,
                                    core::GlobalState &gs, std::vector<ast::ParsedFile> &indexed);
 } // namespace sorbet::realmain::cache
 

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -7,7 +7,7 @@
 
 namespace sorbet {
 class WorkerPool;
-class OwnedKeyValueStore;
+class KeyValueStore;
 } // namespace sorbet
 
 namespace sorbet::realmain::lsp {
@@ -29,7 +29,7 @@ class LSPIndexer final {
      * this global state every time we need to perform a slow path typechecking operation. */
     std::unique_ptr<core::GlobalState> initialGS;
     /** Key-value store used during initialization. */
-    std::unique_ptr<const OwnedKeyValueStore> kvstore;
+    std::unique_ptr<KeyValueStore> kvstore;
     /** Contains a copy of the last edit committed on the slow path. Used in slow path cancelation logic. */
     LSPFileUpdates pendingTypecheckUpdates;
     /** Contains a clone of the latency timers for each new edit in the pending typecheck operation. Is used to ensure
@@ -51,7 +51,7 @@ class LSPIndexer final {
 
 public:
     LSPIndexer(std::shared_ptr<const LSPConfiguration> config, std::unique_ptr<core::GlobalState> initialGS,
-               std::unique_ptr<const OwnedKeyValueStore> kvstore);
+               std::unique_ptr<KeyValueStore> kvstore);
     ~LSPIndexer();
 
     /**

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -17,7 +17,7 @@ using namespace std;
 namespace sorbet::realmain::lsp {
 
 LSPLoop::LSPLoop(std::unique_ptr<core::GlobalState> initialGS, WorkerPool &workers,
-                 const std::shared_ptr<LSPConfiguration> &config, std::unique_ptr<const OwnedKeyValueStore> kvstore)
+                 const std::shared_ptr<LSPConfiguration> &config, std::unique_ptr<KeyValueStore> kvstore)
     : config(config), taskQueueMutex(make_shared<absl::Mutex>()), taskQueue(make_shared<TaskQueueState>()),
       epochManager(initialGS->epochManager), preprocessor(config, taskQueueMutex, taskQueue),
       typecheckerCoord(config, make_shared<core::lsp::PreemptionTaskManager>(initialGS->epochManager), workers),

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -63,7 +63,7 @@ class LSPLoop {
 
 public:
     LSPLoop(std::unique_ptr<core::GlobalState> initialGS, WorkerPool &workers,
-            const std::shared_ptr<LSPConfiguration> &config, std::unique_ptr<const OwnedKeyValueStore> kvstore);
+            const std::shared_ptr<LSPConfiguration> &config, std::unique_ptr<KeyValueStore> kvstore);
     /**
      * Runs the language server on a dedicated thread. Returns the final global state if it exits cleanly, or nullopt
      * on error.

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -29,7 +29,7 @@ void setRequiredLSPOptions(core::GlobalState &gs, options::Options &options) {
     options.runLSP = true;
 }
 
-pair<unique_ptr<core::GlobalState>, unique_ptr<const OwnedKeyValueStore>>
+pair<unique_ptr<core::GlobalState>, unique_ptr<KeyValueStore>>
 createGlobalStateAndOtherObjects(string_view rootPath, options::Options &options, int numWorkerThreads,
                                  shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> &stderrColorSinkOut,
                                  shared_ptr<spd::logger> &loggerOut, shared_ptr<spd::logger> &typeErrorsConsoleOut) {
@@ -43,16 +43,10 @@ createGlobalStateAndOtherObjects(string_view rootPath, options::Options &options
     typeErrorsConsoleOut->set_pattern("%v");
     auto gs = make_unique<core::GlobalState>(make_shared<core::ErrorQueue>(*typeErrorsConsoleOut, *loggerOut));
 
-    unique_ptr<const OwnedKeyValueStore> kvstore;
-    {
-        auto unownedKvstore = cache::maybeCreateKeyValueStore(options);
-        if (unownedKvstore != nullptr) {
-            kvstore = make_unique<OwnedKeyValueStore>(move(unownedKvstore));
-        }
-    }
+    unique_ptr<const OwnedKeyValueStore> kvstore = cache::maybeCreateKeyValueStore(options);
     payload::createInitialGlobalState(gs, options, kvstore);
     setRequiredLSPOptions(*gs, options);
-    return make_pair(move(gs), move(kvstore));
+    return make_pair(move(gs), OwnedKeyValueStore::abort(move(kvstore)));
 }
 
 } // namespace
@@ -86,7 +80,7 @@ void MultiThreadedLSPWrapper::send(const std::string &json) {
 LSPWrapper::LSPWrapper(unique_ptr<core::GlobalState> gs, shared_ptr<options::Options> opts,
                        std::shared_ptr<spd::logger> logger,
                        shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
-                       shared_ptr<spd::logger> typeErrorsConsole, unique_ptr<const OwnedKeyValueStore> kvstore,
+                       shared_ptr<spd::logger> typeErrorsConsole, unique_ptr<KeyValueStore> kvstore,
                        bool disableFastPath)
     : logger(logger), workers(WorkerPool::create(opts->threads, *logger)), stderrColorSink(move(stderrColorSink)),
       typeErrorsConsole(move(typeErrorsConsole)), output(make_shared<LSPOutputToVector>()),
@@ -99,7 +93,7 @@ SingleThreadedLSPWrapper::SingleThreadedLSPWrapper(unique_ptr<core::GlobalState>
                                                    shared_ptr<spd::logger> logger,
                                                    shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
                                                    shared_ptr<spd::logger> typeErrorsConsole,
-                                                   unique_ptr<const OwnedKeyValueStore> kvstore, bool disableFastPath)
+                                                   unique_ptr<KeyValueStore> kvstore, bool disableFastPath)
     : LSPWrapper(move(gs), move(opts), move(logger), move(stderrColorSink), move(typeErrorsConsole), move(kvstore),
                  disableFastPath) {}
 
@@ -107,7 +101,7 @@ MultiThreadedLSPWrapper::MultiThreadedLSPWrapper(unique_ptr<core::GlobalState> g
                                                  shared_ptr<spd::logger> logger,
                                                  shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
                                                  shared_ptr<spd::logger> typeErrorsConsole,
-                                                 unique_ptr<const OwnedKeyValueStore> kvstore, bool disableFastPath)
+                                                 unique_ptr<KeyValueStore> kvstore, bool disableFastPath)
     : LSPWrapper(move(gs), move(opts), move(logger), move(stderrColorSink), move(typeErrorsConsole), move(kvstore),
                  disableFastPath),
       input(make_shared<LSPProgrammaticInput>()),
@@ -120,9 +114,10 @@ MultiThreadedLSPWrapper::~MultiThreadedLSPWrapper() {
     // lspThread implements that behavior.
 }
 
-unique_ptr<SingleThreadedLSPWrapper> SingleThreadedLSPWrapper::createWithGlobalState(
-    unique_ptr<core::GlobalState> gs, shared_ptr<options::Options> options, shared_ptr<spdlog::logger> logger,
-    std::unique_ptr<const OwnedKeyValueStore> kvstore, bool disableFastPath) {
+unique_ptr<SingleThreadedLSPWrapper>
+SingleThreadedLSPWrapper::createWithGlobalState(unique_ptr<core::GlobalState> gs, shared_ptr<options::Options> options,
+                                                shared_ptr<spdlog::logger> logger,
+                                                std::unique_ptr<KeyValueStore> kvstore, bool disableFastPath) {
     setRequiredLSPOptions(*gs, *options);
     // Note: To keep the constructor private, we need to construct with `new` and put it into a `unique_ptr` privately.
     // `make_unique` doesn't work because that method doesn't have access to the constructor.

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -13,7 +13,7 @@ namespace spd = spdlog;
 
 namespace sorbet {
 class WorkerPool;
-class OwnedKeyValueStore;
+class KeyValueStore;
 } // namespace sorbet
 
 namespace sorbet::realmain::lsp {
@@ -43,7 +43,7 @@ protected:
     LSPWrapper(std::unique_ptr<core::GlobalState> gs, std::shared_ptr<options::Options> opts,
                std::shared_ptr<spd::logger> logger,
                std::shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
-               std::shared_ptr<spd::logger> typeErrorsConsole, std::unique_ptr<const OwnedKeyValueStore> kvstore,
+               std::shared_ptr<spd::logger> typeErrorsConsole, std::unique_ptr<KeyValueStore> kvstore,
                bool disableFastPath);
 
 public:
@@ -84,14 +84,15 @@ class SingleThreadedLSPWrapper final : public LSPWrapper {
     SingleThreadedLSPWrapper(std::unique_ptr<core::GlobalState> gs, std::shared_ptr<options::Options> opts,
                              std::shared_ptr<spd::logger> logger,
                              std::shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
-                             std::shared_ptr<spd::logger> typeErrorsConsole,
-                             std::unique_ptr<const OwnedKeyValueStore> kvstore, bool disableFastPath);
+                             std::shared_ptr<spd::logger> typeErrorsConsole, std::unique_ptr<KeyValueStore> kvstore,
+                             bool disableFastPath);
 
 public:
-    static std::unique_ptr<SingleThreadedLSPWrapper>
-    createWithGlobalState(std::unique_ptr<core::GlobalState> gs, std::shared_ptr<options::Options> options,
-                          std::shared_ptr<spdlog::logger> logger, std::unique_ptr<const OwnedKeyValueStore> kvstore,
-                          bool disableFastPath = false);
+    static std::unique_ptr<SingleThreadedLSPWrapper> createWithGlobalState(std::unique_ptr<core::GlobalState> gs,
+                                                                           std::shared_ptr<options::Options> options,
+                                                                           std::shared_ptr<spdlog::logger> logger,
+                                                                           std::unique_ptr<KeyValueStore> kvstore,
+                                                                           bool disableFastPath = false);
 
     static std::unique_ptr<SingleThreadedLSPWrapper>
     create(std::string_view rootPath = std::string_view(),
@@ -124,8 +125,8 @@ class MultiThreadedLSPWrapper final : public LSPWrapper {
     MultiThreadedLSPWrapper(std::unique_ptr<core::GlobalState> gs, std::shared_ptr<options::Options> opts,
                             std::shared_ptr<spd::logger> logger,
                             std::shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
-                            std::shared_ptr<spd::logger> typeErrorsConsole,
-                            std::unique_ptr<const OwnedKeyValueStore> kvstore, bool disableFastPath);
+                            std::shared_ptr<spd::logger> typeErrorsConsole, std::unique_ptr<KeyValueStore> kvstore,
+                            bool disableFastPath);
 
 public:
     static std::unique_ptr<MultiThreadedLSPWrapper>

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -97,9 +97,6 @@ unique_ptr<core::serialize::CachedFile> fetchFileFromCache(core::GlobalState &gs
             prodCounterInc("types.input.files.kvstore.hit");
             auto cachedTree = core::serialize::Serializer::loadFile(gs, fref, maybeCached);
             ENFORCE(cachedTree.tree->loc.file() == fref);
-            // Ensure that the trees were read in the same session that read GlobalState -- otherwise, it may reference
-            // a name not in the name table!
-            ENFORCE(kvstore->sessionId() == gs.kvstoreSessionId);
             return make_unique<core::serialize::CachedFile>(move(cachedTree));
         } else {
             prodCounterInc("types.input.files.kvstore.miss");

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -484,8 +484,6 @@ int realmain(int argc, char *argv[]) {
         }
 
         { indexed = pipeline::index(gs, inputFiles, opts, *workers, kvstore); }
-
-        // Create a new OwnedKeyValueStore to reset const-ness.
         cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(move(kvstore)), opts, *gs, indexed);
 
         if (gs->runningUnderAutogen) {

--- a/payload/payload.h
+++ b/payload/payload.h
@@ -10,6 +10,10 @@ namespace sorbet::payload {
 void createInitialGlobalState(std::unique_ptr<core::GlobalState> &gs, const realmain::options::Options &options,
                               const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
 
+/** Returns 'true' if the given GlobalState was originally created from the current contents of kvstore (e.g., kvstore
+ * has not since been modified). */
+bool kvstoreUnchangedSinceGsCreation(const core::GlobalState &gs, const std::unique_ptr<OwnedKeyValueStore> &kvstore);
+
 /** Writes the GlobalState to kvstore, but only if it was modified. Returns 'true' if a write happens. */
 bool retainGlobalState(core::GlobalState &gs, const realmain::options::Options &options,
                        const std::unique_ptr<OwnedKeyValueStore> &kvstore);

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -13,10 +13,34 @@
 #include "sorbet_version/sorbet_version.h"
 #include "spdlog/sinks/null_sink.h"
 #include "test/helpers/lsp.h"
+#include <signal.h>
 
 namespace sorbet::test::lsp {
 using namespace std;
 using namespace sorbet::realmain::lsp;
+
+namespace {
+// Inspired by https://github.com/google/googletest/issues/1153#issuecomment-428247477
+int wait_for_child_fork(int pid) {
+    int status;
+    if (0 > waitpid(pid, &status, 0)) {
+        std::cerr << "[----------]  Waitpid error!" << std::endl;
+        return -1;
+    }
+    if (WIFEXITED(status)) {
+        return WEXITSTATUS(status);
+    } else {
+        std::cerr << "[----------]  Non-normal exit from child!" << std::endl;
+        return -2;
+    }
+}
+
+function<void(int)> _handler;
+// Used to register a lambda as a signal handler.
+void baseHandler(int signal) {
+    _handler(signal);
+}
+} // namespace
 
 TEST_P(ProtocolTest, LSPUsesCache) {
     // Write a file to disk.
@@ -52,7 +76,7 @@ TEST_P(ProtocolTest, LSPUsesCache) {
         // Release cache lock.
         lspWrapper = nullptr;
 
-        auto kvstore = make_unique<const OwnedKeyValueStore>(realmain::cache::maybeCreateKeyValueStore(*opts));
+        unique_ptr<const OwnedKeyValueStore> kvstore = realmain::cache::maybeCreateKeyValueStore(*opts);
         EXPECT_EQ(kvstore->read(updatedKey), nullptr);
 
         auto contents = kvstore->read(key);
@@ -104,7 +128,7 @@ TEST_P(ProtocolTest, LSPUsesCache) {
 
         // Release cache lock.
         lspWrapper = nullptr;
-        auto kvstore = make_unique<const OwnedKeyValueStore>(realmain::cache::maybeCreateKeyValueStore(*opts));
+        unique_ptr<const OwnedKeyValueStore> kvstore = realmain::cache::maybeCreateKeyValueStore(*opts);
         auto updatedFileData = kvstore->read(updatedKey);
         ASSERT_NE(updatedFileData, nullptr);
 
@@ -118,6 +142,102 @@ TEST_P(ProtocolTest, LSPUsesCache) {
         EXPECT_EQ(cachedFile.file->path(), filePath);
         EXPECT_EQ(cachedFile.file->source(), updatedFileContents);
         EXPECT_NE(cachedFile.file->getFileHash(), nullptr);
+    }
+}
+
+TEST_P(ProtocolTest, LSPDoesNotUseCacheIfModified) {
+    // Write a file to disk.
+    auto relativeFilepath = "test.rb";
+    auto filePath = fmt::format("{}/{}", rootPath, relativeFilepath);
+    // This file has an error to indirectly assert that LSP is actually typechecking the file during initialization.
+    auto fileContents = "# typed: true\nclass Foo extend T::Sig\nsig {returns(Integer)}\ndef bar\n'hello'\nend\nend\n";
+    auto key =
+        realmain::pipeline::fileKey(core::File(string(filePath), string(fileContents), core::File::Type::Normal, 0));
+
+    // Note: We need to introduce a new name, otherwise nametable doesn't change and we don't update the cache.
+    auto updatedFileContents = "# typed: true\nclass NewName\nend\n";
+
+    // LSP should write a cache to disk corresponding to initialization state.
+    {
+        writeFilesToFS({{relativeFilepath, fileContents}});
+
+        lspWrapper->opts->inputFileNames.push_back(filePath);
+        assertDiagnostics(initializeLSP(),
+                          {{relativeFilepath, 4, "Returning value that does not conform to method result type"}});
+    }
+
+    // LSP should have written cache to disk with file hashes from initialization.
+    {
+        auto opts = lspWrapper->opts;
+
+        // Release cache lock.
+        lspWrapper = nullptr;
+
+        unique_ptr<const OwnedKeyValueStore> kvstore = realmain::cache::maybeCreateKeyValueStore(*opts);
+        auto contents = kvstore->read(key);
+        ASSERT_NE(contents, nullptr);
+
+        auto sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+        auto logger = std::make_shared<spdlog::logger>("null", sink);
+        auto gs = make_unique<core::GlobalState>((make_shared<core::ErrorQueue>(*logger, *logger)));
+        payload::createInitialGlobalState(gs, *opts, kvstore);
+
+        // If caching fails, gs gets modified during payload creation.
+        EXPECT_FALSE(gs->wasModified());
+
+        auto cachedFile = core::serialize::Serializer::loadFile(*gs, core::FileRef{10}, contents);
+        EXPECT_TRUE(cachedFile.file->cached);
+        EXPECT_EQ(cachedFile.file->path(), filePath);
+        EXPECT_EQ(cachedFile.file->source(), fileContents);
+        EXPECT_NE(cachedFile.file->getFileHash(), nullptr);
+    }
+
+    // LSP should read from disk when the cache gets updated by a different process mid-process.
+    {
+        // Register signal handler _before_ forking to avoid race.
+        bool signaled = false;
+        _handler = [&signaled](int code) { signaled = true; };
+        signal(SIGHUP, baseHandler);
+        // Fork before grabbing DB lock.
+        const int child_pid = fork();
+        if (child_pid == 0) {
+            // Child process; wait for signal before writing to cache.
+            while (!signaled) {
+            }
+
+            // Let's update a file and write over the cache.
+            resetState();
+            writeFilesToFS({{relativeFilepath, updatedFileContents}});
+
+            lspWrapper->opts->inputFileNames.push_back(filePath);
+            assertDiagnostics(initializeLSP(), {});
+
+            // File was updated, so no cache hits.
+            auto counters = getCounters();
+            EXPECT_GT(counters.getCounter("types.input.files.kvstore.miss"), 0);
+            EXPECT_EQ(counters.getCounter("types.input.files.kvstore.hit"), 0);
+            EXPECT_EQ(counters.getCounter("cache.committed"), 1);
+
+            // Exit explicitly here to stop fork from running the rest of the test suite.
+            exit(testing::Test::HasFailure());
+        } else {
+            resetState();
+            // Tell child process to mutate the cache.
+            kill(child_pid, SIGHUP);
+
+            // Wait for child process to finish mutating the cache.
+            EXPECT_EQ(0, wait_for_child_fork(child_pid));
+
+            lspWrapper->opts->inputFileNames.push_back(filePath);
+            writeFilesToFS({{relativeFilepath, fileContents}});
+            assertDiagnostics(initializeLSP(),
+                              {{relativeFilepath, 4, "Returning value that does not conform to method result type"}});
+
+            // We should not use the cache since it has been dirtied.
+            auto counters = getCounters();
+            EXPECT_EQ(counters.getCounter("types.input.files.kvstore.hit"), 0);
+            EXPECT_EQ(counters.getCounter("cache.committed"), 0);
+        }
     }
 }
 

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -189,6 +189,8 @@ TEST_P(ProtocolTest, LSPDoesNotUseCacheIfModified) {
 
     // LSP should read from disk when the cache gets updated by a different process mid-process.
     {
+        // Note: I had trouble getting signals to work in CI. Even in a loop where the parent process sent a signal to
+        // the child, the child never received the signal. So, I'm using a file to communicate instead.
         auto signalFile = cacheDir + "/signal_file";
         // Fork before grabbing DB lock.
         const int child_pid = fork();

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -207,7 +207,7 @@ TEST_P(ProtocolTest, LSPDoesNotUseCacheIfModified) {
             cerr << "CHILD: Waiting for signal\n";
             bool signaled = false;
             _handler = [&signaled](int code) { signaled = true; };
-            signal(SIGHUP, baseHandler);
+            signal(SIGUSR1, baseHandler);
             // Child process; wait for signal before writing to cache.
             while (!signaled) {
             }
@@ -239,7 +239,7 @@ TEST_P(ProtocolTest, LSPDoesNotUseCacheIfModified) {
             int exitCode = 0;
             while (true) {
                 // Tell child process to mutate the cache.
-                kill(child_pid, SIGHUP);
+                kill(child_pid, SIGUSR1);
                 // Returns -1 if child is still running, or exitcode if it exited. Other negative values are errors.
                 exitCode = wait_for_child_fork(child_pid);
                 ASSERT_GE(exitCode, -1);

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -219,7 +219,6 @@ TEST_P(ProtocolTest, LSPDoesNotUseCacheIfModified) {
             resetState();
 
             // Tell child process to mutate the cache by writing a file.
-            // Returns -1 if child is still running, or exitcode if it exited. Other negative values are errors.
             FileOps::write(signalFile, " ");
 
             // Wait for child process to finish mutating the cache.

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -194,7 +194,7 @@ TEST_P(ProtocolTest, LSPDoesNotUseCacheIfModified) {
 
     // LSP should read from disk when the cache gets updated by a different process mid-process.
     {
-        cout << "PHASE 2\n";
+        cerr << "PHASE 2\n";
         // Register signal handler _before_ forking to avoid race.
         bool signaled = false;
         _handler = [&signaled](int code) { signaled = true; };
@@ -202,11 +202,11 @@ TEST_P(ProtocolTest, LSPDoesNotUseCacheIfModified) {
         // Fork before grabbing DB lock.
         const int child_pid = fork();
         if (child_pid == 0) {
-            cout << "CHILD: Waiting for signal\n";
+            cerr << "CHILD: Waiting for signal\n";
             // Child process; wait for signal before writing to cache.
             while (!signaled) {
             }
-            cout << "CHILD: Signal received\n";
+            cerr << "CHILD: Signal received\n";
 
             // Let's update a file and write over the cache.
             resetState();
@@ -221,30 +221,30 @@ TEST_P(ProtocolTest, LSPDoesNotUseCacheIfModified) {
             EXPECT_EQ(counters.getCounter("types.input.files.kvstore.hit"), 0);
             EXPECT_EQ(counters.getCounter("cache.committed"), 1);
 
-            cout << "CHILD: Exiting " << testing::Test::HasFailure() << "\n";
+            cerr << "CHILD: Exiting " << testing::Test::HasFailure() << "\n";
 
             // Exit explicitly here to stop fork from running the rest of the test suite.
             exit(testing::Test::HasFailure());
         } else {
-            cout << "PARENT: resetState\n";
+            cerr << "PARENT: resetState\n";
             resetState();
-            cout << "PARENT: Sending signal to child\n";
+            cerr << "PARENT: Sending signal to child\n";
             // Tell child process to mutate the cache.
             kill(child_pid, SIGHUP);
 
-            cout << "PARENT: waiting for child to exit\n";
+            cerr << "PARENT: waiting for child to exit\n";
 
             // Wait for child process to finish mutating the cache.
             EXPECT_EQ(0, wait_for_child_fork(child_pid));
 
-            cout << "PARENT: Running LSP\n";
+            cerr << "PARENT: Running LSP\n";
 
             lspWrapper->opts->inputFileNames.push_back(filePath);
             writeFilesToFS({{relativeFilepath, fileContents}});
             assertDiagnostics(initializeLSP(),
                               {{relativeFilepath, 4, "Returning value that does not conform to method result type"}});
 
-            cout << "PARENT: Done\n";
+            cerr << "PARENT: Done\n";
 
             // We should not use the cache since it has been dirtied.
             auto counters = getCounters();


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Update kvstore to open / close transactions on the same thread.

The cache is ignored if it gets updated between ownership changes, as enforced by cache::ownIfUnchanged.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes deadlock that occurs when a write transaction is committed or aborted by a different thread than the one that started it.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
