### PR TITLE
Fix decode_www_form_component signature

### DIFF
--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -215,7 +215,7 @@ module URI
         str: String,
         enc: Encoding,
     )
-    .returns(T::Array[[String, String]])
+    .returns(String)
   end
   def self.decode_www_form_component(str, enc=Encoding::UTF_8); end
 


### PR DESCRIPTION
### Motivation
`decode_www_form_component` returns a string, not an array of string tuples like `decode_www_form`. See source at
https://docs.ruby-lang.org/en/2.6.0/URI.html#method-c-decode_www_form_component (`force_encoding` [returns a string](https://apidock.com/ruby/String/force_encoding)).


### Test plan
I don't think tests are necessary here - I manually verified by looking at source code for `decode_www_form_component` and forced this type through `T.cast(URI.decode_www_form_component(text), String)` in a work project.
