### PR TITLE
Docs: Examples of where to put `extend T::Sig` for class methods

### DIFF
--- a/website/docs/sigs.md
+++ b/website/docs/sigs.md
@@ -250,6 +250,47 @@ end
 Main.name_length(Main.greet('Alice')) # => error!
 ```
 
+## Class Methods
+
+There are at least three ways to define class (static) methods in Ruby.
+Sorbet only supports the first.
+
+1. `def self.greet` - supported
+
+```ruby
+class Main
+  extend T::Sig
+  
+  sig {params(name: String).void}
+  def self.greet(name)
+    puts "Hello, #{name}!"
+  end
+end
+```
+
+2. `class << self` - not supported
+
+```ruby
+class Main
+  class << self
+    extend T::Sig
+    sig {params(name: String).void}
+    def greet(name)
+      # etc.
+```
+
+3. `def Main.greet` - not supported
+
+```ruby
+extend T::Sig
+sig {params(name: String).void}
+def Main.greet(name)
+  # etc.
+```
+
+In addition to being unsupported by Sorbet, the third style (`def Main.greet`)
+should be avoided because it defines `sig` on the global namespace.
+
 ## Why do we need signatures?
 
 Taking a step back, why do we need `sig`s in the first place?

--- a/website/docs/sigs.md
+++ b/website/docs/sigs.md
@@ -250,46 +250,41 @@ end
 Main.name_length(Main.greet('Alice')) # => error!
 ```
 
-## Class Methods
+## Adding sigs to class methods
 
-There are at least three ways to define class (static) methods in Ruby.
-Sorbet only supports the first.
+There are many ways to define class (static) methods in Ruby. How a method is
+defined changes where the `extend T::Sig` line needs to go. These are the two
+preferred ways to define class methods with sigs:
 
-1. `def self.greet` - supported
+1.  `def self.greet`
 
-```ruby
-class Main
-  extend T::Sig
-  
-  sig {params(name: String).void}
-  def self.greet(name)
-    puts "Hello, #{name}!"
-  end
-end
-```
+    ```ruby
+    class Main
+      # In this style, at the top level of the class
+      extend T::Sig
 
-2. `class << self` - not supported
+      sig {params(name: String).void}
+      def self.greet(name)
+        puts "Hello, #{name}!"
+      end
+    end
+    ```
 
-```ruby
-class Main
-  class << self
-    extend T::Sig
-    sig {params(name: String).void}
-    def greet(name)
-      # etc.
-```
+2.  `class << self`
 
-3. `def Main.greet` - not supported
+    ```ruby
+    class Main
+      class << self
+        # In this style, inside the `class << self`
+        extend T::Sig
 
-```ruby
-extend T::Sig
-sig {params(name: String).void}
-def Main.greet(name)
-  # etc.
-```
-
-In addition to being unsupported by Sorbet, the third style (`def Main.greet`)
-should be avoided because it defines `sig` on the global namespace.
+        sig {params(name: String).void}
+        def greet(name)
+          # ...
+        end
+      end
+    end
+    ```
 
 ## Why do we need signatures?
 


### PR DESCRIPTION
### Motivation

The placement of the `extend T::Sig` for class methods varies depending on the type of method definition.

### Test plan

N/A, docs