### PR TITLE
Make common/Counters.h not depend on common/common.h

### DIFF
--- a/common/Counters.h
+++ b/common/Counters.h
@@ -1,7 +1,9 @@
 #ifndef SORBET_COUNTERS_H
 #define SORBET_COUNTERS_H
+#include "absl/container/flat_hash_map.h"
 #include "common/ConstExprStr.h"
-#include "common/common.h"
+#include "sorbet_version/sorbet_version.h"
+#include "spdlog/spdlog.h"
 #include <chrono>
 #include <string>
 
@@ -99,7 +101,7 @@ void timingAdd(ConstExprStr measure, std::chrono::time_point<std::chrono::steady
                std::vector<std::pair<ConstExprStr, ConstExprStr>> tags, FlowId self, FlowId previous,
                std::vector<int> histogramBuckets);
 
-UnorderedMap<long, long> getAndClearHistogram(ConstExprStr histogram);
+absl::flat_hash_map<long, long> getAndClearHistogram(ConstExprStr histogram);
 std::string getCounterStatistics(std::vector<std::string> names);
 
 } // namespace sorbet

--- a/main/lsp/LSPMessage.h
+++ b/main/lsp/LSPMessage.h
@@ -2,6 +2,7 @@
 #define RUBY_TYPER_LSP_LSPMESSAGE_H
 
 #include "common/Timer.h"
+#include "common/common.h"
 #include "main/lsp/json_enums.h"
 #include "rapidjson/document.h"
 #include <variant>


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I want to give each ENFORCE a Timer. ENFORCE is defined in common.h.
That would make common.h depend on Timer.h, but Timer.h depends on
Counters.h. Thus I need to break the Counters.h -> common.h dependency
to break the cycle.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.