### PR TITLE
Fix `File.zero?` return type

### DIFF
--- a/rbi/core/file.rbi
+++ b/rbi/core/file.rbi
@@ -1060,7 +1060,7 @@ class File < IO
     params(
         file: T.any(String, Pathname, IO),
     )
-    .returns(T.nilable(Integer))
+    .returns(T::Boolean)
   end
   def self.zero?(file); end
 


### PR DESCRIPTION
As can be seen from the implementation of `File.zero?`, it always returns `true` or `false` and not `T.nilable(Integer)` like the current signature suggests.

```c
static VALUE
rb_file_zero_p(VALUE obj, VALUE fname)
{
    struct stat st;

    if (rb_stat(fname, &st) < 0) return Qfalse;
    if (st.st_size == 0) return Qtrue;
    return Qfalse;
}
```

### Motivation

Unexpected type result from code like: `some_boolean_value && File.zero?("some_file_name")`

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No tests.
