### PR TITLE
Make Timers faster

### DIFF
--- a/common/Counters.cc
+++ b/common/Counters.cc
@@ -198,15 +198,16 @@ vector<pair<const char *, const char *>> givenTags2StoredTags(vector<pair<ConstE
     return stored;
 }
 
-void timingAdd(ConstExprStr measure, std::chrono::time_point<std::chrono::steady_clock> start,
-               std::chrono::time_point<std::chrono::steady_clock> end, vector<pair<ConstExprStr, string>> args,
-               vector<pair<ConstExprStr, ConstExprStr>> tags, FlowId self, FlowId previous,
-               vector<int> histogramBuckets) {
-    ENFORCE(
-        (self.id == 0) || (previous.id == 0),
-        "format doesn't support chaining"); // see "case 1" in
-                                            // https://docs.google.com/document/d/1La_0PPfsTqHJihazYhff96thhjPtvq1KjAUOJu0dvEg/edit?pli=1#
-                                            // for workaround
+void timingAdd(ConstExprStr measure, chrono::nanoseconds start, chrono::nanoseconds end,
+               vector<pair<ConstExprStr, string>> args, vector<pair<ConstExprStr, ConstExprStr>> tags, FlowId self,
+               FlowId previous, vector<int> histogramBuckets) {
+    // Can't use ENFORCE, because each ENFORCE creates a new Timer.
+    if (!(self.id == 0 || previous.id == 0)) {
+        // see "case 1" in https://docs.google.com/document/d/1La_0PPfsTqHJihazYhff96thhjPtvq1KjAUOJu0dvEg/edit?pli=1#
+        // for workaround
+        Exception::raise("format doesn't support chaining");
+    }
+
     CounterImpl::Timing tim{0,
                             measure.str,
                             start,

--- a/common/Counters.cc
+++ b/common/Counters.cc
@@ -88,7 +88,7 @@ void CounterImpl::timingAdd(CounterImpl::Timing timing) {
     if (fuzz_mode) {
         return;
     }
-    this->timings.emplace_back(timing);
+    this->timings.emplace_back(move(timing));
 }
 
 thread_local CounterImpl counterState;
@@ -139,7 +139,7 @@ void counterConsume(CounterState cs) {
         counterState.prodCounterAdd(e.first, e.second);
     }
     for (auto &e : cs.counters->timings) {
-        counterState.timingAdd(e);
+        counterState.timingAdd(move(e));
     }
 }
 
@@ -181,25 +181,37 @@ int getThreadId() {
     return counter;
 }
 
-vector<pair<const char *, string>> givenArgs2StoredArgs(vector<pair<ConstExprStr, string>> given) {
-    vector<pair<const char *, string>> stored;
-    for (auto &e : given) {
-        stored.emplace_back(e.first.str, move(e.second));
+unique_ptr<vector<pair<const char *, string>>>
+givenArgs2StoredArgs(unique_ptr<vector<pair<ConstExprStr, string>>> given) {
+    if (given == nullptr) {
+        return nullptr;
+    }
+
+    unique_ptr<vector<pair<const char *, string>>> stored = make_unique<vector<pair<const char *, string>>>();
+    for (auto &e : *given) {
+        stored->emplace_back(e.first.str, move(e.second));
     }
     return stored;
 }
 
-vector<pair<const char *, const char *>> givenTags2StoredTags(vector<pair<ConstExprStr, ConstExprStr>> given) {
-    vector<pair<const char *, const char *>> stored;
-    for (auto &e : given) {
-        stored.emplace_back(e.first.str, e.second.str);
+unique_ptr<vector<pair<const char *, const char *>>>
+givenTags2StoredTags(unique_ptr<vector<pair<ConstExprStr, ConstExprStr>>> given) {
+    if (given == nullptr) {
+        return nullptr;
+    }
+
+    unique_ptr<vector<pair<const char *, const char *>>> stored =
+        make_unique<vector<pair<const char *, const char *>>>();
+    for (auto &e : *given) {
+        stored->emplace_back(e.first.str, e.second.str);
     }
     return stored;
 }
 
-void timingAdd(ConstExprStr measure, microseconds start, microseconds end, vector<pair<ConstExprStr, string>> args,
-               vector<pair<ConstExprStr, ConstExprStr>> tags, FlowId self, FlowId previous,
-               vector<int> histogramBuckets) {
+void timingAdd(ConstExprStr measure, microseconds start, microseconds end,
+               unique_ptr<vector<pair<ConstExprStr, string>>> args,
+               unique_ptr<vector<pair<ConstExprStr, ConstExprStr>>> tags, FlowId self, FlowId previous,
+               unique_ptr<vector<int>> histogramBuckets) {
     // Can't use ENFORCE, because each ENFORCE creates a new Timer.
     if (!(self.id == 0 || previous.id == 0)) {
         // see "case 1" in https://docs.google.com/document/d/1La_0PPfsTqHJihazYhff96thhjPtvq1KjAUOJu0dvEg/edit?pli=1#
@@ -216,16 +228,16 @@ void timingAdd(ConstExprStr measure, microseconds start, microseconds end, vecto
                             givenTags2StoredTags(move(tags)),
                             self,
                             previous};
-    counterState.timingAdd(tim);
+    counterState.timingAdd(move(tim));
 
-    if (!histogramBuckets.empty()) {
-        histogramBuckets.push_back(INT_MAX);
-        fast_sort(histogramBuckets);
+    if (histogramBuckets != nullptr && !histogramBuckets->empty()) {
+        histogramBuckets->push_back(INT_MAX);
+        fast_sort(*histogramBuckets);
 
         auto msCount = (end.usec - start.usec) / 1'000;
         // Find the bucket for this value. The last bucket is INT_MAX, so it's guaranteed to pick one if a histogram
         // is set. If histogramBuckets is empty (which is the common case), then nothing happens.
-        for (const auto bucket : histogramBuckets) {
+        for (const auto bucket : *histogramBuckets) {
             if (msCount < bucket) {
                 prodHistogramInc(measure, bucket);
                 break;
@@ -279,7 +291,7 @@ void CounterImpl::canonicalize() {
     }
 
     for (auto &e : this->timings) {
-        out.timingAdd(e);
+        out.timingAdd(move(e));
     }
 
     this->countersByCategory = std::move(out.countersByCategory);

--- a/common/Counters.h
+++ b/common/Counters.h
@@ -96,9 +96,9 @@ struct FlowId {
 };
 
 void timingAdd(ConstExprStr measure, std::chrono::nanoseconds start, std::chrono::nanoseconds end,
-               std::vector<std::pair<ConstExprStr, std::string>> args,
-               std::vector<std::pair<ConstExprStr, ConstExprStr>> tags, FlowId self, FlowId previous,
-               std::vector<int> histogramBuckets);
+               std::unique_ptr<std::vector<std::pair<ConstExprStr, std::string>>> args,
+               std::unique_ptr<std::vector<std::pair<ConstExprStr, ConstExprStr>>> tags, FlowId self, FlowId previous,
+               std::unique_ptr<std::vector<int>> histogramBuckets);
 
 absl::flat_hash_map<long, long> getAndClearHistogram(ConstExprStr histogram);
 std::string getCounterStatistics(std::vector<std::string> names);

--- a/common/Counters.h
+++ b/common/Counters.h
@@ -95,8 +95,7 @@ struct FlowId {
     int id;
 };
 
-void timingAdd(ConstExprStr measure, std::chrono::time_point<std::chrono::steady_clock> start,
-               std::chrono::time_point<std::chrono::steady_clock> end,
+void timingAdd(ConstExprStr measure, std::chrono::nanoseconds start, std::chrono::nanoseconds end,
                std::vector<std::pair<ConstExprStr, std::string>> args,
                std::vector<std::pair<ConstExprStr, ConstExprStr>> tags, FlowId self, FlowId previous,
                std::vector<int> histogramBuckets);

--- a/common/Counters.h
+++ b/common/Counters.h
@@ -46,6 +46,12 @@ namespace test::lsp {
 class CounterStateDatabase;
 }
 
+// We are explicitly not using <chrono> in this file, because we profiled it and realized that
+// using its abstractions for computing on and gathering times were a substantial overhead.
+struct microseconds {
+    int64_t usec;
+};
+
 struct CounterState {
     CounterState();
     ~CounterState();
@@ -94,7 +100,6 @@ struct FlowId {
     int id;
 };
 
-struct microseconds;
 void timingAdd(ConstExprStr measure, microseconds start, microseconds end,
                std::unique_ptr<std::vector<std::pair<ConstExprStr, std::string>>> args,
                std::unique_ptr<std::vector<std::pair<ConstExprStr, ConstExprStr>>> tags, FlowId self, FlowId previous,

--- a/common/Counters.h
+++ b/common/Counters.h
@@ -4,7 +4,6 @@
 #include "common/ConstExprStr.h"
 #include "sorbet_version/sorbet_version.h"
 #include "spdlog/spdlog.h"
-#include <chrono>
 #include <string>
 
 namespace sorbet {
@@ -95,7 +94,8 @@ struct FlowId {
     int id;
 };
 
-void timingAdd(ConstExprStr measure, std::chrono::nanoseconds start, std::chrono::nanoseconds end,
+struct microseconds;
+void timingAdd(ConstExprStr measure, microseconds start, microseconds end,
                std::unique_ptr<std::vector<std::pair<ConstExprStr, std::string>>> args,
                std::unique_ptr<std::vector<std::pair<ConstExprStr, ConstExprStr>>> tags, FlowId self, FlowId previous,
                std::unique_ptr<std::vector<int>> histogramBuckets);

--- a/common/Counters.h
+++ b/common/Counters.h
@@ -101,9 +101,9 @@ struct FlowId {
 };
 
 void timingAdd(ConstExprStr measure, microseconds start, microseconds end,
-               std::vector<std::pair<ConstExprStr, std::string>> args,
-               std::vector<std::pair<ConstExprStr, ConstExprStr>> tags, FlowId self, FlowId previous,
-               std::vector<int> histogramBuckets);
+               std::unique_ptr<std::vector<std::pair<ConstExprStr, std::string>>> args,
+               std::unique_ptr<std::vector<std::pair<ConstExprStr, ConstExprStr>>> tags, FlowId self, FlowId previous,
+               std::unique_ptr<std::vector<int>> histogramBuckets);
 
 absl::flat_hash_map<long, long> getAndClearHistogram(ConstExprStr histogram);
 std::string getCounterStatistics(std::vector<std::string> names);

--- a/common/Counters.h
+++ b/common/Counters.h
@@ -101,9 +101,9 @@ struct FlowId {
 };
 
 void timingAdd(ConstExprStr measure, microseconds start, microseconds end,
-               std::unique_ptr<std::vector<std::pair<ConstExprStr, std::string>>> args,
-               std::unique_ptr<std::vector<std::pair<ConstExprStr, ConstExprStr>>> tags, FlowId self, FlowId previous,
-               std::unique_ptr<std::vector<int>> histogramBuckets);
+               std::vector<std::pair<ConstExprStr, std::string>> args,
+               std::vector<std::pair<ConstExprStr, ConstExprStr>> tags, FlowId self, FlowId previous,
+               std::vector<int> histogramBuckets);
 
 absl::flat_hash_map<long, long> getAndClearHistogram(ConstExprStr histogram);
 std::string getCounterStatistics(std::vector<std::string> names);

--- a/common/Counters_impl.h
+++ b/common/Counters_impl.h
@@ -37,8 +37,8 @@ struct CounterImpl {
         char const *measure;
         microseconds start, end;
         int threadId;
-        std::vector<std::pair<char const *, std::string>> args;
-        std::vector<std::pair<char const *, char const *>> tags;
+        std::unique_ptr<std::vector<std::pair<char const *, std::string>>> args;
+        std::unique_ptr<std::vector<std::pair<char const *, char const *>>> tags;
         FlowId self;
         FlowId prev;
     };

--- a/common/Counters_impl.h
+++ b/common/Counters_impl.h
@@ -37,8 +37,8 @@ struct CounterImpl {
         char const *measure;
         microseconds start, end;
         int threadId;
-        std::unique_ptr<std::vector<std::pair<char const *, std::string>>> args;
-        std::unique_ptr<std::vector<std::pair<char const *, char const *>>> tags;
+        std::vector<std::pair<char const *, std::string>> args;
+        std::vector<std::pair<char const *, char const *>> tags;
         FlowId self;
         FlowId prev;
     };

--- a/common/Counters_impl.h
+++ b/common/Counters_impl.h
@@ -37,8 +37,8 @@ struct CounterImpl {
         char const *measure;
         std::chrono::nanoseconds start, end;
         int threadId;
-        std::vector<std::pair<char const *, std::string>> args;
-        std::vector<std::pair<char const *, char const *>> tags;
+        std::unique_ptr<std::vector<std::pair<char const *, std::string>>> args;
+        std::unique_ptr<std::vector<std::pair<char const *, char const *>>> tags;
         FlowId self;
         FlowId prev;
     };

--- a/common/Counters_impl.h
+++ b/common/Counters_impl.h
@@ -35,7 +35,7 @@ struct CounterImpl {
         // and https://docs.google.com/document/d/1La_0PPfsTqHJihazYhff96thhjPtvq1KjAUOJu0dvEg/edit
         int id;
         char const *measure;
-        std::chrono::time_point<std::chrono::steady_clock> start, end;
+        std::chrono::nanoseconds start, end;
         int threadId;
         std::vector<std::pair<char const *, std::string>> args;
         std::vector<std::pair<char const *, char const *>> tags;

--- a/common/Counters_impl.h
+++ b/common/Counters_impl.h
@@ -35,7 +35,7 @@ struct CounterImpl {
         // and https://docs.google.com/document/d/1La_0PPfsTqHJihazYhff96thhjPtvq1KjAUOJu0dvEg/edit
         int id;
         char const *measure;
-        std::chrono::nanoseconds start, end;
+        microseconds start, end;
         int threadId;
         std::unique_ptr<std::vector<std::pair<char const *, std::string>>> args;
         std::unique_ptr<std::vector<std::pair<char const *, char const *>>> tags;

--- a/common/Counters_impl.h
+++ b/common/Counters_impl.h
@@ -31,6 +31,12 @@ struct CounterImpl {
     UnorderedMap<std::string_view, const char *> strings_by_value;
     UnorderedMap<const char *, const char *> stringsByPtr;
     struct Timing {
+        Timing() = default;
+        Timing(int id, char const *measure, microseconds start, microseconds end, int threadId,
+               std::unique_ptr<std::vector<std::pair<char const *, std::string>>> args,
+               std::unique_ptr<std::vector<std::pair<char const *, char const *>>> tags, FlowId self, FlowId prev)
+            : id(id), measure(measure), start(start), end(end), threadId(threadId), args(move(args)), tags(move(tags)),
+              self(self), prev(prev) {}
         // see https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/edit
         // and https://docs.google.com/document/d/1La_0PPfsTqHJihazYhff96thhjPtvq1KjAUOJu0dvEg/edit
         int id;

--- a/common/Timer.cc
+++ b/common/Timer.cc
@@ -19,15 +19,7 @@ microseconds clock_gettime_coarse() {
 
 Timer::Timer(spdlog::logger &log, ConstExprStr name, FlowId prev, initializer_list<pair<ConstExprStr, string>> args,
              microseconds start, initializer_list<int> histogramBuckets)
-    : log(log), name(name), prev(prev), self{0}, start(start) {
-    if (args.size() != 0) {
-        this->args = make_unique<vector<pair<ConstExprStr, string>>>(args);
-    }
-
-    if (histogramBuckets.size() != 0) {
-        this->histogramBuckets = make_unique<vector<int>>(histogramBuckets);
-    }
-}
+    : log(log), name(name), prev(prev), self{0}, args(args), start(start), histogramBuckets(histogramBuckets) {}
 
 Timer::Timer(spdlog::logger &log, ConstExprStr name, FlowId prev, initializer_list<pair<ConstExprStr, string>> args,
              initializer_list<int> histogramBuckets)
@@ -86,35 +78,24 @@ Timer Timer::clone() const {
 
 Timer Timer::clone(ConstExprStr name) const {
     Timer forked(log, name, prev, {}, start, {});
-    if (this->args != nullptr) {
-        forked.args = make_unique<vector<pair<ConstExprStr, string>>>(*args);
-    }
-    if (this->tags != nullptr) {
-        forked.tags = make_unique<vector<pair<ConstExprStr, ConstExprStr>>>(*tags);
-    }
+    forked.args = args;
+    forked.tags = tags;
     forked.canceled = canceled;
-    if (this->histogramBuckets != nullptr) {
-        forked.histogramBuckets = make_unique<vector<int>>(*histogramBuckets);
-    }
+    forked.histogramBuckets = histogramBuckets;
     return forked;
 }
 
 void Timer::setTag(ConstExprStr name, ConstExprStr value) {
     // Check if tag is already set; if so, update value.
-    if (tags != nullptr) {
-        for (auto &tag : *tags) {
-            const auto tagName = tag.first;
-            if (tagName.size == name.size && strncmp(tagName.str, name.str, tagName.size) == 0) {
-                tag.second = value;
-                return;
-            }
+    for (auto &tag : tags) {
+        const auto tagName = tag.first;
+        if (tagName.size == name.size && strncmp(tagName.str, name.str, tagName.size) == 0) {
+            tag.second = value;
+            return;
         }
     }
     // Add new tag.
-    if (tags == nullptr) {
-        tags = make_unique<vector<pair<ConstExprStr, ConstExprStr>>>();
-    }
-    tags->push_back(make_pair(name, value));
+    tags.push_back(make_pair(name, value));
 }
 
 Timer::~Timer() {

--- a/common/Timer.cc
+++ b/common/Timer.cc
@@ -120,7 +120,7 @@ void Timer::setTag(ConstExprStr name, ConstExprStr value) {
 Timer::~Timer() {
     auto clock = clock_gettime_coarse();
     auto dur = microseconds{clock.usec - start.usec};
-    auto threshold = microseconds{1'000}; // 1ms
+    auto threshold = microseconds{2'000}; // 2ms
     if (!canceled && dur.usec > threshold.usec) {
         // the trick ^^^ is to skip double comparison in the common case and use the most efficient representation.
         auto durMs = (clock.usec - start.usec) / 1'000;

--- a/common/Timer.cc
+++ b/common/Timer.cc
@@ -10,7 +10,15 @@ chrono::nanoseconds clock_gettime_coarse() {
 
 Timer::Timer(spdlog::logger &log, ConstExprStr name, FlowId prev, initializer_list<pair<ConstExprStr, string>> args,
              chrono::nanoseconds start, initializer_list<int> histogramBuckets)
-    : log(log), name(name), prev(prev), self{0}, args(args), start(start), histogramBuckets(histogramBuckets) {}
+    : log(log), name(name), prev(prev), self{0}, start(start) {
+    if (args.size() != 0) {
+        this->args = make_unique<vector<pair<ConstExprStr, string>>>(args);
+    }
+
+    if (histogramBuckets.size() != 0) {
+        this->histogramBuckets = make_unique<vector<int>>(histogramBuckets);
+    }
+}
 
 Timer::Timer(spdlog::logger &log, ConstExprStr name, FlowId prev, initializer_list<pair<ConstExprStr, string>> args,
              initializer_list<int> histogramBuckets)
@@ -69,24 +77,35 @@ Timer Timer::clone() const {
 
 Timer Timer::clone(ConstExprStr name) const {
     Timer forked(log, name, prev, {}, start, {});
-    forked.args = args;
-    forked.tags = tags;
+    if (this->args != nullptr) {
+        forked.args = make_unique<vector<pair<ConstExprStr, string>>>(*args);
+    }
+    if (this->tags != nullptr) {
+        forked.tags = make_unique<vector<pair<ConstExprStr, ConstExprStr>>>(*tags);
+    }
     forked.canceled = canceled;
-    forked.histogramBuckets = histogramBuckets;
+    if (this->histogramBuckets != nullptr) {
+        forked.histogramBuckets = make_unique<vector<int>>(*histogramBuckets);
+    }
     return forked;
 }
 
 void Timer::setTag(ConstExprStr name, ConstExprStr value) {
     // Check if tag is already set; if so, update value.
-    for (auto &tag : tags) {
-        const auto tagName = tag.first;
-        if (tagName.size == name.size && strncmp(tagName.str, name.str, tagName.size) == 0) {
-            tag.second = value;
-            return;
+    if (tags != nullptr) {
+        for (auto &tag : *tags) {
+            const auto tagName = tag.first;
+            if (tagName.size == name.size && strncmp(tagName.str, name.str, tagName.size) == 0) {
+                tag.second = value;
+                return;
+            }
         }
     }
     // Add new tag.
-    tags.push_back(make_pair(name, value));
+    if (tags == nullptr) {
+        tags = make_unique<vector<pair<ConstExprStr, ConstExprStr>>>();
+    }
+    tags->push_back(make_pair(name, value));
 }
 
 Timer::~Timer() {

--- a/common/Timer.cc
+++ b/common/Timer.cc
@@ -2,12 +2,14 @@
 using namespace std;
 namespace sorbet {
 
+// We are using clock_gettime instead of similar APIs from the C++ <chrono> library,
+// because this was measured to make timers noticably faster.
+//
+// https://stackoverflow.com/questions/48609413/fastest-way-to-get-a-timestamp
 microseconds clock_gettime_coarse() {
     timespec tp;
 #ifdef __linux__
-    // This is faster, as measured via the benchmark here:
-    // https://stackoverflow.com/questions/48609413/fastest-way-to-get-a-timestamp
-    // but is not portable.
+    // This is faster, as measured via the benchmark above, but is not portable.
     clock_gettime(CLOCK_MONOTONIC_COARSE, &tp);
 #else
     clock_gettime(CLOCK_MONOTONIC, &tp);

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -7,12 +7,6 @@
 
 namespace sorbet {
 
-// We are explicitly not using <chrono> in this file, because we profiled it and realized that
-// using its abstractions for computing on and gathering times were a substantial overhead.
-struct microseconds {
-    int64_t usec;
-};
-
 class Timer {
     Timer(spdlog::logger &log, ConstExprStr name, FlowId prev,
           std::initializer_list<std::pair<ConstExprStr, std::string>> args, microseconds start,

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -62,15 +62,15 @@ private:
     FlowId prev;
     FlowId self;
     // 'args' appear in traces, but not in statsd metrics because they can cause an explosion in cardinality
-    std::vector<std::pair<ConstExprStr, std::string>> args;
+    std::unique_ptr<std::vector<std::pair<ConstExprStr, std::string>>> args;
     // 'tags' appear in statsd metrics but not in traces. They are ConstExprStr to limit cardinality.
-    std::vector<std::pair<ConstExprStr, ConstExprStr>> tags;
+    std::unique_ptr<std::vector<std::pair<ConstExprStr, ConstExprStr>>> tags;
     // It would be far better for type safety to store this as a std::chrono::time_point,
     // but we don't know the clock a priori, because it's platform specific.
     const microseconds start;
     // If not empty, report the time for this timer in the given histogram, where each entry forms an upper bound
     // on a bucket.
-    std::vector<int> histogramBuckets;
+    std::unique_ptr<std::vector<int>> histogramBuckets;
     bool canceled = false;
 };
 } // namespace sorbet

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -9,8 +9,8 @@
 namespace sorbet {
 class Timer {
     Timer(spdlog::logger &log, ConstExprStr name, FlowId prev,
-          std::initializer_list<std::pair<ConstExprStr, std::string>> args,
-          std::chrono::time_point<std::chrono::steady_clock> start, std::initializer_list<int> histogramBuckets);
+          std::initializer_list<std::pair<ConstExprStr, std::string>> args, std::chrono::nanoseconds start,
+          std::initializer_list<int> histogramBuckets);
 
 public:
     Timer(spdlog::logger &log, ConstExprStr name);
@@ -65,7 +65,9 @@ private:
     std::vector<std::pair<ConstExprStr, std::string>> args;
     // 'tags' appear in statsd metrics but not in traces. They are ConstExprStr to limit cardinality.
     std::vector<std::pair<ConstExprStr, ConstExprStr>> tags;
-    const std::chrono::time_point<std::chrono::steady_clock> start;
+    // It would be far better for type safety to store this as a std::chrono::time_point,
+    // but we don't know the clock a priori, because it's platform specific.
+    const std::chrono::nanoseconds start;
     // If not empty, report the time for this timer in the given histogram, where each entry forms an upper bound
     // on a bucket.
     std::vector<int> histogramBuckets;

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -7,6 +7,8 @@
 
 namespace sorbet {
 
+// We are explicitly not using <chrono> in this file, because we profiled it and realized that
+// using its abstractions for computing on and gathering times were a substantial overhead.
 struct microseconds {
     int64_t usec;
 };

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -1,15 +1,19 @@
 #ifndef SORBET_TIMER_H
 #define SORBET_TIMER_H
 #include "common/Counters.h"
-#include <chrono>
 #include <memory>
 #include <string>
 #include <thread>
 
 namespace sorbet {
+
+struct microseconds {
+    int64_t usec;
+};
+
 class Timer {
     Timer(spdlog::logger &log, ConstExprStr name, FlowId prev,
-          std::initializer_list<std::pair<ConstExprStr, std::string>> args, std::chrono::nanoseconds start,
+          std::initializer_list<std::pair<ConstExprStr, std::string>> args, microseconds start,
           std::initializer_list<int> histogramBuckets);
 
 public:
@@ -67,7 +71,7 @@ private:
     std::unique_ptr<std::vector<std::pair<ConstExprStr, ConstExprStr>>> tags;
     // It would be far better for type safety to store this as a std::chrono::time_point,
     // but we don't know the clock a priori, because it's platform specific.
-    const std::chrono::nanoseconds start;
+    const microseconds start;
     // If not empty, report the time for this timer in the given histogram, where each entry forms an upper bound
     // on a bucket.
     std::unique_ptr<std::vector<int>> histogramBuckets;

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -62,15 +62,15 @@ private:
     FlowId prev;
     FlowId self;
     // 'args' appear in traces, but not in statsd metrics because they can cause an explosion in cardinality
-    std::unique_ptr<std::vector<std::pair<ConstExprStr, std::string>>> args;
+    std::vector<std::pair<ConstExprStr, std::string>> args;
     // 'tags' appear in statsd metrics but not in traces. They are ConstExprStr to limit cardinality.
-    std::unique_ptr<std::vector<std::pair<ConstExprStr, ConstExprStr>>> tags;
+    std::vector<std::pair<ConstExprStr, ConstExprStr>> tags;
     // It would be far better for type safety to store this as a std::chrono::time_point,
     // but we don't know the clock a priori, because it's platform specific.
     const microseconds start;
     // If not empty, report the time for this timer in the given histogram, where each entry forms an upper bound
     // on a bucket.
-    std::unique_ptr<std::vector<int>> histogramBuckets;
+    std::vector<int> histogramBuckets;
     bool canceled = false;
 };
 } // namespace sorbet

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -62,15 +62,15 @@ private:
     FlowId prev;
     FlowId self;
     // 'args' appear in traces, but not in statsd metrics because they can cause an explosion in cardinality
-    std::vector<std::pair<ConstExprStr, std::string>> args;
+    std::unique_ptr<std::vector<std::pair<ConstExprStr, std::string>>> args;
     // 'tags' appear in statsd metrics but not in traces. They are ConstExprStr to limit cardinality.
-    std::vector<std::pair<ConstExprStr, ConstExprStr>> tags;
+    std::unique_ptr<std::vector<std::pair<ConstExprStr, ConstExprStr>>> tags;
     // It would be far better for type safety to store this as a std::chrono::time_point,
     // but we don't know the clock a priori, because it's platform specific.
     const std::chrono::nanoseconds start;
     // If not empty, report the time for this timer in the given histogram, where each entry forms an upper bound
     // on a bucket.
-    std::vector<int> histogramBuckets;
+    std::unique_ptr<std::vector<int>> histogramBuckets;
     bool canceled = false;
 };
 } // namespace sorbet

--- a/common/statsd/statsd.cc
+++ b/common/statsd/statsd.cc
@@ -68,7 +68,7 @@ public:
         addMetric(name, value, "g", {});
     }
     void timing(const CounterImpl::Timing &tim) { // type: ms
-        auto nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(tim.end - tim.start).count();
+        auto nanoseconds = (tim.end.usec - tim.start.usec) * 1'000;
         if (tim.tags != nullptr) {
             addMetric(absl::StrCat(tim.measure, ".duration_ns"), nanoseconds, "ms",
                       *tim.tags); // format suggested by #observability (@sjung and @an)

--- a/common/statsd/statsd.cc
+++ b/common/statsd/statsd.cc
@@ -69,10 +69,8 @@ public:
     }
     void timing(const CounterImpl::Timing &tim) { // type: ms
         auto nanoseconds = (tim.end.usec - tim.start.usec) * 1'000;
-        if (tim.tags != nullptr) {
-            addMetric(absl::StrCat(tim.measure, ".duration_ns"), nanoseconds, "ms",
-                      *tim.tags); // format suggested by #observability (@sjung and @an)
-        }
+        addMetric(absl::StrCat(tim.measure, ".duration_ns"), nanoseconds, "ms",
+                  tim.tags); // format suggested by #observability (@sjung and @an)
     }
 };
 

--- a/common/statsd/statsd.cc
+++ b/common/statsd/statsd.cc
@@ -69,8 +69,10 @@ public:
     }
     void timing(const CounterImpl::Timing &tim) { // type: ms
         auto nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(tim.end - tim.start).count();
-        addMetric(absl::StrCat(tim.measure, ".duration_ns"), nanoseconds, "ms",
-                  tim.tags); // format suggested by #observability (@sjung and @an)
+        if (tim.tags != nullptr) {
+            addMetric(absl::StrCat(tim.measure, ".duration_ns"), nanoseconds, "ms",
+                      *tim.tags); // format suggested by #observability (@sjung and @an)
+        }
     }
 };
 

--- a/common/statsd/statsd.cc
+++ b/common/statsd/statsd.cc
@@ -69,8 +69,10 @@ public:
     }
     void timing(const CounterImpl::Timing &tim) { // type: ms
         auto nanoseconds = (tim.end.usec - tim.start.usec) * 1'000;
-        addMetric(absl::StrCat(tim.measure, ".duration_ns"), nanoseconds, "ms",
-                  tim.tags); // format suggested by #observability (@sjung and @an)
+        if (tim.tags != nullptr) {
+            addMetric(absl::StrCat(tim.measure, ".duration_ns"), nanoseconds, "ms",
+                      *tim.tags); // format suggested by #observability (@sjung and @an)
+        }
     }
 };
 

--- a/common/web_tracer_framework/tracing.cc
+++ b/common/web_tracer_framework/tracing.cc
@@ -52,11 +52,11 @@ bool Tracing::storeTraces(const CounterState &counters, string_view fileName) {
 
     for (const auto &e : counters.counters->timings) {
         string maybeArgs;
-        if (!e.args.empty()) {
-            maybeArgs = fmt::format(",\"args\":{{{}}}", fmt::map_join(e.args, ",", [](const auto &nameValue) -> string {
-                                        return fmt::format("\"{}\":\"{}\"", JSON::escape(nameValue.first),
-                                                           JSON::escape(nameValue.second));
-                                    }));
+        if (e.args != nullptr && !e.args->empty()) {
+            maybeArgs = fmt::format(
+                ",\"args\":{{{}}}", fmt::map_join(*e.args, ",", [](const auto &nameValue) -> string {
+                    return fmt::format("\"{}\":\"{}\"", JSON::escape(nameValue.first), JSON::escape(nameValue.second));
+                }));
         }
 
         string maybeFlow;

--- a/common/web_tracer_framework/tracing.cc
+++ b/common/web_tracer_framework/tracing.cc
@@ -69,9 +69,7 @@ bool Tracing::storeTraces(const CounterState &counters, string_view fileName) {
 
         fmt::format_to(result,
                        "{{\"name\":\"{}\",\"ph\":\"X\",\"ts\":{:.3f},\"dur\":{:.3f},\"pid\":{},\"tid\":{}{}{}}},\n",
-                       e.measure, (std::chrono::duration<double, std::micro>(e.start)).count(),
-                       (std::chrono::duration<double, std::micro>(e.end - e.start)).count(), pid, e.threadId, maybeArgs,
-                       maybeFlow);
+                       e.measure, e.start.usec, e.end.usec - e.start.usec, pid, e.threadId, maybeArgs, maybeFlow);
     }
 
     fmt::format_to(result, "\n");

--- a/common/web_tracer_framework/tracing.cc
+++ b/common/web_tracer_framework/tracing.cc
@@ -52,11 +52,11 @@ bool Tracing::storeTraces(const CounterState &counters, string_view fileName) {
 
     for (const auto &e : counters.counters->timings) {
         string maybeArgs;
-        if (e.args != nullptr && !e.args->empty()) {
-            maybeArgs = fmt::format(
-                ",\"args\":{{{}}}", fmt::map_join(*e.args, ",", [](const auto &nameValue) -> string {
-                    return fmt::format("\"{}\":\"{}\"", JSON::escape(nameValue.first), JSON::escape(nameValue.second));
-                }));
+        if (!e.args.empty()) {
+            maybeArgs = fmt::format(",\"args\":{{{}}}", fmt::map_join(e.args, ",", [](const auto &nameValue) -> string {
+                                        return fmt::format("\"{}\":\"{}\"", JSON::escape(nameValue.first),
+                                                           JSON::escape(nameValue.second));
+                                    }));
         }
 
         string maybeFlow;

--- a/common/web_tracer_framework/tracing.cc
+++ b/common/web_tracer_framework/tracing.cc
@@ -69,7 +69,7 @@ bool Tracing::storeTraces(const CounterState &counters, string_view fileName) {
 
         fmt::format_to(result,
                        "{{\"name\":\"{}\",\"ph\":\"X\",\"ts\":{:.3f},\"dur\":{:.3f},\"pid\":{},\"tid\":{}{}{}}},\n",
-                       e.measure, (std::chrono::duration<double, std::micro>(e.start.time_since_epoch())).count(),
+                       e.measure, (std::chrono::duration<double, std::micro>(e.start)).count(),
                        (std::chrono::duration<double, std::micro>(e.end - e.start)).count(), pid, e.threadId, maybeArgs,
                        maybeFlow);
     }

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -74,18 +74,15 @@ CounterImpl::CounterType CounterStateDatabase::getHistogramCount(ConstExprStr hi
     return rv;
 }
 
-vector<const CounterImpl::Timing *>
-CounterStateDatabase::getTimings(ConstExprStr counter, vector<pair<ConstExprStr, ConstExprStr>> tags) const {
+vector<CounterImpl::Timing> CounterStateDatabase::getTimings(ConstExprStr counter,
+                                                             vector<pair<ConstExprStr, ConstExprStr>> tags) const {
     // Note: Timers don't have interned names.
-    vector<const CounterImpl::Timing *> rv;
+    vector<CounterImpl::Timing> rv;
     for (const auto &timing : counters.counters->timings) {
-        auto timing_tags_size = timing.tags == nullptr ? 0 : timing.tags->size();
-        if (strncmp(timing.measure, counter.str, counter.size + 1) == 0 && timing_tags_size >= tags.size()) {
+        if (strncmp(timing.measure, counter.str, counter.size + 1) == 0 && timing.tags.size() >= tags.size()) {
             UnorderedMap<std::string, const char *> timingTags;
-            if (timing.tags != nullptr) {
-                for (const auto &tag : *timing.tags) {
-                    timingTags[tag.first] = tag.second;
-                }
+            for (const auto &tag : timing.tags) {
+                timingTags[tag.first] = tag.second;
             }
 
             int tagsMatched = 0;
@@ -101,7 +98,7 @@ CounterStateDatabase::getTimings(ConstExprStr counter, vector<pair<ConstExprStr,
             }
 
             if (tagsMatched == tags.size()) {
-                rv.emplace_back(&timing);
+                rv.emplace_back(timing);
             }
         }
     }

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -74,15 +74,18 @@ CounterImpl::CounterType CounterStateDatabase::getHistogramCount(ConstExprStr hi
     return rv;
 }
 
-vector<CounterImpl::Timing> CounterStateDatabase::getTimings(ConstExprStr counter,
-                                                             vector<pair<ConstExprStr, ConstExprStr>> tags) const {
+vector<const CounterImpl::Timing *>
+CounterStateDatabase::getTimings(ConstExprStr counter, vector<pair<ConstExprStr, ConstExprStr>> tags) const {
     // Note: Timers don't have interned names.
-    vector<CounterImpl::Timing> rv;
+    vector<const CounterImpl::Timing *> rv;
     for (const auto &timing : counters.counters->timings) {
-        if (strncmp(timing.measure, counter.str, counter.size + 1) == 0 && timing.tags.size() >= tags.size()) {
+        auto timing_tags_size = timing.tags == nullptr ? 0 : timing.tags->size();
+        if (strncmp(timing.measure, counter.str, counter.size + 1) == 0 && timing_tags_size >= tags.size()) {
             UnorderedMap<std::string, const char *> timingTags;
-            for (const auto &tag : timing.tags) {
-                timingTags[tag.first] = tag.second;
+            if (timing.tags != nullptr) {
+                for (const auto &tag : *timing.tags) {
+                    timingTags[tag.first] = tag.second;
+                }
             }
 
             int tagsMatched = 0;
@@ -98,7 +101,7 @@ vector<CounterImpl::Timing> CounterStateDatabase::getTimings(ConstExprStr counte
             }
 
             if (tagsMatched == tags.size()) {
-                rv.emplace_back(timing);
+                rv.emplace_back(&timing);
             }
         }
     }

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -74,15 +74,18 @@ CounterImpl::CounterType CounterStateDatabase::getHistogramCount(ConstExprStr hi
     return rv;
 }
 
-vector<CounterImpl::Timing> CounterStateDatabase::getTimings(ConstExprStr counter,
-                                                             vector<pair<ConstExprStr, ConstExprStr>> tags) const {
+vector<const CounterImpl::Timing *>
+CounterStateDatabase::getTimings(ConstExprStr counter, vector<pair<ConstExprStr, ConstExprStr>> tags) const {
     // Note: Timers don't have interned names.
-    vector<CounterImpl::Timing> rv;
+    vector<const CounterImpl::Timing *> rv;
     for (const auto &timing : counters.counters->timings) {
-        if (strncmp(timing.measure, counter.str, counter.size + 1) == 0 && timing.tags.size() >= tags.size()) {
+        auto timing_tags_size = timing.tags == nullptr ? 0 : timing.tags->size();
+        if (strncmp(timing.measure, counter.str, counter.size + 1) == 0 && timing_tags_size >= tags.size()) {
             UnorderedMap<std::string, const char *> timingTags;
-            for (const auto &tag : timing.tags) {
-                timingTags[tag.first] = tag.second;
+            if (timing.tags != nullptr) {
+                for (const auto &tag : *timing.tags) {
+                    timingTags[tag.first] = tag.second;
+                }
             }
 
             int tagsMatched = 0;
@@ -98,7 +101,7 @@ vector<CounterImpl::Timing> CounterStateDatabase::getTimings(ConstExprStr counte
             }
 
             if (tagsMatched == tags.size()) {
-                rv.push_back(timing);
+                rv.emplace_back(&timing);
             }
         }
     }

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -33,8 +33,8 @@ public:
 
     CounterImpl::CounterType getHistogramCount(ConstExprStr histogram) const;
 
-    std::vector<CounterImpl::Timing> getTimings(ConstExprStr counter,
-                                                std::vector<std::pair<ConstExprStr, ConstExprStr>> tags = {}) const;
+    std::vector<const CounterImpl::Timing *>
+    getTimings(ConstExprStr counter, std::vector<std::pair<ConstExprStr, ConstExprStr>> tags = {}) const;
 };
 
 struct ProtocolTestConfig {

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -33,7 +33,7 @@ public:
 
     CounterImpl::CounterType getHistogramCount(ConstExprStr histogram) const;
 
-    std::vector<const CounterImpl::Timing *>
+    std::vector<std::unique_ptr<CounterImpl::Timing>>
     getTimings(ConstExprStr counter, std::vector<std::pair<ConstExprStr, ConstExprStr>> tags = {}) const;
 };
 

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -33,8 +33,8 @@ public:
 
     CounterImpl::CounterType getHistogramCount(ConstExprStr histogram) const;
 
-    std::vector<const CounterImpl::Timing *>
-    getTimings(ConstExprStr counter, std::vector<std::pair<ConstExprStr, ConstExprStr>> tags = {}) const;
+    std::vector<CounterImpl::Timing> getTimings(ConstExprStr counter,
+                                                std::vector<std::pair<ConstExprStr, ConstExprStr>> tags = {}) const;
 };
 
 struct ProtocolTestConfig {

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -52,7 +52,7 @@ TEST_P(ProtocolTest, MultithreadedWrapperWorks) {
     sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::PAUSE, nullopt)));
     sendAsync(*openFile("yolo1.rb", "# typed: true\nclass Foo2\n  def branch\n    2 + \"dog\"\n  end\nend\n"));
     // Pause to differentiate message times
-    this_thread::sleep_for(chrono::microseconds(100));
+    this_thread::sleep_for(chrono::milliseconds(1));
     sendAsync(*changeFile("yolo1.rb", "# typed: true\nclass Foo1\n  def branch\n    1 + \"bear\"\n  end\nend\n", 3));
 
     // Pause so that all latency timers for the above operations get reported.
@@ -97,7 +97,7 @@ TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeFastPathWithOldEdits) {
     // Syntax error in foo.rb.
     sendAsync(*changeFile("foo.rb", "# typed: true\n\nclass Foo\ndef noend\nend\n", 2, true));
     // Pause to differentiate message times
-    this_thread::sleep_for(chrono::microseconds(100));
+    this_thread::sleep_for(chrono::milliseconds(1));
     // Typechecking error in bar.rb
     sendAsync(*changeFile(
         "bar.rb", "# typed: true\n\nclass Bar\nextend T::Sig\n\nsig{returns(Integer)}\ndef hello\n\"hi\"\nend\nend\n",

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -19,20 +19,18 @@ optional<SorbetTypecheckRunStatus> getTypecheckRunStatus(const LSPMessage &msg) 
     return nullopt;
 }
 
-void sortTimersByStartTime(vector<CounterImpl::Timing> &times) {
-    fast_sort(times, [](const CounterImpl::Timing &a, const CounterImpl::Timing &b) -> bool {
-        return a.start.usec < b.start.usec;
-    });
+void sortTimersByStartTime(vector<const CounterImpl::Timing *> &times) {
+    fast_sort(times, [](const auto *a, const auto *b) -> bool { return a->start.usec < b->start.usec; });
 }
 
-void checkDiagnosticTimes(vector<CounterImpl::Timing> times, size_t expectedSize, bool assertUniqueStartTimes) {
+void checkDiagnosticTimes(vector<const CounterImpl::Timing *> times, size_t expectedSize, bool assertUniqueStartTimes) {
     EXPECT_EQ(times.size(), expectedSize);
     sortTimersByStartTime(times);
 
     if (assertUniqueStartTimes) {
         // No two diagnostic latency timers should have the same start timestamp.
         for (size_t i = 1; i < times.size(); i++) {
-            EXPECT_LT(times[i - 1].start.usec, times[i].start.usec);
+            EXPECT_LT(times[i - 1]->start.usec, times[i]->start.usec);
         }
     }
 }
@@ -144,7 +142,7 @@ TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeFastPathWithOldEdits) {
     // We don't report task latencies for merged edits or canceled slow paths.
     auto taskLatency = counters.getTimings("task_latency", {{"method", "sorbet.workspaceEdit"}});
     EXPECT_EQ(taskLatency.size(), 1);
-    EXPECT_GE(taskLatency[0].end.usec - taskLatency[0].start.usec, 5'000 /* 5ms */);
+    EXPECT_GE(taskLatency[0]->end.usec - taskLatency[0]->start.usec, 5'000 /* 5ms */);
     EXPECT_EQ(counters.getCategoryCounterSum("lsp.messages.canceled"), 0);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "fastpath"), 1);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 0);
@@ -153,8 +151,8 @@ TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeFastPathWithOldEdits) {
 
     auto lastDiagnosticLatency = counters.getTimings("last_diagnostic_latency");
     sortTimersByStartTime(lastDiagnosticLatency);
-    EXPECT_GE(lastDiagnosticLatency[0].end.usec - lastDiagnosticLatency[0].start.usec, 5'000 /* 5ms */);
-    EXPECT_GE(lastDiagnosticLatency[1].end.usec - lastDiagnosticLatency[1].start.usec, 5'000 /* 5ms */);
+    EXPECT_GE(lastDiagnosticLatency[0]->end.usec - lastDiagnosticLatency[0]->start.usec, 5'000 /* 5ms */);
+    EXPECT_GE(lastDiagnosticLatency[1]->end.usec - lastDiagnosticLatency[1]->start.usec, 5'000 /* 5ms */);
     // 1 per edit
     checkDiagnosticTimes(move(lastDiagnosticLatency), 3, /* assertUniqueStartTimes */ false);
 }

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -19,11 +19,12 @@ optional<SorbetTypecheckRunStatus> getTypecheckRunStatus(const LSPMessage &msg) 
     return nullopt;
 }
 
-void sortTimersByStartTime(vector<const CounterImpl::Timing *> &times) {
-    fast_sort(times, [](const auto *a, const auto *b) -> bool { return a->start.usec < b->start.usec; });
+void sortTimersByStartTime(vector<unique_ptr<CounterImpl::Timing>> &times) {
+    fast_sort(times, [](const auto &a, const auto &b) -> bool { return a->start.usec < b->start.usec; });
 }
 
-void checkDiagnosticTimes(vector<const CounterImpl::Timing *> times, size_t expectedSize, bool assertUniqueStartTimes) {
+void checkDiagnosticTimes(vector<unique_ptr<CounterImpl::Timing>> times, size_t expectedSize,
+                          bool assertUniqueStartTimes) {
     EXPECT_EQ(times.size(), expectedSize);
     sortTimersByStartTime(times);
 

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -19,17 +19,19 @@ optional<SorbetTypecheckRunStatus> getTypecheckRunStatus(const LSPMessage &msg) 
     return nullopt;
 }
 
-void sortTimersByStartTime(vector<const CounterImpl::Timing *> &times) {
-    fast_sort(times, [](const auto *a, const auto *b) -> bool { return a->start.usec < b->start.usec; });
+void sortTimersByStartTime(vector<CounterImpl::Timing> &times) {
+    fast_sort(times, [](const CounterImpl::Timing &a, const CounterImpl::Timing &b) -> bool {
+        return a.start.usec < b.start.usec;
+    });
 }
 
-void checkDiagnosticTimes(vector<const CounterImpl::Timing *> times, size_t expectedSize) {
+void checkDiagnosticTimes(vector<CounterImpl::Timing> times, size_t expectedSize) {
     EXPECT_EQ(times.size(), expectedSize);
     sortTimersByStartTime(times);
 
     // No two diagnostic latency timers should have the same start timestamp.
     for (size_t i = 1; i < times.size(); i++) {
-        EXPECT_LT(times[i - 1]->start.usec, times[i]->start.usec);
+        EXPECT_LT(times[i - 1].start.usec, times[i].start.usec);
     }
 }
 
@@ -137,7 +139,7 @@ TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeFastPathWithOldEdits) {
     // We don't report task latencies for merged edits or canceled slow paths.
     auto taskLatency = counters.getTimings("task_latency", {{"method", "sorbet.workspaceEdit"}});
     EXPECT_EQ(taskLatency.size(), 1);
-    EXPECT_GE(taskLatency[0]->end.usec - taskLatency[0]->start.usec, 5'000 /* 5ms */);
+    EXPECT_GE(taskLatency[0].end.usec - taskLatency[0].start.usec, 5'000 /* 5ms */);
     EXPECT_EQ(counters.getCategoryCounterSum("lsp.messages.canceled"), 0);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "fastpath"), 1);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 0);
@@ -146,8 +148,8 @@ TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeFastPathWithOldEdits) {
 
     auto lastDiagnosticLatency = counters.getTimings("last_diagnostic_latency");
     sortTimersByStartTime(lastDiagnosticLatency);
-    EXPECT_GE(lastDiagnosticLatency[0]->end.usec - lastDiagnosticLatency[0]->start.usec, 5'000 /* 5ms */);
-    EXPECT_GE(lastDiagnosticLatency[1]->end.usec - lastDiagnosticLatency[1]->start.usec, 5'000 /* 5ms */);
+    EXPECT_GE(lastDiagnosticLatency[0].end.usec - lastDiagnosticLatency[0].start.usec, 5'000 /* 5ms */);
+    EXPECT_GE(lastDiagnosticLatency[1].end.usec - lastDiagnosticLatency[1].start.usec, 5'000 /* 5ms */);
     // 1 per edit
     checkDiagnosticTimes(move(lastDiagnosticLatency), 3);
 }

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -72,7 +72,7 @@ TEST_P(ProtocolTest, MultithreadedWrapperWorks) {
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 1);
     EXPECT_EQ(counters.getCategoryCounterSum("lsp.updates"), 1);
     // 1 per edit
-    checkDiagnosticTimes(counters.getTimings("last_diagnostic_latency"), 2, /* assertUniqueStartTimes */ true);
+    checkDiagnosticTimes(counters.getTimings("last_diagnostic_latency"), 2, /* assertUniqueStartTimes */ false);
 }
 
 TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeFastPathWithOldEdits) {
@@ -217,7 +217,7 @@ TEST_P(ProtocolTest, CancelsSlowPathWhenNewEditWouldTakeSlowPath) {
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "slowpath_canceled"), 1);
     EXPECT_EQ(counters.getCategoryCounter("lsp.updates", "query"), 0);
     // 1 per edit
-    checkDiagnosticTimes(counters.getTimings("last_diagnostic_latency"), 2, /* assertUniqueStartTimes */ true);
+    checkDiagnosticTimes(counters.getTimings("last_diagnostic_latency"), 2, /* assertUniqueStartTimes */ false);
 }
 
 TEST_P(ProtocolTest, CanPreemptSlowPathWithHover) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Review by commit for a summary of the optimizations (there were 3)

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We want to add a Timer to every ENFORCE, so we can see why debug runs of Sorbet
are slower.

Adding a Timer to every ENFORCE itself slowed down the time to generate the
state payload (which runs using host_opt, which always turns on debug checks),
so we wanted to make Timers faster before we put Timers in way more places than
before.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests