### PR TITLE
Fix CSV.generate_line types

### DIFF
--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -381,7 +381,7 @@ class CSV < Object
   #
   # The `:row_sep` `option` defaults to `$INPUT_RECORD_SEPARATOR`
   # (`$/`) when calling this method.
-  sig { params(row: T::Array[String], options: T.untyped).returns(String) }
+  sig { params(row: T::Array[T.nilable(String)], options: T.untyped).returns(String) }
   def self.generate_line(row, **options); end
 end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`CSV.parse` can produce cells containing `nil`, and `CSV.generate_line`
can consume such lines:

    ❯ irb
    irb(main):001:0> require 'csv'
    => true
    irb(main):002:0> x = CSV.parse('foo,,bar,')
    => [["foo", nil, "bar", nil]]
    irb(main):003:0> CSV.generate_line(x[0])
    => "foo,,bar,\n"

Some code at Stripe was relying on this.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.