### PR TITLE
Rewrite uses of sig to T::Sig::WithoutRuntime.sig

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -316,6 +316,22 @@ void GlobalState::initEmpty() {
     id = id.data(*this)->singletonClass(*this);
     ENFORCE(id == Symbols::T_Private_Types_Void_VOIDSingleton());
 
+    // T.class_of(T::Sig::WithoutRuntime)
+    id = Symbols::T_Sig_WithoutRuntime().data(*this)->singletonClass(*this);
+    ENFORCE(id == Symbols::T_Sig_WithoutRuntimeSingleton());
+
+    // T::Sig::WithoutRuntime.sig
+    id = enterMethodSymbol(Loc::none(), Symbols::T_Sig_WithoutRuntimeSingleton(), Names::sig());
+    {
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), id, Names::arg0());
+        arg.flags.isDefault = true;
+    }
+    {
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), id, Names::blkArg());
+        arg.flags.isBlock = true;
+    }
+    ENFORCE(id == Symbols::sigWithoutRuntime());
+
     // Root members
     Symbols::root().dataAllowingNone(*this)->members()[core::Names::Constants::NoSymbol()] = Symbols::noSymbol();
     Symbols::root().dataAllowingNone(*this)->members()[core::Names::Constants::Top()] = Symbols::top();

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -417,6 +417,18 @@ public:
         return SymbolRef(nullptr, 88);
     }
 
+    // 89 is the attached class of VOIDSingleton
+
+    static SymbolRef T_Sig_WithoutRuntimeSingleton() {
+        return SymbolRef(nullptr, 90);
+    }
+
+    // 91 is the attached class of T_Sig_WithoutRuntimeSingleton
+
+    static SymbolRef sigWithoutRuntime() {
+        return SymbolRef(nullptr, 92);
+    }
+
     static constexpr int MAX_PROC_ARITY = 10;
     static SymbolRef Proc0() {
         return SymbolRef(nullptr, MAX_SYNTHETIC_SYMBOLS - MAX_PROC_ARITY * 3 - 3);

--- a/rewriter/SigRewriter.cc
+++ b/rewriter/SigRewriter.cc
@@ -1,0 +1,21 @@
+#include "rewriter/SigRewriter.h"
+#include "ast/Helpers.h"
+#include "ast/treemap/treemap.h"
+
+using namespace std;
+namespace sorbet::rewriter {
+
+// Rewrite all sig usage into explicit uses of `T::Sig::WithoutRuntime.sig`, and
+// mark them as being dsl synthesized.
+void SigRewriter::run(core::MutableContext &ctx, ast::ClassDef *klass) {
+    for (auto &rhs : klass->rhs) {
+        if (auto send = ast::cast_tree<ast::Send>(rhs.get())) {
+            if (send->fun == core::Names::sig() && send->recv->isSelfReference()) {
+                send->recv = ast::MK::Constant(send->loc, core::Symbols::T_Sig_WithoutRuntime());
+                send->flags.isRewriterSynthesized = true;
+            }
+        }
+    }
+}
+
+} // namespace sorbet::rewriter

--- a/rewriter/SigRewriter.h
+++ b/rewriter/SigRewriter.h
@@ -1,0 +1,12 @@
+#ifndef SORBET_SIG_REWRITER_H
+#define SORBET_SIG_REWRITER_H
+
+#include "ast/ast.h"
+
+namespace sorbet::rewriter {
+class SigRewriter {
+public:
+    static void run(core::MutableContext &ctx, ast::ClassDef *klass);
+};
+} // namespace sorbet::rewriter
+#endif

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -24,6 +24,7 @@
 #include "rewriter/Rails.h"
 #include "rewriter/Regexp.h"
 #include "rewriter/SelfNew.h"
+#include "rewriter/SigRewriter.h"
 #include "rewriter/Struct.h"
 #include "rewriter/TEnum.h"
 #include "rewriter/TypeMembers.h"
@@ -138,6 +139,7 @@ public:
         }
         if (replaceNodes.empty()) {
             ModuleFunction::run(ctx, classDef.get());
+            SigRewriter::run(ctx, classDef.get());
             return classDef;
         }
 
@@ -155,6 +157,7 @@ public:
             }
         }
         ModuleFunction::run(ctx, classDef.get());
+        SigRewriter::run(ctx, classDef.get());
 
         return classDef;
     }

--- a/test/cli/forgot-typed/forgot-typed.out
+++ b/test/cli/forgot-typed/forgot-typed.out
@@ -1,5 +1,2 @@
-test/cli/forgot-typed/forgot-typed.rb:2: To use `sig`, this file must declare an explicit `# typed:` sigil (found: none). If you're not sure which one to use, start with `# typed: false` https://srb.help/5038
-     2 |sig {void} # error: `sig` in untyped file. Did you mean to put `# typed: true` in this file?
-        ^^^^^^^^^^
-Errors: 1
+No errors! Great job.
 No errors! Great job.

--- a/test/cli/same-loc/same-loc.out
+++ b/test/cli/same-loc/same-loc.out
@@ -90,10 +90,6 @@ test/cli/same-loc/same-loc.rb:4: Method `unsafe` does not exist on `T.class_of(T
      4 |  const :foo, T::Array[Foo::Baz]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/same-loc/same-loc.rb:4: Method `sig` does not exist on `T.class_of(T::Sig::WithoutRuntime)` https://srb.help/7003
-     4 |  const :foo, T::Array[Foo::Baz]
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 test/cli/same-loc/same-loc.rb:4: Method `params` does not exist on `T.class_of(MyClass)` https://srb.help/7003
      4 |  const :foo, T::Array[Foo::Baz]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -126,10 +122,6 @@ test/cli/same-loc/same-loc.rb:4: Method `unsafe` does not exist on `T.class_of(T
      4 |  const :foo, T::Array[Foo::Baz]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/same-loc/same-loc.rb:4: Method `sig` does not exist on `T.class_of(T::Sig::WithoutRuntime)` https://srb.help/7003
-     4 |  const :foo, T::Array[Foo::Baz]
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 test/cli/same-loc/same-loc.rb:4: Too many arguments provided for method `T::Array.[]`. Expected: `0`, got: `1` https://srb.help/7004
      4 |  const :foo, T::Array[Foo::Baz]
                       ^^^^^^^^^^^^^^^^^^
@@ -144,10 +136,6 @@ test/cli/same-loc/same-loc.rb:4: Too many arguments provided for method `T::Arra
                       ^^^^^^^^^^^^^^^^^^
     ???: `[]` defined here
 
-test/cli/same-loc/same-loc.rb:4: Method `sig` does not exist on `T.class_of(T::Sig::WithoutRuntime)` https://srb.help/7003
-     4 |  const :foo, T::Array[Foo::Baz]
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 test/cli/same-loc/same-loc.rb:4: Method `returns` does not exist on `T.class_of(MyClass::Mutator)` https://srb.help/7003
      4 |  const :foo, T::Array[Foo::Baz]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -159,4 +147,4 @@ test/cli/same-loc/same-loc.rb:4: Method `keep_def` does not exist on `T.class_of
 test/cli/same-loc/same-loc.rb:4: Method `keep_def` does not exist on `T.class_of(Sorbet::Private::Static)` https://srb.help/7003
      4 |  const :foo, T::Array[Foo::Baz]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 41
+Errors: 38

--- a/test/cli/sigil-rbi/sigil-rbi.out
+++ b/test/cli/sigil-rbi/sigil-rbi.out
@@ -1,4 +1,1 @@
-test/cli/sigil-rbi/no_type.rbi:3: To use `sig`, this file must declare an explicit `# typed:` sigil (found: none). If you're not sure which one to use, start with `# typed: false` https://srb.help/5038
-     3 |sig {returns(Integer)}
-        ^^^^^^^^^^^^^^^^^^^^^^
-Errors: 1
+No errors! Great job.

--- a/test/cli/suggest-sig-garbage/suggest-sig-garbage.out
+++ b/test/cli/suggest-sig-garbage/suggest-sig-garbage.out
@@ -298,15 +298,7 @@ suggest-sig-garbage.rb:112: This function does not have a `sig` https://srb.help
 `
      105 |  class Merchant
           ^
-
-suggest-sig-garbage.rb:108: Method `sig` does not exist on `T.class_of(TestCarash)` https://srb.help/7003
-     108 |  sig {params(merchant: Merchant).void}
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-suggest-sig-garbage.rb:108: Method `params` does not exist on `T.class_of(TestCarash)` https://srb.help/7003
-     108 |  sig {params(merchant: Merchant).void}
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 42
+Errors: 40
 
 --------------------------------------------------------------------------
 

--- a/test/cli/suggest-sig/suggest-sig.out
+++ b/test/cli/suggest-sig/suggest-sig.out
@@ -277,15 +277,7 @@ suggest-sig.rb:112: This function does not have a `sig` https://srb.help/7017
 `
      105 |  class Merchant
           ^
-
-suggest-sig.rb:108: Method `sig` does not exist on `T.class_of(TestCarash)` https://srb.help/7003
-     108 |  sig {params(merchant: Merchant).void}
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-suggest-sig.rb:108: Method `params` does not exist on `T.class_of(TestCarash)` https://srb.help/7003
-     108 |  sig {params(merchant: Merchant).void}
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 40
+Errors: 38
 
 --------------------------------------------------------------------------
 

--- a/test/testdata/cfg/array.rb.cfg.exp
+++ b/test/testdata/cfg/array.rb.cfg.exp
@@ -78,7 +78,7 @@ subgraph "cluster_::<Class:TestArray>#<static-init>" {
     "bb::<Class:TestArray>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:TestArray>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(TestArray) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U TestArray>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U TestArray>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: T.class_of(TestArray).sig()\l<selfRestore>$6: T.class_of(TestArray) = <self>\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(TestArray) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U TestArray>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U TestArray>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<statTemp>$4: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$4: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$6: T.class_of(TestArray) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:TestArray>#<static-init>_0" -> "bb::<Class:TestArray>#<static-init>_2" [style="bold"];
@@ -95,7 +95,7 @@ subgraph "cluster_::<Class:TestArray>#<static-init>" {
     "bb::<Class:TestArray>#<static-init>_2" -> "bb::<Class:TestArray>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:TestArray>#<static-init>_3" [
-        label = "block[id=3, rubyBlockId=0](<selfRestore>$6: T.class_of(TestArray), <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$5, sig>\l<self>: T.class_of(TestArray) = <selfRestore>$6\l<block-pre-call-temp>$15: Sorbet::Private::Static::Void = <self>: T.class_of(TestArray).sig()\l<selfRestore>$16: T.class_of(TestArray) = <self>\l<unconditional>\l"
+        label = "block[id=3, rubyBlockId=0](<selfRestore>$6: T.class_of(TestArray), <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$5, sig>\l<self>: T.class_of(TestArray) = <selfRestore>$6\l<statTemp>$14: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$15: Sorbet::Private::Static::Void = <statTemp>$14: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$16: T.class_of(TestArray) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:TestArray>#<static-init>_3" -> "bb::<Class:TestArray>#<static-init>_6" [style="bold"];

--- a/test/testdata/cfg/break.rb.cfg.exp
+++ b/test/testdata/cfg/break.rb.cfg.exp
@@ -64,7 +64,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: T.class_of(<root>).sig()\l<selfRestore>$6: T.class_of(<root>) = <self>\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<statTemp>$4: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$4: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$6: T.class_of(<root>) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_2" [style="bold"];

--- a/test/testdata/core/fuzz_bad_subtyping.rb
+++ b/test/testdata/core/fuzz_bad_subtyping.rb
@@ -5,8 +5,6 @@ module MyEnumerable
 extend T::Generic
 A = type_member
   sig {params(a: MyEnumerable[])} # error: Malformed `sig`: No return type specified. Specify one with .returns()
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Method `sig` does not exist on `T.class_of(MyEnumerable)`
-     # ^^^^^^^^^^^^^^^^^^^^^^^^^ error: Method `params` does not exist on `T.class_of(MyEnumerable)`
                # ^^^^^^^^^^^^^^ error-with-dupes: Wrong number of type parameters for `MyEnumerable`.
   def-(a) end
  class MySet

--- a/test/testdata/desugar/sclass.rb.flatten-tree.exp
+++ b/test/testdata/desugar/sclass.rb.flatten-tree.exp
@@ -152,7 +152,7 @@ begin
 
     def self.<static-init>(<blk>)
       begin
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"f" => ::Integer}).returns(::Integer)
         end
         ::Sorbet::Private::Static.keep_def(<self>, :"initialize")

--- a/test/testdata/infer/control_flow/simple.rb.cfg.exp
+++ b/test/testdata/infer/control_flow/simple.rb.cfg.exp
@@ -353,7 +353,7 @@ subgraph "cluster_::<Class:ControlFlow>#<static-init>" {
     "bb::<Class:ControlFlow>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:ControlFlow>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(ControlFlow) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U ControlFlow>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U ControlFlow>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: T.class_of(ControlFlow).sig()\l<selfRestore>$6: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(ControlFlow) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U ControlFlow>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U ControlFlow>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<statTemp>$4: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$4: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$6: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_0" -> "bb::<Class:ControlFlow>#<static-init>_2" [style="bold"];
@@ -370,7 +370,7 @@ subgraph "cluster_::<Class:ControlFlow>#<static-init>" {
     "bb::<Class:ControlFlow>#<static-init>_2" -> "bb::<Class:ControlFlow>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:ControlFlow>#<static-init>_3" [
-        label = "block[id=3, rubyBlockId=0](<selfRestore>$6: T.class_of(ControlFlow), <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$5, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$6\l<block-pre-call-temp>$23: Sorbet::Private::Static::Void = <self>: T.class_of(ControlFlow).sig()\l<selfRestore>$24: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
+        label = "block[id=3, rubyBlockId=0](<selfRestore>$6: T.class_of(ControlFlow), <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$5, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$6\l<statTemp>$22: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$23: Sorbet::Private::Static::Void = <statTemp>$22: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$24: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_3" -> "bb::<Class:ControlFlow>#<static-init>_6" [style="bold"];
@@ -387,7 +387,7 @@ subgraph "cluster_::<Class:ControlFlow>#<static-init>" {
     "bb::<Class:ControlFlow>#<static-init>_6" -> "bb::<Class:ControlFlow>#<static-init>_7" [style="tapered"];
 
     "bb::<Class:ControlFlow>#<static-init>_7" [
-        label = "block[id=7, rubyBlockId=0](<selfRestore>$24: T.class_of(ControlFlow), <block-pre-call-temp>$23: Sorbet::Private::Static::Void)\l<statTemp>$21: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$23, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$24\l<block-pre-call-temp>$38: Sorbet::Private::Static::Void = <self>: T.class_of(ControlFlow).sig()\l<selfRestore>$39: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
+        label = "block[id=7, rubyBlockId=0](<selfRestore>$24: T.class_of(ControlFlow), <block-pre-call-temp>$23: Sorbet::Private::Static::Void)\l<statTemp>$21: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$23, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$24\l<statTemp>$37: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$38: Sorbet::Private::Static::Void = <statTemp>$37: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$39: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_7" -> "bb::<Class:ControlFlow>#<static-init>_10" [style="bold"];
@@ -404,7 +404,7 @@ subgraph "cluster_::<Class:ControlFlow>#<static-init>" {
     "bb::<Class:ControlFlow>#<static-init>_10" -> "bb::<Class:ControlFlow>#<static-init>_11" [style="tapered"];
 
     "bb::<Class:ControlFlow>#<static-init>_11" [
-        label = "block[id=11, rubyBlockId=0](<selfRestore>$39: T.class_of(ControlFlow), <block-pre-call-temp>$38: Sorbet::Private::Static::Void)\l<statTemp>$36: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$38, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$39\l<block-pre-call-temp>$56: Sorbet::Private::Static::Void = <self>: T.class_of(ControlFlow).sig()\l<selfRestore>$57: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
+        label = "block[id=11, rubyBlockId=0](<selfRestore>$39: T.class_of(ControlFlow), <block-pre-call-temp>$38: Sorbet::Private::Static::Void)\l<statTemp>$36: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$38, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$39\l<statTemp>$55: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$56: Sorbet::Private::Static::Void = <statTemp>$55: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$57: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_11" -> "bb::<Class:ControlFlow>#<static-init>_14" [style="bold"];
@@ -421,7 +421,7 @@ subgraph "cluster_::<Class:ControlFlow>#<static-init>" {
     "bb::<Class:ControlFlow>#<static-init>_14" -> "bb::<Class:ControlFlow>#<static-init>_15" [style="tapered"];
 
     "bb::<Class:ControlFlow>#<static-init>_15" [
-        label = "block[id=15, rubyBlockId=0](<selfRestore>$57: T.class_of(ControlFlow), <block-pre-call-temp>$56: Sorbet::Private::Static::Void)\l<statTemp>$54: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$56, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$57\l<block-pre-call-temp>$74: Sorbet::Private::Static::Void = <self>: T.class_of(ControlFlow).sig()\l<selfRestore>$75: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
+        label = "block[id=15, rubyBlockId=0](<selfRestore>$57: T.class_of(ControlFlow), <block-pre-call-temp>$56: Sorbet::Private::Static::Void)\l<statTemp>$54: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$56, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$57\l<statTemp>$73: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$74: Sorbet::Private::Static::Void = <statTemp>$73: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$75: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_15" -> "bb::<Class:ControlFlow>#<static-init>_18" [style="bold"];
@@ -438,7 +438,7 @@ subgraph "cluster_::<Class:ControlFlow>#<static-init>" {
     "bb::<Class:ControlFlow>#<static-init>_18" -> "bb::<Class:ControlFlow>#<static-init>_19" [style="tapered"];
 
     "bb::<Class:ControlFlow>#<static-init>_19" [
-        label = "block[id=19, rubyBlockId=0](<selfRestore>$75: T.class_of(ControlFlow), <block-pre-call-temp>$74: Sorbet::Private::Static::Void)\l<statTemp>$72: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$74, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$75\l<block-pre-call-temp>$92: Sorbet::Private::Static::Void = <self>: T.class_of(ControlFlow).sig()\l<selfRestore>$93: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
+        label = "block[id=19, rubyBlockId=0](<selfRestore>$75: T.class_of(ControlFlow), <block-pre-call-temp>$74: Sorbet::Private::Static::Void)\l<statTemp>$72: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$74, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$75\l<statTemp>$91: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$92: Sorbet::Private::Static::Void = <statTemp>$91: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$93: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_19" -> "bb::<Class:ControlFlow>#<static-init>_22" [style="bold"];
@@ -455,7 +455,7 @@ subgraph "cluster_::<Class:ControlFlow>#<static-init>" {
     "bb::<Class:ControlFlow>#<static-init>_22" -> "bb::<Class:ControlFlow>#<static-init>_23" [style="tapered"];
 
     "bb::<Class:ControlFlow>#<static-init>_23" [
-        label = "block[id=23, rubyBlockId=0](<selfRestore>$93: T.class_of(ControlFlow), <block-pre-call-temp>$92: Sorbet::Private::Static::Void)\l<statTemp>$90: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$92, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$93\l<block-pre-call-temp>$110: Sorbet::Private::Static::Void = <self>: T.class_of(ControlFlow).sig()\l<selfRestore>$111: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
+        label = "block[id=23, rubyBlockId=0](<selfRestore>$93: T.class_of(ControlFlow), <block-pre-call-temp>$92: Sorbet::Private::Static::Void)\l<statTemp>$90: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$92, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$93\l<statTemp>$109: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$110: Sorbet::Private::Static::Void = <statTemp>$109: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$111: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_23" -> "bb::<Class:ControlFlow>#<static-init>_26" [style="bold"];
@@ -472,7 +472,7 @@ subgraph "cluster_::<Class:ControlFlow>#<static-init>" {
     "bb::<Class:ControlFlow>#<static-init>_26" -> "bb::<Class:ControlFlow>#<static-init>_27" [style="tapered"];
 
     "bb::<Class:ControlFlow>#<static-init>_27" [
-        label = "block[id=27, rubyBlockId=0](<selfRestore>$111: T.class_of(ControlFlow), <block-pre-call-temp>$110: Sorbet::Private::Static::Void)\l<statTemp>$108: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$110, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$111\l<block-pre-call-temp>$128: Sorbet::Private::Static::Void = <self>: T.class_of(ControlFlow).sig()\l<selfRestore>$129: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
+        label = "block[id=27, rubyBlockId=0](<selfRestore>$111: T.class_of(ControlFlow), <block-pre-call-temp>$110: Sorbet::Private::Static::Void)\l<statTemp>$108: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$110, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$111\l<statTemp>$127: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$128: Sorbet::Private::Static::Void = <statTemp>$127: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$129: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_27" -> "bb::<Class:ControlFlow>#<static-init>_30" [style="bold"];
@@ -489,7 +489,7 @@ subgraph "cluster_::<Class:ControlFlow>#<static-init>" {
     "bb::<Class:ControlFlow>#<static-init>_30" -> "bb::<Class:ControlFlow>#<static-init>_31" [style="tapered"];
 
     "bb::<Class:ControlFlow>#<static-init>_31" [
-        label = "block[id=31, rubyBlockId=0](<selfRestore>$129: T.class_of(ControlFlow), <block-pre-call-temp>$128: Sorbet::Private::Static::Void)\l<statTemp>$126: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$128, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$129\l<block-pre-call-temp>$146: Sorbet::Private::Static::Void = <self>: T.class_of(ControlFlow).sig()\l<selfRestore>$147: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
+        label = "block[id=31, rubyBlockId=0](<selfRestore>$129: T.class_of(ControlFlow), <block-pre-call-temp>$128: Sorbet::Private::Static::Void)\l<statTemp>$126: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$128, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$129\l<statTemp>$145: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$146: Sorbet::Private::Static::Void = <statTemp>$145: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$147: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_31" -> "bb::<Class:ControlFlow>#<static-init>_34" [style="bold"];

--- a/test/testdata/infer/flatten_methods.rb.flatten-tree.exp
+++ b/test/testdata/infer/flatten_methods.rb.flatten-tree.exp
@@ -29,10 +29,10 @@ begin
 
     def self.<static-init>(<blk>)
       begin
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"x" => ::Integer}).void()
         end
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"x" => ::Integer}).void()
         end
         <self>.extend(::T::Sig)

--- a/test/testdata/infer/flatten_private.rb.flatten-tree.exp
+++ b/test/testdata/infer/flatten_private.rb.flatten-tree.exp
@@ -36,10 +36,10 @@ begin
 
     def self.<static-init>(<blk>)
       begin
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"arg0" => ::Integer}).void()
         end
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"arg0" => ::Integer}).void()
         end
         <self>.extend(::T::Sig)

--- a/test/testdata/infer/isa_generic.rb.cfg.exp
+++ b/test/testdata/infer/isa_generic.rb.cfg.exp
@@ -102,7 +102,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: T.class_of(<root>).sig()\l<selfRestore>$6: T.class_of(<root>) = <self>\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<statTemp>$4: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$4: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$6: T.class_of(<root>) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_2" [style="bold"];
@@ -119,7 +119,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_2" -> "bb::<Class:<root>>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_3" [
-        label = "block[id=3, rubyBlockId=0](<selfRestore>$6: T.class_of(<root>), <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$5, sig>\l<self>: T.class_of(<root>) = <selfRestore>$6\l<block-pre-call-temp>$22: Sorbet::Private::Static::Void = <self>: T.class_of(<root>).sig()\l<selfRestore>$23: T.class_of(<root>) = <self>\l<unconditional>\l"
+        label = "block[id=3, rubyBlockId=0](<selfRestore>$6: T.class_of(<root>), <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$5, sig>\l<self>: T.class_of(<root>) = <selfRestore>$6\l<statTemp>$21: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$22: Sorbet::Private::Static::Void = <statTemp>$21: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$23: T.class_of(<root>) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_3" -> "bb::<Class:<root>>#<static-init>_6" [style="bold"];

--- a/test/testdata/infer/rebind.rb.cfg.exp
+++ b/test/testdata/infer/rebind.rb.cfg.exp
@@ -78,7 +78,7 @@ subgraph "cluster_::<Class:B>#<static-init>" {
     "bb::<Class:B>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:B>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(B) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U B>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U B>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: T.class_of(B).sig()\l<selfRestore>$6: T.class_of(B) = <self>\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(B) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U B>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U B>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<statTemp>$4: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$4: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$6: T.class_of(B) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:B>#<static-init>_0" -> "bb::<Class:B>#<static-init>_2" [style="bold"];
@@ -131,7 +131,7 @@ subgraph "cluster_::<Class:A>#<static-init>" {
     "bb::<Class:A>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:A>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: T.class_of(A).sig()\l<selfRestore>$6: T.class_of(A) = <self>\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<statTemp>$4: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$4: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$6: T.class_of(A) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_0" -> "bb::<Class:A>#<static-init>_2" [style="bold"];

--- a/test/testdata/infer/self_type.rb.cfg.exp
+++ b/test/testdata/infer/self_type.rb.cfg.exp
@@ -96,7 +96,7 @@ subgraph "cluster_::<Class:Parent>#<static-init>" {
     "bb::<Class:Parent>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Parent>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Parent) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Parent>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Parent>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: T.class_of(Parent).sig()\l<selfRestore>$6: T.class_of(Parent) = <self>\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Parent) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Parent>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Parent>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<statTemp>$4: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$4: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$6: T.class_of(Parent) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Parent>#<static-init>_0" -> "bb::<Class:Parent>#<static-init>_2" [style="bold"];
@@ -167,7 +167,7 @@ subgraph "cluster_::<Class:Generic>#<static-init>" {
     "bb::<Class:Generic>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Generic>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<C TM>$21: <Type: Generic::TM> = alias <C TM>\l<self>: T.class_of(Generic) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Generic>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Generic>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: T.class_of(Generic).sig()\l<selfRestore>$6: T.class_of(Generic) = <self>\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<C TM>$21: <Type: Generic::TM> = alias <C TM>\l<self>: T.class_of(Generic) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Generic>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Generic>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<statTemp>$4: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$4: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$6: T.class_of(Generic) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Generic>#<static-init>_0" -> "bb::<Class:Generic>#<static-init>_2" [style="bold"];
@@ -238,7 +238,7 @@ subgraph "cluster_::<Class:Array>#<static-init>" {
     "bb::<Class:Array>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Array>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Array) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Array>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Array>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: T.class_of(Array).sig()\l<selfRestore>$6: T.class_of(Array) = <self>\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Array) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Array>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Array>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<statTemp>$4: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$4: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$6: T.class_of(Array) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Array>#<static-init>_0" -> "bb::<Class:Array>#<static-init>_2" [style="bold"];
@@ -309,7 +309,7 @@ subgraph "cluster_::<Class:B>#<static-init>" {
     "bb::<Class:B>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:B>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(B) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U B>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U B>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: T.class_of(B).sig()\l<selfRestore>$6: T.class_of(B) = <self>\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(B) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U B>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U B>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<statTemp>$4: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$4: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$6: T.class_of(B) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:B>#<static-init>_0" -> "bb::<Class:B>#<static-init>_2" [style="bold"];

--- a/test/testdata/infer/transitive.rb.cfg.exp
+++ b/test/testdata/infer/transitive.rb.cfg.exp
@@ -42,7 +42,7 @@ subgraph "cluster_::<Class:A>#<static-init>" {
     "bb::<Class:A>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:A>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: T.class_of(A).sig()\l<selfRestore>$6: T.class_of(A) = <self>\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<statTemp>$4: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$4: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$6: T.class_of(A) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_0" -> "bb::<Class:A>#<static-init>_2" [style="bold"];
@@ -95,7 +95,7 @@ subgraph "cluster_::<Class:Bar>#<static-init>" {
     "bb::<Class:Bar>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Bar>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Bar) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Bar>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Bar>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: T.class_of(Bar).sig()\l<selfRestore>$6: T.class_of(Bar) = <self>\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Bar) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Bar>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Bar>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<statTemp>$4: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$4: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$6: T.class_of(Bar) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Bar>#<static-init>_0" -> "bb::<Class:Bar>#<static-init>_2" [style="bold"];

--- a/test/testdata/lsp/completion/sig.A.rbedited
+++ b/test/testdata/lsp/completion/sig.A.rbedited
@@ -22,7 +22,7 @@ class Normal
 end
 
 class NoSigInScope
-  sig # error: does not exist
-  #  ^ completion: (nothing)
+  sig # error: `sig` requires a block parameter
+  #  ^ completion: sig
   def no_results_without_extend_tsig; end
 end

--- a/test/testdata/lsp/completion/sig.B.rbedited
+++ b/test/testdata/lsp/completion/sig.B.rbedited
@@ -22,7 +22,7 @@ class Normal
 end
 
 class NoSigInScope
-  sig # error: does not exist
-  #  ^ completion: (nothing)
+  sig # error: `sig` requires a block parameter
+  #  ^ completion: sig
   def no_results_without_extend_tsig; end
 end

--- a/test/testdata/lsp/completion/sig.rb
+++ b/test/testdata/lsp/completion/sig.rb
@@ -22,7 +22,7 @@ class Normal
 end
 
 class NoSigInScope
-  sig # error: does not exist
-  #  ^ completion: (nothing)
+  sig # error: `sig` requires a block parameter
+  #  ^ completion: sig
   def no_results_without_extend_tsig; end
 end

--- a/test/testdata/lsp/completion/sig_no_method.A.rbedited
+++ b/test/testdata/lsp/completion/sig_no_method.A.rbedited
@@ -13,9 +13,7 @@ class Outer
     # Even though there are method defs after this, none are in the right
     # scope, so no suggested sig.
 
-    sig do
-  ${1}
-end${0} # error: no block
+    sig {returns(NilClass)}${0} # error: no block
     #  ^ apply-completion: [A] item: 0
   end
 

--- a/test/testdata/lsp/struct_fuzz.rb
+++ b/test/testdata/lsp/struct_fuzz.rb
@@ -3,7 +3,6 @@
   ::B=Struct.new:x
 # ^^^^^^^^^^^^^^^^ error: Method `keep_def` does not exist on `T.class_of(Sorbet::Private::Static)`
 # ^^^^^^^^^^^^^^^^ error: Method `params` does not exist on `T.class_of(B)`
-# ^^^^^^^^^^^^^^^^ error: Method `sig` does not exist on `T.class_of(T::Sig::WithoutRuntime)`
 # ^^^^^^^^^^^^^^^^ error: Method `type_member` does not exist on `T.class_of(B)`
 # ^^^^^^^^^^^^^^^^ error: Method `unsafe` does not exist on `T.class_of(T)`
 #                ^ error: Method `keep_def` does not exist on `T.class_of(Sorbet::Private::Static)`

--- a/test/testdata/namer/alias_cross_file.flatten-tree.exp
+++ b/test/testdata/namer/alias_cross_file.flatten-tree.exp
@@ -16,7 +16,7 @@ begin
 
     def self.<static-init>(<blk>)
       begin
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.returns(::T2)
         end
         ::Sorbet::Private::Static.keep_def(<self>, :"test_resolve")

--- a/test/testdata/namer/module_function.rb.cfg.exp
+++ b/test/testdata/namer/module_function.rb.cfg.exp
@@ -132,7 +132,7 @@ subgraph "cluster_::<Class:Funcs>#<static-init>" {
     "bb::<Class:Funcs>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Funcs>#<static-init>_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Funcs) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Funcs>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Funcs>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: T.class_of(Funcs).sig()\l<selfRestore>$6: T.class_of(Funcs) = <self>\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Funcs) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Funcs>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Funcs>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<statTemp>$4: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$4: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$6: T.class_of(Funcs) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_0" -> "bb::<Class:Funcs>#<static-init>_2" [style="bold"];
@@ -149,7 +149,7 @@ subgraph "cluster_::<Class:Funcs>#<static-init>" {
     "bb::<Class:Funcs>#<static-init>_2" -> "bb::<Class:Funcs>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:Funcs>#<static-init>_3" [
-        label = "block[id=3, rubyBlockId=0](<selfRestore>$6: T.class_of(Funcs), <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$5, sig>\l<self>: T.class_of(Funcs) = <selfRestore>$6\l<block-pre-call-temp>$20: Sorbet::Private::Static::Void = <self>: T.class_of(Funcs).sig()\l<selfRestore>$21: T.class_of(Funcs) = <self>\l<unconditional>\l"
+        label = "block[id=3, rubyBlockId=0](<selfRestore>$6: T.class_of(Funcs), <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$5, sig>\l<self>: T.class_of(Funcs) = <selfRestore>$6\l<statTemp>$19: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$20: Sorbet::Private::Static::Void = <statTemp>$19: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$21: T.class_of(Funcs) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_3" -> "bb::<Class:Funcs>#<static-init>_6" [style="bold"];
@@ -166,7 +166,7 @@ subgraph "cluster_::<Class:Funcs>#<static-init>" {
     "bb::<Class:Funcs>#<static-init>_6" -> "bb::<Class:Funcs>#<static-init>_7" [style="tapered"];
 
     "bb::<Class:Funcs>#<static-init>_7" [
-        label = "block[id=7, rubyBlockId=0](<selfRestore>$21: T.class_of(Funcs), <block-pre-call-temp>$20: Sorbet::Private::Static::Void)\l<statTemp>$18: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$20, sig>\l<self>: T.class_of(Funcs) = <selfRestore>$21\l<block-pre-call-temp>$35: Sorbet::Private::Static::Void = <self>: T.class_of(Funcs).sig()\l<selfRestore>$36: T.class_of(Funcs) = <self>\l<unconditional>\l"
+        label = "block[id=7, rubyBlockId=0](<selfRestore>$21: T.class_of(Funcs), <block-pre-call-temp>$20: Sorbet::Private::Static::Void)\l<statTemp>$18: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$20, sig>\l<self>: T.class_of(Funcs) = <selfRestore>$21\l<statTemp>$34: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$35: Sorbet::Private::Static::Void = <statTemp>$34: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$36: T.class_of(Funcs) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_7" -> "bb::<Class:Funcs>#<static-init>_10" [style="bold"];
@@ -183,7 +183,7 @@ subgraph "cluster_::<Class:Funcs>#<static-init>" {
     "bb::<Class:Funcs>#<static-init>_10" -> "bb::<Class:Funcs>#<static-init>_11" [style="tapered"];
 
     "bb::<Class:Funcs>#<static-init>_11" [
-        label = "block[id=11, rubyBlockId=0](<selfRestore>$36: T.class_of(Funcs), <block-pre-call-temp>$35: Sorbet::Private::Static::Void)\l<statTemp>$33: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$35, sig>\l<self>: T.class_of(Funcs) = <selfRestore>$36\l<block-pre-call-temp>$50: Sorbet::Private::Static::Void = <self>: T.class_of(Funcs).sig()\l<selfRestore>$51: T.class_of(Funcs) = <self>\l<unconditional>\l"
+        label = "block[id=11, rubyBlockId=0](<selfRestore>$36: T.class_of(Funcs), <block-pre-call-temp>$35: Sorbet::Private::Static::Void)\l<statTemp>$33: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$35, sig>\l<self>: T.class_of(Funcs) = <selfRestore>$36\l<statTemp>$49: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$50: Sorbet::Private::Static::Void = <statTemp>$49: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$51: T.class_of(Funcs) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_11" -> "bb::<Class:Funcs>#<static-init>_14" [style="bold"];
@@ -200,7 +200,7 @@ subgraph "cluster_::<Class:Funcs>#<static-init>" {
     "bb::<Class:Funcs>#<static-init>_14" -> "bb::<Class:Funcs>#<static-init>_15" [style="tapered"];
 
     "bb::<Class:Funcs>#<static-init>_15" [
-        label = "block[id=15, rubyBlockId=0](<selfRestore>$51: T.class_of(Funcs), <block-pre-call-temp>$50: Sorbet::Private::Static::Void)\l<statTemp>$48: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$50, sig>\l<self>: T.class_of(Funcs) = <selfRestore>$51\l<block-pre-call-temp>$65: Sorbet::Private::Static::Void = <self>: T.class_of(Funcs).sig()\l<selfRestore>$66: T.class_of(Funcs) = <self>\l<unconditional>\l"
+        label = "block[id=15, rubyBlockId=0](<selfRestore>$51: T.class_of(Funcs), <block-pre-call-temp>$50: Sorbet::Private::Static::Void)\l<statTemp>$48: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$50, sig>\l<self>: T.class_of(Funcs) = <selfRestore>$51\l<statTemp>$64: T.class_of(T::Sig::WithoutRuntime) = alias <C WithoutRuntime>\l<block-pre-call-temp>$65: Sorbet::Private::Static::Void = <statTemp>$64: T.class_of(T::Sig::WithoutRuntime).sig()\l<selfRestore>$66: T.class_of(Funcs) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_15" -> "bb::<Class:Funcs>#<static-init>_18" [style="bold"];

--- a/test/testdata/namer/redefinition_method.rb.flatten-tree.exp
+++ b/test/testdata/namer/redefinition_method.rb.flatten-tree.exp
@@ -24,7 +24,7 @@ begin
 
     def self.<static-init>(<blk>)
       begin
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"a" => ::Integer}).returns(::Integer)
         end
         <self>.extend(::T::Sig)

--- a/test/testdata/resolver/optional_nil.rb.flatten-tree.exp
+++ b/test/testdata/resolver/optional_nil.rb.flatten-tree.exp
@@ -44,28 +44,28 @@ begin
 
     def self.<static-init>(<blk>)
       begin
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"x" => ::String}).returns(::String)
         end
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"y" => ::String}).returns(::String)
         end
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"z" => ::String}).returns(::String)
         end
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"w" => ::String}).returns(::String)
         end
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"x" => ::String}).returns(::String)
         end
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"y" => ::String}).returns(::String)
         end
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"z" => ::String}).returns(::String)
         end
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"w" => ::String}).returns(::String)
         end
         <self>.extend(::T::Sig)

--- a/test/testdata/resolver/optional_nil.rb.name-tree.exp
+++ b/test/testdata/resolver/optional_nil.rb.name-tree.exp
@@ -2,7 +2,7 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     begin
       class ::Test<<C Test>> < (::<todo sym>)
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"x" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
         end
 
@@ -10,7 +10,7 @@ begin
           x
         end
 
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"y" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
         end
 
@@ -18,7 +18,7 @@ begin
           y
         end
 
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"z" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
         end
 
@@ -26,7 +26,7 @@ begin
           z
         end
 
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"w" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
         end
 
@@ -34,7 +34,7 @@ begin
           w
         end
 
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"x" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
         end
 
@@ -42,7 +42,7 @@ begin
           nil
         end
 
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"y" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
         end
 
@@ -50,7 +50,7 @@ begin
           nil
         end
 
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"z" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
         end
 
@@ -58,7 +58,7 @@ begin
           ""
         end
 
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"w" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
         end
 

--- a/test/testdata/rewriter/attr.rb.flatten-tree.exp
+++ b/test/testdata/rewriter/attr.rb.flatten-tree.exp
@@ -57,22 +57,22 @@ begin
 
     def self.<static-init>(<blk>)
       begin
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.void()
         end
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.returns(::Integer)
         end
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"v1" => ::Integer}).returns(::Integer)
         end
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.returns(::String)
         end
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.params({:"v2" => ::String}).returns(::String)
         end
-        <self>.sig() do ||
+        ::T::Sig::WithoutRuntime.sig() do ||
           <self>.returns(::String)
         end
         <self>.extend(::T::Sig)

--- a/test/testdata/rewriter/attr_multi.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/attr_multi.rb.rewrite-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Test><<C <todo sym>>> < (::<todo sym>)
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
     end
 
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @a
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({:"a" => <emptyTree>::<C T>.nilable(<emptyTree>::<C String>)}).returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
     end
 
@@ -16,7 +16,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @a = ::T.let(a, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
@@ -24,7 +24,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @b
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
@@ -32,7 +32,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @c
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({:"b" => <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>)}).returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
@@ -40,7 +40,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @b = ::T.let(b, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({:"c" => <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>)}).returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
@@ -48,7 +48,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @c = ::T.let(c, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.returns(<emptyTree>::<C String>)
     end
 
@@ -56,7 +56,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @d
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.returns(<emptyTree>::<C String>)
     end
 
@@ -64,7 +64,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @e
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.returns(<emptyTree>::<C String>)
     end
 
@@ -72,7 +72,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @f
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({:"g" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
     end
 
@@ -80,7 +80,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @g = g
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({:"h" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
     end
 
@@ -88,7 +88,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @h = h
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({:"i" => <emptyTree>::<C String>}).params({:"h" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
     end
 

--- a/test/testdata/rewriter/command.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/command.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C MyCommand><<C <todo sym>>> < (<emptyTree>::<C Opus>::<C Command>)
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({:"x" => <emptyTree>::<C Integer>}).returns(<emptyTree>::<C String>)
     end
 
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       x.to_s()
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({:"x" => <emptyTree>::<C Integer>}).returns(<emptyTree>::<C String>)
     end
 
@@ -28,7 +28,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.assert_type!(<emptyTree>::<C MyCommand>.call(7), <emptyTree>::<C String>)
 
   class <emptyTree>::<C OtherCommand><<C <todo sym>>> < (::<root>::<C Opus>::<C Command>)
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({:"x" => <emptyTree>::<C String>}).returns(<emptyTree>::<C Integer>)
     end
 
@@ -36,7 +36,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.Integer(x)
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({:"x" => <emptyTree>::<C String>}).returns(<emptyTree>::<C Integer>)
     end
 
@@ -52,7 +52,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.assert_type!(<emptyTree>::<C OtherCommand>.call("8"), <emptyTree>::<C Integer>)
 
   class <emptyTree>::<C NotACommand><<C <todo sym>>> < (<emptyTree>::<C Llamas>::<C Opus>::<C Command>)
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({:"x" => <emptyTree>::<C String>}).returns(<emptyTree>::<C Integer>)
     end
 

--- a/test/testdata/rewriter/default_args.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/default_args.rb.rewrite-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  <self>.sig() do ||
+  ::T::Sig::WithoutRuntime.sig() do ||
     <self>.params({:"a" => <emptyTree>::<C String>, :"b" => <emptyTree>::<C Integer>, :"c" => <emptyTree>::<C Integer>}).void()
   end
 
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  <self>.sig() do ||
+  ::T::Sig::WithoutRuntime.sig() do ||
     <self>.params({:"a" => <emptyTree>::<C String>, :"b" => <emptyTree>::<C Integer>, :"c" => <emptyTree>::<C Integer>}).returns(<emptyTree>::<C Integer>)
   end
 
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     1
   end
 
-  <self>.sig() do ||
+  ::T::Sig::WithoutRuntime.sig() do ||
     <self>.params({:"a" => <emptyTree>::<C String>, :"b" => <emptyTree>::<C Integer>, :"c" => <emptyTree>::<C Integer>}).returns(<emptyTree>::<C Integer>)
   end
 

--- a/test/testdata/rewriter/default_args_malformed_sig.rb
+++ b/test/testdata/rewriter/default_args_malformed_sig.rb
@@ -3,6 +3,6 @@
 # This test used to crash the DefaultArgs pass because it tried to dereference
 # the block pointer to get it's body, but the block itself was nullptr.
 
-sig # error: does not exist
+sig # error: `sig` requires a block parameter
 def foo(x: nil)
 end

--- a/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
@@ -14,7 +14,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.type_parameters(:"U").params({:"arg" => <emptyTree>::<C T>::<C Enumerable>.[](<emptyTree>::<C T>.type_parameter(:"U")), :"blk" => <emptyTree>::<C T>.proc().params({:"arg0" => <emptyTree>::<C T>.type_parameter(:"U")}).void()}).void()
     end
 
@@ -22,7 +22,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.type_parameters(:"K", :"V").params({:"arg" => <emptyTree>::<C T>::<C Hash>.[](<emptyTree>::<C T>.type_parameter(:"K"), <emptyTree>::<C T>.type_parameter(:"V")), :"blk" => <emptyTree>::<C T>.proc().params({:"arg0" => <emptyTree>::<C T>.type_parameter(:"K"), :"arg1" => <emptyTree>::<C T>.type_parameter(:"V")}).void()}).void()
     end
 
@@ -30,7 +30,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({:"name" => <emptyTree>::<C String>, :"blk" => <emptyTree>::<C T>.proc().void()}).void()
     end
 

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -1509,8 +1509,9 @@ ClassDef{
         }
 
         Send{
-          recv = Local{
-            localVariable = <U <self>>
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = ::T::Sig::WithoutRuntime
           }
           fun = <U sig>
           block = Block {
@@ -1589,8 +1590,9 @@ ClassDef{
         }
 
         Send{
-          recv = Local{
-            localVariable = <U <self>>
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = ::T::Sig::WithoutRuntime
           }
           fun = <U sig>
           block = Block {

--- a/test/testdata/rewriter/prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree.exp
@@ -96,7 +96,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
     end
 
@@ -104,7 +104,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C T>.cast(<emptyTree>::<C T>.unsafe(nil), <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({:"arg0" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
     end
 

--- a/test/testdata/rewriter/prop_computed_by.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_computed_by.rb.rewrite-tree.exp
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.assert_type!(<self>.class().compute_num_ok(::T.unsafe(nil)), <emptyTree>::<C Integer>)
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({:"n" => <emptyTree>::<C Integer>}).returns(<emptyTree>::<C Integer>)
     end
 
@@ -32,7 +32,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.assert_type!(<self>.class().compute_num_wrong_value(::T.unsafe(nil)), <emptyTree>::<C Integer>)
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({:"inputs" => <emptyTree>::<C T>.untyped()}).returns(<emptyTree>::<C String>)
     end
 
@@ -48,7 +48,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.assert_type!(<self>.class().compute_num_wrong_type(::T.unsafe(nil)), <emptyTree>::<C Integer>)
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({:"inputs" => <emptyTree>::<C T>.untyped()}).returns(<emptyTree>::<C Integer>)
     end
 

--- a/test/testdata/rewriter/rails/cattr_accessor.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rails/cattr_accessor.rb.rewrite-tree.exp
@@ -152,7 +152,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.void()
     end
 

--- a/test/testdata/rewriter/rails/cattr_reader.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rails/cattr_reader.rb.rewrite-tree.exp
@@ -56,7 +56,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.void()
     end
 

--- a/test/testdata/rewriter/rails/cattr_writer.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rails/cattr_writer.rb.rewrite-tree.exp
@@ -56,7 +56,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.void()
     end
 

--- a/test/testdata/rewriter/rails/class_attribute.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rails/class_attribute.rb.rewrite-tree.exp
@@ -256,7 +256,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.void()
     end
 

--- a/test/testdata/rewriter/rails/delegate.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rails/delegate.rb.rewrite-tree.exp
@@ -80,7 +80,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.void()
     end
 

--- a/test/testdata/rewriter/rails/mattr_accessor.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rails/mattr_accessor.rb.rewrite-tree.exp
@@ -152,7 +152,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.void()
     end
 

--- a/test/testdata/rewriter/rails/mattr_reader.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rails/mattr_reader.rb.rewrite-tree.exp
@@ -56,7 +56,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.void()
     end
 

--- a/test/testdata/rewriter/rails/mattr_writer.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rails/mattr_writer.rb.rewrite-tree.exp
@@ -56,7 +56,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.void()
     end
 

--- a/test/testdata/rewriter/struct.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/struct.rb.rewrite-tree.exp
@@ -107,7 +107,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         arg0
       end
 
-      <self>.sig() do ||
+      ::T::Sig::WithoutRuntime.sig() do ||
         <self>.params({:"foo" => <emptyTree>::<C BasicObject>, :"bar" => <emptyTree>::<C BasicObject>}).returns(<emptyTree>::<C A>)
       end
 
@@ -115,7 +115,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <emptyTree>::<C T>.cast(nil, <emptyTree>::<C A>)
       end
 
-      <self>.sig() do ||
+      ::T::Sig::WithoutRuntime.sig() do ||
         <self>.params({:"foo" => <emptyTree>::<C BasicObject>, :"bar" => <emptyTree>::<C BasicObject>}).returns(<emptyTree>::<C BasicObject>)
       end
 
@@ -123,7 +123,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         nil
       end
 
-      <self>.sig() do ||
+      ::T::Sig::WithoutRuntime.sig() do ||
         <self>.params({:"foo" => <emptyTree>::<C BasicObject>, :"bar" => <emptyTree>::<C BasicObject>}).returns(<emptyTree>::<C BasicObject>)
       end
 

--- a/test/testdata/rewriter/t_struct/override.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/override.rb.rewrite-tree.exp
@@ -24,7 +24,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
     end
 
-    <self>.sig() do ||
+    ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({:"foo" => <emptyTree>::<C Integer>}).void()
     end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Work towards more uniform treatment of `sig` as special internally.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
