### PR TITLE
Fix osx linker errors on master

### DIFF
--- a/common/JSON.cc
+++ b/common/JSON.cc
@@ -1,6 +1,6 @@
 #include "common/JSON.h"
 #include "spdlog/spdlog.h"
-// break between spdlog.h and fmt.h to stop clang-format from sorting
+// spdlog.h must be included before fmt.h https://github.com/sorbet/sorbet/pull/2839
 #include "spdlog/fmt/fmt.h"
 
 using namespace std;

--- a/common/JSON.cc
+++ b/common/JSON.cc
@@ -1,4 +1,6 @@
 #include "common/JSON.h"
+#include "spdlog/spdlog.h"
+// break between spdlog.h and fmt.h to stop clang-format from sorting
 #include "spdlog/fmt/fmt.h"
 
 using namespace std;

--- a/common/formatting.h
+++ b/common/formatting.h
@@ -2,6 +2,8 @@
 #define SORBET_COMMON_FORMATTING_HPP
 
 #include "common/common.h"
+#include "spdlog/spdlog.h"
+// break between spdlog.h and fmt.h to stop clang-format from sorting
 #include "spdlog/fmt/fmt.h"
 
 namespace fmt {

--- a/common/formatting.h
+++ b/common/formatting.h
@@ -3,7 +3,7 @@
 
 #include "common/common.h"
 #include "spdlog/spdlog.h"
-// break between spdlog.h and fmt.h to stop clang-format from sorting
+// spdlog.h must be included before fmt.h https://github.com/sorbet/sorbet/pull/2839
 #include "spdlog/fmt/fmt.h"
 
 namespace fmt {

--- a/core/Error.h
+++ b/core/Error.h
@@ -5,7 +5,7 @@
 #include "core/Loc.h"
 #include "core/StrictLevel.h"
 #include "spdlog/spdlog.h"
-// break between spdlog.h and fmt.h to stop clang-format from sorting
+// spdlog.h must be included before fmt.h https://github.com/sorbet/sorbet/pull/2839
 #include "spdlog/fmt/fmt.h"
 #include <initializer_list>
 #include <memory>

--- a/core/Error.h
+++ b/core/Error.h
@@ -4,6 +4,8 @@
 #include "core/AutocorrectSuggestion.h"
 #include "core/Loc.h"
 #include "core/StrictLevel.h"
+#include "spdlog/spdlog.h"
+// break between spdlog.h and fmt.h to stop clang-format from sorting
 #include "spdlog/fmt/fmt.h"
 #include <initializer_list>
 #include <memory>


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Ensure that spdlog.h is included before fmt.h.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fix master.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.