### PR TITLE
Remove <iostream> reference from common.h

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -18,12 +18,6 @@ static_assert(false, "Need c++14 to compile this codebase");
 #include <string_view>
 #include <type_traits>
 
-#if !defined(NDEBUG)
-// So you can use `cout` when debugging. Not included in production as it is a
-// performance hit.
-#include <iostream>
-#endif
-
 namespace sorbet {
 
 template <class T, size_t N> using InlinedVector = absl::InlinedVector<T, N>;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We already include fmtlib everywhere, which means that it's always
possible to `fmt::print` instead of `cout <<`. I don't think anyone uses
`cout` for debugging anymore.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.