### PR TITLE
kvstore: Disable TLS to avoid stale readers.

### DIFF
--- a/common/kvstore/KeyValueStore.cc
+++ b/common/kvstore/KeyValueStore.cc
@@ -36,6 +36,9 @@ static void throw_mdb_error(string_view what, int err) {
 // That function is called in OwnedKeyValueStore.
 static atomic<bool> kvstoreInUse = false;
 
+// Callback to `mdb_reader_list`. `msg` is the lock table contents in human-readable form, `ctx` is a `string*` passed
+// in at the `mdb_reader_list` callsite. It copies `msg` into `ctx` to pass the lock table back to the callsite, and
+// returns 0 to indicate success.
 int mdbReaderListCallback(const char *msg, void *ctx) {
     string *output = (string *)ctx;
     *output = string(msg);
@@ -63,8 +66,12 @@ KeyValueStore::KeyValueStore(string version, string path, string flavor)
     if (rc != 0) {
         goto fail;
     }
-    // _disable_ thread local storage so that any thread can close/abort a reader transaction.
-    // otherwise, we will end up leaving stale transactions in the database, leading to `MDB_READERS_FULL` errors.
+    // _disable_ thread local storage so that the writer thread can close/abort a reader transaction.
+    // MDB_NOTLS instructs LMDB to store transactions into the `MDB_txn` objects rather than thread-local storage.
+    // It allows read-only transactions to migrate across threads (letting the writer thread clean up reader
+    // transactions), but users are expected to manage concurrent access. We already restrict concurrent access by
+    // manually maintaining a map from thread to transaction.
+    // Avoids MDB_READERS_FULL issues with concurrent Sorbet processes.
     rc = mdb_env_open(dbState->env, this->path.c_str(), MDB_NOTLS, 0664);
     if (rc != 0) {
         goto fail;
@@ -83,6 +90,19 @@ KeyValueStore::~KeyValueStore() noexcept(false) {
 
 string KeyValueStore::getReaderLockTable() {
     string ctxString;
+    /*
+     * LMDB only has two APIs to grok the reader list
+     * (http://www.lmdb.tech/doc/group__mdb.html#ga8550000cd0501a44f57ee6dff0188744)
+     *
+     * - `mdb_reader_check`, which checks for stale transactions. Unfortunately a reader isn't stale if the owning
+     * thread is still alive, and LMDB seems to clean up stale transactions automatically somehow prior to me calling
+     * this function, so it doesn't work.
+     * - `mdb_reader_list`, which produces a human-readable string containing the lock table contents (used in mdb_stat
+     * CLI tool). It accepts a callback.
+     *
+     * I use the latter, as it's the only way to check if the lock table contains contents when we expect that it
+     * doesn't.
+     */
     const int err = mdb_reader_list(dbState->env, mdbReaderListCallback, &ctxString);
     if (err < 0) {
         throw_mdb_error("Failure checking for stale readers", err);

--- a/common/kvstore/KeyValueStore.h
+++ b/common/kvstore/KeyValueStore.h
@@ -3,7 +3,6 @@
 #include "absl/synchronization/mutex.h"
 #include "common/common.h"
 #include <thread>
-
 namespace sorbet {
 
 class OwnedKeyValueStore;

--- a/common/kvstore/KeyValueStore.h
+++ b/common/kvstore/KeyValueStore.h
@@ -3,6 +3,7 @@
 #include "absl/synchronization/mutex.h"
 #include "common/common.h"
 #include <thread>
+
 namespace sorbet {
 
 class OwnedKeyValueStore;
@@ -38,6 +39,9 @@ public:
      */
     KeyValueStore(std::string version, std::string path, std::string flavor);
     ~KeyValueStore() noexcept(false);
+
+    // Used in tests to assert that OwnedKeyValueStore cleans up reader transactions.
+    std::string getReaderLockTable();
 
     friend class OwnedKeyValueStore;
 };

--- a/common/kvstore/KeyValueStore.h
+++ b/common/kvstore/KeyValueStore.h
@@ -40,7 +40,7 @@ public:
     ~KeyValueStore() noexcept(false);
 
     // Used in tests to assert that OwnedKeyValueStore cleans up reader transactions.
-    std::string getReaderLockTable();
+    void enforceNoOutstandingReaders() const;
 
     friend class OwnedKeyValueStore;
 };

--- a/common/kvstore/test/kvstore_test.cc
+++ b/common/kvstore/test/kvstore_test.cc
@@ -28,11 +28,6 @@ protected:
     void TearDown() override {
         exec(fmt::format("rm -r {}", directory));
     }
-
-    void assertNoStaleTransactions(KeyValueStore &kvstore) {
-        auto lockTable = kvstore.getReaderLockTable();
-        EXPECT_TRUE(lockTable.find("(no active readers)") != string::npos) << lockTable;
-    }
 };
 } // namespace
 
@@ -138,6 +133,6 @@ TEST_F(KeyValueStoreTest, LeavesNoStaleTransactions) {
     kvstore = OwnedKeyValueStore::abort(move(owned));
 
     // Thread is now ended; if it left a reader transaction, it'll appear stale in the table.
-    assertNoStaleTransactions(*kvstore);
-    testFinished.Notify();
+    auto lockTable = kvstore.getReaderLockTable();
+    EXPECT_TRUE(lockTable.find("(no active readers)") != string::npos) << lockTable;
 }

--- a/common/kvstore/test/kvstore_test.cc
+++ b/common/kvstore/test/kvstore_test.cc
@@ -135,4 +135,5 @@ TEST_F(KeyValueStoreTest, LeavesNoStaleTransactions) {
     // Thread is now ended; if it left a reader transaction, it'll appear stale in the table.
     auto lockTable = kvstore->getReaderLockTable();
     EXPECT_TRUE(lockTable.find("(no active readers)") != string::npos) << lockTable;
+    testFinished.Notify();
 }

--- a/common/kvstore/test/kvstore_test.cc
+++ b/common/kvstore/test/kvstore_test.cc
@@ -3,6 +3,7 @@
 #include "spdlog/spdlog.h"
 // has to go above null_sink.h; this comment prevents reordering.
 #include "absl/strings/str_split.h" // For StripAsciiWhitespace
+#include "absl/synchronization/notification.h"
 #include "common/FileOps.h"
 #include "common/common.h"
 #include "common/kvstore/KeyValueStore.h"
@@ -26,6 +27,11 @@ protected:
 
     void TearDown() override {
         exec(fmt::format("rm -r {}", directory));
+    }
+
+    void assertNoStaleTransactions(KeyValueStore &kvstore) {
+        auto lockTable = kvstore.getReaderLockTable();
+        EXPECT_TRUE(lockTable.find("(no active readers)") != string::npos) << lockTable;
     }
 };
 } // namespace
@@ -112,4 +118,26 @@ TEST_F(KeyValueStoreTest, FlavorsHaveDifferentContents) {
 TEST_F(KeyValueStoreTest, CannotCreateTwoKvstores) {
     auto kvstore1 = make_unique<KeyValueStore>("1", directory, "vanilla");
     EXPECT_THROW(make_unique<KeyValueStore>("1", directory, "vanilla"), invalid_argument);
+}
+
+TEST_F(KeyValueStoreTest, LeavesNoStaleTransactions) {
+    auto kvstore = make_unique<KeyValueStore>("1", directory, "vanilla");
+    auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
+    absl::Notification readFinished;
+    absl::Notification testFinished;
+    // Create a reader transaction.
+    // Note: We have to keep the thread alive, otherwise LMDB will clean up transactions that don't point to a live
+    // thread when we check the reader lock table.
+    auto thread = runInAThread("reader", [&owned, &readFinished, &testFinished]() {
+        owned->readString("hello");
+        readFinished.Notify();
+        testFinished.WaitForNotification();
+    });
+    readFinished.WaitForNotification();
+    // Disown KVstore to end transactions
+    kvstore = OwnedKeyValueStore::abort(move(owned));
+
+    // Thread is now ended; if it left a reader transaction, it'll appear stale in the table.
+    assertNoStaleTransactions(*kvstore);
+    testFinished.Notify();
 }

--- a/common/kvstore/test/kvstore_test.cc
+++ b/common/kvstore/test/kvstore_test.cc
@@ -133,6 +133,6 @@ TEST_F(KeyValueStoreTest, LeavesNoStaleTransactions) {
     kvstore = OwnedKeyValueStore::abort(move(owned));
 
     // Thread is now ended; if it left a reader transaction, it'll appear stale in the table.
-    auto lockTable = kvstore.getReaderLockTable();
+    auto lockTable = kvstore->getReaderLockTable();
     EXPECT_TRUE(lockTable.find("(no active readers)") != string::npos) << lockTable;
 }

--- a/common/kvstore/test/kvstore_test.cc
+++ b/common/kvstore/test/kvstore_test.cc
@@ -133,7 +133,6 @@ TEST_F(KeyValueStoreTest, LeavesNoStaleTransactions) {
     kvstore = OwnedKeyValueStore::abort(move(owned));
 
     // Thread is now ended; if it left a reader transaction, it'll appear stale in the table.
-    auto lockTable = kvstore->getReaderLockTable();
-    EXPECT_TRUE(lockTable.find("(no active readers)") != string::npos) << lockTable;
+    EXPECT_NO_THROW(kvstore->enforceNoOutstandingReaders());
     testFinished.Notify();
 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Disable thread local storage to avoid stale readers.

Add test that fails w/o this change.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We encountered issues on large CI machines where the reader lock table became full. I discovered that we weren't properly clearing reader transactions that we were done with during a single execution.

Summary:

* With TLS on, reader transactions are stored in thread-local storage.
* We cleanup all reader and writer transactions on the writer thread.
* Cleaning up reader transactions silently fails with TLS on.
* All transactions ultimately get cleared when the process closes the MDB environment, so nothing is left on disk after Sorbet finishes, but the reader table can fill up as other Sorbet processes jump in concurrently between write transactions to read the DB.

By disabling TLS, the writer thread can properly clear reader transactions at the same time it releases the lock on the database, which should prevent reader lock table exhaustion.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
