### PR TITLE
Fix tracing.cc after faster-timers PR

### DIFF
--- a/common/Timer.h
+++ b/common/Timer.h
@@ -7,6 +7,8 @@
 
 namespace sorbet {
 
+microseconds clock_gettime_coarse();
+
 class Timer {
     Timer(spdlog::logger &log, ConstExprStr name, FlowId prev,
           std::initializer_list<std::pair<ConstExprStr, std::string>> args, microseconds start,

--- a/common/common.h
+++ b/common/common.h
@@ -36,19 +36,19 @@ template <class E> using UnorderedSet = absl::flat_hash_set<E>;
 // where there is some assumption that you believe should always hold.
 // Please use this to explicitly write down what assumptions was the code written under.
 // One day they might be violated and you'll help the next person debug the issue.
-#define ENFORCE(x, ...)                                                                                        \
-    do {                                                                                                       \
-        if (::sorbet::debug_mode) {                                                                            \
-            auto __enforceTimer =                                                                              \
-                ::sorbet::Timer(*(::spdlog::default_logger_raw()), "ENFORCE: " __FILE__ ":" QUOTED(__LINE__)); \
-            if (!(x)) {                                                                                        \
-                ::sorbet::Exception::failInFuzzer();                                                           \
-                if (stopInDebugger()) {                                                                        \
-                    (void)!(x);                                                                                \
-                }                                                                                              \
-                ::sorbet::Exception::enforce_handler(#x, __FILE__, __LINE__ _MAYBE_ADD_COMMA(__VA_ARGS__));    \
-            }                                                                                                  \
-        }                                                                                                      \
+#define ENFORCE(x, ...)                                                                                           \
+    do {                                                                                                          \
+        if (::sorbet::debug_mode) {                                                                               \
+            auto __enforceTimer =                                                                                 \
+                ::sorbet::Timer(*(::spdlog::default_logger_raw()), "ENFORCE(" __FILE__ ":" QUOTED(__LINE__) ")"); \
+            if (!(x)) {                                                                                           \
+                ::sorbet::Exception::failInFuzzer();                                                              \
+                if (stopInDebugger()) {                                                                           \
+                    (void)!(x);                                                                                   \
+                }                                                                                                 \
+                ::sorbet::Exception::enforce_handler(#x, __FILE__, __LINE__ _MAYBE_ADD_COMMA(__VA_ARGS__));       \
+            }                                                                                                     \
+        }                                                                                                         \
     } while (false);
 
 #define DEBUG_ONLY(X) \

--- a/test/cli/web-trace-file/web-trace-file.out
+++ b/test/cli/web-trace-file/web-trace-file.out
@@ -1,0 +1,23 @@
+No errors! Great job.
+Backtrace:
+  #3 0x179c666 
+  #4 0x179c5ff 
+  #5 0xa92d4f fmt::v6::internal::error_handler::on_error()
+  #6 0xa93566 
+  #7 0xab7071 fmt::v6::internal::specs_handler<>::on_error()
+  #8 0xab9235 fmt::v6::internal::numeric_specs_checker<>::check_precision()
+  #9 0xab869e fmt::v6::internal::specs_checker<>::end_precision()
+  #10 0xab7015 fmt::v6::internal::parse_precision<>()
+  #11 0xab670c fmt::v6::internal::parse_format_specs<>()
+  #12 0xa9321f fmt::v6::format_handler<>::on_format_specs()
+  #13 0xa92948 fmt::v6::internal::parse_format_string<>()
+  #14 0xa9257b fmt::v6::vformat_to<>()
+  #15 0xa92194 fmt::v6::internal::vformat_to<>()
+  #16 0xe281f7 fmt::v6::format_to<>()
+  #17 0xe26bdb sorbet::web_tracer_framework::Tracing::storeTraces()
+  #18 0xaeab27 sorbet::realmain::realmain()
+  #19 0xa8e0e2 main
+  #20 0x7fbbfcfd1830 __libc_start_main
+  #21 0xa8e029 _start
+
+terminate_handler unexpectedly returned

--- a/test/cli/web-trace-file/web-trace-file.out
+++ b/test/cli/web-trace-file/web-trace-file.out
@@ -1,23 +1,2 @@
 No errors! Great job.
-Backtrace:
-  #3 0x179c666 
-  #4 0x179c5ff 
-  #5 0xa92d4f fmt::v6::internal::error_handler::on_error()
-  #6 0xa93566 
-  #7 0xab7071 fmt::v6::internal::specs_handler<>::on_error()
-  #8 0xab9235 fmt::v6::internal::numeric_specs_checker<>::check_precision()
-  #9 0xab869e fmt::v6::internal::specs_checker<>::end_precision()
-  #10 0xab7015 fmt::v6::internal::parse_precision<>()
-  #11 0xab670c fmt::v6::internal::parse_format_specs<>()
-  #12 0xa9321f fmt::v6::format_handler<>::on_format_specs()
-  #13 0xa92948 fmt::v6::internal::parse_format_string<>()
-  #14 0xa9257b fmt::v6::vformat_to<>()
-  #15 0xa92194 fmt::v6::internal::vformat_to<>()
-  #16 0xe281f7 fmt::v6::format_to<>()
-  #17 0xe26bdb sorbet::web_tracer_framework::Tracing::storeTraces()
-  #18 0xaeab27 sorbet::realmain::realmain()
-  #19 0xa8e0e2 main
-  #20 0x7fbbfcfd1830 __libc_start_main
-  #21 0xa8e029 _start
-
-terminate_handler unexpectedly returned
+Web trace file exists and has size greater than zero.

--- a/test/cli/web-trace-file/web-trace-file.sh
+++ b/test/cli/web-trace-file/web-trace-file.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+trace_json="$(mktemp)"
+# shellcheck disable=SC2064
+trap "rm -f '$trace_json'" EXIT
+
+main/sorbet --silence-dev-message --web-trace-file="$trace_json" -e 0 2>&1
+
+if [ -s "$trace_json" ]; then
+  echo 'Web trace file exists and has size greater than zero.'
+else
+  echo 'Web trace file does not exist or has size zero!'
+fi


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In #2831 we made Timers faster. A downside of that change was that we broke the
ability to record web trace files. We had zero tests for `--web-trace-file`. I
added a trivial test (which was failing) and fixed it.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.