### PR TITLE
Define DEBUG_MODE even in C

### DIFF
--- a/sorbet_version/sorbet_version.h
+++ b/sorbet_version/sorbet_version.h
@@ -16,7 +16,7 @@ extern "C" {
 #ifdef __cplusplus
 namespace sorbet {
 
-#if !defined(NDEBUG) || defined(FORCE_DEBUG)
+#ifdef DEBUG_MODE
 constexpr bool debug_mode = true;
 #else
 constexpr bool debug_mode = false;

--- a/sorbet_version/sorbet_version.h
+++ b/sorbet_version/sorbet_version.h
@@ -7,14 +7,18 @@
 extern "C" {
 #endif
 
+#if !defined(NDEBUG) || defined(FORCE_DEBUG)
+#define DEBUG_MODE
+#else
+#undef DEBUG_MODE
+#endif
+
 #ifdef __cplusplus
 namespace sorbet {
 
 #if !defined(NDEBUG) || defined(FORCE_DEBUG)
-#define DEBUG_MODE
 constexpr bool debug_mode = true;
 #else
-#undef DEBUG_MODE
 constexpr bool debug_mode = false;
 #endif
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This lets us access DEBUG_MODE from sorbet_version.c to show
`debug_mode=true` (so that for example, you can check the `sorbet
--version` to see if ENFORCEs are turned on or not).

The change to add `debug_mode=true` is already in sorbet_version.c, but
it just hadn't been working because it was a C file, so DEBUG_MODE
wasn't defined (it was only defined in C++ before).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

```
❯ bazel build //main:sorbet
...
INFO: Build completed successfully, 184 total actions

❯ bazel-bin/main/sorbet --version
Sorbet typechecker 0.5.0 (non-release) debug_symbols=false clean=0 debug_mode=true


❯ bazel build //main:sorbet --config=release-linux
...
INFO: Build completed successfully, 184 total actions

❯ bazel-bin/main/sorbet --version
Sorbet typechecker 0.5.0 (non-release) debug_symbols=false clean=0


❯ bazel build //main:sorbet --config=release-debug-linux
...
INFO: Build completed successfully, 184 total actions

❯ bazel-bin/main/sorbet --version
Sorbet typechecker 0.5.0 (non-release) debug_symbols=false clean=0 debug_mode=true
```