### PR TITLE
Bump Timer.cc threshold to 8ms

### DIFF
--- a/common/Timer.cc
+++ b/common/Timer.cc
@@ -122,7 +122,7 @@ void Timer::setTag(ConstExprStr name, ConstExprStr value) {
 Timer::~Timer() {
     auto clock = clock_gettime_coarse();
     auto dur = microseconds{clock.usec - start.usec};
-    auto threshold = microseconds{2'000}; // 2ms
+    auto threshold = microseconds{8'000}; // 8ms
     if (!canceled && dur.usec > threshold.usec) {
         // the trick ^^^ is to skip double comparison in the common case and use the most efficient representation.
         auto durMs = (clock.usec - start.usec) / 1'000;

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -7,8 +7,6 @@
 
 namespace sorbet {
 
-microseconds clock_gettime_coarse();
-
 class Timer {
     Timer(spdlog::logger &log, ConstExprStr name, FlowId prev,
           std::initializer_list<std::pair<ConstExprStr, std::string>> args, microseconds start,
@@ -57,6 +55,8 @@ public:
         log.debug("{}: sleeping for {}ms", name.str, dur.count());
         std::this_thread::sleep_for(sleep_duration);
     }
+
+    static microseconds clock_gettime_coarse();
 
 private:
     spdlog::logger &log;

--- a/common/web_tracer_framework/tracing.cc
+++ b/common/web_tracer_framework/tracing.cc
@@ -40,7 +40,7 @@ bool Tracing::storeTraces(const CounterState &counters, string_view fileName) {
     rapidjson::StringBuffer result;
     rapidjson::Writer<rapidjson::StringBuffer> writer(result);
 
-    auto now = clock_gettime_coarse();
+    auto now = Timer::clock_gettime_coarse();
     auto pid = getpid();
 
     if (!FileOps::exists(fileName)) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It looks the granularity of our CLOCK_MONOTONIC_COARSE timers is
actually closer to 4ms, which mean that we should bump this up to 8ms.

It turns out that the macOS CLOCK_MONOTONIC_RAW_APPROX reports a resolution of 1ns, which just means that if you call `clock_settime` it won't clamp your value to anything other than what you give it, but empirically the time between clocks varies wildly. On a tiny sample program I was getting anywhere from 22us to 1.6ms between clock times in a tight loop calling `clock_gettime`. Because of that, I added a clamp on the value so that we still throw away timers below 1ms if our clock can actually measure that fine grained of a time.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.