### PR TITLE
Add print statement to help lldb debugging

### DIFF
--- a/test/test_corpus_forwarder.sh
+++ b/test/test_corpus_forwarder.sh
@@ -12,4 +12,8 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
+echo -n "bazel-bin/test/test_corpus_runner"
+printf ' %q' "$@"
+echo
+
 "$(rlocation com_stripe_ruby_typer/test/test_corpus_runner)" "$@"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There used to be something in the bazel test output that would show the
command and arguments it ran when running a test. This was super
helpful, because it could be copy/pasted after `lldb --` and then you
could start debugging.

I think probably one of the bazel upgrades killed that. Instead, I opted
to just add back the print statement manually in our forwarder:

    ==================== Test output for //test:test_LSPTests/testdata/lsp/completion/constants_all_kinds:
    bazel-bin/test/test_corpus_runner --single_test=test/testdata/lsp/completion/constants_all_kinds.rb --gtest_filter=LSPTests/\*
    Note: Google Test filter = LSPTests/*
    [==========] Running 1 test from 1 test suite.
    ...


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.