### PR TITLE
Emit raw, pre-formatted values for timestamps

### DIFF
--- a/common/web_tracer_framework/tracing.cc
+++ b/common/web_tracer_framework/tracing.cc
@@ -83,7 +83,8 @@ bool Tracing::storeTraces(const CounterState &counters, string_view fileName) {
         writer.String("C");
 
         writer.String("ts");
-        writer.String(fmt::format("{:.3f}", now.usec * 1.0));
+        auto ts = fmt::format("{:.3f}", now.usec * 1.0);
+        writer.RawValue(ts.c_str(), ts.length(), rapidjson::Type::kNumberType);
 
         writer.String("pid");
         writer.Int(pid);
@@ -110,7 +111,8 @@ bool Tracing::storeTraces(const CounterState &counters, string_view fileName) {
         writer.String("C");
 
         writer.String("ts");
-        writer.String(fmt::format("{:.3f}", now.usec * 1.0));
+        auto ts = fmt::format("{:.3f}", now.usec * 1.0);
+        writer.RawValue(ts.c_str(), ts.length(), rapidjson::Type::kNumberType);
 
         writer.String("pid");
         writer.Int(pid);
@@ -138,10 +140,12 @@ bool Tracing::storeTraces(const CounterState &counters, string_view fileName) {
         writer.String("X");
 
         writer.String("ts");
-        writer.String(fmt::format("{:.3f}", timing.start.usec * 1.0));
+        auto ts = fmt::format("{:.3f}", timing.start.usec * 1.0);
+        writer.RawValue(ts.c_str(), ts.length(), rapidjson::Type::kNumberType);
 
         writer.String("dur");
-        writer.String(fmt::format("{:.3f}", (timing.end.usec - timing.start.usec) * 1.0));
+        auto dur = fmt::format("{:.3f}", (timing.end.usec - timing.start.usec) * 1.0);
+        writer.RawValue(dur.c_str(), dur.length(), rapidjson::Type::kNumberType);
 
         writer.String("pid");
         writer.Int(pid);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This gets us back to parity with what tracing.cc was doing before I
refactored it to use rapidjson instead of fmt::format_to.

We use `fmt::format` to turn a fixed `int64_t` into a floating point
number with 3 digits of precision (rather than dividing by 1000.0).
`writer.String` takes that std::string and treats it as a JSON string
when serializing it (so the type of `"ts"` is a JSON strong).  On the
other hand `writer.RawValue` takes that std::string and treats it as an
already-formatted JSON value, with a given type. That makes the type for
`"ts"` back into a number.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.