### PR TITLE
Second param of `Kernel.raise` can be anything

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -2628,7 +2628,7 @@ module Kernel
   sig do
     params(
         arg0: Class,
-        arg1: String,
+        arg1: T.untyped,
         arg2: T::Array[String],
     )
     .returns(T.noreturn)
@@ -2636,7 +2636,7 @@ module Kernel
   sig do
     params(
         arg0: Exception,
-        arg1: String,
+        arg1: T.untyped,
         arg2: T::Array[String],
     )
     .returns(T.noreturn)


### PR DESCRIPTION
This PR is changing the type of the second argument to `Kernel.raise` from `String` to `T.untyped`.

### Motivation

While Ruby documentation claims that the second parameter is expected to be a `message` which is a `String` object, it allows users to pass in any object for that parameter.
The `message` parameter is passed to the given exception class' constructor directly.

Many libraries and frameworks already use the pattern of passing in arbitrary objects for exceptions via the `message` parameter already. That pattern looks like:

```ruby
class ClientError < StandardError
  attr_reader :http_response

  def initialize(http_response)
    @http_response = http_response
    super("some dynamic message")
  end
end

raise ClientError, http_response
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No tests.
