### PR TITLE
Allow :const nodes in deserialize nil handler

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/generated_code_validation.rb
+++ b/gems/sorbet-runtime/lib/types/props/generated_code_validation.rb
@@ -170,8 +170,8 @@ module T::Props
 
     private_class_method def self.validate_deserialize_handle_nil(node)
       case node.type
-      when :hash, :array, :str, :sym, :int, :float, :true, :false, :nil
-        # Primitives are safe
+      when :hash, :array, :str, :sym, :int, :float, :true, :false, :nil, :const
+        # Primitives and constants are safe
       when :send
         receiver, method, arg = node.children
         if receiver.nil?

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -728,6 +728,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     prop :array_of_unidentified_type, T::Array[Object]
     prop :defaulted_unidentified_type, Object, default: Object.new
     prop :hash_with_unidentified_types, T::Hash[Object, Object]
+    prop :infinity_float, Float, default: Float::INFINITY
   end
 
   describe 'generated code' do


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
The current verification blocks consts when it seems they should be allowed.  I'm not actually sure if this is the right fix.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
