### PR TITLE
Fix splat destructuring type information

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -283,9 +283,10 @@ unique_ptr<Expression> desugarMlhs(DesugarContext dctx, core::LocOffsets loc, pa
                 auto lhloc = lh->loc;
                 auto index = MK::Send3(lhloc, MK::Constant(lhloc, core::Symbols::Range()), core::Names::new_(),
                                        MK::Int(lhloc, left), MK::Int(lhloc, -right), std::move(exclusive));
-                stats.emplace_back(
-                    MK::Assign(lhloc, std::move(lh),
-                               MK::Send1(loc, MK::Local(loc, tempExpanded), core::Names::slice(), std::move(index))));
+                auto slice = MK::Send1(loc, MK::Local(loc, tempExpanded), core::Names::slice(), std::move(index));
+                stats.emplace_back(MK::Assign(
+                    lhloc, std::move(lh),
+                    MK::Send1(lhloc, MK::Constant(lhloc, core::Symbols::T()), core::Names::must(), std::move(slice))));
             }
             i = -right;
         } else {

--- a/test/testdata/desugar/multi_assign.rb.desugar-tree.exp
+++ b/test/testdata/desugar/multi_assign.rb.desugar-tree.exp
@@ -36,13 +36,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           <assignTemp>$8 = array
           <assignTemp>$9 = ::<Magic>.<expand-splat>(<assignTemp>$8, 1, 0)
           a = <assignTemp>$9.[](0)
-          b = <assignTemp>$9.slice(::Range.new(1, -1, false))
+          b = ::T.must(<assignTemp>$9.slice(::Range.new(1, -1, false)))
           <assignTemp>$8
         end
         begin
           <assignTemp>$10 = array
           <assignTemp>$11 = ::<Magic>.<expand-splat>(<assignTemp>$10, 0, 1)
-          a = <assignTemp>$11.slice(::Range.new(0, -1, true))
+          a = ::T.must(<assignTemp>$11.slice(::Range.new(0, -1, true)))
           b = <assignTemp>$11.[](-1)
           <assignTemp>$10
         end
@@ -51,7 +51,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           <assignTemp>$13 = ::<Magic>.<expand-splat>(<assignTemp>$12, 2, 2)
           a = <assignTemp>$13.[](0)
           b = <assignTemp>$13.[](1)
-          c = <assignTemp>$13.slice(::Range.new(2, -2, true))
+          c = ::T.must(<assignTemp>$13.slice(::Range.new(2, -2, true)))
           d = <assignTemp>$13.[](-2)
           e = <assignTemp>$13.[](-1)
           <assignTemp>$12

--- a/test/testdata/parser/misc.rb.desugar-tree.exp
+++ b/test/testdata/parser/misc.rb.desugar-tree.exp
@@ -184,7 +184,7 @@ rescue <emptyTree>::<C E> => x
   begin
     <assignTemp>$12 = y.to_a()
     <assignTemp>$13 = ::<Magic>.<expand-splat>(<assignTemp>$12, 0, 0)
-    x = <assignTemp>$13.slice(::Range.new(0, -1, false))
+    x = ::T.must(<assignTemp>$13.slice(::Range.new(0, -1, false)))
     <assignTemp>$12
   end
 


### PR DESCRIPTION
The desugaring for processing splat destructuring uses `.slice` which returns a nilable result, thus corrupting the type of the splat parameter which should always be a non-nilable array type.

The quick fix is to add a `T.must` around that `.slice` call to fix the semantics of the desugaring, which is what this commit does.

### Motivation

Fixes: #2020 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No automated tests.
