### PR TITLE
Fix the return type for URI.parse

### DIFF
--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -422,7 +422,7 @@ module URI
     params(
         uri: String,
     )
-    .returns(URI::HTTP)
+    .returns(URI::Generic)
   end
   def self.parse(uri); end
 

--- a/test/testdata/rbi/uri.rb
+++ b/test/testdata/rbi/uri.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+sig {params(uri_string: String).returns(URI::Generic)}
+def validate_http(uri_string)
+  uri = URI.parse(uri_string)
+  raise 'Must be an HTTP URI' unless uri.is_a?(URI::HTTP)
+  uri
+end


### PR DESCRIPTION
Use the correct return type (`URI::Generic`) for `URI.parse` in `stdlib/uri.rbi`

[The ruby docs](https://ruby-doc.org/stdlib-2.7.0/libdoc/uri/rdoc/URI.html#method-c-parse) say `URI.parse` can return one of the URI’s subclasses. [`URI::Generic`](https://ruby-doc.org/stdlib-2.7.0/libdoc/uri/rdoc/URI/Generic.html) is the base class for all URI classes.

You can see here `URI::HTTP` is not the correct return type:
```ruby
URI.parse('http://example.com').class
# => URI::HTTP
URI.parse('http://example.com').is_a?(URI::Generic)
# => true
URI.parse('example.com').class
# => URI::Generic
URI.parse('example.com').is_a?(URI::HTTP)
# => false
```

### Motivation
Fix an inaccurate return type in the stdlib

### Test plan
See included automated tests. The new test was failing with an unreachable code error at the line
```ruby
raise 'Must be an HTTP URI' unless uri.is_a?(URI::HTTP)
```
because of the incorrect return type.
