### PR TITLE
Fixes error in example in sigs.md

### DIFF
--- a/website/docs/sigs.md
+++ b/website/docs/sigs.md
@@ -127,7 +127,7 @@ sig do
 end
 def self.main(*args, **kwargs)
   # Positional rest args become an Array in the method body:
-  T.reveal_type(rest) # => Revealed type: `T::Array[Integer]`
+  T.reveal_type(args) # => Revealed type: `T::Array[Integer]`
 
   # Keyword rest args become a Hash in the method body:
   T.reveal_type(kwargs) # => Revealed: type `T::Hash[Symbol, Float]`


### PR DESCRIPTION
Fixes an error in the rest parameters example (changed `rest` to `args`).

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

To fix a typo in the documentation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Requested screenshot:

<img width="632" alt="Screen Shot 2020-04-08 at 7 58 51 PM" src="https://user-images.githubusercontent.com/25065270/78844307-5fc49300-79d3-11ea-9016-46e02f3d0179.png">
