### PR TITLE
Set prop value after call_validation_error_handler

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
@@ -71,6 +71,7 @@ module T::Props
               non_nil_type,
               val,
             )
+            instance_variable_set(accessor_key, val)
           end
         end
       end
@@ -101,6 +102,7 @@ module T::Props
               non_nil_type,
               val,
             )
+            instance_variable_set(accessor_key, val)
           end
         end
       end

--- a/gems/sorbet-runtime/test/types/props/struct.rb
+++ b/gems/sorbet-runtime/test/types/props/struct.rb
@@ -51,6 +51,19 @@ class Opus::Types::Test::Props::StructTest < Critic::Unit::UnitTest
       StructWithPredefinedHash.new(hash_field1: {a: 100, b: 200}, hash_field2: {a: 'foo', b: 200})
     end
   end
+
+  it 'uses the original value when value is invalid in a soft error environment' do
+    T::Configuration.call_validation_error_handler = Proc.new do
+      # no raise
+    end
+
+    hash_field1 = {a: 'foo', b: 200}
+    doc = StructWithPredefinedHash.new(hash_field1: hash_field1)
+    assert_equal('foo', doc.hash_field1[:a])
+  ensure
+    T::Configuration.call_validation_error_handler = nil
+  end
+
   it 'can initialize a struct with a prop named "class" if without_accessors is true' do
     doc = StructWithClassProp.new(class: "the_class")
     assert_equal(StructWithClassProp, doc.class)


### PR DESCRIPTION
### Motivation
To adopt sorbet incrementally, we use a soft error environment to capture the type errors without interrupting the existing flow. Currently, when the prop setter receives an invalid value, it calls the error handler without setting the value, which would disrupt the flow and cause unexpected downstream errors.

This addresses the issue by setting the value after the error handler (if the handler does not raise the error).

### Test plan
See included automated tests.
