### PR TITLE
release-debug-*: Replace --config=dbg with --config=debugsymbols

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -82,11 +82,11 @@ build:release-mac --config=release-common
 
 build:release-debug-linux --config=release-linux
 build:release-debug-linux --config=forcedebug
-build:release-debug-linux --config=dbg
+build:release-debug-linux --config=debugsymbols
 
 build:release-debug-mac --config=release-mac
 build:release-debug-mac --config=forcedebug
-build:release-debug-mac --config=dbg
+build:release-debug-mac --config=debugsymbols
 
 build:release-sanitized-linux --copt=-O2
 build:release-sanitized-linux --config=sanitize-linux

--- a/.bazelrc
+++ b/.bazelrc
@@ -74,6 +74,10 @@ build:release-common --config=backtracesymbols
 build:release-common --config=static-libs
 build:release-common --config=versioned
 
+build:release-debug-common --config=forcedebug
+build:release-debug-common --config=debugsymbols
+build:release-debug-common --config=skipslowenforce
+
 # harden: mark relocation sections read-only
 build:release-linux --linkopt=-Wl,-z,relro,-z,now
 build:release-linux --config=lto-linux --config=release-common
@@ -81,24 +85,20 @@ build:release-linux --config=lto-linux --config=release-common
 build:release-mac --config=release-common
 
 build:release-debug-linux --config=release-linux
-build:release-debug-linux --config=forcedebug
-build:release-debug-linux --config=debugsymbols
+build:release-debug-linux --config=release-debug-common
 
 build:release-debug-mac --config=release-mac
-build:release-debug-mac --config=forcedebug
-build:release-debug-mac --config=debugsymbols
+build:release-debug-mac --config=release-debug-common
 
 build:release-sanitized-linux --copt=-O2
 build:release-sanitized-linux --config=sanitize-linux
 build:release-sanitized-linux --define jemalloc=false
-build:release-sanitized-linux --config=debugsymbols
-build:release-sanitized-linux --config=forcedebug
+build:release-sanitized-linux --config=release-debug-common
 
 build:release-sanitized-mac --copt=-O2
-build:release-sanitized-mac --config=forcedebug
-build:release-sanitized-mac --config=debugsymbols
 build:release-sanitized-mac --config=sanitize-mac
 build:release-sanitized-mac --define jemalloc=false
+build:release-sanitized-linux --config=release-debug-common
 
 ##
 ## Configuration used to to as much testing as possible in CI
@@ -133,6 +133,13 @@ test:travis --test_output=errors
 # DEBUG_MODE is set by default for all builds except --config=release.
 # Use this flag to set DEBUG_MODE even for --config=release.
 build:forcedebug --copt=-DFORCE_DEBUG
+
+# DEBUG_MODE controls whether ENFORCEs are enabled.  Some ENFORCEs are super
+# slow and/or don't pass on Stripe's codebase.  Long term we should definitely
+# make these checks pass and maybe even make them fast, but for now we provide
+# a way to skip slow debug checks (for example, when compiling debug release
+# builds)
+build:skipslowenforce --copt=-DSKIP_SLOW_ENFORCE
 
 # LTO build. Much longer compilation time. Smaller size and better perf.
 build:lto --copt=-flto=thin

--- a/common/common.h
+++ b/common/common.h
@@ -51,6 +51,22 @@ template <class E> using UnorderedSet = absl::flat_hash_set<E>;
         }                                                                                                         \
     } while (false);
 
+#ifdef SKIP_SLOW_ENFORCE
+constexpr bool skip_slow_enforce = true;
+#else
+constexpr bool skip_slow_enforce = false;
+#endif
+
+// Some ENFORCEs are super slow and/or don't pass on Stripe's codebase.
+// Long term we should definitely make these checks pass and maybe even make them fast,
+// but for now we provide a way to skip slow debug checks (for example, when compiling debug release builds)
+#define SLOW_ENFORCE(...)                   \
+    do {                                    \
+        if (!::sorbet::skip_slow_enforce) { \
+            ENFORCE(__VA_ARGS__);           \
+        }                                   \
+    } while (false);
+
 #define DEBUG_ONLY(X) \
     if (debug_mode) { \
         X;            \

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -14,10 +14,10 @@ TypePtr lubGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
 
 TypePtr Types::any(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
     auto ret = lub(gs, t1, t2);
-    ENFORCE(Types::isSubType(gs, t1, ret), "\n{}\nis not a super type of\n{}\nwas lubbing with {}", ret->toString(gs),
-            t1->toString(gs), t2->toString(gs));
-    ENFORCE(Types::isSubType(gs, t2, ret), "\n{}\nis not a super type of\n{}\nwas lubbing with {}", ret->toString(gs),
-            t2->toString(gs), t1->toString(gs));
+    SLOW_ENFORCE(Types::isSubType(gs, t1, ret), "\n{}\nis not a super type of\n{}\nwas lubbing with {}",
+                 ret->toString(gs), t1->toString(gs), t2->toString(gs));
+    SLOW_ENFORCE(Types::isSubType(gs, t2, ret), "\n{}\nis not a super type of\n{}\nwas lubbing with {}",
+                 ret->toString(gs), t2->toString(gs), t1->toString(gs));
 
     //  TODO: @dmitry, reenable
     //    ENFORCE(t1->hasUntyped() || t2->hasUntyped() || ret->hasUntyped() || // check if this test makes sense
@@ -528,11 +528,11 @@ TypePtr Types::all(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
     auto ret = glb(gs, t1, t2);
     ret->sanityCheck(gs);
 
-    ENFORCE(Types::isSubType(gs, ret, t1), "\n{}\nis not a subtype of\n{}\nwas glbbing with\n{}", ret->toString(gs),
-            t1->toString(gs), t2->toString(gs));
+    SLOW_ENFORCE(Types::isSubType(gs, ret, t1), "\n{}\nis not a subtype of\n{}\nwas glbbing with\n{}",
+                 ret->toString(gs), t1->toString(gs), t2->toString(gs));
 
-    ENFORCE(Types::isSubType(gs, ret, t2), "\n{}\n is not a subtype of\n{}\nwas glbbing with\n{}", ret->toString(gs),
-            t2->toString(gs), t1->toString(gs));
+    SLOW_ENFORCE(Types::isSubType(gs, ret, t2), "\n{}\n is not a subtype of\n{}\nwas glbbing with\n{}",
+                 ret->toString(gs), t2->toString(gs), t1->toString(gs));
     //  TODO: @dmitry, reenable
     //    ENFORCE(t1->hasUntyped() || t2->hasUntyped() || ret->hasUntyped() || // check if this test makes sense
     //                !Types::isSubTypeUnderConstraint(gs, t1, t2) || ret == t1 || ret->isUntyped(),

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -207,9 +207,9 @@ TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from, Symbol
             }
         },
         [&](Type *) { result = from; });
-    ENFORCE(Types::isSubType(gs, result, from),
-            "dropSubtypesOf({}, {}) returned {}, which is not a subtype of the input", from->toString(gs),
-            klass.data(gs)->showFullName(gs), result->toString(gs));
+    SLOW_ENFORCE(Types::isSubType(gs, result, from),
+                 "dropSubtypesOf({}, {}) returned {}, which is not a subtype of the input", from->toString(gs),
+                 klass.data(gs)->showFullName(gs), result->toString(gs));
     return result;
 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`--config=dbg` includes `-O0`, which is great for using with a debugger, but
is terribly slow on Stripe's codebase:

- after this change: ~10x faster

release-common already includes `--config=backtracesymbols`, but this
change explicitly overrides that to have `--config=debugsymbols`. This will
have things like names of local variables in the frame.

That being said, because so many things have been inlined, optimized, and
LTO'd, it's possible that certain methods you'd like to be able to call on
those local variables might not exist, so it's not perfect for debugging.

Ultimately, the goal here is to have `release-debug-linux` be something
which runs fast and runs all ENFORCE checks.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.