### PR TITLE
Added keyword parameter chomp to IO::readlines.

### DIFF
--- a/rbi/core/io.rbi
+++ b/rbi/core/io.rbi
@@ -1788,10 +1788,11 @@ class IO < Object
         binmode: BasicObject,
         autoclose: BasicObject,
         mode: String,
+        chomp: T::Boolean
     )
     .returns(T::Array[String])
   end
-  def self.readlines(name, sep=T.unsafe(nil), limit=T.unsafe(nil), external_encoding: T.unsafe(nil), internal_encoding: T.unsafe(nil), encoding: T.unsafe(nil), textmode: T.unsafe(nil), binmode: T.unsafe(nil), autoclose: T.unsafe(nil), mode: T.unsafe(nil)); end
+  def self.readlines(name, sep=T.unsafe(nil), limit=T.unsafe(nil), external_encoding: T.unsafe(nil), internal_encoding: T.unsafe(nil), encoding: T.unsafe(nil), textmode: T.unsafe(nil), binmode: T.unsafe(nil), autoclose: T.unsafe(nil), mode: T.unsafe(nil), chomp: T.unsafe(nil)); end
 
   # Calls select(2) system call. It monitors given arrays of `IO` objects, waits
   # until one or more of `IO` objects are ready for reading, are ready for

--- a/test/testdata/rbi/io.rb
+++ b/test/testdata/rbi/io.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+sig {params(file_name: String).returns(T::Array[String])}
+def test_io_readlines_chomp(file_name)
+  IO.readlines(file_name, chomp: true)
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

To add support for missing documented keyword parameter `chomp` in `IO::readlines`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. The new test was failing due to missing keyword parameter `chomp`.
