### PR TITLE
Make the canonical loc of a symbol the strictest

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1216,7 +1216,11 @@ void Symbol::addLoc(const core::GlobalState &gs, core::Loc loc) {
     }
 
     if (loc.file().data(gs).sourceType == core::File::Type::Normal && !loc.file().data(gs).isRBI()) {
-        locs_.insert(locs_.begin(), loc);
+        if (this->loc().exists() && loc.file().data(gs).strictLevel >= this->loc().file().data(gs).strictLevel) {
+            locs_.insert(locs_.begin(), loc);
+        } else {
+            locs_.emplace_back(loc);
+        }
     } else {
         locs_.emplace_back(loc);
     }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -419,16 +419,46 @@ void validateFinal(core::Context ctx, const core::SymbolRef klass, const unique_
     validateFinalMethodHelper(ctx, singleton, klass);
 }
 
+// Ignore RBI files for the purpose of checking sealed (unless there are no other files).
+// Sealed violations in RBI files too frequently come from generated RBI files, and usually if
+// people are using sealed!, they're trying to make the source available to Sorbet anyways.
+// Regardless, the runtime will still ultimately check violations in untyped code.
+core::FileRef bestNonRBIFile(core::Context ctx, const core::SymbolRef klass) {
+    core::FileRef bestFile;
+    for (const auto &cur : klass.data(ctx)->locs()) {
+        auto curFile = cur.file();
+
+        if (!bestFile.exists()) {
+            bestFile = curFile;
+            continue;
+        }
+
+        if (curFile.data(ctx).isRBI()) {
+            continue;
+        }
+
+        if (bestFile.data(ctx).isRBI()) {
+            bestFile = curFile;
+            continue;
+        }
+
+        if (curFile.data(ctx).strictLevel > bestFile.data(ctx).strictLevel) {
+            bestFile = curFile;
+        }
+    }
+
+    return bestFile;
+}
+
 void validateSealedAncestorHelper(core::Context ctx, const core::SymbolRef klass,
                                   const unique_ptr<ast::ClassDef> &classDef, const core::SymbolRef errMsgClass,
                                   const string_view verb) {
-    auto klassFile = klass.data(ctx)->loc().file();
+    auto klassFile = bestNonRBIFile(ctx, klass);
     for (const auto &mixin : klass.data(ctx)->mixins()) {
         if (!mixin.data(ctx)->isClassOrModuleSealed()) {
             continue;
         }
-        // Statically, we allow including / extending in any file that adds a loc to sealedLocs.
-        // This is less restrictive than the runtime, because the runtime doesn't have to deal with RBI files.
+        // TODO(jez) sealedLocs is actually always one loc. We should add an ENFORCE or error message for this.
         if (absl::c_any_of(mixin.data(ctx)->sealedLocs(ctx),
                            [klassFile](auto loc) { return loc.file() == klassFile; })) {
             continue;
@@ -446,9 +476,7 @@ void validateSealedAncestorHelper(core::Context ctx, const core::SymbolRef klass
 
 void validateSealed(core::Context ctx, const core::SymbolRef klass, const unique_ptr<ast::ClassDef> &classDef) {
     const auto superClass = klass.data(ctx)->superClass();
-    // Statically, we allow a subclass in any file that adds a loc to sealedLocs.
-    // This is less restrictive than the runtime, because the runtime doesn't have to deal with RBI files.
-    auto file = klass.data(ctx)->loc().file();
+    auto file = bestNonRBIFile(ctx, klass);
     if (superClass.exists() && superClass.data(ctx)->isClassOrModuleSealed() &&
         !absl::c_any_of(superClass.data(ctx)->sealedLocs(ctx), [file](auto loc) { return loc.file() == file; })) {
         if (auto e =

--- a/rbi/sorbet/compatibility_patches.rbi
+++ b/rbi/sorbet/compatibility_patches.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 # These modules provide optional runtime compatibility patches to fix
 # behaviour modified by sorbet-runtime

--- a/rbi/sorbet/tprivate.rbi
+++ b/rbi/sorbet/tprivate.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 # These things are things that Sorbet considers unstable internal APIs that
 # could (and do) change at any moment without notice.

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 # The vast majority Most of the methods defined below are arguably private
 # APIs, but are actually not private because they're used by Chalk::ODM.

--- a/rbi/sorbet/ttypes.rbi
+++ b/rbi/sorbet/ttypes.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 # These model the runtime representations of Sorbet's type syntax.  This is
 # considered a private API and might be changed at any time without notice.

--- a/test/testdata/infer/sigil_max__1.rb
+++ b/test/testdata/infer/sigil_max__1.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+def einhorn_main # error: This function does not have a `sig`
+end

--- a/test/testdata/infer/sigil_max__2.rb
+++ b/test/testdata/infer/sigil_max__2.rb
@@ -1,0 +1,4 @@
+# typed: false
+
+def einhorn_main
+end

--- a/test/testdata/resolver/sealed_redeclare__1.rb
+++ b/test/testdata/resolver/sealed_redeclare__1.rb
@@ -7,7 +7,9 @@ end
 
 class A
   extend T::Helpers
-  # This is an error in the runtime, but we haven't put the time to get an error here statically because it's tricky to get to work in incremental resolve.
+  # This is an error in the runtime, but we haven't put the time to get an
+  # error here statically because it's tricky to get to work in incremental
+  # resolve.
   sealed!
 end
 

--- a/test/testdata/resolver/sealed_redeclare__1.rb
+++ b/test/testdata/resolver/sealed_redeclare__1.rb
@@ -1,0 +1,22 @@
+# typed: strict
+
+class A
+  extend T::Helpers
+  sealed!
+end
+
+class A
+  extend T::Helpers
+  # This is an error in the runtime, but we haven't put the time to get an error here statically because it's tricky to get to work in incremental resolve.
+  sealed!
+end
+
+class B
+  extend T::Helpers
+  sealed!
+end
+
+class C
+  extend T::Helpers
+  sealed!
+end

--- a/test/testdata/resolver/sealed_redeclare__2.rb
+++ b/test/testdata/resolver/sealed_redeclare__2.rb
@@ -2,6 +2,8 @@
 
 class B
   extend T::Helpers
-  # This is an error in the runtime, but we haven't put the time to get an error here statically because it's tricky to get to work in incremental resolve.
+  # This is an error in the runtime, but we haven't put the time to get an
+  # error here statically because it's tricky to get to work in incremental
+  # resolve.
   sealed!
 end

--- a/test/testdata/resolver/sealed_redeclare__2.rb
+++ b/test/testdata/resolver/sealed_redeclare__2.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+class B
+  extend T::Helpers
+  # This is an error in the runtime, but we haven't put the time to get an error here statically because it's tricky to get to work in incremental resolve.
+  sealed!
+end

--- a/test/testdata/resolver/sealed_redeclare__3.rbi
+++ b/test/testdata/resolver/sealed_redeclare__3.rbi
@@ -1,0 +1,11 @@
+# typed: strict
+
+class C
+  extend T::Helpers
+  # This is not an error at runtime because RBI files don't affect the runtime.
+  #
+  # But this does represent an order depencence bug statically, because if this
+  # file is read before the source file, Sorbet will think that `C` can only be
+  # inherited in this file.
+  sealed!
+end


### PR DESCRIPTION
### Commit summary

-   **Add failing test** (3da0e69fd)


-   **Make the canonical loc of a symbol the strictest** (60ace5a88)


-   **Change some sealed locs** (a46789225)

    After changing the canonical loc, some symbols' locs moved around. In
    particular, if you had

    ```
    class TrueClass; end
    ```

    in a Ruby file, previously the loc of the Symbol for `TrueClass` would
    be this Ruby file, but now it is always the one in the stdlib, unless
    the current file's strictness level is greater than or equal to the RBI
    (which in the case of TrueClass is __STDLIB_INTERNAL).

    Then the problem becomes: what if that RBI file definition isn't in the
    stdlib but instead generated by reflection? Then then it looks like the
    RBI file isn't allowed to include some constant.

    So instead, I've opted to recreate the way that the "canonical loc"
    selection used to work with a helper directly in validator.cc, to
    preserve the old behavior.

-   **RBIs that don't actually write sigs for all their methods** (ceeca638d)





<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This fixes an issue we had at Stripe where because a method with the same name
was defined in multiple files with different strictnesses, we would
nondeterministically get errors in LSP mode because files would be read in
different orders.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
