### PR TITLE
match_data: values_at arg either Integer or Symbol

### DIFF
--- a/rbi/core/match_data.rbi
+++ b/rbi/core/match_data.rbi
@@ -355,7 +355,7 @@ class MatchData < Object
   # ```
   sig do
     params(
-        indexes: Integer,
+        indexes: T.any(Integer, Symbol),
     )
     .returns(T::Array[String])
   end


### PR DESCRIPTION
As [documented in `sorbet/rbi/core/match_data.rbi `](https://github.com/giovannibonetti/sorbet/blob/master/rbi/core/match_data.rbi#L344-L355), the values_at function should work either with integers or symbols:

```ruby
m = /(.)(.)(\d+)(\d)/.match("THX1138: The Movie")
m.to_a               #=> ["HX1138", "H", "X", "113", "8"]
m.values_at(0, 2, -2)   #=> ["HX1138", "X", "113"]

m = /(?<a>\d+) *(?<op>[+\-*\/]) *(?<b>\d+)/.match("1 + 2")
m.to_a               #=> ["1 + 2", "1", "+", "2"]
m.values_at(:a, :b, :op) #=> ["1", "2", "+"]
```

### Motivation

I'm working in a project that uses a regular expression like the last one and Sorbet shows a nonexistent error for `Regexp.last_match.values_at(:a, b)`, for example.

### Test plan

I would need help to create automated tests for it, given that I couldn't find anything related to it so far in the `test` folder.
