### PR TITLE
Raise for unimplemented parts of rewriter phases

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -407,6 +407,14 @@ public:
         return Send(loc, std::move(magic), core::Names::defineTopClassOrModule(), std::move(args), flags);
     }
 
+    static std::unique_ptr<ast::Send> RaiseUnimplemented(core::LocOffsets loc) {
+        auto kernel = Constant(loc, core::Symbols::Kernel());
+        auto msg = String(loc, core::Names::rewriterRaiseUnimplemented());
+        auto ret = Send1(loc, std::move(kernel), core::Names::raise(), std::move(msg));
+        ret->flags.isRewriterSynthesized = true;
+        return ret;
+    }
+
     static bool isMagicClass(ast::Expression *expr) {
         if (auto *recv = cast_tree<ConstantLit>(expr)) {
             return recv->symbol == core::Symbols::Magic();

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -253,6 +253,9 @@ NameDef names[] = {
     {"Compatibility", "Compatibility", true},
 
     {"instance"},
+
+    {"raise"},
+    {"rewriterRaiseUnimplemented", "Sorbet rewriter pass partially unimplemented"},
     // end DSL methods
 
     // The next two names are used as keys in SymbolInfo::members to store

--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -102,15 +102,15 @@ vector<unique_ptr<ast::Expression>> DSLBuilder::run(core::MutableContext ctx, as
         // def self.get_<prop>
         core::NameRef getName = ctx.state.enterNameUTF8("get_" + name.data(ctx)->show(ctx));
         stats.emplace_back(ast::MK::Sig0(loc, ASTUtil::dupType(type.get())));
-        auto defSelfGetProp = ast::MK::SyntheticMethod(loc, core::Loc(ctx.file, loc), getName, {},
-                                                       ast::MK::Unsafe(loc, ast::MK::Nil(loc)));
+        auto defSelfGetProp =
+            ast::MK::SyntheticMethod(loc, core::Loc(ctx.file, loc), getName, {}, ast::MK::RaiseUnimplemented(loc));
         defSelfGetProp->flags.isSelfMethod = true;
         stats.emplace_back(move(defSelfGetProp));
 
         // def <prop>()
         stats.emplace_back(ast::MK::Sig0(loc, ASTUtil::dupType(type.get())));
         stats.emplace_back(
-            ast::MK::SyntheticMethod(loc, core::Loc(ctx.file, loc), name, {}, ast::MK::Unsafe(loc, ast::MK::Nil(loc))));
+            ast::MK::SyntheticMethod(loc, core::Loc(ctx.file, loc), name, {}, ast::MK::RaiseUnimplemented(loc)));
     }
 
     return stats;

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -249,7 +249,8 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
                                                  computedByMethodName, std::move(unsafeNil));
         auto assertTypeMatches = ast::MK::AssertType(computedByMethodNameLoc, std::move(sendComputedMethod),
                                                      ASTUtil::dupType(getType.get()));
-        ret.nodes.emplace_back(ASTUtil::mkGet(core::Loc(ctx.file, loc), name, std::move(assertTypeMatches)));
+        auto insSeq = ast::MK::InsSeq1(loc, std::move(assertTypeMatches), ast::MK::RaiseUnimplemented(loc));
+        ret.nodes.emplace_back(ASTUtil::mkGet(core::Loc(ctx.file, loc), name, std::move(insSeq)));
     } else {
         ret.nodes.emplace_back(ASTUtil::mkGet(core::Loc(ctx.file, loc), name, ast::MK::RaiseUnimplemented(loc)));
     }

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -192,7 +192,7 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
     } else if (rules == nullptr) {
         ret.propInfo.default_ = std::nullopt;
     } else if (ASTUtil::hasTruthyHashValue(ctx, *rules, core::Names::factory())) {
-        ret.propInfo.default_ = ast::MK::Unsafe(ret.propInfo.loc, ast::MK::Nil(ret.propInfo.loc));
+        ret.propInfo.default_ = ast::MK::RaiseUnimplemented(ret.propInfo.loc);
     } else if (ASTUtil::hasHashValue(ctx, *rules, core::Names::default_())) {
         auto [key, val] = ASTUtil::extractHashValue(ctx, *rules, core::Names::default_());
         ret.propInfo.default_ = std::move(val);
@@ -251,7 +251,7 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
                                                      ASTUtil::dupType(getType.get()));
         ret.nodes.emplace_back(ASTUtil::mkGet(core::Loc(ctx.file, loc), name, std::move(assertTypeMatches)));
     } else {
-        ret.nodes.emplace_back(ASTUtil::mkGet(core::Loc(ctx.file, loc), name, ast::MK::Cast(loc, std::move(getType))));
+        ret.nodes.emplace_back(ASTUtil::mkGet(core::Loc(ctx.file, loc), name, ast::MK::RaiseUnimplemented(loc)));
     }
 
     core::NameRef setName = name.addEq(ctx);
@@ -263,7 +263,7 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
             loc, ast::MK::Hash1(loc, ast::MK::Symbol(nameLoc, core::Names::arg0()), ASTUtil::dupType(setType.get())),
             ASTUtil::dupType(setType.get())));
         ret.nodes.emplace_back(
-            ASTUtil::mkSet(core::Loc(ctx.file, loc), setName, nameLoc, ast::MK::Cast(loc, std::move(setType))));
+            ASTUtil::mkSet(core::Loc(ctx.file, loc), setName, nameLoc, ast::MK::RaiseUnimplemented(loc)));
     }
 
     // Compute the `_` foreign accessor
@@ -292,7 +292,7 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
         unique_ptr<ast::Expression> arg =
             ast::MK::RestArg(nameLoc, ast::MK::KeywordArg(nameLoc, ast::MK::Local(nameLoc, core::Names::opts())));
         ret.nodes.emplace_back(ast::MK::SyntheticMethod1(loc, core::Loc(ctx.file, loc), fkMethod, std::move(arg),
-                                                         ast::MK::Unsafe(loc, ast::MK::Nil(loc))));
+                                                         ast::MK::RaiseUnimplemented(loc)));
 
         // sig {params(opts: T.untyped).returns($foreign)}
         ret.nodes.emplace_back(ast::MK::Sig1(loc, ast::MK::Symbol(nameLoc, core::Names::opts()), ast::MK::Untyped(loc),
@@ -306,7 +306,7 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
         unique_ptr<ast::Expression> arg2 =
             ast::MK::RestArg(nameLoc, ast::MK::KeywordArg(nameLoc, ast::MK::Local(nameLoc, core::Names::opts())));
         ret.nodes.emplace_back(ast::MK::SyntheticMethod1(loc, core::Loc(ctx.file, loc), fkMethodBang, std::move(arg2),
-                                                         ast::MK::Unsafe(loc, ast::MK::Nil(loc))));
+                                                         ast::MK::RaiseUnimplemented(loc)));
     }
 
     // Compute the Mutator
@@ -317,8 +317,7 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
         rhs.emplace_back(ast::MK::Sig(
             loc, ast::MK::Hash1(loc, ast::MK::Symbol(nameLoc, core::Names::arg0()), ASTUtil::dupType(setType.get())),
             ASTUtil::dupType(setType.get())));
-        rhs.emplace_back(
-            ASTUtil::mkSet(core::Loc(ctx.file, loc), setName, nameLoc, ast::MK::Cast(loc, std::move(setType))));
+        rhs.emplace_back(ASTUtil::mkSet(core::Loc(ctx.file, loc), setName, nameLoc, ast::MK::RaiseUnimplemented(loc)));
 
         // Maybe make a getter
         unique_ptr<ast::Expression> mutator;
@@ -349,7 +348,7 @@ optional<NodesAndPropInfo> processProp(core::MutableContext ctx, ast::Send *send
 
         if (mutator.get()) {
             rhs.emplace_back(ast::MK::Sig0(loc, ASTUtil::dupType(mutator.get())));
-            rhs.emplace_back(ASTUtil::mkGet(core::Loc(ctx.file, loc), name, ast::MK::Cast(loc, std::move(mutator))));
+            rhs.emplace_back(ASTUtil::mkGet(core::Loc(ctx.file, loc), name, ast::MK::RaiseUnimplemented(loc)));
 
             ast::ClassDef::ANCESTORS_store ancestors;
             auto name = core::Names::Constants::Mutator();

--- a/test/cli/same-loc/same-loc.out
+++ b/test/cli/same-loc/same-loc.out
@@ -10,22 +10,6 @@ test/cli/same-loc/same-loc.rb:4: Unable to resolve constant `ODM` https://srb.he
      4 |  const :foo, T::Array[Foo::Baz]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/same-loc/same-loc.rb:4: Unable to resolve constant `ODM` https://srb.help/5002
-     4 |  const :foo, T::Array[Foo::Baz]
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-test/cli/same-loc/same-loc.rb:4: Unable to resolve constant `Foo` https://srb.help/5002
-     4 |  const :foo, T::Array[Foo::Baz]
-                               ^^^
-
-test/cli/same-loc/same-loc.rb:4: Unable to resolve constant `Foo` https://srb.help/5002
-     4 |  const :foo, T::Array[Foo::Baz]
-                               ^^^
-
-test/cli/same-loc/same-loc.rb:4: Unable to resolve constant `Foo` https://srb.help/5002
-     4 |  const :foo, T::Array[Foo::Baz]
-                               ^^^
-
 test/cli/same-loc/same-loc.rb:4: Unable to resolve constant `Foo` https://srb.help/5002
      4 |  const :foo, T::Array[Foo::Baz]
                                ^^^
@@ -61,32 +45,11 @@ test/cli/same-loc/same-loc.rb:4: Too many arguments provided for method `T::Arra
                       ^^^^^^^^^^^^^^^^^^
     ???: `[]` defined here
 
-test/cli/same-loc/same-loc.rb:4: Too many arguments provided for method `T::Array.[]`. Expected: `0`, got: `1` https://srb.help/7004
-     4 |  const :foo, T::Array[Foo::Baz]
-                      ^^^^^^^^^^^^^^^^^^
-    ???: `[]` defined here
-
-test/cli/same-loc/same-loc.rb:4: Method `[]` does not exist on `T.class_of(Sorbet::Private::Static::StubModule)` https://srb.help/7003
-     4 |  const :foo, T::Array[Foo::Baz]
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-test/cli/same-loc/same-loc.rb:4: Too many arguments provided for method `T::Array.[]`. Expected: `0`, got: `1` https://srb.help/7004
-     4 |  const :foo, T::Array[Foo::Baz]
-                      ^^^^^^^^^^^^^^^^^^
-    ???: `[]` defined here
-
 test/cli/same-loc/same-loc.rb: Method `keep_for_ide` does not exist on `T.class_of(Sorbet::Private::Static)` https://srb.help/7003
 
 test/cli/same-loc/same-loc.rb: Method `keep_for_ide` does not exist on `T.class_of(Sorbet::Private::Static)` https://srb.help/7003
 
-test/cli/same-loc/same-loc.rb:4: Too many arguments provided for method `T::Array.[]`. Expected: `0`, got: `1` https://srb.help/7004
-     4 |  const :foo, T::Array[Foo::Baz]
-                      ^^^^^^^^^^^^^^^^^^
-    ???: `[]` defined here
-
-test/cli/same-loc/same-loc.rb: Method `keep_for_typechecking` does not exist on `T.class_of(Sorbet::Private::Static)` https://srb.help/7003
-
-test/cli/same-loc/same-loc.rb:4: Method `unsafe` does not exist on `T.class_of(T)` https://srb.help/7003
+test/cli/same-loc/same-loc.rb:4: Method `raise` does not exist on `T.class_of(Kernel)` https://srb.help/7003
      4 |  const :foo, T::Array[Foo::Baz]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -105,20 +68,11 @@ test/cli/same-loc/same-loc.rb:4: Method `keep_def` does not exist on `T.class_of
 
 test/cli/same-loc/same-loc.rb: Method `keep_for_ide` does not exist on `T.class_of(Sorbet::Private::Static)` https://srb.help/7003
 
-test/cli/same-loc/same-loc.rb:4: Too many arguments provided for method `T::Array.[]`. Expected: `0`, got: `1` https://srb.help/7004
-     4 |  const :foo, T::Array[Foo::Baz]
-                      ^^^^^^^^^^^^^^^^^^
-    ???: `[]` defined here
-
-test/cli/same-loc/same-loc.rb: Method `keep_for_typechecking` does not exist on `T.class_of(Sorbet::Private::Static)` https://srb.help/7003
-
-test/cli/same-loc/same-loc.rb:4: Method `unsafe` does not exist on `T.class_of(T)` https://srb.help/7003
+test/cli/same-loc/same-loc.rb:4: Method `raise` does not exist on `T.class_of(Kernel)` https://srb.help/7003
      4 |  const :foo, T::Array[Foo::Baz]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/same-loc/same-loc.rb: Method `keep_for_typechecking` does not exist on `T.class_of(Sorbet::Private::Static)` https://srb.help/7003
-
-test/cli/same-loc/same-loc.rb:4: Method `unsafe` does not exist on `T.class_of(T)` https://srb.help/7003
+test/cli/same-loc/same-loc.rb:4: Method `raise` does not exist on `T.class_of(Kernel)` https://srb.help/7003
      4 |  const :foo, T::Array[Foo::Baz]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -147,4 +101,4 @@ test/cli/same-loc/same-loc.rb:4: Method `keep_def` does not exist on `T.class_of
 test/cli/same-loc/same-loc.rb:4: Method `keep_def` does not exist on `T.class_of(Sorbet::Private::Static)` https://srb.help/7003
      4 |  const :foo, T::Array[Foo::Baz]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 38
+Errors: 26

--- a/test/testdata/rewriter/data_interface_prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/data_interface_prop.rb.rewrite-tree.exp
@@ -16,7 +16,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -24,7 +24,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -32,7 +32,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo_<<C <todo sym>>>(*opts:, &<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -40,7 +40,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo_!<<C <todo sym>>>(*opts:, &<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foo")

--- a/test/testdata/rewriter/dsl_builder.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/dsl_builder.rb.rewrite-tree.exp
@@ -13,7 +13,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def self.get_opt_string<<C <todo sym>>>(&<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def opt_string<<C <todo sym>>>(&<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -37,7 +37,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def self.get_opt_int_defaulted<<C <todo sym>>>(&<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -45,7 +45,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def opt_int_defaulted<<C <todo sym>>>(&<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -61,7 +61,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def self.get_req_string<<C <todo sym>>>(&<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -69,7 +69,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def req_string<<C <todo sym>>>(&<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -85,7 +85,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def self.get_implied_string<<C <todo sym>>>(&<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -93,7 +93,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def implied_string<<C <todo sym>>>(&<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -109,7 +109,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def self.get_no_setter<<C <todo sym>>>(&<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -117,7 +117,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def no_setter<<C <todo sym>>>(&<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -133,7 +133,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def self.get_class_of<<C <todo sym>>>(&<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -141,7 +141,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def class_of<<C <todo sym>>>(&<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -157,7 +157,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def self.get_root_const<<C <todo sym>>>(&<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -165,7 +165,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def root_const<<C <todo sym>>>(&<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::Sorbet::Private::Static.keep_self_def(<self>, :"opt_string")

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -1403,26 +1403,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U String>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -1484,26 +1470,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U String>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -1811,26 +1783,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U String>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -1892,26 +1850,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U String>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -1973,36 +1917,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              Send{
-                recv = UnresolvedConstantLit{
-                  scope = EmptyTree
-                  cnst = <C <U T>>
-                }
-                fun = <U nilable>
-                block = nullptr
-                args = [
-                  UnresolvedConstantLit{
-                    scope = EmptyTree
-                    cnst = <C <U String>>
-                  }
-                ]
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -2084,36 +2004,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              Send{
-                recv = UnresolvedConstantLit{
-                  scope = EmptyTree
-                  cnst = <C <U T>>
-                }
-                fun = <U nilable>
-                block = nullptr
-                args = [
-                  UnresolvedConstantLit{
-                    scope = EmptyTree
-                    cnst = <C <U String>>
-                  }
-                ]
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -2165,26 +2061,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U String>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -2246,26 +2128,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U String>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -2317,26 +2185,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U Array>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -2398,26 +2252,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U Array>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -2479,36 +2319,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T::Array
-                }
-                fun = <U []>
-                block = nullptr
-                args = [
-                  UnresolvedConstantLit{
-                    scope = EmptyTree
-                    cnst = <C <U String>>
-                  }
-                ]
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -2590,36 +2406,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T::Array
-                }
-                fun = <U []>
-                block = nullptr
-                args = [
-                  UnresolvedConstantLit{
-                    scope = EmptyTree
-                    cnst = <C <U String>>
-                  }
-                ]
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -2671,26 +2463,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U Array>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -2752,26 +2530,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U Array>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -2836,39 +2600,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              Send{
-                recv = UnresolvedConstantLit{
-                  scope = UnresolvedConstantLit{
-                    scope = EmptyTree
-                    cnst = <C <U T>>
-                  }
-                  cnst = <C <U Array>>
-                }
-                fun = <U []>
-                block = nullptr
-                args = [
-                  UnresolvedConstantLit{
-                    scope = EmptyTree
-                    cnst = <C <U String>>
-                  }
-                ]
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -2956,39 +2693,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              Send{
-                recv = UnresolvedConstantLit{
-                  scope = UnresolvedConstantLit{
-                    scope = EmptyTree
-                    cnst = <C <U T>>
-                  }
-                  cnst = <C <U Array>>
-                }
-                fun = <U []>
-                block = nullptr
-                args = [
-                  UnresolvedConstantLit{
-                    scope = EmptyTree
-                    cnst = <C <U String>>
-                  }
-                ]
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -3057,43 +2767,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              Send{
-                recv = UnresolvedConstantLit{
-                  scope = UnresolvedConstantLit{
-                    scope = EmptyTree
-                    cnst = <C <U T>>
-                  }
-                  cnst = <C <U Hash>>
-                }
-                fun = <U []>
-                block = nullptr
-                args = [
-                  UnresolvedConstantLit{
-                    scope = EmptyTree
-                    cnst = <C <U Symbol>>
-                  }
-                  UnresolvedConstantLit{
-                    scope = EmptyTree
-                    cnst = <C <U String>>
-                  }
-                ]
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -3189,43 +2868,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              Send{
-                recv = UnresolvedConstantLit{
-                  scope = UnresolvedConstantLit{
-                    scope = EmptyTree
-                    cnst = <C <U T>>
-                  }
-                  cnst = <C <U Hash>>
-                }
-                fun = <U []>
-                block = nullptr
-                args = [
-                  UnresolvedConstantLit{
-                    scope = EmptyTree
-                    cnst = <C <U Symbol>>
-                  }
-                  UnresolvedConstantLit{
-                    scope = EmptyTree
-                    cnst = <C <U String>>
-                  }
-                ]
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -3277,26 +2925,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U String>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -3348,26 +2982,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U String>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -3419,26 +3039,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U Array>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -3496,12 +3102,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U unsafe>
+            fun = <U raise>
             block = nullptr
             args = [
-              Literal{ value = nil }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -3553,26 +3159,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U String>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -3634,26 +3226,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U String>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -3731,12 +3309,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U unsafe>
+            fun = <U raise>
             block = nullptr
             args = [
-              Literal{ value = nil }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -3804,12 +3382,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U unsafe>
+            fun = <U raise>
             block = nullptr
             args = [
-              Literal{ value = nil }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -3861,26 +3439,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U String>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -3942,26 +3506,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U String>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -4039,12 +3589,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U unsafe>
+            fun = <U raise>
             block = nullptr
             args = [
-              Literal{ value = nil }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -4112,12 +3662,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U unsafe>
+            fun = <U raise>
             block = nullptr
             args = [
-              Literal{ value = nil }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -4169,26 +3719,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U String>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -4250,26 +3786,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U String>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -4347,12 +3869,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U unsafe>
+            fun = <U raise>
             block = nullptr
             args = [
-              Literal{ value = nil }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -4420,12 +3942,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U unsafe>
+            fun = <U raise>
             block = nullptr
             args = [
-              Literal{ value = nil }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -4477,26 +3999,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U String>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -4558,26 +4066,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U String>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -4651,12 +4145,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U unsafe>
+            fun = <U raise>
             block = nullptr
             args = [
-              Literal{ value = nil }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -4730,12 +4224,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U unsafe>
+            fun = <U raise>
             block = nullptr
             args = [
-              Literal{ value = nil }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -4787,26 +4281,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U String>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -4868,26 +4348,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U String>>
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -4949,36 +4415,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              Send{
-                recv = UnresolvedConstantLit{
-                  scope = EmptyTree
-                  cnst = <C <U T>>
-                }
-                fun = <U nilable>
-                block = nullptr
-                args = [
-                  UnresolvedConstantLit{
-                    scope = EmptyTree
-                    cnst = <C <U String>>
-                  }
-                ]
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -5060,36 +4502,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              Send{
-                recv = UnresolvedConstantLit{
-                  scope = EmptyTree
-                  cnst = <C <U T>>
-                }
-                fun = <U nilable>
-                block = nullptr
-                args = [
-                  UnresolvedConstantLit{
-                    scope = EmptyTree
-                    cnst = <C <U String>>
-                  }
-                ]
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -5290,26 +4708,12 @@ ClassDef{
               rhs = Send{
                 recv = ConstantLit{
                   orig = nullptr
-                  symbol = ::T
+                  symbol = ::Kernel
                 }
-                fun = <U cast>
+                fun = <U raise>
                 block = nullptr
                 args = [
-                  Send{
-                    recv = ConstantLit{
-                      orig = nullptr
-                      symbol = ::T
-                    }
-                    fun = <U unsafe>
-                    block = nullptr
-                    args = [
-                      Literal{ value = nil }
-                    ]
-                  }
-                  UnresolvedConstantLit{
-                    scope = EmptyTree
-                    cnst = <C <U Array>>
-                  }
+                  Literal{ value = "Sorbet rewriter pass partially unimplemented" }
                 ]
               }
             }
@@ -5382,57 +4786,12 @@ ClassDef{
               rhs = Send{
                 recv = ConstantLit{
                   orig = nullptr
-                  symbol = ::T
+                  symbol = ::Kernel
                 }
-                fun = <U cast>
+                fun = <U raise>
                 block = nullptr
                 args = [
-                  Send{
-                    recv = ConstantLit{
-                      orig = nullptr
-                      symbol = ::T
-                    }
-                    fun = <U unsafe>
-                    block = nullptr
-                    args = [
-                      Literal{ value = nil }
-                    ]
-                  }
-                  Send{
-                    recv = UnresolvedConstantLit{
-                      scope = UnresolvedConstantLit{
-                        scope = UnresolvedConstantLit{
-                          scope = UnresolvedConstantLit{
-                            scope = UnresolvedConstantLit{
-                              scope = ConstantLit{
-                                orig = nullptr
-                                symbol = ::<root>
-                              }
-                              cnst = <C <U Chalk>>
-                            }
-                            cnst = <C <U ODM>>
-                          }
-                          cnst = <C <U Mutator>>
-                        }
-                        cnst = <C <U Private>>
-                      }
-                      cnst = <C <U ArrayMutator>>
-                    }
-                    fun = <U []>
-                    block = nullptr
-                    args = [
-                      Send{
-                        recv = ConstantLit{
-                          orig = nullptr
-                          symbol = ::T
-                        }
-                        fun = <U untyped>
-                        block = nullptr
-                        args = [
-                        ]
-                      }
-                    ]
-                  }
+                  Literal{ value = "Sorbet rewriter pass partially unimplemented" }
                 ]
               }
             }
@@ -5594,26 +4953,12 @@ ClassDef{
               rhs = Send{
                 recv = ConstantLit{
                   orig = nullptr
-                  symbol = ::T
+                  symbol = ::Kernel
                 }
-                fun = <U cast>
+                fun = <U raise>
                 block = nullptr
                 args = [
-                  Send{
-                    recv = ConstantLit{
-                      orig = nullptr
-                      symbol = ::T
-                    }
-                    fun = <U unsafe>
-                    block = nullptr
-                    args = [
-                      Literal{ value = nil }
-                    ]
-                  }
-                  UnresolvedConstantLit{
-                    scope = EmptyTree
-                    cnst = <C <U Array>>
-                  }
+                  Literal{ value = "Sorbet rewriter pass partially unimplemented" }
                 ]
               }
             }
@@ -5686,57 +5031,12 @@ ClassDef{
               rhs = Send{
                 recv = ConstantLit{
                   orig = nullptr
-                  symbol = ::T
+                  symbol = ::Kernel
                 }
-                fun = <U cast>
+                fun = <U raise>
                 block = nullptr
                 args = [
-                  Send{
-                    recv = ConstantLit{
-                      orig = nullptr
-                      symbol = ::T
-                    }
-                    fun = <U unsafe>
-                    block = nullptr
-                    args = [
-                      Literal{ value = nil }
-                    ]
-                  }
-                  Send{
-                    recv = UnresolvedConstantLit{
-                      scope = UnresolvedConstantLit{
-                        scope = UnresolvedConstantLit{
-                          scope = UnresolvedConstantLit{
-                            scope = UnresolvedConstantLit{
-                              scope = ConstantLit{
-                                orig = nullptr
-                                symbol = ::<root>
-                              }
-                              cnst = <C <U Chalk>>
-                            }
-                            cnst = <C <U ODM>>
-                          }
-                          cnst = <C <U Mutator>>
-                        }
-                        cnst = <C <U Private>>
-                      }
-                      cnst = <C <U ArrayMutator>>
-                    }
-                    fun = <U []>
-                    block = nullptr
-                    args = [
-                      Send{
-                        recv = ConstantLit{
-                          orig = nullptr
-                          symbol = ::T
-                        }
-                        fun = <U untyped>
-                        block = nullptr
-                        args = [
-                        ]
-                      }
-                    ]
-                  }
+                  Literal{ value = "Sorbet rewriter pass partially unimplemented" }
                 ]
               }
             }
@@ -5894,39 +5194,12 @@ ClassDef{
               rhs = Send{
                 recv = ConstantLit{
                   orig = nullptr
-                  symbol = ::T
+                  symbol = ::Kernel
                 }
-                fun = <U cast>
+                fun = <U raise>
                 block = nullptr
                 args = [
-                  Send{
-                    recv = ConstantLit{
-                      orig = nullptr
-                      symbol = ::T
-                    }
-                    fun = <U unsafe>
-                    block = nullptr
-                    args = [
-                      Literal{ value = nil }
-                    ]
-                  }
-                  Send{
-                    recv = UnresolvedConstantLit{
-                      scope = UnresolvedConstantLit{
-                        scope = EmptyTree
-                        cnst = <C <U T>>
-                      }
-                      cnst = <C <U Array>>
-                    }
-                    fun = <U []>
-                    block = nullptr
-                    args = [
-                      UnresolvedConstantLit{
-                        scope = EmptyTree
-                        cnst = <C <U String>>
-                      }
-                    ]
-                  }
+                  Literal{ value = "Sorbet rewriter pass partially unimplemented" }
                 ]
               }
             }
@@ -5993,51 +5266,12 @@ ClassDef{
               rhs = Send{
                 recv = ConstantLit{
                   orig = nullptr
-                  symbol = ::T
+                  symbol = ::Kernel
                 }
-                fun = <U cast>
+                fun = <U raise>
                 block = nullptr
                 args = [
-                  Send{
-                    recv = ConstantLit{
-                      orig = nullptr
-                      symbol = ::T
-                    }
-                    fun = <U unsafe>
-                    block = nullptr
-                    args = [
-                      Literal{ value = nil }
-                    ]
-                  }
-                  Send{
-                    recv = UnresolvedConstantLit{
-                      scope = UnresolvedConstantLit{
-                        scope = UnresolvedConstantLit{
-                          scope = UnresolvedConstantLit{
-                            scope = UnresolvedConstantLit{
-                              scope = ConstantLit{
-                                orig = nullptr
-                                symbol = ::<root>
-                              }
-                              cnst = <C <U Chalk>>
-                            }
-                            cnst = <C <U ODM>>
-                          }
-                          cnst = <C <U Mutator>>
-                        }
-                        cnst = <C <U Private>>
-                      }
-                      cnst = <C <U ArrayMutator>>
-                    }
-                    fun = <U []>
-                    block = nullptr
-                    args = [
-                      UnresolvedConstantLit{
-                        scope = EmptyTree
-                        cnst = <C <U String>>
-                      }
-                    ]
-                  }
+                  Literal{ value = "Sorbet rewriter pass partially unimplemented" }
                 ]
               }
             }
@@ -6203,43 +5437,12 @@ ClassDef{
               rhs = Send{
                 recv = ConstantLit{
                   orig = nullptr
-                  symbol = ::T
+                  symbol = ::Kernel
                 }
-                fun = <U cast>
+                fun = <U raise>
                 block = nullptr
                 args = [
-                  Send{
-                    recv = ConstantLit{
-                      orig = nullptr
-                      symbol = ::T
-                    }
-                    fun = <U unsafe>
-                    block = nullptr
-                    args = [
-                      Literal{ value = nil }
-                    ]
-                  }
-                  Send{
-                    recv = UnresolvedConstantLit{
-                      scope = UnresolvedConstantLit{
-                        scope = EmptyTree
-                        cnst = <C <U T>>
-                      }
-                      cnst = <C <U Hash>>
-                    }
-                    fun = <U []>
-                    block = nullptr
-                    args = [
-                      UnresolvedConstantLit{
-                        scope = EmptyTree
-                        cnst = <C <U Symbol>>
-                      }
-                      UnresolvedConstantLit{
-                        scope = EmptyTree
-                        cnst = <C <U String>>
-                      }
-                    ]
-                  }
+                  Literal{ value = "Sorbet rewriter pass partially unimplemented" }
                 ]
               }
             }
@@ -6310,55 +5513,12 @@ ClassDef{
               rhs = Send{
                 recv = ConstantLit{
                   orig = nullptr
-                  symbol = ::T
+                  symbol = ::Kernel
                 }
-                fun = <U cast>
+                fun = <U raise>
                 block = nullptr
                 args = [
-                  Send{
-                    recv = ConstantLit{
-                      orig = nullptr
-                      symbol = ::T
-                    }
-                    fun = <U unsafe>
-                    block = nullptr
-                    args = [
-                      Literal{ value = nil }
-                    ]
-                  }
-                  Send{
-                    recv = UnresolvedConstantLit{
-                      scope = UnresolvedConstantLit{
-                        scope = UnresolvedConstantLit{
-                          scope = UnresolvedConstantLit{
-                            scope = UnresolvedConstantLit{
-                              scope = ConstantLit{
-                                orig = nullptr
-                                symbol = ::<root>
-                              }
-                              cnst = <C <U Chalk>>
-                            }
-                            cnst = <C <U ODM>>
-                          }
-                          cnst = <C <U Mutator>>
-                        }
-                        cnst = <C <U Private>>
-                      }
-                      cnst = <C <U HashMutator>>
-                    }
-                    fun = <U []>
-                    block = nullptr
-                    args = [
-                      UnresolvedConstantLit{
-                        scope = EmptyTree
-                        cnst = <C <U Symbol>>
-                      }
-                      UnresolvedConstantLit{
-                        scope = EmptyTree
-                        cnst = <C <U String>>
-                      }
-                    ]
-                  }
+                  Literal{ value = "Sorbet rewriter pass partially unimplemented" }
                 ]
               }
             }
@@ -6505,26 +5665,12 @@ ClassDef{
               rhs = Send{
                 recv = ConstantLit{
                   orig = nullptr
-                  symbol = ::T
+                  symbol = ::Kernel
                 }
-                fun = <U cast>
+                fun = <U raise>
                 block = nullptr
                 args = [
-                  Send{
-                    recv = ConstantLit{
-                      orig = nullptr
-                      symbol = ::T
-                    }
-                    fun = <U unsafe>
-                    block = nullptr
-                    args = [
-                      Literal{ value = nil }
-                    ]
-                  }
-                  UnresolvedConstantLit{
-                    scope = EmptyTree
-                    cnst = <C <U Array>>
-                  }
+                  Literal{ value = "Sorbet rewriter pass partially unimplemented" }
                 ]
               }
             }
@@ -6597,57 +5743,12 @@ ClassDef{
               rhs = Send{
                 recv = ConstantLit{
                   orig = nullptr
-                  symbol = ::T
+                  symbol = ::Kernel
                 }
-                fun = <U cast>
+                fun = <U raise>
                 block = nullptr
                 args = [
-                  Send{
-                    recv = ConstantLit{
-                      orig = nullptr
-                      symbol = ::T
-                    }
-                    fun = <U unsafe>
-                    block = nullptr
-                    args = [
-                      Literal{ value = nil }
-                    ]
-                  }
-                  Send{
-                    recv = UnresolvedConstantLit{
-                      scope = UnresolvedConstantLit{
-                        scope = UnresolvedConstantLit{
-                          scope = UnresolvedConstantLit{
-                            scope = UnresolvedConstantLit{
-                              scope = ConstantLit{
-                                orig = nullptr
-                                symbol = ::<root>
-                              }
-                              cnst = <C <U Chalk>>
-                            }
-                            cnst = <C <U ODM>>
-                          }
-                          cnst = <C <U Mutator>>
-                        }
-                        cnst = <C <U Private>>
-                      }
-                      cnst = <C <U ArrayMutator>>
-                    }
-                    fun = <U []>
-                    block = nullptr
-                    args = [
-                      Send{
-                        recv = ConstantLit{
-                          orig = nullptr
-                          symbol = ::T
-                        }
-                        fun = <U untyped>
-                        block = nullptr
-                        args = [
-                        ]
-                      }
-                    ]
-                  }
+                  Literal{ value = "Sorbet rewriter pass partially unimplemented" }
                 ]
               }
             }
@@ -7059,26 +6160,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              ConstantLit{
-                orig = nullptr
-                symbol = ::String
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -7140,26 +6227,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              ConstantLit{
-                orig = nullptr
-                symbol = ::String
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -7211,26 +6284,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              ConstantLit{
-                orig = nullptr
-                symbol = ::Float
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -7292,26 +6351,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              ConstantLit{
-                orig = nullptr
-                symbol = ::Float
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -7436,26 +6481,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              ConstantLit{
-                orig = nullptr
-                symbol = ::String
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -7517,26 +6548,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              ConstantLit{
-                orig = nullptr
-                symbol = ::String
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -7588,26 +6605,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              ConstantLit{
-                orig = nullptr
-                symbol = ::Float
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -7717,26 +6720,12 @@ ClassDef{
           rhs = Send{
             recv = ConstantLit{
               orig = nullptr
-              symbol = ::T
+              symbol = ::Kernel
             }
-            fun = <U cast>
+            fun = <U raise>
             block = nullptr
             args = [
-              Send{
-                recv = ConstantLit{
-                  orig = nullptr
-                  symbol = ::T
-                }
-                fun = <U unsafe>
-                block = nullptr
-                args = [
-                  Literal{ value = nil }
-                ]
-              }
-              ConstantLit{
-                orig = nullptr
-                symbol = ::String
-              }
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }

--- a/test/testdata/rewriter/prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree.exp
@@ -85,7 +85,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -93,7 +93,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -131,7 +131,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def default<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -139,7 +139,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def default=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -147,7 +147,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def t_nilable<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -155,7 +155,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def t_nilable=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -163,7 +163,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def type<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -171,7 +171,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def type=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -179,7 +179,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def array<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C Array>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -187,7 +187,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def array=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C Array>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -195,7 +195,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def array_of<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), ::T::Array.[](<emptyTree>::<C String>))
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -203,7 +203,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def array_of=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), ::T::Array.[](<emptyTree>::<C String>))
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -211,7 +211,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def array_of_explicit<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C Array>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -219,7 +219,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def array_of_explicit=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C Array>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -227,7 +227,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def t_array<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C String>))
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -235,7 +235,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def t_array=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C String>))
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -243,7 +243,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def hash_of<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C T>::<C Hash>.[](<emptyTree>::<C Symbol>, <emptyTree>::<C String>))
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -251,7 +251,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def hash_of=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C T>::<C Hash>.[](<emptyTree>::<C Symbol>, <emptyTree>::<C String>))
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -259,7 +259,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def const_explicit<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -267,7 +267,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def const<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -275,7 +275,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def no_class_arg<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C Array>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -283,7 +283,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def enum_prop<<C <todo sym>>>(&<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -291,7 +291,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -299,7 +299,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -307,7 +307,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_<<C <todo sym>>>(*opts:, &<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -315,7 +315,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_!<<C <todo sym>>>(*opts:, &<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -323,7 +323,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_lazy<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -331,7 +331,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_lazy=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -339,7 +339,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_lazy_<<C <todo sym>>>(*opts:, &<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -347,7 +347,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_lazy_!<<C <todo sym>>>(*opts:, &<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -355,7 +355,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_proc<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -363,7 +363,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_proc=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -371,7 +371,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_proc_<<C <todo sym>>>(*opts:, &<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -379,7 +379,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_proc_!<<C <todo sym>>>(*opts:, &<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -387,7 +387,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_invalid<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -395,7 +395,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_invalid=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -403,7 +403,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_invalid_<<C <todo sym>>>(*opts:, &<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -411,7 +411,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_invalid_!<<C <todo sym>>>(*opts:, &<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -419,7 +419,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def ifunset<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -427,7 +427,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def ifunset=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -435,7 +435,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def ifunset_nilable<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -443,7 +443,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def ifunset_nilable=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::Sorbet::Private::Static.keep_def(<self>, :"default")
@@ -470,7 +470,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def array=<<C <todo sym>>>(arg0, &<blk>)
-        ::T.cast(::T.unsafe(nil), <emptyTree>::<C Array>)
+        ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
       end
 
       ::T::Sig::WithoutRuntime.sig() do ||
@@ -478,7 +478,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def array<<C <todo sym>>>(&<blk>)
-        ::T.cast(::T.unsafe(nil), ::<root>::<C Chalk>::<C ODM>::<C Mutator>::<C Private>::<C ArrayMutator>.[](::T.untyped()))
+        ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :"array=")
@@ -500,7 +500,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def array_of_explicit=<<C <todo sym>>>(arg0, &<blk>)
-        ::T.cast(::T.unsafe(nil), <emptyTree>::<C Array>)
+        ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
       end
 
       ::T::Sig::WithoutRuntime.sig() do ||
@@ -508,7 +508,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def array_of_explicit<<C <todo sym>>>(&<blk>)
-        ::T.cast(::T.unsafe(nil), ::<root>::<C Chalk>::<C ODM>::<C Mutator>::<C Private>::<C ArrayMutator>.[](::T.untyped()))
+        ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :"array_of_explicit=")
@@ -526,7 +526,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def t_array=<<C <todo sym>>>(arg0, &<blk>)
-        ::T.cast(::T.unsafe(nil), <emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C String>))
+        ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
       end
 
       ::T::Sig::WithoutRuntime.sig() do ||
@@ -534,7 +534,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def t_array<<C <todo sym>>>(&<blk>)
-        ::T.cast(::T.unsafe(nil), ::<root>::<C Chalk>::<C ODM>::<C Mutator>::<C Private>::<C ArrayMutator>.[](<emptyTree>::<C String>))
+        ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :"t_array=")
@@ -552,7 +552,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def hash_of=<<C <todo sym>>>(arg0, &<blk>)
-        ::T.cast(::T.unsafe(nil), <emptyTree>::<C T>::<C Hash>.[](<emptyTree>::<C Symbol>, <emptyTree>::<C String>))
+        ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
       end
 
       ::T::Sig::WithoutRuntime.sig() do ||
@@ -560,7 +560,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def hash_of<<C <todo sym>>>(&<blk>)
-        ::T.cast(::T.unsafe(nil), ::<root>::<C Chalk>::<C ODM>::<C Mutator>::<C Private>::<C HashMutator>.[](<emptyTree>::<C Symbol>, <emptyTree>::<C String>))
+        ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :"hash_of=")
@@ -580,7 +580,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def no_class_arg=<<C <todo sym>>>(arg0, &<blk>)
-        ::T.cast(::T.unsafe(nil), <emptyTree>::<C Array>)
+        ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
       end
 
       ::T::Sig::WithoutRuntime.sig() do ||
@@ -588,7 +588,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def no_class_arg<<C <todo sym>>>(&<blk>)
-        ::T.cast(::T.unsafe(nil), ::<root>::<C Chalk>::<C ODM>::<C Mutator>::<C Private>::<C ArrayMutator>.[](::T.untyped()))
+        ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :"no_class_arg=")
@@ -645,7 +645,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def token<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), ::String)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -653,7 +653,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def token=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), ::String)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -661,7 +661,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def created<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), ::Float)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -669,7 +669,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def created=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), ::Float)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::Sorbet::Private::Static.keep_def(<self>, :"token")
@@ -687,7 +687,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def token<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), ::String)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -695,7 +695,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def token=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), ::String)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -703,7 +703,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def created<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), ::Float)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::Sorbet::Private::Static.keep_def(<self>, :"token")
@@ -719,7 +719,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def merchant<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), ::String)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::Sorbet::Private::Static.keep_def(<self>, :"merchant")

--- a/test/testdata/rewriter/prop_computed_by.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_computed_by.rb.rewrite-tree.exp
@@ -5,7 +5,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def num_ok<<C <todo sym>>>(&<blk>)
-      ::T.assert_type!(<self>.class().compute_num_ok(::T.unsafe(nil)), <emptyTree>::<C Integer>)
+      begin
+        ::T.assert_type!(<self>.class().compute_num_ok(::T.unsafe(nil)), <emptyTree>::<C Integer>)
+        ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+      end
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -21,7 +24,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def missing<<C <todo sym>>>(&<blk>)
-      ::T.assert_type!(<self>.class().compute_missing(::T.unsafe(nil)), <emptyTree>::<C Integer>)
+      begin
+        ::T.assert_type!(<self>.class().compute_missing(::T.unsafe(nil)), <emptyTree>::<C Integer>)
+        ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+      end
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -29,7 +35,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def num_wrong_value<<C <todo sym>>>(&<blk>)
-      ::T.assert_type!(<self>.class().compute_num_wrong_value(::T.unsafe(nil)), <emptyTree>::<C Integer>)
+      begin
+        ::T.assert_type!(<self>.class().compute_num_wrong_value(::T.unsafe(nil)), <emptyTree>::<C Integer>)
+        ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+      end
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -45,7 +54,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def num_wrong_type<<C <todo sym>>>(&<blk>)
-      ::T.assert_type!(<self>.class().compute_num_wrong_type(::T.unsafe(nil)), <emptyTree>::<C Integer>)
+      begin
+        ::T.assert_type!(<self>.class().compute_num_wrong_type(::T.unsafe(nil)), <emptyTree>::<C Integer>)
+        ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+      end
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -69,7 +81,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def num_unknown_type<<C <todo sym>>>(&<blk>)
-      ::T.assert_type!(<self>.class().compute_num_unknown_type(::T.unsafe(nil)), <emptyTree>::<C Integer>)
+      begin
+        ::T.assert_type!(<self>.class().compute_num_unknown_type(::T.unsafe(nil)), <emptyTree>::<C Integer>)
+        ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+      end
     end
 
     def self.compute_num_unknown_type<<C <todo sym>>>(inputs, &<blk>)

--- a/test/testdata/rewriter/prop_computed_by.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_computed_by.rb.rewrite-tree.exp
@@ -61,7 +61,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def not_a_symbol<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||

--- a/test/testdata/rewriter/t_struct/default.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/default.rb.rewrite-tree.exp
@@ -13,7 +13,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C Integer>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C Integer>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||

--- a/test/testdata/rewriter/t_struct/inexact.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/inexact.rb.rewrite-tree.exp
@@ -5,7 +5,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C Integer>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -13,7 +13,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C Integer>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def bar<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -29,7 +29,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def bar=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foo")

--- a/test/testdata/rewriter/t_struct/nilable.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/nilable.rb.rewrite-tree.exp
@@ -13,7 +13,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||

--- a/test/testdata/rewriter/t_struct/normal.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/normal.rb.rewrite-tree.exp
@@ -13,7 +13,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C Integer>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C Integer>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::Sorbet::Private::Static.keep_def(<self>, :"initialize")

--- a/test/testdata/rewriter/t_struct/override.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/override.rb.rewrite-tree.exp
@@ -13,7 +13,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C String>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||

--- a/test/testdata/rewriter/t_struct/param_order.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/param_order.rb.rewrite-tree.exp
@@ -13,7 +13,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C Integer>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C Integer>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -29,7 +29,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def bar<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C Integer>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -37,7 +37,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def bar=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C Integer>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||

--- a/test/testdata/rewriter/t_struct/root.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/root.rb.rewrite-tree.exp
@@ -13,7 +13,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C Integer>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C Integer>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::Sorbet::Private::Static.keep_def(<self>, :"initialize")

--- a/test/testdata/rewriter/t_struct/some_default.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/some_default.rb.rewrite-tree.exp
@@ -13,7 +13,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C Integer>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C Integer>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -29,7 +29,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def bar<<C <todo sym>>>(&<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C T>::<C Boolean>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -37,7 +37,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def bar=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.cast(::T.unsafe(nil), <emptyTree>::<C T>::<C Boolean>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Rather than lying and returning `nil` or accessing an instance variable
or something, we should raise to indicate that the DSL pass is not fully
accurate w.r.t. what would happen at runtime.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.