### PR TITLE
Improve caching of snapshot tests

### DIFF
--- a/gems/sorbet/test/hidden-method-finder/hidden_methods.bzl
+++ b/gems/sorbet/test/hidden-method-finder/hidden_methods.bzl
@@ -33,7 +33,7 @@ def _hidden_methods_test(test_path, ruby):
     native.genrule(
         name = "actual_{}/{}".format(ruby, test_path),
         message = "Running {} ({})".format(test_path, ruby),
-        tools = [
+        exec_tools = [
             ":hidden_methods_bazel",
         ],
         srcs = [

--- a/gems/sorbet/test/hidden-method-finder/hidden_methods.bzl
+++ b/gems/sorbet/test/hidden-method-finder/hidden_methods.bzl
@@ -33,7 +33,7 @@ def _hidden_methods_test(test_path, ruby):
     native.genrule(
         name = "actual_{}/{}".format(ruby, test_path),
         message = "Running {} ({})".format(test_path, ruby),
-        exec_tools = [
+        tools = [
             ":hidden_methods_bazel",
         ],
         srcs = [

--- a/gems/sorbet/test/snapshot/BUILD
+++ b/gems/sorbet/test/snapshot/BUILD
@@ -6,6 +6,11 @@ sh_library(
 )
 
 sh_library(
+    name = "hermetic_tar",
+    srcs = ["hermetic_tar.sh"],
+)
+
+sh_library(
     name = "validate_utils",
     srcs = ["validate_utils.sh"],
     deps = [":logging"],
@@ -26,6 +31,7 @@ sh_binary(
     # NOTE: ensure that this rule isn't caught in //...
     tags = ["manual"],
     deps = [
+        ":hermetic_tar",
         ":logging",
         "@bazel_tools//tools/bash/runfiles",
     ],

--- a/gems/sorbet/test/snapshot/hermetic_tar.sh
+++ b/gems/sorbet/test/snapshot/hermetic_tar.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# If we have gtar installed (darwin), use that instead
+if hash gtar 2>/dev/null; then
+    alias tar=gtar
+fi
+
+hermetic_tar() {
+    SRC="$1"
+    OUT="$2"
+    # Check if our tar supports --sort (we assume --sort support implies --mtime support)
+    if [[ $(tar --sort 2>&1) =~ requires\ an\ argument ]]; then
+        tar --sort=name --owner=0 --group=0 --numeric-owner --mtime='UTC 1970-01-01 00:00' -h -C "$SRC" -rf "$OUT" .
+    elif [[ $(tar --mtime 2>&1) =~ requires\ an\ argument ]]; then
+        (cd "$SRC" && find . -print0) | \
+          LC_ALL=C sort -z | \
+          tar -h -C "$SRC" --no-recursion --null -T - --owner=0 --group=0 --numeric-owner --mtime='UTC 1970-01-01 00:00' -rf "$OUT" .
+    else
+        # Oh well, no hermetic tar for you
+        tar -h -C "$SRC" -rf "$OUT" .
+    fi
+}

--- a/gems/sorbet/test/snapshot/run_one.sh
+++ b/gems/sorbet/test/snapshot/run_one.sh
@@ -45,6 +45,9 @@ test_dir="${repo_root}/gems/sorbet/test/snapshot/${test_name}"
 # shellcheck disable=SC1090
 source "$(rlocation com_stripe_ruby_typer/gems/sorbet/test/snapshot/logging.sh)"
 
+# shellcheck disable=SC1090
+source "$(rlocation com_stripe_ruby_typer/gems/sorbet/test/snapshot/hermetic_tar.sh)"
+
 
 # ----- Environment setup and validation -----
 
@@ -202,7 +205,10 @@ fi
   info "├─ archiving results"
 
   # archive the test
-  tar -cz -f "$output_archive" sorbet err.log out.log
+  output="$(mktemp -d)"
+  cp -r sorbet err.log out.log "$output"
+  hermetic_tar "$output" "$output_archive"
+  rm -rf "$output"
 )
 
 # cleanup

--- a/gems/sorbet/test/snapshot/snapshot.bzl
+++ b/gems/sorbet/test/snapshot/snapshot.bzl
@@ -46,7 +46,7 @@ def _snapshot_test(test_path, ruby):
     native.genrule(
         name = "actual_{}/{}".format(ruby, test_path),
         message = "Running {} ({})".format(test_path, ruby),
-        exec_tools = [
+        tools = [
             ":run_one",
         ],
         srcs = [

--- a/gems/sorbet/test/snapshot/snapshot.bzl
+++ b/gems/sorbet/test/snapshot/snapshot.bzl
@@ -41,12 +41,12 @@ def _snapshot_test(test_path, ruby):
     """
 
     res = {}
-    actual = "{}/actual_{}.tar.gz".format(test_path, ruby)
+    actual = "{}/actual_{}.tar".format(test_path, ruby)
 
     native.genrule(
         name = "actual_{}/{}".format(ruby, test_path),
         message = "Running {} ({})".format(test_path, ruby),
-        tools = [
+        exec_tools = [
             ":run_one",
         ],
         srcs = [


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Use hermetic_tar in the snapshot tests, and switch ruby dependencies to `exec_tools`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Speeding up the build by not building multiple rubies, and hopefully getting better cache hits in CI.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
