### PR TITLE
Report incorrect computed_by usage directly

### DIFF
--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -12,5 +12,6 @@ constexpr ErrorClass TEnumOutsideEnumsDo{3506, StrictLevel::False};
 constexpr ErrorClass TEnumConstNotEnumValue{3506, StrictLevel::False};
 constexpr ErrorClass BadTestEach{3507, StrictLevel::True};
 constexpr ErrorClass PropForeignStrict{3508, StrictLevel::False};
+constexpr ErrorClass ComputedBySymbol{3509, StrictLevel::False};
 } // namespace sorbet::core::errors::Rewriter
 #endif

--- a/test/testdata/rewriter/prop_computed_by.rb
+++ b/test/testdata/rewriter/prop_computed_by.rb
@@ -27,7 +27,7 @@ class ComputingProps
   end
 
   const :not_a_symbol, String, computed_by: 'not_a_symbol'
-                                          # ^^^^^^^^^^^^^^ error: Argument does not have asserted type `Symbol`
+                                          # ^^^^^^^^^^^^^^ error: Value for `computed_by` must be a symbol literal
 
   const :num_unknown_type, Integer, computed_by: :compute_num_unknown_type
                                                # ^^^^^^^^^^^^^^^^^^^^^^^^^ error: The typechecker was unable to infer the type of the asserted value

--- a/test/testdata/rewriter/prop_computed_by.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_computed_by.rb.rewrite-tree.exp
@@ -107,8 +107,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     ::Sorbet::Private::Static.keep_self_def(<self>, :"compute_num_wrong_type")
 
-    ::T.let("not_a_symbol", <emptyTree>::<C Symbol>)
-
     ::Sorbet::Private::Static.keep_def(<self>, :"not_a_symbol")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"num_unknown_type")


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm trying to split processProp into two halves: the half that parses a
prop into it's data, and the half that consumes that data to write out
new expressions.

The logic for computed_by violates that: it writes out expressions and
parses the data at the same time, so I rewrote it to not do that.

I opted to introduce a new error, rather than relying on the error
assertion from a `T.let` in infer. There's two reasons:

1. Don't have to prematurely change the tree before we've parsed a prop
2. The error is more specific: not only does it have to have type
   Symbol, it has to syntactically be a Symbol literal.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.