### PR TITLE
Split processProp into two helprs

### DIFF
--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -41,11 +41,11 @@ bool isTStruct(ast::Expression *expr) {
 struct PropInfo {
     core::LocOffsets loc;
     bool isImmutable = false;
-    core::NameRef name;
+    core::NameRef name = core::NameRef::noName();
     core::LocOffsets nameLoc;
     unique_ptr<ast::Expression> type;
     optional<unique_ptr<ast::Expression>> default_;
-    core::NameRef computedByMethodName;
+    core::NameRef computedByMethodName = core::NameRef::noName();
     core::LocOffsets computedByMethodNameLoc;
     unique_ptr<ast::Expression> foreign;
 };

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -139,12 +139,6 @@ ASTUtil::extractHashValue(core::MutableContext ctx, ast::Hash &hash, core::NameR
     return make_pair(nullptr, nullptr);
 }
 
-void ASTUtil::putBackHashValue(core::MutableContext ctx, ast::Hash &hash, unique_ptr<ast::Expression> key,
-                               unique_ptr<ast::Expression> value) {
-    hash.keys.emplace_back(move(key));
-    hash.values.emplace_back(move(value));
-}
-
 // This will return nullptr if the argument is not the right shape as a sig (i.e. a send to a method called `sig` with 0
 // or 1 arguments, that in turn contains a block that contains a send) and it also checks the final method of the send
 // against the provided `returns` (so that some uses can specifically look for `void` sigs while others can specifically

--- a/rewriter/Util.h
+++ b/rewriter/Util.h
@@ -16,8 +16,6 @@ public:
     static std::pair<std::unique_ptr<ast::Expression>, std::unique_ptr<ast::Expression>>
     extractHashValue(core::MutableContext ctx, ast::Hash &hash, core::NameRef name);
 
-    static void putBackHashValue(core::MutableContext ctx, ast::Hash &hash, std::unique_ptr<ast::Expression> key,
-                                 std::unique_ptr<ast::Expression> value);
     static const ast::Send *castSig(const ast::Expression *expr, core::NameRef returns);
 
     static std::unique_ptr<ast::Expression> mkGet(core::Loc loc, core::NameRef name,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These two helpers both operate on `const` data structures, which means that we
won't have to be so careful manually. Previously, it was almost like you had to
understand the entire 400-some lines of `procesProp` to know how and were data
was initialized, whether it had been mutated before you, etc.

This time, `parseProp` takes in a `const ast::Send *` which means that it can't
change any fields of the underlying `ast::Send` corresponding to this `prop`,
and `processProp` takes in a `const PropInfo &` which means that it can't steal
any of the fields of the `PropInfo` when constructing the new expressions.


### Commit summary

- **Split processProp into two functions** (659d383ba)

  At this point, parseProp type checks, but doesn't do much useful (drops
  most of what it parsed on the floor) and the new processProp doesn't
  even typecheck. But I wanted to start somewhere to show a small diff.

  The contract here is:

  - parseProp doesn't mutate the prop it's parsing at all, so that we can
   early exit at any point and not have consumed any part of the tree
  - eventually processProp will be a pure function of the PropInfo that
   parseProp created.

  To make this work out, rather than worrying about where we're copy and
  where we're not, I unconditionally copy the entire `rules` hash. Some
  parts of parsing the prop will consume this parsed `rules` hash, but
  since it's a copy, it won't affect the underlying prop.

- **Accumulate all information into PropInfo** (a3209e35f)

  Don't store anything that should be persisted in locals; put it all in
  the `PropInfo ret` variable.

- **Make the rest of it typecheck** (f7d235862)


- **Fix problem with NameRefs** (9ae6f9b33)

  For some reason,

      SymbolRef sym;

  initializes a valid SymbolRef that doesn’t exist (`_id == 0`), but

      NameRef name;

  initializes an invalid NameRef, for which `.exists()` returns true
  (`_id == -1`). I think this is probably something we should change in
  NameRef.h, but that can be another change.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered extensively by existing tests, which don't change at all.