### PR TITLE
Fix Coverage.line_stub RBI

### DIFF
--- a/rbi/stdlib/coverage.rbi
+++ b/rbi/stdlib/coverage.rbi
@@ -39,8 +39,8 @@
 # p Coverage.result  #=> {"foo.rb"=>[1, 1, 10, nil, nil, 1, 1, nil, 0, nil]}
 # ```
 module Coverage
-  sig {returns(T.untyped)}
-  def self.line_stub(); end
+  sig {params(file: T.untyped).returns(T.untyped)}
+  def self.line_stub(file); end
 
   # Returns a hash that contains filename as key and coverage array as value.
   # This is the same as `Coverage.result(stop: false, clear: false)`.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

```
sorbet/shims/autogenerated/missing_methods/external.rbi:5486: Method Coverage.line_stub redefined without matching argument count. Expected: 0, got: 1 http://go/e/4010
    5486 |  def self.line_stub(file); end
            ^^^^^^^^^^^^^^^^^^^^^^^^
    https://github.com/sorbet/sorbet/tree/69fe15edc206f0e56730aa57547b86e49b1fde01/external/com_stripe_ruby_typer/rbi/stdlib/coverage.rbi#L43: Previous definition
    43 |  def self.line_stub(); end
          ^^^^^^^^^^^^^^^^^^^^
```


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.