### PR TITLE
Add ensureDir and removeDir to FileOps

### DIFF
--- a/common/FileOps.h
+++ b/common/FileOps.h
@@ -25,6 +25,17 @@ public:
     static bool writeIfDifferent(std::string_view filename, std::string_view text);
     static bool dirExists(std::string_view path);
     static void createDir(std::string_view path);
+
+    // This differs from createDir, as it will not raise an exception if the directory already exists. Returns true when
+    // the directory was created, and false if it already existed.
+    //
+    // NOTE: This does not create parent directories if they exist.
+    static bool ensureDir(std::string_view path);
+
+    // NOTE: this is a minimal wrapper around rmdir, and as such will raise an exception if the directory is not empty
+    // when it's removed.
+    static void removeDir(std::string_view path);
+
     static void removeFile(std::string_view path);
     /**
      * Returns a list of all files in the given directory. Returns paths that include the path to directory.

--- a/common/common.cc
+++ b/common/common.cc
@@ -72,6 +72,26 @@ void sorbet::FileOps::createDir(string_view path) {
     }
 }
 
+bool sorbet::FileOps::ensureDir(string_view path) {
+    auto err = mkdir(string(path).c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+    if (err) {
+        if (errno == EEXIST) {
+            return false;
+        }
+
+        throw sorbet::CreateDirException(fmt::format("Error in createDir('{}'): {}", path, errno));
+    }
+
+    return true;
+}
+
+void sorbet::FileOps::removeDir(string_view path) {
+    auto err = rmdir(string(path).c_str());
+    if (err) {
+        throw sorbet::CreateDirException(fmt::format("Error in removeDir('{}'): {}", path, errno));
+    }
+}
+
 void sorbet::FileOps::removeFile(string_view path) {
     auto err = remove(string(path).c_str());
     if (err) {

--- a/common/test/common_test.cc
+++ b/common/test/common_test.cc
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 // violates our requirements, thus has to go first
+#include "common/FileOps.h"
 #include "common/Levenstein.h"
 #include "common/common.h"
 
@@ -10,6 +11,24 @@ TEST(CommonTest, Levenstein) { // NOLINT
     EXPECT_EQ(5, Levenstein::distance("Ruby", "Scala", 10));
     EXPECT_EQ(3, Levenstein::distance("Java", "Scala", 10));
     EXPECT_EQ(INT_MAX, Levenstein::distance("Java", "S", 1));
+}
+
+class EnsureDirTest : public ::testing::Test {
+protected:
+    EnsureDirTest() {
+        if (FileOps::dirExists("common_test_dir")) {
+            FileOps::removeDir("common_test_dir");
+        }
+    }
+
+    void TearDown() override {
+        FileOps::removeDir("common_test_dir");
+    }
+};
+
+TEST(EnsureDirTest, Test) { // NOLINT
+    EXPECT_TRUE(FileOps::ensureDir("common_test_dir"));
+    EXPECT_FALSE(FileOps::ensureDir("common_test_dir"));
 }
 
 } // namespace sorbet::common


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Add two additional `FileOps` methods:

* `ensureDir` creates a directory, but doesn't fail if the directory already exists
* `removeDir` is a thin wrapper over `rmdir`

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
I needed a variation on `createDir` that doesn't fail if a directory already exists.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
