### PR TITLE
Remove special handling for enum: in prop

### DIFF
--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -143,15 +143,6 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
     }
 
     if (ret.type == nullptr) {
-        if (ASTUtil::hasTruthyHashValue(ctx, *rules, core::Names::enum_())) {
-            // Handle enum: by setting the type to untyped, so that we'll parse
-            // the declaration. Don't allow assigning it from typed code by deleting setter
-            ret.type = ast::MK::Send0(ret.loc, ast::MK::T(ret.loc), core::Names::untyped());
-            ret.isImmutable = true;
-        }
-    }
-
-    if (ret.type == nullptr) {
         return nullopt;
     }
 

--- a/test/testdata/rewriter/not_prop.rb
+++ b/test/testdata/rewriter/not_prop.rb
@@ -7,4 +7,5 @@ class ThingsWhichUsedToBePropSyntax
   prop :array_of_explicit, Array, array: String
   prop :no_class_arg, type: Array, immutable: true, array: String # error: `prop` does not exist
   prop :proc_type, type: T.proc.params(x: Integer).void # error: `prop` does not exist
+  prop :enum_prop, enum: ["hello", "goodbye"] # error: `prop` does not exist
 end

--- a/test/testdata/rewriter/not_prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/not_prop.rb.rewrite-tree.exp
@@ -51,5 +51,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.prop(:"no_class_arg", {:"type" => <emptyTree>::<C Array>, :"immutable" => true, :"array" => <emptyTree>::<C String>})
 
     <self>.prop(:"proc_type", {:"type" => <emptyTree>::<C T>.proc().params({:"x" => <emptyTree>::<C Integer>}).void()})
+
+    <self>.prop(:"enum_prop", {:"enum" => ["hello", "goodbye"]})
   end
 end

--- a/test/testdata/rewriter/prop.rb
+++ b/test/testdata/rewriter/prop.rb
@@ -92,7 +92,7 @@ def main
     T.reveal_type(AdvancedODM.new.const) # error: Revealed type: `String`
     AdvancedODM.new.const = 'b' # error: Method `const=` does not exist on `AdvancedODM`
 
-    T.reveal_type(AdvancedODM.new.enum_prop) # error: Revealed type: `T.untyped`
+    T.reveal_type(AdvancedODM.new.enum_prop) # error: Revealed type: `String`
     AdvancedODM.new.enum_prop = "hello"
 
     T.reveal_type(AdvancedODM.new.foreign_) # error: Revealed type: `T.nilable(ForeignClass)`

--- a/test/testdata/rewriter/prop.rb
+++ b/test/testdata/rewriter/prop.rb
@@ -45,7 +45,7 @@ class AdvancedODM
     prop :const_explicit, String, immutable: true
     const :const, String
 
-    prop :enum_prop, enum: ["hello", "goodbye"]
+    prop :enum_prop, String, enum: ["hello", "goodbye"]
 
     prop :foreign, String, foreign: ForeignClass # error: must be a lambda
     prop :foreign_lazy, String, foreign: -> {ForeignClass}
@@ -93,7 +93,7 @@ def main
     AdvancedODM.new.const = 'b' # error: Method `const=` does not exist on `AdvancedODM`
 
     T.reveal_type(AdvancedODM.new.enum_prop) # error: Revealed type: `T.untyped`
-    AdvancedODM.new.enum_prop = "hello" # error: Method `enum_prop=` does not exist
+    AdvancedODM.new.enum_prop = "hello"
 
     T.reveal_type(AdvancedODM.new.foreign_) # error: Revealed type: `T.nilable(ForeignClass)`
     T.reveal_type(AdvancedODM.new.foreign_!) # error: Revealed type: `ForeignClass`

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -2439,15 +2439,9 @@ ClassDef{
               fun = <U returns>
               block = nullptr
               args = [
-                Send{
-                  recv = ConstantLit{
-                    orig = nullptr
-                    symbol = ::T
-                  }
-                  fun = <U untyped>
-                  block = nullptr
-                  args = [
-                  ]
+                UnresolvedConstantLit{
+                  scope = EmptyTree
+                  cnst = <C <U String>>
                 }
               ]
             }
@@ -2460,6 +2454,73 @@ ClassDef{
           flags = {rewriter}
           name = <U enum_prop><<C <U <todo sym>>>>
           args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = Send{
+            recv = ConstantLit{
+              orig = nullptr
+              symbol = ::Kernel
+            }
+            fun = <U raise>
+            block = nullptr
+            args = [
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
+            ]
+          }
+        }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = ::T::Sig::WithoutRuntime
+          }
+          fun = <U sig>
+          block = Block {
+            args = [
+            ]
+            body = Send{
+              recv = Send{
+                recv = Local{
+                  localVariable = <U <self>>
+                }
+                fun = <U params>
+                block = nullptr
+                args = [
+                  Hash{
+                    pairs = [
+                      [
+                        key = Literal{ value = :"arg0" }
+                        value = UnresolvedConstantLit{
+                          scope = EmptyTree
+                          cnst = <C <U String>>
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              }
+              fun = <U returns>
+              block = nullptr
+              args = [
+                UnresolvedConstantLit{
+                  scope = EmptyTree
+                  cnst = <C <U String>>
+                }
+              ]
+            }
+          }
+          args = [
+          ]
+        }
+
+        MethodDef{
+          flags = {rewriter}
+          name = <U enum_prop=><<C <U <todo sym>>>>
+          args = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -4675,6 +4736,21 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :"enum_prop" }
+          ]
+        }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = ::Sorbet::Private::Static
+          }
+          fun = <U keep_def>
+          block = nullptr
+          args = [
+            Local{
+              localVariable = <U <self>>
+            }
+            Literal{ value = :"enum_prop=" }
           ]
         }
 

--- a/test/testdata/rewriter/prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree.exp
@@ -216,10 +216,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
-      <self>.params({}).returns(::T.untyped())
+      <self>.params({}).returns(<emptyTree>::<C String>)
     end
 
     def enum_prop<<C <todo sym>>>(&<blk>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({:"arg0" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
+    end
+
+    def enum_prop=<<C <todo sym>>>(arg0, &<blk>)
       ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -474,6 +482,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     ::Sorbet::Private::Static.keep_def(<self>, :"const")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"enum_prop")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"enum_prop=")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foreign")
 

--- a/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
@@ -37,7 +37,10 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     method <C <U AdvancedODM>><U default=> (default, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=38:5 end=38:39}
       argument default<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=38:11 end=38:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U enum_prop> (<blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=48:5 end=48:48}
+    method <C <U AdvancedODM>><U enum_prop> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=48:5 end=48:56}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <C <U AdvancedODM>><U enum_prop=> (enum_prop, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=48:5 end=48:56}
+      argument enum_prop<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=48:11 end=48:20}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>><U foreign> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=50:5 end=50:49}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We used to allow specifying a prop as `enum:` without specifying a type. We
don't allow that anymore. All `enum:` props must have been given a type
explicitly.

Also, I'm removing the part that says enum props are immutable, and the
part that says enum props are untyped.

- The immutable part will remove a bunch of lines from the missing
  methods RBI files
- The untyped part will start surfacing a lot more errors on
  pay-server's codebase. We'll probably have to `T.unsafe` some of them.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.