### PR TITLE
fix Tempfile rbi

### DIFF
--- a/rbi/stdlib/tempfile.rbi
+++ b/rbi/stdlib/tempfile.rbi
@@ -121,15 +121,14 @@ class Tempfile < File
   # end
   # ```
   sig do
-    type_parameters(:U)
-    .params(
+    params(
       basename: T.any(String, [String, String]),
       tmpdir: T.nilable(String),
       mode: Integer,
       options: T.untyped,
-      blk: T.nilable(T.proc.params(arg0: File).returns(T.type_parameter(:U))),
+      blk: T.nilable(T.proc.params(arg0: File).returns(T.untyped)),
     )
-    .returns(T.any(File, T.type_parameter(:U)))
+    .returns(T.untyped)
   end
   def self.create(basename="", tmpdir=nil, mode: 0, **options, &blk); end
 
@@ -163,15 +162,14 @@ class Tempfile < File
   # end
   # ```
   sig do
-    type_parameters(:U)
-    .params(
+    params(
       basename: T.any(String, [String, String]),
       tmpdir: T.nilable(String),
       mode: Integer,
       options: T.untyped,
-      blk: T.nilable(T.proc.params(arg0: Tempfile).returns(T.type_parameter(:U))),
+      blk: T.nilable(T.proc.params(arg0: Tempfile).returns(T.untyped)),
     )
-    .returns(T.any(Tempfile, T.type_parameter(:U)))
+    .returns(T.untyped)
   end
   def self.open(basename='', tmpdir=nil, mode: 0, **options, &blk); end
 

--- a/rbi/stdlib/tempfile.rbi
+++ b/rbi/stdlib/tempfile.rbi
@@ -125,22 +125,13 @@ class Tempfile < File
     .params(
       basename: T.any(String, [String, String]),
       tmpdir: T.nilable(String),
-      mode: String,
-      options: T::Hash[Symbol, T.untyped],
-      blk: T.proc.params(arg0: File).returns(T.type_parameter(:U)),
+      mode: Integer,
+      options: T.untyped,
+      blk: T.nilable(T.proc.params(arg0: File).returns(T.type_parameter(:U))),
     )
-    .returns(T.type_parameter(:U))
+    .returns(T.any(File, T.type_parameter(:U)))
   end
-  sig do
-    params(
-      basename: T.any(String, [String, String]),
-      tmpdir: T.nilable(String),
-      mode: String,
-      options: T::Hash[Symbol, T.untyped],
-    )
-    .returns(File)
-  end
-  def self.create(basename="", tmpdir=nil, mode='o', options={}, &blk); end
+  def self.create(basename="", tmpdir=nil, mode: 0, **options, &blk); end
 
   # Creates a new
   # [`Tempfile`](https://docs.ruby-lang.org/en/2.6.0/Tempfile.html).
@@ -176,33 +167,24 @@ class Tempfile < File
     .params(
       basename: T.any(String, [String, String]),
       tmpdir: T.nilable(String),
-      mode: String,
-      options: T::Hash[Symbol, T.untyped],
-      blk: T.proc.params(arg0: Tempfile).returns(T.type_parameter(:U)),
+      mode: Integer,
+      options: T.untyped,
+      blk: T.nilable(T.proc.params(arg0: Tempfile).returns(T.type_parameter(:U))),
     )
-    .returns(T.type_parameter(:U))
+    .returns(T.any(Tempfile, T.type_parameter(:U)))
   end
-  sig do
-    params(
-      basename: T.any(String, [String, String]),
-      tmpdir: T.nilable(String),
-      mode: String,
-      options: T::Hash[Symbol, T.untyped],
-    )
-    .returns(Tempfile)
-  end
-  def self.open(basename='', tmpdir=nil, mode='o', options={}, &blk); end
+  def self.open(basename='', tmpdir=nil, mode: 0, **options, &blk); end
 
   sig do
     params(
       basename: T.any(String, [String, String]),
       tmpdir: T.nilable(String),
-      mode: String,
-      options: T::Hash[Symbol, T.untyped],
+      mode: Integer,
+      options: T.untyped,
     )
     .void
   end
-  def initialize(basename='', tmpdir=nil, mode='o', options={}); end
+  def initialize(basename='', tmpdir=nil, mode: 0, **options); end
 
   # Closes the file. If `unlink_now` is true, then the file will be unlinked
   # (deleted) after closing. Of course, you can choose to later call

--- a/test/testdata/rbi/tempfile.rb
+++ b/test/testdata/rbi/tempfile.rb
@@ -36,3 +36,10 @@ Tempfile.open('hello', '/tmp') do; end
 Tempfile.open('hello', '/tmp', encoding: 'ascii-8bit') do; end
 Tempfile.open('hello', '/tmp', mode: 0) do; end
 Tempfile.open('hello', '/tmp', mode: 0, encoding: 'ascii-8bit') do; end
+
+# can return any value from block
+i = Tempfile.create('hello') { 1 }
+i + 1
+
+i = Tempfile.open('hello') { 1 }
+i + 1

--- a/test/testdata/rbi/tempfile.rb
+++ b/test/testdata/rbi/tempfile.rb
@@ -1,0 +1,38 @@
+# typed: true
+
+require 'tempfile'
+
+Tempfile.new('hello')
+Tempfile.new(['hello', '.jpg'])
+Tempfile.new('hello', '/tmp')
+Tempfile.new('hello', '/tmp', encoding: 'ascii-8bit')
+Tempfile.new('hello', '/tmp', mode: 0)
+Tempfile.new('hello', '/tmp', mode: 0, encoding: 'ascii-8bit')
+
+Tempfile.create('hello')
+Tempfile.create(['hello', '.jpg'])
+Tempfile.create('hello', '/tmp')
+Tempfile.create('hello', '/tmp', encoding: 'ascii-8bit')
+Tempfile.create('hello', '/tmp', mode: 0)
+Tempfile.create('hello', '/tmp', mode: 0, encoding: 'ascii-8bit')
+
+Tempfile.create('hello') do; end
+Tempfile.create(['hello', '.jpg']) do; end
+Tempfile.create('hello', '/tmp') do; end
+Tempfile.create('hello', '/tmp', encoding: 'ascii-8bit') do; end
+Tempfile.create('hello', '/tmp', mode: 0) do; end
+Tempfile.create('hello', '/tmp', mode: 0, encoding: 'ascii-8bit') do; end
+
+Tempfile.open('hello')
+Tempfile.open(['hello', '.jpg'])
+Tempfile.open('hello', '/tmp')
+Tempfile.open('hello', '/tmp', encoding: 'ascii-8bit')
+Tempfile.open('hello', '/tmp', mode: 0)
+Tempfile.open('hello', '/tmp', mode: 0, encoding: 'ascii-8bit')
+
+Tempfile.open('hello') do; end
+Tempfile.open(['hello', '.jpg']) do; end
+Tempfile.open('hello', '/tmp') do; end
+Tempfile.open('hello', '/tmp', encoding: 'ascii-8bit') do; end
+Tempfile.open('hello', '/tmp', mode: 0) do; end
+Tempfile.open('hello', '/tmp', mode: 0, encoding: 'ascii-8bit') do; end


### PR DESCRIPTION
For Tempfile initialize, open and create:
* make `mode` a keyword parameter
* make `options` a rest parameter
* remove overloading to work around 5003 error per sorbet/sorbet#2248

With the first two changes I was getting an `Overloaded functions cannot have keyword arguments` error so I followed the approach in sorbet/sorbet#2248 and changed the return to a `T.any`. I'm not sure if this is the best path here and open for suggestions.

### Motivation
Per [the Tempfile docs](https://docs.ruby-lang.org/en/2.6.0/Tempfile.html): `mode keyword argument, as accepted by Tempfile, can only be numeric, combination of the modes defined in File::Constants`

### Test plan

See included automated tests.
