### PR TITLE
Do not exclude include/extend sends from autogen refs

### DIFF
--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -217,8 +217,7 @@ public:
     }
 
     unique_ptr<ast::Send> preTransformSend(core::Context ctx, unique_ptr<ast::Send> original) {
-        if (original->fun == core::Names::keepForIde() || original->fun == core::Names::include() ||
-            original->fun == core::Names::extend()) {
+        if (original->fun == core::Names::keepForIde()) {
             ignoring.emplace_back(original.get());
         }
         if (original->flags.isPrivateOk && original->fun == core::Names::require() && original->args.size() == 1) {

--- a/test/cli/print_to_file/a.rb
+++ b/test/cli/print_to_file/a.rb
@@ -2,5 +2,8 @@
 
 module A
   class Foo
+    method do
+      include X
+    end
   end
 end

--- a/test/cli/print_to_file/print_to_file.out
+++ b/test/cli/print_to_file/print_to_file.out
@@ -13,8 +13,8 @@ requires: []
  defining_ref=[A]
 [def id=2]
  type=class
- defines_behavior=0
- is_empty=1
+ defines_behavior=1
+ is_empty=0
  defining_ref=[Foo]
 ## refs:
 [ref id=0]
@@ -31,6 +31,13 @@ requires: []
  resolved=[A Foo]
  loc=test/cli/print_to_file/a.rb:4
  is_defining_ref=1
+[ref id=2]
+ scope=[A Foo]
+ name=[X]
+ nesting=[[A Foo] [A]]
+ resolved=[]
+ loc=test/cli/print_to_file/a.rb:6
+ is_defining_ref=0
 # ParsedFile: test/cli/print_to_file/b.rb
 requires: []
 ## defs:
@@ -65,6 +72,6 @@ requires: []
  is_defining_ref=1
 --- autogen.txt end ---
 
-9022334ba198d9ea50ee7e05b1c299618f96fbec  autogen.msgpack
+1da3719d4a0198a1aeb120373cbfed8e27359f6b  autogen.msgpack
 
 --print=cfg specified multiple times with inconsistent output options


### PR DESCRIPTION
Stop filtering `include/`extend` sends from autogen ref output.


### Motivation
Fix issue where static analysis tools based on this output were missing references.
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
See included automated tests.

Without this change fails with:
```
==================== Test output for //test/cli:test_print_to_file:
No errors! Great job.
--- test/cli/print_to_file/print_to_file.out	2020-04-17 19:04:24.000000000 +0000
+++ /dev/fd/63	2020-04-17 19:05:50.000000000 +0000
@@ -31,13 +31,6 @@
  resolved=[A Foo]
  loc=test/cli/print_to_file/a.rb:4
  is_defining_ref=1
-[ref id=2]
- scope=[A Foo]
- name=[X]
- nesting=[[A Foo] [A]]
- resolved=[]
- loc=test/cli/print_to_file/a.rb:6
- is_defining_ref=0
 # ParsedFile: test/cli/print_to_file/b.rb
 requires: []
 ## defs:
@@ -72,6 +65,6 @@
  is_defining_ref=1
 --- autogen.txt end ---

-1da3719d4a0198a1aeb120373cbfed8e27359f6b  autogen.msgpack
+89391a3240e42c4ba30d6ebbf111bc94d9cfd208  autogen.msgpack
```
