### PR TITLE
Revert "Do not exclude include/extend sends from autogen refs"

### DIFF
--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -217,7 +217,8 @@ public:
     }
 
     unique_ptr<ast::Send> preTransformSend(core::Context ctx, unique_ptr<ast::Send> original) {
-        if (original->fun == core::Names::keepForIde()) {
+        if (original->fun == core::Names::keepForIde() || original->fun == core::Names::include() ||
+            original->fun == core::Names::extend()) {
             ignoring.emplace_back(original.get());
         }
         if (original->flags.isPrivateOk && original->fun == core::Names::require() && original->args.size() == 1) {

--- a/test/cli/print_to_file/a.rb
+++ b/test/cli/print_to_file/a.rb
@@ -2,8 +2,5 @@
 
 module A
   class Foo
-    method do
-      include X
-    end
   end
 end

--- a/test/cli/print_to_file/print_to_file.out
+++ b/test/cli/print_to_file/print_to_file.out
@@ -13,8 +13,8 @@ requires: []
  defining_ref=[A]
 [def id=2]
  type=class
- defines_behavior=1
- is_empty=0
+ defines_behavior=0
+ is_empty=1
  defining_ref=[Foo]
 ## refs:
 [ref id=0]
@@ -31,13 +31,6 @@ requires: []
  resolved=[A Foo]
  loc=test/cli/print_to_file/a.rb:4
  is_defining_ref=1
-[ref id=2]
- scope=[A Foo]
- name=[X]
- nesting=[[A Foo] [A]]
- resolved=[]
- loc=test/cli/print_to_file/a.rb:6
- is_defining_ref=0
 # ParsedFile: test/cli/print_to_file/b.rb
 requires: []
 ## defs:
@@ -72,6 +65,6 @@ requires: []
  is_defining_ref=1
 --- autogen.txt end ---
 
-1da3719d4a0198a1aeb120373cbfed8e27359f6b  autogen.msgpack
+9022334ba198d9ea50ee7e05b1c299618f96fbec  autogen.msgpack
 
 --print=cfg specified multiple times with inconsistent output options


### PR DESCRIPTION
Reverts sorbet/sorbet#2902

Found that this was causing duplicate refs in certain cases.