### PR TITLE
Censor more information

### DIFF
--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -209,6 +209,14 @@ string Loc::filePosToString(const GlobalState &gs) const {
         buf << "???";
     } else {
         auto path = gs.getPrintablePath(file().data(gs).path());
+        auto externalPrefix = "external/com_stripe_ruby_typer/"sv;
+        if (gs.censorForSnapshotTests) {
+            if (absl::StartsWith(path, externalPrefix)) {
+                // When running tests from outside of the sorbet repo, the files have a different path in the sandbox.
+                path.remove_prefix(externalPrefix.size());
+            }
+        }
+
         buf << path;
         if (exists()) {
             auto pos = position(gs);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Causes tests to fail when run outside of the Sorbet repo.
Specifically, we were seeing symbol-table tests fails (the previous
censoring changes had only been for symbol-table-raw changes).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Can't be tested, because it only reproduces outside of this repo.