### PR TITLE
Do not exclude include/extend sends from autogen refs

### DIFF
--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -237,7 +237,8 @@ public:
         // class/module level. These cases are handled in `preTransformClassDef`. Do not ignore in
         // block scope so that we a ref to the included module is still rendered.
         if (original->fun == core::Names::keepForIde() ||
-            (!inBlock && (original->fun == core::Names::include() || original->fun == core::Names::extend()))) {
+            (!inBlock && original->recv->isSelfReference() &&
+             (original->fun == core::Names::include() || original->fun == core::Names::extend()))) {
             ignoring.emplace_back(original.get());
         }
         if (original->flags.isPrivateOk && original->fun == core::Names::require() && original->args.size() == 1) {

--- a/test/cli/autogen-subclasses/a.rb
+++ b/test/cli/autogen-subclasses/a.rb
@@ -31,3 +31,9 @@ class Opus::DupChild < Opus::Parent; end # Only appears once in output
 class Opus::Risk::Model::Mixins::RiskSafeMachine; end
 
 class FooSafeMachine < Opus::Risk::Model::Mixins::RiskSafeMachine; end
+
+module MyMixin; end
+class MyClass
+  X = Y
+  include MyMixin
+end

--- a/test/cli/autogen-subclasses/autogen-subclasses.out
+++ b/test/cli/autogen-subclasses/autogen-subclasses.out
@@ -1,4 +1,6 @@
 --- autogen-subclasses ---
+module MyMixin
+ class MyClass
 module Opus::Mixin
  class Opus::Mixed
  class Opus::MixedDescendant

--- a/test/cli/autogen-subclasses/autogen-subclasses.sh
+++ b/test/cli/autogen-subclasses/autogen-subclasses.sh
@@ -7,4 +7,5 @@ main/sorbet --silence-dev-message --stop-after=namer -p autogen-subclasses \
   --autogen-subclasses-parent=Opus::Parent \
   --autogen-subclasses-parent=Opus::IDontExist \
   --autogen-subclasses-parent=Opus::NeverSubclassed \
+  --autogen-subclasses-parent=MyMixin \
   test/cli/autogen-subclasses/a.rb

--- a/test/cli/print_to_file/c.rb
+++ b/test/cli/print_to_file/c.rb
@@ -6,14 +6,14 @@ module C
   class BarChild < Bar;
     include ::X
     some_method do
-      include ::TodoX # Currently missing from dep analysis
+      include ::InMethodX
     end
   end
 
   module TestExtend
     extend ::Y
     some_method do
-      extend ::TodoY # Currently missing from dep analysis
+      extend ::InMethodY
     end
   end
 end

--- a/test/cli/print_to_file/c.rb
+++ b/test/cli/print_to_file/c.rb
@@ -15,6 +15,8 @@ module C
     some_method do
       extend ::InMethodY
     end
+
+    app.include ::ViaMethod
   end
 end
 

--- a/test/cli/print_to_file/c.rb
+++ b/test/cli/print_to_file/c.rb
@@ -1,0 +1,20 @@
+# typed: true
+
+module C
+  class Bar; end
+
+  class BarChild < Bar;
+    include ::X
+    some_method do
+      include ::TodoX # Currently missing from dep analysis
+    end
+  end
+
+  module TestExtend
+    extend ::Y
+    some_method do
+      extend ::TodoY # Currently missing from dep analysis
+    end
+  end
+end
+

--- a/test/cli/print_to_file/d.rb
+++ b/test/cli/print_to_file/d.rb
@@ -1,0 +1,7 @@
+# typed: true
+#
+module MyMixin; end
+class MyClass
+  X = Y
+  include MyMixin
+end

--- a/test/cli/print_to_file/print_to_file.out
+++ b/test/cli/print_to_file/print_to_file.out
@@ -157,6 +157,13 @@ requires: []
  resolved=[]
  loc=test/cli/print_to_file/c.rb:16
  is_defining_ref=0
+[ref id=9]
+ scope=[]
+ name=[ViaMethod]
+ nesting=[]
+ resolved=[]
+ loc=test/cli/print_to_file/c.rb:19
+ is_defining_ref=0
 # ParsedFile: test/cli/print_to_file/d.rb
 requires: []
 ## defs:
@@ -219,6 +226,6 @@ requires: []
  is_defining_ref=0
 --- autogen.txt end ---
 
-79cc8659d260cbcbffb83cb05ab7da0ba328b573  autogen.msgpack
+304d23737beec8076d49ec970a5d6b85c940b9c6  autogen.msgpack
 
 --print=cfg specified multiple times with inconsistent output options

--- a/test/cli/print_to_file/print_to_file.out
+++ b/test/cli/print_to_file/print_to_file.out
@@ -63,8 +63,88 @@ requires: []
  resolved=[B Bar]
  loc=test/cli/print_to_file/b.rb:4
  is_defining_ref=1
+# ParsedFile: test/cli/print_to_file/c.rb
+requires: []
+## defs:
+[def id=0]
+ type=module
+ defines_behavior=0
+ is_empty=0
+[def id=1]
+ type=module
+ defines_behavior=0
+ is_empty=0
+ defining_ref=[C]
+[def id=2]
+ type=class
+ defines_behavior=0
+ is_empty=1
+ defining_ref=[Bar]
+[def id=3]
+ type=class
+ defines_behavior=1
+ is_empty=0
+ defining_ref=[BarChild]
+ parent_ref=[Bar]
+[def id=4]
+ type=module
+ defines_behavior=1
+ is_empty=0
+ defining_ref=[TestExtend]
+## refs:
+[ref id=0]
+ scope=[]
+ name=[C]
+ nesting=[]
+ resolved=[C]
+ loc=test/cli/print_to_file/c.rb:3
+ is_defining_ref=1
+[ref id=1]
+ scope=[C]
+ name=[Bar]
+ nesting=[[C]]
+ resolved=[C Bar]
+ loc=test/cli/print_to_file/c.rb:4
+ is_defining_ref=1
+[ref id=2]
+ scope=[C]
+ name=[BarChild]
+ nesting=[[C]]
+ resolved=[C BarChild]
+ loc=test/cli/print_to_file/c.rb:6
+ is_defining_ref=1
+[ref id=3]
+ scope=[C]
+ name=[Bar]
+ nesting=[[C]]
+ resolved=[C Bar]
+ loc=test/cli/print_to_file/c.rb:6
+ is_defining_ref=0
+ parent_of=[C BarChild]
+[ref id=4]
+ scope=[]
+ name=[X]
+ nesting=[]
+ resolved=[]
+ loc=test/cli/print_to_file/c.rb:7
+ is_defining_ref=0
+ parent_of=[C BarChild]
+[ref id=5]
+ scope=[C]
+ name=[TestExtend]
+ nesting=[[C]]
+ resolved=[C TestExtend]
+ loc=test/cli/print_to_file/c.rb:13
+ is_defining_ref=1
+[ref id=6]
+ scope=[]
+ name=[Y]
+ nesting=[]
+ resolved=[]
+ loc=test/cli/print_to_file/c.rb:14
+ is_defining_ref=0
 --- autogen.txt end ---
 
-9022334ba198d9ea50ee7e05b1c299618f96fbec  autogen.msgpack
+48d6cb30b600d7df4f6b42e5dd94b3d88f700622  autogen.msgpack
 
 --print=cfg specified multiple times with inconsistent output options

--- a/test/cli/print_to_file/print_to_file.out
+++ b/test/cli/print_to_file/print_to_file.out
@@ -130,18 +130,32 @@ requires: []
  is_defining_ref=0
  parent_of=[C BarChild]
 [ref id=5]
+ scope=[]
+ name=[InMethodX]
+ nesting=[]
+ resolved=[]
+ loc=test/cli/print_to_file/c.rb:9
+ is_defining_ref=0
+[ref id=6]
  scope=[C]
  name=[TestExtend]
  nesting=[[C]]
  resolved=[C TestExtend]
  loc=test/cli/print_to_file/c.rb:13
  is_defining_ref=1
-[ref id=6]
+[ref id=7]
  scope=[]
  name=[Y]
  nesting=[]
  resolved=[]
  loc=test/cli/print_to_file/c.rb:14
+ is_defining_ref=0
+[ref id=8]
+ scope=[]
+ name=[InMethodY]
+ nesting=[]
+ resolved=[]
+ loc=test/cli/print_to_file/c.rb:16
  is_defining_ref=0
 # ParsedFile: test/cli/print_to_file/d.rb
 requires: []
@@ -205,6 +219,6 @@ requires: []
  is_defining_ref=0
 --- autogen.txt end ---
 
-8066a70741700776133b04fffaba2790d2b92341  autogen.msgpack
+79cc8659d260cbcbffb83cb05ab7da0ba328b573  autogen.msgpack
 
 --print=cfg specified multiple times with inconsistent output options

--- a/test/cli/print_to_file/print_to_file.out
+++ b/test/cli/print_to_file/print_to_file.out
@@ -143,8 +143,68 @@ requires: []
  resolved=[]
  loc=test/cli/print_to_file/c.rb:14
  is_defining_ref=0
+# ParsedFile: test/cli/print_to_file/d.rb
+requires: []
+## defs:
+[def id=0]
+ type=module
+ defines_behavior=0
+ is_empty=0
+[def id=1]
+ type=module
+ defines_behavior=0
+ is_empty=1
+ defining_ref=[MyMixin]
+[def id=2]
+ type=class
+ defines_behavior=1
+ is_empty=0
+ defining_ref=[MyClass]
+[def id=3]
+ type=alias
+ defines_behavior=1
+ is_empty=0
+ defining_ref=[X]
+ aliased_ref=[Y]
+## refs:
+[ref id=0]
+ scope=[]
+ name=[MyMixin]
+ nesting=[]
+ resolved=[MyMixin]
+ loc=test/cli/print_to_file/d.rb:3
+ is_defining_ref=1
+[ref id=1]
+ scope=[]
+ name=[MyClass]
+ nesting=[]
+ resolved=[MyClass]
+ loc=test/cli/print_to_file/d.rb:4
+ is_defining_ref=1
+[ref id=2]
+ scope=[MyClass]
+ name=[MyMixin]
+ nesting=[[MyClass]]
+ resolved=[MyMixin]
+ loc=test/cli/print_to_file/d.rb:6
+ is_defining_ref=0
+ parent_of=[MyClass]
+[ref id=3]
+ scope=[MyClass]
+ name=[X]
+ nesting=[[MyClass]]
+ resolved=[MyClass X]
+ loc=test/cli/print_to_file/d.rb:5
+ is_defining_ref=1
+[ref id=4]
+ scope=[MyClass]
+ name=[Y]
+ nesting=[[MyClass]]
+ resolved=[]
+ loc=test/cli/print_to_file/d.rb:5
+ is_defining_ref=0
 --- autogen.txt end ---
 
-48d6cb30b600d7df4f6b42e5dd94b3d88f700622  autogen.msgpack
+8066a70741700776133b04fffaba2790d2b92341  autogen.msgpack
 
 --print=cfg specified multiple times with inconsistent output options

--- a/test/cli/print_to_file/print_to_file.sh
+++ b/test/cli/print_to_file/print_to_file.sh
@@ -3,7 +3,7 @@ set -eu
 
 main/sorbet --silence-dev-message --stop-after namer --autogen-version=2 \
   -p autogen:autogen.txt -p autogen-msgpack:autogen.msgpack \
-  test/cli/print_to_file/{a,b}.rb
+  test/cli/print_to_file/{a,b,c}.rb
 
 echo "--- autogen.txt start ---"
 cat autogen.txt

--- a/test/cli/print_to_file/print_to_file.sh
+++ b/test/cli/print_to_file/print_to_file.sh
@@ -3,7 +3,7 @@ set -eu
 
 main/sorbet --silence-dev-message --stop-after namer --autogen-version=2 \
   -p autogen:autogen.txt -p autogen-msgpack:autogen.msgpack \
-  test/cli/print_to_file/{a,b,c}.rb
+  test/cli/print_to_file/*.rb
 
 echo "--- autogen.txt start ---"
 cat autogen.txt


### PR DESCRIPTION
Alternative implementation to https://github.com/sorbet/sorbet/pull/2912 that does not re-order the processing.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
