### PR TITLE
ZSuperArgs: Wrap up keyword args into the final hash arg

### DIFF
--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -124,9 +124,9 @@ public:
 
 UnorderedSet<string> knownExpectations = {
     "parse-tree",       "parse-tree-json", "parse-tree-whitequark", "desugar-tree", "desugar-tree-raw", "rewrite-tree",
-    "rewrite-tree-raw", "symbol-table",    "symbol-table-raw",      "name-tree",    "name-tree-raw",    "resolve-tree",
-    "resolve-tree-raw", "flatten-tree",    "flatten-tree-raw",      "cfg",          "cfg-raw",          "autogen",
-    "document-symbols"};
+    "rewrite-tree-raw", "index-tree",      "index-tree-raw",        "symbol-table", "symbol-table-raw", "name-tree",
+    "name-tree-raw",    "resolve-tree",    "resolve-tree-raw",      "flatten-tree", "flatten-tree-raw", "cfg",
+    "cfg-raw",          "autogen",         "document-symbols"};
 
 ast::ParsedFile testSerialize(core::GlobalState &gs, ast::ParsedFile expr) {
     auto &savedFile = expr.file.data(gs);
@@ -289,6 +289,9 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
 
             core::MutableContext ctx(*gs, core::Symbols::root(), desugared.file);
             localNamed = testSerialize(*gs, local_vars::LocalVars::run(ctx, move(rewriten)));
+
+            handler.addObserved("index-tree", [&]() { return localNamed.tree->toString(*gs); });
+            handler.addObserved("index-tree-raw", [&]() { return localNamed.tree->showRaw(*gs); });
         } else {
             core::MutableContext ctx(*gs, core::Symbols::root(), desugared.file);
             localNamed = testSerialize(*gs, local_vars::LocalVars::run(ctx, move(desugared)));
@@ -507,6 +510,8 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
 
         // local vars
         file = testSerialize(*gs, local_vars::LocalVars::run(ctx, move(file)));
+        handler.addObserved("index-tree", [&]() { return file.tree->toString(*gs); });
+        handler.addObserved("index-tree-raw", [&]() { return file.tree->showRaw(*gs); });
 
         // namer
         {

--- a/test/testdata/infer/zsuper.rb.cfg.exp
+++ b/test/testdata/infer/zsuper.rb.cfg.exp
@@ -60,7 +60,7 @@ subgraph "cluster_::Bar#baz" {
     "bb::Bar#baz_1" [shape = parallelogram];
 
     "bb::Bar#baz_0" [
-        label = "block[id=0, rubyBlockId=0]()\l<self>: Bar = cast(<self>: NilClass, Bar);\lb: T.untyped = load_arg(b)\l<blk>: T.untyped = load_arg(<blk>)\l<block-pre-call-temp>$6: Sorbet::Private::Static::Void = <self>: Bar.super(b: T.untyped, <blk>: T.untyped)\l<selfRestore>$7: Bar = <self>\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: Bar = cast(<self>: NilClass, Bar);\lb: T.untyped = load_arg(b)\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: Bar.super(b: T.untyped)\l<selfRestore>$6: Bar = <self>\l<unconditional>\l"
     ];
 
     "bb::Bar#baz_0" -> "bb::Bar#baz_2" [style="bold"];
@@ -70,19 +70,19 @@ subgraph "cluster_::Bar#baz" {
 
     "bb::Bar#baz_1" -> "bb::Bar#baz_1" [style="bold"];
     "bb::Bar#baz_2" [
-        label = "block[id=2, rubyBlockId=1](<self>: Bar, <selfRestore>$7: Bar, <block-pre-call-temp>$6: Sorbet::Private::Static::Void)\louterLoops: 1\l<block-call>: NilClass\l"
+        label = "block[id=2, rubyBlockId=1](<self>: Bar, <selfRestore>$6: Bar, <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
 
     "bb::Bar#baz_2" -> "bb::Bar#baz_5" [style="bold"];
     "bb::Bar#baz_2" -> "bb::Bar#baz_3" [style="tapered"];
 
     "bb::Bar#baz_3" [
-        label = "block[id=3, rubyBlockId=0](<selfRestore>$7: Bar, <block-pre-call-temp>$6: Sorbet::Private::Static::Void)\l<returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$6, super>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
+        label = "block[id=3, rubyBlockId=0](<selfRestore>$6: Bar, <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\l<returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$5, super>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::Bar#baz_3" -> "bb::Bar#baz_1" [style="bold"];
     "bb::Bar#baz_5" [
-        label = "block[id=5, rubyBlockId=1](<self>: Bar, <selfRestore>$7: Bar, <block-pre-call-temp>$6: Sorbet::Private::Static::Void)\louterLoops: 1\l<self>: Bar = loadSelf\l<blk>$8: T.untyped = load_yield_params(super)\l<blk>$9: Integer(0) = 0\la$1: T.untyped = <blk>$8: T.untyped.[](<blk>$9: Integer(0))\l<blockReturnTemp>$10: NilClass = <self>: Bar.puts(a$1: T.untyped)\l<blockReturnTemp>$13: T.noreturn = blockreturn<super> <blockReturnTemp>$10: NilClass\l<unconditional>\l"
+        label = "block[id=5, rubyBlockId=1](<self>: Bar, <selfRestore>$6: Bar, <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\louterLoops: 1\l<self>: Bar = loadSelf\l<blk>$7: T.untyped = load_yield_params(super)\l<blk>$8: Integer(0) = 0\la$1: T.untyped = <blk>$7: T.untyped.[](<blk>$8: Integer(0))\l<blockReturnTemp>$9: NilClass = <self>: Bar.puts(a$1: T.untyped)\l<blockReturnTemp>$12: T.noreturn = blockreturn<super> <blockReturnTemp>$9: NilClass\l<unconditional>\l"
     ];
 
     "bb::Bar#baz_5" -> "bb::Bar#baz_2" [style="bold"];

--- a/test/testdata/local_vars/z_super_args.rb
+++ b/test/testdata/local_vars/z_super_args.rb
@@ -1,0 +1,63 @@
+# typed: true
+
+class Parent
+  def takes_positional(arg0)
+    p arg0
+  end
+
+  def takes_keyword(arg0:)
+    p arg0
+  end
+
+  def takes_two_keyword(arg0:, arg1:)
+    p arg0
+    p arg1
+  end
+
+  def takes_positional_then_keyword(arg0, arg1:)
+    p arg0
+    p arg1
+  end
+
+  def takes_rest(*args)
+    p args
+  end
+
+  def takes_keyword_rest(**args)
+    p args
+  end
+
+  def takes_block(&blk)
+    p blk
+  end
+end
+
+class Child < Parent
+  def takes_positional(arg0)
+    super
+  end
+
+  def takes_keyword(arg0:)
+    super
+  end
+
+  def takes_two_keyword(arg0:, arg1:)
+    super
+  end
+
+  def takes_positional_then_keyword(arg0, arg1:)
+    super
+  end
+
+  def takes_rest(*args)
+    super
+  end
+
+  def takes_keyword_rest(**args)
+    super
+  end
+
+  def takes_block(&blk)
+    super
+  end
+end

--- a/test/testdata/local_vars/z_super_args.rb.index-tree.exp
+++ b/test/testdata/local_vars/z_super_args.rb.index-tree.exp
@@ -1,0 +1,95 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Parent><<C <todo sym>>> < (::<todo sym>)
+    def takes_positional<<C <todo sym>>>(arg0, &<blk>)
+      <self>.p(arg0)
+    end
+
+    def takes_keyword<<C <todo sym>>>(arg0:, &<blk>)
+      <self>.p(arg0)
+    end
+
+    def takes_two_keyword<<C <todo sym>>>(arg0:, arg1:, &<blk>)
+      begin
+        <self>.p(arg0)
+        <self>.p(arg1)
+      end
+    end
+
+    def takes_positional_then_keyword<<C <todo sym>>>(arg0, arg1:, &<blk>)
+      begin
+        <self>.p(arg0)
+        <self>.p(arg1)
+      end
+    end
+
+    def takes_rest<<C <todo sym>>>(*args, &<blk>)
+      <self>.p(args)
+    end
+
+    def takes_keyword_rest<<C <todo sym>>>(*args:, &<blk>)
+      <self>.p(args)
+    end
+
+    def takes_block<<C <todo sym>>>(&blk)
+      <self>.p(blk)
+    end
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"takes_positional")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"takes_keyword")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"takes_two_keyword")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"takes_positional_then_keyword")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"takes_rest")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"takes_keyword_rest")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"takes_block")
+  end
+
+  class <emptyTree>::<C Child><<C <todo sym>>> < (<emptyTree>::<C Parent>)
+    def takes_positional<<C <todo sym>>>(arg0, &<blk>)
+      <self>.super(arg0, <blk>)
+    end
+
+    def takes_keyword<<C <todo sym>>>(arg0:, &<blk>)
+      <self>.super(arg0, <blk>)
+    end
+
+    def takes_two_keyword<<C <todo sym>>>(arg0:, arg1:, &<blk>)
+      <self>.super(arg0, arg1, <blk>)
+    end
+
+    def takes_positional_then_keyword<<C <todo sym>>>(arg0, arg1:, &<blk>)
+      <self>.super(arg0, arg1, <blk>)
+    end
+
+    def takes_rest<<C <todo sym>>>(*args, &<blk>)
+      <self>.super(args, <blk>)
+    end
+
+    def takes_keyword_rest<<C <todo sym>>>(*args:, &<blk>)
+      <self>.super(args, <blk>)
+    end
+
+    def takes_block<<C <todo sym>>>(&blk)
+      <self>.super(blk)
+    end
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"takes_positional")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"takes_keyword")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"takes_two_keyword")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"takes_positional_then_keyword")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"takes_rest")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"takes_keyword_rest")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"takes_block")
+  end
+end

--- a/test/testdata/local_vars/z_super_args.rb.index-tree.exp
+++ b/test/testdata/local_vars/z_super_args.rb.index-tree.exp
@@ -51,31 +51,31 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C Child><<C <todo sym>>> < (<emptyTree>::<C Parent>)
     def takes_positional<<C <todo sym>>>(arg0, &<blk>)
-      <self>.super(arg0, <blk>)
+      <self>.super(arg0)
     end
 
     def takes_keyword<<C <todo sym>>>(arg0:, &<blk>)
-      <self>.super(arg0, <blk>)
+      <self>.super({:"arg0" => arg0})
     end
 
     def takes_two_keyword<<C <todo sym>>>(arg0:, arg1:, &<blk>)
-      <self>.super(arg0, arg1, <blk>)
+      <self>.super({:"arg0" => arg0, :"arg1" => arg1})
     end
 
     def takes_positional_then_keyword<<C <todo sym>>>(arg0, arg1:, &<blk>)
-      <self>.super(arg0, arg1, <blk>)
+      <self>.super(arg0, {:"arg1" => arg1})
     end
 
     def takes_rest<<C <todo sym>>>(*args, &<blk>)
-      <self>.super(args, <blk>)
+      <self>.super()
     end
 
     def takes_keyword_rest<<C <todo sym>>>(*args:, &<blk>)
-      <self>.super(args, <blk>)
+      <self>.super()
     end
 
     def takes_block<<C <todo sym>>>(&blk)
-      <self>.super(blk)
+      <self>.super()
     end
 
     ::Sorbet::Private::Static.keep_def(<self>, :"takes_positional")


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

More accurately model what `super` would do at runtime.

This doesn't model it perfectly (still ignoring all splats and blocks, but it
wasn't doing those correctly before either so this is still a step in the right
direction).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.