### PR TITLE
Update the return type for URI.parse

### DIFF
--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -422,7 +422,7 @@ module URI
     params(
         uri: String,
     )
-    .returns(URI::HTTP)
+    .returns(URI::Generic)
   end
   def self.parse(uri); end
 

--- a/test/testdata/rbi/uri.rb
+++ b/test/testdata/rbi/uri.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+sig {params(uri_string: String).returns(URI::Generic)}
+def validate_http(uri_string)
+  uri = URI.parse(uri_string)
+  raise 'Must be an HTTP URI' unless uri.is_a?(URI::HTTP)
+  uri
+end


### PR DESCRIPTION
I'm having permission issues, so @trevor-stripe is helping me prep https://github.com/sorbet/sorbet/pull/2865 for end-to-end testing by creating this branch in the public Sorbet repo.

The rest of the maintainers can ignore this.