### PR TITLE
Get rid of warning on every bazel invocation

### DIFF
--- a/bazel
+++ b/bazel
@@ -110,25 +110,6 @@ fi
 
 
 
-BAZEL_RC_PATH=${TMPDIR}/bazel_bazel_rc_${RND_UID}
-echo "" > $BAZEL_RC_PATH
-
-if [ -f $REPO_ROOT/shared_tools/default_bazel_rc ]; then
-  cat $REPO_ROOT/shared_tools/default_bazel_rc >> $BAZEL_RC_PATH
-fi
-
-if [ -f /etc/bazelrc ]; then
-  cat /etc/bazelrc >> $BAZEL_RC_PATH
-fi
-
-if [ -f $HOME/.bazelrc ]; then
-  cat $HOME/.bazelrc >> $BAZEL_RC_PATH
-fi
-
-if [ -f $REPO_ROOT/.bazelrc ]; then
-  cat $REPO_ROOT/.bazelrc >> $BAZEL_RC_PATH
-fi
-
 IS_CACHE_WORTHY_COMMAND=false
 for var in "$@"
 do
@@ -171,7 +152,7 @@ mkdir -p $BAZEL_BIN_LOC
 export BAZEL_EXEC_PATH=$BAZEL_BIN_LOC/$BAZEL_VERSION/bin/bazel-real
 
 if [ -f "$BAZEL_EXEC_PATH" ]; then
-    exec $BAZEL_EXEC_PATH --bazelrc $BAZEL_RC_PATH "$@"
+    exec $BAZEL_EXEC_PATH "$@"
 fi
 
 RND_UID=$(date "+%s")
@@ -207,4 +188,4 @@ mkdir -p $BUILD_DIR
 rm -rf $BUILD_DIR
 
 cd $ORIGINAL_PWD
-exec $BAZEL_EXEC_PATH --bazelrc $BAZEL_RC_PATH "$@"
+exec $BAZEL_EXEC_PATH "$@"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I would see this message on every bazel invocation:

    WARNING: Duplicate rc file: /Users/jez/stripe/sorbet/.bazelrc.local is read multiple times, most recently imported from /private/var/folders/5p/z_n7b95s1yz02fdjwvk8cwp80000gn/T/bazel_bazel_rc_1587612772

It's because bazel reads **all** config files provided to it, as they
have in the docs:

    https://docs.bazel.build/versions/master/guide.html#bazelrc

My guess is that there was a point in time when this wasn't the case at
Stripe, and we needed these lines. But as far as I can tell, we no
longer need them, and it meant that the `try-import` in our `.bazelrc`
in this repo was getting processed twice and printing that warning.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I plan to kick off a Stripe build tomorrow to make sure this wasn't important.