### PR TITLE
Keep all `prop` definitions in the tree

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -183,6 +183,7 @@ NameDef names[] = {
     {"merchant"},
     {"foreign"},
     {"ifunset"},
+    {"withoutAccessors", "without_accessors"},
     {"computedBy", "computed_by"},
     {"factory"},
     {"Chalk", "Chalk", true},

--- a/test/cli/model_mutator_behavior/model_mutator_behavior__1.rb
+++ b/test/cli/model_mutator_behavior/model_mutator_behavior__1.rb
@@ -1,5 +1,6 @@
 # typed: true
 
 class Foo::MyModel
+  include T::Props
   prop :array_of_explicit, Array, array: String
 end

--- a/test/cli/same-loc/same-loc.out
+++ b/test/cli/same-loc/same-loc.out
@@ -26,6 +26,10 @@ test/cli/same-loc/same-loc.rb:4: Unable to resolve constant `Foo` https://srb.he
      4 |  const :foo, T::Array[Foo::Baz]
                                ^^^
 
+test/cli/same-loc/same-loc.rb:4: Unable to resolve constant `Foo` https://srb.help/5002
+     4 |  const :foo, T::Array[Foo::Baz]
+                               ^^^
+
 test/cli/same-loc/same-loc.rb:4: Too many arguments provided for method `T::Array.[]`. Expected: `0`, got: `1` https://srb.help/7004
      4 |  const :foo, T::Array[Foo::Baz]
                       ^^^^^^^^^^^^^^^^^^
@@ -61,6 +65,15 @@ test/cli/same-loc/same-loc.rb:4: Too many arguments provided for method `T::Arra
      4 |  const :foo, T::Array[Foo::Baz]
                       ^^^^^^^^^^^^^^^^^^
     ???: `[]` defined here
+
+test/cli/same-loc/same-loc.rb:4: Too many arguments provided for method `T::Array.[]`. Expected: `0`, got: `1` https://srb.help/7004
+     4 |  const :foo, T::Array[Foo::Baz]
+                      ^^^^^^^^^^^^^^^^^^
+    ???: `[]` defined here
+
+test/cli/same-loc/same-loc.rb:4: Method `const` does not exist on `T.class_of(MyClass)` https://srb.help/7003
+     4 |  const :foo, T::Array[Foo::Baz]
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 test/cli/same-loc/same-loc.rb:4: Method `keep_def` does not exist on `T.class_of(Sorbet::Private::Static)` https://srb.help/7003
      4 |  const :foo, T::Array[Foo::Baz]
@@ -101,4 +114,4 @@ test/cli/same-loc/same-loc.rb:4: Method `keep_def` does not exist on `T.class_of
 test/cli/same-loc/same-loc.rb:4: Method `keep_def` does not exist on `T.class_of(Sorbet::Private::Static)` https://srb.help/7003
      4 |  const :foo, T::Array[Foo::Baz]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 26
+Errors: 29

--- a/test/cli/suggest-foreign-lambda/suggest-foreign-lambda.out
+++ b/test/cli/suggest-foreign-lambda/suggest-foreign-lambda.out
@@ -1,9 +1,9 @@
-suggest-foreign-lambda.rb:6: The argument to `foreign:` must be a lambda https://srb.help/3508
-     6 |  prop :my_model, String, foreign: MyModel
+suggest-foreign-lambda.rb:7: The argument to `foreign:` must be a lambda https://srb.help/3508
+     7 |  prop :my_model, String, foreign: MyModel
                                            ^^^^^^^
   Autocorrect: Done
-    suggest-foreign-lambda.rb:6: Replaced with `-> {MyModel}`
-     6 |  prop :my_model, String, foreign: MyModel
+    suggest-foreign-lambda.rb:7: Replaced with `-> {MyModel}`
+     7 |  prop :my_model, String, foreign: MyModel
                                            ^^^^^^^
 Errors: 1
 
@@ -14,5 +14,6 @@ Errors: 1
 class MyModel; end
 
 class MyOtherModel
+  include T::Props
   prop :my_model, String, foreign: -> {MyModel}
 end

--- a/test/cli/suggest-foreign-lambda/suggest-foreign-lambda.rb
+++ b/test/cli/suggest-foreign-lambda/suggest-foreign-lambda.rb
@@ -3,5 +3,6 @@
 class MyModel; end
 
 class MyOtherModel
+  include T::Props
   prop :my_model, String, foreign: MyModel
 end

--- a/test/testdata/rewriter/coerce_in_prop.rb
+++ b/test/testdata/rewriter/coerce_in_prop.rb
@@ -4,7 +4,7 @@
 # doesn't crash on it. Any reasonable behvior is fine.
   class Inputs
     PAYMENT_METHODS_HASH = {a: Integer}
-    def self.prop(sym, type); end;
+    def self.prop(sym, type, opts={}); end;
 
     prop :supported_payment_methods1, T.coerce(PAYMENT_METHODS_HASH) # error-with-dupes: Unsupported method `T.coerce`
     prop :supported_payment_methods2, T.coerce({a: Integer})

--- a/test/testdata/rewriter/not_prop.rb
+++ b/test/testdata/rewriter/not_prop.rb
@@ -4,7 +4,7 @@ class ThingsWhichUsedToBePropSyntax
   prop :type, type: String # error: `prop` does not exist
   prop :object # error: `prop` does not exist
   prop :array_of, array: String # error: `prop` does not exist
-  prop :array_of_explicit, Array, array: String
+  prop :array_of_explicit, Array, array: String # error: `prop` does not exist
   prop :no_class_arg, type: Array, immutable: true, array: String # error: `prop` does not exist
   prop :proc_type, type: T.proc.params(x: Integer).void # error: `prop` does not exist
   prop :enum_prop, enum: ["hello", "goodbye"] # error: `prop` does not exist

--- a/test/testdata/rewriter/not_prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/not_prop.rb.rewrite-tree.exp
@@ -22,6 +22,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.prop(:"array_of", {:"array" => <emptyTree>::<C String>})
 
+    <self>.prop(:"array_of_explicit", <emptyTree>::<C Array>, {:"array" => <emptyTree>::<C String>, :"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"array_of_explicit")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"array_of_explicit=")

--- a/test/testdata/rewriter/prop.rb
+++ b/test/testdata/rewriter/prop.rb
@@ -59,24 +59,26 @@ class AdvancedODM
 end
 
 class PropHelpers
-  include T::Props
+  def self.token_prop(opts={}); end
+  def self.created_prop(opts={}); end
   token_prop
   created_prop
 end
 
 class PropHelpers2
-  include T::Props
+  def self.timestamped_token_prop(opts={}); end
+  def self.created_prop(opts={}); end
   timestamped_token_prop
   created_prop(immutable: true)
 end
 
 class ShardingProp
-  include T::Props
+  def self.merchant_prop(opts={}); end
   merchant_prop
 end
 
 class EncryptedProp
-  include T::Props
+  def self.encrypted_prop(opts={}); end
   encrypted_prop :foo
   encrypted_prop :bar, migrating: true, immutable: true
 end

--- a/test/testdata/rewriter/prop.rb
+++ b/test/testdata/rewriter/prop.rb
@@ -22,6 +22,7 @@ end
 
 class SomeODM
     extend T::Sig
+    include T::Props
 
     prop :foo, String
 
@@ -35,6 +36,7 @@ class ForeignClass
 end
 
 class AdvancedODM
+    include T::Props
     prop :default, String, default: ""
     prop :t_nilable, T.nilable(String)
 
@@ -57,20 +59,24 @@ class AdvancedODM
 end
 
 class PropHelpers
+  include T::Props
   token_prop
   created_prop
 end
 
 class PropHelpers2
+  include T::Props
   timestamped_token_prop
   created_prop(immutable: true)
 end
 
 class ShardingProp
+  include T::Props
   merchant_prop
 end
 
 class EncryptedProp
+  include T::Props
   encrypted_prop :foo
   encrypted_prop :bar, migrating: true, immutable: true
 end

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -6002,6 +6002,38 @@ ClassDef{
           symbol = ::<todo sym>
         }]
       rhs = [
+        MethodDef{
+          flags = {self}
+          name = <U token_prop><<C <U <todo sym>>>>
+          args = [OptionalArg{
+              expr = UnresolvedIdent{
+                kind = Local
+                name = <U opts>
+              }
+              default_ = EmptyTree
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = EmptyTree
+        }
+
+        MethodDef{
+          flags = {self}
+          name = <U created_prop><<C <U <todo sym>>>>
+          args = [OptionalArg{
+              expr = UnresolvedIdent{
+                kind = Local
+                name = <U opts>
+              }
+              default_ = EmptyTree
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = EmptyTree
+        }
+
         Send{
           recv = ConstantLit{
             orig = nullptr
@@ -6290,20 +6322,71 @@ ClassDef{
           }
         }
 
-        Send{
-          recv = Local{
-            localVariable = <U <self>>
+        MethodDef{
+          flags = {self, rewriter}
+          name = <DA <U token_prop> $1><<C <U <todo sym>>>>
+          args = [OptionalArg{
+              expr = UnresolvedIdent{
+                kind = Local
+                name = <U opts>
+              }
+              default_ = EmptyTree
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = Hash{
+            pairs = [
+            ]
           }
-          fun = <U include>
+        }
+
+        MethodDef{
+          flags = {self, rewriter}
+          name = <DA <U created_prop> $1><<C <U <todo sym>>>>
+          args = [OptionalArg{
+              expr = UnresolvedIdent{
+                kind = Local
+                name = <U opts>
+              }
+              default_ = EmptyTree
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = Hash{
+            pairs = [
+            ]
+          }
+        }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = ::Sorbet::Private::Static
+          }
+          fun = <U keep_self_def>
           block = nullptr
           args = [
-            UnresolvedConstantLit{
-              scope = UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U T>>
-              }
-              cnst = <C <U Props>>
+            Local{
+              localVariable = <U <self>>
             }
+            Literal{ value = :"token_prop" }
+          ]
+        }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = ::Sorbet::Private::Static
+          }
+          fun = <U keep_self_def>
+          block = nullptr
+          args = [
+            Local{
+              localVariable = <U <self>>
+            }
+            Literal{ value = :"created_prop" }
           ]
         }
 
@@ -6402,6 +6485,36 @@ ClassDef{
             Literal{ value = :"created=" }
           ]
         }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = ::Sorbet::Private::Static
+          }
+          fun = <U keep_self_def>
+          block = nullptr
+          args = [
+            Local{
+              localVariable = <U <self>>
+            }
+            Literal{ value = :"token_prop<defaultArg>1" }
+          ]
+        }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = ::Sorbet::Private::Static
+          }
+          fun = <U keep_self_def>
+          block = nullptr
+          args = [
+            Local{
+              localVariable = <U <self>>
+            }
+            Literal{ value = :"created_prop<defaultArg>1" }
+          ]
+        }
       ]
     }
 
@@ -6416,6 +6529,38 @@ ClassDef{
           symbol = ::<todo sym>
         }]
       rhs = [
+        MethodDef{
+          flags = {self}
+          name = <U timestamped_token_prop><<C <U <todo sym>>>>
+          args = [OptionalArg{
+              expr = UnresolvedIdent{
+                kind = Local
+                name = <U opts>
+              }
+              default_ = EmptyTree
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = EmptyTree
+        }
+
+        MethodDef{
+          flags = {self}
+          name = <U created_prop><<C <U <todo sym>>>>
+          args = [OptionalArg{
+              expr = UnresolvedIdent{
+                kind = Local
+                name = <U opts>
+              }
+              default_ = EmptyTree
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = EmptyTree
+        }
+
         Send{
           recv = ConstantLit{
             orig = nullptr
@@ -6627,20 +6772,71 @@ ClassDef{
           }
         }
 
-        Send{
-          recv = Local{
-            localVariable = <U <self>>
+        MethodDef{
+          flags = {self, rewriter}
+          name = <DA <U timestamped_token_prop> $1><<C <U <todo sym>>>>
+          args = [OptionalArg{
+              expr = UnresolvedIdent{
+                kind = Local
+                name = <U opts>
+              }
+              default_ = EmptyTree
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = Hash{
+            pairs = [
+            ]
           }
-          fun = <U include>
+        }
+
+        MethodDef{
+          flags = {self, rewriter}
+          name = <DA <U created_prop> $1><<C <U <todo sym>>>>
+          args = [OptionalArg{
+              expr = UnresolvedIdent{
+                kind = Local
+                name = <U opts>
+              }
+              default_ = EmptyTree
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = Hash{
+            pairs = [
+            ]
+          }
+        }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = ::Sorbet::Private::Static
+          }
+          fun = <U keep_self_def>
           block = nullptr
           args = [
-            UnresolvedConstantLit{
-              scope = UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U T>>
-              }
-              cnst = <C <U Props>>
+            Local{
+              localVariable = <U <self>>
             }
+            Literal{ value = :"timestamped_token_prop" }
+          ]
+        }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = ::Sorbet::Private::Static
+          }
+          fun = <U keep_self_def>
+          block = nullptr
+          args = [
+            Local{
+              localVariable = <U <self>>
+            }
+            Literal{ value = :"created_prop" }
           ]
         }
 
@@ -6728,6 +6924,36 @@ ClassDef{
             Literal{ value = :"created" }
           ]
         }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = ::Sorbet::Private::Static
+          }
+          fun = <U keep_self_def>
+          block = nullptr
+          args = [
+            Local{
+              localVariable = <U <self>>
+            }
+            Literal{ value = :"timestamped_token_prop<defaultArg>1" }
+          ]
+        }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = ::Sorbet::Private::Static
+          }
+          fun = <U keep_self_def>
+          block = nullptr
+          args = [
+            Local{
+              localVariable = <U <self>>
+            }
+            Literal{ value = :"created_prop<defaultArg>1" }
+          ]
+        }
       ]
     }
 
@@ -6742,6 +6968,22 @@ ClassDef{
           symbol = ::<todo sym>
         }]
       rhs = [
+        MethodDef{
+          flags = {self}
+          name = <U merchant_prop><<C <U <todo sym>>>>
+          args = [OptionalArg{
+              expr = UnresolvedIdent{
+                kind = Local
+                name = <U opts>
+              }
+              default_ = EmptyTree
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = EmptyTree
+        }
+
         Send{
           recv = ConstantLit{
             orig = nullptr
@@ -6809,20 +7051,37 @@ ClassDef{
           }
         }
 
-        Send{
-          recv = Local{
-            localVariable = <U <self>>
+        MethodDef{
+          flags = {self, rewriter}
+          name = <DA <U merchant_prop> $1><<C <U <todo sym>>>>
+          args = [OptionalArg{
+              expr = UnresolvedIdent{
+                kind = Local
+                name = <U opts>
+              }
+              default_ = EmptyTree
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = Hash{
+            pairs = [
+            ]
           }
-          fun = <U include>
+        }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = ::Sorbet::Private::Static
+          }
+          fun = <U keep_self_def>
           block = nullptr
           args = [
-            UnresolvedConstantLit{
-              scope = UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U T>>
-              }
-              cnst = <C <U Props>>
+            Local{
+              localVariable = <U <self>>
             }
+            Literal{ value = :"merchant_prop" }
           ]
         }
 
@@ -6858,6 +7117,21 @@ ClassDef{
             Literal{ value = :"merchant" }
           ]
         }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = ::Sorbet::Private::Static
+          }
+          fun = <U keep_self_def>
+          block = nullptr
+          args = [
+            Local{
+              localVariable = <U <self>>
+            }
+            Literal{ value = :"merchant_prop<defaultArg>1" }
+          ]
+        }
       ]
     }
 
@@ -6872,6 +7146,22 @@ ClassDef{
           symbol = ::<todo sym>
         }]
       rhs = [
+        MethodDef{
+          flags = {self}
+          name = <U encrypted_prop><<C <U <todo sym>>>>
+          args = [OptionalArg{
+              expr = UnresolvedIdent{
+                kind = Local
+                name = <U opts>
+              }
+              default_ = EmptyTree
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = EmptyTree
+        }
+
         Send{
           recv = ConstantLit{
             orig = nullptr
@@ -7434,20 +7724,37 @@ ClassDef{
           }
         }
 
-        Send{
-          recv = Local{
-            localVariable = <U <self>>
+        MethodDef{
+          flags = {self, rewriter}
+          name = <DA <U encrypted_prop> $1><<C <U <todo sym>>>>
+          args = [OptionalArg{
+              expr = UnresolvedIdent{
+                kind = Local
+                name = <U opts>
+              }
+              default_ = EmptyTree
+            }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = Hash{
+            pairs = [
+            ]
           }
-          fun = <U include>
+        }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = ::Sorbet::Private::Static
+          }
+          fun = <U keep_self_def>
           block = nullptr
           args = [
-            UnresolvedConstantLit{
-              scope = UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U T>>
-              }
-              cnst = <C <U Props>>
+            Local{
+              localVariable = <U <self>>
             }
+            Literal{ value = :"encrypted_prop" }
           ]
         }
 
@@ -7538,6 +7845,21 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :"encrypted_bar" }
+          ]
+        }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = ::Sorbet::Private::Static
+          }
+          fun = <U keep_self_def>
+          block = nullptr
+          args = [
+            Local{
+              localVariable = <U <self>>
+            }
+            Literal{ value = :"encrypted_prop<defaultArg>1" }
           ]
         }
       ]

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -1493,6 +1493,46 @@ ClassDef{
         }
 
         Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U include>
+          block = nullptr
+          args = [
+            UnresolvedConstantLit{
+              scope = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U T>>
+              }
+              cnst = <C <U Props>>
+            }
+          ]
+        }
+
+        Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U prop>
+          block = nullptr
+          args = [
+            Literal{ value = :"foo" }
+            UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U String>>
+            }
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"without_accessors" }
+                  value = Literal{ value = true }
+                ]
+              ]
+            }
+          ]
+        }
+
+        Send{
           recv = ConstantLit{
             orig = nullptr
             symbol = ::Sorbet::Private::Static
@@ -4298,6 +4338,50 @@ ClassDef{
         }
 
         Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U include>
+          block = nullptr
+          args = [
+            UnresolvedConstantLit{
+              scope = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U T>>
+              }
+              cnst = <C <U Props>>
+            }
+          ]
+        }
+
+        Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U prop>
+          block = nullptr
+          args = [
+            Literal{ value = :"default" }
+            UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U String>>
+            }
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"default" }
+                  value = Literal{ value = "" }
+                ]
+                [
+                  key = Literal{ value = :"without_accessors" }
+                  value = Literal{ value = true }
+                ]
+              ]
+            }
+          ]
+        }
+
+        Send{
           recv = ConstantLit{
             orig = nullptr
             symbol = ::Sorbet::Private::Static
@@ -4328,6 +4412,39 @@ ClassDef{
         }
 
         Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U prop>
+          block = nullptr
+          args = [
+            Literal{ value = :"t_nilable" }
+            Send{
+              recv = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U T>>
+              }
+              fun = <U nilable>
+              block = nullptr
+              args = [
+                UnresolvedConstantLit{
+                  scope = EmptyTree
+                  cnst = <C <U String>>
+                }
+              ]
+            }
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"without_accessors" }
+                  value = Literal{ value = true }
+                ]
+              ]
+            }
+          ]
+        }
+
+        Send{
           recv = ConstantLit{
             orig = nullptr
             symbol = ::Sorbet::Private::Static
@@ -4354,6 +4471,29 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :"t_nilable=" }
+          ]
+        }
+
+        Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U prop>
+          block = nullptr
+          args = [
+            Literal{ value = :"array" }
+            UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U Array>>
+            }
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"without_accessors" }
+                  value = Literal{ value = true }
+                ]
+              ]
+            }
           ]
         }
 
@@ -4587,6 +4727,42 @@ ClassDef{
                   localVariable = <U <self>>
                 }
                 Literal{ value = :"array" }
+              ]
+            }
+          ]
+        }
+
+        Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U prop>
+          block = nullptr
+          args = [
+            Literal{ value = :"t_array" }
+            Send{
+              recv = UnresolvedConstantLit{
+                scope = UnresolvedConstantLit{
+                  scope = EmptyTree
+                  cnst = <C <U T>>
+                }
+                cnst = <C <U Array>>
+              }
+              fun = <U []>
+              block = nullptr
+              args = [
+                UnresolvedConstantLit{
+                  scope = EmptyTree
+                  cnst = <C <U String>>
+                }
+              ]
+            }
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"without_accessors" }
+                  value = Literal{ value = true }
+                ]
               ]
             }
           ]
@@ -4842,6 +5018,46 @@ ClassDef{
                   localVariable = <U <self>>
                 }
                 Literal{ value = :"t_array" }
+              ]
+            }
+          ]
+        }
+
+        Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U prop>
+          block = nullptr
+          args = [
+            Literal{ value = :"hash_of" }
+            Send{
+              recv = UnresolvedConstantLit{
+                scope = UnresolvedConstantLit{
+                  scope = EmptyTree
+                  cnst = <C <U T>>
+                }
+                cnst = <C <U Hash>>
+              }
+              fun = <U []>
+              block = nullptr
+              args = [
+                UnresolvedConstantLit{
+                  scope = EmptyTree
+                  cnst = <C <U Symbol>>
+                }
+                UnresolvedConstantLit{
+                  scope = EmptyTree
+                  cnst = <C <U String>>
+                }
+              ]
+            }
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"without_accessors" }
+                  value = Literal{ value = true }
+                ]
               ]
             }
           ]
@@ -5115,6 +5331,33 @@ ClassDef{
         }
 
         Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U prop>
+          block = nullptr
+          args = [
+            Literal{ value = :"const_explicit" }
+            UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U String>>
+            }
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"immutable" }
+                  value = Literal{ value = true }
+                ]
+                [
+                  key = Literal{ value = :"without_accessors" }
+                  value = Literal{ value = true }
+                ]
+              ]
+            }
+          ]
+        }
+
+        Send{
           recv = ConstantLit{
             orig = nullptr
             symbol = ::Sorbet::Private::Static
@@ -5130,6 +5373,29 @@ ClassDef{
         }
 
         Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U const>
+          block = nullptr
+          args = [
+            Literal{ value = :"const" }
+            UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U String>>
+            }
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"without_accessors" }
+                  value = Literal{ value = true }
+                ]
+              ]
+            }
+          ]
+        }
+
+        Send{
           recv = ConstantLit{
             orig = nullptr
             symbol = ::Sorbet::Private::Static
@@ -5141,6 +5407,38 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :"const" }
+          ]
+        }
+
+        Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U prop>
+          block = nullptr
+          args = [
+            Literal{ value = :"enum_prop" }
+            UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U String>>
+            }
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"enum" }
+                  value = Array{
+                    elems = [
+                      Literal{ value = "hello" }
+                      Literal{ value = "goodbye" }
+                    ]
+                  }
+                ]
+                [
+                  key = Literal{ value = :"without_accessors" }
+                  value = Literal{ value = true }
+                ]
+              ]
+            }
           ]
         }
 
@@ -5171,6 +5469,36 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :"enum_prop=" }
+          ]
+        }
+
+        Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U prop>
+          block = nullptr
+          args = [
+            Literal{ value = :"foreign" }
+            UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U String>>
+            }
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"foreign" }
+                  value = UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U ForeignClass>>
+                  }
+                ]
+                [
+                  key = Literal{ value = :"without_accessors" }
+                  value = Literal{ value = true }
+                ]
+              ]
+            }
           ]
         }
 
@@ -5235,6 +5563,48 @@ ClassDef{
         }
 
         Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U prop>
+          block = nullptr
+          args = [
+            Literal{ value = :"foreign_lazy" }
+            UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U String>>
+            }
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"foreign" }
+                  value = Send{
+                    recv = Local{
+                      localVariable = <U <self>>
+                    }
+                    fun = <U lambda>
+                    block = Block {
+                      args = [
+                      ]
+                      body = UnresolvedConstantLit{
+                        scope = EmptyTree
+                        cnst = <C <U ForeignClass>>
+                      }
+                    }
+                    args = [
+                    ]
+                  }
+                ]
+                [
+                  key = Literal{ value = :"without_accessors" }
+                  value = Literal{ value = true }
+                ]
+              ]
+            }
+          ]
+        }
+
+        Send{
           recv = ConstantLit{
             orig = nullptr
             symbol = ::Sorbet::Private::Static
@@ -5291,6 +5661,48 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :"foreign_lazy_!" }
+          ]
+        }
+
+        Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U prop>
+          block = nullptr
+          args = [
+            Literal{ value = :"foreign_proc" }
+            UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U String>>
+            }
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"foreign" }
+                  value = Send{
+                    recv = Local{
+                      localVariable = <U <self>>
+                    }
+                    fun = <U proc>
+                    block = Block {
+                      args = [
+                      ]
+                      body = UnresolvedConstantLit{
+                        scope = EmptyTree
+                        cnst = <C <U ForeignClass>>
+                      }
+                    }
+                    args = [
+                    ]
+                  }
+                ]
+                [
+                  key = Literal{ value = :"without_accessors" }
+                  value = Literal{ value = true }
+                ]
+              ]
+            }
           ]
         }
 
@@ -5355,6 +5767,45 @@ ClassDef{
         }
 
         Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U prop>
+          block = nullptr
+          args = [
+            Literal{ value = :"foreign_invalid" }
+            UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U String>>
+            }
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"foreign" }
+                  value = Send{
+                    recv = Local{
+                      localVariable = <U <self>>
+                    }
+                    fun = <U proc>
+                    block = Block {
+                      args = [
+                      ]
+                      body = Literal{ value = :"not_a_type" }
+                    }
+                    args = [
+                    ]
+                  }
+                ]
+                [
+                  key = Literal{ value = :"without_accessors" }
+                  value = Literal{ value = true }
+                ]
+              ]
+            }
+          ]
+        }
+
+        Send{
           recv = ConstantLit{
             orig = nullptr
             symbol = ::Sorbet::Private::Static
@@ -5415,6 +5866,33 @@ ClassDef{
         }
 
         Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U prop>
+          block = nullptr
+          args = [
+            Literal{ value = :"ifunset" }
+            UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U String>>
+            }
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"ifunset" }
+                  value = Literal{ value = "" }
+                ]
+                [
+                  key = Literal{ value = :"without_accessors" }
+                  value = Literal{ value = true }
+                ]
+              ]
+            }
+          ]
+        }
+
+        Send{
           recv = ConstantLit{
             orig = nullptr
             symbol = ::Sorbet::Private::Static
@@ -5441,6 +5919,43 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :"ifunset=" }
+          ]
+        }
+
+        Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U prop>
+          block = nullptr
+          args = [
+            Literal{ value = :"ifunset_nilable" }
+            Send{
+              recv = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U T>>
+              }
+              fun = <U nilable>
+              block = nullptr
+              args = [
+                UnresolvedConstantLit{
+                  scope = EmptyTree
+                  cnst = <C <U String>>
+                }
+              ]
+            }
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"ifunset" }
+                  value = Literal{ value = "" }
+                ]
+                [
+                  key = Literal{ value = :"without_accessors" }
+                  value = Literal{ value = true }
+                ]
+              ]
+            }
           ]
         }
 
@@ -5776,6 +6291,41 @@ ClassDef{
         }
 
         Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U include>
+          block = nullptr
+          args = [
+            UnresolvedConstantLit{
+              scope = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U T>>
+              }
+              cnst = <C <U Props>>
+            }
+          ]
+        }
+
+        Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U token_prop>
+          block = nullptr
+          args = [
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"without_accessors" }
+                  value = Literal{ value = true }
+                ]
+              ]
+            }
+          ]
+        }
+
+        Send{
           recv = ConstantLit{
             orig = nullptr
             symbol = ::Sorbet::Private::Static
@@ -5802,6 +6352,24 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :"token=" }
+          ]
+        }
+
+        Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U created_prop>
+          block = nullptr
+          args = [
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"without_accessors" }
+                  value = Literal{ value = true }
+                ]
+              ]
+            }
           ]
         }
 
@@ -6060,6 +6628,41 @@ ClassDef{
         }
 
         Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U include>
+          block = nullptr
+          args = [
+            UnresolvedConstantLit{
+              scope = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U T>>
+              }
+              cnst = <C <U Props>>
+            }
+          ]
+        }
+
+        Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U timestamped_token_prop>
+          block = nullptr
+          args = [
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"without_accessors" }
+                  value = Literal{ value = true }
+                ]
+              ]
+            }
+          ]
+        }
+
+        Send{
           recv = ConstantLit{
             orig = nullptr
             symbol = ::Sorbet::Private::Static
@@ -6086,6 +6689,28 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :"token=" }
+          ]
+        }
+
+        Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U created_prop>
+          block = nullptr
+          args = [
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"immutable" }
+                  value = Literal{ value = true }
+                ]
+                [
+                  key = Literal{ value = :"without_accessors" }
+                  value = Literal{ value = true }
+                ]
+              ]
+            }
           ]
         }
 
@@ -6182,6 +6807,41 @@ ClassDef{
               Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
+        }
+
+        Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U include>
+          block = nullptr
+          args = [
+            UnresolvedConstantLit{
+              scope = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U T>>
+              }
+              cnst = <C <U Props>>
+            }
+          ]
+        }
+
+        Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U merchant_prop>
+          block = nullptr
+          args = [
+            Hash{
+              pairs = [
+                [
+                  key = Literal{ value = :"without_accessors" }
+                  value = Literal{ value = true }
+                ]
+              ]
+            }
+          ]
         }
 
         Send{
@@ -6772,6 +7432,23 @@ ClassDef{
               Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
+        }
+
+        Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U include>
+          block = nullptr
+          args = [
+            UnresolvedConstantLit{
+              scope = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U T>>
+              }
+              cnst = <C <U Props>>
+            }
+          ]
         }
 
         Send{

--- a/test/testdata/rewriter/prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree.exp
@@ -567,6 +567,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C PropHelpers><<C <todo sym>>> < (::<todo sym>)
+    def self.token_prop<<C <todo sym>>>(opts = <emptyTree>, &<blk>)
+      <emptyTree>
+    end
+
+    def self.created_prop<<C <todo sym>>>(opts = <emptyTree>, &<blk>)
+      <emptyTree>
+    end
+
     ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({}).returns(::String)
     end
@@ -599,7 +607,17 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
-    <self>.include(<emptyTree>::<C T>::<C Props>)
+    def self.token_prop<defaultArg>1<<C <todo sym>>>(opts = <emptyTree>, &<blk>)
+      {}
+    end
+
+    def self.created_prop<defaultArg>1<<C <todo sym>>>(opts = <emptyTree>, &<blk>)
+      {}
+    end
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :"token_prop")
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :"created_prop")
 
     <self>.token_prop({:"without_accessors" => true})
 
@@ -612,9 +630,21 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     ::Sorbet::Private::Static.keep_def(<self>, :"created")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"created=")
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :"token_prop<defaultArg>1")
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :"created_prop<defaultArg>1")
   end
 
   class <emptyTree>::<C PropHelpers2><<C <todo sym>>> < (::<todo sym>)
+    def self.timestamped_token_prop<<C <todo sym>>>(opts = <emptyTree>, &<blk>)
+      <emptyTree>
+    end
+
+    def self.created_prop<<C <todo sym>>>(opts = <emptyTree>, &<blk>)
+      <emptyTree>
+    end
+
     ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({}).returns(::String)
     end
@@ -639,7 +669,17 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
-    <self>.include(<emptyTree>::<C T>::<C Props>)
+    def self.timestamped_token_prop<defaultArg>1<<C <todo sym>>>(opts = <emptyTree>, &<blk>)
+      {}
+    end
+
+    def self.created_prop<defaultArg>1<<C <todo sym>>>(opts = <emptyTree>, &<blk>)
+      {}
+    end
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :"timestamped_token_prop")
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :"created_prop")
 
     <self>.timestamped_token_prop({:"without_accessors" => true})
 
@@ -650,9 +690,17 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.created_prop({:"immutable" => true, :"without_accessors" => true})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"created")
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :"timestamped_token_prop<defaultArg>1")
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :"created_prop<defaultArg>1")
   end
 
   class <emptyTree>::<C ShardingProp><<C <todo sym>>> < (::<todo sym>)
+    def self.merchant_prop<<C <todo sym>>>(opts = <emptyTree>, &<blk>)
+      <emptyTree>
+    end
+
     ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({}).returns(::String)
     end
@@ -661,14 +709,24 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
-    <self>.include(<emptyTree>::<C T>::<C Props>)
+    def self.merchant_prop<defaultArg>1<<C <todo sym>>>(opts = <emptyTree>, &<blk>)
+      {}
+    end
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :"merchant_prop")
 
     <self>.merchant_prop({:"without_accessors" => true})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"merchant")
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :"merchant_prop<defaultArg>1")
   end
 
   class <emptyTree>::<C EncryptedProp><<C <todo sym>>> < (::<todo sym>)
+    def self.encrypted_prop<<C <todo sym>>>(opts = <emptyTree>, &<blk>)
+      <emptyTree>
+    end
+
     ::T::Sig::WithoutRuntime.sig() do ||
       <self>.params({}).returns(::T.nilable(::String))
     end
@@ -717,7 +775,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
-    <self>.include(<emptyTree>::<C T>::<C Props>)
+    def self.encrypted_prop<defaultArg>1<<C <todo sym>>>(opts = <emptyTree>, &<blk>)
+      {}
+    end
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :"encrypted_prop")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foo")
 
@@ -730,6 +792,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     ::Sorbet::Private::Static.keep_def(<self>, :"bar")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"encrypted_bar")
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :"encrypted_prop<defaultArg>1")
   end
 
   ::Sorbet::Private::Static.keep_def(<self>, :"main")

--- a/test/testdata/rewriter/prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree.exp
@@ -107,6 +107,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.extend(<emptyTree>::<C T>::<C Sig>)
 
+    <self>.include(<emptyTree>::<C T>::<C Props>)
+
+    <self>.prop(:"foo", <emptyTree>::<C String>, {:"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"foo")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foo=")
@@ -391,13 +395,21 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
+    <self>.include(<emptyTree>::<C T>::<C Props>)
+
+    <self>.prop(:"default", <emptyTree>::<C String>, {:"default" => "", :"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"default")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"default=")
 
+    <self>.prop(:"t_nilable", <emptyTree>::<C T>.nilable(<emptyTree>::<C String>), {:"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"t_nilable")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"t_nilable=")
+
+    <self>.prop(:"array", <emptyTree>::<C Array>, {:"without_accessors" => true})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"array")
 
@@ -425,6 +437,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::Sorbet::Private::Static.keep_def(<self>, :"array")
     end
 
+    <self>.prop(:"t_array", <emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C String>), {:"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"t_array")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"t_array=")
@@ -450,6 +464,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
       ::Sorbet::Private::Static.keep_def(<self>, :"t_array")
     end
+
+    <self>.prop(:"hash_of", <emptyTree>::<C T>::<C Hash>.[](<emptyTree>::<C Symbol>, <emptyTree>::<C String>), {:"without_accessors" => true})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"hash_of")
 
@@ -477,13 +493,21 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::Sorbet::Private::Static.keep_def(<self>, :"hash_of")
     end
 
+    <self>.prop(:"const_explicit", <emptyTree>::<C String>, {:"immutable" => true, :"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"const_explicit")
 
+    <self>.const(:"const", <emptyTree>::<C String>, {:"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"const")
+
+    <self>.prop(:"enum_prop", <emptyTree>::<C String>, {:"enum" => ["hello", "goodbye"], :"without_accessors" => true})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"enum_prop")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"enum_prop=")
+
+    <self>.prop(:"foreign", <emptyTree>::<C String>, {:"foreign" => <emptyTree>::<C ForeignClass>, :"without_accessors" => true})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foreign")
 
@@ -493,6 +517,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foreign_!")
 
+    <self>.prop(:"foreign_lazy", <emptyTree>::<C String>, {:"foreign" => <self>.lambda() do ||
+          <emptyTree>::<C ForeignClass>
+        end, :"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"foreign_lazy")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foreign_lazy=")
@@ -500,6 +528,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     ::Sorbet::Private::Static.keep_def(<self>, :"foreign_lazy_")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foreign_lazy_!")
+
+    <self>.prop(:"foreign_proc", <emptyTree>::<C String>, {:"foreign" => <self>.proc() do ||
+          <emptyTree>::<C ForeignClass>
+        end, :"without_accessors" => true})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foreign_proc")
 
@@ -509,6 +541,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foreign_proc_!")
 
+    <self>.prop(:"foreign_invalid", <emptyTree>::<C String>, {:"foreign" => <self>.proc() do ||
+          :"not_a_type"
+        end, :"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"foreign_invalid")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foreign_invalid=")
@@ -517,9 +553,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foreign_invalid_!")
 
+    <self>.prop(:"ifunset", <emptyTree>::<C String>, {:"ifunset" => "", :"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"ifunset")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"ifunset=")
+
+    <self>.prop(:"ifunset_nilable", <emptyTree>::<C T>.nilable(<emptyTree>::<C String>), {:"ifunset" => "", :"without_accessors" => true})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"ifunset_nilable")
 
@@ -559,9 +599,15 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
+    <self>.include(<emptyTree>::<C T>::<C Props>)
+
+    <self>.token_prop({:"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"token")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"token=")
+
+    <self>.created_prop({:"without_accessors" => true})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"created")
 
@@ -593,9 +639,15 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
+    <self>.include(<emptyTree>::<C T>::<C Props>)
+
+    <self>.timestamped_token_prop({:"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"token")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"token=")
+
+    <self>.created_prop({:"immutable" => true, :"without_accessors" => true})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"created")
   end
@@ -608,6 +660,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def merchant<<C <todo sym>>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
+
+    <self>.include(<emptyTree>::<C T>::<C Props>)
+
+    <self>.merchant_prop({:"without_accessors" => true})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"merchant")
   end
@@ -660,6 +716,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def encrypted_bar<<C <todo sym>>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
+
+    <self>.include(<emptyTree>::<C T>::<C Props>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foo")
 

--- a/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=139:4})
+class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=141:4})
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=139:4}
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=141:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U AdvancedODM>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=38:1 end=38:18}
     class <C <U AdvancedODM>><C <U Mutator>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=45:5 end=45:43}
@@ -115,24 +115,30 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
     type-member(+) <S <C <U AdvancedODM>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U AdvancedODM>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AdvancedODM) @ Loc {file=test/testdata/rewriter/prop.rb start=38:7 end=38:18}
     method <S <C <U AdvancedODM>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=38:1 end=59:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U EncryptedProp>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=78:1 end=78:20}
-    method <C <U EncryptedProp>><U bar> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=81:3 end=81:56}
+  class <C <U EncryptedProp>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=80:1 end=80:20}
+    method <C <U EncryptedProp>><U bar> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=83:3 end=83:56}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U EncryptedProp>><U encrypted_bar> (<blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=81:3 end=81:56}
+    method <C <U EncryptedProp>><U encrypted_bar> (<blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=83:3 end=83:56}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U EncryptedProp>><U encrypted_foo> (<blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=80:3 end=80:22}
+    method <C <U EncryptedProp>><U encrypted_foo> (<blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=82:3 end=82:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U EncryptedProp>><U encrypted_foo=> (foo, <blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=80:3 end=80:22}
-      argument foo<> -> T.nilable(Opus::DB::Model::Mixins::Encryptable::EncryptedValue) @ Loc {file=test/testdata/rewriter/prop.rb start=80:19 end=80:22}
+    method <C <U EncryptedProp>><U encrypted_foo=> (foo, <blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=82:3 end=82:22}
+      argument foo<> -> T.nilable(Opus::DB::Model::Mixins::Encryptable::EncryptedValue) @ Loc {file=test/testdata/rewriter/prop.rb start=82:19 end=82:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U EncryptedProp>><U foo> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=80:3 end=80:22}
+    method <C <U EncryptedProp>><U foo> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=82:3 end=82:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U EncryptedProp>><U foo=> (foo, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=80:3 end=80:22}
-      argument foo<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=80:19 end=80:22}
+    method <C <U EncryptedProp>><U foo=> (foo, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=82:3 end=82:22}
+      argument foo<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=82:19 end=82:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U EncryptedProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=78:7 end=78:20}
-    type-member(+) <S <C <U EncryptedProp>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U EncryptedProp>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=EncryptedProp) @ Loc {file=test/testdata/rewriter/prop.rb start=78:7 end=78:20}
-    method <S <C <U EncryptedProp>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=78:1 end=82:4}
+  class <S <C <U EncryptedProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=80:7 end=80:20}
+    type-member(+) <S <C <U EncryptedProp>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U EncryptedProp>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=EncryptedProp) @ Loc {file=test/testdata/rewriter/prop.rb start=80:7 end=80:20}
+    method <S <C <U EncryptedProp>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=80:1 end=84:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <S <C <U EncryptedProp>> $1><DA <U encrypted_prop> $1> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=81:32 end=81:34}
+      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=81:27 end=81:31}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <S <C <U EncryptedProp>> $1><U encrypted_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=81:3 end=81:35}
+      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=81:27 end=81:31}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U ForeignClass>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=35:1 end=35:19}
   class <S <C <U ForeignClass>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=35:7 end=35:19}
@@ -148,41 +154,71 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
       argument args<repeated> @ Loc {file=test/testdata/rewriter/prop.rb start=3:20 end=3:24}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U Object>> < <C <U BasicObject>> (<C <U Kernel>>) @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed}
-    method <C <U Object>><U main> : private (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=84:1 end=84:9}
+    method <C <U Object>><U main> : private (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=86:1 end=86:9}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U PropHelpers>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=61:1 end=61:18}
-    method <C <U PropHelpers>><U created> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=64:3 end=64:15}
+  class <C <U PropHelpers>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=61:1 end=61:18}
+    method <C <U PropHelpers>><U created> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=65:3 end=65:15}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U PropHelpers>><U created=> (created, <blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=64:3 end=64:15}
-      argument created<> -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=64:3 end=64:10}
+    method <C <U PropHelpers>><U created=> (created, <blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=65:3 end=65:15}
+      argument created<> -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=65:3 end=65:10}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U PropHelpers>><U token> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=63:3 end=63:13}
+    method <C <U PropHelpers>><U token> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=64:3 end=64:13}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U PropHelpers>><U token=> (token, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=63:3 end=63:13}
-      argument token<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=63:3 end=63:8}
+    method <C <U PropHelpers>><U token=> (token, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=64:3 end=64:13}
+      argument token<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=64:3 end=64:8}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U PropHelpers>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=61:7 end=61:18}
+  class <S <C <U PropHelpers>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=61:7 end=61:18}
     type-member(+) <S <C <U PropHelpers>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U PropHelpers>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=PropHelpers) @ Loc {file=test/testdata/rewriter/prop.rb start=61:7 end=61:18}
-    method <S <C <U PropHelpers>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=61:1 end=65:4}
+    method <S <C <U PropHelpers>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=61:1 end=66:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U PropHelpers2>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=67:1 end=67:19}
-    method <C <U PropHelpers2>><U created> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=70:3 end=70:32}
-      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U PropHelpers2>><U token> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=69:3 end=69:25}
-      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U PropHelpers2>><U token=> (token, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=69:3 end=69:25}
-      argument token<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=69:15 end=69:20}
-      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U PropHelpers2>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=67:7 end=67:19}
-    type-member(+) <S <C <U PropHelpers2>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U PropHelpers2>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=PropHelpers2) @ Loc {file=test/testdata/rewriter/prop.rb start=67:7 end=67:19}
-    method <S <C <U PropHelpers2>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=67:1 end=71:4}
+    method <S <C <U PropHelpers>> $1><DA <U created_prop> $1> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=63:30 end=63:32}
+      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=63:25 end=63:29}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U ShardingProp>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=73:1 end=73:19}
-    method <C <U ShardingProp>><U merchant> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=75:3 end=75:16}
+    method <S <C <U PropHelpers>> $1><U created_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=63:3 end=63:33}
+      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=63:25 end=63:29}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <S <C <U PropHelpers>> $1><DA <U token_prop> $1> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=62:28 end=62:30}
+      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=62:23 end=62:27}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <S <C <U PropHelpers>> $1><U token_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=62:3 end=62:31}
+      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=62:23 end=62:27}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+  class <C <U PropHelpers2>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=68:1 end=68:19}
+    method <C <U PropHelpers2>><U created> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=72:3 end=72:32}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U ShardingProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=73:7 end=73:19}
-    type-member(+) <S <C <U ShardingProp>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U ShardingProp>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=ShardingProp) @ Loc {file=test/testdata/rewriter/prop.rb start=73:7 end=73:19}
-    method <S <C <U ShardingProp>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=73:1 end=76:4}
+    method <C <U PropHelpers2>><U token> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=71:3 end=71:25}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <C <U PropHelpers2>><U token=> (token, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=71:3 end=71:25}
+      argument token<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=71:15 end=71:20}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+  class <S <C <U PropHelpers2>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=68:7 end=68:19}
+    type-member(+) <S <C <U PropHelpers2>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U PropHelpers2>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=PropHelpers2) @ Loc {file=test/testdata/rewriter/prop.rb start=68:7 end=68:19}
+    method <S <C <U PropHelpers2>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=68:1 end=73:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <S <C <U PropHelpers2>> $1><DA <U created_prop> $1> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=70:30 end=70:32}
+      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=70:25 end=70:29}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <S <C <U PropHelpers2>> $1><U created_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=70:3 end=70:33}
+      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=70:25 end=70:29}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <S <C <U PropHelpers2>> $1><DA <U timestamped_token_prop> $1> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=69:40 end=69:42}
+      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=69:35 end=69:39}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <S <C <U PropHelpers2>> $1><U timestamped_token_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=69:3 end=69:43}
+      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=69:35 end=69:39}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+  class <C <U ShardingProp>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=75:1 end=75:19}
+    method <C <U ShardingProp>><U merchant> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=77:3 end=77:16}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+  class <S <C <U ShardingProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=75:7 end=75:19}
+    type-member(+) <S <C <U ShardingProp>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U ShardingProp>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=ShardingProp) @ Loc {file=test/testdata/rewriter/prop.rb start=75:7 end=75:19}
+    method <S <C <U ShardingProp>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=75:1 end=78:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <S <C <U ShardingProp>> $1><DA <U merchant_prop> $1> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=76:31 end=76:33}
+      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=76:26 end=76:30}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <S <C <U ShardingProp>> $1><U merchant_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=76:3 end=76:34}
+      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=76:26 end=76:30}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U SomeODM>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=23:1 end=23:14}
     method <C <U SomeODM>><U foo> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=27:5 end=27:22}

--- a/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
@@ -1,143 +1,143 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=133:4})
+class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=139:4})
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=133:4}
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=139:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U AdvancedODM>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=37:1 end=37:18}
-    class <C <U AdvancedODM>><C <U Mutator>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=43:5 end=43:43}
-      method <C <U AdvancedODM>><C <U Mutator>><U array> (<blk>) -> AppliedType {         klass = <C <U Chalk>><C <U ODM>><C <U Mutator>><C <U Private>><C <U ArrayMutator>>         targs = [           <C <U Elem>> = T.untyped         ]       } @ Loc {file=test/testdata/rewriter/prop.rb start=41:5 end=41:23}
+  class <C <U AdvancedODM>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=38:1 end=38:18}
+    class <C <U AdvancedODM>><C <U Mutator>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=45:5 end=45:43}
+      method <C <U AdvancedODM>><C <U Mutator>><U array> (<blk>) -> AppliedType {         klass = <C <U Chalk>><C <U ODM>><C <U Mutator>><C <U Private>><C <U ArrayMutator>>         targs = [           <C <U Elem>> = T.untyped         ]       } @ Loc {file=test/testdata/rewriter/prop.rb start=43:5 end=43:23}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-      method <C <U AdvancedODM>><C <U Mutator>><U array=> (array, <blk>) -> AppliedType {         klass = <C <U Array>>         targs = [           <C <U Elem>> = T.untyped         ]       } @ Loc {file=test/testdata/rewriter/prop.rb start=41:5 end=41:23}
-        argument array<> -> T::Array[T.untyped] @ Loc {file=test/testdata/rewriter/prop.rb start=41:11 end=41:16}
+      method <C <U AdvancedODM>><C <U Mutator>><U array=> (array, <blk>) -> AppliedType {         klass = <C <U Array>>         targs = [           <C <U Elem>> = T.untyped         ]       } @ Loc {file=test/testdata/rewriter/prop.rb start=43:5 end=43:23}
+        argument array<> -> T::Array[T.untyped] @ Loc {file=test/testdata/rewriter/prop.rb start=43:11 end=43:16}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-      method <C <U AdvancedODM>><C <U Mutator>><U hash_of> (<blk>) -> AppliedType {         klass = <C <U Chalk>><C <U ODM>><C <U Mutator>><C <U Private>><C <U HashMutator>>         targs = [           <C <U K>> = Symbol           <C <U V>> = String         ]       } @ Loc {file=test/testdata/rewriter/prop.rb start=43:5 end=43:43}
+      method <C <U AdvancedODM>><C <U Mutator>><U hash_of> (<blk>) -> AppliedType {         klass = <C <U Chalk>><C <U ODM>><C <U Mutator>><C <U Private>><C <U HashMutator>>         targs = [           <C <U K>> = Symbol           <C <U V>> = String         ]       } @ Loc {file=test/testdata/rewriter/prop.rb start=45:5 end=45:43}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-      method <C <U AdvancedODM>><C <U Mutator>><U hash_of=> (hash_of, <blk>) -> AppliedType {         klass = <C <U Hash>>         targs = [           <C <U K>> = Symbol           <C <U V>> = String           <C <U Elem>> = TupleType {               0 = Symbol               1 = String             }         ]       } @ Loc {file=test/testdata/rewriter/prop.rb start=43:5 end=43:43}
-        argument hash_of<> -> T::Hash[Symbol, String] @ Loc {file=test/testdata/rewriter/prop.rb start=43:11 end=43:18}
+      method <C <U AdvancedODM>><C <U Mutator>><U hash_of=> (hash_of, <blk>) -> AppliedType {         klass = <C <U Hash>>         targs = [           <C <U K>> = Symbol           <C <U V>> = String           <C <U Elem>> = TupleType {               0 = Symbol               1 = String             }         ]       } @ Loc {file=test/testdata/rewriter/prop.rb start=45:5 end=45:43}
+        argument hash_of<> -> T::Hash[Symbol, String] @ Loc {file=test/testdata/rewriter/prop.rb start=45:11 end=45:18}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-      method <C <U AdvancedODM>><C <U Mutator>><U t_array> (<blk>) -> AppliedType {         klass = <C <U Chalk>><C <U ODM>><C <U Mutator>><C <U Private>><C <U ArrayMutator>>         targs = [           <C <U Elem>> = String         ]       } @ Loc {file=test/testdata/rewriter/prop.rb start=42:5 end=42:36}
+      method <C <U AdvancedODM>><C <U Mutator>><U t_array> (<blk>) -> AppliedType {         klass = <C <U Chalk>><C <U ODM>><C <U Mutator>><C <U Private>><C <U ArrayMutator>>         targs = [           <C <U Elem>> = String         ]       } @ Loc {file=test/testdata/rewriter/prop.rb start=44:5 end=44:36}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-      method <C <U AdvancedODM>><C <U Mutator>><U t_array=> (t_array, <blk>) -> AppliedType {         klass = <C <U Array>>         targs = [           <C <U Elem>> = String         ]       } @ Loc {file=test/testdata/rewriter/prop.rb start=42:5 end=42:36}
-        argument t_array<> -> T::Array[String] @ Loc {file=test/testdata/rewriter/prop.rb start=42:11 end=42:18}
+      method <C <U AdvancedODM>><C <U Mutator>><U t_array=> (t_array, <blk>) -> AppliedType {         klass = <C <U Array>>         targs = [           <C <U Elem>> = String         ]       } @ Loc {file=test/testdata/rewriter/prop.rb start=44:5 end=44:36}
+        argument t_array<> -> T::Array[String] @ Loc {file=test/testdata/rewriter/prop.rb start=44:11 end=44:18}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    class <C <U AdvancedODM>><S <C <U Mutator>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=41:5 end=41:23}
-      type-member(+) <C <U AdvancedODM>><S <C <U Mutator>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U AdvancedODM>><S <C <U Mutator>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AdvancedODM::Mutator) @ Loc {file=test/testdata/rewriter/prop.rb start=41:5 end=41:23}
-      method <C <U AdvancedODM>><S <C <U Mutator>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=41:5 end=41:23}
+    class <C <U AdvancedODM>><S <C <U Mutator>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=43:5 end=43:23}
+      type-member(+) <C <U AdvancedODM>><S <C <U Mutator>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U AdvancedODM>><S <C <U Mutator>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AdvancedODM::Mutator) @ Loc {file=test/testdata/rewriter/prop.rb start=43:5 end=43:23}
+      method <C <U AdvancedODM>><S <C <U Mutator>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=43:5 end=43:23}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U array> (<blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=41:5 end=41:23}
+    method <C <U AdvancedODM>><U array> (<blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=43:5 end=43:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U array=> (array, <blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=41:5 end=41:23}
-      argument array<> -> T::Array[T.untyped] @ Loc {file=test/testdata/rewriter/prop.rb start=41:11 end=41:16}
+    method <C <U AdvancedODM>><U array=> (array, <blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=43:5 end=43:23}
+      argument array<> -> T::Array[T.untyped] @ Loc {file=test/testdata/rewriter/prop.rb start=43:11 end=43:16}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U const> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=46:5 end=46:25}
+    method <C <U AdvancedODM>><U const> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=48:5 end=48:25}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U const_explicit> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=45:5 end=45:50}
+    method <C <U AdvancedODM>><U const_explicit> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=47:5 end=47:50}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U default> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=38:5 end=38:39}
+    method <C <U AdvancedODM>><U default> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=40:5 end=40:39}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U default=> (default, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=38:5 end=38:39}
-      argument default<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=38:11 end=38:18}
+    method <C <U AdvancedODM>><U default=> (default, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=40:5 end=40:39}
+      argument default<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=40:11 end=40:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U enum_prop> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=48:5 end=48:56}
+    method <C <U AdvancedODM>><U enum_prop> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=50:5 end=50:56}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U enum_prop=> (enum_prop, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=48:5 end=48:56}
-      argument enum_prop<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=48:11 end=48:20}
+    method <C <U AdvancedODM>><U enum_prop=> (enum_prop, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=50:5 end=50:56}
+      argument enum_prop<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=50:11 end=50:20}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=50:5 end=50:49}
+    method <C <U AdvancedODM>><U foreign> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign=> (foreign, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=50:5 end=50:49}
-      argument foreign<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=50:11 end=50:18}
+    method <C <U AdvancedODM>><U foreign=> (foreign, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
+      argument foreign<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=50:5 end=50:49}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=50:11 end=50:18}
+    method <C <U AdvancedODM>><U foreign_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
+      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=50:5 end=50:49}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=50:11 end=50:18}
+    method <C <U AdvancedODM>><U foreign_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
+      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_invalid> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:65}
+    method <C <U AdvancedODM>><U foreign_invalid> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_invalid=> (foreign_invalid, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:65}
-      argument foreign_invalid<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:26}
+    method <C <U AdvancedODM>><U foreign_invalid=> (foreign_invalid, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
+      argument foreign_invalid<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_invalid_> (opts, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:65}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:26}
+    method <C <U AdvancedODM>><U foreign_invalid_> (opts, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
+      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_invalid_!> (opts, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:65}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:26}
+    method <C <U AdvancedODM>><U foreign_invalid_!> (opts, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
+      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_lazy> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=51:5 end=51:59}
+    method <C <U AdvancedODM>><U foreign_lazy> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_lazy=> (foreign_lazy, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=51:5 end=51:59}
-      argument foreign_lazy<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=51:11 end=51:23}
+    method <C <U AdvancedODM>><U foreign_lazy=> (foreign_lazy, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
+      argument foreign_lazy<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_lazy_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=51:5 end=51:59}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=51:11 end=51:23}
+    method <C <U AdvancedODM>><U foreign_lazy_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
+      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_lazy_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=51:5 end=51:59}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=51:11 end=51:23}
+    method <C <U AdvancedODM>><U foreign_lazy_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
+      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_proc> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:61}
+    method <C <U AdvancedODM>><U foreign_proc> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_proc=> (foreign_proc, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:61}
-      argument foreign_proc<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:23}
+    method <C <U AdvancedODM>><U foreign_proc=> (foreign_proc, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
+      argument foreign_proc<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_proc_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:61}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:23}
+    method <C <U AdvancedODM>><U foreign_proc_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
+      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_proc_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:61}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:23}
+    method <C <U AdvancedODM>><U foreign_proc_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
+      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U hash_of> (<blk>) -> AppliedType {       klass = <C <U Hash>>       targs = [         <C <U K>> = Symbol         <C <U V>> = String         <C <U Elem>> = TupleType {             0 = Symbol             1 = String           }       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=43:5 end=43:43}
+    method <C <U AdvancedODM>><U hash_of> (<blk>) -> AppliedType {       klass = <C <U Hash>>       targs = [         <C <U K>> = Symbol         <C <U V>> = String         <C <U Elem>> = TupleType {             0 = Symbol             1 = String           }       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=45:5 end=45:43}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U hash_of=> (hash_of, <blk>) -> AppliedType {       klass = <C <U Hash>>       targs = [         <C <U K>> = Symbol         <C <U V>> = String         <C <U Elem>> = TupleType {             0 = Symbol             1 = String           }       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=43:5 end=43:43}
-      argument hash_of<> -> T::Hash[Symbol, String] @ Loc {file=test/testdata/rewriter/prop.rb start=43:11 end=43:18}
+    method <C <U AdvancedODM>><U hash_of=> (hash_of, <blk>) -> AppliedType {       klass = <C <U Hash>>       targs = [         <C <U K>> = Symbol         <C <U V>> = String         <C <U Elem>> = TupleType {             0 = Symbol             1 = String           }       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=45:5 end=45:43}
+      argument hash_of<> -> T::Hash[Symbol, String] @ Loc {file=test/testdata/rewriter/prop.rb start=45:11 end=45:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U ifunset> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:39}
+    method <C <U AdvancedODM>><U ifunset> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=57:5 end=57:39}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U ifunset=> (ifunset, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:39}
-      argument ifunset<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:18}
+    method <C <U AdvancedODM>><U ifunset=> (ifunset, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=57:5 end=57:39}
+      argument ifunset<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=57:11 end=57:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U ifunset_nilable> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=56:5 end=56:58}
+    method <C <U AdvancedODM>><U ifunset_nilable> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=58:5 end=58:58}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U ifunset_nilable=> (ifunset_nilable, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=56:5 end=56:58}
-      argument ifunset_nilable<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=56:11 end=56:26}
+    method <C <U AdvancedODM>><U ifunset_nilable=> (ifunset_nilable, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=58:5 end=58:58}
+      argument ifunset_nilable<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=58:11 end=58:26}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U t_array> (<blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = String       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=42:5 end=42:36}
+    method <C <U AdvancedODM>><U t_array> (<blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = String       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=44:5 end=44:36}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U t_array=> (t_array, <blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = String       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=42:5 end=42:36}
-      argument t_array<> -> T::Array[String] @ Loc {file=test/testdata/rewriter/prop.rb start=42:11 end=42:18}
+    method <C <U AdvancedODM>><U t_array=> (t_array, <blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = String       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=44:5 end=44:36}
+      argument t_array<> -> T::Array[String] @ Loc {file=test/testdata/rewriter/prop.rb start=44:11 end=44:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U t_nilable> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=39:5 end=39:39}
+    method <C <U AdvancedODM>><U t_nilable> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=41:5 end=41:39}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U t_nilable=> (t_nilable, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=39:5 end=39:39}
-      argument t_nilable<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=39:11 end=39:20}
+    method <C <U AdvancedODM>><U t_nilable=> (t_nilable, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=41:5 end=41:39}
+      argument t_nilable<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=41:11 end=41:20}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U AdvancedODM>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=37:7 end=37:18}
-    type-member(+) <S <C <U AdvancedODM>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U AdvancedODM>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AdvancedODM) @ Loc {file=test/testdata/rewriter/prop.rb start=37:7 end=37:18}
-    method <S <C <U AdvancedODM>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=37:1 end=57:4}
+  class <S <C <U AdvancedODM>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=38:7 end=38:18}
+    type-member(+) <S <C <U AdvancedODM>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U AdvancedODM>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AdvancedODM) @ Loc {file=test/testdata/rewriter/prop.rb start=38:7 end=38:18}
+    method <S <C <U AdvancedODM>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=38:1 end=59:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U EncryptedProp>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=73:1 end=73:20}
-    method <C <U EncryptedProp>><U bar> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=75:3 end=75:56}
+  class <C <U EncryptedProp>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=78:1 end=78:20}
+    method <C <U EncryptedProp>><U bar> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=81:3 end=81:56}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U EncryptedProp>><U encrypted_bar> (<blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=75:3 end=75:56}
+    method <C <U EncryptedProp>><U encrypted_bar> (<blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=81:3 end=81:56}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U EncryptedProp>><U encrypted_foo> (<blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=74:3 end=74:22}
+    method <C <U EncryptedProp>><U encrypted_foo> (<blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=80:3 end=80:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U EncryptedProp>><U encrypted_foo=> (foo, <blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=74:3 end=74:22}
-      argument foo<> -> T.nilable(Opus::DB::Model::Mixins::Encryptable::EncryptedValue) @ Loc {file=test/testdata/rewriter/prop.rb start=74:19 end=74:22}
+    method <C <U EncryptedProp>><U encrypted_foo=> (foo, <blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=80:3 end=80:22}
+      argument foo<> -> T.nilable(Opus::DB::Model::Mixins::Encryptable::EncryptedValue) @ Loc {file=test/testdata/rewriter/prop.rb start=80:19 end=80:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U EncryptedProp>><U foo> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=74:3 end=74:22}
+    method <C <U EncryptedProp>><U foo> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=80:3 end=80:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U EncryptedProp>><U foo=> (foo, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=74:3 end=74:22}
-      argument foo<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=74:19 end=74:22}
+    method <C <U EncryptedProp>><U foo=> (foo, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=80:3 end=80:22}
+      argument foo<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=80:19 end=80:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U EncryptedProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=73:7 end=73:20}
-    type-member(+) <S <C <U EncryptedProp>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U EncryptedProp>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=EncryptedProp) @ Loc {file=test/testdata/rewriter/prop.rb start=73:7 end=73:20}
-    method <S <C <U EncryptedProp>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=73:1 end=76:4}
+  class <S <C <U EncryptedProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=78:7 end=78:20}
+    type-member(+) <S <C <U EncryptedProp>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U EncryptedProp>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=EncryptedProp) @ Loc {file=test/testdata/rewriter/prop.rb start=78:7 end=78:20}
+    method <S <C <U EncryptedProp>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=78:1 end=82:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U ForeignClass>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=34:1 end=34:19}
-  class <S <C <U ForeignClass>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=34:7 end=34:19}
-    type-member(+) <S <C <U ForeignClass>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U ForeignClass>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=ForeignClass) @ Loc {file=test/testdata/rewriter/prop.rb start=34:7 end=34:19}
-    method <S <C <U ForeignClass>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=34:1 end=35:4}
+  class <C <U ForeignClass>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=35:1 end=35:19}
+  class <S <C <U ForeignClass>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=35:7 end=35:19}
+    type-member(+) <S <C <U ForeignClass>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U ForeignClass>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=ForeignClass) @ Loc {file=test/testdata/rewriter/prop.rb start=35:7 end=35:19}
+    method <S <C <U ForeignClass>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=35:1 end=36:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U NotAODM>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=2:14}
   class <S <C <U NotAODM>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=2:7 end=2:14}
@@ -148,55 +148,55 @@ class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {
       argument args<repeated> @ Loc {file=test/testdata/rewriter/prop.rb start=3:20 end=3:24}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U Object>> < <C <U BasicObject>> (<C <U Kernel>>) @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed}
-    method <C <U Object>><U main> : private (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=78:1 end=78:9}
+    method <C <U Object>><U main> : private (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=84:1 end=84:9}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U PropHelpers>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=59:1 end=59:18}
-    method <C <U PropHelpers>><U created> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=61:3 end=61:15}
+  class <C <U PropHelpers>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=61:1 end=61:18}
+    method <C <U PropHelpers>><U created> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=64:3 end=64:15}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U PropHelpers>><U created=> (created, <blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=61:3 end=61:15}
-      argument created<> -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=61:3 end=61:10}
+    method <C <U PropHelpers>><U created=> (created, <blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=64:3 end=64:15}
+      argument created<> -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=64:3 end=64:10}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U PropHelpers>><U token> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=60:3 end=60:13}
+    method <C <U PropHelpers>><U token> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=63:3 end=63:13}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U PropHelpers>><U token=> (token, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=60:3 end=60:13}
-      argument token<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=60:3 end=60:8}
+    method <C <U PropHelpers>><U token=> (token, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=63:3 end=63:13}
+      argument token<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=63:3 end=63:8}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U PropHelpers>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=59:7 end=59:18}
-    type-member(+) <S <C <U PropHelpers>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U PropHelpers>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=PropHelpers) @ Loc {file=test/testdata/rewriter/prop.rb start=59:7 end=59:18}
-    method <S <C <U PropHelpers>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=59:1 end=62:4}
+  class <S <C <U PropHelpers>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=61:7 end=61:18}
+    type-member(+) <S <C <U PropHelpers>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U PropHelpers>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=PropHelpers) @ Loc {file=test/testdata/rewriter/prop.rb start=61:7 end=61:18}
+    method <S <C <U PropHelpers>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=61:1 end=65:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U PropHelpers2>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=64:1 end=64:19}
-    method <C <U PropHelpers2>><U created> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=66:3 end=66:32}
+  class <C <U PropHelpers2>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=67:1 end=67:19}
+    method <C <U PropHelpers2>><U created> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=70:3 end=70:32}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U PropHelpers2>><U token> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=65:3 end=65:25}
+    method <C <U PropHelpers2>><U token> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=69:3 end=69:25}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U PropHelpers2>><U token=> (token, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=65:3 end=65:25}
-      argument token<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=65:15 end=65:20}
+    method <C <U PropHelpers2>><U token=> (token, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=69:3 end=69:25}
+      argument token<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=69:15 end=69:20}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U PropHelpers2>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=64:7 end=64:19}
-    type-member(+) <S <C <U PropHelpers2>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U PropHelpers2>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=PropHelpers2) @ Loc {file=test/testdata/rewriter/prop.rb start=64:7 end=64:19}
-    method <S <C <U PropHelpers2>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=64:1 end=67:4}
+  class <S <C <U PropHelpers2>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=67:7 end=67:19}
+    type-member(+) <S <C <U PropHelpers2>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U PropHelpers2>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=PropHelpers2) @ Loc {file=test/testdata/rewriter/prop.rb start=67:7 end=67:19}
+    method <S <C <U PropHelpers2>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=67:1 end=71:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U ShardingProp>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=69:1 end=69:19}
-    method <C <U ShardingProp>><U merchant> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=70:3 end=70:16}
+  class <C <U ShardingProp>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=73:1 end=73:19}
+    method <C <U ShardingProp>><U merchant> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=75:3 end=75:16}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U ShardingProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=69:7 end=69:19}
-    type-member(+) <S <C <U ShardingProp>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U ShardingProp>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=ShardingProp) @ Loc {file=test/testdata/rewriter/prop.rb start=69:7 end=69:19}
-    method <S <C <U ShardingProp>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=69:1 end=71:4}
+  class <S <C <U ShardingProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=73:7 end=73:19}
+    type-member(+) <S <C <U ShardingProp>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U ShardingProp>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=ShardingProp) @ Loc {file=test/testdata/rewriter/prop.rb start=73:7 end=73:19}
+    method <S <C <U ShardingProp>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=73:1 end=76:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U SomeODM>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=23:1 end=23:14}
-    method <C <U SomeODM>><U foo> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=26:5 end=26:22}
+  class <C <U SomeODM>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=23:1 end=23:14}
+    method <C <U SomeODM>><U foo> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=27:5 end=27:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U SomeODM>><U foo2> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=29:5 end=29:13}
+    method <C <U SomeODM>><U foo2> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=30:5 end=30:13}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U SomeODM>><U foo2=> (arg0, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=31:5 end=31:20}
-      argument arg0<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=30:17 end=30:21}
+    method <C <U SomeODM>><U foo2=> (arg0, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=32:5 end=32:20}
+      argument arg0<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=31:17 end=31:21}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U SomeODM>><U foo=> (foo, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=26:5 end=26:22}
-      argument foo<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=26:11 end=26:14}
+    method <C <U SomeODM>><U foo=> (foo, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=27:5 end=27:22}
+      argument foo<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=27:11 end=27:14}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U SomeODM>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U Sig>>) @ Loc {file=test/testdata/rewriter/prop.rb start=23:7 end=23:14}
+  class <S <C <U SomeODM>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>, <C <U Sig>>) @ Loc {file=test/testdata/rewriter/prop.rb start=23:7 end=23:14}
     type-member(+) <S <C <U SomeODM>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U SomeODM>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=SomeODM) @ Loc {file=test/testdata/rewriter/prop.rb start=23:7 end=23:14}
-    method <S <C <U SomeODM>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=23:1 end=32:4}
+    method <S <C <U SomeODM>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=23:1 end=33:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
 

--- a/test/testdata/rewriter/prop_computed_by.rb
+++ b/test/testdata/rewriter/prop_computed_by.rb
@@ -2,6 +2,7 @@
 
 class ComputingProps
   extend T::Sig
+  include T::Props
 
   const :num_ok, Integer, computed_by: :compute_num_ok
   sig {params(n: Integer).returns(Integer)}

--- a/test/testdata/rewriter/prop_computed_by.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_computed_by.rb.rewrite-tree.exp
@@ -101,25 +101,41 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.extend(<emptyTree>::<C T>::<C Sig>)
 
+    <self>.include(<emptyTree>::<C T>::<C Props>)
+
+    <self>.const(:"num_ok", <emptyTree>::<C Integer>, {:"computed_by" => :"compute_num_ok", :"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"num_ok")
 
     ::Sorbet::Private::Static.keep_self_def(<self>, :"compute_num_ok")
 
+    <self>.const(:"missing", <emptyTree>::<C Integer>, {:"computed_by" => :"compute_missing", :"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"missing")
+
+    <self>.const(:"num_wrong_value", <emptyTree>::<C Integer>, {:"computed_by" => :"compute_num_wrong_value", :"without_accessors" => true})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"num_wrong_value")
 
     ::Sorbet::Private::Static.keep_self_def(<self>, :"compute_num_wrong_value")
 
+    <self>.const(:"num_wrong_type", <emptyTree>::<C Integer>, {:"computed_by" => :"compute_num_wrong_type", :"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"num_wrong_type")
 
     ::Sorbet::Private::Static.keep_self_def(<self>, :"compute_num_wrong_type")
+
+    <self>.const(:"not_a_symbol", <emptyTree>::<C String>, {:"computed_by" => "not_a_symbol", :"without_accessors" => true})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"not_a_symbol")
 
     symbol_in_variable = :"symbol_in_variable"
 
+    <self>.const(:"symbol_in_variable", <emptyTree>::<C String>, {:"computed_by" => symbol_in_variable, :"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"symbol_in_variable")
+
+    <self>.const(:"num_unknown_type", <emptyTree>::<C Integer>, {:"computed_by" => :"compute_num_unknown_type", :"without_accessors" => true})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"num_unknown_type")
 

--- a/test/testdata/rewriter/prop_enum.rb
+++ b/test/testdata/rewriter/prop_enum.rb
@@ -1,5 +1,6 @@
 # typed: true
 class EnumProp
+  include T::Props
   prop :enum_field, T.enum(["hi", "there"])
 end
 

--- a/test/testdata/rewriter/prop_missing.rb
+++ b/test/testdata/rewriter/prop_missing.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+class ForgotTStructOrTProps
+  prop :foo, Integer # error: `prop` does not exist
+  const :bar, Integer # error: `const` does not exist
+end

--- a/test/testdata/rewriter/prop_missing.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_missing.rb.rewrite-tree.exp
@@ -1,0 +1,37 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C ForgotTStructOrTProps><<C <todo sym>>> < (::<todo sym>)
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({}).returns(<emptyTree>::<C Integer>)
+    end
+
+    def foo<<C <todo sym>>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({:"arg0" => <emptyTree>::<C Integer>}).returns(<emptyTree>::<C Integer>)
+    end
+
+    def foo=<<C <todo sym>>>(arg0, &<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({}).returns(<emptyTree>::<C Integer>)
+    end
+
+    def bar<<C <todo sym>>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    <self>.prop(:"foo", <emptyTree>::<C Integer>, {:"without_accessors" => true})
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"foo")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"foo=")
+
+    <self>.const(:"bar", <emptyTree>::<C Integer>, {:"without_accessors" => true})
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"bar")
+  end
+end

--- a/test/testdata/rewriter/prop_mutator.rb
+++ b/test/testdata/rewriter/prop_mutator.rb
@@ -1,5 +1,6 @@
 # typed: true
 class Foo
+    include T::Props
     prop :int, Integer
     prop :hash, Hash
     prop :t_hash, T::Hash[T.untyped, T.untyped]

--- a/test/testdata/rewriter/t_struct/default.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/default.rb.rewrite-tree.exp
@@ -37,6 +37,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :"initialize")
 
+    <self>.prop(:"foo", <emptyTree>::<C Integer>, {:"default" => 3, :"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"foo")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foo=")

--- a/test/testdata/rewriter/t_struct/inexact.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/inexact.rb.rewrite-tree.exp
@@ -32,9 +32,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
+    <self>.prop(:"foo", <emptyTree>::<C Integer>, {:"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"foo")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foo=")
+
+    <self>.prop(:"bar", <emptyTree>::<C String>, {:"without_accessors" => true})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"bar")
 

--- a/test/testdata/rewriter/t_struct/nilable.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/nilable.rb.rewrite-tree.exp
@@ -37,6 +37,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :"initialize")
 
+    <self>.prop(:"foo", <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>), {:"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"foo")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foo=")

--- a/test/testdata/rewriter/t_struct/normal.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/normal.rb.rewrite-tree.exp
@@ -29,6 +29,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :"initialize")
 
+    <self>.prop(:"foo", <emptyTree>::<C Integer>, {:"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"foo")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foo=")

--- a/test/testdata/rewriter/t_struct/override.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/override.rb.rewrite-tree.exp
@@ -39,6 +39,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.extend(<emptyTree>::<C T>::<C Sig>)
 
+    <self>.prop(:"foo", <emptyTree>::<C String>, {:"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"foo")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foo=")

--- a/test/testdata/rewriter/t_struct/param_order.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/param_order.rb.rewrite-tree.exp
@@ -54,9 +54,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :"initialize")
 
+    <self>.prop(:"foo", <emptyTree>::<C Integer>, {:"default" => 3, :"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"foo")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foo=")
+
+    <self>.prop(:"bar", <emptyTree>::<C Integer>, {:"without_accessors" => true})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"bar")
 

--- a/test/testdata/rewriter/t_struct/root.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/root.rb.rewrite-tree.exp
@@ -29,6 +29,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :"initialize")
 
+    <self>.prop(:"foo", <emptyTree>::<C Integer>, {:"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"foo")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foo=")

--- a/test/testdata/rewriter/t_struct/some_default.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/some_default.rb.rewrite-tree.exp
@@ -54,9 +54,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :"initialize")
 
+    <self>.prop(:"foo", <emptyTree>::<C Integer>, {:"without_accessors" => true})
+
     ::Sorbet::Private::Static.keep_def(<self>, :"foo")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foo=")
+
+    <self>.prop(:"bar", <emptyTree>::<C T>::<C Boolean>, {:"default" => false, :"without_accessors" => true})
 
     ::Sorbet::Private::Static.keep_def(<self>, :"bar")
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This will serve two purposes:

- People will get errors when they forgot to `include T::Props` or add
  `< T::Struct`
- The `prop` call will be left in the tree, which more accurately
  models what happens at runtime.

sorbet-runtime includes a `without_accessors` rule on all props that says to
skip getter / setter definitions and puts the burden on the user to define them
(like using codegen). We use that option here.

### Commit summary


- **Keep all `prop` definitions in the tree** (30d8cd71f)

  This will serve two purposes:

  - People will get errors when they forgot to `include T::Props` or add
   `< T::Struct`
  - The `prop` call will be left in the tree, which more accurately
   models what happens at runtime.

- **Add test that ensures error for forgetting T::Props** (eaf2f0cef)


- **Fix problems with `prop` not being defined** (237286f6a)


- **tools/scripts/update_testdata_exp.sh** (c8ad7526a)


- **Fix prop test** (e161988b7)


- **Fix some other tests** (c75a96faa)





### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.