### PR TITLE
[easy] add a couple method RBI's for Sorbet::Private::Static::ENVClass

### DIFF
--- a/rbi/sorbet/sorbet.rbi
+++ b/rbi/sorbet/sorbet.rbi
@@ -141,7 +141,7 @@ class Sorbet::Private::Static::ENVClass
 
   sig do
     params(
-        blk: T.proc.params(name: String, value: String).returns(BasicObject),
+        blk: T.proc.params(name: String).returns(BasicObject),
     )
     .returns(Sorbet::Private::Static::ENVClass)
   end
@@ -159,7 +159,7 @@ class Sorbet::Private::Static::ENVClass
 
   sig do
     params(
-        blk: T.proc.params(name: String, value: String).returns(BasicObject),
+        blk: T.proc.params(value: String).returns(BasicObject),
     )
     .returns(Sorbet::Private::Static::ENVClass)
   end

--- a/rbi/sorbet/sorbet.rbi
+++ b/rbi/sorbet/sorbet.rbi
@@ -130,6 +130,42 @@ class Sorbet::Private::Static::ENVClass
   sig {returns(T::Enumerator[Elem])}
   def delete_if(&blk); end
 
+  sig do
+    params(
+        blk: T.proc.params(name: String, value: String).returns(BasicObject),
+    )
+    .returns(Sorbet::Private::Static::ENVClass)
+  end
+  sig {returns(T::Enumerator[Elem])}
+  def each(&blk); end
+
+  sig do
+    params(
+        blk: T.proc.params(name: String, value: String).returns(BasicObject),
+    )
+    .returns(Sorbet::Private::Static::ENVClass)
+  end
+  sig {returns(T::Enumerator[Elem])}
+  def each_key(&blk); end
+
+  sig do
+    params(
+        blk: T.proc.params(name: String, value: String).returns(BasicObject),
+    )
+    .returns(Sorbet::Private::Static::ENVClass)
+  end
+  sig {returns(T::Enumerator[Elem])}
+  def each_pair(&blk); end
+
+  sig do
+    params(
+        blk: T.proc.params(name: String, value: String).returns(BasicObject),
+    )
+    .returns(Sorbet::Private::Static::ENVClass)
+  end
+  sig {returns(T::Enumerator[Elem])}
+  def each_value(&blk); end
+
   sig {returns(T::Boolean)}
   def empty?(); end
 
@@ -174,6 +210,22 @@ class Sorbet::Private::Static::ENVClass
   end
   sig {returns(T::Enumerator[Elem])}
   def filter!(&blk); end
+
+  sig do
+    params(
+        key: String
+    )
+    .returns(T::Boolean)
+  end
+  def has_key?(key); end
+
+  sig do
+    params(
+        key: String
+    )
+    .returns(T::Boolean)
+  end
+  def has_value?(key); end
 
   sig do
     params(
@@ -261,6 +313,14 @@ class Sorbet::Private::Static::ENVClass
     .returns(T::Hash[String, T.nilable(String)])
   end
   def update(key, &blk); end
+
+  sig do
+    params(
+        value: String
+    )
+    .returns(T::Boolean)
+  end
+  def value?(key); end
 end
 # [`ENV`](https://docs.ruby-lang.org/en/2.6.0/ENV.html) is a hash-like accessor
 # for environment variables.

--- a/rbi/sorbet/sorbet.rbi
+++ b/rbi/sorbet/sorbet.rbi
@@ -221,11 +221,11 @@ class Sorbet::Private::Static::ENVClass
 
   sig do
     params(
-        key: String
+        value: String
     )
     .returns(T::Boolean)
   end
-  def has_value?(key); end
+  def has_value?(value); end
 
   sig do
     params(
@@ -320,7 +320,7 @@ class Sorbet::Private::Static::ENVClass
     )
     .returns(T::Boolean)
   end
-  def value?(key); end
+  def value?(value); end
 end
 # [`ENV`](https://docs.ruby-lang.org/en/2.6.0/ENV.html) is a hash-like accessor
 # for environment variables.


### PR DESCRIPTION
Add a couple of (IMO) commonly used method RBI's per the ENV docs here:  https://docs.ruby-lang.org/en/2.5.0/ENV.html

### Motivation
While making a few changes to some legacy code, our CI asked that I "sorbetify" the file and `has_key?(...)` in particular was missing. 

### Test plan
I couldn't find any for tests for ENV specifically, though I'm happy to add some if y'all would like.  
