### PR TITLE
Implement non_forcing_is_a? in sorbet-runtime

### DIFF
--- a/gems/sorbet-runtime/lib/sorbet-runtime.rb
+++ b/gems/sorbet-runtime/lib/sorbet-runtime.rb
@@ -110,5 +110,6 @@ require_relative 'types/props/private/parser'
 require_relative 'types/props/generated_code_validation'
 
 require_relative 'types/struct'
+require_relative 'types/non_forcing_constants'
 
 require_relative 'types/compatibility_patches'

--- a/gems/sorbet-runtime/lib/types/non_forcing_constants.rb
+++ b/gems/sorbet-runtime/lib/types/non_forcing_constants.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+# typed: strict
+
+module T::NonForcingConstants
+  # NOTE: This method is documented on the RBI in Sorbet's payload, so that it
+  # shows up in the hover/completion documentation via LSP.
+  T::Sig::WithoutRuntime.sig {params(val: BasicObject, klass: String).returns(T::Boolean)}
+  def self.non_forcing_is_a?(val, klass)
+    method_name = "T::NonForcingConstants.non_forcing_is_a?"
+    if klass.empty?
+      raise ArgumentError.new("The string given to `#{method_name}` must not be empty")
+    end
+
+    current_klass = T.let(nil, T.nilable(Module))
+    current_prefix = T.let(nil, T.nilable(String))
+
+    parts = klass.split('::')
+    parts.each do |part|
+      if current_klass.nil?
+        # First iteration
+        if part != ""
+          raise ArgumentError.new("The string given to `#{method_name}` must be an absolute constant reference that starts with `::`")
+        end
+
+        current_klass = Object
+        current_prefix = ''
+      else
+        if current_klass.autoload?(part)
+          # There's an autoload registered for that constant, which means it's not
+          # yet loaded. `value` can't be an instance of something not yet loaded.
+          return false
+        end
+
+        # Sorbet guarantees that the string is an absolutely resolved name.
+        search_inheritance_chain = false
+        if !current_klass.const_defined?(part, search_inheritance_chain)
+          return false
+        end
+
+        current_klass = current_klass.const_get(part)
+        current_prefix = "#{current_prefix}::#{part}"
+
+        if !Module.===(current_klass)
+          raise ArgumentError.new("#{current_prefix} is not a class or module")
+        end
+      end
+    end
+
+    return current_klass.===(val)
+  end
+end

--- a/gems/sorbet-runtime/test/types/fixtures/always_raise.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/always_raise.rb
@@ -1,0 +1,1 @@
+raise "This file was loaded, but shouldn't have been."

--- a/gems/sorbet-runtime/test/types/non_forcing_constants.rb
+++ b/gems/sorbet-runtime/test/types/non_forcing_constants.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+class Opus::Types::Test::NonForcingConstantsTest < Critic::Unit::UnitTest
+  class MyClass
+  end
+
+  MyField = 0
+
+  autoload :RaisesIfLoaded, "#{__dir__}/fixtures/always_raise.rb"
+
+  describe "T::NonForcingConstants.non_forcing_is_a?" do
+    it "empty string" do
+      exn = assert_raises(ArgumentError) do
+        T::NonForcingConstants.non_forcing_is_a?(nil, '')
+      end
+      assert_match(/must not be empty/, exn.message)
+    end
+
+    it "non-absolute" do
+      exn = assert_raises(ArgumentError) do
+        T::NonForcingConstants.non_forcing_is_a?(nil, 'X')
+      end
+      assert_match(/must be an absolute constant reference/, exn.message)
+    end
+
+    it "when doesn't exist" do
+      res = T::NonForcingConstants.non_forcing_is_a?(nil, '::DoesntExist')
+      assert_equal(false, res)
+
+      res = T::NonForcingConstants.non_forcing_is_a?(nil, '::Doesnt::Exist')
+      assert_equal(false, res)
+    end
+
+    it "when exists but isn't is_a?" do
+      res = T::NonForcingConstants.non_forcing_is_a?(nil, '::Integer')
+      assert_equal(false, res)
+    end
+
+    it "when exists and is_a?" do
+      res = T::NonForcingConstants.non_forcing_is_a?(0, '::Integer')
+      assert_equal(true, res)
+    end
+
+    it "multi-part" do
+      outer = Opus::Types::Test::NonForcingConstantsTest::MyClass.new
+
+      res = T::NonForcingConstants.non_forcing_is_a?(outer, '::Opus::Types::Test::NonForcingConstantsTest::DoesntExist')
+      assert_equal(false, res)
+
+      res = T::NonForcingConstants.non_forcing_is_a?(outer, '::Opus::Types::Test::NonForcingConstantsTest::MyClass')
+      assert_equal(true, res)
+    end
+
+    it "sanity check our fixture" do
+      exn = assert_raises(RuntimeError) do
+        ::Opus::Types::Test::NonForcingConstantsTest::RaisesIfLoaded
+      end
+      assert_match(/This file was loaded, but shouldn't have been/, exn.message)
+
+      # Do it again to prove that there's no cleanup we'd have to do
+      # (like re-register the autoload after failing to force it once)
+      exn = assert_raises(RuntimeError) do
+        ::Opus::Types::Test::NonForcingConstantsTest::RaisesIfLoaded
+      end
+      assert_match(/This file was loaded, but shouldn't have been/, exn.message)
+    end
+
+    it "doesn't force autoloads" do
+      res = T::NonForcingConstants.non_forcing_is_a?(nil, '::Opus::Types::Test::NonForcingConstantsTest::RaisesIfLoaded')
+      assert_equal(false, res)
+
+      # Note that we return `false` even if the constant doesn't ultimately exist,
+      # because sometimes we can only know whether it exists by forcing the constant.
+      # In these cases, Sorbet's static checks guarantee that the string literal
+      # resolves to a valid constant.
+      res = T::NonForcingConstants.non_forcing_is_a?(nil, '::Opus::Types::Test::NonForcingConstantsTest::RaisesIfLoaded::DoesntExist')
+      assert_equal(false, res)
+    end
+
+    it "requires class/module, not static-fields" do
+      exn = assert_raises(ArgumentError) do
+        T::NonForcingConstants.non_forcing_is_a?(nil, '::Opus::Types::Test::NonForcingConstantsTest::MyField')
+      end
+      assert_match(/is not a class or module/, exn.message)
+
+      exn = assert_raises(ArgumentError) do
+        T::NonForcingConstants.non_forcing_is_a?(nil, '::Opus::Types::Test::NonForcingConstantsTest::MyField::DoesntExist')
+      end
+      assert_match(/is not a class or module/, exn.message)
+    end
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

See the tests for now; docs will follow.

It uses `autoload?` to guard `const_defined?` in a loop to attempt to
resolve a constant. The idea is that if a constant is not yet loaded,
the `is_a?` check is necessarily `false`, and you don't need to force
the constant to load to arrive at that result. This makes it possible to
break up certain kinds of load-time / runtime dependencies.

This feature is backed by Sorbet statically, so even though the runtime
won't know whether a constant actually exists at runtime, Sorbet will be
able to step in and guarantee that there were no typos in the name. In
particular, the runtime returns `false` if both the constant doesn't
exist and if it might exist but we can't tell because it's not yet
loaded. Another option would have been to raise in cases when we were
sure that a constant didn't exist (because there wasn't even an autoload
registered for it), but I figured that would be more surprising
(makes it more load-order dependent).

I think at Stripe there are also some use cases to have a variant of
this that's backed by `Module#<` as well, for comparing class objects,
not instances of classes. We should feel free to implement that when the
need arrises.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.