### PR TITLE
Report timings even when they don't have tags

### DIFF
--- a/common/statsd/statsd.cc
+++ b/common/statsd/statsd.cc
@@ -69,10 +69,9 @@ public:
     }
     void timing(const CounterImpl::Timing &tim) { // type: ms
         auto nanoseconds = (tim.end.usec - tim.start.usec) * 1'000;
-        if (tim.tags != nullptr) {
-            addMetric(absl::StrCat(tim.measure, ".duration_ns"), nanoseconds, "ms",
-                      *tim.tags); // format suggested by #observability (@sjung and @an)
-        }
+        // format suggested by #observability (@sjung and @an)
+        addMetric(absl::StrCat(tim.measure, ".duration_ns"), nanoseconds, "ms",
+                  tim.tags == nullptr ? (vector<pair<const char *, const char *>>{}) : *tim.tags);
     }
 };
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This bug was introduced a few weeks ago in 39f4dd0c3ef982.
`tim.tags == nullptr` means that there are no tags; it doesn't mean that
we should not send a metric with the duration of the timer.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.