### PR TITLE
[RFC+WIP] Proof-of-concept of opaque type support

### DIFF
--- a/gems/sorbet-runtime/lib/sorbet-runtime.rb
+++ b/gems/sorbet-runtime/lib/sorbet-runtime.rb
@@ -80,6 +80,7 @@ require_relative 'types/private/abstract/hooks'
 require_relative 'types/private/casts'
 require_relative 'types/private/methods/decl_builder'
 require_relative 'types/private/methods/signature'
+require_relative 'types/types/opaque'
 require_relative 'types/utils'
 require_relative 'types/boolean'
 

--- a/gems/sorbet-runtime/lib/types/generic.rb
+++ b/gems/sorbet-runtime/lib/types/generic.rb
@@ -14,10 +14,10 @@ module T::Generic
   end
 
   def type_member(variance=:invariant, fixed: nil, lower: T.untyped, upper: BasicObject)
-    T::Types::TypeMember.new(variance) # rubocop:disable PrisonGuard/UseOpusTypesShortcut
+    T::Types::TypeMember.new(variance, fixed) # rubocop:disable PrisonGuard/UseOpusTypesShortcut
   end
 
   def type_template(variance=:invariant, fixed: nil, lower: T.untyped, upper: BasicObject)
-    T::Types::TypeTemplate.new(variance) # rubocop:disable PrisonGuard/UseOpusTypesShortcut
+    T::Types::TypeTemplate.new(variance, fixed) # rubocop:disable PrisonGuard/UseOpusTypesShortcut
   end
 end

--- a/gems/sorbet-runtime/lib/types/types/opaque.rb
+++ b/gems/sorbet-runtime/lib/types/types/opaque.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+# typed: true
+
+module T::Types
+  class Opaque
+    extend T::Sig
+    extend T::Generic
+
+    ConcreteType = type_template
+
+    sig(:final) {params(obj: ConcreteType).returns(T.attached_class)}
+    def self.let(obj)
+      T.unsafe(obj)
+    end
+
+    sig(:final) {returns(Class)}
+    def self.concrete_type
+      self.const_get(:ConcreteType, false).fixed
+    end
+
+    # There should never be instances of Opaque types
+    private_class_method :new
+  end
+end

--- a/gems/sorbet-runtime/lib/types/types/type_variable.rb
+++ b/gems/sorbet-runtime/lib/types/types/type_variable.rb
@@ -5,15 +5,16 @@ module T::Types
   # Since we do type erasure at runtime, this just validates the variance and
   # provides some syntax for the static type checker
   class TypeVariable < Base
-    attr_reader :variance
+    attr_reader :variance, :fixed
 
     VALID_VARIANCES = [:in, :out, :invariant]
 
-    def initialize(variance)
+    def initialize(variance, fixed=nil)
       if !VALID_VARIANCES.include?(variance)
         raise TypeError.new("invalid variance #{variance}")
       end
       @variance = variance
+      @fixed = fixed
     end
 
     def valid?(obj)

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -21,7 +21,11 @@ module T::Utils
     elsif val == ::Range
       T::Range[T.untyped]
     elsif val.is_a?(Module)
-      T::Types::Simple.new(val) # rubocop:disable PrisonGuard/UseOpusTypesShortcut
+      if val <= T::Types::Opaque
+        T::Types::Simple.new(T.cast(val, T.class_of(T::Types::Opaque)).concrete_type) # rubocop:disable PrisonGuard/UseOpusTypesShortcut
+      else
+        T::Types::Simple.new(val) # rubocop:disable PrisonGuard/UseOpusTypesShortcut
+      end
     elsif val.is_a?(::Array)
       T::Types::FixedArray.new(val) # rubocop:disable PrisonGuard/UseOpusTypesShortcut
     elsif val.is_a?(::Hash)

--- a/gems/sorbet-runtime/test/types/opaque.rb
+++ b/gems/sorbet-runtime/test/types/opaque.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+module Opus::Types::Test
+  class OpaqueTest < Critic::Unit::UnitTest
+    extend T::Sig
+
+    class OpaqueString < T::Types::Opaque
+      ConcreteType = type_template(fixed: String)
+    end
+
+    describe 'coercion' do
+      it 'allows a string' do
+        assert(T::Utils.coerce(OpaqueString).valid?(""))
+      end
+
+      it 'does not allow an integer' do
+        refute(T::Utils.coerce(OpaqueString).valid?(0))
+      end
+    end
+
+    sig {params(x: OpaqueString).void}
+    def takes_opaque_type(x); end
+
+    sig {params(x: String).void}
+    def takes_concrete_type(x); end
+
+    describe 'method validation' do
+      it 'allows either concrete or opaque type' do
+        takes_opaque_type(OpaqueString.let(""))
+        takes_opaque_type("")
+        takes_concrete_type(OpaqueString.let(""))
+        takes_concrete_type("")
+      end
+    end
+  end
+end

--- a/rbi/sorbet/ttypes.rbi
+++ b/rbi/sorbet/ttypes.rbi
@@ -102,7 +102,7 @@ end
 # --- user-defined generics ---
 
 class T::Types::TypeVariable < T::Types::Base
-  def initialize(variance); end
+  def initialize(variance, fixed); end
   def name; end
   def subtype_of_single?(type); end
   def valid?(obj); end
@@ -167,3 +167,12 @@ class T::Types::TypedEnumerator < T::Types::TypedEnumerable
   def type; end
 end
 
+class T::Types::Opaque
+  extend T::Sig
+  extend T::Generic
+
+  ConcreteType = type_template
+
+  sig(:final) {params(obj: ConcreteType).returns(T.attached_class)}
+  def self.let(obj); end
+end

--- a/test/testdata/opaque.rb
+++ b/test/testdata/opaque.rb
@@ -1,0 +1,18 @@
+# typed: strict
+
+extend T::Sig
+
+class OpaqueString < T::Types::Opaque
+  ConcreteType = type_template(fixed: String)
+end
+
+sig {params(x: OpaqueString).void}
+def takes_opaque_type(x); end
+
+sig {params(x: String).void}
+def takes_concrete_type(x); end
+
+takes_opaque_type(OpaqueString.let(""))
+takes_opaque_type("") # error: Expected `OpaqueString` but found `String("")` for argument `x`
+takes_concrete_type(OpaqueString.let("")) # error: Expected `String` but found `OpaqueString` for argument `x`
+takes_concrete_type("")


### PR DESCRIPTION
This adds minimal opaque type support in a way that requires changes only to the runtime.

With this, you can declare a class like:
```
class Seconds < T::Types::Opaque
  ConcreteType = type_template(fixed: Float)
end
```
and then use it like:
```
x = Seconds.let(1.0)
```

At runtime, `x` will just be an integer, and `T::Utils.coerce(Seconds)` will produce the same thing as `T::Utils.coerce(Integer)` (which is helpful in that we don't break existing metaprogramming), but statically, we deliberately force Sorbet to forget that these are the same.

The only reason this can't be done with Sorbet without this PR (AFAICT) is that you need a way to disable or customize runtime validation for one specific type. If `T::Types::Simple` used `@type === obj` instead of `obj.is_a?(@type)` this PR would be unnecessary, but I think that ship has sailed...

(We could also accomplish basically the same thing as this PR by monkeypatching `is_a?` on Object, but yuck.)

### Motivation
We've discussed various use cases for opaque types, and this could be useful for them.

A significant downside is that error messages could be pretty confusing with this implementation, since we haven't changed the C++ side at all. 

I'm not sure it's worth shipping a quick-and-dirty version like this; maybe we shouldn't do it at all unless we're going to do it right. That's why this is marked "RFC". (Also, no urgency on it.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
