### PR TITLE
wip: Initialize all non-module prop ivars

### DIFF
--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -384,8 +384,8 @@ unique_ptr<ast::Send> ensureWithoutAccessors(const PropInfo &prop, const ast::Se
     }
 }
 
-vector<unique_ptr<ast::Expression>> mkTStructInitialize(core::MutableContext ctx, core::LocOffsets klassLoc,
-                                                        const vector<PropInfo> &props) {
+vector<unique_ptr<ast::Expression>> mkTypedInitialize(core::MutableContext ctx, core::LocOffsets klassLoc,
+                                                      const vector<PropInfo> &props) {
     ast::MethodDef::ARGS_store args;
     ast::Hash::ENTRY_store sigKeys;
     ast::Hash::ENTRY_store sigVals;
@@ -468,9 +468,10 @@ void Prop::run(core::MutableContext ctx, ast::ClassDef *klass) {
     auto oldRHS = std::move(klass->rhs);
     klass->rhs.clear();
     klass->rhs.reserve(oldRHS.size());
+    // we define our synthesized initialize first so that if the user wrote one themselves, it overrides ours.
     if (forTStruct) {
-        // we define our synthesized initialize first so that if the user wrote one themselves, it overrides ours.
-        for (auto &stat : mkTStructInitialize(ctx, klass->loc, props)) {
+        // For direct T::Struct subclasses, we know that seeing no props means the constructor should be zero-arity.
+        for (auto &stat : mkTypedInitialize(ctx, klass->loc, props)) {
             klass->rhs.emplace_back(std::move(stat));
         }
     }

--- a/test/testdata/rewriter/prop_ivar.rb
+++ b/test/testdata/rewriter/prop_ivar.rb
@@ -1,0 +1,27 @@
+# typed: strict
+
+# There should be no errors for accessing instance variables here, because the
+# Prop rewriter pass declares them.
+
+class AbstractGrandparent < T::InexactStruct
+  # Trying to be representative that we won't always see inheritance syntactically.
+end
+
+class Parent < AbstractGrandparent
+  const :in_parent, Integer
+
+  sig {void}
+  def parent_helper
+    p @in_parent
+  end
+end
+
+class Child < Parent
+  const :in_child, String
+
+  sig {void}
+  def child_helper
+    p @in_parent
+    p @in_child
+  end
+end

--- a/test/testdata/rewriter/prop_ivar_module.rb
+++ b/test/testdata/rewriter/prop_ivar_module.rb
@@ -1,0 +1,10 @@
+# typed: strict
+
+# There should be no errors for accessing instance variables here, because the
+# Prop rewriter pass declares them.
+
+module MixesInProps
+  include T::Props
+
+  const :in_parent, Integer
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is pre-work for a change that will more accurately model prop getters and
setters in non-T::Struct subclasses.

We want to be able to more accurately model prop getters and setters, which
will mean accessing instance variables. When we make it visible to Sorbet that
these classes are accessing the instance variables directly, it would otherwise
prevent `prop`s from being used in `typed: strict`. We have to define these
ivars to prevent that.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

wip tests incoming