### PR TITLE
Fix RBI types for each_key and each_value

### DIFF
--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -425,7 +425,7 @@ class Hash < Object
     )
     .returns(T::Hash[K, V])
   end
-  sig {returns(T::Enumerator[[K, V]])}
+  sig {returns(T::Enumerator[K])}
   def each_key(&blk); end
 
   # Calls *block* once for each key in *hsh*, passing the key-value pair as
@@ -474,7 +474,7 @@ class Hash < Object
     )
     .returns(T::Hash[K, V])
   end
-  sig {returns(T::Enumerator[[K, V]])}
+  sig {returns(T::Enumerator[V])}
   def each_value(&blk); end
 
   # Returns `true` if *hsh* contains no key-value pairs.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
The return-an-enumerator overload for `Hash#each_key` and `Hash#each_value` had the same type as `Hash#each` but they should only return an enumerator of the keys or values, respectively:

```ruby
irb(main):001:0> {a:22, b:33}.each_key.to_a
=> [:a, :b]
irb(main):002:0> {a:22, b:33}.each_value.to_a
=> [22, 33]
```


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
