### PR TITLE
Compile spdlog as a library (not header only)

### DIFF
--- a/common/common.cc
+++ b/common/common.cc
@@ -14,6 +14,8 @@
 #include <memory>
 #include <vector>
 
+#include <sys/stat.h>
+
 using namespace std;
 
 namespace {

--- a/common/os/linux.cc
+++ b/common/os/linux.cc
@@ -5,6 +5,7 @@
 #include <csignal>
 #include <cstdio>
 #include <cstring>
+#include <fnctl.h>
 #include <sstream>
 #include <string>
 #include <sys/stat.h>

--- a/common/os/linux.cc
+++ b/common/os/linux.cc
@@ -5,7 +5,7 @@
 #include <csignal>
 #include <cstdio>
 #include <cstring>
-#include <fnctl.h>
+#include <fcntl.h>
 #include <sstream>
 #include <string>
 #include <sys/stat.h>

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -623,6 +623,8 @@ See [core/Symbols.h] and [core/SymbolRef.h] for more information.
   - `toString` is "internal representation" (like Rust `Debug` trait)
 - `gems/sorbet/` (`srb init`)
 - `gems/sorbet-runtime/`
+- `bazel build //foo --copt=-ftime-trace --spawn_strategy=standalone`
+  - generates <chrome://tracing> profiles for clang
 
 <!-- -- Links -------------------------------------------------------------- -->
 

--- a/third_party/spdlog.BUILD
+++ b/third_party/spdlog.BUILD
@@ -3,18 +3,18 @@ cc_library(
     srcs = glob([
         "src/**/*.cpp",
     ]),
+    hdrs = glob([
+        "include/spdlog/**/*.h",
+    ]),
+    copts = [
+        "-Iexternal/spdlog/",
+    ],
     defines = [
         # This define switches from using spdlog as a header-only library to a
         # compiled library (*.a / *.so). When this change was implemented, it
         # dropped the time to recompile a change to common/common.h (included
         # ~everywhere) from ~5 minutes to ~3 minutes (May 2020).
         "SPDLOG_COMPILED_LIB",
-    ],
-    hdrs = glob([
-        "include/spdlog/**/*.h",
-    ]),
-    copts = [
-        "-Iexternal/spdlog/",
     ],
     includes = [
         "include/",

--- a/third_party/spdlog.BUILD
+++ b/third_party/spdlog.BUILD
@@ -4,6 +4,10 @@ cc_library(
         "src/**/*.cpp",
     ]),
     defines = [
+        # This define switches from using spdlog as a header-only library to a
+        # compiled library (*.a / *.so). When this change was implemented, it
+        # dropped the time to recompile a change to common/common.h (included
+        # ~everywhere) from ~5 minutes to ~3 minutes (May 2020).
         "SPDLOG_COMPILED_LIB",
     ],
     hdrs = glob([

--- a/third_party/spdlog.BUILD
+++ b/third_party/spdlog.BUILD
@@ -1,9 +1,13 @@
 cc_library(
     name = "spdlog",
-    srcs = [],
+    srcs = glob([
+        "src/**/*.cpp",
+    ]),
+    defines = [
+        "SPDLOG_COMPILED_LIB",
+    ],
     hdrs = glob([
         "include/spdlog/**/*.h",
-        "include/spdlog/**/*.cc",
     ]),
     copts = [
         "-Iexternal/spdlog/",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This makes compiling Sorbet significantly faster (~5 minutes to ~3 minutes on
my 8-core MacBook Pro `Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz`).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.