### PR TITLE
Add support for dedenting XString heredoc

### DIFF
--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -540,6 +540,17 @@ public:
                 result = std::move(node);
             },
 
+            [&](XString *d) {
+                for (auto &p : d->nodes) {
+                    if (auto *s = parser::cast_node<String>(p.get())) {
+                        std::string dedented = dedenter.dedent(s->val.data(gs_)->shortName(gs_));
+                        unique_ptr<Node> newstr = make_unique<String>(s->loc, gs_.enterNameUTF8(dedented));
+                        p.swap(newstr);
+                    }
+                }
+                result = std::move(node);
+            },
+
             [&](Node *n) { Exception::raise("Unexpected dedent node: {}", n->nodeName()); });
 
         return result;

--- a/test/whitequark/test_bug_heredoc_xstring_0.rb
+++ b/test/whitequark/test_bug_heredoc_xstring_0.rb
@@ -3,3 +3,11 @@
 p <<~`E`
       pwd
   E
+
+puts <<~`E`
+    a
+    rather
+  long command
+        with bad
+    indentation
+    E

--- a/test/whitequark/test_bug_heredoc_xstring_0.rb
+++ b/test/whitequark/test_bug_heredoc_xstring_0.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+p <<~`E`
+      pwd
+  E


### PR DESCRIPTION
### Motivation
Sorbet currently doesn't supportdedenting XString heredocs. This adds support for that.

Fixes #1628

### Test plan
See included automated tests.
