### PR TITLE
Only flush errors after final typechecking pass on file

### DIFF
--- a/core/Error.cc
+++ b/core/Error.cc
@@ -105,8 +105,6 @@ string Error::toString(const GlobalState &gs) const {
     return buf.str();
 }
 
-ErrorRegion::~ErrorRegion() {}
-
 ErrorBuilder::ErrorBuilder(const GlobalState &gs, bool willBuild, Loc loc, ErrorClass what)
     : gs(gs), state(willBuild ? State::WillBuild : State::Unreported), loc(loc), what(what) {
     ENFORCE(willBuild || what.minLevel != StrictLevel::Internal);

--- a/core/Error.cc
+++ b/core/Error.cc
@@ -105,9 +105,7 @@ string Error::toString(const GlobalState &gs) const {
     return buf.str();
 }
 
-ErrorRegion::~ErrorRegion() {
-    gs.errorQueue->markFileForFlushing(this->f);
-}
+ErrorRegion::~ErrorRegion() {}
 
 ErrorBuilder::ErrorBuilder(const GlobalState &gs, bool willBuild, Loc loc, ErrorClass what)
     : gs(gs), state(willBuild ? State::WillBuild : State::Unreported), loc(loc), what(what) {

--- a/core/Error.h
+++ b/core/Error.h
@@ -92,17 +92,16 @@ public:
  * Used to batch errors in an RAII fashion:
  *
  * {
- *   ErrorRegion errs(gs);
+ *   ErrorRegion errs(fref);
  *   runNamer();
  * }
  */
 class ErrorRegion {
 public:
-    ErrorRegion(const GlobalState &gs, FileRef f) : gs(gs), f(f){};
+    ErrorRegion(FileRef f) : f(f){};
     ~ErrorRegion();
 
 private:
-    const GlobalState &gs;
     FileRef f;
 };
 

--- a/core/Error.h
+++ b/core/Error.h
@@ -88,23 +88,6 @@ public:
     }
 };
 
-/*
- * Used to batch errors in an RAII fashion:
- *
- * {
- *   ErrorRegion errs(fref);
- *   runNamer();
- * }
- */
-class ErrorRegion {
-public:
-    ErrorRegion(FileRef f) : f(f){};
-    ~ErrorRegion();
-
-private:
-    FileRef f;
-};
-
 class ErrorBuilder {
     // An ErrorBuilder can be in three states:
     //

--- a/core/ErrorQueue.cc
+++ b/core/ErrorQueue.cc
@@ -153,7 +153,7 @@ vector<unique_ptr<core::ErrorQueueMessage>> ErrorQueue::drainFlushed() {
 }
 
 void ErrorQueue::markFileForFlushing(core::FileRef file) {
-    filesFlushedCount++;
+    filesFlushedCount.fetch_add(1);
     core::ErrorQueueMessage msg;
     msg.kind = core::ErrorQueueMessage::Kind::Flush;
     msg.whatFile = file;

--- a/core/ErrorQueue.cc
+++ b/core/ErrorQueue.cc
@@ -186,4 +186,16 @@ bool ErrorQueue::queueIsEmptyApprox() const {
     return this->queue.sizeEstimate() == 0;
 }
 
+bool ErrorQueue::hasFlushesFor(core::FileRef file) const {
+    auto it = collected.find(file);
+    if (it != collected.end()) {
+        for (auto &msg : it->second) {
+            if (msg.kind == core::ErrorQueueMessage::Kind::Flush) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
 } // namespace sorbet::core

--- a/core/ErrorQueue.cc
+++ b/core/ErrorQueue.cc
@@ -35,6 +35,10 @@ using namespace std;
 ErrorQueue::ErrorQueue(spdlog::logger &logger, spdlog::logger &tracer)
     : owner(this_thread::get_id()), logger(logger), tracer(tracer){};
 
+ErrorQueue::~ErrorQueue() {
+    flushErrors(true);
+}
+
 pair<vector<unique_ptr<core::Error>>, vector<unique_ptr<core::lsp::QueryResponse>>>
 ErrorQueue::drainWithQueryResponses() {
     checkOwned();

--- a/core/ErrorQueue.h
+++ b/core/ErrorQueue.h
@@ -27,6 +27,7 @@ public:
     spdlog::logger &tracer;
     std::atomic<bool> hadCritical{false};
     std::atomic<int> nonSilencedErrorCount{0};
+    std::atomic<int> filesFlushedCount{0};
     bool ignoreFlushes{false};
 
     ErrorQueue(spdlog::logger &logger, spdlog::logger &tracer);
@@ -50,9 +51,6 @@ public:
 
     /** Checks if the queue is empty. Is approximate if there are any concurrent dequeue/enqueue operations */
     bool queueIsEmptyApprox() const;
-
-    /** Checks if the queue contains any flushes for a given file */
-    bool hasFlushesFor(core::FileRef file) const;
 };
 
 } // namespace core

--- a/core/ErrorQueue.h
+++ b/core/ErrorQueue.h
@@ -30,6 +30,7 @@ public:
     bool ignoreFlushes{false};
 
     ErrorQueue(spdlog::logger &logger, spdlog::logger &tracer);
+    ~ErrorQueue();
 
     /** register a new error to be reported */
     void pushError(const GlobalState &gs, std::unique_ptr<Error> error);

--- a/core/ErrorQueue.h
+++ b/core/ErrorQueue.h
@@ -49,6 +49,9 @@ public:
 
     /** Checks if the queue is empty. Is approximate if there are any concurrent dequeue/enqueue operations */
     bool queueIsEmptyApprox() const;
+
+    /** Checks if the queue contains any flushes for a given file */
+    bool hasFlushesFor(core::FileRef file) const;
 };
 
 } // namespace core

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -18,7 +18,6 @@ class NameRef;
 class Symbol;
 class SymbolRef;
 class GlobalSubstitution;
-class ErrorRegion;
 class ErrorQueue;
 struct GlobalStateHash;
 
@@ -40,7 +39,6 @@ class GlobalState final {
     friend File;
     friend FileRef;
     friend GlobalSubstitution;
-    friend ErrorRegion;
     friend ErrorBuilder;
     friend serialize::Serializer;
     friend serialize::SerializerImpl;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -920,7 +920,7 @@ ast::ParsedFilesOrCancelled typecheck(unique_ptr<core::GlobalState> &gs, vector<
                                       optional<shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager) {
     // Unless the error queue had a critical error, only typecheck should flush errors to the client, otherwise we will
     // drop errors in LSP mode.
-    ENFORCE(gs->errorQueue->filesFlushedCount == 0);
+    ENFORCE(gs->hadCriticalError() || gs->errorQueue->filesFlushedCount == 0);
 
     vector<ast::ParsedFile> typecheck_result;
     const auto &epochManager = *gs->epochManager;

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -40,8 +40,7 @@ typecheck(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> w
           WorkerPool &workers, bool cancelable = false,
           std::optional<std::shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager = std::nullopt);
 
-ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Options &opts,
-                             const core::GlobalState &gs);
+ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Options &opts);
 
 // Computes file hashes for the given files, and stores them in the files. If supplied, attempts to retrieve hashes from
 // the key-value store. Returns 'true' if it had to compute any file hashes.

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -40,7 +40,8 @@ typecheck(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> w
           WorkerPool &workers, bool cancelable = false,
           std::optional<std::shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager = std::nullopt);
 
-ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Options &opts);
+ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Options &opts,
+                             const core::GlobalState &gs);
 
 // Computes file hashes for the given files, and stores them in the files. If supplied, attempts to retrieve hashes from
 // the key-value store. Returns 'true' if it had to compute any file hashes.

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -513,7 +513,7 @@ int realmain(int argc, char *argv[]) {
                 vector<core::ErrorRegion> errs;
                 for (auto &tree : indexed) {
                     auto file = tree.file;
-                    errs.emplace_back(*gs, file);
+                    errs.emplace_back(file);
                 }
                 indexed = resolver::Resolver::runConstantResolution(*gs, move(indexed), *workers);
                 autoloaderCfg = autogen::AutoloaderConfig::enterConfig(*gs, opts.autoloaderConfig);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -510,11 +510,6 @@ int realmain(int argc, char *argv[]) {
                 core::UnfreezeNameTable nameTableAccess(*gs);
                 core::UnfreezeSymbolTable symbolAccess(*gs);
 
-                vector<core::ErrorRegion> errs;
-                for (auto &tree : indexed) {
-                    auto file = tree.file;
-                    errs.emplace_back(file);
-                }
                 indexed = resolver::Resolver::runConstantResolution(*gs, move(indexed), *workers);
                 autoloaderCfg = autogen::AutoloaderConfig::enterConfig(*gs, opts.autoloaderConfig);
             }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -995,7 +995,6 @@ std::vector<ast::ParsedFile> Namer::run(core::GlobalState &gs, std::vector<ast::
             ast::ParsedFile ast;
             {
                 Timer timeit(gs.tracer(), "naming", {{"file", (string)file.data(gs).path()}});
-                core::ErrorRegion errs(file);
                 tree.tree = ast::ShallowMap::apply(ctx, nameInserter, std::move(tree.tree));
             }
         } catch (SorbetException &) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -995,7 +995,7 @@ std::vector<ast::ParsedFile> Namer::run(core::GlobalState &gs, std::vector<ast::
             ast::ParsedFile ast;
             {
                 Timer timeit(gs.tracer(), "naming", {{"file", (string)file.data(gs).path()}});
-                core::ErrorRegion errs(ctx, file);
+                core::ErrorRegion errs(file);
                 tree.tree = ast::ShallowMap::apply(ctx, nameInserter, std::move(tree.tree));
             }
         } catch (SorbetException &) {

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -241,7 +241,7 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
 
     vector<core::ErrorRegion> errs;
     for (auto file : files) {
-        errs.emplace_back(*gs, file);
+        errs.emplace_back(file);
 
         if (FileOps::getFileName(file.data(*gs).path()) != whitelistedTypedNoneTest &&
             file.data(*gs).source().find("# typed:") == string::npos) {
@@ -595,7 +595,7 @@ TEST_P(WhitequarkParserTest, PerPhaseTest) { // NOLINT
 
     vector<core::ErrorRegion> errs;
     for (auto file : files) {
-        errs.emplace_back(gs, file);
+        errs.emplace_back(file);
 
         if (FileOps::getFileName(file.data(gs).path()) != whitelistedTypedNoneTest &&
             file.data(gs).source().find("# typed:") == string::npos) {

--- a/test/test_corpus.cc
+++ b/test/test_corpus.cc
@@ -239,10 +239,7 @@ TEST_P(ExpectationTest, PerPhaseTest) { // NOLINT
     vector<ast::ParsedFile> trees;
     ExpectationHandler handler(test, errorQueue);
 
-    vector<core::ErrorRegion> errs;
     for (auto file : files) {
-        errs.emplace_back(file);
-
         if (FileOps::getFileName(file.data(*gs).path()) != whitelistedTypedNoneTest &&
             file.data(*gs).source().find("# typed:") == string::npos) {
             ADD_FAILURE_AT(file.data(*gs).path().data(), 1) << "Add a `# typed: strict` line to the top of this file";
@@ -593,10 +590,7 @@ TEST_P(WhitequarkParserTest, PerPhaseTest) { // NOLINT
     vector<ast::ParsedFile> trees;
     map<string, string> got;
 
-    vector<core::ErrorRegion> errs;
     for (auto file : files) {
-        errs.emplace_back(file);
-
         if (FileOps::getFileName(file.data(gs).path()) != whitelistedTypedNoneTest &&
             file.data(gs).source().find("# typed:") == string::npos) {
             ADD_FAILURE_AT(file.data(gs).path().data(), 1) << "Add a `# typed: strict` line to the top of this file";


### PR DESCRIPTION
- Mark each file for flushing at the end of typechecking 
- Enforce that typechecking happens before flushing
- Remove calls to error flushing in other passes
- Flush all errors in `ErrorQueue` destructor

### Motivation
Milestone 2 towards improving time to first and last error by sending diagnostics as typechecking is finished for each file