### PR TITLE
Remove support from T::Props::CustomType for custom `instance?`

### DIFF
--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -97,17 +97,8 @@ class T::Enum
     @mapping.include?(serialized_val)
   end
 
-
-  ## T::Props::CustomType
-
   # Note: Failed CriticalMethodsNoRuntimeTypingTest
-  sig {params(value: T.untyped).returns(T::Boolean).checked(:never)}
-  def self.instance?(value)
-    value.is_a?(self)
-  end
-
-  # Note: Failed CriticalMethodsNoRuntimeTypingTest
-  sig {params(instance: T.nilable(T::Enum)).returns(SerializedVal).checked(:never)}
+  sig {override.params(instance: T.nilable(T::Enum)).returns(SerializedVal).checked(:never)}
   def self.serialize(instance)
     # This is needed otherwise if a Chalk::ODM::Document with a property of the shape
     # T::Hash[T.nilable(MyEnum), Integer] and a value that looks like {nil => 0} is
@@ -124,7 +115,7 @@ class T::Enum
   end
 
   # Note: Failed CriticalMethodsNoRuntimeTypingTest
-  sig {params(mongo_value: SerializedVal).returns(T.attached_class).checked(:never)}
+  sig {override.params(mongo_value: SerializedVal).returns(T.attached_class).checked(:never)}
   def self.deserialize(mongo_value)
     if self == T::Enum
       raise "Cannot call T::Enum.deserialize directly. You must call on a specific child class."

--- a/gems/sorbet-runtime/lib/types/props/_props.rb
+++ b/gems/sorbet-runtime/lib/types/props/_props.rb
@@ -39,7 +39,7 @@ module T::Props
     # a document class.
     #
     # @param name [Symbol] The name of this property
-    # @param cls [Class,T::Props::CustomType] (String) The type of this
+    # @param cls [Class,T::Types::Base] The type of this
     #   property. If the type is itself a {Document} subclass, this
     #   property will be recursively serialized/deserialized.
     # @param rules [Hash] Options to control this property's behavior.
@@ -90,10 +90,6 @@ module T::Props
     #   none is provided.
     # @option rules [T::Boolean] :immutable If true, this prop cannot be
     #   modified after an instance is created or loaded from a hash.
-    # @option rules [Class,T::Props::CustomType] :array If set, specifies the
-    #   type of individual members of a prop with `type` `Array`. This
-    #   allows for typechecking of arrays, and also for recursive
-    #   serialization of arrays of sub-{Document}s.
     # @option rules [T::Boolean] :override It is an error to redeclare a
     #   `prop` that has already been declared (including on a
     #   superclass), unless `:override` is set to `true`.

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -12,7 +12,7 @@ class T::Props::Decorator
 
   Rules = T.type_alias {T::Hash[Symbol, T.untyped]}
   DecoratedInstance = T.type_alias {Object} # Would be T::Props, but that produces circular reference errors in some circumstances
-  PropType = T.type_alias {T.any(T::Types::Base, T::Props::CustomType)}
+  PropType = T.type_alias {T::Types::Base}
   PropTypeOrClass = T.type_alias {T.any(PropType, Module)}
 
   class NoRulesError < StandardError; end
@@ -335,10 +335,7 @@ class T::Props::Decorator
     if !cls.is_a?(Module)
       cls = convert_type_to_class(cls)
     end
-    type_object = type
-    if !(type_object.singleton_class < T::Props::CustomType)
-      type_object = smart_coerce(type_object, array: rules[:array], enum: rules[:enum])
-    end
+    type_object = smart_coerce(type, array: rules[:array], enum: rules[:enum])
 
     prop_validate_definition!(name, cls, rules, type_object)
 

--- a/gems/sorbet-runtime/lib/types/props/private/serde_transform.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/serde_transform.rb
@@ -128,8 +128,7 @@ module T::Props
       private_class_method def self.handle_custom_type(varname, type, mode)
         case mode
         when Serialize
-          type_name = T.must(module_name(type))
-          "T::Props::CustomType.checked_serialize(#{type_name}, #{varname})"
+          "T::Props::CustomType.checked_serialize(#{varname})"
         when Deserialize
           type_name = T.must(module_name(type))
           "#{type_name}.deserialize(#{varname})"

--- a/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
@@ -20,17 +20,10 @@ module T::Props
       end
       def self.build_setter_proc(klass, prop, rules)
         # Our nil check works differently than a simple T.nilable for various
-        # reasons (including the `raise_on_nil_write` setting, the existence
-        # of defaults & factories, and the fact that we allow `T.nilable(Foo)`
-        # where Foo < T::Props::CustomType as a prop type even though calling
-        # `valid?` on it won't work as expected), so unwrap any T.nilable and
-        # do a check manually. (Note this hack does not fix custom types as
-        # collection elements.)
+        # reasons (including the `raise_on_nil_write` setting and the existence
+        # of defaults & factories), so unwrap any T.nilable and do a check
+        # manually.
         non_nil_type = T::Utils::Nilable.get_underlying_type_object(rules.fetch(:type_object))
-        if non_nil_type.is_a?(T::Types::Simple) && non_nil_type.raw_type.singleton_class < T::Props::CustomType
-          non_nil_type = non_nil_type.raw_type
-        end
-
         accessor_key = rules.fetch(:accessor_key)
         validate = rules[:setter_validate]
 
@@ -51,7 +44,7 @@ module T::Props
         params(
           prop: Symbol,
           accessor_key: Symbol,
-          non_nil_type: T.any(T::Types::Base, T.all(T::Props::CustomType, Module)),
+          non_nil_type: T::Types::Base,
           klass: T.all(Module, T::Props::ClassMethods),
           validate: T.nilable(ValidateProc)
         )
@@ -80,7 +73,7 @@ module T::Props
         params(
           prop: Symbol,
           accessor_key: Symbol,
-          non_nil_type: T.any(T::Types::Base, T.all(T::Props::CustomType, Module)),
+          non_nil_type: T::Types::Base,
           klass: T.all(Module, T::Props::ClassMethods),
           validate: T.nilable(ValidateProc),
         )

--- a/gems/sorbet-runtime/lib/types/props/type_validation.rb
+++ b/gems/sorbet-runtime/lib/types/props/type_validation.rb
@@ -28,7 +28,7 @@ module T::Props::TypeValidation
     def prop_validate_definition!(name, _cls, rules, type)
       super
 
-      if !rules[:DEPRECATED_underspecified_type] && !(type.singleton_class <= T::Props::CustomType)
+      if !rules[:DEPRECATED_underspecified_type]
         validate_type(type, field_name: name)
       elsif rules[:DEPRECATED_underspecified_type] && find_invalid_subtype(type).nil?
         raise ArgumentError.new("DEPRECATED_underspecified_type set unnecessarily for #{@class.name}.#{name} - #{type} is a valid type")

--- a/gems/sorbet-runtime/test/types/props/_props.rb
+++ b/gems/sorbet-runtime/test/types/props/_props.rb
@@ -256,16 +256,20 @@ class Opus::Types::Test::Props::PropsTest < Critic::Unit::UnitTest
   class MyCustomType
     extend T::Props::CustomType
 
-    def self.instance?(value)
-      value.is_a?(String)
+    attr_accessor :value
+
+    def initialize(value)
+      @value = value
     end
 
     def self.deserialize(value)
-      value.clone.freeze
+      result = new
+      result.value = value.clone.freeze
+      result
     end
 
     def self.serialize(instance)
-      instance
+      instance.value
     end
   end
 
@@ -283,26 +287,24 @@ class Opus::Types::Test::Props::PropsTest < Critic::Unit::UnitTest
     end
 
     it 'work when plain' do
-      @obj.custom = "foo"
-      assert_equal("foo", @obj.custom)
+      @obj.custom = MyCustomType.new("foo")
+      assert_equal("foo", @obj.custom.value)
     end
 
     it 'work when nilable' do
       @obj.nilable_custom = nil
       assert_nil(@obj.nilable_custom)
 
-      @obj.nilable_custom = "foo"
-      assert_equal("foo", @obj.nilable_custom)
+      @obj.nilable_custom = MyCustomType.new("foo")
+      assert_equal("foo", @obj.nilable_custom.value)
     end
 
     it 'work as collection element' do
-      skip "this isn't supported"
-
       @obj.collection_custom = []
       assert_empty(@obj.collection_custom)
 
-      @obj.collection_custom = ["foo"]
-      assert_equal(["foo"], @obj.collection_custom)
+      @obj.collection_custom = [MyCustomType.new("foo")]
+      assert_equal(["foo"], @obj.collection_custom.map(&:value))
     end
   end
 

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -473,16 +473,16 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
   class CustomType
     extend T::Props::CustomType
 
-    def self.instance?(value)
-      value.is_a?(String)
-    end
+    attr_accessor :value
 
     def self.deserialize(value)
-      value.clone.freeze
+      result = new
+      result.value = value.clone.freeze
+      result
     end
 
     def self.serialize(instance)
-      instance
+      instance.value
     end
   end
 
@@ -720,7 +720,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     prop :hash_of_substruct, T::Hash[String, MySerializable]
     prop :custom_type, CustomType
     prop :nilable_custom_type, T.nilable(CustomType)
-    prop :default_custom_type, CustomType, default: ''
+    prop :default_custom_type, CustomType, default: CustomType.new
     prop :array_of_custom_type, T::Array[CustomType]
     prop :hash_of_custom_type_to_substruct, T::Hash[CustomType, MySerializable]
     prop :unidentified_type, Object

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -35,7 +35,7 @@ module T::Props::CustomType
   def deserialize(_mongo_scalar); end
   def instance?(_value); end
   def self.scalar_type?(val); end
-  def self.valid_serialization?(val, type = nil); end
+  def self.valid_serialization?(val); end
   def serialize(_instance); end
   def valid?(value); end
   include Kernel
@@ -49,7 +49,7 @@ end
 class T::Props::Decorator
   Rules = T.type_alias {T::Hash[Symbol, T.untyped]}
   DecoratedInstance = T.type_alias {T.untyped} # Would be T::Props, but that produces circular reference errors in some circumstances
-  PropType = T.type_alias {T.any(T::Types::Base, T::Props::CustomType)}
+  PropType = T.type_alias {T::Types::Base}
   PropTypeOrClass = T.type_alias {T.any(PropType, Module)}
 end
 


### PR DESCRIPTION
`T::Props::CustomType` has historically supported the following pattern:

```ruby
class Foo
  extend T::Props::CustomType

  def self.instance?(obj)
    obj.is_a?(String)
  end
end
```

This was never supported in the Sorbet runtime, except for a couple of hacks internal to T::Props - T::Sig never had any knowledge of CustomType and would not use the custom `instance?` method. This PR removes support from T::Props as well. `T::Props::CustomType` can still be used to provide custom serialization, but only instances of a class that extends CustomType will be settable for props of that type.

This breaks backwards compatibility in two ways:
* The obvious one, above;
* A bugfix for props of the form `prop :foo, SomeCustomType, enum: [SomeCustomType.a, SomeCustomType.b]` in which previously the `enum:` validation would have been ignored (at runtime; it was and is still ignored statically)

### Motivation
Restrict T::Props to what the rest of Sorbet actually supports.

(The handful of cases of custom `instance?` in Stripe code have been replaced by uses of `T.type_alias`).

### Test plan
Passing build here & in pay-server: https://cibot.corp.stripe.com/builds/bui_HDcvf1mcVfxXc1