### PR TITLE
Split body and else apart in exception handling

### DIFF
--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -283,6 +283,10 @@ void CFGBuilder::removeDeadAssigns(core::Context ctx, const CFG::ReadsAndWrites 
 
 void CFGBuilder::computeMinMaxLoops(core::Context ctx, const CFG::ReadsAndWrites &RnW, CFG &cfg) {
     for (const auto &bb : cfg.basicBlocks) {
+        if (bb.get() == cfg.deadBlock()) {
+            continue;
+        }
+
         for (const core::LocalVariable what : RnW.reads[bb->id]) {
             const auto minIt = cfg.minLoops.find(what);
             int curMin = minIt != cfg.minLoops.end() ? minIt->second : INT_MAX;
@@ -293,6 +297,10 @@ void CFGBuilder::computeMinMaxLoops(core::Context ctx, const CFG::ReadsAndWrites
         }
     }
     for (const auto &bb : cfg.basicBlocks) {
+        if (bb.get() == cfg.deadBlock()) {
+            continue;
+        }
+
         for (const auto &expr : bb->exprs) {
             auto what = expr.bind.variable;
             const auto minIt = cfg.minLoops.find(what);

--- a/test/testdata/cfg/dealias_with_return.rb.cfg.exp
+++ b/test/testdata/cfg/dealias_with_return.rb.cfg.exp
@@ -13,7 +13,7 @@ subgraph "cluster_::Object#a" {
     "bb::Object#a_0" -> "bb::Object#a_4" [style="tapered"];
 
     "bb::Object#a_1" [
-        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+        label = "block[id=1, rubyBlockId=0]()\l<exceptionValue>$4 = <unanalyzable>\l<unconditional>\l"
     ];
 
     "bb::Object#a_1" -> "bb::Object#a_1" [style="bold"];
@@ -21,33 +21,33 @@ subgraph "cluster_::Object#a" {
         label = "block[id=3, rubyBlockId=2](<exceptionValue>$4: T.untyped)\l<exceptionClassTemp>$6: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$7: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<exceptionClassTemp>$6: T.class_of(StandardError))\l<isaCheckTemp>$7: T.untyped\l"
     ];
 
-    "bb::Object#a_3" -> "bb::Object#a_8" [style="bold"];
-    "bb::Object#a_3" -> "bb::Object#a_9" [style="tapered"];
+    "bb::Object#a_3" -> "bb::Object#a_7" [style="bold"];
+    "bb::Object#a_3" -> "bb::Object#a_8" [style="tapered"];
 
     "bb::Object#a_4" [
         label = "block[id=4, rubyBlockId=1]()\l<returnTemp>$5: Integer(1) = 1\l<statTemp>$3: T.noreturn = return <returnTemp>$5: Integer(1)\l<unconditional>\l"
     ];
 
     "bb::Object#a_4" -> "bb::Object#a_1" [style="bold"];
+    "bb::Object#a_7" [
+        label = "block[id=7, rubyBlockId=2]()\la: Integer(2) = 2\l<gotoDeadTemp>$8: NilClass\l"
+    ];
+
+    "bb::Object#a_7" -> "bb::Object#a_1" [style="bold"];
+    "bb::Object#a_7" -> "bb::Object#a_9" [style="tapered"];
+
     "bb::Object#a_8" [
-        label = "block[id=8, rubyBlockId=2]()\la: Integer(2) = 2\l<gotoDeadTemp>$8: NilClass\l"
+        label = "block[id=8, rubyBlockId=2]()\l<gotoDeadTemp>$8: TrueClass(true) = true\l<gotoDeadTemp>$8: TrueClass(true)\l"
     ];
 
     "bb::Object#a_8" -> "bb::Object#a_1" [style="bold"];
-    "bb::Object#a_8" -> "bb::Object#a_10" [style="tapered"];
+    "bb::Object#a_8" -> "bb::Object#a_9" [style="tapered"];
 
     "bb::Object#a_9" [
-        label = "block[id=9, rubyBlockId=2]()\l<gotoDeadTemp>$8: TrueClass(true) = true\l<gotoDeadTemp>$8: TrueClass(true)\l"
+        label = "block[id=9, rubyBlockId=0](a: Integer(2))\l<statTemp>$11: Integer(3) = 3\l<returnMethodTemp>$2: Integer = a: Integer(2).+(<statTemp>$11: Integer(3))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer\l<unconditional>\l"
     ];
 
     "bb::Object#a_9" -> "bb::Object#a_1" [style="bold"];
-    "bb::Object#a_9" -> "bb::Object#a_10" [style="tapered"];
-
-    "bb::Object#a_10" [
-        label = "block[id=10, rubyBlockId=0](a: Integer(2))\l<statTemp>$11: Integer(3) = 3\l<returnMethodTemp>$2: Integer = a: Integer(2).+(<statTemp>$11: Integer(3))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer\l<unconditional>\l"
-    ];
-
-    "bb::Object#a_10" -> "bb::Object#a_1" [style="bold"];
 }
 
 subgraph "cluster_::<Class:<root>>#<static-init>" {

--- a/test/testdata/cfg/reassign_dead_block_bug.rb
+++ b/test/testdata/cfg/reassign_dead_block_bug.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# typed: true
+
+2.times do
+  x = 1
+  return 1
+  x = 10
+end

--- a/test/testdata/cfg/reassign_dead_block_bug.rb.cfg.exp
+++ b/test/testdata/cfg/reassign_dead_block_bug.rb.cfg.exp
@@ -1,0 +1,38 @@
+digraph "reassign_dead_block_bug.rb" {
+subgraph "cluster_::<Class:<root>>#<static-init>" {
+    label = "::<Class:<root>>#<static-init>";
+    color = blue;
+    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
+    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
+
+    "bb::<Class:<root>>#<static-init>_0" [
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<statTemp>$3: Integer(2) = 2\l<block-pre-call-temp>$4: Sorbet::Private::Static::Void = <statTemp>$3: Integer(2).times()\l<unconditional>\l"
+    ];
+
+    "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_2" [style="bold"];
+    "bb::<Class:<root>>#<static-init>_1" [
+        label = "block[id=1, rubyBlockId=0]()\lx$1 = 10\l<unconditional>\l"
+    ];
+
+    "bb::<Class:<root>>#<static-init>_1" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
+    "bb::<Class:<root>>#<static-init>_2" [
+        label = "block[id=2, rubyBlockId=1](<self>: T.class_of(<root>), <block-pre-call-temp>$4: Sorbet::Private::Static::Void)\louterLoops: 1\l<block-call>: NilClass\l"
+    ];
+
+    "bb::<Class:<root>>#<static-init>_2" -> "bb::<Class:<root>>#<static-init>_5" [style="bold"];
+    "bb::<Class:<root>>#<static-init>_2" -> "bb::<Class:<root>>#<static-init>_3" [style="tapered"];
+
+    "bb::<Class:<root>>#<static-init>_3" [
+        label = "block[id=3, rubyBlockId=0](<self>: T.class_of(<root>), <block-pre-call-temp>$4: Sorbet::Private::Static::Void)\l<returnMethodTemp>$2: Integer = Solve<<block-pre-call-temp>$4, times>\l<self>: T.class_of(<root>) = <self>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer\l<unconditional>\l"
+    ];
+
+    "bb::<Class:<root>>#<static-init>_3" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
+    "bb::<Class:<root>>#<static-init>_5" [
+        label = "block[id=5, rubyBlockId=1](<self>: T.class_of(<root>))\louterLoops: 1\l<self>: T.class_of(<root>) = loadSelf\lx$1: Integer(1) = 1\l<returnTemp>$11: Integer(1) = 1\l<statTemp>$10: T.noreturn = return <returnTemp>$11: Integer(1)\l<unconditional>\l"
+    ];
+
+    "bb::<Class:<root>>#<static-init>_5" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
+}
+
+}
+

--- a/test/testdata/cfg/rescue.rb.cfg.exp
+++ b/test/testdata/cfg/rescue.rb.cfg.exp
@@ -21,38 +21,43 @@ subgraph "cluster_::Object#main" {
         label = "block[id=3, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <self>: Object, <exceptionValue>$3: T.untyped)\l<exceptionClassTemp>$6: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$7: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<exceptionClassTemp>$6: T.class_of(StandardError))\l<isaCheckTemp>$7: T.untyped\l"
     ];
 
-    "bb::Object#main_3" -> "bb::Object#main_8" [style="bold"];
-    "bb::Object#main_3" -> "bb::Object#main_9" [style="tapered"];
+    "bb::Object#main_3" -> "bb::Object#main_7" [style="bold"];
+    "bb::Object#main_3" -> "bb::Object#main_8" [style="tapered"];
 
     "bb::Object#main_4" [
-        label = "block[id=4, rubyBlockId=1](<self>: Object)\l<returnMethodTemp>$2: T.untyped = <self>: Object.a()\l<returnMethodTemp>$2: T.untyped = <self>: Object.c()\l<exceptionValue>$3: T.untyped = <unanalyzable>\l<exceptionValue>$3: T.untyped\l"
+        label = "block[id=4, rubyBlockId=1](<self>: Object)\l<returnMethodTemp>$2: T.untyped = <self>: Object.a()\l<exceptionValue>$3: T.untyped = <unanalyzable>\l<exceptionValue>$3: T.untyped\l"
     ];
 
     "bb::Object#main_4" -> "bb::Object#main_3" [style="bold"];
-    "bb::Object#main_4" -> "bb::Object#main_6" [style="tapered"];
+    "bb::Object#main_4" -> "bb::Object#main_5" [style="tapered"];
 
+    "bb::Object#main_5" [
+        label = "block[id=5, rubyBlockId=4](<self>: Object)\l<returnMethodTemp>$2: T.untyped = <self>: Object.c()\l<unconditional>\l"
+    ];
+
+    "bb::Object#main_5" -> "bb::Object#main_6" [style="bold"];
     "bb::Object#main_6" [
         label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <self>: Object, <gotoDeadTemp>$9: T.nilable(TrueClass))\l<throwAwayTemp>$10: T.untyped = <self>: Object.d()\l<gotoDeadTemp>$9: T.nilable(TrueClass)\l"
     ];
 
     "bb::Object#main_6" -> "bb::Object#main_1" [style="bold"];
-    "bb::Object#main_6" -> "bb::Object#main_10" [style="tapered"];
+    "bb::Object#main_6" -> "bb::Object#main_9" [style="tapered"];
 
+    "bb::Object#main_7" [
+        label = "block[id=7, rubyBlockId=2](<self>: Object)\l<returnMethodTemp>$2: T.untyped = <self>: Object.b()\l<unconditional>\l"
+    ];
+
+    "bb::Object#main_7" -> "bb::Object#main_6" [style="bold"];
     "bb::Object#main_8" [
-        label = "block[id=8, rubyBlockId=2](<self>: Object)\l<returnMethodTemp>$2: T.untyped = <self>: Object.b()\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <self>: Object)\l<gotoDeadTemp>$9: TrueClass(true) = true\l<unconditional>\l"
     ];
 
     "bb::Object#main_8" -> "bb::Object#main_6" [style="bold"];
     "bb::Object#main_9" [
-        label = "block[id=9, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <self>: Object)\l<gotoDeadTemp>$9: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
-    "bb::Object#main_9" -> "bb::Object#main_6" [style="bold"];
-    "bb::Object#main_10" [
-        label = "block[id=10, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
-    ];
-
-    "bb::Object#main_10" -> "bb::Object#main_1" [style="bold"];
+    "bb::Object#main_9" -> "bb::Object#main_1" [style="bold"];
 }
 
 subgraph "cluster_::Object#a" {

--- a/test/testdata/cfg/rescue_complex.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_complex.rb.cfg.exp
@@ -147,8 +147,8 @@ subgraph "cluster_::TestRescue#multiple_rescue" {
         label = "block[id=3, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <self>: TestRescue, <exceptionValue>$3: T.untyped)\l<exceptionClassTemp>$5: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$6: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<exceptionClassTemp>$5: T.class_of(StandardError))\l<isaCheckTemp>$6: T.untyped\l"
     ];
 
-    "bb::TestRescue#multiple_rescue_3" -> "bb::TestRescue#multiple_rescue_8" [style="bold"];
-    "bb::TestRescue#multiple_rescue_3" -> "bb::TestRescue#multiple_rescue_9" [style="tapered"];
+    "bb::TestRescue#multiple_rescue_3" -> "bb::TestRescue#multiple_rescue_7" [style="bold"];
+    "bb::TestRescue#multiple_rescue_3" -> "bb::TestRescue#multiple_rescue_8" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_4" [
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()\l<exceptionValue>$3: T.untyped = <unanalyzable>\l<exceptionValue>$3: T.untyped\l"
@@ -162,41 +162,41 @@ subgraph "cluster_::TestRescue#multiple_rescue" {
     ];
 
     "bb::TestRescue#multiple_rescue_6" -> "bb::TestRescue#multiple_rescue_1" [style="bold"];
-    "bb::TestRescue#multiple_rescue_6" -> "bb::TestRescue#multiple_rescue_12" [style="tapered"];
+    "bb::TestRescue#multiple_rescue_6" -> "bb::TestRescue#multiple_rescue_11" [style="tapered"];
+
+    "bb::TestRescue#multiple_rescue_7" [
+        label = "block[id=7, rubyBlockId=2](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()\l<gotoDeadTemp>$11: NilClass\l"
+    ];
+
+    "bb::TestRescue#multiple_rescue_7" -> "bb::TestRescue#multiple_rescue_1" [style="bold"];
+    "bb::TestRescue#multiple_rescue_7" -> "bb::TestRescue#multiple_rescue_11" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_8" [
-        label = "block[id=8, rubyBlockId=2](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()\l<gotoDeadTemp>$11: NilClass\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <self>: TestRescue, <exceptionValue>$3: T.untyped)\l<exceptionClassTemp>$8: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$9: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<exceptionClassTemp>$8: T.class_of(StandardError))\l<isaCheckTemp>$9: T.untyped\l"
     ];
 
-    "bb::TestRescue#multiple_rescue_8" -> "bb::TestRescue#multiple_rescue_1" [style="bold"];
-    "bb::TestRescue#multiple_rescue_8" -> "bb::TestRescue#multiple_rescue_12" [style="tapered"];
+    "bb::TestRescue#multiple_rescue_8" -> "bb::TestRescue#multiple_rescue_9" [style="bold"];
+    "bb::TestRescue#multiple_rescue_8" -> "bb::TestRescue#multiple_rescue_10" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_9" [
-        label = "block[id=9, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <self>: TestRescue, <exceptionValue>$3: T.untyped)\l<exceptionClassTemp>$8: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$9: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<exceptionClassTemp>$8: T.class_of(StandardError))\l<isaCheckTemp>$9: T.untyped\l"
+        label = "block[id=9, rubyBlockId=2](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$11: NilClass\l"
     ];
 
-    "bb::TestRescue#multiple_rescue_9" -> "bb::TestRescue#multiple_rescue_10" [style="bold"];
+    "bb::TestRescue#multiple_rescue_9" -> "bb::TestRescue#multiple_rescue_1" [style="bold"];
     "bb::TestRescue#multiple_rescue_9" -> "bb::TestRescue#multiple_rescue_11" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_10" [
-        label = "block[id=10, rubyBlockId=2](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$11: NilClass\l"
+        label = "block[id=10, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<gotoDeadTemp>$11: TrueClass(true)\l"
     ];
 
     "bb::TestRescue#multiple_rescue_10" -> "bb::TestRescue#multiple_rescue_1" [style="bold"];
-    "bb::TestRescue#multiple_rescue_10" -> "bb::TestRescue#multiple_rescue_12" [style="tapered"];
+    "bb::TestRescue#multiple_rescue_10" -> "bb::TestRescue#multiple_rescue_11" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_11" [
-        label = "block[id=11, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<gotoDeadTemp>$11: TrueClass(true)\l"
+        label = "block[id=11, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::TestRescue#multiple_rescue_11" -> "bb::TestRescue#multiple_rescue_1" [style="bold"];
-    "bb::TestRescue#multiple_rescue_11" -> "bb::TestRescue#multiple_rescue_12" [style="tapered"];
-
-    "bb::TestRescue#multiple_rescue_12" [
-        label = "block[id=12, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
-    ];
-
-    "bb::TestRescue#multiple_rescue_12" -> "bb::TestRescue#multiple_rescue_1" [style="bold"];
 }
 
 subgraph "cluster_::TestRescue#multiple_rescue_classes" {
@@ -221,8 +221,8 @@ subgraph "cluster_::TestRescue#multiple_rescue_classes" {
         label = "block[id=3, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped)\lbaz: T.untyped = <exceptionValue>$3\l<exceptionClassTemp>$5: T.untyped = alias <C T.untyped>\l<isaCheckTemp>$6: T.untyped = baz: T.untyped.is_a?(<exceptionClassTemp>$5: T.untyped)\l<isaCheckTemp>$6: T.untyped\l"
     ];
 
-    "bb::TestRescue#multiple_rescue_classes_3" -> "bb::TestRescue#multiple_rescue_classes_8" [style="bold"];
-    "bb::TestRescue#multiple_rescue_classes_3" -> "bb::TestRescue#multiple_rescue_classes_9" [style="tapered"];
+    "bb::TestRescue#multiple_rescue_classes_3" -> "bb::TestRescue#multiple_rescue_classes_7" [style="bold"];
+    "bb::TestRescue#multiple_rescue_classes_3" -> "bb::TestRescue#multiple_rescue_classes_8" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_classes_4" [
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()\l<exceptionValue>$3: T.untyped = <unanalyzable>\l<exceptionValue>$3: T.untyped\l"
@@ -236,34 +236,34 @@ subgraph "cluster_::TestRescue#multiple_rescue_classes" {
     ];
 
     "bb::TestRescue#multiple_rescue_classes_6" -> "bb::TestRescue#multiple_rescue_classes_1" [style="bold"];
-    "bb::TestRescue#multiple_rescue_classes_6" -> "bb::TestRescue#multiple_rescue_classes_11" [style="tapered"];
+    "bb::TestRescue#multiple_rescue_classes_6" -> "bb::TestRescue#multiple_rescue_classes_10" [style="tapered"];
+
+    "bb::TestRescue#multiple_rescue_classes_7" [
+        label = "block[id=7, rubyBlockId=2](baz: T.untyped)\l<returnMethodTemp>$2: T.untyped = baz\l<gotoDeadTemp>$9: NilClass\l"
+    ];
+
+    "bb::TestRescue#multiple_rescue_classes_7" -> "bb::TestRescue#multiple_rescue_classes_1" [style="bold"];
+    "bb::TestRescue#multiple_rescue_classes_7" -> "bb::TestRescue#multiple_rescue_classes_10" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_classes_8" [
-        label = "block[id=8, rubyBlockId=2](baz: T.untyped)\l<returnMethodTemp>$2: T.untyped = baz\l<gotoDeadTemp>$9: NilClass\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, baz: T.untyped)\l<exceptionClassTemp>$7: T.untyped = alias <C T.untyped>\l<isaCheckTemp>$8: T.untyped = baz: T.untyped.is_a?(<exceptionClassTemp>$7: T.untyped)\l<isaCheckTemp>$8: T.untyped\l"
     ];
 
-    "bb::TestRescue#multiple_rescue_classes_8" -> "bb::TestRescue#multiple_rescue_classes_1" [style="bold"];
-    "bb::TestRescue#multiple_rescue_classes_8" -> "bb::TestRescue#multiple_rescue_classes_11" [style="tapered"];
+    "bb::TestRescue#multiple_rescue_classes_8" -> "bb::TestRescue#multiple_rescue_classes_7" [style="bold"];
+    "bb::TestRescue#multiple_rescue_classes_8" -> "bb::TestRescue#multiple_rescue_classes_9" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_classes_9" [
-        label = "block[id=9, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, baz: T.untyped)\l<exceptionClassTemp>$7: T.untyped = alias <C T.untyped>\l<isaCheckTemp>$8: T.untyped = baz: T.untyped.is_a?(<exceptionClassTemp>$7: T.untyped)\l<isaCheckTemp>$8: T.untyped\l"
+        label = "block[id=9, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$9: TrueClass(true) = true\l<gotoDeadTemp>$9: TrueClass(true)\l"
     ];
 
-    "bb::TestRescue#multiple_rescue_classes_9" -> "bb::TestRescue#multiple_rescue_classes_8" [style="bold"];
+    "bb::TestRescue#multiple_rescue_classes_9" -> "bb::TestRescue#multiple_rescue_classes_1" [style="bold"];
     "bb::TestRescue#multiple_rescue_classes_9" -> "bb::TestRescue#multiple_rescue_classes_10" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_classes_10" [
-        label = "block[id=10, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$9: TrueClass(true) = true\l<gotoDeadTemp>$9: TrueClass(true)\l"
+        label = "block[id=10, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::TestRescue#multiple_rescue_classes_10" -> "bb::TestRescue#multiple_rescue_classes_1" [style="bold"];
-    "bb::TestRescue#multiple_rescue_classes_10" -> "bb::TestRescue#multiple_rescue_classes_11" [style="tapered"];
-
-    "bb::TestRescue#multiple_rescue_classes_11" [
-        label = "block[id=11, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
-    ];
-
-    "bb::TestRescue#multiple_rescue_classes_11" -> "bb::TestRescue#multiple_rescue_classes_1" [style="bold"];
 }
 
 subgraph "cluster_::TestRescue#parse_rescue_ensure" {
@@ -288,8 +288,8 @@ subgraph "cluster_::TestRescue#parse_rescue_ensure" {
         label = "block[id=3, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <self>: TestRescue, <exceptionValue>$3: T.untyped)\l<exceptionClassTemp>$5: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$6: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<exceptionClassTemp>$5: T.class_of(StandardError))\l<isaCheckTemp>$6: T.untyped\l"
     ];
 
-    "bb::TestRescue#parse_rescue_ensure_3" -> "bb::TestRescue#parse_rescue_ensure_8" [style="bold"];
-    "bb::TestRescue#parse_rescue_ensure_3" -> "bb::TestRescue#parse_rescue_ensure_9" [style="tapered"];
+    "bb::TestRescue#parse_rescue_ensure_3" -> "bb::TestRescue#parse_rescue_ensure_7" [style="bold"];
+    "bb::TestRescue#parse_rescue_ensure_3" -> "bb::TestRescue#parse_rescue_ensure_8" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_ensure_4" [
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()\l<exceptionValue>$3: T.untyped = <unanalyzable>\l<exceptionValue>$3: T.untyped\l"
@@ -303,23 +303,23 @@ subgraph "cluster_::TestRescue#parse_rescue_ensure" {
     ];
 
     "bb::TestRescue#parse_rescue_ensure_6" -> "bb::TestRescue#parse_rescue_ensure_1" [style="bold"];
-    "bb::TestRescue#parse_rescue_ensure_6" -> "bb::TestRescue#parse_rescue_ensure_10" [style="tapered"];
+    "bb::TestRescue#parse_rescue_ensure_6" -> "bb::TestRescue#parse_rescue_ensure_9" [style="tapered"];
 
+    "bb::TestRescue#parse_rescue_ensure_7" [
+        label = "block[id=7, rubyBlockId=2](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()\l<unconditional>\l"
+    ];
+
+    "bb::TestRescue#parse_rescue_ensure_7" -> "bb::TestRescue#parse_rescue_ensure_6" [style="bold"];
     "bb::TestRescue#parse_rescue_ensure_8" [
-        label = "block[id=8, rubyBlockId=2](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <self>: TestRescue)\l<gotoDeadTemp>$8: TrueClass(true) = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_ensure_8" -> "bb::TestRescue#parse_rescue_ensure_6" [style="bold"];
     "bb::TestRescue#parse_rescue_ensure_9" [
-        label = "block[id=9, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <self>: TestRescue)\l<gotoDeadTemp>$8: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_rescue_ensure_9" -> "bb::TestRescue#parse_rescue_ensure_6" [style="bold"];
-    "bb::TestRescue#parse_rescue_ensure_10" [
-        label = "block[id=10, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
-    ];
-
-    "bb::TestRescue#parse_rescue_ensure_10" -> "bb::TestRescue#parse_rescue_ensure_1" [style="bold"];
+    "bb::TestRescue#parse_rescue_ensure_9" -> "bb::TestRescue#parse_rescue_ensure_1" [style="bold"];
 }
 
 subgraph "cluster_::TestRescue#parse_bug_rescue_empty_else" {
@@ -333,7 +333,7 @@ subgraph "cluster_::TestRescue#parse_bug_rescue_empty_else" {
     ];
 
     "bb::TestRescue#parse_bug_rescue_empty_else_0" -> "bb::TestRescue#parse_bug_rescue_empty_else_3" [style="bold"];
-    "bb::TestRescue#parse_bug_rescue_empty_else_0" -> "bb::TestRescue#parse_bug_rescue_empty_else_7" [style="tapered"];
+    "bb::TestRescue#parse_bug_rescue_empty_else_0" -> "bb::TestRescue#parse_bug_rescue_empty_else_4" [style="tapered"];
 
     "bb::TestRescue#parse_bug_rescue_empty_else_1" [
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
@@ -345,34 +345,34 @@ subgraph "cluster_::TestRescue#parse_bug_rescue_empty_else" {
     ];
 
     "bb::TestRescue#parse_bug_rescue_empty_else_3" -> "bb::TestRescue#parse_bug_rescue_empty_else_6" [style="bold"];
-    "bb::TestRescue#parse_bug_rescue_empty_else_3" -> "bb::TestRescue#parse_bug_rescue_empty_else_9" [style="tapered"];
+    "bb::TestRescue#parse_bug_rescue_empty_else_3" -> "bb::TestRescue#parse_bug_rescue_empty_else_8" [style="tapered"];
+
+    "bb::TestRescue#parse_bug_rescue_empty_else_4" [
+        label = "block[id=4, rubyBlockId=1]()\l<exceptionValue>$3: T.untyped = <unanalyzable>\l<exceptionValue>$3: T.untyped\l"
+    ];
+
+    "bb::TestRescue#parse_bug_rescue_empty_else_4" -> "bb::TestRescue#parse_bug_rescue_empty_else_3" [style="bold"];
+    "bb::TestRescue#parse_bug_rescue_empty_else_4" -> "bb::TestRescue#parse_bug_rescue_empty_else_6" [style="tapered"];
 
     "bb::TestRescue#parse_bug_rescue_empty_else_6" [
         label = "block[id=6, rubyBlockId=3](<gotoDeadTemp>$6: NilClass)\l<gotoDeadTemp>$6: NilClass\l"
     ];
 
     "bb::TestRescue#parse_bug_rescue_empty_else_6" -> "bb::TestRescue#parse_bug_rescue_empty_else_1" [style="bold"];
-    "bb::TestRescue#parse_bug_rescue_empty_else_6" -> "bb::TestRescue#parse_bug_rescue_empty_else_10" [style="tapered"];
+    "bb::TestRescue#parse_bug_rescue_empty_else_6" -> "bb::TestRescue#parse_bug_rescue_empty_else_9" [style="tapered"];
 
-    "bb::TestRescue#parse_bug_rescue_empty_else_7" [
-        label = "block[id=7, rubyBlockId=3]()\l<exceptionValue>$3: T.untyped = <unanalyzable>\l<exceptionValue>$3: T.untyped\l"
+    "bb::TestRescue#parse_bug_rescue_empty_else_8" [
+        label = "block[id=8, rubyBlockId=2]()\l<gotoDeadTemp>$6: TrueClass(true) = true\l<gotoDeadTemp>$6: TrueClass(true)\l"
     ];
 
-    "bb::TestRescue#parse_bug_rescue_empty_else_7" -> "bb::TestRescue#parse_bug_rescue_empty_else_3" [style="bold"];
-    "bb::TestRescue#parse_bug_rescue_empty_else_7" -> "bb::TestRescue#parse_bug_rescue_empty_else_6" [style="tapered"];
+    "bb::TestRescue#parse_bug_rescue_empty_else_8" -> "bb::TestRescue#parse_bug_rescue_empty_else_1" [style="bold"];
+    "bb::TestRescue#parse_bug_rescue_empty_else_8" -> "bb::TestRescue#parse_bug_rescue_empty_else_9" [style="tapered"];
 
     "bb::TestRescue#parse_bug_rescue_empty_else_9" [
-        label = "block[id=9, rubyBlockId=2]()\l<gotoDeadTemp>$6: TrueClass(true) = true\l<gotoDeadTemp>$6: TrueClass(true)\l"
+        label = "block[id=9, rubyBlockId=0]()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_bug_rescue_empty_else_9" -> "bb::TestRescue#parse_bug_rescue_empty_else_1" [style="bold"];
-    "bb::TestRescue#parse_bug_rescue_empty_else_9" -> "bb::TestRescue#parse_bug_rescue_empty_else_10" [style="tapered"];
-
-    "bb::TestRescue#parse_bug_rescue_empty_else_10" [
-        label = "block[id=10, rubyBlockId=0]()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
-    ];
-
-    "bb::TestRescue#parse_bug_rescue_empty_else_10" -> "bb::TestRescue#parse_bug_rescue_empty_else_1" [style="bold"];
 }
 
 subgraph "cluster_::TestRescue#parse_ruby_bug_12686" {
@@ -397,8 +397,8 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12686" {
         label = "block[id=3, rubyBlockId=2](<statTemp>$4: T.untyped, <self>: TestRescue, <exceptionValue>$5: T.untyped)\l<exceptionClassTemp>$7: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$8: T.untyped = <exceptionValue>$5: T.untyped.is_a?(<exceptionClassTemp>$7: T.class_of(StandardError))\l<isaCheckTemp>$8: T.untyped\l"
     ];
 
-    "bb::TestRescue#parse_ruby_bug_12686_3" -> "bb::TestRescue#parse_ruby_bug_12686_8" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12686_3" -> "bb::TestRescue#parse_ruby_bug_12686_9" [style="tapered"];
+    "bb::TestRescue#parse_ruby_bug_12686_3" -> "bb::TestRescue#parse_ruby_bug_12686_7" [style="bold"];
+    "bb::TestRescue#parse_ruby_bug_12686_3" -> "bb::TestRescue#parse_ruby_bug_12686_8" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12686_4" [
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue)\l<statTemp>$4: T.untyped = <self>: TestRescue.bar()\l<exceptionValue>$5: T.untyped = <unanalyzable>\l<exceptionValue>$5: T.untyped\l"
@@ -412,27 +412,27 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12686" {
     ];
 
     "bb::TestRescue#parse_ruby_bug_12686_6" -> "bb::TestRescue#parse_ruby_bug_12686_1" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12686_6" -> "bb::TestRescue#parse_ruby_bug_12686_10" [style="tapered"];
+    "bb::TestRescue#parse_ruby_bug_12686_6" -> "bb::TestRescue#parse_ruby_bug_12686_9" [style="tapered"];
+
+    "bb::TestRescue#parse_ruby_bug_12686_7" [
+        label = "block[id=7, rubyBlockId=2](<self>: TestRescue)\l<statTemp>$4: NilClass = nil\l<gotoDeadTemp>$9: NilClass\l"
+    ];
+
+    "bb::TestRescue#parse_ruby_bug_12686_7" -> "bb::TestRescue#parse_ruby_bug_12686_1" [style="bold"];
+    "bb::TestRescue#parse_ruby_bug_12686_7" -> "bb::TestRescue#parse_ruby_bug_12686_9" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12686_8" [
-        label = "block[id=8, rubyBlockId=2](<self>: TestRescue)\l<statTemp>$4: NilClass = nil\l<gotoDeadTemp>$9: NilClass\l"
+        label = "block[id=8, rubyBlockId=2](<statTemp>$4: T.untyped, <self>: TestRescue)\l<gotoDeadTemp>$9: TrueClass(true) = true\l<gotoDeadTemp>$9: TrueClass(true)\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12686_8" -> "bb::TestRescue#parse_ruby_bug_12686_1" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12686_8" -> "bb::TestRescue#parse_ruby_bug_12686_10" [style="tapered"];
+    "bb::TestRescue#parse_ruby_bug_12686_8" -> "bb::TestRescue#parse_ruby_bug_12686_9" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12686_9" [
-        label = "block[id=9, rubyBlockId=2](<statTemp>$4: T.untyped, <self>: TestRescue)\l<gotoDeadTemp>$9: TrueClass(true) = true\l<gotoDeadTemp>$9: TrueClass(true)\l"
+        label = "block[id=9, rubyBlockId=0](<statTemp>$4: T.untyped, <self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.take_arg(<statTemp>$4: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12686_9" -> "bb::TestRescue#parse_ruby_bug_12686_1" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12686_9" -> "bb::TestRescue#parse_ruby_bug_12686_10" [style="tapered"];
-
-    "bb::TestRescue#parse_ruby_bug_12686_10" [
-        label = "block[id=10, rubyBlockId=0](<statTemp>$4: T.untyped, <self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.take_arg(<statTemp>$4: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
-    ];
-
-    "bb::TestRescue#parse_ruby_bug_12686_10" -> "bb::TestRescue#parse_ruby_bug_12686_1" [style="bold"];
 }
 
 subgraph "cluster_::TestRescue#parse_rescue_mod" {
@@ -457,8 +457,8 @@ subgraph "cluster_::TestRescue#parse_rescue_mod" {
         label = "block[id=3, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <self>: TestRescue, <exceptionValue>$3: T.untyped)\l<exceptionClassTemp>$5: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$6: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<exceptionClassTemp>$5: T.class_of(StandardError))\l<isaCheckTemp>$6: T.untyped\l"
     ];
 
-    "bb::TestRescue#parse_rescue_mod_3" -> "bb::TestRescue#parse_rescue_mod_8" [style="bold"];
-    "bb::TestRescue#parse_rescue_mod_3" -> "bb::TestRescue#parse_rescue_mod_9" [style="tapered"];
+    "bb::TestRescue#parse_rescue_mod_3" -> "bb::TestRescue#parse_rescue_mod_7" [style="bold"];
+    "bb::TestRescue#parse_rescue_mod_3" -> "bb::TestRescue#parse_rescue_mod_8" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_mod_4" [
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()\l<exceptionValue>$3: T.untyped = <unanalyzable>\l<exceptionValue>$3: T.untyped\l"
@@ -472,27 +472,27 @@ subgraph "cluster_::TestRescue#parse_rescue_mod" {
     ];
 
     "bb::TestRescue#parse_rescue_mod_6" -> "bb::TestRescue#parse_rescue_mod_1" [style="bold"];
-    "bb::TestRescue#parse_rescue_mod_6" -> "bb::TestRescue#parse_rescue_mod_10" [style="tapered"];
+    "bb::TestRescue#parse_rescue_mod_6" -> "bb::TestRescue#parse_rescue_mod_9" [style="tapered"];
+
+    "bb::TestRescue#parse_rescue_mod_7" [
+        label = "block[id=7, rubyBlockId=2](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$8: NilClass\l"
+    ];
+
+    "bb::TestRescue#parse_rescue_mod_7" -> "bb::TestRescue#parse_rescue_mod_1" [style="bold"];
+    "bb::TestRescue#parse_rescue_mod_7" -> "bb::TestRescue#parse_rescue_mod_9" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_mod_8" [
-        label = "block[id=8, rubyBlockId=2](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$8: NilClass\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$8: TrueClass(true) = true\l<gotoDeadTemp>$8: TrueClass(true)\l"
     ];
 
     "bb::TestRescue#parse_rescue_mod_8" -> "bb::TestRescue#parse_rescue_mod_1" [style="bold"];
-    "bb::TestRescue#parse_rescue_mod_8" -> "bb::TestRescue#parse_rescue_mod_10" [style="tapered"];
+    "bb::TestRescue#parse_rescue_mod_8" -> "bb::TestRescue#parse_rescue_mod_9" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_mod_9" [
-        label = "block[id=9, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$8: TrueClass(true) = true\l<gotoDeadTemp>$8: TrueClass(true)\l"
+        label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_mod_9" -> "bb::TestRescue#parse_rescue_mod_1" [style="bold"];
-    "bb::TestRescue#parse_rescue_mod_9" -> "bb::TestRescue#parse_rescue_mod_10" [style="tapered"];
-
-    "bb::TestRescue#parse_rescue_mod_10" [
-        label = "block[id=10, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
-    ];
-
-    "bb::TestRescue#parse_rescue_mod_10" -> "bb::TestRescue#parse_rescue_mod_1" [style="bold"];
 }
 
 subgraph "cluster_::TestRescue#parse_resbody_list_var" {
@@ -517,8 +517,8 @@ subgraph "cluster_::TestRescue#parse_resbody_list_var" {
         label = "block[id=3, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <self>: TestRescue, <exceptionValue>$3: T.untyped)\lex: T.untyped = <exceptionValue>$3\l<exceptionClassTemp>$5: T.untyped = <self>: TestRescue.foo()\l<isaCheckTemp>$7: T.untyped = ex: T.untyped.is_a?(<exceptionClassTemp>$5: T.untyped)\l<isaCheckTemp>$7: T.untyped\l"
     ];
 
-    "bb::TestRescue#parse_resbody_list_var_3" -> "bb::TestRescue#parse_resbody_list_var_8" [style="bold"];
-    "bb::TestRescue#parse_resbody_list_var_3" -> "bb::TestRescue#parse_resbody_list_var_9" [style="tapered"];
+    "bb::TestRescue#parse_resbody_list_var_3" -> "bb::TestRescue#parse_resbody_list_var_7" [style="bold"];
+    "bb::TestRescue#parse_resbody_list_var_3" -> "bb::TestRescue#parse_resbody_list_var_8" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_list_var_4" [
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()\l<exceptionValue>$3: T.untyped = <unanalyzable>\l<exceptionValue>$3: T.untyped\l"
@@ -532,27 +532,27 @@ subgraph "cluster_::TestRescue#parse_resbody_list_var" {
     ];
 
     "bb::TestRescue#parse_resbody_list_var_6" -> "bb::TestRescue#parse_resbody_list_var_1" [style="bold"];
-    "bb::TestRescue#parse_resbody_list_var_6" -> "bb::TestRescue#parse_resbody_list_var_10" [style="tapered"];
+    "bb::TestRescue#parse_resbody_list_var_6" -> "bb::TestRescue#parse_resbody_list_var_9" [style="tapered"];
+
+    "bb::TestRescue#parse_resbody_list_var_7" [
+        label = "block[id=7, rubyBlockId=2](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$9: NilClass\l"
+    ];
+
+    "bb::TestRescue#parse_resbody_list_var_7" -> "bb::TestRescue#parse_resbody_list_var_1" [style="bold"];
+    "bb::TestRescue#parse_resbody_list_var_7" -> "bb::TestRescue#parse_resbody_list_var_9" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_list_var_8" [
-        label = "block[id=8, rubyBlockId=2](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$9: NilClass\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$9: TrueClass(true) = true\l<gotoDeadTemp>$9: TrueClass(true)\l"
     ];
 
     "bb::TestRescue#parse_resbody_list_var_8" -> "bb::TestRescue#parse_resbody_list_var_1" [style="bold"];
-    "bb::TestRescue#parse_resbody_list_var_8" -> "bb::TestRescue#parse_resbody_list_var_10" [style="tapered"];
+    "bb::TestRescue#parse_resbody_list_var_8" -> "bb::TestRescue#parse_resbody_list_var_9" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_list_var_9" [
-        label = "block[id=9, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$9: TrueClass(true) = true\l<gotoDeadTemp>$9: TrueClass(true)\l"
+        label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_resbody_list_var_9" -> "bb::TestRescue#parse_resbody_list_var_1" [style="bold"];
-    "bb::TestRescue#parse_resbody_list_var_9" -> "bb::TestRescue#parse_resbody_list_var_10" [style="tapered"];
-
-    "bb::TestRescue#parse_resbody_list_var_10" [
-        label = "block[id=10, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
-    ];
-
-    "bb::TestRescue#parse_resbody_list_var_10" -> "bb::TestRescue#parse_resbody_list_var_1" [style="bold"];
 }
 
 subgraph "cluster_::TestRescue#parse_rescue_else_ensure" {
@@ -577,38 +577,43 @@ subgraph "cluster_::TestRescue#parse_rescue_else_ensure" {
         label = "block[id=3, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <self>: TestRescue, <exceptionValue>$3: T.untyped)\l<exceptionClassTemp>$6: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$7: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<exceptionClassTemp>$6: T.class_of(StandardError))\l<isaCheckTemp>$7: T.untyped\l"
     ];
 
-    "bb::TestRescue#parse_rescue_else_ensure_3" -> "bb::TestRescue#parse_rescue_else_ensure_8" [style="bold"];
-    "bb::TestRescue#parse_rescue_else_ensure_3" -> "bb::TestRescue#parse_rescue_else_ensure_9" [style="tapered"];
+    "bb::TestRescue#parse_rescue_else_ensure_3" -> "bb::TestRescue#parse_rescue_else_ensure_7" [style="bold"];
+    "bb::TestRescue#parse_rescue_else_ensure_3" -> "bb::TestRescue#parse_rescue_else_ensure_8" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_else_ensure_4" [
-        label = "block[id=4, rubyBlockId=1](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.foo()\l<exceptionValue>$3: T.untyped = <unanalyzable>\l<exceptionValue>$3: T.untyped\l"
+        label = "block[id=4, rubyBlockId=1](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()\l<exceptionValue>$3: T.untyped = <unanalyzable>\l<exceptionValue>$3: T.untyped\l"
     ];
 
     "bb::TestRescue#parse_rescue_else_ensure_4" -> "bb::TestRescue#parse_rescue_else_ensure_3" [style="bold"];
-    "bb::TestRescue#parse_rescue_else_ensure_4" -> "bb::TestRescue#parse_rescue_else_ensure_6" [style="tapered"];
+    "bb::TestRescue#parse_rescue_else_ensure_4" -> "bb::TestRescue#parse_rescue_else_ensure_5" [style="tapered"];
 
+    "bb::TestRescue#parse_rescue_else_ensure_5" [
+        label = "block[id=5, rubyBlockId=4](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.foo()\l<unconditional>\l"
+    ];
+
+    "bb::TestRescue#parse_rescue_else_ensure_5" -> "bb::TestRescue#parse_rescue_else_ensure_6" [style="bold"];
     "bb::TestRescue#parse_rescue_else_ensure_6" [
         label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <self>: TestRescue, <gotoDeadTemp>$9: T.nilable(TrueClass))\l<throwAwayTemp>$10: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$9: T.nilable(TrueClass)\l"
     ];
 
     "bb::TestRescue#parse_rescue_else_ensure_6" -> "bb::TestRescue#parse_rescue_else_ensure_1" [style="bold"];
-    "bb::TestRescue#parse_rescue_else_ensure_6" -> "bb::TestRescue#parse_rescue_else_ensure_10" [style="tapered"];
+    "bb::TestRescue#parse_rescue_else_ensure_6" -> "bb::TestRescue#parse_rescue_else_ensure_9" [style="tapered"];
 
+    "bb::TestRescue#parse_rescue_else_ensure_7" [
+        label = "block[id=7, rubyBlockId=2](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()\l<unconditional>\l"
+    ];
+
+    "bb::TestRescue#parse_rescue_else_ensure_7" -> "bb::TestRescue#parse_rescue_else_ensure_6" [style="bold"];
     "bb::TestRescue#parse_rescue_else_ensure_8" [
-        label = "block[id=8, rubyBlockId=2](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <self>: TestRescue)\l<gotoDeadTemp>$9: TrueClass(true) = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_else_ensure_8" -> "bb::TestRescue#parse_rescue_else_ensure_6" [style="bold"];
     "bb::TestRescue#parse_rescue_else_ensure_9" [
-        label = "block[id=9, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <self>: TestRescue)\l<gotoDeadTemp>$9: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_rescue_else_ensure_9" -> "bb::TestRescue#parse_rescue_else_ensure_6" [style="bold"];
-    "bb::TestRescue#parse_rescue_else_ensure_10" [
-        label = "block[id=10, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
-    ];
-
-    "bb::TestRescue#parse_rescue_else_ensure_10" -> "bb::TestRescue#parse_rescue_else_ensure_1" [style="bold"];
+    "bb::TestRescue#parse_rescue_else_ensure_9" -> "bb::TestRescue#parse_rescue_else_ensure_1" [style="bold"];
 }
 
 subgraph "cluster_::TestRescue#parse_rescue" {
@@ -633,8 +638,8 @@ subgraph "cluster_::TestRescue#parse_rescue" {
         label = "block[id=3, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <self>: TestRescue, <exceptionValue>$3: T.untyped)\l<exceptionClassTemp>$5: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$6: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<exceptionClassTemp>$5: T.class_of(StandardError))\l<isaCheckTemp>$6: T.untyped\l"
     ];
 
-    "bb::TestRescue#parse_rescue_3" -> "bb::TestRescue#parse_rescue_8" [style="bold"];
-    "bb::TestRescue#parse_rescue_3" -> "bb::TestRescue#parse_rescue_9" [style="tapered"];
+    "bb::TestRescue#parse_rescue_3" -> "bb::TestRescue#parse_rescue_7" [style="bold"];
+    "bb::TestRescue#parse_rescue_3" -> "bb::TestRescue#parse_rescue_8" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_4" [
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()\l<exceptionValue>$3: T.untyped = <unanalyzable>\l<exceptionValue>$3: T.untyped\l"
@@ -648,27 +653,27 @@ subgraph "cluster_::TestRescue#parse_rescue" {
     ];
 
     "bb::TestRescue#parse_rescue_6" -> "bb::TestRescue#parse_rescue_1" [style="bold"];
-    "bb::TestRescue#parse_rescue_6" -> "bb::TestRescue#parse_rescue_10" [style="tapered"];
+    "bb::TestRescue#parse_rescue_6" -> "bb::TestRescue#parse_rescue_9" [style="tapered"];
+
+    "bb::TestRescue#parse_rescue_7" [
+        label = "block[id=7, rubyBlockId=2](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.foo()\l<gotoDeadTemp>$8: NilClass\l"
+    ];
+
+    "bb::TestRescue#parse_rescue_7" -> "bb::TestRescue#parse_rescue_1" [style="bold"];
+    "bb::TestRescue#parse_rescue_7" -> "bb::TestRescue#parse_rescue_9" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_8" [
-        label = "block[id=8, rubyBlockId=2](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.foo()\l<gotoDeadTemp>$8: NilClass\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$8: TrueClass(true) = true\l<gotoDeadTemp>$8: TrueClass(true)\l"
     ];
 
     "bb::TestRescue#parse_rescue_8" -> "bb::TestRescue#parse_rescue_1" [style="bold"];
-    "bb::TestRescue#parse_rescue_8" -> "bb::TestRescue#parse_rescue_10" [style="tapered"];
+    "bb::TestRescue#parse_rescue_8" -> "bb::TestRescue#parse_rescue_9" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_9" [
-        label = "block[id=9, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$8: TrueClass(true) = true\l<gotoDeadTemp>$8: TrueClass(true)\l"
+        label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_9" -> "bb::TestRescue#parse_rescue_1" [style="bold"];
-    "bb::TestRescue#parse_rescue_9" -> "bb::TestRescue#parse_rescue_10" [style="tapered"];
-
-    "bb::TestRescue#parse_rescue_10" [
-        label = "block[id=10, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
-    ];
-
-    "bb::TestRescue#parse_rescue_10" -> "bb::TestRescue#parse_rescue_1" [style="bold"];
 }
 
 subgraph "cluster_::TestRescue#parse_resbody_var" {
@@ -693,8 +698,8 @@ subgraph "cluster_::TestRescue#parse_resbody_var" {
         label = "block[id=3, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <self>: TestRescue, <exceptionValue>$3: T.untyped)\lex: T.untyped = <exceptionValue>$3\l<exceptionClassTemp>$5: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$6: T.untyped = ex: T.untyped.is_a?(<exceptionClassTemp>$5: T.class_of(StandardError))\l<isaCheckTemp>$6: T.untyped\l"
     ];
 
-    "bb::TestRescue#parse_resbody_var_3" -> "bb::TestRescue#parse_resbody_var_8" [style="bold"];
-    "bb::TestRescue#parse_resbody_var_3" -> "bb::TestRescue#parse_resbody_var_9" [style="tapered"];
+    "bb::TestRescue#parse_resbody_var_3" -> "bb::TestRescue#parse_resbody_var_7" [style="bold"];
+    "bb::TestRescue#parse_resbody_var_3" -> "bb::TestRescue#parse_resbody_var_8" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_var_4" [
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()\l<exceptionValue>$3: T.untyped = <unanalyzable>\l<exceptionValue>$3: T.untyped\l"
@@ -708,27 +713,27 @@ subgraph "cluster_::TestRescue#parse_resbody_var" {
     ];
 
     "bb::TestRescue#parse_resbody_var_6" -> "bb::TestRescue#parse_resbody_var_1" [style="bold"];
-    "bb::TestRescue#parse_resbody_var_6" -> "bb::TestRescue#parse_resbody_var_10" [style="tapered"];
+    "bb::TestRescue#parse_resbody_var_6" -> "bb::TestRescue#parse_resbody_var_9" [style="tapered"];
+
+    "bb::TestRescue#parse_resbody_var_7" [
+        label = "block[id=7, rubyBlockId=2](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$8: NilClass\l"
+    ];
+
+    "bb::TestRescue#parse_resbody_var_7" -> "bb::TestRescue#parse_resbody_var_1" [style="bold"];
+    "bb::TestRescue#parse_resbody_var_7" -> "bb::TestRescue#parse_resbody_var_9" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_var_8" [
-        label = "block[id=8, rubyBlockId=2](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$8: NilClass\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$8: TrueClass(true) = true\l<gotoDeadTemp>$8: TrueClass(true)\l"
     ];
 
     "bb::TestRescue#parse_resbody_var_8" -> "bb::TestRescue#parse_resbody_var_1" [style="bold"];
-    "bb::TestRescue#parse_resbody_var_8" -> "bb::TestRescue#parse_resbody_var_10" [style="tapered"];
+    "bb::TestRescue#parse_resbody_var_8" -> "bb::TestRescue#parse_resbody_var_9" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_var_9" [
-        label = "block[id=9, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$8: TrueClass(true) = true\l<gotoDeadTemp>$8: TrueClass(true)\l"
+        label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_resbody_var_9" -> "bb::TestRescue#parse_resbody_var_1" [style="bold"];
-    "bb::TestRescue#parse_resbody_var_9" -> "bb::TestRescue#parse_resbody_var_10" [style="tapered"];
-
-    "bb::TestRescue#parse_resbody_var_10" [
-        label = "block[id=10, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
-    ];
-
-    "bb::TestRescue#parse_resbody_var_10" -> "bb::TestRescue#parse_resbody_var_1" [style="bold"];
 }
 
 subgraph "cluster_::TestRescue#parse_resbody_var_1" {
@@ -753,8 +758,8 @@ subgraph "cluster_::TestRescue#parse_resbody_var_1" {
         label = "block[id=3, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <self>: TestRescue, <exceptionValue>$3: T.untyped, @ex$8: T.nilable(StandardError))\l<exceptionClassTemp>$5: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$6: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<exceptionClassTemp>$5: T.class_of(StandardError))\l<isaCheckTemp>$6: T.untyped\l"
     ];
 
-    "bb::TestRescue#parse_resbody_var_1_3" -> "bb::TestRescue#parse_resbody_var_1_8" [style="bold"];
-    "bb::TestRescue#parse_resbody_var_1_3" -> "bb::TestRescue#parse_resbody_var_1_9" [style="tapered"];
+    "bb::TestRescue#parse_resbody_var_1_3" -> "bb::TestRescue#parse_resbody_var_1_7" [style="bold"];
+    "bb::TestRescue#parse_resbody_var_1_3" -> "bb::TestRescue#parse_resbody_var_1_8" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_var_1_4" [
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue, @ex$8: T.nilable(StandardError))\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()\l<exceptionValue>$3: T.untyped = <unanalyzable>\l<exceptionValue>$3: T.untyped\l"
@@ -768,27 +773,27 @@ subgraph "cluster_::TestRescue#parse_resbody_var_1" {
     ];
 
     "bb::TestRescue#parse_resbody_var_1_6" -> "bb::TestRescue#parse_resbody_var_1_1" [style="bold"];
-    "bb::TestRescue#parse_resbody_var_1_6" -> "bb::TestRescue#parse_resbody_var_1_10" [style="tapered"];
+    "bb::TestRescue#parse_resbody_var_1_6" -> "bb::TestRescue#parse_resbody_var_1_9" [style="tapered"];
+
+    "bb::TestRescue#parse_resbody_var_1_7" [
+        label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <exceptionValue>$3: StandardError, @ex$8: T.nilable(StandardError))\l@ex$8: StandardError = <exceptionValue>$3\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$10: NilClass\l"
+    ];
+
+    "bb::TestRescue#parse_resbody_var_1_7" -> "bb::TestRescue#parse_resbody_var_1_1" [style="bold"];
+    "bb::TestRescue#parse_resbody_var_1_7" -> "bb::TestRescue#parse_resbody_var_1_9" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_var_1_8" [
-        label = "block[id=8, rubyBlockId=2](<self>: TestRescue, <exceptionValue>$3: StandardError, @ex$8: T.nilable(StandardError))\l@ex$8: StandardError = <exceptionValue>$3\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$10: NilClass\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$10: TrueClass(true) = true\l<gotoDeadTemp>$10: TrueClass(true)\l"
     ];
 
     "bb::TestRescue#parse_resbody_var_1_8" -> "bb::TestRescue#parse_resbody_var_1_1" [style="bold"];
-    "bb::TestRescue#parse_resbody_var_1_8" -> "bb::TestRescue#parse_resbody_var_1_10" [style="tapered"];
+    "bb::TestRescue#parse_resbody_var_1_8" -> "bb::TestRescue#parse_resbody_var_1_9" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_var_1_9" [
-        label = "block[id=9, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$10: TrueClass(true) = true\l<gotoDeadTemp>$10: TrueClass(true)\l"
+        label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_resbody_var_1_9" -> "bb::TestRescue#parse_resbody_var_1_1" [style="bold"];
-    "bb::TestRescue#parse_resbody_var_1_9" -> "bb::TestRescue#parse_resbody_var_1_10" [style="tapered"];
-
-    "bb::TestRescue#parse_resbody_var_1_10" [
-        label = "block[id=10, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
-    ];
-
-    "bb::TestRescue#parse_resbody_var_1_10" -> "bb::TestRescue#parse_resbody_var_1_1" [style="bold"];
 }
 
 subgraph "cluster_::TestRescue#parse_rescue_mod_op_assign" {
@@ -813,8 +818,8 @@ subgraph "cluster_::TestRescue#parse_rescue_mod_op_assign" {
         label = "block[id=3, rubyBlockId=2](<statTemp>$3: NilClass, <statTemp>$4: T.untyped, <self>: TestRescue, <exceptionValue>$5: T.untyped)\l<exceptionClassTemp>$7: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$8: T.untyped = <exceptionValue>$5: T.untyped.is_a?(<exceptionClassTemp>$7: T.class_of(StandardError))\l<isaCheckTemp>$8: T.untyped\l"
     ];
 
-    "bb::TestRescue#parse_rescue_mod_op_assign_3" -> "bb::TestRescue#parse_rescue_mod_op_assign_8" [style="bold"];
-    "bb::TestRescue#parse_rescue_mod_op_assign_3" -> "bb::TestRescue#parse_rescue_mod_op_assign_9" [style="tapered"];
+    "bb::TestRescue#parse_rescue_mod_op_assign_3" -> "bb::TestRescue#parse_rescue_mod_op_assign_7" [style="bold"];
+    "bb::TestRescue#parse_rescue_mod_op_assign_3" -> "bb::TestRescue#parse_rescue_mod_op_assign_8" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_mod_op_assign_4" [
         label = "block[id=4, rubyBlockId=1](<statTemp>$3: NilClass, <self>: TestRescue)\l<statTemp>$4: T.untyped = <self>: TestRescue.meth()\l<exceptionValue>$5: T.untyped = <unanalyzable>\l<exceptionValue>$5: T.untyped\l"
@@ -828,27 +833,27 @@ subgraph "cluster_::TestRescue#parse_rescue_mod_op_assign" {
     ];
 
     "bb::TestRescue#parse_rescue_mod_op_assign_6" -> "bb::TestRescue#parse_rescue_mod_op_assign_1" [style="bold"];
-    "bb::TestRescue#parse_rescue_mod_op_assign_6" -> "bb::TestRescue#parse_rescue_mod_op_assign_10" [style="tapered"];
+    "bb::TestRescue#parse_rescue_mod_op_assign_6" -> "bb::TestRescue#parse_rescue_mod_op_assign_9" [style="tapered"];
+
+    "bb::TestRescue#parse_rescue_mod_op_assign_7" [
+        label = "block[id=7, rubyBlockId=2](<statTemp>$3: NilClass, <self>: TestRescue)\l<statTemp>$4: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$10: NilClass\l"
+    ];
+
+    "bb::TestRescue#parse_rescue_mod_op_assign_7" -> "bb::TestRescue#parse_rescue_mod_op_assign_1" [style="bold"];
+    "bb::TestRescue#parse_rescue_mod_op_assign_7" -> "bb::TestRescue#parse_rescue_mod_op_assign_9" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_mod_op_assign_8" [
-        label = "block[id=8, rubyBlockId=2](<statTemp>$3: NilClass, <self>: TestRescue)\l<statTemp>$4: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$10: NilClass\l"
+        label = "block[id=8, rubyBlockId=2](<statTemp>$3: NilClass, <statTemp>$4: T.untyped)\l<gotoDeadTemp>$10: TrueClass(true) = true\l<gotoDeadTemp>$10: TrueClass(true)\l"
     ];
 
     "bb::TestRescue#parse_rescue_mod_op_assign_8" -> "bb::TestRescue#parse_rescue_mod_op_assign_1" [style="bold"];
-    "bb::TestRescue#parse_rescue_mod_op_assign_8" -> "bb::TestRescue#parse_rescue_mod_op_assign_10" [style="tapered"];
+    "bb::TestRescue#parse_rescue_mod_op_assign_8" -> "bb::TestRescue#parse_rescue_mod_op_assign_9" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_mod_op_assign_9" [
-        label = "block[id=9, rubyBlockId=2](<statTemp>$3: NilClass, <statTemp>$4: T.untyped)\l<gotoDeadTemp>$10: TrueClass(true) = true\l<gotoDeadTemp>$10: TrueClass(true)\l"
+        label = "block[id=9, rubyBlockId=0](<statTemp>$3: NilClass, <statTemp>$4: T.untyped)\lfoo: T.untyped = <statTemp>$3: NilClass.+(<statTemp>$4: T.untyped)\l<returnMethodTemp>$2: T.untyped = foo\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_mod_op_assign_9" -> "bb::TestRescue#parse_rescue_mod_op_assign_1" [style="bold"];
-    "bb::TestRescue#parse_rescue_mod_op_assign_9" -> "bb::TestRescue#parse_rescue_mod_op_assign_10" [style="tapered"];
-
-    "bb::TestRescue#parse_rescue_mod_op_assign_10" [
-        label = "block[id=10, rubyBlockId=0](<statTemp>$3: NilClass, <statTemp>$4: T.untyped)\lfoo: T.untyped = <statTemp>$3: NilClass.+(<statTemp>$4: T.untyped)\l<returnMethodTemp>$2: T.untyped = foo\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
-    ];
-
-    "bb::TestRescue#parse_rescue_mod_op_assign_10" -> "bb::TestRescue#parse_rescue_mod_op_assign_1" [style="bold"];
 }
 
 subgraph "cluster_::TestRescue#parse_ruby_bug_12402" {
@@ -873,8 +878,8 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402" {
         label = "block[id=3, rubyBlockId=2](<exceptionValue>$3: T.untyped, foo: NilClass)\l<exceptionClassTemp>$7: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$8: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<exceptionClassTemp>$7: T.class_of(StandardError))\l<isaCheckTemp>$8: T.untyped\l"
     ];
 
-    "bb::TestRescue#parse_ruby_bug_12402_3" -> "bb::TestRescue#parse_ruby_bug_12402_8" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_3" -> "bb::TestRescue#parse_ruby_bug_12402_9" [style="tapered"];
+    "bb::TestRescue#parse_ruby_bug_12402_3" -> "bb::TestRescue#parse_ruby_bug_12402_7" [style="bold"];
+    "bb::TestRescue#parse_ruby_bug_12402_3" -> "bb::TestRescue#parse_ruby_bug_12402_8" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_4" [
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue)\l<statTemp>$5: T.untyped = <self>: TestRescue.bar()\lfoo: T.noreturn = <self>: TestRescue.raise(<statTemp>$5: T.untyped)\l<exceptionValue>$3 = <unanalyzable>\l<exceptionValue>$3\l"
@@ -888,27 +893,27 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402" {
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_6" -> "bb::TestRescue#parse_ruby_bug_12402_1" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_6" -> "bb::TestRescue#parse_ruby_bug_12402_10" [style="tapered"];
+    "bb::TestRescue#parse_ruby_bug_12402_6" -> "bb::TestRescue#parse_ruby_bug_12402_9" [style="tapered"];
+
+    "bb::TestRescue#parse_ruby_bug_12402_7" [
+        label = "block[id=7, rubyBlockId=2]()\lfoo: NilClass = nil\l<gotoDeadTemp>$9: NilClass\l"
+    ];
+
+    "bb::TestRescue#parse_ruby_bug_12402_7" -> "bb::TestRescue#parse_ruby_bug_12402_1" [style="bold"];
+    "bb::TestRescue#parse_ruby_bug_12402_7" -> "bb::TestRescue#parse_ruby_bug_12402_9" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_8" [
-        label = "block[id=8, rubyBlockId=2]()\lfoo: NilClass = nil\l<gotoDeadTemp>$9: NilClass\l"
+        label = "block[id=8, rubyBlockId=2](foo: NilClass)\l<gotoDeadTemp>$9: TrueClass(true) = true\l<gotoDeadTemp>$9: TrueClass(true)\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_8" -> "bb::TestRescue#parse_ruby_bug_12402_1" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_8" -> "bb::TestRescue#parse_ruby_bug_12402_10" [style="tapered"];
+    "bb::TestRescue#parse_ruby_bug_12402_8" -> "bb::TestRescue#parse_ruby_bug_12402_9" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_9" [
-        label = "block[id=9, rubyBlockId=2](foo: NilClass)\l<gotoDeadTemp>$9: TrueClass(true) = true\l<gotoDeadTemp>$9: TrueClass(true)\l"
+        label = "block[id=9, rubyBlockId=0](foo: NilClass)\l<returnMethodTemp>$2: NilClass = foo\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_9" -> "bb::TestRescue#parse_ruby_bug_12402_1" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_9" -> "bb::TestRescue#parse_ruby_bug_12402_10" [style="tapered"];
-
-    "bb::TestRescue#parse_ruby_bug_12402_10" [
-        label = "block[id=10, rubyBlockId=0](foo: NilClass)\l<returnMethodTemp>$2: NilClass = foo\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
-    ];
-
-    "bb::TestRescue#parse_ruby_bug_12402_10" -> "bb::TestRescue#parse_ruby_bug_12402_1" [style="bold"];
 }
 
 subgraph "cluster_::TestRescue#parse_ruby_bug_12402_1" {
@@ -933,8 +938,8 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402_1" {
         label = "block[id=3, rubyBlockId=2](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <exceptionValue>$5: T.untyped)\l<exceptionClassTemp>$9: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$10: T.untyped = <exceptionValue>$5: T.untyped.is_a?(<exceptionClassTemp>$9: T.class_of(StandardError))\l<isaCheckTemp>$10: T.untyped\l"
     ];
 
-    "bb::TestRescue#parse_ruby_bug_12402_1_3" -> "bb::TestRescue#parse_ruby_bug_12402_1_8" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_1_3" -> "bb::TestRescue#parse_ruby_bug_12402_1_9" [style="tapered"];
+    "bb::TestRescue#parse_ruby_bug_12402_1_3" -> "bb::TestRescue#parse_ruby_bug_12402_1_7" [style="bold"];
+    "bb::TestRescue#parse_ruby_bug_12402_1_3" -> "bb::TestRescue#parse_ruby_bug_12402_1_8" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_1_4" [
         label = "block[id=4, rubyBlockId=1](<statTemp>$3: NilClass, <self>: TestRescue)\l<statTemp>$7: T.untyped = <self>: TestRescue.bar()\l<statTemp>$4: T.noreturn = <self>: TestRescue.raise(<statTemp>$7: T.untyped)\l<exceptionValue>$5 = <unanalyzable>\l<exceptionValue>$5\l"
@@ -948,27 +953,27 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402_1" {
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_1_6" -> "bb::TestRescue#parse_ruby_bug_12402_1_1" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_1_6" -> "bb::TestRescue#parse_ruby_bug_12402_1_10" [style="tapered"];
+    "bb::TestRescue#parse_ruby_bug_12402_1_6" -> "bb::TestRescue#parse_ruby_bug_12402_1_9" [style="tapered"];
+
+    "bb::TestRescue#parse_ruby_bug_12402_1_7" [
+        label = "block[id=7, rubyBlockId=2](<statTemp>$3: NilClass)\l<statTemp>$4: NilClass = nil\l<gotoDeadTemp>$11: NilClass\l"
+    ];
+
+    "bb::TestRescue#parse_ruby_bug_12402_1_7" -> "bb::TestRescue#parse_ruby_bug_12402_1_1" [style="bold"];
+    "bb::TestRescue#parse_ruby_bug_12402_1_7" -> "bb::TestRescue#parse_ruby_bug_12402_1_9" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_1_8" [
-        label = "block[id=8, rubyBlockId=2](<statTemp>$3: NilClass)\l<statTemp>$4: NilClass = nil\l<gotoDeadTemp>$11: NilClass\l"
+        label = "block[id=8, rubyBlockId=2](<statTemp>$3: NilClass, <statTemp>$4: NilClass)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<gotoDeadTemp>$11: TrueClass(true)\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_1_8" -> "bb::TestRescue#parse_ruby_bug_12402_1_1" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_1_8" -> "bb::TestRescue#parse_ruby_bug_12402_1_10" [style="tapered"];
+    "bb::TestRescue#parse_ruby_bug_12402_1_8" -> "bb::TestRescue#parse_ruby_bug_12402_1_9" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_1_9" [
-        label = "block[id=9, rubyBlockId=2](<statTemp>$3: NilClass, <statTemp>$4: NilClass)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<gotoDeadTemp>$11: TrueClass(true)\l"
+        label = "block[id=9, rubyBlockId=0](<statTemp>$3: NilClass, <statTemp>$4: NilClass)\lfoo: T.untyped = <statTemp>$3: NilClass.+(<statTemp>$4: NilClass)\l<returnMethodTemp>$2: T.untyped = foo\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_1_9" -> "bb::TestRescue#parse_ruby_bug_12402_1_1" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_1_9" -> "bb::TestRescue#parse_ruby_bug_12402_1_10" [style="tapered"];
-
-    "bb::TestRescue#parse_ruby_bug_12402_1_10" [
-        label = "block[id=10, rubyBlockId=0](<statTemp>$3: NilClass, <statTemp>$4: NilClass)\lfoo: T.untyped = <statTemp>$3: NilClass.+(<statTemp>$4: NilClass)\l<returnMethodTemp>$2: T.untyped = foo\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
-    ];
-
-    "bb::TestRescue#parse_ruby_bug_12402_1_10" -> "bb::TestRescue#parse_ruby_bug_12402_1_1" [style="bold"];
 }
 
 subgraph "cluster_::TestRescue#parse_ruby_bug_12402_2" {
@@ -993,8 +998,8 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402_2" {
         label = "block[id=3, rubyBlockId=2](<statTemp>$9: T.untyped, <statTemp>$12: NilClass, <exceptionValue>$13: T.untyped, []$3: T.untyped, []$4: Integer(0))\l<exceptionClassTemp>$17: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$18: T.untyped = <exceptionValue>$13: T.untyped.is_a?(<exceptionClassTemp>$17: T.class_of(StandardError))\l<isaCheckTemp>$18: T.untyped\l"
     ];
 
-    "bb::TestRescue#parse_ruby_bug_12402_2_3" -> "bb::TestRescue#parse_ruby_bug_12402_2_8" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_2_3" -> "bb::TestRescue#parse_ruby_bug_12402_2_9" [style="tapered"];
+    "bb::TestRescue#parse_ruby_bug_12402_2_3" -> "bb::TestRescue#parse_ruby_bug_12402_2_7" [style="bold"];
+    "bb::TestRescue#parse_ruby_bug_12402_2_3" -> "bb::TestRescue#parse_ruby_bug_12402_2_8" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_2_4" [
         label = "block[id=4, rubyBlockId=1](<statTemp>$9: T.untyped, <self>: TestRescue, []$3: T.untyped, []$4: Integer(0))\l<statTemp>$15: T.untyped = <self>: TestRescue.bar()\l<statTemp>$12: T.noreturn = <self>: TestRescue.raise(<statTemp>$15: T.untyped)\l<exceptionValue>$13 = <unanalyzable>\l<exceptionValue>$13\l"
@@ -1008,27 +1013,27 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402_2" {
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_2_6" -> "bb::TestRescue#parse_ruby_bug_12402_2_1" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_2_6" -> "bb::TestRescue#parse_ruby_bug_12402_2_10" [style="tapered"];
+    "bb::TestRescue#parse_ruby_bug_12402_2_6" -> "bb::TestRescue#parse_ruby_bug_12402_2_9" [style="tapered"];
+
+    "bb::TestRescue#parse_ruby_bug_12402_2_7" [
+        label = "block[id=7, rubyBlockId=2](<statTemp>$9: T.untyped, []$3: T.untyped, []$4: Integer(0))\l<statTemp>$12: NilClass = nil\l<gotoDeadTemp>$19: NilClass\l"
+    ];
+
+    "bb::TestRescue#parse_ruby_bug_12402_2_7" -> "bb::TestRescue#parse_ruby_bug_12402_2_1" [style="bold"];
+    "bb::TestRescue#parse_ruby_bug_12402_2_7" -> "bb::TestRescue#parse_ruby_bug_12402_2_9" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_2_8" [
-        label = "block[id=8, rubyBlockId=2](<statTemp>$9: T.untyped, []$3: T.untyped, []$4: Integer(0))\l<statTemp>$12: NilClass = nil\l<gotoDeadTemp>$19: NilClass\l"
+        label = "block[id=8, rubyBlockId=2](<statTemp>$9: T.untyped, <statTemp>$12: NilClass, []$3: T.untyped, []$4: Integer(0))\l<gotoDeadTemp>$19: TrueClass(true) = true\l<gotoDeadTemp>$19: TrueClass(true)\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_2_8" -> "bb::TestRescue#parse_ruby_bug_12402_2_1" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_2_8" -> "bb::TestRescue#parse_ruby_bug_12402_2_10" [style="tapered"];
+    "bb::TestRescue#parse_ruby_bug_12402_2_8" -> "bb::TestRescue#parse_ruby_bug_12402_2_9" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_2_9" [
-        label = "block[id=9, rubyBlockId=2](<statTemp>$9: T.untyped, <statTemp>$12: NilClass, []$3: T.untyped, []$4: Integer(0))\l<gotoDeadTemp>$19: TrueClass(true) = true\l<gotoDeadTemp>$19: TrueClass(true)\l"
+        label = "block[id=9, rubyBlockId=0](<statTemp>$9: T.untyped, <statTemp>$12: NilClass, []$3: T.untyped, []$4: Integer(0))\l<statTemp>$8: T.untyped = <statTemp>$9: T.untyped.+(<statTemp>$12: NilClass)\l<returnMethodTemp>$2: T.untyped = []$3: T.untyped.[]=([]$4: Integer(0), <statTemp>$8: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_2_9" -> "bb::TestRescue#parse_ruby_bug_12402_2_1" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_2_9" -> "bb::TestRescue#parse_ruby_bug_12402_2_10" [style="tapered"];
-
-    "bb::TestRescue#parse_ruby_bug_12402_2_10" [
-        label = "block[id=10, rubyBlockId=0](<statTemp>$9: T.untyped, <statTemp>$12: NilClass, []$3: T.untyped, []$4: Integer(0))\l<statTemp>$8: T.untyped = <statTemp>$9: T.untyped.+(<statTemp>$12: NilClass)\l<returnMethodTemp>$2: T.untyped = []$3: T.untyped.[]=([]$4: Integer(0), <statTemp>$8: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
-    ];
-
-    "bb::TestRescue#parse_ruby_bug_12402_2_10" -> "bb::TestRescue#parse_ruby_bug_12402_2_1" [style="bold"];
 }
 
 subgraph "cluster_::<Class:TestRescue>#<static-init>" {

--- a/test/testdata/cfg/rescue_else_block.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_else_block.rb.cfg.exp
@@ -22,46 +22,48 @@ subgraph "cluster_::Object#foo" {
     ];
 
     "bb::Object#foo_3" -> "bb::Object#foo_9" [style="bold"];
-    "bb::Object#foo_3" -> "bb::Object#foo_12" [style="tapered"];
+    "bb::Object#foo_3" -> "bb::Object#foo_11" [style="tapered"];
 
     "bb::Object#foo_4" [
-        label = "block[id=4, rubyBlockId=1]()\l<returnMethodTemp>$2: Integer(1) = 1\l<ifTemp>$4: Integer(2) = 2\l<ifTemp>$4: Integer(2)\l"
+        label = "block[id=4, rubyBlockId=1]()\l<returnMethodTemp>$2: Integer(1) = 1\l<exceptionValue>$3: T.untyped = <unanalyzable>\l<exceptionValue>$3: T.untyped\l"
     ];
 
-    "bb::Object#foo_4" -> "bb::Object#foo_6" [style="bold"];
-    "bb::Object#foo_4" -> "bb::Object#foo_10" [style="tapered"];
+    "bb::Object#foo_4" -> "bb::Object#foo_3" [style="bold"];
+    "bb::Object#foo_4" -> "bb::Object#foo_5" [style="tapered"];
+
+    "bb::Object#foo_5" [
+        label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: Integer(1))\l<ifTemp>$4: Integer(2) = 2\l<ifTemp>$4: Integer(2)\l"
+    ];
+
+    "bb::Object#foo_5" -> "bb::Object#foo_6" [style="bold"];
+    "bb::Object#foo_5" -> "bb::Object#foo_9" [style="tapered"];
 
     "bb::Object#foo_6" [
-        label = "block[id=6, rubyBlockId=4]()\l<returnMethodTemp>$2: Integer(3) = 3\l<unconditional>\l"
+        label = "block[id=6, rubyBlockId=4]()\l<returnMethodTemp>$2: Integer(3) = 3\l<gotoDeadTemp>$7: NilClass\l"
     ];
 
-    "bb::Object#foo_6" -> "bb::Object#foo_10" [style="bold"];
+    "bb::Object#foo_6" -> "bb::Object#foo_1" [style="bold"];
+    "bb::Object#foo_6" -> "bb::Object#foo_12" [style="tapered"];
+
     "bb::Object#foo_9" [
         label = "block[id=9, rubyBlockId=3](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$7: NilClass)\l<gotoDeadTemp>$7: NilClass\l"
     ];
 
     "bb::Object#foo_9" -> "bb::Object#foo_1" [style="bold"];
-    "bb::Object#foo_9" -> "bb::Object#foo_13" [style="tapered"];
+    "bb::Object#foo_9" -> "bb::Object#foo_12" [style="tapered"];
 
-    "bb::Object#foo_10" [
-        label = "block[id=10, rubyBlockId=3](<returnMethodTemp>$2: Integer(3))\l<exceptionValue>$3: T.untyped = <unanalyzable>\l<exceptionValue>$3: T.untyped\l"
+    "bb::Object#foo_11" [
+        label = "block[id=11, rubyBlockId=2](<returnMethodTemp>$2: T.nilable(Integer))\l<gotoDeadTemp>$7: TrueClass(true) = true\l<gotoDeadTemp>$7: TrueClass(true)\l"
     ];
 
-    "bb::Object#foo_10" -> "bb::Object#foo_3" [style="bold"];
-    "bb::Object#foo_10" -> "bb::Object#foo_9" [style="tapered"];
+    "bb::Object#foo_11" -> "bb::Object#foo_1" [style="bold"];
+    "bb::Object#foo_11" -> "bb::Object#foo_12" [style="tapered"];
 
     "bb::Object#foo_12" [
-        label = "block[id=12, rubyBlockId=2](<returnMethodTemp>$2: T.nilable(Integer))\l<gotoDeadTemp>$7: TrueClass(true) = true\l<gotoDeadTemp>$7: TrueClass(true)\l"
+        label = "block[id=12, rubyBlockId=0](<returnMethodTemp>$2: T.nilable(Integer))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)\l<unconditional>\l"
     ];
 
     "bb::Object#foo_12" -> "bb::Object#foo_1" [style="bold"];
-    "bb::Object#foo_12" -> "bb::Object#foo_13" [style="tapered"];
-
-    "bb::Object#foo_13" [
-        label = "block[id=13, rubyBlockId=0](<returnMethodTemp>$2: T.nilable(Integer))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)\l<unconditional>\l"
-    ];
-
-    "bb::Object#foo_13" -> "bb::Object#foo_1" [style="bold"];
 }
 
 subgraph "cluster_::<Class:<root>>#<static-init>" {

--- a/test/testdata/cfg/rescue_expression.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_expression.rb.cfg.exp
@@ -21,8 +21,8 @@ subgraph "cluster_::Object#foo" {
         label = "block[id=3, rubyBlockId=2](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: T.untyped)\le: T.untyped = <exceptionValue>$3\l<statTemp>$9: T.class_of(MyException) = alias <C MyException>\l<statTemp>$8: MyException = <statTemp>$9: T.class_of(MyException).new()\l<exceptionClassTemp>$7: T.class_of(MyException) = <statTemp>$8: MyException.class()\l<isaCheckTemp>$10: T.untyped = e: T.untyped.is_a?(<exceptionClassTemp>$7: T.class_of(MyException))\l<isaCheckTemp>$10: T.untyped\l"
     ];
 
-    "bb::Object#foo_3" -> "bb::Object#foo_8" [style="bold"];
-    "bb::Object#foo_3" -> "bb::Object#foo_9" [style="tapered"];
+    "bb::Object#foo_3" -> "bb::Object#foo_7" [style="bold"];
+    "bb::Object#foo_3" -> "bb::Object#foo_8" [style="tapered"];
 
     "bb::Object#foo_4" [
         label = "block[id=4, rubyBlockId=1](<self>: Object)\l<statTemp>$6: T.class_of(MyException) = alias <C MyException>\l<statTemp>$5: MyException = <statTemp>$6: T.class_of(MyException).new()\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$5: MyException)\l<exceptionValue>$3 = <unanalyzable>\l<exceptionValue>$3\l"
@@ -36,27 +36,27 @@ subgraph "cluster_::Object#foo" {
     ];
 
     "bb::Object#foo_6" -> "bb::Object#foo_1" [style="bold"];
-    "bb::Object#foo_6" -> "bb::Object#foo_10" [style="tapered"];
+    "bb::Object#foo_6" -> "bb::Object#foo_9" [style="tapered"];
+
+    "bb::Object#foo_7" [
+        label = "block[id=7, rubyBlockId=2]()\l<returnMethodTemp>$2: Integer(3) = 3\l<gotoDeadTemp>$11: NilClass\l"
+    ];
+
+    "bb::Object#foo_7" -> "bb::Object#foo_1" [style="bold"];
+    "bb::Object#foo_7" -> "bb::Object#foo_9" [style="tapered"];
 
     "bb::Object#foo_8" [
-        label = "block[id=8, rubyBlockId=2]()\l<returnMethodTemp>$2: Integer(3) = 3\l<gotoDeadTemp>$11: NilClass\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<gotoDeadTemp>$11: TrueClass(true)\l"
     ];
 
     "bb::Object#foo_8" -> "bb::Object#foo_1" [style="bold"];
-    "bb::Object#foo_8" -> "bb::Object#foo_10" [style="tapered"];
+    "bb::Object#foo_8" -> "bb::Object#foo_9" [style="tapered"];
 
     "bb::Object#foo_9" [
-        label = "block[id=9, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<gotoDeadTemp>$11: TrueClass(true)\l"
+        label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: Integer(3))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)\l<unconditional>\l"
     ];
 
     "bb::Object#foo_9" -> "bb::Object#foo_1" [style="bold"];
-    "bb::Object#foo_9" -> "bb::Object#foo_10" [style="tapered"];
-
-    "bb::Object#foo_10" [
-        label = "block[id=10, rubyBlockId=0](<returnMethodTemp>$2: Integer(3))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)\l<unconditional>\l"
-    ];
-
-    "bb::Object#foo_10" -> "bb::Object#foo_1" [style="bold"];
 }
 
 subgraph "cluster_::<Class:<root>>#<static-init>" {

--- a/test/testdata/cfg/rescue_two_return.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_two_return.rb.cfg.exp
@@ -13,7 +13,7 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_0" -> "bb::Object#foo_4" [style="tapered"];
 
     "bb::Object#foo_1" [
-        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+        label = "block[id=1, rubyBlockId=0]()\l<exceptionValue>$4 = <unanalyzable>\l<unconditional>\l"
     ];
 
     "bb::Object#foo_1" -> "bb::Object#foo_1" [style="bold"];
@@ -21,31 +21,31 @@ subgraph "cluster_::Object#foo" {
         label = "block[id=3, rubyBlockId=2](<self>: Object, <exceptionValue>$4: T.untyped)\l<exceptionClassTemp>$6: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$7: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<exceptionClassTemp>$6: T.class_of(StandardError))\l<isaCheckTemp>$7: T.untyped\l"
     ];
 
-    "bb::Object#foo_3" -> "bb::Object#foo_8" [style="bold"];
-    "bb::Object#foo_3" -> "bb::Object#foo_9" [style="tapered"];
+    "bb::Object#foo_3" -> "bb::Object#foo_7" [style="bold"];
+    "bb::Object#foo_3" -> "bb::Object#foo_8" [style="tapered"];
 
     "bb::Object#foo_4" [
         label = "block[id=4, rubyBlockId=1]()\l<returnTemp>$5: Integer(1) = 1\l<statTemp>$3: T.noreturn = return <returnTemp>$5: Integer(1)\l<unconditional>\l"
     ];
 
     "bb::Object#foo_4" -> "bb::Object#foo_1" [style="bold"];
+    "bb::Object#foo_7" [
+        label = "block[id=7, rubyBlockId=2]()\l<returnTemp>$8: Integer(2) = 2\l<statTemp>$3: T.noreturn = return <returnTemp>$8: Integer(2)\l<unconditional>\l"
+    ];
+
+    "bb::Object#foo_7" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_8" [
-        label = "block[id=8, rubyBlockId=2]()\l<returnTemp>$8: Integer(2) = 2\l<statTemp>$3: T.noreturn = return <returnTemp>$8: Integer(2)\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2](<self>: Object)\l<gotoDeadTemp>$9: TrueClass(true) = true\l<gotoDeadTemp>$9: TrueClass(true)\l"
     ];
 
     "bb::Object#foo_8" -> "bb::Object#foo_1" [style="bold"];
+    "bb::Object#foo_8" -> "bb::Object#foo_9" [style="tapered"];
+
     "bb::Object#foo_9" [
-        label = "block[id=9, rubyBlockId=2](<self>: Object)\l<gotoDeadTemp>$9: TrueClass(true) = true\l<gotoDeadTemp>$9: TrueClass(true)\l"
+        label = "block[id=9, rubyBlockId=0](<self>: Object)\l<returnMethodTemp>$2 = <self>.deadcode()\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
 
     "bb::Object#foo_9" -> "bb::Object#foo_1" [style="bold"];
-    "bb::Object#foo_9" -> "bb::Object#foo_10" [style="tapered"];
-
-    "bb::Object#foo_10" [
-        label = "block[id=10, rubyBlockId=0](<self>: Object)\l<returnMethodTemp>$2 = <self>.deadcode()\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
-    ];
-
-    "bb::Object#foo_10" -> "bb::Object#foo_1" [style="bold"];
 }
 
 subgraph "cluster_::<Class:<root>>#<static-init>" {

--- a/test/testdata/cfg/rescue_var_expression.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_var_expression.rb.cfg.exp
@@ -21,8 +21,8 @@ subgraph "cluster_::Object#foo" {
         label = "block[id=3, rubyBlockId=2](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: T.untyped)\l<exceptionClassTemp>$6: T.class_of(Exception) = alias <C Exception>\l<isaCheckTemp>$7: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<exceptionClassTemp>$6: T.class_of(Exception))\l<isaCheckTemp>$7: T.untyped\l"
     ];
 
-    "bb::Object#foo_3" -> "bb::Object#foo_8" [style="bold"];
-    "bb::Object#foo_3" -> "bb::Object#foo_9" [style="tapered"];
+    "bb::Object#foo_3" -> "bb::Object#foo_7" [style="bold"];
+    "bb::Object#foo_3" -> "bb::Object#foo_8" [style="tapered"];
 
     "bb::Object#foo_4" [
         label = "block[id=4, rubyBlockId=1](<self>: Object)\l<statTemp>$5: String(\"boop\") = \"boop\"\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$5: String(\"boop\"))\l<exceptionValue>$3 = <unanalyzable>\l<exceptionValue>$3\l"
@@ -36,27 +36,27 @@ subgraph "cluster_::Object#foo" {
     ];
 
     "bb::Object#foo_6" -> "bb::Object#foo_1" [style="bold"];
-    "bb::Object#foo_6" -> "bb::Object#foo_10" [style="tapered"];
+    "bb::Object#foo_6" -> "bb::Object#foo_9" [style="tapered"];
+
+    "bb::Object#foo_7" [
+        label = "block[id=7, rubyBlockId=2](<exceptionValue>$3: Exception)\l<statTemp>$10: T.class_of(MyClass) = alias <C MyClass>\l<statTemp>$9: MyClass = <statTemp>$10: T.class_of(MyClass).new()\l<statTemp>$8: Exception = <statTemp>$9: MyClass.foo=(<exceptionValue>$3: Exception)\l<returnMethodTemp>$2: Integer(3) = 3\l<gotoDeadTemp>$12: NilClass\l"
+    ];
+
+    "bb::Object#foo_7" -> "bb::Object#foo_1" [style="bold"];
+    "bb::Object#foo_7" -> "bb::Object#foo_9" [style="tapered"];
 
     "bb::Object#foo_8" [
-        label = "block[id=8, rubyBlockId=2](<exceptionValue>$3: Exception)\l<statTemp>$10: T.class_of(MyClass) = alias <C MyClass>\l<statTemp>$9: MyClass = <statTemp>$10: T.class_of(MyClass).new()\l<statTemp>$8: Exception = <statTemp>$9: MyClass.foo=(<exceptionValue>$3: Exception)\l<returnMethodTemp>$2: Integer(3) = 3\l<gotoDeadTemp>$12: NilClass\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$12: TrueClass(true) = true\l<gotoDeadTemp>$12: TrueClass(true)\l"
     ];
 
     "bb::Object#foo_8" -> "bb::Object#foo_1" [style="bold"];
-    "bb::Object#foo_8" -> "bb::Object#foo_10" [style="tapered"];
+    "bb::Object#foo_8" -> "bb::Object#foo_9" [style="tapered"];
 
     "bb::Object#foo_9" [
-        label = "block[id=9, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$12: TrueClass(true) = true\l<gotoDeadTemp>$12: TrueClass(true)\l"
+        label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: Integer(3))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)\l<unconditional>\l"
     ];
 
     "bb::Object#foo_9" -> "bb::Object#foo_1" [style="bold"];
-    "bb::Object#foo_9" -> "bb::Object#foo_10" [style="tapered"];
-
-    "bb::Object#foo_10" [
-        label = "block[id=10, rubyBlockId=0](<returnMethodTemp>$2: Integer(3))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)\l<unconditional>\l"
-    ];
-
-    "bb::Object#foo_10" -> "bb::Object#foo_1" [style="bold"];
 }
 
 subgraph "cluster_::<Class:<root>>#<static-init>" {

--- a/test/testdata/cfg/rescue_with_return.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_with_return.rb.cfg.exp
@@ -13,7 +13,7 @@ subgraph "cluster_::Object#a" {
     "bb::Object#a_0" -> "bb::Object#a_4" [style="tapered"];
 
     "bb::Object#a_1" [
-        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+        label = "block[id=1, rubyBlockId=0]()\l<exceptionValue>$3 = <unanalyzable>\l<unconditional>\l"
     ];
 
     "bb::Object#a_1" -> "bb::Object#a_1" [style="bold"];
@@ -22,7 +22,7 @@ subgraph "cluster_::Object#a" {
     ];
 
     "bb::Object#a_3" -> "bb::Object#a_6" [style="bold"];
-    "bb::Object#a_3" -> "bb::Object#a_9" [style="tapered"];
+    "bb::Object#a_3" -> "bb::Object#a_8" [style="tapered"];
 
     "bb::Object#a_4" [
         label = "block[id=4, rubyBlockId=1]()\l<returnTemp>$4: Integer(1) = 1\l<returnMethodTemp>$2: T.noreturn = return <returnTemp>$4: Integer(1)\l<unconditional>\l"
@@ -34,20 +34,20 @@ subgraph "cluster_::Object#a" {
     ];
 
     "bb::Object#a_6" -> "bb::Object#a_1" [style="bold"];
-    "bb::Object#a_6" -> "bb::Object#a_10" [style="tapered"];
+    "bb::Object#a_6" -> "bb::Object#a_9" [style="tapered"];
+
+    "bb::Object#a_8" [
+        label = "block[id=8, rubyBlockId=2]()\l<gotoDeadTemp>$7: TrueClass(true) = true\l<gotoDeadTemp>$7: TrueClass(true)\l"
+    ];
+
+    "bb::Object#a_8" -> "bb::Object#a_1" [style="bold"];
+    "bb::Object#a_8" -> "bb::Object#a_9" [style="tapered"];
 
     "bb::Object#a_9" [
-        label = "block[id=9, rubyBlockId=2]()\l<gotoDeadTemp>$7: TrueClass(true) = true\l<gotoDeadTemp>$7: TrueClass(true)\l"
+        label = "block[id=9, rubyBlockId=0]()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::Object#a_9" -> "bb::Object#a_1" [style="bold"];
-    "bb::Object#a_9" -> "bb::Object#a_10" [style="tapered"];
-
-    "bb::Object#a_10" [
-        label = "block[id=10, rubyBlockId=0]()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
-    ];
-
-    "bb::Object#a_10" -> "bb::Object#a_1" [style="bold"];
 }
 
 subgraph "cluster_::<Class:<root>>#<static-init>" {

--- a/test/testdata/cfg/retry.rb.cfg.exp
+++ b/test/testdata/cfg/retry.rb.cfg.exp
@@ -26,52 +26,52 @@ subgraph "cluster_::Object#main" {
         label = "block[id=3, rubyBlockId=2](<returnMethodTemp>$2: NilClass, <self>: Object, <exceptionValue>$4: T.untyped, try: Integer(0))\l<exceptionClassTemp>$13: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$14: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<exceptionClassTemp>$13: T.class_of(StandardError))\l<isaCheckTemp>$14: T.untyped\l"
     ];
 
-    "bb::Object#main_3" -> "bb::Object#main_11" [style="bold"];
-    "bb::Object#main_3" -> "bb::Object#main_12" [style="tapered"];
+    "bb::Object#main_3" -> "bb::Object#main_10" [style="bold"];
+    "bb::Object#main_3" -> "bb::Object#main_11" [style="tapered"];
 
     "bb::Object#main_4" [
         label = "block[id=4, rubyBlockId=1](<returnMethodTemp>$2: NilClass, <self>: Object, try: Integer(0))\l<statTemp>$7: Integer(3) = 3\l<ifTemp>$5: T::Boolean = try: Integer(0).<(<statTemp>$7: Integer(3))\l<ifTemp>$5: T::Boolean\l"
     ];
 
     "bb::Object#main_4" -> "bb::Object#main_5" [style="bold"];
-    "bb::Object#main_4" -> "bb::Object#main_10" [style="tapered"];
+    "bb::Object#main_4" -> "bb::Object#main_7" [style="tapered"];
 
     "bb::Object#main_5" [
         label = "block[id=5, rubyBlockId=1](<self>: Object, try: Integer(0))\l<statTemp>$9: Integer(0) = try\l<statTemp>$10: Integer(1) = 1\ltry: Integer = <statTemp>$9: Integer(0).+(<statTemp>$10: Integer(1))\l<statTemp>$12: String(\"e\") = \"e\"\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$12: String(\"e\"))\l<unconditional>\l"
     ];
 
-    "bb::Object#main_5" -> "bb::Object#main_10" [style="bold"];
+    "bb::Object#main_5" -> "bb::Object#main_7" [style="bold"];
+    "bb::Object#main_7" [
+        label = "block[id=7, rubyBlockId=1](<returnMethodTemp>$2: NilClass, <self>: Object, try: Integer(0))\l<exceptionValue>$4: T.untyped = <unanalyzable>\l<exceptionValue>$4: T.untyped\l"
+    ];
+
+    "bb::Object#main_7" -> "bb::Object#main_3" [style="bold"];
+    "bb::Object#main_7" -> "bb::Object#main_9" [style="tapered"];
+
     "bb::Object#main_9" [
         label = "block[id=9, rubyBlockId=3](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$19: NilClass)\l<gotoDeadTemp>$19: NilClass\l"
     ];
 
     "bb::Object#main_9" -> "bb::Object#main_1" [style="bold"];
-    "bb::Object#main_9" -> "bb::Object#main_13" [style="tapered"];
+    "bb::Object#main_9" -> "bb::Object#main_12" [style="tapered"];
 
     "bb::Object#main_10" [
-        label = "block[id=10, rubyBlockId=3](<returnMethodTemp>$2: NilClass, <self>: Object, try: Integer(0))\l<exceptionValue>$4: T.untyped = <unanalyzable>\l<exceptionValue>$4: T.untyped\l"
+        label = "block[id=10, rubyBlockId=2](<returnMethodTemp>$2: NilClass, <self>: Object, <exceptionValue>$4: StandardError, try: Integer(0))\l<statTemp>$17: String(\"rescue\") = \"rescue\"\l<statTemp>$15: NilClass = <self>: Object.puts(<statTemp>$17: String(\"rescue\"))\l<unconditional>\l"
     ];
 
-    "bb::Object#main_10" -> "bb::Object#main_3" [style="bold"];
-    "bb::Object#main_10" -> "bb::Object#main_9" [style="tapered"];
-
+    "bb::Object#main_10" -> "bb::Object#main_2" [style="bold"];
     "bb::Object#main_11" [
-        label = "block[id=11, rubyBlockId=2](<returnMethodTemp>$2: NilClass, <self>: Object, <exceptionValue>$4: StandardError, try: Integer(0))\l<statTemp>$17: String(\"rescue\") = \"rescue\"\l<statTemp>$15: NilClass = <self>: Object.puts(<statTemp>$17: String(\"rescue\"))\l<unconditional>\l"
+        label = "block[id=11, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$19: TrueClass(true) = true\l<gotoDeadTemp>$19: TrueClass(true)\l"
     ];
 
-    "bb::Object#main_11" -> "bb::Object#main_2" [style="bold"];
+    "bb::Object#main_11" -> "bb::Object#main_1" [style="bold"];
+    "bb::Object#main_11" -> "bb::Object#main_12" [style="tapered"];
+
     "bb::Object#main_12" [
-        label = "block[id=12, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$19: TrueClass(true) = true\l<gotoDeadTemp>$19: TrueClass(true)\l"
+        label = "block[id=12, rubyBlockId=0](<returnMethodTemp>$2: NilClass)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::Object#main_12" -> "bb::Object#main_1" [style="bold"];
-    "bb::Object#main_12" -> "bb::Object#main_13" [style="tapered"];
-
-    "bb::Object#main_13" [
-        label = "block[id=13, rubyBlockId=0](<returnMethodTemp>$2: NilClass)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
-    ];
-
-    "bb::Object#main_13" -> "bb::Object#main_1" [style="bold"];
 }
 
 subgraph "cluster_::<Class:<root>>#<static-init>" {

--- a/test/testdata/cfg/retry_multiple.rb.cfg.exp
+++ b/test/testdata/cfg/retry_multiple.rb.cfg.exp
@@ -26,8 +26,8 @@ subgraph "cluster_::Object#main" {
         label = "block[id=3, rubyBlockId=2](<returnMethodTemp>$2: NilClass, <self>: Object, <exceptionValue>$4: T.untyped, try: Integer(0))\l<exceptionClassTemp>$23: T.class_of(A) = alias <C A>\l<isaCheckTemp>$24: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<exceptionClassTemp>$23: T.class_of(A))\l<isaCheckTemp>$24: T.untyped\l"
     ];
 
-    "bb::Object#main_3" -> "bb::Object#main_14" [style="bold"];
-    "bb::Object#main_3" -> "bb::Object#main_15" [style="tapered"];
+    "bb::Object#main_3" -> "bb::Object#main_13" [style="bold"];
+    "bb::Object#main_3" -> "bb::Object#main_14" [style="tapered"];
 
     "bb::Object#main_4" [
         label = "block[id=4, rubyBlockId=1](<returnMethodTemp>$2: NilClass, <self>: Object, try: Integer(0))\l<statTemp>$7: Integer(3) = 3\l<ifTemp>$5: T::Boolean = try: Integer(0).<(<statTemp>$7: Integer(3))\l<ifTemp>$5: T::Boolean\l"
@@ -40,62 +40,62 @@ subgraph "cluster_::Object#main" {
         label = "block[id=5, rubyBlockId=1](<self>: Object, try: Integer(0))\l<statTemp>$9: Integer(0) = try\l<statTemp>$10: Integer(1) = 1\ltry: Integer = <statTemp>$9: Integer(0).+(<statTemp>$10: Integer(1))\l<statTemp>$13: T.class_of(A) = alias <C A>\l<statTemp>$12: A = <statTemp>$13: T.class_of(A).new()\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$12: A)\l<unconditional>\l"
     ];
 
-    "bb::Object#main_5" -> "bb::Object#main_13" [style="bold"];
+    "bb::Object#main_5" -> "bb::Object#main_10" [style="bold"];
     "bb::Object#main_6" [
         label = "block[id=6, rubyBlockId=1](<returnMethodTemp>$2: NilClass, <self>: Object, try: Integer(0))\l<statTemp>$16: Integer(6) = 6\l<ifTemp>$14: T::Boolean = try: Integer(0).<(<statTemp>$16: Integer(6))\l<ifTemp>$14: T::Boolean\l"
     ];
 
     "bb::Object#main_6" -> "bb::Object#main_7" [style="bold"];
-    "bb::Object#main_6" -> "bb::Object#main_13" [style="tapered"];
+    "bb::Object#main_6" -> "bb::Object#main_10" [style="tapered"];
 
     "bb::Object#main_7" [
         label = "block[id=7, rubyBlockId=1](<self>: Object, try: Integer(0))\l<statTemp>$18: Integer(0) = try\l<statTemp>$19: Integer(1) = 1\ltry: Integer = <statTemp>$18: Integer(0).+(<statTemp>$19: Integer(1))\l<statTemp>$22: T.class_of(B) = alias <C B>\l<statTemp>$21: B = <statTemp>$22: T.class_of(B).new()\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$21: B)\l<unconditional>\l"
     ];
 
-    "bb::Object#main_7" -> "bb::Object#main_13" [style="bold"];
+    "bb::Object#main_7" -> "bb::Object#main_10" [style="bold"];
+    "bb::Object#main_10" [
+        label = "block[id=10, rubyBlockId=1](<returnMethodTemp>$2: NilClass, <self>: Object, try: Integer(0))\l<exceptionValue>$4: T.untyped = <unanalyzable>\l<exceptionValue>$4: T.untyped\l"
+    ];
+
+    "bb::Object#main_10" -> "bb::Object#main_3" [style="bold"];
+    "bb::Object#main_10" -> "bb::Object#main_12" [style="tapered"];
+
     "bb::Object#main_12" [
         label = "block[id=12, rubyBlockId=3](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$35: NilClass)\l<gotoDeadTemp>$35: NilClass\l"
     ];
 
     "bb::Object#main_12" -> "bb::Object#main_1" [style="bold"];
-    "bb::Object#main_12" -> "bb::Object#main_18" [style="tapered"];
+    "bb::Object#main_12" -> "bb::Object#main_17" [style="tapered"];
 
     "bb::Object#main_13" [
-        label = "block[id=13, rubyBlockId=3](<returnMethodTemp>$2: NilClass, <self>: Object, try: Integer(0))\l<exceptionValue>$4: T.untyped = <unanalyzable>\l<exceptionValue>$4: T.untyped\l"
+        label = "block[id=13, rubyBlockId=2](<returnMethodTemp>$2: NilClass, <self>: Object, <exceptionValue>$4: A, try: Integer(0))\l<statTemp>$27: String(\"rescue A \") = \"rescue A \"\l<statTemp>$25: NilClass = <self>: Object.puts(<statTemp>$27: String(\"rescue A \"))\l<unconditional>\l"
     ];
 
-    "bb::Object#main_13" -> "bb::Object#main_3" [style="bold"];
-    "bb::Object#main_13" -> "bb::Object#main_12" [style="tapered"];
-
+    "bb::Object#main_13" -> "bb::Object#main_2" [style="bold"];
     "bb::Object#main_14" [
-        label = "block[id=14, rubyBlockId=2](<returnMethodTemp>$2: NilClass, <self>: Object, <exceptionValue>$4: A, try: Integer(0))\l<statTemp>$27: String(\"rescue A \") = \"rescue A \"\l<statTemp>$25: NilClass = <self>: Object.puts(<statTemp>$27: String(\"rescue A \"))\l<unconditional>\l"
+        label = "block[id=14, rubyBlockId=2](<returnMethodTemp>$2: NilClass, <self>: Object, <exceptionValue>$4: T.untyped, try: Integer(0))\l<exceptionClassTemp>$29: T.class_of(B) = alias <C B>\l<isaCheckTemp>$30: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<exceptionClassTemp>$29: T.class_of(B))\l<isaCheckTemp>$30: T.untyped\l"
     ];
 
-    "bb::Object#main_14" -> "bb::Object#main_2" [style="bold"];
+    "bb::Object#main_14" -> "bb::Object#main_15" [style="bold"];
+    "bb::Object#main_14" -> "bb::Object#main_16" [style="tapered"];
+
     "bb::Object#main_15" [
-        label = "block[id=15, rubyBlockId=2](<returnMethodTemp>$2: NilClass, <self>: Object, <exceptionValue>$4: T.untyped, try: Integer(0))\l<exceptionClassTemp>$29: T.class_of(B) = alias <C B>\l<isaCheckTemp>$30: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<exceptionClassTemp>$29: T.class_of(B))\l<isaCheckTemp>$30: T.untyped\l"
+        label = "block[id=15, rubyBlockId=2](<returnMethodTemp>$2: NilClass, <self>: Object, <exceptionValue>$4: B, try: Integer(0))\l<statTemp>$33: String(\"rescue B \") = \"rescue B \"\l<statTemp>$31: NilClass = <self>: Object.puts(<statTemp>$33: String(\"rescue B \"))\l<unconditional>\l"
     ];
 
-    "bb::Object#main_15" -> "bb::Object#main_16" [style="bold"];
-    "bb::Object#main_15" -> "bb::Object#main_17" [style="tapered"];
-
+    "bb::Object#main_15" -> "bb::Object#main_2" [style="bold"];
     "bb::Object#main_16" [
-        label = "block[id=16, rubyBlockId=2](<returnMethodTemp>$2: NilClass, <self>: Object, <exceptionValue>$4: B, try: Integer(0))\l<statTemp>$33: String(\"rescue B \") = \"rescue B \"\l<statTemp>$31: NilClass = <self>: Object.puts(<statTemp>$33: String(\"rescue B \"))\l<unconditional>\l"
+        label = "block[id=16, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$35: TrueClass(true) = true\l<gotoDeadTemp>$35: TrueClass(true)\l"
     ];
 
-    "bb::Object#main_16" -> "bb::Object#main_2" [style="bold"];
+    "bb::Object#main_16" -> "bb::Object#main_1" [style="bold"];
+    "bb::Object#main_16" -> "bb::Object#main_17" [style="tapered"];
+
     "bb::Object#main_17" [
-        label = "block[id=17, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$35: TrueClass(true) = true\l<gotoDeadTemp>$35: TrueClass(true)\l"
+        label = "block[id=17, rubyBlockId=0](<returnMethodTemp>$2: NilClass)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::Object#main_17" -> "bb::Object#main_1" [style="bold"];
-    "bb::Object#main_17" -> "bb::Object#main_18" [style="tapered"];
-
-    "bb::Object#main_18" [
-        label = "block[id=18, rubyBlockId=0](<returnMethodTemp>$2: NilClass)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
-    ];
-
-    "bb::Object#main_18" -> "bb::Object#main_1" [style="bold"];
 }
 
 subgraph "cluster_::<Class:<root>>#<static-init>" {

--- a/test/testdata/cfg/retry_nested.rb.cfg.exp
+++ b/test/testdata/cfg/retry_nested.rb.cfg.exp
@@ -26,8 +26,8 @@ subgraph "cluster_::Object#main" {
         label = "block[id=3, rubyBlockId=2](<returnMethodTemp>$2: NilClass, <self>: Object, <exceptionValue>$4: T.untyped, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<exceptionClassTemp>$35: T.class_of(B) = alias <C B>\l<isaCheckTemp>$36: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<exceptionClassTemp>$35: T.class_of(B))\l<isaCheckTemp>$36: T.untyped\l"
     ];
 
-    "bb::Object#main_3" -> "bb::Object#main_23" [style="bold"];
-    "bb::Object#main_3" -> "bb::Object#main_24" [style="tapered"];
+    "bb::Object#main_3" -> "bb::Object#main_21" [style="bold"];
+    "bb::Object#main_3" -> "bb::Object#main_22" [style="tapered"];
 
     "bb::Object#main_4" [
         label = "block[id=4, rubyBlockId=1](<returnMethodTemp>$2: NilClass, <self>: Object, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<statTemp>$7: String(\"top\") = \"top\"\l<statTemp>$5: NilClass = <self>: Object.puts(<statTemp>$7: String(\"top\"))\l<unconditional>\l"
@@ -45,8 +45,8 @@ subgraph "cluster_::Object#main" {
         label = "block[id=6, rubyBlockId=6](<returnMethodTemp>$2: NilClass, <self>: Object, <exceptionValue>$8: T.untyped, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<exceptionClassTemp>$27: T.class_of(A) = alias <C A>\l<isaCheckTemp>$28: T.untyped = <exceptionValue>$8: T.untyped.is_a?(<exceptionClassTemp>$27: T.class_of(A))\l<isaCheckTemp>$28: T.untyped\l"
     ];
 
-    "bb::Object#main_6" -> "bb::Object#main_17" [style="bold"];
-    "bb::Object#main_6" -> "bb::Object#main_18" [style="tapered"];
+    "bb::Object#main_6" -> "bb::Object#main_16" [style="bold"];
+    "bb::Object#main_6" -> "bb::Object#main_17" [style="tapered"];
 
     "bb::Object#main_7" [
         label = "block[id=7, rubyBlockId=5](<returnMethodTemp>$2: NilClass, <self>: Object, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<statTemp>$11: Integer(3) = 3\l<ifTemp>$9: T::Boolean = try: Integer(0).<(<statTemp>$11: Integer(3))\l<ifTemp>$9: T::Boolean\l"
@@ -59,76 +59,76 @@ subgraph "cluster_::Object#main" {
         label = "block[id=8, rubyBlockId=5](<self>: Object, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<statTemp>$13: Integer(0) = try\l<statTemp>$14: Integer(1) = 1\ltry: Integer = <statTemp>$13: Integer(0).+(<statTemp>$14: Integer(1))\l<statTemp>$17: T.class_of(A) = alias <C A>\l<statTemp>$16: A = <statTemp>$17: T.class_of(A).new()\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$16: A)\l<unconditional>\l"
     ];
 
-    "bb::Object#main_8" -> "bb::Object#main_16" [style="bold"];
+    "bb::Object#main_8" -> "bb::Object#main_13" [style="bold"];
     "bb::Object#main_9" [
         label = "block[id=9, rubyBlockId=5](<returnMethodTemp>$2: NilClass, <self>: Object, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<statTemp>$20: Integer(6) = 6\l<ifTemp>$18: T::Boolean = try: Integer(0).<(<statTemp>$20: Integer(6))\l<ifTemp>$18: T::Boolean\l"
     ];
 
     "bb::Object#main_9" -> "bb::Object#main_10" [style="bold"];
-    "bb::Object#main_9" -> "bb::Object#main_16" [style="tapered"];
+    "bb::Object#main_9" -> "bb::Object#main_13" [style="tapered"];
 
     "bb::Object#main_10" [
         label = "block[id=10, rubyBlockId=5](<self>: Object, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<statTemp>$22: Integer(0) = try\l<statTemp>$23: Integer(1) = 1\ltry: Integer = <statTemp>$22: Integer(0).+(<statTemp>$23: Integer(1))\l<statTemp>$26: T.class_of(B) = alias <C B>\l<statTemp>$25: B = <statTemp>$26: T.class_of(B).new()\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$25: B)\l<unconditional>\l"
     ];
 
-    "bb::Object#main_10" -> "bb::Object#main_16" [style="bold"];
+    "bb::Object#main_10" -> "bb::Object#main_13" [style="bold"];
+    "bb::Object#main_13" [
+        label = "block[id=13, rubyBlockId=5](<returnMethodTemp>$2: NilClass, <self>: Object, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<exceptionValue>$8: T.untyped = <unanalyzable>\l<exceptionValue>$8: T.untyped\l"
+    ];
+
+    "bb::Object#main_13" -> "bb::Object#main_6" [style="bold"];
+    "bb::Object#main_13" -> "bb::Object#main_15" [style="tapered"];
+
     "bb::Object#main_15" [
         label = "block[id=15, rubyBlockId=7](<returnMethodTemp>$2: NilClass, <self>: Object, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<gotoDeadTemp>$33: NilClass\l"
     ];
 
     "bb::Object#main_15" -> "bb::Object#main_1" [style="bold"];
-    "bb::Object#main_15" -> "bb::Object#main_22" [style="tapered"];
+    "bb::Object#main_15" -> "bb::Object#main_18" [style="tapered"];
 
     "bb::Object#main_16" [
-        label = "block[id=16, rubyBlockId=7](<returnMethodTemp>$2: NilClass, <self>: Object, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<exceptionValue>$8: T.untyped = <unanalyzable>\l<exceptionValue>$8: T.untyped\l"
+        label = "block[id=16, rubyBlockId=6](<returnMethodTemp>$2: NilClass, <self>: Object, <exceptionValue>$8: A, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<statTemp>$31: String(\"rescue A\") = \"rescue A\"\l<statTemp>$29: NilClass = <self>: Object.puts(<statTemp>$31: String(\"rescue A\"))\l<unconditional>\l"
     ];
 
-    "bb::Object#main_16" -> "bb::Object#main_6" [style="bold"];
-    "bb::Object#main_16" -> "bb::Object#main_15" [style="tapered"];
-
+    "bb::Object#main_16" -> "bb::Object#main_5" [style="bold"];
     "bb::Object#main_17" [
-        label = "block[id=17, rubyBlockId=6](<returnMethodTemp>$2: NilClass, <self>: Object, <exceptionValue>$8: A, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<statTemp>$31: String(\"rescue A\") = \"rescue A\"\l<statTemp>$29: NilClass = <self>: Object.puts(<statTemp>$31: String(\"rescue A\"))\l<unconditional>\l"
+        label = "block[id=17, rubyBlockId=6](<returnMethodTemp>$2: NilClass, <self>: Object, try: Integer(0))\l<gotoDeadTemp>$33: TrueClass(true) = true\l<gotoDeadTemp>$33: TrueClass(true)\l"
     ];
 
-    "bb::Object#main_17" -> "bb::Object#main_5" [style="bold"];
+    "bb::Object#main_17" -> "bb::Object#main_1" [style="bold"];
+    "bb::Object#main_17" -> "bb::Object#main_18" [style="tapered"];
+
     "bb::Object#main_18" [
-        label = "block[id=18, rubyBlockId=6](<returnMethodTemp>$2: NilClass, <self>: Object, try: Integer(0))\l<gotoDeadTemp>$33: TrueClass(true) = true\l<gotoDeadTemp>$33: TrueClass(true)\l"
+        label = "block[id=18, rubyBlockId=1](<returnMethodTemp>$2: NilClass, <self>: Object, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<exceptionValue>$4: T.untyped = <unanalyzable>\l<exceptionValue>$4: T.untyped\l"
     ];
 
-    "bb::Object#main_18" -> "bb::Object#main_1" [style="bold"];
-    "bb::Object#main_18" -> "bb::Object#main_22" [style="tapered"];
+    "bb::Object#main_18" -> "bb::Object#main_3" [style="bold"];
+    "bb::Object#main_18" -> "bb::Object#main_20" [style="tapered"];
+
+    "bb::Object#main_20" [
+        label = "block[id=20, rubyBlockId=3](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$41: NilClass)\l<gotoDeadTemp>$41: NilClass\l"
+    ];
+
+    "bb::Object#main_20" -> "bb::Object#main_1" [style="bold"];
+    "bb::Object#main_20" -> "bb::Object#main_23" [style="tapered"];
 
     "bb::Object#main_21" [
-        label = "block[id=21, rubyBlockId=3](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$41: NilClass)\l<gotoDeadTemp>$41: NilClass\l"
+        label = "block[id=21, rubyBlockId=2](<returnMethodTemp>$2: NilClass, <self>: Object, <exceptionValue>$4: B, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<statTemp>$39: String(\"rescue B \") = \"rescue B \"\l<statTemp>$37: NilClass = <self>: Object.puts(<statTemp>$39: String(\"rescue B \"))\l<unconditional>\l"
     ];
 
-    "bb::Object#main_21" -> "bb::Object#main_1" [style="bold"];
-    "bb::Object#main_21" -> "bb::Object#main_25" [style="tapered"];
-
+    "bb::Object#main_21" -> "bb::Object#main_2" [style="bold"];
     "bb::Object#main_22" [
-        label = "block[id=22, rubyBlockId=3](<returnMethodTemp>$2: NilClass, <self>: Object, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<exceptionValue>$4: T.untyped = <unanalyzable>\l<exceptionValue>$4: T.untyped\l"
+        label = "block[id=22, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$41: TrueClass(true) = true\l<gotoDeadTemp>$41: TrueClass(true)\l"
     ];
 
-    "bb::Object#main_22" -> "bb::Object#main_3" [style="bold"];
-    "bb::Object#main_22" -> "bb::Object#main_21" [style="tapered"];
+    "bb::Object#main_22" -> "bb::Object#main_1" [style="bold"];
+    "bb::Object#main_22" -> "bb::Object#main_23" [style="tapered"];
 
     "bb::Object#main_23" [
-        label = "block[id=23, rubyBlockId=2](<returnMethodTemp>$2: NilClass, <self>: Object, <exceptionValue>$4: B, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<statTemp>$39: String(\"rescue B \") = \"rescue B \"\l<statTemp>$37: NilClass = <self>: Object.puts(<statTemp>$39: String(\"rescue B \"))\l<unconditional>\l"
+        label = "block[id=23, rubyBlockId=0](<returnMethodTemp>$2: NilClass)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
-    "bb::Object#main_23" -> "bb::Object#main_2" [style="bold"];
-    "bb::Object#main_24" [
-        label = "block[id=24, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$41: TrueClass(true) = true\l<gotoDeadTemp>$41: TrueClass(true)\l"
-    ];
-
-    "bb::Object#main_24" -> "bb::Object#main_1" [style="bold"];
-    "bb::Object#main_24" -> "bb::Object#main_25" [style="tapered"];
-
-    "bb::Object#main_25" [
-        label = "block[id=25, rubyBlockId=0](<returnMethodTemp>$2: NilClass)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
-    ];
-
-    "bb::Object#main_25" -> "bb::Object#main_1" [style="bold"];
+    "bb::Object#main_23" -> "bb::Object#main_1" [style="bold"];
 }
 
 subgraph "cluster_::<Class:<root>>#<static-init>" {

--- a/test/testdata/cfg/uaf1.rb.cfg.exp
+++ b/test/testdata/cfg/uaf1.rb.cfg.exp
@@ -56,8 +56,8 @@ subgraph "cluster_::A#initialize" {
         label = "block[id=7, rubyBlockId=3](<blockReturnTemp>$9: T.nilable(Integer), <self>: A, <selfRestore>$6: A, <exceptionValue>$10: T.untyped, <gotoDeadTemp>$13: NilClass, <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\louterLoops: 1\lse$1: T.untyped = <exceptionValue>$10\l<exceptionClassTemp>$11: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$12: T.untyped = se$1: T.untyped.is_a?(<exceptionClassTemp>$11: T.class_of(StandardError))\l<isaCheckTemp>$12: T.untyped\l"
     ];
 
-    "bb::A#initialize_7" -> "bb::A#initialize_12" [style="bold"];
-    "bb::A#initialize_7" -> "bb::A#initialize_13" [style="tapered"];
+    "bb::A#initialize_7" -> "bb::A#initialize_11" [style="bold"];
+    "bb::A#initialize_7" -> "bb::A#initialize_12" [style="tapered"];
 
     "bb::A#initialize_8" [
         label = "block[id=8, rubyBlockId=2](<self>: A, <selfRestore>$6: A, <gotoDeadTemp>$13: NilClass, <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\louterLoops: 1\l<blockReturnTemp>$9: Integer(1) = 1\l<exceptionValue>$10: T.untyped = <unanalyzable>\l<exceptionValue>$10: T.untyped\l"
@@ -71,27 +71,27 @@ subgraph "cluster_::A#initialize" {
     ];
 
     "bb::A#initialize_10" -> "bb::A#initialize_1" [style="bold"];
-    "bb::A#initialize_10" -> "bb::A#initialize_14" [style="tapered"];
+    "bb::A#initialize_10" -> "bb::A#initialize_13" [style="tapered"];
+
+    "bb::A#initialize_11" [
+        label = "block[id=11, rubyBlockId=3](<self>: A, <selfRestore>$6: A, <gotoDeadTemp>$13: NilClass, <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\louterLoops: 1\l<blockReturnTemp>$9: Integer(2) = 2\l<gotoDeadTemp>$13: NilClass\l"
+    ];
+
+    "bb::A#initialize_11" -> "bb::A#initialize_1" [style="bold"];
+    "bb::A#initialize_11" -> "bb::A#initialize_13" [style="tapered"];
 
     "bb::A#initialize_12" [
-        label = "block[id=12, rubyBlockId=3](<self>: A, <selfRestore>$6: A, <gotoDeadTemp>$13: NilClass, <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\louterLoops: 1\l<blockReturnTemp>$9: Integer(2) = 2\l<gotoDeadTemp>$13: NilClass\l"
+        label = "block[id=12, rubyBlockId=3](<blockReturnTemp>$9: T.nilable(Integer), <self>: A, <selfRestore>$6: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\louterLoops: 1\l<gotoDeadTemp>$13: TrueClass(true) = true\l<gotoDeadTemp>$13: TrueClass(true)\l"
     ];
 
     "bb::A#initialize_12" -> "bb::A#initialize_1" [style="bold"];
-    "bb::A#initialize_12" -> "bb::A#initialize_14" [style="tapered"];
+    "bb::A#initialize_12" -> "bb::A#initialize_13" [style="tapered"];
 
     "bb::A#initialize_13" [
-        label = "block[id=13, rubyBlockId=3](<blockReturnTemp>$9: T.nilable(Integer), <self>: A, <selfRestore>$6: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\louterLoops: 1\l<gotoDeadTemp>$13: TrueClass(true) = true\l<gotoDeadTemp>$13: TrueClass(true)\l"
+        label = "block[id=13, rubyBlockId=1](<blockReturnTemp>$9: Integer, <self>: A, <selfRestore>$6: A, <gotoDeadTemp>$13: NilClass, <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\louterLoops: 1\l<blockReturnTemp>$15: T.noreturn = blockreturn<map> <blockReturnTemp>$9: Integer\l<unconditional>\l"
     ];
 
-    "bb::A#initialize_13" -> "bb::A#initialize_1" [style="bold"];
-    "bb::A#initialize_13" -> "bb::A#initialize_14" [style="tapered"];
-
-    "bb::A#initialize_14" [
-        label = "block[id=14, rubyBlockId=1](<blockReturnTemp>$9: Integer, <self>: A, <selfRestore>$6: A, <gotoDeadTemp>$13: NilClass, <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\louterLoops: 1\l<blockReturnTemp>$15: T.noreturn = blockreturn<map> <blockReturnTemp>$9: Integer\l<unconditional>\l"
-    ];
-
-    "bb::A#initialize_14" -> "bb::A#initialize_2" [style="bold"];
+    "bb::A#initialize_13" -> "bb::A#initialize_2" [style="bold"];
 }
 
 subgraph "cluster_::<Class:A>#<static-init>" {

--- a/test/testdata/desugar/ensure_without_rescue.rb.cfg.exp
+++ b/test/testdata/desugar/ensure_without_rescue.rb.cfg.exp
@@ -34,13 +34,13 @@ subgraph "cluster_::Object#main" {
     ];
 
     "bb::Object#main_6" -> "bb::Object#main_1" [style="bold"];
-    "bb::Object#main_6" -> "bb::Object#main_8" [style="tapered"];
+    "bb::Object#main_6" -> "bb::Object#main_7" [style="tapered"];
 
-    "bb::Object#main_8" [
-        label = "block[id=8, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
+    "bb::Object#main_7" [
+        label = "block[id=7, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
-    "bb::Object#main_8" -> "bb::Object#main_1" [style="bold"];
+    "bb::Object#main_7" -> "bb::Object#main_1" [style="bold"];
 }
 
 subgraph "cluster_::Object#a" {

--- a/test/testdata/infer/control_flow/complex_implication_1.rb.cfg.exp
+++ b/test/testdata/infer/control_flow/complex_implication_1.rb.cfg.exp
@@ -28,7 +28,7 @@ subgraph "cluster_::ModuleMethods#instrumented_request" {
     ];
 
     "bb::ModuleMethods#instrumented_request_0" -> "bb::ModuleMethods#instrumented_request_3" [style="bold"];
-    "bb::ModuleMethods#instrumented_request_0" -> "bb::ModuleMethods#instrumented_request_7" [style="tapered"];
+    "bb::ModuleMethods#instrumented_request_0" -> "bb::ModuleMethods#instrumented_request_4" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_1" [
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
@@ -39,103 +39,103 @@ subgraph "cluster_::ModuleMethods#instrumented_request" {
         label = "block[id=3, rubyBlockId=2](<exceptionValue>$4: T.untyped, final_attempt: T.untyped, foo: T.untyped)\le: T.untyped = <exceptionValue>$4\l<exceptionClassTemp>$5: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$6: T.untyped = e: T.untyped.is_a?(<exceptionClassTemp>$5: T.class_of(StandardError))\l<isaCheckTemp>$6: T.untyped\l"
     ];
 
-    "bb::ModuleMethods#instrumented_request_3" -> "bb::ModuleMethods#instrumented_request_8" [style="bold"];
-    "bb::ModuleMethods#instrumented_request_3" -> "bb::ModuleMethods#instrumented_request_9" [style="tapered"];
+    "bb::ModuleMethods#instrumented_request_3" -> "bb::ModuleMethods#instrumented_request_7" [style="bold"];
+    "bb::ModuleMethods#instrumented_request_3" -> "bb::ModuleMethods#instrumented_request_8" [style="tapered"];
+
+    "bb::ModuleMethods#instrumented_request_4" [
+        label = "block[id=4, rubyBlockId=1](final_attempt: T.untyped, foo: T.untyped)\l<exceptionValue>$4: T.untyped = <unanalyzable>\l<exceptionValue>$4: T.untyped\l"
+    ];
+
+    "bb::ModuleMethods#instrumented_request_4" -> "bb::ModuleMethods#instrumented_request_3" [style="bold"];
+    "bb::ModuleMethods#instrumented_request_4" -> "bb::ModuleMethods#instrumented_request_6" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_6" [
         label = "block[id=6, rubyBlockId=3](<gotoDeadTemp>$7: NilClass, err: NilClass, final_attempt: T.untyped, foo: T.untyped)\l<gotoDeadTemp>$7: NilClass\l"
     ];
 
     "bb::ModuleMethods#instrumented_request_6" -> "bb::ModuleMethods#instrumented_request_1" [style="bold"];
-    "bb::ModuleMethods#instrumented_request_6" -> "bb::ModuleMethods#instrumented_request_10" [style="tapered"];
+    "bb::ModuleMethods#instrumented_request_6" -> "bb::ModuleMethods#instrumented_request_9" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_7" [
-        label = "block[id=7, rubyBlockId=3](final_attempt: T.untyped, foo: T.untyped)\l<exceptionValue>$4: T.untyped = <unanalyzable>\l<exceptionValue>$4: T.untyped\l"
+        label = "block[id=7, rubyBlockId=2](e: StandardError, final_attempt: T.untyped, foo: T.untyped)\lerr: StandardError = e\l<gotoDeadTemp>$7: NilClass\l"
     ];
 
-    "bb::ModuleMethods#instrumented_request_7" -> "bb::ModuleMethods#instrumented_request_3" [style="bold"];
-    "bb::ModuleMethods#instrumented_request_7" -> "bb::ModuleMethods#instrumented_request_6" [style="tapered"];
+    "bb::ModuleMethods#instrumented_request_7" -> "bb::ModuleMethods#instrumented_request_1" [style="bold"];
+    "bb::ModuleMethods#instrumented_request_7" -> "bb::ModuleMethods#instrumented_request_9" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_8" [
-        label = "block[id=8, rubyBlockId=2](e: StandardError, final_attempt: T.untyped, foo: T.untyped)\lerr: StandardError = e\l<gotoDeadTemp>$7: NilClass\l"
+        label = "block[id=8, rubyBlockId=2](final_attempt: T.untyped, foo: T.untyped)\l<gotoDeadTemp>$7: TrueClass(true) = true\l<gotoDeadTemp>$7: TrueClass(true)\l"
     ];
 
     "bb::ModuleMethods#instrumented_request_8" -> "bb::ModuleMethods#instrumented_request_1" [style="bold"];
-    "bb::ModuleMethods#instrumented_request_8" -> "bb::ModuleMethods#instrumented_request_10" [style="tapered"];
+    "bb::ModuleMethods#instrumented_request_8" -> "bb::ModuleMethods#instrumented_request_9" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_9" [
-        label = "block[id=9, rubyBlockId=2](final_attempt: T.untyped, foo: T.untyped)\l<gotoDeadTemp>$7: TrueClass(true) = true\l<gotoDeadTemp>$7: TrueClass(true)\l"
+        label = "block[id=9, rubyBlockId=0](err: T.nilable(StandardError), final_attempt: T.untyped, foo: T.untyped)\lis_successful: T::Boolean = err: T.nilable(StandardError).nil?()\lis_successful: T::Boolean\l"
     ];
 
-    "bb::ModuleMethods#instrumented_request_9" -> "bb::ModuleMethods#instrumented_request_1" [style="bold"];
-    "bb::ModuleMethods#instrumented_request_9" -> "bb::ModuleMethods#instrumented_request_10" [style="tapered"];
+    "bb::ModuleMethods#instrumented_request_9" -> "bb::ModuleMethods#instrumented_request_10" [style="bold"];
+    "bb::ModuleMethods#instrumented_request_9" -> "bb::ModuleMethods#instrumented_request_11" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_10" [
-        label = "block[id=10, rubyBlockId=0](err: T.nilable(StandardError), final_attempt: T.untyped, foo: T.untyped)\lis_successful: T::Boolean = err: T.nilable(StandardError).nil?()\lis_successful: T::Boolean\l"
+        label = "block[id=10, rubyBlockId=0](err: NilClass, foo: T.untyped, is_successful: TrueClass)\l||$2: TrueClass = is_successful\l||$2: TrueClass\l"
     ];
 
-    "bb::ModuleMethods#instrumented_request_10" -> "bb::ModuleMethods#instrumented_request_11" [style="bold"];
-    "bb::ModuleMethods#instrumented_request_10" -> "bb::ModuleMethods#instrumented_request_12" [style="tapered"];
+    "bb::ModuleMethods#instrumented_request_10" -> "bb::ModuleMethods#instrumented_request_13" [style="bold"];
+    "bb::ModuleMethods#instrumented_request_10" -> "bb::ModuleMethods#instrumented_request_14" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_11" [
-        label = "block[id=11, rubyBlockId=0](err: NilClass, foo: T.untyped, is_successful: TrueClass)\l||$2: TrueClass = is_successful\l||$2: TrueClass\l"
+        label = "block[id=11, rubyBlockId=0](err: StandardError, final_attempt: T.untyped, foo: T.untyped, is_successful: FalseClass)\l||$2: T.untyped = final_attempt\l||$2: T.untyped\l"
     ];
 
-    "bb::ModuleMethods#instrumented_request_11" -> "bb::ModuleMethods#instrumented_request_14" [style="bold"];
-    "bb::ModuleMethods#instrumented_request_11" -> "bb::ModuleMethods#instrumented_request_15" [style="tapered"];
+    "bb::ModuleMethods#instrumented_request_11" -> "bb::ModuleMethods#instrumented_request_13" [style="bold"];
+    "bb::ModuleMethods#instrumented_request_11" -> "bb::ModuleMethods#instrumented_request_14" [style="tapered"];
 
-    "bb::ModuleMethods#instrumented_request_12" [
-        label = "block[id=12, rubyBlockId=0](err: StandardError, final_attempt: T.untyped, foo: T.untyped, is_successful: FalseClass)\l||$2: T.untyped = final_attempt\l||$2: T.untyped\l"
+    "bb::ModuleMethods#instrumented_request_13" [
+        label = "block[id=13, rubyBlockId=0](is_successful: T::Boolean, ||$2: T.untyped)\l<ifTemp>$11: T.untyped = ||$2\l<ifTemp>$11: T.untyped\l"
     ];
 
-    "bb::ModuleMethods#instrumented_request_12" -> "bb::ModuleMethods#instrumented_request_14" [style="bold"];
-    "bb::ModuleMethods#instrumented_request_12" -> "bb::ModuleMethods#instrumented_request_15" [style="tapered"];
+    "bb::ModuleMethods#instrumented_request_13" -> "bb::ModuleMethods#instrumented_request_19" [style="bold"];
+    "bb::ModuleMethods#instrumented_request_13" -> "bb::ModuleMethods#instrumented_request_24" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_14" [
-        label = "block[id=14, rubyBlockId=0](is_successful: T::Boolean, ||$2: T.untyped)\l<ifTemp>$11: T.untyped = ||$2\l<ifTemp>$11: T.untyped\l"
+        label = "block[id=14, rubyBlockId=0](err: StandardError, foo: T.untyped, is_successful: FalseClass)\lerr: StandardError\l"
     ];
 
-    "bb::ModuleMethods#instrumented_request_14" -> "bb::ModuleMethods#instrumented_request_20" [style="bold"];
-    "bb::ModuleMethods#instrumented_request_14" -> "bb::ModuleMethods#instrumented_request_25" [style="tapered"];
+    "bb::ModuleMethods#instrumented_request_14" -> "bb::ModuleMethods#instrumented_request_15" [style="bold"];
+    "bb::ModuleMethods#instrumented_request_14" -> "bb::ModuleMethods#instrumented_request_16" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_15" [
-        label = "block[id=15, rubyBlockId=0](err: StandardError, foo: T.untyped, is_successful: FalseClass)\lerr: StandardError\l"
+        label = "block[id=15, rubyBlockId=0](foo: T.untyped, is_successful: FalseClass)\l<ifTemp>$11: T.untyped = foo\l<ifTemp>$11: T.untyped\l"
     ];
 
-    "bb::ModuleMethods#instrumented_request_15" -> "bb::ModuleMethods#instrumented_request_16" [style="bold"];
-    "bb::ModuleMethods#instrumented_request_15" -> "bb::ModuleMethods#instrumented_request_17" [style="tapered"];
+    "bb::ModuleMethods#instrumented_request_15" -> "bb::ModuleMethods#instrumented_request_19" [style="bold"];
+    "bb::ModuleMethods#instrumented_request_15" -> "bb::ModuleMethods#instrumented_request_24" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_16" [
-        label = "block[id=16, rubyBlockId=0](foo: T.untyped, is_successful: FalseClass)\l<ifTemp>$11: T.untyped = foo\l<ifTemp>$11: T.untyped\l"
+        label = "block[id=16, rubyBlockId=0](err: StandardError, is_successful: FalseClass)\l<ifTemp>$11 = err\l<ifTemp>$11\l"
     ];
 
-    "bb::ModuleMethods#instrumented_request_16" -> "bb::ModuleMethods#instrumented_request_20" [style="bold"];
-    "bb::ModuleMethods#instrumented_request_16" -> "bb::ModuleMethods#instrumented_request_25" [style="tapered"];
+    "bb::ModuleMethods#instrumented_request_16" -> "bb::ModuleMethods#instrumented_request_19" [style="bold"];
+    "bb::ModuleMethods#instrumented_request_16" -> "bb::ModuleMethods#instrumented_request_24" [style="tapered"];
 
-    "bb::ModuleMethods#instrumented_request_17" [
-        label = "block[id=17, rubyBlockId=0](err: StandardError, is_successful: FalseClass)\l<ifTemp>$11 = err\l<ifTemp>$11\l"
+    "bb::ModuleMethods#instrumented_request_19" [
+        label = "block[id=19, rubyBlockId=0](is_successful: T::Boolean)\l<ifTemp>$16: T::Boolean = is_successful: T::Boolean.!()\l<ifTemp>$16: T::Boolean\l"
     ];
 
-    "bb::ModuleMethods#instrumented_request_17" -> "bb::ModuleMethods#instrumented_request_20" [style="bold"];
-    "bb::ModuleMethods#instrumented_request_17" -> "bb::ModuleMethods#instrumented_request_25" [style="tapered"];
+    "bb::ModuleMethods#instrumented_request_19" -> "bb::ModuleMethods#instrumented_request_21" [style="bold"];
+    "bb::ModuleMethods#instrumented_request_19" -> "bb::ModuleMethods#instrumented_request_24" [style="tapered"];
 
-    "bb::ModuleMethods#instrumented_request_20" [
-        label = "block[id=20, rubyBlockId=0](is_successful: T::Boolean)\l<ifTemp>$16: T::Boolean = is_successful: T::Boolean.!()\l<ifTemp>$16: T::Boolean\l"
+    "bb::ModuleMethods#instrumented_request_21" [
+        label = "block[id=21, rubyBlockId=0]()\l<returnMethodTemp>$2: Integer(1) = 1\l<unconditional>\l"
     ];
 
-    "bb::ModuleMethods#instrumented_request_20" -> "bb::ModuleMethods#instrumented_request_22" [style="bold"];
-    "bb::ModuleMethods#instrumented_request_20" -> "bb::ModuleMethods#instrumented_request_25" [style="tapered"];
-
-    "bb::ModuleMethods#instrumented_request_22" [
-        label = "block[id=22, rubyBlockId=0]()\l<returnMethodTemp>$2: Integer(1) = 1\l<unconditional>\l"
+    "bb::ModuleMethods#instrumented_request_21" -> "bb::ModuleMethods#instrumented_request_24" [style="bold"];
+    "bb::ModuleMethods#instrumented_request_24" [
+        label = "block[id=24, rubyBlockId=0](<returnMethodTemp>$2: T.nilable(Integer))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)\l<unconditional>\l"
     ];
 
-    "bb::ModuleMethods#instrumented_request_22" -> "bb::ModuleMethods#instrumented_request_25" [style="bold"];
-    "bb::ModuleMethods#instrumented_request_25" [
-        label = "block[id=25, rubyBlockId=0](<returnMethodTemp>$2: T.nilable(Integer))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)\l<unconditional>\l"
-    ];
-
-    "bb::ModuleMethods#instrumented_request_25" -> "bb::ModuleMethods#instrumented_request_1" [style="bold"];
+    "bb::ModuleMethods#instrumented_request_24" -> "bb::ModuleMethods#instrumented_request_1" [style="bold"];
 }
 
 subgraph "cluster_::<Class:ModuleMethods>#<static-init>" {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Split apart the `body` and `else` blocks when building the CFG, with the body transitioning either to the handlers or to `else` depending on the state of `exceptionValue`. Additionally, `else` will now unconditionally jump to `ensure`, modeling the control flow for when exceptions are raised in the `else` block.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Closer modeling of the control flow during exception handling.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
