### PR TITLE
Remove CFGContext.rubyBlockId

### DIFF
--- a/cfg/builder/builder.h
+++ b/cfg/builder/builder.h
@@ -31,7 +31,6 @@ public:
     core::LocalVariable target;
     core::LocalVariable blockBreakTarget;
     int loops;
-    int rubyBlockId;
     bool isInsideRubyBlock;
     BasicBlock *nextScope;
     BasicBlock *breakScope;
@@ -46,18 +45,17 @@ public:
     CFGContext withBlockBreakTarget(core::LocalVariable blockBreakTarget);
     CFGContext withLoopScope(BasicBlock *nextScope, BasicBlock *breakScope, bool insideRubyBlock = false);
     CFGContext withSendAndBlockLink(const std::shared_ptr<core::SendAndBlockLink> &link);
-    CFGContext withRubyBlockId(int newBlockId);
 
     core::LocalVariable newTemporary(core::NameRef name);
 
 private:
     friend std::unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md);
-    CFGContext(core::Context ctx, CFG &inWhat, core::LocalVariable target, int loops, int rubyBlockId,
-               BasicBlock *nextScope, BasicBlock *breakScope, BasicBlock *rescueScope,
+    CFGContext(core::Context ctx, CFG &inWhat, core::LocalVariable target, int loops, BasicBlock *nextScope,
+               BasicBlock *breakScope, BasicBlock *rescueScope,
                UnorderedMap<core::SymbolRef, core::LocalVariable> &aliases,
                UnorderedMap<core::NameRef, core::LocalVariable> &discoveredUndeclaredFields, u4 &temporaryCounter)
-        : ctx(ctx), inWhat(inWhat), target(target), loops(loops), rubyBlockId(rubyBlockId), isInsideRubyBlock(false),
-          nextScope(nextScope), breakScope(breakScope), rescueScope(rescueScope), aliases(aliases),
+        : ctx(ctx), inWhat(inWhat), target(target), loops(loops), isInsideRubyBlock(false), nextScope(nextScope),
+          breakScope(breakScope), rescueScope(rescueScope), aliases(aliases),
           discoveredUndeclaredFields(discoveredUndeclaredFields), temporaryCounter(temporaryCounter){};
 };
 } // namespace sorbet::cfg

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -18,7 +18,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
     u4 temporaryCounter = 1;
     UnorderedMap<core::SymbolRef, core::LocalVariable> aliases;
     UnorderedMap<core::NameRef, core::LocalVariable> discoveredUndeclaredFields;
-    CFGContext cctx(ctx, *res.get(), core::LocalVariable(), 0, 0, nullptr, nullptr, nullptr, aliases,
+    CFGContext cctx(ctx, *res.get(), core::LocalVariable(), 0, nullptr, nullptr, nullptr, aliases,
                     discoveredUndeclaredFields, temporaryCounter);
 
     core::LocalVariable retSym = cctx.newTemporary(core::Names::returnMethodTemp());
@@ -121,12 +121,6 @@ void CFGBuilder::fillInTopoSorts(core::Context ctx, CFG &cfg) {
 CFGContext CFGContext::withTarget(core::LocalVariable target) {
     auto ret = CFGContext(*this);
     ret.target = target;
-    return ret;
-}
-
-CFGContext CFGContext::withRubyBlockId(int blockId) {
-    auto ret = CFGContext(*this);
-    ret.rubyBlockId = blockId;
     return ret;
 }
 

--- a/test/testdata/cfg/rescue_else_block.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_else_block.rb.cfg.exp
@@ -32,7 +32,7 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_4" -> "bb::Object#foo_10" [style="tapered"];
 
     "bb::Object#foo_6" [
-        label = "block[id=6, rubyBlockId=0]()\l<returnMethodTemp>$2: Integer(3) = 3\l<unconditional>\l"
+        label = "block[id=6, rubyBlockId=4]()\l<returnMethodTemp>$2: Integer(3) = 3\l<unconditional>\l"
     ];
 
     "bb::Object#foo_6" -> "bb::Object#foo_10" [style="bold"];

--- a/test/testdata/cfg/retry.rb.cfg.exp
+++ b/test/testdata/cfg/retry.rb.cfg.exp
@@ -37,7 +37,7 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_4" -> "bb::Object#main_10" [style="tapered"];
 
     "bb::Object#main_5" [
-        label = "block[id=5, rubyBlockId=0](<self>: Object, try: Integer(0))\l<statTemp>$9: Integer(0) = try\l<statTemp>$10: Integer(1) = 1\ltry: Integer = <statTemp>$9: Integer(0).+(<statTemp>$10: Integer(1))\l<statTemp>$12: String(\"e\") = \"e\"\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$12: String(\"e\"))\l<unconditional>\l"
+        label = "block[id=5, rubyBlockId=1](<self>: Object, try: Integer(0))\l<statTemp>$9: Integer(0) = try\l<statTemp>$10: Integer(1) = 1\ltry: Integer = <statTemp>$9: Integer(0).+(<statTemp>$10: Integer(1))\l<statTemp>$12: String(\"e\") = \"e\"\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$12: String(\"e\"))\l<unconditional>\l"
     ];
 
     "bb::Object#main_5" -> "bb::Object#main_10" [style="bold"];

--- a/test/testdata/cfg/retry_multiple.rb.cfg.exp
+++ b/test/testdata/cfg/retry_multiple.rb.cfg.exp
@@ -37,19 +37,19 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_4" -> "bb::Object#main_6" [style="tapered"];
 
     "bb::Object#main_5" [
-        label = "block[id=5, rubyBlockId=0](<self>: Object, try: Integer(0))\l<statTemp>$9: Integer(0) = try\l<statTemp>$10: Integer(1) = 1\ltry: Integer = <statTemp>$9: Integer(0).+(<statTemp>$10: Integer(1))\l<statTemp>$13: T.class_of(A) = alias <C A>\l<statTemp>$12: A = <statTemp>$13: T.class_of(A).new()\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$12: A)\l<unconditional>\l"
+        label = "block[id=5, rubyBlockId=1](<self>: Object, try: Integer(0))\l<statTemp>$9: Integer(0) = try\l<statTemp>$10: Integer(1) = 1\ltry: Integer = <statTemp>$9: Integer(0).+(<statTemp>$10: Integer(1))\l<statTemp>$13: T.class_of(A) = alias <C A>\l<statTemp>$12: A = <statTemp>$13: T.class_of(A).new()\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$12: A)\l<unconditional>\l"
     ];
 
     "bb::Object#main_5" -> "bb::Object#main_13" [style="bold"];
     "bb::Object#main_6" [
-        label = "block[id=6, rubyBlockId=0](<returnMethodTemp>$2: NilClass, <self>: Object, try: Integer(0))\l<statTemp>$16: Integer(6) = 6\l<ifTemp>$14: T::Boolean = try: Integer(0).<(<statTemp>$16: Integer(6))\l<ifTemp>$14: T::Boolean\l"
+        label = "block[id=6, rubyBlockId=1](<returnMethodTemp>$2: NilClass, <self>: Object, try: Integer(0))\l<statTemp>$16: Integer(6) = 6\l<ifTemp>$14: T::Boolean = try: Integer(0).<(<statTemp>$16: Integer(6))\l<ifTemp>$14: T::Boolean\l"
     ];
 
     "bb::Object#main_6" -> "bb::Object#main_7" [style="bold"];
     "bb::Object#main_6" -> "bb::Object#main_13" [style="tapered"];
 
     "bb::Object#main_7" [
-        label = "block[id=7, rubyBlockId=0](<self>: Object, try: Integer(0))\l<statTemp>$18: Integer(0) = try\l<statTemp>$19: Integer(1) = 1\ltry: Integer = <statTemp>$18: Integer(0).+(<statTemp>$19: Integer(1))\l<statTemp>$22: T.class_of(B) = alias <C B>\l<statTemp>$21: B = <statTemp>$22: T.class_of(B).new()\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$21: B)\l<unconditional>\l"
+        label = "block[id=7, rubyBlockId=1](<self>: Object, try: Integer(0))\l<statTemp>$18: Integer(0) = try\l<statTemp>$19: Integer(1) = 1\ltry: Integer = <statTemp>$18: Integer(0).+(<statTemp>$19: Integer(1))\l<statTemp>$22: T.class_of(B) = alias <C B>\l<statTemp>$21: B = <statTemp>$22: T.class_of(B).new()\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$21: B)\l<unconditional>\l"
     ];
 
     "bb::Object#main_7" -> "bb::Object#main_13" [style="bold"];

--- a/test/testdata/cfg/retry_nested.rb.cfg.exp
+++ b/test/testdata/cfg/retry_nested.rb.cfg.exp
@@ -35,7 +35,7 @@ subgraph "cluster_::Object#main" {
 
     "bb::Object#main_4" -> "bb::Object#main_5" [style="bold"];
     "bb::Object#main_5" [
-        label = "block[id=5, rubyBlockId=0](<returnMethodTemp>$2: NilClass, <self>: Object, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<exceptionValue>$8: T.untyped = <unanalyzable>\l<exceptionValue>$8: T.untyped\l"
+        label = "block[id=5, rubyBlockId=1](<returnMethodTemp>$2: NilClass, <self>: Object, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<exceptionValue>$8: T.untyped = <unanalyzable>\l<exceptionValue>$8: T.untyped\l"
     ];
 
     "bb::Object#main_5" -> "bb::Object#main_6" [style="bold"];
@@ -56,19 +56,19 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_7" -> "bb::Object#main_9" [style="tapered"];
 
     "bb::Object#main_8" [
-        label = "block[id=8, rubyBlockId=0](<self>: Object, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<statTemp>$13: Integer(0) = try\l<statTemp>$14: Integer(1) = 1\ltry: Integer = <statTemp>$13: Integer(0).+(<statTemp>$14: Integer(1))\l<statTemp>$17: T.class_of(A) = alias <C A>\l<statTemp>$16: A = <statTemp>$17: T.class_of(A).new()\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$16: A)\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=5](<self>: Object, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<statTemp>$13: Integer(0) = try\l<statTemp>$14: Integer(1) = 1\ltry: Integer = <statTemp>$13: Integer(0).+(<statTemp>$14: Integer(1))\l<statTemp>$17: T.class_of(A) = alias <C A>\l<statTemp>$16: A = <statTemp>$17: T.class_of(A).new()\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$16: A)\l<unconditional>\l"
     ];
 
     "bb::Object#main_8" -> "bb::Object#main_16" [style="bold"];
     "bb::Object#main_9" [
-        label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: NilClass, <self>: Object, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<statTemp>$20: Integer(6) = 6\l<ifTemp>$18: T::Boolean = try: Integer(0).<(<statTemp>$20: Integer(6))\l<ifTemp>$18: T::Boolean\l"
+        label = "block[id=9, rubyBlockId=5](<returnMethodTemp>$2: NilClass, <self>: Object, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<statTemp>$20: Integer(6) = 6\l<ifTemp>$18: T::Boolean = try: Integer(0).<(<statTemp>$20: Integer(6))\l<ifTemp>$18: T::Boolean\l"
     ];
 
     "bb::Object#main_9" -> "bb::Object#main_10" [style="bold"];
     "bb::Object#main_9" -> "bb::Object#main_16" [style="tapered"];
 
     "bb::Object#main_10" [
-        label = "block[id=10, rubyBlockId=0](<self>: Object, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<statTemp>$22: Integer(0) = try\l<statTemp>$23: Integer(1) = 1\ltry: Integer = <statTemp>$22: Integer(0).+(<statTemp>$23: Integer(1))\l<statTemp>$26: T.class_of(B) = alias <C B>\l<statTemp>$25: B = <statTemp>$26: T.class_of(B).new()\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$25: B)\l<unconditional>\l"
+        label = "block[id=10, rubyBlockId=5](<self>: Object, <gotoDeadTemp>$33: NilClass, try: Integer(0))\l<statTemp>$22: Integer(0) = try\l<statTemp>$23: Integer(1) = 1\ltry: Integer = <statTemp>$22: Integer(0).+(<statTemp>$23: Integer(1))\l<statTemp>$26: T.class_of(B) = alias <C B>\l<statTemp>$25: B = <statTemp>$26: T.class_of(B).new()\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$25: B)\l<unconditional>\l"
     ];
 
     "bb::Object#main_10" -> "bb::Object#main_16" [style="bold"];


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This field is redundant with `current->rubyBlockId`, and is difficult to keep in sync.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Removing this field makes it easier to construct a CFG during the builder walk that has the correct rubyBlockId assignments.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
There were some changes to the CFG exp files for programs that used exception handling. I examined the changed graphs with `tools/scripts/cfg-view.sh`, and the new graphs make sense.

See included automated tests.