### PR TITLE
Clean up old foreign key getter

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -605,14 +605,6 @@ class T::Props::Decorator
       end
       loaded_foreign
     end
-
-    @class.send(:define_method, "#{prop_name}_record") do |allow_direct_mutation: nil|
-      T::Configuration.soft_assert_handler(
-        "Using deprecated 'model.#{prop_name}_record' foreign key syntax. You should replace this with 'model.#{prop_name}_'",
-        notify: 'vasi'
-      )
-      send(fk_method, allow_direct_mutation: allow_direct_mutation)
-    end
   end
 
   # checked(:never) - Rules hash is expensive to check


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Clean up old code since Stripe side does not use the old foreign key getter any more. 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The removed method was not tested in sorbet-runtime.
