### PR TITLE
Fix the FileOps::ensureDir test

### DIFF
--- a/common/test/common_test.cc
+++ b/common/test/common_test.cc
@@ -15,7 +15,7 @@ TEST(CommonTest, Levenstein) { // NOLINT
 
 class EnsureDirTest : public ::testing::Test {
 protected:
-    EnsureDirTest() {
+    void SetUp() override {
         if (FileOps::dirExists("common_test_dir")) {
             FileOps::removeDir("common_test_dir");
         }
@@ -26,7 +26,7 @@ protected:
     }
 };
 
-TEST(EnsureDirTest, Test) { // NOLINT
+TEST_F(EnsureDirTest, Test) { // NOLINT
     EXPECT_TRUE(FileOps::ensureDir("common_test_dir"));
     EXPECT_FALSE(FileOps::ensureDir("common_test_dir"));
 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The test for `FileOps::ensureDir` wasn't calling the setup/teardown methods of the fixture, as it was defined with `TEST` instead of `TEST_F`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.