### PR TITLE
Widen type returned by non_forcing_is_a?

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1177,16 +1177,10 @@ public:
             return;
         }
 
-        auto resolvedType = current.data(gs)->externalType(gs);
-        if (args.args[0]->type->isUntyped()) {
-            res.returnType = Types::Boolean();
-        } else if (Types::isSubType(gs, args.args[0]->type, resolvedType)) {
-            res.returnType = Types::trueClass();
-        } else if (Types::glb(gs, args.args[0]->type, resolvedType)->isBottom()) {
-            res.returnType = Types::falseClass();
-        } else {
-            res.returnType = Types::Boolean();
-        }
+        // The generated code relies on being able to generate calls non_forcing_is_a? unconditionally.
+        // If we were do to something smarter here with the returnType, infer would report dead code
+        // errors when it could prove that the check was always false, so we always return T::Boolean.
+        // (Well, it's implicit from the sig.)
     }
 } T_NonForcingConstants_nonForcingIsA_p;
 

--- a/test/testdata/infer/non_forcing_is_a.rb
+++ b/test/testdata/infer/non_forcing_is_a.rb
@@ -36,15 +36,15 @@ end
 
 p ::Outer::N::Inner
 x = T::NonForcingConstants.non_forcing_is_a?(Outer::Nested::Inner.new, '::Outer::N::Inner')
-T.reveal_type(x) # error: Revealed type: `TrueClass`
+T.reveal_type(x) # error: Revealed type: `T::Boolean`
 
 # Prints first symbol to not resolve when name doesn't exist
 T::NonForcingConstants.non_forcing_is_a?(x, '::Integer::DoesntExist::After') # error: Unable to resolve constant `::Integer::DoesntExist`
 # Prints first symbol to not resolve when name exists but symbol doesn't
 T::NonForcingConstants.non_forcing_is_a?(x, '::Integer::String::After') # error: Unable to resolve constant `::Integer::String`
 
-T.reveal_type(T::NonForcingConstants.non_forcing_is_a?('', '::String')) # error: Revealed type: `TrueClass`
-T.reveal_type(T::NonForcingConstants.non_forcing_is_a?(0, '::String')) # error: Revealed type: `FalseClass`
+T.reveal_type(T::NonForcingConstants.non_forcing_is_a?('', '::String')) # error: Revealed type: `T::Boolean`
+T.reveal_type(T::NonForcingConstants.non_forcing_is_a?(0, '::String')) # error: Revealed type: `T::Boolean`
 
 i_or_s = T.let(0, T.any(Integer, String))
 T.reveal_type(T::NonForcingConstants.non_forcing_is_a?(i_or_s, '::String')) # error: Revealed type: `T::Boolean`

--- a/test/testdata/infer/non_forcing_is_a_dead.rb
+++ b/test/testdata/infer/non_forcing_is_a_dead.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+class MyStruct
+  sig {returns(Integer)}
+  def foo
+    # We know this check is false, but we can't say so, because similar checks
+    # get included in generated code before we can know that the generated check
+    # will fail.
+    if T::NonForcingConstants.non_forcing_is_a?(self, '::Integer')
+      puts self
+    end
+
+    0
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is prework for a prop change:

> The generated code relies on being able to generate calls non_forcing_is_a?
> unconditionally. If we were do to something smarter here with the returnType,
> infer would report dead code errors when it could prove that the check was
> always false, so we always return T::Boolean. (Well, it's implicit from the
> sig.)



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.