### PR TITLE
sorbet-runtime raises only TypeErrors

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/custom_type.rb
+++ b/gems/sorbet-runtime/lib/types/props/custom_type.rb
@@ -100,7 +100,7 @@ module T::Props
         if val.is_a?(Hash)
           msg += "\nIf you want to store a structured Hash, consider using a T::Struct as your type."
         end
-        raise T::Props::InvalidValueError.new(msg)
+        raise TypeError.new(msg)
       end
       val
     end

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -25,7 +25,7 @@ module T::Props::Serializable
         :generate_serialize_source
       )
       if msg
-        raise T::Props::InvalidValueError.new(msg)
+        raise TypeError.new(msg)
       else
         raise
       end
@@ -62,7 +62,7 @@ module T::Props::Serializable
         :generate_deserialize_source
       )
       if msg
-        raise T::Props::InvalidValueError.new(msg)
+        raise TypeError.new(msg)
       else
         raise
       end
@@ -138,7 +138,7 @@ module T::Props::Serializable
         prop: prop, class: self.class.name, id: self.class.decorator.get_id(self)
       )
     else
-      raise T::Props::InvalidValueError.new("#{self.class.name}.#{prop} not set for non-optional prop")
+      raise TypeError.new("#{self.class.name}.#{prop} not set for non-optional prop")
     end
   end
 

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -159,7 +159,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
         raise "#{msg} #{extra.inspect}"
       end
 
-      e = assert_raises(T::Props::InvalidValueError) do
+      e = assert_raises(TypeError) do
         MySerializable.from_hash({'foo' => "Won't respond like hash"})
       end
 
@@ -171,7 +171,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     it 'includes relevant generated code on serialize' do
       m = a_serializable
       m.instance_variable_set(:@foo, "Won't respond like hash")
-      e = assert_raises(T::Props::InvalidValueError) do
+      e = assert_raises(TypeError) do
         m.serialize
       end
 
@@ -309,7 +309,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
 
     it 'throws exception on nil serialize' do
       foo = NilFieldStruct.allocate
-      ex = assert_raises(T::Props::InvalidValueError) do
+      ex = assert_raises(TypeError) do
         foo.serialize
       end
       assert_includes(ex.message, 'Opus::Types::Test::Props::SerializableTest::NilFieldStruct.foo not set for non-optional prop')
@@ -338,7 +338,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
 
       it 'throws exception on nil serialize' do
         struct = NilFieldWeakConstructor.new
-        assert_raises(T::Props::InvalidValueError) do
+        assert_raises(TypeError) do
           struct.serialize
         end
       end
@@ -364,7 +364,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
 
       it 'throws exception on nil serialize' do
         struct = NilDefaultStruct.new
-        assert_raises(T::Props::InvalidValueError) do
+        assert_raises(TypeError) do
           struct.serialize
         end
       end

--- a/gems/sorbet-runtime/test/types/props/struct.rb
+++ b/gems/sorbet-runtime/test/types/props/struct.rb
@@ -163,12 +163,12 @@ class Opus::Types::Test::Props::StructTest < Critic::Unit::UnitTest
       assert_equal(10, doc.foo1)
       assert_equal(20, doc.foo2)
 
-      assert_raises(T::Props::InvalidValueError) do
+      assert_raises(TypeError) do
         StructWithReqiredField.from_hash({'foo2' => 20})
       end
 
       # The code should behave for deserialization.
-      assert_raises(T::Props::InvalidValueError) do
+      assert_raises(TypeError) do
         StructWithReqiredField.from_hash({'foo1' => 10})
       end
     end


### PR DESCRIPTION
Raise TypeError where we previously would raise InvalidPropValue.  Merging this means blocking releasing sorbet-runtime to pay-server until http://go/pr/231190 is merged.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
InvalidValueErrors are TypeErrors and we want consistency during codegen.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
