### PR TITLE
Allow string subclasses for foreign props and improve error message

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -623,8 +623,8 @@ class T::Props::Decorator
       :foreign, foreign, valid_type_msg: "a model class or a Proc that returns one"
     )
 
-    if prop_cls != String
-      raise ArgumentError.new("`foreign` can only be used with a prop type of String")
+    if !(prop_cls <= String)
+      raise ArgumentError.new("`foreign` can only be used with a prop type of String, but property `#{prop_name}` uses `#{prop_cls}`")
     end
 
     if foreign.is_a?(Array)

--- a/gems/sorbet-runtime/test/types/props/decorator.rb
+++ b/gems/sorbet-runtime/test/types/props/decorator.rb
@@ -163,6 +163,32 @@ class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest
         end
       end
     end
+
+    it 'allows foreign props that are Strings' do
+      Class.new do
+        include T::Props
+        prop :foo, String, foreign: -> {Class} # boom: =
+      end 
+    end
+
+    it 'allows foreign props that are String subclasses' do
+      class InheritsString < String
+      end
+
+      Class.new do
+        include T::Props
+        prop :foo, InheritsString, foreign: -> {Class} # boom: =
+      end 
+    end
+
+    it 'disallows foreign props that are not Strings' do
+      assert_raises(ArgumentError) do
+        Class.new do
+          include T::Props
+          prop :foo, Integer, foreign: -> {Class} # boom: =
+        end
+      end
+    end
   end
 
   class StructHash < T::Struct


### PR DESCRIPTION
This change allows `foreign` props to be not just `String`, but any String subclass. It also improves the error message when you violate this constraint.


### Motivation
I believe this change makes sense in general (it's more like `is_a?` instead of `class ==`), but it also unblocks a much better version of the typed token experience I'm prototyping, which is the immediate motivation.


### Test plan
Added tests for the new and old behavior in `gems/sorbet-runtime/test/types/props/decorator.rb`

