### PR TITLE
Fix the bazel-toolchain dependency

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -138,9 +138,9 @@ package(default_visibility = ["//visibility:public"])
     # https://github.com/DarkDimius/bazel-toolchain/tree/dp-srb-now
     http_archive(
         name = "com_grail_bazel_toolchain",
-        urls = _github_public_urls("DarkDimius/bazel-toolchain/archive/dce4dc28a78fc7d2c89439cf40327e2b3da20d5c.zip"),
-        sha256 = "f1545a86e59eb026bbbfa6ed45a4118bc7fd544882ddbed9aea080cf7dfe08cd",
-        strip_prefix = "bazel-toolchain-dce4dc28a78fc7d2c89439cf40327e2b3da20d5c",
+        urls = _github_public_urls("DarkDimius/bazel-toolchain/archive/8c80ac885551e9efa7d3b5c441841afae49704db.zip"),
+        sha256 = "a11d9fe8861f71b98706171d4b98cc1cfbed9925e38a4f10f5b42d9c581b6407",
+        strip_prefix = "bazel-toolchain-8c80ac885551e9efa7d3b5c441841afae49704db",
     )
 
     http_archive(


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
LLVM.org has started rejecting downloads to `https://releases.llvm.org/9.0.0/clang%2Bllvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz`. We were manually translating from `+` to `%2B`, so the change here is just to bump to an updated version of `bazel-toolchain` that doesn't do that translation.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fix master.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
