### PR TITLE
Skip generating bodies for props in modules

### DIFF
--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -96,6 +96,11 @@ bool wantTypedInitialize(SyntacticSuperClass syntacticSuperClass) {
     }
 }
 
+struct PropContext {
+    SyntacticSuperClass syntacticSuperClass = SyntacticSuperClass::Unknown;
+    ast::ClassDef::Kind classDefKind;
+};
+
 struct PropInfo {
     core::LocOffsets loc;
     bool isImmutable = false;
@@ -271,7 +276,7 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
 }
 
 vector<unique_ptr<ast::Expression>> processProp(core::MutableContext ctx, const PropInfo &ret,
-                                                SyntacticSuperClass syntacticSuperClass) {
+                                                PropContext propContext) {
     vector<unique_ptr<ast::Expression>> nodes;
 
     const auto loc = ret.loc;
@@ -300,8 +305,8 @@ vector<unique_ptr<ast::Expression>> processProp(core::MutableContext ctx, const 
         auto insSeq = ast::MK::InsSeq1(loc, std::move(assertTypeMatches), ast::MK::RaiseUnimplemented(loc));
         nodes.emplace_back(ASTUtil::mkGet(ctx, loc, name, std::move(insSeq)));
     } else if (ret.ifunset == nullptr) {
-        if (knownNonModel(syntacticSuperClass)) {
-            if (wantTypedInitialize(syntacticSuperClass)) {
+        if (knownNonModel(propContext.syntacticSuperClass)) {
+            if (wantTypedInitialize(propContext.syntacticSuperClass)) {
                 nodes.emplace_back(ASTUtil::mkGet(ctx, loc, name, ast::MK::Instance(nameLoc, ivarName)));
             } else {
                 // Need to hide the instance variable access, because there wasn't a typed constructor to declare it
@@ -327,8 +332,8 @@ vector<unique_ptr<ast::Expression>> processProp(core::MutableContext ctx, const 
             loc, ast::MK::Hash1(loc, ast::MK::Symbol(nameLoc, core::Names::arg0()), ASTUtil::dupType(setType.get())),
             ASTUtil::dupType(setType.get())));
 
-        if (ret.enum_ == nullptr && knownNonDocument(syntacticSuperClass)) {
-            if (wantTypedInitialize(syntacticSuperClass)) {
+        if (ret.enum_ == nullptr && knownNonDocument(propContext.syntacticSuperClass)) {
+            if (wantTypedInitialize(propContext.syntacticSuperClass)) {
                 auto ivarSet = ast::MK::Assign(loc, ast::MK::Instance(nameLoc, ivarName),
                                                ast::MK::Local(nameLoc, core::Names::arg0()));
                 nodes.emplace_back(ASTUtil::mkSet(ctx, loc, setName, nameLoc, std::move(ivarSet)));
@@ -530,6 +535,7 @@ void Prop::run(core::MutableContext ctx, ast::ClassDef *klass) {
             syntacticSuperClass = SyntacticSuperClass::ChalkODMDocument;
         }
     }
+    auto propContext = PropContext{syntacticSuperClass, klass->kind};
     UnorderedMap<ast::Expression *, vector<unique_ptr<ast::Expression>>> replaceNodes;
     vector<PropInfo> props;
     for (auto &stat : klass->rhs) {
@@ -541,7 +547,7 @@ void Prop::run(core::MutableContext ctx, ast::ClassDef *klass) {
         if (!propInfo.has_value()) {
             continue;
         }
-        auto processed = processProp(ctx, propInfo.value(), syntacticSuperClass);
+        auto processed = processProp(ctx, propInfo.value(), propContext);
         ENFORCE(!processed.empty(), "if parseProp completed successfully, processProp must complete too");
 
         vector<unique_ptr<ast::Expression>> nodes;

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -304,14 +304,16 @@ vector<unique_ptr<ast::Expression>> processProp(core::MutableContext ctx, const 
                                                      ASTUtil::dupType(getType.get()));
         auto insSeq = ast::MK::InsSeq1(loc, std::move(assertTypeMatches), ast::MK::RaiseUnimplemented(loc));
         nodes.emplace_back(ASTUtil::mkGet(ctx, loc, name, std::move(insSeq)));
+    } else if (propContext.classDefKind == ast::ClassDef::Kind::Module) {
+        // Not all modules include Kernel, can't make an initialize, etc. so we're punting on props in modules rn.
+        nodes.emplace_back(ASTUtil::mkGet(ctx, loc, name, ast::MK::RaiseUnimplemented(loc)));
     } else if (ret.ifunset == nullptr) {
         if (knownNonModel(propContext.syntacticSuperClass)) {
             if (wantTypedInitialize(propContext.syntacticSuperClass)) {
                 nodes.emplace_back(ASTUtil::mkGet(ctx, loc, name, ast::MK::Instance(nameLoc, ivarName)));
             } else {
                 // Need to hide the instance variable access, because there wasn't a typed constructor to declare it
-                auto castSelf = ast::MK::Unsafe(loc, ast::MK::Self(loc));
-                auto ivarGet = ast::MK::Send1(loc, std::move(castSelf), core::Names::instanceVariableGet(),
+                auto ivarGet = ast::MK::Send1(loc, ast::MK::Self(loc), core::Names::instanceVariableGet(),
                                               ast::MK::Symbol(nameLoc, ivarName));
                 nodes.emplace_back(ASTUtil::mkGet(ctx, loc, name, std::move(ivarGet)));
             }
@@ -332,16 +334,18 @@ vector<unique_ptr<ast::Expression>> processProp(core::MutableContext ctx, const 
             loc, ast::MK::Hash1(loc, ast::MK::Symbol(nameLoc, core::Names::arg0()), ASTUtil::dupType(setType.get())),
             ASTUtil::dupType(setType.get())));
 
-        if (ret.enum_ == nullptr && knownNonDocument(propContext.syntacticSuperClass)) {
+        if (propContext.classDefKind == ast::ClassDef::Kind::Module) {
+            // Not all modules include Kernel, can't make an initialize, etc. so we're punting on props in modules rn.
+            nodes.emplace_back(ASTUtil::mkGet(ctx, loc, name, ast::MK::RaiseUnimplemented(loc)));
+        } else if (ret.enum_ == nullptr && knownNonDocument(propContext.syntacticSuperClass)) {
             if (wantTypedInitialize(propContext.syntacticSuperClass)) {
                 auto ivarSet = ast::MK::Assign(loc, ast::MK::Instance(nameLoc, ivarName),
                                                ast::MK::Local(nameLoc, core::Names::arg0()));
                 nodes.emplace_back(ASTUtil::mkSet(ctx, loc, setName, nameLoc, std::move(ivarSet)));
             } else {
                 // need to hide the instance variable access, because there wasn't a typed constructor to declare it
-                auto castSelf = ast::MK::Unsafe(loc, ast::MK::Self(loc));
                 auto ivarSet =
-                    ast::MK::Send2(loc, std::move(castSelf), core::Names::instanceVariableSet(),
+                    ast::MK::Send2(loc, ast::MK::Self(loc), core::Names::instanceVariableSet(),
                                    ast::MK::Symbol(nameLoc, ivarName), ast::MK::Local(nameLoc, core::Names::arg0()));
                 nodes.emplace_back(ASTUtil::mkSet(ctx, loc, setName, nameLoc, std::move(ivarSet)));
             }

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -336,7 +336,7 @@ vector<unique_ptr<ast::Expression>> processProp(core::MutableContext ctx, const 
 
         if (propContext.classDefKind == ast::ClassDef::Kind::Module) {
             // Not all modules include Kernel, can't make an initialize, etc. so we're punting on props in modules rn.
-            nodes.emplace_back(ASTUtil::mkGet(ctx, loc, name, ast::MK::RaiseUnimplemented(loc)));
+            nodes.emplace_back(ASTUtil::mkSet(ctx, loc, setName, nameLoc, ast::MK::RaiseUnimplemented(loc)));
         } else if (ret.enum_ == nullptr && knownNonDocument(propContext.syntacticSuperClass)) {
             if (wantTypedInitialize(propContext.syntacticSuperClass)) {
                 auto ivarSet = ast::MK::Assign(loc, ast::MK::Instance(nameLoc, ivarName),

--- a/test/testdata/rewriter/chalk_odm_document.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/chalk_odm_document.rb.rewrite-tree.exp
@@ -5,7 +5,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def my_parent_method<<C <todo sym>>>(&<blk>)
-      ::T.unsafe(<self>).instance_variable_get(:"@my_parent_method")
+      <self>.instance_variable_get(:"@my_parent_method")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||

--- a/test/testdata/rewriter/prop_in_module.rb
+++ b/test/testdata/rewriter/prop_in_module.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+module BagOfProps
+  include T::Props
+
+  prop :foo, String
+end

--- a/test/testdata/rewriter/prop_in_module.rb
+++ b/test/testdata/rewriter/prop_in_module.rb
@@ -5,3 +5,11 @@ module BagOfProps
 
   prop :foo, String
 end
+
+class MyClass
+  include BagOfProps
+end
+
+my_class = MyClass.new
+p my_class.foo = 'hello'
+p my_class.foo

--- a/test/testdata/rewriter/prop_in_module.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_in_module.rb.rewrite-tree.exp
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params({:"arg0" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo=<<C <todo sym>>>(arg0, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -22,6 +22,16 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :"foo")
 
-    ::Sorbet::Private::Static.keep_def(<self>, :"foo")
+    ::Sorbet::Private::Static.keep_def(<self>, :"foo=")
   end
+
+  class <emptyTree>::<C MyClass><<C <todo sym>>> < (::<todo sym>)
+    <self>.include(<emptyTree>::<C BagOfProps>)
+  end
+
+  my_class = <emptyTree>::<C MyClass>.new()
+
+  <self>.p(my_class.foo=("hello"))
+
+  <self>.p(my_class.foo())
 end

--- a/test/testdata/rewriter/prop_in_module.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_in_module.rb.rewrite-tree.exp
@@ -1,0 +1,27 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C BagOfProps><<C <todo sym>>> < ()
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({}).returns(<emptyTree>::<C String>)
+    end
+
+    def foo<<C <todo sym>>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params({:"arg0" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
+    end
+
+    def foo<<C <todo sym>>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    <self>.include(<emptyTree>::<C T>::<C Props>)
+
+    <self>.prop(:"foo", <emptyTree>::<C String>, {:"without_accessors" => true})
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"foo")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"foo")
+  end
+end

--- a/test/testdata/rewriter/t_struct/inexact.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/inexact.rb.rewrite-tree.exp
@@ -5,7 +5,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo<<C <todo sym>>>(&<blk>)
-      ::T.unsafe(<self>).instance_variable_get(:"@foo")
+      <self>.instance_variable_get(:"@foo")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -13,7 +13,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.unsafe(<self>).instance_variable_set(:"@foo", arg0)
+      <self>.instance_variable_set(:"@foo", arg0)
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def bar<<C <todo sym>>>(&<blk>)
-      ::T.unsafe(<self>).instance_variable_get(:"@bar")
+      <self>.instance_variable_get(:"@bar")
     end
 
     ::T::Sig::WithoutRuntime.sig() do ||
@@ -29,7 +29,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def bar=<<C <todo sym>>>(arg0, &<blk>)
-      ::T.unsafe(<self>).instance_variable_set(:"@bar", arg0)
+      <self>.instance_variable_set(:"@bar", arg0)
     end
 
     <self>.prop(:"foo", <emptyTree>::<C Integer>, {:"without_accessors" => true})


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This means we don't have to put T.unsafe or T.cast in the bodies, which
will give us better confidence that these implementations are correct.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.