### PR TITLE
Support more clang mirrors

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -26,7 +26,7 @@ steps:
 
   - label: ":mac: test-static-sanitized.sh (master only)"
     command: .buildkite/test-static-sanitized.sh
-    #branches: "master"
+    branches: "master"
     artifact_paths: _out_/profile.json
     agents:
       os: mac

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -26,7 +26,7 @@ steps:
 
   - label: ":mac: test-static-sanitized.sh (master only)"
     command: .buildkite/test-static-sanitized.sh
-    branches: "master"
+    #branches: "master"
     artifact_paths: _out_/profile.json
     agents:
       os: mac

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,6 +9,10 @@ load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 llvm_toolchain(
     name = "llvm_toolchain",
     absolute_paths = True,
+    llvm_mirror_prefixes = [
+        "https://artifactory-content.stripe.build/artifactory/github-archives/llvm/llvm-project/releases/download/llvmorg-",
+        "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    ],
     llvm_version = "9.0.0",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,6 +10,7 @@ llvm_toolchain(
     name = "llvm_toolchain",
     absolute_paths = True,
     llvm_mirror_prefixes = [
+        "https://sorbet-deps.s3-us-west-2.amazonaws.com/",
         "https://artifactory-content.stripe.build/artifactory/github-archives/llvm/llvm-project/releases/download/llvmorg-",
         "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
     ],

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -138,9 +138,9 @@ package(default_visibility = ["//visibility:public"])
     # https://github.com/DarkDimius/bazel-toolchain/tree/dp-srb-now
     http_archive(
         name = "com_grail_bazel_toolchain",
-        urls = _github_public_urls("DarkDimius/bazel-toolchain/archive/8c80ac885551e9efa7d3b5c441841afae49704db.zip"),
-        sha256 = "a11d9fe8861f71b98706171d4b98cc1cfbed9925e38a4f10f5b42d9c581b6407",
-        strip_prefix = "bazel-toolchain-8c80ac885551e9efa7d3b5c441841afae49704db",
+        urls = _github_public_urls("DarkDimius/bazel-toolchain/archive/923f084848b8dde2f0c0ee516170e4a13651f6b7.zip"),
+        sha256 = "70c33f8375bd7127b6b4d293e3eafa8e5366cfc79fb8d11cfa49d159b85302a9",
+        strip_prefix = "bazel-toolchain-923f084848b8dde2f0c0ee516170e4a13651f6b7",
     )
 
     http_archive(

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -138,9 +138,9 @@ package(default_visibility = ["//visibility:public"])
     # https://github.com/DarkDimius/bazel-toolchain/tree/dp-srb-now
     http_archive(
         name = "com_grail_bazel_toolchain",
-        urls = _github_public_urls("DarkDimius/bazel-toolchain/archive/923f084848b8dde2f0c0ee516170e4a13651f6b7.zip"),
-        sha256 = "70c33f8375bd7127b6b4d293e3eafa8e5366cfc79fb8d11cfa49d159b85302a9",
-        strip_prefix = "bazel-toolchain-923f084848b8dde2f0c0ee516170e4a13651f6b7",
+        urls = _github_public_urls("DarkDimius/bazel-toolchain/archive/e9d159aa3100905f83415c8a663627e74edaa4fd.zip"),
+        sha256 = "52d14c50a22de18a818f286a057d1ad5ef082b2980b2ad676f1e7db18edded63",
+        strip_prefix = "bazel-toolchain-e9d159aa3100905f83415c8a663627e74edaa4fd",
     )
 
     http_archive(


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Modify the `llvm_toolchain` use in WORKSPACE to specify mirrors on both github and artifactory (inside stripe). This is paired with a modification to bazel-toolchain: https://github.com/DarkDimius/bazel-toolchain/commit/923f084848b8dde2f0c0ee516170e4a13651f6b7

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
There have been some recent issues fetching clang from https://release.llvm.org, and this will help mitigate that going forward.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.