### PR TITLE
Improve loc of invalid argument type errors.

### DIFF
--- a/test/cli/at/at.out
+++ b/test/cli/at/at.out
@@ -1,6 +1,6 @@
 test/cli/at/at.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
-        ^^^^^^^
+            ^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
      148 |        arg0: Integer,
                   ^^^^

--- a/test/cli/error-blacklist/error-blacklist.out
+++ b/test/cli/error-blacklist/error-blacklist.out
@@ -1,6 +1,6 @@
 test/cli/error-blacklist/error-blacklist.rb:3: Expected `Integer` but found `String("1")` for argument `arg0` https://srb.help/7002
      3 |1 + "1"
-        ^^^^^^^
+            ^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
      148 |        arg0: Integer,
                   ^^^^

--- a/test/cli/errors/errors.out
+++ b/test/cli/errors/errors.out
@@ -22,7 +22,7 @@ test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument
 
 test/cli/errors/errors.rb:19: Expected `Integer` but found `String("foo")` for argument `arg` https://srb.help/7002
     .. |    foo("foo")
-            ^^^^^^^^^^
+                ^^^^^
     test/cli/errors/errors.rb:12: Method `ComplexError#foo` has specified `arg` as `Integer`
     .. |  sig {params(arg: Integer).returns(NilClass)}
                       ^^^
@@ -76,7 +76,7 @@ test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument
 
 test/cli/errors/errors.rb:19: Expected `Integer` but found `String("foo")` for argument `arg` https://srb.help/7002
     .. |    foo("foo")
-            ^^^^^^^^^^
+                ^^^^^
     test/cli/errors/errors.rb:12: Method `ComplexError#foo` has specified `arg` as `Integer`
     .. |  sig {params(arg: Integer).returns(NilClass)}
                       ^^^
@@ -130,7 +130,7 @@ test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument
 
 test/cli/errors/errors.rb:19: Expected `Integer` but found `String("foo")` for argument `arg` https://srb.help/7002
     .. |    foo("foo")
-            ^^^^^^^^^^
+                ^^^^^
     test/cli/errors/errors.rb:12: Method `ComplexError#foo` has specified `arg` as `Integer`
     .. |  sig {params(arg: Integer).returns(NilClass)}
                       ^^^

--- a/test/cli/escaping/escaping.out
+++ b/test/cli/escaping/escaping.out
@@ -1,8 +1,6 @@
-test/cli/escaping/escaping.rb:9: Expected `Integer` but found `String("\n")` for argument `a` https://srb.help/7002
-     9 |foo( # error: Expected `Integer` but found `String("\n")`
+test/cli/escaping/escaping.rb:10: Expected `Integer` but found `String("\n")` for argument `a` https://srb.help/7002
     10 |'
     11 |'
-    12 |)
     test/cli/escaping/escaping.rb:4: Method `Object#foo` has specified `a` as `Integer`
      4 |sig{params(a: Integer).void}
                    ^

--- a/test/cli/folder-input-dir-and-file/folder-input-dir-and-file.out
+++ b/test/cli/folder-input-dir-and-file/folder-input-dir-and-file.out
@@ -1,6 +1,6 @@
 test/cli/folder-input-dir-and-file/foo.rb:4: Expected `Integer` but found `String("foo.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "foo.rb"
-        ^^^^^^^^^^^^
+            ^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
      148 |        arg0: Integer,
                   ^^^^
@@ -11,7 +11,7 @@ test/cli/folder-input-dir-and-file/foo.rb:4: Expected `Integer` but found `Strin
 
 test/cli/folder-input-dir-and-file/input/subfolder/baz.rb:4: Expected `Integer` but found `String("baz.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "baz.rb"
-        ^^^^^^^^^^^^
+            ^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
      148 |        arg0: Integer,
                   ^^^^
@@ -22,7 +22,7 @@ test/cli/folder-input-dir-and-file/input/subfolder/baz.rb:4: Expected `Integer` 
 
 test/cli/folder-input-dir-and-file/input/bar.rb:3: Expected `Integer` but found `String("bar.rb")` for argument `arg0` https://srb.help/7002
      3 |1 + "bar.rb"
-        ^^^^^^^^^^^^
+            ^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
      148 |        arg0: Integer,
                   ^^^^

--- a/test/cli/folder-input/folder-input.out
+++ b/test/cli/folder-input/folder-input.out
@@ -1,6 +1,6 @@
 test/cli/folder-input/foo.rb:4: Expected `Integer` but found `String("foo.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "foo.rb"
-        ^^^^^^^^^^^^
+            ^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
      148 |        arg0: Integer,
                   ^^^^
@@ -11,7 +11,7 @@ test/cli/folder-input/foo.rb:4: Expected `Integer` but found `String("foo.rb")` 
 
 test/cli/folder-input/input/subfolder/baz.rb:4: Expected `Integer` but found `String("baz.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "baz.rb"
-        ^^^^^^^^^^^^
+            ^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
      148 |        arg0: Integer,
                   ^^^^
@@ -22,7 +22,7 @@ test/cli/folder-input/input/subfolder/baz.rb:4: Expected `Integer` but found `St
 
 test/cli/folder-input/input/bar.rb:3: Expected `Integer` but found `String("bar.rb")` for argument `arg0` https://srb.help/7002
      3 |1 + "bar.rb"
-        ^^^^^^^^^^^^
+            ^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
      148 |        arg0: Integer,
                   ^^^^

--- a/test/cli/ignore-slash/ignore-slash.out
+++ b/test/cli/ignore-slash/ignore-slash.out
@@ -1,6 +1,6 @@
 bar.rb:4: Expected `Integer` but found `String("bar.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "bar.rb"
-        ^^^^^^^^^^^^
+            ^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
      148 |        arg0: Integer,
                   ^^^^

--- a/test/cli/ignore/ignore.out
+++ b/test/cli/ignore/ignore.out
@@ -1,6 +1,6 @@
 subfolder2/subfolder/bar.rb:4: Expected `Integer` but found `String("subfolder2/subfolder/bar.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "subfolder2/subfolder/bar.rb"
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
      148 |        arg0: Integer,
                   ^^^^
@@ -11,7 +11,7 @@ subfolder2/subfolder/bar.rb:4: Expected `Integer` but found `String("subfolder2/
 
 bar.rb:4: Expected `Integer` but found `String("bar.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "bar.rb"
-        ^^^^^^^^^^^^
+            ^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
      148 |        arg0: Integer,
                   ^^^^

--- a/test/cli/kwarg-loc/kwarg-loc.out
+++ b/test/cli/kwarg-loc/kwarg-loc.out
@@ -1,12 +1,10 @@
-kwarg-loc.rb:16: Expected `Integer` but found `String("1")` for argument `d` https://srb.help/7002
-    16 |foo(
+kwarg-loc.rb:17: Expected `Integer` but found `String("1")` for argument `d` https://srb.help/7002
     17 |  a: 1,
     18 |  b: 1,
     19 |  c: 1,
     20 |  d: "1",
     21 |  e: 1,
     22 |  f: 1,
-    23 |)
     kwarg-loc.rb:8: Method `Object#foo` has specified `d` as `Integer`
      8 |    d: Integer,
             ^
@@ -19,15 +17,9 @@ kwarg-loc.rb:16: Expected `Integer` but found `String("1")` for argument `d` htt
     21 |  e: 1,
     22 |  f: 1,
 
-kwarg-loc.rb:38: Expected `Integer` but found `String("1")` for argument `d` https://srb.help/7002
-    38 |bar(
-    39 |  1,
-    40 |  1,
-    41 |  1,
+kwarg-loc.rb:42: Expected `Integer` but found `String("1")` for argument `d` https://srb.help/7002
     42 |  "1",
-    43 |  1,
-    44 |  1,
-    45 |)
+          ^^^
     kwarg-loc.rb:30: Method `Object#bar` has specified `d` as `Integer`
     30 |    d: Integer,
             ^

--- a/test/cli/override-typed-bad/override-typed-bad.out
+++ b/test/cli/override-typed-bad/override-typed-bad.out
@@ -2,7 +2,7 @@ test/cli/override-typed-bad/override-typed-bad.rb: Useless override of strictnes
 
 test/cli/override-typed-bad/override-typed-bad.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
-        ^^^^^^^
+            ^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
      148 |        arg0: Integer,
                   ^^^^
@@ -14,7 +14,7 @@ Errors: 2
 ----
 test/cli/override-typed-bad/override-typed-bad.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
-        ^^^^^^^
+            ^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
      148 |        arg0: Integer,
                   ^^^^
@@ -26,7 +26,7 @@ Errors: 1
 ----
 test/cli/override-typed-bad/override-typed-bad.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
-        ^^^^^^^
+            ^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
      148 |        arg0: Integer,
                   ^^^^

--- a/test/cli/override-typed/override-typed.out
+++ b/test/cli/override-typed/override-typed.out
@@ -1,6 +1,6 @@
 test/cli/override-typed/override-typed.rb:1: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      1 |1 + "s"
-        ^^^^^^^
+            ^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
      148 |        arg0: Integer,
                   ^^^^
@@ -11,7 +11,7 @@ test/cli/override-typed/override-typed.rb:1: Expected `Integer` but found `Strin
 Errors: 1
 ./test/cli/override-typed/override-typed.rb:1: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      1 |1 + "s"
-        ^^^^^^^
+            ^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
      148 |        arg0: Integer,
                   ^^^^
@@ -22,7 +22,7 @@ Errors: 1
 Errors: 1
 test/cli/override-typed/override-typed.rb:1: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      1 |1 + "s"
-        ^^^^^^^
+            ^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
      148 |        arg0: Integer,
                   ^^^^

--- a/test/cli/remove-path-prefix-https/remove-path-prefix-https.out
+++ b/test/cli/remove-path-prefix-https/remove-path-prefix-https.out
@@ -1,6 +1,6 @@
 test/cli/remove-path-prefix-https/remove-path-prefix-https.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
-        ^^^^^^^
+            ^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
      148 |        arg0: Integer,
                   ^^^^

--- a/test/cli/remove-path-prefix-no-match/remove-path-prefix-no-match.out
+++ b/test/cli/remove-path-prefix-no-match/remove-path-prefix-no-match.out
@@ -1,6 +1,6 @@
 test/cli/remove-path-prefix-no-match/remove-path-prefix-no-match.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
-        ^^^^^^^
+            ^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
      148 |        arg0: Integer,
                   ^^^^

--- a/test/cli/remove-path-prefix/remove-path-prefix.out
+++ b/test/cli/remove-path-prefix/remove-path-prefix.out
@@ -1,6 +1,6 @@
 remove-path-prefix.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
-        ^^^^^^^
+            ^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
      148 |        arg0: Integer,
                   ^^^^

--- a/test/testdata/desugar/complex.rb
+++ b/test/testdata/desugar/complex.rb
@@ -35,7 +35,7 @@ bc.foo(Complex(0, 1))
 bc.foo(-Complex(0, 1))
 bc.foo(Complex(0, -1))
  bc.foo(-1)
-#^^^^^^^^^^ error: Expected `Complex` but found `Integer(-1)` for argument `x`
+#       ^^ error: Expected `Complex` but found `Integer(-1)` for argument `x`
 
 MyBasicClass.new.bar
 
@@ -46,4 +46,4 @@ kc.foo(Complex(0, 1))
 kc.foo(-Complex(0, 1))
 kc.foo(Complex(0, -1))
  kc.foo(-1)
-#^^^^^^^^^^ error: Expected `Complex` but found `Integer(-1)` for argument `x`
+#       ^^ error: Expected `Complex` but found `Integer(-1)` for argument `x`

--- a/test/testdata/infer/arg_matching.rb
+++ b/test/testdata/infer/arg_matching.rb
@@ -65,7 +65,7 @@ class TestArgs
 
     # We error on each incorrect argument
     repeated("hi", "there") # error: Expected `Integer` but found `String("hi")` for argument `x`
-  # ^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Integer` but found `String("there")` for argument `x`
+  #                ^^^^^^^ error: Expected `Integer` but found `String("there")` for argument `x`
   end
 
   sig do

--- a/test/testdata/infer/lub_between_self_params.rb
+++ b/test/testdata/infer/lub_between_self_params.rb
@@ -5,8 +5,8 @@
 				   V = type_member
            def explain_for(which)
              self["explain_#{which}"] || self[:"explain_#{which}"]
-#            ^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `QueryProfile::V` but found `String` for argument `arg0`
-#                                        ^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `QueryProfile::V` but found `Symbol` for argument `arg0`
+#                 ^^^^^^^^^^^^^^^^^^ error: Expected `QueryProfile::V` but found `String` for argument `arg0`
+#                                             ^^^^^^^^^^^^^^^^^^^ error: Expected `QueryProfile::V` but found `Symbol` for argument `arg0`
            end
          end
 
@@ -23,7 +23,7 @@ class Child < Parent
   A = type_member
   def foo(which)
     self["foo"] || self["bar"]
-#   ^^^^^^^^^^^ error: Expected `Child::A` but found `String("foo")` for argument `k`
+#        ^^^^^ error: Expected `Child::A` but found `String("foo")` for argument `k`
 #                       ^^^^^ error: This code is unreachable
   end
 end

--- a/test/testdata/infer/non_forcing_is_a.rb
+++ b/test/testdata/infer/non_forcing_is_a.rb
@@ -5,7 +5,7 @@ x = T.unsafe(nil)
 T::NonForcingConstants.non_forcing_is_a? # error: Not enough arguments
 
 p T::NonForcingConstants.non_forcing_is_a?(nil, nil)
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `String`
+#                                               ^^^ error: Expected `String`
 #                                               ^^^  error: only accepts string literals
 
 T::NonForcingConstants.non_forcing_is_a?(x, '') # error: must not be empty

--- a/test/testdata/infer/overloads_test.rb
+++ b/test/testdata/infer/overloads_test.rb
@@ -81,7 +81,7 @@ class Foo
     h.overloaded(1) # error: Expected `String` but found `Integer(1)` for argument `_`
                     # should ask for string
     h.overloaded("1", 2) # error: Expected `Class` but found `String("1")` for argument `_`
-  # ^^^^^^^^^^^^^^^^^^^^ error: Expected `String` but found `Integer(2)` for argument `_1`
+  #                   ^ error: Expected `String` but found `Integer(2)` for argument `_1`
 
     g = OverloadAndGenerics[Integer].new
     T.assert_type!(g.overloaded("hi"), String)

--- a/test/testdata/infer/star_star_args.rb
+++ b/test/testdata/infer/star_star_args.rb
@@ -38,12 +38,12 @@ class Main
         one_kwarg(foo: "bad", a: "bad") # error: Expected `Integer` but found `String("bad")` for argument `foo`
         one_kwarg(foo: 1, a: 1) # error: Expected `String` but found `Integer(1)` for argument `args`
         one_kwarg(foo: "bad", a: 1) # error: Expected `Integer` but found `String("bad")` for argument `foo`
-      # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `String` but found `Integer(1)` for argument `args`
+      #           ^^^^^^^^^^^^^^^^ error: Expected `String` but found `Integer(1)` for argument `args`
         with_type
         with_type(a: 1)
         with_type(a: "bad") # error: Expected `Integer` but found `String("bad")` for argument `args`
         with_type(a: "bad", b: "bad2") # error: Expected `Integer` but found `String("bad")` for argument `args`
-      # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Integer` but found `String("bad2")` for argument `args`
+      #           ^^^^^^^^^^^^^^^^^^^ error: Expected `Integer` but found `String("bad2")` for argument `args`
 
         # This should assign `z`, instead of assigning `x={z: :foo}`,
         # which would happen with `y={}`

--- a/test/testdata/lsp/method_call_errors.rb
+++ b/test/testdata/lsp/method_call_errors.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+sig {params(a: String).returns(String)}
+def test(a:)
+  a
+end
+
+
+test(
+  a: 10
+# ^^^^^ error: Expected `String` but found `Integer(10)`
+)


### PR DESCRIPTION
Improve loc of invalid argument type errors.

Use a loc that matches relevant problematic arg rather than whole call site, if available.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes https://github.com/sorbet/sorbet/issues/2988

6 internal users complained about this issue.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
