### PR TITLE
Make arg parsing not mutate the AST.

### DIFF
--- a/ast/ArgParsing.cc
+++ b/ast/ArgParsing.cc
@@ -7,32 +7,33 @@ using namespace std;
 
 namespace sorbet::ast {
 
-ParsedArg ArgParsing::parseArg(core::Context ctx, unique_ptr<ast::Reference> arg) {
+namespace {
+ParsedArg parseArg(const ast::Reference &arg) {
     ParsedArg parsedArg;
 
     typecase(
-        arg.get(), [&](ast::UnresolvedIdent *nm) { Exception::raise("Unexpected unresolved name in arg!"); },
-        [&](ast::RestArg *rest) {
-            parsedArg = parseArg(ctx, move(rest->expr));
-            parsedArg.repeated = true;
+        &arg,
+        [&](const ast::RestArg *rest) {
+            parsedArg = parseArg(*rest->expr);
+            parsedArg.flags.isRepeated = true;
         },
-        [&](ast::KeywordArg *kw) {
-            parsedArg = parseArg(ctx, move(kw->expr));
-            parsedArg.keyword = true;
+        [&](const ast::KeywordArg *kw) {
+            parsedArg = parseArg(*kw->expr);
+            parsedArg.flags.isKeyword = true;
         },
-        [&](ast::OptionalArg *opt) {
-            parsedArg = parseArg(ctx, move(opt->expr));
-            parsedArg.default_ = move(opt->default_);
+        [&](const ast::OptionalArg *opt) {
+            parsedArg = parseArg(*opt->expr);
+            parsedArg.flags.isDefault = true;
         },
-        [&](ast::BlockArg *blk) {
-            parsedArg = parseArg(ctx, move(blk->expr));
-            parsedArg.block = true;
+        [&](const ast::BlockArg *blk) {
+            parsedArg = parseArg(*blk->expr);
+            parsedArg.flags.isBlock = true;
         },
-        [&](ast::ShadowArg *shadow) {
-            parsedArg = parseArg(ctx, move(shadow->expr));
-            parsedArg.shadow = true;
+        [&](const ast::ShadowArg *shadow) {
+            parsedArg = parseArg(*shadow->expr);
+            parsedArg.flags.isShadow = true;
         },
-        [&](ast::Local *local) {
+        [&](const ast::Local *local) {
             parsedArg.local = local->localVariable;
             parsedArg.loc = local->loc;
         });
@@ -40,47 +41,73 @@ ParsedArg ArgParsing::parseArg(core::Context ctx, unique_ptr<ast::Reference> arg
     return parsedArg;
 }
 
-vector<ParsedArg> ArgParsing::parseArgs(core::Context ctx, ast::MethodDef::ARGS_store &args) {
+unique_ptr<ast::Expression> getDefaultValue(unique_ptr<ast::Expression> arg) {
+    auto *refExp = ast::cast_tree<ast::Reference>(arg.get());
+    if (!refExp) {
+        Exception::raise("Must be a reference!");
+    }
+    unique_ptr<ast::Expression> default_;
+    typecase(
+        refExp, [&](ast::RestArg *rest) { default_ = getDefaultValue(move(rest->expr)); },
+        [&](ast::KeywordArg *kw) { default_ = getDefaultValue(move(kw->expr)); },
+        [&](ast::OptionalArg *opt) { default_ = move(opt->default_); },
+        [&](ast::BlockArg *blk) { default_ = getDefaultValue(move(blk->expr)); },
+        [&](ast::ShadowArg *shadow) { default_ = getDefaultValue(move(shadow->expr)); },
+        [&](ast::Local *local) {
+            // No default.
+        });
+    ENFORCE(default_ != nullptr);
+    return default_;
+}
+
+} // namespace
+
+vector<ParsedArg> ArgParsing::parseArgs(const ast::MethodDef::ARGS_store &args) {
     vector<ParsedArg> parsedArgs;
     for (auto &arg : args) {
         auto *refExp = ast::cast_tree<ast::Reference>(arg.get());
         if (!refExp) {
             Exception::raise("Must be a reference!");
         }
-        unique_ptr<ast::Reference> refExpImpl(refExp);
-        arg.release();
-        parsedArgs.emplace_back(parseArg(ctx, move(refExpImpl)));
+        parsedArgs.emplace_back(parseArg(*refExp));
     }
 
     return parsedArgs;
 }
 
-std::vector<u4> ArgParsing::hashArgs(core::Context ctx, std::vector<ParsedArg> &args) {
+std::vector<u4> ArgParsing::hashArgs(core::Context ctx, const std::vector<ParsedArg> &args) {
     std::vector<u4> result;
     result.reserve(args.size());
     for (const auto &e : args) {
         u4 arg = 0;
         u1 flags = 0;
-        if (e.keyword) {
+        if (e.flags.isKeyword) {
             arg = core::mix(arg, core::_hash(e.local._name.data(ctx)->shortName(ctx)));
             flags += 1;
         }
-        if (e.repeated) {
+        if (e.flags.isRepeated) {
             flags += 2;
         }
-        if (e.default_) {
+        if (e.flags.isDefault) {
             flags += 4;
         }
-        if (e.shadow) {
+        if (e.flags.isShadow) {
             flags += 8;
         }
-        if (e.block) {
+        if (e.flags.isBlock) {
             flags += 16;
         }
 
         result.push_back(core::mix(arg, flags));
     }
     return result;
+}
+
+unique_ptr<ast::Expression> ArgParsing::getDefault(const ParsedArg &parsedArg, unique_ptr<ast::Expression> arg) {
+    if (!parsedArg.flags.isDefault) {
+        return nullptr;
+    }
+    return getDefaultValue(move(arg));
 }
 
 } // namespace sorbet::ast

--- a/ast/ArgParsing.h
+++ b/ast/ArgParsing.h
@@ -5,17 +5,15 @@ namespace sorbet::ast {
 struct ParsedArg {
     core::LocOffsets loc;
     core::LocalVariable local;
-    std::unique_ptr<ast::Expression> default_;
-    bool keyword = false;
-    bool block = false;
-    bool repeated = false;
-    bool shadow = false;
+    core::ArgInfo::ArgFlags flags;
 };
 class ArgParsing {
 public:
-    static ParsedArg parseArg(core::Context ctx, std::unique_ptr<ast::Reference> arg);
-    static std::vector<ParsedArg> parseArgs(core::Context ctx, ast::MethodDef::ARGS_store &args);
-    static std::vector<u4> hashArgs(core::Context ctx, std::vector<ParsedArg> &args);
+    static std::vector<ParsedArg> parseArgs(const ast::MethodDef::ARGS_store &args);
+    static std::vector<u4> hashArgs(core::Context ctx, const std::vector<ParsedArg> &args);
+    // Returns the default argument value for the given argument, or nullptr if not specified. Mutates arg.
+    static std::unique_ptr<ast::Expression> getDefault(const ParsedArg &parsedArg,
+                                                       std::unique_ptr<ast::Expression> arg);
 };
 }; // namespace sorbet::ast
 

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -311,14 +311,14 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::Expression *what, BasicBlock 
 
                 if (s->block != nullptr) {
                     auto newRubyBlockId = ++cctx.inWhat.maxRubyBlockId;
-                    vector<ast::ParsedArg> blockArgs = ast::ArgParsing::parseArgs(cctx.ctx, s->block->args);
+                    vector<ast::ParsedArg> blockArgs = ast::ArgParsing::parseArgs(s->block->args);
                     vector<core::ArgInfo::ArgFlags> argFlags;
                     for (auto &e : blockArgs) {
                         auto &target = argFlags.emplace_back();
-                        target.isKeyword = e.keyword;
-                        target.isRepeated = e.repeated;
-                        target.isDefault = e.default_ != nullptr;
-                        target.isShadow = e.shadow;
+                        target.isKeyword = e.flags.isKeyword;
+                        target.isRepeated = e.flags.isRepeated;
+                        target.isDefault = e.flags.isDefault;
+                        target.isShadow = e.flags.isShadow;
                     }
                     auto link = make_shared<core::SendAndBlockLink>(s->fun, move(argFlags), newRubyBlockId);
                     auto send =
@@ -347,7 +347,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::Expression *what, BasicBlock 
                         auto &arg = blockArgs[i];
                         core::LocalVariable argLoc = arg.local;
 
-                        if (arg.repeated) {
+                        if (arg.flags.isRepeated) {
                             if (i != 0) {
                                 // Mixing positional and rest args in blocks is
                                 // not currently supported; drop in an untyped.

--- a/main/lsp/LocalVarFinder.cc
+++ b/main/lsp/LocalVarFinder.cc
@@ -29,7 +29,7 @@ unique_ptr<ast::MethodDef> LocalVarFinder::preTransformMethodDef(core::Context c
     auto currentMethod = methodDef->symbol;
 
     if (currentMethod == this->targetMethod) {
-        auto parsedArgs = ast::ArgParsing::parseArgs(ctx, methodDef->args);
+        auto parsedArgs = ast::ArgParsing::parseArgs(methodDef->args);
         for (const auto &parsedArg : parsedArgs) {
             this->result_.emplace_back(parsedArg.local);
         }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Make arg parsing not mutate the AST. The AST only gets mutated if you need to retrieve the default argument.

Also standardizes the data structure used to represent arg flags.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Required to parallelize namer such that the "name collection" phase does not mutate the AST.

These changes were pulled from https://github.com/sorbet/sorbet/pull/2986

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

There are existing tests.
