### PR TITLE
Implement value-based struct equality.

### DIFF
--- a/gems/sorbet-runtime/lib/types/struct.rb
+++ b/gems/sorbet-runtime/lib/types/struct.rb
@@ -2,9 +2,19 @@
 # typed: true
 
 class T::InexactStruct
+  extend T::Sig
+
   include T::Props
   include T::Props::Serializable
   include T::Props::Constructor
+
+  sig {params(other: Object).returns(T::Boolean)}
+  def ==(other)
+    return true if self.equal?(other)
+    return false unless other.is_a?(self.class)
+
+    self.class.props.all? { |prop, _| self.send(prop) == other.send(prop) }
+  end
 end
 
 class T::Struct < T::InexactStruct

--- a/gems/sorbet-runtime/test/types/struct.rb
+++ b/gems/sorbet-runtime/test/types/struct.rb
@@ -9,4 +9,43 @@ class Opus::Types::Test::StructValidationTest < Critic::Unit::UnitTest
     end
     assert_includes(err.message, "is a subclass of T::Struct and cannot be subclassed")
   end
+
+  describe "#==" do
+    class TestStruct < T::Struct
+      prop :x, Integer
+      prop :y, Float
+    end
+
+    class AnotherTestStruct < T::Struct
+      prop :x, Integer
+      prop :y, Float
+    end
+
+    it "is reflexively true" do
+      a = TestStruct.new(x: 1, y: 0.2)
+
+      assert_equal(a, a)
+    end
+
+    it "is true if all properties are equal" do
+      a = TestStruct.new(x: 1, y: 4.2)
+      b = TestStruct.new(x: 1, y: 4.2)
+
+      assert_equal(a, b)
+    end
+
+    it "is false if objects are not the same class" do
+      a = TestStruct.new(x: 1, y: 4.2)
+      b = AnotherTestStruct.new(x: 1, y: 4.2)
+
+      refute_equal(a, b)
+    end
+
+    it "is false if some properties are not equal" do
+      a = TestStruct.new(x: 1, y: 4.2)
+      b = TestStruct.new(x: 2, y: 1.1)
+
+      refute_equal(a, b)
+    end
+  end
 end


### PR DESCRIPTION
This change makes struct equality follow the similar value-based semantics as stdlib structs. This addresses #1540 

### Motivation
This will make the Sorbet Struct type more closely match the stdlib struct type, and thus will ease the transition of people onboarding their code-bases onto Sorbet from vanilla Ruby.

### Test plan
See included automated tests.
