### PR TITLE
WIP: Allow LSP server to boot with multiple input directories

### DIFF
--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -16,10 +16,6 @@ constexpr string_view httpsScheme = "https"sv;
 namespace {
 
 string getRootPath(const options::Options &opts, const shared_ptr<spdlog::logger> &logger) {
-    if (opts.rawInputDirNames.size() != 1) {
-        logger->error("Sorbet's language server requires a single input directory.");
-        throw options::EarlyReturnWithCode(1);
-    }
     return opts.rawInputDirNames.at(0);
 }
 
@@ -35,7 +31,12 @@ MarkupKind getPreferredMarkupKind(vector<MarkupKind> formats) {
 LSPConfiguration::LSPConfiguration(const options::Options &opts, const shared_ptr<LSPOutput> &output,
                                    const shared_ptr<spdlog::logger> &logger, bool skipConfigatron, bool disableFastPath)
     : initialized(atomic<bool>(false)), opts(opts), output(output), logger(logger), skipConfigatron(skipConfigatron),
-      disableFastPath(disableFastPath), rootPath(getRootPath(opts, logger)) {}
+      disableFastPath(disableFastPath), rootPath(getRootPath(opts, logger)) {
+    if (opts.rawInputDirNames.size() == 0) {
+        logger->error("Sorbet's language server requires at least one input directory.");
+        throw options::EarlyReturnWithCode(1);
+    }
+}
 
 void LSPConfiguration::assertHasClientConfig() const {
     if (!clientConfig) {

--- a/main/lsp/LSPConfiguration.h
+++ b/main/lsp/LSPConfiguration.h
@@ -20,6 +20,10 @@ public:
     /** Root of LSP client workspace. May be different than rootPath. At Stripe, editing happens locally but Sorbet
      * runs on a remote server. */
     std::string rootUri = "";
+
+    /** Workspace root URI of the client translated into the root path of the server. */
+    std::string workspaceRootPath = "";
+
     /**
      * If true, then LSP will send the client notifications at the start and end of slow operations.
      * We don't want to send these notifications to clients that don't know what to do with them,
@@ -81,8 +85,6 @@ public:
     const bool skipConfigatron;
     /** If true, all queries will hit the slow path. */
     const bool disableFastPath;
-    /** File system root of LSP client workspace. May be empty if it is the current working directory. */
-    const std::string rootPath;
 
     // The following properties are configured during initialization.
 

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -342,8 +342,7 @@ LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<WatchmanQueryResponse> query
     auto edit = make_unique<SorbetWorkspaceEditParams>();
     edit->epoch = v;
     for (auto file : queryResponse->files) {
-        // Don't append rootPath if it is empty.
-        string localPath = !config->rootPath.empty() ? absl::StrCat(config->rootPath, "/", file) : file;
+        string localPath = absl::StrCat(queryResponse->root, "/", file);
         // Editor contents supercede file system updates.
         if (!config->isFileIgnored(localPath) && !openFiles.contains(localPath)) {
             edit->updates.push_back(make_shared<core::File>(move(localPath), readFile(localPath, *config->opts.fs),

--- a/main/lsp/test/generate_lsp_messages_test.cc
+++ b/main/lsp/test/generate_lsp_messages_test.cc
@@ -294,13 +294,15 @@ TEST_CASE("DiscriminatedUnionInvalidDiscriminant") {
 
 TEST_CASE("RenamedFieldsWorkProperly") {
     parseTest<WatchmanQueryResponse>("{\"version\": \"versionstring\", \"clock\": \"clockvalue\", "
-                                     "\"is_fresh_instance\": true, \"files\": [\"foo.rb\"]}",
+                                     "\"is_fresh_instance\": true, \"files\": [\"foo.rb\"], "
+                                     "\"root\":\"/home/user/workdir\"}",
                                      [](auto &watchmanQueryResponse) -> void {
                                          REQUIRE_EQ(watchmanQueryResponse->version, "versionstring");
                                          REQUIRE_EQ(watchmanQueryResponse->clock, "clockvalue");
                                          REQUIRE(watchmanQueryResponse->isFreshInstance);
                                          REQUIRE_EQ(watchmanQueryResponse->files.size(), 1);
                                          REQUIRE_EQ(watchmanQueryResponse->files.at(0), "foo.rb");
+                                         REQUIRE_EQ(watchmanQueryResponse->root, "/home/user/workdir");
                                      });
 }
 

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -70,7 +70,7 @@ LSPPreprocessor makePreprocessor(shared_ptr<absl::Mutex> taskQueueMutex, shared_
 }
 
 unique_ptr<LSPMessage> makeWatchman(vector<string> files) {
-    auto params = make_unique<WatchmanQueryResponse>("", "", false, files);
+    auto params = make_unique<WatchmanQueryResponse>("", "", false, files, "");
     auto msg = make_unique<LSPMessage>(
         make_unique<NotificationMessage>("2.0", LSPMethod::SorbetWatchmanFileChange, move(params)));
     return msg;

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -1270,6 +1270,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                                 makeField("clock", JSONString),
                                                 makeField("is_fresh_instance", "isFreshInstance", JSONBool),
                                                 makeField("files", makeArray(JSONString)),
+                                                makeField("root", JSONString),
                                             },
                                             classTypes);
 

--- a/test/cli/lsp-requires-input-dir/lsp-requires-input-dir.out
+++ b/test/cli/lsp-requires-input-dir/lsp-requires-input-dir.out
@@ -1,1 +1,1 @@
-Sorbet's language server requires a single input directory.
+Sorbet's language server requires an input directory.

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -215,8 +215,9 @@ unique_ptr<LSPMessage> ProtocolTest::getDefinition(string_view path, int line, i
 }
 
 unique_ptr<LSPMessage> ProtocolTest::watchmanFileUpdate(vector<string> updatedFilePaths) {
-    auto req = make_unique<NotificationMessage>("2.0", LSPMethod::SorbetWatchmanFileChange,
-                                                make_unique<WatchmanQueryResponse>("", "", false, updatedFilePaths));
+    auto req =
+        make_unique<NotificationMessage>("2.0", LSPMethod::SorbetWatchmanFileChange,
+                                         make_unique<WatchmanQueryResponse>("", "", false, updatedFilePaths, ""));
     return make_unique<LSPMessage>(move(req));
 }
 


### PR DESCRIPTION
This is a work-in-progress for allowing the LSP server to work with multiple input directories. It is currently failing existing tests that needs to be fixed as well as missing additional tests for the new behavior.
Before adding that I want to make sure this is in a desired direction.

The idea is essentially to remove the existing `rootPath` and instead figure out the workspace root path based on the `rootUri` sent from the client. Additionally if a file is not in the workspace root we'll address it using the absolute file path that the client also sends back.


### Motivation
Sorbet will currently refuse to boot up with LSP enabled when given multiple input directories. This is a problem for projects that depends on gems that include rbi files (https://github.com/sorbet/sorbet/issues/2732).


### Test plan
See included automated tests.
