### PR TITLE
Stop using the --no-prune flag in the snapshot tests

### DIFF
--- a/gems/sorbet/test/snapshot/run_one.sh
+++ b/gems/sorbet/test/snapshot/run_one.sh
@@ -158,10 +158,11 @@ fi
   fi
 
   # Configuring output to vendor/bundle
+  # Setting no-prune to not delete unused gems in vendor/cache
   # Passing --local to never consult rubygems.org
-  # Passing --no-prune to not delete unused gems in vendor/cache
   info "├─ Installing dependencies to BUNDLE_PATH"
-  bundle install --verbose --local --no-prune
+  bundle config set no-prune true
+  bundle install --verbose --local
 
   info "├─ Checking installation"
   bundle check

--- a/gems/sorbet/test/snapshot/run_one.sh
+++ b/gems/sorbet/test/snapshot/run_one.sh
@@ -161,7 +161,7 @@ fi
   # Setting no-prune to not delete unused gems in vendor/cache
   # Passing --local to never consult rubygems.org
   info "├─ Installing dependencies to BUNDLE_PATH"
-  bundle config set no-prune true
+  bundle config set no_prune true
   bundle install --verbose --local
 
   info "├─ Checking installation"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Clean up our use of bundler in the snapshot tests.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
When the snapshot tests fail, they complain about the use of the `--no-prune` with bundle. This change switches to setting the `no-prune` config option instead.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.