### PR TITLE
Move non_forcing_is_a? to resolver

### DIFF
--- a/core/errors/infer.h
+++ b/core/errors/infer.h
@@ -33,6 +33,6 @@ constexpr ErrorClass AbstractClassInstantiated{7025, StrictLevel::True};
 constexpr ErrorClass NotExhaustive{7026, StrictLevel::True};
 constexpr ErrorClass UntypedConstantSuggestion{7027, StrictLevel::Strict};
 constexpr ErrorClass GenericTypeParamBoundMismatch{7028, StrictLevel::False};
-constexpr ErrorClass LazyResolve{7029, StrictLevel::True};
+// constexpr ErrorClass LazyResolve{7029, StrictLevel::True};
 } // namespace sorbet::core::errors::Infer
 #endif

--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -64,6 +64,7 @@ constexpr ErrorClass ExperimentalAttachedClass{5056, StrictLevel::False};
 // constexpr ErrorClass GeneratedDeprecated{5056, StrictLevel::False};
 constexpr ErrorClass StaticAbstractModuleMethod{5057, StrictLevel::False};
 constexpr ErrorClass AttachedClassAsParam{5058, StrictLevel::False};
+constexpr ErrorClass LazyResolve{5059, StrictLevel::False};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -14,6 +14,7 @@
 #include "resolver/type_syntax.h"
 
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_split.h"
 #include "common/Timer.h"
 #include "common/concurrency/ConcurrentQueue.h"
 #include "core/Symbols.h"
@@ -1866,6 +1867,97 @@ private:
         return true;
     }
 
+    void validateNonForcingIsA(core::Context ctx, const ast::Send &send) {
+        constexpr string_view method = "T::NonForcingConstants.non_forcing_is_a?";
+
+        if (send.args.size() != 2) {
+            return;
+        }
+
+        auto stringLoc = send.args[1]->loc;
+
+        auto literalNode = ast::cast_tree<ast::Literal>(send.args[1].get());
+        if (literalNode == nullptr) {
+            if (auto e = ctx.beginError(stringLoc, core::errors::Resolver::LazyResolve)) {
+                e.setHeader("`{}` only accepts string literals", method);
+            }
+            return;
+        }
+
+        auto literal = core::cast_type<core::LiteralType>(literalNode->value.get());
+        if (literal == nullptr) {
+            if (auto e = ctx.beginError(stringLoc, core::errors::Resolver::LazyResolve)) {
+                e.setHeader("`{}` only accepts string literals", method);
+            }
+            return;
+        }
+
+        if (literal->literalKind != core::LiteralType::LiteralTypeKind::String) {
+            // Infer will report a type error
+            return;
+        }
+
+        auto name = core::NameRef(ctx.state, literal->value);
+        auto shortName = name.data(ctx)->shortName(ctx);
+        if (shortName.empty()) {
+            if (auto e = ctx.beginError(stringLoc, core::errors::Resolver::LazyResolve)) {
+                e.setHeader("The string given to `{}` must not be empty", method);
+            }
+            return;
+        }
+
+        auto parts = absl::StrSplit(shortName, "::");
+        core::SymbolRef current;
+        for (auto part : parts) {
+            if (!current.exists()) {
+                // First iteration
+                if (part != "") {
+                    if (auto e = ctx.beginError(stringLoc, core::errors::Resolver::LazyResolve)) {
+                        e.setHeader(
+                            "The string given to `{}` must be an absolute constant reference that starts with `{}`",
+                            method, "::");
+                    }
+                    return;
+                }
+
+                current = core::Symbols::root();
+            } else {
+                auto member = ctx.state.lookupNameConstant(part);
+                if (!member.exists()) {
+                    if (auto e = ctx.beginError(stringLoc, core::errors::Resolver::LazyResolve)) {
+                        auto prettyCurrent =
+                            current == core::Symbols::root() ? "" : "::" + current.data(ctx)->show(ctx);
+                        auto pretty = fmt::format("{}::{}", prettyCurrent, part);
+                        e.setHeader("Unable to resolve constant `{}`", pretty);
+                    }
+                    return;
+                }
+
+                auto newCurrent = current.data(ctx)->findMember(ctx, member);
+                if (!newCurrent.exists()) {
+                    if (auto e = ctx.beginError(stringLoc, core::errors::Resolver::LazyResolve)) {
+                        auto prettyCurrent =
+                            current == core::Symbols::root() ? "" : "::" + current.data(ctx)->show(ctx);
+                        auto pretty = fmt::format("{}::{}", prettyCurrent, part);
+                        e.setHeader("Unable to resolve constant `{}`", pretty);
+                    }
+                    return;
+                }
+                current = newCurrent;
+            }
+        }
+
+        ENFORCE(current.exists(), "Loop invariant violated");
+
+        if (!current.data(ctx)->isClassOrModule()) {
+            if (auto e = ctx.beginError(stringLoc, core::errors::Resolver::LazyResolve)) {
+                e.setHeader("The string given to `{}` must resolve to a class or module", method);
+                e.addErrorLine(current.data(ctx)->loc(), "Resolved to this constant");
+            }
+            return;
+        }
+    }
+
     core::SymbolRef methodOwner(core::Context ctx) {
         core::SymbolRef owner = ctx.owner.data(ctx)->enclosingClass(ctx);
         if (owner == core::Symbols::root()) {
@@ -1990,8 +2082,7 @@ public:
                                             make_unique<ast::Cast>(send->loc, type, std::move(expr), send->fun));
                 }
                 case core::Names::revealType()._id:
-                case core::Names::absurd()._id:
-                case core::Names::nonForcingIsA_p()._id: {
+                case core::Names::absurd()._id: {
                     // These errors do not match up with our "upper error levels are super sets
                     // of errors from lower levels" claim. This is ONLY an error in lower levels.
 
@@ -2012,6 +2103,9 @@ public:
                     }
                     return send;
                 }
+                case core::Names::nonForcingIsA_p()._id:
+                    validateNonForcingIsA(ctx, *send);
+                    return send;
                 default:
                     return send;
             }

--- a/test/testdata/infer/non_forcing_is_a_false.rb
+++ b/test/testdata/infer/non_forcing_is_a_false.rb
@@ -1,4 +1,10 @@
 # typed: false
 
-T::NonForcingConstants.non_forcing_is_a?('::Integer') # error: in `# typed: true` files
-T::NonForcingConstants.non_forcing_is_a?('::DoesntExist') # error: in `# typed: true` files
+# We used to implement non_forcing_is_a? as an intrinsic method in calls.cc,
+# which meant that we had the same `typed: false` behavior as `T.reveal_type`
+# did (complaining that you can't use it at that strictness level).
+#
+# But now it lives elsewhere, so being in a `typed: false` file is fine.
+
+T::NonForcingConstants.non_forcing_is_a?(self, '::Integer')
+T::NonForcingConstants.non_forcing_is_a?(self, '::DoesntExist') # error: Unable to resolve constant `::DoesntExist`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This lets us use non_forcing_is_a? in `typed: false` files.

The implementation is nearly copy / pasted with a few small
substitutions to get it to type check. The tests are unchanged except
for the test that asserted we emitted an error in `typed: false` files.


This unblocks #3001 which we had to revert in #3002 because there were many
errors (for `prop` definitions in `typed: false` files).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.