### PR TITLE
Print out diffs when expectations don't match in tests.

### DIFF
--- a/test/helpers/BUILD
+++ b/test/helpers/BUILD
@@ -16,5 +16,6 @@ cc_library(
         "//core",
         "//main/lsp",
         "@doctest",
+        "@dtl",
     ],
 )

--- a/test/helpers/expectations.cc
+++ b/test/helpers/expectations.cc
@@ -172,7 +172,7 @@ void CHECK_EQ_DIFF(std::string_view expected, std::string_view actual, std::stri
 
     vector<string> expectedLines = absl::StrSplit(expected, '\n');
     vector<string> actualLines = absl::StrSplit(actual, '\n');
-    dtl::Diff<string, vector<string>> diff(actualLines, expectedLines);
+    dtl::Diff<string, vector<string>> diff(expectedLines, actualLines);
     diff.compose();
     diff.composeUnifiedHunks();
 

--- a/test/helpers/expectations.cc
+++ b/test/helpers/expectations.cc
@@ -172,7 +172,7 @@ void CHECK_EQ_DIFF(std::string_view expected, std::string_view actual, std::stri
 
     vector<string> expectedLines = absl::StrSplit(expected, '\n');
     vector<string> actualLines = absl::StrSplit(actual, '\n');
-    dtl::Diff<string, vector<string>> diff(expectedLines, actualLines);
+    dtl::Diff<string, vector<string>> diff(actualLines, expectedLines);
     diff.compose();
     diff.composeUnifiedHunks();
 

--- a/test/helpers/expectations.h
+++ b/test/helpers/expectations.h
@@ -19,6 +19,10 @@ struct Expectations {
 
     static Expectations getExpectations(std::string singleTest);
 };
+
+// A variant of CHECK_EQ that prints a diff on failure.
+void CHECK_EQ_DIFF(std::string_view expected, std::string_view actual, std::string_view errorMessage);
+
 } // namespace sorbet::test
 
 #endif // TEST_HELPERS_EXPECTATIONS_H

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -261,8 +261,8 @@ void testDocumentSymbols(LSPWrapper &lspWrapper, Expectations &test, int &nextId
         get<variant<JSONNullObject, vector<unique_ptr<DocumentSymbol>>>>(*expectedResp.result);
 
     // Simple string comparison, just like other *.exp files.
-    INFO("Mismatch on: " << expectedSymbolsPath);
-    CHECK_EQ(documentSymbolsToString(expectedSymbolResponse), documentSymbolsToString(receivedSymbolResponse));
+    CHECK_EQ_DIFF(documentSymbolsToString(expectedSymbolResponse), documentSymbolsToString(receivedSymbolResponse),
+                  "Mismatch on: " + expectedSymbolsPath);
 }
 
 TEST_CASE("LSPTest") {

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -125,10 +125,7 @@ public:
             auto checker = test.folder + expectation->second.begin()->second;
             auto expect = FileOps::read(checker);
 
-            {
-                INFO(prefix << "Mismatch on: " << checker);
-                CHECK_EQ(expect, gotPhase.second);
-            }
+            { CHECK_EQ_DIFF(expect, gotPhase.second, fmt::format("{}Mismatch on: {}", prefix, checker)); }
             if (expect == gotPhase.second) {
                 MESSAGE(gotPhase.first << " OK");
             }
@@ -396,14 +393,13 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     if (test.expectations.contains("symbol-table")) {
         string table = gs->toString() + '\n';
-        INFO("symbol-table should not be mutated by CFG+inference");
-        CHECK_EQ(handler.got["symbol-table"], table);
+        CHECK_EQ_DIFF(handler.got["symbol-table"], table, "symbol-table should not be mutated by CFG+inference");
     }
 
     if (test.expectations.contains("symbol-table-raw")) {
         string table = gs->showRaw() + '\n';
-        INFO("symbol-table-raw should not be mutated by CFG+inference");
-        CHECK_EQ(handler.got["symbol-table-raw"], table);
+        CHECK_EQ_DIFF(handler.got["symbol-table-raw"], table,
+                      "symbol-table-raw should not be mutated by CFG+inference");
     }
 
     // Check warnings and errors

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -125,7 +125,7 @@ public:
             auto checker = test.folder + expectation->second.begin()->second;
             auto expect = FileOps::read(checker);
 
-            { CHECK_EQ_DIFF(expect, gotPhase.second, fmt::format("{}Mismatch on: {}", prefix, checker)); }
+            CHECK_EQ_DIFF(expect, gotPhase.second, fmt::format("{}Mismatch on: {}", prefix, checker));
             if (expect == gotPhase.second) {
                 MESSAGE(gotPhase.first << " OK");
             }

--- a/third_party/dtl.BUILD
+++ b/third_party/dtl.BUILD
@@ -1,0 +1,5 @@
+cc_library(
+    name = "dtl",
+    hdrs = glob(["dtl/**/*.hpp"]),
+    visibility = ["//visibility:public"],
+)

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -11,6 +11,14 @@ def register_sorbet_dependencies():
     )
 
     http_archive(
+        name = "dtl",
+        urls = _github_public_urls("cubicdaiya/dtl/archive/v1.19.tar.gz"),
+        sha256 = "f47b99dd11e5d771ad32a8dc960db4ab2fbe349fb0346fa0795f53c846a99c5d",
+        build_file = "@com_stripe_ruby_typer//third_party:dtl.BUILD",
+        strip_prefix = "dtl-1.19",
+    )
+
+    http_archive(
         name = "yaml_cpp",
         urls = _github_public_urls("jbeder/yaml-cpp/archive/yaml-cpp-0.6.3.zip"),
         sha256 = "7c0ddc08a99655508ae110ba48726c67e4a10b290c214aed866ce4bbcbe3e84c",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Print out diffs when expectations don't match in tests.

One question: Did I get the ordering of expected and actual correct?

From:

```
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //test:test_PosTests/testdata/resolver/optional_nil
-----------------------------------------------------------------------------
+ exec test/pipeline_test_runner --single_test=test/testdata/resolver/optional_nil.rb
[doctest] doctest version is "2.3.7"
[doctest] run with "--help" for options
===============================================================================
test/pipeline_test_runner.cc:149:
TEST CASE:  PerPhaseTest

test/pipeline_test_runner.cc:130: ERROR: CHECK_EQ( expect, gotPhase.second ) is NOT correct!
  values: CHECK_EQ( begin
  class <emptyTree><<C <root>>> < (::<todo sym>)
    begin
      class ::Test<<C Test>> < (::<todo sym>)
        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"x" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def fo(x, <blk>)
          x
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"y" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def bar(y, <blk>)
          y
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"z" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def qux(z, <blk>)
          z
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"w" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def baz(w, <blk>)
          w
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"x" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def foo<defaultArg>1(x, <blk>)
          nil
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"y" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def bar<defaultArg>1(y, <blk>)
          nil
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"z" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def qux<defaultArg>1(z, <blk>)
          ""
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"w" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def baz<defaultArg>1(w, <blk>)
          ""
        end

        <self>.extend(<emptyTree>::<C T>::<C Sig>)

        ::Sorbet::Private::Static.keep_def(<self>, :"foo")

        ::Sorbet::Private::Static.keep_def(<self>, :"bar")

        ::Sorbet::Private::Static.keep_def(<self>, :"qux")

        ::Sorbet::Private::Static.keep_def(<self>, :"baz")

        ::Sorbet::Private::Static.keep_def(<self>, :"foo<defaultArg>1")

        ::Sorbet::Private::Static.keep_def(<self>, :"bar<defaultArg>1")

        ::Sorbet::Private::Static.keep_def(<self>, :"qux<defaultArg>1")

        ::Sorbet::Private::Static.keep_def(<self>, :"baz<defaultArg>1")
      end
      ::Sorbet::Private::Static.keep_for_ide(::Test)
      <emptyTree>
    end
  end
  <emptyTree>
end
, begin
  class <emptyTree><<C <root>>> < (::<todo sym>)
    begin
      class ::Test<<C Test>> < (::<todo sym>)
        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"x" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def foo(x, <blk>)
          x
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"y" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def bar(y, <blk>)
          y
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"z" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def qux(z, <blk>)
          z
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"w" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def baz(w, <blk>)
          w
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"x" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def foo<defaultArg>1(x, <blk>)
          nil
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"y" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def bar<defaultArg>1(y, <blk>)
          nil
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"z" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def qux<defaultArg>1(z, <blk>)
          ""
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"w" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def baz<defaultArg>1(w, <blk>)
          ""
        end

        <self>.extend(<emptyTree>::<C T>::<C Sig>)

        ::Sorbet::Private::Static.keep_def(<self>, :"foo")

        ::Sorbet::Private::Static.keep_def(<self>, :"bar")

        ::Sorbet::Private::Static.keep_def(<self>, :"qux")

        ::Sorbet::Private::Static.keep_def(<self>, :"baz")

        ::Sorbet::Private::Static.keep_def(<self>, :"foo<defaultArg>1")

        ::Sorbet::Private::Static.keep_def(<self>, :"bar<defaultArg>1")

        ::Sorbet::Private::Static.keep_def(<self>, :"qux<defaultArg>1")

        ::Sorbet::Private::Static.keep_def(<self>, :"baz<defaultArg>1")
      end
      ::Sorbet::Private::Static.keep_for_ide(::Test)
      <emptyTree>
    end
  end
  <emptyTree>
end
 )
  logged: Mismatch on: test/testdata/resolver/optional_nil.rb.name-tree.exp

test/pipeline_test_runner.cc:133: MESSAGE: flatten-tree OK

test/pipeline_test_runner.cc:130: ERROR: CHECK_EQ( expect, gotPhase.second ) is NOT correct!
  values: CHECK_EQ( begin
  class <emptyTree><<C <root>>> < (::<todo sym>)
    begin
      class ::Test<<C Test>> < (::<todo sym>)
        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"x" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def fo(x, <blk>)
          x
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"y" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def bar(y, <blk>)
          y
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"z" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def qux(z, <blk>)
          z
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"w" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def baz(w, <blk>)
          w
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"x" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def foo<defaultArg>1(x, <blk>)
          nil
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"y" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def bar<defaultArg>1(y, <blk>)
          nil
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"z" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def qux<defaultArg>1(z, <blk>)
          ""
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"w" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def baz<defaultArg>1(w, <blk>)
          ""
        end

        <self>.extend(<emptyTree>::<C T>::<C Sig>)

        ::Sorbet::Private::Static.keep_def(<self>, :"foo")

        ::Sorbet::Private::Static.keep_def(<self>, :"bar")

        ::Sorbet::Private::Static.keep_def(<self>, :"qux")

        ::Sorbet::Private::Static.keep_def(<self>, :"baz")

        ::Sorbet::Private::Static.keep_def(<self>, :"foo<defaultArg>1")

        ::Sorbet::Private::Static.keep_def(<self>, :"bar<defaultArg>1")

        ::Sorbet::Private::Static.keep_def(<self>, :"qux<defaultArg>1")

        ::Sorbet::Private::Static.keep_def(<self>, :"baz<defaultArg>1")
      end
      ::Sorbet::Private::Static.keep_for_ide(::Test)
      <emptyTree>
    end
  end
  <emptyTree>
end
, begin
  class <emptyTree><<C <root>>> < (::<todo sym>)
    begin
      class ::Test<<C Test>> < (::<todo sym>)
        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"x" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def foo(x, <blk>)
          x
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"y" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def bar(y, <blk>)
          y
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"z" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def qux(z, <blk>)
          z
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"w" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def baz(w, <blk>)
          w
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"x" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def foo<defaultArg>1(x, <blk>)
          nil
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"y" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def bar<defaultArg>1(y, <blk>)
          nil
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"z" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def qux<defaultArg>1(z, <blk>)
          ""
        end

        ::T::Sig::WithoutRuntime.sig() do ||
          <self>.params({:"w" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
        end

        def baz<defaultArg>1(w, <blk>)
          ""
        end

        <self>.extend(<emptyTree>::<C T>::<C Sig>)

        ::Sorbet::Private::Static.keep_def(<self>, :"foo")

        ::Sorbet::Private::Static.keep_def(<self>, :"bar")

        ::Sorbet::Private::Static.keep_def(<self>, :"qux")

        ::Sorbet::Private::Static.keep_def(<self>, :"baz")

        ::Sorbet::Private::Static.keep_def(<self>, :"foo<defaultArg>1")

        ::Sorbet::Private::Static.keep_def(<self>, :"bar<defaultArg>1")

        ::Sorbet::Private::Static.keep_def(<self>, :"qux<defaultArg>1")

        ::Sorbet::Private::Static.keep_def(<self>, :"baz<defaultArg>1")
      end
      ::Sorbet::Private::Static.keep_for_ide(::Test)
      <emptyTree>
    end
  end
  <emptyTree>
end
 )
  logged: [stress-incremental] Mismatch on: test/testdata/resolver/optional_nil.rb.name-tree.exp

===============================================================================
[doctest] test cases:      1 |      0 passed |      1 failed |      0 skipped
[doctest] assertions:     12 |     10 passed |      2 failed |
[doctest] Status: FAILURE!

```


To:

```
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //test:test_PosTests/testdata/resolver/optional_nil
-----------------------------------------------------------------------------
+ exec test/pipeline_test_runner --single_test=test/testdata/resolver/optional_nil.rb
[doctest] doctest version is "2.3.7"
[doctest] run with "--help" for options
===============================================================================
test/pipeline_test_runner.cc:146:
TEST CASE:  PerPhaseTest

test/helpers/expectations.cc:145: ERROR: Mismatch on: test/testdata/resolver/optional_nil.rb.name-tree.exp
@@ -6,7 +6,7 @@
           <self>.params({:"x" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
         end
 
-        def fo(x, <blk>)
+        def foo(x, <blk>)
           x
         end
 


test/pipeline_test_runner.cc:130: MESSAGE: flatten-tree OK

test/helpers/expectations.cc:145: ERROR: [stress-incremental] Mismatch on: test/testdata/resolver/optional_nil.rb.name-tree.exp
@@ -6,7 +6,7 @@
           <self>.params({:"x" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
         end
 
-        def fo(x, <blk>)
+        def foo(x, <blk>)
           x
         end
 


===============================================================================
[doctest] test cases:      1 |      0 passed |      1 failed |      0 skipped
[doctest] assertions:     11 |      9 passed |      2 failed |
[doctest] Status: FAILURE!
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Easier to grok test failures. We used to have this with gtest, but doctest does not produce diffs. The long test failures are ~useless as I work on parallelizing namer.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

N/A
