### PR TITLE
Docs: Update FAQ re: ruby 2.7

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -253,7 +253,12 @@ bundle exec srb rbi suggest-typed
 ## What platforms does Sorbet support?
 
 The `sorbet` and `sorbet-runtime` gems are currently only tested on Ruby 2.5
-andd Ruby 2.6. Ruby 2.7 should mostly work, but feel free to open issues for it.
+andd Ruby 2.6.
+
+Ruby 2.7 has
+[known issues](https://github.com/sorbet/sorbet/issues?q=is%3Aissue+2.7+) and is
+[not being worked on yet](https://github.com/sorbet/sorbet/issues/2771#issuecomment-599761098)
+(as of May 2020) but PRs are welcome!
 
 The static checker is only tested on macOS 10.14 (Mojave) and Ubuntu 18 (Bionic
 Beaver). We expect it to work on macOS 10.10 (Yosemite) and most Linux


### PR DESCRIPTION
### Motivation

"Ruby 2.7 should mostly work" seems incorrect, per https://github.com/sorbet/sorbet/issues/2771

### Test plan

N/A, docs.
