### PR TITLE
Add RBIs for missing definitions in stdlib

### DIFF
--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_5_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_5_hidden.rbi.exp
@@ -9842,3 +9842,4 @@ end
 module Warning
   extend ::Warning
 end
+

--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_hidden.rbi.exp
@@ -10039,3 +10039,4 @@ end
 module Warning
   extend ::Warning
 end
+

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_5_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_5_hidden.rbi.exp
@@ -9848,3 +9848,4 @@ end
 module Warning
   extend ::Warning
 end
+

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_hidden.rbi.exp
@@ -10045,3 +10045,4 @@ end
 module Warning
   extend ::Warning
 end
+

--- a/rbi/stdlib/dbm.rbi
+++ b/rbi/stdlib/dbm.rbi
@@ -1,0 +1,256 @@
+# typed: __STDLIB_INTERNAL
+
+# ## Introduction
+#
+# The [`DBM`](https://docs.ruby-lang.org/en/2.6.0/DBM.html) class provides a
+# wrapper to a Unix-style [dbm](http://en.wikipedia.org/wiki/Dbm) or Database
+# Manager library.
+#
+# Dbm databases do not have tables or columns; they are simple key-value data
+# stores, like a Ruby [`Hash`](https://docs.ruby-lang.org/en/2.6.0/Hash.html)
+# except not resident in RAM. Keys and values must be strings.
+#
+# The exact library used depends on how Ruby was compiled. It could be any of
+# the following:
+#
+# *   The original ndbm library is released in 4.3BSD. It is based on dbm
+#     library in Unix Version 7 but has different API to support multiple
+#     databases in a process.
+# *   [Berkeley DB](http://en.wikipedia.org/wiki/Berkeley_DB) versions 1 thru 6,
+#     also known as BDB and Sleepycat DB, now owned by Oracle Corporation.
+# *   Berkeley DB 1.x, still found in 4.4BSD derivatives (FreeBSD, OpenBSD,
+#     etc).
+# *   [gdbm](http://www.gnu.org/software/gdbm/), the GNU implementation of dbm.
+# *   [qdbm](http://fallabs.com/qdbm/index.html), another open source
+#     reimplementation of dbm.
+#
+#
+# All of these dbm implementations have their own Ruby interfaces available,
+# which provide richer (but varying) APIs.
+#
+# ## Cautions
+#
+# Before you decide to use
+# [`DBM`](https://docs.ruby-lang.org/en/2.6.0/DBM.html), there are some issues
+# you should consider:
+#
+# *   Each implementation of dbm has its own file format. Generally, dbm
+#     libraries will not read each other's files. This makes dbm files a bad
+#     choice for data exchange.
+#
+# *   Even running the same OS and the same dbm implementation, the database
+#     file format may depend on the CPU architecture. For example, files may not
+#     be portable between PowerPC and 386, or between 32 and 64 bit Linux.
+#
+# *   Different versions of Berkeley DB use different file formats. A change to
+#     the OS may therefore break
+#     [`DBM`](https://docs.ruby-lang.org/en/2.6.0/DBM.html) access to existing
+#     files.
+#
+# *   [`Data`](https://docs.ruby-lang.org/en/2.6.0/Data.html) size limits vary
+#     between implementations. Original Berkeley DB was limited to 2GB of data.
+#     Dbm libraries also sometimes limit the total size of a key/value pair, and
+#     the total size of all the keys that hash to the same value. These limits
+#     can be as little as 512 bytes. That said, gdbm and recent versions of
+#     Berkeley DB do away with these limits.
+#
+#
+# Given the above cautions,
+# [`DBM`](https://docs.ruby-lang.org/en/2.6.0/DBM.html) is not a good choice for
+# long term storage of important data. It is probably best used as a fast and
+# easy alternative to a [`Hash`](https://docs.ruby-lang.org/en/2.6.0/Hash.html)
+# for processing large amounts of data.
+#
+# ## Example
+#
+# ```ruby
+# require 'dbm'
+# db = DBM.open('rfcs', 0666, DBM::WRCREAT)
+# db['822'] = 'Standard for the Format of ARPA Internet Text Messages'
+# db['1123'] = 'Requirements for Internet Hosts - Application and Support'
+# db['3068'] = 'An Anycast Prefix for 6to4 Relay Routers'
+# puts db['822']
+# ```
+class DBM
+  include(::Enumerable)
+
+  Elem = type_member(:out)
+
+  # Indicates that dbm\_open() should open the database in read/write mode,
+  # create it if it does not already exist, and delete all contents if it does
+  # already exist.
+  NEWDB = T.let(T.unsafe(nil), Integer)
+
+  # Indicates that dbm\_open() should open the database in read-only mode
+  READER = T.let(T.unsafe(nil), Integer)
+
+  # Identifies ndbm library version.
+  #
+  # Examples:
+  #
+  # *   "ndbm (4.3BSD)"
+  # *   "Berkeley DB 4.8.30: (April  9, 2010)"
+  # *   "Berkeley DB (unknown)" (4.4BSD, maybe)
+  # *   "GDBM version 1.8.3. 10/15/2002 (built Jul  1 2011 12:32:45)"
+  # *   "QDBM 1.8.78"
+  VERSION = T.let(T.unsafe(nil), String)
+
+  # Indicates that dbm\_open() should open the database in read/write mode, and
+  # create it if it does not already exist
+  WRCREAT = T.let(T.unsafe(nil), Integer)
+
+  # Indicates that dbm\_open() should open the database in read/write mode
+  WRITER = T.let(T.unsafe(nil), Integer)
+
+  # Return a value from the database by locating the key string provided. If the
+  # key is not found, returns nil.
+  def [](key); end
+
+  # Stores the specified string value in the database, indexed via the string
+  # key provided.
+  def []=(key, value); end
+
+  # Deletes all data from the database.
+  def clear; end
+
+  # Closes the database.
+  def close; end
+
+  # Returns true if the database is closed, false otherwise.
+  def closed?; end
+
+  # Deletes an entry from the database.
+  def delete(key); end
+
+  # Deletes all entries for which the code block returns true. Returns self.
+  def delete_if(&blk); end
+
+  # Calls the block once for each key string in the database. Returns self.
+  def each_key(&blk); end
+
+  # Calls the block once for each [key, value] pair in the database. Returns
+  # self.
+  def each_pair(&blk); end
+
+  # Calls the block once for each value string in the database. Returns self.
+  def each_value(&blk); end
+
+  # Returns true if the database is empty, false otherwise.
+  def empty?; end
+
+  # Return a value from the database by locating the key string provided. If the
+  # key is not found, returns `ifnone`. If `ifnone` is not given, raises
+  # [`IndexError`](https://docs.ruby-lang.org/en/2.6.0/IndexError.html).
+  def fetch(key, if_none = nil); end
+
+  # Returns true if the database contains the specified key, false otherwise.
+  def has_key?(key); end
+
+  # Returns true if the database contains the specified string value, false
+  # otherwise.
+  def has_value?(value); end
+
+  # Returns true if the database contains the specified key, false otherwise.
+  def include?(key); end
+
+  # Returns a [`Hash`](https://docs.ruby-lang.org/en/2.6.0/Hash.html) (not a
+  # [`DBM`](https://docs.ruby-lang.org/en/2.6.0/DBM.html) database) created by
+  # using each value in the database as a key, with the corresponding key as its
+  # value.
+  def invert; end
+
+  # Returns the key for the specified value.
+  def key(value); end
+
+  # Returns true if the database contains the specified key, false otherwise.
+  def key?(value); end
+
+  # Returns an array of all the string keys in the database.
+  def keys; end
+
+  # Returns the number of entries in the database.
+  def length; end
+
+  # Returns true if the database contains the specified key, false otherwise.
+  def member?(key); end
+
+  # Converts the contents of the database to an in-memory
+  # [`Hash`](https://docs.ruby-lang.org/en/2.6.0/Hash.html), then calls
+  # [`Hash#reject`](https://docs.ruby-lang.org/en/2.6.0/Hash.html#method-i-reject)
+  # with the specified code block, returning a new
+  # [`Hash`](https://docs.ruby-lang.org/en/2.6.0/Hash.html).
+  def reject(&blk); end
+
+  # Deletes all entries for which the code block returns true. Returns self.
+  def reject!; end
+
+  # Replaces the contents of the database with the contents of the specified
+  # object. Takes any object which implements the
+  # [`each_pair`](https://docs.ruby-lang.org/en/2.6.0/DBM.html#method-i-each_pair)
+  # method, including [`Hash`](https://docs.ruby-lang.org/en/2.6.0/Hash.html)
+  # and [`DBM`](https://docs.ruby-lang.org/en/2.6.0/DBM.html) objects.
+  def replace(_); end
+
+  # Returns a new array consisting of the [key, value] pairs for which the code
+  # block returns true.
+  def select; end
+
+  # Removes a [key, value] pair from the database, and returns it. If the
+  # database is empty, returns nil. The order in which values are
+  # removed/returned is not guaranteed.
+  def shift; end
+
+  # Returns the number of entries in the database.
+  def size; end
+
+  # Stores the specified string value in the database, indexed via the string
+  # key provided.
+  def store(_, _); end
+
+  # Converts the contents of the database to an array of [key, value] arrays,
+  # and returns it.
+  def to_a; end
+
+  # Converts the contents of the database to an in-memory
+  # [`Hash`](https://docs.ruby-lang.org/en/2.6.0/Hash.html) object, and returns
+  # it.
+  def to_hash; end
+
+  # Updates the database with multiple values from the specified object. Takes
+  # any object which implements the
+  # [`each_pair`](https://docs.ruby-lang.org/en/2.6.0/DBM.html#method-i-each_pair)
+  # method, including [`Hash`](https://docs.ruby-lang.org/en/2.6.0/Hash.html)
+  # and [`DBM`](https://docs.ruby-lang.org/en/2.6.0/DBM.html) objects.
+  def update(_); end
+
+  # Returns true if the database contains the specified string value, false
+  # otherwise.
+  def value?(_); end
+
+  # Returns an array of all the string values in the database.
+  def values; end
+
+  # Returns an array containing the values associated with the given keys.
+  def values_at(*_); end
+
+  # Open a dbm database with the specified name, which can include a directory
+  # path. Any file extensions needed will be supplied automatically by the dbm
+  # library. For example, Berkeley DB appends '.db', and GNU gdbm uses two
+  # physical files with extensions '.dir' and '.pag'.
+  #
+  # The mode should be an integer, as for Unix chmod.
+  #
+  # Flags should be one of
+  # [`READER`](https://docs.ruby-lang.org/en/2.6.0/DBM.html#READER),
+  # [`WRITER`](https://docs.ruby-lang.org/en/2.6.0/DBM.html#WRITER),
+  # [`WRCREAT`](https://docs.ruby-lang.org/en/2.6.0/DBM.html#WRCREAT) or
+  # [`NEWDB`](https://docs.ruby-lang.org/en/2.6.0/DBM.html#NEWDB).
+  def self.new(*_); end
+
+  # Open a dbm database and yields it if a block is given. See also `DBM.new`.
+  def self.open(*_); end
+end
+
+# [`Exception`](https://docs.ruby-lang.org/en/2.6.0/Exception.html) class used
+# to return errors from the dbm library.
+class DBMError < ::StandardError; end

--- a/rbi/stdlib/fiddle.rbi
+++ b/rbi/stdlib/fiddle.rbi
@@ -1,0 +1,716 @@
+# typed: __STDLIB_INTERNAL
+
+# A libffi wrapper for Ruby.
+#
+# ## Description
+#
+# [`Fiddle`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html) is an extension to
+# translate a foreign function interface (FFI) with ruby.
+#
+# It wraps [libffi](http://sourceware.org/libffi/), a popular C library which
+# provides a portable interface that allows code written in one language to call
+# code written in another language.
+#
+# ## Example
+#
+# Here we will use
+# [`Fiddle::Function`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Function.html)
+# to wrap [floor(3) from libm](http://linux.die.net/man/3/floor)
+#
+# ```ruby
+# require 'fiddle'
+#
+# libm = Fiddle.dlopen('/lib/libm.so.6')
+#
+# floor = Fiddle::Function.new(
+#   libm['floor'],
+#   [Fiddle::TYPE_DOUBLE],
+#   Fiddle::TYPE_DOUBLE
+# )
+#
+# puts floor.call(3.14159) #=> 3.0
+# ```
+module Fiddle
+  # [`ALIGN_CHAR`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#ALIGN_CHAR)
+  #
+  # The alignment size of a char
+  ALIGN_CHAR = T.let(T.unsafe(nil), Integer)
+
+  # [`ALIGN_DOUBLE`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#ALIGN_DOUBLE)
+  #
+  # The alignment size of a double
+  ALIGN_DOUBLE = T.let(T.unsafe(nil), Integer)
+
+  # [`ALIGN_FLOAT`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#ALIGN_FLOAT)
+  #
+  # The alignment size of a float
+  ALIGN_FLOAT = T.let(T.unsafe(nil), Integer)
+
+  # [`ALIGN_INT`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#ALIGN_INT)
+  #
+  # The alignment size of an int
+  ALIGN_INT = T.let(T.unsafe(nil), Integer)
+
+  # [`ALIGN_INTPTR_T`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#ALIGN_INTPTR_T)
+  #
+  # The alignment size of a intptr\_t
+  ALIGN_INTPTR_T = T.let(T.unsafe(nil), Integer)
+
+  # [`ALIGN_LONG`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#ALIGN_LONG)
+  #
+  # The alignment size of a long
+  ALIGN_LONG = T.let(T.unsafe(nil), Integer)
+
+  # [`ALIGN_LONG_LONG`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#ALIGN_LONG_LONG)
+  #
+  # The alignment size of a long long
+  ALIGN_LONG_LONG = T.let(T.unsafe(nil), Integer)
+
+  # [`ALIGN_PTRDIFF_T`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#ALIGN_PTRDIFF_T)
+  #
+  # The alignment size of a ptrdiff\_t
+  ALIGN_PTRDIFF_T = T.let(T.unsafe(nil), Integer)
+
+  # [`ALIGN_SHORT`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#ALIGN_SHORT)
+  #
+  # The alignment size of a short
+  ALIGN_SHORT = T.let(T.unsafe(nil), Integer)
+
+  # [`ALIGN_SIZE_T`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#ALIGN_SIZE_T)
+  #
+  # The alignment size of a size\_t
+  ALIGN_SIZE_T = T.let(T.unsafe(nil), Integer)
+
+  # [`ALIGN_SSIZE_T`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#ALIGN_SSIZE_T)
+  #
+  # The alignment size of a ssize\_t
+  ALIGN_SSIZE_T = T.let(T.unsafe(nil), Integer)
+
+  # [`ALIGN_UINTPTR_T`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#ALIGN_UINTPTR_T)
+  #
+  # The alignment size of a uintptr\_t
+  ALIGN_UINTPTR_T = T.let(T.unsafe(nil), Integer)
+
+  # [`ALIGN_VOIDP`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#ALIGN_VOIDP)
+  #
+  # The alignment size of a void\*
+  ALIGN_VOIDP = T.let(T.unsafe(nil), Integer)
+
+  # [`BUILD_RUBY_PLATFORM`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#BUILD_RUBY_PLATFORM)
+  #
+  # Platform built against (i.e. "x86\_64-linux", etc.)
+  #
+  # See also RUBY\_PLATFORM
+  BUILD_RUBY_PLATFORM = T.let(T.unsafe(nil), String)
+
+  # [`RUBY_FREE`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#RUBY_FREE)
+  #
+  # Address of the ruby\_xfree() function
+  RUBY_FREE = T.let(T.unsafe(nil), Integer)
+
+  # [`SIZEOF_CHAR`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#SIZEOF_CHAR)
+  #
+  # size of a char
+  SIZEOF_CHAR = T.let(T.unsafe(nil), Integer)
+
+  # [`SIZEOF_DOUBLE`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#SIZEOF_DOUBLE)
+  #
+  # size of a double
+  SIZEOF_DOUBLE = T.let(T.unsafe(nil), Integer)
+
+  # [`SIZEOF_FLOAT`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#SIZEOF_FLOAT)
+  #
+  # size of a float
+  SIZEOF_FLOAT = T.let(T.unsafe(nil), Integer)
+
+  # [`SIZEOF_INT`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#SIZEOF_INT)
+  #
+  # size of an int
+  SIZEOF_INT = T.let(T.unsafe(nil), Integer)
+
+  # [`SIZEOF_INTPTR_T`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#SIZEOF_INTPTR_T)
+  #
+  # size of a intptr\_t
+  SIZEOF_INTPTR_T = T.let(T.unsafe(nil), Integer)
+
+  # [`SIZEOF_LONG`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#SIZEOF_LONG)
+  #
+  # size of a long
+  SIZEOF_LONG = T.let(T.unsafe(nil), Integer)
+
+  # [`SIZEOF_LONG_LONG`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#SIZEOF_LONG_LONG)
+  #
+  # size of a long long
+  SIZEOF_LONG_LONG = T.let(T.unsafe(nil), Integer)
+
+  # [`SIZEOF_PTRDIFF_T`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#SIZEOF_PTRDIFF_T)
+  #
+  # size of a ptrdiff\_t
+  SIZEOF_PTRDIFF_T = T.let(T.unsafe(nil), Integer)
+
+  # [`SIZEOF_SHORT`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#SIZEOF_SHORT)
+  #
+  # size of a short
+  SIZEOF_SHORT = T.let(T.unsafe(nil), Integer)
+
+  # [`SIZEOF_SIZE_T`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#SIZEOF_SIZE_T)
+  #
+  # size of a size\_t
+  SIZEOF_SIZE_T = T.let(T.unsafe(nil), Integer)
+
+  # [`SIZEOF_SSIZE_T`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#SIZEOF_SSIZE_T)
+  #
+  # size of a ssize\_t
+  SIZEOF_SSIZE_T = T.let(T.unsafe(nil), Integer)
+
+  # [`SIZEOF_UINTPTR_T`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#SIZEOF_UINTPTR_T)
+  #
+  # size of a uintptr\_t
+  SIZEOF_UINTPTR_T = T.let(T.unsafe(nil), Integer)
+
+  # [`SIZEOF_VOIDP`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#SIZEOF_VOIDP)
+  #
+  # size of a void\*
+  SIZEOF_VOIDP = T.let(T.unsafe(nil), Integer)
+
+  # [`TYPE_CHAR`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#TYPE_CHAR)
+  #
+  # C type - char
+  TYPE_CHAR = T.let(T.unsafe(nil), Integer)
+
+  # [`TYPE_DOUBLE`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#TYPE_DOUBLE)
+  #
+  # C type - double
+  TYPE_DOUBLE = T.let(T.unsafe(nil), Integer)
+
+  # [`TYPE_FLOAT`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#TYPE_FLOAT)
+  #
+  # C type - float
+  TYPE_FLOAT = T.let(T.unsafe(nil), Integer)
+
+  # [`TYPE_INT`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#TYPE_INT)
+  #
+  # C type - int
+  TYPE_INT = T.let(T.unsafe(nil), Integer)
+
+  # [`TYPE_INTPTR_T`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#TYPE_INTPTR_T)
+  #
+  # C type - intptr\_t
+  TYPE_INTPTR_T = T.let(T.unsafe(nil), Integer)
+
+  # [`TYPE_LONG`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#TYPE_LONG)
+  #
+  # C type - long
+  TYPE_LONG = T.let(T.unsafe(nil), Integer)
+
+  # [`TYPE_LONG_LONG`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#TYPE_LONG_LONG)
+  #
+  # C type - long long
+  TYPE_LONG_LONG = T.let(T.unsafe(nil), Integer)
+
+  # [`TYPE_PTRDIFF_T`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#TYPE_PTRDIFF_T)
+  #
+  # C type - ptrdiff\_t
+  TYPE_PTRDIFF_T = T.let(T.unsafe(nil), Integer)
+
+  # [`TYPE_SHORT`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#TYPE_SHORT)
+  #
+  # C type - short
+  TYPE_SHORT = T.let(T.unsafe(nil), Integer)
+
+  # [`TYPE_SIZE_T`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#TYPE_SIZE_T)
+  #
+  # C type - size\_t
+  TYPE_SIZE_T = T.let(T.unsafe(nil), Integer)
+
+  # [`TYPE_SSIZE_T`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#TYPE_SSIZE_T)
+  #
+  # C type - ssize\_t
+  TYPE_SSIZE_T = T.let(T.unsafe(nil), Integer)
+
+  # [`TYPE_UINTPTR_T`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#TYPE_UINTPTR_T)
+  #
+  # C type - uintptr\_t
+  TYPE_UINTPTR_T = T.let(T.unsafe(nil), Integer)
+
+  # [`TYPE_VOID`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#TYPE_VOID)
+  #
+  # C type - void
+  TYPE_VOID = T.let(T.unsafe(nil), Integer)
+
+  # [`TYPE_VOIDP`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#TYPE_VOIDP)
+  #
+  # C type - void\*
+  TYPE_VOIDP = T.let(T.unsafe(nil), Integer)
+
+  # Creates a new handler that opens `library`, and returns an instance of
+  # [`Fiddle::Handle`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Handle.html).
+  #
+  # If `nil` is given for the `library`, Fiddle::Handle::DEFAULT is used, which
+  # is the equivalent to RTLD\_DEFAULT. See `man 3 dlopen` for more.
+  #
+  # ```ruby
+  # lib = Fiddle.dlopen(nil)
+  # ```
+  #
+  # The default is dependent on OS, and provide a handle for all libraries
+  # already loaded. For example, in most cases you can use this to access `libc`
+  # functions, or ruby functions like `rb_str_new`.
+  #
+  # See
+  # [`Fiddle::Handle.new`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Handle.html#method-c-new)
+  # for more.
+  def self.dlopen(library); end
+
+  # Returns the hexadecimal representation of a memory pointer address `addr`
+  #
+  # Example:
+  #
+  # ```
+  # lib = Fiddle.dlopen('/lib64/libc-2.15.so')
+  # => #<Fiddle::Handle:0x00000001342460>
+  #
+  # lib['strcpy'].to_s(16)
+  # => "7f59de6dd240"
+  #
+  # Fiddle.dlunwrap(Fiddle.dlwrap(lib['strcpy'].to_s(16)))
+  # => "7f59de6dd240"
+  # ```
+  def self.dlunwrap(_); end
+
+  # Returns a memory pointer of a function's hexadecimal address location `val`
+  #
+  # Example:
+  #
+  # ```
+  # lib = Fiddle.dlopen('/lib64/libc-2.15.so')
+  # => #<Fiddle::Handle:0x00000001342460>
+  #
+  # Fiddle.dlwrap(lib['strcpy'].to_s(16))
+  # => 25522520
+  # ```
+  def self.dlwrap(_); end
+
+  # Free the memory at address `addr`
+  def self.free(_); end
+
+  # Returns the last `Error` of the current executing `Thread` or nil if none
+  def self.last_error; end
+
+  # Sets the last `Error` of the current executing `Thread` to `error`
+  def self.last_error=(error); end
+
+  # Allocate `size` bytes of memory and return the integer memory address for
+  # the allocated memory.
+  def self.malloc(_); end
+
+  # Change the size of the memory allocated at the memory location `addr` to
+  # `size` bytes. Returns the memory address of the reallocated memory, which
+  # may be different than the address passed in.
+  def self.realloc(_, _); end
+end
+
+# ## Description
+#
+# An FFI closure wrapper, for handling callbacks.
+#
+# ## Example
+#
+# ```ruby
+# closure = Class.new(Fiddle::Closure) {
+#   def call
+#     10
+#   end
+# }.new(Fiddle::TYPE_INT, [])
+#    #=> #<#<Class:0x0000000150d308>:0x0000000150d240>
+# func = Fiddle::Function.new(closure, [], Fiddle::TYPE_INT)
+#    #=> #<Fiddle::Function:0x00000001516e58>
+# func.call
+#    #=> 10
+# ```
+class Fiddle::Closure
+  def initialize(*_); end
+
+  # arguments of the FFI closure
+  def args; end
+
+  # the C type of the return of the FFI closure
+  def ctype; end
+
+  # Returns the memory address for this closure
+  def to_i; end
+end
+
+# Extends
+# [`Fiddle::Closure`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Closure.html)
+# to allow for building the closure in a block
+# Extends
+# [`Fiddle::Closure`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Closure.html)
+# to allow for building the closure in a block
+# Extends
+# [`Fiddle::Closure`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Closure.html)
+# to allow for building the closure in a block
+# Extends
+# [`Fiddle::Closure`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Closure.html)
+# to allow for building the closure in a block
+class Fiddle::Closure::BlockCaller < ::Fiddle::Closure
+  def initialize(ctype, args, abi = _, &block); end
+
+  # Calls the constructed
+  # [`BlockCaller`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Closure/BlockCaller.html),
+  # with `args`
+  #
+  # For an example see
+  # [`Fiddle::Closure::BlockCaller.new`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Closure/BlockCaller.html#method-c-new)
+  def call(*args); end
+end
+
+# standard dynamic load exception
+class Fiddle::DLError < ::StandardError
+end
+
+# ## Description
+#
+# A representation of a C function
+#
+# ## Examples
+#
+# ### 'strcpy'
+#
+# ```
+# @libc = Fiddle.dlopen "/lib/libc.so.6"
+#    #=> #<Fiddle::Handle:0x00000001d7a8d8>
+# f = Fiddle::Function.new(
+#   @libc['strcpy'],
+#   [Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP],
+#   Fiddle::TYPE_VOIDP)
+#    #=> #<Fiddle::Function:0x00000001d8ee00>
+# buff = "000"
+#    #=> "000"
+# str = f.call(buff, "123")
+#    #=> #<Fiddle::Pointer:0x00000001d0c380 ptr=0x000000018a21b8 size=0 free=0x00000000000000>
+# str.to_s
+# => "123"
+# ```
+#
+# ### ABI check
+#
+# ```ruby
+# @libc = Fiddle.dlopen "/lib/libc.so.6"
+#    #=> #<Fiddle::Handle:0x00000001d7a8d8>
+# f = Fiddle::Function.new(@libc['strcpy'], [TYPE_VOIDP, TYPE_VOIDP], TYPE_VOIDP)
+#    #=> #<Fiddle::Function:0x00000001d8ee00>
+# f.abi == Fiddle::Function::DEFAULT
+#    #=> true
+# ```
+class Fiddle::Function
+  # [`DEFAULT`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Function.html#DEFAULT)
+  #
+  # Default ABI
+  DEFAULT = T.let(T.unsafe(nil), Integer)
+
+  def initialize(*_); end
+
+  # The ABI of the
+  # [`Function`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Function.html).
+  def abi; end
+
+  # Calls the constructed
+  # [`Function`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Function.html), with
+  # `args`. Caller must ensure the underlying function is called in a
+  # thread-safe manner if running in a multi-threaded process.
+  #
+  # For an example see
+  # [`Fiddle::Function`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Function.html)
+  def call(*_); end
+
+  # The name of this function
+  def name; end
+
+  # The address of this function
+  def ptr; end
+
+  # The integer memory location of this function
+  def to_i; end
+end
+
+# The [`Fiddle::Handle`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Handle.html)
+# is the manner to access the dynamic library
+#
+# ## Example
+#
+# ### Setup
+#
+# ```
+# libc_so = "/lib64/libc.so.6"
+# => "/lib64/libc.so.6"
+# @handle = Fiddle::Handle.new(libc_so)
+# => #<Fiddle::Handle:0x00000000d69ef8>
+# ```
+#
+# ### Setup, with flags
+#
+# ```
+# libc_so = "/lib64/libc.so.6"
+# => "/lib64/libc.so.6"
+# @handle = Fiddle::Handle.new(libc_so, Fiddle::RTLD_LAZY | Fiddle::RTLD_GLOBAL)
+# => #<Fiddle::Handle:0x00000000d69ef8>
+# ```
+#
+# See
+# [`RTLD_LAZY`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Handle.html#RTLD_LAZY)
+# and
+# [`RTLD_GLOBAL`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Handle.html#RTLD_GLOBAL)
+#
+# ### Addresses to symbols
+#
+# ```
+# strcpy_addr = @handle['strcpy']
+# => 140062278451968
+# ```
+#
+# or
+#
+# ```
+# strcpy_addr = @handle.sym('strcpy')
+# => 140062278451968
+# ```
+class Fiddle::Handle
+  # [`DEFAULT`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Handle.html#DEFAULT)
+  #
+  # A predefined pseudo-handle of RTLD\_DEFAULT
+  #
+  # Which will find the first occurrence of the desired symbol using the default
+  # library search order
+  DEFAULT = T.let(T.unsafe(nil), Fiddle::Handle)
+
+  # [`NEXT`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Handle.html#NEXT)
+  #
+  # A predefined pseudo-handle of RTLD\_NEXT
+  #
+  # Which will find the next occurrence of a function in the search order after
+  # the current library.
+  NEXT = T.let(T.unsafe(nil), Fiddle::Handle)
+
+  # [`RTLD_GLOBAL`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Handle.html#RTLD_GLOBAL)
+  #
+  # rtld
+  # [`Fiddle::Handle`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Handle.html)
+  # flag.
+  #
+  # The symbols defined by this library will be made available for symbol
+  # resolution of subsequently loaded libraries.
+  RTLD_GLOBAL = T.let(T.unsafe(nil), Integer)
+
+  # [`RTLD_LAZY`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Handle.html#RTLD_LAZY)
+  #
+  # rtld
+  # [`Fiddle::Handle`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Handle.html)
+  # flag.
+  #
+  # Perform lazy binding. Only resolve symbols as the code that references them
+  # is executed. If the  symbol is never referenced, then it is never resolved.
+  # (Lazy binding is only performed for function references; references to
+  # variables are always immediately bound when the library is loaded.)
+  RTLD_LAZY = T.let(T.unsafe(nil), Integer)
+
+  # [`RTLD_NOW`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Handle.html#RTLD_NOW)
+  #
+  # rtld
+  # [`Fiddle::Handle`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Handle.html)
+  # flag.
+  #
+  # If this value is specified or the environment variable LD\_BIND\_NOW is set
+  # to a nonempty string, all undefined symbols in the library are resolved
+  # before
+  # [`Fiddle.dlopen`](https://docs.ruby-lang.org/en/2.6.0/Fiddle.html#method-c-dlopen)
+  # returns. If this cannot be done an error is returned.
+  RTLD_NOW = T.let(T.unsafe(nil), Integer)
+
+  def initialize(*_); end
+
+  # Get the address as an
+  # [`Integer`](https://docs.ruby-lang.org/en/2.6.0/Integer.html) for the
+  # function named `name`.
+  def [](_); end
+
+  # Close this handle.
+  #
+  # Calling close more than once will raise a
+  # [`Fiddle::DLError`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/DLError.html)
+  # exception.
+  def close; end
+
+  # Returns `true` if dlclose() will be called when this handle is garbage
+  # collected.
+  #
+  # See man(3) dlclose() for more info.
+  def close_enabled?; end
+
+  # Disable a call to dlclose() when this handle is garbage collected.
+  def disable_close; end
+
+  # Enable a call to dlclose() when this handle is garbage collected.
+  def enable_close; end
+
+  # Get the address as an
+  # [`Integer`](https://docs.ruby-lang.org/en/2.6.0/Integer.html) for the
+  # function named `name`.
+  def sym(_); end
+
+  # Returns the memory address for this handle.
+  def to_i; end
+
+  # Get the address as an
+  # [`Integer`](https://docs.ruby-lang.org/en/2.6.0/Integer.html) for the
+  # function named `name`. The function is searched via dlsym on RTLD\_NEXT.
+  #
+  # See man(3) dlsym() for more info.
+  def self.[](_); end
+
+  # Get the address as an
+  # [`Integer`](https://docs.ruby-lang.org/en/2.6.0/Integer.html) for the
+  # function named `name`.
+  def self.sym(_); end
+end
+
+# [`Fiddle::Pointer`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Pointer.html)
+# is a class to handle C pointers
+class Fiddle::Pointer
+  def initialize(*_); end
+
+  # Returns a new pointer instance that has been advanced `n` bytes.
+  def +(_); end
+
+  # Returns a new
+  # [`Fiddle::Pointer`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Pointer.html)
+  # instance that is a dereferenced pointer for this pointer.
+  #
+  # Analogous to the star operator in C.
+  def +@; end
+
+  # Returns a new pointer instance that has been moved back `n` bytes.
+  def -(_); end
+
+  # Returns a new
+  # [`Fiddle::Pointer`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Pointer.html)
+  # instance that is a reference pointer for this pointer.
+  #
+  # Analogous to the ampersand operator in C.
+  def -@; end
+
+  # Returns -1 if less than, 0 if equal to, 1 if greater than `other`.
+  #
+  # Returns nil if `ptr` cannot be compared to `other`.
+  def <=>(_); end
+
+  # Returns true if `other` wraps the same pointer, otherwise returns false.
+  def ==(_); end
+
+  # Returns integer stored at *index*.
+  #
+  # If *start* and *length* are given, a string containing the bytes from
+  # *start* of *length* will be returned.
+  def [](*_); end
+
+  # [`Set`](https://docs.ruby-lang.org/en/2.6.0/Set.html) the value at `index`
+  # to `int`.
+  #
+  # Or, set the memory at `start` until `length` with the contents of `string`,
+  # the memory from `dl_cptr`, or the memory pointed at by the memory address
+  # `addr`.
+  def []=(*_); end
+
+  # Returns true if `other` wraps the same pointer, otherwise returns false.
+  def eql?(_); end
+
+  # Get the free function for this pointer.
+  #
+  # Returns a new instance of
+  # [`Fiddle::Function`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Function.html).
+  #
+  # See
+  # [`Fiddle::Function.new`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Function.html#method-c-new)
+  def free; end
+
+  # [`Set`](https://docs.ruby-lang.org/en/2.6.0/Set.html) the free function for
+  # this pointer to `function` in the given
+  # [`Fiddle::Function`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Function.html).
+  def free=(_); end
+
+  # Returns a string formatted with an easily readable representation of the
+  # internal state of the pointer.
+  def inspect; end
+
+  # Returns `true` if this is a null pointer.
+  def null?; end
+
+  # Returns a new
+  # [`Fiddle::Pointer`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Pointer.html)
+  # instance that is a dereferenced pointer for this pointer.
+  #
+  # Analogous to the star operator in C.
+  def ptr; end
+
+  # Returns a new
+  # [`Fiddle::Pointer`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Pointer.html)
+  # instance that is a reference pointer for this pointer.
+  #
+  # Analogous to the ampersand operator in C.
+  def ref; end
+
+  # Get the size of this pointer.
+  def size; end
+
+  # [`Set`](https://docs.ruby-lang.org/en/2.6.0/Set.html) the size of this
+  # pointer to `size`
+  def size=(_); end
+
+  # Returns the integer memory location of this pointer.
+  def to_i; end
+
+  # Returns the integer memory location of this pointer.
+  def to_int; end
+
+  # Returns the pointer contents as a string.
+  #
+  # When called with no arguments, this method will return the contents until
+  # the first NULL byte.
+  #
+  # When called with `len`, a string of `len` bytes will be returned.
+  #
+  # See
+  # [`to_str`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Pointer.html#method-i-to_str)
+  def to_s(*_); end
+
+  # Returns the pointer contents as a string.
+  #
+  # When called with no arguments, this method will return the contents with the
+  # length of this pointer's `size`.
+  #
+  # When called with `len`, a string of `len` bytes will be returned.
+  #
+  # See
+  # [`to_s`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Pointer.html#method-i-to_s)
+  def to_str(*_); end
+
+  # Cast this pointer to a ruby object.
+  def to_value; end
+
+  # Get the underlying pointer for ruby object `val` and return it as a
+  # [`Fiddle::Pointer`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Pointer.html)
+  # object.
+  def self.[](_); end
+
+  # Allocate `size` bytes of memory and associate it with an optional `freefunc`
+  # that will be called when the pointer is garbage collected.
+  #
+  # `freefunc` must be an address pointing to a function or an instance of
+  # [`Fiddle::Function`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Function.html)
+  def self.malloc(*_); end
+
+  # Get the underlying pointer for ruby object `val` and return it as a
+  # [`Fiddle::Pointer`](https://docs.ruby-lang.org/en/2.6.0/Fiddle/Pointer.html)
+  # object.
+  def self.to_ptr(_); end
+end

--- a/rbi/stdlib/gdbm.rbi
+++ b/rbi/stdlib/gdbm.rbi
@@ -1,0 +1,293 @@
+# typed: __STDLIB_INTERNAL
+
+# ## Summary
+#
+# Ruby extension for GNU dbm (gdbm) -- a simple database engine for storing
+# key-value pairs on disk.
+#
+# ## Description
+#
+# GNU dbm is a library for simple databases. A database is a file that stores
+# key-value pairs. Gdbm allows the user to store, retrieve, and delete data by
+# key. It furthermore allows a non-sorted traversal of all key-value pairs. A
+# gdbm database thus provides the same functionality as a hash. As with objects
+# of the [`Hash`](https://docs.ruby-lang.org/en/2.6.0/Hash.html) class, elements
+# can be accessed with `[]`. Furthermore,
+# [`GDBM`](https://docs.ruby-lang.org/en/2.6.0/GDBM.html) mixes in the
+# [`Enumerable`](https://docs.ruby-lang.org/en/2.6.0/Enumerable.html) module,
+# thus providing convenient methods such as
+# [`find`](https://docs.ruby-lang.org/en/2.6.0/Enumerable.html#method-i-find),
+# [`collect`](https://docs.ruby-lang.org/en/2.6.0/Enumerable.html#method-i-collect),
+# [`map`](https://docs.ruby-lang.org/en/2.6.0/Enumerable.html#method-i-map),
+# etc.
+#
+# A process is allowed to open several different databases at the same time. A
+# process can open a database as a "reader" or a "writer". Whereas a reader has
+# only read-access to the database, a writer has read- and write-access. A
+# database can be accessed either by any number of readers or by exactly one
+# writer at the same time.
+#
+# ## Examples
+#
+# 1.  Opening/creating a database, and filling it with some entries:
+#
+# ```ruby
+# require 'gdbm'
+#
+# gdbm = GDBM.new("fruitstore.db")
+# gdbm["ananas"]    = "3"
+# gdbm["banana"]    = "8"
+# gdbm["cranberry"] = "4909"
+# gdbm.close
+# ```
+#
+# 2.  Reading out a database:
+#
+# ```ruby
+# require 'gdbm'
+#
+# gdbm = GDBM.new("fruitstore.db")
+# gdbm.each_pair do |key, value|
+#   print "#{key}: #{value}\n"
+# end
+# gdbm.close
+# ```
+#
+#     produces
+#
+# ```
+# banana: 8
+# ananas: 3
+# cranberry: 4909
+# ```
+#
+#
+# ## Links
+#
+# *   http://www.gnu.org/software/gdbm/
+class GDBM
+  include(::Enumerable)
+
+  Elem = type_member(:out)
+
+  # flag for new and
+  # [`open`](https://docs.ruby-lang.org/en/2.6.0/Kernel.html#method-i-open).
+  # this flag is obsolete for gdbm >= 1.8
+  FAST = T.let(T.unsafe(nil), Integer)
+
+  # open database as a writer; overwrite any existing databases
+  NEWDB = T.let(T.unsafe(nil), Integer)
+
+  # flag for new and
+  # [`open`](https://docs.ruby-lang.org/en/2.6.0/Kernel.html#method-i-open)
+  NOLOCK = T.let(T.unsafe(nil), Integer)
+
+  # open database as a reader
+  READER = T.let(T.unsafe(nil), Integer)
+
+  # flag for new and
+  # [`open`](https://docs.ruby-lang.org/en/2.6.0/Kernel.html#method-i-open).
+  # only for gdbm >= 1.8
+  SYNC = T.let(T.unsafe(nil), Integer)
+
+  # version of the gdbm library
+  VERSION = T.let(T.unsafe(nil), String)
+
+  # open database as a writer; if the database does not exist, create a new one
+  WRCREAT = T.let(T.unsafe(nil), Integer)
+
+  # open database as a writer
+  WRITER = T.let(T.unsafe(nil), Integer)
+
+  def initialize(*_); end
+
+  # Retrieves the *value* corresponding to *key*.
+  def [](_); end
+
+  # Associates the value *value* with the specified *key*.
+  def []=(_, _); end
+
+  # Sets the size of the internal bucket cache to *size*.
+  def cachesize=(_); end
+
+  # Removes all the key-value pairs within *gdbm*.
+  def clear; end
+
+  # Closes the associated database file.
+  def close; end
+
+  # Returns true if the associated database file has been closed.
+  def closed?; end
+
+  # Removes the key-value-pair with the specified *key* from this database and
+  # returns the corresponding *value*. Returns nil if the database is empty.
+  def delete(_); end
+
+  # Deletes every key-value pair from *gdbm* for which *block* evaluates to
+  # true.
+  def delete_if; end
+
+  # Executes *block* for each key in the database, passing the *key* and the
+  # corresponding *value* as a parameter.
+  def each; end
+
+  # Executes *block* for each key in the database, passing the *key* as a
+  # parameter.
+  def each_key; end
+
+  # Executes *block* for each key in the database, passing the *key* and the
+  # corresponding *value* as a parameter.
+  def each_pair; end
+
+  # Executes *block* for each key in the database, passing the corresponding
+  # *value* as a parameter.
+  def each_value; end
+
+  # Returns true if the database is empty.
+  def empty?; end
+
+  # Turns the database's fast mode on or off. If fast mode is turned on, gdbm
+  # does not wait for writes to be flushed to the disk before continuing.
+  #
+  # This option is obsolete for gdbm >= 1.8 since fast mode is turned on by
+  # default. See also:
+  # [`syncmode=`](https://docs.ruby-lang.org/en/2.6.0/GDBM.html#method-i-syncmode-3D)
+  def fastmode=(_); end
+
+  # Retrieves the *value* corresponding to *key*. If there is no value
+  # associated with *key*, *default* will be returned instead.
+  def fetch(*_); end
+
+  # Returns true if the given key *k* exists within the database. Returns false
+  # otherwise.
+  def has_key?(_); end
+
+  # Returns true if the given value *v* exists within the database. Returns
+  # false otherwise.
+  def has_value?(_); end
+
+  # Returns true if the given key *k* exists within the database. Returns false
+  # otherwise.
+  def include?(_); end
+
+  def index(_); end
+
+  # Returns a hash created by using *gdbm*'s values as keys, and the keys as
+  # values.
+  def invert; end
+
+  # Returns the *key* for a given *value*. If several keys may map to the same
+  # value, the key that is found first will be returned.
+  def key(_); end
+
+  # Returns true if the given key *k* exists within the database. Returns false
+  # otherwise.
+  def key?(_); end
+
+  # Returns an array of all keys of this database.
+  def keys; end
+
+  # Returns the number of key-value pairs in this database.
+  def length; end
+
+  # Returns true if the given key *k* exists within the database. Returns false
+  # otherwise.
+  def member?(_); end
+
+  # Returns a hash copy of *gdbm* where all key-value pairs from *gdbm* for
+  # which *block* evaluates to true are removed. See also:
+  # [`delete_if`](https://docs.ruby-lang.org/en/2.6.0/GDBM.html#method-i-delete_if)
+  def reject; end
+
+  # Deletes every key-value pair from *gdbm* for which *block* evaluates to
+  # true.
+  def reject!; end
+
+  # Reorganizes the database file. This operation removes reserved space of
+  # elements that have already been deleted. It is only useful after a lot of
+  # deletions in the database.
+  def reorganize; end
+
+  # Replaces the content of *gdbm* with the key-value pairs of *other*. *other*
+  # must have an
+  # [`each_pair`](https://docs.ruby-lang.org/en/2.6.0/GDBM.html#method-i-each_pair)
+  # method.
+  def replace(_); end
+
+  # Returns a new array of all key-value pairs of the database for which *block*
+  # evaluates to true.
+  def select; end
+
+  # Removes a key-value-pair from this database and returns it as a two-item
+  # array [ *key*, *value* ]. Returns nil if the database is empty.
+  def shift; end
+
+  # Returns the number of key-value pairs in this database.
+  def size; end
+
+  # Associates the value *value* with the specified *key*.
+  def store(_, _); end
+
+  # Unless the *gdbm* object has been opened with the **SYNC** flag, it is not
+  # guaranteed that database modification operations are immediately applied to
+  # the database file. This method ensures that all recent modifications to the
+  # database are written to the file. Blocks until all writing operations to the
+  # disk have been finished.
+  def sync; end
+
+  # Turns the database's synchronization mode on or off. If the synchronization
+  # mode is turned on, the database's in-memory state will be synchronized to
+  # disk after every database modification operation. If the synchronization
+  # mode is turned off, [`GDBM`](https://docs.ruby-lang.org/en/2.6.0/GDBM.html)
+  # does not wait for writes to be flushed to the disk before continuing.
+  #
+  # This option is only available for gdbm >= 1.8 where syncmode is turned off
+  # by default. See also:
+  # [`fastmode=`](https://docs.ruby-lang.org/en/2.6.0/GDBM.html#method-i-fastmode-3D)
+  def syncmode=(_); end
+
+  # Returns an array of all key-value pairs contained in the database.
+  def to_a; end
+
+  # Returns a hash of all key-value pairs contained in the database.
+  def to_hash; end
+
+  # Adds the key-value pairs of *other* to *gdbm*, overwriting entries with
+  # duplicate keys with those from *other*. *other* must have an
+  # [`each_pair`](https://docs.ruby-lang.org/en/2.6.0/GDBM.html#method-i-each_pair)
+  # method.
+  def update(_); end
+
+  # Returns true if the given value *v* exists within the database. Returns
+  # false otherwise.
+  def value?(_); end
+
+  # Returns an array of all values of this database.
+  def values; end
+
+  # Returns an array of the values associated with each specified *key*.
+  def values_at(*_); end
+
+  # If called without a block, this is synonymous to
+  # [`GDBM::new`](https://docs.ruby-lang.org/en/2.6.0/GDBM.html#method-c-new).
+  # If a block is given, the new
+  # [`GDBM`](https://docs.ruby-lang.org/en/2.6.0/GDBM.html) instance will be
+  # passed to the block as a parameter, and the corresponding database file will
+  # be closed after the execution of the block code has been finished.
+  #
+  # Example for an open call with a block:
+  #
+  # ```ruby
+  # require 'gdbm'
+  # GDBM.open("fruitstore.db") do |gdbm|
+  #   gdbm.each_pair do |key, value|
+  #     print "#{key}: #{value}\n"
+  #   end
+  # end
+  # ```
+  def self.open(*_); end
+end
+
+class GDBMError < ::StandardError; end
+
+class GDBMFatalError < ::Exception; end

--- a/rbi/stdlib/getoptlong.rbi
+++ b/rbi/stdlib/getoptlong.rbi
@@ -1,0 +1,240 @@
+# typed: __STDLIB_INTERNAL
+
+# The [`GetoptLong`](https://docs.ruby-lang.org/en/2.6.0/GetoptLong.html) class
+# allows you to parse command line options similarly to the GNU getopt\_long() C
+# library call. Note, however, that
+# [`GetoptLong`](https://docs.ruby-lang.org/en/2.6.0/GetoptLong.html) is a pure
+# Ruby implementation.
+#
+# [`GetoptLong`](https://docs.ruby-lang.org/en/2.6.0/GetoptLong.html) allows for
+# POSIX-style options like `--file` as well as single letter options like `-f`
+#
+# The empty option `--` (two minus symbols) is used to end option processing.
+# This can be particularly important if options have optional arguments.
+#
+# Here is a simple example of usage:
+#
+# ```ruby
+# require 'getoptlong'
+#
+# opts = GetoptLong.new(
+#   [ '--help', '-h', GetoptLong::NO_ARGUMENT ],
+#   [ '--repeat', '-n', GetoptLong::REQUIRED_ARGUMENT ],
+#   [ '--name', GetoptLong::OPTIONAL_ARGUMENT ]
+# )
+#
+# dir = nil
+# name = nil
+# repetitions = 1
+# opts.each do |opt, arg|
+#   case opt
+#     when '--help'
+#       puts <<-EOF
+# hello [OPTION] ... DIR
+#
+# -h, --help:
+#    show help
+#
+# --repeat x, -n x:
+#    repeat x times
+#
+# --name [name]:
+#    greet user by name, if name not supplied default is John
+#
+# DIR: The directory in which to issue the greeting.
+#       EOF
+#     when '--repeat'
+#       repetitions = arg.to_i
+#     when '--name'
+#       if arg == ''
+#         name = 'John'
+#       else
+#         name = arg
+#       end
+#   end
+# end
+#
+# if ARGV.length != 1
+#   puts "Missing dir argument (try --help)"
+#   exit 0
+# end
+#
+# dir = ARGV.shift
+#
+# Dir.chdir(dir)
+# for i in (1..repetitions)
+#   print "Hello"
+#   if name
+#     print ", #{name}"
+#   end
+#   puts
+# end
+# ```
+#
+# Example command line:
+#
+# ```
+# hello -n 6 --name -- /tmp
+# ```
+class GetoptLong
+
+  # Argument flags.
+  ARGUMENT_FLAGS = T.let(T.unsafe(nil), T::Array[String])
+
+  # Orderings.
+  ORDERINGS = T.let(T.unsafe(nil), T::Array[String])
+
+  STATUS_TERMINATED = T.let(T.unsafe(nil), Integer)
+
+  VERSION = T.let(T.unsafe(nil), String)
+
+  def initialize(*arguments); end
+
+  # Iterator version of 'get'.
+  #
+  # The block is called repeatedly with two arguments: The first is the option
+  # name. The second is the argument which followed it (if any). Example:
+  # ('--opt', 'value')
+  #
+  # The option name is always converted to the first (preferred) name given in
+  # the original options to
+  # [`GetoptLong.new`](https://docs.ruby-lang.org/en/2.6.0/GetoptLong.html#method-c-new).
+  #
+  # Also aliased as:
+  # [`each_option`](https://docs.ruby-lang.org/en/2.6.0/GetoptLong.html#method-i-each_option)
+  def each; end
+
+  # 'each\_option' is an alias of 'each'.
+  #
+  # Alias for:
+  # [`each`](https://docs.ruby-lang.org/en/2.6.0/GetoptLong.html#method-i-each)
+  def each_option; end
+
+  # Examine whether an option processing is failed.
+  def error; end
+
+  # Examine whether an option processing is failed.
+  def error?; end
+
+  # Return the appropriate error message in POSIX-defined format. If no error
+  # has occurred, returns nil.
+  def error_message; end
+
+  # Get next option name and its argument, as an
+  # [`Array`](https://docs.ruby-lang.org/en/2.6.0/Array.html) of two elements.
+  #
+  # The option name is always converted to the first (preferred) name given in
+  # the original options to
+  # [`GetoptLong.new`](https://docs.ruby-lang.org/en/2.6.0/GetoptLong.html#method-c-new).
+  #
+  # Example: ['--option', 'value']
+  #
+  # Returns nil if the processing is complete (as determined by
+  # [`STATUS_TERMINATED`](https://docs.ruby-lang.org/en/2.6.0/GetoptLong.html#STATUS_TERMINATED)).
+  #
+  # Also aliased as:
+  # [`get_option`](https://docs.ruby-lang.org/en/2.6.0/GetoptLong.html#method-i-get_option)
+  def get; end
+
+  # 'get\_option' is an alias of 'get'.
+  #
+  # Alias for:
+  # [`get`](https://docs.ruby-lang.org/en/2.6.0/GetoptLong.html#method-i-get)
+  def get_option; end
+
+  # Return ordering.
+  def ordering; end
+
+  # [`Set`](https://docs.ruby-lang.org/en/2.6.0/Set.html) the handling of the
+  # ordering of options and arguments. A
+  # [`RuntimeError`](https://docs.ruby-lang.org/en/2.6.0/RuntimeError.html) is
+  # raised if option processing has already started.
+  #
+  # The supplied value must be a member of
+  # [`GetoptLong::ORDERINGS`](https://docs.ruby-lang.org/en/2.6.0/GetoptLong.html#ORDERINGS).
+  # It alters the processing of options as follows:
+  #
+  # **REQUIRE\_ORDER** :
+  #
+  # Options are required to occur before non-options.
+  #
+  # Processing of options ends as soon as a word is encountered that has not
+  # been preceded by an appropriate option flag.
+  #
+  # For example, if -a and -b are options which do not take arguments, parsing
+  # command line arguments of '-a one -b two' would result in 'one', '-b', 'two'
+  # being left in ARGV, and only ('-a', '') being processed as an option/arg
+  # pair.
+  #
+  # This is the default ordering, if the environment variable POSIXLY\_CORRECT
+  # is set. (This is for compatibility with GNU getopt\_long.)
+  #
+  # **PERMUTE** :
+  #
+  # Options can occur anywhere in the command line parsed. This is the default
+  # behavior.
+  #
+  # Every sequence of words which can be interpreted as an option (with or
+  # without argument) is treated as an option; non-option words are skipped.
+  #
+  # For example, if -a does not require an argument and -b optionally takes an
+  # argument, parsing '-a one -b two three' would result in ('-a',") and ('-b',
+  # 'two') being processed as option/arg pairs, and 'one','three' being left in
+  # ARGV.
+  #
+  # If the ordering is set to PERMUTE but the environment variable
+  # POSIXLY\_CORRECT is set, REQUIRE\_ORDER is used instead. This is for
+  # compatibility with GNU getopt\_long.
+  #
+  # **RETURN\_IN\_ORDER** :
+  #
+  # All words on the command line are processed as options. Words not preceded
+  # by a short or long option flag are passed as arguments with an option of ''
+  # (empty string).
+  #
+  # For example, if -a requires an argument but -b does not, a command line of
+  # '-a one -b two three' would result in option/arg pairs of ('-a', 'one')
+  # ('-b', ''), (", 'two'), (", 'three') being processed.
+  def ordering=(ordering); end
+
+  # Set/Unset 'quiet' mode.
+  def quiet; end
+
+  # Set/Unset 'quiet' mode.
+  def quiet=(_); end
+
+  # Set/Unset 'quiet' mode.
+  def quiet?; end
+
+  # [`Set`](https://docs.ruby-lang.org/en/2.6.0/Set.html) options. Takes the
+  # same argument as
+  # [`GetoptLong.new`](https://docs.ruby-lang.org/en/2.6.0/GetoptLong.html#method-c-new).
+  #
+  # Raises a
+  # [`RuntimeError`](https://docs.ruby-lang.org/en/2.6.0/RuntimeError.html) if
+  # option processing has already started.
+  def set_options(*arguments); end
+
+  # Explicitly terminate option processing.
+  def terminate; end
+
+  # Returns true if option processing has terminated, false otherwise.
+  def terminated?; end
+
+  protected
+
+  # [`Set`](https://docs.ruby-lang.org/en/2.6.0/Set.html) an error (a protected
+  # method).
+  def set_error(type, message); end
+end
+
+class GetoptLong::AmbiguousOption < ::GetoptLong::Error; end
+
+# [`Error`](https://docs.ruby-lang.org/en/2.6.0/GetoptLong/Error.html) types.
+class GetoptLong::Error < ::StandardError; end
+
+class GetoptLong::InvalidOption < ::GetoptLong::Error; end
+
+class GetoptLong::MissingArgument < ::GetoptLong::Error; end
+
+class GetoptLong::NeedlessArgument < ::GetoptLong::Error; end

--- a/rbi/stdlib/nkf.rbi
+++ b/rbi/stdlib/nkf.rbi
@@ -1,0 +1,372 @@
+# typed: __STDLIB_INTERNAL
+
+# [`NKF`](https://docs.ruby-lang.org/en/2.6.0/NKF.html) - Ruby extension for
+# Network Kanji Filter
+#
+# ## Description
+#
+# This is a Ruby Extension version of nkf (Network Kanji Filter). It converts
+# the first argument and returns converted result. Conversion details are
+# specified by flags as the first argument.
+#
+# **Nkf** is a yet another kanji code converter among networks, hosts and
+# terminals. It converts input kanji code to designated kanji code such as
+# ISO-2022-JP, Shift\_JIS, EUC-JP, UTF-8 or UTF-16.
+#
+# One of the most unique faculty of **nkf** is the guess of the input kanji
+# encodings. It currently recognizes ISO-2022-JP, Shift\_JIS, EUC-JP, UTF-8 and
+# UTF-16. So users needn't set the input kanji code explicitly.
+#
+# By default, X0201 kana is converted into X0208 kana. For X0201 kana, SO/SI,
+# SSO and ESC-(-I methods are supported. For automatic code detection, nkf
+# assumes no X0201 kana in Shift\_JIS. To accept X0201 in Shift\_JIS, use
+# **-X**, **-x** or **-S**.
+#
+# ## Flags
+#
+# ### -b -u
+#
+# Output is buffered (DEFAULT), Output is unbuffered.
+#
+# ### -j -s -e -w -w16 -w32
+#
+# Output code is ISO-2022-JP (7bit
+# [`JIS`](https://docs.ruby-lang.org/en/2.6.0/NKF.html#JIS)), Shift\_JIS,
+# EUC-JP, UTF-8N, UTF-16BE, UTF-32BE. Without this option and compile option,
+# ISO-2022-JP is assumed.
+#
+# ### -J -S -E -W -W16 -W32
+#
+# Input assumption is [`JIS`](https://docs.ruby-lang.org/en/2.6.0/NKF.html#JIS)
+# 7 bit, Shift\_JIS, EUC-JP, UTF-8, UTF-16, UTF-32.
+#
+# #### -J
+#
+# Assume  [`JIS`](https://docs.ruby-lang.org/en/2.6.0/NKF.html#JIS) input. It
+# also accepts EUC-JP. This is the default. This flag does not exclude
+# Shift\_JIS.
+#
+# #### -S
+#
+# Assume Shift\_JIS and X0201 kana input. It also accepts
+# [`JIS`](https://docs.ruby-lang.org/en/2.6.0/NKF.html#JIS). EUC-JP is
+# recognized as X0201 kana. Without **-x** flag, X0201 kana (halfwidth kana) is
+# converted into X0208.
+#
+# #### -E
+#
+# Assume EUC-JP input. It also accepts
+# [`JIS`](https://docs.ruby-lang.org/en/2.6.0/NKF.html#JIS). Same as -J.
+#
+# ### -t
+#
+# No conversion.
+#
+# ### -i\_
+#
+# Output sequence to designate JIS-kanji. (DEFAULT B)
+#
+# ### -o\_
+#
+# Output sequence to designate
+# [`ASCII`](https://docs.ruby-lang.org/en/2.6.0/NKF.html#ASCII). (DEFAULT B)
+#
+# ### -r
+#
+# {de/en}crypt ROT13/47
+#
+# ### -[h](123) --hiragana --katakana --katakana-hiragana
+#
+# -h1 --hiragana
+# :   Katakana to Hiragana conversion.
+#
+# -h2 --katakana
+# :   Hiragana to Katakana conversion.
+#
+# -h3 --katakana-hiragana
+# :   Katakana to Hiragana and Hiragana to Katakana conversion.
+#
+#
+# ### -T
+#
+# Text mode output (MS-DOS)
+#
+# ### -l
+#
+# ISO8859-1 (Latin-1) support
+#
+# ### -f[`m` [- `n`]]
+#
+# Folding on `m` length with `n` margin in a line. Without this option, fold
+# length is 60 and fold margin is 10.
+#
+# ### -F
+#
+# New line preserving line folding.
+#
+# ### -[Z](0-3)
+#
+# Convert X0208 alphabet (Fullwidth Alphabets) to
+# [`ASCII`](https://docs.ruby-lang.org/en/2.6.0/NKF.html#ASCII).
+#
+# -Z -Z0
+# :   Convert X0208 alphabet to
+#     [`ASCII`](https://docs.ruby-lang.org/en/2.6.0/NKF.html#ASCII).
+#
+# -Z1
+# :   Converts X0208 kankaku to single
+#     [`ASCII`](https://docs.ruby-lang.org/en/2.6.0/NKF.html#ASCII) space.
+#
+# -Z2
+# :   Converts X0208 kankaku to double
+#     [`ASCII`](https://docs.ruby-lang.org/en/2.6.0/NKF.html#ASCII) spaces.
+#
+# -Z3
+# :   Replacing Fullwidth >, <, ", & into '&gt;', '&lt;', '&quot;', '&amp;' as
+#     in HTML.
+#
+#
+# ### -X -x
+#
+# Assume X0201 kana in MS-Kanji. With **-X** or without this option, X0201 is
+# converted into X0208 Kana. With **-x**, try to preserve X0208 kana and do not
+# convert X0201 kana to X0208. In
+# [`JIS`](https://docs.ruby-lang.org/en/2.6.0/NKF.html#JIS) output, ESC-(-I is
+# used. In [`EUC`](https://docs.ruby-lang.org/en/2.6.0/NKF.html#EUC) output, SSO
+# is used.
+#
+# ### -[B](0-2)
+#
+# Assume broken JIS-Kanji input, which lost ESC. Useful when your site is using
+# old B-News Nihongo patch.
+#
+# -B1
+# :   allows any char after ESC-( or ESC-$.
+#
+# -B2
+# :   forces [`ASCII`](https://docs.ruby-lang.org/en/2.6.0/NKF.html#ASCII) after
+#     NL.
+#
+#
+# ### -I
+#
+# Replacing non iso-2022-jp char into a geta character (substitute character in
+# Japanese).
+#
+# ### -d -c
+#
+# Delete r in line feed, Add r in line feed.
+#
+# ### -[m](BQN0)
+#
+# MIME ISO-2022-JP/ISO8859-1 decode. (DEFAULT) To see ISO8859-1 (Latin-1) -l is
+# necessary.
+#
+# -mB
+# :   Decode MIME base64 encoded stream. Remove header or other part before
+#
+# conversion.
+#
+# -mQ
+# :   Decode MIME quoted stream. '\_' in quoted stream is converted to space.
+#
+# -mN
+# :   Non-strict decoding.
+#
+# It allows line break in the middle of the base64 encoding.
+#
+# -m0
+# :   No MIME decode.
+#
+#
+# ### -M
+#
+# MIME encode. Header style. All
+# [`ASCII`](https://docs.ruby-lang.org/en/2.6.0/NKF.html#ASCII) code and control
+# characters are intact. Kanji conversion is performed before encoding, so this
+# cannot be used as a picture encoder.
+#
+# -MB
+# :   MIME encode [`Base64`](https://docs.ruby-lang.org/en/2.6.0/Base64.html)
+#     stream.
+#
+# -MQ
+# :   Perfome quoted encoding.
+#
+#
+# ### -l
+#
+# Input and output code is ISO8859-1 (Latin-1) and ISO-2022-JP. **-s**, **-e**
+# and **-x** are not compatible with this option.
+#
+# ### -[L](uwm)
+#
+# new line mode Without this option, nkf doesn't convert line breaks.
+#
+# -Lu
+# :   unix (LF)
+#
+# -Lw
+# :   windows (CRLF)
+#
+# -Lm
+# :   mac (CR)
+#
+#
+# ### --fj --unix --mac --msdos --windows
+#
+# convert for these system
+#
+# ### --jis --euc --sjis --mime --base64
+#
+# convert for named code
+#
+# ### --jis-input --euc-input --sjis-input --mime-input --base64-input
+#
+# assume input system
+#
+# ### --ic=`input codeset` --oc=`output codeset`
+#
+# [`Set`](https://docs.ruby-lang.org/en/2.6.0/Set.html) the input or output
+# codeset. [`NKF`](https://docs.ruby-lang.org/en/2.6.0/NKF.html) supports
+# following codesets and those codeset name are case insensitive.
+#
+# ISO-2022-JP
+# :   a.k.a. RFC1468, 7bit
+#     [`JIS`](https://docs.ruby-lang.org/en/2.6.0/NKF.html#JIS), JUNET
+#
+# EUC-JP (eucJP-nkf)
+# :   a.k.a. AT&T [`JIS`](https://docs.ruby-lang.org/en/2.6.0/NKF.html#JIS),
+#     Japanese [`EUC`](https://docs.ruby-lang.org/en/2.6.0/NKF.html#EUC), UJIS
+#
+# eucJP-ascii
+# :   a.k.a. x-eucjp-open-19970715-ascii
+#
+# eucJP-ms
+# :   a.k.a. x-eucjp-open-19970715-ms
+#
+# CP51932
+# :   Microsoft Version of EUC-JP.
+#
+# Shift\_JIS
+# :   [`SJIS`](https://docs.ruby-lang.org/en/2.6.0/NKF.html#SJIS), MS-Kanji
+#
+# Windows-31J
+# :   a.k.a. CP932
+#
+# UTF-8
+# :   same as UTF-8N
+#
+# UTF-8N
+# :   UTF-8 without BOM
+#
+# UTF-8-BOM
+# :   UTF-8 with BOM
+#
+# UTF-16
+# :   same as UTF-16BE
+#
+# UTF-16BE
+# :   UTF-16 Big Endian without BOM
+#
+# UTF-16BE-BOM
+# :   UTF-16 Big Endian with BOM
+#
+# UTF-16LE
+# :   UTF-16 Little Endian without BOM
+#
+# UTF-16LE-BOM
+# :   UTF-16 Little Endian with BOM
+#
+# UTF-32
+# :   same as UTF-32BE
+#
+# UTF-32BE
+# :   UTF-32 Big Endian without BOM
+#
+# UTF-32BE-BOM
+# :   UTF-32 Big Endian with BOM
+#
+# UTF-32LE
+# :   UTF-32 Little Endian without BOM
+#
+# UTF-32LE-BOM
+# :   UTF-32 Little Endian with BOM
+#
+# UTF8-MAC
+# :   NKDed UTF-8, a.k.a. UTF8-NFD (input only)
+#
+#
+# ### --fb-{skip, html, xml, perl, java, subchar}
+#
+# Specify the way that nkf handles unassigned characters. Without this option,
+# --fb-skip is assumed.
+#
+# ### --prefix= `escape character` `target character` ..
+#
+# When nkf converts to Shift\_JIS, nkf adds a specified escape character to
+# specified 2nd byte of Shift\_JIS characters. 1st byte of argument is the
+# escape character and following bytes are target characters.
+#
+# ### --no-cp932ext
+#
+# Handle the characters extended in CP932 as unassigned characters.
+#
+# ## --no-best-fit-chars
+#
+# When Unicode to Encoded byte conversion, don't convert characters which is not
+# round trip safe. When Unicode to Unicode conversion, with this and -x option,
+# nkf can be used as UTF converter. (In other words, without this and -x option,
+# nkf doesn't save some characters)
+#
+# When nkf convert string which related to path, you should use this opion.
+#
+# ### --cap-input
+#
+# Decode hex encoded characters.
+#
+# ### --url-input
+#
+# Unescape percent escaped characters.
+#
+# ### --
+#
+# Ignore rest of -option.
+module NKF
+  ASCII = T.let(T.unsafe(nil), Encoding)
+
+  BINARY = T.let(T.unsafe(nil), Encoding)
+
+  EUC = T.let(T.unsafe(nil), Encoding)
+
+  JIS = T.let(T.unsafe(nil), Encoding)
+
+  # Release date of nkf
+  NKF_RELEASE_DATE = T.let(T.unsafe(nil), String)
+
+  # Version of nkf
+  NKF_VERSION = T.let(T.unsafe(nil), String)
+
+  SJIS = T.let(T.unsafe(nil), Encoding)
+
+  UTF16 = T.let(T.unsafe(nil), Encoding)
+
+  UTF32 = T.let(T.unsafe(nil), Encoding)
+
+  UTF8 = T.let(T.unsafe(nil), Encoding)
+
+  # Full version string of nkf
+  VERSION = T.let(T.unsafe(nil), String)
+
+  # Returns guessed encoding of *str* by nkf routine.
+  def self.guess(str); end
+
+  # Convert *str* and return converted result. Conversion details are specified
+  # by *opt* as [`String`](https://docs.ruby-lang.org/en/2.6.0/String.html).
+  #
+  # ```ruby
+  # require 'nkf'
+  # output = NKF.nkf("-s", input)
+  # ```
+  def self.nkf(opt, str); end
+end

--- a/rbi/stdlib/observable.rbi
+++ b/rbi/stdlib/observable.rbi
@@ -1,0 +1,175 @@
+# typed: __STDLIB_INTERNAL
+
+# The Observer pattern (also known as publish/subscribe) provides a simple
+# mechanism for one object to inform a set of interested third-party objects
+# when its state changes.
+#
+# ## Mechanism
+#
+# The notifying class mixes in the `Observable` module, which provides the
+# methods for managing the associated observer objects.
+#
+# The observable object must:
+# *   assert that it has `#changed`
+# *   call `#notify_observers`
+#
+#
+# An observer subscribes to updates using
+# [`Observable#add_observer`](https://docs.ruby-lang.org/en/2.6.0/Observable.html#method-i-add_observer),
+# which also specifies the method called via
+# [`notify_observers`](https://docs.ruby-lang.org/en/2.6.0/Observable.html#method-i-notify_observers).
+# The default method for
+# [`notify_observers`](https://docs.ruby-lang.org/en/2.6.0/Observable.html#method-i-notify_observers)
+# is update.
+#
+# ### Example
+#
+# The following example demonstrates this nicely. A `Ticker`, when run,
+# continually receives the stock `Price` for its `@symbol`. A `Warner` is a
+# general observer of the price, and two warners are demonstrated, a `WarnLow`
+# and a `WarnHigh`, which print a warning if the price is below or above their
+# set limits, respectively.
+#
+# The `update` callback allows the warners to run without being explicitly
+# called. The system is set up with the `Ticker` and several observers, and the
+# observers do their duty without the top-level code having to interfere.
+#
+# Note that the contract between publisher and subscriber (observable and
+# observer) is not declared or enforced. The `Ticker` publishes a time and a
+# price, and the warners receive that. But if you don't ensure that your
+# contracts are correct, nothing else can warn you.
+#
+# ```ruby
+# require "observer"
+#
+# class Ticker          ### Periodically fetch a stock price.
+#   include Observable
+#
+#   def initialize(symbol)
+#     @symbol = symbol
+#   end
+#
+#   def run
+#     last_price = nil
+#     loop do
+#       price = Price.fetch(@symbol)
+#       print "Current price: #{price}\n"
+#       if price != last_price
+#         changed                 # notify observers
+#         last_price = price
+#         notify_observers(Time.now, price)
+#       end
+#       sleep 1
+#     end
+#   end
+# end
+#
+# class Price           ### A mock class to fetch a stock price (60 - 140).
+#   def self.fetch(symbol)
+#     60 + rand(80)
+#   end
+# end
+#
+# class Warner          ### An abstract observer of Ticker objects.
+#   def initialize(ticker, limit)
+#     @limit = limit
+#     ticker.add_observer(self)
+#   end
+# end
+#
+# class WarnLow < Warner
+#   def update(time, price)       # callback for observer
+#     if price < @limit
+#       print "--- #{time.to_s}: Price below #@limit: #{price}\n"
+#     end
+#   end
+# end
+#
+# class WarnHigh < Warner
+#   def update(time, price)       # callback for observer
+#     if price > @limit
+#       print "+++ #{time.to_s}: Price above #@limit: #{price}\n"
+#     end
+#   end
+# end
+#
+# ticker = Ticker.new("MSFT")
+# WarnLow.new(ticker, 80)
+# WarnHigh.new(ticker, 120)
+# ticker.run
+# ```
+#
+# Produces:
+#
+# ```
+# Current price: 83
+# Current price: 75
+# --- Sun Jun 09 00:10:25 CDT 2002: Price below 80: 75
+# Current price: 90
+# Current price: 134
+# +++ Sun Jun 09 00:10:25 CDT 2002: Price above 120: 134
+# Current price: 134
+# Current price: 112
+# Current price: 79
+# --- Sun Jun 09 00:10:25 CDT 2002: Price below 80: 79
+# ```
+module Observable
+  # Add `observer` as an observer on this object. So that it will receive
+  # notifications.
+  #
+  # `observer`
+  # :   the object that will be notified of changes.
+  # `func`
+  # :   [`Symbol`](https://docs.ruby-lang.org/en/2.6.0/Symbol.html) naming the
+  #     method that will be called when this
+  #     [`Observable`](https://docs.ruby-lang.org/en/2.6.0/Observable.html) has
+  #     changes.
+  #
+  #     This method must return true for `observer.respond_to?` and will receive
+  #     `*arg` when
+  #     [`notify_observers`](https://docs.ruby-lang.org/en/2.6.0/Observable.html#method-i-notify_observers)
+  #     is called, where `*arg` is the value passed to
+  #     [`notify_observers`](https://docs.ruby-lang.org/en/2.6.0/Observable.html#method-i-notify_observers)
+  #     by this
+  #     [`Observable`](https://docs.ruby-lang.org/en/2.6.0/Observable.html)
+  def add_observer(observer, func = _); end
+
+  # [`Set`](https://docs.ruby-lang.org/en/2.6.0/Set.html) the changed state of
+  # this object. Notifications will be sent only if the changed `state` is
+  # `true`.
+  #
+  # `state`
+  # :   Boolean indicating the changed state of this
+  #     [`Observable`](https://docs.ruby-lang.org/en/2.6.0/Observable.html).
+  def changed(state = _); end
+
+  # Returns true if this object's state has been changed since the last
+  # [`notify_observers`](https://docs.ruby-lang.org/en/2.6.0/Observable.html#method-i-notify_observers)
+  # call.
+  def changed?; end
+
+  # Return the number of observers associated with this object.
+  def count_observers; end
+
+  # Remove `observer` as an observer on this object so that it will no longer
+  # receive notifications.
+  #
+  # `observer`
+  # :   An observer of this
+  #     [`Observable`](https://docs.ruby-lang.org/en/2.6.0/Observable.html)
+  def delete_observer(observer); end
+
+  # Remove all observers associated with this object.
+  def delete_observers; end
+
+  # Notify observers of a change in state **if** this object's changed state is
+  # `true`.
+  #
+  # This will invoke the method named in
+  # [`add_observer`](https://docs.ruby-lang.org/en/2.6.0/Observable.html#method-i-add_observer),
+  # passing `*arg`. The changed state is then set to `false`.
+  #
+  # `*arg`
+  # :   Any arguments to pass to the observers.
+  def notify_observers(*arg); end
+end

--- a/rbi/stdlib/open_uri.rbi
+++ b/rbi/stdlib/open_uri.rbi
@@ -1,0 +1,387 @@
+# typed: __STDLIB_INTERNAL
+
+# [`OpenURI`](https://docs.ruby-lang.org/en/2.6.0/OpenURI.html) is an
+# easy-to-use wrapper for
+# [`Net::HTTP`](https://docs.ruby-lang.org/en/2.6.0/Net/HTTP.html), Net::HTTPS
+# and [`Net::FTP`](https://docs.ruby-lang.org/en/2.6.0/Net/FTP.html).
+#
+# ## Example
+#
+# It is possible to open an http, https or ftp URL as though it were a file:
+#
+# ```ruby
+# open("http://www.ruby-lang.org/") {|f|
+#   f.each_line {|line| p line}
+# }
+# ```
+#
+# The opened file has several getter methods for its meta-information, as
+# follows, since it is extended by
+# [`OpenURI::Meta`](https://docs.ruby-lang.org/en/2.6.0/OpenURI/Meta.html).
+#
+# ```ruby
+# open("http://www.ruby-lang.org/en") {|f|
+#   f.each_line {|line| p line}
+#   p f.base_uri         # <URI::HTTP:0x40e6ef2 URL:http://www.ruby-lang.org/en/>
+#   p f.content_type     # "text/html"
+#   p f.charset          # "iso-8859-1"
+#   p f.content_encoding # []
+#   p f.last_modified    # Thu Dec 05 02:45:02 UTC 2002
+# }
+# ```
+#
+# Additional header fields can be specified by an optional hash argument.
+#
+# ```ruby
+# open("http://www.ruby-lang.org/en/",
+#   "User-Agent" => "Ruby/#{RUBY_VERSION}",
+#   "From" => "foo@bar.invalid",
+#   "Referer" => "http://www.ruby-lang.org/") {|f|
+#   # ...
+# }
+# ```
+#
+# The environment variables such as http\_proxy, https\_proxy and ftp\_proxy are
+# in effect by default. Here we disable proxy:
+#
+# ```ruby
+# open("http://www.ruby-lang.org/en/", :proxy => nil) {|f|
+#   # ...
+# }
+# ```
+#
+# See
+# [`OpenURI::OpenRead.open`](https://docs.ruby-lang.org/en/2.6.0/OpenURI/OpenRead.html#method-i-open)
+# and
+# [`Kernel#open`](https://docs.ruby-lang.org/en/2.6.0/Kernel.html#method-i-open)
+# for more on available options.
+#
+# [`URI`](https://docs.ruby-lang.org/en/2.6.0/URI.html) objects can be opened in
+# a similar way.
+#
+# ```ruby
+# uri = URI.parse("http://www.ruby-lang.org/en/")
+# uri.open {|f|
+#   # ...
+# }
+# ```
+#
+# [`URI`](https://docs.ruby-lang.org/en/2.6.0/URI.html) objects can be read
+# directly. The returned string is also extended by
+# [`OpenURI::Meta`](https://docs.ruby-lang.org/en/2.6.0/OpenURI/Meta.html).
+#
+# ```ruby
+# str = uri.read
+# p str.base_uri
+# ```
+#
+# Author
+# :   Tanaka Akira <akr@m17n.org>
+module OpenURI
+  Options = T.let(T.unsafe(nil), T::Hash[Symbol, T.untyped])
+end
+
+class OpenURI::HTTPError < ::StandardError
+  def io; end
+
+  def self.new(message, io); end
+end
+
+# Raised on redirection, only occurs when `redirect` option for HTTP is `false`.
+class OpenURI::HTTPRedirect < ::OpenURI::HTTPError
+  def uri; end
+
+  def self.new(message, io, uri); end
+end
+
+# Mixin for holding meta-information.
+module OpenURI::Meta
+  # returns a [`URI`](https://docs.ruby-lang.org/en/2.6.0/URI.html) that is the
+  # base of relative URIs in the data. It may differ from the
+  # [`URI`](https://docs.ruby-lang.org/en/2.6.0/URI.html) supplied by a user due
+  # to redirection.
+  def base_uri; end
+
+  # returns a [`URI`](https://docs.ruby-lang.org/en/2.6.0/URI.html) that is the
+  # base of relative URIs in the data. It may differ from the
+  # [`URI`](https://docs.ruby-lang.org/en/2.6.0/URI.html) supplied by a user due
+  # to redirection.
+  def base_uri=(_); end
+
+  # returns a charset parameter in Content-Type field. It is downcased for
+  # canonicalization.
+  #
+  # If charset parameter is not given but a block is given, the block is called
+  # and its result is returned. It can be used to guess charset.
+  #
+  # If charset parameter and block is not given, nil is returned except text
+  # type in HTTP. In that case, "iso-8859-1" is returned as defined by RFC2616
+  # 3.7.1.
+  def charset; end
+
+  # Returns a list of encodings in Content-Encoding field as an array of
+  # strings.
+  #
+  # The encodings are downcased for canonicalization.
+  def content_encoding; end
+
+  # returns "type/subtype" which is MIME Content-Type. It is downcased for
+  # canonicalization. Content-Type parameters are stripped.
+  def content_type; end
+
+  # returns a [`Time`](https://docs.ruby-lang.org/en/2.6.0/Time.html) that
+  # represents the Last-Modified field.
+  def last_modified; end
+
+  # returns a [`Hash`](https://docs.ruby-lang.org/en/2.6.0/Hash.html) that
+  # represents header fields. The
+  # [`Hash`](https://docs.ruby-lang.org/en/2.6.0/Hash.html) keys are downcased
+  # for canonicalization. The
+  # [`Hash`](https://docs.ruby-lang.org/en/2.6.0/Hash.html) values are a field
+  # body. If there are multiple field with same field name, the field values are
+  # concatenated with a comma.
+  def meta; end
+
+  # returns a [`Hash`](https://docs.ruby-lang.org/en/2.6.0/Hash.html) that
+  # represents header fields. The
+  # [`Hash`](https://docs.ruby-lang.org/en/2.6.0/Hash.html) keys are downcased
+  # for canonicalization. The
+  # [`Hash`](https://docs.ruby-lang.org/en/2.6.0/Hash.html) value are an array
+  # of field values.
+  def metas; end
+
+  # returns an [`Array`](https://docs.ruby-lang.org/en/2.6.0/Array.html) that
+  # consists of status code and message.
+  def status; end
+
+  # returns an [`Array`](https://docs.ruby-lang.org/en/2.6.0/Array.html) that
+  # consists of status code and message.
+  def status=(_); end
+end
+
+
+# Mixin for HTTP and FTP URIs.
+module OpenURI::OpenRead
+  # [`OpenURI::OpenRead#open`](https://docs.ruby-lang.org/en/2.6.0/OpenURI/OpenRead.html#method-i-open)
+  # provides 'open' for
+  # [`URI::HTTP`](https://docs.ruby-lang.org/en/2.6.0/URI/HTTP.html) and
+  # [`URI::FTP`](https://docs.ruby-lang.org/en/2.6.0/URI/FTP.html).
+  #
+  # [`OpenURI::OpenRead#open`](https://docs.ruby-lang.org/en/2.6.0/OpenURI/OpenRead.html#method-i-open)
+  # takes optional 3 arguments as:
+  #
+  # ```ruby
+  # OpenURI::OpenRead#open([mode [, perm]] [, options]) [{|io| ... }]
+  # ```
+  #
+  # [`OpenURI::OpenRead#open`](https://docs.ruby-lang.org/en/2.6.0/OpenURI/OpenRead.html#method-i-open)
+  # returns an IO-like object if block is not given. Otherwise it yields the
+  # [`IO`](https://docs.ruby-lang.org/en/2.6.0/IO.html) object and return the
+  # value of the block. The [`IO`](https://docs.ruby-lang.org/en/2.6.0/IO.html)
+  # object is extended with
+  # [`OpenURI::Meta`](https://docs.ruby-lang.org/en/2.6.0/OpenURI/Meta.html).
+  #
+  # `mode` and `perm` are the same as
+  # [`Kernel#open`](https://docs.ruby-lang.org/en/2.6.0/Kernel.html#method-i-open).
+  #
+  # However, `mode` must be read mode because
+  # [`OpenURI::OpenRead#open`](https://docs.ruby-lang.org/en/2.6.0/OpenURI/OpenRead.html#method-i-open)
+  # doesn't support write mode (yet). Also `perm` is ignored because it is
+  # meaningful only for file creation.
+  #
+  # `options` must be a hash.
+  #
+  # Each option with a string key specifies an extra header field for HTTP.
+  # I.e., it is ignored for FTP without HTTP proxy.
+  #
+  # The hash may include other options, where keys are symbols:
+  #
+  # :proxy
+  # :   Synopsis:
+  #
+  # ```
+  # :proxy => "http://proxy.foo.com:8000/"
+  # :proxy => URI.parse("http://proxy.foo.com:8000/")
+  # :proxy => true
+  # :proxy => false
+  # :proxy => nil
+  # ```
+  #
+  #     If :proxy option is specified, the value should be
+  #     [`String`](https://docs.ruby-lang.org/en/2.6.0/String.html),
+  #     [`URI`](https://docs.ruby-lang.org/en/2.6.0/URI.html), boolean or nil.
+  #
+  #     When [`String`](https://docs.ruby-lang.org/en/2.6.0/String.html) or
+  #     [`URI`](https://docs.ruby-lang.org/en/2.6.0/URI.html) is given, it is
+  #     treated as proxy [`URI`](https://docs.ruby-lang.org/en/2.6.0/URI.html).
+  #
+  #     When true is given or the option itself is not specified, environment
+  #     variable 'scheme\_proxy' is examined. 'scheme' is replaced by 'http',
+  #     'https' or 'ftp'.
+  #
+  #     When false or nil is given, the environment variables are ignored and
+  #     connection will be made to a server directly.
+  #
+  # :proxy\_http\_basic\_authentication
+  # :   Synopsis:
+  #
+  # ```
+  # :proxy_http_basic_authentication =>
+  #   ["http://proxy.foo.com:8000/", "proxy-user", "proxy-password"]
+  # :proxy_http_basic_authentication =>
+  #   [URI.parse("http://proxy.foo.com:8000/"),
+  #    "proxy-user", "proxy-password"]
+  # ```
+  #
+  #     If :proxy option is specified, the value should be an
+  #     [`Array`](https://docs.ruby-lang.org/en/2.6.0/Array.html) with 3
+  #     elements. It should contain a proxy
+  #     [`URI`](https://docs.ruby-lang.org/en/2.6.0/URI.html), a proxy user name
+  #     and a proxy password. The proxy
+  #     [`URI`](https://docs.ruby-lang.org/en/2.6.0/URI.html) should be a
+  #     [`String`](https://docs.ruby-lang.org/en/2.6.0/String.html), an
+  #     [`URI`](https://docs.ruby-lang.org/en/2.6.0/URI.html) or nil. The proxy
+  #     user name and password should be a
+  #     [`String`](https://docs.ruby-lang.org/en/2.6.0/String.html).
+  #
+  #     If nil is given for the proxy
+  #     [`URI`](https://docs.ruby-lang.org/en/2.6.0/URI.html), this option is
+  #     just ignored.
+  #
+  #     If :proxy and :proxy\_http\_basic\_authentication is specified,
+  #     [`ArgumentError`](https://docs.ruby-lang.org/en/2.6.0/ArgumentError.html)
+  #     is raised.
+  #
+  # :http\_basic\_authentication
+  # :   Synopsis:
+  #
+  # ```
+  # :http_basic_authentication=>[user, password]
+  # ```
+  #
+  #     If :http\_basic\_authentication is specified, the value should be an
+  #     array which contains 2 strings: username and password. It is used for
+  #     HTTP Basic authentication defined by RFC 2617.
+  #
+  # :content\_length\_proc
+  # :   Synopsis:
+  #
+  # ```
+  # :content_length_proc => lambda {|content_length| ... }
+  # ```
+  #
+  #     If :content\_length\_proc option is specified, the option value
+  #     procedure is called before actual transfer is started. It takes one
+  #     argument, which is expected content length in bytes.
+  #
+  #     If two or more transfers are performed by HTTP redirection, the
+  #     procedure is called only once for the last transfer.
+  #
+  #     When expected content length is unknown, the procedure is called with
+  #     nil. This happens when the HTTP response has no Content-Length header.
+  #
+  # :progress\_proc
+  # :   Synopsis:
+  #
+  # ```
+  # :progress_proc => lambda {|size| ...}
+  # ```
+  #
+  #     If :progress\_proc option is specified, the proc is called with one
+  #     argument each time when 'open' gets content fragment from network. The
+  #     argument `size` is the accumulated transferred size in bytes.
+  #
+  #     If two or more transfer is done by HTTP redirection, the procedure is
+  #     called only one for a last transfer.
+  #
+  #     :progress\_proc and :content\_length\_proc are intended to be used for
+  #     progress bar. For example, it can be implemented as follows using
+  #     Ruby/ProgressBar.
+  #
+  # ```
+  # pbar = nil
+  # open("http://...",
+  #   :content_length_proc => lambda {|t|
+  #     if t && 0 < t
+  #       pbar = ProgressBar.new("...", t)
+  #       pbar.file_transfer_mode
+  #     end
+  #   },
+  #   :progress_proc => lambda {|s|
+  #     pbar.set s if pbar
+  #   }) {|f| ... }
+  # ```
+  #
+  # :read\_timeout
+  # :   Synopsis:
+  #
+  # ```
+  # :read_timeout=>nil     (no timeout)
+  # :read_timeout=>10      (10 second)
+  # ```
+  #
+  #     :read\_timeout option specifies a timeout of read for http connections.
+  #
+  # :open\_timeout
+  # :   Synopsis:
+  #
+  # ```
+  # :open_timeout=>nil     (no timeout)
+  # :open_timeout=>10      (10 second)
+  # ```
+  #
+  #     :open\_timeout option specifies a timeout of open for http connections.
+  #
+  # :ssl\_ca\_cert
+  # :   Synopsis:
+  #
+  # ```
+  # :ssl_ca_cert=>filename or an Array of filenames
+  # ```
+  #
+  #     :ssl\_ca\_cert is used to specify CA certificate for SSL. If it is
+  #     given, default certificates are not used.
+  #
+  # :ssl\_verify\_mode
+  # :   Synopsis:
+  #
+  # ```
+  # :ssl_verify_mode=>mode
+  # ```
+  #
+  #     :ssl\_verify\_mode is used to specify openssl verify mode.
+  #
+  # :ftp\_active\_mode
+  # :   Synopsis:
+  #
+  # ```
+  # :ftp_active_mode=>bool
+  # ```
+  #
+  #     `:ftp_active_mode => true` is used to make ftp active mode. Ruby 1.9
+  #     uses passive mode by default. Note that the active mode is default in
+  #     Ruby 1.8 or prior.
+  #
+  # :redirect
+  # :   Synopsis:
+  #
+  # ```
+  # :redirect=>bool
+  # ```
+  #
+  #     `:redirect` is true by default. `:redirect => false` is used to disable
+  #     all HTTP redirects.
+  #
+  #     [`OpenURI::HTTPRedirect`](https://docs.ruby-lang.org/en/2.6.0/OpenURI/HTTPRedirect.html)
+  #     exception raised on redirection. Using `true` also means that
+  #     redirections between http and ftp are permitted.
+  def open(*rest, &block); end
+
+  # [`[OpenURI::OpenRead#read(](options)`](https://docs.ruby-lang.org/en/2.6.0/OpenURI/OpenRead.html#method-i-read))
+  # reads a content referenced by self and returns the content as string. The
+  # string is extended with
+  # [`OpenURI::Meta`](https://docs.ruby-lang.org/en/2.6.0/OpenURI/Meta.html).
+  # The argument `options` is same as
+  # [`OpenURI::OpenRead#open`](https://docs.ruby-lang.org/en/2.6.0/OpenURI/OpenRead.html#method-i-open).
+  def read(options = _); end
+end

--- a/rbi/stdlib/prime.rbi
+++ b/rbi/stdlib/prime.rbi
@@ -1,0 +1,315 @@
+# typed: __STDLIB_INTERNAL
+
+# The set of all prime numbers.
+#
+# ## Example
+#
+# ```ruby
+# Prime.each(100) do |prime|
+#   p prime  #=> 2, 3, 5, 7, 11, ...., 97
+# end
+# ```
+#
+# [`Prime`](https://docs.ruby-lang.org/en/2.6.0/Prime.html) is Enumerable:
+#
+# ```ruby
+# Prime.first 5 # => [2, 3, 5, 7, 11]
+# ```
+#
+# ## Retrieving the instance
+#
+# For convenience, each instance method of `Prime`.instance can be accessed as a
+# class method of `Prime`.
+#
+# e.g.
+#
+# ```ruby
+# Prime.instance.prime?(2)  #=> true
+# Prime.prime?(2)           #=> true
+# ```
+#
+# ## Generators
+#
+# A "generator" provides an implementation of enumerating pseudo-prime numbers
+# and it remembers the position of enumeration and upper bound. Furthermore, it
+# is an external iterator of prime enumeration which is compatible with an
+# [`Enumerator`](https://docs.ruby-lang.org/en/2.6.0/Enumerator.html).
+#
+# `Prime`::`PseudoPrimeGenerator` is the base class for generators. There are
+# few implementations of generator.
+#
+# `Prime`::`EratosthenesGenerator`
+# :   Uses eratosthenes' sieve.
+# `Prime`::`TrialDivisionGenerator`
+# :   Uses the trial division method.
+# `Prime`::`Generator23`
+# :   Generates all positive integers which are not divisible by either 2 or 3.
+#     This sequence is very bad as a pseudo-prime sequence. But this is faster
+#     and uses much less memory than the other generators. So, it is suitable
+#     for factorizing an integer which is not large but has many prime factors.
+#     e.g. for
+#     [`Prime#prime?`](https://docs.ruby-lang.org/en/2.6.0/Prime.html#method-i-prime-3F)
+#     .
+class Prime
+  include(::Singleton)
+  include(::Enumerable)
+
+  Elem = type_member(:out)
+
+  # Iterates the given block over all prime numbers.
+  #
+  # ## Parameters
+  #
+  # `ubound`
+  # :   Optional. An arbitrary positive number. The upper bound of enumeration.
+  #     The method enumerates prime numbers infinitely if `ubound` is nil.
+  # `generator`
+  # :   Optional. An implementation of pseudo-prime generator.
+  #
+  #
+  # ## Return value
+  #
+  # An evaluated value of the given block at the last time. Or an enumerator
+  # which is compatible to an `Enumerator` if no block given.
+  #
+  # ## Description
+  #
+  # Calls `block` once for each prime number, passing the prime as a parameter.
+  #
+  # `ubound`
+  # :   Upper bound of prime numbers. The iterator stops after it yields all
+  #     prime numbers p <= `ubound`.
+  def each(ubound = nil, generator = Prime::EratosthenesGenerator.new, &block); end
+
+  # Returns `true` if `obj` is an
+  # [`Integer`](https://docs.ruby-lang.org/en/2.6.0/Integer.html) and is prime.
+  # Also returns true if `obj` is a Module that is an ancestor of `Prime`.
+  # Otherwise returns false.
+  def include?(obj); end
+
+  # Re-composes a prime factorization and returns the product.
+  #
+  # ## Parameters
+  # `pd`
+  # :   [`Array`](https://docs.ruby-lang.org/en/2.6.0/Array.html) of pairs of
+  #     integers. The each internal pair consists of a prime number -- a prime
+  #     factor -- and a natural number -- an exponent.
+  #
+  #
+  # ## Example
+  # For `[[p_1, e_1], [p_2, e_2], ...., [p_n, e_n]]`, it returns:
+  #
+  # ```
+  # p_1**e_1 * p_2**e_2 * .... * p_n**e_n.
+  #
+  # Prime.int_from_prime_division([[2,2], [3,1]])  #=> 12
+  # ```
+  def int_from_prime_division(pd); end
+
+  # Returns true if `value` is a prime number, else returns false.
+  #
+  # ## Parameters
+  #
+  # `value`
+  # :   an arbitrary integer to be checked.
+  # `generator`
+  # :   optional. A pseudo-prime generator.
+  def prime?(value, generator = Prime::Generator23.new); end
+
+  # Returns the factorization of `value`.
+  #
+  # ## Parameters
+  # `value`
+  # :   An arbitrary integer.
+  # `generator`
+  # :   Optional. A pseudo-prime generator. `generator`.succ must return the
+  #     next pseudo-prime number in the ascending order. It must generate all
+  #     prime numbers, but may also generate non prime numbers too.
+  #
+  #
+  # ### Exceptions
+  # `ZeroDivisionError`
+  # :   when `value` is zero.
+  #
+  #
+  # ## Example
+  # For an arbitrary integer:
+  #
+  # ```
+  # n = p_1**e_1 * p_2**e_2 * .... * p_n**e_n,
+  # ```
+  #
+  # [`prime_division`](https://docs.ruby-lang.org/en/2.6.0/Prime.html#method-i-prime_division)(n)
+  # returns:
+  #
+  # ```
+  # [[p_1, e_1], [p_2, e_2], ...., [p_n, e_n]].
+  #
+  # Prime.prime_division(12) #=> [[2,2], [3,1]]
+  # ```
+  def prime_division(value, generator = Prime::Generator23.new); end
+
+  # Returns true if `value` is a prime number, else returns false.
+  #
+  # ## Parameters
+  #
+  # `value`
+  # :   an arbitrary integer to be checked.
+  # `generator`
+  # :   optional. A pseudo-prime generator.
+  def self.prime?(value, generator = Prime::Generator23.new); end
+
+  # Returns the factorization of `value`.
+  #
+  # ## Parameters
+  # `value`
+  # :   An arbitrary integer.
+  # `generator`
+  # :   Optional. A pseudo-prime generator. `generator`.succ must return the
+  #     next pseudo-prime number in the ascending order. It must generate all
+  #     prime numbers, but may also generate non prime numbers too.
+  #
+  #
+  # ### Exceptions
+  # `ZeroDivisionError`
+  # :   when `value` is zero.
+  #
+  #
+  # ## Example
+  # For an arbitrary integer:
+  #
+  # ```
+  # n = p_1**e_1 * p_2**e_2 * .... * p_n**e_n,
+  # ```
+  #
+  # [`prime_division`](https://docs.ruby-lang.org/en/2.6.0/Prime.html#method-i-prime_division)(n)
+  # returns:
+  #
+  # ```
+  # [[p_1, e_1], [p_2, e_2], ...., [p_n, e_n]].
+  #
+  # Prime.prime_division(12) #=> [[2,2], [3,1]]
+  # ```
+  def self.prime_division(value, generator = Prime::Generator23.new); end
+end
+
+# An implementation of `PseudoPrimeGenerator`.
+#
+# Uses `EratosthenesSieve`.
+class Prime::EratosthenesGenerator < ::Prime::PseudoPrimeGenerator
+  Elem = type_member(:out)
+
+  # Alias for:
+  # [`succ`](https://docs.ruby-lang.org/en/2.6.0/Prime/EratosthenesGenerator.html#method-i-succ)
+  def next; end
+
+  def rewind; end
+
+  # Also aliased as:
+  # [`next`](https://docs.ruby-lang.org/en/2.6.0/Prime/EratosthenesGenerator.html#method-i-next)
+  def succ; end
+
+  def self.new; end
+end
+
+# Internal use. An implementation of Eratosthenes' sieve
+class Prime::EratosthenesSieve
+  include(::Singleton)
+  extend(::Singleton::SingletonClassMethods)
+
+  def get_nth_prime(n); end
+
+  def self.new; end
+end
+
+# Generates all integers which are greater than 2 and are not divisible by
+# either 2 or 3.
+#
+# This is a pseudo-prime generator, suitable on checking primality of an integer
+# by brute force method.
+class Prime::Generator23 < ::Prime::PseudoPrimeGenerator
+  Elem = type_member(:out)
+
+  # Alias for:
+  # [`succ`](https://docs.ruby-lang.org/en/2.6.0/Prime/Generator23.html#method-i-succ)
+  def next; end
+
+  def rewind; end
+
+  # Also aliased as:
+  # [`next`](https://docs.ruby-lang.org/en/2.6.0/Prime/Generator23.html#method-i-next)
+  def succ; end
+
+  def self.new; end
+end
+
+# An abstract class for enumerating pseudo-prime numbers.
+#
+# Concrete subclasses should override succ, next, rewind.
+class Prime::PseudoPrimeGenerator
+  include(::Enumerable)
+
+  Elem = type_member(:out)
+
+  # Iterates the given block for each prime number.
+  def each; end
+
+  # alias of `succ`.
+  def next; end
+
+  # Rewinds the internal position for enumeration.
+  #
+  # See `Enumerator`#rewind.
+  def rewind; end
+
+  def size; end
+
+  # returns the next pseudo-prime number, and move the internal position
+  # forward.
+  #
+  # `PseudoPrimeGenerator`#succ raises `NotImplementedError`.
+  def succ; end
+
+  def upper_bound; end
+
+  def upper_bound=(ubound); end
+
+  # see `Enumerator`#with\_index.
+  def with_index(offset = 0); end
+
+  # see `Enumerator`#with\_object.
+  def with_object(obj); end
+
+  def self.new(ubound = nil); end
+end
+
+# Internal use. An implementation of prime table by trial division method.
+class Prime::TrialDivision
+  include(::Singleton)
+  extend(::Singleton::SingletonClassMethods)
+
+  # Returns the +index+th prime number.
+  #
+  # `index` is a 0-based index.
+  def [](index); end
+
+  def self.new; end
+end
+
+# An implementation of `PseudoPrimeGenerator` which uses a prime table generated
+# by trial division.
+class Prime::TrialDivisionGenerator < ::Prime::PseudoPrimeGenerator
+  Elem = type_member(:out)
+
+  # Alias for:
+  # [`succ`](https://docs.ruby-lang.org/en/2.6.0/Prime/TrialDivisionGenerator.html#method-i-succ)
+  def next; end
+
+  def rewind; end
+
+  # Also aliased as:
+  # [`next`](https://docs.ruby-lang.org/en/2.6.0/Prime/TrialDivisionGenerator.html#method-i-next)
+  def succ; end
+
+  def self.new; end
+end

--- a/rbi/stdlib/pstore.rbi
+++ b/rbi/stdlib/pstore.rbi
@@ -1,0 +1,299 @@
+# typed: __STDLIB_INTERNAL
+
+# [`PStore`](https://docs.ruby-lang.org/en/2.6.0/PStore.html) implements a file
+# based persistence mechanism based on a
+# [`Hash`](https://docs.ruby-lang.org/en/2.6.0/Hash.html). User code can store
+# hierarchies of Ruby objects (values) into the data store file by name (keys).
+# An object hierarchy may be just a single object. User code may later read
+# values back from the data store or even update data, as needed.
+#
+# The transactional behavior ensures that any changes succeed or fail together.
+# This can be used to ensure that the data store is not left in a transitory
+# state, where some values were updated but others were not.
+#
+# Behind the scenes, Ruby objects are stored to the data store file with
+# Marshal. That carries the usual limitations. Proc objects cannot be
+# marshalled, for example.
+#
+# ## Usage example:
+#
+# ```ruby
+# require "pstore"
+#
+# # a mock wiki object...
+# class WikiPage
+#   def initialize( page_name, author, contents )
+#     @page_name = page_name
+#     @revisions = Array.new
+#
+#     add_revision(author, contents)
+#   end
+#
+#   attr_reader :page_name
+#
+#   def add_revision( author, contents )
+#     @revisions << { :created  => Time.now,
+#                     :author   => author,
+#                     :contents => contents }
+#   end
+#
+#   def wiki_page_references
+#     [@page_name] + @revisions.last[:contents].scan(/\b(?:[A-Z]+[a-z]+){2,}/)
+#   end
+#
+#   # ...
+# end
+#
+# # create a new page...
+# home_page = WikiPage.new( "HomePage", "James Edward Gray II",
+#                           "A page about the JoysOfDocumentation..." )
+#
+# # then we want to update page data and the index together, or not at all...
+# wiki = PStore.new("wiki_pages.pstore")
+# wiki.transaction do  # begin transaction; do all of this or none of it
+#   # store page...
+#   wiki[home_page.page_name] = home_page
+#   # ensure that an index has been created...
+#   wiki[:wiki_index] ||= Array.new
+#   # update wiki index...
+#   wiki[:wiki_index].push(*home_page.wiki_page_references)
+# end                   # commit changes to wiki data store file
+#
+# ### Some time later... ###
+#
+# # read wiki data...
+# wiki.transaction(true) do  # begin read-only transaction, no changes allowed
+#   wiki.roots.each do |data_root_name|
+#     p data_root_name
+#     p wiki[data_root_name]
+#   end
+# end
+# ```
+#
+# ## Transaction modes
+#
+# By default, file integrity is only ensured as long as the operating system
+# (and the underlying hardware) doesn't raise any unexpected I/O errors. If an
+# I/O error occurs while
+# [`PStore`](https://docs.ruby-lang.org/en/2.6.0/PStore.html) is writing to its
+# file, then the file will become corrupted.
+#
+# You can prevent this by setting *pstore.ultra\_safe = true*. However, this
+# results in a minor performance loss, and only works on platforms that support
+# atomic file renames. Please consult the documentation for `ultra_safe` for
+# details.
+#
+# Needless to say, if you're storing valuable data with
+# [`PStore`](https://docs.ruby-lang.org/en/2.6.0/PStore.html), then you should
+# backup the [`PStore`](https://docs.ruby-lang.org/en/2.6.0/PStore.html) files
+# from time to time.
+class PStore
+  # Constant for relieving Ruby's garbage collector.
+  CHECKSUM_ALGO = Digest::SHA512
+
+  EMPTY_MARSHAL_CHECKSUM = T.let(T.unsafe(nil), String)
+
+  EMPTY_MARSHAL_DATA = T.let(T.unsafe(nil), String)
+
+  EMPTY_STRING = T.let(T.unsafe(nil), String)
+
+  RDWR_ACCESS = T.let(T.unsafe(nil), T::Hash[Symbol, T.untyped])
+
+  RD_ACCESS = T.let(T.unsafe(nil), T::Hash[Symbol, T.untyped])
+
+  WR_ACCESS = T.let(T.unsafe(nil), T::Hash[Symbol, T.untyped])
+
+  # Retrieves a value from the
+  # [`PStore`](https://docs.ruby-lang.org/en/2.6.0/PStore.html) file data, by
+  # *name*. The hierarchy of Ruby objects stored under that root *name* will be
+  # returned.
+  #
+  # **WARNING**:  This method is only valid in a
+  # [`PStore#transaction`](https://docs.ruby-lang.org/en/2.6.0/PStore.html#method-i-transaction).
+  # It will raise
+  # [`PStore::Error`](https://docs.ruby-lang.org/en/2.6.0/PStore/Error.html) if
+  # called at any other time.
+  def [](name); end
+
+  # Stores an individual Ruby object or a hierarchy of Ruby objects in the data
+  # store file under the root *name*. Assigning to a *name* already in the data
+  # store clobbers the old data.
+  #
+  # ## Example:
+  #
+  # ```ruby
+  # require "pstore"
+  #
+  # store = PStore.new("data_file.pstore")
+  # store.transaction do  # begin transaction
+  #   # load some data into the store...
+  #   store[:single_object] = "My data..."
+  #   store[:obj_hierarchy] = { "Kev Jackson" => ["rational.rb", "pstore.rb"],
+  #                             "James Gray"  => ["erb.rb", "pstore.rb"] }
+  # end                   # commit changes to data store file
+  # ```
+  #
+  # **WARNING**:  This method is only valid in a
+  # [`PStore#transaction`](https://docs.ruby-lang.org/en/2.6.0/PStore.html#method-i-transaction)
+  # and it cannot be read-only. It will raise
+  # [`PStore::Error`](https://docs.ruby-lang.org/en/2.6.0/PStore/Error.html) if
+  # called at any other time.
+  def []=(name, value); end
+
+  # Ends the current
+  # [`PStore#transaction`](https://docs.ruby-lang.org/en/2.6.0/PStore.html#method-i-transaction),
+  # discarding any changes to the data store.
+  #
+  # ## Example:
+  #
+  # ```ruby
+  # require "pstore"
+  #
+  # store = PStore.new("data_file.pstore")
+  # store.transaction do  # begin transaction
+  #   store[:one] = 1     # this change is not applied, see below...
+  #   store[:two] = 2     # this change is not applied, see below...
+  #
+  #   store.abort         # end transaction here, discard all changes
+  #
+  #   store[:three] = 3   # this change is never reached
+  # end
+  # ```
+  #
+  # **WARNING**:  This method is only valid in a
+  # [`PStore#transaction`](https://docs.ruby-lang.org/en/2.6.0/PStore.html#method-i-transaction).
+  # It will raise
+  # [`PStore::Error`](https://docs.ruby-lang.org/en/2.6.0/PStore/Error.html) if
+  # called at any other time.
+  def abort; end
+
+  # Ends the current
+  # [`PStore#transaction`](https://docs.ruby-lang.org/en/2.6.0/PStore.html#method-i-transaction),
+  # committing any changes to the data store immediately.
+  #
+  # ## Example:
+  #
+  # ```ruby
+  # require "pstore"
+  #
+  # store = PStore.new("data_file.pstore")
+  # store.transaction do  # begin transaction
+  #   # load some data into the store...
+  #   store[:one] = 1
+  #   store[:two] = 2
+  #
+  #   store.commit        # end transaction here, committing changes
+  #
+  #   store[:three] = 3   # this change is never reached
+  # end
+  # ```
+  #
+  # **WARNING**:  This method is only valid in a
+  # [`PStore#transaction`](https://docs.ruby-lang.org/en/2.6.0/PStore.html#method-i-transaction).
+  # It will raise
+  # [`PStore::Error`](https://docs.ruby-lang.org/en/2.6.0/PStore/Error.html) if
+  # called at any other time.
+  def commit; end
+
+  # Removes an object hierarchy from the data store, by *name*.
+  #
+  # **WARNING**:  This method is only valid in a
+  # [`PStore#transaction`](https://docs.ruby-lang.org/en/2.6.0/PStore.html#method-i-transaction)
+  # and it cannot be read-only. It will raise
+  # [`PStore::Error`](https://docs.ruby-lang.org/en/2.6.0/PStore/Error.html) if
+  # called at any other time.
+  def delete(name); end
+
+  # This method is just like
+  # [`PStore#[]`](https://docs.ruby-lang.org/en/2.6.0/PStore.html#method-i-5B-5D),
+  # save that you may also provide a *default* value for the object. In the
+  # event the specified *name* is not found in the data store, your *default*
+  # will be returned instead. If you do not specify a default,
+  # [`PStore::Error`](https://docs.ruby-lang.org/en/2.6.0/PStore/Error.html)
+  # will be raised if the object is not found.
+  #
+  # **WARNING**:  This method is only valid in a
+  # [`PStore#transaction`](https://docs.ruby-lang.org/en/2.6.0/PStore.html#method-i-transaction).
+  # It will raise
+  # [`PStore::Error`](https://docs.ruby-lang.org/en/2.6.0/PStore/Error.html) if
+  # called at any other time.
+  def fetch(name, default = PStore::Error); end
+
+  # Returns the path to the data store file.
+  def path; end
+
+  # Returns true if the supplied *name* is currently in the data store.
+  #
+  # **WARNING**:  This method is only valid in a
+  # [`PStore#transaction`](https://docs.ruby-lang.org/en/2.6.0/PStore.html#method-i-transaction).
+  # It will raise
+  # [`PStore::Error`](https://docs.ruby-lang.org/en/2.6.0/PStore/Error.html) if
+  # called at any other time.
+  def root?(name); end
+
+  # Returns the names of all object hierarchies currently in the store.
+  #
+  # **WARNING**:  This method is only valid in a
+  # [`PStore#transaction`](https://docs.ruby-lang.org/en/2.6.0/PStore.html#method-i-transaction).
+  # It will raise
+  # [`PStore::Error`](https://docs.ruby-lang.org/en/2.6.0/PStore/Error.html) if
+  # called at any other time.
+  def roots; end
+
+  # Opens a new transaction for the data store. Code executed inside a block
+  # passed to this method may read and write data to and from the data store
+  # file.
+  #
+  # At the end of the block, changes are committed to the data store
+  # automatically. You may exit the transaction early with a call to either
+  # [`PStore#commit`](https://docs.ruby-lang.org/en/2.6.0/PStore.html#method-i-commit)
+  # or
+  # [`PStore#abort`](https://docs.ruby-lang.org/en/2.6.0/PStore.html#method-i-abort).
+  # See those methods for details about how changes are handled. Raising an
+  # uncaught [`Exception`](https://docs.ruby-lang.org/en/2.6.0/Exception.html)
+  # in the block is equivalent to calling
+  # [`PStore#abort`](https://docs.ruby-lang.org/en/2.6.0/PStore.html#method-i-abort).
+  #
+  # If *read\_only* is set to `true`, you will only be allowed to read from the
+  # data store during the transaction and any attempts to change the data will
+  # raise a
+  # [`PStore::Error`](https://docs.ruby-lang.org/en/2.6.0/PStore/Error.html).
+  #
+  # Note that [`PStore`](https://docs.ruby-lang.org/en/2.6.0/PStore.html) does
+  # not support nested transactions.
+  def transaction(read_only = false); end
+
+  # Whether [`PStore`](https://docs.ruby-lang.org/en/2.6.0/PStore.html) should
+  # do its best to prevent file corruptions, even when under unlikely-to-occur
+  # error conditions such as out-of-space conditions and other unusual OS
+  # filesystem errors. Setting this flag comes at the price in the form of a
+  # performance loss.
+  #
+  # This flag only has effect on platforms on which file renames are atomic
+  # (e.g. all POSIX platforms: Linux, MacOS X, FreeBSD, etc). The default value
+  # is false.
+  def ultra_safe; end
+
+  # Whether [`PStore`](https://docs.ruby-lang.org/en/2.6.0/PStore.html) should
+  # do its best to prevent file corruptions, even when under unlikely-to-occur
+  # error conditions such as out-of-space conditions and other unusual OS
+  # filesystem errors. Setting this flag comes at the price in the form of a
+  # performance loss.
+  #
+  # This flag only has effect on platforms on which file renames are atomic
+  # (e.g. all POSIX platforms: Linux, MacOS X, FreeBSD, etc). The default value
+  # is false.
+  def ultra_safe=(_); end
+
+  # To construct a [`PStore`](https://docs.ruby-lang.org/en/2.6.0/PStore.html)
+  # object, pass in the *file* path where you would like the data to be stored.
+  #
+  # [`PStore`](https://docs.ruby-lang.org/en/2.6.0/PStore.html) objects are
+  # always reentrant. But if *thread\_safe* is set to true, then it will become
+  # thread-safe at the cost of a minor performance hit.
+  def self.new(file, thread_safe = false); end
+end
+
+# The error type thrown by all
+# [`PStore`](https://docs.ruby-lang.org/en/2.6.0/PStore.html) methods.
+class PStore::Error < ::StandardError; end

--- a/rbi/stdlib/readline.rbi
+++ b/rbi/stdlib/readline.rbi
@@ -1,0 +1,598 @@
+# typed: __STDLIB_INTERNAL
+
+# The [`Readline`](https://docs.ruby-lang.org/en/2.6.0/Readline.html) module
+# provides interface for GNU
+# [`Readline`](https://docs.ruby-lang.org/en/2.6.0/Readline.html). This module
+# defines a number of methods to facilitate completion and accesses input
+# history from the Ruby interpreter. This module supported Edit Line(libedit)
+# too. libedit is compatible with GNU
+# [`Readline`](https://docs.ruby-lang.org/en/2.6.0/Readline.html).
+#
+# GNU [`Readline`](https://docs.ruby-lang.org/en/2.6.0/Readline.html)
+# :   http://www.gnu.org/directory/readline.html
+# libedit
+# :   http://www.thrysoee.dk/editline/
+#
+#
+# Reads one inputted line with line edit by
+# [`Readline.readline`](https://docs.ruby-lang.org/en/2.6.0/Readline.html#method-c-readline)
+# method. At this time, the facilitatation completion and the key bind like
+# Emacs can be operated like GNU
+# [`Readline`](https://docs.ruby-lang.org/en/2.6.0/Readline.html).
+#
+# ```ruby
+# require "readline"
+# while buf = Readline.readline("> ", true)
+#   p buf
+# end
+# ```
+#
+# The content that the user input can be recorded to the history. The history
+# can be accessed by
+# [`Readline::HISTORY`](https://docs.ruby-lang.org/en/2.6.0/Readline.html#HISTORY)
+# constant.
+#
+# ```ruby
+# require "readline"
+# while buf = Readline.readline("> ", true)
+#   p Readline::HISTORY.to_a
+#   print("-> ", buf, "\n")
+# end
+# ```
+#
+# Documented by Kouji Takao <kouji dot takao at gmail dot com>.
+module Readline
+
+  # The [`Object`](https://docs.ruby-lang.org/en/2.6.0/Object.html) with the
+  # call method that is a completion for filename. This is sets by
+  # [`Readline.completion_proc=`](https://docs.ruby-lang.org/en/2.6.0/Readline.html#method-c-completion_proc-3D)
+  # method.
+  FILENAME_COMPLETION_PROC = T.let(T.unsafe(nil), Object)
+
+  # The history buffer. It extends
+  # [`Enumerable`](https://docs.ruby-lang.org/en/2.6.0/Enumerable.html) module,
+  # so it behaves just like an array. For example, gets the fifth content that
+  # the user input by [HISTORY](4).
+  HISTORY = T.let(T.unsafe(nil), Object)
+
+  # The [`Object`](https://docs.ruby-lang.org/en/2.6.0/Object.html) with the
+  # call method that is a completion for usernames. This is sets by
+  # [`Readline.completion_proc=`](https://docs.ruby-lang.org/en/2.6.0/Readline.html#method-c-completion_proc-3D)
+  # method.
+  USERNAME_COMPLETION_PROC = T.let(T.unsafe(nil), Object)
+
+  # Version string of GNU
+  # [`Readline`](https://docs.ruby-lang.org/en/2.6.0/Readline.html) or libedit.
+  VERSION = T.let(T.unsafe(nil), String)
+
+  # Gets a list of quote characters which can cause a word break.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.basic_quote_characters; end
+
+  # Sets a list of quote characters which can cause a word break.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.basic_quote_characters=(_); end
+
+  # Gets the basic list of characters that signal a break between words for the
+  # completer routine.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.basic_word_break_characters; end
+
+  # Sets the basic list of characters that signal a break between words for the
+  # completer routine. The default is the characters which break words for
+  # completion in Bash: " t\\n\\"\\\\'`@$><=;|&{(".
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.basic_word_break_characters=(_); end
+
+  # Gets a list of characters which can be used to quote a substring of the
+  # line.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.completer_quote_characters; end
+
+  # Sets a list of characters which can be used to quote a substring of the
+  # line. Completion occurs on the entire substring, and within the substring
+  # [`Readline.completer_word_break_characters`](https://docs.ruby-lang.org/en/2.6.0/Readline.html#method-c-completer_word_break_characters)
+  # are treated as any other character, unless they also appear within this
+  # list.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.completer_quote_characters=(_); end
+
+  # Gets the basic list of characters that signal a break between words for
+  # rl\_complete\_internal().
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.completer_word_break_characters; end
+
+  # Sets the basic list of characters that signal a break between words for
+  # rl\_complete\_internal(). The default is the value of
+  # [`Readline.basic_word_break_characters`](https://docs.ruby-lang.org/en/2.6.0/Readline.html#method-c-basic_word_break_characters).
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.completer_word_break_characters=(_); end
+
+  # Returns a string containing a character to be appended on completion. The
+  # default is a space (" ").
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.completion_append_character; end
+
+  # Specifies a character to be appended on completion. Nothing will be appended
+  # if an empty string ("") or nil is specified.
+  #
+  # For example:
+  #
+  # ```ruby
+  # require "readline"
+  #
+  # Readline.readline("> ", true)
+  # Readline.completion_append_character = " "
+  # ```
+  #
+  # Result:
+  #
+  # ```
+  # >
+  # Input "/var/li".
+  #
+  # > /var/li
+  # Press TAB key.
+  #
+  # > /var/lib
+  # Completes "b" and appends " ". So, you can continuously input "/usr".
+  #
+  # > /var/lib /usr
+  # ```
+  #
+  # NOTE: Only one character can be specified. When "string" is specified, sets
+  # only "s" that is the first.
+  #
+  # ```ruby
+  # require "readline"
+  #
+  # Readline.completion_append_character = "string"
+  # p Readline.completion_append_character # => "s"
+  # ```
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.completion_append_character=(_); end
+
+  # Returns true if completion ignores case. If no, returns false.
+  #
+  # NOTE: Returns the same object that is specified by
+  # [`Readline.completion_case_fold=`](https://docs.ruby-lang.org/en/2.6.0/Readline.html#method-c-completion_case_fold-3D)
+  # method.
+  #
+  # ```ruby
+  # require "readline"
+  #
+  # Readline.completion_case_fold = "This is a String."
+  # p Readline.completion_case_fold # => "This is a String."
+  # ```
+  def self.completion_case_fold; end
+
+  # Sets whether or not to ignore case on completion.
+  def self.completion_case_fold=(_); end
+
+  # Returns the completion
+  # [`Proc`](https://docs.ruby-lang.org/en/2.6.0/Proc.html) object.
+  def self.completion_proc; end
+
+  # Specifies a [`Proc`](https://docs.ruby-lang.org/en/2.6.0/Proc.html) object
+  # `proc` to determine completion behavior. It should take input string and
+  # return an array of completion candidates.
+  #
+  # The default completion is used if `proc` is nil.
+  #
+  # The [`String`](https://docs.ruby-lang.org/en/2.6.0/String.html) that is
+  # passed to the [`Proc`](https://docs.ruby-lang.org/en/2.6.0/Proc.html)
+  # depends on the
+  # [`Readline.completer_word_break_characters`](https://docs.ruby-lang.org/en/2.6.0/Readline.html#method-c-completer_word_break_characters)
+  # property. By default the word under the cursor is passed to the
+  # [`Proc`](https://docs.ruby-lang.org/en/2.6.0/Proc.html). For example, if the
+  # input is "foo bar" then only "bar" would be passed to the completion
+  # [`Proc`](https://docs.ruby-lang.org/en/2.6.0/Proc.html).
+  #
+  # Upon successful completion the
+  # [`Readline.completion_append_character`](https://docs.ruby-lang.org/en/2.6.0/Readline.html#method-c-completion_append_character)
+  # will be appended to the input so the user can start working on their next
+  # argument.
+  #
+  # # Examples
+  #
+  # ## Completion for a Static List
+  #
+  # ```ruby
+  # require 'readline'
+  #
+  # LIST = [
+  #   'search', 'download', 'open',
+  #   'help', 'history', 'quit',
+  #   'url', 'next', 'clear',
+  #   'prev', 'past'
+  # ].sort
+  #
+  # comp = proc { |s| LIST.grep(/^#{Regexp.escape(s)}/) }
+  #
+  # Readline.completion_append_character = " "
+  # Readline.completion_proc = comp
+  #
+  # while line = Readline.readline('> ', true)
+  #   p line
+  # end
+  # ```
+  #
+  # ## Completion For Directory Contents
+  #
+  # ```ruby
+  # require 'readline'
+  #
+  # Readline.completion_append_character = " "
+  # Readline.completion_proc = Proc.new do |str|
+  #   Dir[str+'*'].grep(/^#{Regexp.escape(str)}/)
+  # end
+  #
+  # while line = Readline.readline('> ', true)
+  #   p line
+  # end
+  # ```
+  #
+  # # Autocomplete strategies
+  #
+  # When working with auto-complete there are some strategies that work well. To
+  # get some ideas you can take a look at the
+  # [completion.rb](https://svn.ruby-lang.org/repos/ruby/trunk/lib/irb/completion.rb)
+  # file for irb.
+  #
+  # The common strategy is to take a list of possible completions and filter it
+  # down to those completions that start with the user input. In the above
+  # examples
+  # [`Enumerator.grep`](https://docs.ruby-lang.org/en/2.6.0/Enumerable.html#method-i-grep)
+  # is used. The input is escaped to prevent
+  # [`Regexp`](https://docs.ruby-lang.org/en/2.6.0/Regexp.html) special
+  # characters from interfering with the matching.
+  #
+  # It may also be helpful to use the
+  # [`Abbrev`](https://docs.ruby-lang.org/en/2.6.0/Abbrev.html) library to
+  # generate completions.
+  #
+  # Raises
+  # [`ArgumentError`](https://docs.ruby-lang.org/en/2.6.0/ArgumentError.html) if
+  # `proc` does not respond to the call method.
+  def self.completion_proc=(_); end
+
+  # Delete text between start and end in the current line.
+  #
+  # See GNU Readline's rl\_delete\_text function.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.delete_text(*_); end
+
+  # Specifies Emacs editing mode. The default is this mode. See the manual of
+  # GNU [`Readline`](https://docs.ruby-lang.org/en/2.6.0/Readline.html) for
+  # details of Emacs editing mode.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.emacs_editing_mode; end
+
+  # Returns true if emacs mode is active. Returns false if not.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.emacs_editing_mode?; end
+
+  # Gets a list of characters that cause a filename to be quoted by the
+  # completer when they appear in a completed filename.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.filename_quote_characters; end
+
+  # Sets a list of characters that cause a filename to be quoted by the
+  # completer when they appear in a completed filename. The default is nil.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.filename_quote_characters=(_); end
+
+  # Returns the terminal's rows and columns.
+  #
+  # See GNU Readline's rl\_get\_screen\_size function.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.get_screen_size; end
+
+  # Specifies a [`File`](https://docs.ruby-lang.org/en/2.6.0/File.html) object
+  # `input` that is input stream for
+  # [`Readline.readline`](https://docs.ruby-lang.org/en/2.6.0/Readline.html#method-c-readline)
+  # method.
+  def self.input=(_); end
+
+  # Insert text into the line at the current cursor position.
+  #
+  # See GNU Readline's rl\_insert\_text function.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.insert_text(_); end
+
+  # Returns the full line that is being edited. This is useful from within the
+  # complete\_proc for determining the context of the completion request.
+  #
+  # The length of `Readline.line_buffer` and GNU Readline's rl\_end are same.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.line_buffer; end
+
+  # Specifies a [`File`](https://docs.ruby-lang.org/en/2.6.0/File.html) object
+  # `output` that is output stream for
+  # [`Readline.readline`](https://docs.ruby-lang.org/en/2.6.0/Readline.html#method-c-readline)
+  # method.
+  def self.output=(_); end
+
+  # Returns the index of the current cursor position in `Readline.line_buffer`.
+  #
+  # The index in `Readline.line_buffer` which matches the start of input-string
+  # passed to
+  # [`completion_proc`](https://docs.ruby-lang.org/en/2.6.0/Readline.html#method-c-completion_proc)
+  # is computed by subtracting the length of input-string from `Readline.point`.
+  #
+  # ```ruby
+  # start = (the length of input-string) - Readline.point
+  # ```
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.point; end
+
+  # [`Set`](https://docs.ruby-lang.org/en/2.6.0/Set.html) the index of the
+  # current cursor position in `Readline.line_buffer`.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  #
+  # See `Readline.point`.
+  def self.point=(_); end
+
+  # Returns a [`Proc`](https://docs.ruby-lang.org/en/2.6.0/Proc.html) object
+  # `proc` to call after the first prompt has been printed and just before
+  # readline starts reading input characters. The default is nil.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.pre_input_hook; end
+
+  # Specifies a [`Proc`](https://docs.ruby-lang.org/en/2.6.0/Proc.html) object
+  # `proc` to call after the first prompt has been printed and just before
+  # readline starts reading input characters.
+  #
+  # See GNU Readline's rl\_pre\_input\_hook variable.
+  #
+  # Raises
+  # [`ArgumentError`](https://docs.ruby-lang.org/en/2.6.0/ArgumentError.html) if
+  # `proc` does not respond to the call method.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.pre_input_hook=(_); end
+
+  # Returns the quoting detection
+  # [`Proc`](https://docs.ruby-lang.org/en/2.6.0/Proc.html) object.
+  def self.quoting_detection_proc; end
+
+  # Specifies a [`Proc`](https://docs.ruby-lang.org/en/2.6.0/Proc.html) object
+  # `proc` to determine if a character in the user's input is escaped. It should
+  # take the user's input and the index of the character in question as input,
+  # and return a boolean (true if the specified character is escaped).
+  #
+  # [`Readline`](https://docs.ruby-lang.org/en/2.6.0/Readline.html) will only
+  # call this proc with characters specified in `completer_quote_characters`, to
+  # discover if they indicate the end of a quoted argument, or characters
+  # specified in `completer_word_break_characters`, to discover if they indicate
+  # a break between arguments.
+  #
+  # If `completer_quote_characters` is not set, or if the user input doesn't
+  # contain one of the `completer_quote_characters` or a ++ character,
+  # [`Readline`](https://docs.ruby-lang.org/en/2.6.0/Readline.html) will not
+  # attempt to use this proc at all.
+  #
+  # Raises
+  # [`ArgumentError`](https://docs.ruby-lang.org/en/2.6.0/ArgumentError.html) if
+  # `proc` does not respond to the call method.
+  def self.quoting_detection_proc=(_); end
+
+  # Shows the `prompt` and reads the inputted line with line editing. The
+  # inputted line is added to the history if `add_hist` is true.
+  #
+  # Returns nil when the inputted line is empty and user inputs EOF (Presses ^D
+  # on UNIX).
+  #
+  # Raises [`IOError`](https://docs.ruby-lang.org/en/2.6.0/IOError.html)
+  # exception if one of below conditions are satisfied.
+  # 1.  stdin was closed.
+  # 2.  stdout was closed.
+  #
+  #
+  # This method supports thread. Switches the thread context when waits
+  # inputting line.
+  #
+  # Supports line edit when inputs line. Provides VI and Emacs editing mode.
+  # Default is Emacs editing mode.
+  #
+  # NOTE: Terminates ruby interpreter and does not return the terminal status
+  # after user pressed '^C' when wait inputting line. Give 3 examples that avoid
+  # it.
+  #
+  # *   Catches the
+  #     [`Interrupt`](https://docs.ruby-lang.org/en/2.6.0/Interrupt.html)
+  #     exception by pressed ^C after returns terminal status:
+  #
+  # ```
+  # require "readline"
+  #
+  # stty_save = `stty -g`.chomp
+  # begin
+  #   while buf = Readline.readline
+  #       p buf
+  #       end
+  #     rescue Interrupt
+  #       system("stty", stty_save)
+  #       exit
+  #     end
+  #   end
+  # end
+  # ```
+  #
+  # *   Catches the INT signal by pressed ^C after returns terminal status:
+  #
+  # ```ruby
+  # require "readline"
+  #
+  # stty_save = `stty -g`.chomp
+  # trap("INT") { system "stty", stty_save; exit }
+  #
+  # while buf = Readline.readline
+  #   p buf
+  # end
+  # ```
+  #
+  # *   Ignores pressing ^C:
+  #
+  # ```ruby
+  # require "readline"
+  #
+  # trap("INT", "SIG_IGN")
+  #
+  # while buf = Readline.readline
+  #   p buf
+  # end
+  # ```
+  #
+  #
+  # Can make as follows with
+  # [`Readline::HISTORY`](https://docs.ruby-lang.org/en/2.6.0/Readline.html#HISTORY)
+  # constant. It does not record to the history if the inputted line is empty or
+  # the same it as last one.
+  #
+  # ```ruby
+  # require "readline"
+  #
+  # while buf = Readline.readline("> ", true)
+  #   # p Readline::HISTORY.to_a
+  #   Readline::HISTORY.pop if /^\s*$/ =~ buf
+  #
+  #   begin
+  #     if Readline::HISTORY[Readline::HISTORY.length-2] == buf
+  #       Readline::HISTORY.pop
+  #     end
+  #   rescue IndexError
+  #   end
+  #
+  #   # p Readline::HISTORY.to_a
+  #   print "-> ", buf, "\n"
+  # end
+  # ```
+  def self.readline(*_); end
+
+  # Change what's displayed on the screen to reflect the current contents.
+  #
+  # See GNU Readline's rl\_redisplay function.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.redisplay; end
+
+  # Clear the current input line.
+  def self.refresh_line; end
+
+  # [`Set`](https://docs.ruby-lang.org/en/2.6.0/Set.html) terminal size to
+  # `rows` and `columns`.
+  #
+  # See GNU Readline's rl\_set\_screen\_size function.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.set_screen_size(_, _); end
+
+  # Gets the list of characters that are word break characters, but should be
+  # left in text when it is passed to the completion function.
+  #
+  # See GNU Readline's rl\_special\_prefixes variable.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.special_prefixes; end
+
+  # Sets the list of characters that are word break characters, but should be
+  # left in text when it is passed to the completion function. Programs can use
+  # this to help determine what kind of completing to do. For instance, Bash
+  # sets this variable to "$@" so that it can complete shell variables and
+  # hostnames.
+  #
+  # See GNU Readline's rl\_special\_prefixes variable.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.special_prefixes=(_); end
+
+  # Specifies VI editing mode. See the manual of GNU
+  # [`Readline`](https://docs.ruby-lang.org/en/2.6.0/Readline.html) for details
+  # of VI editing mode.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.vi_editing_mode; end
+
+  # Returns true if vi mode is active. Returns false if not.
+  #
+  # Raises
+  # [`NotImplementedError`](https://docs.ruby-lang.org/en/2.6.0/NotImplementedError.html)
+  # if the using readline library does not support.
+  def self.vi_editing_mode?; end
+end

--- a/rbi/stdlib/rinda.rbi
+++ b/rbi/stdlib/rinda.rbi
@@ -1,0 +1,700 @@
+# typed: __STDLIB_INTERNAL
+
+# A module to implement the Linda distributed computing paradigm in Ruby.
+#
+# [`Rinda`](https://docs.ruby-lang.org/en/2.6.0/Rinda.html) is part of
+# [`DRb`](https://docs.ruby-lang.org/en/2.6.0/DRb.html) (dRuby).
+#
+# ## Example(s)
+#
+# See the sample/drb/ directory in the Ruby distribution, from 1.8.2 onwards.
+module Rinda; end
+
+# *Documentation?*
+class Rinda::DRbObjectTemplate
+  # Creates a new
+  # [`DRbObjectTemplate`](https://docs.ruby-lang.org/en/2.6.0/Rinda/DRbObjectTemplate.html)
+  # that will match against `uri` and `ref`.
+  def self.new(uri = _, ref = _); end
+
+  # This
+  # [`DRbObjectTemplate`](https://docs.ruby-lang.org/en/2.6.0/Rinda/DRbObjectTemplate.html)
+  # matches `ro` if the remote object's drburi and drbref are the same. `nil` is
+  # used as a wildcard.
+  def ===(ro); end
+end
+
+# Raised when a hash-based tuple has an invalid key.
+class Rinda::InvalidHashTupleKey < ::Rinda::RindaError; end
+
+# A
+# [`NotifyTemplateEntry`](https://docs.ruby-lang.org/en/2.6.0/Rinda/NotifyTemplateEntry.html)
+# is returned by TupleSpace#notify and is notified of TupleSpace changes. You
+# may receive either your subscribed event or the 'close' event when iterating
+# over notifications.
+#
+# See TupleSpace#notify\_event for valid notification types.
+#
+# ## Example
+#
+# ```ruby
+# ts = Rinda::TupleSpace.new
+# observer = ts.notify 'write', [nil]
+#
+# Thread.start do
+#   observer.each { |t| p t }
+# end
+#
+# 3.times { |i| ts.write [i] }
+# ```
+#
+# Outputs:
+#
+# ```ruby
+# ['write', [0]]
+# ['write', [1]]
+# ['write', [2]]
+# ```
+class Rinda::NotifyTemplateEntry < ::Rinda::TemplateEntry
+  # Creates a new
+  # [`NotifyTemplateEntry`](https://docs.ruby-lang.org/en/2.6.0/Rinda/NotifyTemplateEntry.html)
+  # that watches `place` for +event+s that match `tuple`.
+  def self.new(place, event, tuple, expires = _); end
+
+  # Yields event/tuple pairs until this
+  # [`NotifyTemplateEntry`](https://docs.ruby-lang.org/en/2.6.0/Rinda/NotifyTemplateEntry.html)
+  # expires.
+  def each; end
+
+  # Called by TupleSpace to notify this
+  # [`NotifyTemplateEntry`](https://docs.ruby-lang.org/en/2.6.0/Rinda/NotifyTemplateEntry.html)
+  # of a new event.
+  def notify(ev); end
+
+  # Retrieves a notification. Raises RequestExpiredError when this
+  # [`NotifyTemplateEntry`](https://docs.ruby-lang.org/en/2.6.0/Rinda/NotifyTemplateEntry.html)
+  # expires.
+  def pop; end
+end
+
+# Raised when trying to use a canceled tuple.
+class Rinda::RequestCanceledError < ::ThreadError; end
+
+# Raised when trying to use an expired tuple.
+class Rinda::RequestExpiredError < ::ThreadError; end
+
+# [`Rinda`](https://docs.ruby-lang.org/en/2.6.0/Rinda.html) error base class
+class Rinda::RindaError < ::RuntimeError; end
+
+# [`RingFinger`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingFinger.html) is
+# used by RingServer clients to discover the RingServer's TupleSpace. Typically,
+# all a client needs to do is call
+# [`RingFinger.primary`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingFinger.html#method-c-primary)
+# to retrieve the remote TupleSpace, which it can then begin using.
+#
+# To find the first available remote TupleSpace:
+#
+# ```ruby
+# Rinda::RingFinger.primary
+# ```
+#
+# To create a
+# [`RingFinger`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingFinger.html) that
+# broadcasts to a custom list:
+#
+# ```ruby
+# rf = Rinda::RingFinger.new  ['localhost', '192.0.2.1']
+# rf.primary
+# ```
+#
+# [`Rinda::RingFinger`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingFinger.html)
+# also understands multicast addresses and sets them up properly. This allows
+# you to run multiple RingServers on the same host:
+#
+# ```ruby
+# rf = Rinda::RingFinger.new ['239.0.0.1']
+# rf.primary
+# ```
+#
+# You can set the hop count (or TTL) for multicast searches using
+# [`multicast_hops`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingFinger.html#attribute-i-multicast_hops).
+#
+# If you use IPv6 multicast you may need to set both an address and the outbound
+# interface index:
+#
+# ```ruby
+# rf = Rinda::RingFinger.new ['ff02::1']
+# rf.multicast_interface = 1
+# rf.primary
+# ```
+#
+# At this time there is no easy way to get an interface index by name.
+class Rinda::RingFinger
+  # Creates a new
+  # [`RingFinger`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingFinger.html)
+  # that will look for RingServers at `port` on the addresses in
+  # `broadcast_list`.
+  #
+  # If `broadcast_list` contains a multicast address then multicast queries will
+  # be made using the given
+  # [`multicast_hops`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingFinger.html#attribute-i-multicast_hops)
+  # and multicast\_interface.
+  def self.new(broadcast_list = _, port = _); end
+
+  # The list of addresses where
+  # [`RingFinger`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingFinger.html)
+  # will send query packets.
+  def broadcast_list; end
+
+  # The list of addresses where
+  # [`RingFinger`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingFinger.html)
+  # will send query packets.
+  def broadcast_list=(_); end
+
+  # Iterates over all discovered TupleSpaces starting with the primary.
+  def each; end
+
+  # Looks up RingServers waiting `timeout` seconds. RingServers will be given
+  # `block` as a callback, which will be called with the remote TupleSpace.
+  def lookup_ring(timeout = _, &block); end
+
+  # Returns the first found remote TupleSpace. Any further recovered TupleSpaces
+  # can be found by calling `to_a`.
+  def lookup_ring_any(timeout = _); end
+
+  def make_socket(address); end
+
+  # Maximum number of hops for sent multicast packets (if using a multicast
+  # address in the broadcast list). The default is 1 (same as UDP broadcast).
+  def multicast_hops; end
+
+  # Maximum number of hops for sent multicast packets (if using a multicast
+  # address in the broadcast list). The default is 1 (same as UDP broadcast).
+  def multicast_hops=(_); end
+
+  # The interface index to send IPv6 multicast packets from.
+  def multicast_interface; end
+
+  # The interface index to send IPv6 multicast packets from.
+  def multicast_interface=(_); end
+
+  # The port that
+  # [`RingFinger`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingFinger.html)
+  # will send query packets to.
+  def port; end
+
+  # The port that
+  # [`RingFinger`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingFinger.html)
+  # will send query packets to.
+  def port=(_); end
+
+  # Contain the first advertised TupleSpace after
+  # [`lookup_ring_any`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingFinger.html#method-i-lookup_ring_any)
+  # is called.
+  def primary; end
+
+  # Contain the first advertised TupleSpace after
+  # [`lookup_ring_any`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingFinger.html#method-i-lookup_ring_any)
+  # is called.
+  def primary=(_); end
+
+  def send_message(address, message); end
+
+  # Contains all discovered TupleSpaces except for the primary.
+  def to_a; end
+
+  # Creates a singleton
+  # [`RingFinger`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingFinger.html)
+  # and looks for a RingServer. Returns the created
+  # [`RingFinger`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingFinger.html).
+  def self.finger; end
+
+  # Returns the first advertised TupleSpace.
+  def self.primary; end
+
+  # Contains all discovered TupleSpaces except for the primary.
+  def self.to_a; end
+end
+
+# [`RingProvider`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingProvider.html)
+# uses a RingServer advertised TupleSpace as a name service. TupleSpace clients
+# can register themselves with the remote TupleSpace and look up other provided
+# services via the remote TupleSpace.
+#
+# Services are registered with a tuple of the format [:name, klass, DRbObject,
+# description].
+class Rinda::RingProvider
+  # Creates a
+  # [`RingProvider`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingProvider.html)
+  # that will provide a `klass` service running on `front`, with a
+  # `description`. `renewer` is optional.
+  def self.new(klass, front, desc, renewer = _); end
+
+  # Advertises this service on the primary remote TupleSpace.
+  def provide; end
+end
+
+# A [`RingServer`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingServer.html)
+# allows a
+# [`Rinda::TupleSpace`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TupleSpace.html)
+# to be located via UDP broadcasts. Default service location uses the following
+# steps:
+#
+# 1.  A
+#     [`RingServer`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingServer.html)
+#     begins listening on the network broadcast UDP address.
+# 2.  A RingFinger sends a UDP packet containing the
+#     [`DRb`](https://docs.ruby-lang.org/en/2.6.0/DRb.html)
+#     [`URI`](https://docs.ruby-lang.org/en/2.6.0/URI.html) where it will listen
+#     for a reply.
+# 3.  The
+#     [`RingServer`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingServer.html)
+#     receives the UDP packet and connects back to the provided
+#     [`DRb`](https://docs.ruby-lang.org/en/2.6.0/DRb.html)
+#     [`URI`](https://docs.ruby-lang.org/en/2.6.0/URI.html) with the
+#     [`DRb`](https://docs.ruby-lang.org/en/2.6.0/DRb.html) service.
+#
+#
+# A [`RingServer`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingServer.html)
+# requires a TupleSpace:
+#
+# ```ruby
+# ts = Rinda::TupleSpace.new
+# rs = Rinda::RingServer.new
+# ```
+#
+# [`RingServer`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingServer.html) can
+# also listen on multicast addresses for announcements. This allows multiple
+# RingServers to run on the same host. To use network broadcast and multicast:
+#
+# ```ruby
+# ts = Rinda::TupleSpace.new
+# rs = Rinda::RingServer.new ts, %w[Socket::INADDR_ANY, 239.0.0.1 ff02::1]
+# ```
+class Rinda::RingServer
+  include(::DRb::DRbUndumped)
+
+  # Advertises `ts` on the given `addresses` at `port`.
+  #
+  # If `addresses` is omitted only the UDP broadcast address is used.
+  #
+  # `addresses` can contain multiple addresses. If a multicast address is given
+  # in `addresses` then the
+  # [`RingServer`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingServer.html)
+  # will listen for multicast queries.
+  #
+  # If you use IPv4 multicast you may need to set an address of the inbound
+  # interface which joins a multicast group.
+  #
+  # ```ruby
+  # ts = Rinda::TupleSpace.new
+  # rs = Rinda::RingServer.new(ts, [['239.0.0.1', '9.5.1.1']])
+  # ```
+  #
+  # You can set addresses as an
+  # [`Array`](https://docs.ruby-lang.org/en/2.6.0/Array.html)
+  # [`Object`](https://docs.ruby-lang.org/en/2.6.0/Object.html). The first
+  # element of the [`Array`](https://docs.ruby-lang.org/en/2.6.0/Array.html) is
+  # a multicast address and the second is an inbound interface address. If the
+  # second is omitted then '0.0.0.0' is used.
+  #
+  # If you use IPv6 multicast you may need to set both the local interface
+  # address and the inbound interface index:
+  #
+  # ```ruby
+  # rs = Rinda::RingServer.new(ts, [['ff02::1', '::1', 1]])
+  # ```
+  #
+  # The first element is a multicast address and the second is an inbound
+  # interface address. The third is an inbound interface index.
+  #
+  # At this time there is no easy way to get an interface index by name.
+  #
+  # If the second is omitted then '::1' is used. If the third is omitted then 0
+  # (default interface) is used.
+  def self.new(ts, addresses = _, port = _); end
+
+  # Pulls lookup tuples out of the TupleSpace and sends their
+  # [`DRb`](https://docs.ruby-lang.org/en/2.6.0/DRb.html) object the address of
+  # the local TupleSpace.
+  def do_reply; end
+
+  # Extracts the response [`URI`](https://docs.ruby-lang.org/en/2.6.0/URI.html)
+  # from `msg` and adds it to TupleSpace where it will be picked up by
+  # `reply_service` for notification.
+  def do_write(msg); end
+
+  # Creates a socket at `address`
+  #
+  # If `address` is multicast address then `interface_address` and
+  # `multicast_interface` can be set as optional.
+  #
+  # A created socket is bound to `interface_address`. If you use IPv4 multicast
+  # then the interface of `interface_address` is used as the inbound interface.
+  # If `interface_address` is omitted or nil then '0.0.0.0' or '::1' is used.
+  #
+  # If you use IPv6 multicast then `multicast_interface` is used as the inbound
+  # interface. `multicast_interface` is a network interface index. If
+  # `multicast_interface` is omitted then 0 (default interface) is used.
+  def make_socket(address, interface_address = _, multicast_interface = _); end
+
+  # Creates a thread that notifies waiting clients from the TupleSpace.
+  def reply_service; end
+
+  # Shuts down the
+  # [`RingServer`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingServer.html)
+  def shutdown; end
+
+  # Creates threads that pick up UDP packets and passes them to
+  # [`do_write`](https://docs.ruby-lang.org/en/2.6.0/Rinda/RingServer.html#method-i-do_write)
+  # for decoding.
+  def write_services; end
+end
+
+class Rinda::RingServer::Renewer
+  include(::DRb::DRbUndumped)
+
+  def self.new; end
+
+  def renew; end
+
+  def renew=(_); end
+end
+
+# The default port Ring discovery will use.
+Rinda::Ring_PORT = T.let(T.unsafe(nil), Integer)
+
+# An
+# [`SimpleRenewer`](https://docs.ruby-lang.org/en/2.6.0/Rinda/SimpleRenewer.html)
+# allows a TupleSpace to check if a TupleEntry is still alive.
+class Rinda::SimpleRenewer
+  include(::DRb::DRbUndumped)
+
+  # Creates a new
+  # [`SimpleRenewer`](https://docs.ruby-lang.org/en/2.6.0/Rinda/SimpleRenewer.html)
+  # that keeps an object alive for another `sec` seconds.
+  def self.new(sec = _); end
+
+  # Called by the TupleSpace to check if the object is still alive.
+  def renew; end
+end
+
+# Templates are used to match tuples in
+# [`Rinda`](https://docs.ruby-lang.org/en/2.6.0/Rinda.html).
+class Rinda::Template < ::Rinda::Tuple
+  # Alias for
+  # [`match`](https://docs.ruby-lang.org/en/2.6.0/Rinda/Template.html#method-i-match).
+  def ===(tuple); end
+
+  # Matches this template against `tuple`. The `tuple` must be the same size as
+  # the template. An element with a `nil` value in a template acts as a
+  # wildcard, matching any value in the corresponding position in the tuple.
+  # Elements of the template match the `tuple` if the are #== or
+  # [`===`](https://docs.ruby-lang.org/en/2.6.0/Rinda/Template.html#method-i-3D-3D-3D).
+  #
+  # ```ruby
+  # Template.new([:foo, 5]).match   Tuple.new([:foo, 5]) # => true
+  # Template.new([:foo, nil]).match Tuple.new([:foo, 5]) # => true
+  # Template.new([String]).match    Tuple.new(['hello']) # => true
+  #
+  # Template.new([:foo]).match      Tuple.new([:foo, 5]) # => false
+  # Template.new([:foo, 6]).match   Tuple.new([:foo, 5]) # => false
+  # Template.new([:foo, nil]).match Tuple.new([:foo])    # => false
+  # Template.new([:foo, 6]).match   Tuple.new([:foo])    # => false
+  # ```
+  def match(tuple); end
+end
+
+# A
+# [`TemplateEntry`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TemplateEntry.html)
+# is a Template together with expiry and cancellation data.
+class Rinda::TemplateEntry < ::Rinda::TupleEntry
+  # Alias for:
+  # [`match`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TemplateEntry.html#method-i-match)
+  def ===(tuple); end
+
+  def make_tuple(ary); end
+
+  # Matches this
+  # [`TemplateEntry`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TemplateEntry.html)
+  # against `tuple`. See Template#match for details on how a Template matches a
+  # Tuple.
+  #
+  # Also aliased as:
+  # [`===`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TemplateEntry.html#method-i-3D-3D-3D)
+  def match(tuple); end
+end
+
+# A tuple is the elementary object in
+# [`Rinda`](https://docs.ruby-lang.org/en/2.6.0/Rinda.html) programming. Tuples
+# may be matched against templates if the tuple and the template are the same
+# size.
+class Rinda::Tuple
+  # Creates a new
+  # [`Tuple`](https://docs.ruby-lang.org/en/2.6.0/Rinda/Tuple.html) from
+  # `ary_or_hash` which must be an
+  # [`Array`](https://docs.ruby-lang.org/en/2.6.0/Array.html) or
+  # [`Hash`](https://docs.ruby-lang.org/en/2.6.0/Hash.html).
+  def self.new(ary_or_hash); end
+
+  # Accessor method for elements of the tuple.
+  def [](k); end
+
+  # Iterate through the tuple, yielding the index or key, and the value, thus
+  # ensuring arrays are iterated similarly to hashes.
+  def each; end
+
+  # Fetches item `k` from the tuple.
+  def fetch(k); end
+
+  # The number of elements in the tuple.
+  def size; end
+
+  # Return the tuple itself
+  def value; end
+end
+
+# [`TupleBag`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TupleBag.html) is an
+# unordered collection of tuples. It is the basis of Tuplespace.
+class Rinda::TupleBag
+  def self.new; end
+
+  # Removes `tuple` from the
+  # [`TupleBag`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TupleBag.html).
+  def delete(tuple); end
+
+  # Delete tuples which dead tuples from the
+  # [`TupleBag`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TupleBag.html),
+  # returning the deleted tuples.
+  def delete_unless_alive; end
+
+  # Finds a live tuple that matches `template`.
+  def find(template); end
+
+  # Finds all live tuples that match `template`.
+  def find_all(template); end
+
+  # Finds all tuples in the
+  # [`TupleBag`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TupleBag.html) which
+  # when treated as templates, match `tuple` and are alive.
+  def find_all_template(tuple); end
+
+  # `true` if the
+  # [`TupleBag`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TupleBag.html) to see
+  # if it has any expired entries.
+  def has_expires?; end
+
+  # Add `tuple` to the
+  # [`TupleBag`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TupleBag.html).
+  def push(tuple); end
+end
+
+class Rinda::TupleBag::TupleBin
+  extend(::Forwardable)
+
+  def self.new; end
+
+  def add(tuple); end
+
+  def delete(tuple); end
+
+  def delete_if(*args, &block); end
+
+  def each(*args, &block); end
+
+  def empty?(*args, &block); end
+
+  def find; end
+
+  def find_all(*args, &block); end
+end
+
+# A [`TupleEntry`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TupleEntry.html) is
+# a Tuple (i.e. a possible entry in some Tuplespace) together with expiry and
+# cancellation data.
+class Rinda::TupleEntry
+  include(::DRb::DRbUndumped)
+
+  # Creates a
+  # [`TupleEntry`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TupleEntry.html)
+  # based on `ary` with an optional renewer or expiry time `sec`.
+  #
+  # A renewer must implement the `renew` method which returns a Numeric, nil, or
+  # true to indicate when the tuple has expired.
+  def self.new(ary, sec = _); end
+
+  # Retrieves `key` from the tuple.
+  def [](key); end
+
+  # A [`TupleEntry`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TupleEntry.html)
+  # is dead when it is canceled or expired.
+  def alive?; end
+
+  # Marks this
+  # [`TupleEntry`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TupleEntry.html) as
+  # canceled.
+  def cancel; end
+
+  # Returns the canceled status.
+  def canceled?; end
+
+  # Has this tuple expired? (true/false).
+  #
+  # A tuple has expired when its expiry timer based on the `sec` argument to
+  # initialize runs out.
+  def expired?; end
+
+  def expires; end
+
+  def expires=(_); end
+
+  # Fetches `key` from the tuple.
+  def fetch(key); end
+
+  # Returns an expiry [`Time`](https://docs.ruby-lang.org/en/2.6.0/Time.html)
+  # based on `sec` which can be one of:
+  # Numeric
+  # :   `sec` seconds into the future
+  # `true`
+  # :   the expiry time is the start of 1970 (i.e. expired)
+  # `nil`
+  # :   it is  Tue Jan 19 03:14:07 GMT Standard
+  #     [`Time`](https://docs.ruby-lang.org/en/2.6.0/Time.html) 2038 (i.e. when
+  #     UNIX clocks will die)
+  def make_expires(sec = _); end
+
+  # Creates a
+  # [`Rinda::Tuple`](https://docs.ruby-lang.org/en/2.6.0/Rinda/Tuple.html) for
+  # `ary`.
+  def make_tuple(ary); end
+
+  # Reset the expiry time according to `sec_or_renewer`.
+  #
+  # `nil`
+  # :   it is set to expire in the far future.
+  # `true`
+  # :   it has expired.
+  # Numeric
+  # :   it will expire in that many seconds.
+  #
+  #
+  # Otherwise the argument refers to some kind of renewer object which will
+  # reset its expiry time.
+  def renew(sec_or_renewer); end
+
+  # The size of the tuple.
+  def size; end
+
+  # Return the object which makes up the tuple itself: the
+  # [`Array`](https://docs.ruby-lang.org/en/2.6.0/Array.html) or
+  # [`Hash`](https://docs.ruby-lang.org/en/2.6.0/Hash.html).
+  def value; end
+end
+
+# The Tuplespace manages access to the tuples it contains, ensuring mutual
+# exclusion requirements are met.
+#
+# The `sec` option for the write, take, move, read and notify methods may either
+# be a number of seconds or a Renewer object.
+class Rinda::TupleSpace
+  include(::MonitorMixin)
+  include(::DRb::DRbUndumped)
+
+  # Creates a new
+  # [`TupleSpace`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TupleSpace.html).
+  # `period` is used to control how often to look for dead tuples after
+  # modifications to the
+  # [`TupleSpace`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TupleSpace.html).
+  #
+  # If no dead tuples are found `period` seconds after the last modification,
+  # the
+  # [`TupleSpace`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TupleSpace.html)
+  # will stop looking for dead tuples.
+  def self.new(period = _); end
+
+  # Moves `tuple` to `port`.
+  def move(port, tuple, sec = _); end
+
+  # Registers for notifications of `event`. Returns a NotifyTemplateEntry. See
+  # NotifyTemplateEntry for examples of how to listen for notifications.
+  #
+  # `event` can be:
+  # 'write'
+  # :   A tuple was added
+  # 'take'
+  # :   A tuple was taken or moved
+  # 'delete'
+  # :   A tuple was lost after being overwritten or expiring
+  #
+  #
+  # The
+  # [`TupleSpace`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TupleSpace.html)
+  # will also notify you of the 'close' event when the NotifyTemplateEntry has
+  # expired.
+  def notify(event, tuple, sec = _); end
+
+  # Reads `tuple`, but does not remove it.
+  def read(tuple, sec = _); end
+
+  # Returns all tuples matching `tuple`. Does not remove the found tuples.
+  def read_all(tuple); end
+
+  # Removes `tuple`
+  def take(tuple, sec = _, &block); end
+
+  # Adds `tuple`
+  def write(tuple, sec = _); end
+end
+
+# [`TupleSpaceProxy`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TupleSpaceProxy.html)
+# allows a remote Tuplespace to appear as local.
+class Rinda::TupleSpaceProxy
+  # Creates a new
+  # [`TupleSpaceProxy`](https://docs.ruby-lang.org/en/2.6.0/Rinda/TupleSpaceProxy.html)
+  # to wrap `ts`.
+  def self.new(ts); end
+
+  # Registers for notifications of event `ev` on the proxied TupleSpace. See
+  # TupleSpace#notify
+  def notify(ev, tuple, sec = _); end
+
+  # Reads `tuple` from the proxied TupleSpace. See TupleSpace#read.
+  def read(tuple, sec = _, &block); end
+
+  # Reads all tuples matching `tuple` from the proxied TupleSpace. See
+  # TupleSpace#read\_all.
+  def read_all(tuple); end
+
+  # Takes `tuple` from the proxied TupleSpace. See TupleSpace#take.
+  def take(tuple, sec = _, &block); end
+
+  # Adds `tuple` to the proxied TupleSpace. See TupleSpace#write.
+  def write(tuple, sec = _); end
+end
+
+class Rinda::TupleSpaceProxy::Port
+  def self.new; end
+
+  def close; end
+
+  def push(value); end
+
+  def value; end
+
+  def self.deliver; end
+end
+
+# *Documentation?*
+class Rinda::WaitTemplateEntry < ::Rinda::TemplateEntry
+  def self.new(place, ary, expires = _); end
+
+  def cancel; end
+
+  def found; end
+
+  def read(tuple); end
+
+  def signal; end
+
+  def wait; end
+end

--- a/rbi/stdlib/shellwords.rbi
+++ b/rbi/stdlib/shellwords.rbi
@@ -1,0 +1,207 @@
+# typed: __STDLIB_INTERNAL
+
+# ## Manipulates strings like the UNIX Bourne shell
+#
+# This module manipulates strings according to the word parsing rules of the
+# UNIX Bourne shell.
+#
+# The shellwords() function was originally a port of shellwords.pl, but modified
+# to conform to the [`Shell`](https://docs.ruby-lang.org/en/2.6.0/Shell.html) &
+# Utilities volume of the IEEE Std 1003.1-2008, 2016 Edition [1].
+#
+# ### Usage
+#
+# You can use
+# [`Shellwords`](https://docs.ruby-lang.org/en/2.6.0/Shellwords.html) to parse a
+# string into a Bourne shell friendly
+# [`Array`](https://docs.ruby-lang.org/en/2.6.0/Array.html).
+#
+# ```ruby
+# require 'shellwords'
+#
+# argv = Shellwords.split('three blind "mice"')
+# argv #=> ["three", "blind", "mice"]
+# ```
+#
+# Once you've required
+# [`Shellwords`](https://docs.ruby-lang.org/en/2.6.0/Shellwords.html), you can
+# use the split alias
+# [`String#shellsplit`](https://docs.ruby-lang.org/en/2.6.0/String.html#method-i-shellsplit).
+#
+# ```ruby
+# argv = "see how they run".shellsplit
+# argv #=> ["see", "how", "they", "run"]
+# ```
+#
+# Be careful you don't leave a quote unmatched.
+#
+# ```ruby
+# argv = "they all ran after the farmer's wife".shellsplit
+#      #=> ArgumentError: Unmatched double quote: ...
+# ```
+#
+# In this case, you might want to use
+# [`Shellwords.escape`](https://docs.ruby-lang.org/en/2.6.0/Shellwords.html#method-c-escape),
+# or its alias
+# [`String#shellescape`](https://docs.ruby-lang.org/en/2.6.0/String.html#method-i-shellescape).
+#
+# This method will escape the
+# [`String`](https://docs.ruby-lang.org/en/2.6.0/String.html) for you to safely
+# use with a Bourne shell.
+#
+# ```ruby
+# argv = Shellwords.escape("special's.txt")
+# argv #=> "special\\'s.txt"
+# system("cat " + argv)
+# ```
+#
+# [`Shellwords`](https://docs.ruby-lang.org/en/2.6.0/Shellwords.html) also comes
+# with a core extension for
+# [`Array`](https://docs.ruby-lang.org/en/2.6.0/Array.html),
+# [`Array#shelljoin`](https://docs.ruby-lang.org/en/2.6.0/Array.html#method-i-shelljoin).
+#
+# ```ruby
+# argv = %w{ls -lta lib}
+# system(argv.shelljoin)
+# ```
+#
+# You can use this method to create an escaped string out of an array of tokens
+# separated by a space. In this example we used the literal shortcut for
+# Array.new.
+#
+# ### Authors
+# *   Wakou Aoyama
+# *   Akinori MUSHA <knu@iDaemons.org>
+#
+#
+# ### Contact
+# *   Akinori MUSHA <knu@iDaemons.org> (current maintainer)
+#
+#
+# ### Resources
+#
+# 1: [IEEE Std 1003.1-2008, 2016 Edition, the Shell & Utilities
+# volume](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/contents.html)
+module Shellwords
+  # Alias for:
+  # [`shellescape`](https://docs.ruby-lang.org/en/2.6.0/Shellwords.html#method-c-shellescape)
+  def self.escape(str); end
+
+  # Alias for:
+  # [`shelljoin`](https://docs.ruby-lang.org/en/2.6.0/Shellwords.html#method-c-shelljoin)
+  def self.join(array); end
+
+  # Escapes a string so that it can be safely used in a Bourne shell command
+  # line. `str` can be a non-string object that responds to `to_s`.
+  #
+  # Note that a resulted string should be used unquoted and is not intended for
+  # use in double quotes nor in single quotes.
+  #
+  # ```ruby
+  # argv = Shellwords.escape("It's better to give than to receive")
+  # argv #=> "It\\'s\\ better\\ to\\ give\\ than\\ to\\ receive"
+  # ```
+  #
+  # [`String#shellescape`](https://docs.ruby-lang.org/en/2.6.0/String.html#method-i-shellescape)
+  # is a shorthand for this function.
+  #
+  # ```ruby
+  # argv = "It's better to give than to receive".shellescape
+  # argv #=> "It\\'s\\ better\\ to\\ give\\ than\\ to\\ receive"
+  #
+  # # Search files in lib for method definitions
+  # pattern = "^[ \t]*def "
+  # open("| grep -Ern #{pattern.shellescape} lib") { |grep|
+  #   grep.each_line { |line|
+  #     file, lineno, matched_line = line.split(':', 3)
+  #     # ...
+  #   }
+  # }
+  # ```
+  #
+  # It is the caller's responsibility to encode the string in the right encoding
+  # for the shell environment where this string is used.
+  #
+  # Multibyte characters are treated as multibyte characters, not as bytes.
+  #
+  # Returns an empty quoted
+  # [`String`](https://docs.ruby-lang.org/en/2.6.0/String.html) if `str` has a
+  # length of zero.
+  #
+  # Also aliased as:
+  # [`escape`](https://docs.ruby-lang.org/en/2.6.0/Shellwords.html#method-c-escape)
+  def self.shellescape(str); end
+
+  # Builds a command line string from an argument list, `array`.
+  #
+  # All elements are joined into a single string with fields separated by a
+  # space, where each element is escaped for the Bourne shell and stringified
+  # using `to_s`.
+  #
+  # ```ruby
+  # ary = ["There's", "a", "time", "and", "place", "for", "everything"]
+  # argv = Shellwords.join(ary)
+  # argv #=> "There\\'s a time and place for everything"
+  # ```
+  #
+  # [`Array#shelljoin`](https://docs.ruby-lang.org/en/2.6.0/Array.html#method-i-shelljoin)
+  # is a shortcut for this function.
+  #
+  # ```ruby
+  # ary = ["Don't", "rock", "the", "boat"]
+  # argv = ary.shelljoin
+  # argv #=> "Don\\'t rock the boat"
+  # ```
+  #
+  # You can also mix non-string objects in the elements as allowed in
+  # Array#join.
+  #
+  # ```ruby
+  # output = `#{['ps', '-p', $$].shelljoin}`
+  # ```
+  #
+  #
+  # Also aliased as:
+  # [`join`](https://docs.ruby-lang.org/en/2.6.0/Shellwords.html#method-c-join)
+  def self.shelljoin(array); end
+
+  # Splits a string into an array of tokens in the same way the UNIX Bourne
+  # shell does.
+  #
+  # ```ruby
+  # argv = Shellwords.split('here are "two words"')
+  # argv #=> ["here", "are", "two words"]
+  # ```
+  #
+  # Note, however, that this is not a command line parser.
+  # [`Shell`](https://docs.ruby-lang.org/en/2.6.0/Shell.html) metacharacters
+  # except for the single and double quotes and backslash are not treated as
+  # such.
+  #
+  # ```ruby
+  # argv = Shellwords.split('ruby my_prog.rb | less')
+  # argv #=> ["ruby", "my_prog.rb", "|", "less"]
+  # ```
+  #
+  # [`String#shellsplit`](https://docs.ruby-lang.org/en/2.6.0/String.html#method-i-shellsplit)
+  # is a shortcut for this function.
+  #
+  # ```ruby
+  # argv = 'here are "two words"'.shellsplit
+  # argv #=> ["here", "are", "two words"]
+  # ```
+  #
+  #
+  # Also aliased as:
+  # [`shellwords`](https://docs.ruby-lang.org/en/2.6.0/Shellwords.html#method-c-shellwords),
+  # [`split`](https://docs.ruby-lang.org/en/2.6.0/Shellwords.html#method-c-split)
+  def self.shellsplit(line); end
+
+  # Alias for:
+  # [`shellsplit`](https://docs.ruby-lang.org/en/2.6.0/Shellwords.html#method-i-shellsplit)
+  def self.shellwords(line); end
+
+  # Alias for:
+  # [`shellsplit`](https://docs.ruby-lang.org/en/2.6.0/Shellwords.html#method-c-shellsplit)
+  def self.split(line); end
+end

--- a/rbi/stdlib/thwait.rbi
+++ b/rbi/stdlib/thwait.rbi
@@ -1,0 +1,82 @@
+# typed: __STDLIB_INTERNAL
+
+# This class watches for termination of multiple threads. Basic functionality
+# (wait until specified threads have terminated) can be accessed through the
+# class method
+# [`ThreadsWait::all_waits`](https://docs.ruby-lang.org/en/2.6.0/ThreadsWait.html#method-c-all_waits).
+# Finer control can be gained using instance methods.
+#
+# Example:
+#
+# ```
+# ThreadsWait.all_waits(thr1, thr2, ...) do |t|
+#   STDERR.puts "Thread #{t} has terminated."
+# end
+#
+# th = ThreadsWait.new(thread1,...)
+# th.next_wait # next one to be done
+# ```
+ThWait = ThreadsWait
+
+# This class watches for termination of multiple threads. Basic functionality
+# (wait until specified threads have terminated) can be accessed through the
+# class method
+# [`ThreadsWait::all_waits`](https://docs.ruby-lang.org/en/2.6.0/ThreadsWait.html#method-c-all_waits).
+# Finer control can be gained using instance methods.
+#
+# Example:
+#
+# ```
+# ThreadsWait.all_waits(thr1, thr2, ...) do |t|
+#   STDERR.puts "Thread #{t} has terminated."
+# end
+#
+# th = ThreadsWait.new(thread1,...)
+# th.next_wait # next one to be done
+# ```
+class ThreadsWait
+  extend(::Exception2MessageMapper)
+
+  # Creates a
+  # [`ThreadsWait`](https://docs.ruby-lang.org/en/2.6.0/ThreadsWait.html)
+  # object, specifying the threads to wait on. Non-blocking.
+  def self.new(*threads); end
+
+  def Fail(err = _, *rest); end
+
+  def Raise(err = _, *rest); end
+
+  # Waits until all of the specified threads are terminated. If a block is
+  # supplied for the method, it is executed for each thread termination.
+  #
+  # Raises exceptions in the same manner as `next_wait`.
+  def all_waits; end
+
+  # Returns `true` if there are no threads in the pool still running.
+  def empty?; end
+
+  # Returns `true` if any thread has terminated and is ready to be collected.
+  def finished?; end
+
+  # Waits for specified threads to terminate, and returns when one of the
+  # threads terminated.
+  def join(*threads); end
+
+  # Specifies the threads that this object will wait for, but does not actually
+  # wait.
+  def join_nowait(*threads); end
+
+  # Waits until any of the specified threads has terminated, and returns the one
+  # that does.
+  #
+  # If there is no thread to wait, raises `ErrNoWaitingThread`. If `nonblock` is
+  # true, and there is no terminated thread, raises `ErrNoFinishedThread`.
+  def next_wait(nonblock = _); end
+
+  # Returns the array of threads that have not terminated yet.
+  def threads; end
+
+  # Waits until all specified threads have terminated. If a block is provided,
+  # it is executed for each thread as they terminate.
+  def self.all_waits(*threads); end
+end

--- a/rbi/stdlib/weakref.rbi
+++ b/rbi/stdlib/weakref.rbi
@@ -1,0 +1,35 @@
+# typed: __STDLIB_INTERNAL
+
+# Weak Reference class that allows a referenced object to be garbage-collected.
+#
+# A [`WeakRef`](https://docs.ruby-lang.org/en/2.6.0/WeakRef.html) may be used
+# exactly like the object it references.
+#
+# Usage:
+#
+# ```ruby
+# foo = Object.new            # create a new object instance
+# p foo.to_s                  # original's class
+# foo = WeakRef.new(foo)      # reassign foo with WeakRef instance
+# p foo.to_s                  # should be same class
+# GC.start                    # start the garbage collector
+# p foo.to_s                  # should raise exception (recycled)
+# ```
+class WeakRef < Delegator
+  # Creates a weak reference to `orig`
+  #
+  # Raises an ArgumentError if the given `orig` is immutable, such as
+  # [`Symbol`](https://docs.ruby-lang.org/en/2.6.0/Symbol.html),
+  # [`Integer`](https://docs.ruby-lang.org/en/2.6.0/Integer.html), or
+  # [`Float`](https://docs.ruby-lang.org/en/2.6.0/Float.html).
+  def self.new(orig); end
+
+  # Returns true if the referenced object is still alive.
+  def weakref_alive?; end
+end
+
+class WeakRef::ObjectSpace; end
+
+# [`RefError`](https://docs.ruby-lang.org/en/2.6.0/WeakRef/RefError.html) is
+# raised when a referenced object has been recycled by the garbage collector
+class WeakRef::RefError < ::StandardError; end


### PR DESCRIPTION
We have a few more definitions for stdlib that do not have signatures but I think it still can be useful as:
* The constants and methods are defined which allow more code to be `typed: true`
* The documentation can popup in the editor

Here's the list of modules included in this PR:
* `dbm`
* `fiddle`
* `gdbm`
* `getoptlong`
* `nfk`
* `obersable`
* `readline`
* `openuri`
* `prime`
* `pstore`
* `rinda`
* `shellwords`
* `thwait`
* `weakref`