### PR TITLE
Don't jump over blocks if their rubyBlockId doesn't match

### DIFF
--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -48,7 +48,8 @@ void CFGBuilder::simplify(core::Context ctx, CFG &cfg) {
                 // Remove condition from unconditional jumps
                 bb->bexit.cond = core::LocalVariable::unconditional();
             }
-            if (thenb == elseb && thenb != cfg.deadBlock() && thenb != bb) { // can be squashed togather
+            if (thenb == elseb && thenb != cfg.deadBlock() && thenb != bb &&
+                bb->rubyBlockId == thenb->rubyBlockId) { // can be squashed togather
                 if (thenb->backEdges.size() == 1 && thenb->outerLoops == bb->outerLoops) {
                     bb->exprs.insert(bb->exprs.end(), make_move_iterator(thenb->exprs.begin()),
                                      make_move_iterator(thenb->exprs.end()));
@@ -79,8 +80,8 @@ void CFGBuilder::simplify(core::Context ctx, CFG &cfg) {
                     continue;
                 }
             }
-            if (thenb != cfg.deadBlock() && thenb->exprs.empty() && thenb->bexit.thenb == thenb->bexit.elseb &&
-                bb->bexit.thenb != thenb->bexit.thenb) {
+            if (thenb != cfg.deadBlock() && bb->rubyBlockId == thenb->rubyBlockId && thenb->exprs.empty() &&
+                thenb->bexit.thenb == thenb->bexit.elseb && bb->bexit.thenb != thenb->bexit.thenb) {
                 // shortcut then
                 bb->bexit.thenb = thenb->bexit.thenb;
                 thenb->bexit.thenb->backEdges.emplace_back(bb);
@@ -90,8 +91,8 @@ void CFGBuilder::simplify(core::Context ctx, CFG &cfg) {
                 sanityCheck(ctx, cfg);
                 continue;
             }
-            if (elseb != cfg.deadBlock() && elseb->exprs.empty() && elseb->bexit.thenb == elseb->bexit.elseb &&
-                bb->bexit.elseb != elseb->bexit.elseb) {
+            if (elseb != cfg.deadBlock() && bb->rubyBlockId == thenb->rubyBlockId && elseb->exprs.empty() &&
+                elseb->bexit.thenb == elseb->bexit.elseb && bb->bexit.elseb != elseb->bexit.elseb) {
                 // shortcut else
                 sanityCheck(ctx, cfg);
                 bb->bexit.elseb = elseb->bexit.elseb;

--- a/test/testdata/cfg/dealias_with_return.rb.cfg.exp
+++ b/test/testdata/cfg/dealias_with_return.rb.cfg.exp
@@ -29,20 +29,23 @@ subgraph "cluster_::Object#a" {
     ];
 
     "bb::Object#a_4" -> "bb::Object#a_1" [style="bold"];
+    "bb::Object#a_6" [
+        label = "block[id=6, rubyBlockId=3](<gotoDeadTemp>$10: T.nilable(TrueClass), a: T.nilable(Integer))\l<gotoDeadTemp>$10: T.nilable(TrueClass)\l"
+    ];
+
+    "bb::Object#a_6" -> "bb::Object#a_1" [style="bold"];
+    "bb::Object#a_6" -> "bb::Object#a_9" [style="tapered"];
+
     "bb::Object#a_7" [
-        label = "block[id=7, rubyBlockId=2](<magic>$6: T.class_of(<Magic>))\l<exceptionValue>$4: NilClass = nil\l<keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)\la: Integer(2) = 2\l<gotoDeadTemp>$10: NilClass\l"
+        label = "block[id=7, rubyBlockId=2](<magic>$6: T.class_of(<Magic>))\l<exceptionValue>$4: NilClass = nil\l<keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)\la: Integer(2) = 2\l<unconditional>\l"
     ];
 
-    "bb::Object#a_7" -> "bb::Object#a_1" [style="bold"];
-    "bb::Object#a_7" -> "bb::Object#a_9" [style="tapered"];
-
+    "bb::Object#a_7" -> "bb::Object#a_6" [style="bold"];
     "bb::Object#a_8" [
-        label = "block[id=8, rubyBlockId=2]()\l<gotoDeadTemp>$10: TrueClass(true) = true\l<gotoDeadTemp>$10: TrueClass(true)\l"
+        label = "block[id=8, rubyBlockId=2]()\l<gotoDeadTemp>$10: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::Object#a_8" -> "bb::Object#a_1" [style="bold"];
-    "bb::Object#a_8" -> "bb::Object#a_9" [style="tapered"];
-
+    "bb::Object#a_8" -> "bb::Object#a_6" [style="bold"];
     "bb::Object#a_9" [
         label = "block[id=9, rubyBlockId=0](a: Integer(2))\l<statTemp>$13: Integer(3) = 3\l<returnMethodTemp>$2: Integer = a: Integer(2).+(<statTemp>$13: Integer(3))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/rescue_complex.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_complex.rb.cfg.exp
@@ -155,22 +155,25 @@ subgraph "cluster_::TestRescue#multiple_rescue" {
     ];
 
     "bb::TestRescue#multiple_rescue_4" -> "bb::TestRescue#multiple_rescue_3" [style="bold"];
-    "bb::TestRescue#multiple_rescue_4" -> "bb::TestRescue#multiple_rescue_6" [style="tapered"];
+    "bb::TestRescue#multiple_rescue_4" -> "bb::TestRescue#multiple_rescue_5" [style="tapered"];
 
+    "bb::TestRescue#multiple_rescue_5" [
+        label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: T.untyped)\l<unconditional>\l"
+    ];
+
+    "bb::TestRescue#multiple_rescue_5" -> "bb::TestRescue#multiple_rescue_6" [style="bold"];
     "bb::TestRescue#multiple_rescue_6" [
-        label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$14: NilClass)\l<gotoDeadTemp>$14: NilClass\l"
+        label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$14: T.nilable(TrueClass))\l<gotoDeadTemp>$14: T.nilable(TrueClass)\l"
     ];
 
     "bb::TestRescue#multiple_rescue_6" -> "bb::TestRescue#multiple_rescue_1" [style="bold"];
     "bb::TestRescue#multiple_rescue_6" -> "bb::TestRescue#multiple_rescue_11" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_7" [
-        label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()\l<gotoDeadTemp>$14: NilClass\l"
+        label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#multiple_rescue_7" -> "bb::TestRescue#multiple_rescue_1" [style="bold"];
-    "bb::TestRescue#multiple_rescue_7" -> "bb::TestRescue#multiple_rescue_11" [style="tapered"];
-
+    "bb::TestRescue#multiple_rescue_7" -> "bb::TestRescue#multiple_rescue_6" [style="bold"];
     "bb::TestRescue#multiple_rescue_8" [
         label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <self>: TestRescue, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>))\l<exceptionClassTemp>$11: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$12: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<exceptionClassTemp>$11: T.class_of(StandardError))\l<isaCheckTemp>$12: T.untyped\l"
     ];
@@ -179,19 +182,15 @@ subgraph "cluster_::TestRescue#multiple_rescue" {
     "bb::TestRescue#multiple_rescue_8" -> "bb::TestRescue#multiple_rescue_10" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_9" [
-        label = "block[id=9, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$10: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$14: NilClass\l"
+        label = "block[id=9, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$10: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#multiple_rescue_9" -> "bb::TestRescue#multiple_rescue_1" [style="bold"];
-    "bb::TestRescue#multiple_rescue_9" -> "bb::TestRescue#multiple_rescue_11" [style="tapered"];
-
+    "bb::TestRescue#multiple_rescue_9" -> "bb::TestRescue#multiple_rescue_6" [style="bold"];
     "bb::TestRescue#multiple_rescue_10" [
-        label = "block[id=10, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$14: TrueClass(true) = true\l<gotoDeadTemp>$14: TrueClass(true)\l"
+        label = "block[id=10, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$14: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#multiple_rescue_10" -> "bb::TestRescue#multiple_rescue_1" [style="bold"];
-    "bb::TestRescue#multiple_rescue_10" -> "bb::TestRescue#multiple_rescue_11" [style="tapered"];
-
+    "bb::TestRescue#multiple_rescue_10" -> "bb::TestRescue#multiple_rescue_6" [style="bold"];
     "bb::TestRescue#multiple_rescue_11" [
         label = "block[id=11, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -229,22 +228,25 @@ subgraph "cluster_::TestRescue#multiple_rescue_classes" {
     ];
 
     "bb::TestRescue#multiple_rescue_classes_4" -> "bb::TestRescue#multiple_rescue_classes_3" [style="bold"];
-    "bb::TestRescue#multiple_rescue_classes_4" -> "bb::TestRescue#multiple_rescue_classes_6" [style="tapered"];
+    "bb::TestRescue#multiple_rescue_classes_4" -> "bb::TestRescue#multiple_rescue_classes_5" [style="tapered"];
 
+    "bb::TestRescue#multiple_rescue_classes_5" [
+        label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: T.untyped)\l<unconditional>\l"
+    ];
+
+    "bb::TestRescue#multiple_rescue_classes_5" -> "bb::TestRescue#multiple_rescue_classes_6" [style="bold"];
     "bb::TestRescue#multiple_rescue_classes_6" [
-        label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: NilClass)\l<gotoDeadTemp>$11: NilClass\l"
+        label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass))\l<gotoDeadTemp>$11: T.nilable(TrueClass)\l"
     ];
 
     "bb::TestRescue#multiple_rescue_classes_6" -> "bb::TestRescue#multiple_rescue_classes_1" [style="bold"];
     "bb::TestRescue#multiple_rescue_classes_6" -> "bb::TestRescue#multiple_rescue_classes_10" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_classes_7" [
-        label = "block[id=7, rubyBlockId=2](<magic>$5: T.class_of(<Magic>), baz: T.untyped)\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = baz\l<gotoDeadTemp>$11: NilClass\l"
+        label = "block[id=7, rubyBlockId=2](<magic>$5: T.class_of(<Magic>), baz: T.untyped)\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = baz\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#multiple_rescue_classes_7" -> "bb::TestRescue#multiple_rescue_classes_1" [style="bold"];
-    "bb::TestRescue#multiple_rescue_classes_7" -> "bb::TestRescue#multiple_rescue_classes_10" [style="tapered"];
-
+    "bb::TestRescue#multiple_rescue_classes_7" -> "bb::TestRescue#multiple_rescue_classes_6" [style="bold"];
     "bb::TestRescue#multiple_rescue_classes_8" [
         label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <magic>$5: T.class_of(<Magic>), baz: T.untyped)\l<exceptionClassTemp>$9: T.untyped = alias <C T.untyped>\l<isaCheckTemp>$10: T.untyped = baz: T.untyped.is_a?(<exceptionClassTemp>$9: T.untyped)\l<isaCheckTemp>$10: T.untyped\l"
     ];
@@ -253,12 +255,10 @@ subgraph "cluster_::TestRescue#multiple_rescue_classes" {
     "bb::TestRescue#multiple_rescue_classes_8" -> "bb::TestRescue#multiple_rescue_classes_9" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_classes_9" [
-        label = "block[id=9, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<gotoDeadTemp>$11: TrueClass(true)\l"
+        label = "block[id=9, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#multiple_rescue_classes_9" -> "bb::TestRescue#multiple_rescue_classes_1" [style="bold"];
-    "bb::TestRescue#multiple_rescue_classes_9" -> "bb::TestRescue#multiple_rescue_classes_10" [style="tapered"];
-
+    "bb::TestRescue#multiple_rescue_classes_9" -> "bb::TestRescue#multiple_rescue_classes_6" [style="bold"];
     "bb::TestRescue#multiple_rescue_classes_10" [
         label = "block[id=10, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -296,8 +296,13 @@ subgraph "cluster_::TestRescue#parse_rescue_ensure" {
     ];
 
     "bb::TestRescue#parse_rescue_ensure_4" -> "bb::TestRescue#parse_rescue_ensure_3" [style="bold"];
-    "bb::TestRescue#parse_rescue_ensure_4" -> "bb::TestRescue#parse_rescue_ensure_6" [style="tapered"];
+    "bb::TestRescue#parse_rescue_ensure_4" -> "bb::TestRescue#parse_rescue_ensure_5" [style="tapered"];
 
+    "bb::TestRescue#parse_rescue_ensure_5" [
+        label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: T.untyped, <self>: TestRescue)\l<unconditional>\l"
+    ];
+
+    "bb::TestRescue#parse_rescue_ensure_5" -> "bb::TestRescue#parse_rescue_ensure_6" [style="bold"];
     "bb::TestRescue#parse_rescue_ensure_6" [
         label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <self>: TestRescue, <gotoDeadTemp>$10: T.nilable(TrueClass))\l<throwAwayTemp>$11: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$10: T.nilable(TrueClass)\l"
     ];
@@ -352,29 +357,30 @@ subgraph "cluster_::TestRescue#parse_bug_rescue_empty_else" {
     ];
 
     "bb::TestRescue#parse_bug_rescue_empty_else_4" -> "bb::TestRescue#parse_bug_rescue_empty_else_3" [style="bold"];
-    "bb::TestRescue#parse_bug_rescue_empty_else_4" -> "bb::TestRescue#parse_bug_rescue_empty_else_6" [style="tapered"];
+    "bb::TestRescue#parse_bug_rescue_empty_else_4" -> "bb::TestRescue#parse_bug_rescue_empty_else_5" [style="tapered"];
 
+    "bb::TestRescue#parse_bug_rescue_empty_else_5" [
+        label = "block[id=5, rubyBlockId=4]()\l<unconditional>\l"
+    ];
+
+    "bb::TestRescue#parse_bug_rescue_empty_else_5" -> "bb::TestRescue#parse_bug_rescue_empty_else_6" [style="bold"];
     "bb::TestRescue#parse_bug_rescue_empty_else_6" [
-        label = "block[id=6, rubyBlockId=3](<gotoDeadTemp>$8: NilClass)\l<gotoDeadTemp>$8: NilClass\l"
+        label = "block[id=6, rubyBlockId=3](<gotoDeadTemp>$8: T.nilable(TrueClass))\l<gotoDeadTemp>$8: T.nilable(TrueClass)\l"
     ];
 
     "bb::TestRescue#parse_bug_rescue_empty_else_6" -> "bb::TestRescue#parse_bug_rescue_empty_else_1" [style="bold"];
     "bb::TestRescue#parse_bug_rescue_empty_else_6" -> "bb::TestRescue#parse_bug_rescue_empty_else_9" [style="tapered"];
 
     "bb::TestRescue#parse_bug_rescue_empty_else_7" [
-        label = "block[id=7, rubyBlockId=2](<magic>$4: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$5: Sorbet::Private::Static::Void = <magic>$4: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<gotoDeadTemp>$8: NilClass\l"
+        label = "block[id=7, rubyBlockId=2](<magic>$4: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$5: Sorbet::Private::Static::Void = <magic>$4: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_bug_rescue_empty_else_7" -> "bb::TestRescue#parse_bug_rescue_empty_else_1" [style="bold"];
-    "bb::TestRescue#parse_bug_rescue_empty_else_7" -> "bb::TestRescue#parse_bug_rescue_empty_else_9" [style="tapered"];
-
+    "bb::TestRescue#parse_bug_rescue_empty_else_7" -> "bb::TestRescue#parse_bug_rescue_empty_else_6" [style="bold"];
     "bb::TestRescue#parse_bug_rescue_empty_else_8" [
-        label = "block[id=8, rubyBlockId=2]()\l<gotoDeadTemp>$8: TrueClass(true) = true\l<gotoDeadTemp>$8: TrueClass(true)\l"
+        label = "block[id=8, rubyBlockId=2]()\l<gotoDeadTemp>$8: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_bug_rescue_empty_else_8" -> "bb::TestRescue#parse_bug_rescue_empty_else_1" [style="bold"];
-    "bb::TestRescue#parse_bug_rescue_empty_else_8" -> "bb::TestRescue#parse_bug_rescue_empty_else_9" [style="tapered"];
-
+    "bb::TestRescue#parse_bug_rescue_empty_else_8" -> "bb::TestRescue#parse_bug_rescue_empty_else_6" [style="bold"];
     "bb::TestRescue#parse_bug_rescue_empty_else_9" [
         label = "block[id=9, rubyBlockId=0]()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
@@ -412,29 +418,30 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12686" {
     ];
 
     "bb::TestRescue#parse_ruby_bug_12686_4" -> "bb::TestRescue#parse_ruby_bug_12686_3" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12686_4" -> "bb::TestRescue#parse_ruby_bug_12686_6" [style="tapered"];
+    "bb::TestRescue#parse_ruby_bug_12686_4" -> "bb::TestRescue#parse_ruby_bug_12686_5" [style="tapered"];
 
+    "bb::TestRescue#parse_ruby_bug_12686_5" [
+        label = "block[id=5, rubyBlockId=4](<statTemp>$4: T.untyped, <self>: TestRescue)\l<unconditional>\l"
+    ];
+
+    "bb::TestRescue#parse_ruby_bug_12686_5" -> "bb::TestRescue#parse_ruby_bug_12686_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12686_6" [
-        label = "block[id=6, rubyBlockId=3](<statTemp>$4: T.untyped, <self>: TestRescue, <gotoDeadTemp>$11: NilClass)\l<gotoDeadTemp>$11: NilClass\l"
+        label = "block[id=6, rubyBlockId=3](<statTemp>$4: T.untyped, <self>: TestRescue, <gotoDeadTemp>$11: T.nilable(TrueClass))\l<gotoDeadTemp>$11: T.nilable(TrueClass)\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12686_6" -> "bb::TestRescue#parse_ruby_bug_12686_1" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12686_6" -> "bb::TestRescue#parse_ruby_bug_12686_9" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12686_7" [
-        label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$7: T.class_of(<Magic>))\l<exceptionValue>$5: NilClass = nil\l<keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)\l<statTemp>$4: NilClass = nil\l<gotoDeadTemp>$11: NilClass\l"
+        label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$7: T.class_of(<Magic>))\l<exceptionValue>$5: NilClass = nil\l<keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)\l<statTemp>$4: NilClass = nil\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_ruby_bug_12686_7" -> "bb::TestRescue#parse_ruby_bug_12686_1" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12686_7" -> "bb::TestRescue#parse_ruby_bug_12686_9" [style="tapered"];
-
+    "bb::TestRescue#parse_ruby_bug_12686_7" -> "bb::TestRescue#parse_ruby_bug_12686_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12686_8" [
-        label = "block[id=8, rubyBlockId=2](<statTemp>$4: T.untyped, <self>: TestRescue)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<gotoDeadTemp>$11: TrueClass(true)\l"
+        label = "block[id=8, rubyBlockId=2](<statTemp>$4: T.untyped, <self>: TestRescue)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_ruby_bug_12686_8" -> "bb::TestRescue#parse_ruby_bug_12686_1" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12686_8" -> "bb::TestRescue#parse_ruby_bug_12686_9" [style="tapered"];
-
+    "bb::TestRescue#parse_ruby_bug_12686_8" -> "bb::TestRescue#parse_ruby_bug_12686_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12686_9" [
         label = "block[id=9, rubyBlockId=0](<statTemp>$4: T.untyped, <self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.take_arg(<statTemp>$4: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -472,29 +479,30 @@ subgraph "cluster_::TestRescue#parse_rescue_mod" {
     ];
 
     "bb::TestRescue#parse_rescue_mod_4" -> "bb::TestRescue#parse_rescue_mod_3" [style="bold"];
-    "bb::TestRescue#parse_rescue_mod_4" -> "bb::TestRescue#parse_rescue_mod_6" [style="tapered"];
+    "bb::TestRescue#parse_rescue_mod_4" -> "bb::TestRescue#parse_rescue_mod_5" [style="tapered"];
 
+    "bb::TestRescue#parse_rescue_mod_5" [
+        label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: T.untyped)\l<unconditional>\l"
+    ];
+
+    "bb::TestRescue#parse_rescue_mod_5" -> "bb::TestRescue#parse_rescue_mod_6" [style="bold"];
     "bb::TestRescue#parse_rescue_mod_6" [
-        label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$10: NilClass)\l<gotoDeadTemp>$10: NilClass\l"
+        label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$10: T.nilable(TrueClass))\l<gotoDeadTemp>$10: T.nilable(TrueClass)\l"
     ];
 
     "bb::TestRescue#parse_rescue_mod_6" -> "bb::TestRescue#parse_rescue_mod_1" [style="bold"];
     "bb::TestRescue#parse_rescue_mod_6" -> "bb::TestRescue#parse_rescue_mod_9" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_mod_7" [
-        label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$10: NilClass\l"
+        label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_rescue_mod_7" -> "bb::TestRescue#parse_rescue_mod_1" [style="bold"];
-    "bb::TestRescue#parse_rescue_mod_7" -> "bb::TestRescue#parse_rescue_mod_9" [style="tapered"];
-
+    "bb::TestRescue#parse_rescue_mod_7" -> "bb::TestRescue#parse_rescue_mod_6" [style="bold"];
     "bb::TestRescue#parse_rescue_mod_8" [
-        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$10: TrueClass(true) = true\l<gotoDeadTemp>$10: TrueClass(true)\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$10: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_rescue_mod_8" -> "bb::TestRescue#parse_rescue_mod_1" [style="bold"];
-    "bb::TestRescue#parse_rescue_mod_8" -> "bb::TestRescue#parse_rescue_mod_9" [style="tapered"];
-
+    "bb::TestRescue#parse_rescue_mod_8" -> "bb::TestRescue#parse_rescue_mod_6" [style="bold"];
     "bb::TestRescue#parse_rescue_mod_9" [
         label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -532,29 +540,30 @@ subgraph "cluster_::TestRescue#parse_resbody_list_var" {
     ];
 
     "bb::TestRescue#parse_resbody_list_var_4" -> "bb::TestRescue#parse_resbody_list_var_3" [style="bold"];
-    "bb::TestRescue#parse_resbody_list_var_4" -> "bb::TestRescue#parse_resbody_list_var_6" [style="tapered"];
+    "bb::TestRescue#parse_resbody_list_var_4" -> "bb::TestRescue#parse_resbody_list_var_5" [style="tapered"];
 
+    "bb::TestRescue#parse_resbody_list_var_5" [
+        label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: T.untyped)\l<unconditional>\l"
+    ];
+
+    "bb::TestRescue#parse_resbody_list_var_5" -> "bb::TestRescue#parse_resbody_list_var_6" [style="bold"];
     "bb::TestRescue#parse_resbody_list_var_6" [
-        label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: NilClass)\l<gotoDeadTemp>$11: NilClass\l"
+        label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass))\l<gotoDeadTemp>$11: T.nilable(TrueClass)\l"
     ];
 
     "bb::TestRescue#parse_resbody_list_var_6" -> "bb::TestRescue#parse_resbody_list_var_1" [style="bold"];
     "bb::TestRescue#parse_resbody_list_var_6" -> "bb::TestRescue#parse_resbody_list_var_9" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_list_var_7" [
-        label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$11: NilClass\l"
+        label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_resbody_list_var_7" -> "bb::TestRescue#parse_resbody_list_var_1" [style="bold"];
-    "bb::TestRescue#parse_resbody_list_var_7" -> "bb::TestRescue#parse_resbody_list_var_9" [style="tapered"];
-
+    "bb::TestRescue#parse_resbody_list_var_7" -> "bb::TestRescue#parse_resbody_list_var_6" [style="bold"];
     "bb::TestRescue#parse_resbody_list_var_8" [
-        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<gotoDeadTemp>$11: TrueClass(true)\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_resbody_list_var_8" -> "bb::TestRescue#parse_resbody_list_var_1" [style="bold"];
-    "bb::TestRescue#parse_resbody_list_var_8" -> "bb::TestRescue#parse_resbody_list_var_9" [style="tapered"];
-
+    "bb::TestRescue#parse_resbody_list_var_8" -> "bb::TestRescue#parse_resbody_list_var_6" [style="bold"];
     "bb::TestRescue#parse_resbody_list_var_9" [
         label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -653,29 +662,30 @@ subgraph "cluster_::TestRescue#parse_rescue" {
     ];
 
     "bb::TestRescue#parse_rescue_4" -> "bb::TestRescue#parse_rescue_3" [style="bold"];
-    "bb::TestRescue#parse_rescue_4" -> "bb::TestRescue#parse_rescue_6" [style="tapered"];
+    "bb::TestRescue#parse_rescue_4" -> "bb::TestRescue#parse_rescue_5" [style="tapered"];
 
+    "bb::TestRescue#parse_rescue_5" [
+        label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: T.untyped)\l<unconditional>\l"
+    ];
+
+    "bb::TestRescue#parse_rescue_5" -> "bb::TestRescue#parse_rescue_6" [style="bold"];
     "bb::TestRescue#parse_rescue_6" [
-        label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$10: NilClass)\l<gotoDeadTemp>$10: NilClass\l"
+        label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$10: T.nilable(TrueClass))\l<gotoDeadTemp>$10: T.nilable(TrueClass)\l"
     ];
 
     "bb::TestRescue#parse_rescue_6" -> "bb::TestRescue#parse_rescue_1" [style="bold"];
     "bb::TestRescue#parse_rescue_6" -> "bb::TestRescue#parse_rescue_9" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_7" [
-        label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.foo()\l<gotoDeadTemp>$10: NilClass\l"
+        label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.foo()\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_rescue_7" -> "bb::TestRescue#parse_rescue_1" [style="bold"];
-    "bb::TestRescue#parse_rescue_7" -> "bb::TestRescue#parse_rescue_9" [style="tapered"];
-
+    "bb::TestRescue#parse_rescue_7" -> "bb::TestRescue#parse_rescue_6" [style="bold"];
     "bb::TestRescue#parse_rescue_8" [
-        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$10: TrueClass(true) = true\l<gotoDeadTemp>$10: TrueClass(true)\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$10: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_rescue_8" -> "bb::TestRescue#parse_rescue_1" [style="bold"];
-    "bb::TestRescue#parse_rescue_8" -> "bb::TestRescue#parse_rescue_9" [style="tapered"];
-
+    "bb::TestRescue#parse_rescue_8" -> "bb::TestRescue#parse_rescue_6" [style="bold"];
     "bb::TestRescue#parse_rescue_9" [
         label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -713,29 +723,30 @@ subgraph "cluster_::TestRescue#parse_resbody_var" {
     ];
 
     "bb::TestRescue#parse_resbody_var_4" -> "bb::TestRescue#parse_resbody_var_3" [style="bold"];
-    "bb::TestRescue#parse_resbody_var_4" -> "bb::TestRescue#parse_resbody_var_6" [style="tapered"];
+    "bb::TestRescue#parse_resbody_var_4" -> "bb::TestRescue#parse_resbody_var_5" [style="tapered"];
 
+    "bb::TestRescue#parse_resbody_var_5" [
+        label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: T.untyped)\l<unconditional>\l"
+    ];
+
+    "bb::TestRescue#parse_resbody_var_5" -> "bb::TestRescue#parse_resbody_var_6" [style="bold"];
     "bb::TestRescue#parse_resbody_var_6" [
-        label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$10: NilClass)\l<gotoDeadTemp>$10: NilClass\l"
+        label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$10: T.nilable(TrueClass))\l<gotoDeadTemp>$10: T.nilable(TrueClass)\l"
     ];
 
     "bb::TestRescue#parse_resbody_var_6" -> "bb::TestRescue#parse_resbody_var_1" [style="bold"];
     "bb::TestRescue#parse_resbody_var_6" -> "bb::TestRescue#parse_resbody_var_9" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_var_7" [
-        label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$10: NilClass\l"
+        label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_resbody_var_7" -> "bb::TestRescue#parse_resbody_var_1" [style="bold"];
-    "bb::TestRescue#parse_resbody_var_7" -> "bb::TestRescue#parse_resbody_var_9" [style="tapered"];
-
+    "bb::TestRescue#parse_resbody_var_7" -> "bb::TestRescue#parse_resbody_var_6" [style="bold"];
     "bb::TestRescue#parse_resbody_var_8" [
-        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$10: TrueClass(true) = true\l<gotoDeadTemp>$10: TrueClass(true)\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$10: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_resbody_var_8" -> "bb::TestRescue#parse_resbody_var_1" [style="bold"];
-    "bb::TestRescue#parse_resbody_var_8" -> "bb::TestRescue#parse_resbody_var_9" [style="tapered"];
-
+    "bb::TestRescue#parse_resbody_var_8" -> "bb::TestRescue#parse_resbody_var_6" [style="bold"];
     "bb::TestRescue#parse_resbody_var_9" [
         label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -773,29 +784,30 @@ subgraph "cluster_::TestRescue#parse_resbody_var_1" {
     ];
 
     "bb::TestRescue#parse_resbody_var_1_4" -> "bb::TestRescue#parse_resbody_var_1_3" [style="bold"];
-    "bb::TestRescue#parse_resbody_var_1_4" -> "bb::TestRescue#parse_resbody_var_1_6" [style="tapered"];
+    "bb::TestRescue#parse_resbody_var_1_4" -> "bb::TestRescue#parse_resbody_var_1_5" [style="tapered"];
 
+    "bb::TestRescue#parse_resbody_var_1_5" [
+        label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: T.untyped)\l<unconditional>\l"
+    ];
+
+    "bb::TestRescue#parse_resbody_var_1_5" -> "bb::TestRescue#parse_resbody_var_1_6" [style="bold"];
     "bb::TestRescue#parse_resbody_var_1_6" [
-        label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: NilClass)\l<gotoDeadTemp>$12: NilClass\l"
+        label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass))\l<gotoDeadTemp>$12: T.nilable(TrueClass)\l"
     ];
 
     "bb::TestRescue#parse_resbody_var_1_6" -> "bb::TestRescue#parse_resbody_var_1_1" [style="bold"];
     "bb::TestRescue#parse_resbody_var_1_6" -> "bb::TestRescue#parse_resbody_var_1_9" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_var_1_7" [
-        label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), @ex$10: T.nilable(StandardError), <rescueTemp>$2: T.untyped)\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l@ex$10: T.untyped = <rescueTemp>$2\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$12: NilClass\l"
+        label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), @ex$10: T.nilable(StandardError), <rescueTemp>$2: T.untyped)\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l@ex$10: T.untyped = <rescueTemp>$2\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_resbody_var_1_7" -> "bb::TestRescue#parse_resbody_var_1_1" [style="bold"];
-    "bb::TestRescue#parse_resbody_var_1_7" -> "bb::TestRescue#parse_resbody_var_1_9" [style="tapered"];
-
+    "bb::TestRescue#parse_resbody_var_1_7" -> "bb::TestRescue#parse_resbody_var_1_6" [style="bold"];
     "bb::TestRescue#parse_resbody_var_1_8" [
-        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$12: TrueClass(true) = true\l<gotoDeadTemp>$12: TrueClass(true)\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$12: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_resbody_var_1_8" -> "bb::TestRescue#parse_resbody_var_1_1" [style="bold"];
-    "bb::TestRescue#parse_resbody_var_1_8" -> "bb::TestRescue#parse_resbody_var_1_9" [style="tapered"];
-
+    "bb::TestRescue#parse_resbody_var_1_8" -> "bb::TestRescue#parse_resbody_var_1_6" [style="bold"];
     "bb::TestRescue#parse_resbody_var_1_9" [
         label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -833,29 +845,30 @@ subgraph "cluster_::TestRescue#parse_rescue_mod_op_assign" {
     ];
 
     "bb::TestRescue#parse_rescue_mod_op_assign_4" -> "bb::TestRescue#parse_rescue_mod_op_assign_3" [style="bold"];
-    "bb::TestRescue#parse_rescue_mod_op_assign_4" -> "bb::TestRescue#parse_rescue_mod_op_assign_6" [style="tapered"];
+    "bb::TestRescue#parse_rescue_mod_op_assign_4" -> "bb::TestRescue#parse_rescue_mod_op_assign_5" [style="tapered"];
 
+    "bb::TestRescue#parse_rescue_mod_op_assign_5" [
+        label = "block[id=5, rubyBlockId=4](<statTemp>$3: NilClass, <statTemp>$4: T.untyped)\l<unconditional>\l"
+    ];
+
+    "bb::TestRescue#parse_rescue_mod_op_assign_5" -> "bb::TestRescue#parse_rescue_mod_op_assign_6" [style="bold"];
     "bb::TestRescue#parse_rescue_mod_op_assign_6" [
-        label = "block[id=6, rubyBlockId=3](<statTemp>$3: NilClass, <statTemp>$4: T.untyped, <gotoDeadTemp>$12: NilClass)\l<gotoDeadTemp>$12: NilClass\l"
+        label = "block[id=6, rubyBlockId=3](<statTemp>$3: NilClass, <statTemp>$4: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass))\l<gotoDeadTemp>$12: T.nilable(TrueClass)\l"
     ];
 
     "bb::TestRescue#parse_rescue_mod_op_assign_6" -> "bb::TestRescue#parse_rescue_mod_op_assign_1" [style="bold"];
     "bb::TestRescue#parse_rescue_mod_op_assign_6" -> "bb::TestRescue#parse_rescue_mod_op_assign_9" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_mod_op_assign_7" [
-        label = "block[id=7, rubyBlockId=2](<statTemp>$3: NilClass, <self>: TestRescue, <magic>$7: T.class_of(<Magic>))\l<exceptionValue>$5: NilClass = nil\l<keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)\l<statTemp>$4: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$12: NilClass\l"
+        label = "block[id=7, rubyBlockId=2](<statTemp>$3: NilClass, <self>: TestRescue, <magic>$7: T.class_of(<Magic>))\l<exceptionValue>$5: NilClass = nil\l<keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)\l<statTemp>$4: T.untyped = <self>: TestRescue.bar()\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_rescue_mod_op_assign_7" -> "bb::TestRescue#parse_rescue_mod_op_assign_1" [style="bold"];
-    "bb::TestRescue#parse_rescue_mod_op_assign_7" -> "bb::TestRescue#parse_rescue_mod_op_assign_9" [style="tapered"];
-
+    "bb::TestRescue#parse_rescue_mod_op_assign_7" -> "bb::TestRescue#parse_rescue_mod_op_assign_6" [style="bold"];
     "bb::TestRescue#parse_rescue_mod_op_assign_8" [
-        label = "block[id=8, rubyBlockId=2](<statTemp>$3: NilClass, <statTemp>$4: T.untyped)\l<gotoDeadTemp>$12: TrueClass(true) = true\l<gotoDeadTemp>$12: TrueClass(true)\l"
+        label = "block[id=8, rubyBlockId=2](<statTemp>$3: NilClass, <statTemp>$4: T.untyped)\l<gotoDeadTemp>$12: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_rescue_mod_op_assign_8" -> "bb::TestRescue#parse_rescue_mod_op_assign_1" [style="bold"];
-    "bb::TestRescue#parse_rescue_mod_op_assign_8" -> "bb::TestRescue#parse_rescue_mod_op_assign_9" [style="tapered"];
-
+    "bb::TestRescue#parse_rescue_mod_op_assign_8" -> "bb::TestRescue#parse_rescue_mod_op_assign_6" [style="bold"];
     "bb::TestRescue#parse_rescue_mod_op_assign_9" [
         label = "block[id=9, rubyBlockId=0](<statTemp>$3: NilClass, <statTemp>$4: T.untyped)\lfoo: T.untyped = <statTemp>$3: NilClass.+(<statTemp>$4: T.untyped)\l<returnMethodTemp>$2: T.untyped = foo\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -893,29 +906,30 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402" {
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_4" -> "bb::TestRescue#parse_ruby_bug_12402_3" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_4" -> "bb::TestRescue#parse_ruby_bug_12402_6" [style="tapered"];
+    "bb::TestRescue#parse_ruby_bug_12402_4" -> "bb::TestRescue#parse_ruby_bug_12402_5" [style="tapered"];
 
+    "bb::TestRescue#parse_ruby_bug_12402_5" [
+        label = "block[id=5, rubyBlockId=4](foo: NilClass)\l<unconditional>\l"
+    ];
+
+    "bb::TestRescue#parse_ruby_bug_12402_5" -> "bb::TestRescue#parse_ruby_bug_12402_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_6" [
-        label = "block[id=6, rubyBlockId=3](<gotoDeadTemp>$11: NilClass, foo: NilClass)\l<gotoDeadTemp>$11\l"
+        label = "block[id=6, rubyBlockId=3](<gotoDeadTemp>$11: T.nilable(TrueClass), foo: NilClass)\l<gotoDeadTemp>$11: T.nilable(TrueClass)\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_6" -> "bb::TestRescue#parse_ruby_bug_12402_1" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_6" -> "bb::TestRescue#parse_ruby_bug_12402_9" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_7" [
-        label = "block[id=7, rubyBlockId=2](<magic>$7: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\lfoo: NilClass = nil\l<gotoDeadTemp>$11: NilClass\l"
+        label = "block[id=7, rubyBlockId=2](<magic>$7: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\lfoo: NilClass = nil\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_ruby_bug_12402_7" -> "bb::TestRescue#parse_ruby_bug_12402_1" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_7" -> "bb::TestRescue#parse_ruby_bug_12402_9" [style="tapered"];
-
+    "bb::TestRescue#parse_ruby_bug_12402_7" -> "bb::TestRescue#parse_ruby_bug_12402_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_8" [
-        label = "block[id=8, rubyBlockId=2](foo: NilClass)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<gotoDeadTemp>$11: TrueClass(true)\l"
+        label = "block[id=8, rubyBlockId=2](foo: NilClass)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_ruby_bug_12402_8" -> "bb::TestRescue#parse_ruby_bug_12402_1" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_8" -> "bb::TestRescue#parse_ruby_bug_12402_9" [style="tapered"];
-
+    "bb::TestRescue#parse_ruby_bug_12402_8" -> "bb::TestRescue#parse_ruby_bug_12402_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_9" [
         label = "block[id=9, rubyBlockId=0](foo: NilClass)\l<returnMethodTemp>$2: NilClass = foo\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
@@ -953,29 +967,30 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402_1" {
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_1_4" -> "bb::TestRescue#parse_ruby_bug_12402_1_3" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_1_4" -> "bb::TestRescue#parse_ruby_bug_12402_1_6" [style="tapered"];
+    "bb::TestRescue#parse_ruby_bug_12402_1_4" -> "bb::TestRescue#parse_ruby_bug_12402_1_5" [style="tapered"];
 
+    "bb::TestRescue#parse_ruby_bug_12402_1_5" [
+        label = "block[id=5, rubyBlockId=4](<statTemp>$3: NilClass, <statTemp>$4: NilClass)\l<unconditional>\l"
+    ];
+
+    "bb::TestRescue#parse_ruby_bug_12402_1_5" -> "bb::TestRescue#parse_ruby_bug_12402_1_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_1_6" [
-        label = "block[id=6, rubyBlockId=3](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <gotoDeadTemp>$13: NilClass)\l<gotoDeadTemp>$13\l"
+        label = "block[id=6, rubyBlockId=3](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <gotoDeadTemp>$13: T.nilable(TrueClass))\l<gotoDeadTemp>$13: T.nilable(TrueClass)\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_1_6" -> "bb::TestRescue#parse_ruby_bug_12402_1_1" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_1_6" -> "bb::TestRescue#parse_ruby_bug_12402_1_9" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_1_7" [
-        label = "block[id=7, rubyBlockId=2](<statTemp>$3: NilClass, <magic>$9: T.class_of(<Magic>))\l<exceptionValue>$5: NilClass = nil\l<keepForCfgTemp>$10: Sorbet::Private::Static::Void = <magic>$9: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)\l<statTemp>$4: NilClass = nil\l<gotoDeadTemp>$13: NilClass\l"
+        label = "block[id=7, rubyBlockId=2](<statTemp>$3: NilClass, <magic>$9: T.class_of(<Magic>))\l<exceptionValue>$5: NilClass = nil\l<keepForCfgTemp>$10: Sorbet::Private::Static::Void = <magic>$9: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)\l<statTemp>$4: NilClass = nil\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_ruby_bug_12402_1_7" -> "bb::TestRescue#parse_ruby_bug_12402_1_1" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_1_7" -> "bb::TestRescue#parse_ruby_bug_12402_1_9" [style="tapered"];
-
+    "bb::TestRescue#parse_ruby_bug_12402_1_7" -> "bb::TestRescue#parse_ruby_bug_12402_1_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_1_8" [
-        label = "block[id=8, rubyBlockId=2](<statTemp>$3: NilClass, <statTemp>$4: NilClass)\l<gotoDeadTemp>$13: TrueClass(true) = true\l<gotoDeadTemp>$13: TrueClass(true)\l"
+        label = "block[id=8, rubyBlockId=2](<statTemp>$3: NilClass, <statTemp>$4: NilClass)\l<gotoDeadTemp>$13: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_ruby_bug_12402_1_8" -> "bb::TestRescue#parse_ruby_bug_12402_1_1" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_1_8" -> "bb::TestRescue#parse_ruby_bug_12402_1_9" [style="tapered"];
-
+    "bb::TestRescue#parse_ruby_bug_12402_1_8" -> "bb::TestRescue#parse_ruby_bug_12402_1_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_1_9" [
         label = "block[id=9, rubyBlockId=0](<statTemp>$3: NilClass, <statTemp>$4: NilClass)\lfoo: T.untyped = <statTemp>$3: NilClass.+(<statTemp>$4: NilClass)\l<returnMethodTemp>$2: T.untyped = foo\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -1013,29 +1028,30 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402_2" {
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_2_4" -> "bb::TestRescue#parse_ruby_bug_12402_2_3" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_2_4" -> "bb::TestRescue#parse_ruby_bug_12402_2_6" [style="tapered"];
+    "bb::TestRescue#parse_ruby_bug_12402_2_4" -> "bb::TestRescue#parse_ruby_bug_12402_2_5" [style="tapered"];
 
+    "bb::TestRescue#parse_ruby_bug_12402_2_5" [
+        label = "block[id=5, rubyBlockId=4](<statTemp>$9: NilClass, <statTemp>$12: NilClass, []$3: NilClass, []$4: NilClass)\l<unconditional>\l"
+    ];
+
+    "bb::TestRescue#parse_ruby_bug_12402_2_5" -> "bb::TestRescue#parse_ruby_bug_12402_2_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_2_6" [
-        label = "block[id=6, rubyBlockId=3](<statTemp>$9: NilClass, <statTemp>$12: NilClass, <gotoDeadTemp>$21: NilClass, []$3: NilClass, []$4: NilClass)\l<gotoDeadTemp>$21\l"
+        label = "block[id=6, rubyBlockId=3](<statTemp>$9: T.untyped, <statTemp>$12: NilClass, <gotoDeadTemp>$21: T.nilable(TrueClass), []$3: T.untyped, []$4: Integer(0))\l<gotoDeadTemp>$21: T.nilable(TrueClass)\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_2_6" -> "bb::TestRescue#parse_ruby_bug_12402_2_1" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_2_6" -> "bb::TestRescue#parse_ruby_bug_12402_2_9" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_2_7" [
-        label = "block[id=7, rubyBlockId=2](<statTemp>$9: T.untyped, <magic>$17: T.class_of(<Magic>), []$3: T.untyped, []$4: Integer(0))\l<exceptionValue>$13: NilClass = nil\l<keepForCfgTemp>$18: Sorbet::Private::Static::Void = <magic>$17: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$13: NilClass)\l<statTemp>$12: NilClass = nil\l<gotoDeadTemp>$21: NilClass\l"
+        label = "block[id=7, rubyBlockId=2](<statTemp>$9: T.untyped, <magic>$17: T.class_of(<Magic>), []$3: T.untyped, []$4: Integer(0))\l<exceptionValue>$13: NilClass = nil\l<keepForCfgTemp>$18: Sorbet::Private::Static::Void = <magic>$17: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$13: NilClass)\l<statTemp>$12: NilClass = nil\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_ruby_bug_12402_2_7" -> "bb::TestRescue#parse_ruby_bug_12402_2_1" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_2_7" -> "bb::TestRescue#parse_ruby_bug_12402_2_9" [style="tapered"];
-
+    "bb::TestRescue#parse_ruby_bug_12402_2_7" -> "bb::TestRescue#parse_ruby_bug_12402_2_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_2_8" [
-        label = "block[id=8, rubyBlockId=2](<statTemp>$9: T.untyped, <statTemp>$12: NilClass, []$3: T.untyped, []$4: Integer(0))\l<gotoDeadTemp>$21: TrueClass(true) = true\l<gotoDeadTemp>$21: TrueClass(true)\l"
+        label = "block[id=8, rubyBlockId=2](<statTemp>$9: T.untyped, <statTemp>$12: NilClass, []$3: T.untyped, []$4: Integer(0))\l<gotoDeadTemp>$21: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::TestRescue#parse_ruby_bug_12402_2_8" -> "bb::TestRescue#parse_ruby_bug_12402_2_1" [style="bold"];
-    "bb::TestRescue#parse_ruby_bug_12402_2_8" -> "bb::TestRescue#parse_ruby_bug_12402_2_9" [style="tapered"];
-
+    "bb::TestRescue#parse_ruby_bug_12402_2_8" -> "bb::TestRescue#parse_ruby_bug_12402_2_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_2_9" [
         label = "block[id=9, rubyBlockId=0](<statTemp>$9: T.untyped, <statTemp>$12: NilClass, []$3: T.untyped, []$4: Integer(0))\l<statTemp>$8: T.untyped = <statTemp>$9: T.untyped.+(<statTemp>$12: NilClass)\l<returnMethodTemp>$2: T.untyped = []$3: T.untyped.[]=([]$4: Integer(0), <statTemp>$8: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/rescue_else_block.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_else_block.rb.cfg.exp
@@ -39,33 +39,27 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_5" -> "bb::Object#foo_9" [style="tapered"];
 
     "bb::Object#foo_6" [
-        label = "block[id=6, rubyBlockId=4]()\l<returnMethodTemp>$2: Integer(3) = 3\l<gotoDeadTemp>$9: NilClass\l"
+        label = "block[id=6, rubyBlockId=4]()\l<returnMethodTemp>$2: Integer(3) = 3\l<unconditional>\l"
     ];
 
-    "bb::Object#foo_6" -> "bb::Object#foo_1" [style="bold"];
-    "bb::Object#foo_6" -> "bb::Object#foo_12" [style="tapered"];
-
+    "bb::Object#foo_6" -> "bb::Object#foo_9" [style="bold"];
     "bb::Object#foo_9" [
-        label = "block[id=9, rubyBlockId=3](<returnMethodTemp>$2: Integer(1), <gotoDeadTemp>$9: NilClass)\l<gotoDeadTemp>$9\l"
+        label = "block[id=9, rubyBlockId=3](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$9: T.nilable(TrueClass))\l<gotoDeadTemp>$9: T.nilable(TrueClass)\l"
     ];
 
     "bb::Object#foo_9" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_9" -> "bb::Object#foo_12" [style="tapered"];
 
     "bb::Object#foo_10" [
-        label = "block[id=10, rubyBlockId=2](<returnMethodTemp>$2: T.nilable(Integer), <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<gotoDeadTemp>$9: NilClass\l"
+        label = "block[id=10, rubyBlockId=2](<returnMethodTemp>$2: T.nilable(Integer), <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<unconditional>\l"
     ];
 
-    "bb::Object#foo_10" -> "bb::Object#foo_1" [style="bold"];
-    "bb::Object#foo_10" -> "bb::Object#foo_12" [style="tapered"];
-
+    "bb::Object#foo_10" -> "bb::Object#foo_9" [style="bold"];
     "bb::Object#foo_11" [
-        label = "block[id=11, rubyBlockId=2](<returnMethodTemp>$2: T.nilable(Integer))\l<gotoDeadTemp>$9: TrueClass(true) = true\l<gotoDeadTemp>$9: TrueClass(true)\l"
+        label = "block[id=11, rubyBlockId=2](<returnMethodTemp>$2: T.nilable(Integer))\l<gotoDeadTemp>$9: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::Object#foo_11" -> "bb::Object#foo_1" [style="bold"];
-    "bb::Object#foo_11" -> "bb::Object#foo_12" [style="tapered"];
-
+    "bb::Object#foo_11" -> "bb::Object#foo_9" [style="bold"];
     "bb::Object#foo_12" [
         label = "block[id=12, rubyBlockId=0](<returnMethodTemp>$2: T.nilable(Integer))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/rescue_expression.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_expression.rb.cfg.exp
@@ -29,29 +29,30 @@ subgraph "cluster_::Object#foo" {
     ];
 
     "bb::Object#foo_4" -> "bb::Object#foo_3" [style="bold"];
-    "bb::Object#foo_4" -> "bb::Object#foo_6" [style="tapered"];
+    "bb::Object#foo_4" -> "bb::Object#foo_5" [style="tapered"];
 
+    "bb::Object#foo_5" [
+        label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: NilClass)\l<unconditional>\l"
+    ];
+
+    "bb::Object#foo_5" -> "bb::Object#foo_6" [style="bold"];
     "bb::Object#foo_6" [
-        label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$13: NilClass)\l<gotoDeadTemp>$13\l"
+        label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$13: T.nilable(TrueClass))\l<gotoDeadTemp>$13: T.nilable(TrueClass)\l"
     ];
 
     "bb::Object#foo_6" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_6" -> "bb::Object#foo_9" [style="tapered"];
 
     "bb::Object#foo_7" [
-        label = "block[id=7, rubyBlockId=2](<magic>$7: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: Integer(3) = 3\l<gotoDeadTemp>$13: NilClass\l"
+        label = "block[id=7, rubyBlockId=2](<magic>$7: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: Integer(3) = 3\l<unconditional>\l"
     ];
 
-    "bb::Object#foo_7" -> "bb::Object#foo_1" [style="bold"];
-    "bb::Object#foo_7" -> "bb::Object#foo_9" [style="tapered"];
-
+    "bb::Object#foo_7" -> "bb::Object#foo_6" [style="bold"];
     "bb::Object#foo_8" [
-        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$13: TrueClass(true) = true\l<gotoDeadTemp>$13: TrueClass(true)\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$13: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::Object#foo_8" -> "bb::Object#foo_1" [style="bold"];
-    "bb::Object#foo_8" -> "bb::Object#foo_9" [style="tapered"];
-
+    "bb::Object#foo_8" -> "bb::Object#foo_6" [style="bold"];
     "bb::Object#foo_9" [
         label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: Integer(3))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/rescue_two_return.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_two_return.rb.cfg.exp
@@ -29,18 +29,23 @@ subgraph "cluster_::Object#foo" {
     ];
 
     "bb::Object#foo_4" -> "bb::Object#foo_1" [style="bold"];
+    "bb::Object#foo_6" [
+        label = "block[id=6, rubyBlockId=3](<self>: Object, <gotoDeadTemp>$11: TrueClass(true))\l<gotoDeadTemp>$11: TrueClass(true)\l"
+    ];
+
+    "bb::Object#foo_6" -> "bb::Object#foo_1" [style="bold"];
+    "bb::Object#foo_6" -> "bb::Object#foo_9" [style="tapered"];
+
     "bb::Object#foo_7" [
         label = "block[id=7, rubyBlockId=2](<magic>$6: T.class_of(<Magic>))\l<exceptionValue>$4: NilClass = nil\l<keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)\l<returnTemp>$10: Integer(2) = 2\l<statTemp>$3: T.noreturn = return <returnTemp>$10: Integer(2)\l<unconditional>\l"
     ];
 
     "bb::Object#foo_7" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_8" [
-        label = "block[id=8, rubyBlockId=2](<self>: Object)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<gotoDeadTemp>$11: TrueClass(true)\l"
+        label = "block[id=8, rubyBlockId=2](<self>: Object)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::Object#foo_8" -> "bb::Object#foo_1" [style="bold"];
-    "bb::Object#foo_8" -> "bb::Object#foo_9" [style="tapered"];
-
+    "bb::Object#foo_8" -> "bb::Object#foo_6" [style="bold"];
     "bb::Object#foo_9" [
         label = "block[id=9, rubyBlockId=0](<self>: Object)\l<returnMethodTemp>$2 = <self>.deadcode()\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/rescue_var_expression.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_var_expression.rb.cfg.exp
@@ -29,29 +29,30 @@ subgraph "cluster_::Object#foo" {
     ];
 
     "bb::Object#foo_4" -> "bb::Object#foo_3" [style="bold"];
-    "bb::Object#foo_4" -> "bb::Object#foo_6" [style="tapered"];
+    "bb::Object#foo_4" -> "bb::Object#foo_5" [style="tapered"];
 
+    "bb::Object#foo_5" [
+        label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: NilClass)\l<unconditional>\l"
+    ];
+
+    "bb::Object#foo_5" -> "bb::Object#foo_6" [style="bold"];
     "bb::Object#foo_6" [
-        label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$14: NilClass)\l<gotoDeadTemp>$14\l"
+        label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$14: T.nilable(TrueClass))\l<gotoDeadTemp>$14: T.nilable(TrueClass)\l"
     ];
 
     "bb::Object#foo_6" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_6" -> "bb::Object#foo_9" [style="tapered"];
 
     "bb::Object#foo_7" [
-        label = "block[id=7, rubyBlockId=2](<magic>$6: T.class_of(<Magic>), <rescueTemp>$2: T.untyped)\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<statTemp>$12: T.class_of(MyClass) = alias <C MyClass>\l<statTemp>$11: MyClass = <statTemp>$12: T.class_of(MyClass).new()\l<statTemp>$10: T.untyped = <statTemp>$11: MyClass.foo=(<rescueTemp>$2: T.untyped)\l<returnMethodTemp>$2: Integer(3) = 3\l<gotoDeadTemp>$14: NilClass\l"
+        label = "block[id=7, rubyBlockId=2](<magic>$6: T.class_of(<Magic>), <rescueTemp>$2: T.untyped)\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<statTemp>$12: T.class_of(MyClass) = alias <C MyClass>\l<statTemp>$11: MyClass = <statTemp>$12: T.class_of(MyClass).new()\l<statTemp>$10: T.untyped = <statTemp>$11: MyClass.foo=(<rescueTemp>$2: T.untyped)\l<returnMethodTemp>$2: Integer(3) = 3\l<unconditional>\l"
     ];
 
-    "bb::Object#foo_7" -> "bb::Object#foo_1" [style="bold"];
-    "bb::Object#foo_7" -> "bb::Object#foo_9" [style="tapered"];
-
+    "bb::Object#foo_7" -> "bb::Object#foo_6" [style="bold"];
     "bb::Object#foo_8" [
-        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$14: TrueClass(true) = true\l<gotoDeadTemp>$14: TrueClass(true)\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$14: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::Object#foo_8" -> "bb::Object#foo_1" [style="bold"];
-    "bb::Object#foo_8" -> "bb::Object#foo_9" [style="tapered"];
-
+    "bb::Object#foo_8" -> "bb::Object#foo_6" [style="bold"];
     "bb::Object#foo_9" [
         label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: Integer(3))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/rescue_with_return.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_with_return.rb.cfg.exp
@@ -29,20 +29,23 @@ subgraph "cluster_::Object#a" {
     ];
 
     "bb::Object#a_4" -> "bb::Object#a_1" [style="bold"];
+    "bb::Object#a_6" [
+        label = "block[id=6, rubyBlockId=3](<gotoDeadTemp>$9: T.nilable(TrueClass))\l<gotoDeadTemp>$9: T.nilable(TrueClass)\l"
+    ];
+
+    "bb::Object#a_6" -> "bb::Object#a_1" [style="bold"];
+    "bb::Object#a_6" -> "bb::Object#a_9" [style="tapered"];
+
     "bb::Object#a_7" [
-        label = "block[id=7, rubyBlockId=2](<magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<gotoDeadTemp>$9: NilClass\l"
+        label = "block[id=7, rubyBlockId=2](<magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<unconditional>\l"
     ];
 
-    "bb::Object#a_7" -> "bb::Object#a_1" [style="bold"];
-    "bb::Object#a_7" -> "bb::Object#a_9" [style="tapered"];
-
+    "bb::Object#a_7" -> "bb::Object#a_6" [style="bold"];
     "bb::Object#a_8" [
-        label = "block[id=8, rubyBlockId=2]()\l<gotoDeadTemp>$9: TrueClass(true) = true\l<gotoDeadTemp>$9: TrueClass(true)\l"
+        label = "block[id=8, rubyBlockId=2]()\l<gotoDeadTemp>$9: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::Object#a_8" -> "bb::Object#a_1" [style="bold"];
-    "bb::Object#a_8" -> "bb::Object#a_9" [style="tapered"];
-
+    "bb::Object#a_8" -> "bb::Object#a_6" [style="bold"];
     "bb::Object#a_9" [
         label = "block[id=9, rubyBlockId=0]()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/retry.rb.cfg.exp
+++ b/test/testdata/cfg/retry.rb.cfg.exp
@@ -46,10 +46,15 @@ subgraph "cluster_::Object#main" {
     ];
 
     "bb::Object#main_7" -> "bb::Object#main_3" [style="bold"];
-    "bb::Object#main_7" -> "bb::Object#main_9" [style="tapered"];
+    "bb::Object#main_7" -> "bb::Object#main_8" [style="tapered"];
 
+    "bb::Object#main_8" [
+        label = "block[id=8, rubyBlockId=4](<returnMethodTemp>$2: NilClass)\l<unconditional>\l"
+    ];
+
+    "bb::Object#main_8" -> "bb::Object#main_9" [style="bold"];
     "bb::Object#main_9" [
-        label = "block[id=9, rubyBlockId=3](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$21: NilClass)\l<gotoDeadTemp>$21: NilClass\l"
+        label = "block[id=9, rubyBlockId=3](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$21: T.nilable(TrueClass))\l<gotoDeadTemp>$21: T.nilable(TrueClass)\l"
     ];
 
     "bb::Object#main_9" -> "bb::Object#main_1" [style="bold"];
@@ -61,12 +66,10 @@ subgraph "cluster_::Object#main" {
 
     "bb::Object#main_10" -> "bb::Object#main_2" [style="bold"];
     "bb::Object#main_11" [
-        label = "block[id=11, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$21: TrueClass(true) = true\l<gotoDeadTemp>$21: TrueClass(true)\l"
+        label = "block[id=11, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$21: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::Object#main_11" -> "bb::Object#main_1" [style="bold"];
-    "bb::Object#main_11" -> "bb::Object#main_12" [style="tapered"];
-
+    "bb::Object#main_11" -> "bb::Object#main_9" [style="bold"];
     "bb::Object#main_12" [
         label = "block[id=12, rubyBlockId=0](<returnMethodTemp>$2: NilClass)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/retry_multiple.rb.cfg.exp
+++ b/test/testdata/cfg/retry_multiple.rb.cfg.exp
@@ -58,10 +58,15 @@ subgraph "cluster_::Object#main" {
     ];
 
     "bb::Object#main_10" -> "bb::Object#main_3" [style="bold"];
-    "bb::Object#main_10" -> "bb::Object#main_12" [style="tapered"];
+    "bb::Object#main_10" -> "bb::Object#main_11" [style="tapered"];
 
+    "bb::Object#main_11" [
+        label = "block[id=11, rubyBlockId=4](<returnMethodTemp>$2: NilClass)\l<unconditional>\l"
+    ];
+
+    "bb::Object#main_11" -> "bb::Object#main_12" [style="bold"];
     "bb::Object#main_12" [
-        label = "block[id=12, rubyBlockId=3](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$38: NilClass)\l<gotoDeadTemp>$38: NilClass\l"
+        label = "block[id=12, rubyBlockId=3](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$38: T.nilable(TrueClass))\l<gotoDeadTemp>$38: T.nilable(TrueClass)\l"
     ];
 
     "bb::Object#main_12" -> "bb::Object#main_1" [style="bold"];
@@ -85,12 +90,10 @@ subgraph "cluster_::Object#main" {
 
     "bb::Object#main_15" -> "bb::Object#main_2" [style="bold"];
     "bb::Object#main_16" [
-        label = "block[id=16, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$38: TrueClass(true) = true\l<gotoDeadTemp>$38: TrueClass(true)\l"
+        label = "block[id=16, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$38: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::Object#main_16" -> "bb::Object#main_1" [style="bold"];
-    "bb::Object#main_16" -> "bb::Object#main_17" [style="tapered"];
-
+    "bb::Object#main_16" -> "bb::Object#main_12" [style="bold"];
     "bb::Object#main_17" [
         label = "block[id=17, rubyBlockId=0](<returnMethodTemp>$2: NilClass)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/retry_nested.rb.cfg.exp
+++ b/test/testdata/cfg/retry_nested.rb.cfg.exp
@@ -77,10 +77,15 @@ subgraph "cluster_::Object#main" {
     ];
 
     "bb::Object#main_13" -> "bb::Object#main_6" [style="bold"];
-    "bb::Object#main_13" -> "bb::Object#main_15" [style="tapered"];
+    "bb::Object#main_13" -> "bb::Object#main_14" [style="tapered"];
 
+    "bb::Object#main_14" [
+        label = "block[id=14, rubyBlockId=8](<returnMethodTemp>$2: NilClass, <self>: Object, <gotoDeadTemp>$35: NilClass, <magic>$37: T.class_of(<Magic>), try: Integer(0))\l<unconditional>\l"
+    ];
+
+    "bb::Object#main_14" -> "bb::Object#main_15" [style="bold"];
     "bb::Object#main_15" [
-        label = "block[id=15, rubyBlockId=7](<returnMethodTemp>$2: NilClass, <self>: Object, <gotoDeadTemp>$35: NilClass, <magic>$37: T.class_of(<Magic>), try: Integer(0))\l<gotoDeadTemp>$35: NilClass\l"
+        label = "block[id=15, rubyBlockId=7](<returnMethodTemp>$2: NilClass, <self>: Object, <gotoDeadTemp>$35: T.nilable(TrueClass), <magic>$37: T.class_of(<Magic>), try: Integer(0))\l<gotoDeadTemp>$35: T.nilable(TrueClass)\l"
     ];
 
     "bb::Object#main_15" -> "bb::Object#main_1" [style="bold"];
@@ -92,21 +97,24 @@ subgraph "cluster_::Object#main" {
 
     "bb::Object#main_16" -> "bb::Object#main_5" [style="bold"];
     "bb::Object#main_17" [
-        label = "block[id=17, rubyBlockId=6](<returnMethodTemp>$2: NilClass, <self>: Object, <magic>$37: T.class_of(<Magic>), try: Integer(0))\l<gotoDeadTemp>$35: TrueClass(true) = true\l<gotoDeadTemp>$35: TrueClass(true)\l"
+        label = "block[id=17, rubyBlockId=6](<returnMethodTemp>$2: NilClass, <self>: Object, <magic>$37: T.class_of(<Magic>), try: Integer(0))\l<gotoDeadTemp>$35: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::Object#main_17" -> "bb::Object#main_1" [style="bold"];
-    "bb::Object#main_17" -> "bb::Object#main_18" [style="tapered"];
-
+    "bb::Object#main_17" -> "bb::Object#main_15" [style="bold"];
     "bb::Object#main_18" [
         label = "block[id=18, rubyBlockId=1](<returnMethodTemp>$2: NilClass, <self>: Object, <gotoDeadTemp>$35: NilClass, <magic>$37: T.class_of(<Magic>), try: Integer(0))\l<exceptionValue>$4: T.untyped = <get-current-exception>\l<exceptionValue>$4: T.untyped\l"
     ];
 
     "bb::Object#main_18" -> "bb::Object#main_3" [style="bold"];
-    "bb::Object#main_18" -> "bb::Object#main_20" [style="tapered"];
+    "bb::Object#main_18" -> "bb::Object#main_19" [style="tapered"];
 
+    "bb::Object#main_19" [
+        label = "block[id=19, rubyBlockId=4](<returnMethodTemp>$2: NilClass)\l<unconditional>\l"
+    ];
+
+    "bb::Object#main_19" -> "bb::Object#main_20" [style="bold"];
     "bb::Object#main_20" [
-        label = "block[id=20, rubyBlockId=3](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$45: NilClass)\l<gotoDeadTemp>$45: NilClass\l"
+        label = "block[id=20, rubyBlockId=3](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$45: T.nilable(TrueClass))\l<gotoDeadTemp>$45: T.nilable(TrueClass)\l"
     ];
 
     "bb::Object#main_20" -> "bb::Object#main_1" [style="bold"];
@@ -118,12 +126,10 @@ subgraph "cluster_::Object#main" {
 
     "bb::Object#main_21" -> "bb::Object#main_2" [style="bold"];
     "bb::Object#main_22" [
-        label = "block[id=22, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$45: TrueClass(true) = true\l<gotoDeadTemp>$45: TrueClass(true)\l"
+        label = "block[id=22, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$45: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::Object#main_22" -> "bb::Object#main_1" [style="bold"];
-    "bb::Object#main_22" -> "bb::Object#main_23" [style="tapered"];
-
+    "bb::Object#main_22" -> "bb::Object#main_20" [style="bold"];
     "bb::Object#main_23" [
         label = "block[id=23, rubyBlockId=0](<returnMethodTemp>$2: NilClass)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/uaf1.rb.cfg.exp
+++ b/test/testdata/cfg/uaf1.rb.cfg.exp
@@ -64,29 +64,30 @@ subgraph "cluster_::A#initialize" {
     ];
 
     "bb::A#initialize_8" -> "bb::A#initialize_7" [style="bold"];
-    "bb::A#initialize_8" -> "bb::A#initialize_10" [style="tapered"];
+    "bb::A#initialize_8" -> "bb::A#initialize_9" [style="tapered"];
 
+    "bb::A#initialize_9" [
+        label = "block[id=9, rubyBlockId=5](<blockReturnTemp>$9: Integer(1), <self>: A, <selfRestore>$6: A, <gotoDeadTemp>$15: NilClass, <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\louterLoops: 1\l<unconditional>\l"
+    ];
+
+    "bb::A#initialize_9" -> "bb::A#initialize_10" [style="bold"];
     "bb::A#initialize_10" [
-        label = "block[id=10, rubyBlockId=4](<blockReturnTemp>$9: Integer(1), <self>: A, <selfRestore>$6: A, <gotoDeadTemp>$15: NilClass, <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\louterLoops: 1\l<gotoDeadTemp>$15: NilClass\l"
+        label = "block[id=10, rubyBlockId=4](<blockReturnTemp>$9: T.nilable(Integer), <self>: A, <selfRestore>$6: A, <gotoDeadTemp>$15: T.nilable(TrueClass), <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\louterLoops: 1\l<gotoDeadTemp>$15: T.nilable(TrueClass)\l"
     ];
 
     "bb::A#initialize_10" -> "bb::A#initialize_1" [style="bold"];
     "bb::A#initialize_10" -> "bb::A#initialize_13" [style="tapered"];
 
     "bb::A#initialize_11" [
-        label = "block[id=11, rubyBlockId=3](<self>: A, <selfRestore>$6: A, <gotoDeadTemp>$15: NilClass, <magic>$11: T.class_of(<Magic>), <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\louterLoops: 1\l<exceptionValue>$10: NilClass = nil\l<keepForCfgTemp>$12: Sorbet::Private::Static::Void = <magic>$11: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$10: NilClass)\l<blockReturnTemp>$9: Integer(2) = 2\l<gotoDeadTemp>$15: NilClass\l"
+        label = "block[id=11, rubyBlockId=3](<self>: A, <selfRestore>$6: A, <gotoDeadTemp>$15: NilClass, <magic>$11: T.class_of(<Magic>), <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\louterLoops: 1\l<exceptionValue>$10: NilClass = nil\l<keepForCfgTemp>$12: Sorbet::Private::Static::Void = <magic>$11: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$10: NilClass)\l<blockReturnTemp>$9: Integer(2) = 2\l<unconditional>\l"
     ];
 
-    "bb::A#initialize_11" -> "bb::A#initialize_1" [style="bold"];
-    "bb::A#initialize_11" -> "bb::A#initialize_13" [style="tapered"];
-
+    "bb::A#initialize_11" -> "bb::A#initialize_10" [style="bold"];
     "bb::A#initialize_12" [
-        label = "block[id=12, rubyBlockId=3](<blockReturnTemp>$9: T.nilable(Integer), <self>: A, <selfRestore>$6: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\louterLoops: 1\l<gotoDeadTemp>$15: TrueClass(true) = true\l<gotoDeadTemp>$15: TrueClass(true)\l"
+        label = "block[id=12, rubyBlockId=3](<blockReturnTemp>$9: T.nilable(Integer), <self>: A, <selfRestore>$6: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\louterLoops: 1\l<gotoDeadTemp>$15: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::A#initialize_12" -> "bb::A#initialize_1" [style="bold"];
-    "bb::A#initialize_12" -> "bb::A#initialize_13" [style="tapered"];
-
+    "bb::A#initialize_12" -> "bb::A#initialize_10" [style="bold"];
     "bb::A#initialize_13" [
         label = "block[id=13, rubyBlockId=1](<blockReturnTemp>$9: Integer, <self>: A, <selfRestore>$6: A, <gotoDeadTemp>$15: NilClass, <block-pre-call-temp>$5: Sorbet::Private::Static::Void)\louterLoops: 1\l<blockReturnTemp>$17: T.noreturn = blockreturn<map> <blockReturnTemp>$9: Integer\l<unconditional>\l"
     ];

--- a/test/testdata/desugar/ensure_without_rescue.rb.cfg.exp
+++ b/test/testdata/desugar/ensure_without_rescue.rb.cfg.exp
@@ -27,8 +27,13 @@ subgraph "cluster_::Object#main" {
     ];
 
     "bb::Object#main_4" -> "bb::Object#main_3" [style="bold"];
-    "bb::Object#main_4" -> "bb::Object#main_6" [style="tapered"];
+    "bb::Object#main_4" -> "bb::Object#main_5" [style="tapered"];
 
+    "bb::Object#main_5" [
+        label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: T.untyped, <self>: Object)\l<unconditional>\l"
+    ];
+
+    "bb::Object#main_5" -> "bb::Object#main_6" [style="bold"];
     "bb::Object#main_6" [
         label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <self>: Object, <gotoDeadTemp>$6: T.nilable(TrueClass))\l<throwAwayTemp>$7: T.untyped = <self>: Object.b()\l<gotoDeadTemp>$6: T.nilable(TrueClass)\l"
     ];

--- a/test/testdata/infer/control_flow/complex_implication_1.rb.cfg.exp
+++ b/test/testdata/infer/control_flow/complex_implication_1.rb.cfg.exp
@@ -47,29 +47,30 @@ subgraph "cluster_::ModuleMethods#instrumented_request" {
     ];
 
     "bb::ModuleMethods#instrumented_request_4" -> "bb::ModuleMethods#instrumented_request_3" [style="bold"];
-    "bb::ModuleMethods#instrumented_request_4" -> "bb::ModuleMethods#instrumented_request_6" [style="tapered"];
+    "bb::ModuleMethods#instrumented_request_4" -> "bb::ModuleMethods#instrumented_request_5" [style="tapered"];
 
+    "bb::ModuleMethods#instrumented_request_5" [
+        label = "block[id=5, rubyBlockId=4](final_attempt: T.untyped, foo: T.untyped)\l<unconditional>\l"
+    ];
+
+    "bb::ModuleMethods#instrumented_request_5" -> "bb::ModuleMethods#instrumented_request_6" [style="bold"];
     "bb::ModuleMethods#instrumented_request_6" [
-        label = "block[id=6, rubyBlockId=3](<gotoDeadTemp>$9: NilClass, err: NilClass, final_attempt: T.untyped, foo: T.untyped)\l<gotoDeadTemp>$9: NilClass\l"
+        label = "block[id=6, rubyBlockId=3](<gotoDeadTemp>$9: T.nilable(TrueClass), err: T.nilable(StandardError), final_attempt: T.untyped, foo: T.untyped)\l<gotoDeadTemp>$9: T.nilable(TrueClass)\l"
     ];
 
     "bb::ModuleMethods#instrumented_request_6" -> "bb::ModuleMethods#instrumented_request_1" [style="bold"];
     "bb::ModuleMethods#instrumented_request_6" -> "bb::ModuleMethods#instrumented_request_9" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_7" [
-        label = "block[id=7, rubyBlockId=2](<magic>$5: T.class_of(<Magic>), e: StandardError, final_attempt: T.untyped, foo: T.untyped)\l<exceptionValue>$4: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)\lerr: StandardError = e\l<gotoDeadTemp>$9: NilClass\l"
+        label = "block[id=7, rubyBlockId=2](<magic>$5: T.class_of(<Magic>), e: StandardError, final_attempt: T.untyped, foo: T.untyped)\l<exceptionValue>$4: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)\lerr: StandardError = e\l<unconditional>\l"
     ];
 
-    "bb::ModuleMethods#instrumented_request_7" -> "bb::ModuleMethods#instrumented_request_1" [style="bold"];
-    "bb::ModuleMethods#instrumented_request_7" -> "bb::ModuleMethods#instrumented_request_9" [style="tapered"];
-
+    "bb::ModuleMethods#instrumented_request_7" -> "bb::ModuleMethods#instrumented_request_6" [style="bold"];
     "bb::ModuleMethods#instrumented_request_8" [
-        label = "block[id=8, rubyBlockId=2](final_attempt: T.untyped, foo: T.untyped)\l<gotoDeadTemp>$9: TrueClass(true) = true\l<gotoDeadTemp>$9: TrueClass(true)\l"
+        label = "block[id=8, rubyBlockId=2](final_attempt: T.untyped, foo: T.untyped)\l<gotoDeadTemp>$9: TrueClass(true) = true\l<unconditional>\l"
     ];
 
-    "bb::ModuleMethods#instrumented_request_8" -> "bb::ModuleMethods#instrumented_request_1" [style="bold"];
-    "bb::ModuleMethods#instrumented_request_8" -> "bb::ModuleMethods#instrumented_request_9" [style="tapered"];
-
+    "bb::ModuleMethods#instrumented_request_8" -> "bb::ModuleMethods#instrumented_request_6" [style="bold"];
     "bb::ModuleMethods#instrumented_request_9" [
         label = "block[id=9, rubyBlockId=0](err: T.nilable(StandardError), final_attempt: T.untyped, foo: T.untyped)\lis_successful: T::Boolean = err: T.nilable(StandardError).nil?()\lis_successful: T::Boolean\l"
     ];


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Exception handling code that doesn't use `else` and `ensure` is having those blocks collapsed into the same block. The result is that it's impossible to tell which was which in the resulting CFG.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.