### PR TITLE
Given `prop :foo, SomeType, enum: [...]`, actually enforce SomeType

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -440,14 +440,16 @@ class T::Props::Decorator
   end
   private def smart_coerce(type, enum:)
     # Backwards compatibility for pre-T::Types style
-    if !enum.nil?
-      if T::Utils.unwrap_nilable(type)
-        T.nilable(T.enum(enum))
-      else
-        T.enum(enum)
-      end
+    type = T::Utils.coerce(type)
+    if enum.nil?
+      type
     else
-      T::Utils.coerce(type)
+      nonnil_type = T::Utils.unwrap_nilable(type)
+      if nonnil_type
+        T.nilable(T.all(nonnil_type, T.enum(enum)))
+      else
+        T.all(type, T.enum(enum))
+      end
     end
   end
 

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -220,12 +220,6 @@ class T::Props::Decorator
       raise ArgumentError.new("At least one invalid prop arg supplied in #{self}: #{rules.keys.inspect}")
     end
 
-    if (array = rules[:array])
-      unless array.is_a?(Module)
-        raise ArgumentError.new("Bad class as subtype in prop #{@class.name}.#{name}: #{array.inspect}")
-      end
-    end
-
     if !(rules[:clobber_existing_method!]) && !(rules[:without_accessors])
       if BANNED_METHOD_NAMES.include?(name.to_sym)
         raise ArgumentError.new(
@@ -350,7 +344,7 @@ class T::Props::Decorator
     if !cls.is_a?(Module)
       cls = convert_type_to_class(cls)
     end
-    type_object = smart_coerce(type, array: rules[:array], enum: rules[:enum])
+    type_object = smart_coerce(type, enum: rules[:enum])
 
     prop_validate_definition!(name, cls, rules, type_object)
 
@@ -441,20 +435,12 @@ class T::Props::Decorator
   end
 
   sig do
-    params(type: PropTypeOrClass, array: T.untyped, enum: T.untyped)
+    params(type: PropTypeOrClass, enum: T.untyped)
     .returns(T::Types::Base)
   end
-  private def smart_coerce(type, array:, enum:)
+  private def smart_coerce(type, enum:)
     # Backwards compatibility for pre-T::Types style
-    if !array.nil? && !enum.nil?
-      raise ArgumentError.new("Cannot specify both :array and :enum options")
-    elsif !array.nil?
-      if type == Set
-        T::Set[array]
-      else
-        T::Array[array]
-      end
-    elsif !enum.nil?
+    if !enum.nil?
       if T::Utils.unwrap_nilable(type)
         T.nilable(T.enum(enum))
       else

--- a/gems/sorbet-runtime/lib/types/props/private/serde_transform.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/serde_transform.rb
@@ -99,6 +99,38 @@ module T::Props
               "T::Props::Utils.deep_clone_object(#{varname})"
             end
           end
+        when T::Types::Intersection
+          dynamic_fallback = "T::Props::Utils.deep_clone_object(#{varname})"
+
+          # Transformations for any members of the intersection type where we
+          # know what we need to do and did not have to fall back to the
+          # dynamic deep clone method.
+          #
+          # NB: This deliberately does include `nil`, which means we know we
+          # don't need to do any transforming.
+          inner_known = type.types
+            .map {|t| generate(t, mode, varname)}
+            .reject {|t| t == dynamic_fallback}
+            .uniq
+
+          if inner_known.size != 1
+            # If there were no cases where we could tell what we need to do,
+            # e.g. if this is `T.all(SomethingWeird, WhoKnows)`, just use the
+            # dynamic fallback.
+            #
+            # If there were multiple cases and they weren't consistent, e.g.
+            # if this is `T.all(String, T::Array[Integer])`, the type is probably
+            # bogus/uninhabited, but use the dynamic fallback because we still
+            # don't have a better option, and this isn't the place to raise that
+            # error.
+            dynamic_fallback
+          else
+            # This is probably something like `T.all(String, SomeMarker)` or
+            # `T.all(SomeEnum, T.enum(SomeEnum::FOO))` and we should treat it
+            # like String or SomeEnum even if we don't know what to do with
+            # the rest of the type.
+            inner_known.first
+          end
         when T::Types::Enum
           generate(T::Utils.lift_enum(type), mode, varname)
         else

--- a/gems/sorbet-runtime/lib/types/props/type_validation.rb
+++ b/gems/sorbet-runtime/lib/types/props/type_validation.rb
@@ -63,7 +63,16 @@ module T::Props::TypeValidation
       when T::Types::FixedHash
         type.types.values.map {|subtype| find_invalid_subtype(subtype)}.compact.first
       when T::Types::Union, T::Types::FixedArray
+        # `T.any` is valid if all of the members are valid
         type.types.map {|subtype| find_invalid_subtype(subtype)}.compact.first
+      when T::Types::Intersection
+        # `T.all` is valid if at least one of the members is valid
+        invalid = type.types.map {|subtype| find_invalid_subtype(subtype)}.compact
+        if invalid.length == type.types.length
+          invalid.first
+        else
+          nil
+        end
       when T::Types::Enum, T::Types::ClassOf
         nil
       when T::Private::Types::TypeAlias

--- a/gems/sorbet-runtime/test/types/props/_props.rb
+++ b/gems/sorbet-runtime/test/types/props/_props.rb
@@ -324,4 +324,37 @@ class Opus::Types::Test::Props::PropsTest < Critic::Unit::UnitTest
     end
   end
 
+  class TypeValidating
+    include T::Props
+    include T::Props::TypeValidation
+  end
+
+  describe 'type validation' do
+    it 'bans plain Object' do
+      assert_raises(T::Props::TypeValidation::UnderspecifiedType) do
+        Class.new(TypeValidating) do
+          prop :object, Object
+        end
+      end
+    end
+
+    it 'allows with DEPRECATED_underspecified_type' do
+      c = Class.new(TypeValidating) do
+        prop :object, Object, DEPRECATED_underspecified_type: true
+      end
+      o = c.new
+      o.object = 1
+      assert_equal(1, o.object)
+    end
+
+    it 'allows T.all' do
+      c = Class.new(TypeValidating) do
+        prop :intersection, T.all(Object, T.enum(["foo"]))
+      end
+      o = c.new
+      o.intersection = "foo"
+      assert_equal("foo", o.intersection)
+    end
+  end
+
 end

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -528,6 +528,10 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     prop :enum_of_enums, T.nilable(T.enum([MyEnum::BAR]))
   end
 
+  class RedundantEnumStruct < T::Struct
+    prop :enum, T.all(MyEnum, T.enum(MyEnum.values))
+  end
+
   describe 'enum' do
     it 'round trips' do
       s = EnumStruct.new(enum: MyEnum::FOO, enum_of_enums: MyEnum::BAR)
@@ -539,6 +543,15 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       roundtripped = EnumStruct.from_hash(serialized)
       assert_equal(MyEnum::FOO, roundtripped.enum)
       assert_equal(MyEnum::BAR, roundtripped.enum_of_enums)
+    end
+
+    it 'does not break during serde when used redundantly with legacy T.enum' do
+      s = RedundantEnumStruct.new(enum: MyEnum::FOO)
+      serialized = s.serialize
+      assert_equal('foo', serialized['enum'])
+
+      roundtripped = RedundantEnumStruct.from_hash(serialized)
+      assert_equal(MyEnum::FOO, roundtripped.enum)
     end
   end
 

--- a/gems/sorbet-runtime/test/types/props/struct.rb
+++ b/gems/sorbet-runtime/test/types/props/struct.rb
@@ -122,7 +122,7 @@ class Opus::Types::Test::Props::StructTest < Critic::Unit::UnitTest
         prop :wday, T.nilable(String), enum: ['mon', 'tue']
       end
       assert_equal(T.nilable(String), c.props[:foo][:type_object])
-      assert_equal(T.nilable(T.enum(['mon', 'tue'])), c.props[:wday][:type_object])
+      assert_equal(T.nilable(T.all(String, T.enum(['mon', 'tue']))), c.props[:wday][:type_object])
     end
 
     it 'tstruct deserialize optional fields' do


### PR DESCRIPTION
Bugfix! Previously, you could have a mismatch - you could do `prop :foo, String, enum: [:a, :b]` and statically Sorbet would expect strings but at runtime we'd actually enforce symbols.

Doing this via `T.all` (which seems like the right approach, since it gives us a clean deprecation path for the `enum` param) requires adding some support for `T.all` to serde.

Also clean up some stray references to the old `array` key.

### Motivation
We'd like to deprecate `enum` but we should fix the existing broken cases first.

### Test plan
See updated test + will test in pay-server (which will involve fixing some breakage).