### PR TITLE
Add sig for the 3-param variant of Time.at

### DIFF
--- a/rbi/core/time.rbi
+++ b/rbi/core/time.rbi
@@ -219,7 +219,15 @@ class Time < Object
     )
     .returns(Time)
   end
-  def self.at(seconds, microseconds_with_frac=T.unsafe(nil)); end
+  sig do
+    params(
+        seconds: Numeric,
+        microseconds_with_frac: Numeric,
+        fractional_precision: Symbol
+    )
+    .returns(Time)
+  end
+  def self.at(seconds, microseconds_with_frac=T.unsafe(nil), fractional_precision=T.unsafe(nil)); end
 
   # Creates a [`Time`](https://docs.ruby-lang.org/en/2.6.0/Time.html) object
   # based on given values, interpreted as UTC (GMT). The year must be specified.

--- a/test/testdata/rbi/time.rb
+++ b/test/testdata/rbi/time.rb
@@ -1,3 +1,4 @@
 # typed: true
 Time.at(1)
 Time.at(Time.now)
+Time.at(0, 1589855340108, :milliseconds)


### PR DESCRIPTION
Supports:
* `Time.at(seconds, milliseconds, :millisecond) → time`
* `Time.at(seconds, microseconds, :usec) → time`
* `Time.at(seconds, microseconds, :microsecond) → time`
* `Time.at(seconds, nanoseconds, :nsec) → time`
* `Time.at(seconds, nanoseconds, :nanosecond) → time`

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Using the 3-param variant of `Time.at` failed type checks.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Added to `test/testdata/rbi/time.rb`