### PR TITLE
Fix warnings on Ruby 2.7

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/abstract/declare.rb
+++ b/gems/sorbet-runtime/lib/types/private/abstract/declare.rb
@@ -40,6 +40,9 @@ module T::Private::Abstract::Declare
         end
         super(*args, &blk)
       end
+      if mod.respond_to?(:ruby2_keywords, true)
+        mod.send(:ruby2_keywords, :initialize)
+      end
     end
   end
 end

--- a/gems/sorbet-runtime/lib/types/private/class_utils.rb
+++ b/gems/sorbet-runtime/lib/types/private/class_utils.rb
@@ -98,6 +98,9 @@ module T::Private::ClassUtils
     T::Configuration.without_ruby_warnings do
       T::Private::DeclState.current.without_on_method_added do
         mod.send(:define_method, name, &blk) # rubocop:disable PrisonGuard/UsePublicSend
+        if blk.arity < 0 && mod.respond_to?(:ruby2_keywords, true)
+          mod.send(:ruby2_keywords, name)
+        end
       end
     end
     mod.send(original_visibility, name) # rubocop:disable PrisonGuard/UsePublicSend

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -185,6 +185,9 @@ module T::Private::Methods::CallValidation
     mod.send(:define_method, method_sig.method_name) do |*args, &blk|
       CallValidation.validate_call(self, original_method, method_sig, args, blk)
     end
+    if mod.respond_to?(:ruby2_keywords, true)
+      mod.send(:ruby2_keywords, method_sig.method_name)
+    end
   end
 
   def self.create_validator_method_fast(mod, original_method, method_sig)

--- a/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
+++ b/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
@@ -70,6 +70,9 @@ module T::Props
           self.class.decorator.send(:eval_lazily_defined_method!, name)
           send(name, *args)
         end
+        if cls.respond_to?(:ruby2_keywords, true)
+          cls.send(:ruby2_keywords, name)
+        end
         cls.send(:private, name)
       end
 

--- a/gems/sorbet-runtime/test/types/abstract_validation.rb
+++ b/gems/sorbet-runtime/test/types/abstract_validation.rb
@@ -491,5 +491,20 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
       err.message,
       "Your definition of `foo` must have `*args` to be compatible with the method it implements",
     )
+
+    parent = Class.new do
+      def initialize(foo:)
+        @foo = foo
+      end
+    end
+
+    abstract = Class.new(parent) do
+      extend T::Sig
+      extend T::Helpers
+      abstract!
+    end
+
+    concrete = Class.new(abstract)
+    concrete.new(foo: 1)
   end
 end

--- a/gems/sorbet-runtime/test/types/method_validation.rb
+++ b/gems/sorbet-runtime/test/types/method_validation.rb
@@ -476,11 +476,20 @@ module Opus::Types::Test
           assert_match(/wrong number of arguments \(given 0, expected 1..2/, err.message)
         end
 
-        it "fails if a required kwarg is missing" do
-          err = assert_raises(ArgumentError) do
-            @mod.foo({})
+        if RUBY_VERSION >= '2.7'
+          it "fails if a required kwarg is missing" do
+            err = assert_raises(ArgumentError) do
+              @mod.foo({})
+            end
+            assert_equal("missing keyword: :kwreq_int", err.message)
           end
-          assert_equal("missing keyword: kwreq_int", err.message)
+        else
+          it "fails if a required kwarg is missing" do
+            err = assert_raises(ArgumentError) do
+              @mod.foo({})
+            end
+            assert_equal("missing keyword: kwreq_int", err.message)
+          end
         end
       end
     end


### PR DESCRIPTION
Alternative to https://github.com/sorbet/sorbet/pull/2731

This PR mostly rely on `ruby2_keywords` because in some cases it is the only way to do blind argument delegation without breaking backward compatibility.

The test suite passes on 2.7 with no deprecation warnings at all.

