### PR TITLE
Add -isystem on macOS Catalina to fix ruby build

### DIFF
--- a/third_party/ruby/build-ruby.bzl
+++ b/third_party/ruby/build-ruby.bzl
@@ -81,8 +81,8 @@ OUTFLAG="-fvisibility=default -o" \
 CC="{cc}" \
 CFLAGS="{copts}" \
 CXXFLAGS="{copts}" \
-CPPFLAGS="${{inc_path[*]:-}} {cppopts}" \
-LDFLAGS="${{lib_path[*]:-}} {linkopts}" \
+CPPFLAGS="{sysroot_flag} ${{inc_path[*]:-}} {cppopts}" \
+LDFLAGS="{sysroot_flag} ${{lib_path[*]:-}} {linkopts}" \
 run_cmd ./configure \
         {configure_flags} \
         --enable-load-relative \
@@ -198,6 +198,7 @@ def _build_ruby_impl(ctx):
             libs = " ".join(libs),
             bundler = ctx.files.bundler[0].path,
             configure_flags = " ".join(ctx.attr.configure_flags),
+            sysroot_flag = ctx.attr.osx_include_path,
         )),
     )
 
@@ -237,6 +238,7 @@ _build_ruby = rule(
         "_cc_toolchain": attr.label(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
         ),
+        "sysroot_flag": attr.string(),
     },
     fragments = ["cpp"],
     provides = [
@@ -438,6 +440,11 @@ def ruby(bundler, configure_flags = [], copts = [], cppopts = [], linkopts = [],
         cppopts = cppopts,
         linkopts = linkopts,
         deps = deps,
+        # This is a hack because macOS Catalina changed the way that system headers and libraries work.
+        sysroot_flag = select({
+            "@com_stripe_ruby_typer//tools/config:darwin": "-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",
+            "//conditions:default": "",
+        }),
     )
 
     _ruby_headers(

--- a/third_party/ruby/build-ruby.bzl
+++ b/third_party/ruby/build-ruby.bzl
@@ -198,7 +198,7 @@ def _build_ruby_impl(ctx):
             libs = " ".join(libs),
             bundler = ctx.files.bundler[0].path,
             configure_flags = " ".join(ctx.attr.configure_flags),
-            sysroot_flag = ctx.attr.osx_include_path,
+            sysroot_flag = ctx.attr.sysroot_flag,
         )),
     )
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This manifested as an error that looked like:

    command ./configure --enable-load-relative --with-destdir=/private/var/tmp/_bazel_jez/491a13d243378e23690a7f8390a5c09f/sandbox/darwin-sandbox/2/execroot/com_stripe_ruby_typer/bazel-out/darwin-fastbuild/bin/external/ruby_2_6/toolchain --with-rubyhdrdir=${includedir} --with-rubyarchhdrdir=${includedir}/ruby-arch --disable-install-doc --prefix=/ failed!
    checking for ruby... /usr/bin/ruby
    tool/config.guess already exists
    tool/config.sub already exists
    checking build system type... x86_64-apple-darwin19.3.0
    checking host system type... x86_64-apple-darwin19.3.0
    checking target system type... x86_64-apple-darwin19.3.0
    checking whether the C compiler works... yes
    checking for C compiler default output file name... a.out
    checking for suffix of executables...
    checking whether we are cross compiling... configure: error: in `/var/folders/5p/z_n7b95s1yz02fdjwvk8cwp80000gn/T/tmp.FpE76u33':
    configure: error: cannot run C compiled programs.
    If you meant to cross compile, use `--host'.
    See `config.log' for more details
    build dir: /var/folders/5p/z_n7b95s1yz02fdjwvk8cwp80000gn/T/tmp.FpE76u33
    Target @ruby_2_6//:ruby failed to build

cc @Morriar @jvilk-stripe this should fix the errors you were seeing trying to
build `@ruby_2_6` locally.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested in my personal laptop running macOS Catalina, and also on my work laptop
running macOS Mojave.