### PR TITLE
Fix debug symbols on test runner.

### DIFF
--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -42,7 +42,7 @@ exp_test = rule(
         ),
         "runner": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "target",
             allow_files = True,
         ),
     },


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Fix debug symbols on test runner.

Change cfg from host to target so we can use lldb on the test runner and see symbolized stack traces when ENFORCE fails.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I sometimes have to debug test runner. :) 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

N/A
