### PR TITLE
Two bits of minor cleanup in runtime

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -66,7 +66,6 @@ class T::Props::Decorator
     without_accessors
     clobber_existing_method!
     extra
-    optional
     setter_validate
     _tnilable
   }.map {|k| [k, true]}.to_h.freeze, T::Hash[Symbol, T::Boolean])
@@ -289,47 +288,6 @@ class T::Props::Decorator
   end
   def prop_defined(name, cls, rules={})
     cls = T::Utils.resolve_alias(cls)
-    if rules[:optional] == true
-      T::Configuration.hard_assert_handler(
-        'Use of `optional: true` is deprecated, please use `T.nilable(...)` instead.',
-        storytime: {
-          name: name,
-          cls_or_args: cls.to_s,
-          args: rules,
-          klass: decorated_class.name,
-        },
-      )
-    elsif rules[:optional] == false
-      T::Configuration.hard_assert_handler(
-        'Use of `optional: :false` is deprecated as it\'s the default value.',
-        storytime: {
-          name: name,
-          cls_or_args: cls.to_s,
-          args: rules,
-          klass: decorated_class.name,
-        },
-      )
-    elsif rules[:optional] == :on_load
-      T::Configuration.hard_assert_handler(
-        'Use of `optional: :on_load` is deprecated. You probably want `T.nilable(...)` with :raise_on_nil_write instead.',
-        storytime: {
-          name: name,
-          cls_or_args: cls.to_s,
-          args: rules,
-          klass: decorated_class.name,
-        },
-      )
-    elsif rules[:optional] == :existing
-      T::Configuration.hard_assert_handler(
-        'Use of `optional: :existing` is not allowed: you should use use T.nilable (http://go/optional)',
-        storytime: {
-          name: name,
-          cls_or_args: cls.to_s,
-          args: rules,
-          klass: decorated_class.name,
-        },
-      )
-    end
 
     if T::Utils::Nilable.is_union_with_nilclass(cls)
       # :_tnilable is introduced internally for performance purpose so that clients do not need to call

--- a/gems/sorbet-runtime/lib/types/props/optional.rb
+++ b/gems/sorbet-runtime/lib/types/props/optional.rb
@@ -14,19 +14,9 @@ end
 module T::Props::Optional::DecoratorMethods
   extend T::Sig
 
-  # TODO: clean this up. This set of options is confusing, and some of them are not universally
-  # applicable (e.g., :on_load only applies when using T::Serializable).
-  VALID_OPTIONAL_RULES = Set[
-    :existing, # deprecated
-    :on_load,
-    false,
-    true,
-  ].freeze
-
   VALID_RULE_KEYS = {
     default: true,
     factory: true,
-    optional: true,
   }.freeze
   private_constant :VALID_RULE_KEYS
 
@@ -73,12 +63,6 @@ module T::Props::Optional::DecoratorMethods
 
   def prop_validate_definition!(name, cls, rules, type)
     result = super
-
-    if (rules_optional = rules[:optional])
-      if !VALID_OPTIONAL_RULES.include?(rules_optional)
-        raise ArgumentError.new(":optional must be one of #{VALID_OPTIONAL_RULES.inspect}")
-      end
-    end
 
     if rules.key?(:default) && rules.key?(:factory)
       raise ArgumentError.new("Setting both :default and :factory is invalid. See: go/chalk-docs")

--- a/gems/sorbet-runtime/lib/types/props/private/serde_transform.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/serde_transform.rb
@@ -26,7 +26,7 @@ module T::Props
 
       sig do
         params(
-          type: T.any(T::Types::Base, Module),
+          type: T::Types::Base,
           mode: ModeType,
           varname: String,
         )
@@ -134,12 +134,7 @@ module T::Props
         when T::Types::Enum
           generate(T::Utils.lift_enum(type), mode, varname)
         else
-          if type.singleton_class < T::Props::CustomType
-            # Sometimes this comes wrapped in a T::Types::Simple and sometimes not
-            handle_custom_type(varname, T.unsafe(type), mode)
-          else
-            "T::Props::Utils.deep_clone_object(#{varname})"
-          end
+          "T::Props::Utils.deep_clone_object(#{varname})"
         end
       end
 

--- a/gems/sorbet-runtime/test/types/props/decorator.rb
+++ b/gems/sorbet-runtime/test/types/props/decorator.rb
@@ -196,12 +196,6 @@ class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest
       assert_equal(Integer, foo.fetch(:array), Integer)
       assert(T::Props::Utils.optional_prop?(foo))
     end
-
-    it "validates setting 'optional' argument when defining with 'optional' keyword" do
-      assert_prop_error(/:optional must be one of/, mixin: T::Props::Serializable) do
-        prop :foo, String, optional: :arglebargle
-      end
-    end
   end
 
   class OptionalMigrate
@@ -300,7 +294,7 @@ class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest
       assert(foo.fetch(:immutable))
     end
 
-    it "validates setting 'optional' argument when defining with 'optional' keyword" do
+    it "validates setting 'immutable' argument when defining with 'immutable' keyword" do
       assert_prop_error(/Cannot pass 'immutable' argument/) do
         const :foo, String, immutable: :false
       end
@@ -358,29 +352,6 @@ class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest
     assert_nil(MatrixStruct.new.c)
     assert_equal(91, MatrixStruct.new.d)
     assert_nil(MatrixStruct.new.e)
-  end
-
-  it 'hard asserts if `optional` is ever specified' do
-    e = assert_raises do
-      Class.new(T::Struct) do
-        prop :optional_true, T::Boolean, optional: true
-      end
-    end
-    assert_match(/Use of `optional: true` is deprecated/, e.message)
-
-    e = assert_raises do
-      Class.new(T::Struct) do
-        prop :optional_on_load, T::Boolean, optional: :on_load
-      end
-    end
-    assert_match(/Use of `optional: :on_load` is deprecated/, e.message)
-
-    e = assert_raises do
-      Class.new(T::Struct) do
-        prop :optional_existing, T::Boolean, optional: :existing
-      end
-    end
-    assert_match(/Use of `optional: :existing` is not allowed/, e.message)
   end
 
   it 'raises if the word secret appears in a prop without a sensitivity annotation' do


### PR DESCRIPTION
Commit-by-commit:
- Clean up references to the old `optional` keyword; use of this has been hard-asserting for months or years
- Clean up a type in SerdeTransform that doesn't need to accept `Module` anymore now that CustomTypes are less lurky

### Motivation
Couple things I noticed while writing https://github.com/sorbet/sorbet/pull/3048 but wanted to isolate

### Test plan
I think the automated tests in this repo should be sufficient here but I am building pay-server too just in case
