### PR TITLE
Allow disabling optimization that doesn't report timers below threshold

### DIFF
--- a/common/Timer.cc
+++ b/common/Timer.cc
@@ -143,8 +143,8 @@ void Timer::setTag(ConstExprStr name, ConstExprStr value) {
     tags->push_back(make_pair(name, value));
 }
 
-void Timer::disableDroppingShortTimersForTests() {
-    keepShortTimers = true;
+void Timer::setKeepShortTimersForTests(bool keepShortTimersForTests) {
+    keepShortTimers = keepShortTimersForTests;
 }
 
 Timer::~Timer() {

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -58,6 +58,9 @@ public:
 
     static microseconds clock_gettime_coarse();
 
+    // Disable dropping timers with duration below clock_threshold_coarse for tests
+    static void disableDroppingShortTimersForTests();
+
 private:
     spdlog::logger &log;
     ConstExprStr name;
@@ -74,6 +77,7 @@ private:
     // on a bucket.
     std::unique_ptr<std::vector<int>> histogramBuckets;
     bool canceled = false;
+    static bool keepShortTimers;
 };
 } // namespace sorbet
 

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -58,8 +58,8 @@ public:
 
     static microseconds clock_gettime_coarse();
 
-    // Disable dropping timers with duration below clock_threshold_coarse for tests
-    static void disableDroppingShortTimersForTests();
+    // Toggle dropping timers with duration below clock_threshold_coarse for tests
+    static void setKeepShortTimersForTests(bool keepShortTimersForTests);
 
 private:
     spdlog::logger &log;

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -36,9 +36,6 @@ void checkDiagnosticTimes(vector<unique_ptr<CounterImpl::Timing>> times, size_t 
     }
 }
 
-// The resolution of MONOTONIC_COARSE seems to be ~1ms, so we use >1ms delay to ensure unique clock values.
-constexpr auto timestampGranularity = chrono::milliseconds(2);
-
 class MultithreadedProtocolTest : public ProtocolTest {
 public:
     MultithreadedProtocolTest() : ProtocolTest(/*multithreading*/ true, /*caching*/ false) {}
@@ -60,12 +57,12 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "MultithreadedWrapperWorks") {
 
     sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::PAUSE, nullopt)));
     sendAsync(*openFile("yolo1.rb", "# typed: true\nclass Foo2\n  def branch\n    2 + \"dog\"\n  end\nend\n"));
-    // Pause to differentiate message times.
-    this_thread::sleep_for(timestampGranularity);
+    // Ensure all latency timers get reported.
+    Timer::disableDroppingShortTimersForTests();
     sendAsync(*changeFile("yolo1.rb", "# typed: true\nclass Foo1\n  def branch\n    1 + \"bear\"\n  end\nend\n", 3));
 
-    // Pause so that all latency timers for the above operations get reported.
-    this_thread::sleep_for(chrono::milliseconds(2));
+    // Ensure all latency timers get reported.
+    Timer::disableDroppingShortTimersForTests();
 
     assertDiagnostics(send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::RESUME, nullopt))),
                       {{"yolo1.rb", 3, "bear"}});
@@ -105,8 +102,8 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CancelsSlowPathWhenNewEditWouldTak
     sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::PAUSE, nullopt)));
     // Syntax error in foo.rb.
     sendAsync(*changeFile("foo.rb", "# typed: true\n\nclass Foo\ndef noend\nend\n", 2, true));
-    // Pause to differentiate message times
-    this_thread::sleep_for(chrono::milliseconds(2));
+    // Ensure all latency timers get reported.
+    Timer::disableDroppingShortTimersForTests();
     // Typechecking error in bar.rb
     sendAsync(*changeFile(
         "bar.rb", "# typed: true\n\nclass Bar\nextend T::Sig\n\nsig{returns(Integer)}\ndef hello\n\"hi\"\nend\nend\n",
@@ -193,8 +190,8 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CancelsSlowPathWhenNewEditWouldTak
     sendAsync(*changeFile("bar.rb",
                           "# typed: true\n\nclass Bar\nextend T::Sig\nsig{returns(String)}\ndef bar\n10\nend\nend\n", 2,
                           false));
-    // Pause so that all latency timers for the above operations get reported.
-    this_thread::sleep_for(timestampGranularity);
+    // Ensure all latency timers get reported.
+    Timer::disableDroppingShortTimersForTests();
     sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::RESUME, nullopt)));
 
     // Wait for first typecheck run to get canceled.
@@ -251,8 +248,8 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanPreemptSlowPathWithHover") {
     sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::PAUSE, nullopt)));
     // Send a hover to request the documentation string.
     sendAsync(*hover("foo.rb", 2, 6));
-    // Pause so that all latency timers for the above operations get reported.
-    this_thread::sleep_for(chrono::milliseconds(2));
+    // Ensure all latency timers get reported.
+    Timer::disableDroppingShortTimersForTests();
     sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::RESUME, nullopt)));
 
     // First response should be hover.
@@ -618,8 +615,8 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanceledRequestsDontReportLatencyM
     sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::PAUSE, nullopt)));
     // Send a hover to request the documentation string.
     sendAsync(*hover("foo.rb", 2, 6));
-    // Pause so that all latency timer for the hover is >1ms and would normally get reported.
-    this_thread::sleep_for(chrono::milliseconds(2));
+    // Ensure all latency timers are reported.
+    Timer::disableDroppingShortTimersForTests();
     // Cancel the hover.
     sendAsync(*cancelRequest(nextId - 1));
     sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::RESUME, nullopt)));


### PR DESCRIPTION
### Motivation
Allow us to write tests involving timers without having to use `sleep`s so timers are reported
