### PR TITLE
Always report last_diagnostic_latency_timers

### DIFF
--- a/common/Timer.h
+++ b/common/Timer.h
@@ -10,7 +10,7 @@ namespace sorbet {
 class Timer {
     Timer(spdlog::logger &log, ConstExprStr name, FlowId prev,
           std::initializer_list<std::pair<ConstExprStr, std::string>> args, microseconds start,
-          std::initializer_list<int> histogramBuckets);
+          std::initializer_list<int> histogramBuckets, bool alwaysReport = false);
 
 public:
     Timer(spdlog::logger &log, ConstExprStr name);
@@ -45,7 +45,7 @@ public:
     Timer clone() const;
 
     // Creates a new timer with the same start time, tags, and args but a different name.
-    Timer clone(ConstExprStr name) const;
+    Timer clone(ConstExprStr name, bool alwaysReportTimer = false) const;
 
     // TODO We could add more overloads for this if we need them (to create other kinds of Timers)
     // We could also make this more generic to allow more sleep duration types.
@@ -74,6 +74,7 @@ private:
     // on a bucket.
     std::unique_ptr<std::vector<int>> histogramBuckets;
     bool canceled = false;
+    bool alwaysReport = false;
 };
 } // namespace sorbet
 

--- a/main/lsp/notifications/sorbet_workspace_edit.cc
+++ b/main/lsp/notifications/sorbet_workspace_edit.cc
@@ -51,7 +51,7 @@ void SorbetWorkspaceEditTask::preprocess(LSPPreprocessor &preprocessor) {
     // latencyTimer is assigned prior to preprocess.
     if (this->latencyTimer != nullptr && !params->updates.empty()) {
         params->diagnosticLatencyTimers.push_back(
-            make_unique<Timer>(this->latencyTimer->clone("last_diagnostic_latency")));
+            make_unique<Timer>(this->latencyTimer->clone("last_diagnostic_latency", /*alwaysReportTimer*/ true)));
     }
 }
 


### PR DESCRIPTION
### Motivation
Ensure that `last_diagnostic_latency` timers are always reported even if their duration falls below threshold. Also means tests involving timers don't need to use sleeps so timers are reported anymore