### PR TITLE
Move GenericTypeParamBoundMismatch to resolver

### DIFF
--- a/core/errors/infer.h
+++ b/core/errors/infer.h
@@ -32,7 +32,8 @@ constexpr ErrorClass GenericPassedAsBlock{7024, StrictLevel::True};
 constexpr ErrorClass AbstractClassInstantiated{7025, StrictLevel::True};
 constexpr ErrorClass NotExhaustive{7026, StrictLevel::True};
 constexpr ErrorClass UntypedConstantSuggestion{7027, StrictLevel::Strict};
-constexpr ErrorClass GenericTypeParamBoundMismatch{7028, StrictLevel::False};
+// constexpr ErrorClass GenericTypeParamBoundMismatch{7028, StrictLevel::False};
 // constexpr ErrorClass LazyResolve{7029, StrictLevel::True};
+// N.B infer does not run for untyped call at all. StrictLevel::False here would be meaningless
 } // namespace sorbet::core::errors::Infer
 #endif

--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -65,6 +65,7 @@ constexpr ErrorClass ExperimentalAttachedClass{5056, StrictLevel::False};
 constexpr ErrorClass StaticAbstractModuleMethod{5057, StrictLevel::False};
 constexpr ErrorClass AttachedClassAsParam{5058, StrictLevel::False};
 constexpr ErrorClass LazyResolve{5059, StrictLevel::False};
+constexpr ErrorClass GenericTypeParamBoundMismatch{5060, StrictLevel::False};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -9,6 +9,7 @@
 #include "core/TypeConstraint.h"
 #include "core/Types.h"
 #include "core/errors/infer.h"
+#include "core/errors/resolver.h"
 #include <algorithm> // find_if, sort
 
 #include "absl/strings/str_cat.h"
@@ -1176,6 +1177,12 @@ public:
 
 class T_Generic_squareBrackets : public IntrinsicMethod {
 public:
+    // This method is actually special: not only is it called from processBinding in infer, it's
+    // also called directly by type_syntax parsing in resolver (because this method checks some
+    // invariants of generics that we want to hold even in `typed: false` files).
+    //
+    // Unfortunately, this means that some errors are double reported (once by resolver, and then
+    // again by infer).
     void apply(const GlobalState &gs, DispatchArgs args, const Type *thisType, DispatchResult &res) const override {
         SymbolRef attachedClass;
 
@@ -1240,7 +1247,7 @@ public:
                 // Validate type parameter bounds.
                 if (!Types::isSubType(gs, argType, memType->upperBound)) {
                     validBounds = false;
-                    if (auto e = gs.beginError(loc, errors::Infer::GenericTypeParamBoundMismatch)) {
+                    if (auto e = gs.beginError(loc, errors::Resolver::GenericTypeParamBoundMismatch)) {
                         auto argStr = argType->show(gs);
                         e.setHeader("`{}` cannot be used for type member `{}`", argStr, memData->showFullName(gs));
                         e.addErrorLine(loc, "`{}` is not a subtype of `{}`", argStr, memType->upperBound->show(gs));
@@ -1250,7 +1257,7 @@ public:
                 if (!Types::isSubType(gs, memType->lowerBound, argType)) {
                     validBounds = false;
 
-                    if (auto e = gs.beginError(loc, errors::Infer::GenericTypeParamBoundMismatch)) {
+                    if (auto e = gs.beginError(loc, errors::Resolver::GenericTypeParamBoundMismatch)) {
                         auto argStr = argType->show(gs);
                         e.setHeader("`{}` cannot be used for type member `{}`", argStr, memData->showFullName(gs));
                         e.addErrorLine(loc, "`{}` is not a subtype of `{}`", memType->lowerBound->show(gs), argStr);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is super weird. I didn't realize that resolver worked this way (it
dispatches a call manually from type_syntax parsing), which means that
there is at least one intrinsic in calls.cc that can report errors in
`typed: false` files. I decided to move the error code to resolver to
make that more clear.

(It looks like that dispatchCall goes back all the way to Feb 2018, so it far
predates the more recent work to add bounds checking).

Separately, I think we should fix this, so that we don't double report
those errors.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.