### PR TITLE
Improve error message for bad bound error

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1242,8 +1242,10 @@ public:
                     validBounds = false;
                     if (auto e = gs.beginError(loc, errors::Infer::GenericTypeParamBoundMismatch)) {
                         auto argStr = argType->show(gs);
-                        e.setHeader("`{}` cannot be used for type member `{}`", argStr, memData->showFullName(gs));
-                        e.addErrorLine(loc, "`{}` is not a subtype of `{}`", argStr, memType->upperBound->show(gs));
+                        e.setHeader("`{}` is not a subtype of upper bound of type member `{}`", argStr,
+                                    memData->showFullName(gs));
+                        e.addErrorLine(memData->loc(), "`{}` is `{}` bounded by `{}` here", memData->showFullName(gs),
+                                       "upper", memType->upperBound->show(gs));
                     }
                 }
 
@@ -1252,8 +1254,10 @@ public:
 
                     if (auto e = gs.beginError(loc, errors::Infer::GenericTypeParamBoundMismatch)) {
                         auto argStr = argType->show(gs);
-                        e.setHeader("`{}` cannot be used for type member `{}`", argStr, memData->showFullName(gs));
-                        e.addErrorLine(loc, "`{}` is not a subtype of `{}`", memType->lowerBound->show(gs), argStr);
+                        e.setHeader("`{}` is not a supertype of lower bound of type member `{}`", argStr,
+                                    memData->showFullName(gs));
+                        e.addErrorLine(memData->loc(), "`{}` is `{}` bounded by `{}` here", memData->showFullName(gs),
+                                       "lower", memType->lowerBound->show(gs));
                     }
                 }
 

--- a/test/testdata/infer/generics/bad_bound_typed_false.rb
+++ b/test/testdata/infer/generics/bad_bound_typed_false.rb
@@ -13,6 +13,7 @@ class Test
 
   # NOTE, there are two errors raised here, one for each bound not satisfied.
   sig {params(x: A[String]).void}
-                 # ^^^^^^ error-with-dupes: `String` cannot be used for type member
+                 # ^^^^^^ error: `String` is not a supertype of lower bound of type member `::A::X`
+                 # ^^^^^^ error: `String` is not a subtype of upper bound of type member `::A::X`
   def foo(x); end
 end

--- a/test/testdata/infer/generics/bounds.rb
+++ b/test/testdata/infer/generics/bounds.rb
@@ -83,9 +83,11 @@ class Test
   sig {params(arg1: A2[Animal], arg2: A2[Cat], arg3: A2[Persian]).void}
   def test1(arg1, arg2, arg3); end
 
+  # There are duplicate errors here because both resolver and infer report the same error. This is not intentional.
   # should fail: Integer is not within the Animal/Persian bounds.
   sig {params(arg1: A2[Integer], arg2: A2[BasicObject]).void}
-                     # ^^^^^^^ error-with-dupes: `Integer` cannot be used for type member `::A2::X`
-                                        # ^^^^^^^^^^^ error-with-dupes: `BasicObject` cannot be used for type member `::A2::X`
+  #                    ^^^^^^^ error-with-dupes: `Integer` is not a subtype of upper bound of type member `::A2::X`
+  #                    ^^^^^^^ error-with-dupes: `Integer` is not a supertype of lower bound of type member `::A2::X`
+  #                                       ^^^^^^^^^^^ error-with-dupes: `BasicObject` is not a subtype of upper bound of type member `::A2::X`
   def test2(arg1, arg2); end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Better errors.

This means we can remove a couple `error-with-dupes` lines from the test suite,
and also shows people where the type member's bound was defined in the first
place.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

###### Before

<img width="1160" alt="Screen Shot 2020-05-25 at 12 17 56 PM" src="https://user-images.githubusercontent.com/5544532/82833598-0da4d780-9e84-11ea-9982-0c9abc5968c1.png">


###### After

<img width="1160" alt="Screen Shot 2020-05-25 at 12 18 11 PM" src="https://user-images.githubusercontent.com/5544532/82833602-13022200-9e84-11ea-99da-d1e63a3e5489.png">

