### PR TITLE
Add Array#each_with_index

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1060,7 +1060,7 @@ class Array < Object
     )
     .returns(T::Array[Elem])
   end
-  sig {returns(T::Enumerator[Elem])}
+  sig {returns(T::Enumerator[[Elem,Integer]])}
   def each_with_index(&blk); end
   
   # Returns `true` if `self` contains no elements.

--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1037,6 +1037,32 @@ class Array < Object
   sig {returns(T::Enumerator[Elem])}
   def each_index(&blk); end
 
+  # Same as Enumerator#with_index(0), i.e. there is no starting offset.
+  #
+  # If no block is given, a new [`Enumerator`](https://apidock.com/ruby/Enumerator) is
+  # returned that includes the index.
+  #
+  # ```ruby
+  # a = [ "a", "b", "c" ]
+  # a.each_with_index {|x, i| puts "value: #{x}, index: #{i}" }
+  # ```
+  #
+  # produces:
+  #
+  # ```
+  # value: a, index: 0
+  # value: b, index: 1
+  # value: c, index: 2
+  # ```
+  sig do
+    params(
+        blk: T.proc.params(arg0: Elem, arg1: Integer).returns(BasicObject),
+    )
+    .returns(T::Array[Elem])
+  end
+  sig {returns(T::Enumerator[Elem])}
+  def each_with_index(&blk); end
+  
   # Returns `true` if `self` contains no elements.
   #
   # ```ruby


### PR DESCRIPTION
Add RBI definition for `Array#each_with_index` based on [the documentation on Apidock](https://apidock.com/ruby/Enumerator/each_with_index).

### Motivation
In my company we are very happy with our progress using Sorbet. We are gradually increasing type coverage and noticed Sorbet didn't know how to handle `Array#each_with_index` automatically.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Need help to guide me how to test this. I've tried:
- seeing how the tests for `each_index` were done, but [I found none](https://github.com/sorbet/sorbet/search?q=each_index&unscoped_q=each_index);
- seeing [other tests for Array methods](https://github.com/sorbet/sorbet/blob/master/test/testdata/rbi/array.rb), but none seemed to apply for this case, since we need to check the block arguments.

Is `T.assert_type!` useful in this case? 🤔 