### PR TITLE
Change canonical loc to be _end_ of vector.

### DIFF
--- a/core/Context.cc
+++ b/core/Context.cc
@@ -32,14 +32,14 @@ bool Context::permitOverloadDefinitions(const core::GlobalState &gs, FileRef sig
     }
     for (auto loc : owner.data(gs)->locs()) {
         auto &file = loc.file().data(gs);
-        constexpr string_view whitelistedTest = "overloads_test.rb"sv;
-        if (((file.isPayload() || file.isStdlib()) && owner != Symbols::root() &&
-             (owner != Symbols::Object() || sigLoc.data(gs).isStdlib())) ||
-            FileOps::getFileName(file.path()) == whitelistedTest) {
+        if ((file.isPayload() || file.isStdlib()) && owner != Symbols::root() &&
+            (owner != Symbols::Object() || sigLoc.data(gs).isStdlib())) {
             return true;
         }
     }
-    return false;
+
+    constexpr string_view whitelistedTest = "overloads_test.rb"sv;
+    return FileOps::getFileName(sigLoc.data(gs).path()) == whitelistedTest;
 }
 
 bool MutableContext::permitOverloadDefinitions(FileRef sigLoc) const {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1208,12 +1208,14 @@ void Symbol::addLoc(const core::GlobalState &gs, core::Loc loc) {
         return;
     }
 
-    if (ref(gs) != Symbols::root()) {
-        for (auto &existing : locs_) {
-            if (existing.file() == loc.file()) {
-                existing = loc;
-                return;
-            }
+    // We shouldn't add locs for <root>, otherwise it'll end up with a massive loc list (O(number of files)).
+    // Those locs aren't useful, either.
+    ENFORCE(ref(gs) != Symbols::root());
+
+    for (auto &existing : locs_) {
+        if (existing.file() == loc.file()) {
+            existing = loc;
+            return;
         }
     }
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1214,12 +1214,13 @@ void Symbol::addLoc(const core::GlobalState &gs, core::Loc loc) {
         }
     }
 
-    if (loc.file().data(gs).sourceType == core::File::Type::Normal && !loc.file().data(gs).isRBI()) {
+    if (locs_.empty() || (loc.file().data(gs).sourceType == core::File::Type::Normal && !loc.file().data(gs).isRBI())) {
         // Make this the new canonical loc.
         locs_.emplace_back(loc);
     } else {
-        // If we have other locs, use them as the canonical loc.
-        locs_.insert(locs_.begin(), loc);
+        // This is an RBI file; continue to use existing loc as the canonical loc.
+        // Insert just before end.
+        locs_.insert(locs_.end() - 1, loc);
     }
 }
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1194,7 +1194,7 @@ bool Symbol::ignoreInHashing(const GlobalState &gs) const {
 }
 Loc Symbol::loc() const {
     if (!locs_.empty()) {
-        return locs_[0];
+        return locs_.back();
     }
     return Loc::none();
 }
@@ -1215,9 +1215,11 @@ void Symbol::addLoc(const core::GlobalState &gs, core::Loc loc) {
     }
 
     if (loc.file().data(gs).sourceType == core::File::Type::Normal && !loc.file().data(gs).isRBI()) {
-        locs_.insert(locs_.begin(), loc);
-    } else {
+        // Make this the new canonical loc.
         locs_.emplace_back(loc);
+    } else {
+        // If we have other locs, use them as the canonical loc.
+        locs_.insert(locs_.begin(), loc);
     }
 }
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1207,10 +1207,13 @@ void Symbol::addLoc(const core::GlobalState &gs, core::Loc loc) {
     if (!loc.file().exists()) {
         return;
     }
-    for (auto &existing : locs_) {
-        if (existing.file() == loc.file()) {
-            existing = loc;
-            return;
+
+    if (ref(gs) != Symbols::root()) {
+        for (auto &existing : locs_) {
+            if (existing.file() == loc.file()) {
+                existing = loc;
+                return;
+            }
         }
     }
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1054,7 +1054,10 @@ class SymbolDefiner {
             symbol.data(ctx)->setSuperClass(core::Symbols::Net_Protocol());
         }
 
-        symbol.data(ctx)->addLoc(ctx, klass.declLoc);
+        // Don't add locs for root; 1) they aren't useful and 2) it'll end up with O(files in project) locs!
+        if (symbol != core::Symbols::root()) {
+            symbol.data(ctx)->addLoc(ctx, klass.declLoc);
+        }
         symbol.data(ctx)->singletonClass(ctx); // force singleton class into existence
 
         // make sure we've added a static init symbol so we have it ready for the flatten pass later

--- a/test/cli/cache-keeps-print-options/cache-keeps-print-options.out
+++ b/test/cli/cache-keeps-print-options/cache-keeps-print-options.out
@@ -1,4 +1,4 @@
-class ::<root> < ::Object () @ (... removed core rbi locs ..., test/cli/cache-keeps-print-options/cache-keeps-print-options.rb:1)
+class ::<root> < ::Object ()
   class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
     method ::<Class:<root>>#<static-init> (<blk>) @ test/cli/cache-keeps-print-options/cache-keeps-print-options.rb:1
       argument <blk><block> @ Loc {file=test/cli/cache-keeps-print-options/cache-keeps-print-options.rb start=??? end=???}
@@ -8,7 +8,7 @@ class ::<root> < ::Object () @ (... removed core rbi locs ..., test/cli/cache-ke
     method ::<Class:CCCCCCCCC>#<static-init> (<blk>) @ test/cli/cache-keeps-print-options/cache-keeps-print-options.rb:1
       argument <blk><block> @ Loc {file=test/cli/cache-keeps-print-options/cache-keeps-print-options.rb start=??? end=???}
 
-class ::<root> < ::Object () @ (... removed core rbi locs ..., test/cli/cache-keeps-print-options/cache-keeps-print-options.rb:1)
+class ::<root> < ::Object ()
   class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
     method ::<Class:<root>>#<static-init> (<blk>) @ test/cli/cache-keeps-print-options/cache-keeps-print-options.rb:1
       argument <blk><block> @ Loc {file=test/cli/cache-keeps-print-options/cache-keeps-print-options.rb start=??? end=???}

--- a/test/cli/dash-e/dash-e.out
+++ b/test/cli/dash-e/dash-e.out
@@ -1,5 +1,5 @@
 No errors! Great job.
-class ::<root> < ::Object () @ (... removed core rbi locs ..., -e:1)
+class ::<root> < ::Object ()
   class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
     method ::<Class:<root>>#<static-init> (<blk>) @ -e:1
       argument <blk><block> @ Loc {file=-e start=??? end=???}

--- a/test/cli/module-redefinition/module-redefinition.out
+++ b/test/cli/module-redefinition/module-redefinition.out
@@ -1,10 +1,10 @@
 test/cli/module-redefinition/module-redefinition-3.rb:3: `A` was previously defined as a `class` https://srb.help/4012
      3 |module A
         ^^^^^^^^
-    test/cli/module-redefinition/module-redefinition-2.rb:3: Previous definition
+    test/cli/module-redefinition/module-redefinition-1.rb:3: Previous definition
      3 |class A
         ^^^^^^^
-    test/cli/module-redefinition/module-redefinition-1.rb:3: Previous definition
+    test/cli/module-redefinition/module-redefinition-2.rb:3: Previous definition
      3 |class A
         ^^^^^^^
 Errors: 1

--- a/test/cli/phases/phases.out
+++ b/test/cli/phases/phases.out
@@ -239,14 +239,14 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 
 --- cfg-raw end ---
 --- symbol-table start ---
-class ::<root> < ::Object () @ (... removed core rbi locs ..., -e:1)
+class ::<root> < ::Object ()
   class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
     method ::<Class:<root>>#<static-init> (<blk>) @ -e:1
       argument <blk><block> @ Loc {file=-e start=??? end=???}
 
 --- symbol-table end ---
 --- symbol-table-raw start ---
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=-e start=1:1 end=1:2})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=-e start=1:1 end=1:2}
       argument <blk><block> @ Loc {file=-e start=??? end=???}

--- a/test/cli/stop-after-namer/stop-after-namer.out
+++ b/test/cli/stop-after-namer/stop-after-namer.out
@@ -1,5 +1,5 @@
 No errors! Great job.
-class ::<root> < ::<todo sym> () @ test/cli/stop-after-namer/stop-after-namer.rb:3
+class ::<root> < ::<todo sym> ()
   class ::<Class:<root>>[<AttachedClass>] < ::<todo sym> ()
     method ::<Class:<root>>#<static-init> (<blk>) @ test/cli/stop-after-namer/stop-after-namer.rb:3
       argument <blk><block> @ Loc {file=test/cli/stop-after-namer/stop-after-namer.rb start=??? end=???}

--- a/test/cli/subprocess-plugin/subprocess-plugin.out
+++ b/test/cli/subprocess-plugin/subprocess-plugin.out
@@ -600,10 +600,10 @@ class ::<root> < ::Object () @ (... removed core rbi locs ..., test/cli/subproce
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi6.rb//plugin-generated|0.rbi start=??? end=???}
     method ::<Class:<root>>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi6.rb//plugin-generated|1.rbi:1
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi6.rb//plugin-generated|1.rbi start=??? end=???}
-  module ::Fish < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ (test/cli/subprocess-plugin/multi2.rb:3, test/cli/subprocess-plugin/multi2.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi2.rb//plugin-generated|1.rbi:1)
+  module ::Fish < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ (test/cli/subprocess-plugin/multi2.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi2.rb//plugin-generated|1.rbi:1, test/cli/subprocess-plugin/multi2.rb:3)
     method ::Fish#foo (<blk>) @ test/cli/subprocess-plugin/multi2.rb//plugin-generated|0.rbi:2
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi2.rb//plugin-generated|0.rbi start=??? end=???}
-  class ::<Class:Fish>[<AttachedClass>] < ::Module () @ (test/cli/subprocess-plugin/multi2.rb:5, test/cli/subprocess-plugin/multi2.rb//plugin-generated|1.rbi:1)
+  class ::<Class:Fish>[<AttachedClass>] < ::Module () @ (test/cli/subprocess-plugin/multi2.rb//plugin-generated|1.rbi:1, test/cli/subprocess-plugin/multi2.rb:5)
     type-member(+) ::<Class:Fish>::<AttachedClass> -> T.attached_class (of Fish) @ test/cli/subprocess-plugin/multi2.rb:3
     method ::<Class:Fish>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi2.rb:3
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi2.rb start=??? end=???}
@@ -614,7 +614,7 @@ class ::<root> < ::Object () @ (... removed core rbi locs ..., test/cli/subproce
     type-member(+) ::<Class:<Class:Fish>>::<AttachedClass> -> T.attached_class (of T.class_of(Fish)) @ test/cli/subprocess-plugin/multi2.rb:5
     method ::<Class:<Class:Fish>>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi2.rb:5
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi2.rb start=??? end=???}
-  class ::Haze < ::Object () @ (test/cli/subprocess-plugin/multi4.rb:3, test/cli/subprocess-plugin/multi4.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi4.rb//plugin-generated|1.rbi:1)
+  class ::Haze < ::Object () @ (test/cli/subprocess-plugin/multi4.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi4.rb//plugin-generated|1.rbi:1, test/cli/subprocess-plugin/multi4.rb:3)
     static-field ::Haze::Lion -> TrueClass @ test/cli/subprocess-plugin/multi4.rb//plugin-generated|1.rbi:3
     method ::Haze#bar (<blk>) @ test/cli/subprocess-plugin/multi4.rb//plugin-generated|0.rbi:2
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi4.rb//plugin-generated|0.rbi start=??? end=???}
@@ -624,20 +624,20 @@ class ::<root> < ::Object () @ (... removed core rbi locs ..., test/cli/subproce
     type-member(+) ::<Class:Haze>::<AttachedClass> -> T.attached_class (of Haze) @ test/cli/subprocess-plugin/multi4.rb:3
     method ::<Class:Haze>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi4.rb:3
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi4.rb start=??? end=???}
-  module ::Hi < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ (test/cli/subprocess-plugin/multi1.rb:15, test/cli/subprocess-plugin/multi1.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|1.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|2.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|3.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|4.rbi:1)
+  module ::Hi < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ (test/cli/subprocess-plugin/multi1.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|1.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|2.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|3.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|4.rbi:1, test/cli/subprocess-plugin/multi1.rb:15)
     static-field ::Hi::Bird -> TrueClass @ test/cli/subprocess-plugin/multi1.rb//plugin-generated|0.rbi:3
     static-field ::Hi::Penguin -> TrueClass @ test/cli/subprocess-plugin/multi1.rb//plugin-generated|1.rbi:3
     method ::Hi#bird (<blk>) @ test/cli/subprocess-plugin/multi1.rb//plugin-generated|0.rbi:2
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi1.rb//plugin-generated|0.rbi start=??? end=???}
     method ::Hi#penguin (<blk>) @ test/cli/subprocess-plugin/multi1.rb//plugin-generated|1.rbi:2
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi1.rb//plugin-generated|1.rbi start=??? end=???}
-  class ::<Class:Hi>[<AttachedClass>] < ::Module () @ (test/cli/subprocess-plugin/multi1.rb:17, test/cli/subprocess-plugin/multi1.rb//plugin-generated|2.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|3.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|4.rbi:1)
+  class ::<Class:Hi>[<AttachedClass>] < ::Module () @ (test/cli/subprocess-plugin/multi1.rb//plugin-generated|2.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|3.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|4.rbi:1, test/cli/subprocess-plugin/multi1.rb:17)
     type-member(+) ::<Class:Hi>::<AttachedClass> -> T.attached_class (of Hi) @ test/cli/subprocess-plugin/multi1.rb:15
     method ::<Class:Hi>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi1.rb:15
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi1.rb start=??? end=???}
     static-field ::<Class:Hi>::Cat -> TrueClass @ test/cli/subprocess-plugin/multi1.rb//plugin-generated|3.rbi:3
     static-field ::<Class:Hi>::Fish -> TrueClass @ test/cli/subprocess-plugin/multi1.rb//plugin-generated|2.rbi:3
-    class ::<Class:Hi>::Hello < ::Object () @ (test/cli/subprocess-plugin/multi1.rb:19, test/cli/subprocess-plugin/multi1.rb//plugin-generated|4.rbi:1)
+    class ::<Class:Hi>::Hello < ::Object () @ (test/cli/subprocess-plugin/multi1.rb//plugin-generated|4.rbi:1, test/cli/subprocess-plugin/multi1.rb:19)
       static-field ::<Class:Hi>::Hello::Rabbit -> TrueClass @ test/cli/subprocess-plugin/multi1.rb//plugin-generated|4.rbi:3
       method ::<Class:Hi>::Hello#rabbit (<blk>) @ test/cli/subprocess-plugin/multi1.rb//plugin-generated|4.rbi:2
         argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi1.rb//plugin-generated|4.rbi start=??? end=???}
@@ -653,8 +653,8 @@ class ::<root> < ::Object () @ (... removed core rbi locs ..., test/cli/subproce
     type-member(+) ::<Class:<Class:Hi>>::<AttachedClass> -> T.attached_class (of T.class_of(Hi)) @ test/cli/subprocess-plugin/multi1.rb:17
     method ::<Class:<Class:Hi>>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi1.rb:17
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi1.rb start=??? end=???}
-  class ::Kick < ::Object () @ (test/cli/subprocess-plugin/multi6.rb:3, test/cli/subprocess-plugin/multi6.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi6.rb//plugin-generated|1.rbi:1)
-    module ::Kick::Down < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ (test/cli/subprocess-plugin/multi6.rb:4, test/cli/subprocess-plugin/multi6.rb//plugin-generated|1.rbi:1)
+  class ::Kick < ::Object () @ (test/cli/subprocess-plugin/multi6.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi6.rb//plugin-generated|1.rbi:1, test/cli/subprocess-plugin/multi6.rb:3)
+    module ::Kick::Down < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ (test/cli/subprocess-plugin/multi6.rb//plugin-generated|1.rbi:1, test/cli/subprocess-plugin/multi6.rb:4)
       static-field ::Kick::Down::Whale -> TrueClass @ test/cli/subprocess-plugin/multi6.rb//plugin-generated|1.rbi:3
       method ::Kick::Down#whale (<blk>) @ test/cli/subprocess-plugin/multi6.rb//plugin-generated|1.rbi:2
         argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi6.rb//plugin-generated|1.rbi start=??? end=???}
@@ -668,10 +668,10 @@ class ::<root> < ::Object () @ (... removed core rbi locs ..., test/cli/subproce
     type-member(+) ::<Class:Kick>::<AttachedClass> -> T.attached_class (of Kick) @ test/cli/subprocess-plugin/multi6.rb:3
     method ::<Class:Kick>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi6.rb:3
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi6.rb start=??? end=???}
-  class ::Nope < ::Object () @ (test/cli/subprocess-plugin/multi5.rb:3, test/cli/subprocess-plugin/multi5.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi5.rb//plugin-generated|1.rbi:1)
+  class ::Nope < ::Object () @ (test/cli/subprocess-plugin/multi5.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi5.rb//plugin-generated|1.rbi:1, test/cli/subprocess-plugin/multi5.rb:3)
     method ::Nope#foo (<blk>) @ test/cli/subprocess-plugin/multi5.rb//plugin-generated|0.rbi:2
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi5.rb//plugin-generated|0.rbi start=??? end=???}
-  class ::<Class:Nope>[<AttachedClass>] < ::<Class:Object> () @ (test/cli/subprocess-plugin/multi5.rb:4, test/cli/subprocess-plugin/multi5.rb//plugin-generated|1.rbi:1)
+  class ::<Class:Nope>[<AttachedClass>] < ::<Class:Object> () @ (test/cli/subprocess-plugin/multi5.rb//plugin-generated|1.rbi:1, test/cli/subprocess-plugin/multi5.rb:4)
     type-member(+) ::<Class:Nope>::<AttachedClass> -> T.attached_class (of Nope) @ test/cli/subprocess-plugin/multi5.rb:3
     method ::<Class:Nope>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi5.rb:3
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi5.rb start=??? end=???}
@@ -692,7 +692,7 @@ class ::<root> < ::Object () @ (... removed core rbi locs ..., test/cli/subproce
     method ::Object#gen : private (_arg, <blk>) @ test/cli/subprocess-plugin/multi1.rb:3
       argument _arg<> @ Loc {file=test/cli/subprocess-plugin/multi1.rb start=3:9 end=3:13}
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi1.rb start=??? end=???}
-  class ::Something < ::Object () @ (test/cli/subprocess-plugin/multi3.rb:3, test/cli/subprocess-plugin/multi3.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi3.rb//plugin-generated|1.rbi:1, test/cli/subprocess-plugin/multi3.rb//plugin-generated|2.rbi:1)
+  class ::Something < ::Object () @ (test/cli/subprocess-plugin/multi3.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi3.rb//plugin-generated|1.rbi:1, test/cli/subprocess-plugin/multi3.rb//plugin-generated|2.rbi:1, test/cli/subprocess-plugin/multi3.rb:3)
     static-field ::Something::Camel -> TrueClass @ test/cli/subprocess-plugin/multi3.rb//plugin-generated|2.rbi:3
     method ::Something#bar (<blk>) @ test/cli/subprocess-plugin/multi3.rb//plugin-generated|0.rbi:2
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi3.rb//plugin-generated|0.rbi start=??? end=???}

--- a/test/cli/subprocess-plugin/subprocess-plugin.out
+++ b/test/cli/subprocess-plugin/subprocess-plugin.out
@@ -554,7 +554,7 @@ end;
 class Kick;module Down;
 end;end;
 ------ Multi file symbol table
-class ::<root> < ::Object () @ (... removed core rbi locs ..., test/cli/subprocess-plugin/multi1.rb:3, test/cli/subprocess-plugin/multi1.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|1.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|2.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|3.rbi:1, test/cli/subprocess-plugin/multi1.rb//plugin-generated|4.rbi:1, test/cli/subprocess-plugin/multi2.rb:3, test/cli/subprocess-plugin/multi2.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi2.rb//plugin-generated|1.rbi:1, test/cli/subprocess-plugin/multi3.rb:3, test/cli/subprocess-plugin/multi3.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi3.rb//plugin-generated|1.rbi:1, test/cli/subprocess-plugin/multi3.rb//plugin-generated|2.rbi:1, test/cli/subprocess-plugin/multi4.rb:3, test/cli/subprocess-plugin/multi4.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi4.rb//plugin-generated|1.rbi:1, test/cli/subprocess-plugin/multi5.rb:3, test/cli/subprocess-plugin/multi5.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi5.rb//plugin-generated|1.rbi:1, test/cli/subprocess-plugin/multi6.rb:3, test/cli/subprocess-plugin/multi6.rb//plugin-generated|0.rbi:1, test/cli/subprocess-plugin/multi6.rb//plugin-generated|1.rbi:1)
+class ::<root> < ::Object ()
   class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
     method ::<Class:<root>>#<static-init> (<blk>) @ test/cli/subprocess-plugin/multi1.rb:3
       argument <blk><block> @ Loc {file=test/cli/subprocess-plugin/multi1.rb start=??? end=???}

--- a/test/testdata/autogen/no_dsls.rb.autogen.exp
+++ b/test/testdata/autogen/no_dsls.rb.autogen.exp
@@ -16,12 +16,12 @@ requires: []
  name=[A]
  nesting=[]
  resolved=[A]
- loc=test/testdata/autogen/no_dsls.rb:4
+ loc=test/testdata/autogen/no_dsls.rb:3
  is_defining_ref=1
 [ref id=1]
  scope=[]
  name=[Struct]
  nesting=[]
  resolved=[Struct]
- loc=test/testdata/autogen/no_dsls.rb:4
+ loc=test/testdata/autogen/no_dsls.rb:3
  is_defining_ref=0

--- a/test/testdata/cfg/blocks.rb.symbol-table-raw.exp
+++ b/test/testdata/cfg/blocks.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/cfg/blocks.rb start=2:1 end=8:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/cfg/blocks.rb start=2:1 end=8:4}
       argument <blk><block> @ Loc {file=test/testdata/cfg/blocks.rb start=??? end=???}

--- a/test/testdata/cfg/examples.rb.symbol-table-raw.exp
+++ b/test/testdata/cfg/examples.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/cfg/examples.rb start=2:1 end=92:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/cfg/examples.rb start=2:1 end=92:4}
       argument <blk><block> @ Loc {file=test/testdata/cfg/examples.rb start=??? end=???}

--- a/test/testdata/cfg/singleton_lazy.rb.symbol-table-raw.exp
+++ b/test/testdata/cfg/singleton_lazy.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/cfg/singleton_lazy.rb start=2:1 end=7:5})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/cfg/singleton_lazy.rb start=2:1 end=7:5}
       argument <blk><block> @ Loc {file=test/testdata/cfg/singleton_lazy.rb start=??? end=???}

--- a/test/testdata/desugar/constant_error.rb.symbol-table-raw.exp
+++ b/test/testdata/desugar/constant_error.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/desugar/constant_error.rb start=2:1 end=4:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/desugar/constant_error.rb start=2:1 end=4:4}
       argument <blk><block> @ Loc {file=test/testdata/desugar/constant_error.rb start=??? end=???}

--- a/test/testdata/desugar/destructure.rb.symbol-table-raw.exp
+++ b/test/testdata/desugar/destructure.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/desugar/destructure.rb start=2:1 end=9:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/desugar/destructure.rb start=2:1 end=9:4}
       argument <blk><block> @ Loc {file=test/testdata/desugar/destructure.rb start=??? end=???}

--- a/test/testdata/desugar/multi_assign.rb.symbol-table-raw.exp
+++ b/test/testdata/desugar/multi_assign.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/desugar/multi_assign.rb start=2:1 end=15:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/desugar/multi_assign.rb start=2:1 end=15:4}
       argument <blk><block> @ Loc {file=test/testdata/desugar/multi_assign.rb start=??? end=???}

--- a/test/testdata/desugar/sclass.rb.symbol-table-raw.exp
+++ b/test/testdata/desugar/sclass.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/desugar/sclass.rb start=2:1 end=94:5})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=2:1 end=94:5}
       argument <blk><block> @ Loc {file=test/testdata/desugar/sclass.rb start=??? end=???}

--- a/test/testdata/desugar/sclass_inheritance.rb.symbol-table-raw.exp
+++ b/test/testdata/desugar/sclass_inheritance.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/desugar/sclass_inheritance.rb start=2:1 end=35:5})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/desugar/sclass_inheritance.rb start=2:1 end=35:5}
       argument <blk><block> @ Loc {file=test/testdata/desugar/sclass_inheritance.rb start=??? end=???}

--- a/test/testdata/desugar/top_level_const.rb.symbol-table-raw.exp
+++ b/test/testdata/desugar/top_level_const.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/desugar/top_level_const.rb start=2:1 end=2:16})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/desugar/top_level_const.rb start=2:1 end=2:16}
       argument <blk><block> @ Loc {file=test/testdata/desugar/top_level_const.rb start=??? end=???}

--- a/test/testdata/deviations/non_ruby_names.rb.symbol-table-raw.exp
+++ b/test/testdata/deviations/non_ruby_names.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/deviations/non_ruby_names.rb start=2:1 end=9:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/deviations/non_ruby_names.rb start=2:1 end=9:4}
       argument <blk><block> @ Loc {file=test/testdata/deviations/non_ruby_names.rb start=??? end=???}

--- a/test/testdata/deviations/superclass_implicit.rb.symbol-table-raw.exp
+++ b/test/testdata/deviations/superclass_implicit.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/deviations/superclass_implicit.rb start=8:1 end=15:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/deviations/superclass_implicit.rb start=8:1 end=15:4}
       argument <blk><block> @ Loc {file=test/testdata/deviations/superclass_implicit.rb start=??? end=???}

--- a/test/testdata/infer/infer1.rb.symbol-table-raw.exp
+++ b/test/testdata/infer/infer1.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/infer/infer1.rb start=2:1 end=50:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/infer/infer1.rb start=2:1 end=50:4}
       argument <blk><block> @ Loc {file=test/testdata/infer/infer1.rb start=??? end=???}

--- a/test/testdata/infer/lub_tuples.rb.symbol-table-raw.exp
+++ b/test/testdata/infer/lub_tuples.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/infer/lub_tuples.rb start=2:1 end=16:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/infer/lub_tuples.rb start=2:1 end=16:4}
       argument <blk><block> @ Loc {file=test/testdata/infer/lub_tuples.rb start=??? end=???}

--- a/test/testdata/namer/alias_cross_file.symbol-table-raw.exp
+++ b/test/testdata/namer/alias_cross_file.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/alias_cross_file__01.rb start=2:1 end=5:4}, Loc {file=test/testdata/namer/alias_cross_file__02.rb start=2:1 end=3:8})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/alias_cross_file__01.rb start=2:1 end=5:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/alias_cross_file__01.rb start=??? end=???}

--- a/test/testdata/namer/alias_method.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/alias_method.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/alias_method.rb start=2:1 end=12:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/alias_method.rb start=2:1 end=12:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/alias_method.rb start=??? end=???}

--- a/test/testdata/namer/ancestors.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/ancestors.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/ancestors.rb start=2:1 end=15:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/ancestors.rb start=2:1 end=15:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/ancestors.rb start=??? end=???}

--- a/test/testdata/namer/arguments.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/arguments.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/arguments.rb start=2:1 end=10:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/arguments.rb start=2:1 end=10:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/arguments.rb start=??? end=???}

--- a/test/testdata/namer/circular_mixin.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/circular_mixin.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/circular_mixin.rb start=2:1 end=13:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/circular_mixin.rb start=2:1 end=13:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/circular_mixin.rb start=??? end=???}

--- a/test/testdata/namer/class_and_alias.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/class_and_alias.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/class_and_alias.rb start=2:1 end=8:7})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/class_and_alias.rb start=2:1 end=8:7}
       argument <blk><block> @ Loc {file=test/testdata/namer/class_and_alias.rb start=??? end=???}

--- a/test/testdata/namer/conflicting_names.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/conflicting_names.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/conflicting_names.rb start=2:1 end=8:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/conflicting_names.rb start=2:1 end=8:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/conflicting_names.rb start=??? end=???}

--- a/test/testdata/namer/constant_in_block.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/constant_in_block.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/constant_in_block.rb start=2:1 end=9:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/constant_in_block.rb start=2:1 end=9:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/constant_in_block.rb start=??? end=???}

--- a/test/testdata/namer/constant_types.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/constant_types.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/constant_types.rb start=3:1 end=10:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/constant_types.rb start=3:1 end=10:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/constant_types.rb start=??? end=???}

--- a/test/testdata/namer/constants.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/constants.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/constants.rb start=2:1 end=14:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/constants.rb start=2:1 end=14:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/constants.rb start=??? end=???}

--- a/test/testdata/namer/defs_in_blocks.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/defs_in_blocks.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/defs_in_blocks.rb start=2:1 end=13:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/defs_in_blocks.rb start=2:1 end=13:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/defs_in_blocks.rb start=??? end=???}

--- a/test/testdata/namer/dynamic_method_with_class.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/dynamic_method_with_class.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/dynamic_method_with_class.rb start=2:1 end=12:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/dynamic_method_with_class.rb start=2:1 end=12:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/dynamic_method_with_class.rb start=??? end=???}

--- a/test/testdata/namer/extend.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/extend.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/extend.rb start=2:1 end=19:16})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/extend.rb start=2:1 end=19:16}
       argument <blk><block> @ Loc {file=test/testdata/namer/extend.rb start=??? end=???}

--- a/test/testdata/namer/fuzz_type_template_overwrite.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/fuzz_type_template_overwrite.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/fuzz_type_template_overwrite.rb start=3:1 end=6:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/fuzz_type_template_overwrite.rb start=3:1 end=6:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/fuzz_type_template_overwrite.rb start=??? end=???}

--- a/test/testdata/namer/gvar.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/gvar.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/gvar.rb start=2:1 end=10:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/gvar.rb start=2:1 end=10:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/gvar.rb start=??? end=???}

--- a/test/testdata/namer/locals.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/locals.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/locals.rb start=2:1 end=21:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/locals.rb start=2:1 end=21:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/locals.rb start=??? end=???}

--- a/test/testdata/namer/module_function.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/module_function.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/module_function.rb start=2:1 end=33:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/module_function.rb start=2:1 end=33:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/module_function.rb start=??? end=???}

--- a/test/testdata/namer/multiple_stubs.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/multiple_stubs.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/multiple_stubs.rb start=2:1 end=3:16})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/multiple_stubs.rb start=2:1 end=3:16}
       argument <blk><block> @ Loc {file=test/testdata/namer/multiple_stubs.rb start=??? end=???}

--- a/test/testdata/namer/redefines_module_as_static_field.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/redefines_module_as_static_field.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/redefines_module_as_static_field.rb start=3:1 end=39:98})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/redefines_module_as_static_field.rb start=3:1 end=39:98}
       argument <blk><block> @ Loc {file=test/testdata/namer/redefines_module_as_static_field.rb start=??? end=???}

--- a/test/testdata/namer/root_private.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/root_private.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/root_private.rb start=5:1 end=16:18})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/root_private.rb start=5:1 end=16:18}
       argument <blk><block> @ Loc {file=test/testdata/namer/root_private.rb start=??? end=???}

--- a/test/testdata/namer/simple.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/simple.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/simple.rb start=2:1 end=34:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/simple.rb start=2:1 end=34:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/simple.rb start=??? end=???}

--- a/test/testdata/namer/singleton_class.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/singleton_class.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/singleton_class.rb start=2:1 end=8:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/singleton_class.rb start=2:1 end=8:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/singleton_class.rb start=??? end=???}

--- a/test/testdata/namer/superclass_redefinition.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/superclass_redefinition.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/superclass_redefinition.rb start=2:1 end=8:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/superclass_redefinition.rb start=2:1 end=8:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/superclass_redefinition.rb start=??? end=???}

--- a/test/testdata/namer/type_alias.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/type_alias.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/type_alias.rb start=2:1 end=11:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/type_alias.rb start=2:1 end=11:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/type_alias.rb start=??? end=???}

--- a/test/testdata/namer/visibility.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/visibility.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/visibility.rb start=3:1 end=55:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=3:1 end=55:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}

--- a/test/testdata/namer/yield.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/yield.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/namer/yield.rb start=2:1 end=27:14})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/yield.rb start=2:1 end=27:14}
       argument <blk><block> @ Loc {file=test/testdata/namer/yield.rb start=??? end=???}

--- a/test/testdata/resolver/alias.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/alias.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/alias.rb start=2:1 end=35:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/alias.rb start=2:1 end=35:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/alias.rb start=??? end=???}

--- a/test/testdata/resolver/bind_class_of.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/bind_class_of.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/bind_class_of.rb start=3:1 end=13:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/bind_class_of.rb start=3:1 end=13:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/bind_class_of.rb start=??? end=???}

--- a/test/testdata/resolver/cbase.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/cbase.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/cbase.rb start=2:1 end=8:2})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/cbase.rb start=2:1 end=8:2}
       argument <blk><block> @ Loc {file=test/testdata/resolver/cbase.rb start=??? end=???}

--- a/test/testdata/resolver/class_instance_vars.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/class_instance_vars.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/class_instance_vars.rb start=2:1 end=38:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/class_instance_vars.rb start=2:1 end=38:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/class_instance_vars.rb start=??? end=???}

--- a/test/testdata/resolver/flatten.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/flatten.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/flatten.rb start=2:1 end=34:12})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/flatten.rb start=2:1 end=34:12}
       argument <blk><block> @ Loc {file=test/testdata/resolver/flatten.rb start=??? end=???}

--- a/test/testdata/resolver/fuzz_type_member_scope.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/fuzz_type_member_scope.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/fuzz_type_member_scope.rb start=2:1 end=3:14})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/fuzz_type_member_scope.rb start=2:1 end=3:14}
       argument <blk><block> @ Loc {file=test/testdata/resolver/fuzz_type_member_scope.rb start=??? end=???}

--- a/test/testdata/resolver/inherit_alias.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/inherit_alias.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/inherit_alias.rb start=2:1 end=10:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/inherit_alias.rb start=2:1 end=10:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/inherit_alias.rb start=??? end=???}

--- a/test/testdata/resolver/invalid_alias.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/invalid_alias.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/invalid_alias.rb start=3:1 end=15:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/invalid_alias.rb start=3:1 end=15:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/invalid_alias.rb start=??? end=???}

--- a/test/testdata/resolver/let_errors.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/let_errors.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/let_errors.rb start=2:1 end=23:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/let_errors.rb start=2:1 end=23:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/let_errors.rb start=??? end=???}

--- a/test/testdata/resolver/let_var.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/let_var.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/let_var.rb start=2:1 end=41:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/let_var.rb start=2:1 end=41:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/let_var.rb start=??? end=???}

--- a/test/testdata/resolver/linearization/includes_class.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/linearization/includes_class.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/linearization/includes_class.rb start=3:1 end=21:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=3:1 end=21:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=??? end=???}

--- a/test/testdata/resolver/linearization/linearization1.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/linearization/linearization1.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/linearization/linearization1.rb start=2:1 end=22:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/linearization/linearization1.rb start=2:1 end=22:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/linearization/linearization1.rb start=??? end=???}

--- a/test/testdata/resolver/linearization/linearization2.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/linearization/linearization2.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/linearization/linearization2.rb start=2:1 end=18:14})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/linearization/linearization2.rb start=2:1 end=18:14}
       argument <blk><block> @ Loc {file=test/testdata/resolver/linearization/linearization2.rb start=??? end=???}

--- a/test/testdata/resolver/linearization/linearization3.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/linearization/linearization3.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/linearization/linearization3.rb start=2:1 end=12:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/linearization/linearization3.rb start=2:1 end=12:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/linearization/linearization3.rb start=??? end=???}

--- a/test/testdata/resolver/linearization/linearization4.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/linearization/linearization4.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/linearization/linearization4.rb start=2:1 end=19:11})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/linearization/linearization4.rb start=2:1 end=19:11}
       argument <blk><block> @ Loc {file=test/testdata/resolver/linearization/linearization4.rb start=??? end=???}

--- a/test/testdata/resolver/linearization/linearization4a.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/linearization/linearization4a.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/linearization/linearization4a.rb start=2:1 end=19:11})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/linearization/linearization4a.rb start=2:1 end=19:11}
       argument <blk><block> @ Loc {file=test/testdata/resolver/linearization/linearization4a.rb start=??? end=???}

--- a/test/testdata/resolver/linearization/linearization5.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/linearization/linearization5.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/linearization/linearization5.rb start=2:1 end=18:11})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/linearization/linearization5.rb start=2:1 end=18:11}
       argument <blk><block> @ Loc {file=test/testdata/resolver/linearization/linearization5.rb start=??? end=???}

--- a/test/testdata/resolver/linearization/linearization6.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/linearization/linearization6.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/linearization/linearization6.rb start=2:1 end=15:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/linearization/linearization6.rb start=2:1 end=15:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/linearization/linearization6.rb start=??? end=???}

--- a/test/testdata/resolver/mixes_in_class_methods.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/mixes_in_class_methods.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=2:1 end=51:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=2:1 end=51:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=??? end=???}

--- a/test/testdata/resolver/proc.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/proc.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/proc.rb start=3:1 end=42:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/proc.rb start=3:1 end=42:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/proc.rb start=??? end=???}

--- a/test/testdata/resolver/recover_from_bad_superclass.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/recover_from_bad_superclass.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=3:1 end=31:16})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=3:1 end=31:16}
       argument <blk><block> @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=??? end=???}

--- a/test/testdata/resolver/resolution_order.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/resolution_order.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/resolution_order.rb start=8:1 end=64:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=8:1 end=64:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/resolution_order.rb start=??? end=???}

--- a/test/testdata/resolver/resolution_scoping.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/resolution_scoping.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/resolution_scoping.rb start=2:1 end=15:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/resolution_scoping.rb start=2:1 end=15:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/resolution_scoping.rb start=??? end=???}

--- a/test/testdata/resolver/resolve_through_alias.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/resolve_through_alias.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/resolve_through_alias.rb start=3:1 end=11:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/resolve_through_alias.rb start=3:1 end=11:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/resolve_through_alias.rb start=??? end=???}

--- a/test/testdata/resolver/self.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/self.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/self.rb start=3:1 end=42:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/self.rb start=3:1 end=42:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/self.rb start=??? end=???}

--- a/test/testdata/resolver/sig_bad.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/sig_bad.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/sig_bad.rb start=2:1 end=39:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/sig_bad.rb start=2:1 end=39:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/sig_bad.rb start=??? end=???}

--- a/test/testdata/resolver/sig_compat.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/sig_compat.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/sig_compat.rb start=4:1 end=13:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/sig_compat.rb start=4:1 end=13:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/sig_compat.rb start=??? end=???}

--- a/test/testdata/resolver/sig_good.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/sig_good.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/sig_good.rb start=2:1 end=33:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/sig_good.rb start=2:1 end=33:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/sig_good.rb start=??? end=???}

--- a/test/testdata/resolver/sig_misc.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/sig_misc.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/sig_misc.rb start=2:1 end=114:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/sig_misc.rb start=2:1 end=114:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/sig_misc.rb start=??? end=???}

--- a/test/testdata/resolver/simple.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/simple.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/simple.rb start=2:1 end=28:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/simple.rb start=2:1 end=28:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/simple.rb start=??? end=???}

--- a/test/testdata/resolver/stub_missing_class_alias.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/stub_missing_class_alias.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/stub_missing_class_alias.rb start=4:1 end=22:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/stub_missing_class_alias.rb start=4:1 end=22:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/stub_missing_class_alias.rb start=??? end=???}

--- a/test/testdata/resolver/type_arguments.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/type_arguments.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/type_arguments.rb start=3:1 end=13:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/type_arguments.rb start=3:1 end=13:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/type_arguments.rb start=??? end=???}

--- a/test/testdata/resolver/type_member_constant_assignment.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/type_member_constant_assignment.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=3:1 end=17:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=3:1 end=17:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/type_member_constant_assignment.rb start=??? end=???}

--- a/test/testdata/resolver/type_member_missing.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/type_member_missing.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/type_member_missing.rb start=3:1 end=12:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/type_member_missing.rb start=3:1 end=12:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/type_member_missing.rb start=??? end=???}

--- a/test/testdata/resolver/type_member_singleton_members.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/type_member_singleton_members.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/resolver/type_member_singleton_members.rb start=3:1 end=13:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/type_member_singleton_members.rb start=3:1 end=13:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/type_member_singleton_members.rb start=??? end=???}

--- a/test/testdata/rewriter/attr.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/attr.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/rewriter/attr.rb start=2:1 end=26:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/attr.rb start=2:1 end=26:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}

--- a/test/testdata/rewriter/attr_multi.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/attr_multi.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/rewriter/attr_multi.rb start=3:1 end=23:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/attr_multi.rb start=3:1 end=23:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/attr_multi.rb start=??? end=???}

--- a/test/testdata/rewriter/flatten_module_private_class_method.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/flatten_module_private_class_method.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=3:1 end=15:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=3:1 end=15:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=??? end=???}

--- a/test/testdata/rewriter/flatten_nested_sclass.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/flatten_nested_sclass.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=3:1 end=34:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=3:1 end=34:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_nested_sclass.rb start=??? end=???}

--- a/test/testdata/rewriter/not_prop.rb.symbol-table.exp
+++ b/test/testdata/rewriter/not_prop.rb.symbol-table.exp
@@ -1,4 +1,4 @@
-class ::<root> < ::Object () @ (... removed core rbi locs ..., test/testdata/rewriter/not_prop.rb:3)
+class ::<root> < ::Object ()
   class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
     method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/rewriter/not_prop.rb:3
       argument <blk><block> @ Loc {file=test/testdata/rewriter/not_prop.rb start=??? end=???}

--- a/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=145:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=145:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}

--- a/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/rewriter/struct.rb start=2:1 end=101:19})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=2:1 end=101:19}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}

--- a/test/testdata/todo/block_in_class.rb.symbol-table-raw.exp
+++ b/test/testdata/todo/block_in_class.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/todo/block_in_class.rb start=2:1 end=4:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/todo/block_in_class.rb start=2:1 end=4:4}
       argument <blk><block> @ Loc {file=test/testdata/todo/block_in_class.rb start=??? end=???}

--- a/test/testdata/todo/const_in_block.rb.symbol-table-raw.exp
+++ b/test/testdata/todo/const_in_block.rb.symbol-table-raw.exp
@@ -1,4 +1,4 @@
-class <C <U <root>>> < <C <U Object>> () @ (... removed core rbi locs ..., Loc {file=test/testdata/todo/const_in_block.rb start=2:1 end=9:4})
+class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/todo/const_in_block.rb start=2:1 end=9:4}
       argument <blk><block> @ Loc {file=test/testdata/todo/const_in_block.rb start=??? end=???}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Change canonical loc to be _end_ of vector.

Reduces copying overhead on symbols with many locs.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests should catch any behavior changes.
