### PR TITLE
Serialize type_parameter argument correctly

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/type_parameter.rb
+++ b/gems/sorbet-runtime/lib/types/types/type_parameter.rb
@@ -17,7 +17,7 @@ module T::Types
     end
 
     def name
-      "T.type_parameter(#{@name})"
+      "T.type_parameter(:#{@name})"
     end
   end
 end

--- a/gems/sorbet-runtime/test/types/types_to_ruby.rb
+++ b/gems/sorbet-runtime/test/types/types_to_ruby.rb
@@ -45,6 +45,9 @@ class Opus::Types::Test::TypesToRubyTest < Critic::Unit::UnitTest
 
     # Set:
     [T::Set[Integer], "T::Set[Integer]"],
+
+    # T.type_parameter:
+    [T.type_parameter(:A), "T.type_parameter(:A)"],
   ]
 
   cases.each do |c|


### PR DESCRIPTION
The parameter of `T.type_parameter` is expected to be a `Symbol` but when the type is returning its name, it was not respecting that and converting the name of the parameter into a `Symbol`.

This commit corrects that and adds a test case for `T.type_parameter` serialization.

### Motivation

Trying to serialize a runtime signature back to a string requires extra hoops to fix this serialization problem.

### Test plan

See included automated tests.
