### PR TITLE
Replace --reserve-mem-kb with --reserve-symbol-table-capacity and --reserve-name-table-capacity

### DIFF
--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -54,7 +54,7 @@ public:
     void initEmpty();
     void installIntrinsics();
 
-    // Expand tables to the given sizes. Does nothing if the value is <= current capacity.
+    // Expand symbol and name tables to the given lengths. Does nothing if the value is <= current capacity.
     void preallocateTables(u4 symbolSize, u4 nameSize);
 
     GlobalState(const GlobalState &) = delete;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -54,9 +54,8 @@ public:
     void initEmpty();
     void installIntrinsics();
 
-    // Expand tables to use approximate `kb` KiB of memory. Can be used prior to
-    // operation to avoid table resizes.
-    void reserveMemory(u4 kb);
+    // Expand tables to the given sizes. Does nothing if the value is <= current capacity.
+    void preallocateTables(u4 symbolSize, u4 nameSize);
 
     GlobalState(const GlobalState &) = delete;
     GlobalState(GlobalState &&) = delete;
@@ -254,7 +253,7 @@ private:
     bool symbolTableFrozen = true;
     bool fileTableFrozen = true;
 
-    void expandNames(int growBy = 2);
+    void expandNames(u4 newSize);
 
     SymbolRef synthesizeClass(NameRef nameID, u4 superclass = Symbols::todo()._id, bool isModule = false);
     SymbolRef enterSymbol(Loc loc, SymbolRef owner, NameRef name, u4 flags);

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -314,9 +314,12 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                     cxxopts::value<string>()->default_value(empty.webTraceFile), "file");
     options.add_options("advanced")("debug-log-file", "Path to debug log file",
                                     cxxopts::value<string>()->default_value(empty.debugLogFile), "file");
-    options.add_options("advanced")("reserve-mem-kb",
-                                    "Preallocate the specified amount of memory for symbol+name tables",
-                                    cxxopts::value<u8>()->default_value(fmt::format("{}", empty.reserveMemKiB)));
+    options.add_options("advanced")(
+        "preallocate-symbol-size", "Preallocate the specified amount of entries in the symbol table",
+        cxxopts::value<u4>()->default_value(fmt::format("{}", empty.preallocateSymbolSize)));
+    options.add_options("advanced")("preallocate-name-size",
+                                    "Preallocate the specified amount of entries in the name table",
+                                    cxxopts::value<u4>()->default_value(fmt::format("{}", empty.preallocateNameSize)));
     options.add_options("advanced")("stdout-hup-hack", "Monitor STDERR for HUP and exit on hangup");
     options.add_options("advanced")("remove-path-prefix",
                                     "Remove the provided path prefix from all printed paths. Defaults to the input "
@@ -809,7 +812,8 @@ void readOptions(Options &opts,
                 }
             }
         }
-        opts.reserveMemKiB = raw["reserve-mem-kb"].as<u8>();
+        opts.preallocateNameSize = raw["preallocate-name-size"].as<u4>();
+        opts.preallocateSymbolSize = raw["preallocate-symbol-size"].as<u4>();
         if (raw.count("autogen-version") > 0) {
             if (!opts.print.AutogenMsgPack.enabled) {
                 logger->error("`{}` must also include `{}`", "--autogen-version", "-p autogen-msgpack");

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -315,10 +315,10 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("debug-log-file", "Path to debug log file",
                                     cxxopts::value<string>()->default_value(empty.debugLogFile), "file");
     options.add_options("advanced")(
-        "preallocate-symbol-size", "Preallocate the specified amount of entries in the symbol table",
+        "preallocate-symbol-size", "Preallocate the specified number of entries in the symbol table",
         cxxopts::value<u4>()->default_value(fmt::format("{}", empty.preallocateSymbolSize)));
     options.add_options("advanced")("preallocate-name-size",
-                                    "Preallocate the specified amount of entries in the name table",
+                                    "Preallocate the specified number of entries in the name table",
                                     cxxopts::value<u4>()->default_value(fmt::format("{}", empty.preallocateNameSize)));
     options.add_options("advanced")("stdout-hup-hack", "Monitor STDERR for HUP and exit on hangup");
     options.add_options("advanced")("remove-path-prefix",

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -315,11 +315,11 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("debug-log-file", "Path to debug log file",
                                     cxxopts::value<string>()->default_value(empty.debugLogFile), "file");
     options.add_options("advanced")(
-        "preallocate-symbol-size", "Preallocate the specified number of entries in the symbol table",
-        cxxopts::value<u4>()->default_value(fmt::format("{}", empty.preallocateSymbolSize)));
-    options.add_options("advanced")("preallocate-name-size",
-                                    "Preallocate the specified number of entries in the name table",
-                                    cxxopts::value<u4>()->default_value(fmt::format("{}", empty.preallocateNameSize)));
+        "reserve-symbol-table-capacity", "Preallocate the specified number of entries in the symbol table",
+        cxxopts::value<u4>()->default_value(fmt::format("{}", empty.reserveSymbolTableCapacity)));
+    options.add_options("advanced")(
+        "reserve-name-table-capacity", "Preallocate the specified number of entries in the name table",
+        cxxopts::value<u4>()->default_value(fmt::format("{}", empty.reserveNameTableCapacity)));
     options.add_options("advanced")("stdout-hup-hack", "Monitor STDERR for HUP and exit on hangup");
     options.add_options("advanced")("remove-path-prefix",
                                     "Remove the provided path prefix from all printed paths. Defaults to the input "
@@ -812,8 +812,8 @@ void readOptions(Options &opts,
                 }
             }
         }
-        opts.preallocateNameSize = raw["preallocate-name-size"].as<u4>();
-        opts.preallocateSymbolSize = raw["preallocate-symbol-size"].as<u4>();
+        opts.reserveNameTableCapacity = raw["reserve-name-table-capacity"].as<u4>();
+        opts.reserveSymbolTableCapacity = raw["reserve-symbol-table-capacity"].as<u4>();
         if (raw.count("autogen-version") > 0) {
             if (!opts.print.AutogenMsgPack.enabled) {
                 logger->error("`{}` must also include `{}`", "--autogen-version", "-p autogen-msgpack");

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -157,7 +157,8 @@ struct Options {
     /** Prefix to remove from all printed paths. */
     std::string pathPrefix;
 
-    u4 reserveMemKiB = 0;
+    u4 preallocateSymbolSize = 0;
+    u4 preallocateNameSize = 0;
 
     std::string statsdHost;
     std::string statsdPrefix = "ruby_typer.unknown";

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -157,8 +157,8 @@ struct Options {
     /** Prefix to remove from all printed paths. */
     std::string pathPrefix;
 
-    u4 preallocateSymbolSize = 0;
-    u4 preallocateNameSize = 0;
+    u4 reserveSymbolTableCapacity = 0;
+    u4 reserveNameTableCapacity = 0;
 
     std::string statsdHost;
     std::string statsdPrefix = "ruby_typer.unknown";

--- a/main/options/test/options_test.cc
+++ b/main/options/test/options_test.cc
@@ -53,7 +53,8 @@ TEST_CASE("DefaultConstructorMatchesReadOptions") {
     CHECK_EQ(empty.errorCodeWhiteList, opts.errorCodeWhiteList);
     CHECK_EQ(empty.errorCodeBlackList, opts.errorCodeBlackList);
     CHECK_EQ(empty.pathPrefix, opts.pathPrefix);
-    CHECK_EQ(empty.reserveMemKiB, opts.reserveMemKiB);
+    CHECK_EQ(empty.preallocateNameSize, opts.preallocateNameSize);
+    CHECK_EQ(empty.preallocateSymbolSize, opts.preallocateSymbolSize);
     CHECK_EQ(empty.statsdHost, opts.statsdHost);
     CHECK_EQ(empty.statsdPrefix, opts.statsdPrefix);
     CHECK_EQ(empty.statsdPort, opts.statsdPort);

--- a/main/options/test/options_test.cc
+++ b/main/options/test/options_test.cc
@@ -53,8 +53,8 @@ TEST_CASE("DefaultConstructorMatchesReadOptions") {
     CHECK_EQ(empty.errorCodeWhiteList, opts.errorCodeWhiteList);
     CHECK_EQ(empty.errorCodeBlackList, opts.errorCodeBlackList);
     CHECK_EQ(empty.pathPrefix, opts.pathPrefix);
-    CHECK_EQ(empty.preallocateNameSize, opts.preallocateNameSize);
-    CHECK_EQ(empty.preallocateSymbolSize, opts.preallocateSymbolSize);
+    CHECK_EQ(empty.reserveNameTableCapacity, opts.reserveNameTableCapacity);
+    CHECK_EQ(empty.reserveSymbolTableCapacity, opts.reserveSymbolTableCapacity);
     CHECK_EQ(empty.statsdHost, opts.statsdHost);
     CHECK_EQ(empty.statsdPrefix, opts.statsdPrefix);
     CHECK_EQ(empty.statsdPort, opts.statsdPort);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -443,7 +443,7 @@ int realmain(int argc, char *argv[]) {
     if (opts.sleepInSlowPath) {
         gs->sleepInSlowPath = true;
     }
-    gs->preallocateTables(opts.preallocateSymbolSize, opts.preallocateNameSize);
+    gs->preallocateTables(opts.reserveSymbolTableCapacity, opts.reserveNameTableCapacity);
     for (auto code : opts.errorCodeWhiteList) {
         gs->onlyShowErrorClass(code);
     }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -443,9 +443,7 @@ int realmain(int argc, char *argv[]) {
     if (opts.sleepInSlowPath) {
         gs->sleepInSlowPath = true;
     }
-    if (opts.reserveMemKiB > 0) {
-        gs->reserveMemory(opts.reserveMemKiB);
-    }
+    gs->preallocateTables(opts.preallocateSymbolSize, opts.preallocateNameSize);
     for (auto code : opts.errorCodeWhiteList) {
         gs->onlyShowErrorClass(code);
     }

--- a/test/cli/cache-reserve-mem/cache-reserve-mem.out
+++ b/test/cli/cache-reserve-mem/cache-reserve-mem.out
@@ -1,1 +1,1 @@
---reserve-mem-kb OK
+--preallocate-symbol-size --preallocate-name-size OK

--- a/test/cli/cache-reserve-mem/cache-reserve-mem.out
+++ b/test/cli/cache-reserve-mem/cache-reserve-mem.out
@@ -1,1 +1,1 @@
---preallocate-symbol-size --preallocate-name-size OK
+--reserve-symbol-table-capacity --reserve-name-table-capacity OK

--- a/test/cli/cache-reserve-mem/cache-reserve-mem.sh
+++ b/test/cli/cache-reserve-mem/cache-reserve-mem.sh
@@ -5,6 +5,6 @@ cleanup() {
 }
 trap cleanup EXIT
 set -e
-main/sorbet --silence-dev-message -vvv --preallocate-symbol-size 4000 --preallocate-name-size 4000 --cache-dir "$dir" test/cli/cache-reserve-mem/input.rb
-main/sorbet --silence-dev-message -vvv --preallocate-symbol-size 4000 --preallocate-name-size 4000 --cache-dir "$dir" test/cli/cache-reserve-mem/input.rb
-echo "--preallocate-symbol-size --preallocate-name-size OK"
+main/sorbet --silence-dev-message -vvv --reserve-symbol-table-capacity 4000 --reserve-name-table-capacity 4000 --cache-dir "$dir" test/cli/cache-reserve-mem/input.rb
+main/sorbet --silence-dev-message -vvv --reserve-symbol-table-capacity 4000 --reserve-name-table-capacity 4000 --cache-dir "$dir" test/cli/cache-reserve-mem/input.rb
+echo "--reserve-symbol-table-capacity --reserve-name-table-capacity OK"

--- a/test/cli/cache-reserve-mem/cache-reserve-mem.sh
+++ b/test/cli/cache-reserve-mem/cache-reserve-mem.sh
@@ -5,6 +5,6 @@ cleanup() {
 }
 trap cleanup EXIT
 set -e
-main/sorbet --silence-dev-message -vvv --reserve-mem-kb 128000 --cache-dir "$dir" test/cli/cache-reserve-mem/input.rb
-main/sorbet --silence-dev-message -vvv --reserve-mem-kb 128000 --cache-dir "$dir" test/cli/cache-reserve-mem/input.rb
-echo "--reserve-mem-kb OK"
+main/sorbet --silence-dev-message -vvv --preallocate-symbol-size 4000 --preallocate-name-size 4000 --cache-dir "$dir" test/cli/cache-reserve-mem/input.rb
+main/sorbet --silence-dev-message -vvv --preallocate-symbol-size 4000 --preallocate-name-size 4000 --cache-dir "$dir" test/cli/cache-reserve-mem/input.rb
+echo "--preallocate-symbol-size --preallocate-name-size OK"

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -52,8 +52,12 @@ Usage:
       --web-trace-file file     Web trace file. For use with chrome
                                 about://tracing (default: "")
       --debug-log-file file     Path to debug log file (default: "")
-      --reserve-mem-kb arg      Preallocate the specified amount of memory
-                                for symbol+name tables (default: 0)
+      --preallocate-symbol-size arg
+                                Preallocate the specified amount of entries
+                                in the symbol table (default: 0)
+      --preallocate-name-size arg
+                                Preallocate the specified amount of entries
+                                in the name table (default: 0)
       --stdout-hup-hack         Monitor STDERR for HUP and exit on hangup
       --remove-path-prefix prefix
                                 Remove the provided path prefix from all

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -53,10 +53,10 @@ Usage:
                                 about://tracing (default: "")
       --debug-log-file file     Path to debug log file (default: "")
       --preallocate-symbol-size arg
-                                Preallocate the specified amount of entries
+                                Preallocate the specified number of entries
                                 in the symbol table (default: 0)
       --preallocate-name-size arg
-                                Preallocate the specified amount of entries
+                                Preallocate the specified number of entries
                                 in the name table (default: 0)
       --stdout-hup-hack         Monitor STDERR for HUP and exit on hangup
       --remove-path-prefix prefix

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -52,10 +52,10 @@ Usage:
       --web-trace-file file     Web trace file. For use with chrome
                                 about://tracing (default: "")
       --debug-log-file file     Path to debug log file (default: "")
-      --preallocate-symbol-size arg
+      --reserve-symbol-table-capacity arg
                                 Preallocate the specified number of entries
                                 in the symbol table (default: 0)
-      --preallocate-name-size arg
+      --reserve-name-table-capacity arg
                                 Preallocate the specified number of entries
                                 in the name table (default: 0)
       --stdout-hup-hack         Monitor STDERR for HUP and exit on hangup


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Replace --reserve-mem-kb with --reserve-symbol-table-capacity and --reserve-name-table-capacity.

Makes it easier to determine what value to pass on the CLI to avoid resizing those tables.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Reduce copying overhead during namer (and probably indexing).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
