### PR TITLE
Use an InlinedVector for Symbol::arguments_.

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -142,8 +142,7 @@ class MethodDef final : public Declaration {
 public:
     std::unique_ptr<Expression> rhs;
 
-    static constexpr int EXPECTED_ARGS_COUNT = 2;
-    using ARGS_store = InlinedVector<std::unique_ptr<Expression>, EXPECTED_ARGS_COUNT>;
+    using ARGS_store = InlinedVector<std::unique_ptr<Expression>, core::SymbolRef::EXPECTED_METHOD_ARGS_COUNT>;
     ARGS_store args;
 
     core::NameRef name;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -38,6 +38,10 @@ public:
     SymbolRef(const GlobalState &from, u4 _id);
     SymbolRef() : _id(0){};
 
+    // From experimentation, in the common case, methods typically have 2 or fewer arguments.
+    // Placed here so it can be used across packages for common case optimizations.
+    static constexpr int EXPECTED_METHOD_ARGS_COUNT = 2;
+
     bool inline exists() const {
         return _id;
     }

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -568,7 +568,9 @@ public:
     }
 
     UnorderedMap<NameRef, SymbolRef> members_;
-    std::vector<ArgInfo> arguments_;
+
+    using ArgumentsStore = InlinedVector<ArgInfo, core::SymbolRef::EXPECTED_METHOD_ARGS_COUNT>;
+    ArgumentsStore arguments_;
 
     UnorderedMap<NameRef, SymbolRef> &members() {
         return members_;
@@ -577,12 +579,12 @@ public:
         return members_;
     };
 
-    std::vector<ArgInfo> &arguments() {
+    ArgumentsStore &arguments() {
         ENFORCE(isMethod());
         return arguments_;
     }
 
-    const std::vector<ArgInfo> &arguments() const {
+    const ArgumentsStore &arguments() const {
         ENFORCE(isMethod());
         return arguments_;
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Use an InlinedVector for Symbol::arguments_.

I wasn't sure where it made sense to put this new constant. I put it into `SymbolRef` rather than `Symbol` because `Trees.h` pulls in `SymbolRef.h` but not `Symbol.h` and I hesitated to lurk in another #include there. I can just as easily drop it into the core namespace directly if people have FUD.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Reduce CPU overhead due to vector allocation during namer when we populate the symbol table.

Also, centralizes the constant for this common case optimization so we can use the same value for `MethodDef` nodes as `Symbol`s.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
