### PR TITLE
Support canceling more passes of resolver.

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -308,7 +308,10 @@ vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, vector<ast::Pa
             core::UnfreezeSymbolTable symbolTable(gs);
             core::UnfreezeNameTable nameTable(gs);
 
-            what = sorbet::resolver::Resolver::runTreePasses(gs, move(what));
+            auto result = sorbet::resolver::Resolver::runTreePasses(gs, move(what));
+            // incrementalResolve is not cancelable.
+            ENFORCE(result.hasResult());
+            what = move(result.result());
         }
     } catch (SorbetException &) {
         if (auto e = gs.beginError(sorbet::core::Loc::none(), sorbet::core::errors::Internal::InternalError)) {

--- a/resolver/resolver.h
+++ b/resolver/resolver.h
@@ -16,7 +16,7 @@ public:
     /** Only runs tree passes, used for incremental changes that do not affect global state. Assumes that `run` was
      * called on a tree that contains same definitions before (LSP uses heuristics that should only have false negatives
      * to find this) */
-    static std::vector<ast::ParsedFile> runTreePasses(core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
+    static ast::ParsedFilesOrCancelled runTreePasses(core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
 
     // used by autogen only
     static std::vector<ast::ParsedFile> runConstantResolution(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
@@ -26,9 +26,9 @@ private:
     static void finalizeAncestors(core::GlobalState &gs);
     static void finalizeSymbols(core::GlobalState &gs);
     static void computeLinearization(core::GlobalState &gs);
-    static std::vector<ast::ParsedFile> resolveSigs(core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
-    static std::vector<ast::ParsedFile> resolveMixesInClassMethods(core::GlobalState &gs,
-                                                                   std::vector<ast::ParsedFile> trees);
+    static ast::ParsedFilesOrCancelled resolveSigs(core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
+    static ast::ParsedFilesOrCancelled resolveMixesInClassMethods(core::GlobalState &gs,
+                                                                  std::vector<ast::ParsedFile> trees);
     static void sanityCheck(core::GlobalState &gs, std::vector<ast::ParsedFile> &trees);
 };
 

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -477,7 +477,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     }
 
     // resolver
-    trees = resolver::Resolver::runTreePasses(*gs, move(newTrees));
+    trees = move(resolver::Resolver::runTreePasses(*gs, move(newTrees)).result());
 
     for (auto &resolvedTree : trees) {
         handler.addObserved("resolve-tree", [&]() { return resolvedTree.tree->toString(*gs); });


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Support canceling more passes of resolver.

These passes can take a long time in large codebases, impacting the responsiveness of slow path cancelation.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Make LSP more responsive, especially when there's a syntax error!

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

It's not possible to test extra cancelation points in tests without hand-inserting special paths in the codebase, but since existing callers of `Resolver.run()` are already aware of the possibility of cancelation, these new cancelation points should not disrupt anything.
