### PR TITLE
Array#each_index returns an enumerable of integer type

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1111,9 +1111,9 @@ class Array < Object
     params(
         blk: T.proc.params(arg0: Integer).returns(BasicObject),
     )
-    .returns(T::Array[Elem])
+    .returns(T::Array[Integer])
   end
-  sig {returns(T::Enumerator[Elem])}
+  sig {returns(T::Enumerator[Integer])}
   def each_index(&blk); end
 
   # Same as Enumerator#with_index(0), i.e. there is no starting offset.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Resolves https://github.com/sorbet/sorbet/issues/3110

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The return type for the Array#each_index method is incorrect. This method should return a collection of type Integer, not the element type of the array

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
