### PR TITLE
Array#each_index returns an enumerable of integer type

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1113,7 +1113,7 @@ class Array < Object
     )
     .returns(T::Array[Elem])
   end
-  sig {returns(T::Enumerator[Elem])}
+  sig {returns(T::Enumerator[Integer])}
   def each_index(&blk); end
 
   # Same as Enumerator#with_index(0), i.e. there is no starting offset.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The Array#each_index method returns an Enumarable of Integer type, not the type of the elements of the Array

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Resolves https://github.com/sorbet/sorbet/issues/3110

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

When a block is supplied to the Array#each_index method the types of the returned elements are the same as the input array. See this example:
```ruby
list = ['hello', 'bye']
list.each_index{ |i| puts i.is_a?(Integer) }
```
results in this output:
```
true
true
=> ["hello", "bye"]
```

This tells us that the Array rbi currently has the correct element type specified for the return type when a block is specified.

However, when there is no block specified the Enumerable returned by the Array#each_index method does not enumerate over elements that match the type of elements in the array. Instead it
enumerates over Integers as shown by the two true values printed from the `i.is_a?(Integer)` code.