### PR TITLE
Support cancellation during namer.

### DIFF
--- a/infer/test/infer_test.cc
+++ b/infer/test/infer_test.cc
@@ -40,7 +40,7 @@ void processSource(core::GlobalState &cb, string str) {
     vector<ast::ParsedFile> trees;
     trees.emplace_back(move(tree));
     auto workers = WorkerPool::create(0, *logger);
-    trees = namer::Namer::run(cb, move(trees), *workers);
+    trees = move(namer::Namer::run(cb, move(trees), *workers).result());
     auto resolved = resolver::Resolver::run(cb, move(trees), *workers);
     for (auto &tree : resolved.result()) {
         sorbet::core::MutableContext ctx(cb, core::Symbols::root(), tree.file);

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -31,8 +31,8 @@ ast::ParsedFilesOrCancelled resolve(std::unique_ptr<core::GlobalState> &gs, std:
 std::vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
                                                 const options::Options &opts);
 
-std::vector<ast::ParsedFile> name(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
-                                  const options::Options &opts, WorkerPool &workers, bool skipConfigatron = false);
+ast::ParsedFilesOrCancelled name(core::GlobalState &gs, std::vector<ast::ParsedFile> what, const options::Options &opts,
+                                 WorkerPool &workers, bool skipConfigatron = false);
 
 // Note: `cancelable` and `preemption task manager` are only applicable to LSP.
 ast::ParsedFilesOrCancelled

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -528,7 +528,7 @@ int realmain(int argc, char *argv[]) {
             gs->suppressErrorClass(core::errors::Namer::ModuleKindRedefinition.code);
             gs->suppressErrorClass(core::errors::Resolver::StubConstant.code);
 
-            indexed = pipeline::name(*gs, move(indexed), opts, *workers);
+            indexed = move(pipeline::name(*gs, move(indexed), opts, *workers).result());
             autogen::AutoloaderConfig autoloaderCfg;
             {
                 core::UnfreezeNameTable nameTableAccess(*gs);

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1730,8 +1730,11 @@ ast::ParsedFilesOrCancelled defineSymbols(core::GlobalState &gs, vector<SymbolFi
     vector<ast::ParsedFile> output;
     output.reserve(allFoundDefinitions.size());
     const auto &epochManager = *gs.epochManager;
+    u4 count = 0;
     for (auto &fileFoundDefinitions : allFoundDefinitions) {
-        if (epochManager.wasTypecheckingCanceled()) {
+        count++;
+        // defineSymbols is really fast. Avoid this mildly expensive check for most turns of the loop.
+        if (count % 250 == 0 && epochManager.wasTypecheckingCanceled()) {
             return ast::ParsedFilesOrCancelled();
         }
         core::MutableContext ctx(gs, core::Symbols::root(), fileFoundDefinitions.tree.file);

--- a/namer/namer.h
+++ b/namer/namer.h
@@ -11,8 +11,8 @@ namespace sorbet::namer {
 
 class Namer final {
 public:
-    static std::vector<ast::ParsedFile> run(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
-                                            WorkerPool &workers);
+    static ast::ParsedFilesOrCancelled run(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
+                                           WorkerPool &workers);
 
     Namer() = delete;
 };

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -46,7 +46,7 @@ vector<ast::ParsedFile> runNamer(core::GlobalState &gs, ast::ParsedFile tree) {
     vector<ast::ParsedFile> v;
     v.emplace_back(move(tree));
     auto workers = WorkerPool::create(0, *logger);
-    return namer::Namer::run(gs, move(v), *workers);
+    return move(namer::Namer::run(gs, move(v), *workers).result());
 }
 
 } // namespace

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2313,8 +2313,11 @@ ast::ParsedFilesOrCancelled Resolver::resolveSigs(core::GlobalState &gs, vector<
     ResolveSignaturesWalk sigs;
     const auto &epochManager = gs.epochManager;
     Timer timeit(gs.tracer(), "resolver.sigs_vars_and_flatten");
+    u4 count = 0;
     for (auto &tree : trees) {
-        if (epochManager->wasTypecheckingCanceled()) {
+        count++;
+        // Don't check every turn of the loop. We want to be responsive to cancelation without harming throughput.
+        if (count % 250 == 0 && epochManager->wasTypecheckingCanceled()) {
             return ast::ParsedFilesOrCancelled();
         }
         core::MutableContext ctx(gs, core::Symbols::root(), tree.file);
@@ -2328,8 +2331,11 @@ ast::ParsedFilesOrCancelled Resolver::resolveMixesInClassMethods(core::GlobalSta
     ResolveMixesInClassMethodsWalk mixesInClassMethods;
     const auto &epochManager = gs.epochManager;
     Timer timeit(gs.tracer(), "resolver.mixes_in_class_methods");
+    u4 count = 0;
     for (auto &tree : trees) {
-        if (epochManager->wasTypecheckingCanceled()) {
+        count++;
+        // Don't check every turn of the loop. We want to be responsive to cancelation without harming throughput.
+        if (count % 250 == 0 && epochManager->wasTypecheckingCanceled()) {
             return ast::ParsedFilesOrCancelled();
         }
         core::MutableContext ctx(gs, core::Symbols::root(), tree.file);

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -254,7 +254,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             core::UnfreezeSymbolTable symbolTableAccess(*gs); // enters symbols
             vector<ast::ParsedFile> vTmp;
             vTmp.emplace_back(move(localNamed));
-            vTmp = namer::Namer::run(*gs, move(vTmp), *workers);
+            vTmp = move(namer::Namer::run(*gs, move(vTmp), *workers).result());
             namedTree = testSerialize(*gs, move(vTmp[0]));
         }
 
@@ -467,7 +467,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             core::UnfreezeSymbolTable symbolTableAccess(*gs);
             vector<ast::ParsedFile> vTmp;
             vTmp.emplace_back(move(file));
-            vTmp = namer::Namer::run(*gs, move(vTmp), *workers);
+            vTmp = move(namer::Namer::run(*gs, move(vTmp), *workers).result());
             file = testSerialize(*gs, move(vTmp[0]));
         }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Support cancellation during namer.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Will make LSP more responsive to slow path edits that occur during a slow path (e.g. syntax error fixes).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

It's not possible to test new cancellation spots like this, but the happy path (no cancelation) is covered by existing tests.
