### PR TITLE
Correct the definition of `wait2`

### DIFF
--- a/rbi/core/process.rbi
+++ b/rbi/core/process.rbi
@@ -1048,7 +1048,7 @@ module Process
         pid: Integer,
         flags: Integer,
     )
-    .returns([Integer, Process::Status])
+    .returns(T.nilable([Integer, Process::Status]))
   end
   def self.wait2(pid=T.unsafe(nil), flags=T.unsafe(nil)); end
 


### PR DESCRIPTION
wait2 will return nil if the `Process::WNOHANG` flag is specified
and no children are ready to be reaped.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
