### PR TITLE
When deepCopying GlobalState, reserve the same amount of space for the symbol table

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1485,7 +1485,7 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     result->namesByHash.reserve(this->namesByHash.size());
     result->namesByHash = this->namesByHash;
 
-    result->symbols.reserve(this->symbols.size());
+    result->symbols.reserve(this->symbols.capacity());
     for (auto &sym : this->symbols) {
         result->symbols.emplace_back(sym.deepCopy(*result, keepId));
     }


### PR DESCRIPTION
When deepCopying GlobalState, reserve the same amount of space for the symbol table.

Now the symbol table size passed in via --reserve-symbol-table-capacity is propagated to copies, which is useful for LSP.

This might be a no-op if `reserve` already upgrades the passed-in size to the nearest power of 2, but I'd rather not take my chances here. :)

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Reduce copying/allocation overhead in LSP.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

N/A
