### PR TITLE
Make it possible to disable gem RBI loading

### DIFF
--- a/gems/sorbet/README.md
+++ b/gems/sorbet/README.md
@@ -71,6 +71,12 @@ behavior:
   Pin the sorbet-typed cache to a specific revision. (The default is to fetch
   and use the latest `master` commit.)
 
+- `SRB_SKIP_GEM_RBIS`
+
+  Disables the loading of
+  [RBI files exported from gems](https://sorbet.org/docs/rbi#rbis-within-gems).
+  This allows the LSP mode to work properly even when some gems in the Gemfile
+  are exporting RBI files.
 
 ## Running locally
 

--- a/gems/sorbet/bin/srb
+++ b/gems/sorbet/bin/srb
@@ -47,7 +47,7 @@ typecheck() {
   args=("$@")
   cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/sorbet/gem-rbis"
 
-  if [ -f Gemfile.lock ]; then
+  if [ -z "$SRB_SKIP_GEM_RBIS" ] && [ -f Gemfile.lock ]; then
     [ -d "$cache_dir" ] || mkdir -p "$cache_dir"
     cache_hash=$(compute_md5 Gemfile.lock | awk '{ print $1 }')
     cache_file="${cache_dir}/${cache_hash}"


### PR DESCRIPTION
This commit adds an environment variable `SRB_SKIP_GEM_RBIS`, which, if defined, disables the gem RBI loading process, thus allowing people to use LSP mode again.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Gem RBI loading is currently automatic and there is no way to disable it. However, loading gem RBIs means that more than one source folder is being loaded and, currently, LSP mode does not work with that. In turn, that means that whenever one of your dependencies starts to export RBIs, you can't continue to use the editor integration.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No automated tests.
