### PR TITLE
Fix sigs for CSV::Table and a few of the main methods to parse CSVs

### DIFF
--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -270,7 +270,7 @@ class CSV < Object
     params(
         path: T.any(String, ::Sorbet::Private::Static::IOLike),
         options: T::Hash[Symbol, BasicObject],
-        blk: T.proc.params(arg0: T.any(T::Array[T.nilable(BasicObject)], CSV::Row)).void,
+        blk: T.proc.params(arg0: T.any(T::Array[T.nilable(T.untyped)], CSV::Row)).void,
     )
     .void
   end
@@ -279,7 +279,7 @@ class CSV < Object
         path: T.any(String, ::Sorbet::Private::Static::IOLike),
         options: T::Hash[Symbol, BasicObject],
     )
-    .returns(T::Enumerator[T.any(T::Array[T.nilable(BasicObject)], CSV::Row)])
+    .returns(T::Enumerator[T.any(T::Array[T.nilable(T.untyped)], CSV::Row)])
   end
   def self.foreach(path, options=T.unsafe(nil), &blk); end
 
@@ -490,8 +490,8 @@ class CSV < Object
     )
     .returns(
       T.any(
-        CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])],
-        T::Array[T::Array[T.nilable(BasicObject)]],
+        CSV::Table[T.any(CSV::Row, T::Array[T.nilable(T.untyped)])],
+        T::Array[T::Array[T.nilable(T.untyped)]],
       )
     )
   end
@@ -499,7 +499,7 @@ class CSV < Object
     params(
         str: String,
         options: T::Hash[Symbol, T.untyped],
-        blk: T.proc.params(arg0: T.any(CSV::Row, T::Array[T.nilable(BasicObject)])).void
+        blk: T.proc.params(arg0: T.any(CSV::Row, T::Array[T.nilable(T.untyped)])).void
     ).void
   end
   def self.parse(str, options=T.unsafe(nil), &blk); end
@@ -942,7 +942,7 @@ class CSV::Row < Object
   include Enumerable
 
   extend T::Generic
-  Elem = type_member(:out, fixed: T.nilable(BasicObject))
+  Elem = type_member(:out, fixed: T.nilable(T.untyped))
 
   # Construct a new
   # [`CSV::Row`](https://docs.ruby-lang.org/en/2.6.0/CSV/Row.html) from
@@ -1211,7 +1211,7 @@ class CSV::Table < Object
   # *   empty?()
   # *   length()
   # *   size()
-  sig { params(array_of_rows: T::Array[CSV::Row], headers: T::Array[BasicObject]).returns(CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])]) }
+  sig { params(array_of_rows: T::Array[CSV::Row], headers: T::Array[BasicObject]).returns(CSV::Table[T.any(CSV::Row, T::Array[T.nilable(T.untyped)])]) }
   def self.new(array_of_rows, headers: nil); end
 
   # Adds a new row to the bottom end of this table. You can provide an
@@ -1224,13 +1224,13 @@ class CSV::Table < Object
   # This method returns the table for chaining.
   sig do
     params(
-      row_or_array: T.any(CSV::Row, T::Array[T.nilable(BasicObject)])
+      row_or_array: T.any(CSV::Row, T::Array[T.nilable(T.untyped)])
     ).returns(T.self_type)
   end
   def <<(row_or_array); end
 
   # Returns `true` if all rows of this table ==() `other`'s rows.
-  sig { params(other: CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])]).returns(T::Boolean) }
+  sig { params(other: CSV::Table[T.any(CSV::Row, T::Array[T.nilable(T.untyped)])]).returns(T::Boolean) }
   def ==(other); end
 
   # In the default mixed mode, this method returns rows for index access and
@@ -1246,7 +1246,7 @@ class CSV::Table < Object
   # no effect on the table.
   sig { params(index_or_header: Integer).returns(T.nilable(Elem)) }
   sig { params(index_or_header: T::Range[Integer]).returns(T::Array[Elem]) }
-  sig { params(index_or_header: BasicObject).returns(T::Array[T.nilable(BasicObject)]) }
+  sig { params(index_or_header: BasicObject).returns(T::Array[T.nilable(T.untyped)]) }
   def [](index_or_header); end
 
   # In the default mixed mode, this method assigns rows for index access and
@@ -1280,14 +1280,14 @@ class CSV::Table < Object
   # This method returns the duplicate table for chaining. Don't chain
   # destructive methods (like []=()) this way though, since you are working with
   # a duplicate.
-  sig { returns(CSV::Table[T::Array[T.nilable(BasicObject)]]) }
+  sig { returns(CSV::Table[T::Array[T.nilable(T.untyped)]]) }
   def by_col; end
 
   # Switches the mode of this table to column mode. All calls to indexing and
   # iteration methods will work with columns until the mode is changed again.
   #
   # This method returns the table and is safe to chain.
-  sig { returns(CSV::Table[T::Array[T.nilable(BasicObject)]]) }
+  sig { returns(CSV::Table[T::Array[T.nilable(T.untyped)]]) }
   def by_col!; end
 
   # Returns a duplicate table object, in mixed mode. This is handy for chaining
@@ -1297,7 +1297,7 @@ class CSV::Table < Object
   # This method returns the duplicate table for chaining. Don't chain
   # destructive methods (like []=()) this way though, since you are working with
   # a duplicate.
-  sig { returns(CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])]) }
+  sig { returns(CSV::Table[T.any(CSV::Row, T::Array[T.nilable(T.untyped)])]) }
   def by_col_or_row; end
 
   # Switches the mode of this table to mixed mode. All calls to indexing and
@@ -1306,7 +1306,7 @@ class CSV::Table < Object
   # reference while anything else is assumed to be column access by headers.
   #
   # This method returns the table and is safe to chain.
-  sig { returns(CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])]) }
+  sig { returns(CSV::Table[T.any(CSV::Row, T::Array[T.nilable(T.untyped)])]) }
   def by_col_or_row!; end
 
   # Returns a duplicate table object, in row mode. This is handy for chaining in
@@ -1351,12 +1351,12 @@ class CSV::Table < Object
   # If no block is given, an
   # [`Enumerator`](https://docs.ruby-lang.org/en/2.6.0/Enumerator.html) is
   # returned.
-  sig { params(blk: T.proc.params(arg0: T.untyped).returns(BasicObject)).returns(T.self_type) }
+  sig { params(blk: T.proc.params(arg0: T.untyped).returns(T.untyped)).returns(T.self_type) }
   sig { returns(T::Enumerator[T.untyped]) }
   def delete_if(&blk); end
 
   sig { params(index_or_header: BasicObject).returns(Elem) }
-  sig { params(index_or_header: BasicObject, index_or_headers: BasicObject).returns(T.nilable(BasicObject)) }
+  sig { params(index_or_header: BasicObject, index_or_headers: BasicObject).returns(T.nilable(T.untyped)) }
   def dig(index_or_header, *index_or_headers); end
 
   # In the default mixed mode or row mode, iteration is the standard row major
@@ -1379,7 +1379,7 @@ class CSV::Table < Object
   # [`Array`](https://docs.ruby-lang.org/en/2.6.0/Array.html) passed to
   # [`CSV::Table.new`](https://docs.ruby-lang.org/en/2.6.0/CSV/Table.html#method-c-new)
   # is returned for empty tables.
-  sig { returns(T::Array[BasicObject]) }
+  sig { returns(T::Array[T.untyped]) }
   def headers; end
 
   # Shows the mode and size of this table in a US-ASCII
@@ -1400,7 +1400,7 @@ class CSV::Table < Object
   # This method returns the table for chaining.
   sig do
     params(
-      rows: T.any(CSV::Row, T::Array[T.nilable(BasicObject)])
+      rows: T.any(CSV::Row, T::Array[T.nilable(T.untyped)])
     ).returns(T.self_type)
   end
   def push(*rows); end
@@ -1408,7 +1408,7 @@ class CSV::Table < Object
   # Returns the table as an
   # [`Array`](https://docs.ruby-lang.org/en/2.6.0/Array.html) of Arrays. Headers
   # will be the first row, then all of the field rows will follow.
-  sig { returns(T::Array[T::Array[T.nilable(BasicObject)]]) }
+  sig { returns(T::Array[T::Array[T.nilable(T.untyped)]]) }
   def to_a; end
 
   # Returns the table as a complete

--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -486,17 +486,23 @@ class CSV < Object
   sig do
     params(
         str: String,
-        options: T.untyped,
-        blk: T.nilable(T.proc.params(arg0: T::Array[T.nilable(String)]).void)
+        options: T::Hash[Symbol, T.untyped],
     )
     .returns(
       T.any(
         CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)],
-        T::Array[T::Array[T.nilable(String)]],
+        T::Array[T::Array[T.nilable(BasicObject)]],
       )
     )
   end
-  def self.parse(str, **options, &blk); end
+  sig do
+    params(
+        str: String,
+        options: T::Hash[Symbol, T.untyped],
+        blk: T.proc.params(arg0: T.any(CSV::Row, T::Array[T.nilable(BasicObject)])).void
+    ).void
+  end
+  def self.parse(str, options=T.unsafe(nil), &blk); end
 
   # This method is a shortcut for converting a single line of a
   # [`CSV`](https://docs.ruby-lang.org/en/2.6.0/CSV.html)

--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -270,7 +270,7 @@ class CSV < Object
     params(
         path: T.any(String, ::Sorbet::Private::Static::IOLike),
         options: T::Hash[Symbol, BasicObject],
-        blk: T.proc.params(arg0: T.any(T::Array[T.nilable(String)], CSV::Row)).void,
+        blk: T.proc.params(arg0: T.any(T::Array[T.nilable(BasicObject)], CSV::Row)).void,
     )
     .void
   end

--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -1203,7 +1203,8 @@ class CSV::Table < Object
   # *   empty?()
   # *   length()
   # *   size()
-  def self.new(array_of_rows); end
+  sig { params(array_of_rows: T::Array[CSV::Row], headers: T::Array[BasicObject]).returns(CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)]) }
+  def self.new(array_of_rows, headers: nil); end
 
   # Adds a new row to the bottom end of this table. You can provide an
   # [`Array`](https://docs.ruby-lang.org/en/2.6.0/Array.html), which will be

--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -490,7 +490,7 @@ class CSV < Object
     )
     .returns(
       T.any(
-        CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)],
+        CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])],
         T::Array[T::Array[T.nilable(BasicObject)]],
       )
     )
@@ -1184,11 +1184,6 @@ end
 #
 # All tables returned by [`CSV`](https://docs.ruby-lang.org/en/2.6.0/CSV.html)
 # will be constructed from this class, if header row processing is activated.
-CSVRowModeElem = T.type_alias { CSV::Row }
-CSVColumnModeElem = T.type_alias { T::Array[T.nilable(BasicObject)] }
-CSVRowModeTable = T.type_alias { CSV::Table[CSVRowModeElem] }
-CSVColumnModeTable = T.type_alias { CSV::Table[CSVColumnModeElem] }
-
 class CSV::Table < Object
   include Enumerable
 
@@ -1216,7 +1211,7 @@ class CSV::Table < Object
   # *   empty?()
   # *   length()
   # *   size()
-  sig { params(array_of_rows: T::Array[CSV::Row], headers: T::Array[BasicObject]).returns(CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)]) }
+  sig { params(array_of_rows: T::Array[CSV::Row], headers: T::Array[BasicObject]).returns(CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])]) }
   def self.new(array_of_rows, headers: nil); end
 
   # Adds a new row to the bottom end of this table. You can provide an
@@ -1235,7 +1230,7 @@ class CSV::Table < Object
   def <<(row_or_array); end
 
   # Returns `true` if all rows of this table ==() `other`'s rows.
-  sig { params(other: CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)]).returns(T::Boolean) }
+  sig { params(other: CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])]).returns(T::Boolean) }
   def ==(other); end
 
   # In the default mixed mode, this method returns rows for index access and
@@ -1251,7 +1246,7 @@ class CSV::Table < Object
   # no effect on the table.
   sig { params(index_or_header: Integer).returns(T.nilable(Elem)) }
   sig { params(index_or_header: T::Range[Integer]).returns(T::Array[Elem]) }
-  sig { params(index_or_header: BasicObject).returns(CSVColumnModeElem) }
+  sig { params(index_or_header: BasicObject).returns(T::Array[T.nilable(BasicObject)]) }
   def [](index_or_header); end
 
   # In the default mixed mode, this method assigns rows for index access and
@@ -1285,14 +1280,14 @@ class CSV::Table < Object
   # This method returns the duplicate table for chaining. Don't chain
   # destructive methods (like []=()) this way though, since you are working with
   # a duplicate.
-  sig { returns(CSVColumnModeTable) }
+  sig { returns(CSV::Table[T::Array[T.nilable(BasicObject)]]) }
   def by_col; end
 
   # Switches the mode of this table to column mode. All calls to indexing and
   # iteration methods will work with columns until the mode is changed again.
   #
   # This method returns the table and is safe to chain.
-  sig { returns(CSVColumnModeTable) }
+  sig { returns(CSV::Table[T::Array[T.nilable(BasicObject)]]) }
   def by_col!; end
 
   # Returns a duplicate table object, in mixed mode. This is handy for chaining
@@ -1302,7 +1297,7 @@ class CSV::Table < Object
   # This method returns the duplicate table for chaining. Don't chain
   # destructive methods (like []=()) this way though, since you are working with
   # a duplicate.
-  sig { returns(CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)]) }
+  sig { returns(CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])]) }
   def by_col_or_row; end
 
   # Switches the mode of this table to mixed mode. All calls to indexing and
@@ -1311,7 +1306,7 @@ class CSV::Table < Object
   # reference while anything else is assumed to be column access by headers.
   #
   # This method returns the table and is safe to chain.
-  sig { returns(CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)]) }
+  sig { returns(CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])]) }
   def by_col_or_row!; end
 
   # Returns a duplicate table object, in row mode. This is handy for chaining in
@@ -1321,14 +1316,14 @@ class CSV::Table < Object
   # This method returns the duplicate table for chaining. Don't chain
   # destructive methods (like []=()) this way though, since you are working with
   # a duplicate.
-  sig { returns(CSVRowModeTable) }
+  sig { returns(CSV::Table[CSV::Row]) }
   def by_row; end
 
   # Switches the mode of this table to row mode. All calls to indexing and
   # iteration methods will work with rows until the mode is changed again.
   #
   # This method returns the table and is safe to chain.
-  sig { returns(CSVRowModeTable) }
+  sig { returns(CSV::Table[CSV::Row]) }
   def by_row!; end
 
   # Removes and returns the indicated columns or rows. In the default mixed mode

--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -270,7 +270,7 @@ class CSV < Object
     type_parameters(:U).params(
         path: T.any(String, ::Sorbet::Private::Static::IOLike),
         options: T::Hash[Symbol, T.type_parameter(:U)],
-        blk: T.proc.params(arg0: T::Array[T.nilable(String)]).void,
+        blk: T.proc.params(arg0: T.any(T::Array[T.nilable(String)], CSV::Row)).void,
     )
     .void
   end
@@ -479,7 +479,7 @@ class CSV < Object
   sig do
     params(
         str: String,
-        options: T::Hash[Symbol, T.untyped],
+        options: T.untyped,
         blk: T.nilable(T.proc.params(arg0: T::Array[T.nilable(String)]).void)
     )
     .returns(
@@ -489,7 +489,7 @@ class CSV < Object
       )
     )
   end
-  def self.parse(str, options=T.unsafe(nil), &blk); end
+  def self.parse(str, **options, &blk); end
 
   # This method is a shortcut for converting a single line of a
   # [`CSV`](https://docs.ruby-lang.org/en/2.6.0/CSV.html)

--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -1188,7 +1188,7 @@ class CSV::Table < Object
   include Enumerable
 
   extend T::Generic
-  Elem = type_member(fixed: CSV::Row)
+  Elem = type_member(:out)
 
   # Construct a new
   # [`CSV::Table`](https://docs.ruby-lang.org/en/2.6.0/CSV/Table.html) from

--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -1378,6 +1378,7 @@ class CSV::Table < Object
   def inspect; end
 
   # The current access mode for indexing and iteration.
+  sig { returns(Symbol) }
   def mode; end
 
   # A shortcut for appending multiple rows. Equivalent to:
@@ -1387,6 +1388,11 @@ class CSV::Table < Object
   # ```
   #
   # This method returns the table for chaining.
+  sig do
+    params(
+      rows: T.any(CSV::Row, T::Array[T.nilable(BasicObject)])
+    ).returns(T.self_type)
+  end
   def push(*rows); end
 
   # Internal data format used to compare equality.

--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -267,12 +267,19 @@ class CSV < Object
   # would read UTF-32BE data from the file but transcode it to UTF-8 before
   # [`CSV`](https://docs.ruby-lang.org/en/2.6.0/CSV.html) parses it.
   sig do
-    type_parameters(:U).params(
+    params(
         path: T.any(String, ::Sorbet::Private::Static::IOLike),
-        options: T::Hash[Symbol, T.type_parameter(:U)],
+        options: T::Hash[Symbol, BasicObject],
         blk: T.proc.params(arg0: T.any(T::Array[T.nilable(String)], CSV::Row)).void,
     )
     .void
+  end
+  sig do
+    params(
+        path: T.any(String, ::Sorbet::Private::Static::IOLike),
+        options: T::Hash[Symbol, BasicObject],
+    )
+    .returns(T::Enumerator[T.any(T::Array[T.nilable(BasicObject)], CSV::Row)])
   end
   def self.foreach(path, options=T.unsafe(nil), &blk); end
 

--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -1362,6 +1362,8 @@ class CSV::Table < Object
   # If no block is given, an
   # [`Enumerator`](https://docs.ruby-lang.org/en/2.6.0/Enumerator.html) is
   # returned.
+  sig { params(block: T.proc.params(arg0: T.untyped).void).returns(T.self_type) }
+  sig { returns(T::Enumerator[T.untyped]) }
   def each(&block); end
 
   # Returns the headers for the first row of this table (assumed to match all

--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -1395,9 +1395,6 @@ class CSV::Table < Object
   end
   def push(*rows); end
 
-  # Internal data format used to compare equality.
-  def table; end
-
   # Returns the table as an
   # [`Array`](https://docs.ruby-lang.org/en/2.6.0/Array.html) of Arrays. Headers
   # will be the first row, then all of the field rows will follow.

--- a/test/testdata/rbi/csv.rb
+++ b/test/testdata/rbi/csv.rb
@@ -59,6 +59,10 @@ if csv.is_a?(CSV::Table)
   T.assert_type!(csv.headers, T::Array[BasicObject])
 
   T.assert_type!(csv.inspect, String)
+
+  T.assert_type!(csv.mode, Symbol)
+
+  T.assert_type!(csv.push([[1, {}, nil, '1'], CSV::Row.new(['1', '2'], [1, 2])]), CSV::Table)
   
   T.assert_type!(csv.to_a, T::Array[T::Array[T.nilable(BasicObject)]])
 

--- a/test/testdata/rbi/csv.rb
+++ b/test/testdata/rbi/csv.rb
@@ -71,6 +71,18 @@ if csv.is_a?(CSV::Table)
 
   T.assert_type!(csv.values_at(0, {}), T.any(T.nilable(CSV::Row), T::Array[T.nilable(BasicObject)], T::Array[T.nilable(CSV::Row)], T::Array[T::Array[T.nilable(BasicObject)]]))
 
+  csv.by_col.each do |header, entry|
+  end
+
+  csv.each do |entry|
+  end
+
+  csv.each do |header, entry|
+  end
+
+  csv.by_row.each do |entry|
+  end
+
   # errors
   csv.table # error: Method `table` does not exist on `CSV::Table[T.any(CSV::Row, T::Array[BasicObject])]`
 else

--- a/test/testdata/rbi/csv.rb
+++ b/test/testdata/rbi/csv.rb
@@ -4,7 +4,7 @@ require 'csv'
 T.assert_type!(CSV.foreach('source.csv', headers: true), T::Enumerator[T.any(T::Array[T.nilable(BasicObject)], CSV::Row)])
 T.assert_type!(CSV.foreach('source.csv', headers: true, col_sep: ','), T::Enumerator[T.any(T::Array[T.nilable(BasicObject)], CSV::Row)])
 CSV.foreach('source.csv') do |row|
-  T.assert_type!(row, T.any(T::Array[T.nilable(String)], CSV::Row))
+  T.assert_type!(row, T.any(T::Array[T.nilable(BasicObject)], CSV::Row))
 end
 
 csv = CSV::Table.new([CSV::Row.new(['1', '2'], [1, 2]), CSV::Row.new(['1', '2'], [2, 3])])

--- a/test/testdata/rbi/csv.rb
+++ b/test/testdata/rbi/csv.rb
@@ -8,10 +8,10 @@ CSV.foreach('source.csv') do |row|
 end
 
 csv = CSV::Table.new([CSV::Row.new(['1', '2'], [1, 2]), CSV::Row.new(['1', '2'], [2, 3])])
-T.assert_type!(csv, CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)])
+T.assert_type!(csv, CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])])
 
 csv = CSV::Table.new([CSV::Row.new(['1', '2'], [1, 2]), CSV::Row.new(['1', '2'], [2, 3])], headers: ['1', '2'])
-T.assert_type!(csv, CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)])
+T.assert_type!(csv, CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])])
 
 CSV.parse("1,2,3\n3,,abc\n5,6,1") do |line|
   T.assert_type!(line, T.any(CSV::Row, T::Array[T.nilable(BasicObject)]))
@@ -20,7 +20,7 @@ end
 csv = CSV.parse("1,2,3\n3,,abc\n5,6,1", { headers: true, converters: %i[numeric] })
 
 if csv.is_a?(CSV::Table)
-  T.assert_type!(csv << [1, {}, nil, '1'], CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)])
+  T.assert_type!(csv << [1, {}, nil, '1'], CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])])
 
   T.assert_type!(csv == csv, T::Boolean)
 
@@ -30,20 +30,20 @@ if csv.is_a?(CSV::Table)
 
   T.assert_type!(csv[5] = CSV::Row.new(['1', '2'], [1, 2]), CSV::Row)
 
-  T.assert_type!(csv.by_col, CSVColumnModeTable)
-  T.assert_type!(csv.by_col!, CSVColumnModeTable)
-  T.assert_type!(csv.by_col_or_row, CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)])
-  T.assert_type!(csv.by_col_or_row!, CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)])
-  T.assert_type!(csv.by_row, CSVRowModeTable)
-  T.assert_type!(csv.by_row!, CSVRowModeTable)
+  T.assert_type!(csv.by_col, CSV::Table[T::Array[T.nilable(BasicObject)]])
+  T.assert_type!(csv.by_col!, CSV::Table[T::Array[T.nilable(BasicObject)]])
+  T.assert_type!(csv.by_col_or_row, CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])])
+  T.assert_type!(csv.by_col_or_row!, CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])])
+  T.assert_type!(csv.by_row, CSV::Table[CSV::Row])
+  T.assert_type!(csv.by_row!, CSV::Table[CSV::Row])
 
   T.assert_type!(csv.delete(0), T.any(T.nilable(CSV::Row), T::Array[T.nilable(BasicObject)], T::Array[T.nilable(CSV::Row)], T::Array[T::Array[T.nilable(BasicObject)]]))
   T.assert_type!(csv.delete(0, 1), T.any(T.nilable(CSV::Row), T::Array[T.nilable(BasicObject)], T::Array[T.nilable(CSV::Row)], T::Array[T::Array[T.nilable(BasicObject)]]))
   T.assert_type!(csv.delete(0, {}, 1), T.any(T.nilable(CSV::Row), T::Array[T.nilable(BasicObject)], T::Array[T.nilable(CSV::Row)], T::Array[T::Array[T.nilable(BasicObject)]]))
 
-  T.assert_type!(csv.delete_if, T::Enumerator[T.any(CSVRowModeElem, CSVColumnModeElem)])
-  T.assert_type!(csv.delete_if, T::Enumerator[T.any(CSVRowModeElem, CSVColumnModeElem)])
-  T.assert_type!(csv.delete_if, T::Enumerator[[T.nilable(BasicObject), T.any(CSVRowModeElem, CSVColumnModeElem)]])
+  T.assert_type!(csv.delete_if, T::Enumerator[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])])
+  T.assert_type!(csv.delete_if, T::Enumerator[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])])
+  T.assert_type!(csv.delete_if, T::Enumerator[[T.nilable(BasicObject), T.any(CSV::Row, T::Array[T.nilable(BasicObject)])]])
 
   csv.by_col.delete_if do |header, entry|
   end
@@ -72,7 +72,7 @@ if csv.is_a?(CSV::Table)
 
   T.assert_type!(csv.mode, Symbol)
 
-  T.assert_type!(csv.push([[1, {}, nil, '1'], CSV::Row.new(['1', '2'], [1, 2])]), CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)])
+  T.assert_type!(csv.push([[1, {}, nil, '1'], CSV::Row.new(['1', '2'], [1, 2])]), CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])])
   
   T.assert_type!(csv.to_a, T::Array[T::Array[T.nilable(BasicObject)]])
 

--- a/test/testdata/rbi/csv.rb
+++ b/test/testdata/rbi/csv.rb
@@ -1,0 +1,65 @@
+# typed: true
+require 'csv'
+
+csv = CSV.parse("1,2,3\n3,,abc\n5,6,1", { headers: true, converters: %i[numeric] })
+
+if csv.is_a?(CSV::Table)
+  T.assert_type!(csv << [1, {}, nil, '1'], CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)])
+
+  T.assert_type!(csv == csv, T::Boolean)
+
+  T.assert_type!(csv[0], T.any(T.nilable(CSV::Row), T::Array[T::nilable(BasicObject)]))
+  T.assert_type!(csv[0..1], T.any(T::Array[CSV::Row], T::Array[T::Array[T::nilable(BasicObject)]]))
+  T.assert_type!(csv[{}], T::Array[T::nilable(BasicObject)])
+
+  T.assert_type!(csv[5] = CSV::Row.new(['1', '2'], [1, 2]), CSV::Row)
+
+  T.assert_type!(csv.by_col, CSVColumnModeTable)
+  T.assert_type!(csv.by_col!, CSVColumnModeTable)
+  T.assert_type!(csv.by_col_or_row, CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)])
+  T.assert_type!(csv.by_col_or_row!, CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)])
+  T.assert_type!(csv.by_row, CSVRowModeTable)
+  T.assert_type!(csv.by_row!, CSVRowModeTable)
+
+  T.assert_type!(csv.delete(0), T.any(T.nilable(CSV::Row), T::Array[T.nilable(BasicObject)], T::Array[T.nilable(CSV::Row)], T::Array[T::Array[T.nilable(BasicObject)]]))
+  T.assert_type!(csv.delete(0, 1), T.any(T.nilable(CSV::Row), T::Array[T.nilable(BasicObject)], T::Array[T.nilable(CSV::Row)], T::Array[T::Array[T.nilable(BasicObject)]]))
+  T.assert_type!(csv.delete(0, {}, 1), T.any(T.nilable(CSV::Row), T::Array[T.nilable(BasicObject)], T::Array[T.nilable(CSV::Row)], T::Array[T::Array[T.nilable(BasicObject)]]))
+
+  T.assert_type!(csv.delete_if, T::Enumerator[T.any(CSVRowModeElem, CSVColumnModeElem)])
+  T.assert_type!(csv.delete_if, T::Enumerator[T.any(CSVRowModeElem, CSVColumnModeElem)])
+  T.assert_type!(csv.delete_if, T::Enumerator[[T.nilable(BasicObject), T.any(CSVRowModeElem, CSVColumnModeElem)]])
+
+  csv.by_col.delete_if do |header, entry|
+  end
+
+  csv.delete_if do |entry|
+  end
+
+  csv.delete_if do |header, entry|
+  end
+
+  csv.by_row.delete_if do |entry|
+  end
+
+  csv.delete_if.with_index do |entry, index|
+    T.assert_type!(index, Integer)
+  end
+
+  T.assert_type!(csv.dig(0), T.any(CSV::Row, T::Array[T.nilable(BasicObject)]))
+  T.assert_type!(csv.by_row.dig(0), CSV::Row)
+  T.assert_type!(csv.by_col.dig(0), T::Array[T.nilable(BasicObject)])
+  T.assert_type!(csv.dig(0, 1), T.nilable(BasicObject))
+
+  T.assert_type!(csv.headers, T::Array[BasicObject])
+
+  T.assert_type!(csv.inspect, String)
+  
+  T.assert_type!(csv.to_a, T::Array[T::Array[T.nilable(BasicObject)]])
+
+  T.assert_type!(csv.to_csv, String)
+  T.assert_type!(csv.to_s, String)
+
+  T.assert_type!(csv.values_at(0, {}), T.any(T.nilable(CSV::Row), T::Array[T.nilable(BasicObject)], T::Array[T.nilable(CSV::Row)], T::Array[T::Array[T.nilable(BasicObject)]]))
+else
+  T.assert_type!(csv, T::Array[T::Array[T.nilable(BasicObject)]])
+end

--- a/test/testdata/rbi/csv.rb
+++ b/test/testdata/rbi/csv.rb
@@ -1,6 +1,12 @@
 # typed: true
 require 'csv'
 
+csv = CSV::Table.new([CSV::Row.new(['1', '2'], [1, 2]), CSV::Row.new(['1', '2'], [2, 3])])
+T.assert_type!(csv, CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)])
+
+csv = CSV::Table.new([CSV::Row.new(['1', '2'], [1, 2]), CSV::Row.new(['1', '2'], [2, 3])], headers: ['1', '2'])
+T.assert_type!(csv, CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)])
+
 csv = CSV.parse("1,2,3\n3,,abc\n5,6,1", { headers: true, converters: %i[numeric] })
 
 if csv.is_a?(CSV::Table)

--- a/test/testdata/rbi/csv.rb
+++ b/test/testdata/rbi/csv.rb
@@ -1,6 +1,12 @@
 # typed: true
 require 'csv'
 
+T.assert_type!(CSV.foreach('source.csv', headers: true), T::Enumerator[T.any(T::Array[T.nilable(BasicObject)], CSV::Row)])
+T.assert_type!(CSV.foreach('source.csv', headers: true, col_sep: ','), T::Enumerator[T.any(T::Array[T.nilable(BasicObject)], CSV::Row)])
+CSV.foreach('source.csv') do |row|
+  T.assert_type!(row, T.any(T::Array[T.nilable(String)], CSV::Row))
+end
+
 csv = CSV::Table.new([CSV::Row.new(['1', '2'], [1, 2]), CSV::Row.new(['1', '2'], [2, 3])])
 T.assert_type!(csv, CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)])
 

--- a/test/testdata/rbi/csv.rb
+++ b/test/testdata/rbi/csv.rb
@@ -62,7 +62,7 @@ if csv.is_a?(CSV::Table)
 
   T.assert_type!(csv.mode, Symbol)
 
-  T.assert_type!(csv.push([[1, {}, nil, '1'], CSV::Row.new(['1', '2'], [1, 2])]), CSV::Table)
+  T.assert_type!(csv.push([[1, {}, nil, '1'], CSV::Row.new(['1', '2'], [1, 2])]), CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)])
   
   T.assert_type!(csv.to_a, T::Array[T::Array[T.nilable(BasicObject)]])
 
@@ -70,6 +70,9 @@ if csv.is_a?(CSV::Table)
   T.assert_type!(csv.to_s, String)
 
   T.assert_type!(csv.values_at(0, {}), T.any(T.nilable(CSV::Row), T::Array[T.nilable(BasicObject)], T::Array[T.nilable(CSV::Row)], T::Array[T::Array[T.nilable(BasicObject)]]))
+
+  # errors
+  csv.table # error: Method `table` does not exist on `CSV::Table[T.any(CSV::Row, T::Array[BasicObject])]`
 else
   T.assert_type!(csv, T::Array[T::Array[T.nilable(BasicObject)]])
 end

--- a/test/testdata/rbi/csv.rb
+++ b/test/testdata/rbi/csv.rb
@@ -13,6 +13,10 @@ T.assert_type!(csv, CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)])
 csv = CSV::Table.new([CSV::Row.new(['1', '2'], [1, 2]), CSV::Row.new(['1', '2'], [2, 3])], headers: ['1', '2'])
 T.assert_type!(csv, CSV::Table[T.any(CSVRowModeElem, CSVColumnModeElem)])
 
+CSV.parse("1,2,3\n3,,abc\n5,6,1") do |line|
+  T.assert_type!(line, T.any(CSV::Row, T::Array[T.nilable(BasicObject)]))
+end
+
 csv = CSV.parse("1,2,3\n3,,abc\n5,6,1", { headers: true, converters: %i[numeric] })
 
 if csv.is_a?(CSV::Table)

--- a/test/testdata/rbi/csv.rb
+++ b/test/testdata/rbi/csv.rb
@@ -4,7 +4,7 @@ require 'csv'
 T.assert_type!(CSV.foreach('source.csv', headers: true), T::Enumerator[T.any(T::Array[T.nilable(BasicObject)], CSV::Row)])
 T.assert_type!(CSV.foreach('source.csv', headers: true, col_sep: ','), T::Enumerator[T.any(T::Array[T.nilable(BasicObject)], CSV::Row)])
 CSV.foreach('source.csv') do |row|
-  T.assert_type!(row, T.any(T::Array[T.nilable(BasicObject)], CSV::Row))
+  T.assert_type!(row, T.any(T::Array[T.untyped], CSV::Row))
 end
 
 csv = CSV::Table.new([CSV::Row.new(['1', '2'], [1, 2]), CSV::Row.new(['1', '2'], [2, 3])])
@@ -14,7 +14,7 @@ csv = CSV::Table.new([CSV::Row.new(['1', '2'], [1, 2]), CSV::Row.new(['1', '2'],
 T.assert_type!(csv, CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])])
 
 CSV.parse("1,2,3\n3,,abc\n5,6,1") do |line|
-  T.assert_type!(line, T.any(CSV::Row, T::Array[T.nilable(BasicObject)]))
+  T.assert_type!(line, T.any(CSV::Row, T::Array[T.untyped]))
 end
 
 csv = CSV.parse("1,2,3\n3,,abc\n5,6,1", { headers: true, converters: %i[numeric] })
@@ -64,7 +64,7 @@ if csv.is_a?(CSV::Table)
   T.assert_type!(csv.dig(0), T.any(CSV::Row, T::Array[T.nilable(BasicObject)]))
   T.assert_type!(csv.by_row.dig(0), CSV::Row)
   T.assert_type!(csv.by_col.dig(0), T::Array[T.nilable(BasicObject)])
-  T.assert_type!(csv.dig(0, 1), T.nilable(BasicObject))
+  T.let(csv.dig(0, 1), T.untyped)
 
   T.assert_type!(csv.headers, T::Array[BasicObject])
 
@@ -94,7 +94,7 @@ if csv.is_a?(CSV::Table)
   end
 
   # errors
-  csv.table # error: Method `table` does not exist on `CSV::Table[T.any(CSV::Row, T::Array[BasicObject])]`
+  csv.table # error: Method `table` does not exist on `CSV::Table[T.any(CSV::Row, T::Array[T.untyped])]`
 else
   T.assert_type!(csv, T::Array[T::Array[T.nilable(BasicObject)]])
 end


### PR DESCRIPTION
* Added sigs for all the CSV::Table methods
* Since CSV::Table, depending on the mode either returns `CSV::Row` entries or Arrays of nilable objects, added the proper return values to the classes that are used to parse the CSV
* Fixed the sigs for `parse` and `foreach` method
* Updated the type_member of `CSV::Row` from `String` to nilable `BasicObject`
* Removed a `table` method from the `CSV::Table`, since it's protected
* Added basic tests for `CSV`

### Motivation
This should fix two open issues: https://github.com/sorbet/sorbet/issues/2379 and https://github.com/sorbet/sorbet/issues/1579
There are a few problems:
1. The problem is that when we are parsing CSV, depending on whether we provide headers options to `parse` and `foreach` methods the returned results will be different
Example:
*  with headers
```
CSV.parse("1,2,3\n3,,abc\n5,6,1", { headers: true, converters: %i[numeric] })
=> #<CSV::Table mode:col_or_row row_count:3>
```
* without headers or `headers: false`
```
CSV.parse("1,2,3\n3,,abc\n5,6,1", { headers: false, converters: %i[numeric] })
=> [[1, 2, 3], [3, nil, "abc"], [5, 6, 1]]
```
2. `CSV::Row` can contain any object, not only strings (see the previous example where converters are passed)
3. CSV::Table has no sigs

### Outstanding questions
I'm new to contributing to Sorbet and there are no docs around the Generics, so I based it on the assumptions from what I read in the code. A few things that crossed my mind:
1) Is there a way to create a Generic where we limit the possible `Elem` values to a fixed set. I know there is a way to indicate the range of classes in the chain of inheritance, but I couldn't find a way to say that there is a possible subset of values to select from
2) I was trying to figure out if there is a good way of using shapes to create overloaded method signatures for the `parse` and `foreach` method based on the value of headers. However to the best of my knowledge it's not possible currently (based on the discussions in https://github.com/sorbet/sorbet/pull/2248). Would like to know if there is a way around

### Test plan
Added the `testdata` csv tests to cover any changed sigs
