### PR TITLE
Fix errors with the yaml RBI

### DIFF
--- a/gems/sorbet/lib/constant_cache.rb
+++ b/gems/sorbet/lib/constant_cache.rb
@@ -107,7 +107,10 @@ class Sorbet::Private::ConstantLookupCache
           # an alias that exists at the top-level
           next false if prefix == ""
 
-          # ignore aliases whose owners are the same, but syntactically different
+          # if the prefix is the same syntactically, then this is a good alias
+          next false if prefix == struct.owner.primary_name
+
+          # skip the alias if the owner is the same
           other_owner_const = Sorbet::Private::RealStdlib.real_const_get(Object, prefix, false)
           struct.owner.const == other_owner_const
         end

--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_5_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_5_hidden.rbi.exp
@@ -5168,25 +5168,7 @@ class Gem::DependencyInstaller
   def gems_to_install(*args, &block); end
 end
 
-class Gem::Resolver
-end
-
-Gem::DependencyResolver::Conflict = Gem::Resolver::Conflict
-
-Gem::DependencyResolver::DependencyConflict = Gem::Resolver::Conflict
-
-module Gem::Resolver::Molinillo
-end
-
-Gem::DependencyResolver::Molinillo::SpecificationProvider = Gem::Resolver::Molinillo::SpecificationProvider
-
-Gem::DependencyResolver::Molinillo::UI = Gem::Resolver::Molinillo::UI
-
-module Gem::Resolver::Molinillo
-end
-
-class Gem::Resolver
-end
+Gem::DependencyResolver = Gem::Resolver
 
 class Gem::Ext::BuildError
 end

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_5_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_5_hidden.rbi.exp
@@ -5174,25 +5174,7 @@ class Gem::DependencyInstaller
   def gems_to_install(*args, &block); end
 end
 
-class Gem::Resolver
-end
-
-Gem::DependencyResolver::Conflict = Gem::Resolver::Conflict
-
-Gem::DependencyResolver::DependencyConflict = Gem::Resolver::Conflict
-
-module Gem::Resolver::Molinillo
-end
-
-Gem::DependencyResolver::Molinillo::SpecificationProvider = Gem::Resolver::Molinillo::SpecificationProvider
-
-Gem::DependencyResolver::Molinillo::UI = Gem::Resolver::Molinillo::UI
-
-module Gem::Resolver::Molinillo
-end
-
-class Gem::Resolver
-end
+Gem::DependencyResolver = Gem::Resolver
 
 class Gem::Ext::BuildError
 end

--- a/gems/sorbet/test/snapshot/partial/yaml/src/Gemfile.lock
+++ b/gems/sorbet/test/snapshot/partial/yaml/src/Gemfile.lock
@@ -1,0 +1,10 @@
+GEM
+  specs:
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+
+BUNDLED WITH
+   2.1.2

--- a/gems/sorbet/test/snapshot/partial/yaml/src/test.rb
+++ b/gems/sorbet/test/snapshot/partial/yaml/src/test.rb
@@ -1,0 +1,4 @@
+# This exposes an issue with the hidden-method-finder and constants that are
+# nested in a top-level module that has an alias to it.
+
+require 'yaml'


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The YAML rbi contains a top-level alias to the Psych module. All of the constants defined are discovered by the hidden method finder under both the YAML and Psych namespaces. A result of this is that we end up writing out a bunch of self-assignments that look like this:

```ruby
YAML::Visitors::JSONTree = Psych::Visitors::JSONTree
```

which raise errors in sorbet, and fail when processing the reflection rbi. This branch changes that behavior to not emit aliases when their owner is the same, but used with different names.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixes #3125.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
