### PR TITLE
Speedup caching by compressing files in parallel.

### DIFF
--- a/main/cache/cache-orig.cc
+++ b/main/cache/cache-orig.cc
@@ -12,7 +12,7 @@ unique_ptr<OwnedKeyValueStore> ownIfUnchanged(const core::GlobalState &gs, uniqu
 }
 
 void maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore> kvstore, const options::Options &opts,
-                                   core::GlobalState &gs, vector<ast::ParsedFile> &indexed) {
+                                   core::GlobalState &gs, WorkerPool &workers, vector<ast::ParsedFile> &indexed) {
     return;
 }
 

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -31,7 +31,7 @@ unique_ptr<OwnedKeyValueStore> ownIfUnchanged(const core::GlobalState &gs, uniqu
 }
 
 void maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore> kvstore, const options::Options &opts,
-                                   core::GlobalState &gs, vector<ast::ParsedFile> &indexed) {
+                                   core::GlobalState &gs, WorkerPool &workers, vector<ast::ParsedFile> &indexed) {
     if (kvstore == nullptr) {
         return;
     }
@@ -40,7 +40,7 @@ void maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore> kvstore, const opti
     auto wroteGlobalState = payload::retainGlobalState(gs, opts, ownedKvstore);
     if (wroteGlobalState) {
         // Only write changes to disk if GlobalState changed since the last time.
-        pipeline::cacheTreesAndFiles(gs, indexed, ownedKvstore);
+        pipeline::cacheTreesAndFiles(gs, workers, indexed, ownedKvstore);
         OwnedKeyValueStore::bestEffortCommit(gs.tracer(), move(ownedKvstore));
         prodCounterInc("cache.committed");
     } else {

--- a/main/cache/cache.h
+++ b/main/cache/cache.h
@@ -6,6 +6,7 @@
 namespace sorbet {
 class KeyValueStore;
 class OwnedKeyValueStore;
+class WorkerPool;
 namespace ast {
 struct ParsedFile;
 }
@@ -27,7 +28,7 @@ std::unique_ptr<OwnedKeyValueStore> ownIfUnchanged(const core::GlobalState &gs, 
 // If kvstore is not null, caches global state and the given files to disk if they have changed. Can silently fail to
 // cache
 void maybeCacheGlobalStateAndFiles(std::unique_ptr<KeyValueStore> kvstore, const options::Options &opts,
-                                   core::GlobalState &gs, std::vector<ast::ParsedFile> &indexed);
+                                   core::GlobalState &gs, WorkerPool &workers, std::vector<ast::ParsedFile> &indexed);
 } // namespace sorbet::realmain::cache
 
 #endif

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -172,7 +172,7 @@ void LSPIndexer::initialize(LSPFileUpdates &updates, WorkerPool &workers) {
 
     pipeline::computeFileHashes(initialGS->getFiles(), *config->logger, workers);
     cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(move(ownedKvstore)), config->opts, *initialGS,
-                                         indexed);
+                                         workers, indexed);
 
     // When inputFileNames is 0 (as in tests), indexed ends up being size 0 because we don't index payload files.
     // At the same time, we expect indexed to be the same size as GlobalStateHash, which _does_ have payload files.

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1231,15 +1231,13 @@ bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, vector
     Timer timeit(gs.tracer(), "pipeline::cacheTreesAndFiles");
 
     // Compress files in parallel.
-    shared_ptr<ConcurrentBoundedQueue<ast::ParsedFile *>> fileq =
-        make_shared<ConcurrentBoundedQueue<ast::ParsedFile *>>(parsedFiles.size());
+    auto fileq = make_shared<ConcurrentBoundedQueue<ast::ParsedFile *>>(parsedFiles.size());
     for (auto &parsedFile : parsedFiles) {
         auto ptr = &parsedFile;
         fileq->push(move(ptr), 1);
     }
 
-    shared_ptr<BlockingBoundedQueue<vector<pair<string, vector<u1>>>>> resultq =
-        make_shared<BlockingBoundedQueue<vector<pair<string, vector<u1>>>>>(parsedFiles.size());
+    auto resultq = make_shared<BlockingBoundedQueue<vector<pair<string, vector<u1>>>>>(parsedFiles.size());
     workers.multiplexJob("compressTreesAndFiles", [fileq, resultq, &gs]() {
         vector<pair<string, vector<u1>>> threadResult;
         int processedByThread = 0;

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -51,7 +51,7 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
                                     const options::Options &opts);
 
 // Caches any uncached trees and files. Returns true if it modifies kvstore.
-bool cacheTreesAndFiles(const core::GlobalState &gs, std::vector<ast::ParsedFile> &parsedFiles,
+bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, std::vector<ast::ParsedFile> &parsedFiles,
                         const std::unique_ptr<OwnedKeyValueStore> &kvstore);
 
 // Exported for tests only.

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -513,7 +513,7 @@ int realmain(int argc, char *argv[]) {
         }
 
         { indexed = pipeline::index(gs, inputFiles, opts, *workers, kvstore); }
-        cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(move(kvstore)), opts, *gs, indexed);
+        cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(move(kvstore)), opts, *gs, *workers, indexed);
 
         if (gs->runningUnderAutogen) {
 #ifdef SORBET_REALMAIN_MIN


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Speedup caching by compressing files in parallel.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Significantly speeds up LSP cold cache startup times on large codebases.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
