### PR TITLE
Fix signature for OpenSSL::Buffering#write

### DIFF
--- a/rbi/stdlib/openssl.rbi
+++ b/rbi/stdlib/openssl.rbi
@@ -2343,7 +2343,7 @@ module OpenSSL::Buffering
     )
     .returns(::T.untyped)
   end
-  def write(s); end
+  def write(*s); end
 
   # Writes *s* in the non-blocking manner.
   #


### PR DESCRIPTION
### Motivation

The `write` method accept a variadic for `s` as it can be seen [here](https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/Buffering.html#method-i-write).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
