### PR TITLE
Fix some issues with incorrect superclasses in rubygems.rbi.

### DIFF
--- a/rbi/stdlib/rubygems.rbi
+++ b/rbi/stdlib/rubygems.rbi
@@ -3662,15 +3662,17 @@ class Gem::S3URISigner
   def uri=(uri); end
 end
 
-class Gem::S3URISigner::ConfigurationError
+class Gem::S3URISigner::ConfigurationError < Gem::Exception
   def initialize(message); end
 end
 
-class Gem::S3URISigner::InstanceProfileError
+class Gem::S3URISigner::InstanceProfileError < Gem::Exception
   def initialize(message); end
 end
 
-class Gem::S3URISigner::S3Config
+class Gem::S3URISigner::S3Config < Struct
+  Elem = type_member(:out, fixed: T.untyped)
+
   def access_key_id(); end
 
   def access_key_id=(_); end


### PR DESCRIPTION
Fix some missing superclasses for the rubygems.rbi.

I think this wasn't caught by the automated tests previously because CI using an older version of RubyGems, but I'm honestly not entirely sure.

### Motivation

I updated my app to Sorbet 0.5.5725 and it got these errors when generating the hidden definitions:

```
/var/folders/2n/6l8d3x457wq9m5fpry0dltb40000gn/T/d20200603-85674-14hjxge/reflection.rbi:183449: Parent of class `Gem::S3URISigner::ConfigurationError` redefined from `Object` to `Gem::Exception` https://srb.help/5012
      183449 |class Gem::S3URISigner::ConfigurationError < Gem::Exception
                                                           ^^^^^^^^^^^^^^

/var/folders/2n/6l8d3x457wq9m5fpry0dltb40000gn/T/d20200603-85674-14hjxge/reflection.rbi:183460: Parent of class `Gem::S3URISigner::InstanceProfileError` redefined from `Object` to `Gem::Exception` https://srb.help/5012
      183460 |class Gem::S3URISigner::InstanceProfileError < Gem::Exception
                                                             ^^^^^^^^^^^^^^

/var/folders/2n/6l8d3x457wq9m5fpry0dltb40000gn/T/d20200603-85674-14hjxge/reflection.rbi:183471: Parent of class `Gem::S3URISigner::S3Config` redefined from `Object` to `Struct` https://srb.help/5012
      183471 |class Gem::S3URISigner::S3Config < Struct
                                                 ^^^^^^
```

### Test plan

See included automated tests.
