### PR TITLE
Preserve the generated error class on serialize

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -25,7 +25,7 @@ module T::Props::Serializable
         :generate_serialize_source
       )
       if msg
-        raise TypeError.new(msg)
+        raise e.class.new(msg)
       else
         raise
       end

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -62,7 +62,7 @@ module T::Props::Serializable
         :generate_deserialize_source
       )
       if msg
-        raise TypeError.new(msg)
+        raise e.class.new(msg)
       else
         raise
       end

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -25,7 +25,11 @@ module T::Props::Serializable
         :generate_serialize_source
       )
       if msg
-        raise e.class.new(msg)
+        begin
+          raise e.class.new(msg)
+        rescue ArgumentError
+          raise TypeError.new(msg)
+        end
       else
         raise
       end
@@ -62,7 +66,11 @@ module T::Props::Serializable
         :generate_deserialize_source
       )
       if msg
-        raise e.class.new(msg)
+        begin
+          raise e.class.new(msg)
+        rescue ArgumentError
+          raise TypeError.new(msg)
+        end
       else
         raise
       end

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -171,7 +171,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     it 'includes relevant generated code on serialize' do
       m = a_serializable
       m.instance_variable_set(:@foo, "Won't respond like hash")
-      e = assert_raises(TypeError) do
+      e = assert_raises(NoMethodError) do
         m.serialize
       end
 

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -159,7 +159,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
         raise "#{msg} #{extra.inspect}"
       end
 
-      e = assert_raises(TypeError) do
+      e = assert_raises(RuntimeError) do
         MySerializable.from_hash({'foo' => "Won't respond like hash"})
       end
 

--- a/gems/sorbet-runtime/test/types/props/struct.rb
+++ b/gems/sorbet-runtime/test/types/props/struct.rb
@@ -163,12 +163,12 @@ class Opus::Types::Test::Props::StructTest < Critic::Unit::UnitTest
       assert_equal(10, doc.foo1)
       assert_equal(20, doc.foo2)
 
-      assert_raises(TypeError) do
+      assert_raises(RuntimeError) do
         StructWithReqiredField.from_hash({'foo2' => 20})
       end
 
       # The code should behave for deserialization.
-      assert_raises(TypeError) do
+      assert_raises(RuntimeError) do
         StructWithReqiredField.from_hash({'foo1' => 10})
       end
     end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We do some fancy wrapping logic that tries to provide more context on
where the error message came from when it came from the generated
serialize, probably because the line numbers look terrible with the
module_eval tricks we're doing.

The problem is that this means sometimes the error kind can change
depending on the order the code loads.

The change to the test exemplifies this. We swallowed a NoMethodError
and converted it to a TypeError.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.