### PR TITLE
Add backup urls for the remaining direct dependencies

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -210,7 +210,7 @@ package(default_visibility = ["//visibility:public"])
 
     http_archive(
         name = "emscripten_clang_linux",
-        url = "https://storage.googleapis.com/webassembly/emscripten-releases-builds/old/linux/emscripten-llvm-e1.38.25.tar.gz",
+        urls = _emscripten_urls("linux/emscripten-llvm-e1.38.25.tar.gz"),
         build_file = "@com_stripe_ruby_typer//third_party:emscripten-clang.BUILD",
         sha256 = "0e9a5a114a60c21604f4038b573109bd31424aeba275b4173480485ca0a56ba4",
         strip_prefix = "emscripten-llvm-e1.38.25",
@@ -218,7 +218,7 @@ package(default_visibility = ["//visibility:public"])
 
     http_archive(
         name = "emscripten_clang_darwin",
-        url = "https://storage.googleapis.com/webassembly/emscripten-releases-builds/old/mac/emscripten-llvm-e1.38.25.tar.gz",
+        urls = _emscripten_urls("mac/emscripten-llvm-e1.38.25.tar.gz"),
         build_file = "@com_stripe_ruby_typer//third_party:emscripten-clang.BUILD",
         sha256 = "01519125c613d0b013193eaf5ac5031e6ec34aac2451c357fd4097874ceee38c",
         strip_prefix = "emscripten-llvm-e1.38.25",
@@ -253,13 +253,13 @@ package(default_visibility = ["//visibility:public"])
 
     http_file(
         name = "bundler_2_1_4",
-        urls = ["https://rubygems.org/downloads/bundler-2.1.4.gem"],
+        urls = _rubygems_urls("bundler-2.1.4.gem"),
         sha256 = "50014d21d6712079da4d6464de12bb93c278f87c9200d0b60ba99f32c25af489",
     )
 
     http_archive(
         name = "ruby_2_5",
-        url = "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.8.tar.gz",
+        urls = _ruby_urls("2.5/ruby-2.5.8.tar.gz"),
         sha256 = "6c0bdf07876c69811a9e7dc237c43d40b1cb6369f68e0e17953d7279b524ad9a",
         strip_prefix = "ruby-2.5.8",
         build_file = "@com_stripe_ruby_typer//third_party/ruby:ruby.BUILD",
@@ -267,7 +267,7 @@ package(default_visibility = ["//visibility:public"])
 
     http_archive(
         name = "ruby_2_6",
-        url = "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.gz",
+        urls = _ruby_urls("2.6/ruby-2.6.5.tar.gz"),
         sha256 = "66976b716ecc1fd34f9b7c3c2b07bbd37631815377a2e3e85a5b194cfdcbed7d",
         strip_prefix = "ruby-2.6.5",
         build_file = "@com_stripe_ruby_typer//third_party/ruby:ruby.BUILD",
@@ -292,4 +292,31 @@ def _github_public_urls(path):
     return [
         "https://github.com/{}".format(path),
         "https://artifactory-content.stripe.build/artifactory/github-archives/{}".format(path),
+    ]
+
+def _emscripten_urls(path):
+    """
+    Produce a url list that works both with emscripten, and stripe's internal artifact cache.
+    """
+    return [
+        "https://storage.googleapis.com/webassembly/emscripten-releases-builds/old/{}".format(path),
+        "https://artifactory.corp.stripe.com/artifactory/googleapis-storage-cache/webassembly/emscripten-releases-builds/old/{}".format(path),
+    ]
+
+def _rubygems_urls(gem):
+    """
+    Produce a url list that works both with rubygems, and stripe's internal gem cache.
+    """
+    return [
+        "https://rubygems.org/downloads/{}".format(gem),
+        "https://intgems.local.corp.stripe.com:446/gems/{}".format(gem),
+    ]
+
+def _ruby_urls(path):
+    """
+    Produce a url list that works both with ruby-lang.org, and stripe's internal artifact cache.
+    """
+    return [
+        "https://cache.ruby-lang.org/pub/ruby/{}".format(path),
+        "https://artifactory.corp.stripe.com/artifactory/ruby-lang-cache/pub/ruby/{}".format(path),
     ]


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This adds artifactory backup URLs for the remaining dependencies in externals.bzl.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
