### PR TITLE
Adding sig to freeze method

### DIFF
--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -999,6 +999,7 @@ class String < Object
   end
   def force_encoding(arg0); end
 
+  sig {returns(String)}
   def freeze; end
 
   # returns the *index*th byte as an integer.

--- a/test/testdata/rbi/string.rb
+++ b/test/testdata/rbi/string.rb
@@ -12,6 +12,7 @@ x, y, z = s.rpartition('')
 T.assert_type!(x, String)
 T.assert_type!(y, String)
 T.assert_type!(z, String)
+T.assert_type!(x.freeze, String)
 
 u = "abcdefg\0\0abc".unpack('CdAD')
 T.assert_type!(u, T::Array[T.nilable(T.any(Integer, Float, String))])


### PR DESCRIPTION
Added the sig to the `freeze` method of the String

### Motivation
When defining the constants in Ruby, it's quite common to define them as frozen literals so that they are immutable. As a result code like this `MY_CONST = T.let('my_const'.freeze, String)` is failing the type check

### Test plan
Added a quick one line test for the method