### PR TITLE
Fix signature for `Dir::glob` so it accept the keyword parameter `base`

### DIFF
--- a/rbi/core/dir.rbi
+++ b/rbi/core/dir.rbi
@@ -283,19 +283,36 @@ class Dir < Object
   sig do
     params(
         pattern: T.any(String, T::Array[String]),
-        flags: Integer,
+        flags: T.nilable(Integer),
+        opts: T.nilable(T::Hash[Symbol, String]),
     )
     .returns(T::Array[String])
   end
   sig do
     params(
         pattern: T.any(String, T::Array[String]),
-        flags: Integer,
+        flags: T.nilable(Integer),
+        opts: T.nilable(T::Hash[Symbol, String]),
         blk: T.proc.params(arg0: String).returns(BasicObject),
     )
     .returns(NilClass)
   end
-  def self.glob(pattern, flags=T.unsafe(nil), &blk); end
+  sig do
+    params(
+        pattern: T.any(String, T::Array[String]),
+        opts: T.nilable(T::Hash[Symbol, String]),
+        blk: T.proc.params(arg0: String).returns(BasicObject),
+    )
+    .returns(NilClass)
+  end
+  sig do
+    params(
+        pattern: T.any(String, T::Array[String]),
+        opts: T.nilable(T::Hash[Symbol, String]),
+    )
+    .returns(T::Array[String])
+  end
+  def self.glob(pattern, flags=T.unsafe(nil), opts=T.unsafe(nil), &blk); end
 
   # Returns the home directory of the current user or the named user if given.
   sig do


### PR DESCRIPTION
### Motivation

Making the [following example](https://sorbet.run/#%23%20typed%3A%20true%0A%0ADir.glob(%22foo%22%2C%20base%3A%20%22bar%22)) pass:

```ruby
Dir.glob("foo", base: "bar")
```

As we can see in the [documentation](https://ruby-doc.org/core-2.5.1/Dir.html#method-c-glob), the `glob` method accepts a `base:` keyword parameter.

Since Sorbet doesn't play nicely with keyword parameters in overload, the proposed signature accepts the different usages we have in our codebase.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
