### PR TITLE
Improve Object#then and Object#yield_self signature

### DIFF
--- a/rbi/core/object.rbi
+++ b/rbi/core/object.rbi
@@ -74,7 +74,11 @@ class Object < BasicObject
   # # does not meet condition, drop value
   # 2.yield_self.detect(&:odd?)            # => nil
   # ```
-  sig {params(blk: T.proc.params(arg: T.untyped).returns(T.untyped)).returns(T.untyped)}
+  sig do
+    type_parameters(:X)
+      .params(blk: T.proc.params(arg: T.untyped).returns(T.type_parameter(:X)))
+      .returns(T.type_parameter(:X))
+  end
   def yield_self(&blk); end
 
   ### `then` is just an alias of `yield_self`. Separately def'd here for easier IDE integration
@@ -106,6 +110,10 @@ class Object < BasicObject
   # # does not meet condition, drop value
   # 2.yield_self.detect(&:odd?)            # => nil
   # ```
-  sig {params(blk: T.proc.params(arg: T.untyped).returns(T.untyped)).returns(T.untyped)}
+  sig do
+    type_parameters(:X)
+      .params(blk: T.proc.params(arg: T.untyped).returns(T.type_parameter(:X)))
+      .returns(T.type_parameter(:X))
+  end
   def then(&blk); end
 end


### PR DESCRIPTION
Improve the accuracy of `Object#then` and `Object#yield_self`.
Instead of returning `T.untyped` it now returns the block output type.

I also wanted to add `T.self_type` to the block input type but it is currently not allowed.
```ruby
class Object < BasicObject
  sig do
    type_parameters(:X)
      .params(blk: T.proc.params(arg: T.self_type).returns(T.type_parameter(:X)))
      .returns(T.type_parameter(:X))
  end
  def then(&blk); end
end
```
```
sorbet/hand-written-rbi/lib/object.rbi:6: Only top-level T.self_type is supported https://srb.help/5004
     6 |      .params(blk: T.proc.params(arg: T.self_type).returns(T.type_parameter(:X)))
```

### Motivation

Based on #484
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan

I plan on waiting for the results of the existing tests and change them as necessary.
