### PR TITLE
Fix type member for CSV::Table

### DIFF
--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -1168,7 +1168,7 @@ class CSV::Table < Object
   include Enumerable
 
   extend T::Generic
-  Elem = type_member(:out)
+  Elem = type_member(fixed: CSV::Row)
 
   # Construct a new
   # [`CSV::Table`](https://docs.ruby-lang.org/en/2.6.0/CSV/Table.html) from


### PR DESCRIPTION
### Motivation

The type member for `CSV::Table` should be fixed to `CSV::Row`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
