### PR TITLE
Fix AttrReader rewriter for sigs with .checked. Fixes #3104

### DIFF
--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -70,24 +70,33 @@ bool isTNilableOrUntyped(const ast::TreePtr &expr) {
            isT(send->recv);
 }
 
+ast::Send *findSendReturns(core::MutableContext ctx, ast::Send *sharedSig) {
+    ENFORCE(ASTUtil::castSig(sharedSig), "We weren't given a send node that's a valid signature");
+
+    auto block = ast::cast_tree<ast::Block>(sharedSig->block);
+    auto body = ast::cast_tree<ast::Send>(block->body);
+
+    while (body->fun != core::Names::returns() && body->fun != core::Names::void_()) {
+        body = ast::cast_tree<ast::Send>(body->recv);
+    }
+
+    return body->fun == core::Names::returns() ? body : nullptr;
+}
+
 bool hasNilableOrUntypedReturns(core::MutableContext ctx, ast::TreePtr &sharedSig) {
-    ENFORCE(ASTUtil::castSig(sharedSig, core::Names::returns()),
-            "We weren't given a send node that's a valid signature");
+    ENFORCE(ASTUtil::castSig(sharedSig), "We weren't given a send node that's a valid signature");
 
-    auto &send = ast::cast_tree_nonnull<ast::Send>(sharedSig);
-    auto &block = ast::cast_tree_nonnull<ast::Block>(send.block);
-    auto &body = ast::cast_tree_nonnull<ast::Send>(block.body);
+    auto *body = findSendReturns(ctx, ASTUtil::castSig(sharedSig));
 
-    ENFORCE(body.fun == core::Names::returns());
-    if (body.args.size() != 1) {
+    ENFORCE(body->fun == core::Names::returns());
+    if (body->args.size() != 1) {
         return false;
     }
-    return isTNilableOrUntyped(body.args[0]);
+    return isTNilableOrUntyped(body->args[0]);
 }
 
 ast::TreePtr dupReturnsType(core::MutableContext ctx, ast::Send *sharedSig) {
-    ENFORCE(ASTUtil::castSig(sharedSig, core::Names::returns()),
-            "We weren't given a send node that's a valid signature");
+    ENFORCE(ASTUtil::castSig(sharedSig), "We weren't given a send node that's a valid signature");
 
     auto block = ast::cast_tree_const<ast::Block>(sharedSig->block);
     auto body = ast::cast_tree_const<ast::Send>(block->body);
@@ -120,17 +129,14 @@ void ensureSafeSig(core::MutableContext ctx, const core::NameRef attrFun, ast::S
 // value into the `sig {params(...)}` using whatever name we have for the setter.
 ast::TreePtr toWriterSigForName(core::MutableContext ctx, ast::Send *sharedSig, const core::NameRef name,
                                 core::LocOffsets nameLoc) {
-    ENFORCE(ASTUtil::castSig(sharedSig, core::Names::returns()),
-            "We weren't given a send node that's a valid signature");
+    ENFORCE(ASTUtil::castSig(sharedSig), "We weren't given a send node that's a valid signature");
 
     // There's a bit of work here because deepCopy gives us back an Expression when we know it's a Send.
     ast::TreePtr sigExpr = sharedSig->deepCopy();
     auto *sig = ast::cast_tree<ast::Send>(sigExpr);
     ENFORCE(sig != nullptr, "Just deep copied this, so it should be non-null");
 
-    // Loop down the chain of recv's until we get to the inner 'sig' node.
-    auto block = ast::cast_tree<ast::Block>(sig->block);
-    auto body = ast::cast_tree<ast::Send>(block->body);
+    auto *body = findSendReturns(ctx, sig);
 
     ENFORCE(body->fun == core::Names::returns());
     if (body->args.size() != 1) {
@@ -176,7 +182,9 @@ ast::TreePtr toWriterSigForName(core::MutableContext ctx, ast::Send *sharedSig, 
 // above will actually be untouched in the syntax tree, but (2), (3), and (4)
 // will have to be synthesized. Handling this case gets a little tricky
 // considering that this Rewriter pass handles all three of attr_reader,
-// attr_writer, and attr_accessor.
+// attr_writer, and attr_accessor. Also the `sig` might contain an
+// explicit checked (or on_failure) call as in
+// `sig {returns(String}.checked(:always)}` that needs to be preserved.
 //
 // Also note that the burden is on the user to provide an accurate type signature.
 // All attr_accessor's should probably have `T.nilable(...)` to account for a
@@ -206,8 +214,10 @@ vector<ast::TreePtr> AttrReader::run(core::MutableContext ctx, ast::Send *send, 
 
     ast::Send *sig = nullptr;
     if (prevStat) {
-        sig = ASTUtil::castSig(*prevStat, core::Names::returns());
-        if (sig != nullptr) {
+        sig = ASTUtil::castSig(*prevStat);
+        if (sig != nullptr && findSendReturns(ctx, sig) == nullptr) {
+            sig = nullptr;
+        } else if (sig != nullptr) {
             ensureSafeSig(ctx, send->fun, sig);
         }
     }

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -98,8 +98,7 @@ bool hasNilableOrUntypedReturns(core::MutableContext ctx, ast::TreePtr &sharedSi
 ast::TreePtr dupReturnsType(core::MutableContext ctx, ast::Send *sharedSig) {
     ENFORCE(ASTUtil::castSig(sharedSig), "We weren't given a send node that's a valid signature");
 
-    auto block = ast::cast_tree_const<ast::Block>(sharedSig->block);
-    auto body = ast::cast_tree_const<ast::Send>(block->body);
+    auto *body = findSendReturns(ctx, ASTUtil::castSig(sharedSig));
 
     ENFORCE(body->fun == core::Names::returns());
     if (body->args.size() != 1) {

--- a/rewriter/Initializer.cc
+++ b/rewriter/Initializer.cc
@@ -70,7 +70,7 @@ void Initializer::run(core::MutableContext ctx, ast::MethodDef *methodDef, ast::
         return;
     }
     // make sure that the `sig` block looks like a valid sig block
-    auto *sig = ASTUtil::castSig(*prevStat, core::Names::void_());
+    auto *sig = ASTUtil::castSig(*prevStat);
     if (sig == nullptr) {
         return;
     }

--- a/rewriter/Util.h
+++ b/rewriter/Util.h
@@ -16,8 +16,8 @@ public:
     static std::pair<ast::TreePtr, ast::TreePtr> extractHashValue(core::MutableContext ctx, ast::Hash &hash,
                                                                   core::NameRef name);
 
-    static ast::Send *castSig(ast::TreePtr &expr, core::NameRef returns);
-    static ast::Send *castSig(ast::Send *expr, core::NameRef returns);
+    static ast::Send *castSig(ast::TreePtr &expr);
+    static ast::Send *castSig(ast::Send *expr);
 
     static ast::TreePtr mkGet(core::Context ctx, core::LocOffsets loc, core::NameRef name, ast::TreePtr rhs);
 

--- a/test/testdata/rewriter/attr_checked.rb
+++ b/test/testdata/rewriter/attr_checked.rb
@@ -26,6 +26,9 @@ class TestAttr
   sig {void.on_failure(:raise)}
   attr_accessor :str8 # error: This function does not have a `sig`
 
+  sig {params(str9: T.nilable(String)).returns(T.nilable(String)).checked(:never)}
+  attr_writer :str9
+
   sig {void}
   def initialize
     @str1 = T.let('', String)
@@ -36,6 +39,7 @@ class TestAttr
     @str6 = T.let('', String)
     @str7 = T.let('', String)
     @str8 = T.let('', String)
+    @str9 = ''
   end
 
 end

--- a/test/testdata/rewriter/attr_checked.rb
+++ b/test/testdata/rewriter/attr_checked.rb
@@ -1,0 +1,41 @@
+# typed: strict
+class TestAttr
+  extend T::Sig
+
+  sig {returns(String).checked(:always)}
+  attr_accessor :str1
+
+  sig {returns(String).checked(:always)}
+  attr_reader :str2
+
+  sig {params(str3:String).returns(String).checked(:always)}
+  attr_writer :str3
+
+  sig {returns(String).on_failure(:raise)}
+  attr_accessor :str4
+
+  sig {returns(String).checked(:always).on_failure(:raise)}
+  attr_accessor :str5
+
+  sig {void.checked(:always)}
+  attr_reader :str6
+
+  sig {params(str7:String).void.checked(:always).on_failure(:raise)}
+  attr_writer :str7
+
+  sig {void.on_failure(:raise)}
+  attr_accessor :str8 # error: This function does not have a `sig`
+
+  sig {void}
+  def initialize
+    @str1 = T.let('', String)
+    @str2 = T.let('', String)
+    @str3 = T.let('', String)
+    @str4 = T.let('', String)
+    @str5 = T.let('', String)
+    @str6 = T.let('', String)
+    @str7 = T.let('', String)
+    @str8 = T.let('', String)
+  end
+
+end

--- a/test/testdata/rewriter/initializer.rb
+++ b/test/testdata/rewriter/initializer.rb
@@ -128,3 +128,31 @@ class NestedConstructor
     T.reveal_type(@x)  # error: Revealed type: `T.untyped`
   end
 end
+
+class Checked
+  extend T::Sig
+
+  sig {params(x: Integer).void.checked(:never)}
+  def initialize(x)
+    @x = x
+  end
+
+  sig {void}
+  def foo
+    T.reveal_type(@x) # error: Revealed type: `Integer`
+  end
+end
+
+class OnFailure
+  extend T::Sig
+
+  sig {params(x: Integer).void.on_failure(:soft, notify: 'sorbet')}
+  def initialize(x)
+    @x = x
+  end
+
+  sig {void}
+  def foo
+    T.reveal_type(@x) # error: Revealed type: `Integer`
+  end
+end


### PR DESCRIPTION
Makes the rewriter behavior be triggered properly not only for
sig {returns(...)}, but also for sig {returns(...).checked(...)}.

This is the first time I'm touching the sorbet code, so I'm not sure about coding style and if I have covered all bases. Please let me know of any improvements in style or approach.

The code was only checking for `sig{returns(...))`, which made it break in some cases where a `sig` of the form `sig{returns(...).checked(...)}` was used. My solution was to accept both when casting the input expression node and check for both forms when retrieving the internal returns node from the `sig`. 

### Motivation
Fixes #3104 

### Test plan
See included automated tests.
