### PR TITLE
Remove detail from DocumentSymbols in language server

### DIFF
--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -51,12 +51,12 @@ std::unique_ptr<DocumentSymbol> symbolRef2DocumentSymbol(const core::GlobalState
         prefix = "self.";
     }
     auto result = make_unique<DocumentSymbol>(prefix + sym->name.show(gs), kind, move(range), move(selectionRange));
-    if (sym->isMethod()) {
-        result->detail = prettyTypeForMethod(gs, symRef, nullptr, nullptr, nullptr);
-    } else {
-        // Currently released version of VSCode has a bug that requires this non-optional field to be present
-        result->detail = "";
-    }
+
+    // Previous versions of VSCode have a bug that requires this non-optional field to be present.
+    // This previously tried to include the method signature but due to issues where large signatures were not readable
+    // when put on one line and given that currently details are only visible in the outline view but not seen in the
+    // symbol search. Additionally, no other language server implementations we could find used this field.
+    result->detail = "";
 
     vector<unique_ptr<DocumentSymbol>> children;
     symbolRef2DocumentSymbolWalkMembers(gs, symRef, filter, children);

--- a/test/testdata/lsp/document_symbols.rb.document-symbols.exp
+++ b/test/testdata/lsp/document_symbols.rb.document-symbols.exp
@@ -56,7 +56,7 @@
                 },
                 {
                     "name": "initialize",
-                    "detail": "sig {void}\ndef initialize; end",
+                    "detail": "",
                     "kind": 9,
                     "range": {
                         "start": {
@@ -82,7 +82,7 @@
                 },
                 {
                     "name": "next",
-                    "detail": "sig {returns(Integer)}\ndef next; end",
+                    "detail": "",
                     "kind": 6,
                     "range": {
                         "start": {
@@ -108,7 +108,7 @@
                 },
                 {
                     "name": "self.bar",
-                    "detail": "sig {returns(T.untyped)}\ndef self.bar; end",
+                    "detail": "",
                     "kind": 6,
                     "range": {
                         "start": {
@@ -187,7 +187,7 @@
                 },
                 {
                     "name": "bye",
-                    "detail": "sig(:final) {params(x: String).returns(String)}\ndef bye(x); end",
+                    "detail": "",
                     "kind": 6,
                     "range": {
                         "start": {
@@ -213,7 +213,7 @@
                 },
                 {
                     "name": "hi",
-                    "detail": "sig {params(x: String).returns(String)}\ndef hi(x); end",
+                    "detail": "",
                     "kind": 6,
                     "range": {
                         "start": {
@@ -266,7 +266,7 @@
             "children": [
                 {
                     "name": "sum_many",
-                    "detail": "sig do\n  abstract\n  .params(\n    first: Integer,\n    second: Integer,\n    third: Integer,\n    fourth: Integer,\n    fifth: Integer\n  )\n  .returns(Integer)\nend\ndef sum_many(first, second, third, fourth, fifth); end",
+                    "detail": "",
                     "kind": 6,
                     "range": {
                         "start": {
@@ -319,7 +319,7 @@
             "children": [
                 {
                     "name": "sum_many",
-                    "detail": "sig do\n  override\n  .params(\n    first: Integer,\n    second: Integer,\n    third: Integer,\n    fourth: Integer,\n    fifth: Integer\n  )\n  .returns(Integer)\nend\ndef sum_many(first, second, third, fourth, fifth); end",
+                    "detail": "",
                     "kind": 6,
                     "range": {
                         "start": {

--- a/test/testdata/lsp/field_edits.1.rbupdate.document-symbols.exp
+++ b/test/testdata/lsp/field_edits.1.rbupdate.document-symbols.exp
@@ -56,7 +56,7 @@
                 },
                 {
                     "name": "bar",
-                    "detail": "sig {returns(T.untyped)}\ndef bar; end",
+                    "detail": "",
                     "kind": 6,
                     "range": {
                         "start": {

--- a/test/testdata/lsp/field_edits.2.rbupdate.document-symbols.exp
+++ b/test/testdata/lsp/field_edits.2.rbupdate.document-symbols.exp
@@ -56,7 +56,7 @@
                 },
                 {
                     "name": "bar",
-                    "detail": "sig {returns(T.untyped)}\ndef bar; end",
+                    "detail": "",
                     "kind": 6,
                     "range": {
                         "start": {

--- a/test/testdata/lsp/field_edits.rb.document-symbols.exp
+++ b/test/testdata/lsp/field_edits.rb.document-symbols.exp
@@ -56,7 +56,7 @@
                 },
                 {
                     "name": "bar",
-                    "detail": "sig {returns(T.untyped)}\ndef bar; end",
+                    "detail": "",
                     "kind": 6,
                     "range": {
                         "start": {

--- a/test/testdata/lsp/good_field_edits.1.rbupdate.document-symbols.exp
+++ b/test/testdata/lsp/good_field_edits.1.rbupdate.document-symbols.exp
@@ -56,7 +56,7 @@
                 },
                 {
                     "name": "bar",
-                    "detail": "sig {returns(T.untyped)}\ndef bar; end",
+                    "detail": "",
                     "kind": 6,
                     "range": {
                         "start": {

--- a/test/testdata/lsp/good_field_edits.rb.document-symbols.exp
+++ b/test/testdata/lsp/good_field_edits.rb.document-symbols.exp
@@ -56,7 +56,7 @@
                 },
                 {
                     "name": "bar",
-                    "detail": "sig {returns(T.untyped)}\ndef bar; end",
+                    "detail": "",
                     "kind": 6,
                     "range": {
                         "start": {


### PR DESCRIPTION
This previously tried to include the method signature in the detail field which
had a number of issues:

* VSCode only displays one line for the content in the detail field and forcing
  the signatures on to one line makes them long and difficult to read

* signatures are only shown in the outline view and never in the other symbol
  list UIs (e.g. symbol search)

Additionally, no other language server implementations we could find used this
field.

Before:
![Screen Shot 2020-06-08 at 2 58 14 PM](https://user-images.githubusercontent.com/66448904/84084512-7b7af400-a998-11ea-83e2-e39542b2e2ff.png)

After:
![Screen Shot 2020-06-08 at 2 57 31 PM](https://user-images.githubusercontent.com/66448904/84084473-62724300-a998-11ea-84ee-518125013a28.png)

### Motivation

#2192

### Test plan

Covered by existing tests.