### PR TITLE
Improve String#chars signature

### DIFF
--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -467,7 +467,7 @@ class String < Object
   #
   # If a block is given, which is a deprecated form, works the same as
   # `each_char`.
-  sig {returns(T::Array[T.untyped])}
+  sig {returns(T::Array[String])}
   def chars(); end
 
   # Returns a new `String` with the given record separator removed from the end

--- a/test/testdata/rbi/string.rb
+++ b/test/testdata/rbi/string.rb
@@ -16,3 +16,6 @@ T.assert_type!(x.freeze, String)
 
 u = "abcdefg\0\0abc".unpack('CdAD')
 T.assert_type!(u, T::Array[T.nilable(T.any(Integer, Float, String))])
+
+w = "aãeéèbc".chars
+T.assert_type!(w, T::Array[String])


### PR DESCRIPTION
Make `String#chars` signature more precise, from `T::Array[T.untyped]` to `T::Array[String]`.

### Motivation
More precision is better, right?

### Test plan
See included automated tests.
