### PR TITLE
Stop flipping $VERBOSE and make the test suite pass with no warnings in verbose mode

### DIFF
--- a/gems/sorbet-runtime/Rakefile
+++ b/gems/sorbet-runtime/Rakefile
@@ -15,3 +15,5 @@ begin
 rescue LoadError
   # Expected when using packaged gem
 end
+
+task default: :test

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -83,6 +83,7 @@ module T::Configuration
     raise error
   end
 
+  @inline_type_error_handler = nil
   def self.inline_type_error_handler(error)
     if @inline_type_error_handler
       @inline_type_error_handler.call(error)
@@ -123,6 +124,7 @@ module T::Configuration
     raise ArgumentError.new("#{location.path}:#{location.lineno}: Error interpreting `sig`:\n  #{error.message}\n\n")
   end
 
+  @sig_builder_error_handler = nil
   def self.sig_builder_error_handler(error, location)
     if @sig_builder_error_handler
       @sig_builder_error_handler.call(error, location)
@@ -173,6 +175,7 @@ module T::Configuration
     raise error
   end
 
+  @sig_validation_error_handler = nil
   def self.sig_validation_error_handler(error, opts={})
     if @sig_validation_error_handler
       @sig_validation_error_handler.call(error, opts)
@@ -219,6 +222,7 @@ module T::Configuration
     raise TypeError.new(opts[:pretty_message])
   end
 
+  @call_validation_error_handler = nil
   def self.call_validation_error_handler(signature, opts={})
     if @call_validation_error_handler
       @call_validation_error_handler.call(signature, opts)
@@ -319,6 +323,7 @@ module T::Configuration
     raise str
   end
 
+  @hard_assert_handler = nil
   def self.hard_assert_handler(str, extra={})
     if @hard_assert_handler
       @hard_assert_handler.call(str, extra)
@@ -347,6 +352,7 @@ module T::Configuration
     end
   end
 
+  @scalar_types = nil
   @default_scalar_types = Set.new(%w{
     NilClass
     TrueClass
@@ -358,7 +364,6 @@ module T::Configuration
     Time
     T::Enum
   }).freeze
-
   def self.scalar_types
     @scalar_types || @default_scalar_types
   end
@@ -383,12 +388,15 @@ module T::Configuration
     end
   end
 
+  @legacy_t_enum_migration_mode = false
   def self.enable_legacy_t_enum_migration_mode
     @legacy_t_enum_migration_mode = true
   end
+
   def self.disable_legacy_t_enum_migration_mode
     @legacy_t_enum_migration_mode = false
   end
+
   def self.legacy_t_enum_migration_mode?
     @legacy_t_enum_migration_mode || false
   end
@@ -416,6 +424,8 @@ module T::Configuration
 
     @sealed_violation_whitelist = sealed_violation_whitelist
   end
+
+  @sealed_violation_whitelist = nil
   def self.sealed_violation_whitelist
     @sealed_violation_whitelist
   end

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -368,26 +368,6 @@ module T::Configuration
     @scalar_types || @default_scalar_types
   end
 
-  # Temporarily disable ruby warnings while executing the given block. This is
-  # useful when doing something that would normally cause a warning to be
-  # emitted in Ruby verbose mode ($VERBOSE = true).
-  #
-  # @yield
-  #
-  def self.without_ruby_warnings
-    if $VERBOSE
-      begin
-        original_verbose = $VERBOSE
-        $VERBOSE = false
-        yield
-      ensure
-        $VERBOSE = original_verbose
-      end
-    else
-      yield
-    end
-  end
-
   @legacy_t_enum_migration_mode = false
   def self.enable_legacy_t_enum_migration_mode
     @legacy_t_enum_migration_mode = true

--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -280,14 +280,14 @@ class T::Enum
 
   sig {returns(T::Boolean)}
   def self.started_initializing?
-    @started_initializing = T.let(@started_initializing, T.nilable(T::Boolean))
     @started_initializing ||= false
+    @started_initializing = T.let(@started_initializing, T.nilable(T::Boolean))
   end
 
   sig {returns(T::Boolean)}
   def self.fully_initialized?
-    @fully_initialized = T.let(@fully_initialized, T.nilable(T::Boolean))
     @fully_initialized ||= false
+    @fully_initialized = T.let(@fully_initialized, T.nilable(T::Boolean))
   end
 
   # Maintains the order in which values are defined
@@ -302,8 +302,8 @@ class T::Enum
   sig {params(blk: T.proc.void).void}
   def self.enums(&blk)
     raise "enums cannot be defined for T::Enum" if self == T::Enum
-    raise "Enum #{self} was already initialized" if @fully_initialized
-    raise "Enum #{self} is still initializing" if @started_initializing
+    raise "Enum #{self} was already initialized" if defined?(@fully_initialized) && @fully_initialized
+    raise "Enum #{self} is still initializing" if defined?(@started_initializing) && @started_initializing
 
     @started_initializing = true
 

--- a/gems/sorbet-runtime/lib/types/private/abstract/data.rb
+++ b/gems/sorbet-runtime/lib/types/private/abstract/data.rb
@@ -12,7 +12,9 @@
 # modules that override the `hash` method with something completely broken.
 module T::Private::Abstract::Data
   def self.get(mod, key)
-    mod.instance_variable_get("@opus_abstract__#{key}") # rubocop:disable PrisonGuard/NoLurkyInstanceVariableAccess
+    if key?(mod, key)
+      mod.instance_variable_get("@opus_abstract__#{key}") # rubocop:disable PrisonGuard/NoLurkyInstanceVariableAccess
+    end
   end
 
   def self.set(mod, key, value)

--- a/gems/sorbet-runtime/lib/types/private/abstract/declare.rb
+++ b/gems/sorbet-runtime/lib/types/private/abstract/declare.rb
@@ -31,7 +31,7 @@ module T::Private::Abstract::Declare
         raise "You must call `abstract!` *before* defining an initialize method"
       end
 
-      # Don't need to silence warnings via without_ruby_warnings when calling
+      # Don't need to silence warnings via silence_redefinition_of_method when calling
       # define_method because of the guard above
 
       mod.send(:define_method, :initialize) do |*args, &blk|

--- a/gems/sorbet-runtime/lib/types/props/constructor.rb
+++ b/gems/sorbet-runtime/lib/types/props/constructor.rb
@@ -17,6 +17,8 @@ module T::Props::Constructor::DecoratorMethods
   # checked(:never) - O(runtime object construction)
   sig {params(instance: T::Props::Constructor, hash: T::Hash[Symbol, T.untyped]).returns(Integer).checked(:never)}
   def construct_props_without_defaults(instance, hash)
+    return 0 unless defined?(@props_without_defaults)
+
     @props_without_defaults&.count do |p, setter_proc|
       begin
         val = hash[p]

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -150,7 +150,9 @@ class T::Props::Decorator
     .checked(:never)
   end
   def prop_get(instance, prop, rules=prop_rules(prop))
-    val = instance.instance_variable_get(rules[:accessor_key])
+    val = if instance.instance_variable_defined?(rules[:accessor_key])
+      instance.instance_variable_get(rules[:accessor_key])
+    end
     if !val.nil?
       val
     else
@@ -172,7 +174,9 @@ class T::Props::Decorator
     .checked(:never)
   end
   def prop_get_if_set(instance, prop, rules=prop_rules(prop))
-    instance.instance_variable_get(rules[:accessor_key])
+    if instance.instance_variable_defined?(rules[:accessor_key])
+      instance.instance_variable_get(rules[:accessor_key])
+    end
   end
   alias_method :get, :prop_get_if_set # Alias for backwards compatibility
 

--- a/gems/sorbet-runtime/lib/types/props/generated_code_validation.rb
+++ b/gems/sorbet-runtime/lib/types/props/generated_code_validation.rb
@@ -16,10 +16,13 @@ module T::Props
 
     def self.validate_deserialize(source)
       parsed = parse(source)
+      
+      parsed = parsed.children[2] # Ignore the T::Configuration.without_ruby_warnings do
 
       # def %<name>(hash)
       #   ...
       # end
+      
       assert_equal(:def, parsed.type)
       name, args, body = parsed.children
       assert_equal(:__t_props_generated_deserialize, name)
@@ -48,6 +51,8 @@ module T::Props
 
     def self.validate_serialize(source)
       parsed = parse(source)
+      
+      parsed = parsed.children[2] # Ignore the T::Configuration.without_ruby_warnings do
 
       # def %<name>(strict)
       # ...
@@ -76,8 +81,16 @@ module T::Props
       condition, if_body, else_body = clause.children
 
       # if @%<accessor_key>.nil?
-      assert_equal(:send, condition.type)
-      receiver, method = condition.children
+      assert_equal(:or, condition.type)
+
+      guard, guard_receiver = condition.children
+
+      assert_equal(:send, guard.type)
+      assert_equal(:defined?, guard.children.first.type)
+
+      assert_equal(:send, guard_receiver.type)
+      receiver, method = guard_receiver.children
+
       assert_equal(:ivar, receiver.type)
       assert_equal(:nil?, method)
 

--- a/gems/sorbet-runtime/lib/types/props/generated_code_validation.rb
+++ b/gems/sorbet-runtime/lib/types/props/generated_code_validation.rb
@@ -17,7 +17,7 @@ module T::Props
     def self.validate_deserialize(source)
       parsed = parse(source)
       
-      parsed = parsed.children[2] # Ignore the T::Configuration.without_ruby_warnings do
+      parsed = parsed.children[1]
 
       # def %<name>(hash)
       #   ...
@@ -51,8 +51,7 @@ module T::Props
 
     def self.validate_serialize(source)
       parsed = parse(source)
-      
-      parsed = parsed.children[2] # Ignore the T::Configuration.without_ruby_warnings do
+      parsed = parsed.children[1]
 
       # def %<name>(strict)
       # ...

--- a/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
+++ b/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
@@ -65,11 +65,9 @@ module T::Props
         lazily_defined_methods[name] = blk
 
         cls = decorated_class
-        T::Configuration.without_ruby_warnings do
-          cls.send(:define_method, name) do |*args|
-            self.class.decorator.send(:eval_lazily_defined_method!, name)
-            send(name, *args)
-          end
+        T::Private::ClassUtils.redefine_method(cls, name) do |*args|
+          self.class.decorator.send(:eval_lazily_defined_method!, name)
+          send(name, *args)
         end
         if cls.respond_to?(:ruby2_keywords, true)
           cls.send(:ruby2_keywords, name)

--- a/gems/sorbet-runtime/lib/types/props/optional.rb
+++ b/gems/sorbet-runtime/lib/types/props/optional.rb
@@ -49,13 +49,17 @@ module T::Props::Optional::DecoratorMethods
     if default_setter
       @props_with_defaults ||= {}
       @props_with_defaults[prop] = default_setter
-      @props_without_defaults&.delete(prop) # Handle potential override
+      if defined?(@props_without_defaults)
+        @props_without_defaults&.delete(prop) # Handle potential override
+      end
 
       rules[DEFAULT_SETTER_RULE_KEY] = default_setter
     else
       @props_without_defaults ||= {}
       @props_without_defaults[prop] = rules.fetch(:setter_proc)
-      @props_with_defaults&.delete(prop) # Handle potential override
+      if defined?(@props_with_defaults)
+        @props_with_defaults&.delete(prop) # Handle potential override
+      end
     end
 
     super

--- a/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
@@ -94,12 +94,11 @@ module T::Props
         end
 
         <<~RUBY
-          T::Configuration.without_ruby_warnings do
-            def __t_props_generated_deserialize(hash)
-              found = #{stored_props.size}
-              #{parts.join("\n\n")}
-              found
-            end
+          T::Private::ClassUtils.silence_redefinition_of_method(self, :__t_props_generated_deserialize)
+          def __t_props_generated_deserialize(hash)
+            found = #{stored_props.size}
+            #{parts.join("\n\n")}
+            found
           end
         RUBY
       end

--- a/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
@@ -94,10 +94,12 @@ module T::Props
         end
 
         <<~RUBY
-          def __t_props_generated_deserialize(hash)
-            found = #{stored_props.size}
-            #{parts.join("\n\n")}
-            found
+          T::Configuration.without_ruby_warnings do
+            def __t_props_generated_deserialize(hash)
+              found = #{stored_props.size}
+              #{parts.join("\n\n")}
+              found
+            end
           end
         RUBY
       end

--- a/gems/sorbet-runtime/lib/types/props/private/serializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/serializer_generator.rb
@@ -55,7 +55,7 @@ module T::Props
           # nil value itself and the field name in the serialized BSON
           # document)
           <<~RUBY
-            if #{ivar_name}.nil?
+            if !defined?(#{ivar_name}) || #{ivar_name}.nil?
               #{nil_asserter}
             else
               h[#{hash_key.inspect}] = #{transformed_val}
@@ -64,10 +64,12 @@ module T::Props
         end
 
         <<~RUBY
-          def __t_props_generated_serialize(strict)
-            h = {}
-            #{parts.join("\n\n")}
-            h
+          T::Configuration.without_ruby_warnings do
+            def __t_props_generated_serialize(strict)
+              h = {}
+              #{parts.join("\n\n")}
+              h
+            end
           end
         RUBY
       end

--- a/gems/sorbet-runtime/lib/types/props/private/serializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/serializer_generator.rb
@@ -64,12 +64,11 @@ module T::Props
         end
 
         <<~RUBY
-          T::Configuration.without_ruby_warnings do
-            def __t_props_generated_serialize(strict)
-              h = {}
-              #{parts.join("\n\n")}
-              h
-            end
+          T::Private::ClassUtils.silence_redefinition_of_method(self, :__t_props_generated_serialize)
+          def __t_props_generated_serialize(strict)
+            h = {}
+            #{parts.join("\n\n")}
+            h
           end
         RUBY
       end

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -34,8 +34,10 @@ module T::Props::Serializable
         raise
       end
     end
-
-    h.merge!(@_extra_props) if @_extra_props
+    
+    if defined?(@_extra_props) && @_extra_props
+      h.merge!(@_extra_props)
+    end
     h
   end
 
@@ -121,8 +123,8 @@ module T::Props::Serializable
   private def with_existing_hash(changed_props, existing_hash:)
     serialized = existing_hash
     new_val = self.class.from_hash(serialized.merge(recursive_stringify_keys(changed_props)))
-    old_extra = self.instance_variable_get(:@_extra_props) # rubocop:disable PrisonGuard/NoLurkyInstanceVariableAccess
-    new_extra = new_val.instance_variable_get(:@_extra_props) # rubocop:disable PrisonGuard/NoLurkyInstanceVariableAccess
+    old_extra = @_extra_props if defined?(@_extra_props) # rubocop:disable PrisonGuard/NoLurkyInstanceVariableAccess
+    new_extra = new_val.instance_variable_get(:@_extra_props) if new_val.instance_variable_defined?(:@_extra_props) # rubocop:disable PrisonGuard/NoLurkyInstanceVariableAccess
     if old_extra != new_extra
       difference =
         if old_extra
@@ -137,7 +139,7 @@ module T::Props::Serializable
 
   # Asserts if this property is missing during strict serialize
   private def required_prop_missing_from_serialize(prop)
-    if @_required_props_missing_from_deserialize&.include?(prop)
+    if defined?(@_required_props_missing_from_deserialize) && @_required_props_missing_from_deserialize&.include?(prop)
       # If the prop was already missing during deserialization, that means the application
       # code already had to deal with a nil value, which means we wouldn't be accomplishing
       # much by raising here (other than causing an unnecessary breakage).
@@ -289,7 +291,11 @@ module T::Props::Serializable::DecoratorMethods
   private_constant :EMPTY_EXTRA_PROPS
 
   def extra_props(instance)
-    instance.instance_variable_get(:@_extra_props) || EMPTY_EXTRA_PROPS
+    if instance.instance_variable_defined?(:@_extra_props)
+      instance.instance_variable_get(:@_extra_props) || EMPTY_EXTRA_PROPS
+    else
+      EMPTY_EXTRA_PROPS
+    end
   end
 
   # @override T::Props::PrettyPrintable

--- a/gems/sorbet-runtime/lib/types/props/weak_constructor.rb
+++ b/gems/sorbet-runtime/lib/types/props/weak_constructor.rb
@@ -30,6 +30,8 @@ module T::Props::WeakConstructor::DecoratorMethods
   # checked(:never) - O(runtime object construction)
   sig {params(instance: T::Props::WeakConstructor, hash: T::Hash[Symbol, T.untyped]).returns(Integer).checked(:never)}
   def construct_props_without_defaults(instance, hash)
+    return 0 unless defined?(@props_without_defaults)
+
     @props_without_defaults&.count do |p, setter_proc|
       if hash.key?(p)
         instance.instance_exec(hash[p], &setter_proc)
@@ -49,6 +51,8 @@ module T::Props::WeakConstructor::DecoratorMethods
   # checked(:never) - O(runtime object construction)
   sig {params(instance: T::Props::WeakConstructor, hash: T::Hash[Symbol, T.untyped]).returns(Integer).checked(:never)}
   def construct_props_with_defaults(instance, hash)
+    return 0 unless defined?(@props_with_defaults)
+
     @props_with_defaults&.count do |p, default_struct|
       if hash.key?(p)
         instance.instance_exec(hash[p], &default_struct.setter_proc)

--- a/gems/sorbet-runtime/lib/types/sig.rb
+++ b/gems/sorbet-runtime/lib/types/sig.rb
@@ -9,15 +9,12 @@ module T::Sig
     # as T::Sig#sig. Only use it in cases where you can't use T::Sig#sig.
     def self.sig(arg0=nil, &blk); end # rubocop:disable PrisonGuard/BanBuiltinMethodOverride
 
-    original_verbose = $VERBOSE
-    $VERBOSE = false
 
+    T::Private::ClassUtils.silence_redefinition_of_method(singleton_class, :sig)
     # At runtime, does nothing, but statically it is treated exactly the same
     # as T::Sig#sig. Only use it in cases where you can't use T::Sig#sig.
     T::Sig::WithoutRuntime.sig {params(arg0: T.nilable(Symbol), blk: T.proc.bind(T::Private::Methods::DeclBuilder).void).void}
     def self.sig(arg0=nil, &blk); end # rubocop:disable PrisonGuard/BanBuiltinMethodOverride, Lint/DuplicateMethods
-
-    $VERBOSE = original_verbose
   end
 
   # Declares a method with type signatures and/or

--- a/gems/sorbet-runtime/test/test_helper.rb
+++ b/gems/sorbet-runtime/test/test_helper.rb
@@ -2,7 +2,7 @@
 
 # Ideally we might run tests with warnings enabled, but currently this triggers
 # a number of uninitialized instance variable warnings.
-# $VERBOSE = true
+$VERBOSE = true
 
 require 'minitest/autorun'
 require 'minitest/spec'

--- a/gems/sorbet-runtime/test/types/attached_class.rb
+++ b/gems/sorbet-runtime/test/types/attached_class.rb
@@ -9,8 +9,10 @@ module Opus::Types::Test
         extend T::Sig
 
         sig {returns(T.attached_class)}
-        def self.make
-          new
+        T::Configuration.without_ruby_warnings do
+          def self.make
+            new
+          end
         end
       end
 
@@ -26,8 +28,10 @@ module Opus::Types::Test
         extend T::Sig
 
         sig {returns(T.attached_class)}
-        def self.make
-          new
+        T::Configuration.without_ruby_warnings do
+          def self.make
+            new
+          end
         end
       end
 
@@ -43,8 +47,10 @@ module Opus::Types::Test
         extend T::Sig
 
         sig {returns(T.attached_class)}
-        def self.make
-          self.new
+        T::Configuration.without_ruby_warnings do
+          def self.make
+            self.new
+          end
         end
       end
 
@@ -60,8 +66,11 @@ module Opus::Types::Test
         extend T::Sig
 
         sig {returns(T.attached_class)}
-        def self.make
-          10
+
+        T::Configuration.without_ruby_warnings do
+          def self.make
+            10
+          end
         end
       end
 

--- a/gems/sorbet-runtime/test/types/attached_class.rb
+++ b/gems/sorbet-runtime/test/types/attached_class.rb
@@ -8,11 +8,10 @@ module Opus::Types::Test
       class Base
         extend T::Sig
 
+        T::Private::ClassUtils.silence_redefinition_of_method(singleton_class, :make)
         sig {returns(T.attached_class)}
-        T::Configuration.without_ruby_warnings do
-          def self.make
-            new
-          end
+        def self.make
+          new
         end
       end
 
@@ -27,11 +26,10 @@ module Opus::Types::Test
       class Base
         extend T::Sig
 
+        T::Private::ClassUtils.silence_redefinition_of_method(singleton_class, :make)
         sig {returns(T.attached_class)}
-        T::Configuration.without_ruby_warnings do
-          def self.make
-            new
-          end
+        def self.make
+          new
         end
       end
 
@@ -46,11 +44,10 @@ module Opus::Types::Test
       class Base
         extend T::Sig
 
+        T::Private::ClassUtils.silence_redefinition_of_method(singleton_class, :make)
         sig {returns(T.attached_class)}
-        T::Configuration.without_ruby_warnings do
-          def self.make
-            self.new
-          end
+        def self.make
+          self.new
         end
       end
 
@@ -65,12 +62,10 @@ module Opus::Types::Test
       class Base
         extend T::Sig
 
+        T::Private::ClassUtils.silence_redefinition_of_method(singleton_class, :make)
         sig {returns(T.attached_class)}
-
-        T::Configuration.without_ruby_warnings do
-          def self.make
-            10
-          end
+        def self.make
+          10
         end
       end
 

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -34,7 +34,9 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         sig(:final) {void}
         def foo; end
         sig(:final) {void}
-        def foo; end
+        T::Configuration.without_ruby_warnings do
+          def foo; end
+        end
       end
     end
     assert_match(/^The method `foo` on #<Class:0x[0-9a-f]+> was declared as final and cannot be redefined$/, err.message)
@@ -47,7 +49,9 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         sig(:final) {void}
         def self.foo; end
         sig(:final) {void}
-        def self.foo; end
+        T::Configuration.without_ruby_warnings do
+          def self.foo; end
+        end
       end
     end
     assert_match(/^The method `foo` on #<Class:#<Class:0x[0-9a-f]+>> was declared as final and cannot be redefined$/, err.message)
@@ -60,7 +64,9 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         sig(:final) {void}
         def foo; end
         sig {void}
-        def foo; end
+        T::Configuration.without_ruby_warnings do
+          def foo; end
+        end
       end
     end
     assert_match(/^The method `foo` on #<Class:0x[0-9a-f]+> was declared as final and cannot be redefined$/, err.message)
@@ -73,7 +79,9 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         sig(:final) {void}
         def self.foo; end
         sig {void}
-        def self.foo; end
+        T::Configuration.without_ruby_warnings do
+          def self.foo; end
+        end
       end
     end
     assert_match(/^The method `foo` on #<Class:#<Class:0x[0-9a-f]+>> was declared as final and cannot be redefined$/, err.message)
@@ -85,7 +93,9 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend T::Sig
         sig(:final) {void}
         def foo; end
-        def foo; end
+        T::Configuration.without_ruby_warnings do
+          def foo; end
+        end
       end
     end
     assert_match(/^The method `foo` on #<Class:0x[0-9a-f]+> was declared as final and cannot be redefined$/, err.message)
@@ -97,7 +107,9 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend T::Sig
         sig(:final) {void}
         def self.foo; end
-        def self.foo; end
+        T::Configuration.without_ruby_warnings do
+          def self.foo; end
+        end
       end
     end
     assert_match(/^The method `foo` on #<Class:#<Class:0x[0-9a-f]+>> was declared as final and cannot be redefined$/, err.message)
@@ -108,7 +120,9 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
       extend T::Sig
       def foo; end
       sig(:final) {void}
-      def foo; end
+      T::Configuration.without_ruby_warnings do
+        def foo; end
+      end
     end
   end
 
@@ -117,7 +131,9 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
       extend T::Sig
       def self.foo; end
       sig(:final) {void}
-      def self.foo; end
+      T::Configuration.without_ruby_warnings do
+        def self.foo; end
+      end
     end
   end
 

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -33,10 +33,10 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend T::Sig
         sig(:final) {void}
         def foo; end
+
+        T::Private::ClassUtils.silence_redefinition_of_method(self, :foo)
         sig(:final) {void}
-        T::Configuration.without_ruby_warnings do
-          def foo; end
-        end
+        def foo; end
       end
     end
     assert_match(/^The method `foo` on #<Class:0x[0-9a-f]+> was declared as final and cannot be redefined$/, err.message)
@@ -48,10 +48,10 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend T::Sig
         sig(:final) {void}
         def self.foo; end
+
+        T::Private::ClassUtils.silence_redefinition_of_method(singleton_class, :foo)
         sig(:final) {void}
-        T::Configuration.without_ruby_warnings do
-          def self.foo; end
-        end
+        def self.foo; end
       end
     end
     assert_match(/^The method `foo` on #<Class:#<Class:0x[0-9a-f]+>> was declared as final and cannot be redefined$/, err.message)
@@ -63,10 +63,10 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend T::Sig
         sig(:final) {void}
         def foo; end
+
+        T::Private::ClassUtils.silence_redefinition_of_method(self, :foo)
         sig {void}
-        T::Configuration.without_ruby_warnings do
-          def foo; end
-        end
+        def foo; end
       end
     end
     assert_match(/^The method `foo` on #<Class:0x[0-9a-f]+> was declared as final and cannot be redefined$/, err.message)
@@ -78,10 +78,10 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend T::Sig
         sig(:final) {void}
         def self.foo; end
+
+        T::Private::ClassUtils.silence_redefinition_of_method(singleton_class, :foo)
         sig {void}
-        T::Configuration.without_ruby_warnings do
-          def self.foo; end
-        end
+        def self.foo; end
       end
     end
     assert_match(/^The method `foo` on #<Class:#<Class:0x[0-9a-f]+>> was declared as final and cannot be redefined$/, err.message)
@@ -93,9 +93,9 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend T::Sig
         sig(:final) {void}
         def foo; end
-        T::Configuration.without_ruby_warnings do
-          def foo; end
-        end
+        
+        T::Private::ClassUtils.silence_redefinition_of_method(self, :foo)
+        def foo; end
       end
     end
     assert_match(/^The method `foo` on #<Class:0x[0-9a-f]+> was declared as final and cannot be redefined$/, err.message)
@@ -107,9 +107,9 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend T::Sig
         sig(:final) {void}
         def self.foo; end
-        T::Configuration.without_ruby_warnings do
-          def self.foo; end
-        end
+
+        T::Private::ClassUtils.silence_redefinition_of_method(singleton_class, :foo)
+        def self.foo; end
       end
     end
     assert_match(/^The method `foo` on #<Class:#<Class:0x[0-9a-f]+>> was declared as final and cannot be redefined$/, err.message)
@@ -119,10 +119,10 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
     Class.new do
       extend T::Sig
       def foo; end
+
+      T::Private::ClassUtils.silence_redefinition_of_method(self, :foo)
       sig(:final) {void}
-      T::Configuration.without_ruby_warnings do
-        def foo; end
-      end
+      def foo; end
     end
   end
 
@@ -130,10 +130,10 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
     Class.new do
       extend T::Sig
       def self.foo; end
+
+      T::Private::ClassUtils.silence_redefinition_of_method(singleton_class, :foo)
       sig(:final) {void}
-      T::Configuration.without_ruby_warnings do
-        def self.foo; end
-      end
+      def self.foo; end
     end
   end
 

--- a/gems/sorbet-runtime/test/types/method_modes.rb
+++ b/gems/sorbet-runtime/test/types/method_modes.rb
@@ -103,7 +103,7 @@ class Opus::Types::Test::MethodModesTest < Critic::Unit::UnitTest
         def foo; end
       end
 
-      klass = Class.new(parent) do
+      Class.new(parent) do
         extend T::Sig
         extend T::Helpers
         sig {override.returns(Object)}

--- a/gems/sorbet-runtime/test/types/props/_props.rb
+++ b/gems/sorbet-runtime/test/types/props/_props.rb
@@ -49,14 +49,10 @@ class Opus::Types::Test::Props::PropsTest < Critic::Unit::UnitTest
     prop :prop2, Integer, ifunset: 42
     prop :shadowed, String
 
-    orig_verbose = $VERBOSE
-    $VERBOSE = false
-
+    T::Private::ClassUtils.silence_redefinition_of_method(self, :shadowed)
     def shadowed
       "I can't let you see that"
     end
-
-    $VERBOSE = orig_verbose
   end
 
   class SubProps


### PR DESCRIPTION
### Motivation

In our app we're redefining `Warning.warn` to catch warnings and manage them with https://github.com/Shopify/deprecation_toolkit. However I noticed that quite a lot of warnings that should be fired at definition time actually aren't.

After investigating I figured this was caused by `Configuration.without_ruby_warnings`.

### Execution

I initially wanted to only get rid of `Configuration.without_ruby_warnings`, but the problem is that it was very hard to see if I broke something or not without enabling warnings. So I backtracked a bit and first started by eliminating all warnings in the test suite, and then worked on the replacement of `Configuration.without_ruby_warnings`.

### Concerns

I understand how getting the code free of `uninitialized instance variable` warnings makes the code more terse. I have to admit I don't really pay attention to these myself. But as a low level dependency, I think it makes sense for sorbet to not cause these.
