### PR TITLE
Turn off runtime type-checking of Enum.has_serialized?

### DIFF
--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -88,7 +88,7 @@ class T::Enum
 
   # Note: It would have been nice to make this method final before people started overriding it.
   # @return [Boolean] Does the given serialized value correspond with any of this enum's values.
-  sig {overridable.params(serialized_val: SerializedVal).returns(T::Boolean)}
+  sig {overridable.params(serialized_val: SerializedVal).returns(T::Boolean).checked(:never)}
   def self.has_serialized?(serialized_val)
     if @mapping.nil?
       raise "Attempting to access serialization map of #{self.class} before it has been initialized." \

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -121,6 +121,10 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
       assert_equal(false, CardSuitCustom.has_serialized?('spade'))
       assert_equal(false, CardSuitCustom.has_serialized?('blerg'))
     end
+
+    it 'does not break for arbitrary objects' do
+      assert_equal(false, CardSuitCustom.has_serialized?(Class.new.new))
+    end
   end
 
   describe 'try_deserialize' do


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This method can get pretty expensive to runtime-typecheck, especially in deeply-nested recursion that uses string->Enum conversions. Let's turn it off.


### Test plan

Added one test for the (faintly absurd) possibility that somebody might pass an arbitrary instance of something weird in.