### PR TITLE
Fix default args regression

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -188,7 +188,7 @@ class T::Props::Decorator
     .returns(T.untyped)
     .checked(:never)
   end
-  def foreign_prop_get(instance, prop, foreign_class, rules=props[prop.to_sym], opts={})
+  def foreign_prop_get(instance, prop, foreign_class, rules=prop_rules(prop), opts={})
     return if !(value = prop_get(instance, prop, rules))
     T.unsafe(foreign_class).load(value, {}, opts)
   end

--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_5_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_5_hidden.rbi.exp
@@ -2705,7 +2705,6 @@ class IO
   def wait_readable(*_); end
 
   def wait_writable(*_); end
-
 end
 
 IO::EWOULDBLOCKWaitReadable = IO::EAGAINWaitReadable
@@ -2957,7 +2956,6 @@ end
 module URI
   extend ::URI::Escape
   def self.get_encoding(label); end
-
 end
 
 module UnicodeNormalize

--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_hidden.rbi.exp
@@ -2769,7 +2769,6 @@ class IO
   def wait_readable(*_); end
 
   def wait_writable(*_); end
-
 end
 
 IO::EWOULDBLOCKWaitReadable = IO::EAGAINWaitReadable
@@ -3109,7 +3108,6 @@ end
 module URI
   extend ::URI::Escape
   def self.get_encoding(label); end
-
 end
 
 module UnicodeNormalize

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_5_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_5_hidden.rbi.exp
@@ -2711,7 +2711,6 @@ class IO
   def wait_readable(*_); end
 
   def wait_writable(*_); end
-
 end
 
 IO::EWOULDBLOCKWaitReadable = IO::EAGAINWaitReadable
@@ -2963,7 +2962,6 @@ end
 module URI
   extend ::URI::Escape
   def self.get_encoding(label); end
-
 end
 
 module UnicodeNormalize

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_hidden.rbi.exp
@@ -2775,7 +2775,6 @@ class IO
   def wait_readable(*_); end
 
   def wait_writable(*_); end
-
 end
 
 IO::EWOULDBLOCKWaitReadable = IO::EAGAINWaitReadable
@@ -3115,7 +3114,6 @@ end
 module URI
   extend ::URI::Escape
   def self.get_encoding(label); end
-
 end
 
 module UnicodeNormalize

--- a/rewriter/DefaultArgs.cc
+++ b/rewriter/DefaultArgs.cc
@@ -133,6 +133,8 @@ void DefaultArgs::run(core::MutableContext ctx, ast::ClassDef *klass) {
             stat.get(),
             [&](ast::Send *send) {
                 if (send->fun != core::Names::sig()) {
+                    isOverload = false;
+                    lastSig = nullptr;
                     return;
                 }
                 if (lastSig != nullptr) {
@@ -149,6 +151,8 @@ void DefaultArgs::run(core::MutableContext ctx, ast::ClassDef *klass) {
                     // defaults and how is super hard. This is one of the
                     // reasons we don't let users write them, and only have them
                     // in the stdlib.
+                    isOverload = false;
+                    lastSig = nullptr;
                     return;
                 }
                 auto i = -1;

--- a/rewriter/DefaultArgs.cc
+++ b/rewriter/DefaultArgs.cc
@@ -10,195 +10,206 @@ namespace sorbet::rewriter {
 
 namespace {
 
-ast::TreePtr mangleSig(core::Context ctx, ast::TreePtr expr, ast::TreePtr &param) {
-    auto sig = ast::cast_tree<ast::Send>(expr);
-    ENFORCE(sig);
-    ENFORCE(sig->fun == core::Names::sig());
+class DefaultArgsWalk {
+    ast::TreePtr mangleSig(core::Context ctx, ast::TreePtr expr, ast::TreePtr &param) {
+        auto sig = ast::cast_tree<ast::Send>(expr);
+        ENFORCE(sig);
+        ENFORCE(sig->fun == core::Names::sig());
 
-    ast::UnresolvedIdent *ident = nullptr;
-    if (auto *kw = ast::cast_tree<ast::KeywordArg>(param)) {
-        ident = ast::cast_tree<ast::UnresolvedIdent>(kw->expr);
-    } else {
-        ident = ast::cast_tree<ast::UnresolvedIdent>(param);
-    }
+        ast::UnresolvedIdent *ident = nullptr;
+        if (auto *kw = ast::cast_tree<ast::KeywordArg>(param)) {
+            ident = ast::cast_tree<ast::UnresolvedIdent>(kw->expr);
+        } else {
+            ident = ast::cast_tree<ast::UnresolvedIdent>(param);
+        }
 
-    if (!ident) {
-        return ast::MK::EmptyTree();
-    }
-    auto name = ident->name;
+        if (!ident) {
+            return ast::MK::EmptyTree();
+        }
+        auto name = ident->name;
 
-    ast::TreePtr retType;
+        ast::TreePtr retType;
 
-    if (sig->block == nullptr) {
-        return ast::MK::EmptyTree();
-    }
+        if (sig->block == nullptr) {
+            return ast::MK::EmptyTree();
+        }
 
-    auto &sigBlock = ast::cast_tree_nonnull<ast::Block>(sig->block);
-    auto send = ast::cast_tree<ast::Send>(sigBlock.body);
-    if (!send) {
-        return ast::MK::EmptyTree();
-    }
+        auto &sigBlock = ast::cast_tree_nonnull<ast::Block>(sig->block);
+        auto send = ast::cast_tree<ast::Send>(sigBlock.body);
+        if (!send) {
+            return ast::MK::EmptyTree();
+        }
 
-    while (send != nullptr) {
-        switch (send->fun._id) {
-            case core::Names::params()._id: {
-                if (send->args.size() != 1) {
-                    return ast::MK::EmptyTree();
-                }
-                auto *hash = ast::cast_tree<ast::Hash>(send->args[0]);
-                if (!hash) {
-                    return ast::MK::EmptyTree();
-                }
-                int i = -1;
-                for (auto &key : hash->keys) {
-                    i++;
-                    auto &value = hash->values[i];
-                    auto lit = ast::cast_tree<ast::Literal>(key);
-                    if (lit && lit->isSymbol(ctx)) {
-                        auto symName = lit->asSymbol(ctx);
-                        if (name == symName) {
-                            retType = value->deepCopy();
+        while (send != nullptr) {
+            switch (send->fun._id) {
+                case core::Names::params()._id: {
+                    if (send->args.size() != 1) {
+                        return ast::MK::EmptyTree();
+                    }
+                    auto *hash = ast::cast_tree<ast::Hash>(send->args[0]);
+                    if (!hash) {
+                        return ast::MK::EmptyTree();
+                    }
+                    int i = -1;
+                    for (auto &key : hash->keys) {
+                        i++;
+                        auto &value = hash->values[i];
+                        auto lit = ast::cast_tree<ast::Literal>(key);
+                        if (lit && lit->isSymbol(ctx)) {
+                            auto symName = lit->asSymbol(ctx);
+                            if (name == symName) {
+                                retType = value->deepCopy();
+                            }
                         }
                     }
+                    break;
                 }
-                break;
-            }
 
-            case core::Names::abstract()._id: {
-                // Don't make this method at all since abstract methods can't
-                // have bodies
-                return nullptr;
-            }
-
-            case core::Names::override_()._id: {
-                // A total hack but we allow .void.void or .void.returns and
-                // the one with content wins
-                send->fun = core::Names::void_();
-            }
-        }
-        auto recv = ast::cast_tree<ast::Send>(send->recv);
-        send = recv;
-    }
-
-    send = ast::cast_tree<ast::Send>(sigBlock.body);
-    while (send != nullptr) {
-        switch (send->fun._id) {
-            case core::Names::returns()._id: {
-                if (!retType) {
-                    return ast::MK::EmptyTree();
+                case core::Names::abstract()._id: {
+                    // Don't make this method at all since abstract methods can't
+                    // have bodies
+                    return nullptr;
                 }
-                send->args[0] = move(retType);
-                break;
-            }
 
-            case core::Names::void_()._id: {
-                if (!retType) {
-                    return ast::MK::EmptyTree();
+                case core::Names::override_()._id: {
+                    // A total hack but we allow .void.void or .void.returns and
+                    // the one with content wins
+                    send->fun = core::Names::void_();
                 }
-                send->fun = core::Names::returns();
-                send->args.emplace_back(move(retType));
-                break;
             }
+            auto recv = ast::cast_tree<ast::Send>(send->recv);
+            send = recv;
         }
 
-        auto recv = ast::cast_tree<ast::Send>(send->recv);
-        send = recv;
-    }
-    return expr;
-}
+        send = ast::cast_tree<ast::Send>(sigBlock.body);
+        while (send != nullptr) {
+            switch (send->fun._id) {
+                case core::Names::returns()._id: {
+                    if (!retType) {
+                        return ast::MK::EmptyTree();
+                    }
+                    send->args[0] = move(retType);
+                    break;
+                }
 
-ast::TreePtr dupRef(ast::TreePtr &arg) {
-    ast::TreePtr newArg = nullptr;
-    typecase(
-        *arg, [&](ast::UnresolvedIdent *nm) { newArg = ast::MK::Local(arg->loc, nm->name); },
-        [&](ast::RestArg *rest) { newArg = ast::MK::RestArg(arg->loc, dupRef(rest->expr)); },
-        [&](ast::KeywordArg *kw) { newArg = ast::MK::KeywordArg(arg->loc, dupRef(kw->expr)); },
-        [&](ast::OptionalArg *opt) {
-            newArg = ast::MK::OptionalArg(arg->loc, dupRef(opt->expr), ast::MK::EmptyTree());
-        },
-        [&](ast::BlockArg *blk) { newArg = ast::MK::BlockArg(arg->loc, dupRef(blk->expr)); },
-        [&](ast::ShadowArg *shadow) { newArg = ast::MK::ShadowArg(arg->loc, dupRef(shadow->expr)); });
-    return newArg;
-}
+                case core::Names::void_()._id: {
+                    if (!retType) {
+                        return ast::MK::EmptyTree();
+                    }
+                    send->fun = core::Names::returns();
+                    send->args.emplace_back(move(retType));
+                    break;
+                }
+            }
+
+            auto recv = ast::cast_tree<ast::Send>(send->recv);
+            send = recv;
+        }
+        return expr;
+    }
+
+    ast::TreePtr dupRef(ast::TreePtr &arg) {
+        ast::TreePtr newArg = nullptr;
+        typecase(
+            *arg, [&](ast::UnresolvedIdent *nm) { newArg = ast::MK::Local(arg->loc, nm->name); },
+            [&](ast::RestArg *rest) { newArg = ast::MK::RestArg(arg->loc, dupRef(rest->expr)); },
+            [&](ast::KeywordArg *kw) { newArg = ast::MK::KeywordArg(arg->loc, dupRef(kw->expr)); },
+            [&](ast::OptionalArg *opt) {
+                newArg = ast::MK::OptionalArg(arg->loc, dupRef(opt->expr), ast::MK::EmptyTree());
+            },
+            [&](ast::BlockArg *blk) { newArg = ast::MK::BlockArg(arg->loc, dupRef(blk->expr)); },
+            [&](ast::ShadowArg *shadow) { newArg = ast::MK::ShadowArg(arg->loc, dupRef(shadow->expr)); });
+        return newArg;
+    }
+
+public:
+    ast::TreePtr postTransformClassDef(core::MutableContext ctx, ast::TreePtr tree) {
+        auto &klass = ast::cast_tree_nonnull<ast::ClassDef>(tree);
+
+        vector<ast::TreePtr> newMethods;
+        ast::Send *lastSig = nullptr;
+        bool isOverload = false;
+
+        for (auto &stat : klass.rhs) {
+            typecase(
+                stat.get(),
+                [&](ast::Send *send) {
+                    if (send->fun != core::Names::sig()) {
+                        return;
+                    }
+                    if (lastSig != nullptr) {
+                        isOverload = true;
+                        return;
+                    }
+                    lastSig = send;
+                },
+                [&](ast::MethodDef *mdef) {
+                    if (isOverload) {
+                        // Overloaded methods have multiple signatures, not all of
+                        // which include all the arguments. Programatically copying
+                        // them over and figuring out which ones apply to which
+                        // defaults and how is super hard. This is one of the
+                        // reasons we don't let users write them, and only have them
+                        // in the stdlib.
+                        isOverload = false;
+                        lastSig = nullptr;
+                        return;
+                    }
+                    auto i = -1;
+                    auto uniqueNum = 1;
+                    for (auto &methodArg : mdef->args) {
+                        ++i;
+                        auto arg = ast::cast_tree<ast::OptionalArg>(methodArg);
+                        if (!arg) {
+                            continue;
+                        }
+
+                        ENFORCE(ast::isa_tree<ast::UnresolvedIdent>(arg->expr) ||
+                                ast::isa_tree<ast::KeywordArg>(arg->expr));
+                        auto name =
+                            ctx.state.freshNameUnique(core::UniqueNameKind::DefaultArg, mdef->name, uniqueNum++);
+                        ast::MethodDef::ARGS_store args;
+                        for (auto &arg : mdef->args) {
+                            args.emplace_back(dupRef(arg));
+                        }
+                        auto loc = arg->default_->loc;
+                        auto rhs = move(arg->default_);
+                        arg->default_ = ast::MK::EmptyTree();
+
+                        if (lastSig) {
+                            auto sig = mangleSig(ctx, lastSig->deepCopy(), arg->expr);
+                            if (sig == nullptr) {
+                                continue;
+                            }
+                            newMethods.emplace_back(move(sig));
+                        }
+                        auto defaultArgDef = ast::MK::SyntheticMethod(loc, core::Loc(ctx.file, loc), name,
+                                                                      std::move(args), std::move(rhs));
+                        {
+                            auto &defaultDef = ast::cast_tree_nonnull<ast::MethodDef>(defaultArgDef);
+                            defaultDef.flags.isSelfMethod = mdef->flags.isSelfMethod;
+                        }
+                        newMethods.emplace_back(move(defaultArgDef));
+                    }
+                    lastSig = nullptr;
+                },
+
+                [&](ast::Expression *expr) {});
+        }
+
+        for (auto &stat : newMethods) {
+            klass.rhs.emplace_back(move(stat));
+        }
+
+        return tree;
+    }
+};
 
 } // namespace
 
-void DefaultArgs::run(core::MutableContext ctx, ast::ClassDef *klass) {
-    vector<ast::TreePtr> newMethods;
-    ast::Send *lastSig = nullptr;
-    bool isOverload = false;
-
-    for (auto &stat : klass->rhs) {
-        typecase(
-            stat.get(),
-            [&](ast::Send *send) {
-                if (send->fun != core::Names::sig()) {
-                    isOverload = false;
-                    lastSig = nullptr;
-                    return;
-                }
-                if (lastSig != nullptr) {
-                    isOverload = true;
-                    return;
-                }
-                lastSig = send;
-            },
-            [&](ast::MethodDef *mdef) {
-                if (isOverload) {
-                    // Overloaded methods have multiple signatures, not all of
-                    // which include all the arguments. Programatically copying
-                    // them over and figuring out which ones apply to which
-                    // defaults and how is super hard. This is one of the
-                    // reasons we don't let users write them, and only have them
-                    // in the stdlib.
-                    isOverload = false;
-                    lastSig = nullptr;
-                    return;
-                }
-                auto i = -1;
-                auto uniqueNum = 1;
-                for (auto &methodArg : mdef->args) {
-                    ++i;
-                    auto arg = ast::cast_tree<ast::OptionalArg>(methodArg);
-                    if (!arg) {
-                        continue;
-                    }
-
-                    ENFORCE(ast::isa_tree<ast::UnresolvedIdent>(arg->expr) ||
-                            ast::isa_tree<ast::KeywordArg>(arg->expr));
-                    auto name = ctx.state.freshNameUnique(core::UniqueNameKind::DefaultArg, mdef->name, uniqueNum++);
-                    ast::MethodDef::ARGS_store args;
-                    for (auto &arg : mdef->args) {
-                        args.emplace_back(dupRef(arg));
-                    }
-                    auto loc = arg->default_->loc;
-                    auto rhs = move(arg->default_);
-                    arg->default_ = ast::MK::EmptyTree();
-
-                    if (lastSig) {
-                        auto sig = mangleSig(ctx, lastSig->deepCopy(), arg->expr);
-                        if (sig == nullptr) {
-                            continue;
-                        }
-                        newMethods.emplace_back(move(sig));
-                    }
-                    auto defaultArgDef =
-                        ast::MK::SyntheticMethod(loc, core::Loc(ctx.file, loc), name, std::move(args), std::move(rhs));
-                    {
-                        auto &defaultDef = ast::cast_tree_nonnull<ast::MethodDef>(defaultArgDef);
-                        defaultDef.flags.isSelfMethod = mdef->flags.isSelfMethod;
-                    }
-                    newMethods.emplace_back(move(defaultArgDef));
-                }
-                lastSig = nullptr;
-            },
-
-            [&](ast::Expression *expr) {});
-    }
-
-    for (auto &stat : newMethods) {
-        klass->rhs.emplace_back(move(stat));
-    }
+ast::TreePtr DefaultArgs::run(core::MutableContext ctx, ast::TreePtr tree) {
+    DefaultArgsWalk defaultArgs;
+    return ast::TreeMap::apply(ctx, defaultArgs, std::move(tree));
 }
 
 } // namespace sorbet::rewriter

--- a/rewriter/DefaultArgs.h
+++ b/rewriter/DefaultArgs.h
@@ -23,7 +23,7 @@ namespace sorbet::rewriter {
  */
 class DefaultArgs final {
 public:
-    static void run(core::MutableContext ctx, ast::ClassDef *klass);
+    static ast::TreePtr run(core::MutableContext ctx, ast::TreePtr klass);
 
     DefaultArgs() = delete;
 };

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -45,7 +45,6 @@ public:
         Flatfiles::run(ctx, classDef);
         Prop::run(ctx, classDef);
         TypeMembers::run(ctx, classDef);
-        DefaultArgs::run(ctx, classDef);
 
         for (auto &extension : ctx.state.semanticExtensions) {
             extension->run(ctx, classDef);
@@ -188,7 +187,8 @@ ast::TreePtr Rewriter::run(core::MutableContext ctx, ast::TreePtr tree) {
     // This AST flattening pass requires that we mutate the AST in a way that our previous DSL passes were not designed
     // around, which is why it runs all at once and is not expressed as a `patch` method like the other DSL passes. This
     // is a rare case: in general, we should *not* add new DSL passes here.
-    auto flattened = Flatten::run(ctx, std::move(ast));
+    auto defaulted = DefaultArgs::run(ctx, std::move(ast));
+    auto flattened = Flatten::run(ctx, std::move(defaulted));
     auto cleaned = Cleanup::run(ctx, std::move(flattened));
     auto verifiedResult = ast::Verifier::run(ctx, std::move(cleaned));
     return verifiedResult;

--- a/test/testdata/lsp/struct_fuzz.rb
+++ b/test/testdata/lsp/struct_fuzz.rb
@@ -3,10 +3,12 @@
   ::B=Struct.new:x
 # ^^^^^^^^^^^^^^^^ error: Method `keep_def` does not exist on `T.class_of(Sorbet::Private::Static)`
 # ^^^^^^^^^^^^^^^^ error: Method `params` does not exist on `T.class_of(B)`
+# ^^^^^^^^^^^^^^^^ error: Method `params` does not exist on `T.class_of(B)`
 # ^^^^^^^^^^^^^^^^ error: Method `type_member` does not exist on `T.class_of(B)`
 # ^^^^^^^^^^^^^^^^ error: Method `unsafe` does not exist on `T.class_of(T)`
 # ^^^^^^^^^^^^^^^^ error: Method `unsafe` does not exist on `T.class_of(T)`
 # ^^^^^^^^^^^^^^^^ error: Method `unsafe` does not exist on `T.class_of(T)`
+#                ^ error: Method `keep_def` does not exist on `T.class_of(Sorbet::Private::Static)`
 #                ^ error: Method `keep_def` does not exist on `T.class_of(Sorbet::Private::Static)`
 #                ^ error: Method `keep_def` does not exist on `T.class_of(Sorbet::Private::Static)`
 # these errors aren't actually what we're checking for, we just want to make sure sorbet doesn't crash on this input

--- a/test/testdata/rewriter/default_args.rb
+++ b/test/testdata/rewriter/default_args.rb
@@ -19,4 +19,8 @@ class B
     @foo = "test"
     @x = x
   end
+
+  sig {params(x: Integer).void}
+  puts "hi"
+  def test(x=297); end
 end

--- a/test/testdata/rewriter/default_args.rb
+++ b/test/testdata/rewriter/default_args.rb
@@ -1,6 +1,22 @@
 # typed: true
 
-extend T::Sig
-sig {params(a: String, b: Integer, c: Integer).void}
-def foo(a, b=1, c=2)
+class A
+  extend T::Sig
+
+  sig {params(a: String, b: Integer, c: Integer).void}
+  def foo(a, b=1, c=2)
+  end
+end
+
+class B
+  extend T::Sig
+
+  sig {returns(String)}
+  attr_reader :foo
+
+  sig {params(x: String).void}
+  def initialize(x="")
+    @foo = "test"
+    @x = x
+  end
 end

--- a/test/testdata/rewriter/default_args.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/default_args.rb.rewrite-tree.exp
@@ -54,11 +54,27 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params({:"x" => <emptyTree>::<C Integer>}).void()
+    end
+
+    def test<<C <todo sym>>>(x = <emptyTree>, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.params({:"x" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
     end
 
     def initialize<defaultArg>1<<C <todo sym>>>(x = <emptyTree>, &<blk>)
       ""
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params({:"x" => <emptyTree>::<C Integer>}).returns(<emptyTree>::<C Integer>)
+    end
+
+    def test<defaultArg>1<<C <todo sym>>>(x = <emptyTree>, &<blk>)
+      297
     end
 
     <self>.extend(<emptyTree>::<C T>::<C Sig>)
@@ -67,6 +83,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :"initialize")
 
+    <self>.puts("hi")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"test")
+
     ::Sorbet::Private::Static.keep_def(<self>, :"initialize<defaultArg>1")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"test<defaultArg>1")
   end
 end

--- a/test/testdata/rewriter/default_args.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/default_args.rb.rewrite-tree.exp
@@ -1,33 +1,72 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  ::Sorbet::Private::Static.sig(<self>) do ||
-    <self>.params({:"a" => <emptyTree>::<C String>, :"b" => <emptyTree>::<C Integer>, :"c" => <emptyTree>::<C Integer>}).void()
+  class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params({:"a" => <emptyTree>::<C String>, :"b" => <emptyTree>::<C Integer>, :"c" => <emptyTree>::<C Integer>}).void()
+    end
+
+    def foo<<C <todo sym>>>(a, b = <emptyTree>, c = <emptyTree>, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params({:"a" => <emptyTree>::<C String>, :"b" => <emptyTree>::<C Integer>, :"c" => <emptyTree>::<C Integer>}).returns(<emptyTree>::<C Integer>)
+    end
+
+    def foo<defaultArg>1<<C <todo sym>>>(a, b = <emptyTree>, c = <emptyTree>, &<blk>)
+      1
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params({:"a" => <emptyTree>::<C String>, :"b" => <emptyTree>::<C Integer>, :"c" => <emptyTree>::<C Integer>}).returns(<emptyTree>::<C Integer>)
+    end
+
+    def foo<defaultArg>2<<C <todo sym>>>(a, b = <emptyTree>, c = <emptyTree>, &<blk>)
+      2
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"foo")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"foo<defaultArg>1")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"foo<defaultArg>2")
   end
 
-  def foo<<C <todo sym>>>(a, b = <emptyTree>, c = <emptyTree>, &<blk>)
-    <emptyTree>
+  class <emptyTree>::<C B><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.returns(<emptyTree>::<C String>)
+    end
+
+    def foo<<C <todo sym>>>(&<blk>)
+      @foo
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params({:"x" => <emptyTree>::<C String>}).void()
+    end
+
+    def initialize<<C <todo sym>>>(x = <emptyTree>, &<blk>)
+      begin
+        @foo = "test"
+        @x = ::T.let(x, <emptyTree>::<C String>)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params({:"x" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
+    end
+
+    def initialize<defaultArg>1<<C <todo sym>>>(x = <emptyTree>, &<blk>)
+      ""
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"foo")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"initialize")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"initialize<defaultArg>1")
   end
-
-  ::Sorbet::Private::Static.sig(<self>) do ||
-    <self>.params({:"a" => <emptyTree>::<C String>, :"b" => <emptyTree>::<C Integer>, :"c" => <emptyTree>::<C Integer>}).returns(<emptyTree>::<C Integer>)
-  end
-
-  def foo<defaultArg>1<<C <todo sym>>>(a, b = <emptyTree>, c = <emptyTree>, &<blk>)
-    1
-  end
-
-  ::Sorbet::Private::Static.sig(<self>) do ||
-    <self>.params({:"a" => <emptyTree>::<C String>, :"b" => <emptyTree>::<C Integer>, :"c" => <emptyTree>::<C Integer>}).returns(<emptyTree>::<C Integer>)
-  end
-
-  def foo<defaultArg>2<<C <todo sym>>>(a, b = <emptyTree>, c = <emptyTree>, &<blk>)
-    2
-  end
-
-  <self>.extend(<emptyTree>::<C T>::<C Sig>)
-
-  ::Sorbet::Private::Static.keep_def(<self>, :"foo")
-
-  ::Sorbet::Private::Static.keep_def(<self>, :"foo<defaultArg>1")
-
-  ::Sorbet::Private::Static.keep_def(<self>, :"foo<defaultArg>2")
 end

--- a/test/testdata/rewriter/dsl_builder.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/dsl_builder.rb.rewrite-tree.exp
@@ -76,7 +76,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params({:"implied_string" => <emptyTree>::<C String>}).returns(::NilClass)
     end
 
-    def self.implied_string<<C <todo sym>>>(implied_string = ::T.untyped(), &<blk>)
+    def self.implied_string<<C <todo sym>>>(implied_string = <emptyTree>, &<blk>)
       <emptyTree>
     end
 
@@ -168,6 +168,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params({:"implied_string" => <emptyTree>::<C String>}).returns(<emptyTree>::<C String>)
+    end
+
+    def self.implied_string<defaultArg>1<<C <todo sym>>>(implied_string = <emptyTree>, &<blk>)
+      ::T.untyped()
+    end
+
     ::Sorbet::Private::Static.keep_self_def(<self>, :"opt_string")
 
     ::Sorbet::Private::Static.keep_self_def(<self>, :"get_opt_string")
@@ -211,6 +219,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     ::Sorbet::Private::Static.keep_self_def(<self>, :"get_root_const")
 
     ::Sorbet::Private::Static.keep_def(<self>, :"root_const")
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :"implied_string<defaultArg>1")
   end
 
   class <emptyTree>::<C TestChild><<C <todo sym>>> < (<emptyTree>::<C TestDSLBuilder>)

--- a/test/testdata/rewriter/struct.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/struct.rb.rewrite-tree.exp
@@ -33,8 +33,24 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.params({:"foo" => ::BasicObject, :"bar" => ::BasicObject}).void()
       end
 
-      def initialize<<C <todo sym>>>(foo = nil, bar = nil, &<blk>)
+      def initialize<<C <todo sym>>>(foo = <emptyTree>, bar = <emptyTree>, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.params({:"foo" => ::BasicObject, :"bar" => ::BasicObject}).returns(::BasicObject)
+      end
+
+      def initialize<defaultArg>1<<C <todo sym>>>(foo = <emptyTree>, bar = <emptyTree>, &<blk>)
+        nil
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.params({:"foo" => ::BasicObject, :"bar" => ::BasicObject}).returns(::BasicObject)
+      end
+
+      def initialize<defaultArg>2<<C <todo sym>>>(foo = <emptyTree>, bar = <emptyTree>, &<blk>)
+        nil
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :"foo")
@@ -48,6 +64,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C Elem> = <self>.type_member({:"fixed" => ::T.untyped()})
 
       ::Sorbet::Private::Static.keep_def(<self>, :"initialize")
+
+      ::Sorbet::Private::Static.keep_def(<self>, :"initialize<defaultArg>1")
+
+      ::Sorbet::Private::Static.keep_def(<self>, :"initialize<defaultArg>2")
     end
 
     class <emptyTree>::<C KeywordInit><<C <todo sym>>> < (::<root>::<C Struct>)
@@ -71,8 +91,24 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.params({:"foo" => ::BasicObject, :"bar" => ::BasicObject}).void()
       end
 
-      def initialize<<C <todo sym>>>(foo: = nil, bar: = nil, &<blk>)
+      def initialize<<C <todo sym>>>(foo: = <emptyTree>, bar: = <emptyTree>, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.params({:"foo" => ::BasicObject, :"bar" => ::BasicObject}).returns(::BasicObject)
+      end
+
+      def initialize<defaultArg>1<<C <todo sym>>>(foo: = <emptyTree>, bar: = <emptyTree>, &<blk>)
+        nil
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.params({:"foo" => ::BasicObject, :"bar" => ::BasicObject}).returns(::BasicObject)
+      end
+
+      def initialize<defaultArg>2<<C <todo sym>>>(foo: = <emptyTree>, bar: = <emptyTree>, &<blk>)
+        nil
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :"foo")
@@ -86,6 +122,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C Elem> = <self>.type_member({:"fixed" => ::T.untyped()})
 
       ::Sorbet::Private::Static.keep_def(<self>, :"initialize")
+
+      ::Sorbet::Private::Static.keep_def(<self>, :"initialize<defaultArg>1")
+
+      ::Sorbet::Private::Static.keep_def(<self>, :"initialize<defaultArg>2")
     end
   end
 
@@ -163,8 +203,16 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.params({:"foo" => ::BasicObject}).void()
       end
 
-      def initialize<<C <todo sym>>>(foo = nil, &<blk>)
+      def initialize<<C <todo sym>>>(foo = <emptyTree>, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.params({:"foo" => ::BasicObject}).returns(::BasicObject)
+      end
+
+      def initialize<defaultArg>1<<C <todo sym>>>(foo = <emptyTree>, &<blk>)
+        nil
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :"foo")
@@ -174,6 +222,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C Elem> = <self>.type_member({:"fixed" => ::T.untyped()})
 
       ::Sorbet::Private::Static.keep_def(<self>, :"initialize")
+
+      ::Sorbet::Private::Static.keep_def(<self>, :"initialize<defaultArg>1")
     end
 
     class <emptyTree>::<C B><<C <todo sym>>> < (::<root>::<C Struct>)
@@ -189,8 +239,16 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.params({:"foo" => ::BasicObject}).void()
       end
 
-      def initialize<<C <todo sym>>>(foo = nil, &<blk>)
+      def initialize<<C <todo sym>>>(foo = <emptyTree>, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.params({:"foo" => ::BasicObject}).returns(::BasicObject)
+      end
+
+      def initialize<defaultArg>1<<C <todo sym>>>(foo = <emptyTree>, &<blk>)
+        nil
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :"foo")
@@ -200,6 +258,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C Elem> = <self>.type_member({:"fixed" => ::T.untyped()})
 
       ::Sorbet::Private::Static.keep_def(<self>, :"initialize")
+
+      ::Sorbet::Private::Static.keep_def(<self>, :"initialize<defaultArg>1")
     end
   end
 
@@ -227,8 +287,24 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.params({:"foo" => ::BasicObject, :"bar" => ::BasicObject}).void()
       end
 
-      def initialize<<C <todo sym>>>(foo = nil, bar = nil, &<blk>)
+      def initialize<<C <todo sym>>>(foo = <emptyTree>, bar = <emptyTree>, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.params({:"foo" => ::BasicObject, :"bar" => ::BasicObject}).returns(::BasicObject)
+      end
+
+      def initialize<defaultArg>1<<C <todo sym>>>(foo = <emptyTree>, bar = <emptyTree>, &<blk>)
+        nil
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.params({:"foo" => ::BasicObject, :"bar" => ::BasicObject}).returns(::BasicObject)
+      end
+
+      def initialize<defaultArg>2<<C <todo sym>>>(foo = <emptyTree>, bar = <emptyTree>, &<blk>)
+        nil
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :"foo")
@@ -242,6 +318,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C Elem> = <self>.type_member({:"fixed" => ::T.untyped()})
 
       ::Sorbet::Private::Static.keep_def(<self>, :"initialize")
+
+      ::Sorbet::Private::Static.keep_def(<self>, :"initialize<defaultArg>1")
+
+      ::Sorbet::Private::Static.keep_def(<self>, :"initialize<defaultArg>2")
     end
   end
 
@@ -267,8 +347,16 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.params({:"x" => ::BasicObject}).void()
       end
 
-      def initialize<<C <todo sym>>>(x = nil, &<blk>)
+      def initialize<<C <todo sym>>>(x = <emptyTree>, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.params({:"x" => ::BasicObject}).returns(::BasicObject)
+      end
+
+      def initialize<defaultArg>1<<C <todo sym>>>(x = <emptyTree>, &<blk>)
+        nil
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :"x")
@@ -284,6 +372,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::<Magic>.<self-new>(<self>).foo()
 
       ::Sorbet::Private::Static.keep_def(<self>, :"initialize")
+
+      ::Sorbet::Private::Static.keep_def(<self>, :"initialize<defaultArg>1")
     end
 
     class <emptyTree>::<C MyKeywordInitStruct><<C <todo sym>>> < (::<root>::<C Struct>)
@@ -299,8 +389,16 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.params({:"x" => ::BasicObject}).void()
       end
 
-      def initialize<<C <todo sym>>>(x: = nil, &<blk>)
+      def initialize<<C <todo sym>>>(x: = <emptyTree>, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.params({:"x" => ::BasicObject}).returns(::BasicObject)
+      end
+
+      def initialize<defaultArg>1<<C <todo sym>>>(x: = <emptyTree>, &<blk>)
+        nil
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :"x")
@@ -320,6 +418,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::<Magic>.<self-new>(<self>, {:"giberish" => 1})
 
       ::Sorbet::Private::Static.keep_def(<self>, :"initialize")
+
+      ::Sorbet::Private::Static.keep_def(<self>, :"initialize<defaultArg>1")
     end
 
     <emptyTree>::<C MyKeywordInitStruct>.new(1, 2)

--- a/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
@@ -15,6 +15,14 @@ class <C <U <root>>> < <C <U Object>> ()
       method <C <U AccidentallyStruct>><C <U A>><U foo=> (foo, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=42:21 end=42:24}
         argument foo<> @ Loc {file=test/testdata/rewriter/struct.rb start=42:21 end=42:24}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U AccidentallyStruct>><C <U A>><DA <U initialize> $1> (foo, bar, <blk>) -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=42:21 end=42:24}
+        argument foo<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=42:21 end=42:24}
+        argument bar<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=42:27 end=42:30}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U AccidentallyStruct>><C <U A>><DA <U initialize> $2> (foo, bar, <blk>) -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=42:27 end=42:30}
+        argument foo<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=42:21 end=42:24}
+        argument bar<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=42:27 end=42:30}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
       method <C <U AccidentallyStruct>><C <U A>><U initialize> (foo, bar, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
         argument foo<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=42:21 end=42:24}
         argument bar<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=42:27 end=42:30}
@@ -62,6 +70,9 @@ class <C <U <root>>> < <C <U Object>> ()
   class <C <U MixinStruct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=45:1 end=45:18}
     class <C <U MixinStruct>><C <U MyKeywordInitStruct>> < <C <U Struct>> (<C <U MyMixin>>) @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
       type-member(=) <C <U MixinStruct>><C <U MyKeywordInitStruct>><C <U Elem>> -> LambdaParam(<C <U MixinStruct>><C <U MyKeywordInitStruct>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
+      method <C <U MixinStruct>><C <U MyKeywordInitStruct>><DA <U initialize> $1> (x, <blk>) -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=56:37 end=56:38}
+        argument x<optional, keyword> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=56:37 end=56:38}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
       method <C <U MixinStruct>><C <U MyKeywordInitStruct>><U initialize> (x, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
         argument x<optional, keyword> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=56:37 end=56:38}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
@@ -83,6 +94,9 @@ class <C <U <root>>> < <C <U Object>> ()
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
     class <C <U MixinStruct>><C <U MyStruct>> < <C <U Struct>> (<C <U MyMixin>>) @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=54:6}
       type-member(=) <C <U MixinStruct>><C <U MyStruct>><C <U Elem>> -> LambdaParam(<C <U MixinStruct>><C <U MyStruct>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=54:6}
+      method <C <U MixinStruct>><C <U MyStruct>><DA <U initialize> $1> (x, <blk>) -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=50:26 end=50:27}
+        argument x<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=50:26 end=50:27}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
       method <C <U MixinStruct>><C <U MyStruct>><U initialize> (x, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=50:3 end=54:6}
         argument x<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=50:26 end=50:27}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
@@ -118,6 +132,14 @@ class <C <U <root>>> < <C <U Object>> ()
       method <C <U RealStruct>><C <U A>><U foo=> (foo, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=15:21 end=15:24}
         argument foo<> @ Loc {file=test/testdata/rewriter/struct.rb start=15:21 end=15:24}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U RealStruct>><C <U A>><DA <U initialize> $1> (foo, bar, <blk>) -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=15:21 end=15:24}
+        argument foo<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=15:21 end=15:24}
+        argument bar<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=15:27 end=15:30}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U RealStruct>><C <U A>><DA <U initialize> $2> (foo, bar, <blk>) -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=15:27 end=15:30}
+        argument foo<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=15:21 end=15:24}
+        argument bar<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=15:27 end=15:30}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
       method <C <U RealStruct>><C <U A>><U initialize> (foo, bar, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=15:5 end=15:31}
         argument foo<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=15:21 end=15:24}
         argument bar<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=15:27 end=15:30}
@@ -138,6 +160,14 @@ class <C <U <root>>> < <C <U Object>> ()
       method <C <U RealStruct>><C <U KeywordInit>><U foo=> (foo, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=16:31 end=16:34}
         argument foo<> @ Loc {file=test/testdata/rewriter/struct.rb start=16:31 end=16:34}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U RealStruct>><C <U KeywordInit>><DA <U initialize> $1> (foo, bar, <blk>) -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=16:31 end=16:34}
+        argument foo<optional, keyword> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=16:31 end=16:34}
+        argument bar<optional, keyword> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=16:37 end=16:40}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U RealStruct>><C <U KeywordInit>><DA <U initialize> $2> (foo, bar, <blk>) -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=16:37 end=16:40}
+        argument foo<optional, keyword> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=16:31 end=16:34}
+        argument bar<optional, keyword> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=16:37 end=16:40}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
       method <C <U RealStruct>><C <U KeywordInit>><U initialize> (foo, bar, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=16:5 end=16:61}
         argument foo<optional, keyword> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=16:31 end=16:34}
         argument bar<optional, keyword> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=16:37 end=16:40}
@@ -191,6 +221,9 @@ class <C <U <root>>> < <C <U Object>> ()
       method <C <U TwoStructs>><C <U A>><U foo=> (foo, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=33:21 end=33:24}
         argument foo<> @ Loc {file=test/testdata/rewriter/struct.rb start=33:21 end=33:24}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U TwoStructs>><C <U A>><DA <U initialize> $1> (foo, <blk>) -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=33:21 end=33:24}
+        argument foo<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=33:21 end=33:24}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
       method <C <U TwoStructs>><C <U A>><U initialize> (foo, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=33:5 end=33:25}
         argument foo<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=33:21 end=33:24}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
@@ -205,6 +238,9 @@ class <C <U <root>>> < <C <U Object>> ()
       method <C <U TwoStructs>><C <U B>><U foo=> (foo, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=34:21 end=34:24}
         argument foo<> @ Loc {file=test/testdata/rewriter/struct.rb start=34:21 end=34:24}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U TwoStructs>><C <U B>><DA <U initialize> $1> (foo, <blk>) -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=34:21 end=34:24}
+        argument foo<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=34:21 end=34:24}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
       method <C <U TwoStructs>><C <U B>><U initialize> (foo, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=34:5 end=34:25}
         argument foo<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=34:21 end=34:24}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The overload handling in the DefaultArgs rewrite pass was never clearing its internal state. The result of this was that examples like the following would cause it to start skipping emitting default args methods for all method definitions that followed.

```ruby
sig {returns(String)}
attr_reader :a
```


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
