### PR TITLE
Update types for net-ssh >=6

### DIFF
--- a/rbi/stdlib/net.rbi
+++ b/rbi/stdlib/net.rbi
@@ -8769,19 +8769,7 @@ module Net::SSH::Transport::Kex
   MAP = ::T.unsafe(nil)
 end
 
-class Net::SSH::Transport::Kex::DiffieHellmanGroup14SHA1 < Net::SSH::Transport::Kex::DiffieHellmanGroup1SHA1
-  G = ::T.unsafe(nil)
-  P_r = ::T.unsafe(nil)
-  P_s = ::T.unsafe(nil)
-end
-
-class Net::SSH::Transport::Kex::DiffieHellmanGroup1SHA1
-  include ::Net::SSH::Transport::Constants
-  include ::Net::SSH::Loggable
-  G = ::T.unsafe(nil)
-  P_r = ::T.unsafe(nil)
-  P_s = ::T.unsafe(nil)
-
+class Net::SSH::Transport::Kex::Abstract
   def algorithms(); end
 
   def connection(); end
@@ -8790,13 +8778,30 @@ class Net::SSH::Transport::Kex::DiffieHellmanGroup1SHA1
 
   def dh(); end
 
-  def digester(); end
-
   def exchange_keys(); end
 
-  def g(); end
-
   def initialize(algorithms, connection, data); end
+end
+
+class Net::SSH::Transport::Kex::Abstract5656 < Net::SSH::Transport::Kex::Abstract
+end
+
+class Net::SSH::Transport::Kex::DiffieHellmanGroup14SHA1 < Net::SSH::Transport::Kex::DiffieHellmanGroup1SHA1
+  G = ::T.unsafe(nil)
+  P_r = ::T.unsafe(nil)
+  P_s = ::T.unsafe(nil)
+end
+
+class Net::SSH::Transport::Kex::DiffieHellmanGroup1SHA1 < Net::SSH::Transport::Kex::Abstract
+  include ::Net::SSH::Transport::Constants
+  include ::Net::SSH::Loggable
+  G = ::T.unsafe(nil)
+  P_r = ::T.unsafe(nil)
+  P_s = ::T.unsafe(nil)
+
+  def digester(); end
+
+  def g(); end
 
   def p(); end
 end
@@ -8814,14 +8819,12 @@ class Net::SSH::Transport::Kex::DiffieHellmanGroupExchangeSHA256 < Net::SSH::Tra
   def initialize(*args); end
 end
 
-class Net::SSH::Transport::Kex::EcdhSHA2NistP256 < Net::SSH::Transport::Kex::DiffieHellmanGroup1SHA1
+class Net::SSH::Transport::Kex::EcdhSHA2NistP256 < Net::SSH::Transport::Kex::Abstract5656
   def curve_name(); end
 
   def digester(); end
 
   def ecdh(); end
-
-  def initialize(algorithms, connection, data); end
 end
 
 class Net::SSH::Transport::Kex::EcdhSHA2NistP384 < Net::SSH::Transport::Kex::EcdhSHA2NistP256


### PR DESCRIPTION
In an attempt to allow usage of net-ssh >=6 this PR updates some class signatures in accordance with https://github.com/net-ssh/net-ssh/tree/v6.0.0/lib/net/ssh/transport/kex.

### Motivation

Running `bundle exec srb rbi hidden-definitions` on my project results in a `reflection.json.err` containing:

```
/var/folders/2q/_xjbkr593hg3lzf35_jpqz440000gn/T/d20200611-71340-o9qxnt/reflection.rbi:396654: Parent of class `Net::SSH::Transport::Kex::DiffieHellmanGroup1SHA1` redefined from `Object` to `Net::SSH::Transport::Kex::Abstract` https://srb.help/5012
      396654 |class Net::SSH::Transport::Kex::DiffieHellmanGroup1SHA1 < Net::SSH::Transport::Kex::Abstract
                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

/var/folders/2q/_xjbkr593hg3lzf35_jpqz440000gn/T/d20200611-71340-o9qxnt/reflection.rbi:396727: Parent of class `Net::SSH::Transport::Kex::EcdhSHA2NistP256` redefined from `Net::SSH::Transport::Kex::DiffieHellmanGroup1SHA1` to `Net::SSH::Transport::Kex::Abstract5656` https://srb.help/5012
      396727 |class Net::SSH::Transport::Kex::EcdhSHA2NistP256 < Net::SSH::Transport::Kex::Abstract5656
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```


A comment at the top of the file states
```
# This file is autogenerated. Do not edit it by hand. Regenerate it with:
#   scripts/bin/remote-script sorbet/shim_generation/gems.rb -r net
```
but I cannot find either `remote-script` or `gems.rb` anywhere, so I've done it by hand.

### Test plan
I am not sure how to write a test for this. Happy to follow any advice given.

See included automated tests.
