### PR TITLE
docs/cli: Fix filename specifier in `--typed-override` YAML example

### DIFF
--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -118,7 +118,7 @@ overrides on a file-by-file basis. For example, with this YAML file:
 ```yaml
 # -- foo.yaml --
 true:
-  - foo.rb
+  - ./foo.rb
 ```
 
 and this Ruby file:


### PR DESCRIPTION
Before this change, when copying these examples to test out the `--typed-override` feature:

```
➜ srb tc --typed-override=foo.yaml foo.rb
All relative file names in "foo.yaml" should start with ./
```

After this change:

```
➜ srb tc --typed-override=foo.yaml foo.rb
foo.rb:1: Expected String but found Symbol(:"symbol") for argument arg0 https://srb.help/7002
     1 |"string" + :symbol
                   ^^^^^^^
[...]
Errors: 1
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The docs should be correct to be used as a guide for users implementing Sorbet.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

N/A. They're docs.
