### PR TITLE
Switch to tagged pointers

### DIFF
--- a/ast/ArgParsing.cc
+++ b/ast/ArgParsing.cc
@@ -42,13 +42,9 @@ ParsedArg parseArg(const ast::TreePtr &arg) {
 }
 
 TreePtr getDefaultValue(TreePtr arg) {
-    auto *refExp = ast::cast_tree<ast::Reference>(arg);
-    if (!refExp) {
-        Exception::raise("Must be a reference!");
-    }
     TreePtr default_;
     typecase(
-        refExp, [&](ast::RestArg *rest) { default_ = getDefaultValue(move(rest->expr)); },
+        arg.get(), [&](ast::RestArg *rest) { default_ = getDefaultValue(move(rest->expr)); },
         [&](ast::KeywordArg *kw) { default_ = getDefaultValue(move(kw->expr)); },
         [&](ast::OptionalArg *opt) { default_ = move(opt->default_); },
         [&](ast::BlockArg *blk) { default_ = getDefaultValue(move(blk->expr)); },
@@ -65,7 +61,7 @@ TreePtr getDefaultValue(TreePtr arg) {
 vector<ParsedArg> ArgParsing::parseArgs(const ast::MethodDef::ARGS_store &args) {
     vector<ParsedArg> parsedArgs;
     for (auto &arg : args) {
-        if (!ast::isa_tree<ast::Reference>(arg)) {
+        if (!ast::isa_reference(arg)) {
             Exception::raise("Must be a reference!");
         }
         parsedArgs.emplace_back(parseArg(arg));

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -161,7 +161,6 @@ void TreePtr::deleteTagged(Tag tag, void *ptr) noexcept {
         case Tag::InsSeq:
             delete reinterpret_cast<InsSeq *>(ptr);
             break;
-
     }
 }
 
@@ -174,7 +173,6 @@ bool isa_reference(const TreePtr &what) {
 bool isa_declaration(const TreePtr &what) {
     return isa_tree<MethodDef>(what) || isa_tree<ClassDef>(what);
 }
-
 
 /** https://git.corp.stripe.com/gist/nelhage/51564501674174da24822e60ad770f64
  *

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -42,6 +42,140 @@ using namespace std;
 
 namespace sorbet::ast {
 
+void TreePtr::deleteTagged(Tag tag, void *ptr) noexcept {
+    ENFORCE(ptr != nullptr);
+
+    switch (tag) {
+        case Tag::EmptyTree:
+            delete reinterpret_cast<EmptyTree *>(ptr);
+            break;
+
+        case Tag::Send:
+            delete reinterpret_cast<Send *>(ptr);
+            break;
+
+        case Tag::ClassDef:
+            delete reinterpret_cast<ClassDef *>(ptr);
+            break;
+
+        case Tag::MethodDef:
+            delete reinterpret_cast<MethodDef *>(ptr);
+            break;
+
+        case Tag::If:
+            delete reinterpret_cast<If *>(ptr);
+            break;
+
+        case Tag::While:
+            delete reinterpret_cast<While *>(ptr);
+            break;
+
+        case Tag::Break:
+            delete reinterpret_cast<Break *>(ptr);
+            break;
+
+        case Tag::Retry:
+            delete reinterpret_cast<Retry *>(ptr);
+            break;
+
+        case Tag::Next:
+            delete reinterpret_cast<Next *>(ptr);
+            break;
+
+        case Tag::Return:
+            delete reinterpret_cast<Return *>(ptr);
+            break;
+
+        case Tag::RescueCase:
+            delete reinterpret_cast<RescueCase *>(ptr);
+            break;
+
+        case Tag::Rescue:
+            delete reinterpret_cast<Rescue *>(ptr);
+            break;
+
+        case Tag::Local:
+            delete reinterpret_cast<Local *>(ptr);
+            break;
+
+        case Tag::UnresolvedIdent:
+            delete reinterpret_cast<UnresolvedIdent *>(ptr);
+            break;
+
+        case Tag::RestArg:
+            delete reinterpret_cast<RestArg *>(ptr);
+            break;
+
+        case Tag::KeywordArg:
+            delete reinterpret_cast<KeywordArg *>(ptr);
+            break;
+
+        case Tag::OptionalArg:
+            delete reinterpret_cast<OptionalArg *>(ptr);
+            break;
+
+        case Tag::BlockArg:
+            delete reinterpret_cast<BlockArg *>(ptr);
+            break;
+
+        case Tag::ShadowArg:
+            delete reinterpret_cast<ShadowArg *>(ptr);
+            break;
+
+        case Tag::Assign:
+            delete reinterpret_cast<Assign *>(ptr);
+            break;
+
+        case Tag::Cast:
+            delete reinterpret_cast<Cast *>(ptr);
+            break;
+
+        case Tag::Hash:
+            delete reinterpret_cast<Hash *>(ptr);
+            break;
+
+        case Tag::Array:
+            delete reinterpret_cast<Array *>(ptr);
+            break;
+
+        case Tag::Literal:
+            delete reinterpret_cast<Literal *>(ptr);
+            break;
+
+        case Tag::UnresolvedConstantLit:
+            delete reinterpret_cast<UnresolvedConstantLit *>(ptr);
+            break;
+
+        case Tag::ConstantLit:
+            delete reinterpret_cast<ConstantLit *>(ptr);
+            break;
+
+        case Tag::ZSuperArgs:
+            delete reinterpret_cast<ZSuperArgs *>(ptr);
+            break;
+
+        case Tag::Block:
+            delete reinterpret_cast<Block *>(ptr);
+            break;
+
+        case Tag::InsSeq:
+            delete reinterpret_cast<InsSeq *>(ptr);
+            break;
+
+    }
+}
+
+bool isa_reference(const TreePtr &what) {
+    return isa_tree<Local>(what) || isa_tree<UnresolvedIdent>(what) || isa_tree<RestArg>(what) ||
+           isa_tree<KeywordArg>(what) || isa_tree<OptionalArg>(what) || isa_tree<BlockArg>(what) ||
+           isa_tree<ShadowArg>(what);
+}
+
+bool isa_declaration(const TreePtr &what) {
+    return isa_tree<MethodDef>(what) || isa_tree<ClassDef>(what);
+}
+
+
 /** https://git.corp.stripe.com/gist/nelhage/51564501674174da24822e60ad770f64
  *
  *  [] - prototype only

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -141,6 +141,10 @@ public:
     }
 
     TreePtr &operator=(TreePtr &&other) noexcept {
+        if (*this == other) {
+            return *this;
+        }
+
         resetTagged(other.releaseTagged());
         return *this;
     }

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -158,6 +158,10 @@ public:
         return saved;
     }
 
+    void reset() noexcept {
+        resetTagged(nullptr);
+    }
+
     void reset(std::nullptr_t) noexcept {
         resetTagged(nullptr);
     }

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -137,11 +137,11 @@ public:
     TreePtr &operator=(const TreePtr &) = delete;
 
     TreePtr(TreePtr &&other) noexcept : ptr(nullptr) {
-        std::swap(ptr, other.ptr);
+        ptr = other.releaseTagged();
     }
 
     TreePtr &operator=(TreePtr &&other) noexcept {
-        std::swap(ptr, other.ptr);
+        resetTagged(other.releaseTagged());
         return *this;
     }
 

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -70,22 +70,22 @@ class Expression;
 
 class TreePtr {
 private:
-    static constexpr long TAG_MASK = 0xffff000000000007;
+    static constexpr long long TAG_MASK = 0xffff000000000007;
 
-    static constexpr long PTR_MASK = ~TAG_MASK;
+    static constexpr long long PTR_MASK = ~TAG_MASK;
 
     void *ptr;
 
     template <typename E, typename... Args> friend TreePtr make_tree(Args &&...);
 
     static void *tagPtr(Tag tag, void *expr) {
-        auto val = static_cast<long>(tag);
+        auto val = static_cast<long long>(tag);
         if (val >= 8) {
             // Store the tag in the upper 16 bits of the pointer, as it won't fit in the lower three bits.
             val <<= 48;
         }
 
-        auto maskedPtr = reinterpret_cast<long>(expr) & PTR_MASK;
+        auto maskedPtr = reinterpret_cast<long long>(expr) & PTR_MASK;
 
         return reinterpret_cast<void *>(maskedPtr | val);
     }
@@ -166,7 +166,7 @@ public:
     Tag tag() const noexcept {
         ENFORCE(ptr != nullptr);
 
-        auto value = reinterpret_cast<long>(ptr) & TAG_MASK;
+        auto value = reinterpret_cast<long long>(ptr) & TAG_MASK;
         if (value <= 7) {
             return static_cast<Tag>(value);
         } else {
@@ -175,7 +175,7 @@ public:
     }
 
     Expression *get() const noexcept {
-        auto val = reinterpret_cast<long>(ptr) & PTR_MASK;
+        auto val = reinterpret_cast<long long>(ptr) & PTR_MASK;
 
         // sign extension for the upper 16 bits
         return reinterpret_cast<Expression *>((val << 16) >> 16);

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -6,6 +6,7 @@
 #include "core/LocalVariable.h"
 #include "core/SymbolRef.h"
 #include "core/Types.h"
+#include <cassert>
 #include <memory>
 #include <vector>
 
@@ -28,47 +29,173 @@
 
 namespace sorbet::ast {
 
+enum class Tag {
+    EmptyTree = 1,
+    Send,
+    ClassDef,
+    MethodDef,
+    If,
+    While,
+    Break,
+    Retry,
+    Next,
+    Return,
+    RescueCase,
+    Rescue,
+    Local,
+    UnresolvedIdent,
+    RestArg,
+    KeywordArg,
+    OptionalArg,
+    BlockArg,
+    ShadowArg,
+    Assign,
+    Cast,
+    Hash,
+    Array,
+    Literal,
+    UnresolvedConstantLit,
+    ConstantLit,
+    ZSuperArgs,
+    Block,
+    InsSeq,
+};
+
+// A mapping from tree type to its corresponding tag.
+template <typename T> struct TreeToTag;
+
+// A mapping from tag value to the tree it represents.
+template <Tag T> struct TagToTree;
+
+#define TREE(name)                                                                  \
+    class name;                                                                     \
+    template <> struct TreeToTag<name> { static constexpr Tag value = Tag::name; }; \
+    template <> struct TagToTree<Tag::name> { using value = name; };                \
+    class name final
+
 class Expression;
 
 class TreePtr {
 private:
-    std::unique_ptr<Expression> ptr;
+    static constexpr long TAG_MASK = 0xffff000000000007;
+
+    static constexpr long PTR_MASK = ~TAG_MASK;
+
+    void *ptr;
+
+    template <typename E, typename... Args> friend TreePtr make_tree(Args &&...);
+
+    static void *tagPtr(Tag tag, void *expr) {
+        auto val = static_cast<long>(tag);
+        if (val >= 8) {
+            // Store the tag in the upper 16 bits of the pointer, as it won't fit in the lower three bits.
+            val <<= 48;
+        }
+
+        auto maskedPtr = reinterpret_cast<long>(expr) & PTR_MASK;
+
+        return reinterpret_cast<void *>(maskedPtr | val);
+    }
+
+    explicit TreePtr(Tag tag, void *expr) : ptr(tagPtr(tag, expr)) {}
+
+    static void deleteTagged(Tag tag, void *ptr) noexcept;
+
+    // A version of release that doesn't mask the tag bits
+    void *releaseTagged() noexcept {
+        auto *saved = ptr;
+        ptr = nullptr;
+        return saved;
+    }
+
+    // A version of reset that expects the tagged bits to be set.
+    void resetTagged(void *expr) noexcept {
+        Tag tagVal;
+        void *saved = nullptr;
+
+        if (ptr != nullptr) {
+            tagVal = tag();
+            saved = get();
+        }
+
+        ptr = expr;
+
+        if (saved != nullptr) {
+            deleteTagged(tagVal, saved);
+        }
+    }
 
 public:
     constexpr TreePtr() noexcept : ptr(nullptr) {}
 
-    explicit TreePtr(Expression *ptr) noexcept : ptr(ptr) {}
-
     TreePtr(std::nullptr_t) noexcept : TreePtr() {}
+
+    // Construction from a tagged pointer. This is needed for:
+    // * ResolveConstantsWalk::isFullyResolved
+    explicit TreePtr(void *ptr) : ptr(ptr) {}
+
+    ~TreePtr() {
+        if (ptr != nullptr) {
+            deleteTagged(tag(), get());
+        }
+    }
 
     TreePtr(const TreePtr &) = delete;
     TreePtr &operator=(const TreePtr &) = delete;
 
-    TreePtr(TreePtr &&other) noexcept : ptr(std::move(other.ptr)) {}
+    TreePtr(TreePtr &&other) noexcept : ptr(nullptr) {
+        std::swap(ptr, other.ptr);
+    }
 
     TreePtr &operator=(TreePtr &&other) noexcept {
-        this->ptr = std::move(other.ptr);
+        std::swap(ptr, other.ptr);
         return *this;
     }
 
-    Expression *release() noexcept {
-        return ptr.release();
+    void *release() noexcept {
+        auto *saved = get();
+        ptr = nullptr;
+        return saved;
     }
 
-    void reset(Expression *expr = nullptr) noexcept {
-        ptr.reset(expr);
+    void reset(std::nullptr_t) noexcept {
+        resetTagged(nullptr);
+    }
+
+    template <typename T> void reset(T *expr = nullptr) noexcept {
+        resetTagged(tagPtr(TreeToTag<T>::value, expr));
+    }
+
+    Tag tag() const noexcept {
+        ENFORCE(ptr != nullptr);
+
+        auto value = reinterpret_cast<long>(ptr) & TAG_MASK;
+        if (value <= 7) {
+            return static_cast<Tag>(value);
+        } else {
+            return static_cast<Tag>(value >> 48);
+        }
     }
 
     Expression *get() const noexcept {
-        return ptr.get();
+        auto val = reinterpret_cast<long>(ptr) & PTR_MASK;
+
+        // sign extension for the upper 16 bits
+        return reinterpret_cast<Expression *>((val << 16) >> 16);
+    }
+
+    // Fetch the tagged pointer. This is needed for:
+    // * ResolveConstantsWalk::isFullyResolved
+    void *getTagged() const noexcept {
+        return ptr;
     }
 
     Expression *operator->() const noexcept {
-        return ptr.get();
+        return get();
     }
 
     Expression *operator*() const noexcept {
-        return ptr.get();
+        return get();
     }
 
     explicit operator bool() const noexcept {
@@ -85,7 +212,7 @@ public:
 };
 
 template <class E, typename... Args> TreePtr make_tree(Args &&... args) {
-    return TreePtr(new E(std::forward<Args>(args)...));
+    return TreePtr(TreeToTag<E>::value, new E(std::forward<Args>(args)...));
 }
 
 class Expression {
@@ -133,21 +260,32 @@ public:
     std::vector<ParsedFile> &result();
 };
 
+template <class To> bool isa_tree(const TreePtr &what) {
+    return what != nullptr && what.tag() == TreeToTag<To>::value;
+}
+
+bool isa_reference(const TreePtr &what);
+
+bool isa_declaration(const TreePtr &what);
+
 template <class To> To *cast_tree(TreePtr &what) {
-    return fast_cast<Expression, To>(what.get());
+    if (isa_tree<To>(what)) {
+        return reinterpret_cast<To *>(what.get());
+    } else {
+        return nullptr;
+    }
 }
 
 // A variant of cast_tree that preserves the const-ness (if const in, then const out)
 template <class To> To const *cast_tree_const(const TreePtr &what) {
-    return fast_cast<Expression, To>(const_cast<Expression *>(what.get()));
-}
-
-template <class To> bool isa_tree(const TreePtr &what) {
-    return cast_tree_const<To>(what) != nullptr;
+    if (isa_tree<To>(what)) {
+        return reinterpret_cast<To *>(what.get());
+    } else {
+        return nullptr;
+    }
 }
 
 template <class To> To &cast_tree_nonnull(TreePtr &what) {
-    ENFORCE(what != nullptr);
     ENFORCE(isa_tree<To>(what), "cast_tree_nonnull failed!");
     return *reinterpret_cast<To *>(what.get());
 }
@@ -172,7 +310,7 @@ public:
 };
 CheckSize(Declaration, 32, 8);
 
-class ClassDef final : public Declaration {
+TREE(ClassDef) : public Declaration {
 public:
     enum class Kind : u1 {
         Module,
@@ -205,7 +343,7 @@ private:
 };
 CheckSize(ClassDef, 136, 8);
 
-class MethodDef final : public Declaration {
+TREE(MethodDef) : public Declaration {
 public:
     TreePtr rhs;
 
@@ -237,7 +375,7 @@ private:
 };
 CheckSize(MethodDef, 72, 8);
 
-class If final : public Expression {
+TREE(If) : public Expression {
 public:
     TreePtr cond;
     TreePtr thenp;
@@ -254,7 +392,7 @@ private:
 };
 CheckSize(If, 40, 8);
 
-class While final : public Expression {
+TREE(While) : public Expression {
 public:
     TreePtr cond;
     TreePtr body;
@@ -270,7 +408,7 @@ private:
 };
 CheckSize(While, 32, 8);
 
-class Break final : public Expression {
+TREE(Break) : public Expression {
 public:
     TreePtr expr;
 
@@ -285,7 +423,7 @@ private:
 };
 CheckSize(Break, 24, 8);
 
-class Retry final : public Expression {
+TREE(Retry) : public Expression {
 public:
     Retry(core::LocOffsets loc);
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
@@ -298,7 +436,7 @@ private:
 };
 CheckSize(Retry, 16, 8);
 
-class Next final : public Expression {
+TREE(Next) : public Expression {
 public:
     TreePtr expr;
 
@@ -313,7 +451,7 @@ private:
 };
 CheckSize(Next, 24, 8);
 
-class Return final : public Expression {
+TREE(Return) : public Expression {
 public:
     TreePtr expr;
 
@@ -328,7 +466,7 @@ private:
 };
 CheckSize(Return, 24, 8);
 
-class RescueCase final : public Expression {
+TREE(RescueCase) : public Expression {
 public:
     static constexpr int EXPECTED_EXCEPTION_COUNT = 2;
     using EXCEPTION_store = InlinedVector<TreePtr, EXPECTED_EXCEPTION_COUNT>;
@@ -351,7 +489,7 @@ private:
 };
 CheckSize(RescueCase, 56, 8);
 
-class Rescue final : public Expression {
+TREE(Rescue) : public Expression {
 public:
     static constexpr int EXPECTED_RESCUE_CASE_COUNT = 2;
     using RESCUE_CASE_store = InlinedVector<TreePtr, EXPECTED_RESCUE_CASE_COUNT>;
@@ -372,7 +510,7 @@ private:
 };
 CheckSize(Rescue, 64, 8);
 
-class Local final : public Reference {
+TREE(Local) : public Reference {
 public:
     core::LocalVariable localVariable;
 
@@ -387,7 +525,7 @@ private:
 };
 CheckSize(Local, 24, 8);
 
-class UnresolvedIdent final : public Reference {
+TREE(UnresolvedIdent) : public Reference {
 public:
     enum class Kind : u1 {
         Local,
@@ -409,7 +547,7 @@ private:
 };
 CheckSize(UnresolvedIdent, 24, 8);
 
-class RestArg final : public Reference {
+TREE(RestArg) : public Reference {
 public:
     TreePtr expr;
 
@@ -424,7 +562,7 @@ private:
 };
 CheckSize(RestArg, 24, 8);
 
-class KeywordArg final : public Reference {
+TREE(KeywordArg) : public Reference {
 public:
     TreePtr expr;
 
@@ -439,7 +577,7 @@ private:
 };
 CheckSize(KeywordArg, 24, 8);
 
-class OptionalArg final : public Reference {
+TREE(OptionalArg) : public Reference {
 public:
     TreePtr expr;
     TreePtr default_;
@@ -455,7 +593,7 @@ private:
 };
 CheckSize(OptionalArg, 32, 8);
 
-class BlockArg final : public Reference {
+TREE(BlockArg) : public Reference {
 public:
     TreePtr expr;
 
@@ -470,7 +608,7 @@ private:
 };
 CheckSize(BlockArg, 24, 8);
 
-class ShadowArg final : public Reference {
+TREE(ShadowArg) : public Reference {
 public:
     TreePtr expr;
 
@@ -485,7 +623,7 @@ private:
 };
 CheckSize(ShadowArg, 24, 8);
 
-class Assign final : public Expression {
+TREE(Assign) : public Expression {
 public:
     TreePtr lhs;
     TreePtr rhs;
@@ -501,9 +639,7 @@ private:
 };
 CheckSize(Assign, 32, 8);
 
-class Block;
-
-class Send final : public Expression {
+TREE(Send) : public Expression {
 public:
     core::NameRef fun;
 
@@ -537,7 +673,7 @@ private:
 };
 CheckSize(Send, 64, 8);
 
-class Cast final : public Expression {
+TREE(Cast) : public Expression {
 public:
     // The name of the cast operator.
     core::NameRef cast;
@@ -556,7 +692,7 @@ private:
 };
 CheckSize(Cast, 48, 8);
 
-class Hash final : public Expression {
+TREE(Hash) : public Expression {
 public:
     static constexpr int EXPECTED_ENTRY_COUNT = 2;
     using ENTRY_store = InlinedVector<TreePtr, EXPECTED_ENTRY_COUNT>;
@@ -576,7 +712,7 @@ private:
 };
 CheckSize(Hash, 64, 8);
 
-class Array final : public Expression {
+TREE(Array) : public Expression {
 public:
     static constexpr int EXPECTED_ENTRY_COUNT = 4;
     using ENTRY_store = InlinedVector<TreePtr, EXPECTED_ENTRY_COUNT>;
@@ -595,7 +731,7 @@ private:
 };
 CheckSize(Array, 56, 8);
 
-class Literal final : public Expression {
+TREE(Literal) : public Expression {
 public:
     core::TypePtr value;
 
@@ -617,7 +753,7 @@ private:
 };
 CheckSize(Literal, 32, 8);
 
-class UnresolvedConstantLit final : public Expression {
+TREE(UnresolvedConstantLit) : public Expression {
 public:
     core::NameRef cnst;
     TreePtr scope;
@@ -633,7 +769,7 @@ private:
 };
 CheckSize(UnresolvedConstantLit, 32, 8);
 
-class ConstantLit final : public Expression {
+TREE(ConstantLit) : public Expression {
 public:
     core::SymbolRef symbol; // If this is a normal constant. This symbol may be already dealiased.
     // For constants that failed resolution, symbol will be set to StubModule and resolutionScopes
@@ -647,15 +783,15 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
     virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
-    std::optional<std::pair<core::SymbolRef, std::vector<core::NameRef>>>
-    fullUnresolvedPath(const core::GlobalState &gs) const;
+    std::optional<std::pair<core::SymbolRef, std::vector<core::NameRef>>> fullUnresolvedPath(
+        const core::GlobalState &gs) const;
 
 private:
     virtual void _sanityCheck();
 };
 CheckSize(ConstantLit, 56, 8);
 
-class ZSuperArgs final : public Expression {
+TREE(ZSuperArgs) : public Expression {
 public:
     // null if no block passed
     ZSuperArgs(core::LocOffsets loc);
@@ -669,7 +805,7 @@ private:
 };
 CheckSize(ZSuperArgs, 16, 8);
 
-class Block final : public Expression {
+TREE(Block) : public Expression {
 public:
     MethodDef::ARGS_store args;
     TreePtr body;
@@ -683,7 +819,7 @@ public:
 };
 CheckSize(Block, 48, 8);
 
-class InsSeq final : public Expression {
+TREE(InsSeq) : public Expression {
 public:
     static constexpr int EXPECTED_STATS_COUNT = 4;
     using STATS_store = InlinedVector<TreePtr, EXPECTED_STATS_COUNT>;
@@ -704,7 +840,7 @@ private:
 };
 CheckSize(InsSeq, 64, 8);
 
-class EmptyTree final : public Expression {
+TREE(EmptyTree) : public Expression {
 public:
     EmptyTree();
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -6,7 +6,6 @@
 #include "core/LocalVariable.h"
 #include "core/SymbolRef.h"
 #include "core/Types.h"
-#include <cassert>
 #include <memory>
 #include <vector>
 
@@ -66,12 +65,6 @@ template <typename T> struct TreeToTag;
 
 // A mapping from tag value to the tree it represents.
 template <Tag T> struct TagToTree;
-
-#define TREE(name)                                                                  \
-    class name;                                                                     \
-    template <> struct TreeToTag<name> { static constexpr Tag value = Tag::name; }; \
-    template <> struct TagToTree<Tag::name> { using value = name; };                \
-    class name final
 
 class Expression;
 
@@ -313,6 +306,12 @@ public:
     Declaration(core::LocOffsets loc, core::Loc declLoc, core::SymbolRef symbol);
 };
 CheckSize(Declaration, 32, 8);
+
+#define TREE(name)                                                                  \
+    class name;                                                                     \
+    template <> struct TreeToTag<name> { static constexpr Tag value = Tag::name; }; \
+    template <> struct TagToTree<Tag::name> { using value = name; };                \
+    class name final
 
 TREE(ClassDef) : public Declaration {
 public:

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -560,7 +560,7 @@ TreePtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) {
             [&](parser::And *and_) {
                 auto lhs = node2TreeImpl(dctx, std::move(and_->left));
                 auto rhs = node2TreeImpl(dctx, std::move(and_->right));
-                if (isa_tree<Reference>(lhs)) {
+                if (isa_reference(lhs)) {
                     auto cond = MK::cpRef(lhs);
                     auto iff = MK::If(loc, std::move(cond), std::move(rhs), std::move(lhs));
                     result = std::move(iff);
@@ -576,7 +576,7 @@ TreePtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) {
             [&](parser::Or *or_) {
                 auto lhs = node2TreeImpl(dctx, std::move(or_->left));
                 auto rhs = node2TreeImpl(dctx, std::move(or_->right));
-                if (isa_tree<Reference>(lhs)) {
+                if (isa_reference(lhs)) {
                     auto cond = MK::cpRef(lhs);
                     auto iff = MK::If(loc, std::move(cond), std::move(lhs), std::move(rhs));
                     result = std::move(iff);
@@ -608,7 +608,7 @@ TreePtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) {
                     auto iff = MK::If(sendLoc, MK::Local(sendLoc, tempResult), std::move(body), std::move(elsep));
                     auto wrapped = MK::InsSeq(loc, std::move(stats), std::move(iff));
                     result = std::move(wrapped);
-                } else if (isa_tree<Reference>(recv)) {
+                } else if (isa_reference(recv)) {
                     auto cond = MK::cpRef(recv);
                     auto elsep = MK::cpRef(recv);
                     auto body = MK::Assign(loc, std::move(recv), std::move(arg));
@@ -670,7 +670,7 @@ TreePtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) {
                     auto iff = MK::If(sendLoc, MK::Local(sendLoc, tempResult), std::move(body), std::move(elsep));
                     auto wrapped = MK::InsSeq(loc, std::move(stats), std::move(iff));
                     result = std::move(wrapped);
-                } else if (isa_tree<Reference>(recv)) {
+                } else if (isa_reference(recv)) {
                     auto cond = MK::cpRef(recv);
                     auto elsep = MK::cpRef(recv);
                     auto body = MK::Assign(loc, std::move(recv), std::move(arg));
@@ -730,7 +730,7 @@ TreePtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) {
                                         std::move(assgnArgs), s->flags);
                     auto wrapped = MK::InsSeq(loc, std::move(stats), std::move(res));
                     result = std::move(wrapped);
-                } else if (isa_tree<Reference>(recv)) {
+                } else if (isa_reference(recv)) {
                     auto lhs = MK::cpRef(recv);
                     auto send = MK::Send1(loc, std::move(recv), opAsgn->op, std::move(rhs));
                     auto res = MK::Assign(loc, std::move(lhs), std::move(send));

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1467,11 +1467,8 @@ TreePtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) {
                 Rescue::RESCUE_CASE_store cases;
                 cases.reserve(rescue->rescue.size());
                 for (auto &node : rescue->rescue) {
-                    TreePtr rescueCaseExpr = node2TreeImpl(dctx, std::move(node));
-                    auto rescueCase = cast_tree<RescueCase>(rescueCaseExpr);
-                    ENFORCE(rescueCase != nullptr, "rescue case cast failed");
-                    cases.emplace_back(rescueCase);
-                    rescueCaseExpr.release();
+                    cases.emplace_back(node2TreeImpl(dctx, std::move(node)));
+                    ENFORCE(isa_tree<RescueCase>(cases.back()), "node2TreeImpl failed to produce a rescue case");
                 }
                 TreePtr res = make_tree<Rescue>(loc, node2TreeImpl(dctx, std::move(rescue->body)), std::move(cases),
                                                 node2TreeImpl(dctx, std::move(rescue->else_)), MK::EmptyTree());

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -416,7 +416,7 @@ private:
 
         cast_tree<Rescue>(v)->body = mapIt(std::move(cast_tree<Rescue>(v)->body), ctx);
 
-        for(auto &el : cast_tree<Rescue>(v)->rescueCases) {
+        for (auto &el : cast_tree<Rescue>(v)->rescueCases) {
             ENFORCE(isa_tree<RescueCase>(el), "invalid tree where rescue case was expected");
             el = mapRescueCase(std::move(el), ctx);
             ENFORCE(isa_tree<RescueCase>(el), "rescue case was mapped into non-rescue case");
@@ -864,7 +864,7 @@ private:
 
         cast_tree<Rescue>(v)->body = mapIt(std::move(cast_tree<Rescue>(v)->body), ctx);
 
-        for(auto &el : cast_tree<Rescue>(v)->rescueCases) {
+        for (auto &el : cast_tree<Rescue>(v)->rescueCases) {
             ENFORCE(isa_tree<RescueCase>(el), "invalid tree where rescue case was expected");
             el = mapRescueCase(std::move(el), ctx);
             ENFORCE(isa_tree<RescueCase>(el), "rescue case was mapped into non-rescue case");

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -419,17 +419,8 @@ private:
         int i = 0;
         while (i < cast_tree<Rescue>(v)->rescueCases.size()) {
             auto &el = cast_tree<Rescue>(v)->rescueCases[i];
-            auto *oldRef = el.get();
-            auto narg = mapRescueCase(std::move(el), ctx);
-            if (el.get() != narg.get()) {
-                auto *nargCase = cast_tree<RescueCase>(narg);
-                ENFORCE(nargCase != nullptr, "rescue case was mapped into non-a rescue case");
-                el.reset(nargCase);
-                narg.release();
-            } else {
-                narg.release();
-                el.reset(oldRef);
-            }
+            el = mapRescueCase(std::move(el), ctx);
+            ENFORCE(isa_tree<RescueCase>(el), "rescue case was mapped into non-a rescue case");
             i++;
         }
 
@@ -878,17 +869,8 @@ private:
         int i = 0;
         while (i < cast_tree<Rescue>(v)->rescueCases.size()) {
             auto &el = cast_tree<Rescue>(v)->rescueCases[i];
-            auto *oldRef = el.get();
-            auto narg = mapRescueCase(std::move(el), ctx);
-            if (el.get() != narg.get()) {
-                auto *nargCase = cast_tree<RescueCase>(narg);
-                ENFORCE(nargCase != nullptr, "rescue case was mapped into non-a rescue case");
-                el.reset(nargCase);
-                narg.release();
-            } else {
-                narg.release();
-                el.reset(oldRef);
-            }
+            el = mapRescueCase(std::move(el), ctx);
+            ENFORCE(isa_tree<RescueCase>(el), "rescue case was mapped into non-a rescue case");
             i++;
         }
 

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -416,12 +416,10 @@ private:
 
         cast_tree<Rescue>(v)->body = mapIt(std::move(cast_tree<Rescue>(v)->body), ctx);
 
-        int i = 0;
-        while (i < cast_tree<Rescue>(v)->rescueCases.size()) {
-            auto &el = cast_tree<Rescue>(v)->rescueCases[i];
+        for(auto &el : cast_tree<Rescue>(v)->rescueCases) {
+            ENFORCE(isa_tree<RescueCase>(el), "invalid tree where rescue case was expected");
             el = mapRescueCase(std::move(el), ctx);
-            ENFORCE(isa_tree<RescueCase>(el), "rescue case was mapped into non-a rescue case");
-            i++;
+            ENFORCE(isa_tree<RescueCase>(el), "rescue case was mapped into non-rescue case");
         }
 
         cast_tree<Rescue>(v)->else_ = mapIt(std::move(cast_tree<Rescue>(v)->else_), ctx);
@@ -866,12 +864,10 @@ private:
 
         cast_tree<Rescue>(v)->body = mapIt(std::move(cast_tree<Rescue>(v)->body), ctx);
 
-        int i = 0;
-        while (i < cast_tree<Rescue>(v)->rescueCases.size()) {
-            auto &el = cast_tree<Rescue>(v)->rescueCases[i];
+        for(auto &el : cast_tree<Rescue>(v)->rescueCases) {
+            ENFORCE(isa_tree<RescueCase>(el), "invalid tree where rescue case was expected");
             el = mapRescueCase(std::move(el), ctx);
-            ENFORCE(isa_tree<RescueCase>(el), "rescue case was mapped into non-a rescue case");
-            i++;
+            ENFORCE(isa_tree<RescueCase>(el), "rescue case was mapped into non-rescue case");
         }
 
         cast_tree<Rescue>(v)->else_ = mapIt(std::move(cast_tree<Rescue>(v)->else_), ctx);

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -90,8 +90,7 @@ class LocalNameInserter {
         vector<NamedArg> namedArgs;
         UnorderedSet<core::NameRef> nameSet;
         for (auto &arg : methodArgs) {
-            auto *refExp = ast::cast_tree<ast::Reference>(arg);
-            if (!refExp) {
+            if (!ast::isa_reference(arg)) {
                 Exception::raise("Must be a reference!");
             }
             auto named = nameArg(move(arg));

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -199,7 +199,7 @@ private:
 
     static bool isFullyResolved(core::Context ctx, const ast::TreePtr &expression) {
         ResolutionChecker checker;
-        ast::TreePtr dummy(expression.get());
+        ast::TreePtr dummy(expression.getTagged());
         dummy = ast::TreeMap::apply(ctx, checker, std::move(dummy));
         ENFORCE(dummy == expression);
         dummy.release();


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Switching to using `TreePtr` for the AST representation means that we can change how the type of the underlying tree is encoded. This PR switches from keeping a `unique_ptr<Expression>` inside of `TreePtr` to just a `void *`, and encoding the type of the pointer into the unused bits of the 64-bit pointer.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This change should improve performance in treemap.h, as we're no longer relying on uses of `dynamic_cast` to figure out what node we're processing. Additionally, switching to tagged pointers opens the door to removing virtual methods from the classes in Trees.h.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
