### PR TITLE
Fix signature for IO writing methods

### DIFF
--- a/rbi/core/io.rbi
+++ b/rbi/core/io.rbi
@@ -1739,7 +1739,7 @@ class IO < Object
   # ```
   sig do
     params(
-        arg0: String,
+        arg0: Object,
     )
     .returns(Integer)
   end
@@ -2283,7 +2283,7 @@ class IO < Object
   sig do
     params(
         name: T.any(String, Tempfile, File, Pathname),
-        string: String,
+        string: Object,
         offset: Integer,
         external_encoding: String,
         internal_encoding: String,
@@ -2497,7 +2497,7 @@ class IO < Object
   # should not raise an
   # [`IO::WaitWritable`](https://docs.ruby-lang.org/en/2.6.0/IO/WaitWritable.html)
   # exception, but return the symbol `:wait_writable` instead.
-  sig { params(string: String, exception: T::Boolean).returns(Integer) }
+  sig { params(string: Object, exception: T::Boolean).returns(Integer) }
   def write_nonblock(string, exception: true); end
 end
 


### PR DESCRIPTION
### Motivation

The documentation for [`IO::write`](https://ruby-doc.org/core-2.6/IO.html#method-i-write) states that:

> Arguments that are not a string will be converted to a string using to_s. 

And it goes the same for `IO#write` anf `IO#write_non_block`.

For example with `IO#write`:
```ruby
irb(main):001:0> io = IO.new(1)
=> #<IO:fd 1>
irb(main):002:0> io.write(1)
=> 1
irb(main):003:0> io.write(nil)
=> 0
```

`IO#write_nonblock`:
```ruby
irb(main):001:0> io = IO.new(1)
=> #<IO:fd 1>
irb(main):002:0> io.write_nonblock(nil)
=> 0
```

`IO::write`:
```ruby
irb(main):001:0> IO.write("foo", 1)
=> 1
irb(main):002:0> IO.write("foo", nil)
=> 0
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
