### PR TITLE
Substantial speedup for isSubtype(and thus glb/lub) on big And/Or types

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -470,7 +470,7 @@ private:
     friend class GlobalSubstitution;
     friend class serialize::SerializerImpl;
     friend bool Types::isSubTypeUnderConstraint(const GlobalState &gs, TypeConstraint &constr, const TypePtr &t1,
-                                         const TypePtr &t2, UntypedMode mode);
+                                                const TypePtr &t2, UntypedMode mode);
     friend TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr lubGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
@@ -517,7 +517,7 @@ private:
     friend class TypeConstraint;
 
     friend bool Types::isSubTypeUnderConstraint(const GlobalState &gs, TypeConstraint &constr, const TypePtr &t1,
-                                         const TypePtr &t2, UntypedMode mode);
+                                                const TypePtr &t2, UntypedMode mode);
     friend TypePtr lubGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr glbDistributeAnd(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr glbGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);

--- a/core/Types.h
+++ b/core/Types.h
@@ -469,6 +469,8 @@ private:
     friend TypePtr Types::Boolean();
     friend class GlobalSubstitution;
     friend class serialize::SerializerImpl;
+    friend bool Types::isSubTypeUnderConstraint(const GlobalState &gs, TypeConstraint &constr, const TypePtr &t1,
+                                         const TypePtr &t2, UntypedMode mode);
     friend TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr lubGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
@@ -514,6 +516,8 @@ private:
     friend class serialize::SerializerImpl;
     friend class TypeConstraint;
 
+    friend bool Types::isSubTypeUnderConstraint(const GlobalState &gs, TypeConstraint &constr, const TypePtr &t1,
+                                         const TypePtr &t2, UntypedMode mode);
     friend TypePtr lubGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr glbDistributeAnd(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr glbGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);

--- a/test/testdata/infer/is_subtype_timeout.rb
+++ b/test/testdata/infer/is_subtype_timeout.rb
@@ -1,0 +1,118 @@
+# typed: true
+#
+module Half; end;
+
+class A01; end
+class A02; end
+class A03; end
+class A04; end
+class A05; end
+class A06; end
+class A07; end
+class A08; end
+class A09; end
+class A10; end
+class A11; end
+class A12; end
+class A13; end
+class A14; end
+class A15; end
+class A16; end
+class A17; end
+class A18; end
+class A19; end
+class A20; end
+class A21; end
+class A22; end
+class A23; end
+class A24; end
+class A25; end
+class A26; end
+class A27; end
+class A28; end
+class A29; end
+class A30; end
+class A31; end
+class A32; end
+class A33; end
+class A34; end
+class A35; end
+class A36; end
+class A37; end
+class A38; end
+class A39; end
+class A40; end
+class A41; end
+class A42; end
+class A43; end
+class A44; end
+class A45; end
+class A46; end
+class A47; end
+class A48; end
+class A49; end
+class A50; end
+
+PM = T.type_alias do
+        T.any(
+A01,
+A02,
+A03,
+A04,
+A05,
+A06,
+A07,
+A08,
+A09,
+A10,
+A11,
+A12,
+A13,
+A14,
+A15,
+A16,
+A17,
+A18,
+A19,
+A20,
+A22,
+A23,
+A24,
+A25,
+A26,
+A27,
+A28,
+A29,
+A30,
+A31,
+A32,
+A33,
+A34,
+A35,
+A36,
+A37,
+A38,
+A39,
+A40,
+A41,
+A42,
+A43,
+A44,
+A45,
+A46,
+A47,
+A48,
+A49,
+A50
+)
+end
+
+
+extend T::Sig
+ sig do
+         params(pm: T.all(PM, Half))
+      .void
+    end
+    def used_to_take_forever_to_typecheck(pm)
+        T.assert_type!(pm, Half)
+end


### PR DESCRIPTION


### Motivation
Stripe had a function that took forever to typecheck


### Test plan
Added test that took years before the patch.

