### PR TITLE
Add Marshal support to T::Enum

### DIFF
--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -346,4 +346,15 @@ class T::Enum
 
     raise "Inheriting from children of T::Enum is prohibited" if self != T::Enum
   end
+
+  # Marshal support
+  sig {params(_level: Integer).returns(String)}
+  def _dump(_level)
+    Marshal.dump(serialize)
+  end
+
+  sig {params(args: String).returns(T.attached_class)}
+  def self._load(args)
+    deserialize(Marshal.load(args))
+  end
 end

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -458,6 +458,23 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
     end
   end
 
+  it "is compatible with Marshal" do
+    (CardSuit.values + CardSuitCustom.values).each do |value|
+      roundtrip = Marshal.load(Marshal.dump(value))
+
+      assert_equal(roundtrip, value)
+
+      assert(value === roundtrip)
+
+      assert(
+        case roundtrip
+        when value then true
+        else false
+        end
+      )
+    end
+  end
+
   it 'can be used with an assert' do
     assert(CardSuit::SPADE, 'some message')
   end

--- a/rbi/core/marshal.rbi
+++ b/rbi/core/marshal.rbi
@@ -186,14 +186,14 @@ module Marshal
         arg1: IO,
         arg2: Integer,
     )
-    .returns(Object)
+    .returns(IO)
   end
   sig do
     params(
         arg0: Object,
         arg1: Integer,
     )
-    .returns(Object)
+    .returns(String)
   end
   def self.dump(arg0, arg1=T.unsafe(nil), arg2=T.unsafe(nil)); end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
I added `_dump` and `self._load` methods to `T::Enum`.

I also changed the definition of `Marshal.dump` according to the docs.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Currently, an enum value after a roundtrip of `Marshal` does not evaluate to `true` using the case equality operator (`===`).

This is useful especially for multi-process Ruby parallelisation where IPC is done by passing objects serialized using `Marshal`

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Please see automated tests.

I'm not sure if I should also update/somehow re-generate `rbi/core/enum.rbi`