### PR TITLE
Stream errors from typechecking loop

### DIFF
--- a/common/concurrency/WorkerPool.h
+++ b/common/concurrency/WorkerPool.h
@@ -17,6 +17,7 @@ public:
     static std::unique_ptr<WorkerPool> create(int size, spd::logger &logger);
     virtual void multiplexJob(std::string_view taskName, Task t) = 0;
     virtual ~WorkerPool() = 0;
+    virtual int size() = 0;
     WorkerPool() = default;
     WorkerPool(WorkerPool &) = delete;
     WorkerPool(const WorkerPool &) = delete;

--- a/common/concurrency/WorkerPoolImpl.h
+++ b/common/concurrency/WorkerPoolImpl.h
@@ -10,7 +10,7 @@
 namespace spd = spdlog;
 namespace sorbet {
 class WorkerPoolImpl : public WorkerPool {
-    int size;
+    int _size;
     // Tune queue for small size
     struct ConcurrentQueueCustomTraits {
         // General-purpose size type. std::size_t is strongly recommended.
@@ -90,6 +90,7 @@ public:
     ~WorkerPoolImpl();
 
     void multiplexJob(std::string_view taskName, Task t) override;
+    int size() override;
 };
 };     // namespace sorbet
 #endif // SORBET_WORKERPOOL_IMPL_H

--- a/main/lsp/ErrorReporter.cc
+++ b/main/lsp/ErrorReporter.cc
@@ -135,6 +135,10 @@ ErrorStatus &ErrorReporter::getFileErrorStatus(core::FileRef file) {
     return fileErrorStatuses[file.id()];
 };
 
+u4 ErrorReporter::lastDiagnosticEpochForFile(core::FileRef file) {
+    return getFileErrorStatus(file).lastReportedEpoch;
+}
+
 ErrorEpoch::ErrorEpoch(ErrorReporter &errorReporter, u4 epoch,
                        std::vector<std::unique_ptr<Timer>> diagnosticLatencyTimers)
     : errorReporter(errorReporter), epoch(epoch) {

--- a/main/lsp/ErrorReporter.h
+++ b/main/lsp/ErrorReporter.h
@@ -39,6 +39,7 @@ public:
 
     void beginEpoch(u4 epoch, std::vector<std::unique_ptr<Timer>> diagnosticLatencyTimers);
     void endEpoch(u4 epoch, bool committed = true);
+    u4 lastDiagnosticEpochForFile(core::FileRef file);
 };
 
 class ErrorEpoch final {

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -64,6 +64,17 @@ bool validateMethodHashesHaveSameMethods(const std::vector<std::pair<core::NameH
     return true;
 }
 
+vector<ast::ParsedFile> sortParsedFiles(const core::GlobalState &gs, ErrorReporter &errorReporter,
+                                        vector<ast::ParsedFile> parsedFiles) {
+    fast_sort(parsedFiles, [&](const auto &lhs, const auto &rhs) -> bool {
+        auto lhsEpoch = max(errorReporter.lastDiagnosticEpochForFile(lhs.file), lhs.file.data(gs).epoch);
+        auto rhsEpoch = max(errorReporter.lastDiagnosticEpochForFile(rhs.file), rhs.file.data(gs).epoch);
+
+        return lhsEpoch > rhsEpoch;
+    });
+
+    return parsedFiles;
+}
 } // namespace
 
 LSPTypechecker::LSPTypechecker(std::shared_ptr<const LSPConfiguration> config,
@@ -239,14 +250,8 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
 
     ENFORCE(gs->lspQuery.isEmpty());
     auto resolved = pipeline::incrementalResolve(*gs, move(updatedIndexed), config->opts);
-    fast_sort(resolved, [&](const auto &lhs, const auto &rhs) -> bool {
-        auto lhsEpoch = max(errorReporter->lastDiagnosticEpochForFile(lhs.file), lhs.file.data(*gs).epoch);
-        auto rhsEpoch = max(errorReporter->lastDiagnosticEpochForFile(rhs.file), rhs.file.data(*gs).epoch);
-
-        return lhsEpoch > rhsEpoch;
-    });
-
-    pipeline::typecheck(gs, move(resolved), config->opts, workers, /*presorted*/ true);
+    auto sorted = sortParsedFiles(*gs, *errorReporter, move(resolved));
+    pipeline::typecheck(gs, move(sorted), config->opts, workers, /*presorted*/ true);
     gs->lspTypecheckCount++;
 
     return subset;
@@ -417,14 +422,8 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
             return;
         }
 
-        fast_sort(resolved, [&](const auto &lhs, const auto &rhs) -> bool {
-            auto lhsEpoch = max(errorReporter->lastDiagnosticEpochForFile(lhs.file), lhs.file.data(*gs).epoch);
-            auto rhsEpoch = max(errorReporter->lastDiagnosticEpochForFile(rhs.file), rhs.file.data(*gs).epoch);
-
-            return lhsEpoch > rhsEpoch;
-        });
-
-        pipeline::typecheck(gs, move(resolved), config->opts, workers, cancelable, preemptManager, /*presorted*/ true);
+        auto sorted = sortParsedFiles(*gs, *errorReporter, move(resolved));
+        pipeline::typecheck(gs, move(sorted), config->opts, workers, cancelable, preemptManager, /*presorted*/ true);
     });
 
     // Note: `gs` now holds the value of `finalGS`.
@@ -534,13 +533,6 @@ LSPQueryResult LSPTypechecker::query(const core::lsp::Query &q, const std::vecto
     auto resolved = getResolved(filesForQuery);
     tryApplyDefLocSaver(*gs, resolved);
     tryApplyLocalVarSaver(*gs, resolved);
-
-    fast_sort(resolved, [&](const auto &lhs, const auto &rhs) -> bool {
-        auto lhsEpoch = max(errorReporter->lastDiagnosticEpochForFile(lhs.file), lhs.file.data(*gs).epoch);
-        auto rhsEpoch = max(errorReporter->lastDiagnosticEpochForFile(rhs.file), rhs.file.data(*gs).epoch);
-
-        return lhsEpoch > rhsEpoch;
-    });
 
     pipeline::typecheck(gs, move(resolved), config->opts, workers, /*presorted*/ true);
     gs->lspTypecheckCount++;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -727,11 +727,6 @@ ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const 
     return result;
 }
 
-struct typecheck_thread_result {
-    vector<ast::ParsedFile> trees;
-    CounterState counters;
-};
-
 ast::ParsedFilesOrCancelled name(core::GlobalState &gs, vector<ast::ParsedFile> what, const options::Options &opts,
                                  WorkerPool &workers, bool skipConfigatron) {
     Timer timeit(gs.tracer(), "name");
@@ -932,11 +927,11 @@ ast::ParsedFilesOrCancelled typecheck(unique_ptr<core::GlobalState> &gs, vector<
         }
 
         shared_ptr<ConcurrentBoundedQueue<ast::ParsedFile>> fileq;
-        shared_ptr<BlockingBoundedQueue<typecheck_thread_result>> resultq;
+        shared_ptr<BlockingBoundedQueue<vector<ast::ParsedFile>>> treesq;
 
         {
             fileq = make_shared<ConcurrentBoundedQueue<ast::ParsedFile>>(what.size());
-            resultq = make_shared<BlockingBoundedQueue<typecheck_thread_result>>(what.size());
+            treesq = make_shared<BlockingBoundedQueue<vector<ast::ParsedFile>>>(what.size());
         }
 
         const core::GlobalState &igs = *gs;
@@ -955,8 +950,8 @@ ast::ParsedFilesOrCancelled typecheck(unique_ptr<core::GlobalState> &gs, vector<
         {
             ProgressIndicator cfgInferProgress(opts.showProgress, "CFG+Inference", what.size());
             workers.multiplexJob(
-                "typecheck", [&igs, &opts, epoch, &epochManager, &preemptionManager, fileq, resultq, cancelable]() {
-                    typecheck_thread_result threadResult;
+                "typecheck", [&igs, &opts, epoch, &epochManager, &preemptionManager, fileq, treesq, cancelable]() {
+                    vector<ast::ParsedFile> trees;
                     ast::ParsedFile job;
                     int processedByThread = 0;
 
@@ -981,35 +976,35 @@ ast::ParsedFilesOrCancelled typecheck(unique_ptr<core::GlobalState> &gs, vector<
                                     try {
                                         core::Context ctx(igs, core::Symbols::root(), file);
                                         auto parsedFile = typecheckOne(ctx, move(job), opts);
-                                        threadResult.trees.emplace_back(move(parsedFile));
+                                        trees.emplace_back(move(parsedFile));
                                     } catch (SorbetException &) {
                                         Exception::failInFuzzer();
                                         igs.tracer().error("Exception typing file: {} (backtrace is above)",
                                                            file.data(igs).path());
                                     }
                                     // Stream out errors
-                                    resultq->push(move(threadResult), processedByThread);
+                                    treesq->push(move(trees), processedByThread);
                                     processedByThread = 0;
                                 }
                             }
                         }
                     }
                     if (processedByThread > 0) {
-                        resultq->push(move(threadResult), processedByThread);
+                        treesq->push(move(trees), processedByThread);
                     }
                 });
 
-            typecheck_thread_result threadResult;
+            vector<ast::ParsedFile> trees;
             {
-                for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs->tracer());
+                for (auto result = treesq->wait_pop_timed(trees, WorkerPool::BLOCK_INTERVAL(), gs->tracer());
                      !result.done();
-                     result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs->tracer())) {
+                     result = treesq->wait_pop_timed(trees, WorkerPool::BLOCK_INTERVAL(), gs->tracer())) {
                     if (result.gotItem()) {
-                        typecheck_result.insert(typecheck_result.end(), make_move_iterator(threadResult.trees.begin()),
-                                                make_move_iterator(threadResult.trees.end()));
+                        typecheck_result.insert(typecheck_result.end(), make_move_iterator(trees.begin()),
+                                                make_move_iterator(trees.end()));
                     }
                     cfgInferProgress.reportProgress(fileq->doneEstimate());
-                    for (auto &tree : threadResult.trees) {
+                    for (auto &tree : trees) {
                         gs->errorQueue->flushErrorsForFile(*gs, tree.file);
                     }
                     if (preemptionManager) {
@@ -1022,13 +1017,13 @@ ast::ParsedFilesOrCancelled typecheck(unique_ptr<core::GlobalState> &gs, vector<
             }
 
             if (workers.size() > 0) {
-                auto counterQueue = make_shared<BlockingBoundedQueue<CounterState>>(workers.size());
+                auto counterq = make_shared<BlockingBoundedQueue<CounterState>>(workers.size());
                 workers.multiplexJob("collectCounters",
-                                     [counterQueue]() { counterQueue->push(getAndClearThreadCounters(), 1); });
+                                     [counterq]() { counterq->push(getAndClearThreadCounters(), 1); });
                 {
                     sorbet::CounterState counters;
-                    for (auto result = counterQueue->try_pop(counters); !result.done();
-                         result = counterQueue->try_pop(counters)) {
+                    for (auto result = counterq->try_pop(counters); !result.done();
+                         result = counterq->try_pop(counters)) {
                         if (result.gotItem()) {
                             counterConsume(move(counters));
                         }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -983,6 +983,10 @@ ast::ParsedFilesOrCancelled typecheck(unique_ptr<core::GlobalState> &gs, vector<
                                         igs.tracer().error("Exception typing file: {} (backtrace is above)",
                                                            file.data(igs).path());
                                     }
+                                    // Stream out errors
+                                    threadResult.counters = getAndClearThreadCounters();
+                                    resultq->push(move(threadResult), processedByThread);
+                                    processedByThread = 0;
                                 }
                             }
                         }

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -38,7 +38,8 @@ ast::ParsedFilesOrCancelled name(core::GlobalState &gs, std::vector<ast::ParsedF
 ast::ParsedFilesOrCancelled
 typecheck(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what, const options::Options &opts,
           WorkerPool &workers, bool cancelable = false,
-          std::optional<std::shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager = std::nullopt);
+          std::optional<std::shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager = std::nullopt,
+          bool presorted = false);
 
 ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Options &opts);
 


### PR DESCRIPTION
- Sort files by max of last edited epoch and last diagnostic epoch in LSP mode before typechecking
- Stream errors per file from typechecking loop

### Motivation
Reduce the time it takes for users to see typechecking errors.


### Test plan
Existing tests should cover