### PR TITLE
Fix storage of tree pointers for emscripten

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -71,7 +71,7 @@ class Expression;
 class TreePtr {
 public:
     // We store tagged pointers as 64-bit values.
-    using tagged_storage = long long;
+    using tagged_storage = u64;
 
 private:
     static constexpr tagged_storage TAG_MASK = 0xffff000000000007;

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -74,22 +74,22 @@ public:
     using tagged_storage = long long;
 
 private:
-    static constexpr long long TAG_MASK = 0xffff000000000007;
+    static constexpr tagged_storage TAG_MASK = 0xffff000000000007;
 
-    static constexpr long long PTR_MASK = ~TAG_MASK;
+    static constexpr tagged_storage PTR_MASK = ~TAG_MASK;
 
     tagged_storage ptr;
 
     template <typename E, typename... Args> friend TreePtr make_tree(Args &&...);
 
     static tagged_storage tagPtr(Tag tag, void *expr) {
-        auto val = static_cast<long long>(tag);
+        auto val = static_cast<tagged_storage>(tag);
         if (val >= 8) {
             // Store the tag in the upper 16 bits of the pointer, as it won't fit in the lower three bits.
             val <<= 48;
         }
 
-        auto maskedPtr = reinterpret_cast<long long>(expr) & PTR_MASK;
+        auto maskedPtr = reinterpret_cast<tagged_storage>(expr) & PTR_MASK;
 
         return maskedPtr | val;
     }
@@ -99,7 +99,7 @@ private:
     static void deleteTagged(Tag tag, void *ptr) noexcept;
 
     // A version of release that doesn't mask the tag bits
-    long long releaseTagged() noexcept {
+    tagged_storage releaseTagged() noexcept {
         auto saved = ptr;
         ptr = 0;
         return saved;
@@ -174,7 +174,7 @@ public:
     Tag tag() const noexcept {
         ENFORCE(ptr != 0);
 
-        auto value = reinterpret_cast<long long>(ptr) & TAG_MASK;
+        auto value = reinterpret_cast<tagged_storage>(ptr) & TAG_MASK;
         if (value <= 7) {
             return static_cast<Tag>(value);
         } else {

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -71,7 +71,7 @@ class Expression;
 class TreePtr {
 public:
     // We store tagged pointers as 64-bit values.
-    using tagged_storage = u64;
+    using tagged_storage = u8;
 
 private:
     static constexpr tagged_storage TAG_MASK = 0xffff000000000007;

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -69,16 +69,20 @@ template <Tag T> struct TagToTree;
 class Expression;
 
 class TreePtr {
+public:
+    // We store tagged pointers as 64-bit values.
+    using tagged_storage = long long;
+
 private:
     static constexpr long long TAG_MASK = 0xffff000000000007;
 
     static constexpr long long PTR_MASK = ~TAG_MASK;
 
-    void *ptr;
+    tagged_storage ptr;
 
     template <typename E, typename... Args> friend TreePtr make_tree(Args &&...);
 
-    static void *tagPtr(Tag tag, void *expr) {
+    static tagged_storage tagPtr(Tag tag, void *expr) {
         auto val = static_cast<long long>(tag);
         if (val >= 8) {
             // Store the tag in the upper 16 bits of the pointer, as it won't fit in the lower three bits.
@@ -87,7 +91,7 @@ private:
 
         auto maskedPtr = reinterpret_cast<long long>(expr) & PTR_MASK;
 
-        return reinterpret_cast<void *>(maskedPtr | val);
+        return maskedPtr | val;
     }
 
     explicit TreePtr(Tag tag, void *expr) : ptr(tagPtr(tag, expr)) {}
@@ -95,18 +99,18 @@ private:
     static void deleteTagged(Tag tag, void *ptr) noexcept;
 
     // A version of release that doesn't mask the tag bits
-    void *releaseTagged() noexcept {
-        auto *saved = ptr;
-        ptr = nullptr;
+    long long releaseTagged() noexcept {
+        auto saved = ptr;
+        ptr = 0;
         return saved;
     }
 
     // A version of reset that expects the tagged bits to be set.
-    void resetTagged(void *expr) noexcept {
+    void resetTagged(tagged_storage expr) noexcept {
         Tag tagVal;
         void *saved = nullptr;
 
-        if (ptr != nullptr) {
+        if (ptr != 0) {
             tagVal = tag();
             saved = get();
         }
@@ -119,16 +123,16 @@ private:
     }
 
 public:
-    constexpr TreePtr() noexcept : ptr(nullptr) {}
+    constexpr TreePtr() noexcept : ptr(0) {}
 
     TreePtr(std::nullptr_t) noexcept : TreePtr() {}
 
     // Construction from a tagged pointer. This is needed for:
     // * ResolveConstantsWalk::isFullyResolved
-    explicit TreePtr(void *ptr) : ptr(ptr) {}
+    explicit TreePtr(tagged_storage ptr) : ptr(ptr) {}
 
     ~TreePtr() {
-        if (ptr != nullptr) {
+        if (ptr != 0) {
             deleteTagged(tag(), get());
         }
     }
@@ -136,7 +140,7 @@ public:
     TreePtr(const TreePtr &) = delete;
     TreePtr &operator=(const TreePtr &) = delete;
 
-    TreePtr(TreePtr &&other) noexcept : ptr(nullptr) {
+    TreePtr(TreePtr &&other) noexcept {
         ptr = other.releaseTagged();
     }
 
@@ -151,16 +155,16 @@ public:
 
     void *release() noexcept {
         auto *saved = get();
-        ptr = nullptr;
+        ptr = 0;
         return saved;
     }
 
     void reset() noexcept {
-        resetTagged(nullptr);
+        resetTagged(0);
     }
 
     void reset(std::nullptr_t) noexcept {
-        resetTagged(nullptr);
+        resetTagged(0);
     }
 
     template <typename T> void reset(T *expr = nullptr) noexcept {
@@ -168,7 +172,7 @@ public:
     }
 
     Tag tag() const noexcept {
-        ENFORCE(ptr != nullptr);
+        ENFORCE(ptr != 0);
 
         auto value = reinterpret_cast<long long>(ptr) & TAG_MASK;
         if (value <= 7) {
@@ -179,15 +183,19 @@ public:
     }
 
     Expression *get() const noexcept {
-        auto val = reinterpret_cast<long long>(ptr) & PTR_MASK;
+        auto val = ptr & PTR_MASK;
 
-        // sign extension for the upper 16 bits
-        return reinterpret_cast<Expression *>((val << 16) >> 16);
+        if constexpr (sizeof(void *) == 4) {
+            return reinterpret_cast<Expression *>(val);
+        } else {
+            // sign extension for the upper 16 bits
+            return reinterpret_cast<Expression *>((val << 16) >> 16);
+        }
     }
 
     // Fetch the tagged pointer. This is needed for:
     // * ResolveConstantsWalk::isFullyResolved
-    void *getTagged() const noexcept {
+    tagged_storage getTagged() const noexcept {
         return ptr;
     }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Switch to storing a `long long` value in `TreePtr` instead of `void *`, as pointers are 4-bytes in emscripten.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fix issues with pointer size on emscripten that resulted from the tagged pointers PR #3181.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
