### PR TITLE
Remove Singleton / final! from T::Enum DSL

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -458,6 +458,10 @@ string ClassDef::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
                    this->symbol.dataAllowingNone(gs)->name.data(gs)->toString(gs));
     printArgs(gs, buf, this->ancestors, tabs);
 
+    if (this->rhs.empty()) {
+        fmt::format_to(buf, "{}", '\n');
+    }
+
     for (auto &a : this->rhs) {
         fmt::format_to(buf, "{}", '\n');
         printTabs(buf, tabs + 1);

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -196,6 +196,15 @@ bool Name::isClassName(const GlobalState &gs) const {
     }
 }
 
+bool Name::isTEnumName(const GlobalState &gs) const {
+    if (this->kind != NameKind::CONSTANT) {
+        return false;
+    }
+    auto original = this->cnst.original;
+    return original.data(gs)->kind == NameKind::UNIQUE &&
+           original.data(gs)->unique.uniqueNameKind == UniqueNameKind::TEnum;
+}
+
 NameRefDebugCheck::NameRefDebugCheck(const GlobalState &gs, int _id) {
     // store the globalStateId of the creating global state to allow sharing refs between siblings
     // when the ref refers to a name in the common ancestor

--- a/core/Names.h
+++ b/core/Names.h
@@ -97,6 +97,11 @@ public:
     bool operator!=(const Name &rhs) const;
     bool isClassName(const GlobalState &gs) const;
 
+    // Convenience method, because enums need to be special cased in more places than other kinds of
+    // unique names, and everyone always forget to unwrap the first layer (NameKind::CONSTANT)
+    // before checking for UniqueNameKind::TEnum.
+    bool isTEnumName(const GlobalState &gs) const;
+
     std::string showRaw(const GlobalState &gs) const;
     std::string toString(const GlobalState &gs) const;
     std::string show(const GlobalState &gs) const;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -335,15 +335,6 @@ void Environment::clearKnowledge(core::Context ctx, core::LocalVariable reassign
 
 namespace {
 
-bool isTEnumName(core::Context ctx, core::NameRef name) {
-    if (name.data(ctx)->kind != core::NameKind::CONSTANT) {
-        return false;
-    }
-    auto original = name.data(ctx)->cnst.original;
-    return original.data(ctx)->kind == core::NameKind::UNIQUE &&
-           original.data(ctx)->unique.uniqueNameKind == core::UniqueNameKind::TEnum;
-}
-
 // A singleton is a class which is inhabited by a single value.
 //
 // If a variable != a value whose type is a singleton, then that variable's type must not be that value's type.
@@ -358,7 +349,7 @@ bool isSingleton(core::Context ctx, core::SymbolRef sym) {
     }
 
     // T::Enum values are modeled as singletons of their own fake class.
-    if (isTEnumName(ctx, sym.data(ctx)->name)) {
+    if (sym.data(ctx)->name.data(ctx)->isTEnumName(ctx)) {
         return true;
     }
 

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -619,12 +619,6 @@ unique_ptr<CompletionItem> trySuggestSig(LSPTypecheckerDelegate &typechecker,
     return item;
 }
 
-bool isTEnumName(const core::GlobalState &gs, core::NameRef name) {
-    auto original = name.data(gs)->cnst.original;
-    return original.data(gs)->kind == core::NameKind::UNIQUE &&
-           original.data(gs)->unique.uniqueNameKind == core::UniqueNameKind::TEnum;
-}
-
 bool isSimilarConstant(const core::GlobalState &gs, string_view prefix, core::SymbolRef sym) {
     if (!sym.exists()) {
         return false;
@@ -639,7 +633,7 @@ bool isSimilarConstant(const core::GlobalState &gs, string_view prefix, core::Sy
         return false;
     }
 
-    if (isTEnumName(gs, name)) {
+    if (name.data(gs)->isTEnumName(gs)) {
         // Every T::Enum value gets a class with the ~same name (see rewriter/TEnum.cc for details).
         // This manifests as showing two completion results when we should only show one, so skip the bad kind.
         return false;

--- a/test/cli/cache-keeps-print-options/cache-keeps-print-options.out
+++ b/test/cli/cache-keeps-print-options/cache-keeps-print-options.out
@@ -29,14 +29,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C CCCCCCCCC><<C <todo sym>>> < (::<todo sym>)  end
+  class <emptyTree>::<C CCCCCCCCC><<C <todo sym>>> < (::<todo sym>)
+  end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C CCCCCCCCC><<C <todo sym>>> < (::<todo sym>)  end
+  class <emptyTree>::<C CCCCCCCCC><<C <todo sym>>> < (::<todo sym>)
+  end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C CCCCCCCCC><<C <todo sym>>> < (::<todo sym>)  end
+  class <emptyTree>::<C CCCCCCCCC><<C <todo sym>>> < (::<todo sym>)
+  end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C CCCCCCCCC><<C <todo sym>>> < (::<todo sym>)  end
+  class <emptyTree>::<C CCCCCCCCC><<C <todo sym>>> < (::<todo sym>)
+  end
 end

--- a/test/testdata/rewriter/class_new.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/class_new.rb.rewrite-tree.exp
@@ -27,7 +27,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   <emptyTree>::<C T>.reveal_type(<emptyTree>::<C B>.new().bar())
 
-  module <emptyTree>::<C M><<C <todo sym>>> < ()  end
+  module <emptyTree>::<C M><<C <todo sym>>> < ()
+  end
 
   class <emptyTree>::<C C><<C <todo sym>>> < (::<todo sym>)
     <self>.include(<emptyTree>::<C M>)
@@ -50,10 +51,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C D>.qux()
 
   module <emptyTree>::<C Top><<C <todo sym>>> < ()
-    class <emptyTree>::<C Parent><<C <todo sym>>> < (::<todo sym>)    end
+    class <emptyTree>::<C Parent><<C <todo sym>>> < (::<todo sym>)
+    end
   end
 
-  class <emptyTree>::<C E><<C <todo sym>>> < (<emptyTree>::<C Top>::<C Parent>)  end
+  class <emptyTree>::<C E><<C <todo sym>>> < (<emptyTree>::<C Top>::<C Parent>)
+  end
 
   <emptyTree>::<C T>.let(<emptyTree>::<C E>.new(), <emptyTree>::<C Top>::<C Parent>)
 end

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -218,7 +218,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       begin
-        class <emptyTree>::<C <describe 'nobody should write this but we should still parse it'>><<C <todo sym>>> < (<self>)        end
+        class <emptyTree>::<C <describe 'nobody should write this but we should still parse it'>><<C <todo sym>>> < (<self>)
+        end
         begin
           "contains nested describes"
           ::Sorbet::Private::Static.keep_def(<self>, :"<it \'contains nested describes\'>")
@@ -230,6 +231,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   ::Sorbet::Private::Static.keep_def(<self>, :"junk")
 
   module <emptyTree>::<C Mod><<C <todo sym>>> < ()
-    class <emptyTree>::<C C><<C <todo sym>>> < (::<todo sym>)    end
+    class <emptyTree>::<C C><<C <todo sym>>> < (::<todo sym>)
+    end
   end
 end

--- a/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
@@ -7,7 +7,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     ::Sorbet::Private::Static.keep_def(<self>, :"foo")
   end
 
-  class <emptyTree>::<C Child><<C <todo sym>>> < (<emptyTree>::<C Parent>)  end
+  class <emptyTree>::<C Child><<C <todo sym>>> < (<emptyTree>::<C Parent>)
+  end
 
   class <emptyTree>::<C MyTest><<C <todo sym>>> < (::<todo sym>)
     def outside_method<<C <todo sym>>>(&<blk>)

--- a/test/testdata/rewriter/prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree.exp
@@ -130,7 +130,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     ::Sorbet::Private::Static.keep_def(<self>, :"foo2=")
   end
 
-  class <emptyTree>::<C ForeignClass><<C <todo sym>>> < (::<todo sym>)  end
+  class <emptyTree>::<C ForeignClass><<C <todo sym>>> < (::<todo sym>)
+  end
 
   class <emptyTree>::<C AdvancedODM><<C <todo sym>>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||

--- a/test/testdata/rewriter/struct.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/struct.rb.rewrite-tree.exp
@@ -2,7 +2,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <self>.require_relative("../../t")
 
   module <emptyTree>::<C Foo><<C <todo sym>>> < ()
-    class <emptyTree>::<C Struct><<C <todo sym>>> < (::<todo sym>)    end
+    class <emptyTree>::<C Struct><<C <todo sym>>> < (::<todo sym>)
+    end
   end
 
   class <emptyTree>::<C NotStruct><<C <todo sym>>> < (::<todo sym>)
@@ -264,7 +265,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C AccidentallyStruct><<C <todo sym>>> < (::<todo sym>)
-    class <emptyTree>::<C Struct><<C <todo sym>>> < (::<todo sym>)    end
+    class <emptyTree>::<C Struct><<C <todo sym>>> < (::<todo sym>)
+    end
 
     class <emptyTree>::<C A><<C <todo sym>>> < (::<root>::<C Struct>)
       def foo<<C <todo sym>>>(&<blk>)

--- a/test/testdata/rewriter/t_enum_snapshot.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_enum_snapshot.rb.rewrite-tree.exp
@@ -7,34 +7,19 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.sealed!()
 
     class <emptyTree>::<C X$1><<C <todo sym>>> < (<emptyTree>::<C MyEnum>)
-      <self>.include(::Singleton)
-
-      <self>.final!()
     end
 
-    ::<Magic>.<self-new>(<self>)
-
-    <emptyTree>::<C X> = ::T.let(<emptyTree>::<C X$1>.instance(), <emptyTree>::<C X$1>)
+    <emptyTree>::<C X> = ::T.let(<emptyTree>::<C X$1>.new(), <emptyTree>::<C X$1>)
 
     class <emptyTree>::<C Y$1><<C <todo sym>>> < (<emptyTree>::<C MyEnum>)
-      <self>.include(::Singleton)
-
-      <self>.final!()
     end
 
-    ::<Magic>.<self-new>(<self>, "y")
-
-    <emptyTree>::<C Y> = ::T.let(<emptyTree>::<C Y$1>.instance(), <emptyTree>::<C Y$1>)
+    <emptyTree>::<C Y> = ::T.let(<emptyTree>::<C Y$1>.new("y"), <emptyTree>::<C Y$1>)
 
     class <emptyTree>::<C Z$1><<C <todo sym>>> < (<emptyTree>::<C MyEnum>)
-      <self>.include(::Singleton)
-
-      <self>.final!()
     end
 
-    <emptyTree>::<C T>.let(::<Magic>.<self-new>(<self>), <self>)
-
-    <emptyTree>::<C Z> = ::T.let(<emptyTree>::<C Z$1>.instance(), <emptyTree>::<C Z$1>)
+    <emptyTree>::<C Z> = ::T.let(<emptyTree>::<C Z$1>.new(<self>), <emptyTree>::<C Z$1>)
   end
 
   class <emptyTree>::<C NotAnEnum><<C <todo sym>>> < (::<todo sym>)
@@ -58,34 +43,19 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.sealed!()
 
     class <emptyTree>::<C X$1><<C <todo sym>>> < (<emptyTree>::<C EnumsDoEnum>)
-      <self>.include(::Singleton)
-
-      <self>.final!()
     end
 
-    ::<Magic>.<self-new>(<self>)
-
-    <emptyTree>::<C X> = ::T.let(<emptyTree>::<C X$1>.instance(), <emptyTree>::<C X$1>)
+    <emptyTree>::<C X> = ::T.let(<emptyTree>::<C X$1>.new(), <emptyTree>::<C X$1>)
 
     class <emptyTree>::<C Y$1><<C <todo sym>>> < (<emptyTree>::<C EnumsDoEnum>)
-      <self>.include(::Singleton)
-
-      <self>.final!()
     end
 
-    ::<Magic>.<self-new>(<self>, "y")
-
-    <emptyTree>::<C Y> = ::T.let(<emptyTree>::<C Y$1>.instance(), <emptyTree>::<C Y$1>)
+    <emptyTree>::<C Y> = ::T.let(<emptyTree>::<C Y$1>.new("y"), <emptyTree>::<C Y$1>)
 
     class <emptyTree>::<C Z$1><<C <todo sym>>> < (<emptyTree>::<C EnumsDoEnum>)
-      <self>.include(::Singleton)
-
-      <self>.final!()
     end
 
-    <emptyTree>::<C T>.let(::<Magic>.<self-new>(<self>), <self>)
-
-    <emptyTree>::<C Z> = ::T.let(<emptyTree>::<C Z$1>.instance(), <emptyTree>::<C Z$1>)
+    <emptyTree>::<C Z> = ::T.let(<emptyTree>::<C Z$1>.new(<self>), <emptyTree>::<C Z$1>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :"something_outside")
   end
@@ -98,38 +68,23 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.sealed!()
 
     class <emptyTree>::<C Before$1><<C <todo sym>>> < (<emptyTree>::<C BadConsts>)
-      <self>.include(::Singleton)
-
-      <self>.final!()
     end
 
-    ::<Magic>.<self-new>(<self>)
-
-    <emptyTree>::<C Before> = ::T.let(<emptyTree>::<C Before$1>.instance(), <emptyTree>::<C Before$1>)
+    <emptyTree>::<C Before> = ::T.let(<emptyTree>::<C Before$1>.new(), <emptyTree>::<C Before$1>)
 
     <emptyTree>::<C StaticField1> = 1
 
     class <emptyTree>::<C Inside$1><<C <todo sym>>> < (<emptyTree>::<C BadConsts>)
-      <self>.include(::Singleton)
-
-      <self>.final!()
     end
 
-    ::<Magic>.<self-new>(<self>)
-
-    <emptyTree>::<C Inside> = ::T.let(<emptyTree>::<C Inside$1>.instance(), <emptyTree>::<C Inside$1>)
+    <emptyTree>::<C Inside> = ::T.let(<emptyTree>::<C Inside$1>.new(), <emptyTree>::<C Inside$1>)
 
     <emptyTree>::<C StaticField2> = 2
 
     class <emptyTree>::<C After$1><<C <todo sym>>> < (<emptyTree>::<C BadConsts>)
-      <self>.include(::Singleton)
-
-      <self>.final!()
     end
 
-    ::<Magic>.<self-new>(<self>)
-
-    <emptyTree>::<C After> = ::T.let(<emptyTree>::<C After$1>.instance(), <emptyTree>::<C After$1>)
+    <emptyTree>::<C After> = ::T.let(<emptyTree>::<C After$1>.new(), <emptyTree>::<C After$1>)
 
     <emptyTree>::<C StaticField3> = 3
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->



## Commit summary

Review by commit to make the diff to the exp files nicer.



- **Remove Singleton / final! from T::Enum DSL** (8a484a3df)

  It's more convenient to just special case classes with T::Enum names in
  `isSingleton` than it is to deal with Singleton.

  (e.g., MySingleton.instance doesn't forward args to the parent, so we
  had that hack where we left a call to the original `new` around in the
  tree to be sure that it would be type checked)

  By not using `include Singleton` and `final!`, we don't have to
  compromise quite as much.

  This also means that it's no longer the case that

      MyEnum::A.is_a?(Singleton)

  which was an awkward relic of the old desugaring.

- **Change how empty trees are printed** (f4e453f05)

  After the last change, I realize that we're pretty-printing trees in a
  slightly weird way when a ClassDef's rhs is empty, so I added a special
  case to make them prettier.

  It's also useful to have this because it makes the diff to the T::Enum
  snapshots smaller.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.