### PR TITLE
Use a switch in treemap instead of isa_tree

### DIFF
--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -620,52 +620,100 @@ private:
                     ctx, std::move(what), func);
             }
 
-            if (isa_tree<EmptyTree>(what) || isa_tree<ZSuperArgs>(what)) {
-                return what;
-            }
+            switch (what.tag()) {
+                case Tag::EmptyTree:
+                    return what;
 
-            if (isa_tree<UnresolvedConstantLit>(what)) {
-                return mapUnresolvedConstantLit(std::move(what), ctx);
-            } else if (isa_tree<ConstantLit>(what)) {
-                return mapConstantLit(std::move(what), ctx);
-            } else if (isa_tree<Send>(what)) {
-                return mapSend(std::move(what), ctx);
-            } else if (isa_tree<Literal>(what)) {
-                return mapLiteral(std::move(what), ctx);
-            } else if (isa_tree<UnresolvedIdent>(what)) {
-                return mapUnresolvedIdent(std::move(what), ctx);
-            } else if (isa_tree<Local>(what)) {
-                return mapLocal(std::move(what), ctx);
-            } else if (isa_tree<MethodDef>(what)) {
-                return mapMethodDef(std::move(what), ctx);
-            } else if (isa_tree<InsSeq>(what)) {
-                return mapInsSeq(std::move(what), ctx);
-            } else if (isa_tree<Hash>(what)) {
-                return mapHash(std::move(what), ctx);
-            } else if (isa_tree<ClassDef>(what)) {
-                return mapClassDef(std::move(what), ctx);
-            } else if (isa_tree<If>(what)) {
-                return mapIf(std::move(what), ctx);
-            } else if (isa_tree<While>(what)) {
-                return mapWhile(std::move(what), ctx);
-            } else if (isa_tree<Break>(what)) {
-                return mapBreak(std::move(what), ctx);
-            } else if (isa_tree<Retry>(what)) {
-                return mapRetry(std::move(what), ctx);
-            } else if (isa_tree<Next>(what)) {
-                return mapNext(std::move(what), ctx);
-            } else if (isa_tree<Return>(what)) {
-                return mapReturn(std::move(what), ctx);
-            } else if (isa_tree<Rescue>(what)) {
-                return mapRescue(std::move(what), ctx);
-            } else if (isa_tree<Assign>(what)) {
-                return mapAssign(std::move(what), ctx);
-            } else if (isa_tree<Array>(what)) {
-                return mapArray(std::move(what), ctx);
-            } else if (isa_tree<Cast>(what)) {
-                return mapCast(std::move(what), ctx);
-            } else {
-                Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                case Tag::Send:
+                    return mapSend(std::move(what), ctx);
+
+                case Tag::ClassDef:
+                    return mapClassDef(std::move(what), ctx);
+
+                case Tag::MethodDef:
+                    return mapMethodDef(std::move(what), ctx);
+
+                case Tag::If:
+                    return mapIf(std::move(what), ctx);
+
+                case Tag::While:
+                    return mapWhile(std::move(what), ctx);
+
+                case Tag::Break:
+                    return mapBreak(std::move(what), ctx);
+
+                case Tag::Retry:
+                    return mapRetry(std::move(what), ctx);
+
+                case Tag::Next:
+                    return mapNext(std::move(what), ctx);
+
+                case Tag::Return:
+                    return mapReturn(std::move(what), ctx);
+
+                case Tag::RescueCase:
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    break;
+
+                case Tag::Rescue:
+                    return mapRescue(std::move(what), ctx);
+
+                case Tag::Local:
+                    return mapLocal(std::move(what), ctx);
+
+                case Tag::UnresolvedIdent:
+                    return mapUnresolvedIdent(std::move(what), ctx);
+
+                case Tag::RestArg:
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    break;
+
+                case Tag::KeywordArg:
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    break;
+
+                case Tag::OptionalArg:
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    break;
+
+                case Tag::BlockArg:
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    break;
+
+                case Tag::ShadowArg:
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    break;
+
+                case Tag::Assign:
+                    return mapAssign(std::move(what), ctx);
+
+                case Tag::Cast:
+                    return mapCast(std::move(what), ctx);
+
+                case Tag::Hash:
+                    return mapHash(std::move(what), ctx);
+
+                case Tag::Array:
+                    return mapArray(std::move(what), ctx);
+
+                case Tag::Literal:
+                    return mapLiteral(std::move(what), ctx);
+
+                case Tag::UnresolvedConstantLit:
+                    return mapUnresolvedConstantLit(std::move(what), ctx);
+
+                case Tag::ConstantLit:
+                    return mapConstantLit(std::move(what), ctx);
+
+                case Tag::ZSuperArgs:
+                    return what;
+
+                case Tag::Block:
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    break;
+
+                case Tag::InsSeq:
+                    return mapInsSeq(std::move(what), ctx);
             }
         } catch (SorbetException &e) {
             Exception::failInFuzzer();
@@ -673,7 +721,7 @@ private:
             throw ReportedRubyException{e, loc};
         }
     }
-};
+}; // namespace sorbet::ast
 
 class TreeMap {
 public:
@@ -1068,52 +1116,100 @@ private:
                     ctx, std::move(what), func);
             }
 
-            if (isa_tree<EmptyTree>(what) || isa_tree<ZSuperArgs>(what)) {
-                return what;
-            }
+            switch (what.tag()) {
+                case Tag::EmptyTree:
+                    return what;
 
-            if (isa_tree<UnresolvedConstantLit>(what)) {
-                return mapUnresolvedConstantLit(std::move(what), ctx);
-            } else if (isa_tree<ConstantLit>(what)) {
-                return mapConstantLit(std::move(what), ctx);
-            } else if (isa_tree<Send>(what)) {
-                return mapSend(std::move(what), ctx);
-            } else if (isa_tree<Literal>(what)) {
-                return mapLiteral(std::move(what), ctx);
-            } else if (UnresolvedIdent *u = cast_tree<UnresolvedIdent>(what)) {
-                return mapUnresolvedIdent(std::move(what), ctx);
-            } else if (isa_tree<Local>(what)) {
-                return mapLocal(std::move(what), ctx);
-            } else if (isa_tree<MethodDef>(what)) {
-                return mapMethodDef(std::move(what), ctx);
-            } else if (isa_tree<InsSeq>(what)) {
-                return mapInsSeq(std::move(what), ctx);
-            } else if (isa_tree<Hash>(what)) {
-                return mapHash(std::move(what), ctx);
-            } else if (isa_tree<ClassDef>(what)) {
-                return mapClassDef(std::move(what), ctx);
-            } else if (isa_tree<If>(what)) {
-                return mapIf(std::move(what), ctx);
-            } else if (isa_tree<While>(what)) {
-                return mapWhile(std::move(what), ctx);
-            } else if (isa_tree<Break>(what)) {
-                return mapBreak(std::move(what), ctx);
-            } else if (isa_tree<Retry>(what)) {
-                return mapRetry(std::move(what), ctx);
-            } else if (isa_tree<Next>(what)) {
-                return mapNext(std::move(what), ctx);
-            } else if (isa_tree<Return>(what)) {
-                return mapReturn(std::move(what), ctx);
-            } else if (isa_tree<Rescue>(what)) {
-                return mapRescue(std::move(what), ctx);
-            } else if (isa_tree<Assign>(what)) {
-                return mapAssign(std::move(what), ctx);
-            } else if (isa_tree<Array>(what)) {
-                return mapArray(std::move(what), ctx);
-            } else if (isa_tree<Cast>(what)) {
-                return mapCast(std::move(what), ctx);
-            } else {
-                Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                case Tag::Send:
+                    return mapSend(std::move(what), ctx);
+
+                case Tag::ClassDef:
+                    return mapClassDef(std::move(what), ctx);
+
+                case Tag::MethodDef:
+                    return mapMethodDef(std::move(what), ctx);
+
+                case Tag::If:
+                    return mapIf(std::move(what), ctx);
+
+                case Tag::While:
+                    return mapWhile(std::move(what), ctx);
+
+                case Tag::Break:
+                    return mapBreak(std::move(what), ctx);
+
+                case Tag::Retry:
+                    return mapRetry(std::move(what), ctx);
+
+                case Tag::Next:
+                    return mapNext(std::move(what), ctx);
+
+                case Tag::Return:
+                    return mapReturn(std::move(what), ctx);
+
+                case Tag::RescueCase:
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    break;
+
+                case Tag::Rescue:
+                    return mapRescue(std::move(what), ctx);
+
+                case Tag::Local:
+                    return mapLocal(std::move(what), ctx);
+
+                case Tag::UnresolvedIdent:
+                    return mapUnresolvedIdent(std::move(what), ctx);
+
+                case Tag::RestArg:
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    break;
+
+                case Tag::KeywordArg:
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    break;
+
+                case Tag::OptionalArg:
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    break;
+
+                case Tag::BlockArg:
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    break;
+
+                case Tag::ShadowArg:
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    break;
+
+                case Tag::Assign:
+                    return mapAssign(std::move(what), ctx);
+
+                case Tag::Cast:
+                    return mapCast(std::move(what), ctx);
+
+                case Tag::Hash:
+                    return mapHash(std::move(what), ctx);
+
+                case Tag::Array:
+                    return mapArray(std::move(what), ctx);
+
+                case Tag::Literal:
+                    return mapLiteral(std::move(what), ctx);
+
+                case Tag::UnresolvedConstantLit:
+                    return mapUnresolvedConstantLit(std::move(what), ctx);
+
+                case Tag::ConstantLit:
+                    return mapConstantLit(std::move(what), ctx);
+
+                case Tag::ZSuperArgs:
+                    return what;
+
+                case Tag::Block:
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    break;
+
+                case Tag::InsSeq:
+                    return mapInsSeq(std::move(what), ctx);
             }
         } catch (SorbetException &e) {
             Exception::failInFuzzer();


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
`isa_tree` does a null check in addition to a tag check, which likely blocks optimizations for comparisons to enum values. This PR changes from a chained if-then-else to a switch on the tree tag instaead.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Performance.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
