### PR TITLE
Only make one EmptyTree value

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -47,7 +47,7 @@ void TreePtr::deleteTagged(Tag tag, void *ptr) noexcept {
 
     switch (tag) {
         case Tag::EmptyTree:
-            delete reinterpret_cast<EmptyTree *>(ptr);
+            // explicitly not deleting the empty tree pointer
             break;
 
         case Tag::Send:
@@ -410,6 +410,18 @@ InsSeq::InsSeq(core::LocOffsets loc, STATS_store stats, TreePtr expr)
 EmptyTree::EmptyTree() : Expression(core::LocOffsets::none()) {
     categoryCounterInc("trees", "emptytree");
     _sanityCheck();
+}
+
+namespace {
+
+EmptyTree singletonEmptyTree{};
+
+} // namespace
+
+template <> TreePtr make_tree<EmptyTree>() {
+    TreePtr result = nullptr;
+    result.reset(&singletonEmptyTree);
+    return result;
 }
 
 namespace {

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -868,6 +868,9 @@ private:
 };
 CheckSize(EmptyTree, 16, 8);
 
+// This specialization of make_tree exists to ensure that we only ever create one empty tree.
+template <> TreePtr make_tree<EmptyTree>();
+
 /** https://git.corp.stripe.com/gist/nelhage/51564501674174da24822e60ad770f64
  *
  *  [] - prototype only


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
We don't track location information for `EmptyTree`, and the tagged pointers change makes it easier to only construct a single EmptyTree value that we reuse for all instances.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Performance; less memory will be used as we're only ever making a single `EmptyTree` value.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
