### PR TITLE
Fix sorbet.run crash

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -414,9 +414,7 @@ EmptyTree::EmptyTree() : Expression(core::LocOffsets::none()) {
 
 namespace {
 
-// NOTE: the EmptyTree singleton is explicitly aligned on a 8-byte boundary, to preserve the assumptions of TreePtr when
-// building with emscripten for sorbet.run.
-__attribute__((aligned(8))) EmptyTree singletonEmptyTree{};
+EmptyTree singletonEmptyTree{};
 
 } // namespace
 

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -414,7 +414,9 @@ EmptyTree::EmptyTree() : Expression(core::LocOffsets::none()) {
 
 namespace {
 
-EmptyTree singletonEmptyTree{};
+// NOTE: the EmptyTree singleton is explicitly aligned on a 8-byte boundary, to preserve the assumptions of TreePtr when
+// building with emscripten for sorbet.run.
+__attribute__((aligned(8))) EmptyTree singletonEmptyTree{};
 
 } // namespace
 

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -323,7 +323,7 @@ CheckSize(Declaration, 32, 8);
     class name;                                                                     \
     template <> struct TreeToTag<name> { static constexpr Tag value = Tag::name; }; \
     template <> struct TagToTree<Tag::name> { using value = name; };                \
-    class name final
+    class __attribute__((aligned(8))) name final
 
 TREE(ClassDef) : public Declaration {
 public:


### PR DESCRIPTION
The singleton EmptyTree wasn't allocated on an 8-byte boundary when building with emscripten, which breaks the assumptions of TreePtr. This change adds an alignment attribute to the singleton, which fixes the problem.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fix sorbet.run

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
