### PR TITLE
Collect T::Enum stats into enums do block

### DIFF
--- a/test/testdata/rewriter/t_enum_snapshot.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_enum_snapshot.rb.rewrite-tree.exp
@@ -6,20 +6,20 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.sealed!()
 
-    class <emptyTree>::<C X$1><<C <todo sym>>> < (<emptyTree>::<C MyEnum>)
+    <self>.enums() do ||
+      begin
+        class <emptyTree>::<C X$1><<C <todo sym>>> < (<emptyTree>::<C MyEnum>)
+        end
+        <emptyTree>::<C X> = ::T.let(<emptyTree>::<C X$1>.new(), <emptyTree>::<C X$1>)
+        class <emptyTree>::<C Y$1><<C <todo sym>>> < (<emptyTree>::<C MyEnum>)
+        end
+        <emptyTree>::<C Y> = ::T.let(<emptyTree>::<C Y$1>.new("y"), <emptyTree>::<C Y$1>)
+        class <emptyTree>::<C Z$1><<C <todo sym>>> < (<emptyTree>::<C MyEnum>)
+        end
+        <emptyTree>::<C Z> = ::T.let(<emptyTree>::<C Z$1>.new(<self>), <emptyTree>::<C Z$1>)
+        nil
+      end
     end
-
-    <emptyTree>::<C X> = ::T.let(<emptyTree>::<C X$1>.new(), <emptyTree>::<C X$1>)
-
-    class <emptyTree>::<C Y$1><<C <todo sym>>> < (<emptyTree>::<C MyEnum>)
-    end
-
-    <emptyTree>::<C Y> = ::T.let(<emptyTree>::<C Y$1>.new("y"), <emptyTree>::<C Y$1>)
-
-    class <emptyTree>::<C Z$1><<C <todo sym>>> < (<emptyTree>::<C MyEnum>)
-    end
-
-    <emptyTree>::<C Z> = ::T.let(<emptyTree>::<C Z$1>.new(<self>), <emptyTree>::<C Z$1>)
   end
 
   class <emptyTree>::<C NotAnEnum><<C <todo sym>>> < (::<todo sym>)
@@ -42,20 +42,20 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.sealed!()
 
-    class <emptyTree>::<C X$1><<C <todo sym>>> < (<emptyTree>::<C EnumsDoEnum>)
+    <self>.enums() do ||
+      begin
+        class <emptyTree>::<C X$1><<C <todo sym>>> < (<emptyTree>::<C EnumsDoEnum>)
+        end
+        <emptyTree>::<C X> = ::T.let(<emptyTree>::<C X$1>.new(), <emptyTree>::<C X$1>)
+        class <emptyTree>::<C Y$1><<C <todo sym>>> < (<emptyTree>::<C EnumsDoEnum>)
+        end
+        <emptyTree>::<C Y> = ::T.let(<emptyTree>::<C Y$1>.new("y"), <emptyTree>::<C Y$1>)
+        class <emptyTree>::<C Z$1><<C <todo sym>>> < (<emptyTree>::<C EnumsDoEnum>)
+        end
+        <emptyTree>::<C Z> = ::T.let(<emptyTree>::<C Z$1>.new(<self>), <emptyTree>::<C Z$1>)
+        nil
+      end
     end
-
-    <emptyTree>::<C X> = ::T.let(<emptyTree>::<C X$1>.new(), <emptyTree>::<C X$1>)
-
-    class <emptyTree>::<C Y$1><<C <todo sym>>> < (<emptyTree>::<C EnumsDoEnum>)
-    end
-
-    <emptyTree>::<C Y> = ::T.let(<emptyTree>::<C Y$1>.new("y"), <emptyTree>::<C Y$1>)
-
-    class <emptyTree>::<C Z$1><<C <todo sym>>> < (<emptyTree>::<C EnumsDoEnum>)
-    end
-
-    <emptyTree>::<C Z> = ::T.let(<emptyTree>::<C Z$1>.new(<self>), <emptyTree>::<C Z$1>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :"something_outside")
   end
@@ -74,12 +74,15 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <emptyTree>::<C StaticField1> = 1
 
-    class <emptyTree>::<C Inside$1><<C <todo sym>>> < (<emptyTree>::<C BadConsts>)
+    <self>.enums() do ||
+      begin
+        class <emptyTree>::<C Inside$1><<C <todo sym>>> < (<emptyTree>::<C BadConsts>)
+        end
+        <emptyTree>::<C Inside> = ::T.let(<emptyTree>::<C Inside$1>.new(), <emptyTree>::<C Inside$1>)
+        <emptyTree>::<C StaticField2> = 2
+        nil
+      end
     end
-
-    <emptyTree>::<C Inside> = ::T.let(<emptyTree>::<C Inside$1>.new(), <emptyTree>::<C Inside$1>)
-
-    <emptyTree>::<C StaticField2> = 2
 
     class <emptyTree>::<C After$1><<C <todo sym>>> < (<emptyTree>::<C BadConsts>)
     end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Before, we were silently dropping the call to `enums do` that was present
in the original program. This change lets us more accurately model what the
runtime would have done.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.