### PR TITLE
Add Array#initialize signature that takes an Array

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1437,6 +1437,12 @@ class Array < Object
     )
     .void
   end
+  sig do
+    params(
+      arg0: T::Array[Elem],
+    )
+    .void
+  end
   def initialize(arg0=T.unsafe(nil), arg1=T.unsafe(nil)); end
 
   # Inserts the given values before the element with the given `index`.

--- a/test/testdata/rbi/array.rb
+++ b/test/testdata/rbi/array.rb
@@ -1,5 +1,12 @@
 # typed: strict
 
+# initializing with array
+T.assert_type!(T::Array[String].new(['a', 'b', 'c']), T::Array[String])
+#  initializing with size
+T.assert_type!(T::Array[T.nilable(String)].new(3), T::Array[T.nilable(String)])
+#  initializing with size and initial  element
+T.assert_type!(T::Array[String].new(3, 'a'), T::Array[String])
+
 # no arg, no block
 T.assert_type!(T::Array[Float].new.sum, T.any(Float, Integer))
 T.assert_type!([Rational(1, 2)].sum, T.any(Rational, Integer))


### PR DESCRIPTION
Add the version of the signature that allows an `Array` as a parameter to `Array#initialize` (as described in the [ruby docs](https://ruby-doc.org/core-2.5.6/Array.html#method-c-new))

### Motivation
https://github.com/sorbet/sorbet/issues/1913

### Test plan
Added test case(s) in `test/testdata/rbi/array.rb`
