### PR TITLE
Break up symbol table into per-symbol-type tables.

### DIFF
--- a/core/Context.cc
+++ b/core/Context.cc
@@ -105,11 +105,7 @@ GlobalSubstitution::GlobalSubstitution(const GlobalState &from, GlobalState &to,
         if (from.namesUsed() == optionalCommonParent->namesUsed() &&
             from.allSymbolsUsed() == optionalCommonParent->allSymbolsUsed()) {
             ENFORCE(to.namesUsed() >= from.namesUsed());
-            ENFORCE(to.classAndModulesUsed() >= from.classAndModulesUsed());
-            ENFORCE(to.methodsUsed() >= from.methodsUsed());
-            ENFORCE(to.fieldsUsed() >= from.fieldsUsed());
-            ENFORCE(to.typeArgumentsUsed() >= from.typeArgumentsUsed());
-            ENFORCE(to.typeMembersUsed() >= from.typeMembersUsed());
+            ENFORCE(to.allSymbolsUsed() >= from.allSymbolsUsed());
             fastPath = true;
         }
     }

--- a/core/Context.cc
+++ b/core/Context.cc
@@ -103,9 +103,9 @@ GlobalSubstitution::GlobalSubstitution(const GlobalState &from, GlobalState &to,
     fastPath = false;
     if (optionalCommonParent != nullptr) {
         if (from.namesUsed() == optionalCommonParent->namesUsed() &&
-            from.allSymbolsUsed() == optionalCommonParent->allSymbolsUsed()) {
+            from.symbolsUsedTotal() == optionalCommonParent->symbolsUsedTotal()) {
             ENFORCE(to.namesUsed() >= from.namesUsed());
-            ENFORCE(to.allSymbolsUsed() >= from.allSymbolsUsed());
+            ENFORCE(to.symbolsUsedTotal() >= from.symbolsUsedTotal());
             fastPath = true;
         }
     }

--- a/core/Context.cc
+++ b/core/Context.cc
@@ -77,7 +77,11 @@ GlobalSubstitution::GlobalSubstitution(const GlobalState &from, GlobalState &to,
     : toGlobalStateId(to.globalStateId) {
     Timer timeit(to.tracer(), "GlobalSubstitution.new", from.creation);
     ENFORCE(toGlobalStateId != 0, "toGlobalStateId is only used for sanity checks, but should always be set.");
-    ENFORCE(from.symbols.size() == to.symbols.size(), "Can't substitute symbols yet");
+    ENFORCE(from.classAndModules.size() == to.classAndModules.size(), "Can't substitute symbols yet");
+    ENFORCE(from.methods.size() == to.methods.size(), "Can't substitute symbols yet");
+    ENFORCE(from.fields.size() == to.fields.size(), "Can't substitute symbols yet");
+    ENFORCE(from.typeArguments.size() == to.typeArguments.size(), "Can't substitute symbols yet");
+    ENFORCE(from.typeMembers.size() == to.typeMembers.size(), "Can't substitute symbols yet");
 
     const_cast<GlobalState &>(from).sanityCheck();
     {
@@ -99,9 +103,13 @@ GlobalSubstitution::GlobalSubstitution(const GlobalState &from, GlobalState &to,
     fastPath = false;
     if (optionalCommonParent != nullptr) {
         if (from.namesUsed() == optionalCommonParent->namesUsed() &&
-            from.symbolsUsed() == optionalCommonParent->symbolsUsed()) {
+            from.allSymbolsUsed() == optionalCommonParent->allSymbolsUsed()) {
             ENFORCE(to.namesUsed() >= from.namesUsed());
-            ENFORCE(to.symbolsUsed() >= from.symbolsUsed());
+            ENFORCE(to.classAndModulesUsed() >= from.classAndModulesUsed());
+            ENFORCE(to.methodsUsed() >= from.methodsUsed());
+            ENFORCE(to.fieldsUsed() >= from.fieldsUsed());
+            ENFORCE(to.typeArgumentsUsed() >= from.typeArgumentsUsed());
+            ENFORCE(to.typeMembersUsed() >= from.typeMembersUsed());
             fastPath = true;
         }
     }
@@ -139,9 +147,25 @@ GlobalSubstitution::GlobalSubstitution(const GlobalState &from, GlobalState &to,
         }
 
         // Enforce that the symbol tables are the same
-        for (int i = 0; i < from.symbols.size(); ++i) {
-            ENFORCE(substitute(from.symbols[i].name) == from.symbols[i].name);
-            ENFORCE(from.symbols[i].name == to.symbols[i].name);
+        for (int i = 0; i < from.classAndModules.size(); ++i) {
+            ENFORCE(substitute(from.classAndModules[i].name) == from.classAndModules[i].name);
+            ENFORCE(from.classAndModules[i].name == to.classAndModules[i].name);
+        }
+        for (int i = 0; i < from.methods.size(); ++i) {
+            ENFORCE(substitute(from.methods[i].name) == from.methods[i].name);
+            ENFORCE(from.methods[i].name == to.methods[i].name);
+        }
+        for (int i = 0; i < from.fields.size(); ++i) {
+            ENFORCE(substitute(from.fields[i].name) == from.fields[i].name);
+            ENFORCE(from.fields[i].name == to.fields[i].name);
+        }
+        for (int i = 0; i < from.typeArguments.size(); ++i) {
+            ENFORCE(substitute(from.typeArguments[i].name) == from.typeArguments[i].name);
+            ENFORCE(from.typeArguments[i].name == to.typeArguments[i].name);
+        }
+        for (int i = 0; i < from.typeMembers.size(); ++i) {
+            ENFORCE(substitute(from.typeMembers[i].name) == from.typeMembers[i].name);
+            ENFORCE(from.typeMembers[i].name == to.typeMembers[i].name);
         }
     }
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -58,13 +58,12 @@ GlobalState::GlobalState(shared_ptr<ErrorQueue> errorQueue, shared_ptr<lsp::Type
       lspQuery(lsp::Query::noQuery()), epochManager(move(epochManager)) {
     // Empirically determined to be the smallest powers of two larger than the
     // values required by the payload
-    // TODO(jvilk): Update
-    unsigned int maxNameCount = 8192;
-    unsigned int maxClassAndModuleCount = 16384;
-    unsigned int maxMethodCount = 16384;
-    unsigned int maxFieldCount = 16384;
-    unsigned int maxTypeArgumentCount = 16384;
-    unsigned int maxTypeMemberCount = 16384;
+    unsigned int maxNameCount = 32768;
+    unsigned int maxClassAndModuleCount = 8192;
+    unsigned int maxMethodCount = 32768;
+    unsigned int maxFieldCount = 4096;
+    unsigned int maxTypeArgumentCount = 256;
+    unsigned int maxTypeMemberCount = 4096;
 
     names.reserve(maxNameCount);
     classAndModules.reserve(maxClassAndModuleCount);

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1589,7 +1589,7 @@ unsigned int GlobalState::namesUsed() const {
     return names.size();
 }
 
-unsigned int GlobalState::allSymbolsUsed() const {
+unsigned int GlobalState::symbolsUsedTotal() const {
     return classAndModulesUsed() + methodsUsed() + fieldsUsed() + typeArgumentsUsed() + typeMembersUsed();
 }
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -41,7 +41,7 @@ SymbolRef GlobalState::synthesizeClass(NameRef nameId, u4 superclass, bool isMod
     data->setIsModule(isModule);
     data->setSuperClass(SymbolRef(this, SymbolRef::Kind::ClassOrModule, superclass));
 
-    if (symRef.id() > Symbols::root().id()) {
+    if (symRef.classOrModuleIndex() > Symbols::root().classOrModuleIndex()) {
         Symbols::root().dataAllowingNone(*this)->members()[nameId] = symRef;
     }
     return symRef;
@@ -99,7 +99,7 @@ void GlobalState::initEmpty() {
     ENFORCE(id == Symbols::rootSingleton());
     id = synthesizeClass(core::Names::Constants::Todo(), 0);
     ENFORCE(id == Symbols::todo());
-    id = synthesizeClass(core::Names::Constants::Object(), Symbols::BasicObject().id());
+    id = synthesizeClass(core::Names::Constants::Object(), Symbols::BasicObject().classOrModuleIndex());
     ENFORCE(id == Symbols::Object());
     id = synthesizeClass(core::Names::Constants::Integer());
     ENFORCE(id == Symbols::Integer());
@@ -123,7 +123,7 @@ void GlobalState::initEmpty() {
     ENFORCE(id == Symbols::untyped());
     id = synthesizeClass(core::Names::Constants::Opus(), 0, true);
     ENFORCE(id == Symbols::Opus());
-    id = synthesizeClass(core::Names::Constants::T(), Symbols::todo().id(), true);
+    id = synthesizeClass(core::Names::Constants::T(), Symbols::todo().classOrModuleIndex(), true);
     ENFORCE(id == Symbols::T());
     id = synthesizeClass(core::Names::Constants::Class(), 0);
     ENFORCE(id == Symbols::Class());
@@ -691,8 +691,8 @@ void GlobalState::initEmpty() {
     }
 
     // This fills in all the way up to MAX_SYNTHETIC_CLASS_SYMBOLS
-    ENFORCE(classAndModules.size() < Symbols::Proc0().id());
-    while (classAndModules.size() < Symbols::Proc0().id()) {
+    ENFORCE(classAndModules.size() < Symbols::Proc0().classOrModuleIndex());
+    while (classAndModules.size() < Symbols::Proc0().classOrModuleIndex()) {
         string name = absl::StrCat("<RESERVED_", reservedCount, ">");
         synthesizeClass(enterNameConstant(name));
         reservedCount++;
@@ -700,15 +700,15 @@ void GlobalState::initEmpty() {
 
     for (int arity = 0; arity <= Symbols::MAX_PROC_ARITY; ++arity) {
         string name = absl::StrCat("Proc", arity);
-        auto id = synthesizeClass(enterNameConstant(name), Symbols::Proc().id());
-        ENFORCE(id == Symbols::Proc(arity), "Proc creation failed for arity: {} got: {} expected: {}", arity, id.id(),
-                Symbols::Proc(arity).id());
+        auto id = synthesizeClass(enterNameConstant(name), Symbols::Proc().classOrModuleIndex());
+        ENFORCE(id == Symbols::Proc(arity), "Proc creation failed for arity: {} got: {} expected: {}", arity,
+                id.classOrModuleIndex(), Symbols::Proc(arity).classOrModuleIndex());
         id.data(*this)->singletonClass(*this);
     }
 
-    ENFORCE(classAndModules.size() == Symbols::last_synthetic_class_sym().id() + 1,
+    ENFORCE(classAndModules.size() == Symbols::last_synthetic_class_sym().classOrModuleIndex() + 1,
             "Too many synthetic class symbols? have: {} expected: {}", classAndModules.size(),
-            Symbols::last_synthetic_class_sym().id() + 1);
+            Symbols::last_synthetic_class_sym().classOrModuleIndex() + 1);
 
     ENFORCE(methods.size() == Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS,
             "Too many synthetic method symbols? have: {} expected: {}", methods.size(),

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1938,22 +1938,26 @@ unique_ptr<GlobalStateHash> GlobalState::hash() const {
     for (const auto *symbolType : {&this->classAndModules, &this->fields, &this->typeArguments, &this->typeMembers}) {
         counter = 0;
         for (const auto &sym : *symbolType) {
-            hierarchyHash = mix(hierarchyHash, sym.hash(*this));
-            counter++;
-            if (DEBUG_HASHING_TAIL && counter > symbolType->size() - 15) {
-                errorQueue->logger.info("Hashing symbols: {}, {}", hierarchyHash, sym.name.show(*this));
+            if (!sym.ignoreInHashing(*this)) {
+                hierarchyHash = mix(hierarchyHash, sym.hash(*this));
+                counter++;
+                if (DEBUG_HASHING_TAIL && counter > symbolType->size() - 15) {
+                    errorQueue->logger.info("Hashing symbols: {}, {}", hierarchyHash, sym.name.show(*this));
+                }
             }
         }
     }
 
     counter = 0;
     for (const auto &sym : this->methods) {
-        auto &target = methodHashes[NameHash(*this, sym.name.data(*this))];
-        target = mix(target, sym.hash(*this));
-        hierarchyHash = mix(hierarchyHash, sym.methodShapeHash(*this));
-        counter++;
-        if (DEBUG_HASHING_TAIL && counter > this->methods.size() - 15) {
-            errorQueue->logger.info("Hashing symbols: {}, {}", hierarchyHash, sym.name.show(*this));
+        if (!sym.ignoreInHashing(*this)) {
+            auto &target = methodHashes[NameHash(*this, sym.name.data(*this))];
+            target = mix(target, sym.hash(*this));
+            hierarchyHash = mix(hierarchyHash, sym.methodShapeHash(*this));
+            counter++;
+            if (DEBUG_HASHING_TAIL && counter > this->methods.size() - 15) {
+                errorQueue->logger.info("Hashing method symbols: {}, {}", hierarchyHash, sym.name.show(*this));
+            }
         }
     }
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -31,17 +31,17 @@ namespace sorbet::core {
 SymbolRef GlobalState::synthesizeClass(NameRef nameId, u4 superclass, bool isModule) {
     // This can't use enterClass since there is a chicken and egg problem.
     // These will be added to Symbols::root().members later.
-    SymbolRef symRef = SymbolRef(this, symbols.size());
-    symbols.emplace_back();
+    SymbolRef symRef = SymbolRef(this, SymbolRef::Kind::ClassOrModule, classAndModules.size());
+    classAndModules.emplace_back();
     SymbolData data = symRef.dataAllowingNone(*this); // allowing noSymbol is needed because this enters noSymbol.
     data->name = nameId;
     data->owner = Symbols::root();
     data->flags = 0;
     data->setClassOrModule();
     data->setIsModule(isModule);
-    data->setSuperClass(SymbolRef(this, superclass));
+    data->setSuperClass(SymbolRef(this, SymbolRef::Kind::ClassOrModule, superclass));
 
-    if (symRef._id > Symbols::root()._id) {
+    if (symRef.id() > Symbols::root().id()) {
         Symbols::root().dataAllowingNone(*this)->members()[nameId] = symRef;
     }
     return symRef;
@@ -58,11 +58,21 @@ GlobalState::GlobalState(shared_ptr<ErrorQueue> errorQueue, shared_ptr<lsp::Type
       lspQuery(lsp::Query::noQuery()), epochManager(move(epochManager)) {
     // Empirically determined to be the smallest powers of two larger than the
     // values required by the payload
+    // TODO(jvilk): Update
     unsigned int maxNameCount = 8192;
-    unsigned int maxSymbolCount = 16384;
+    unsigned int maxClassAndModuleCount = 16384;
+    unsigned int maxMethodCount = 16384;
+    unsigned int maxFieldCount = 16384;
+    unsigned int maxTypeArgumentCount = 16384;
+    unsigned int maxTypeMemberCount = 16384;
 
     names.reserve(maxNameCount);
-    symbols.reserve(maxSymbolCount);
+    classAndModules.reserve(maxClassAndModuleCount);
+    methods.reserve(maxMethodCount);
+    fields.reserve(maxFieldCount);
+    typeArguments.reserve(maxTypeArgumentCount);
+    typeMembers.reserve(maxTypeMemberCount);
+
     int namesByHashSize = 2 * maxNameCount;
     namesByHash.resize(namesByHashSize);
     ENFORCE((namesByHashSize & (namesByHashSize - 1)) == 0, "namesByHashSize is not a power of 2");
@@ -90,7 +100,7 @@ void GlobalState::initEmpty() {
     ENFORCE(id == Symbols::rootSingleton());
     id = synthesizeClass(core::Names::Constants::Todo(), 0);
     ENFORCE(id == Symbols::todo());
-    id = synthesizeClass(core::Names::Constants::Object(), Symbols::BasicObject()._id);
+    id = synthesizeClass(core::Names::Constants::Object(), Symbols::BasicObject().id());
     ENFORCE(id == Symbols::Object());
     id = synthesizeClass(core::Names::Constants::Integer());
     ENFORCE(id == Symbols::Integer());
@@ -114,7 +124,7 @@ void GlobalState::initEmpty() {
     ENFORCE(id == Symbols::untyped());
     id = synthesizeClass(core::Names::Constants::Opus(), 0, true);
     ENFORCE(id == Symbols::Opus());
-    id = synthesizeClass(core::Names::Constants::T(), Symbols::todo()._id, true);
+    id = synthesizeClass(core::Names::Constants::T(), Symbols::todo().id(), true);
     ENFORCE(id == Symbols::T());
     id = synthesizeClass(core::Names::Constants::Class(), 0);
     ENFORCE(id == Symbols::Class());
@@ -671,9 +681,9 @@ void GlobalState::initEmpty() {
     // Does it in two passes since the singletonClass will go in the Symbols::root() members which will invalidate the
     // iterator
     vector<SymbolRef> needSingletons;
-    for (auto &sym : symbols) {
+    for (auto &sym : classAndModules) {
         auto ref = sym.ref(*this);
-        if (ref.exists() && sym.isClassOrModule()) {
+        if (ref.exists()) {
             needSingletons.emplace_back(ref);
         }
     }
@@ -681,9 +691,9 @@ void GlobalState::initEmpty() {
         sym.data(*this)->singletonClass(*this);
     }
 
-    // This fills in all the way up to MAX_SYNTHETIC_SYMBOLS
-    ENFORCE(symbols.size() < Symbols::Proc0()._id);
-    while (symbols.size() < Symbols::Proc0()._id) {
+    // This fills in all the way up to MAX_SYNTHETIC_CLASS_SYMBOLS
+    ENFORCE(classAndModules.size() < Symbols::Proc0().id());
+    while (classAndModules.size() < Symbols::Proc0().id()) {
         string name = absl::StrCat("<RESERVED_", reservedCount, ">");
         synthesizeClass(enterNameConstant(name));
         reservedCount++;
@@ -691,14 +701,28 @@ void GlobalState::initEmpty() {
 
     for (int arity = 0; arity <= Symbols::MAX_PROC_ARITY; ++arity) {
         string name = absl::StrCat("Proc", arity);
-        auto id = synthesizeClass(enterNameConstant(name), Symbols::Proc()._id);
-        ENFORCE(id == Symbols::Proc(arity), "Proc creation failed for arity: {} got: {} expected: {}", arity, id._id,
-                Symbols::Proc(arity)._id);
+        auto id = synthesizeClass(enterNameConstant(name), Symbols::Proc().id());
+        ENFORCE(id == Symbols::Proc(arity), "Proc creation failed for arity: {} got: {} expected: {}", arity, id.id(),
+                Symbols::Proc(arity).id());
         id.data(*this)->singletonClass(*this);
     }
 
-    ENFORCE(symbols.size() == Symbols::last_synthetic_sym()._id + 1,
-            "Too many synthetic symbols? have: {} expected: {}", symbols.size(), Symbols::last_synthetic_sym()._id + 1);
+    ENFORCE(classAndModules.size() == Symbols::last_synthetic_class_sym().id() + 1,
+            "Too many synthetic class symbols? have: {} expected: {}", classAndModules.size(),
+            Symbols::last_synthetic_class_sym().id() + 1);
+
+    ENFORCE(methods.size() == Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS,
+            "Too many synthetic method symbols? have: {} expected: {}", methods.size(),
+            Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS);
+    ENFORCE(fields.size() == Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS,
+            "Too many synthetic field symbols? have: {} expected: {}", fields.size(),
+            Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS);
+    ENFORCE(typeMembers.size() == Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS,
+            "Too many synthetic typeMember symbols? have: {} expected: {}", typeMembers.size(),
+            Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS);
+    ENFORCE(typeArguments.size() == Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS,
+            "Too many synthetic typeArgument symbols? have: {} expected: {}", typeArguments.size(),
+            Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS);
 
     installIntrinsics();
 
@@ -734,10 +758,10 @@ void GlobalState::installIntrinsics() {
                 symbol = entry.symbol.data(*this)->singletonClass(*this);
                 break;
         }
-        auto countBefore = symbolsUsed();
+        auto countBefore = methodsUsed();
         SymbolRef method = enterMethodSymbol(Loc::none(), symbol, entry.method);
         method.data(*this)->intrinsic = entry.impl;
-        if (countBefore != symbolsUsed()) {
+        if (countBefore != methodsUsed()) {
             auto &blkArg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
             blkArg.flags.isBlock = true;
         }
@@ -757,16 +781,18 @@ u4 nextPowerOfTwo(u4 v) {
 }
 
 void GlobalState::preallocateTables(u4 symbolSize, u4 nameSize) {
-    u4 symbolSizeScaled = nextPowerOfTwo(symbolSize);
+    // u4 symbolSizeScaled = nextPowerOfTwo(symbolSize);
     u4 nameSizeScaled = nextPowerOfTwo(nameSize);
 
     // Note: reserve is a no-op if size is < current capacity.
-    symbols.reserve(symbolSizeScaled);
+    // TODO: FIX
+    // symbols.reserve(symbolSizeScaled);
     expandNames(nameSizeScaled);
     sanityCheck();
 
-    trace(
-        absl::StrCat("Preallocated symbol and name tables. symbols=", symbols.capacity(), " names=", names.capacity()));
+    // trace(
+    //    absl::StrCat("Preallocated symbol and name tables. symbols=", symbols.capacity(), " names=",
+    //    names.capacity()));
 }
 
 constexpr decltype(GlobalState::STRINGS_PAGE_SIZE) GlobalState::STRINGS_PAGE_SIZE;
@@ -882,9 +908,31 @@ SymbolRef GlobalState::enterSymbol(Loc loc, SymbolRef owner, NameRef name, u4 fl
 
     ENFORCE_NO_TIMER(!symbolTableFrozen);
 
-    SymbolRef ret = SymbolRef(this, symbols.size());
-    store = ret; // DO NOT MOVE this assignment down. emplace_back on symbol invalidates `store`
-    symbols.emplace_back();
+    SymbolRef ret;
+    if (flags & Symbol::Flags::CLASS_OR_MODULE) {
+        ret = SymbolRef(this, SymbolRef::Kind::ClassOrModule, classAndModules.size());
+        store = ret; // DO NOT MOVE this assignment down. emplace_back on classAndModules invalidates `store`
+        classAndModules.emplace_back();
+    } else if (flags & Symbol::Flags::METHOD) {
+        ret = SymbolRef(this, SymbolRef::Kind::Method, methods.size());
+        store = ret; // DO NOT MOVE this assignment down. emplace_back on methods invalidates `store`
+        methods.emplace_back();
+    } else if (flags & (Symbol::Flags::FIELD | Symbol::Flags::STATIC_FIELD)) {
+        ret = SymbolRef(this, SymbolRef::Kind::Field, fields.size());
+        store = ret; // DO NOT MOVE this assignment down. emplace_back on fields invalidates `store`
+        fields.emplace_back();
+    } else if (flags & Symbol::Flags::TYPE_ARGUMENT) {
+        ret = SymbolRef(this, SymbolRef::Kind::TypeArgument, typeArguments.size());
+        store = ret; // DO NOT MOVE this assignment down. emplace_back on typeArguments invalidates `store`
+        typeArguments.emplace_back();
+    } else if (flags & Symbol::Flags::TYPE_MEMBER) {
+        ret = SymbolRef(this, SymbolRef::Kind::TypeMember, typeMembers.size());
+        store = ret; // DO NOT MOVE this assignment down. emplace_back on typeMembers invalidates `store`
+        typeMembers.emplace_back();
+    } else {
+        ENFORCE(false);
+    }
+
     SymbolData data = ret.dataAllowingNone(*this);
     data->name = name;
     data->flags = flags;
@@ -1418,8 +1466,24 @@ void GlobalState::mangleRenameSymbol(SymbolRef what, NameRef origName) {
     }
 }
 
-unsigned int GlobalState::symbolsUsed() const {
-    return symbols.size();
+unsigned int GlobalState::classAndModulesUsed() const {
+    return classAndModules.size();
+}
+
+unsigned int GlobalState::methodsUsed() const {
+    return methods.size();
+}
+
+unsigned int GlobalState::fieldsUsed() const {
+    return fields.size();
+}
+
+unsigned int GlobalState::typeArgumentsUsed() const {
+    return typeArguments.size();
+}
+
+unsigned int GlobalState::typeMembersUsed() const {
+    return typeMembers.size();
 }
 
 unsigned int GlobalState::filesUsed() const {
@@ -1428,6 +1492,10 @@ unsigned int GlobalState::filesUsed() const {
 
 unsigned int GlobalState::namesUsed() const {
     return names.size();
+}
+
+unsigned int GlobalState::allSymbolsUsed() const {
+    return classAndModulesUsed() + methodsUsed() + fieldsUsed() + typeArgumentsUsed() + typeMembersUsed();
 }
 
 string GlobalState::toStringWithOptions(bool showFull, bool showRaw) const {
@@ -1461,11 +1529,23 @@ void GlobalState::sanityCheck() const {
     }
 
     i = -1;
-    for (auto &sym : symbols) {
+    for (auto &sym : classAndModules) {
         i++;
         if (i != 0) {
             sym.sanityCheck(*this);
         }
+    }
+    for (auto &sym : methods) {
+        sym.sanityCheck(*this);
+    }
+    for (auto &sym : fields) {
+        sym.sanityCheck(*this);
+    }
+    for (auto &sym : typeArguments) {
+        sym.sanityCheck(*this);
+    }
+    for (auto &sym : typeMembers) {
+        sym.sanityCheck(*this);
     }
     for (auto &ent : namesByHash) {
         if (ent.second == 0) {
@@ -1557,9 +1637,25 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     result->namesByHash.reserve(this->namesByHash.size());
     result->namesByHash = this->namesByHash;
 
-    result->symbols.reserve(this->symbols.capacity());
-    for (auto &sym : this->symbols) {
-        result->symbols.emplace_back(sym.deepCopy(*result, keepId));
+    result->classAndModules.reserve(this->classAndModules.capacity());
+    for (auto &sym : this->classAndModules) {
+        result->classAndModules.emplace_back(sym.deepCopy(*result, keepId));
+    }
+    result->methods.reserve(this->methods.capacity());
+    for (auto &sym : this->methods) {
+        result->methods.emplace_back(sym.deepCopy(*result, keepId));
+    }
+    result->fields.reserve(this->fields.capacity());
+    for (auto &sym : this->fields) {
+        result->fields.emplace_back(sym.deepCopy(*result, keepId));
+    }
+    result->typeArguments.reserve(this->typeArguments.capacity());
+    for (auto &sym : this->typeArguments) {
+        result->typeArguments.emplace_back(sym.deepCopy(*result, keepId));
+    }
+    result->typeMembers.reserve(this->typeMembers.capacity());
+    for (auto &sym : this->typeMembers) {
+        result->typeMembers.emplace_back(sym.deepCopy(*result, keepId));
     }
     result->pathPrefix = this->pathPrefix;
     for (auto &semanticExtension : this->semanticExtensions) {
@@ -1743,19 +1839,23 @@ unique_ptr<GlobalStateHash> GlobalState::hash() const {
     u4 hierarchyHash = 0;
     UnorderedMap<NameHash, u4> methodHashes;
     int counter = 0;
-    for (const auto &sym : this->symbols) {
-        if (!sym.ignoreInHashing(*this)) {
-            if (sym.isMethod()) {
-                auto &target = methodHashes[NameHash(*this, sym.name.data(*this))];
-                target = mix(target, sym.hash(*this));
-                hierarchyHash = mix(hierarchyHash, sym.methodShapeHash(*this));
-            } else {
-                hierarchyHash = mix(hierarchyHash, sym.hash(*this));
+    vector<const vector<Symbol> *> symbolTypes = {&this->classAndModules, &this->methods, &this->fields,
+                                                  &this->typeArguments, &this->typeMembers};
+    for (const auto symbolType : symbolTypes) {
+        for (const auto &sym : *symbolType) {
+            if (!sym.ignoreInHashing(*this)) {
+                if (sym.isMethod()) {
+                    auto &target = methodHashes[NameHash(*this, sym.name.data(*this))];
+                    target = mix(target, sym.hash(*this));
+                    hierarchyHash = mix(hierarchyHash, sym.methodShapeHash(*this));
+                } else {
+                    hierarchyHash = mix(hierarchyHash, sym.hash(*this));
+                }
             }
-        }
-        counter++;
-        if (DEBUG_HASHING_TAIL && counter > symbolsUsed() - 15) {
-            errorQueue->logger.info("Hashing symbols: {}, {}", hierarchyHash, sym.name.show(*this));
+            counter++;
+            if (DEBUG_HASHING_TAIL && counter > classAndModulesUsed() - 15) {
+                errorQueue->logger.info("Hashing symbols: {}, {}", hierarchyHash, sym.name.show(*this));
+            }
         }
     }
     unique_ptr<GlobalStateHash> result = make_unique<GlobalStateHash>();
@@ -1774,9 +1874,9 @@ const vector<shared_ptr<File>> &GlobalState::getFiles() const {
 }
 
 SymbolRef GlobalState::staticInitForClass(SymbolRef klass, Loc loc) {
-    auto prevCount = symbolsUsed();
+    auto prevCount = methodsUsed();
     auto sym = enterMethodSymbol(loc, klass.data(*this)->singletonClass(*this), core::Names::staticInit());
-    if (prevCount != symbolsUsed()) {
+    if (prevCount != methodsUsed()) {
         auto blkLoc = core::Loc::none(loc.file());
         auto &blkSym = enterMethodArgumentSymbol(blkLoc, sym, core::Names::blkArg());
         blkSym.flags.isBlock = true;
@@ -1794,9 +1894,9 @@ SymbolRef GlobalState::lookupStaticInitForClass(SymbolRef klass) const {
 
 SymbolRef GlobalState::staticInitForFile(Loc loc) {
     auto nm = freshNameUnique(core::UniqueNameKind::Namer, core::Names::staticInit(), loc.file().id());
-    auto prevCount = this->symbolsUsed();
+    auto prevCount = this->methodsUsed();
     auto sym = enterMethodSymbol(loc, core::Symbols::rootSingleton(), nm);
-    if (prevCount != this->symbolsUsed()) {
+    if (prevCount != this->methodsUsed()) {
         auto blkLoc = core::Loc::none(loc.file());
         auto &blkSym = this->enterMethodArgumentSymbol(blkLoc, sym, core::Names::blkArg());
         blkSym.flags.isBlock = true;

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -56,23 +56,15 @@ GlobalState::GlobalState(shared_ptr<ErrorQueue> errorQueue)
 GlobalState::GlobalState(shared_ptr<ErrorQueue> errorQueue, shared_ptr<lsp::TypecheckEpochManager> epochManager)
     : globalStateId(globalStateIdCounter.fetch_add(1)), errorQueue(std::move(errorQueue)),
       lspQuery(lsp::Query::noQuery()), epochManager(move(epochManager)) {
-    // Empirically determined to be the smallest powers of two larger than the
-    // values required by the payload
-    unsigned int maxNameCount = 32768;
-    unsigned int maxClassAndModuleCount = 8192;
-    unsigned int maxMethodCount = 32768;
-    unsigned int maxFieldCount = 4096;
-    unsigned int maxTypeArgumentCount = 256;
-    unsigned int maxTypeMemberCount = 4096;
+    // Reserve memory in internal vectors for the contents of payload.
+    names.reserve(PAYLOAD_MAX_NAME_COUNT);
+    classAndModules.reserve(PAYLOAD_MAX_CLASS_AND_MODULE_COUNT);
+    methods.reserve(PAYLOAD_MAX_METHOD_COUNT);
+    fields.reserve(PAYLOAD_MAX_FIELD_COUNT);
+    typeArguments.reserve(PAYLOAD_MAX_TYPE_ARGUMENT_COUNT);
+    typeMembers.reserve(PAYLOAD_MAX_TYPE_MEMBER_COUNT);
 
-    names.reserve(maxNameCount);
-    classAndModules.reserve(maxClassAndModuleCount);
-    methods.reserve(maxMethodCount);
-    fields.reserve(maxFieldCount);
-    typeArguments.reserve(maxTypeArgumentCount);
-    typeMembers.reserve(maxTypeMemberCount);
-
-    int namesByHashSize = 2 * maxNameCount;
+    int namesByHashSize = 2 * PAYLOAD_MAX_NAME_COUNT;
     namesByHash.resize(namesByHashSize);
     ENFORCE((namesByHashSize & (namesByHashSize - 1)) == 0, "namesByHashSize is not a power of 2");
 }

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -780,19 +780,28 @@ u4 nextPowerOfTwo(u4 v) {
     return v;
 }
 
-void GlobalState::preallocateTables(u4 symbolSize, u4 nameSize) {
-    // u4 symbolSizeScaled = nextPowerOfTwo(symbolSize);
+void GlobalState::preallocateTables(u4 classAndModulesSize, u4 methodsSize, u4 fieldsSize, u4 typeArgumentsSize,
+                                    u4 typeMembersSize, u4 nameSize) {
+    u4 classAndModulesSizeScaled = nextPowerOfTwo(classAndModulesSize);
+    u4 methodsSizeScaled = nextPowerOfTwo(methodsSize);
+    u4 fieldsSizeScaled = nextPowerOfTwo(fieldsSize);
+    u4 typeArgumentsSizeScaled = nextPowerOfTwo(typeArgumentsSize);
+    u4 typeMembersSizeScaled = nextPowerOfTwo(typeMembersSize);
     u4 nameSizeScaled = nextPowerOfTwo(nameSize);
 
     // Note: reserve is a no-op if size is < current capacity.
-    // TODO: FIX
-    // symbols.reserve(symbolSizeScaled);
+    classAndModules.reserve(classAndModulesSizeScaled);
+    methods.reserve(methodsSizeScaled);
+    fields.reserve(fieldsSizeScaled);
+    typeArguments.reserve(typeArgumentsSizeScaled);
+    typeMembers.reserve(typeMembersSizeScaled);
     expandNames(nameSizeScaled);
     sanityCheck();
 
-    // trace(
-    //    absl::StrCat("Preallocated symbol and name tables. symbols=", symbols.capacity(), " names=",
-    //    names.capacity()));
+    trace(fmt::format("Preallocated symbol and name tables. classAndModules={} methods={} fields={} typeArguments={} "
+                      "typeMembers={} names={}",
+                      classAndModules.capacity(), methods.capacity(), fields.capacity(), typeArguments.capacity(),
+                      typeMembers.capacity(), names.capacity()));
 }
 
 constexpr decltype(GlobalState::STRINGS_PAGE_SIZE) GlobalState::STRINGS_PAGE_SIZE;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -136,7 +136,7 @@ public:
     unsigned int typeArgumentsUsed() const;
     unsigned int typeMembersUsed() const;
     unsigned int filesUsed() const;
-    unsigned int allSymbolsUsed() const;
+    unsigned int symbolsUsedTotal() const;
 
     void sanityCheck() const;
     void markAsPayload();

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -120,8 +120,13 @@ public:
     spdlog::logger &tracer() const;
     unsigned int namesUsed() const;
 
-    unsigned int symbolsUsed() const;
+    unsigned int classAndModulesUsed() const;
+    unsigned int methodsUsed() const;
+    unsigned int fieldsUsed() const;
+    unsigned int typeArgumentsUsed() const;
+    unsigned int typeMembersUsed() const;
     unsigned int filesUsed() const;
+    unsigned int allSymbolsUsed() const;
 
     void sanityCheck() const;
     void markAsPayload();
@@ -234,7 +239,11 @@ private:
     u2 stringsLastPageUsed = STRINGS_PAGE_SIZE + 1;
     std::vector<Name> names;
     UnorderedMap<std::string, FileRef> fileRefByPath;
-    std::vector<Symbol> symbols;
+    std::vector<Symbol> classAndModules;
+    std::vector<Symbol> methods;
+    std::vector<Symbol> fields;
+    std::vector<Symbol> typeMembers;
+    std::vector<Symbol> typeArguments;
     std::vector<std::pair<unsigned int, unsigned int>> namesByHash;
     std::vector<std::shared_ptr<File>> files;
     UnorderedSet<int> ignoredForSuggestTypedErrorClasses;
@@ -255,7 +264,7 @@ private:
 
     void expandNames(u4 newSize);
 
-    SymbolRef synthesizeClass(NameRef nameID, u4 superclass = Symbols::todo()._id, bool isModule = false);
+    SymbolRef synthesizeClass(NameRef nameID, u4 superclass = Symbols::todo().id(), bool isModule = false);
     SymbolRef enterSymbol(Loc loc, SymbolRef owner, NameRef name, u4 flags);
 
     SymbolRef lookupSymbolSuchThat(SymbolRef owner, NameRef name, std::function<bool(SymbolRef)> pred) const;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -55,7 +55,8 @@ public:
     void installIntrinsics();
 
     // Expand symbol and name tables to the given lengths. Does nothing if the value is <= current capacity.
-    void preallocateTables(u4 symbolSize, u4 nameSize);
+    void preallocateTables(u4 classAndModulesSize, u4 methodsSize, u4 fieldsSize, u4 typeArgumentsSize,
+                           u4 typeMembersSize, u4 nameSize);
 
     GlobalState(const GlobalState &) = delete;
     GlobalState(GlobalState &&) = delete;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -51,6 +51,15 @@ public:
     GlobalState(std::shared_ptr<ErrorQueue> errorQueue);
     GlobalState(std::shared_ptr<ErrorQueue> errorQueue, std::shared_ptr<lsp::TypecheckEpochManager> epochManager);
 
+    // Empirically determined to be the smallest powers of two larger than the
+    // values required by the payload. Enforced in payload.cc.
+    static constexpr unsigned int PAYLOAD_MAX_NAME_COUNT = 32768;
+    static constexpr unsigned int PAYLOAD_MAX_CLASS_AND_MODULE_COUNT = 8192;
+    static constexpr unsigned int PAYLOAD_MAX_METHOD_COUNT = 32768;
+    static constexpr unsigned int PAYLOAD_MAX_FIELD_COUNT = 4096;
+    static constexpr unsigned int PAYLOAD_MAX_TYPE_ARGUMENT_COUNT = 256;
+    static constexpr unsigned int PAYLOAD_MAX_TYPE_MEMBER_COUNT = 4096;
+
     void initEmpty();
     void installIntrinsics();
 

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -266,7 +266,6 @@ private:
     void expandNames(u4 newSize);
 
     SymbolRef synthesizeClass(NameRef nameID, u4 superclass = Symbols::todo().id(), bool isModule = false);
-    SymbolRef enterSymbol(Loc loc, SymbolRef owner, NameRef name, u4 flags);
 
     SymbolRef lookupSymbolSuchThat(SymbolRef owner, NameRef name, std::function<bool(SymbolRef)> pred) const;
     SymbolRef lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 flags) const;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -265,7 +265,8 @@ private:
 
     void expandNames(u4 newSize);
 
-    SymbolRef synthesizeClass(NameRef nameID, u4 superclass = Symbols::todo().id(), bool isModule = false);
+    SymbolRef synthesizeClass(NameRef nameID, u4 superclass = Symbols::todo().classOrModuleIndex(),
+                              bool isModule = false);
 
     SymbolRef lookupSymbolSuchThat(SymbolRef owner, NameRef name, std::function<bool(SymbolRef)> pred) const;
     SymbolRef lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 flags) const;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -103,7 +103,7 @@ public:
 
     bool inline exists() const {
         // 'false' if Kind is ClassOrModule and index is 0, which is SymbolRef::noSymbol.
-        return _id;
+        return _id != 0;
     }
 
     bool isSynthetic() const;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -102,7 +102,7 @@ public:
     }
 
     bool inline exists() const {
-        // 'false' if Kind is ClassOrModule and index is 0, which is SymbolRef::noSymbol.
+        //  ClassOrModule and id are both 0, for SymbolRef::noSymbol.
         return _id != 0;
     }
 

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -486,13 +486,9 @@ public:
         return SymbolRef(nullptr, SymbolRef::Kind::ClassOrModule, 80);
     }
 
-    // 85 is the attached class of VOIDSingleton
-
     static SymbolRef T_Sig_WithoutRuntimeSingleton() {
         return SymbolRef(nullptr, SymbolRef::Kind::ClassOrModule, 81);
     }
-
-    // 87 is the attached class of T_Sig_WithoutRuntimeSingleton
 
     static SymbolRef sigWithoutRuntime() {
         return SymbolRef(nullptr, SymbolRef::Kind::Method, 3);
@@ -525,8 +521,6 @@ public:
     static SymbolRef PackageSpecSingleton() {
         return SymbolRef(nullptr, SymbolRef::Kind::ClassOrModule, 87);
     }
-
-    // 102 is the attached class of PackageSpecSingleton
 
     static SymbolRef PackageSpec_import() {
         return SymbolRef(nullptr, SymbolRef::Kind::Method, 5);

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -515,33 +515,33 @@ public:
     }
 
     static SymbolRef PackageRegistry() {
-        return SymbolRef(nullptr, 99);
+        return SymbolRef(nullptr, SymbolRef::Kind::ClassOrModule, 85);
     }
 
     static SymbolRef PackageSpec() {
-        return SymbolRef(nullptr, 100);
+        return SymbolRef(nullptr, SymbolRef::Kind::ClassOrModule, 86);
     }
 
     static SymbolRef PackageSpecSingleton() {
-        return SymbolRef(nullptr, 101);
+        return SymbolRef(nullptr, SymbolRef::Kind::ClassOrModule, 87);
     }
 
     // 102 is the attached class of PackageSpecSingleton
 
     static SymbolRef PackageSpec_import() {
-        return SymbolRef(nullptr, 103);
+        return SymbolRef(nullptr, SymbolRef::Kind::Method, 5);
     }
 
     static SymbolRef PackageSpec_export() {
-        return SymbolRef(nullptr, 104);
+        return SymbolRef(nullptr, SymbolRef::Kind::Method, 6);
     }
 
     static SymbolRef PackageSpec_export_methods() {
-        return SymbolRef(nullptr, 105);
+        return SymbolRef(nullptr, SymbolRef::Kind::Method, 7);
     }
 
     static SymbolRef Encoding() {
-        return SymbolRef(nullptr, 106);
+        return SymbolRef(nullptr, SymbolRef::Kind::ClassOrModule, 88);
     }
 
     static constexpr int MAX_PROC_ARITY = 10;
@@ -567,10 +567,10 @@ public:
     }
 
     static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 400;
-    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 24;
+    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 29;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 2;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 2;
-    static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 95;
+    static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 99;
 };
 
 template <typename H> H AbslHashValue(H h, const SymbolRef &m) {

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -53,7 +53,7 @@ public:
 
     // Kind takes up this many bits in _id.
     static constexpr u4 KIND_BITS = 3;
-    static constexpr u4 KIND_MASK = 0x7;
+    static constexpr u4 KIND_MASK = (1 << KIND_BITS) - 1;
 
     Kind kind() const {
         return static_cast<Kind>(_id & KIND_MASK);

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -35,9 +35,10 @@ class SymbolRef final {
     friend class GlobalState;
     friend class Symbol;
 
+    // Stores the symbol's Kind and Index. Kind occupies the upper bits.
     u4 _id;
     u4 unsafeTableIndex() const {
-        return _id >> KIND_BITS;
+        return _id & ID_MASK;
     }
 
 public:
@@ -52,10 +53,11 @@ public:
 
     // Kind takes up this many bits in _id.
     static constexpr u4 KIND_BITS = 3;
-    static constexpr u4 KIND_MASK = (1 << KIND_BITS) - 1;
+    static constexpr u4 ID_BITS = 32 - KIND_BITS;
+    static constexpr u4 ID_MASK = (1 << ID_BITS) - 1;
 
     Kind kind() const {
-        return static_cast<Kind>(_id & KIND_MASK);
+        return static_cast<Kind>(_id >> ID_BITS);
     }
 
     u4 rawId() const {

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -40,6 +40,9 @@ class SymbolRef final {
     friend class Symbol;
 
     u4 _id;
+    u4 unsafeTableIndex() const {
+        return _id >> KIND_BITS;
+    }
 
 public:
     // TODO: Enforce that this is only 3 bits?
@@ -59,12 +62,33 @@ public:
         return static_cast<Kind>(_id & KIND_MASK);
     }
 
-    u4 id() const {
-        return _id >> KIND_BITS;
-    }
-
     u4 raw() const {
         return _id;
+    }
+
+    u4 classOrModuleIndex() const {
+        ENFORCE(kind() == Kind::ClassOrModule);
+        return unsafeTableIndex();
+    }
+
+    u4 methodIndex() const {
+        ENFORCE(kind() == Kind::Method);
+        return unsafeTableIndex();
+    }
+
+    u4 fieldIndex() const {
+        ENFORCE(kind() == Kind::Field);
+        return unsafeTableIndex();
+    }
+
+    u4 typeArgumentIndex() const {
+        ENFORCE(kind() == Kind::TypeArgument);
+        return unsafeTableIndex();
+    }
+
+    u4 typeMemberIndex() const {
+        ENFORCE(kind() == Kind::TypeMember);
+        return unsafeTableIndex();
     }
 
     SymbolRef(GlobalState const *from, Kind type, u4 _id);
@@ -529,7 +553,7 @@ public:
         if (argc > MAX_PROC_ARITY) {
             return noSymbol();
         }
-        return SymbolRef(nullptr, SymbolRef::Kind::ClassOrModule, Proc0().id() + argc * 2);
+        return SymbolRef(nullptr, SymbolRef::Kind::ClassOrModule, Proc0().classOrModuleIndex() + argc * 2);
     }
 
     static SymbolRef last_proc() {
@@ -538,7 +562,7 @@ public:
 
     // Keep as last and update to match the last entry
     static SymbolRef last_synthetic_class_sym() {
-        ENFORCE(last_proc().id() == MAX_SYNTHETIC_CLASS_SYMBOLS - 2);
+        ENFORCE(last_proc().classOrModuleIndex() == MAX_SYNTHETIC_CLASS_SYMBOLS - 2);
         return SymbolRef(nullptr, SymbolRef::Kind::ClassOrModule, MAX_SYNTHETIC_CLASS_SYMBOLS - 1);
     }
 

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -63,10 +63,6 @@ public:
         return _id >> KIND_BITS;
     }
 
-    u4 hash() const {
-        return _id;
-    }
-
     u4 raw() const {
         return _id;
     }
@@ -554,7 +550,7 @@ public:
 };
 
 template <typename H> H AbslHashValue(H h, const SymbolRef &m) {
-    return H::combine(std::move(h), m.hash());
+    return H::combine(std::move(h), m.raw());
 }
 
 } // namespace sorbet::core

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -45,7 +45,7 @@ class SymbolRef final {
     }
 
 public:
-    // TODO: Enforce that this is only 3 bits?
+    // If you add Symbol Kinds, make sure KIND_BITS is kept in sync!
     enum class Kind : u1 {
         ClassOrModule = 0,
         Method = 1,
@@ -67,27 +67,27 @@ public:
     }
 
     u4 classOrModuleIndex() const {
-        ENFORCE(kind() == Kind::ClassOrModule);
+        ENFORCE_NO_TIMER(kind() == Kind::ClassOrModule);
         return unsafeTableIndex();
     }
 
     u4 methodIndex() const {
-        ENFORCE(kind() == Kind::Method);
+        ENFORCE_NO_TIMER(kind() == Kind::Method);
         return unsafeTableIndex();
     }
 
     u4 fieldIndex() const {
-        ENFORCE(kind() == Kind::Field);
+        ENFORCE_NO_TIMER(kind() == Kind::Field);
         return unsafeTableIndex();
     }
 
     u4 typeArgumentIndex() const {
-        ENFORCE(kind() == Kind::TypeArgument);
+        ENFORCE_NO_TIMER(kind() == Kind::TypeArgument);
         return unsafeTableIndex();
     }
 
     u4 typeMemberIndex() const {
-        ENFORCE(kind() == Kind::TypeMember);
+        ENFORCE_NO_TIMER(kind() == Kind::TypeMember);
         return unsafeTableIndex();
     }
 
@@ -106,6 +106,7 @@ public:
     }
 
     bool inline exists() const {
+        // 'false' if Kind is ClassOrModule and index is 0, which is SymbolRef::noSymbol.
         return _id;
     }
 

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -9,11 +9,7 @@ class Symbol;
 class GlobalState;
 struct SymbolDataDebugCheck {
     const GlobalState &gs;
-    const unsigned int classAndModulesAtCreation;
-    const unsigned int methodsAtCreation;
-    const unsigned int fieldsAtCreation;
-    const unsigned int typeArgumentsAtCreation;
-    const unsigned int typeMembersAtCreation;
+    const unsigned int symbolCountAtCreation;
 
     SymbolDataDebugCheck(const GlobalState &gs);
     void check() const;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -87,8 +87,8 @@ public:
         return unsafeTableIndex();
     }
 
-    SymbolRef(GlobalState const *from, Kind type, u4 _id);
-    SymbolRef(const GlobalState &from, Kind type, u4 _id);
+    SymbolRef(GlobalState const *from, Kind type, u4 id);
+    SymbolRef(const GlobalState &from, Kind type, u4 id);
     SymbolRef() : _id(0){};
 
     // From experimentation, in the common case, methods typically have 2 or fewer arguments.

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -557,7 +557,7 @@ public:
         return SymbolRef(nullptr, SymbolRef::Kind::ClassOrModule, MAX_SYNTHETIC_CLASS_SYMBOLS - 1);
     }
 
-    static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 400;
+    static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 200;
     static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 29;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 2;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 2;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -58,7 +58,7 @@ public:
         return static_cast<Kind>(_id & KIND_MASK);
     }
 
-    u4 raw() const {
+    u4 rawId() const {
         return _id;
     }
 
@@ -565,7 +565,7 @@ public:
 };
 
 template <typename H> H AbslHashValue(H h, const SymbolRef &m) {
-    return H::combine(std::move(h), m.raw());
+    return H::combine(std::move(h), m.rawId());
 }
 
 } // namespace sorbet::core

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -151,7 +151,7 @@ SymbolRef Symbol::ref(const GlobalState &gs) const {
         type = SymbolRef::Kind::TypeArgument;
         distance = this - gs.typeArguments.data();
     } else {
-        ENFORCE(false);
+        ENFORCE(false, "Invalid/unrecognized symbol type");
     }
 
     return SymbolRef(gs, type, distance);
@@ -227,15 +227,15 @@ void printTabs(fmt::memory_buffer &to, int count) {
     fmt::format_to(to, "{}", ident);
 }
 
-SymbolRef::SymbolRef(const GlobalState &from, SymbolRef::Kind kind, u4 _id)
-    : _id((_id << KIND_BITS) | static_cast<u4>(kind)) {
+SymbolRef::SymbolRef(const GlobalState &from, SymbolRef::Kind kind, u4 id)
+    : _id((id << KIND_BITS) | static_cast<u4>(kind)) {
     // If this fails, the symbol table is too big :(
-    ENFORCE_NO_TIMER((_id >> (32 - KIND_BITS)) == 0);
+    ENFORCE_NO_TIMER((id >> (32 - KIND_BITS)) == 0);
 }
-SymbolRef::SymbolRef(GlobalState const *from, SymbolRef::Kind kind, u4 _id)
-    : _id((_id << KIND_BITS) | static_cast<u4>(kind)) {
+SymbolRef::SymbolRef(GlobalState const *from, SymbolRef::Kind kind, u4 id)
+    : _id((id << KIND_BITS) | static_cast<u4>(kind)) {
     // If this fails, the symbol table is too big :(
-    ENFORCE_NO_TIMER((_id >> (32 - KIND_BITS)) == 0);
+    ENFORCE_NO_TIMER((id >> (32 - KIND_BITS)) == 0);
 }
 
 string SymbolRef::showRaw(const GlobalState &gs) const {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -134,7 +134,7 @@ bool Symbol::derivesFrom(const GlobalState &gs, SymbolRef sym) const {
 
 SymbolRef Symbol::ref(const GlobalState &gs) const {
     u4 distance = 0;
-    SymbolRef::Kind type = SymbolRef::Kind::ClassOrModule;
+    auto type = SymbolRef::Kind::ClassOrModule;
     if (isClassOrModule()) {
         type = SymbolRef::Kind::ClassOrModule;
         distance = this - gs.classAndModules.data();

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -230,12 +230,12 @@ void printTabs(fmt::memory_buffer &to, int count) {
 SymbolRef::SymbolRef(const GlobalState &from, SymbolRef::Kind kind, u4 _id)
     : _id((_id << KIND_BITS) | static_cast<u4>(kind)) {
     // If this fails, the symbol table is too big :(
-    ENFORCE((_id >> (32 - KIND_BITS)) == 0);
+    ENFORCE_NO_TIMER((_id >> (32 - KIND_BITS)) == 0);
 }
 SymbolRef::SymbolRef(GlobalState const *from, SymbolRef::Kind kind, u4 _id)
     : _id((_id << KIND_BITS) | static_cast<u4>(kind)) {
     // If this fails, the symbol table is too big :(
-    ENFORCE((_id >> (32 - KIND_BITS)) == 0);
+    ENFORCE_NO_TIMER((_id >> (32 - KIND_BITS)) == 0);
 }
 
 string SymbolRef::showRaw(const GlobalState &gs) const {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -163,23 +163,22 @@ SymbolData SymbolRef::data(GlobalState &gs) const {
 }
 
 SymbolData SymbolRef::dataAllowingNone(GlobalState &gs) const {
-    const u4 id = this->id();
     switch (kind()) {
         case SymbolRef::Kind::ClassOrModule:
-            ENFORCE_NO_TIMER(id < gs.classAndModules.size());
-            return SymbolData(gs.classAndModules[id], gs);
+            ENFORCE_NO_TIMER(classOrModuleIndex() < gs.classAndModules.size());
+            return SymbolData(gs.classAndModules[classOrModuleIndex()], gs);
         case SymbolRef::Kind::Method:
-            ENFORCE_NO_TIMER(id < gs.methods.size());
-            return SymbolData(gs.methods[id], gs);
+            ENFORCE_NO_TIMER(methodIndex() < gs.methods.size());
+            return SymbolData(gs.methods[methodIndex()], gs);
         case SymbolRef::Kind::Field:
-            ENFORCE_NO_TIMER(id < gs.fields.size());
-            return SymbolData(gs.fields[id], gs);
+            ENFORCE_NO_TIMER(fieldIndex() < gs.fields.size());
+            return SymbolData(gs.fields[fieldIndex()], gs);
         case SymbolRef::Kind::TypeArgument:
-            ENFORCE_NO_TIMER(id < gs.typeArguments.size());
-            return SymbolData(gs.typeArguments[id], gs);
+            ENFORCE_NO_TIMER(typeArgumentIndex() < gs.typeArguments.size());
+            return SymbolData(gs.typeArguments[typeArgumentIndex()], gs);
         case SymbolRef::Kind::TypeMember:
-            ENFORCE_NO_TIMER(id < gs.typeMembers.size());
-            return SymbolData(gs.typeMembers[id], gs);
+            ENFORCE_NO_TIMER(typeMemberIndex() < gs.typeMembers.size());
+            return SymbolData(gs.typeMembers[typeMemberIndex()], gs);
     }
 }
 
@@ -189,38 +188,37 @@ const SymbolData SymbolRef::data(const GlobalState &gs) const {
 }
 
 const SymbolData SymbolRef::dataAllowingNone(const GlobalState &gs) const {
-    const u4 id = this->id();
     switch (kind()) {
         case SymbolRef::Kind::ClassOrModule:
-            ENFORCE_NO_TIMER(id < gs.classAndModules.size());
-            return SymbolData(const_cast<Symbol &>(gs.classAndModules[id]), gs);
+            ENFORCE_NO_TIMER(classOrModuleIndex() < gs.classAndModules.size());
+            return SymbolData(const_cast<Symbol &>(gs.classAndModules[classOrModuleIndex()]), gs);
         case SymbolRef::Kind::Method:
-            ENFORCE_NO_TIMER(id < gs.methods.size());
-            return SymbolData(const_cast<Symbol &>(gs.methods[id]), gs);
+            ENFORCE_NO_TIMER(methodIndex() < gs.methods.size());
+            return SymbolData(const_cast<Symbol &>(gs.methods[methodIndex()]), gs);
         case SymbolRef::Kind::Field:
-            ENFORCE_NO_TIMER(id < gs.fields.size());
-            return SymbolData(const_cast<Symbol &>(gs.fields[id]), gs);
+            ENFORCE_NO_TIMER(fieldIndex() < gs.fields.size());
+            return SymbolData(const_cast<Symbol &>(gs.fields[fieldIndex()]), gs);
         case SymbolRef::Kind::TypeArgument:
-            ENFORCE_NO_TIMER(id < gs.typeArguments.size());
-            return SymbolData(const_cast<Symbol &>(gs.typeArguments[id]), gs);
+            ENFORCE_NO_TIMER(typeArgumentIndex() < gs.typeArguments.size());
+            return SymbolData(const_cast<Symbol &>(gs.typeArguments[typeArgumentIndex()]), gs);
         case SymbolRef::Kind::TypeMember:
-            ENFORCE_NO_TIMER(id < gs.typeMembers.size());
-            return SymbolData(const_cast<Symbol &>(gs.typeMembers[id]), gs);
+            ENFORCE_NO_TIMER(typeMemberIndex() < gs.typeMembers.size());
+            return SymbolData(const_cast<Symbol &>(gs.typeMembers[typeMemberIndex()]), gs);
     }
 }
 
 bool SymbolRef::isSynthetic() const {
     switch (this->kind()) {
         case Kind::ClassOrModule:
-            return id() < Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS;
+            return classOrModuleIndex() < Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS;
         case Kind::Method:
-            return id() < Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS;
+            return methodIndex() < Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS;
         case Kind::Field:
-            return id() < Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS;
+            return fieldIndex() < Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS;
         case Kind::TypeArgument:
-            return id() < Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS;
+            return typeArgumentIndex() < Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS;
         case Kind::TypeMember:
-            return id() < Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS;
+            return typeMemberIndex() < Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS;
     }
 }
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1372,16 +1372,10 @@ vector<std::pair<NameRef, SymbolRef>> Symbol::membersStableOrderSlow(const Globa
 SymbolData::SymbolData(Symbol &ref, const GlobalState &gs) : DebugOnlyCheck(gs), symbol(ref) {}
 
 SymbolDataDebugCheck::SymbolDataDebugCheck(const GlobalState &gs)
-    : gs(gs), classAndModulesAtCreation(gs.classAndModulesUsed()), methodsAtCreation(gs.methodsUsed()),
-      fieldsAtCreation(gs.fieldsUsed()), typeArgumentsAtCreation(gs.typeArgumentsUsed()),
-      typeMembersAtCreation(gs.typeMembersUsed()) {}
+    : gs(gs), symbolCountAtCreation(gs.symbolsUsedTotal()) {}
 
 void SymbolDataDebugCheck::check() const {
-    ENFORCE_NO_TIMER(classAndModulesAtCreation == gs.classAndModulesUsed());
-    ENFORCE_NO_TIMER(methodsAtCreation == gs.methodsUsed());
-    ENFORCE_NO_TIMER(fieldsAtCreation == gs.fieldsUsed());
-    ENFORCE_NO_TIMER(typeArgumentsAtCreation == gs.typeArgumentsUsed());
-    ENFORCE_NO_TIMER(typeMembersAtCreation == gs.typeMembersUsed());
+    ENFORCE_NO_TIMER(symbolCountAtCreation == gs.symbolsUsedTotal());
 }
 
 Symbol *SymbolData::operator->() {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -134,7 +134,7 @@ bool Symbol::derivesFrom(const GlobalState &gs, SymbolRef sym) const {
 
 SymbolRef Symbol::ref(const GlobalState &gs) const {
     u4 distance = 0;
-    SymbolRef::Kind type;
+    SymbolRef::Kind type = SymbolRef::Kind::ClassOrModule;
     if (isClassOrModule()) {
         type = SymbolRef::Kind::ClassOrModule;
         distance = this - gs.classAndModules.data();

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -228,14 +228,14 @@ void printTabs(fmt::memory_buffer &to, int count) {
 }
 
 SymbolRef::SymbolRef(const GlobalState &from, SymbolRef::Kind kind, u4 id)
-    : _id((id << KIND_BITS) | static_cast<u4>(kind)) {
+    : _id(id | (static_cast<u4>(kind) << ID_BITS)) {
     // If this fails, the symbol table is too big :(
-    ENFORCE_NO_TIMER((id >> (32 - KIND_BITS)) == 0);
+    ENFORCE_NO_TIMER(id <= ID_MASK);
 }
 SymbolRef::SymbolRef(GlobalState const *from, SymbolRef::Kind kind, u4 id)
-    : _id((id << KIND_BITS) | static_cast<u4>(kind)) {
+    : _id(id | (static_cast<u4>(kind) << ID_BITS)) {
     // If this fails, the symbol table is too big :(
-    ENFORCE_NO_TIMER((id >> (32 - KIND_BITS)) == 0);
+    ENFORCE_NO_TIMER(id <= ID_MASK);
 }
 
 string SymbolRef::showRaw(const GlobalState &gs) const {

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -81,7 +81,7 @@ com::stripe::rubytyper::Symbol Proto::toProto(const GlobalState &gs, SymbolRef s
     com::stripe::rubytyper::Symbol symbolProto;
     const auto data = sym.data(gs);
 
-    symbolProto.set_id(sym.raw());
+    symbolProto.set_id(sym.rawId());
     *symbolProto.mutable_name() = toProto(gs, data->name);
 
     if (data->isClassOrModule()) {
@@ -101,7 +101,7 @@ com::stripe::rubytyper::Symbol Proto::toProto(const GlobalState &gs, SymbolRef s
     if (data->isClassOrModule() || data->isMethod()) {
         if (data->isClassOrModule()) {
             for (auto thing : data->mixins()) {
-                symbolProto.add_mixins(thing.raw());
+                symbolProto.add_mixins(thing.rawId());
             }
         } else {
             for (auto &thing : data->arguments()) {
@@ -110,13 +110,13 @@ com::stripe::rubytyper::Symbol Proto::toProto(const GlobalState &gs, SymbolRef s
         }
 
         if (data->isClassOrModule() && data->superClass().exists()) {
-            symbolProto.set_superclass(data->superClass().raw());
+            symbolProto.set_superclass(data->superClass().rawId());
         }
     }
 
     if (data->isStaticField()) {
         if (auto type = core::cast_type<core::AliasType>(data->resultType.get())) {
-            symbolProto.set_aliasto(type->symbol.raw());
+            symbolProto.set_aliasto(type->symbol.rawId());
         }
     }
 

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -81,7 +81,7 @@ com::stripe::rubytyper::Symbol Proto::toProto(const GlobalState &gs, SymbolRef s
     com::stripe::rubytyper::Symbol symbolProto;
     const auto data = sym.data(gs);
 
-    symbolProto.set_id(sym._id);
+    symbolProto.set_id(sym.raw());
     *symbolProto.mutable_name() = toProto(gs, data->name);
 
     if (data->isClassOrModule()) {
@@ -101,7 +101,7 @@ com::stripe::rubytyper::Symbol Proto::toProto(const GlobalState &gs, SymbolRef s
     if (data->isClassOrModule() || data->isMethod()) {
         if (data->isClassOrModule()) {
             for (auto thing : data->mixins()) {
-                symbolProto.add_mixins(thing._id);
+                symbolProto.add_mixins(thing.raw());
             }
         } else {
             for (auto &thing : data->arguments()) {
@@ -110,13 +110,13 @@ com::stripe::rubytyper::Symbol Proto::toProto(const GlobalState &gs, SymbolRef s
         }
 
         if (data->isClassOrModule() && data->superClass().exists()) {
-            symbolProto.set_superclass(data->superClass()._id);
+            symbolProto.set_superclass(data->superClass().raw());
         }
     }
 
     if (data->isStaticField()) {
         if (auto type = core::cast_type<core::AliasType>(data->resultType.get())) {
-            symbolProto.set_aliasto(type->symbol._id);
+            symbolProto.set_aliasto(type->symbol.raw());
         }
     }
 

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -348,7 +348,7 @@ void SerializerImpl::pickle(Pickler &p, Type *what) {
     }
     if (auto *c = cast_type<ClassType>(what)) {
         p.putU4(1);
-        p.putU4(c->symbol._id);
+        p.putU4(c->symbol.raw());
     } else if (auto *o = cast_type<OrType>(what)) {
         p.putU4(2);
         pickle(p, o->left.get());
@@ -381,22 +381,22 @@ void SerializerImpl::pickle(Pickler &p, Type *what) {
         }
     } else if (auto *alias = cast_type<AliasType>(what)) {
         p.putU4(7);
-        p.putU4(alias->symbol._id);
+        p.putU4(alias->symbol.raw());
     } else if (auto *lp = cast_type<LambdaParam>(what)) {
         p.putU4(8);
         pickle(p, lp->lowerBound.get());
         pickle(p, lp->upperBound.get());
-        p.putU4(lp->definition._id);
+        p.putU4(lp->definition.raw());
     } else if (auto *at = cast_type<AppliedType>(what)) {
         p.putU4(9);
-        p.putU4(at->klass._id);
+        p.putU4(at->klass.raw());
         p.putU4(at->targs.size());
         for (auto &t : at->targs) {
             pickle(p, t.get());
         }
     } else if (auto *tp = cast_type<TypeVar>(what)) {
         p.putU4(10);
-        p.putU4(tp->sym._id);
+        p.putU4(tp->sym.raw());
     } else if (auto *st = cast_type<SelfType>(what)) {
         p.putU4(11);
     } else {
@@ -413,7 +413,7 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
             return empty;
         }
         case 1:
-            return make_type<ClassType>(SymbolRef(gs, p.getU4()));
+            return make_type<ClassType>(SymbolRef::fromRaw(p.getU4()));
         case 2:
             return OrType::make_shared(unpickleType(p, gs), unpickleType(p, gs));
         case 3: {
@@ -462,14 +462,14 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
             return result;
         }
         case 7:
-            return make_type<AliasType>(SymbolRef(gs, p.getU4()));
+            return make_type<AliasType>(SymbolRef::fromRaw(p.getU4()));
         case 8: {
             auto lower = unpickleType(p, gs);
             auto upper = unpickleType(p, gs);
-            return make_type<LambdaParam>(SymbolRef(gs, p.getU4()), lower, upper);
+            return make_type<LambdaParam>(SymbolRef::fromRaw(p.getU4()), lower, upper);
         }
         case 9: {
-            SymbolRef klass(gs, p.getU4());
+            auto klass = SymbolRef::fromRaw(p.getU4());
             int sz = p.getU4();
             vector<TypePtr> targs(sz);
             for (auto &t : targs) {
@@ -478,7 +478,7 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
             return make_type<AppliedType>(klass, targs);
         }
         case 10: {
-            SymbolRef sym(gs, p.getU4());
+            auto sym = SymbolRef::fromRaw(p.getU4());
             return make_type<TypeVar>(sym);
         }
         case 11: {
@@ -491,7 +491,7 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
 
 void SerializerImpl::pickle(Pickler &p, const ArgInfo &a) {
     p.putU4(a.name._id);
-    p.putU4(a.rebind._id);
+    p.putU4(a.rebind.raw());
     pickleWithFile(p, a.loc);
     p.putU1(a.flags.toU1());
     pickle(p, a.type.get());
@@ -500,7 +500,7 @@ void SerializerImpl::pickle(Pickler &p, const ArgInfo &a) {
 ArgInfo SerializerImpl::unpickleArgInfo(UnPickler &p, const GlobalState *gs) {
     ArgInfo result;
     result.name = core::NameRef(*gs, p.getU4());
-    result.rebind = core::SymbolRef(gs, p.getU4());
+    result.rebind = core::SymbolRef::fromRaw(p.getU4());
     result.loc = unpickleLoc(p);
     {
         u1 flags = p.getU1();
@@ -511,19 +511,19 @@ ArgInfo SerializerImpl::unpickleArgInfo(UnPickler &p, const GlobalState *gs) {
 }
 
 void SerializerImpl::pickle(Pickler &p, const Symbol &what) {
-    p.putU4(what.owner._id);
+    p.putU4(what.owner.raw());
     p.putU4(what.name._id);
-    p.putU4(what.superClassOrRebind._id);
+    p.putU4(what.superClassOrRebind.raw());
     p.putU4(what.flags);
     if (!what.isMethod()) {
         p.putU4(what.mixins_.size());
         for (SymbolRef s : what.mixins_) {
-            p.putU4(s._id);
+            p.putU4(s.raw());
         }
     }
     p.putU4(what.typeParams.size());
     for (SymbolRef s : what.typeParams) {
-        p.putU4(s._id);
+        p.putU4(s.raw());
     }
     if (what.isMethod()) {
         p.putU4(what.arguments().size());
@@ -535,7 +535,7 @@ void SerializerImpl::pickle(Pickler &p, const Symbol &what) {
     vector<pair<u4, u4>> membersSorted;
 
     for (const auto &member : what.members()) {
-        membersSorted.emplace_back(member.first.id(), member.second._id);
+        membersSorted.emplace_back(member.first.id(), member.second.raw());
     }
     fast_sort(membersSorted, [](auto const &lhs, auto const &rhs) -> bool { return lhs.first < rhs.first; });
 
@@ -553,22 +553,22 @@ void SerializerImpl::pickle(Pickler &p, const Symbol &what) {
 
 Symbol SerializerImpl::unpickleSymbol(UnPickler &p, const GlobalState *gs) {
     Symbol result;
-    result.owner = SymbolRef(gs, p.getU4());
+    result.owner = SymbolRef::fromRaw(p.getU4());
     result.name = NameRef(*gs, p.getU4());
-    result.superClassOrRebind = SymbolRef(gs, p.getU4());
+    result.superClassOrRebind = SymbolRef::fromRaw(p.getU4());
     result.flags = p.getU4();
     if (!result.isMethod()) {
         int mixinsSize = p.getU4();
         result.mixins_.reserve(mixinsSize);
         for (int i = 0; i < mixinsSize; i++) {
-            result.mixins_.emplace_back(SymbolRef(gs, p.getU4()));
+            result.mixins_.emplace_back(SymbolRef::fromRaw(p.getU4()));
         }
     }
     int typeParamsSize = p.getU4();
 
     result.typeParams.reserve(typeParamsSize);
     for (int i = 0; i < typeParamsSize; i++) {
-        result.typeParams.emplace_back(SymbolRef(gs, p.getU4()));
+        result.typeParams.emplace_back(SymbolRef::fromRaw(p.getU4()));
     }
 
     if (result.isMethod()) {
@@ -581,7 +581,7 @@ Symbol SerializerImpl::unpickleSymbol(UnPickler &p, const GlobalState *gs) {
     result.members().reserve(membersSize);
     for (int i = 0; i < membersSize; i++) {
         auto name = NameRef(*gs, p.getU4());
-        auto sym = SymbolRef(gs, p.getU4());
+        auto sym = SymbolRef::fromRaw(p.getU4());
         if (result.name != core::Names::Constants::Root()) {
             ENFORCE(name.exists());
             ENFORCE(sym.exists());
@@ -631,8 +631,28 @@ Pickler SerializerImpl::pickle(const GlobalState &gs, bool payloadOnly) {
         }
     }
 
-    result.putU4(gs.symbols.size());
-    for (const Symbol &s : gs.symbols) {
+    result.putU4(gs.classAndModules.size());
+    for (const Symbol &s : gs.classAndModules) {
+        pickle(result, s);
+    }
+
+    result.putU4(gs.methods.size());
+    for (const Symbol &s : gs.methods) {
+        pickle(result, s);
+    }
+
+    result.putU4(gs.fields.size());
+    for (const Symbol &s : gs.fields) {
+        pickle(result, s);
+    }
+
+    result.putU4(gs.typeArguments.size());
+    for (const Symbol &s : gs.typeArguments) {
+        pickle(result, s);
+    }
+
+    result.putU4(gs.typeMembers.size());
+    for (const Symbol &s : gs.typeMembers) {
         pickle(result, s);
     }
 
@@ -672,8 +692,16 @@ void SerializerImpl::unpickleGS(UnPickler &p, GlobalState &result) {
     files.clear();
     vector<Name> names(std::move(result.names));
     names.clear();
-    vector<Symbol> symbols(std::move(result.symbols));
-    symbols.clear();
+    vector<Symbol> classAndModules(std::move(result.classAndModules));
+    classAndModules.clear();
+    vector<Symbol> methods(std::move(result.methods));
+    methods.clear();
+    vector<Symbol> fields(std::move(result.fields));
+    fields.clear();
+    vector<Symbol> typeArguments(std::move(result.typeArguments));
+    typeArguments.clear();
+    vector<Symbol> typeMembers(std::move(result.typeMembers));
+    typeMembers.clear();
     vector<pair<unsigned int, unsigned int>> namesByHash(std::move(result.namesByHash));
     namesByHash.clear();
     {
@@ -710,11 +738,39 @@ void SerializerImpl::unpickleGS(UnPickler &p, GlobalState &result) {
     {
         Timer timeit(result.tracer(), "readSymbols");
 
-        int symbolSize = p.getU4();
-        ENFORCE(symbolSize > 0);
-        symbols.reserve(symbolSize);
-        for (int i = 0; i < symbolSize; i++) {
-            symbols.emplace_back(unpickleSymbol(p, &result));
+        int classAndModuleSize = p.getU4();
+        ENFORCE(classAndModuleSize > 0);
+        classAndModules.reserve(nearestPowerOf2(classAndModuleSize));
+        for (int i = 0; i < classAndModuleSize; i++) {
+            classAndModules.emplace_back(unpickleSymbol(p, &result));
+        }
+
+        int methodSize = p.getU4();
+        ENFORCE(methodSize > 0);
+        methods.reserve(nearestPowerOf2(methodSize));
+        for (int i = 0; i < methodSize; i++) {
+            methods.emplace_back(unpickleSymbol(p, &result));
+        }
+
+        int fieldSize = p.getU4();
+        ENFORCE(fieldSize > 0);
+        fields.reserve(nearestPowerOf2(fieldSize));
+        for (int i = 0; i < fieldSize; i++) {
+            fields.emplace_back(unpickleSymbol(p, &result));
+        }
+
+        int typeArgumentSize = p.getU4();
+        ENFORCE(typeArgumentSize > 0);
+        typeArguments.reserve(nearestPowerOf2(typeArgumentSize));
+        for (int i = 0; i < typeArgumentSize; i++) {
+            typeArguments.emplace_back(unpickleSymbol(p, &result));
+        }
+
+        int typeMemberSize = p.getU4();
+        ENFORCE(typeMemberSize > 0);
+        typeMembers.reserve(nearestPowerOf2(typeMemberSize));
+        for (int i = 0; i < typeMemberSize; i++) {
+            typeMembers.emplace_back(unpickleSymbol(p, &result));
         }
     }
 
@@ -744,7 +800,11 @@ void SerializerImpl::unpickleGS(UnPickler &p, GlobalState &result) {
         result.fileRefByPath = std::move(fileRefByPath);
         result.files = std::move(files);
         result.names = std::move(names);
-        result.symbols = std::move(symbols);
+        result.classAndModules = std::move(classAndModules);
+        result.methods = std::move(methods);
+        result.fields = std::move(fields);
+        result.typeArguments = std::move(typeArguments);
+        result.typeMembers = std::move(typeMembers);
         result.namesByHash = std::move(namesByHash);
     }
     result.sanityCheck();
@@ -793,7 +853,7 @@ std::vector<u1> Serializer::storePayloadAndNameTable(GlobalState &gs) {
 }
 
 void Serializer::loadGlobalState(GlobalState &gs, const u1 *const data) {
-    ENFORCE(gs.files.empty() && gs.names.empty() && gs.symbols.empty(), "Can't load into a non-empty state");
+    ENFORCE(gs.files.empty() && gs.names.empty() && gs.allSymbolsUsed() == 0, "Can't load into a non-empty state");
     UnPickler p(data, gs.tracer());
     SerializerImpl::unpickleGS(p, gs);
     gs.installIntrinsics();
@@ -947,7 +1007,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::TreePtr &what) {
             pickleAstHeader(p, 21, c);
             pickleWithoutFile(p, c->declLoc);
             p.putU1(static_cast<u2>(c->kind));
-            p.putU4(c->symbol._id);
+            p.putU4(c->symbol.raw());
             p.putU4(c->ancestors.size());
             p.putU4(c->singletonAncestors.size());
             p.putU4(c->rhs.size());
@@ -971,7 +1031,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::TreePtr &what) {
             memcpy(&flags, &c->flags, sizeof(flags));
             p.putU1(flags);
             p.putU4(c->name._id);
-            p.putU4(c->symbol._id);
+            p.putU4(c->symbol.raw());
             p.putU4(c->args.size());
             pickle(p, c->rhs);
             for (auto &a : c->args) {
@@ -1026,7 +1086,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::TreePtr &what) {
         },
         [&](ast::ConstantLit *a) {
             pickleAstHeader(p, 32, a);
-            p.putU4(a->symbol._id);
+            p.putU4(a->symbol.raw());
             pickleTree(p, a->original);
         },
 
@@ -1157,7 +1217,7 @@ ast::TreePtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const GlobalS
         case 21: {
             auto declLoc = unpickleLocInFile(p, file);
             auto kind = p.getU1();
-            SymbolRef symbol(gs, p.getU4());
+            auto symbol = SymbolRef::fromRaw(p.getU4());
             auto ancestorsSize = p.getU4();
             auto singletonAncestorsSize = p.getU4();
             auto rhsSize = p.getU4();
@@ -1191,7 +1251,7 @@ ast::TreePtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const GlobalS
             // Can replace this with std::bit_cast in C++20
             memcpy(&flags, &flagsU1, sizeof(flags));
             NameRef name = unpickleNameRef(p, gs);
-            SymbolRef symbol(gs, p.getU4());
+            auto symbol = SymbolRef::fromRaw(p.getU4());
             auto argsSize = p.getU4();
             auto rhs = unpickleExpr(p, gs, file);
             ast::MethodDef::ARGS_store args(argsSize);
@@ -1260,7 +1320,7 @@ ast::TreePtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const GlobalS
             return ast::make_tree<ast::UnresolvedIdent>(loc, kind, name);
         }
         case 32: {
-            SymbolRef sym(gs, p.getU4());
+            auto sym = SymbolRef::fromRaw(p.getU4());
             auto orig = unpickleExpr(p, gs, file);
             return ast::make_tree<ast::ConstantLit>(loc, sym, std::move(orig));
         }

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -853,7 +853,7 @@ std::vector<u1> Serializer::storePayloadAndNameTable(GlobalState &gs) {
 }
 
 void Serializer::loadGlobalState(GlobalState &gs, const u1 *const data) {
-    ENFORCE(gs.files.empty() && gs.names.empty() && gs.allSymbolsUsed() == 0, "Can't load into a non-empty state");
+    ENFORCE(gs.files.empty() && gs.names.empty() && gs.symbolsUsedTotal() == 0, "Can't load into a non-empty state");
     UnPickler p(data, gs.tracer());
     SerializerImpl::unpickleGS(p, gs);
     gs.installIntrinsics();

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -348,7 +348,7 @@ void SerializerImpl::pickle(Pickler &p, Type *what) {
     }
     if (auto *c = cast_type<ClassType>(what)) {
         p.putU4(1);
-        p.putU4(c->symbol.raw());
+        p.putU4(c->symbol.rawId());
     } else if (auto *o = cast_type<OrType>(what)) {
         p.putU4(2);
         pickle(p, o->left.get());
@@ -381,22 +381,22 @@ void SerializerImpl::pickle(Pickler &p, Type *what) {
         }
     } else if (auto *alias = cast_type<AliasType>(what)) {
         p.putU4(7);
-        p.putU4(alias->symbol.raw());
+        p.putU4(alias->symbol.rawId());
     } else if (auto *lp = cast_type<LambdaParam>(what)) {
         p.putU4(8);
         pickle(p, lp->lowerBound.get());
         pickle(p, lp->upperBound.get());
-        p.putU4(lp->definition.raw());
+        p.putU4(lp->definition.rawId());
     } else if (auto *at = cast_type<AppliedType>(what)) {
         p.putU4(9);
-        p.putU4(at->klass.raw());
+        p.putU4(at->klass.rawId());
         p.putU4(at->targs.size());
         for (auto &t : at->targs) {
             pickle(p, t.get());
         }
     } else if (auto *tp = cast_type<TypeVar>(what)) {
         p.putU4(10);
-        p.putU4(tp->sym.raw());
+        p.putU4(tp->sym.rawId());
     } else if (auto *st = cast_type<SelfType>(what)) {
         p.putU4(11);
     } else {
@@ -491,7 +491,7 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
 
 void SerializerImpl::pickle(Pickler &p, const ArgInfo &a) {
     p.putU4(a.name._id);
-    p.putU4(a.rebind.raw());
+    p.putU4(a.rebind.rawId());
     pickleWithFile(p, a.loc);
     p.putU1(a.flags.toU1());
     pickle(p, a.type.get());
@@ -511,19 +511,19 @@ ArgInfo SerializerImpl::unpickleArgInfo(UnPickler &p, const GlobalState *gs) {
 }
 
 void SerializerImpl::pickle(Pickler &p, const Symbol &what) {
-    p.putU4(what.owner.raw());
+    p.putU4(what.owner.rawId());
     p.putU4(what.name._id);
-    p.putU4(what.superClassOrRebind.raw());
+    p.putU4(what.superClassOrRebind.rawId());
     p.putU4(what.flags);
     if (!what.isMethod()) {
         p.putU4(what.mixins_.size());
         for (SymbolRef s : what.mixins_) {
-            p.putU4(s.raw());
+            p.putU4(s.rawId());
         }
     }
     p.putU4(what.typeParams.size());
     for (SymbolRef s : what.typeParams) {
-        p.putU4(s.raw());
+        p.putU4(s.rawId());
     }
     if (what.isMethod()) {
         p.putU4(what.arguments().size());
@@ -535,7 +535,7 @@ void SerializerImpl::pickle(Pickler &p, const Symbol &what) {
     vector<pair<u4, u4>> membersSorted;
 
     for (const auto &member : what.members()) {
-        membersSorted.emplace_back(member.first.id(), member.second.raw());
+        membersSorted.emplace_back(member.first.id(), member.second.rawId());
     }
     fast_sort(membersSorted, [](auto const &lhs, auto const &rhs) -> bool { return lhs.first < rhs.first; });
 
@@ -1007,7 +1007,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::TreePtr &what) {
             pickleAstHeader(p, 21, c);
             pickleWithoutFile(p, c->declLoc);
             p.putU1(static_cast<u2>(c->kind));
-            p.putU4(c->symbol.raw());
+            p.putU4(c->symbol.rawId());
             p.putU4(c->ancestors.size());
             p.putU4(c->singletonAncestors.size());
             p.putU4(c->rhs.size());
@@ -1031,7 +1031,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::TreePtr &what) {
             memcpy(&flags, &c->flags, sizeof(flags));
             p.putU1(flags);
             p.putU4(c->name._id);
-            p.putU4(c->symbol.raw());
+            p.putU4(c->symbol.rawId());
             p.putU4(c->args.size());
             pickle(p, c->rhs);
             for (auto &a : c->args) {
@@ -1086,7 +1086,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::TreePtr &what) {
         },
         [&](ast::ConstantLit *a) {
             pickleAstHeader(p, 32, a);
-            p.putU4(a->symbol.raw());
+            p.putU4(a->symbol.rawId());
             pickleTree(p, a->original);
         },
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -249,7 +249,7 @@ SymbolRef guessOverload(const GlobalState &gs, SymbolRef inClass, SymbolRef prim
                 return true;
             }
             if (getArity(gs, s1) == getArity(gs, s2)) {
-                return s1.raw() < s2.raw();
+                return s1.rawId() < s2.rawId();
             }
             return false;
         });

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -249,7 +249,7 @@ SymbolRef guessOverload(const GlobalState &gs, SymbolRef inClass, SymbolRef prim
                 return true;
             }
             if (getArity(gs, s1) == getArity(gs, s2)) {
-                return s1._id < s2._id;
+                return s1.raw() < s2.raw();
             }
             return false;
         });

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -673,7 +673,7 @@ void AppliedType::_sanityCheck(const GlobalState &gs) {
     ENFORCE(this->klass.data(gs)->typeMembers().size() == this->targs.size() ||
                 (this->klass == Symbols::Array() && (this->targs.size() == 1)) ||
                 (this->klass == Symbols::Hash() && (this->targs.size() == 3)) ||
-                this->klass._id >= Symbols::Proc0()._id && this->klass._id <= Symbols::last_proc()._id,
+                this->klass.id() >= Symbols::Proc0().id() && this->klass.id() <= Symbols::last_proc().id(),
             this->klass.data(gs)->name.showRaw(gs));
     for (auto &targ : this->targs) {
         targ->sanityCheck(gs);

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -673,7 +673,8 @@ void AppliedType::_sanityCheck(const GlobalState &gs) {
     ENFORCE(this->klass.data(gs)->typeMembers().size() == this->targs.size() ||
                 (this->klass == Symbols::Array() && (this->targs.size() == 1)) ||
                 (this->klass == Symbols::Hash() && (this->targs.size() == 3)) ||
-                this->klass.id() >= Symbols::Proc0().id() && this->klass.id() <= Symbols::last_proc().id(),
+                this->klass.classOrModuleIndex() >= Symbols::Proc0().classOrModuleIndex() &&
+                    this->klass.classOrModuleIndex() <= Symbols::last_proc().classOrModuleIndex(),
             this->klass.data(gs)->name.showRaw(gs));
     for (auto &targ : this->targs) {
         targ->sanityCheck(gs);

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -169,7 +169,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                     if (bind.bind.type && !bind.bind.type->isUntyped()) {
                         typedSendCount++;
                     } else if (bind.bind.type->hasUntyped()) {
-                        DEBUG_ONLY(histogramInc("untyped.sources", bind.bind.type->untypedBlame()._id););
+                        DEBUG_ONLY(histogramInc("untyped.sources", bind.bind.type->untypedBlame().raw()););
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::UntypedValue)) {
                             e.setHeader("This code is untyped");
                         }

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -169,7 +169,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                     if (bind.bind.type && !bind.bind.type->isUntyped()) {
                         typedSendCount++;
                     } else if (bind.bind.type->hasUntyped()) {
-                        DEBUG_ONLY(histogramInc("untyped.sources", bind.bind.type->untypedBlame().raw()););
+                        DEBUG_ONLY(histogramInc("untyped.sources", bind.bind.type->untypedBlame().rawId()););
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::UntypedValue)) {
                             e.setHeader("This code is untyped");
                         }

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -796,7 +796,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
                     return left.depth < right.depth;
                 }
 
-                return left.method.raw() < right.method.raw();
+                return left.method.rawId() < right.method.rawId();
             });
         }
 
@@ -842,7 +842,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
                 return leftShortName < rightShortName;
             }
 
-            return left.method.raw() < right.method.raw();
+            return left.method.rawId() < right.method.rawId();
         });
 
         // TODO(jez) Do something smarter here than "all keywords then all locals then all methods"

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -796,7 +796,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
                     return left.depth < right.depth;
                 }
 
-                return left.method._id < right.method._id;
+                return left.method.raw() < right.method.raw();
             });
         }
 
@@ -842,7 +842,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
                 return leftShortName < rightShortName;
             }
 
-            return left.method._id < right.method._id;
+            return left.method.raw() < right.method.raw();
         });
 
         // TODO(jez) Do something smarter here than "all keywords then all locals then all methods"

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -98,9 +98,7 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerDelegat
         {core::SymbolRef::Kind::TypeArgument, gs.typeArgumentsUsed()},
         {core::SymbolRef::Kind::TypeMember, gs.typeMembersUsed()},
     };
-    for (auto pair : symbolTypes) {
-        auto kind = pair.first;
-        auto used = pair.second;
+    for (auto [kind,used] : symbolTypes) {
         for (u4 idx = 0; idx < used; idx++) {
             core::SymbolRef ref(gs, kind, idx);
             if (!hideSymbol(gs, ref) &&

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -101,7 +101,7 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerDelegat
     for (auto pair : symbolTypes) {
         auto kind = pair.first;
         auto used = pair.second;
-        for (u4 idx = 1; idx < used; idx++) {
+        for (u4 idx = 0; idx < used; idx++) {
             core::SymbolRef ref(gs, kind, idx);
             if (!hideSymbol(gs, ref) &&
                 // a bit counter-intuitive, but this actually should be `!= fref`, as it prevents duplicates.

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -98,7 +98,7 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerDelegat
         {core::SymbolRef::Kind::TypeArgument, gs.typeArgumentsUsed()},
         {core::SymbolRef::Kind::TypeMember, gs.typeMembersUsed()},
     };
-    for (auto [kind,used] : symbolTypes) {
+    for (auto [kind, used] : symbolTypes) {
         for (u4 idx = 0; idx < used; idx++) {
             core::SymbolRef ref(gs, kind, idx);
             if (!hideSymbol(gs, ref) &&

--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -241,7 +241,7 @@ vector<unique_ptr<SymbolInformation>> SymbolMatcher::doQuery(string_view query_v
     // First pass: prefix-only matches on namespace
     {
         Timer timeit(gs.tracer(), "SymbolMatcher::doQuery::pass1");
-        for (auto [kind,size] : symbolKinds) {
+        for (auto [kind, size] : symbolKinds) {
             for (u4 i = 0; i < size; ++i) {
                 auto sym = core::SymbolRef(gs, kind, i);
                 if (sym.exists()) {
@@ -258,7 +258,7 @@ vector<unique_ptr<SymbolInformation>> SymbolMatcher::doQuery(string_view query_v
     vector<pair<core::SymbolRef, int>> candidates;
     {
         Timer timeit(gs.tracer(), "SymbolMatcher::doQuery::pass2");
-        for (auto [kind,size] : symbolKinds) {
+        for (auto [kind, size] : symbolKinds) {
             for (u4 i = 0; i < size; ++i) {
                 auto symbolRef = core::SymbolRef(gs, kind, i);
                 if (!symbolRef.exists()) {
@@ -303,9 +303,7 @@ vector<unique_ptr<SymbolInformation>> SymbolMatcher::doQuery(string_view query_v
             }
         }
     }
-    fast_sort(candidates, [](auto &left, auto &right) -> bool {
-        return left.second < right.second;
-    });
+    fast_sort(candidates, [](auto &left, auto &right) -> bool { return left.second < right.second; });
     for (auto &candidate : candidates) {
         auto ref = candidate.first;
         auto maxLocations = min(MAX_LOCATIONS_PER_SYMBOL, maxResults - results.size());

--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -16,6 +16,11 @@ namespace sorbet::realmain::lsp {
 
 namespace {
 
+struct PartialMatch {
+    uint score = 0;
+    string_view::const_iterator matchEnd = nullptr; // progress in query match
+};
+
 class SymbolMatcher final {
 public:
     static constexpr size_t MAX_RESULTS = 50;
@@ -33,9 +38,35 @@ private:
 
     const LSPConfiguration &config;
     const core::GlobalState &gs;
+    vector<PartialMatch> classOrModuleMatches;
+    vector<PartialMatch> methodMatches;
+    vector<PartialMatch> fieldMatches;
+    vector<PartialMatch> typeArgumentMatches;
+    vector<PartialMatch> typeMemberMatches;
+
+    PartialMatch &getPartialMatch(core::SymbolRef ref) {
+        switch (ref.kind()) {
+            case core::SymbolRef::Kind::ClassOrModule:
+                return classOrModuleMatches[ref.id()];
+            case core::SymbolRef::Kind::Method:
+                return methodMatches[ref.id()];
+            case core::SymbolRef::Kind::Field:
+                return fieldMatches[ref.id()];
+            case core::SymbolRef::Kind::TypeArgument:
+                return typeArgumentMatches[ref.id()];
+            case core::SymbolRef::Kind::TypeMember:
+                return typeMemberMatches[ref.id()];
+        }
+    }
+
+    void updatePartialMatch(core::SymbolRef symbolRef, string_view::const_iterator queryBegin,
+                            string_view::const_iterator queryEnd, size_t &ceilingScore);
 };
 
-SymbolMatcher::SymbolMatcher(const LSPConfiguration &config, const core::GlobalState &gs) : config(config), gs(gs) {}
+SymbolMatcher::SymbolMatcher(const LSPConfiguration &config, const core::GlobalState &gs)
+    : config(config), gs(gs), classOrModuleMatches(gs.classAndModulesUsed()), methodMatches(gs.methodsUsed()),
+      fieldMatches(gs.fieldsUsed()), typeArgumentMatches(gs.typeArgumentsUsed()),
+      typeMemberMatches(gs.typeMembersUsed()) {}
 
 /**
  * Converts a symbol into any (supported) SymbolInformation objects.
@@ -81,11 +112,6 @@ inline bool isEligibleSymbol(const core::NameData &nameData) {
     }
     return true;
 }
-
-struct PartialMatch {
-    uint score = 0;
-    string_view::const_iterator matchEnd = nullptr; // progress in query match
-};
 
 /** Returns a PartialMatch for the given symbol/query. */
 PartialMatch partialMatchSymbol(string_view symbol, string_view::const_iterator queryBegin,
@@ -154,7 +180,45 @@ PartialMatch partialMatchSymbol(string_view symbol, string_view::const_iterator 
     }
     return {score, matchEnd};
 }
-} // namespace
+
+void SymbolMatcher::updatePartialMatch(core::SymbolRef symbolRef, string_view::const_iterator queryBegin,
+                                       string_view::const_iterator queryEnd, size_t &ceilingScore) {
+    auto symbolData = symbolRef.data(gs);
+    auto nameData = symbolData->name.data(gs);
+    if (!isEligibleSymbol(nameData)) {
+        return;
+    }
+    auto shortName = nameData->shortName(gs);
+    auto &partialMatch = getPartialMatch(symbolRef);
+    partialMatch = partialMatchSymbol(shortName, queryBegin, queryEnd, true, ceilingScore);
+    for (auto previousAncestorRef = symbolRef, ancestorRef = symbolData->owner;
+         previousAncestorRef != ancestorRef && ancestorRef.exists();
+         previousAncestorRef = ancestorRef, ancestorRef = ancestorRef.data(gs)->owner) {
+        auto &ancestorMatch = getPartialMatch(ancestorRef);
+        auto ancestorEnd = ancestorMatch.matchEnd;
+        if (ancestorEnd == queryBegin || ancestorEnd == nullptr) {
+            break; // no further ancestor will be of any help
+        }
+        if (ancestorEnd == queryEnd) {
+            continue; // ancestor matched everything, so skip to its parent
+        }
+        auto ancestorScore = ancestorMatch.score;
+        auto plusMatch = partialMatchSymbol(shortName, ancestorEnd, queryEnd, true, ceilingScore - ancestorScore);
+        if (plusMatch.matchEnd - partialMatch.matchEnd > 0) {
+            partialMatch.score = ancestorScore + plusMatch.score;
+            partialMatch.matchEnd = plusMatch.matchEnd;
+        } else if (plusMatch.matchEnd == partialMatch.matchEnd) {
+            auto combinedScore = ancestorScore + plusMatch.score;
+            if (combinedScore < partialMatch.score) {
+                partialMatch.score = combinedScore;
+            }
+        }
+    }
+    if (partialMatch.matchEnd == queryEnd) {
+        // update ceiling so we stop looking at bad matches
+        ceilingScore = min(ceilingScore, partialMatch.score * WORST_TO_BEST_RATIO);
+    }
+}
 
 vector<unique_ptr<SymbolInformation>> SymbolMatcher::doQuery(string_view query_view, size_t maxResults) {
     vector<unique_ptr<SymbolInformation>> results;
@@ -165,47 +229,23 @@ vector<unique_ptr<SymbolInformation>> SymbolMatcher::doQuery(string_view query_v
         return results;
     }
     size_t ceilingScore = INT_MAX;
-    vector<PartialMatch> partialMatches(gs.symbolsUsed());
+
+    const vector<pair<core::SymbolRef::Kind, uint>> symbolKinds = {
+        {core::SymbolRef::Kind::ClassOrModule, gs.classAndModulesUsed()},
+        {core::SymbolRef::Kind::Field, gs.fieldsUsed()},
+        {core::SymbolRef::Kind::Method, gs.methodsUsed()},
+        {core::SymbolRef::Kind::TypeArgument, gs.typeArgumentsUsed()},
+        {core::SymbolRef::Kind::TypeMember, gs.typeMembersUsed()},
+    };
+
     // First pass: prefix-only matches on namespace
     {
         Timer timeit(gs.tracer(), "SymbolMatcher::doQuery::pass1");
-        for (u4 symbolIndex = 1; symbolIndex < gs.symbolsUsed(); symbolIndex++) {
-            auto symbolRef = core::SymbolRef(gs, symbolIndex);
-            auto symbolData = symbolRef.data(gs);
-            auto nameData = symbolData->name.data(gs);
-            if (!isEligibleSymbol(nameData)) {
-                continue;
-            }
-            auto shortName = nameData->shortName(gs);
-            auto &partialMatch = partialMatches[symbolIndex] =
-                partialMatchSymbol(shortName, queryBegin, queryEnd, true, ceilingScore);
-            for (auto previousAncestorRef = symbolRef, ancestorRef = symbolData->owner;
-                 previousAncestorRef != ancestorRef && ancestorRef.exists();
-                 previousAncestorRef = ancestorRef, ancestorRef = ancestorRef.data(gs)->owner) {
-                auto &ancestorMatch = partialMatches[ancestorRef._id];
-                auto ancestorEnd = ancestorMatch.matchEnd;
-                if (ancestorEnd == queryBegin || ancestorEnd == nullptr) {
-                    break; // no further ancestor will be of any help
-                }
-                if (ancestorEnd == queryEnd) {
-                    continue; // ancestor matched everything, so skip to its parent
-                }
-                auto ancestorScore = ancestorMatch.score;
-                auto plusMatch =
-                    partialMatchSymbol(shortName, ancestorEnd, queryEnd, true, ceilingScore - ancestorScore);
-                if (plusMatch.matchEnd - partialMatch.matchEnd > 0) {
-                    partialMatch.score = ancestorScore + plusMatch.score;
-                    partialMatch.matchEnd = plusMatch.matchEnd;
-                } else if (plusMatch.matchEnd == partialMatch.matchEnd) {
-                    auto combinedScore = ancestorScore + plusMatch.score;
-                    if (combinedScore < partialMatch.score) {
-                        partialMatch.score = combinedScore;
-                    }
-                }
-            }
-            if (partialMatch.matchEnd == queryEnd) {
-                // update ceiling so we stop looking at bad matches
-                ceilingScore = min(ceilingScore, partialMatch.score * WORST_TO_BEST_RATIO);
+        for (auto pair : symbolKinds) {
+            const auto kind = pair.first;
+            const auto size = pair.second;
+            for (u4 i = 1; i < size; ++i) {
+                updatePartialMatch(core::SymbolRef(gs, kind, i), queryBegin, queryEnd, ceilingScore);
             }
         }
     }
@@ -214,52 +254,58 @@ vector<unique_ptr<SymbolInformation>> SymbolMatcher::doQuery(string_view query_v
     // prefix-only requirement for non-matches) Don't update partialMatches,
     // because we will continue using it to keep the prefix-only scores for
     // owner-namespaces.
-    vector<pair<u4, int>> candidates;
+    vector<pair<core::SymbolRef, int>> candidates;
     {
         Timer timeit(gs.tracer(), "SymbolMatcher::doQuery::pass2");
-        for (u4 symbolIndex = 1; symbolIndex < gs.symbolsUsed(); symbolIndex++) {
-            auto symbolRef = core::SymbolRef(gs, symbolIndex);
-            auto symbolData = symbolRef.data(gs);
-            auto nameData = symbolData->name.data(gs);
-            if (!isEligibleSymbol(nameData)) {
-                continue;
-            }
-            auto shortName = nameData->shortName(gs);
-            uint bestScore = ceilingScore;
-            auto [partialScore, partialMatchEnd] =
-                partialMatchSymbol(shortName, queryBegin, queryEnd, false, ceilingScore);
-            if (partialMatchEnd == queryEnd) {
-                bestScore = partialScore;
-            }
-            for (auto previousAncestorRef = symbolRef, ancestorRef = symbolData->owner;
-                 previousAncestorRef != ancestorRef && ancestorRef.exists();
-                 previousAncestorRef = ancestorRef, ancestorRef = ancestorRef.data(gs)->owner) {
-                auto [ancestorScore, ancestorEnd] = partialMatches[ancestorRef._id];
-                if (ancestorEnd == queryBegin || ancestorEnd == nullptr) {
-                    break; // no further ancestor will be of any help
+        for (auto pair : symbolKinds) {
+            const auto kind = pair.first;
+            const auto size = pair.second;
+            for (u4 i = 1; i < size; ++i) {
+                auto symbolRef = core::SymbolRef(gs, kind, i);
+                auto symbolData = symbolRef.data(gs);
+                auto nameData = symbolData->name.data(gs);
+                if (!isEligibleSymbol(nameData)) {
+                    continue;
                 }
-                if (ancestorEnd == queryEnd) {
-                    continue; // ancestor matched everything, so skip to its parent
+                auto shortName = nameData->shortName(gs);
+                uint bestScore = ceilingScore;
+                auto [partialScore, partialMatchEnd] =
+                    partialMatchSymbol(shortName, queryBegin, queryEnd, false, ceilingScore);
+                if (partialMatchEnd == queryEnd) {
+                    bestScore = partialScore;
                 }
-                if (ancestorScore >= bestScore) {
-                    continue; // matching this ancestor would be worse
+                for (auto previousAncestorRef = symbolRef, ancestorRef = symbolData->owner;
+                     previousAncestorRef != ancestorRef && ancestorRef.exists();
+                     previousAncestorRef = ancestorRef, ancestorRef = ancestorRef.data(gs)->owner) {
+                    auto [ancestorScore, ancestorEnd] = getPartialMatch(ancestorRef);
+                    if (ancestorEnd == queryBegin || ancestorEnd == nullptr) {
+                        break; // no further ancestor will be of any help
+                    }
+                    if (ancestorEnd == queryEnd) {
+                        continue; // ancestor matched everything, so skip to its parent
+                    }
+                    if (ancestorScore >= bestScore) {
+                        continue; // matching this ancestor would be worse
+                    }
+                    auto [plusScore, plusEnd] =
+                        partialMatchSymbol(shortName, ancestorEnd, queryEnd, false, bestScore - ancestorScore);
+                    if (plusEnd == queryEnd) {
+                        bestScore = min(bestScore, ancestorScore + plusScore);
+                    }
                 }
-                auto [plusScore, plusEnd] =
-                    partialMatchSymbol(shortName, ancestorEnd, queryEnd, false, bestScore - ancestorScore);
-                if (plusEnd == queryEnd) {
-                    bestScore = min(bestScore, ancestorScore + plusScore);
+                if (bestScore < ceilingScore) {
+                    // update ceiling so we stop looking at bad matches
+                    ceilingScore = min(ceilingScore, bestScore * WORST_TO_BEST_RATIO);
+                    candidates.emplace_back(symbolRef, bestScore);
                 }
-            }
-            if (bestScore < ceilingScore) {
-                // update ceiling so we stop looking at bad matches
-                ceilingScore = min(ceilingScore, bestScore * WORST_TO_BEST_RATIO);
-                candidates.emplace_back(symbolIndex, bestScore);
             }
         }
     }
-    fast_sort(candidates, [](pair<u4, int> &left, pair<u4, int> &right) -> bool { return left.second < right.second; });
+    fast_sort(candidates, [](pair<core::SymbolRef, int> &left, pair<core::SymbolRef, int> &right) -> bool {
+        return left.second < right.second;
+    });
     for (auto &candidate : candidates) {
-        core::SymbolRef ref(gs, candidate.first);
+        auto ref = candidate.first;
         auto maxLocations = min(MAX_LOCATIONS_PER_SYMBOL, maxResults - results.size());
         for (auto &symbolInformation : symbolRef2SymbolInformations(ref, maxLocations)) {
             results.emplace_back(move(symbolInformation));
@@ -270,7 +316,8 @@ vector<unique_ptr<SymbolInformation>> SymbolMatcher::doQuery(string_view query_v
     }
     ENFORCE(results.size() <= maxResults);
     return results;
-} // namespace sorbet::realmain::lsp
+}
+} // namespace
 
 WorkspaceSymbolsTask::WorkspaceSymbolsTask(const LSPConfiguration &config, MessageId id,
                                            unique_ptr<WorkspaceSymbolParams> params)

--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -244,8 +244,11 @@ vector<unique_ptr<SymbolInformation>> SymbolMatcher::doQuery(string_view query_v
         for (auto pair : symbolKinds) {
             const auto kind = pair.first;
             const auto size = pair.second;
-            for (u4 i = 1; i < size; ++i) {
-                updatePartialMatch(core::SymbolRef(gs, kind, i), queryBegin, queryEnd, ceilingScore);
+            for (u4 i = 0; i < size; ++i) {
+                auto sym = core::SymbolRef(gs, kind, i);
+                if (sym.exists()) {
+                    updatePartialMatch(core::SymbolRef(gs, kind, i), queryBegin, queryEnd, ceilingScore);
+                }
             }
         }
     }
@@ -260,8 +263,11 @@ vector<unique_ptr<SymbolInformation>> SymbolMatcher::doQuery(string_view query_v
         for (auto pair : symbolKinds) {
             const auto kind = pair.first;
             const auto size = pair.second;
-            for (u4 i = 1; i < size; ++i) {
+            for (u4 i = 0; i < size; ++i) {
                 auto symbolRef = core::SymbolRef(gs, kind, i);
+                if (!symbolRef.exists()) {
+                    continue;
+                }
                 auto symbolData = symbolRef.data(gs);
                 auto nameData = symbolData->name.data(gs);
                 if (!isEligibleSymbol(nameData)) {

--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -241,9 +241,7 @@ vector<unique_ptr<SymbolInformation>> SymbolMatcher::doQuery(string_view query_v
     // First pass: prefix-only matches on namespace
     {
         Timer timeit(gs.tracer(), "SymbolMatcher::doQuery::pass1");
-        for (auto pair : symbolKinds) {
-            const auto kind = pair.first;
-            const auto size = pair.second;
+        for (auto [kind,size] : symbolKinds) {
             for (u4 i = 0; i < size; ++i) {
                 auto sym = core::SymbolRef(gs, kind, i);
                 if (sym.exists()) {
@@ -305,7 +303,7 @@ vector<unique_ptr<SymbolInformation>> SymbolMatcher::doQuery(string_view query_v
             }
         }
     }
-    fast_sort(candidates, [](pair<core::SymbolRef, int> &left, pair<core::SymbolRef, int> &right) -> bool {
+    fast_sort(candidates, [](auto &left, auto &right) -> bool {
         return left.second < right.second;
     });
     for (auto &candidate : candidates) {

--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -47,15 +47,15 @@ private:
     PartialMatch &getPartialMatch(core::SymbolRef ref) {
         switch (ref.kind()) {
             case core::SymbolRef::Kind::ClassOrModule:
-                return classOrModuleMatches[ref.id()];
+                return classOrModuleMatches[ref.classOrModuleIndex()];
             case core::SymbolRef::Kind::Method:
-                return methodMatches[ref.id()];
+                return methodMatches[ref.methodIndex()];
             case core::SymbolRef::Kind::Field:
-                return fieldMatches[ref.id()];
+                return fieldMatches[ref.fieldIndex()];
             case core::SymbolRef::Kind::TypeArgument:
-                return typeArgumentMatches[ref.id()];
+                return typeArgumentMatches[ref.typeArgumentIndex()];
             case core::SymbolRef::Kind::TypeMember:
-                return typeMemberMatches[ref.id()];
+                return typeMemberMatches[ref.typeMemberIndex()];
         }
     }
 

--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -260,9 +260,7 @@ vector<unique_ptr<SymbolInformation>> SymbolMatcher::doQuery(string_view query_v
     vector<pair<core::SymbolRef, int>> candidates;
     {
         Timer timeit(gs.tracer(), "SymbolMatcher::doQuery::pass2");
-        for (auto pair : symbolKinds) {
-            const auto kind = pair.first;
-            const auto size = pair.second;
+        for (auto [kind,size] : symbolKinds) {
             for (u4 i = 0; i < size; ++i) {
                 auto symbolRef = core::SymbolRef(gs, kind, i);
                 if (!symbolRef.exists()) {

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -339,7 +339,7 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
         "reserve-field-table-capacity", "Preallocate the specified number of entries in the field table",
         cxxopts::value<u4>()->default_value(fmt::format("{}", empty.reserveFieldTableCapacity)));
     options.add_options("advanced")(
-        "reserve-type-argument-table-capacity", "Preallocate the specified number of entries in the type member table",
+        "reserve-type-argument-table-capacity", "Preallocate the specified number of entries in the type argument table",
         cxxopts::value<u4>()->default_value(fmt::format("{}", empty.reserveTypeArgumentTableCapacity)));
     options.add_options("advanced")(
         "reserve-type-member-table-capacity", "Preallocate the specified number of entries in the type member table",

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -339,7 +339,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
         "reserve-field-table-capacity", "Preallocate the specified number of entries in the field table",
         cxxopts::value<u4>()->default_value(fmt::format("{}", empty.reserveFieldTableCapacity)));
     options.add_options("advanced")(
-        "reserve-type-argument-table-capacity", "Preallocate the specified number of entries in the type argument table",
+        "reserve-type-argument-table-capacity",
+        "Preallocate the specified number of entries in the type argument table",
         cxxopts::value<u4>()->default_value(fmt::format("{}", empty.reserveTypeArgumentTableCapacity)));
     options.add_options("advanced")(
         "reserve-type-member-table-capacity", "Preallocate the specified number of entries in the type member table",

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -330,8 +330,20 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("debug-log-file", "Path to debug log file",
                                     cxxopts::value<string>()->default_value(empty.debugLogFile), "file");
     options.add_options("advanced")(
-        "reserve-symbol-table-capacity", "Preallocate the specified number of entries in the symbol table",
-        cxxopts::value<u4>()->default_value(fmt::format("{}", empty.reserveSymbolTableCapacity)));
+        "reserve-class-table-capacity", "Preallocate the specified number of entries in the class and modules table",
+        cxxopts::value<u4>()->default_value(fmt::format("{}", empty.reserveClassTableCapacity)));
+    options.add_options("advanced")(
+        "reserve-method-table-capacity", "Preallocate the specified number of entries in the method table",
+        cxxopts::value<u4>()->default_value(fmt::format("{}", empty.reserveMethodTableCapacity)));
+    options.add_options("advanced")(
+        "reserve-field-table-capacity", "Preallocate the specified number of entries in the field table",
+        cxxopts::value<u4>()->default_value(fmt::format("{}", empty.reserveFieldTableCapacity)));
+    options.add_options("advanced")(
+        "reserve-type-argument-table-capacity", "Preallocate the specified number of entries in the type member table",
+        cxxopts::value<u4>()->default_value(fmt::format("{}", empty.reserveTypeArgumentTableCapacity)));
+    options.add_options("advanced")(
+        "reserve-type-member-table-capacity", "Preallocate the specified number of entries in the type member table",
+        cxxopts::value<u4>()->default_value(fmt::format("{}", empty.reserveTypeMemberTableCapacity)));
     options.add_options("advanced")(
         "reserve-name-table-capacity", "Preallocate the specified number of entries in the name table",
         cxxopts::value<u4>()->default_value(fmt::format("{}", empty.reserveNameTableCapacity)));
@@ -833,7 +845,11 @@ void readOptions(Options &opts,
             }
         }
         opts.reserveNameTableCapacity = raw["reserve-name-table-capacity"].as<u4>();
-        opts.reserveSymbolTableCapacity = raw["reserve-symbol-table-capacity"].as<u4>();
+        opts.reserveClassTableCapacity = raw["reserve-class-table-capacity"].as<u4>();
+        opts.reserveMethodTableCapacity = raw["reserve-method-table-capacity"].as<u4>();
+        opts.reserveFieldTableCapacity = raw["reserve-field-table-capacity"].as<u4>();
+        opts.reserveTypeArgumentTableCapacity = raw["reserve-type-argument-table-capacity"].as<u4>();
+        opts.reserveTypeMemberTableCapacity = raw["reserve-type-member-table-capacity"].as<u4>();
         if (raw.count("autogen-version") > 0) {
             if (!opts.print.AutogenMsgPack.enabled) {
                 logger->error("`{}` must also include `{}`", "--autogen-version", "-p autogen-msgpack");

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -166,7 +166,11 @@ struct Options {
     /** Prefix to remove from all printed paths. */
     std::string pathPrefix;
 
-    u4 reserveSymbolTableCapacity = 0;
+    u4 reserveClassTableCapacity = 0;
+    u4 reserveMethodTableCapacity = 0;
+    u4 reserveFieldTableCapacity = 0;
+    u4 reserveTypeArgumentTableCapacity = 0;
+    u4 reserveTypeMemberTableCapacity = 0;
     u4 reserveNameTableCapacity = 0;
 
     std::string statsdHost;

--- a/main/options/test/options_test.cc
+++ b/main/options/test/options_test.cc
@@ -54,7 +54,11 @@ TEST_CASE("DefaultConstructorMatchesReadOptions") {
     CHECK_EQ(empty.errorCodeBlackList, opts.errorCodeBlackList);
     CHECK_EQ(empty.pathPrefix, opts.pathPrefix);
     CHECK_EQ(empty.reserveNameTableCapacity, opts.reserveNameTableCapacity);
-    CHECK_EQ(empty.reserveSymbolTableCapacity, opts.reserveSymbolTableCapacity);
+    CHECK_EQ(empty.reserveClassTableCapacity, opts.reserveClassTableCapacity);
+    CHECK_EQ(empty.reserveMethodTableCapacity, opts.reserveMethodTableCapacity);
+    CHECK_EQ(empty.reserveFieldTableCapacity, opts.reserveFieldTableCapacity);
+    CHECK_EQ(empty.reserveTypeArgumentTableCapacity, opts.reserveTypeArgumentTableCapacity);
+    CHECK_EQ(empty.reserveTypeMemberTableCapacity, opts.reserveTypeMemberTableCapacity);
     CHECK_EQ(empty.statsdHost, opts.statsdHost);
     CHECK_EQ(empty.statsdPrefix, opts.statsdPrefix);
     CHECK_EQ(empty.statsdPort, opts.statsdPort);

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -888,7 +888,7 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
             what = move(maybeResult.result());
         }
         if (opts.stressIncrementalResolver) {
-            auto symbolsBefore = gs->symbolsUsed();
+            auto symbolsBefore = gs->allSymbolsUsed();
             for (auto &f : what) {
                 // Shift contents of file past current file's EOF, re-run incrementalResolve, assert that no locations
                 // appear before file's old EOF.
@@ -905,7 +905,7 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
                 ENFORCE(reresolved.size() == 1);
                 f = checkNoDefinitionsInsideProhibitedLines(*gs, move(reresolved[0]), 0, prohibitedLines);
             }
-            ENFORCE(symbolsBefore == gs->symbolsUsed(),
+            ENFORCE(symbolsBefore == gs->allSymbolsUsed(),
                     "Stressing the incremental resolver should not add any new symbols");
         }
     } catch (SorbetException &) {

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -888,7 +888,7 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
             what = move(maybeResult.result());
         }
         if (opts.stressIncrementalResolver) {
-            auto symbolsBefore = gs->allSymbolsUsed();
+            auto symbolsBefore = gs->symbolsUsedTotal();
             for (auto &f : what) {
                 // Shift contents of file past current file's EOF, re-run incrementalResolve, assert that no locations
                 // appear before file's old EOF.
@@ -905,7 +905,7 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
                 ENFORCE(reresolved.size() == 1);
                 f = checkNoDefinitionsInsideProhibitedLines(*gs, move(reresolved[0]), 0, prohibitedLines);
             }
-            ENFORCE(symbolsBefore == gs->allSymbolsUsed(),
+            ENFORCE(symbolsBefore == gs->symbolsUsedTotal(),
                     "Stressing the incremental resolver should not add any new symbols");
         }
     } catch (SorbetException &) {

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -445,7 +445,9 @@ int realmain(int argc, char *argv[]) {
     if (opts.sleepInSlowPath) {
         gs->sleepInSlowPath = true;
     }
-    gs->preallocateTables(opts.reserveSymbolTableCapacity, opts.reserveNameTableCapacity);
+    gs->preallocateTables(opts.reserveClassTableCapacity, opts.reserveMethodTableCapacity,
+                          opts.reserveFieldTableCapacity, opts.reserveTypeArgumentTableCapacity,
+                          opts.reserveTypeMemberTableCapacity, opts.reserveNameTableCapacity);
     for (auto code : opts.errorCodeWhiteList) {
         gs->onlyShowErrorClass(code);
     }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -607,7 +607,7 @@ int realmain(int argc, char *argv[]) {
             vector<pair<string, int>> withNames;
             long sum = 0;
             for (auto e : untypedSources) {
-                withNames.emplace_back(core::SymbolRef(*gs, e.first).dataAllowingNone(*gs)->showFullName(*gs),
+                withNames.emplace_back(core::SymbolRef::fromRaw(e.first).dataAllowingNone(*gs)->showFullName(*gs),
                                        e.second);
                 sum += e.second;
             }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1022,7 +1022,7 @@ class SymbolDefiner {
 
             auto oldSymCount = ctx.state.classAndModulesUsed();
             auto newSingleton = symbol.data(ctx)->singletonClass(ctx); // force singleton class into existence
-            ENFORCE(newSingleton.id() >= oldSymCount,
+            ENFORCE(newSingleton.classOrModuleIndex() >= oldSymCount,
                     "should be a fresh symbol. Otherwise we could be reusing an existing singletonClass");
             return symbol;
         } else if (symbol.data(ctx)->isClassModuleSet() && isModule != symbol.data(ctx)->isClassOrModuleModule()) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -52,7 +52,7 @@ public:
     FoundDefinitionRef &operator=(const FoundDefinitionRef &rhs) = default;
 
     static FoundDefinitionRef root() {
-        return FoundDefinitionRef(DefinitionKind::Symbol, core::Symbols::root()._id);
+        return FoundDefinitionRef(DefinitionKind::Symbol, core::Symbols::root().raw());
     }
 
     DefinitionKind kind() const {
@@ -200,7 +200,7 @@ public:
     }
 
     FoundDefinitionRef addSymbol(core::SymbolRef symbol) {
-        return FoundDefinitionRef(DefinitionKind::Symbol, symbol._id);
+        return FoundDefinitionRef(DefinitionKind::Symbol, symbol.raw());
     }
 
     void addModifier(Modifier &&mod) {
@@ -283,7 +283,7 @@ const FoundTypeMember &FoundDefinitionRef::typeMember(const FoundDefinitions &fo
 
 core::SymbolRef FoundDefinitionRef::symbol() const {
     ENFORCE(kind() == DefinitionKind::Symbol);
-    return core::SymbolRef(nullptr, _id);
+    return core::SymbolRef::fromRaw(_id);
 }
 
 struct SymbolFinderResult {
@@ -921,9 +921,9 @@ class SymbolDefiner {
         // be about to create it!) and `currentSym` would be `def f()`, because we have not yet progressed far
         // enough in the file to see any other definition of `f`.
         auto &parsedArgs = method.parsedArgs;
-        auto symTableSize = ctx.state.symbolsUsed();
+        auto symTableSize = ctx.state.methodsUsed();
         auto sym = ctx.state.enterMethodSymbol(method.declLoc, owner, method.name);
-        const bool isNewSymbol = symTableSize != ctx.state.symbolsUsed();
+        const bool isNewSymbol = symTableSize != ctx.state.methodsUsed();
         if (!isNewSymbol) {
             // See if this is == to the method we're defining now, or if we have a redefinition error.
             auto matchingSym = ctx.state.lookupMethodSymbolWithHash(owner, method.name, method.argsHash);
@@ -1020,9 +1020,9 @@ class SymbolDefiner {
             symbol = ctx.state.enterClassSymbol(klass.declLoc, symbol.data(ctx)->owner, origName);
             symbol.data(ctx)->setIsModule(isModule);
 
-            auto oldSymCount = ctx.state.symbolsUsed();
+            auto oldSymCount = ctx.state.classAndModulesUsed();
             auto newSingleton = symbol.data(ctx)->singletonClass(ctx); // force singleton class into existence
-            ENFORCE(newSingleton._id >= oldSymCount,
+            ENFORCE(newSingleton.id() >= oldSymCount,
                     "should be a fresh symbol. Otherwise we could be reusing an existing singletonClass");
             return symbol;
         } else if (symbol.data(ctx)->isClassModuleSet() && isModule != symbol.data(ctx)->isClassOrModuleModule()) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -52,7 +52,7 @@ public:
     FoundDefinitionRef &operator=(const FoundDefinitionRef &rhs) = default;
 
     static FoundDefinitionRef root() {
-        return FoundDefinitionRef(DefinitionKind::Symbol, core::Symbols::root().raw());
+        return FoundDefinitionRef(DefinitionKind::Symbol, core::Symbols::root().rawId());
     }
 
     DefinitionKind kind() const {
@@ -200,7 +200,7 @@ public:
     }
 
     FoundDefinitionRef addSymbol(core::SymbolRef symbol) {
-        return FoundDefinitionRef(DefinitionKind::Symbol, symbol.raw());
+        return FoundDefinitionRef(DefinitionKind::Symbol, symbol.rawId());
     }
 
     void addModifier(Modifier &&mod) {

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -75,7 +75,8 @@ TEST_CASE("namer tests") {
     }
 
     SUBCASE("Idempotent") { // NOLINT
-        auto baseSymbols = gs.symbolsUsed();
+        auto baseSymbols = gs.allSymbolsUsed();
+        auto baseMethods = gs.methodsUsed();
         auto baseNames = gs.namesUsed();
 
         auto tree = hello_world(gs);
@@ -91,14 +92,16 @@ TEST_CASE("namer tests") {
         auto staticInit = 1;
         auto extraSymbols = helloWorldMethod + staticInit;
 
-        REQUIRE_EQ(baseSymbols + extraSymbols, gs.symbolsUsed());
+        REQUIRE_EQ(baseSymbols + extraSymbols, gs.allSymbolsUsed());
+        REQUIRE_EQ(baseMethods + extraSymbols, gs.methodsUsed());
         REQUIRE_EQ(baseNames + 2, gs.namesUsed());
 
         // Run it again and get the same numbers
         auto localTree = sorbet::local_vars::LocalVars::run(gs, move(treeCopy));
         runNamer(gs, move(localTree));
 
-        REQUIRE_EQ(baseSymbols + extraSymbols, gs.symbolsUsed());
+        REQUIRE_EQ(baseSymbols + extraSymbols, gs.allSymbolsUsed());
+        REQUIRE_EQ(baseMethods + extraSymbols, gs.methodsUsed());
         REQUIRE_EQ(baseNames + 2, gs.namesUsed());
     }
 

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -75,7 +75,7 @@ TEST_CASE("namer tests") {
     }
 
     SUBCASE("Idempotent") { // NOLINT
-        auto baseSymbols = gs.allSymbolsUsed();
+        auto baseSymbols = gs.symbolsUsedTotal();
         auto baseMethods = gs.methodsUsed();
         auto baseNames = gs.namesUsed();
 
@@ -92,7 +92,7 @@ TEST_CASE("namer tests") {
         auto staticInit = 1;
         auto extraSymbols = helloWorldMethod + staticInit;
 
-        REQUIRE_EQ(baseSymbols + extraSymbols, gs.allSymbolsUsed());
+        REQUIRE_EQ(baseSymbols + extraSymbols, gs.symbolsUsedTotal());
         REQUIRE_EQ(baseMethods + extraSymbols, gs.methodsUsed());
         REQUIRE_EQ(baseNames + 2, gs.namesUsed());
 
@@ -100,7 +100,7 @@ TEST_CASE("namer tests") {
         auto localTree = sorbet::local_vars::LocalVars::run(gs, move(treeCopy));
         runNamer(gs, move(localTree));
 
-        REQUIRE_EQ(baseSymbols + extraSymbols, gs.allSymbolsUsed());
+        REQUIRE_EQ(baseSymbols + extraSymbols, gs.symbolsUsedTotal());
         REQUIRE_EQ(baseMethods + extraSymbols, gs.methodsUsed());
         REQUIRE_EQ(baseNames + 2, gs.namesUsed());
     }

--- a/payload/payload.cc
+++ b/payload/payload.cc
@@ -42,6 +42,31 @@ void createInitialGlobalState(unique_ptr<core::GlobalState> &gs, const realmain:
         Timer timeit(gs->tracer(), "read_global_state.binary");
         core::serialize::Serializer::loadGlobalState(*gs, nameTablePayload);
     }
+    ENFORCE(gs->namesUsed() < core::GlobalState::PAYLOAD_MAX_NAME_COUNT,
+            "Payload defined `{}` names, which is greater than the expected maximum of `{}`. Consider updating "
+            "`PAYLOAD_MAX_NAME_COUNT` in `GlobalState`.",
+            gs->namesUsed(), core::GlobalState::PAYLOAD_MAX_NAME_COUNT);
+    ENFORCE(gs->fieldsUsed() < core::GlobalState::PAYLOAD_MAX_FIELD_COUNT,
+            "Payload defined `{}` fields, which is greater than the expected maximum of `{}`. Consider updating "
+            "`PAYLOAD_MAX_FIELD_COUNT` in `GlobalState`.",
+            gs->fieldsUsed(), core::GlobalState::PAYLOAD_MAX_FIELD_COUNT);
+    ENFORCE(gs->methodsUsed() < core::GlobalState::PAYLOAD_MAX_METHOD_COUNT,
+            "Payload defined `{}` methods, which is greater than the expected maximum of `{}`. Consider updating "
+            "`PAYLOAD_MAX_METHOD_COUNT` in `GlobalState`.",
+            gs->methodsUsed(), core::GlobalState::PAYLOAD_MAX_METHOD_COUNT);
+    ENFORCE(gs->classAndModulesUsed() < core::GlobalState::PAYLOAD_MAX_CLASS_AND_MODULE_COUNT,
+            "Payload defined `{}` classes and modules, which is greater than the expected maximum of `{}`. Consider "
+            "updating `PAYLOAD_MAX_CLASS_AND_MODULE_COUNT` in `GlobalState`.",
+            gs->classAndModulesUsed(), core::GlobalState::PAYLOAD_MAX_CLASS_AND_MODULE_COUNT);
+    ENFORCE(gs->typeMembersUsed() < core::GlobalState::PAYLOAD_MAX_TYPE_MEMBER_COUNT,
+            "Payload defined `{}` type members, which is greater than the expected maximum of `{}`. Consider updating "
+            "`PAYLOAD_MAX_TYPE_MEMBER_COUNT` in `GlobalState`.",
+            gs->typeMembersUsed(), core::GlobalState::PAYLOAD_MAX_TYPE_MEMBER_COUNT);
+    ENFORCE(
+        gs->typeArgumentsUsed() < core::GlobalState::PAYLOAD_MAX_TYPE_ARGUMENT_COUNT,
+        "Payload defined `{}` type arguments, which is greater than the expected maximum of `{}`. Consider updating "
+        "`PAYLOAD_MAX_TYPE_ARGUMENT_COUNT` in `GlobalState`.",
+        gs->typeArgumentsUsed(), core::GlobalState::PAYLOAD_MAX_TYPE_ARGUMENT_COUNT);
 }
 
 namespace {

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -30,7 +30,7 @@ core::SymbolRef dealiasAt(const core::GlobalState &gs, core::SymbolRef tparam, c
             if (!cursor.exists()) {
                 return cursor;
             }
-            for (auto aliasPair : typeAliases[cursor._id]) {
+            for (auto aliasPair : typeAliases[cursor.id()]) {
                 if (aliasPair.first == tparam) {
                     return dealiasAt(gs, aliasPair.second, klass, typeAliases);
                 }
@@ -82,17 +82,17 @@ bool resolveTypeMember(core::GlobalState &gs, core::SymbolRef parent, core::Symb
         }
         return true;
     }
-    typeAliases[sym._id].emplace_back(parentTypeMember, my);
+    typeAliases[sym.id()].emplace_back(parentTypeMember, my);
     return true;
 } // namespace
 
 void resolveTypeMembers(core::GlobalState &gs, core::SymbolRef sym,
                         vector<vector<pair<core::SymbolRef, core::SymbolRef>>> &typeAliases, vector<bool> &resolved) {
     ENFORCE(sym.data(gs)->isClassOrModule());
-    if (resolved[sym._id]) {
+    if (resolved[sym.id()]) {
         return;
     }
-    resolved[sym._id] = true;
+    resolved[sym.id()] = true;
 
     if (sym.data(gs)->superClass().exists()) {
         auto parent = sym.data(gs)->superClass();
@@ -180,20 +180,21 @@ void Resolver::finalizeAncestors(core::GlobalState &gs) {
     Timer timer(gs.tracer(), "resolver.finalize_ancestors");
     int methodCount = 0;
     int classCount = 0;
-    for (int i = 1; i < gs.symbolsUsed(); ++i) {
-        auto ref = core::SymbolRef(&gs, i);
+    for (int i = 1; i < gs.methodsUsed(); ++i) {
+        auto ref = core::SymbolRef(&gs, core::SymbolRef::Kind::Method, i);
+        ENFORCE(ref.data(gs)->isMethod());
         auto loc = ref.data(gs)->loc();
         if (loc.file().exists() && loc.file().data(gs).sourceType == core::File::Type::Normal) {
-            if (ref.data(gs)->isMethod()) {
-                methodCount++;
-            } else if (ref.data(gs)->isClassOrModule()) {
-                classCount++;
-            }
+            methodCount++;
         }
-        if (!ref.data(gs)->isClassOrModule()) {
-            continue;
+    }
+    for (int i = 1; i < gs.classAndModulesUsed(); ++i) {
+        auto ref = core::SymbolRef(&gs, core::SymbolRef::Kind::ClassOrModule, i);
+        ENFORCE(ref.data(gs)->isClassOrModule());
+        auto loc = ref.data(gs)->loc();
+        if (loc.file().exists() && loc.file().data(gs).sourceType == core::File::Type::Normal) {
+            classCount++;
         }
-        classCount++;
         if (!ref.data(gs)->isClassModuleSet()) {
             // we did not see a declaration for this type not did we see it used. Default to module.
             ref.data(gs)->setIsModule(true);
@@ -354,12 +355,10 @@ void Resolver::computeLinearization(core::GlobalState &gs) {
     Timer timer(gs.tracer(), "resolver.compute_linearization");
 
     // TODO: this does not support `prepend`
-    for (int i = 1; i < gs.symbolsUsed(); ++i) {
-        const auto &data = core::SymbolRef(&gs, i).data(gs);
-        if (!data->isClassOrModule()) {
-            continue;
-        }
-        computeClassLinearization(gs, core::SymbolRef(&gs, i));
+    for (int i = 1; i < gs.classAndModulesUsed(); ++i) {
+        const auto &ref = core::SymbolRef(&gs, core::SymbolRef::Kind::ClassOrModule, i);
+        ENFORCE(ref.data(gs)->isClassOrModule());
+        computeClassLinearization(gs, ref);
     }
 }
 
@@ -370,11 +369,9 @@ void Resolver::finalizeSymbols(core::GlobalState &gs) {
     // that resolves types and we don't want to introduce additional passes if
     // we don't have to. It would be a tractable refactor to merge it
     // `ResolveConstantsWalk` if it becomes necessary to process earlier.
-    for (int i = 1; i < gs.symbolsUsed(); ++i) {
-        auto sym = core::SymbolRef(&gs, i);
-        if (!sym.data(gs)->isClassOrModule()) {
-            continue;
-        }
+    for (int i = 1; i < gs.classAndModulesUsed(); ++i) {
+        auto sym = core::SymbolRef(&gs, core::SymbolRef::Kind::ClassOrModule, i);
+        ENFORCE(sym.data(gs)->isClassOrModule());
 
         core::SymbolRef singleton;
         for (auto ancst : sym.data(gs)->mixins()) {
@@ -392,14 +389,13 @@ void Resolver::finalizeSymbols(core::GlobalState &gs) {
     computeLinearization(gs);
 
     vector<vector<pair<core::SymbolRef, core::SymbolRef>>> typeAliases;
-    typeAliases.resize(gs.symbolsUsed());
+    typeAliases.resize(gs.classAndModulesUsed());
     vector<bool> resolved;
-    resolved.resize(gs.symbolsUsed());
-    for (int i = 1; i < gs.symbolsUsed(); ++i) {
-        auto sym = core::SymbolRef(&gs, i);
-        if (sym.data(gs)->isClassOrModule()) {
-            resolveTypeMembers(gs, sym, typeAliases, resolved);
-        }
+    resolved.resize(gs.classAndModulesUsed());
+    for (int i = 1; i < gs.classAndModulesUsed(); ++i) {
+        auto sym = core::SymbolRef(&gs, core::SymbolRef::Kind::ClassOrModule, i);
+        ENFORCE(sym.data(gs)->isClassOrModule());
+        resolveTypeMembers(gs, sym, typeAliases, resolved);
     }
 }
 

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -30,8 +30,7 @@ core::SymbolRef dealiasAt(const core::GlobalState &gs, core::SymbolRef tparam, c
             if (!cursor.exists()) {
                 return cursor;
             }
-            ENFORCE(cursor.kind() == core::SymbolRef::Kind::ClassOrModule);
-            for (auto aliasPair : typeAliases[cursor.id()]) {
+            for (auto aliasPair : typeAliases[cursor.classOrModuleIndex()]) {
                 if (aliasPair.first == tparam) {
                     return dealiasAt(gs, aliasPair.second, klass, typeAliases);
                 }
@@ -83,18 +82,17 @@ bool resolveTypeMember(core::GlobalState &gs, core::SymbolRef parent, core::Symb
         }
         return true;
     }
-    ENFORCE(sym.kind() == core::SymbolRef::Kind::ClassOrModule);
-    typeAliases[sym.id()].emplace_back(parentTypeMember, my);
+    typeAliases[sym.classOrModuleIndex()].emplace_back(parentTypeMember, my);
     return true;
 } // namespace
 
 void resolveTypeMembers(core::GlobalState &gs, core::SymbolRef sym,
                         vector<vector<pair<core::SymbolRef, core::SymbolRef>>> &typeAliases, vector<bool> &resolved) {
     ENFORCE(sym.data(gs)->isClassOrModule());
-    if (resolved[sym.id()]) {
+    if (resolved[sym.classOrModuleIndex()]) {
         return;
     }
-    resolved[sym.id()] = true;
+    resolved[sym.classOrModuleIndex()] = true;
 
     if (sym.data(gs)->superClass().exists()) {
         auto parent = sym.data(gs)->superClass();

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -180,7 +180,7 @@ void Resolver::finalizeAncestors(core::GlobalState &gs) {
     Timer timer(gs.tracer(), "resolver.finalize_ancestors");
     int methodCount = 0;
     int classCount = 0;
-    for (int i = 1; i < gs.methodsUsed(); ++i) {
+    for (int i = 0; i < gs.methodsUsed(); ++i) {
         auto ref = core::SymbolRef(&gs, core::SymbolRef::Kind::Method, i);
         ENFORCE(ref.data(gs)->isMethod());
         auto loc = ref.data(gs)->loc();

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -30,6 +30,7 @@ core::SymbolRef dealiasAt(const core::GlobalState &gs, core::SymbolRef tparam, c
             if (!cursor.exists()) {
                 return cursor;
             }
+            ENFORCE(cursor.kind() == core::SymbolRef::Kind::ClassOrModule);
             for (auto aliasPair : typeAliases[cursor.id()]) {
                 if (aliasPair.first == tparam) {
                     return dealiasAt(gs, aliasPair.second, klass, typeAliases);
@@ -82,6 +83,7 @@ bool resolveTypeMember(core::GlobalState &gs, core::SymbolRef parent, core::Symb
         }
         return true;
     }
+    ENFORCE(sym.kind() == core::SymbolRef::Kind::ClassOrModule);
     typeAliases[sym.id()].emplace_back(parentTypeMember, my);
     return true;
 } // namespace

--- a/test/cli/cache-reserve-mem/cache-reserve-mem.out
+++ b/test/cli/cache-reserve-mem/cache-reserve-mem.out
@@ -1,1 +1,1 @@
---reserve-symbol-table-capacity --reserve-name-table-capacity OK
+--reserve-*-table-capacity OK

--- a/test/cli/cache-reserve-mem/cache-reserve-mem.sh
+++ b/test/cli/cache-reserve-mem/cache-reserve-mem.sh
@@ -5,6 +5,6 @@ cleanup() {
 }
 trap cleanup EXIT
 set -e
-main/sorbet --silence-dev-message -vvv --reserve-symbol-table-capacity 4000 --reserve-name-table-capacity 4000 --cache-dir "$dir" test/cli/cache-reserve-mem/input.rb
-main/sorbet --silence-dev-message -vvv --reserve-symbol-table-capacity 4000 --reserve-name-table-capacity 4000 --cache-dir "$dir" test/cli/cache-reserve-mem/input.rb
-echo "--reserve-symbol-table-capacity --reserve-name-table-capacity OK"
+main/sorbet --silence-dev-message -vvv --reserve-class-table-capacity 4000 --reserve-method-table-capacity 4000 --reserve-field-table-capacity 4000 --reserve-type-argument-table-capacity 4000 --reserve-type-member-table-capacity 4000 --reserve-name-table-capacity 4000 --cache-dir "$dir" test/cli/cache-reserve-mem/input.rb
+main/sorbet --silence-dev-message -vvv --reserve-class-table-capacity 4000 --reserve-method-table-capacity 4000 --reserve-field-table-capacity 4000 --reserve-type-argument-table-capacity 4000 --reserve-type-member-table-capacity 4000 --reserve-name-table-capacity 4000 --cache-dir "$dir" test/cli/cache-reserve-mem/input.rb
+echo '--reserve-*-table-capacity OK'

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -63,7 +63,7 @@ Usage:
                                 in the field table (default: 0)
       --reserve-type-argument-table-capacity arg
                                 Preallocate the specified number of entries
-                                in the type member table (default: 0)
+                                in the type argument table (default: 0)
       --reserve-type-member-table-capacity arg
                                 Preallocate the specified number of entries
                                 in the type member table (default: 0)

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -52,9 +52,21 @@ Usage:
       --web-trace-file file     Web trace file. For use with chrome
                                 about://tracing (default: "")
       --debug-log-file file     Path to debug log file (default: "")
-      --reserve-symbol-table-capacity arg
+      --reserve-class-table-capacity arg
                                 Preallocate the specified number of entries
-                                in the symbol table (default: 0)
+                                in the class and modules table (default: 0)
+      --reserve-method-table-capacity arg
+                                Preallocate the specified number of entries
+                                in the method table (default: 0)
+      --reserve-field-table-capacity arg
+                                Preallocate the specified number of entries
+                                in the field table (default: 0)
+      --reserve-type-argument-table-capacity arg
+                                Preallocate the specified number of entries
+                                in the type member table (default: 0)
+      --reserve-type-member-table-capacity arg
+                                Preallocate the specified number of entries
+                                in the type member table (default: 0)
       --reserve-name-table-capacity arg
                                 Preallocate the specified number of entries
                                 in the name table (default: 0)

--- a/test/hello-test.cc
+++ b/test/hello-test.cc
@@ -188,7 +188,7 @@ TEST_CASE("CloneSubstitutePayload") {
 
     sorbet::core::GlobalSubstitution subst(*c1, *c2);
     REQUIRE_EQ("<U test new name>", subst.substitute(n1).showRaw(*c2));
-    REQUIRE_EQ(c1->symbolsUsed(), c2->symbolsUsed());
-    REQUIRE_EQ(c1->symbolsUsed(), gs.symbolsUsed());
+    REQUIRE_EQ(c1->allSymbolsUsed(), c2->allSymbolsUsed());
+    REQUIRE_EQ(c1->allSymbolsUsed(), gs.allSymbolsUsed());
 }
 } // namespace sorbet

--- a/test/hello-test.cc
+++ b/test/hello-test.cc
@@ -188,7 +188,7 @@ TEST_CASE("CloneSubstitutePayload") {
 
     sorbet::core::GlobalSubstitution subst(*c1, *c2);
     REQUIRE_EQ("<U test new name>", subst.substitute(n1).showRaw(*c2));
-    REQUIRE_EQ(c1->allSymbolsUsed(), c2->allSymbolsUsed());
-    REQUIRE_EQ(c1->allSymbolsUsed(), gs.allSymbolsUsed());
+    REQUIRE_EQ(c1->symbolsUsedTotal(), c2->symbolsUsedTotal());
+    REQUIRE_EQ(c1->symbolsUsedTotal(), gs.symbolsUsedTotal());
 }
 } // namespace sorbet

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -459,7 +459,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     }
 
     handler.clear(*gs);
-    auto symbolsBefore = gs->allSymbolsUsed();
+    auto symbolsBefore = gs->symbolsUsedTotal();
 
     vector<ast::ParsedFile> newTrees;
     for (auto &f : trees) {
@@ -530,7 +530,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     {
         INFO("the incremental resolver should not add new symbols");
-        CHECK_EQ(symbolsBefore, gs->allSymbolsUsed());
+        CHECK_EQ(symbolsBefore, gs->symbolsUsedTotal());
     }
 }
 } // namespace sorbet::test

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -459,7 +459,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     }
 
     handler.clear(*gs);
-    auto symbolsBefore = gs->symbolsUsed();
+    auto symbolsBefore = gs->allSymbolsUsed();
 
     vector<ast::ParsedFile> newTrees;
     for (auto &f : trees) {
@@ -530,7 +530,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     {
         INFO("the incremental resolver should not add new symbols");
-        CHECK_EQ(symbolsBefore, gs->symbolsUsed());
+        CHECK_EQ(symbolsBefore, gs->allSymbolsUsed());
     }
 }
 } // namespace sorbet::test

--- a/test/testdata/packager/lsp_features/bart/bart.rb.document-symbols.exp
+++ b/test/testdata/packager/lsp_features/bart/bart.rb.document-symbols.exp
@@ -4,31 +4,6 @@
     "requestMethod": "textDocument/documentSymbol",
     "result": [
         {
-            "name": "CatchPhrase",
-            "detail": "",
-            "kind": 14,
-            "range": {
-                "start": {
-                    "line": 2,
-                    "character": 4
-                },
-                "end": {
-                    "line": 2,
-                    "character": 15
-                }
-            },
-            "selectionRange": {
-                "start": {
-                    "line": 2,
-                    "character": 4
-                },
-                "end": {
-                    "line": 2,
-                    "character": 15
-                }
-            },
-            "children": []
-        }, {
             "name": "Character",
             "detail": "",
             "kind": 5,
@@ -80,6 +55,31 @@
                     "children": []
                 }
             ]
+        }, {
+            "name": "CatchPhrase",
+            "detail": "",
+            "kind": 14,
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 4
+                },
+                "end": {
+                    "line": 2,
+                    "character": 15
+                }
+            },
+            "selectionRange": {
+                "start": {
+                    "line": 2,
+                    "character": 4
+                },
+                "end": {
+                    "line": 2,
+                    "character": 15
+                }
+            },
+            "children": []
         }
     ]
 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Break up symbol table into per-symbol-type tables.

I've broken up the single monolithic `symbols` vector into 5 vectors:

* `classAndModules`
* `methods`
* `fields` (static and non-static)
* `typeArguments`
* `typeMembers`

I am open to combining any of the above if separating the symbols out yields few benefits. For example, I'm not sure if type arguments and type members actually have any special fields between them.

**One potentially controversial design decision: Index 0 is not reserved as a special "no symbol" slot for every vector.** I did this so that Sorbet only has one "noSymbol" SymbolRef, and that's classAndModules index 0. I figured that having multiple ways to represent no symbol could be a footgun (see also: people complaining about NaN in floating point being a range rather than a single value), but I can be talked into reserving index 0 in every symbol type vector.

Another consequence of this design decision is that the CLI argument to scale the symbol table has been split into 5 separate command line arguments, which I think is fine; that's used for advanced tuning scenarios where performance matters.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

* Make it possible to specialize symbols of a specific type. This will let us 1) reduce memory consumption and 2) make it faster to construct/copy symbols.
* Make it easier to iterate over only the symbol types code cares about. Many passes only need to pass over classes, for example.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
