### PR TITLE
Add some leftovers from the update to 2.6

### DIFF
--- a/test/whitequark/test_ambiuous_quoted_label_in_ternary_operator_2.rb
+++ b/test/whitequark/test_ambiuous_quoted_label_in_ternary_operator_2.rb
@@ -1,3 +1,4 @@
 # typed: true
 
-a ? b ~ '': nil # error: unexpected token "~"
+a ? b ~ '': nil
+#     ^ error: unexpected token "~"

--- a/test/whitequark/test_ambiuous_quoted_label_in_ternary_operator_3.rb
+++ b/test/whitequark/test_ambiuous_quoted_label_in_ternary_operator_3.rb
@@ -1,3 +1,4 @@
 # typed: true
 
-a ? b ! '': nil # error: unexpected token "!"
+a ? b ! '': nil
+#     ^ error: unexpected token "!"

--- a/test/whitequark/test_parser_bug_645_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_parser_bug_645_0.parse-tree-whitequark.exp
@@ -1,0 +1,5 @@
+s(:block,
+  s(:send, nil, :lambda),
+  s(:args,
+    s(:optarg, :arg,
+      s(:hash))), nil)

--- a/test/whitequark/test_parser_bug_645_0.rb
+++ b/test/whitequark/test_parser_bug_645_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+-> (arg={}) {}

--- a/test/whitequark/test_rescue_in_lambda_block_1.rb
+++ b/test/whitequark/test_rescue_in_lambda_block_1.rb
@@ -1,3 +1,4 @@
 # typed: true
 
--> { rescue; } # error: unexpected token "rescue"
+-> { rescue; }
+#    ^^^^^^ error: unexpected token "rescue"

--- a/third_party/parser/cc/driver.cc
+++ b/third_party/parser/cc/driver.cc
@@ -16,7 +16,7 @@ base_driver::base_driver(ruby_version version, const std::string& source, const 
 }
 
 typedruby25::typedruby25(const std::string& source, const struct builder& builder)
-	: base_driver(ruby_version::RUBY_25, source, builder)
+	: base_driver(ruby_version::RUBY_26, source, builder)
 {}
 
 ForeignPtr typedruby25::parse(SelfPtr self) {

--- a/third_party/parser/include/ruby_parser/lexer.hh
+++ b/third_party/parser/include/ruby_parser/lexer.hh
@@ -26,6 +26,7 @@ enum class ruby_version {
     RUBY_23,
     RUBY_24,
     RUBY_25,
+    RUBY_26,
 };
 
 class lexer {


### PR DESCRIPTION
### Motivation

While running the [import_whitequark](https://github.com/sorbet/sorbet/blob/master/tools/scripts/import_whitequark.sh) script for 2.7 I grabbed a few tests belonging to 2.6 so let's add them before doing the bump.

### Test plan

See included automated tests.
