### PR TITLE
Import tests for ruby27 parser and add a few features

### DIFF
--- a/parser/Parser.cc
+++ b/parser/Parser.cc
@@ -52,7 +52,7 @@ unique_ptr<Node> Parser::run(sorbet::core::GlobalState &gs, core::FileRef file,
                              std::vector<std::string> initialLocals) {
     Builder builder(gs, file);
     auto source = file.data(gs).source();
-    ruby_parser::typedruby25 driver(string(source.begin(), source.end()), Builder::interface);
+    ruby_parser::typedruby27 driver(string(source.begin(), source.end()), Builder::interface);
 
     for (string local : initialLocals) {
         driver.lex.declare(local);

--- a/third_party/parser/cc/capi.cc
+++ b/third_party/parser/cc/capi.cc
@@ -1,15 +1,15 @@
 #include <ruby_parser/capi.hh>
 #include <cstdio>
 
-ruby_parser::typedruby25*
-rbdriver_typedruby25_new(const char* source_ptr, size_t source_length, const ruby_parser::builder* builder)
+ruby_parser::typedruby27*
+rbdriver_typedruby27_new(const char* source_ptr, size_t source_length, const ruby_parser::builder* builder)
 {
 	std::string source { source_ptr, source_length };
-	return new ruby_parser::typedruby25(source, *builder);
+	return new ruby_parser::typedruby27(source, *builder);
 }
 
 void
-rbdriver_typedruby25_free(ruby_parser::typedruby25* driver)
+rbdriver_typedruby27_free(ruby_parser::typedruby27* driver)
 {
 	delete driver;
 }

--- a/third_party/parser/cc/driver.cc
+++ b/third_party/parser/cc/driver.cc
@@ -15,12 +15,12 @@ base_driver::base_driver(ruby_version version, const std::string& source, const 
 {
 }
 
-typedruby25::typedruby25(const std::string& source, const struct builder& builder)
-	: base_driver(ruby_version::RUBY_26, source, builder)
+typedruby27::typedruby27(const std::string& source, const struct builder& builder)
+	: base_driver(ruby_version::RUBY_27, source, builder)
 {}
 
-ForeignPtr typedruby25::parse(SelfPtr self) {
-	bison::typedruby25::parser p(*this, self);
+ForeignPtr typedruby27::parse(SelfPtr self) {
+	bison::typedruby27::parser p(*this, self);
 	p.parse();
 	return ast;
 }

--- a/third_party/parser/cc/grammars/typedruby.ypp
+++ b/third_party/parser/cc/grammars/typedruby.ypp
@@ -2429,7 +2429,7 @@ regexp_contents: // nothing
                       $$ = driver.build.symbol(self, $1);
                     }
 
-            dsym: tSYMBEG xstring_contents tSTRING_END
+            dsym: tSYMBEG string_contents tSTRING_END
                     {
                       driver.lex.set_state_expr_end();
                       $$ = driver.build.symbol_compose(self, $1, $2, $3);

--- a/third_party/parser/cc/grammars/typedruby.ypp
+++ b/third_party/parser/cc/grammars/typedruby.ypp
@@ -21,10 +21,10 @@ using namespace std::string_literals;
 #endif
 }
 
-%param { ruby_parser::typedruby25& driver }
+%param { ruby_parser::typedruby27& driver }
 %parse-param { ruby_parser::SelfPtr self }
-%define api.namespace {ruby_parser::bison::typedruby25}
-%define api.prefix {typedruby25}
+%define api.namespace {ruby_parser::bison::typedruby27}
+%define api.prefix {typedruby27}
 %define api.value.type { union parser_value }
 %define api.token.constructor false
 %define parse.assert
@@ -392,7 +392,7 @@ union parser_value {
 %code {
 namespace ruby_parser {
 namespace bison {
-namespace typedruby25 {
+namespace typedruby27 {
 
 #define DIAGCHECK() do { \
 	if (driver.pending_error) { \
@@ -417,7 +417,7 @@ void parser::error(const std::string &msg) {
 		error_message);
 }
 
-int yylex(parser::semantic_type *lval, ruby_parser::typedruby25 &driver) {
+int yylex(parser::semantic_type *lval, ruby_parser::typedruby27 &driver) {
 	auto token = driver.lex.advance();
 	driver.last_token = token;
 	int token_type = static_cast<int>(token->type());

--- a/third_party/parser/cc/grammars/typedruby.ypp
+++ b/third_party/parser/cc/grammars/typedruby.ypp
@@ -212,7 +212,6 @@ using namespace std::string_literals;
   f_opt
   fitem
   for_var
-  fsym
   keyword_variable
   lhs
   literal
@@ -230,6 +229,7 @@ using namespace std::string_literals;
   qsymbols
   qwords
   regexp
+  ssym
   simple_numeric
   singleton
   stmt
@@ -976,14 +976,11 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby27 &driver) {
                 | op
                 | reswords
 
-            fsym: fname
+            fitem: fname
                     {
                       $$ = driver.build.symbol(self, $1);
                     }
                 | symbol
-
-           fitem: fsym
-                | dsym
 
       undef_list: fitem
                     {
@@ -2235,7 +2232,6 @@ opt_block_args_tail:
 
          literal: numeric
                 | symbol
-                | dsym
 
          strings: string
                     {
@@ -2424,7 +2420,10 @@ regexp_contents: // nothing
                 | backref
 
 
-          symbol: tSYMBOL
+          symbol: ssym
+                | dsym
+
+            ssym: tSYMBOL
                     {
                       driver.lex.set_state_expr_end();
                       $$ = driver.build.symbol(self, $1);

--- a/third_party/parser/include/ruby_parser/capi.hh
+++ b/third_party/parser/include/ruby_parser/capi.hh
@@ -16,11 +16,11 @@ struct cdiagnostic {
 	size_t endPos;
 };
 
-ruby_parser::typedruby25*
-rbdriver_typedruby25_new(const char* source, size_t source_length, const ruby_parser::builder* builder);
+ruby_parser::typedruby27*
+rbdriver_typedruby27_new(const char* source, size_t source_length, const ruby_parser::builder* builder);
 
 void
-rbdriver_typedruby25_free(ruby_parser::typedruby25* parser);
+rbdriver_typedruby27_free(ruby_parser::typedruby27* parser);
 
 const void*
 rbdriver_parse(ruby_parser::base_driver* parser, ruby_parser::SelfPtr self);

--- a/third_party/parser/include/ruby_parser/driver.hh
+++ b/third_party/parser/include/ruby_parser/driver.hh
@@ -154,11 +154,11 @@ public:
     }
 };
 
-class typedruby25 : public base_driver {
+class typedruby27 : public base_driver {
 public:
-    typedruby25(const std::string &source, const struct builder &builder);
+    typedruby27(const std::string &source, const struct builder &builder);
     virtual ForeignPtr parse(SelfPtr self);
-    ~typedruby25() {}
+    ~typedruby27() {}
 };
 
 } // namespace ruby_parser

--- a/third_party/parser/include/ruby_parser/lexer.hh
+++ b/third_party/parser/include/ruby_parser/lexer.hh
@@ -27,6 +27,7 @@ enum class ruby_version {
     RUBY_24,
     RUBY_25,
     RUBY_26,
+    RUBY_27,
 };
 
 class lexer {

--- a/tools/scripts/import_whitequark.sh
+++ b/tools/scripts/import_whitequark.sh
@@ -14,8 +14,8 @@
 set -euo pipefail
 set -x
 
-REF=2a705681cfe339261b69b03593d008cb2c4eff35
-TARGET_RUBY_VERSION="2.6"
+REF=b328d5f4d38e5347feb91aa9e55157c858b07cc6
+TARGET_RUBY_VERSION="2.7"
 
 SCRIPT=$(realpath "$0")
 ROOT="$(cd "$(dirname "$SCRIPT")/../.."; pwd)"
@@ -52,6 +52,7 @@ bundle exec racc --superclass=Parser::Base lib/parser/ruby24.y -o lib/parser/rub
 bundle exec racc --superclass=Parser::Base lib/parser/ruby25.y -o lib/parser/ruby25.rb --no-line-convert
 bundle exec racc --superclass=Parser::Base lib/parser/ruby26.y -o lib/parser/ruby26.rb --no-line-convert
 bundle exec racc --superclass=Parser::Base lib/parser/ruby27.y -o lib/parser/ruby27.rb --no-line-convert
+bundle exec racc --superclass=Parser::Base lib/parser/ruby28.y -o lib/parser/ruby28.rb --no-line-convert
 bundle exec racc --superclass=Parser::Base lib/parser/macruby.y -o lib/parser/macruby.rb --no-line-convert
 bundle exec racc --superclass=Parser::Base lib/parser/rubymotion.y -o lib/parser/rubymotion.rb --no-line-convert
 


### PR DESCRIPTION
This pull-request prepares the work for the 2.7 update and also add a few independent features.

1. Update `import_whitequark` script to 2.7
2. Update parser version to 2.7
3. Refactor grammar rules around symbols (no changes to the output)
4. Treat `dsym` as a string (no changes to the output)

This PR may be read commit by commit for an easier review.

I'll submit subsequent PRs with each feature and the related tests imported with the script.

### Test plan

See included automated tests.
