### PR TITLE
Change runtime type printing of TEnum type wrapper

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/t_enum.rb
+++ b/gems/sorbet-runtime/lib/types/types/t_enum.rb
@@ -12,7 +12,12 @@ module T::Types
 
     # @override Base
     def name
-      @val.inspect
+      # Strips the #<...> off, just leaving the ...
+      # Reasoning: the user will have written something like
+      #   T.any(MyEnum::A, MyEnum::B)
+      # in the type, so we should print what they wrote in errors, not:
+      #   T.any(#<MyEnum::A>, #<MyEnum::B>)
+      @val.inspect[2..-2]
     end
 
     # @override Base

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -676,6 +676,7 @@ module Opus::Types::Test
         a = T::Utils.coerce(::MyEnum::A)
         assert_instance_of(T::Types::TEnum, a)
         assert_equal(a.val, ::MyEnum::A)
+        assert_equal(a.name, 'MyEnum::A')
       end
 
       it 'allows T::Enum values in a sig params' do
@@ -723,6 +724,9 @@ module Opus::Types::Test
         assert_raises(TypeError) do
           c.foo(MyEnum::C)
         end
+
+        runtime_type = T.any(MyEnum::A, MyEnum::B)
+        assert_equal("T.any(MyEnum::A, MyEnum::B)", runtime_type.to_s)
       end
     end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Strips the `#<...>` off, just leaving the `...`

Reasoning: the user will have written something like

    T.any(MyEnum::A, MyEnum::B)

in the type, so we should print what they wrote in errors, not:

    T.any(#<MyEnum::A>, #<MyEnum::B>)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.