### PR TITLE
Remove runtime type-checking from enumerable types

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
@@ -23,50 +23,7 @@ module T::Types
 
     # @override Base
     def valid?(obj)
-      return false unless obj.is_a?(Enumerable)
-      case obj
-      when Array
-        begin
-          it = 0
-          while it < obj.count
-            return false unless @type.valid?(obj[it])
-            it += 1
-          end
-          return true
-        end
-      when Hash
-        return false unless @type.is_a?(FixedArray)
-        types = @type.types
-        return false if types.count != 2
-        key_type = types[0]
-        value_type = types[1]
-        obj.each_pair do |key, val|
-          # Some objects (I'm looking at you Rack::Utils::HeaderHash) don't
-          # iterate over a [key, value] array, so we can't juse use the @type.valid?(v)
-          return false if !key_type.valid?(key) || !value_type.valid?(val)
-        end
-        return true
-      when Enumerator
-        # Enumerators can be unbounded: see `[:foo, :bar].cycle`
-        return true
-      when Range
-        # A nil beginning or a nil end does not provide any type information. That is, nil in a range represents
-        # boundlessness, it does not express a type. For example `(nil...nil)` is not a T::Range[NilClass], its a range
-        # of unknown types (T::Range[T.untyped]).
-        # Similarly, `(nil...1)` is not a `T::Range[T.nilable(Integer)]`, it's a boundless range of Integer.
-        (obj.begin.nil? || @type.valid?(obj.begin)) && (obj.end.nil? || @type.valid?(obj.end))
-      when Set
-        obj.each do |item|
-          return false unless @type.valid?(item)
-        end
-
-        return true
-      else
-        # We don't check the enumerable since it isn't guaranteed to be
-        # rewindable (e.g. STDIN) and it may be expensive to enumerate
-        # (e.g. an enumerator that makes an HTTP request)"
-        true
-      end
+      obj.is_a?(Enumerable)
     end
 
     # @override Base

--- a/gems/sorbet-runtime/test/types/props/decorator.rb
+++ b/gems/sorbet-runtime/test/types/props/decorator.rb
@@ -173,11 +173,10 @@ class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest
   end
 
   describe 'validating prop values' do
-    it 'validates subdoc hashes have the correct values' do
+    it 'does not validate subdoc hashes have the correct values' do
 
-      assert_raises(TypeError) do
-        StructHash.new(the_hash: {'foo' => {}})
-      end
+      # no raise:
+      StructHash.new(the_hash: {'foo' => {}})
 
       # no raise:
       StructHash.new(the_hash: {'foo' => StructHash::InnerStruct.new})

--- a/gems/sorbet-runtime/test/types/props/decorator.rb
+++ b/gems/sorbet-runtime/test/types/props/decorator.rb
@@ -172,18 +172,6 @@ class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest
     prop :the_hash, T::Hash[String, InnerStruct]
   end
 
-  describe 'validating prop values' do
-    it 'validates subdoc hashes have the correct values' do
-
-      assert_raises(TypeError) do
-        StructHash.new(the_hash: {'foo' => {}})
-      end
-
-      # no raise:
-      StructHash.new(the_hash: {'foo' => StructHash::InnerStruct.new})
-    end
-  end
-
   class OptionalArrayClass
     include T::Props::Serializable
     prop :foo, T.nilable(T::Array[Integer])

--- a/gems/sorbet-runtime/test/types/props/decorator.rb
+++ b/gems/sorbet-runtime/test/types/props/decorator.rb
@@ -172,6 +172,18 @@ class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest
     prop :the_hash, T::Hash[String, InnerStruct]
   end
 
+  describe 'validating prop values' do
+    it 'validates subdoc hashes have the correct values' do
+
+      assert_raises(TypeError) do
+        StructHash.new(the_hash: {'foo' => {}})
+      end
+
+      # no raise:
+      StructHash.new(the_hash: {'foo' => StructHash::InnerStruct.new})
+    end
+  end
+
   class OptionalArrayClass
     include T::Props::Serializable
     prop :foo, T.nilable(T::Array[Integer])

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -227,19 +227,19 @@ module Opus::Types::Test
       it 'does not fail if any of the values is the wrong type' do
         type = T::Array[T.any(Integer, T::Boolean)]
         value = [true, 3.0, false, 4, "5", false]
-        assert_nil(type.error_message_for_obj)
+        assert_nil(type.error_message_for_obj(value))
       end
 
       it 'does not propose a simple type if only one type exists' do
         type = T::Array[String]
         value = [1, 2, 3]
-        assert_nil(type.error_message_for_obj)
+        assert_nil(type.error_message_for_obj(value))
       end
 
       it 'does not propose a union type if multiple types exist' do
         type = T::Array[String]
         value = [true, false, 1]
-        assert_nil(type.error_message_for_obj)
+        assert_nil(type.error_message_for_obj(value))
       end
 
       it 'is covariant for the type_member for valid?' do

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -212,13 +212,10 @@ module Opus::Types::Test
         assert_equal(Integer, type.type.raw_type)
       end
 
-      it 'fails if an element of the array is the wrong type' do
+      it 'does not fail if an element of the array is the wrong type' do
         type = T::Array[Integer]
         value = [true]
-        msg = type.error_message_for_obj(value)
-        expected_error = "Expected type T::Array[Integer], " \
-                         "got T::Array[T::Boolean]"
-        assert_equal(expected_error, msg)
+        assert_nil(type.error_message_for_obj(value))
       end
 
       it 'succeeds if all values have the correct type' do
@@ -227,31 +224,22 @@ module Opus::Types::Test
         assert_nil(type.error_message_for_obj(value))
       end
 
-      it 'fails if any of the values is the wrong type' do
+      it 'does not fail if any of the values is the wrong type' do
         type = T::Array[T.any(Integer, T::Boolean)]
         value = [true, 3.0, false, 4, "5", false]
-        expected_error = "Expected type T::Array[T.any(Integer, T::Boolean)], " \
-          "got T::Array[T.any(Float, Integer, String, T::Boolean)]"
-        msg = type.error_message_for_obj(value)
-        assert_equal(expected_error, msg)
+        assert_nil(type.error_message_for_obj)
       end
 
-      it 'proposes a simple type if only one type exists' do
+      it 'does not propose a simple type if only one type exists' do
         type = T::Array[String]
         value = [1, 2, 3]
-        expected_error = "Expected type T::Array[String], " \
-                         "got T::Array[Integer]"
-        msg = type.error_message_for_obj(value)
-        assert_equal(expected_error, msg)
+        assert_nil(type.error_message_for_obj)
       end
 
-      it 'proposes a union type if multiple types exist' do
+      it 'does not propose a union type if multiple types exist' do
         type = T::Array[String]
         value = [true, false, 1]
-        expected_error = "Expected type T::Array[String], " \
-          "got T::Array[T.any(Integer, T::Boolean)]"
-        msg = type.error_message_for_obj(value)
-        assert_equal(expected_error, msg)
+        assert_nil(type.error_message_for_obj)
       end
 
       it 'is covariant for the type_member for valid?' do
@@ -264,13 +252,10 @@ module Opus::Types::Test
         assert_nil(type.error_message_for_obj(value))
       end
 
-      it 'is not contravariant for the type_member' do
+      it 'does not check for contravariant type_member' do
         type = T::Array[Integer]
         value = [Object.new]
-        expected_error = "Expected type T::Array[Integer], " \
-          "got T::Array[Object]"
-        msg = type.error_message_for_obj(value)
-        assert_equal(expected_error, msg)
+        assert_nil(type.error_message_for_obj(value))
       end
 
       it 'gives the right error when passed a Hash' do
@@ -316,24 +301,20 @@ module Opus::Types::Test
         assert_equal(T::Hash[T.untyped, T.untyped], T::Utils.coerce(::Hash))
       end
 
-      it 'fails if a key in the Hash is the wrong type' do
+      it 'does not fail if a key in the Hash is the wrong type' do
         type = T::Hash[Symbol, Integer]
         value = {
           'oops_string' => 1,
         }
-        msg = type.error_message_for_obj(value)
-        expected_error = "Expected type T::Hash[Symbol, Integer], got T::Hash[String, Integer]"
-        assert_equal(expected_error, msg)
+        assert_nil(type.error_message_for_obj(value))
       end
 
-      it 'fails if a value in the Hash is the wrong type' do
+      it 'does not fail if a value in the Hash is the wrong type' do
         type = T::Hash[Symbol, Integer]
         value = {
           sym: 1.0,
         }
-        msg = type.error_message_for_obj(value)
-        expected_error = "Expected type T::Hash[Symbol, Integer], got T::Hash[Symbol, Float]"
-        assert_equal(expected_error, msg)
+        assert_nil(type.error_message_for_obj(value))
       end
     end
 
@@ -400,13 +381,10 @@ module Opus::Types::Test
         assert_nil(msg)
       end
 
-      it 'fails if the type is wrong' do
+      it 'does not fail if the type is wrong' do
         type = T::Range[Float]
         value = (3...10)
-        msg = type.error_message_for_obj(value)
-        expected_error = "Expected type T::Range[Float], " \
-                         "got T::Range[Integer]"
-        assert_equal(expected_error, msg)
+        assert_nil(type.error_message_for_obj(value))
       end
 
       it 'can have its metatype instantiated' do
@@ -429,13 +407,10 @@ module Opus::Types::Test
         assert_nil(msg)
       end
 
-      it 'fails if the type is wrong' do
+      it 'does not fail if the type is wrong' do
         type = T::Set[Float]
         value = Set.new([1, 2, 3])
-        msg = type.error_message_for_obj(value)
-        expected_error = "Expected type T::Set[Float], " \
-                         "got T::Set[Integer]"
-        assert_equal(expected_error, msg)
+        assert_nil(type.error_message_for_obj(value))
       end
 
       it 'can have its metatype instantiated' do
@@ -464,13 +439,10 @@ module Opus::Types::Test
         assert_equal(Integer, type.type.raw_type)
       end
 
-      it 'fails if an element of the array is the wrong type' do
+      it 'does not fail if an element of the array is the wrong type' do
         type = T::Enumerable[Integer]
         value = [true]
-        msg = type.error_message_for_obj(value)
-        expected_error = "Expected type T::Enumerable[Integer], " \
-                         "got T::Array[T::Boolean]"
-        assert_equal(expected_error, msg)
+        assert_nil(type.error_message_for_obj(value))
       end
 
       it 'succeeds if all values have the correct type' do
@@ -479,31 +451,22 @@ module Opus::Types::Test
         assert_nil(type.error_message_for_obj(value))
       end
 
-      it 'fails if any of the values is the wrong type' do
+      it 'does not fail if any of the values is the wrong type' do
         type = T::Enumerable[T.any(Integer, T::Boolean)]
         value = [true, 3.0, false, 4, "5", false]
-        expected_error = "Expected type T::Enumerable[T.any(Integer, T::Boolean)], " \
-          "got T::Array[T.any(Float, Integer, String, T::Boolean)]"
-        msg = type.error_message_for_obj(value)
-        assert_equal(expected_error, msg)
+        assert_nil(type.error_message_for_obj(value))
       end
 
-      it 'proposes a simple type if only one type exists' do
+      it 'does not propose a simple type if only one type exists' do
         type = T::Enumerable[String]
         value = [1, 2, 3]
-        expected_error = "Expected type T::Enumerable[String], " \
-                         "got T::Array[Integer]"
-        msg = type.error_message_for_obj(value)
-        assert_equal(expected_error, msg)
+        assert_nil(type.error_message_for_obj(value))
       end
 
-      it 'proposes a union type if multiple types exist' do
+      it 'does not propose a union type if multiple types exist' do
         type = T::Enumerable[String]
         value = [true, false, 1]
-        expected_error = "Expected type T::Enumerable[String], " \
-          "got T::Array[T.any(Integer, T::Boolean)]"
-        msg = type.error_message_for_obj(value)
-        assert_equal(expected_error, msg)
+        assert_nil(type.error_message_for_obj(value))
       end
 
       it 'wont check unrewindable enumerables' do
@@ -518,16 +481,13 @@ module Opus::Types::Test
         assert_nil(type.error_message_for_obj(value))
       end
 
-      it 'is not contravariant for the type_member' do
+      it 'does nto check for contravariant type_member' do
         type = T::Enumerable[Integer]
         value = [Object.new]
-        expected_error = "Expected type T::Enumerable[Integer], " \
-          "got T::Array[Object]"
-        msg = type.error_message_for_obj(value)
-        assert_equal(expected_error, msg)
+        assert_nil(type.error_message_for_obj(value))
       end
 
-      it 'does not check lazy enumerables (for now)' do
+      it 'does not check lazy enumerables' do
         type = T::Enumerable[Integer]
         value = ["bad"].lazy
         msg = type.error_message_for_obj(value)
@@ -541,16 +501,14 @@ module Opus::Types::Test
         assert_nil(msg)
       end
 
-      it 'can serialize enumerables whose each throws' do
+      it 'can serialize enumerables whose each throws but does not check its element types' do
         type = T::Enumerable[Integer]
         value = Class.new(Array) do
           def each
             raise "bad"
           end
         end.new(['str'])
-        msg = type.error_message_for_obj(value)
-        expected_error = "Expected type T::Enumerable[Integer], got T::Array[T.untyped]"
-        assert_equal(expected_error, msg)
+        assert_nil(type.error_message_for_obj(value))
       end
     end
 

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -212,46 +212,10 @@ module Opus::Types::Test
         assert_equal(Integer, type.type.raw_type)
       end
 
-      it 'fails if an element of the array is the wrong type' do
-        type = T::Array[Integer]
-        value = [true]
-        msg = type.error_message_for_obj(value)
-        expected_error = "Expected type T::Array[Integer], " \
-                         "got T::Array[T::Boolean]"
-        assert_equal(expected_error, msg)
-      end
-
       it 'succeeds if all values have the correct type' do
         type = T::Array[T.any(Integer, T::Boolean)]
         value = [true, 3, false, 4, 5, false]
         assert_nil(type.error_message_for_obj(value))
-      end
-
-      it 'fails if any of the values is the wrong type' do
-        type = T::Array[T.any(Integer, T::Boolean)]
-        value = [true, 3.0, false, 4, "5", false]
-        expected_error = "Expected type T::Array[T.any(Integer, T::Boolean)], " \
-          "got T::Array[T.any(Float, Integer, String, T::Boolean)]"
-        msg = type.error_message_for_obj(value)
-        assert_equal(expected_error, msg)
-      end
-
-      it 'proposes a simple type if only one type exists' do
-        type = T::Array[String]
-        value = [1, 2, 3]
-        expected_error = "Expected type T::Array[String], " \
-                         "got T::Array[Integer]"
-        msg = type.error_message_for_obj(value)
-        assert_equal(expected_error, msg)
-      end
-
-      it 'proposes a union type if multiple types exist' do
-        type = T::Array[String]
-        value = [true, false, 1]
-        expected_error = "Expected type T::Array[String], " \
-          "got T::Array[T.any(Integer, T::Boolean)]"
-        msg = type.error_message_for_obj(value)
-        assert_equal(expected_error, msg)
       end
 
       it 'is covariant for the type_member for valid?' do
@@ -262,15 +226,6 @@ module Opus::Types::Test
         # but with type erasure, we have to leave all runtime checks as
         # covariant.
         assert_nil(type.error_message_for_obj(value))
-      end
-
-      it 'is not contravariant for the type_member' do
-        type = T::Array[Integer]
-        value = [Object.new]
-        expected_error = "Expected type T::Array[Integer], " \
-          "got T::Array[Object]"
-        msg = type.error_message_for_obj(value)
-        assert_equal(expected_error, msg)
       end
 
       it 'gives the right error when passed a Hash' do
@@ -314,26 +269,6 @@ module Opus::Types::Test
 
       it 'is coerced from plain hash' do
         assert_equal(T::Hash[T.untyped, T.untyped], T::Utils.coerce(::Hash))
-      end
-
-      it 'fails if a key in the Hash is the wrong type' do
-        type = T::Hash[Symbol, Integer]
-        value = {
-          'oops_string' => 1,
-        }
-        msg = type.error_message_for_obj(value)
-        expected_error = "Expected type T::Hash[Symbol, Integer], got T::Hash[String, Integer]"
-        assert_equal(expected_error, msg)
-      end
-
-      it 'fails if a value in the Hash is the wrong type' do
-        type = T::Hash[Symbol, Integer]
-        value = {
-          sym: 1.0,
-        }
-        msg = type.error_message_for_obj(value)
-        expected_error = "Expected type T::Hash[Symbol, Integer], got T::Hash[Symbol, Float]"
-        assert_equal(expected_error, msg)
       end
     end
 
@@ -400,15 +335,6 @@ module Opus::Types::Test
         assert_nil(msg)
       end
 
-      it 'fails if the type is wrong' do
-        type = T::Range[Float]
-        value = (3...10)
-        msg = type.error_message_for_obj(value)
-        expected_error = "Expected type T::Range[Float], " \
-                         "got T::Range[Integer]"
-        assert_equal(expected_error, msg)
-      end
-
       it 'can have its metatype instantiated' do
         assert_equal((3..4), T::Range[Integer].new(3, 4))
       end
@@ -427,15 +353,6 @@ module Opus::Types::Test
         value = Set.new([1, 2, 3])
         msg = type.error_message_for_obj(value)
         assert_nil(msg)
-      end
-
-      it 'fails if the type is wrong' do
-        type = T::Set[Float]
-        value = Set.new([1, 2, 3])
-        msg = type.error_message_for_obj(value)
-        expected_error = "Expected type T::Set[Float], " \
-                         "got T::Set[Integer]"
-        assert_equal(expected_error, msg)
       end
 
       it 'can have its metatype instantiated' do
@@ -464,46 +381,10 @@ module Opus::Types::Test
         assert_equal(Integer, type.type.raw_type)
       end
 
-      it 'fails if an element of the array is the wrong type' do
-        type = T::Enumerable[Integer]
-        value = [true]
-        msg = type.error_message_for_obj(value)
-        expected_error = "Expected type T::Enumerable[Integer], " \
-                         "got T::Array[T::Boolean]"
-        assert_equal(expected_error, msg)
-      end
-
       it 'succeeds if all values have the correct type' do
         type = T::Enumerable[T.any(Integer, T::Boolean)]
         value = [true, 3, false, 4, 5, false]
         assert_nil(type.error_message_for_obj(value))
-      end
-
-      it 'fails if any of the values is the wrong type' do
-        type = T::Enumerable[T.any(Integer, T::Boolean)]
-        value = [true, 3.0, false, 4, "5", false]
-        expected_error = "Expected type T::Enumerable[T.any(Integer, T::Boolean)], " \
-          "got T::Array[T.any(Float, Integer, String, T::Boolean)]"
-        msg = type.error_message_for_obj(value)
-        assert_equal(expected_error, msg)
-      end
-
-      it 'proposes a simple type if only one type exists' do
-        type = T::Enumerable[String]
-        value = [1, 2, 3]
-        expected_error = "Expected type T::Enumerable[String], " \
-                         "got T::Array[Integer]"
-        msg = type.error_message_for_obj(value)
-        assert_equal(expected_error, msg)
-      end
-
-      it 'proposes a union type if multiple types exist' do
-        type = T::Enumerable[String]
-        value = [true, false, 1]
-        expected_error = "Expected type T::Enumerable[String], " \
-          "got T::Array[T.any(Integer, T::Boolean)]"
-        msg = type.error_message_for_obj(value)
-        assert_equal(expected_error, msg)
       end
 
       it 'wont check unrewindable enumerables' do
@@ -518,15 +399,6 @@ module Opus::Types::Test
         assert_nil(type.error_message_for_obj(value))
       end
 
-      it 'is not contravariant for the type_member' do
-        type = T::Enumerable[Integer]
-        value = [Object.new]
-        expected_error = "Expected type T::Enumerable[Integer], " \
-          "got T::Array[Object]"
-        msg = type.error_message_for_obj(value)
-        assert_equal(expected_error, msg)
-      end
-
       it 'does not check lazy enumerables (for now)' do
         type = T::Enumerable[Integer]
         value = ["bad"].lazy
@@ -539,18 +411,6 @@ module Opus::Types::Test
         value = ["bad"].cycle
         msg = type.error_message_for_obj(value)
         assert_nil(msg)
-      end
-
-      it 'can serialize enumerables whose each throws' do
-        type = T::Enumerable[Integer]
-        value = Class.new(Array) do
-          def each
-            raise "bad"
-          end
-        end.new(['str'])
-        msg = type.error_message_for_obj(value)
-        expected_error = "Expected type T::Enumerable[Integer], got T::Array[T.untyped]"
-        assert_equal(expected_error, msg)
       end
     end
 

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -212,10 +212,46 @@ module Opus::Types::Test
         assert_equal(Integer, type.type.raw_type)
       end
 
+      it 'fails if an element of the array is the wrong type' do
+        type = T::Array[Integer]
+        value = [true]
+        msg = type.error_message_for_obj(value)
+        expected_error = "Expected type T::Array[Integer], " \
+                         "got T::Array[T::Boolean]"
+        assert_equal(expected_error, msg)
+      end
+
       it 'succeeds if all values have the correct type' do
         type = T::Array[T.any(Integer, T::Boolean)]
         value = [true, 3, false, 4, 5, false]
         assert_nil(type.error_message_for_obj(value))
+      end
+
+      it 'fails if any of the values is the wrong type' do
+        type = T::Array[T.any(Integer, T::Boolean)]
+        value = [true, 3.0, false, 4, "5", false]
+        expected_error = "Expected type T::Array[T.any(Integer, T::Boolean)], " \
+          "got T::Array[T.any(Float, Integer, String, T::Boolean)]"
+        msg = type.error_message_for_obj(value)
+        assert_equal(expected_error, msg)
+      end
+
+      it 'proposes a simple type if only one type exists' do
+        type = T::Array[String]
+        value = [1, 2, 3]
+        expected_error = "Expected type T::Array[String], " \
+                         "got T::Array[Integer]"
+        msg = type.error_message_for_obj(value)
+        assert_equal(expected_error, msg)
+      end
+
+      it 'proposes a union type if multiple types exist' do
+        type = T::Array[String]
+        value = [true, false, 1]
+        expected_error = "Expected type T::Array[String], " \
+          "got T::Array[T.any(Integer, T::Boolean)]"
+        msg = type.error_message_for_obj(value)
+        assert_equal(expected_error, msg)
       end
 
       it 'is covariant for the type_member for valid?' do
@@ -226,6 +262,15 @@ module Opus::Types::Test
         # but with type erasure, we have to leave all runtime checks as
         # covariant.
         assert_nil(type.error_message_for_obj(value))
+      end
+
+      it 'is not contravariant for the type_member' do
+        type = T::Array[Integer]
+        value = [Object.new]
+        expected_error = "Expected type T::Array[Integer], " \
+          "got T::Array[Object]"
+        msg = type.error_message_for_obj(value)
+        assert_equal(expected_error, msg)
       end
 
       it 'gives the right error when passed a Hash' do
@@ -269,6 +314,26 @@ module Opus::Types::Test
 
       it 'is coerced from plain hash' do
         assert_equal(T::Hash[T.untyped, T.untyped], T::Utils.coerce(::Hash))
+      end
+
+      it 'fails if a key in the Hash is the wrong type' do
+        type = T::Hash[Symbol, Integer]
+        value = {
+          'oops_string' => 1,
+        }
+        msg = type.error_message_for_obj(value)
+        expected_error = "Expected type T::Hash[Symbol, Integer], got T::Hash[String, Integer]"
+        assert_equal(expected_error, msg)
+      end
+
+      it 'fails if a value in the Hash is the wrong type' do
+        type = T::Hash[Symbol, Integer]
+        value = {
+          sym: 1.0,
+        }
+        msg = type.error_message_for_obj(value)
+        expected_error = "Expected type T::Hash[Symbol, Integer], got T::Hash[Symbol, Float]"
+        assert_equal(expected_error, msg)
       end
     end
 
@@ -335,6 +400,15 @@ module Opus::Types::Test
         assert_nil(msg)
       end
 
+      it 'fails if the type is wrong' do
+        type = T::Range[Float]
+        value = (3...10)
+        msg = type.error_message_for_obj(value)
+        expected_error = "Expected type T::Range[Float], " \
+                         "got T::Range[Integer]"
+        assert_equal(expected_error, msg)
+      end
+
       it 'can have its metatype instantiated' do
         assert_equal((3..4), T::Range[Integer].new(3, 4))
       end
@@ -353,6 +427,15 @@ module Opus::Types::Test
         value = Set.new([1, 2, 3])
         msg = type.error_message_for_obj(value)
         assert_nil(msg)
+      end
+
+      it 'fails if the type is wrong' do
+        type = T::Set[Float]
+        value = Set.new([1, 2, 3])
+        msg = type.error_message_for_obj(value)
+        expected_error = "Expected type T::Set[Float], " \
+                         "got T::Set[Integer]"
+        assert_equal(expected_error, msg)
       end
 
       it 'can have its metatype instantiated' do
@@ -381,10 +464,46 @@ module Opus::Types::Test
         assert_equal(Integer, type.type.raw_type)
       end
 
+      it 'fails if an element of the array is the wrong type' do
+        type = T::Enumerable[Integer]
+        value = [true]
+        msg = type.error_message_for_obj(value)
+        expected_error = "Expected type T::Enumerable[Integer], " \
+                         "got T::Array[T::Boolean]"
+        assert_equal(expected_error, msg)
+      end
+
       it 'succeeds if all values have the correct type' do
         type = T::Enumerable[T.any(Integer, T::Boolean)]
         value = [true, 3, false, 4, 5, false]
         assert_nil(type.error_message_for_obj(value))
+      end
+
+      it 'fails if any of the values is the wrong type' do
+        type = T::Enumerable[T.any(Integer, T::Boolean)]
+        value = [true, 3.0, false, 4, "5", false]
+        expected_error = "Expected type T::Enumerable[T.any(Integer, T::Boolean)], " \
+          "got T::Array[T.any(Float, Integer, String, T::Boolean)]"
+        msg = type.error_message_for_obj(value)
+        assert_equal(expected_error, msg)
+      end
+
+      it 'proposes a simple type if only one type exists' do
+        type = T::Enumerable[String]
+        value = [1, 2, 3]
+        expected_error = "Expected type T::Enumerable[String], " \
+                         "got T::Array[Integer]"
+        msg = type.error_message_for_obj(value)
+        assert_equal(expected_error, msg)
+      end
+
+      it 'proposes a union type if multiple types exist' do
+        type = T::Enumerable[String]
+        value = [true, false, 1]
+        expected_error = "Expected type T::Enumerable[String], " \
+          "got T::Array[T.any(Integer, T::Boolean)]"
+        msg = type.error_message_for_obj(value)
+        assert_equal(expected_error, msg)
       end
 
       it 'wont check unrewindable enumerables' do
@@ -399,6 +518,15 @@ module Opus::Types::Test
         assert_nil(type.error_message_for_obj(value))
       end
 
+      it 'is not contravariant for the type_member' do
+        type = T::Enumerable[Integer]
+        value = [Object.new]
+        expected_error = "Expected type T::Enumerable[Integer], " \
+          "got T::Array[Object]"
+        msg = type.error_message_for_obj(value)
+        assert_equal(expected_error, msg)
+      end
+
       it 'does not check lazy enumerables (for now)' do
         type = T::Enumerable[Integer]
         value = ["bad"].lazy
@@ -411,6 +539,18 @@ module Opus::Types::Test
         value = ["bad"].cycle
         msg = type.error_message_for_obj(value)
         assert_nil(msg)
+      end
+
+      it 'can serialize enumerables whose each throws' do
+        type = T::Enumerable[Integer]
+        value = Class.new(Array) do
+          def each
+            raise "bad"
+          end
+        end.new(['str'])
+        msg = type.error_message_for_obj(value)
+        expected_error = "Expected type T::Enumerable[Integer], got T::Array[T.untyped]"
+        assert_equal(expected_error, msg)
       end
     end
 

--- a/website/docs/stdlib-generics.md
+++ b/website/docs/stdlib-generics.md
@@ -21,7 +21,9 @@ namespace to represent them:
 - `T::Range[Type]`
 
 Inside a sig, just writing `Array` or `Hash` will be treated as
-`T::Array[T.untyped]` and `T::Hash[T.untyped, T.untyped]` respectively.
+`T::Array[T.untyped]` and `T::Hash[T.untyped, T.untyped]` respectively. However,
+using bare `Array` or `Hash` is not allowed at `typed: strict` or above: in
+those cases, you should use the generic form with an explicit argument instead.
 
 ```ruby
 # typed: true
@@ -41,3 +43,15 @@ end
 
 T.reveal_type(bar.first) # Revealed type: T.nilable(T.any(Integer, String))
 ```
+
+The type parameters for the generic types provided by the standard library are
+only used as hints for the static type system, and are ignored entirely by the
+runtime type system.
+
+> **Note**: Sorbet used to take these type parameters into account during
+> runtime type-checking, but this turned out to be an common and
+> difficult-to-debug source of performance problems: In order to verify that an
+> array contained the values it claimed it did, the Sorbet runtime used to
+> recursively check the type of every member of a collection, which would take a
+> long time for arrays or hashes of a sufficiently large size. Consequently,
+> this behavior was eventually removed.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This removes runtime type-checking for collections from Sorbet.

This type-checking is a frequent source of slowness, especially in surprising situations, and as per offline conversation we've decided to remove it.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
