### PR TITLE
Fixes for uri.rbi: Most URI references should be URI::Generic, and merge can accept a URI::Generic

### DIFF
--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -933,7 +933,7 @@ class URI::Generic < Object
   # uri.coerce("http://foo.com")
   # #=> [#<URI::HTTP http://foo.com>, #<URI::HTTP http://my.example.com>]
   # ```
-  sig {params(oth: T.any(URI, String)).returns(T.untyped)}
+  sig {params(oth: T.any(URI::Generic, String)).returns(T.untyped)}
   def coerce(oth); end
 
   # Components of the [`URI`](https://docs.ruby-lang.org/en/2.6.0/URI.html) in
@@ -1192,7 +1192,7 @@ class URI::Generic < Object
   #
   # Also aliased as:
   # [`+`](https://docs.ruby-lang.org/en/2.6.0/URI/Generic.html#method-i-2B)
-  sig {params(oth: String).returns(URI)}
+  sig {params(oth: T.any(String, URI::Generic)).returns(URI::Generic)}
   def merge(oth); end
 
   # ## Args
@@ -1232,7 +1232,7 @@ class URI::Generic < Object
   #
   # *   scheme and host are converted to lowercase,
   # *   an empty path component is set to "/".
-  sig {returns(URI)}
+  sig {returns(URI::Generic)}
   def normalize; end
 
   # Destructive version of


### PR DESCRIPTION
Fixes for uri.rbi: Most URI references should be URI::Generic, and merge can accept a URI::Generic.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Removing URI shims that clobbered stdlib definitions in Stripe's codebase surfaced a few bugs in this file.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

It typechecks.
