### PR TITLE
URI::{FTP, HTTP, HTTPS} include OpenURI::OpenRead

### DIFF
--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -674,6 +674,8 @@ end
 # summary about the de facto spec.
 # http://tools.ietf.org/html/draft-hoffman-ftp-uri-04
 class URI::FTP < URI::Generic
+  include ::OpenURI::OpenRead
+
   ABS_PATH = T.let(T.unsafe(nil), Regexp)
   ABS_URI = T.let(T.unsafe(nil), Regexp)
   ABS_URI_REF = T.let(T.unsafe(nil), Regexp)
@@ -1695,6 +1697,8 @@ end
 # used to be supported in Internet Explorer 5 and 6, before the MS04-004
 # security update. See <URL:http://support.microsoft.com/kb/834489>.
 class URI::HTTP < URI::Generic
+  include ::OpenURI::OpenRead
+
   ABS_PATH = T.let(T.unsafe(nil), Regexp)
   ABS_URI = T.let(T.unsafe(nil), Regexp)
   ABS_URI_REF = T.let(T.unsafe(nil), Regexp)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

URI::{FTP, HTTP, HTTPS} include OpenURI::OpenRead

Enables URI.parse(uri).read and friends.

https://ruby-doc.org/stdlib-2.6.3/libdoc/open-uri/rdoc/OpenURI.html

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fix type errors within Stripe so we can remove underspecified internal module shims.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

CI
