### PR TITLE
Autogen-autoloader: parameterize Opus::Require

### DIFF
--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -42,6 +42,7 @@ AutoloaderConfig AutoloaderConfig::enterConfig(core::GlobalState &gs, const real
     AutoloaderConfig out;
     out.rootDir = cfg.rootDir;
     out.preamble = cfg.preamble;
+    out.registryModule = cfg.registryModule;
     for (auto &str : cfg.modules) {
         out.topLevelNamespaceRefs.emplace(gs.enterNameConstant(str));
     }
@@ -192,11 +193,11 @@ string DefTree::renderAutoloadSrc(const core::GlobalState &gs, const AutoloaderC
                                                        return nr.show(gs);
                                                    }));
         if (!root()) {
-            fmt::format_to(buf, "Opus::Require.on_autoload('{}')\n", fullName);
+            fmt::format_to(buf, "{}.on_autoload('{}')\n", alCfg.registryModule, fullName);
             predeclare(gs, fullName, buf);
         }
         if (!children.empty()) {
-            fmt::format_to(buf, "\nOpus::Require.autoload_map({}, {{\n", fullName);
+            fmt::format_to(buf, "\n{}.autoload_map({}, {{\n", alCfg.registryModule, fullName);
             vector<pair<core::NameRef, string>> childNames;
             std::transform(children.begin(), children.end(), back_inserter(childNames),
                            [&gs](const auto &pair) { return make_pair(pair.first, pair.first.show(gs)); });
@@ -216,7 +217,7 @@ string DefTree::renderAutoloadSrc(const core::GlobalState &gs, const AutoloaderC
     }
 
     if (definingFile.exists()) {
-        fmt::format_to(buf, "\nOpus::Require.for_autoload({}, \"{}\"{})\n", fullName,
+        fmt::format_to(buf, "\n{}.for_autoload({}, \"{}\"{})\n", alCfg.registryModule, fullName,
                        alCfg.normalizePath(gs, definingFile), casgnArg);
     }
     return to_string(buf);

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -22,6 +22,7 @@ struct AutoloaderConfig {
 
     std::string rootDir;
     std::string preamble;
+    std::string registryModule;
     UnorderedSet<core::NameRef> topLevelNamespaceRefs;
     UnorderedSet<core::NameRef> excludedRequireRefs;
     UnorderedSet<std::vector<core::NameRef>> nonCollapsableModuleNames;

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -394,6 +394,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                     cxxopts::value<string>()->default_value(""));
     options.add_options("advanced")("autogen-autoloader-root", "Root directory for autoloader output",
                                     cxxopts::value<string>()->default_value("autoloader"));
+    options.add_options("advanced")("autogen-registry-module", "Name of Ruby module used for autoloader registry",
+                                    cxxopts::value<string>()->default_value("Opus::Require"));
     options.add_options("advanced")("autogen-autoloader-samefile",
                                     "Modules that should never be collapsed into their parent. This helps break cycles "
                                     "in certain cases. (e.g. Foo::Bar::Baz)",
@@ -604,6 +606,7 @@ bool extractAutoloaderConfig(cxxopts::ParseResult &raw, Options &opts, shared_pt
         }
     }
     cfg.preamble = raw["autogen-autoloader-preamble"].as<string>();
+    cfg.registryModule = raw["autogen-registry-module"].as<string>();
     cfg.rootDir = stripTrailingSlashes(raw["autogen-autoloader-root"].as<string>());
     return true;
 }

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -106,6 +106,7 @@ struct AutoloaderConfig {
     std::vector<std::string> modules;
     std::string rootDir;
     std::string preamble;
+    std::string registryModule;
     std::vector<std::string> requireExcludes;
     std::vector<std::vector<std::string>> sameFileModules;
     std::vector<std::string> stripPrefixes;

--- a/test/cli/autogen-autoloader/autogen-autoloader.out
+++ b/test/cli/autogen-autoloader/autogen-autoloader.out
@@ -233,13 +233,13 @@ inplace-output/root.rb
 --- strip-prefixes and root rename
 
 
-Opus::Require.autoload_map(Object, {
+Primus::Require.autoload_map(Object, {
   Foo: "my-autoloader/Foo.rb",
 })
 
-Opus::Require.on_autoload('Foo')
+Primus::Require.on_autoload('Foo')
 
 module Foo
 end
 
-Opus::Require.for_autoload(Foo, "autogen-autoloader/inplace.rb")
+Primus::Require.for_autoload(Foo, "autogen-autoloader/inplace.rb")

--- a/test/cli/autogen-autoloader/autogen-autoloader.sh
+++ b/test/cli/autogen-autoloader/autogen-autoloader.sh
@@ -52,6 +52,7 @@ main/sorbet --silence-dev-message --stop-after=namer \
   --autogen-autoloader-modules=Foo \
   --autogen-autoloader-root my-autoloader/ \
   --autogen-autoloader-strip-prefix test/cli/ \
+  --autogen-registry-module "Primus::Require" \
   test/cli/autogen-autoloader/inplace.rb
 
 cat strip-output/root.rb

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -128,6 +128,9 @@ Usage:
       --autogen-autoloader-root arg
                                 Root directory for autoloader output
                                 (default: autoloader)
+      --autogen-registry-module arg
+                                Name of Ruby module used for autoloader
+                                registry (default: Opus::Require)
       --autogen-autoloader-samefile arg
                                 Modules that should never be collapsed into
                                 their parent. This helps break cycles in


### PR DESCRIPTION
Introduce `--autogen-registry-module` CLI param with backwards compatible default of `Opus::Require`


### Motivation
I need to rename this.
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
See included automated tests.
