### PR TITLE
Added sig for passing pattern to Enumerable#all?, #any?, #none? and #one?

### DIFF
--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -46,7 +46,7 @@ module Enumerable
     )
     .returns(T::Boolean)
   end
-  sig { params(pattern: T.any).returns(T::Boolean) }
+  sig { params(pattern: T.untyped).returns(T::Boolean) }
   def all?(pattern = nil, &blk); end
 
   # Passes each element of the collection to the given block. The method returns
@@ -75,7 +75,7 @@ module Enumerable
     )
     .returns(T::Boolean)
   end
-  sig { params(pattern: T.any).returns(T::Boolean) }
+  sig { params(pattern: T.untyped).returns(T::Boolean) }
   def any?(pattern = nil, &blk); end
 
   # Enumerates over the items, chunking them together based on the return value
@@ -1026,7 +1026,7 @@ module Enumerable
     )
     .returns(T::Boolean)
   end
-  sig { params(pattern: T.any).returns(T::Boolean) }
+  sig { params(pattern: T.untyped).returns(T::Boolean) }
   def none?(pattern = nil, &blk); end
 
   # Passes each element of the collection to the given block. The method returns
@@ -1054,7 +1054,8 @@ module Enumerable
     )
     .returns(T::Boolean)
   end
-  def one?(&blk); end
+  sig { params(pattern: T.untyped).returns(T::Boolean) }
+  def one?(pattern = nil, &blk); end
 
   # Returns two arrays, the first containing the elements of *enum* for which
   # the block evaluates to true, the second containing the rest.

--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -46,7 +46,8 @@ module Enumerable
     )
     .returns(T::Boolean)
   end
-  def all?(&blk); end
+  sig { params(pattern: T.any).returns(T::Boolean) }
+  def all?(pattern = nil, &blk); end
 
   # Passes each element of the collection to the given block. The method returns
   # `true` if the block ever returns a value other than `false` or `nil`. If the
@@ -74,7 +75,8 @@ module Enumerable
     )
     .returns(T::Boolean)
   end
-  def any?(&blk); end
+  sig { params(pattern: T.any).returns(T::Boolean) }
+  def any?(pattern = nil, &blk); end
 
   # Enumerates over the items, chunking them together based on the return value
   # of the block.
@@ -1024,7 +1026,8 @@ module Enumerable
     )
     .returns(T::Boolean)
   end
-  def none?(&blk); end
+  sig { params(pattern: T.any).returns(T::Boolean) }
+  def none?(pattern = nil, &blk); end
 
   # Passes each element of the collection to the given block. The method returns
   # `true` if the block returns `true` exactly once. If the block is not given,

--- a/test/testdata/rbi/enumerable.rb
+++ b/test/testdata/rbi/enumerable.rb
@@ -19,3 +19,15 @@
 [1, 3, 20].sort_by {|n| [n.to_s, [1, 2]]}
 
 T.assert_type!([1].lazy, Enumerator::Lazy[Integer])
+
+# There are 3 different ways to call all?, any? and none?
+a = [1, 3, 20]
+a.all?
+a.all?(1)
+a.all? { |i| i }
+a.any?
+a.any?(1)
+a.any? { |i| i }
+a.none?
+a.none?(1)
+a.none? { |i| i }

--- a/test/testdata/rbi/enumerable.rb
+++ b/test/testdata/rbi/enumerable.rb
@@ -31,3 +31,6 @@ a.any? { |i| i }
 a.none?
 a.none?(1)
 a.none? { |i| i }
+a.one?
+a.one?(1)
+a.one? { |i| i }


### PR DESCRIPTION
### Motivation

Ruby supports passing a pattern to Enumerable#all?, #any? and #none?. Sorbet's rbi did not incorporate this.


### Test plan

See included automated tests.
