### PR TITLE
Improve Hash sigs transform keys and values

### DIFF
--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -1212,7 +1212,16 @@ class Hash < Object
   # ```
   #
   # If no block is given, an enumerator is returned instead.
-  def transform_keys; end
+  sig do
+    type_parameters(:A).params(
+      blk: T.proc.params(arg0: K).returns(T.type_parameter(:A))
+    )
+                       .returns(T::Hash[T.type_parameter(:A), V])
+  end
+  sig do
+    returns(T::Enumerator[K])
+  end
+  def transform_keys(&blk); end
 
   # Invokes the given block once for each key in *hsh*, replacing it with the
   # new key returned by the block, and then returns *hsh*. This method does not
@@ -1227,7 +1236,16 @@ class Hash < Object
   # ```
   #
   # If no block is given, an enumerator is returned instead.
-  def transform_keys!; end
+  sig do
+    type_parameters(:A).params(
+      blk: T.proc.params(arg0: K).returns(T.type_parameter(:A))
+    )
+                       .returns(T::Hash[T.type_parameter(:A), V])
+  end
+  sig do
+    returns(T::Enumerator[K])
+  end
+  def transform_keys!(&blk); end
 
   # Return a new with the results of running block once for every value. This
   # method does not change the keys.
@@ -1265,7 +1283,16 @@ class Hash < Object
   # ```
   #
   # If no block is given, an enumerator is returned instead.
-  def transform_values!; end
+  sig do
+    type_parameters(:A).params(
+      blk: T.proc.params(arg0: V).returns(T.type_parameter(:A))
+    )
+                       .returns(T::Hash[K, T.type_parameter(:A)])
+  end
+  sig do
+    returns(T::Enumerator[V])
+  end
+  def transform_values!(&blk); end
 
   # Adds the contents of the given hashes to the receiver.
   #

--- a/test/testdata/rbi/hash.rb
+++ b/test/testdata/rbi/hash.rb
@@ -53,10 +53,32 @@ h3[nil] = "foo" # error: Expected `Integer` but found `NilClass` for argument `a
 h3[3] = nil # error: Expected `String` but found `NilClass` for argument `arg1`
 
 initial_hash = T.let({ a: 1.0, b: 3.0 }, T::Hash[Symbol, Float])
-transformed_hash = initial_hash.transform_values(&:to_s)
-T.assert_type!(transformed_hash, T::Hash[Symbol, String])
+
+transformed_keys_hash = initial_hash.transform_keys(&:to_s)
+T.assert_type!(transformed_keys_hash, T::Hash[String, Float])
+initial_hash.transform_keys.with_index do |k, i|
+  T.assert_type!(k, Symbol)
+  T.assert_type!(i, Integer)
+end
+
+transformed_keys_bang_hash = initial_hash.dup.transform_keys!(&:to_s)
+T.assert_type!(transformed_keys_bang_hash, T::Hash[String, Float])
+initial_hash.transform_keys!.with_index do |k, i|
+  T.assert_type!(k, Symbol)
+  T.assert_type!(i, Integer)
+end
+
+transformed_values_hash = initial_hash.transform_values(&:to_s)
+T.assert_type!(transformed_values_hash, T::Hash[Symbol, String])
 initial_hash.transform_values(&:size) # error: Method `size` does not exist on `Float`
 initial_hash.transform_values.with_index do |v, i|
+  T.assert_type!(v, Float)
+  T.assert_type!(i, Integer)
+end
+
+transformed_values_bang_hash = initial_hash.dup.transform_values!(&:to_s)
+T.assert_type!(transformed_values_bang_hash, T::Hash[Symbol, String])
+initial_hash.transform_values!.with_index do |v, i|
   T.assert_type!(v, Float)
   T.assert_type!(i, Integer)
 end


### PR DESCRIPTION
This adds sigs to `Hash#transform_keys`, `Hash#transform_keys!` and `Hash#transform_values!` based on the existing sigs for `Hash#transform_values`.

### Motivation

In the project I'm currently working on I noticed these sigs were missing.

### Test plan

See included automated tests.
