### PR TITLE
improve Array and Range bsearch sigs

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -742,7 +742,7 @@ class Array < Object
   # either true/false, or always return a number. It is undefined which value is
   # actually picked up at each iteration.
   sig do
-    params(blk: T.proc.params(arg0: Elem).returns(T::Boolean))
+    params(blk: T.proc.params(arg0: Elem).returns(T.any(Numeric, T::Boolean)))
       .returns(T.nilable(Elem))
   end
   def bsearch(&blk); end
@@ -758,7 +758,7 @@ class Array < Object
   # documentation for
   # [`bsearch`](https://docs.ruby-lang.org/en/2.6.0/Array.html#method-i-bsearch).
   sig do
-    params(blk: T.proc.params(arg0: Elem).returns(T::Boolean))
+    params(blk: T.proc.params(arg0: Elem).returns(T.any(Numeric, T::Boolean)))
       .returns(T.nilable(Integer))
   end
   def bsearch_index(&blk); end

--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -742,10 +742,8 @@ class Array < Object
   # either true/false, or always return a number. It is undefined which value is
   # actually picked up at each iteration.
   sig do
-    params(
-      blk: T.proc.params(arg0: Elem).returns(T::Boolean),
-    )
-    .returns(T.nilable(Elem))
+    params(blk: T.proc.params(arg0: Elem).returns(T::Boolean))
+      .returns(T.nilable(Elem))
   end
   def bsearch(&blk); end
 
@@ -760,10 +758,8 @@ class Array < Object
   # documentation for
   # [`bsearch`](https://docs.ruby-lang.org/en/2.6.0/Array.html#method-i-bsearch).
   sig do
-    params(
-      blk: T.proc.params(arg0: Elem).returns(T::Boolean),
-    )
-    .returns(T.nilable(Integer))
+    params(blk: T.proc.params(arg0: Elem).returns(T::Boolean))
+      .returns(T.nilable(Integer))
   end
   def bsearch_index(&blk); end
 

--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -741,7 +741,13 @@ class Array < Object
   # You must not mix the two modes at a time; the block must always return
   # either true/false, or always return a number. It is undefined which value is
   # actually picked up at each iteration.
-  def bsearch; end
+  sig do
+    params(
+      blk: T.proc.params(arg0: Elem).returns(T::Boolean),
+    )
+    .returns(T.nilable(Elem))
+  end
+  def bsearch(&blk); end
 
   # By using binary search, finds an index of a value from this array which
   # meets the given condition in O(log n) where n is the size of the array.
@@ -753,7 +759,13 @@ class Array < Object
   # the element instead of the element itself. For more details consult the
   # documentation for
   # [`bsearch`](https://docs.ruby-lang.org/en/2.6.0/Array.html#method-i-bsearch).
-  def bsearch_index; end
+  sig do
+    params(
+      blk: T.proc.params(arg0: Elem).returns(T::Boolean),
+    )
+    .returns(T.nilable(Integer))
+  end
+  def bsearch_index(&blk); end
 
   # Removes all elements from `self`.
   #

--- a/rbi/core/range.rbi
+++ b/rbi/core/range.rbi
@@ -216,10 +216,8 @@ class Range < Object
   # either true/false, or always return a number. It is undefined which value is
   # actually picked up at each iteration.
   sig do
-    params(
-      blk: T.proc.params(arg0: Elem).returns(T::Boolean),
-    )
-    .returns(T.nilable(Elem))
+    params(blk: T.proc.params(arg0: Elem).returns(T::Boolean))
+      .returns(T.nilable(Elem))
   end
   def bsearch(&blk); end
 

--- a/rbi/core/range.rbi
+++ b/rbi/core/range.rbi
@@ -216,10 +216,10 @@ class Range < Object
   # either true/false, or always return a number. It is undefined which value is
   # actually picked up at each iteration.
   sig do
-    type_parameters(:U).params(
-        blk: T.proc.params(arg0: Elem).returns(T::Boolean),
+    params(
+      blk: T.proc.params(arg0: Elem).returns(T::Boolean),
     )
-    .returns(T.nilable(T.type_parameter(:U)))
+    .returns(T.nilable(Elem))
   end
   def bsearch(&blk); end
 

--- a/rbi/core/range.rbi
+++ b/rbi/core/range.rbi
@@ -216,7 +216,7 @@ class Range < Object
   # either true/false, or always return a number. It is undefined which value is
   # actually picked up at each iteration.
   sig do
-    params(blk: T.proc.params(arg0: Elem).returns(T::Boolean))
+    params(blk: T.proc.params(arg0: Elem).returns(T.any(Numeric, T::Boolean)))
       .returns(T.nilable(Elem))
   end
   def bsearch(&blk); end

--- a/test/testdata/rbi/array.rb
+++ b/test/testdata/rbi/array.rb
@@ -48,3 +48,7 @@ T.assert_type!(arr[1..2] = [100, 200], T::Array[Integer])
 # errors
 
 T::Array[Float].new.sum.nan? # error: Method `nan?` does not exist on `Integer` component of `T.any(Integer, Float)`
+
+# bsearch
+T.reveal_type([1,2].bsearch {|x| x == 1}) # error: Revealed type: `T.nilable(Integer)`
+T.reveal_type([1,2].bsearch {|x| x}) # error: Revealed type: `T.nilable(Integer)`

--- a/test/testdata/rbi/array.rb
+++ b/test/testdata/rbi/array.rb
@@ -50,5 +50,6 @@ T.assert_type!(arr[1..2] = [100, 200], T::Array[Integer])
 T::Array[Float].new.sum.nan? # error: Method `nan?` does not exist on `Integer` component of `T.any(Integer, Float)`
 
 # bsearch
+T.reveal_type(['a','b','c'].bsearch {|x| x == 'a'}) # error: Revealed type: `T.nilable(String)`
 T.reveal_type([1,2].bsearch {|x| x == 1}) # error: Revealed type: `T.nilable(Integer)`
 T.reveal_type([1,2].bsearch {|x| x}) # error: Revealed type: `T.nilable(Integer)`

--- a/test/testdata/rbi/array.rb
+++ b/test/testdata/rbi/array.rb
@@ -50,6 +50,9 @@ T.assert_type!(arr[1..2] = [100, 200], T::Array[Integer])
 T::Array[Float].new.sum.nan? # error: Method `nan?` does not exist on `Integer` component of `T.any(Integer, Float)`
 
 # bsearch
-T.reveal_type(['a','b','c'].bsearch {|x| x == 'a'}) # error: Revealed type: `T.nilable(String)`
 T.reveal_type([1,2].bsearch {|x| x == 1}) # error: Revealed type: `T.nilable(Integer)`
 T.reveal_type([1,2].bsearch {|x| x}) # error: Revealed type: `T.nilable(Integer)`
+T.reveal_type(['a','b','c'].bsearch {|x| x == 'a'}) # error: Revealed type: `T.nilable(String)`
+
+# bsearch_index
+T.reveal_type(['a','b','c'].bsearch_index {|x| x == 'a'}) # error: Revealed type: `T.nilable(Integer)`

--- a/test/testdata/rbi/range.rb
+++ b/test/testdata/rbi/range.rb
@@ -13,5 +13,6 @@ Range.new(0.5, 2.5).step(2+1i) # error: Expected `T.any(Integer, Float, Rational
 (:a...:z)
 
 # bsearch
+T.reveal_type((0.0..10.0).bsearch {|x| x >= 3}) # error: Revealed type: `T.nilable(Float)`
 T.reveal_type((1..10).bsearch {|x| x == 1}) # error: Revealed type: `T.nilable(Integer)`
 T.reveal_type((1..10).bsearch {|x| x }) # error: Revealed type: `T.nilable(Integer)`

--- a/test/testdata/rbi/range.rb
+++ b/test/testdata/rbi/range.rb
@@ -11,3 +11,7 @@ Range.new(0.5, 2.5).step(2+1i) # error: Expected `T.any(Integer, Float, Rational
 (1.0...20.0)
 ('a'..'z')
 (:a...:z)
+
+# bsearch
+T.reveal_type((1..10).bsearch {|x| x == 1}) # error: Revealed type: `T.nilable(Integer)`
+T.reveal_type((1..10).bsearch {|x| x }) # error: Revealed type: `T.nilable(Integer)`


### PR DESCRIPTION
This patch improves the sigs of `Range#bsearch` and applies the same idea to `Array#bsearch` and `Array#bsearch_index`.

### Motivation

In the project I'm currently working on I noticed these sigs could be improved.


### Test plan

I couldn't find any test for these methods in the test suite.