### PR TITLE
Update snapshot testing instructions to match current functionality

### DIFF
--- a/gems/sorbet/README.md
+++ b/gems/sorbet/README.md
@@ -100,19 +100,19 @@ To make this easier, you can either
 To run all the tests:
 
 ```
-bazel test test/snapshot --config=dbg
+bazel test //gems/sorbet/test/snapshot
 ```
 
 You'll see the name of each test in the output of the above command. To run that individual test:
 
 ```
-bazel test test/snapshot:test_<testname> --config=dbg
+bazel test //gems/sorbet/test/snapshot:test_<testname>
 ```
 
 For example:
 
 ```
-bazel test test/snapshot:test_ruby_2_6/partial/local_rvm_gemset_gem --config=dbg
+bazel test //gems/sorbet/test/snapshot:test_ruby_2_6/partial/local_rvm_gemset_gem
 ```
 
 ## Writing tests
@@ -184,13 +184,13 @@ of a test using the `gems/` folder.
 When it **is** necessary to update a snapshot test:
 
 ```
-bazel test test/snapshot:update_<testname> --config=dbg
+bazel test //gems/sorbet/test/snapshot:update_<testname>
 ```
 
 For example:
 
 ```
-bazel test test/snapshot:update_ruby_2_6/partial/local_rvm_gemset_gem --config=dbg
+bazel test //gems/sorbet/test/snapshot:update_ruby_2_6/partial/local_rvm_gemset_gem
 ```
 
 ### Creating new partial tests

--- a/gems/sorbet/README.md
+++ b/gems/sorbet/README.md
@@ -100,25 +100,20 @@ To make this easier, you can either
 To run all the tests:
 
 ```
-test/snapshot/driver.sh
+bazel test test/snapshot --config=dbg
 ```
 
-The driver.sh output should show you how to re-run a single failing test, but an
-example is like this:
+You'll see the name of each test in the output of the above command. To run that individual test:
 
 ```
-test/snapshot/test_one.sh test/snapshot/total/empty
+bazel test test/snapshot:test_<testname> --config=dbg
 ```
 
-There are more options to `driver.sh` and `test_one.sh`. For the full list of
-available options, use `--help`:
+For example:
 
 ```
-test/snapshot/driver.sh --help
-
-test/snapshot/test_one.sh --help
+bazel test test/snapshot:test_ruby_2_6/partial/local_rvm_gemset_gem --config=dbg
 ```
-
 
 ## Writing tests
 
@@ -186,34 +181,24 @@ of a test using the `gems/` folder.
 
 ### Updating tests
 
-When it **is** necessary to update a snapshot test, run one of:
+When it **is** necessary to update a snapshot test:
 
 ```
-test/snapshot/driver.sh --update
+bazel test test/snapshot:update_<testname> --config=dbg
+```
 
-test/snapshot/test_one.sh <testname> --update
+For example:
+
+```
+bazel test test/snapshot:update_ruby_2_6/partial/local_rvm_gemset_gem --config=dbg
 ```
 
 ### Creating new partial tests
 
 A total test can never be empty, so to record a new total test, just use
-`--update`, like above.
+`update`, like above.
 
 Since a partial test is allowed to have an empty `expected/` folder, there's no
 difference between "a new partial test" and "an existing partial test that just
-asserts no errors". As such, to populate the `expected/` folder of a new partial
-test, use the `--record` flag:
-
-```
-test/snapshot/test_one.sh <testname> --update --record
-```
-
-### Debugging tests
-
-To use `binding.pry` to debug a test, edit your test case and/or the `srb` gem
-to require and call `pry`, and then pass the `--debug` flag when running the
-test:
-
-```
-test/snapshot/test_one.sh <testname> --debug
-```
+asserts no errors". As such, you'll have to manually populate the `expected/`
+with the files you want checked.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

I was trying to run snapshot tests in the sorbet gem and ran into this. It appears the test instructions are somewhat dated and direct the developer to use scripts that no longer exist. There is also some functionality like pry debugging that no longer exists. There appear to be issues for adding back the functionality that was removed (https://github.com/sorbet/sorbet/milestone/10) but in the meantime this documentation is incorrect.

I've updated with bazel test commands that work but I'm new and not overly familiar with bazel so please let me know if these aren't the proper way to do things and I will update the PR.


### Motivation
Outdated documentation is confusing :-)
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
No code, no tests.
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

