### PR TITLE
Allow vanilla ruby installations

### DIFF
--- a/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
@@ -215,7 +215,7 @@ module Sorbet::Private
 
       def gem_from_location(location)
         match =
-          location&.match(/^.*\/gems\/([^\/]+)-([^-\/]+)\//i) || # gem
+          location&.match(/^.*\/(?:gems\/(?:(?:j?ruby-)?[\d.]+(?:@[^\/]+)?(?:\/bundler)?\/)?|ruby\/[\d.]+\/)gems\/([^\/]+)-([^-\/]+)\//i) || # gem
           location&.match(/^.*\/(ruby)\/([\d.]+)\//) || # ruby stdlib
           location&.match(/^.*\/(jruby)-([\d.]+)\//) || # jvm ruby stdlib
           location&.match(/^.*\/(site_ruby)\/([\d.]+)\//) # rubygems

--- a/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
@@ -215,10 +215,10 @@ module Sorbet::Private
 
       def gem_from_location(location)
         match =
+          location&.match(/^.*\/gems\/([^\/]+)-([^-\/]+)\//i) || # gem
           location&.match(/^.*\/(ruby)\/([\d.]+)\//) || # ruby stdlib
           location&.match(/^.*\/(jruby)-([\d.]+)\//) || # jvm ruby stdlib
-          location&.match(/^.*\/(site_ruby)\/([\d.]+)\//) || # rubygems
-          location&.match(/^.*\/gems\/(?:(?:j?ruby-)?[\d.]+(?:@[^\/]+)?(?:\/bundler)?\/)?gems\/([^\/]+)-([^-\/]+)\//i) # gem
+          location&.match(/^.*\/(site_ruby)\/([\d.]+)\//) # rubygems
         if match.nil?
           # uncomment to generate files for methods outside of gems
           # {


### PR DESCRIPTION
The previous logic did not find gems in a default ruby/rubygems installation. For example the default path for user-installed gems on macOS is `$HOME/.gem/ruby/2.6.0`. This was matched by the very first pattern, `/^.*\/(ruby)\/([\d.]+)\//`, determining that this is the location of a gem called `ruby` version 2.6.0, which is wrong.

This PR adds a much more general pattern which matches the default gem path, and also customised BUNDLE_PATH (for users installing gems into `$MY_PROJECT/bundle` for example). The new pattern must come before the `# ruby` pattern for the aforementioned reason, subsuming the previous `# gem` pattern; so that has been removed.

### Motivation
https://github.com/sorbet/sorbet/issues/3166

### Test plan
Have the regex match the tests here: https://regexr.com/57t2q
