### PR TITLE
ruby27: Fix rescue parsing in multi assignement

### DIFF
--- a/test/whitequark/test_rescue_mod_masgn_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_rescue_mod_masgn_0.parse-tree-whitequark.exp
@@ -1,0 +1,10 @@
+s(:masgn,
+  s(:mlhs,
+    s(:lvasgn, :foo),
+    s(:lvasgn, :bar)),
+  s(:rescue,
+    s(:send, nil, :meth),
+    s(:resbody, nil, nil,
+      s(:array,
+        s(:int, "1"),
+        s(:int, "2"))), nil))

--- a/test/whitequark/test_rescue_mod_masgn_0.rb
+++ b/test/whitequark/test_rescue_mod_masgn_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+foo, bar = meth rescue [1, 2]

--- a/third_party/parser/cc/grammars/typedruby.ypp
+++ b/third_party/parser/cc/grammars/typedruby.ypp
@@ -589,6 +589,13 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby27 &driver) {
                     {
                       $$ = driver.build.assign(self, $1, $2, driver.build.array(self, nullptr, $3, nullptr));
                     }
+                | mlhs tEQL mrhs_arg kRESCUE_MOD stmt
+                    {
+                    ruby_parser::node_list rescue_body(
+						driver.build.rescue_body(self, $4, nullptr, nullptr, nullptr, nullptr, $5));
+                      auto begin_body = driver.build.beginBody(self, $3, &rescue_body, nullptr, nullptr, nullptr, nullptr);
+                      $$ = driver.build.multi_assign(self, $1, begin_body);
+                    }
                 | mlhs tEQL mrhs_arg
                     {
                       $$ = driver.build.multi_assign(self, $1, $3);


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

As described in Ruby's [change log](https://rubyreferences.github.io/rubychanges/2.7.html#other-syntax-changes), this PR changes how ruby27 parses the `rescue` modifier with multiple assignment to make it consistent with the singular form:

```ruby
a = raise rescue 1
# => 1
a # => 1 in Ruby 2.6 and 2.7

a, b = raise rescue [1, 2]
# => [1, 2]

# 2.6
a # => nil
b # => nil
# The statement parsed as: (a, b = raise) rescue [1, 2]

# 2.7
a # => 1
b # => 2
# The statement parsed as: a, b = (raise rescue [1, 2])
```

This commit tracks upstream commit ruby/ruby@53b3be5.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
