### PR TITLE
ruby27: Allow comments before leading dot

### DIFF
--- a/test/whitequark/test_comments_before_leading_dot_27_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_comments_before_leading_dot_27_0.parse-tree-whitequark.exp
@@ -1,0 +1,2 @@
+s(:send,
+  s(:send, nil, :a), :foo)

--- a/test/whitequark/test_comments_before_leading_dot_27_0.rb
+++ b/test/whitequark/test_comments_before_leading_dot_27_0.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+a #
+#
+.foo
+

--- a/test/whitequark/test_comments_before_leading_dot_27_1.parse-tree-whitequark.exp
+++ b/test/whitequark/test_comments_before_leading_dot_27_1.parse-tree-whitequark.exp
@@ -1,0 +1,2 @@
+s(:send,
+  s(:send, nil, :a), :foo)

--- a/test/whitequark/test_comments_before_leading_dot_27_1.rb
+++ b/test/whitequark/test_comments_before_leading_dot_27_1.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+a #
+  #
+.foo
+

--- a/test/whitequark/test_comments_before_leading_dot_27_2.parse-tree-whitequark.exp
+++ b/test/whitequark/test_comments_before_leading_dot_27_2.parse-tree-whitequark.exp
@@ -1,0 +1,2 @@
+s(:csend,
+  s(:send, nil, :a), :foo)

--- a/test/whitequark/test_comments_before_leading_dot_27_2.rb
+++ b/test/whitequark/test_comments_before_leading_dot_27_2.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+a #
+#
+&.foo
+

--- a/test/whitequark/test_comments_before_leading_dot_27_3.parse-tree-whitequark.exp
+++ b/test/whitequark/test_comments_before_leading_dot_27_3.parse-tree-whitequark.exp
@@ -1,0 +1,2 @@
+s(:csend,
+  s(:send, nil, :a), :foo)

--- a/test/whitequark/test_comments_before_leading_dot_27_3.rb
+++ b/test/whitequark/test_comments_before_leading_dot_27_3.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+a #
+  #
+&.foo
+


### PR DESCRIPTION
### Motivation

As described in Ruby 2.7 [change log](https://rubyreferences.github.io/rubychanges/2.7.html#other-syntax-changes), this PR allows comments between `.foo` calls:

```ruby
(1..20).select(&:odd?)
       # This was not possible in 2.6
       .map { |x| x**2 }
# => [1, 9, 25, 49, 81, 121, 169, 225, 289, 361]:
```

This commit tracks upstream commit ruby/ruby@3a3f48f.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.