### PR TITLE
ruby27: Reject CSend inside left hand side of mass assign

### DIFF
--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -223,10 +223,13 @@ public:
         return make_unique<Hash>(collectionLoc(begin, pairs, end), std::move(pairs));
     }
 
-    unique_ptr<Node> attrAsgn(unique_ptr<Node> receiver, const token *dot, const token *selector) {
+    unique_ptr<Node> attrAsgn(unique_ptr<Node> receiver, const token *dot, const token *selector, bool masgn) {
         core::NameRef method = gs_.enterNameUTF8(selector->string() + "=");
         core::LocOffsets loc = receiver->loc.join(tokLoc(selector));
         if ((dot != nullptr) && dot->string() == "&.") {
+            if (masgn) {
+                error(ruby_parser::dclass::CSendInLHSOfMAsgn, tokLoc(dot));
+            }
             return make_unique<CSend>(loc, std::move(receiver), method, sorbet::parser::NodeVec());
         }
         return make_unique<Send>(loc, std::move(receiver), method, sorbet::parser::NodeVec());
@@ -1252,9 +1255,9 @@ ForeignPtr associate(SelfPtr builder, const token *begin, const node_list *pairs
     return build->toForeign(build->associate(begin, build->convertNodeList(pairs), end));
 }
 
-ForeignPtr attrAsgn(SelfPtr builder, ForeignPtr receiver, const token *dot, const token *selector) {
+ForeignPtr attrAsgn(SelfPtr builder, ForeignPtr receiver, const token *dot, const token *selector, bool masgn) {
     auto build = cast_builder(builder);
-    return build->toForeign(build->attrAsgn(build->cast_node(receiver), dot, selector));
+    return build->toForeign(build->attrAsgn(build->cast_node(receiver), dot, selector, masgn));
 }
 
 ForeignPtr backRef(SelfPtr builder, const token *tok) {

--- a/test/testdata/desugar/multi_assign.rb
+++ b/test/testdata/desugar/multi_assign.rb
@@ -10,6 +10,5 @@ class Test
     a, b, *c, d, e = array
     a, * = array
     a.x, b = array
-    a&.x, b = array
   end
 end

--- a/test/testdata/desugar/multi_assign.rb.desugar-tree.exp
+++ b/test/testdata/desugar/multi_assign.rb.desugar-tree.exp
@@ -69,20 +69,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           b = <assignTemp>$17.[](1)
           <assignTemp>$16
         end
-        begin
-          <assignTemp>$18 = array
-          <assignTemp>$19 = ::<Magic>.<expand-splat>(<assignTemp>$18, 2, 0)
-          begin
-            <assignTemp>$20 = a
-            if <assignTemp>$20.==(nil)
-              nil
-            else
-              <assignTemp>$20.x=(<assignTemp>$19.[](0))
-            end
-          end
-          b = <assignTemp>$19.[](1)
-          <assignTemp>$18
-        end
       end
     end
   end

--- a/test/testdata/desugar/multi_assign.rb.symbol-table-raw.exp
+++ b/test/testdata/desugar/multi_assign.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/desugar/multi_assign.rb start=2:1 end=15:4}
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/desugar/multi_assign.rb start=2:1 end=14:4}
       argument <blk><block> @ Loc {file=test/testdata/desugar/multi_assign.rb start=??? end=???}
   static-field <C <U A>> @ Loc {file=test/testdata/desugar/multi_assign.rb start=2:1 end=2:2}
   static-field <C <U B>> @ Loc {file=test/testdata/desugar/multi_assign.rb start=2:4 end=2:5}
@@ -11,6 +11,6 @@ class <C <U <root>>> < <C <U Object>> ()
       argument <blk><block> @ Loc {file=test/testdata/desugar/multi_assign.rb start=??? end=???}
   class <S <C <U Test>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/desugar/multi_assign.rb start=4:7 end=4:11}
     type-member(+) <S <C <U Test>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Test>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Test) @ Loc {file=test/testdata/desugar/multi_assign.rb start=4:7 end=4:11}
-    method <S <C <U Test>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/desugar/multi_assign.rb start=4:1 end=15:4}
+    method <S <C <U Test>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/desugar/multi_assign.rb start=4:1 end=14:4}
       argument <blk><block> @ Loc {file=test/testdata/desugar/multi_assign.rb start=??? end=???}
 

--- a/test/whitequark/test_csend_inside_lhs_of_masgn_since_27_0.rb
+++ b/test/whitequark/test_csend_inside_lhs_of_masgn_since_27_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+*a&.x = 0 # error: &. inside multiple assignment destination

--- a/test/whitequark/test_csend_inside_lhs_of_masgn_since_27_1.rb
+++ b/test/whitequark/test_csend_inside_lhs_of_masgn_since_27_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+a&.x, = 0 # error: &. inside multiple assignment destination

--- a/test/whitequark/test_csend_inside_lhs_of_masgn_since_27_2.rb
+++ b/test/whitequark/test_csend_inside_lhs_of_masgn_since_27_2.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+*a&.A = 0 # error: &. inside multiple assignment destination

--- a/third_party/parser/cc/grammars/typedruby.ypp
+++ b/third_party/parser/cc/grammars/typedruby.ypp
@@ -884,15 +884,15 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby27 &driver) {
                     }
                 | primary_value call_op tIDENTIFIER
                     {
-                      $$ = driver.build.attrAsgn(self, $1, $2, $3);
+                      $$ = driver.build.attrAsgn(self, $1, $2, $3, true);
                     }
                 | primary_value tCOLON2 tIDENTIFIER
                     {
-                      $$ = driver.build.attrAsgn(self, $1, $2, $3);
+                      $$ = driver.build.attrAsgn(self, $1, $2, $3, false);
                     }
                 | primary_value call_op tCONSTANT
                     {
-                      $$ = driver.build.attrAsgn(self, $1, $2, $3);
+                      $$ = driver.build.attrAsgn(self, $1, $2, $3, true);
                     }
                 | primary_value tCOLON2 tCONSTANT
                     {
@@ -926,15 +926,15 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby27 &driver) {
                     }
                 | primary_value call_op tIDENTIFIER
                     {
-                      $$ = driver.build.attrAsgn(self, $1, $2, $3);
+                      $$ = driver.build.attrAsgn(self, $1, $2, $3, false);
                     }
                 | primary_value tCOLON2 tIDENTIFIER
                     {
-                      $$ = driver.build.attrAsgn(self, $1, $2, $3);
+                      $$ = driver.build.attrAsgn(self, $1, $2, $3, false);
                     }
                 | primary_value call_op tCONSTANT
                     {
-                      $$ = driver.build.attrAsgn(self, $1, $2, $3);
+                      $$ = driver.build.attrAsgn(self, $1, $2, $3, false);
                     }
                 | primary_value tCOLON2 tCONSTANT
                     {

--- a/third_party/parser/codegen/generate_diagnostics.cc
+++ b/third_party/parser/codegen/generate_diagnostics.cc
@@ -56,6 +56,7 @@ tuple<string, string> MESSAGES[] = {
     {"BlockGivenToYield", "block given to yield"},
     {"InvalidRegexp", "{}"},
     {"InvalidReturn", "Invalid return in class/module body"},
+    {"CSendInLHSOfMAsgn", "&. inside multiple assignment destination"},
 
     // Parser warnings
     {"UselessElse", "else without rescue is useless"},

--- a/third_party/parser/include/ruby_parser/builder.hh
+++ b/third_party/parser/include/ruby_parser/builder.hh
@@ -20,7 +20,7 @@ struct builder {
 	ForeignPtr(*assign)(SelfPtr builder, ForeignPtr lhs, const token* eql, ForeignPtr rhs);
 	ForeignPtr(*assignable)(SelfPtr builder, ForeignPtr node);
 	ForeignPtr(*associate)(SelfPtr builder, const token* begin, const node_list* pairs, const token* end);
-	ForeignPtr(*attrAsgn)(SelfPtr builder, ForeignPtr receiver, const token* dot, const token* selector);
+	ForeignPtr(*attrAsgn)(SelfPtr builder, ForeignPtr receiver, const token* dot, const token* selector, bool masgn);
 	ForeignPtr(*backRef)(SelfPtr builder, const token* tok);
 	ForeignPtr(*begin)(SelfPtr builder, const token* begin, ForeignPtr body, const token* end);
 	ForeignPtr(*beginBody)(SelfPtr builder, ForeignPtr body, const node_list* rescueBodies, const token* elseTok, ForeignPtr else_, const token* ensure_tok, ForeignPtr ensure);


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Before ruby27, the following snippet will cause `ruby` to crash:

```ruby
class A
  def a=(x); end
end

a = A.new
a.a, = 10
a&.a, = 10
```

After ruby27, ruby will return an error instead:

```
:7: &. inside multiple assignment destination
a&.a, = 10
```

This commit tracks upstream commits ruby/ruby@140b811 and ruby/ruby@39ae88a.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.