### PR TITLE
Make deepCopy not virtual

### DIFF
--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -7,240 +7,234 @@ namespace sorbet::ast {
 
 namespace {
 
+TreePtr deepCopy(const Expression *avoid, const TreePtr &tree, bool root = false);
+
 template <class T> T deepCopyVec(const Expression *avoid, const T &origin) {
     T copy;
     copy.reserve(origin.size());
     for (const auto &memb : origin) {
-        copy.emplace_back(memb->_deepCopy(avoid));
+        copy.emplace_back(deepCopy(avoid, memb));
     };
     return copy;
 }
 
+class DeepCopyError {};
+
+TreePtr deepCopy(const Expression *avoid, const Tag tag, const Expression *tree, bool root) {
+    if (!root && tree == avoid) {
+        throw DeepCopyError();
+    }
+
+    switch (tag) {
+        case Tag::EmptyTree:
+            return make_tree<EmptyTree>();
+
+        case Tag::Send: {
+            auto *exp = reinterpret_cast<const Send *>(tree);
+            return make_tree<Send>(exp->loc, deepCopy(avoid, exp->recv), exp->fun, deepCopyVec(avoid, exp->args),
+                                   exp->block == nullptr ? nullptr : deepCopy(avoid, exp->block), exp->flags);
+        }
+
+        case Tag::ClassDef: {
+            auto *exp = reinterpret_cast<const ClassDef *>(tree);
+            return make_tree<ClassDef>(exp->loc, exp->declLoc, exp->symbol, deepCopy(avoid, exp->name),
+                                       deepCopyVec(avoid, exp->ancestors), deepCopyVec(avoid, exp->rhs), exp->kind);
+        }
+
+        case Tag::MethodDef: {
+            auto *exp = reinterpret_cast<const MethodDef *>(tree);
+            return make_tree<MethodDef>(exp->loc, exp->declLoc, exp->symbol, exp->name, deepCopyVec(avoid, exp->args),
+                                        deepCopy(avoid, exp->rhs), exp->flags);
+        }
+
+        case Tag::If: {
+            auto *exp = reinterpret_cast<const If *>(tree);
+            return make_tree<If>(exp->loc, deepCopy(avoid, exp->cond), deepCopy(avoid, exp->thenp),
+                                 deepCopy(avoid, exp->elsep));
+        }
+
+        case Tag::While: {
+            auto *exp = reinterpret_cast<const While *>(tree);
+            return make_tree<While>(exp->loc, deepCopy(avoid, exp->cond), deepCopy(avoid, exp->body));
+        }
+
+        case Tag::Break: {
+            auto *exp = reinterpret_cast<const Break *>(tree);
+            return make_tree<Break>(exp->loc, deepCopy(avoid, exp->expr));
+        }
+
+        case Tag::Retry: {
+            auto *exp = reinterpret_cast<const Retry *>(tree);
+            return make_tree<Retry>(exp->loc);
+        }
+
+        case Tag::Next: {
+            auto *exp = reinterpret_cast<const Next *>(tree);
+            return make_tree<Next>(exp->loc, deepCopy(avoid, exp->expr));
+        }
+
+        case Tag::Return: {
+            auto *exp = reinterpret_cast<const Return *>(tree);
+            return make_tree<Return>(exp->loc, deepCopy(avoid, exp->expr));
+        }
+
+        case Tag::RescueCase: {
+            auto *exp = reinterpret_cast<const RescueCase *>(tree);
+            return make_tree<RescueCase>(exp->loc, deepCopyVec(avoid, exp->exceptions), deepCopy(avoid, exp->var),
+                                         deepCopy(avoid, exp->body));
+        }
+
+        case Tag::Rescue: {
+            auto *exp = reinterpret_cast<const Rescue *>(tree);
+            return make_tree<Rescue>(exp->loc, deepCopy(avoid, exp->body),
+                                     deepCopyVec<Rescue::RESCUE_CASE_store>(avoid, exp->rescueCases),
+                                     deepCopy(avoid, exp->else_), deepCopy(avoid, exp->ensure));
+        }
+
+        case Tag::Local: {
+            auto *exp = reinterpret_cast<const Local *>(tree);
+            return make_tree<Local>(exp->loc, exp->localVariable);
+        }
+
+        case Tag::UnresolvedIdent: {
+            auto *exp = reinterpret_cast<const UnresolvedIdent *>(tree);
+            return make_tree<UnresolvedIdent>(exp->loc, exp->kind, exp->name);
+        }
+
+        case Tag::RestArg: {
+            auto *exp = reinterpret_cast<const RestArg *>(tree);
+            return make_tree<RestArg>(exp->loc, deepCopy(avoid, exp->expr));
+        }
+
+        case Tag::KeywordArg: {
+            auto *exp = reinterpret_cast<const KeywordArg *>(tree);
+            return make_tree<KeywordArg>(exp->loc, deepCopy(avoid, exp->expr));
+        }
+
+        case Tag::OptionalArg: {
+            auto *exp = reinterpret_cast<const OptionalArg *>(tree);
+            return make_tree<OptionalArg>(exp->loc, deepCopy(avoid, exp->expr), deepCopy(avoid, exp->default_));
+        }
+
+        case Tag::BlockArg: {
+            auto *exp = reinterpret_cast<const BlockArg *>(tree);
+            return make_tree<BlockArg>(exp->loc, deepCopy(avoid, exp->expr));
+        }
+
+        case Tag::ShadowArg: {
+            auto *exp = reinterpret_cast<const ShadowArg *>(tree);
+            return make_tree<ShadowArg>(exp->loc, deepCopy(avoid, exp->expr));
+        }
+
+        case Tag::Assign: {
+            auto *exp = reinterpret_cast<const Assign *>(tree);
+            return make_tree<Assign>(exp->loc, deepCopy(avoid, exp->lhs), deepCopy(avoid, exp->rhs));
+        }
+
+        case Tag::Cast: {
+            auto *exp = reinterpret_cast<const Cast *>(tree);
+            return make_tree<Cast>(exp->loc, exp->type, deepCopy(avoid, exp->arg), exp->cast);
+        }
+
+        case Tag::Hash: {
+            auto *exp = reinterpret_cast<const Hash *>(tree);
+            return make_tree<Hash>(exp->loc, deepCopyVec(avoid, exp->keys), deepCopyVec(avoid, exp->values));
+        }
+
+        case Tag::Array: {
+            auto *exp = reinterpret_cast<const Array *>(tree);
+            return make_tree<Array>(exp->loc, deepCopyVec(avoid, exp->elems));
+        }
+
+        case Tag::Literal: {
+            auto *exp = reinterpret_cast<const Literal *>(tree);
+            return make_tree<Literal>(exp->loc, exp->value);
+        }
+
+        case Tag::UnresolvedConstantLit: {
+            auto *exp = reinterpret_cast<const UnresolvedConstantLit *>(tree);
+            return make_tree<UnresolvedConstantLit>(exp->loc, deepCopy(avoid, exp->scope), exp->cnst);
+        }
+
+        case Tag::ConstantLit: {
+            auto *exp = reinterpret_cast<const ConstantLit *>(tree);
+            TreePtr originalC;
+            if (exp->original) {
+                originalC = deepCopy(avoid, exp->original);
+            }
+            return make_tree<ConstantLit>(exp->loc, exp->symbol, move(originalC));
+        }
+
+        case Tag::ZSuperArgs: {
+            auto *exp = reinterpret_cast<const ZSuperArgs *>(tree);
+            return make_tree<ZSuperArgs>(exp->loc);
+        }
+
+        case Tag::Block: {
+            auto *exp = reinterpret_cast<const Block *>(tree);
+            return make_tree<Block>(exp->loc, deepCopyVec(avoid, exp->args), deepCopy(avoid, exp->body));
+        }
+
+        case Tag::InsSeq: {
+            auto *exp = reinterpret_cast<const InsSeq *>(tree);
+            return make_tree<InsSeq>(exp->loc, deepCopyVec(avoid, exp->stats), deepCopy(avoid, exp->expr));
+        }
+    }
+}
+
+TreePtr deepCopy(const Expression *avoid, const TreePtr &tree, bool root) {
+    ENFORCE(tree != nullptr);
+
+    return deepCopy(avoid, tree.tag(), tree.get(), root);
+}
+
 } // namespace
 
-TreePtr Expression::deepCopy() const {
-    TreePtr res;
-
+TreePtr TreePtr::deepCopy() const {
     try {
-        res = this->_deepCopy(this, true);
+        return sorbet::ast::deepCopy(get(), tag(), get(), true);
     } catch (DeepCopyError &e) {
         return nullptr;
     }
-    return res;
 }
 
-TreePtr ClassDef::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
+#define COPY_IMPL(name)                                                             \
+    TreePtr name::deepCopy() const {                                                \
+        try {                                                                       \
+            return sorbet::ast::deepCopy(this, TreeToTag<name>::value, this, true); \
+        } catch (DeepCopyError & e) {                                               \
+            return nullptr;                                                         \
+        }                                                                           \
     }
-    return make_tree<ClassDef>(this->loc, this->declLoc, this->symbol, this->name->_deepCopy(avoid),
-                               deepCopyVec(avoid, this->ancestors), deepCopyVec(avoid, this->rhs), this->kind);
-}
 
-TreePtr MethodDef::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<MethodDef>(this->loc, this->declLoc, this->symbol, this->name, deepCopyVec(avoid, this->args),
-                                rhs->_deepCopy(avoid), flags);
-}
+COPY_IMPL(EmptyTree);
+COPY_IMPL(Send);
+COPY_IMPL(ClassDef);
+COPY_IMPL(MethodDef);
+COPY_IMPL(If);
+COPY_IMPL(While);
+COPY_IMPL(Break);
+COPY_IMPL(Retry);
+COPY_IMPL(Next);
+COPY_IMPL(Return);
+COPY_IMPL(RescueCase);
+COPY_IMPL(Rescue);
+COPY_IMPL(Local);
+COPY_IMPL(UnresolvedIdent);
+COPY_IMPL(RestArg);
+COPY_IMPL(KeywordArg);
+COPY_IMPL(OptionalArg);
+COPY_IMPL(BlockArg);
+COPY_IMPL(ShadowArg);
+COPY_IMPL(Assign);
+COPY_IMPL(Cast);
+COPY_IMPL(Hash);
+COPY_IMPL(Array);
+COPY_IMPL(Literal);
+COPY_IMPL(UnresolvedConstantLit);
+COPY_IMPL(ConstantLit);
+COPY_IMPL(ZSuperArgs);
+COPY_IMPL(Block);
+COPY_IMPL(InsSeq);
 
-TreePtr If::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<If>(this->loc, this->cond->_deepCopy(avoid), this->thenp->_deepCopy(avoid),
-                         this->elsep->_deepCopy(avoid));
-}
-
-TreePtr While::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<While>(this->loc, this->cond->_deepCopy(avoid), this->body->_deepCopy(avoid));
-}
-
-TreePtr Break::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<Break>(this->loc, this->expr->_deepCopy(avoid));
-}
-
-TreePtr Retry::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<Retry>(this->loc);
-}
-
-TreePtr Next::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<Next>(this->loc, this->expr->_deepCopy(avoid));
-}
-
-TreePtr Return::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<Return>(this->loc, this->expr->_deepCopy(avoid));
-}
-
-TreePtr RescueCase::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<RescueCase>(this->loc, deepCopyVec(avoid, this->exceptions), var->_deepCopy(avoid),
-                                 body->_deepCopy(avoid));
-}
-
-TreePtr Rescue::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<Rescue>(this->loc, this->body->_deepCopy(avoid),
-                             deepCopyVec<Rescue::RESCUE_CASE_store>(avoid, rescueCases), else_->_deepCopy(avoid),
-                             ensure->_deepCopy(avoid));
-}
-
-TreePtr Local::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<Local>(loc, localVariable);
-}
-
-TreePtr UnresolvedIdent::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<UnresolvedIdent>(loc, kind, name);
-}
-
-TreePtr RestArg::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<RestArg>(loc, expr->_deepCopy(avoid));
-}
-
-TreePtr KeywordArg::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<KeywordArg>(loc, expr->_deepCopy(avoid));
-}
-
-TreePtr OptionalArg::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<OptionalArg>(loc, expr->_deepCopy(avoid), default_->_deepCopy(avoid));
-}
-
-TreePtr BlockArg::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<BlockArg>(loc, expr->_deepCopy(avoid));
-}
-
-TreePtr ShadowArg::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<ShadowArg>(loc, expr->_deepCopy(avoid));
-}
-
-TreePtr Assign::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<Assign>(loc, lhs->_deepCopy(avoid), rhs->_deepCopy(avoid));
-}
-
-TreePtr Send::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<Send>(loc, recv->_deepCopy(avoid), fun, deepCopyVec(avoid, args),
-                           block == nullptr ? nullptr : block->_deepCopy(avoid), flags);
-}
-
-TreePtr Cast::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<Cast>(loc, type, arg->_deepCopy(avoid), cast);
-}
-
-TreePtr Hash::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<Hash>(loc, deepCopyVec(avoid, keys), deepCopyVec(avoid, values));
-}
-
-TreePtr Array::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<Array>(loc, deepCopyVec(avoid, elems));
-}
-
-TreePtr Literal::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<Literal>(loc, value);
-}
-
-TreePtr UnresolvedConstantLit::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<UnresolvedConstantLit>(loc, scope->_deepCopy(avoid), cnst);
-}
-
-TreePtr ConstantLit::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    TreePtr originalC;
-    if (original) {
-        originalC = original->deepCopy();
-    }
-    return make_tree<ConstantLit>(this->loc, this->symbol, move(originalC));
-}
-
-TreePtr ZSuperArgs::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<ZSuperArgs>(loc);
-}
-
-TreePtr Block::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    auto res = make_tree<Block>(loc, deepCopyVec(avoid, args), body->_deepCopy(avoid));
-    return res;
-}
-
-TreePtr InsSeq::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<InsSeq>(loc, deepCopyVec(avoid, stats), expr->_deepCopy(avoid));
-}
-
-TreePtr EmptyTree::_deepCopy(const Expression *avoid, bool root) const {
-    if (!root && this == avoid) {
-        throw DeepCopyError();
-    }
-    return make_tree<EmptyTree>();
-}
 } // namespace sorbet::ast

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -218,6 +218,8 @@ public:
     bool operator!=(const TreePtr &other) const noexcept {
         return get() != other.get();
     }
+
+    TreePtr deepCopy() const;
 };
 
 template <class E, typename... Args> TreePtr make_tree(Args &&... args) {
@@ -234,14 +236,8 @@ public:
     }
     virtual std::string nodeName() = 0;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) = 0;
-    TreePtr deepCopy() const;
     virtual void _sanityCheck() = 0;
     const core::LocOffsets loc;
-
-    class DeepCopyError {};
-
-    // This function should be private but it makes it hard to access from template methods in TreeCopy.cc
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const = 0;
 
     bool isSelfReference() const;
 };
@@ -348,10 +344,11 @@ public:
     ClassDef(core::LocOffsets loc, core::Loc declLoc, core::SymbolRef symbol, TreePtr name, ANCESTORS_store ancestors,
              RHS_store rhs, ClassDef::Kind kind);
 
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -380,10 +377,12 @@ public:
 
     MethodDef(core::LocOffsets loc, core::Loc declLoc, core::SymbolRef symbol, core::NameRef name, ARGS_store args,
               TreePtr rhs, Flags flags);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -397,10 +396,12 @@ public:
     TreePtr elsep;
 
     If(core::LocOffsets loc, TreePtr cond, TreePtr thenp, TreePtr elsep);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -413,10 +414,12 @@ public:
     TreePtr body;
 
     While(core::LocOffsets loc, TreePtr cond, TreePtr body);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -428,10 +431,12 @@ public:
     TreePtr expr;
 
     Break(core::LocOffsets loc, TreePtr expr);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -441,10 +446,12 @@ CheckSize(Break, 24, 8);
 TREE(Retry) : public Expression {
 public:
     Retry(core::LocOffsets loc);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -456,10 +463,12 @@ public:
     TreePtr expr;
 
     Next(core::LocOffsets loc, TreePtr expr);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -471,10 +480,12 @@ public:
     TreePtr expr;
 
     Return(core::LocOffsets loc, TreePtr expr);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -494,10 +505,12 @@ public:
     TreePtr body;
 
     RescueCase(core::LocOffsets loc, EXCEPTION_store exceptions, TreePtr var, TreePtr body);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -515,10 +528,12 @@ public:
     TreePtr ensure;
 
     Rescue(core::LocOffsets loc, TreePtr body, RESCUE_CASE_store rescueCases, TreePtr else_, TreePtr ensure);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -530,10 +545,12 @@ public:
     core::LocalVariable localVariable;
 
     Local(core::LocOffsets loc, core::LocalVariable localVariable1);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -552,10 +569,12 @@ public:
     Kind kind;
 
     UnresolvedIdent(core::LocOffsets loc, Kind kind, core::NameRef name);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -567,10 +586,12 @@ public:
     TreePtr expr;
 
     RestArg(core::LocOffsets loc, TreePtr arg);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -582,10 +603,12 @@ public:
     TreePtr expr;
 
     KeywordArg(core::LocOffsets loc, TreePtr expr);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -598,10 +621,12 @@ public:
     TreePtr default_;
 
     OptionalArg(core::LocOffsets loc, TreePtr expr, TreePtr default_);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -613,10 +638,12 @@ public:
     TreePtr expr;
 
     BlockArg(core::LocOffsets loc, TreePtr expr);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -628,10 +655,12 @@ public:
     TreePtr expr;
 
     ShadowArg(core::LocOffsets loc, TreePtr expr);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -644,10 +673,12 @@ public:
     TreePtr rhs;
 
     Assign(core::LocOffsets loc, TreePtr lhs, TreePtr rhs);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -678,10 +709,12 @@ public:
 
     Send(core::LocOffsets loc, TreePtr recv, core::NameRef fun, ARGS_store args, TreePtr block = nullptr,
          Flags flags = {});
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -697,10 +730,12 @@ public:
     TreePtr arg;
 
     Cast(core::LocOffsets loc, core::TypePtr ty, TreePtr arg, core::NameRef cast);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -717,10 +752,11 @@ public:
 
     Hash(core::LocOffsets loc, ENTRY_store keys, ENTRY_store values);
 
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -736,10 +772,11 @@ public:
 
     Array(core::LocOffsets loc, ENTRY_store elems);
 
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -751,6 +788,9 @@ public:
     core::TypePtr value;
 
     Literal(core::LocOffsets loc, const core::TypePtr &value);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
@@ -761,7 +801,6 @@ public:
     core::NameRef asSymbol(const core::GlobalState &gs) const;
     bool isTrue(const core::GlobalState &gs) const;
     bool isFalse(const core::GlobalState &gs) const;
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -774,10 +813,12 @@ public:
     TreePtr scope;
 
     UnresolvedConstantLit(core::LocOffsets loc, TreePtr scope, core::NameRef cnst);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -794,10 +835,12 @@ public:
     TreePtr original;
 
     ConstantLit(core::LocOffsets loc, core::SymbolRef symbol, TreePtr original);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
     std::optional<std::pair<core::SymbolRef, std::vector<core::NameRef>>> fullUnresolvedPath(
         const core::GlobalState &gs) const;
 
@@ -810,10 +853,12 @@ TREE(ZSuperArgs) : public Expression {
 public:
     // null if no block passed
     ZSuperArgs(core::LocOffsets loc);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -826,10 +871,12 @@ public:
     TreePtr body;
 
     Block(core::LocOffsets loc, MethodDef::ARGS_store args, TreePtr body);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
     virtual void _sanityCheck();
 };
 CheckSize(Block, 48, 8);
@@ -845,10 +892,12 @@ public:
     TreePtr expr;
 
     InsSeq(core::LocOffsets locOffsets, STATS_store stats, TreePtr expr);
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();
@@ -858,10 +907,12 @@ CheckSize(InsSeq, 64, 8);
 TREE(EmptyTree) : public Expression {
 public:
     EmptyTree();
+
+    TreePtr deepCopy() const;
+
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     virtual std::string nodeName();
-    virtual TreePtr _deepCopy(const Expression *avoid, bool root = false) const;
 
 private:
     virtual void _sanityCheck();

--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -29,7 +29,7 @@ void LSPFileUpdates::mergeOlder(const LSPFileUpdates &older) {
         encountered.emplace(f->path());
         updatedFiles.push_back(f);
         auto &ast = older.updatedFileIndexes[i];
-        updatedFileIndexes.push_back(ast::ParsedFile{ast.tree->deepCopy(), ast.file});
+        updatedFileIndexes.push_back(ast::ParsedFile{ast.tree.deepCopy(), ast.file});
     }
     canTakeFastPath = false;
 }
@@ -45,7 +45,7 @@ LSPFileUpdates LSPFileUpdates::copy() const {
     copy.cancellationExpected = cancellationExpected;
     copy.preemptionsExpected = preemptionsExpected;
     for (auto &ast : updatedFileIndexes) {
-        copy.updatedFileIndexes.push_back(ast::ParsedFile{ast.tree->deepCopy(), ast.file});
+        copy.updatedFileIndexes.push_back(ast::ParsedFile{ast.tree.deepCopy(), ast.file});
     }
     return copy;
 }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -244,7 +244,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     for (auto &f : subset) {
         // TODO(jvilk): We don't need to re-index files that didn't change.
         auto t = pipeline::indexOne(config->opts, *gs, f);
-        updatedIndexed.emplace_back(ast::ParsedFile{t.tree->deepCopy(), t.file});
+        updatedIndexed.emplace_back(ast::ParsedFile{t.tree.deepCopy(), t.file});
         updates.updatedFinalGSFileIndexes.push_back(move(t));
     }
 
@@ -298,7 +298,7 @@ bool LSPTypechecker::copyIndexed(WorkerPool &workers, const UnorderedSet<int> &i
                         const auto &tree = indexed[job];
                         // Note: indexed entries for payload files don't have any contents.
                         if (tree.tree && !ignore.contains(tree.file.id())) {
-                            threadResult.emplace_back(ast::ParsedFile{tree.tree->deepCopy(), tree.file});
+                            threadResult.emplace_back(ast::ParsedFile{tree.tree.deepCopy(), tree.file});
                         }
                     }
                 }
@@ -358,7 +358,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
                 finalGS = move(pair.first);
                 auto &ast = pair.second;
                 if (ast.tree) {
-                    indexedCopies.emplace_back(ast::ParsedFile{ast.tree->deepCopy(), ast.file});
+                    indexedCopies.emplace_back(ast::ParsedFile{ast.tree.deepCopy(), ast.file});
                     updatedFiles.insert(ast.file.id());
                 }
                 updates.updatedFinalGSFileIndexes.push_back(move(ast));
@@ -549,7 +549,7 @@ LSPFileUpdates LSPTypechecker::getNoopUpdate(std::vector<core::FileRef> frefs) c
         ENFORCE(fref.exists());
         ENFORCE(fref.id() < indexed.size());
         auto &index = indexed[fref.id()];
-        noop.updatedFileIndexes.push_back({index.tree->deepCopy(), index.file});
+        noop.updatedFileIndexes.push_back({index.tree.deepCopy(), index.file});
         noop.updatedFiles.push_back(gs->getFiles()[fref.id()]);
     }
     return noop;
@@ -580,7 +580,7 @@ vector<ast::ParsedFile> LSPTypechecker::getResolved(const vector<core::FileRef> 
     for (auto fref : frefs) {
         auto &indexed = getIndexed(fref);
         if (indexed.tree) {
-            updatedIndexed.emplace_back(ast::ParsedFile{indexed.tree->deepCopy(), indexed.file});
+            updatedIndexed.emplace_back(ast::ParsedFile{indexed.tree.deepCopy(), indexed.file});
         }
     }
     return pipeline::incrementalResolve(*gs, move(updatedIndexed), config->opts);

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1394,11 +1394,11 @@ class TreeSymbolizer {
                 continue;
             }
             if (arg->isSelfReference()) {
-                dest->emplace_back(arg->deepCopy());
+                dest->emplace_back(arg.deepCopy());
                 continue;
             }
             if (isValidAncestor(arg)) {
-                dest->emplace_back(arg->deepCopy());
+                dest->emplace_back(arg.deepCopy());
             } else {
                 if (auto e = ctx.beginError(arg->loc, core::errors::Namer::AncestorNotConstant)) {
                     e.setHeader("`{}` must only contain constant literals", send->fun.data(ctx)->show(ctx));
@@ -1482,11 +1482,11 @@ public:
         }
         ast::InsSeq::STATS_store ideSeqs;
         if (ast::isa_tree<ast::ConstantLit>(klass.name)) {
-            ideSeqs.emplace_back(ast::MK::KeepForIDE(klass.name->deepCopy()));
+            ideSeqs.emplace_back(ast::MK::KeepForIDE(klass.name.deepCopy()));
         }
         if (klass.kind == ast::ClassDef::Kind::Class && !klass.ancestors.empty() &&
             shouldLeaveAncestorForIDE(klass.ancestors.front())) {
-            ideSeqs.emplace_back(ast::MK::KeepForIDE(klass.ancestors.front()->deepCopy()));
+            ideSeqs.emplace_back(ast::MK::KeepForIDE(klass.ancestors.front().deepCopy()));
         }
 
         if (klass.symbol != core::Symbols::root() && !klass.declLoc.file().data(ctx).isRBI() &&

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -79,7 +79,7 @@ TEST_CASE("namer tests") {
         auto baseNames = gs.namesUsed();
 
         auto tree = hello_world(gs);
-        ast::ParsedFile treeCopy{tree.tree->deepCopy(), tree.file};
+        ast::ParsedFile treeCopy{tree.tree.deepCopy(), tree.file};
         vector<ast::ParsedFile> trees;
         {
             auto localTree = sorbet::local_vars::LocalVars::run(gs, move(tree));

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -95,7 +95,7 @@ ast::TreePtr dupReturnsType(core::MutableContext ctx, ast::Send *sharedSig) {
     if (body->args.size() != 1) {
         return nullptr;
     }
-    return body->args[0]->deepCopy();
+    return body->args[0].deepCopy();
 }
 
 // This will raise an error if we've given a type that's not what we want
@@ -135,7 +135,7 @@ ast::TreePtr toWriterSigForName(core::MutableContext ctx, ast::Send *sharedSig, 
     if (body->args.size() != 1) {
         return nullptr;
     }
-    ast::TreePtr resultType = body->args[0]->deepCopy();
+    ast::TreePtr resultType = body->args[0].deepCopy();
     ast::Send *cur = body;
     while (cur != nullptr) {
         auto recv = ast::cast_tree<ast::ConstantLit>(cur->recv);

--- a/rewriter/ClassNew.cc
+++ b/rewriter/ClassNew.cc
@@ -55,7 +55,7 @@ vector<ast::TreePtr> ClassNew::run(core::MutableContext ctx, ast::Assign *asgn) 
     auto *block = ast::cast_tree<ast::Block>(send->block);
     if (block != nullptr && block->args.size() == 1) {
         auto blockArg = move(block->args[0]);
-        body.emplace_back(ast::MK::Assign(blockArg->loc, move(blockArg), asgn->lhs->deepCopy()));
+        body.emplace_back(ast::MK::Assign(blockArg->loc, move(blockArg), asgn->lhs.deepCopy()));
     }
 
     if (send->block != nullptr) {

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -83,7 +83,7 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
     ast::MethodDef::ARGS_store newArgs;
     newArgs.reserve(call->args.size());
     for (auto &arg : call->args) {
-        newArgs.emplace_back(arg->deepCopy());
+        newArgs.emplace_back(arg.deepCopy());
     }
 
     auto selfCall = ast::MK::SyntheticMethod(call->loc, core::Loc(ctx.file, call->loc), call->name, std::move(newArgs),

--- a/rewriter/DefaultArgs.cc
+++ b/rewriter/DefaultArgs.cc
@@ -58,7 +58,7 @@ class DefaultArgsWalk {
                         if (lit && lit->isSymbol(ctx)) {
                             auto symName = lit->asSymbol(ctx);
                             if (name == symName) {
-                                retType = value->deepCopy();
+                                retType = value.deepCopy();
                             }
                         }
                     }

--- a/rewriter/Initializer.cc
+++ b/rewriter/Initializer.cc
@@ -42,7 +42,7 @@ void maybeAddLet(core::MutableContext ctx, ast::TreePtr &expr,
     auto typeExpr = argTypeMap.find(rhs->name);
     if (typeExpr != argTypeMap.end() && isCopyableType(*typeExpr->second)) {
         auto loc = rhs->loc;
-        auto newLet = ast::MK::Let(loc, move(assn->rhs), (*typeExpr->second)->deepCopy());
+        auto newLet = ast::MK::Let(loc, move(assn->rhs), (*typeExpr->second).deepCopy());
         assn->rhs = move(newLet);
     }
 }

--- a/rewriter/Mattr.cc
+++ b/rewriter/Mattr.cc
@@ -21,8 +21,8 @@ static bool isLiteralFalse(const core::GlobalState &gs, const ast::TreePtr &node
 }
 
 static void addInstanceCounterPart(vector<ast::TreePtr> &sink, const ast::TreePtr &sig, const ast::TreePtr &def) {
-    sink.emplace_back(sig->deepCopy());
-    auto instanceDef = def->deepCopy();
+    sink.emplace_back(sig.deepCopy());
+    auto instanceDef = def.deepCopy();
     ENFORCE(ast::isa_tree<ast::MethodDef>(def));
     ast::cast_tree<ast::MethodDef>(instanceDef)->flags.isSelfMethod = false;
     ast::cast_tree<ast::MethodDef>(instanceDef)->flags.isRewriterSynthesized = true;

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -23,7 +23,7 @@ public:
         auto raiseUnimplemented = ast::MK::RaiseUnimplemented(loc);
         if (auto send = ast::cast_tree<ast::Send>(asgn.rhs)) {
             if (send->fun == core::Names::let() && send->args.size() == 2) {
-                auto rhs = ast::MK::Let(loc, move(raiseUnimplemented), send->args[1]->deepCopy());
+                auto rhs = ast::MK::Let(loc, move(raiseUnimplemented), send->args[1].deepCopy());
                 return ast::MK::Assign(asgn.loc, move(asgn.lhs), move(rhs));
             }
         }
@@ -170,7 +170,7 @@ bool canMoveIntoMethodDef(const ast::TreePtr &exp) {
 // method, and otherwise we replace it with a synthesized 'nil'
 ast::TreePtr getIteratee(ast::TreePtr &exp) {
     if (canMoveIntoMethodDef(exp)) {
-        return exp->deepCopy();
+        return exp.deepCopy();
     } else {
         return ast::MK::RaiseUnimplemented(exp->loc);
     }
@@ -197,10 +197,10 @@ ast::TreePtr runUnderEach(core::MutableContext ctx, core::NameRef eachName, ast:
             // pull the arg and the iteratee in and synthesize `iterate.each { |arg| body }`
             ast::MethodDef::ARGS_store new_args;
             for (auto &arg : args) {
-                new_args.emplace_back(arg->deepCopy());
+                new_args.emplace_back(arg.deepCopy());
             }
             auto blk = ast::MK::Block(send->loc, move(body), std::move(new_args));
-            auto each = ast::MK::Send0Block(send->loc, iteratee->deepCopy(), core::Names::each(), move(blk));
+            auto each = ast::MK::Send0Block(send->loc, iteratee.deepCopy(), core::Names::each(), move(blk));
             // put that into a method def named the appropriate thing
             auto method = addSigVoid(
                 ast::MK::SyntheticMethod0(send->loc, core::Loc(ctx.file, send->loc), move(name), move(each)));
@@ -296,7 +296,7 @@ ast::TreePtr runSingle(core::MutableContext ctx, ast::Send *send) {
         auto name = ctx.state.enterNameUTF8("<it '" + argString + "'>");
         auto method = addSigVoid(ast::MK::SyntheticMethod0(send->loc, core::Loc(ctx.file, send->loc), std::move(name),
                                                            prepareBody(ctx, std::move(block->body))));
-        method = ast::MK::InsSeq1(send->loc, send->args.front()->deepCopy(), move(method));
+        method = ast::MK::InsSeq1(send->loc, send->args.front().deepCopy(), move(method));
         return constantMover.addConstantsToExpression(send->loc, move(method));
     }
 

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -74,14 +74,14 @@ vector<ast::TreePtr> ModuleFunction::rewriteDefn(core::MutableContext ctx, const
     auto mdef = ast::cast_tree_const<ast::MethodDef>(expr);
     // only do this rewrite to method defs that aren't self methods
     if (mdef == nullptr || mdef->flags.isSelfMethod) {
-        stats.emplace_back(expr->deepCopy());
+        stats.emplace_back(expr.deepCopy());
         return stats;
     }
 
     auto loc = expr->loc;
 
     // this creates a private copy of the method
-    auto privateCopy = expr->deepCopy();
+    auto privateCopy = expr.deepCopy();
     stats.emplace_back(ast::MK::Send1(loc, ast::MK::Self(loc), core::Names::private_(), move(privateCopy)));
 
     // as well as a public static copy of the method signature
@@ -92,7 +92,7 @@ vector<ast::TreePtr> ModuleFunction::rewriteDefn(core::MutableContext ctx, const
             }
         }
     }
-    auto moduleCopy = expr->deepCopy();
+    auto moduleCopy = expr.deepCopy();
     ENFORCE(moduleCopy, "Should be non-nil.");
     auto *newDefn = ast::cast_tree<ast::MethodDef>(moduleCopy);
     newDefn->flags.isSelfMethod = true;

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -317,7 +317,7 @@ vector<ast::TreePtr> processProp(core::MutableContext ctx, PropInfo &ret, PropCo
 
             auto ivarGet = ast::MK::Send1(loc, ast::MK::Self(loc), core::Names::instanceVariableGet(),
                                           ast::MK::Symbol(nameLoc, ivarName));
-            auto assign = ast::MK::Assign(loc, arg2->deepCopy(), std::move(ivarGet));
+            auto assign = ast::MK::Assign(loc, arg2.deepCopy(), std::move(ivarGet));
 
             auto class_ = ast::MK::Send0(loc, ast::MK::Self(loc), core::Names::class_());
             auto decorator = ast::MK::Send0(loc, std::move(class_), core::Names::decorator());
@@ -466,7 +466,7 @@ vector<ast::TreePtr> mkTypedInitialize(core::MutableContext ctx, core::LocOffset
         auto loc = prop.loc;
         args.emplace_back(ast::MK::KeywordArg(loc, ast::MK::Local(loc, prop.name)));
         sigKeys.emplace_back(ast::MK::Symbol(loc, prop.name));
-        sigVals.emplace_back(prop.type->deepCopy());
+        sigVals.emplace_back(prop.type.deepCopy());
     }
 
     // then, add all the optional props.
@@ -476,9 +476,9 @@ vector<ast::TreePtr> mkTypedInitialize(core::MutableContext ctx, core::LocOffset
         }
         auto loc = prop.loc;
         args.emplace_back(ast::MK::OptionalArg(loc, ast::MK::KeywordArg(loc, ast::MK::Local(loc, prop.name)),
-                                               prop.default_->deepCopy()));
+                                               prop.default_.deepCopy()));
         sigKeys.emplace_back(ast::MK::Symbol(loc, prop.name));
-        sigVals.emplace_back(prop.type->deepCopy());
+        sigVals.emplace_back(prop.type.deepCopy());
     }
 
     // then initialize all the instance variables in the body

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -126,9 +126,9 @@ vector<ast::TreePtr> processStat(core::MutableContext ctx, ast::ClassDef *klass,
     auto name = ctx.state.enterNameConstant(ctx.state.freshNameUnique(core::UniqueNameKind::TEnum, lhs->cnst, 1));
     auto classCnst = ast::MK::UnresolvedConstant(lhs->loc, ast::MK::EmptyTree(), name);
     ast::ClassDef::ANCESTORS_store parent;
-    parent.emplace_back(klass->name->deepCopy());
+    parent.emplace_back(klass->name.deepCopy());
     ast::ClassDef::RHS_store classRhs;
-    auto classDef = ast::MK::Class(stat->loc, core::Loc(ctx.file, stat->loc), classCnst->deepCopy(), std::move(parent),
+    auto classDef = ast::MK::Class(stat->loc, core::Loc(ctx.file, stat->loc), classCnst.deepCopy(), std::move(parent),
                                    std::move(classRhs));
 
     ast::Send::ARGS_store args;
@@ -146,7 +146,7 @@ vector<ast::TreePtr> processStat(core::MutableContext ctx, ast::ClassDef *klass,
     auto singletonAsgn = ast::MK::Assign(
         stat->loc, std::move(asgn->lhs),
         ast::MK::Send2(stat->loc, ast::MK::Constant(stat->loc, core::Symbols::T()), core::Names::uncheckedLet(),
-                       ast::MK::Send(stat->loc, classCnst->deepCopy(), core::Names::new_(), std::move(args)),
+                       ast::MK::Send(stat->loc, classCnst.deepCopy(), core::Names::new_(), std::move(args)),
                        std::move(classCnst)));
 
     vector<ast::TreePtr> result;

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -38,7 +38,7 @@ ast::TreePtr ASTUtil::dupType(const ast::TreePtr &orig) {
                 }
 
                 for (auto &key : hash->keys) {
-                    keys.emplace_back(key->deepCopy());
+                    keys.emplace_back(key.deepCopy());
                 }
 
                 auto arg = ast::MK::Hash(hash->loc, std::move(keys), std::move(values));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Tree copying no longer involves virtual dispatch. `deepCopy` still exists as a concrete method on each concrete tree type, but the virtual method on `Expression` is removed in favor of a deepCopy method on `TreePtr`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Working towards removing the `Expression` type, and all virtual methods on ast trees.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
