### PR TITLE
Remove more entries from the Expression vtable

### DIFF
--- a/ast/TreeSanityChecks.cc
+++ b/ast/TreeSanityChecks.cc
@@ -5,6 +5,48 @@ using namespace std;
 
 namespace sorbet::ast {
 
+void TreePtr::_sanityCheck() const {
+    auto *ptr = get();
+    ENFORCE(ptr != nullptr);
+
+#define SANITY_CHECK(name)                             \
+    case Tag::name:                                    \
+        reinterpret_cast<name *>(ptr)->_sanityCheck(); \
+        break;
+    switch (tag()) {
+        SANITY_CHECK(EmptyTree)
+        SANITY_CHECK(Send)
+        SANITY_CHECK(ClassDef)
+        SANITY_CHECK(MethodDef)
+        SANITY_CHECK(If)
+        SANITY_CHECK(While)
+        SANITY_CHECK(Break)
+        SANITY_CHECK(Retry)
+        SANITY_CHECK(Next)
+        SANITY_CHECK(Return)
+        SANITY_CHECK(RescueCase)
+        SANITY_CHECK(Rescue)
+        SANITY_CHECK(Local)
+        SANITY_CHECK(UnresolvedIdent)
+        SANITY_CHECK(RestArg)
+        SANITY_CHECK(KeywordArg)
+        SANITY_CHECK(OptionalArg)
+        SANITY_CHECK(BlockArg)
+        SANITY_CHECK(ShadowArg)
+        SANITY_CHECK(Assign)
+        SANITY_CHECK(Cast)
+        SANITY_CHECK(Hash)
+        SANITY_CHECK(Array)
+        SANITY_CHECK(Literal)
+        SANITY_CHECK(UnresolvedConstantLit)
+        SANITY_CHECK(ConstantLit)
+        SANITY_CHECK(ZSuperArgs)
+        SANITY_CHECK(Block)
+        SANITY_CHECK(InsSeq)
+    }
+#undef SANITY_CHECK
+}
+
 void Array::_sanityCheck() {
     for (auto &node : elems) {
         ENFORCE(node);

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -164,6 +164,48 @@ void TreePtr::deleteTagged(Tag tag, void *ptr) noexcept {
     }
 }
 
+string TreePtr::nodeName() const {
+    auto *ptr = get();
+
+    ENFORCE(ptr != nullptr);
+
+#define NODE_NAME(name) \
+    case Tag::name:     \
+        return reinterpret_cast<name *>(ptr)->nodeName();
+    switch (tag()) {
+        NODE_NAME(EmptyTree)
+        NODE_NAME(Send)
+        NODE_NAME(ClassDef)
+        NODE_NAME(MethodDef)
+        NODE_NAME(If)
+        NODE_NAME(While)
+        NODE_NAME(Break)
+        NODE_NAME(Retry)
+        NODE_NAME(Next)
+        NODE_NAME(Return)
+        NODE_NAME(RescueCase)
+        NODE_NAME(Rescue)
+        NODE_NAME(Local)
+        NODE_NAME(UnresolvedIdent)
+        NODE_NAME(RestArg)
+        NODE_NAME(KeywordArg)
+        NODE_NAME(OptionalArg)
+        NODE_NAME(BlockArg)
+        NODE_NAME(ShadowArg)
+        NODE_NAME(Assign)
+        NODE_NAME(Cast)
+        NODE_NAME(Hash)
+        NODE_NAME(Array)
+        NODE_NAME(Literal)
+        NODE_NAME(UnresolvedConstantLit)
+        NODE_NAME(ConstantLit)
+        NODE_NAME(ZSuperArgs)
+        NODE_NAME(Block)
+        NODE_NAME(InsSeq)
+    }
+#undef NODE_NAME
+}
+
 bool isa_reference(const TreePtr &what) {
     return isa_tree<Local>(what) || isa_tree<UnresolvedIdent>(what) || isa_tree<RestArg>(what) ||
            isa_tree<KeywordArg>(what) || isa_tree<OptionalArg>(what) || isa_tree<BlockArg>(what) ||

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -206,6 +206,48 @@ string TreePtr::nodeName() const {
 #undef NODE_NAME
 }
 
+string TreePtr::showRaw(const core::GlobalState &gs, int tabs) {
+    auto *ptr = get();
+
+    ENFORCE(ptr != nullptr);
+
+#define SHOW_RAW(name) \
+    case Tag::name:    \
+        return reinterpret_cast<name *>(ptr)->showRaw(gs, tabs);
+    switch (tag()) {
+        SHOW_RAW(EmptyTree)
+        SHOW_RAW(Send)
+        SHOW_RAW(ClassDef)
+        SHOW_RAW(MethodDef)
+        SHOW_RAW(If)
+        SHOW_RAW(While)
+        SHOW_RAW(Break)
+        SHOW_RAW(Retry)
+        SHOW_RAW(Next)
+        SHOW_RAW(Return)
+        SHOW_RAW(RescueCase)
+        SHOW_RAW(Rescue)
+        SHOW_RAW(Local)
+        SHOW_RAW(UnresolvedIdent)
+        SHOW_RAW(RestArg)
+        SHOW_RAW(KeywordArg)
+        SHOW_RAW(OptionalArg)
+        SHOW_RAW(BlockArg)
+        SHOW_RAW(ShadowArg)
+        SHOW_RAW(Assign)
+        SHOW_RAW(Cast)
+        SHOW_RAW(Hash)
+        SHOW_RAW(Array)
+        SHOW_RAW(Literal)
+        SHOW_RAW(UnresolvedConstantLit)
+        SHOW_RAW(ConstantLit)
+        SHOW_RAW(ZSuperArgs)
+        SHOW_RAW(Block)
+        SHOW_RAW(InsSeq)
+    }
+#undef SHOW_RAW
+}
+
 bool TreePtr::isSelfReference() const {
     if (auto *local = cast_tree_const<Local>(*this)) {
         return local->localVariable == core::LocalVariable::selfVariable();
@@ -542,7 +584,7 @@ string ClassDef::showRaw(const core::GlobalState &gs, int tabs) {
     printTabs(buf, tabs + 1);
     fmt::format_to(buf, "kind = {}\n", kind == ClassDef::Kind::Module ? "module" : "class");
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "name = {}<{}>\n", name->showRaw(gs, tabs + 1),
+    fmt::format_to(buf, "name = {}<{}>\n", name.showRaw(gs, tabs + 1),
                    this->symbol.dataAllowingNone(gs)->name.data(gs)->showRaw(gs));
     printTabs(buf, tabs + 1);
     fmt::format_to(buf, "ancestors = [");
@@ -552,7 +594,7 @@ string ClassDef::showRaw(const core::GlobalState &gs, int tabs) {
             fmt::format_to(buf, ", ");
         }
         first = false;
-        fmt::format_to(buf, "{}", a->showRaw(gs, tabs + 2));
+        fmt::format_to(buf, "{}", a.showRaw(gs, tabs + 2));
     }
     fmt::format_to(buf, "]\n");
 
@@ -561,7 +603,7 @@ string ClassDef::showRaw(const core::GlobalState &gs, int tabs) {
 
     for (auto &a : this->rhs) {
         printTabs(buf, tabs + 2);
-        fmt::format_to(buf, "{}\n", a->showRaw(gs, tabs + 2));
+        fmt::format_to(buf, "{}\n", a.showRaw(gs, tabs + 2));
         if (&a != &this->rhs.back()) {
             fmt::format_to(buf, "{}", '\n');
         }
@@ -595,13 +637,13 @@ string InsSeq::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::format_to(buf, "stats = [\n");
     for (auto &a : this->stats) {
         printTabs(buf, tabs + 2);
-        fmt::format_to(buf, "{}\n", a->showRaw(gs, tabs + 2));
+        fmt::format_to(buf, "{}\n", a.showRaw(gs, tabs + 2));
     }
     printTabs(buf, tabs + 1);
     fmt::format_to(buf, "],\n");
 
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "expr = {}\n", expr->showRaw(gs, tabs + 1));
+    fmt::format_to(buf, "expr = {}\n", expr.showRaw(gs, tabs + 1));
     printTabs(buf, tabs);
     fmt::format_to(buf, "}}");
     return fmt::to_string(buf);
@@ -673,7 +715,7 @@ string MethodDef::showRaw(const core::GlobalState &gs, int tabs) {
                 fmt::format_to(buf, ", ");
             }
             first = false;
-            fmt::format_to(buf, "{}", a->showRaw(gs, tabs + 2));
+            fmt::format_to(buf, "{}", a.showRaw(gs, tabs + 2));
         }
     } else {
         for (auto &a : this->args) {
@@ -681,12 +723,12 @@ string MethodDef::showRaw(const core::GlobalState &gs, int tabs) {
                 fmt::format_to(buf, ", ");
             }
             first = false;
-            fmt::format_to(buf, "{}", a->showRaw(gs, tabs + 2));
+            fmt::format_to(buf, "{}", a.showRaw(gs, tabs + 2));
         }
     }
     fmt::format_to(buf, "]\n");
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "rhs = {}\n", this->rhs->showRaw(gs, tabs + 1));
+    fmt::format_to(buf, "rhs = {}\n", this->rhs.showRaw(gs, tabs + 1));
     printTabs(buf, tabs);
     fmt::format_to(buf, "}}");
     return fmt::to_string(buf);
@@ -712,11 +754,11 @@ string If::showRaw(const core::GlobalState &gs, int tabs) {
 
     fmt::format_to(buf, "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "cond = {}\n", this->cond->showRaw(gs, tabs + 1));
+    fmt::format_to(buf, "cond = {}\n", this->cond.showRaw(gs, tabs + 1));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "thenp = {}\n", this->thenp->showRaw(gs, tabs + 1));
+    fmt::format_to(buf, "thenp = {}\n", this->thenp.showRaw(gs, tabs + 1));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "elsep = {}\n", this->elsep->showRaw(gs, tabs + 1));
+    fmt::format_to(buf, "elsep = {}\n", this->elsep.showRaw(gs, tabs + 1));
     printTabs(buf, tabs);
     fmt::format_to(buf, "}}");
     return fmt::to_string(buf);
@@ -727,9 +769,9 @@ string Assign::showRaw(const core::GlobalState &gs, int tabs) {
 
     fmt::format_to(buf, "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "lhs = {}\n", this->lhs->showRaw(gs, tabs + 1));
+    fmt::format_to(buf, "lhs = {}\n", this->lhs.showRaw(gs, tabs + 1));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "rhs = {}\n", this->rhs->showRaw(gs, tabs + 1));
+    fmt::format_to(buf, "rhs = {}\n", this->rhs.showRaw(gs, tabs + 1));
     printTabs(buf, tabs);
     fmt::format_to(buf, "}}");
     return fmt::to_string(buf);
@@ -751,9 +793,9 @@ string While::showRaw(const core::GlobalState &gs, int tabs) {
 
     fmt::format_to(buf, "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "cond = {}\n", this->cond->showRaw(gs, tabs + 1));
+    fmt::format_to(buf, "cond = {}\n", this->cond.showRaw(gs, tabs + 1));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "body = {}\n", this->body->showRaw(gs, tabs + 1));
+    fmt::format_to(buf, "body = {}\n", this->body.showRaw(gs, tabs + 1));
     printTabs(buf, tabs);
     fmt::format_to(buf, "}}");
     return fmt::to_string(buf);
@@ -772,7 +814,7 @@ string UnresolvedConstantLit::showRaw(const core::GlobalState &gs, int tabs) {
 
     fmt::format_to(buf, "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "scope = {}\n", this->scope->showRaw(gs, tabs + 1));
+    fmt::format_to(buf, "scope = {}\n", this->scope.showRaw(gs, tabs + 1));
     printTabs(buf, tabs + 1);
     fmt::format_to(buf, "cnst = {}\n", this->cnst.data(gs)->showRaw(gs));
     printTabs(buf, tabs);
@@ -792,7 +834,7 @@ string ConstantLit::showRaw(const core::GlobalState &gs, int tabs) {
 
     fmt::format_to(buf, "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "orig = {}\n", this->original ? this->original->showRaw(gs, tabs + 1) : "nullptr");
+    fmt::format_to(buf, "orig = {}\n", this->original ? this->original.showRaw(gs, tabs + 1) : "nullptr");
     printTabs(buf, tabs + 1);
     fmt::format_to(buf, "symbol = {}\n", this->symbol.dataAllowingNone(gs)->showFullName(gs));
     if (!resolutionScopes.empty()) {
@@ -858,15 +900,15 @@ string UnresolvedIdent::showRaw(const core::GlobalState &gs, int tabs) {
 }
 
 string Return::showRaw(const core::GlobalState &gs, int tabs) {
-    return nodeName() + "{ expr = " + this->expr->showRaw(gs, tabs + 1) + " }";
+    return nodeName() + "{ expr = " + this->expr.showRaw(gs, tabs + 1) + " }";
 }
 
 string Next::showRaw(const core::GlobalState &gs, int tabs) {
-    return nodeName() + "{ expr = " + this->expr->showRaw(gs, tabs + 1) + " }";
+    return nodeName() + "{ expr = " + this->expr.showRaw(gs, tabs + 1) + " }";
 }
 
 string Break::showRaw(const core::GlobalState &gs, int tabs) {
-    return nodeName() + "{ expr = " + this->expr->showRaw(gs, tabs + 1) + " }";
+    return nodeName() + "{ expr = " + this->expr.showRaw(gs, tabs + 1) + " }";
 }
 
 string Retry::showRaw(const core::GlobalState &gs, int tabs) {
@@ -942,14 +984,14 @@ string RescueCase::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::format_to(buf, "exceptions = [\n");
     for (auto &a : exceptions) {
         printTabs(buf, tabs + 2);
-        fmt::format_to(buf, "{}\n", a->showRaw(gs, tabs + 2));
+        fmt::format_to(buf, "{}\n", a.showRaw(gs, tabs + 2));
     }
     printTabs(buf, tabs + 1);
     fmt::format_to(buf, "]\n");
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "var = {}\n", this->var->showRaw(gs, tabs + 1));
+    fmt::format_to(buf, "var = {}\n", this->var.showRaw(gs, tabs + 1));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "body = {}\n", this->body->showRaw(gs, tabs + 1));
+    fmt::format_to(buf, "body = {}\n", this->body.showRaw(gs, tabs + 1));
     printTabs(buf, tabs);
     fmt::format_to(buf, "}}");
     return fmt::to_string(buf);
@@ -984,19 +1026,19 @@ string Rescue::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
     fmt::format_to(buf, "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "body = {}\n", this->body->showRaw(gs, tabs + 1));
+    fmt::format_to(buf, "body = {}\n", this->body.showRaw(gs, tabs + 1));
     printTabs(buf, tabs + 1);
     fmt::format_to(buf, "rescueCases = [\n");
     for (auto &a : rescueCases) {
         printTabs(buf, tabs + 2);
-        fmt::format_to(buf, "{}\n", a->showRaw(gs, tabs + 2));
+        fmt::format_to(buf, "{}\n", a.showRaw(gs, tabs + 2));
     }
     printTabs(buf, tabs + 1);
     fmt::format_to(buf, "]\n");
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "else = {}\n", this->else_->showRaw(gs, tabs + 1));
+    fmt::format_to(buf, "else = {}\n", this->else_.showRaw(gs, tabs + 1));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "ensure = {}\n", this->ensure->showRaw(gs, tabs + 1));
+    fmt::format_to(buf, "ensure = {}\n", this->ensure.showRaw(gs, tabs + 1));
     printTabs(buf, tabs);
     fmt::format_to(buf, "}}");
     return fmt::to_string(buf);
@@ -1017,13 +1059,13 @@ string Send::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
     fmt::format_to(buf, "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "recv = {}\n", this->recv->showRaw(gs, tabs + 1));
+    fmt::format_to(buf, "recv = {}\n", this->recv.showRaw(gs, tabs + 1));
     printTabs(buf, tabs + 1);
     fmt::format_to(buf, "fun = {}\n", this->fun.data(gs)->showRaw(gs));
     printTabs(buf, tabs + 1);
     fmt::format_to(buf, "block = ");
     if (this->block) {
-        fmt::format_to(buf, "{}\n", this->block->showRaw(gs, tabs + 1));
+        fmt::format_to(buf, "{}\n", this->block.showRaw(gs, tabs + 1));
     } else {
         fmt::format_to(buf, "nullptr\n");
     }
@@ -1033,7 +1075,7 @@ string Send::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::format_to(buf, "args = [\n");
     for (auto &a : args) {
         printTabs(buf, tabs + 2);
-        fmt::format_to(buf, "{}\n", a->showRaw(gs, tabs + 2));
+        fmt::format_to(buf, "{}\n", a.showRaw(gs, tabs + 2));
     }
     printTabs(buf, tabs + 1);
     fmt::format_to(buf, "]\n");
@@ -1057,7 +1099,7 @@ string Cast::showRaw(const core::GlobalState &gs, int tabs) {
     printTabs(buf, tabs + 2);
     fmt::format_to(buf, "cast = {},\n", this->cast.showRaw(gs));
     printTabs(buf, tabs + 2);
-    fmt::format_to(buf, "arg = {}\n", this->arg->showRaw(gs, tabs + 2));
+    fmt::format_to(buf, "arg = {}\n", this->arg.showRaw(gs, tabs + 2));
     printTabs(buf, tabs + 2);
     fmt::format_to(buf, "type = {},\n", this->type->toString(gs));
     printTabs(buf, tabs);
@@ -1083,9 +1125,9 @@ string Hash::showRaw(const core::GlobalState &gs, int tabs) {
         printTabs(buf, tabs + 2);
         fmt::format_to(buf, "[\n");
         printTabs(buf, tabs + 3);
-        fmt::format_to(buf, "key = {}\n", key->showRaw(gs, tabs + 3));
+        fmt::format_to(buf, "key = {}\n", key.showRaw(gs, tabs + 3));
         printTabs(buf, tabs + 3);
-        fmt::format_to(buf, "value = {}\n", value->showRaw(gs, tabs + 3));
+        fmt::format_to(buf, "value = {}\n", value.showRaw(gs, tabs + 3));
         printTabs(buf, tabs + 2);
         fmt::format_to(buf, "]\n");
     }
@@ -1104,7 +1146,7 @@ string Array::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::format_to(buf, "elems = [\n");
     for (auto &a : elems) {
         printTabs(buf, tabs + 2);
-        fmt::format_to(buf, "{}\n", a->showRaw(gs, tabs + 2));
+        fmt::format_to(buf, "{}\n", a.showRaw(gs, tabs + 2));
     }
     printTabs(buf, tabs + 1);
     fmt::format_to(buf, "]\n");
@@ -1165,12 +1207,12 @@ string Block::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::format_to(buf, "args = [\n");
     for (auto &a : this->args) {
         printTabs(buf, tabs + 2);
-        fmt::format_to(buf, "{}\n", a->showRaw(gs, tabs + 2));
+        fmt::format_to(buf, "{}\n", a.showRaw(gs, tabs + 2));
     }
     printTabs(buf, tabs + 1);
     fmt::format_to(buf, "]\n");
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "body = {}\n", this->body->showRaw(gs, tabs + 1));
+    fmt::format_to(buf, "body = {}\n", this->body.showRaw(gs, tabs + 1));
     printTabs(buf, tabs);
     fmt::format_to(buf, "}}");
     return fmt::to_string(buf);
@@ -1325,7 +1367,7 @@ string EmptyTree::showRaw(const core::GlobalState &gs, int tabs) {
 }
 
 string RestArg::showRaw(const core::GlobalState &gs, int tabs) {
-    return nodeName() + "{ expr = " + expr->showRaw(gs, tabs) + " }";
+    return nodeName() + "{ expr = " + expr.showRaw(gs, tabs) + " }";
 }
 
 string RestArg::nodeName() {
@@ -1333,7 +1375,7 @@ string RestArg::nodeName() {
 }
 
 string KeywordArg::showRaw(const core::GlobalState &gs, int tabs) {
-    return nodeName() + "{ expr = " + expr->showRaw(gs, tabs) + " }";
+    return nodeName() + "{ expr = " + expr.showRaw(gs, tabs) + " }";
 }
 
 string KeywordArg::nodeName() {
@@ -1344,10 +1386,10 @@ string OptionalArg::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
     fmt::format_to(buf, "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "expr = {}\n", expr->showRaw(gs, tabs + 1));
+    fmt::format_to(buf, "expr = {}\n", expr.showRaw(gs, tabs + 1));
     if (default_) {
         printTabs(buf, tabs + 1);
-        fmt::format_to(buf, "default_ = {}\n", default_->showRaw(gs, tabs + 1));
+        fmt::format_to(buf, "default_ = {}\n", default_.showRaw(gs, tabs + 1));
     }
     printTabs(buf, tabs);
     fmt::format_to(buf, "}}");
@@ -1360,11 +1402,11 @@ string OptionalArg::nodeName() {
 }
 
 string ShadowArg::showRaw(const core::GlobalState &gs, int tabs) {
-    return nodeName() + "{ expr = " + expr->showRaw(gs, tabs) + " }";
+    return nodeName() + "{ expr = " + expr.showRaw(gs, tabs) + " }";
 }
 
 string BlockArg::showRaw(const core::GlobalState &gs, int tabs) {
-    return nodeName() + "{ expr = " + expr->showRaw(gs, tabs) + " }";
+    return nodeName() + "{ expr = " + expr.showRaw(gs, tabs) + " }";
 }
 
 string ShadowArg::nodeName() {

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -289,6 +289,48 @@ core::LocOffsets TreePtr::loc() const {
 #undef CASE
 }
 
+string TreePtr::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
+    auto *ptr = get();
+
+    ENFORCE(ptr != nullptr);
+
+#define CASE(name)  \
+    case Tag::name: \
+        return reinterpret_cast<name *>(ptr)->toStringWithTabs(gs, tabs);
+    switch (tag()) {
+        CASE(EmptyTree)
+        CASE(Send)
+        CASE(ClassDef)
+        CASE(MethodDef)
+        CASE(If)
+        CASE(While)
+        CASE(Break)
+        CASE(Retry)
+        CASE(Next)
+        CASE(Return)
+        CASE(RescueCase)
+        CASE(Rescue)
+        CASE(Local)
+        CASE(UnresolvedIdent)
+        CASE(RestArg)
+        CASE(KeywordArg)
+        CASE(OptionalArg)
+        CASE(BlockArg)
+        CASE(ShadowArg)
+        CASE(Assign)
+        CASE(Cast)
+        CASE(Hash)
+        CASE(Array)
+        CASE(Literal)
+        CASE(UnresolvedConstantLit)
+        CASE(ConstantLit)
+        CASE(ZSuperArgs)
+        CASE(Block)
+        CASE(InsSeq)
+    }
+#undef CASE
+}
+
 bool TreePtr::isSelfReference() const {
     if (auto *local = cast_tree<Local>(*this)) {
         return local->localVariable == core::LocalVariable::selfVariable();
@@ -573,7 +615,7 @@ template <class T> void printElems(const core::GlobalState &gs, fmt::memory_buff
             }
         }
         first = false;
-        fmt::format_to(buf, "{}", a->toStringWithTabs(gs, tabs + 1));
+        fmt::format_to(buf, "{}", a.toStringWithTabs(gs, tabs + 1));
     }
 };
 
@@ -592,7 +634,7 @@ string ClassDef::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     } else {
         fmt::format_to(buf, "class ");
     }
-    fmt::format_to(buf, "{}<{}> < ", name->toStringWithTabs(gs, tabs),
+    fmt::format_to(buf, "{}<{}> < ", name.toStringWithTabs(gs, tabs),
                    this->symbol.dataAllowingNone(gs)->name.data(gs)->toString(gs));
     printArgs(gs, buf, this->ancestors, tabs);
 
@@ -603,7 +645,7 @@ string ClassDef::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     for (auto &a : this->rhs) {
         fmt::format_to(buf, "{}", '\n');
         printTabs(buf, tabs + 1);
-        fmt::format_to(buf, "{}\n", a->toStringWithTabs(gs, tabs + 1));
+        fmt::format_to(buf, "{}\n", a.toStringWithTabs(gs, tabs + 1));
     }
 
     printTabs(buf, tabs);
@@ -653,11 +695,11 @@ string InsSeq::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::format_to(buf, "begin\n");
     for (auto &a : this->stats) {
         printTabs(buf, tabs + 1);
-        fmt::format_to(buf, "{}\n", a->toStringWithTabs(gs, tabs + 1));
+        fmt::format_to(buf, "{}\n", a.toStringWithTabs(gs, tabs + 1));
     }
 
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "{}\n", expr->toStringWithTabs(gs, tabs + 1));
+    fmt::format_to(buf, "{}\n", expr.toStringWithTabs(gs, tabs + 1));
     printTabs(buf, tabs);
     fmt::format_to(buf, "end");
     return fmt::to_string(buf);
@@ -703,7 +745,7 @@ string MethodDef::toStringWithTabs(const core::GlobalState &gs, int tabs) const 
                 fmt::format_to(buf, ", ");
             }
             first = false;
-            fmt::format_to(buf, "{}", a->toStringWithTabs(gs, tabs + 1));
+            fmt::format_to(buf, "{}", a.toStringWithTabs(gs, tabs + 1));
         }
     } else {
         for (auto &a : data->arguments()) {
@@ -716,7 +758,7 @@ string MethodDef::toStringWithTabs(const core::GlobalState &gs, int tabs) const 
     }
     fmt::format_to(buf, ")\n");
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "{}\n", this->rhs->toStringWithTabs(gs, tabs + 1));
+    fmt::format_to(buf, "{}\n", this->rhs.toStringWithTabs(gs, tabs + 1));
     printTabs(buf, tabs);
     fmt::format_to(buf, "end");
     return fmt::to_string(buf);
@@ -770,13 +812,13 @@ string MethodDef::showRaw(const core::GlobalState &gs, int tabs) {
 string If::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
 
-    fmt::format_to(buf, "if {}\n", this->cond->toStringWithTabs(gs, tabs + 1));
+    fmt::format_to(buf, "if {}\n", this->cond.toStringWithTabs(gs, tabs + 1));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "{}\n", this->thenp->toStringWithTabs(gs, tabs + 1));
+    fmt::format_to(buf, "{}\n", this->thenp.toStringWithTabs(gs, tabs + 1));
     printTabs(buf, tabs);
     fmt::format_to(buf, "else\n");
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "{}\n", this->elsep->toStringWithTabs(gs, tabs + 1));
+    fmt::format_to(buf, "{}\n", this->elsep.toStringWithTabs(gs, tabs + 1));
     printTabs(buf, tabs);
     fmt::format_to(buf, "end");
     return fmt::to_string(buf);
@@ -813,9 +855,9 @@ string Assign::showRaw(const core::GlobalState &gs, int tabs) {
 string While::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
 
-    fmt::format_to(buf, "while {}\n", this->cond->toStringWithTabs(gs, tabs + 1));
+    fmt::format_to(buf, "while {}\n", this->cond.toStringWithTabs(gs, tabs + 1));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "{}\n", this->body->toStringWithTabs(gs, tabs + 1));
+    fmt::format_to(buf, "{}\n", this->body.toStringWithTabs(gs, tabs + 1));
     printTabs(buf, tabs);
     fmt::format_to(buf, "end");
     return fmt::to_string(buf);
@@ -839,7 +881,7 @@ string EmptyTree::toStringWithTabs(const core::GlobalState &gs, int tabs) const 
 }
 
 string UnresolvedConstantLit::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
-    return fmt::format("{}::{}", this->scope->toStringWithTabs(gs, tabs), this->cnst.data(gs)->toString(gs));
+    return fmt::format("{}::{}", this->scope.toStringWithTabs(gs, tabs), this->cnst.data(gs)->toString(gs));
 }
 
 string UnresolvedConstantLit::showRaw(const core::GlobalState &gs, int tabs) {
@@ -859,7 +901,7 @@ string ConstantLit::toStringWithTabs(const core::GlobalState &gs, int tabs) cons
     if (symbol.exists() && symbol != core::Symbols::StubModule()) {
         return this->symbol.dataAllowingNone(gs)->showFullName(gs);
     }
-    return "Unresolved: " + this->original->toStringWithTabs(gs, tabs);
+    return "Unresolved: " + this->original.toStringWithTabs(gs, tabs);
 }
 
 string ConstantLit::showRaw(const core::GlobalState &gs, int tabs) {
@@ -949,15 +991,15 @@ string Retry::showRaw(const core::GlobalState &gs, int tabs) {
 }
 
 string Return::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
-    return "return " + this->expr->toStringWithTabs(gs, tabs + 1);
+    return "return " + this->expr.toStringWithTabs(gs, tabs + 1);
 }
 
 string Next::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
-    return "next(" + this->expr->toStringWithTabs(gs, tabs + 1) + ")";
+    return "next(" + this->expr.toStringWithTabs(gs, tabs + 1) + ")";
 }
 
 string Break::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
-    return "break(" + this->expr->toStringWithTabs(gs, tabs + 1) + ")";
+    return "break(" + this->expr.toStringWithTabs(gs, tabs + 1) + ")";
 }
 
 string Retry::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
@@ -988,7 +1030,7 @@ string Literal::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
 }
 
 string Assign::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
-    return this->lhs->toStringWithTabs(gs, tabs) + " = " + this->rhs->toStringWithTabs(gs, tabs);
+    return this->lhs.toStringWithTabs(gs, tabs) + " = " + this->rhs.toStringWithTabs(gs, tabs);
 }
 
 string RescueCase::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
@@ -1002,11 +1044,11 @@ string RescueCase::toStringWithTabs(const core::GlobalState &gs, int tabs) const
         } else {
             fmt::format_to(buf, ", ");
         }
-        fmt::format_to(buf, "{}", exception->toStringWithTabs(gs, tabs));
+        fmt::format_to(buf, "{}", exception.toStringWithTabs(gs, tabs));
     }
-    fmt::format_to(buf, " => {}\n", this->var->toStringWithTabs(gs, tabs));
+    fmt::format_to(buf, " => {}\n", this->var.toStringWithTabs(gs, tabs));
     printTabs(buf, tabs);
-    fmt::format_to(buf, "{}", this->body->toStringWithTabs(gs, tabs));
+    fmt::format_to(buf, "{}", this->body.toStringWithTabs(gs, tabs));
     return fmt::to_string(buf);
 }
 
@@ -1032,25 +1074,25 @@ string RescueCase::showRaw(const core::GlobalState &gs, int tabs) {
 
 string Rescue::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{}", this->body->toStringWithTabs(gs, tabs));
+    fmt::format_to(buf, "{}", this->body.toStringWithTabs(gs, tabs));
     for (auto &rescueCase : this->rescueCases) {
         fmt::format_to(buf, "\n");
         printTabs(buf, tabs - 1);
-        fmt::format_to(buf, "{}", rescueCase->toStringWithTabs(gs, tabs));
+        fmt::format_to(buf, "{}", rescueCase.toStringWithTabs(gs, tabs));
     }
     if (!isa_tree<EmptyTree>(this->else_)) {
         fmt::format_to(buf, "\n");
         printTabs(buf, tabs - 1);
         fmt::format_to(buf, "else\n");
         printTabs(buf, tabs);
-        fmt::format_to(buf, "{}", this->else_->toStringWithTabs(gs, tabs));
+        fmt::format_to(buf, "{}", this->else_.toStringWithTabs(gs, tabs));
     }
     if (!isa_tree<EmptyTree>(this->ensure)) {
         fmt::format_to(buf, "\n");
         printTabs(buf, tabs - 1);
         fmt::format_to(buf, "ensure\n");
         printTabs(buf, tabs);
-        fmt::format_to(buf, "{}", this->ensure->toStringWithTabs(gs, tabs));
+        fmt::format_to(buf, "{}", this->ensure.toStringWithTabs(gs, tabs));
     }
     return fmt::to_string(buf);
 }
@@ -1079,10 +1121,10 @@ string Rescue::showRaw(const core::GlobalState &gs, int tabs) {
 
 string Send::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{}.{}", this->recv->toStringWithTabs(gs, tabs), this->fun.data(gs)->toString(gs));
+    fmt::format_to(buf, "{}.{}", this->recv.toStringWithTabs(gs, tabs), this->fun.data(gs)->toString(gs));
     printArgs(gs, buf, this->args, tabs);
     if (this->block != nullptr) {
-        fmt::format_to(buf, "{}", this->block->toStringWithTabs(gs, tabs));
+        fmt::format_to(buf, "{}", this->block.toStringWithTabs(gs, tabs));
     }
 
     return fmt::to_string(buf);
@@ -1121,7 +1163,7 @@ string Send::showRaw(const core::GlobalState &gs, int tabs) {
 string Cast::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     fmt::format_to(buf, "T.{}", this->cast.toString(gs));
-    fmt::format_to(buf, "({}, {})", this->arg->toStringWithTabs(gs, tabs), this->type->toStringWithTabs(gs, tabs));
+    fmt::format_to(buf, "({}, {})", this->arg.toStringWithTabs(gs, tabs), this->type->toStringWithTabs(gs, tabs));
 
     return fmt::to_string(buf);
 }
@@ -1205,9 +1247,9 @@ string Hash::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
             fmt::format_to(buf, ", ");
         }
         first = false;
-        fmt::format_to(buf, "{}", key->toStringWithTabs(gs, tabs + 1));
+        fmt::format_to(buf, "{}", key.toStringWithTabs(gs, tabs + 1));
         fmt::format_to(buf, " => ");
-        fmt::format_to(buf, "{}", value->toStringWithTabs(gs, tabs + 1));
+        fmt::format_to(buf, "{}", value.toStringWithTabs(gs, tabs + 1));
     }
     fmt::format_to(buf, "}}");
     return fmt::to_string(buf);
@@ -1227,7 +1269,7 @@ string Block::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     printElems(gs, buf, this->args, tabs + 1);
     fmt::format_to(buf, "|\n");
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "{}\n", this->body->toStringWithTabs(gs, tabs + 1));
+    fmt::format_to(buf, "{}\n", this->body.toStringWithTabs(gs, tabs + 1));
     printTabs(buf, tabs);
     fmt::format_to(buf, "end");
     return fmt::to_string(buf);
@@ -1252,28 +1294,28 @@ string Block::showRaw(const core::GlobalState &gs, int tabs) {
 }
 
 string RestArg::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
-    return "*" + this->expr->toStringWithTabs(gs, tabs);
+    return "*" + this->expr.toStringWithTabs(gs, tabs);
 }
 
 string KeywordArg::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
-    return this->expr->toStringWithTabs(gs, tabs) + ":";
+    return this->expr.toStringWithTabs(gs, tabs) + ":";
 }
 
 string OptionalArg::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{}", this->expr->toStringWithTabs(gs, tabs));
+    fmt::format_to(buf, "{}", this->expr.toStringWithTabs(gs, tabs));
     if (this->default_) {
-        fmt::format_to(buf, " = {}", this->default_->toStringWithTabs(gs, tabs));
+        fmt::format_to(buf, " = {}", this->default_.toStringWithTabs(gs, tabs));
     }
     return fmt::to_string(buf);
 }
 
 string ShadowArg::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
-    return this->expr->toStringWithTabs(gs, tabs);
+    return this->expr.toStringWithTabs(gs, tabs);
 }
 
 string BlockArg::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
-    return "&" + this->expr->toStringWithTabs(gs, tabs);
+    return "&" + this->expr.toStringWithTabs(gs, tabs);
 }
 
 string RescueCase::nodeName() {

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -206,6 +206,13 @@ string TreePtr::nodeName() const {
 #undef NODE_NAME
 }
 
+bool TreePtr::isSelfReference() const {
+    if (auto *local = cast_tree_const<Local>(*this)) {
+        return local->localVariable == core::LocalVariable::selfVariable();
+    }
+    return false;
+}
+
 bool isa_reference(const TreePtr &what) {
     return isa_tree<Local>(what) || isa_tree<UnresolvedIdent>(what) || isa_tree<RestArg>(what) ||
            isa_tree<KeywordArg>(what) || isa_tree<OptionalArg>(what) || isa_tree<BlockArg>(what) ||
@@ -806,11 +813,6 @@ string Local::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
 
 string Local::nodeName() {
     return "Local";
-}
-
-bool Expression::isSelfReference() const {
-    auto asLocal = fast_cast<const Expression, const Local>(this);
-    return asLocal && asLocal->localVariable == core::LocalVariable::selfVariable();
 }
 
 string Local::showRaw(const core::GlobalState &gs, int tabs) {

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -249,7 +249,7 @@ string TreePtr::showRaw(const core::GlobalState &gs, int tabs) {
 }
 
 bool TreePtr::isSelfReference() const {
-    if (auto *local = cast_tree_const<Local>(*this)) {
+    if (auto *local = cast_tree<Local>(*this)) {
         return local->localVariable == core::LocalVariable::selfVariable();
     }
     return false;

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -220,6 +220,8 @@ public:
 
     std::string nodeName() const;
 
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+
     bool isSelfReference() const;
 
     void _sanityCheck() const;
@@ -237,7 +239,6 @@ public:
     std::string toString(const core::GlobalState &gs) const {
         return toStringWithTabs(gs);
     }
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) = 0;
     const core::LocOffsets loc;
 };
 CheckSize(Expression, 16, 8);

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -225,6 +225,8 @@ public:
     bool isSelfReference() const;
 
     void _sanityCheck() const;
+
+    core::LocOffsets loc() const;
 };
 
 template <class E, typename... Args> TreePtr make_tree(Args &&... args) {
@@ -233,13 +235,11 @@ template <class E, typename... Args> TreePtr make_tree(Args &&... args) {
 
 class Expression {
 public:
-    Expression(core::LocOffsets loc);
     virtual ~Expression() = default;
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const = 0;
     std::string toString(const core::GlobalState &gs) const {
         return toStringWithTabs(gs);
     }
-    const core::LocOffsets loc;
 };
 CheckSize(Expression, 16, 8);
 
@@ -299,28 +299,17 @@ template <class To> const To &cast_tree_nonnull(const TreePtr &what) {
     return *reinterpret_cast<To *>(what.get());
 }
 
-class Reference : public Expression {
-public:
-    Reference(core::LocOffsets loc);
-};
-CheckSize(Reference, 16, 8);
-
-class Declaration : public Expression {
-public:
-    core::Loc declLoc;
-    core::SymbolRef symbol;
-
-    Declaration(core::LocOffsets loc, core::Loc declLoc, core::SymbolRef symbol);
-};
-CheckSize(Declaration, 32, 8);
-
 #define TREE(name)                                                                  \
     class name;                                                                     \
     template <> struct TreeToTag<name> { static constexpr Tag value = Tag::name; }; \
     class __attribute__((aligned(8))) name final
 
-TREE(ClassDef) : public Declaration {
+TREE(ClassDef) : public Expression {
 public:
+    const core::LocOffsets loc;
+    core::Loc declLoc;
+    core::SymbolRef symbol;
+
     enum class Kind : u1 {
         Module,
         Class,
@@ -352,8 +341,12 @@ public:
 };
 CheckSize(ClassDef, 136, 8);
 
-TREE(MethodDef) : public Declaration {
+TREE(MethodDef) : public Expression {
 public:
+    const core::LocOffsets loc;
+    core::Loc declLoc;
+    core::SymbolRef symbol;
+
     TreePtr rhs;
 
     using ARGS_store = InlinedVector<TreePtr, core::SymbolRef::EXPECTED_METHOD_ARGS_COUNT>;
@@ -387,6 +380,8 @@ CheckSize(MethodDef, 72, 8);
 
 TREE(If) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     TreePtr cond;
     TreePtr thenp;
     TreePtr elsep;
@@ -405,6 +400,8 @@ CheckSize(If, 40, 8);
 
 TREE(While) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     TreePtr cond;
     TreePtr body;
 
@@ -422,6 +419,8 @@ CheckSize(While, 32, 8);
 
 TREE(Break) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     TreePtr expr;
 
     Break(core::LocOffsets loc, TreePtr expr);
@@ -438,6 +437,8 @@ CheckSize(Break, 24, 8);
 
 TREE(Retry) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     Retry(core::LocOffsets loc);
 
     TreePtr deepCopy() const;
@@ -452,6 +453,8 @@ CheckSize(Retry, 16, 8);
 
 TREE(Next) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     TreePtr expr;
 
     Next(core::LocOffsets loc, TreePtr expr);
@@ -468,6 +471,8 @@ CheckSize(Next, 24, 8);
 
 TREE(Return) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     TreePtr expr;
 
     Return(core::LocOffsets loc, TreePtr expr);
@@ -484,6 +489,8 @@ CheckSize(Return, 24, 8);
 
 TREE(RescueCase) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     static constexpr int EXPECTED_EXCEPTION_COUNT = 2;
     using EXCEPTION_store = InlinedVector<TreePtr, EXPECTED_EXCEPTION_COUNT>;
 
@@ -508,6 +515,8 @@ CheckSize(RescueCase, 56, 8);
 
 TREE(Rescue) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     static constexpr int EXPECTED_RESCUE_CASE_COUNT = 2;
     using RESCUE_CASE_store = InlinedVector<TreePtr, EXPECTED_RESCUE_CASE_COUNT>;
 
@@ -528,8 +537,10 @@ public:
 };
 CheckSize(Rescue, 64, 8);
 
-TREE(Local) : public Reference {
+TREE(Local) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     core::LocalVariable localVariable;
 
     Local(core::LocOffsets loc, core::LocalVariable localVariable1);
@@ -544,8 +555,10 @@ public:
 };
 CheckSize(Local, 24, 8);
 
-TREE(UnresolvedIdent) : public Reference {
+TREE(UnresolvedIdent) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     enum class Kind : u1 {
         Local,
         Instance,
@@ -567,8 +580,10 @@ public:
 };
 CheckSize(UnresolvedIdent, 24, 8);
 
-TREE(RestArg) : public Reference {
+TREE(RestArg) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     TreePtr expr;
 
     RestArg(core::LocOffsets loc, TreePtr arg);
@@ -583,8 +598,10 @@ public:
 };
 CheckSize(RestArg, 24, 8);
 
-TREE(KeywordArg) : public Reference {
+TREE(KeywordArg) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     TreePtr expr;
 
     KeywordArg(core::LocOffsets loc, TreePtr expr);
@@ -599,8 +616,10 @@ public:
 };
 CheckSize(KeywordArg, 24, 8);
 
-TREE(OptionalArg) : public Reference {
+TREE(OptionalArg) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     TreePtr expr;
     TreePtr default_;
 
@@ -616,8 +635,10 @@ public:
 };
 CheckSize(OptionalArg, 32, 8);
 
-TREE(BlockArg) : public Reference {
+TREE(BlockArg) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     TreePtr expr;
 
     BlockArg(core::LocOffsets loc, TreePtr expr);
@@ -632,8 +653,10 @@ public:
 };
 CheckSize(BlockArg, 24, 8);
 
-TREE(ShadowArg) : public Reference {
+TREE(ShadowArg) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     TreePtr expr;
 
     ShadowArg(core::LocOffsets loc, TreePtr expr);
@@ -650,6 +673,8 @@ CheckSize(ShadowArg, 24, 8);
 
 TREE(Assign) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     TreePtr lhs;
     TreePtr rhs;
 
@@ -667,6 +692,8 @@ CheckSize(Assign, 32, 8);
 
 TREE(Send) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     core::NameRef fun;
 
     struct Flags {
@@ -742,6 +769,8 @@ CheckSize(Send, 64, 8);
 
 TREE(Cast) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     // The name of the cast operator.
     core::NameRef cast;
 
@@ -762,6 +791,8 @@ CheckSize(Cast, 48, 8);
 
 TREE(Hash) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     static constexpr int EXPECTED_ENTRY_COUNT = 2;
     using ENTRY_store = InlinedVector<TreePtr, EXPECTED_ENTRY_COUNT>;
 
@@ -782,6 +813,8 @@ CheckSize(Hash, 64, 8);
 
 TREE(Array) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     static constexpr int EXPECTED_ENTRY_COUNT = 4;
     using ENTRY_store = InlinedVector<TreePtr, EXPECTED_ENTRY_COUNT>;
 
@@ -801,6 +834,8 @@ CheckSize(Array, 56, 8);
 
 TREE(Literal) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     core::TypePtr value;
 
     Literal(core::LocOffsets loc, const core::TypePtr &value);
@@ -824,6 +859,8 @@ CheckSize(Literal, 32, 8);
 
 TREE(UnresolvedConstantLit) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     core::NameRef cnst;
     TreePtr scope;
 
@@ -841,6 +878,8 @@ CheckSize(UnresolvedConstantLit, 32, 8);
 
 TREE(ConstantLit) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     core::SymbolRef symbol; // If this is a normal constant. This symbol may be already dealiased.
     // For constants that failed resolution, symbol will be set to StubModule and resolutionScopes
     // will be set to whatever nesting scope we estimate the constant could have been defined in.
@@ -864,6 +903,8 @@ CheckSize(ConstantLit, 56, 8);
 
 TREE(ZSuperArgs) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     // null if no block passed
     ZSuperArgs(core::LocOffsets loc);
 
@@ -879,6 +920,8 @@ CheckSize(ZSuperArgs, 16, 8);
 
 TREE(Block) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     MethodDef::ARGS_store args;
     TreePtr body;
 
@@ -895,6 +938,8 @@ CheckSize(Block, 48, 8);
 
 TREE(InsSeq) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     static constexpr int EXPECTED_STATS_COUNT = 4;
     using STATS_store = InlinedVector<TreePtr, EXPECTED_STATS_COUNT>;
     // Statements
@@ -917,6 +962,8 @@ CheckSize(InsSeq, 64, 8);
 
 TREE(EmptyTree) : public Expression {
 public:
+    const core::LocOffsets loc;
+
     EmptyTree();
 
     TreePtr deepCopy() const;

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -227,6 +227,12 @@ public:
     void _sanityCheck() const;
 
     core::LocOffsets loc() const;
+
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+
+    std::string toString(const core::GlobalState &gs) const {
+        return toStringWithTabs(gs);
+    }
 };
 
 template <class E, typename... Args> TreePtr make_tree(Args &&... args) {
@@ -236,12 +242,8 @@ template <class E, typename... Args> TreePtr make_tree(Args &&... args) {
 class Expression {
 public:
     virtual ~Expression() = default;
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const = 0;
-    std::string toString(const core::GlobalState &gs) const {
-        return toStringWithTabs(gs);
-    }
 };
-CheckSize(Expression, 16, 8);
+CheckSize(Expression, 8, 8);
 
 struct ParsedFile {
     TreePtr tree;
@@ -333,8 +335,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -370,8 +372,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -390,8 +392,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -409,8 +411,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -427,8 +429,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -443,8 +445,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -461,8 +463,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -479,8 +481,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -505,8 +507,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -529,8 +531,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -547,8 +549,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -572,8 +574,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -590,8 +592,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -608,8 +610,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -627,8 +629,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -645,8 +647,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -663,8 +665,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -682,8 +684,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -740,8 +742,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     // Returned value is [start, end) indices into ast::Send::args.
@@ -781,8 +783,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -803,8 +805,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -824,8 +826,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -842,8 +844,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
     bool isString(const core::GlobalState &gs) const;
     bool isSymbol(const core::GlobalState &gs) const;
@@ -868,8 +870,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -891,8 +893,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
     std::optional<std::pair<core::SymbolRef, std::vector<core::NameRef>>> fullUnresolvedPath(
         const core::GlobalState &gs) const;
@@ -910,8 +912,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -929,8 +931,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
     void _sanityCheck();
 };
@@ -952,8 +954,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();
@@ -968,8 +970,8 @@ public:
 
     TreePtr deepCopy() const;
 
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
     void _sanityCheck();

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -217,6 +217,8 @@ public:
     }
 
     TreePtr deepCopy() const;
+
+    std::string nodeName() const;
 };
 
 template <class E, typename... Args> TreePtr make_tree(Args &&... args) {
@@ -231,7 +233,6 @@ public:
     std::string toString(const core::GlobalState &gs) const {
         return toStringWithTabs(gs);
     }
-    virtual std::string nodeName() = 0;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) = 0;
     virtual void _sanityCheck() = 0;
     const core::LocOffsets loc;
@@ -343,7 +344,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -377,7 +378,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -396,7 +397,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -414,7 +415,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -431,7 +432,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -446,7 +447,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -463,7 +464,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -480,7 +481,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -505,7 +506,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -528,7 +529,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -545,7 +546,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -569,7 +570,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -586,7 +587,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -603,7 +604,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -621,7 +622,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -638,7 +639,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -655,7 +656,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -673,7 +674,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -730,7 +731,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
     // Returned value is [start, end) indices into ast::Send::args.
     std::pair<int, int> kwArgsRange() const {
@@ -770,7 +771,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -791,7 +792,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -811,7 +812,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -828,7 +829,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
     bool isString(const core::GlobalState &gs) const;
     bool isSymbol(const core::GlobalState &gs) const;
     bool isNil(const core::GlobalState &gs) const;
@@ -853,7 +854,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -875,7 +876,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
     std::optional<std::pair<core::SymbolRef, std::vector<core::NameRef>>> fullUnresolvedPath(
         const core::GlobalState &gs) const;
 
@@ -893,7 +894,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -911,7 +912,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
     virtual void _sanityCheck();
 };
 CheckSize(Block, 48, 8);
@@ -932,7 +933,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();
@@ -947,7 +948,7 @@ public:
 
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    virtual std::string nodeName();
+    std::string nodeName();
 
 private:
     virtual void _sanityCheck();

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -219,6 +219,8 @@ public:
     TreePtr deepCopy() const;
 
     std::string nodeName() const;
+
+    bool isSelfReference() const;
 };
 
 template <class E, typename... Args> TreePtr make_tree(Args &&... args) {
@@ -236,8 +238,6 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) = 0;
     virtual void _sanityCheck() = 0;
     const core::LocOffsets loc;
-
-    bool isSelfReference() const;
 };
 CheckSize(Expression, 16, 8);
 

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -221,6 +221,8 @@ public:
     std::string nodeName() const;
 
     bool isSelfReference() const;
+
+    void _sanityCheck() const;
 };
 
 template <class E, typename... Args> TreePtr make_tree(Args &&... args) {
@@ -236,7 +238,6 @@ public:
         return toStringWithTabs(gs);
     }
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0) = 0;
-    virtual void _sanityCheck() = 0;
     const core::LocOffsets loc;
 };
 CheckSize(Expression, 16, 8);
@@ -346,8 +347,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(ClassDef, 136, 8);
 
@@ -380,8 +380,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(MethodDef, 72, 8);
 
@@ -399,8 +398,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(If, 40, 8);
 
@@ -417,8 +415,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(While, 32, 8);
 
@@ -434,8 +431,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(Break, 24, 8);
 
@@ -449,8 +445,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(Retry, 16, 8);
 
@@ -466,8 +461,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(Next, 24, 8);
 
@@ -483,8 +477,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(Return, 24, 8);
 
@@ -508,8 +501,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(RescueCase, 56, 8);
 
@@ -531,8 +523,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(Rescue, 64, 8);
 
@@ -548,8 +539,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(Local, 24, 8);
 
@@ -572,8 +562,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(UnresolvedIdent, 24, 8);
 
@@ -589,8 +578,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(RestArg, 24, 8);
 
@@ -606,8 +594,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(KeywordArg, 24, 8);
 
@@ -624,8 +611,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(OptionalArg, 32, 8);
 
@@ -641,8 +627,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(BlockArg, 24, 8);
 
@@ -658,8 +643,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(ShadowArg, 24, 8);
 
@@ -676,8 +660,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(Assign, 32, 8);
 
@@ -752,8 +735,7 @@ public:
         return (args.size() - numPosArgs) & 0x1;
     }
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(Send, 64, 8);
 
@@ -773,8 +755,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(Cast, 48, 8);
 
@@ -794,8 +775,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(Hash, 64, 8);
 
@@ -814,8 +794,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(Array, 56, 8);
 
@@ -838,8 +817,7 @@ public:
     bool isTrue(const core::GlobalState &gs) const;
     bool isFalse(const core::GlobalState &gs) const;
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(Literal, 32, 8);
 
@@ -856,8 +834,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(UnresolvedConstantLit, 32, 8);
 
@@ -880,8 +857,7 @@ public:
     std::optional<std::pair<core::SymbolRef, std::vector<core::NameRef>>> fullUnresolvedPath(
         const core::GlobalState &gs) const;
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(ConstantLit, 56, 8);
 
@@ -896,8 +872,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(ZSuperArgs, 16, 8);
 
@@ -913,7 +888,7 @@ public:
     virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(Block, 48, 8);
 
@@ -935,8 +910,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(InsSeq, 64, 8);
 
@@ -950,8 +924,7 @@ public:
     virtual std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
 
-private:
-    virtual void _sanityCheck();
+    void _sanityCheck();
 };
 CheckSize(EmptyTree, 16, 8);
 

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -568,7 +568,7 @@ TreePtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) {
                     // 0-sized Loc, since `self.` doesn't appear in the original file.
                     rec = MK::Self(loc.copyWithZeroLength());
                     flags.isPrivateOk = true;
-                } else if (rec.get()->isSelfReference()) {
+                } else if (rec.isSelfReference()) {
                     // In Ruby 2.7 `self.foo()` is also allowed for private method calls,
                     // not only `foo()`. This pre-emptively allow the new syntax.
                     flags.isPrivateOk = true;

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -652,7 +652,7 @@ private:
                     return mapReturn(std::move(what), ctx);
 
                 case Tag::RescueCase:
-                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what.nodeName());
                     break;
 
                 case Tag::Rescue:
@@ -665,23 +665,23 @@ private:
                     return mapUnresolvedIdent(std::move(what), ctx);
 
                 case Tag::RestArg:
-                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what.nodeName());
                     break;
 
                 case Tag::KeywordArg:
-                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what.nodeName());
                     break;
 
                 case Tag::OptionalArg:
-                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what.nodeName());
                     break;
 
                 case Tag::BlockArg:
-                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what.nodeName());
                     break;
 
                 case Tag::ShadowArg:
-                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what.nodeName());
                     break;
 
                 case Tag::Assign:
@@ -709,7 +709,7 @@ private:
                     return what;
 
                 case Tag::Block:
-                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what.nodeName());
                     break;
 
                 case Tag::InsSeq:
@@ -1148,7 +1148,7 @@ private:
                     return mapReturn(std::move(what), ctx);
 
                 case Tag::RescueCase:
-                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what.nodeName());
                     break;
 
                 case Tag::Rescue:
@@ -1161,23 +1161,23 @@ private:
                     return mapUnresolvedIdent(std::move(what), ctx);
 
                 case Tag::RestArg:
-                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what.nodeName());
                     break;
 
                 case Tag::KeywordArg:
-                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what.nodeName());
                     break;
 
                 case Tag::OptionalArg:
-                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what.nodeName());
                     break;
 
                 case Tag::BlockArg:
-                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what.nodeName());
                     break;
 
                 case Tag::ShadowArg:
-                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what.nodeName());
                     break;
 
                 case Tag::Assign:
@@ -1205,7 +1205,7 @@ private:
                     return what;
 
                 case Tag::Block:
-                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what->nodeName());
+                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what.nodeName());
                     break;
 
                 case Tag::InsSeq:

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -611,7 +611,7 @@ private:
         if (what == nullptr) {
             return what;
         }
-        auto loc = what->loc;
+        auto loc = what.loc();
 
         try {
             // TODO: reorder by frequency
@@ -1107,7 +1107,7 @@ private:
         if (what == nullptr) {
             return what;
         }
-        auto loc = what->loc;
+        auto loc = what.loc();
 
         try {
             // TODO: reorder by frequency

--- a/ast/verifier/Verifier.cc
+++ b/ast/verifier/Verifier.cc
@@ -13,7 +13,7 @@ public:
             ENFORCE(original->loc.exists(), "location is unset");
         }
 
-        original->_sanityCheck();
+        original._sanityCheck();
 
         return original;
     }
@@ -37,7 +37,7 @@ public:
     }
 
     TreePtr preTransformBlock(core::Context ctx, TreePtr original) {
-        original->_sanityCheck();
+        original._sanityCheck();
         return original;
     }
 };

--- a/ast/verifier/Verifier.cc
+++ b/ast/verifier/Verifier.cc
@@ -10,7 +10,7 @@ class VerifierWalker {
 public:
     TreePtr preTransformExpression(core::Context ctx, TreePtr original) {
         if (!isa_tree<EmptyTree>(original)) {
-            ENFORCE(original->loc.exists(), "location is unset");
+            ENFORCE(original.loc().exists(), "location is unset");
         }
 
         original._sanityCheck();

--- a/cfg/builder/builder.h
+++ b/cfg/builder/builder.h
@@ -10,7 +10,7 @@ public:
     static std::unique_ptr<CFG> buildFor(core::Context ctx, ast::MethodDef &md);
 
 private:
-    static BasicBlock *walk(CFGContext cctx, ast::Expression *what, BasicBlock *current);
+    static BasicBlock *walk(CFGContext cctx, const ast::TreePtr &what, BasicBlock *current);
     static void fillInTopoSorts(core::Context ctx, CFG &cfg);
     static void dealias(core::Context ctx, CFG &cfg);
     static void simplify(core::Context ctx, CFG &cfg);

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -83,7 +83,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
             presentCont = joinBlocks(cctx, presentCont, defaultCont);
         }
 
-        cont = walk(cctx.withTarget(retSym), md.rhs.get(), presentCont);
+        cont = walk(cctx.withTarget(retSym), md.rhs, presentCont);
     }
     // Past this point, res->localVariables is a fixed size.
 

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -774,7 +774,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlo
             [&](ast::ClassDef *c) { Exception::raise("Should have been removed by FlattenWalk"); },
             [&](ast::MethodDef *c) { Exception::raise("Should have been removed by FlattenWalk"); },
 
-            [&](ast::Expression *n) { Exception::raise("Unimplemented AST Node: {}", n->nodeName()); });
+            [&](ast::Expression *n) { Exception::raise("Unimplemented AST Node: {}", what.nodeName()); });
 
         // For, Rescue,
         // Symbol, Array,

--- a/class_flatten/class_flatten.cc
+++ b/class_flatten/class_flatten.cc
@@ -137,7 +137,7 @@ public:
             ast::InsSeq::STATS_store stats;
             auto sorted = sortedClasses();
             stats.insert(stats.begin(), make_move_iterator(sorted.begin()), make_move_iterator(sorted.end()));
-            return ast::MK::InsSeq(tree->loc, std::move(stats), std::move(tree));
+            return ast::MK::InsSeq(tree.loc(), std::move(stats), std::move(tree));
         }
 
         for (auto &clas : sortedClasses()) {

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1123,7 +1123,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::TreePtr &what) {
             pickleTree(p, a->original);
         },
 
-        [&](ast::Expression *n) { Exception::raise("Unimplemented AST Node: {}", n->nodeName()); });
+        [&](ast::Expression *n) { Exception::raise("Unimplemented AST Node: {}", what.nodeName()); });
 }
 
 ast::TreePtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const GlobalState &gs, FileRef file) {

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -351,13 +351,13 @@ core::LocOffsets getAncestorLoc(const core::GlobalState &gs, const ast::ClassDef
     for (const auto &anc : classDef->ancestors) {
         const auto ancConst = ast::cast_tree<ast::ConstantLit>(anc);
         if (ancConst != nullptr && ancConst->symbol.data(gs)->dealias(gs) == ancestor) {
-            return anc->loc;
+            return anc.loc();
         }
     }
     for (const auto &anc : classDef->singletonAncestors) {
         const auto ancConst = ast::cast_tree<ast::ConstantLit>(anc);
         if (ancConst != nullptr && ancConst->symbol.data(gs)->dealias(gs) == ancestor) {
-            return anc->loc;
+            return anc.loc();
         }
     }
     // give up

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -49,37 +49,37 @@ class LocalNameInserter {
             [&](ast::UnresolvedIdent *nm) {
                 named.name = nm->name;
                 named.local = enterLocal(named.name);
-                named.loc = arg->loc;
-                named.expr = ast::make_tree<ast::Local>(arg->loc, named.local);
+                named.loc = arg.loc();
+                named.expr = ast::make_tree<ast::Local>(arg.loc(), named.local);
             },
             [&](ast::RestArg *rest) {
                 named = nameArg(move(rest->expr));
-                named.expr = ast::MK::RestArg(arg->loc, move(named.expr));
+                named.expr = ast::MK::RestArg(arg.loc(), move(named.expr));
                 named.flags.repeated = true;
             },
             [&](ast::KeywordArg *kw) {
                 named = nameArg(move(kw->expr));
-                named.expr = ast::MK::KeywordArg(arg->loc, move(named.expr));
+                named.expr = ast::MK::KeywordArg(arg.loc(), move(named.expr));
                 named.flags.keyword = true;
             },
             [&](ast::OptionalArg *opt) {
                 named = nameArg(move(opt->expr));
-                named.expr = ast::MK::OptionalArg(arg->loc, move(named.expr), move(opt->default_));
+                named.expr = ast::MK::OptionalArg(arg.loc(), move(named.expr), move(opt->default_));
             },
             [&](ast::BlockArg *blk) {
                 named = nameArg(move(blk->expr));
-                named.expr = ast::MK::BlockArg(arg->loc, move(named.expr));
+                named.expr = ast::MK::BlockArg(arg.loc(), move(named.expr));
                 named.flags.block = true;
             },
             [&](ast::ShadowArg *shadow) {
                 named = nameArg(move(shadow->expr));
-                named.expr = ast::MK::ShadowArg(arg->loc, move(named.expr));
+                named.expr = ast::MK::ShadowArg(arg.loc(), move(named.expr));
                 named.flags.shadow = true;
             },
             [&](ast::Local *local) {
                 named.name = local->localVariable._name;
                 named.local = enterLocal(named.name);
-                named.loc = arg->loc;
+                named.loc = arg.loc();
                 named.expr = ast::make_tree<ast::Local>(local->loc, named.local);
             });
 

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -284,7 +284,7 @@ public:
         // class/module level. These cases are handled in `preTransformClassDef`. Do not ignore in
         // block scope so that we a ref to the included module is still rendered.
         if (original->fun == core::Names::keepForIde() ||
-            (!inBlock && original->recv->isSelfReference() &&
+            (!inBlock && original->recv.isSelfReference() &&
              (original->fun == core::Names::include() || original->fun == core::Names::extend()))) {
             ignoring.emplace_back(original);
         }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -150,7 +150,7 @@ ast::TreePtr runDesugar(core::GlobalState &gs, core::FileRef file, unique_ptr<pa
         print.DesugarTree.fmt("{}\n", ast->toStringWithTabs(gs, 0));
     }
     if (print.DesugarTreeRaw.enabled) {
-        print.DesugarTreeRaw.fmt("{}\n", ast->showRaw(gs));
+        print.DesugarTreeRaw.fmt("{}\n", ast.showRaw(gs));
     }
     return ast;
 }
@@ -204,7 +204,7 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
             print.RewriterTree.fmt("{}\n", tree->toStringWithTabs(lgs, 0));
         }
         if (print.RewriterTreeRaw.enabled) {
-            print.RewriterTreeRaw.fmt("{}\n", tree->showRaw(lgs));
+            print.RewriterTreeRaw.fmt("{}\n", tree.showRaw(lgs));
         }
         if (opts.stopAfterPhase == options::Phase::REWRITER) {
             return emptyParsedFile(file);
@@ -264,7 +264,7 @@ indexOneWithPlugins(const options::Options &opts, core::GlobalState &gs, core::F
                 print.RewriterTree.fmt("{}\n", tree->toStringWithTabs(gs, 0));
             }
             if (print.RewriterTreeRaw.enabled) {
-                print.RewriterTreeRaw.fmt("{}\n", tree->showRaw(gs));
+                print.RewriterTreeRaw.fmt("{}\n", tree.showRaw(gs));
             }
 
             tree = runLocalVars(gs, ast::ParsedFile{move(tree), file}).tree;
@@ -276,7 +276,7 @@ indexOneWithPlugins(const options::Options &opts, core::GlobalState &gs, core::F
             print.IndexTree.fmt("{}\n", tree->toStringWithTabs(gs, 0));
         }
         if (print.IndexTreeRaw.enabled) {
-            print.IndexTreeRaw.fmt("{}\n", tree->showRaw(gs));
+            print.IndexTreeRaw.fmt("{}\n", tree.showRaw(gs));
         }
         if (opts.stopAfterPhase == options::Phase::REWRITER) {
             return emptyPluginFile(file);
@@ -691,7 +691,7 @@ ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const 
         opts.print.FlattenTree.fmt("{}\n", resolved.tree->toString(ctx));
     }
     if (opts.print.FlattenTreeRaw.enabled || opts.print.ASTRaw.enabled) {
-        opts.print.FlattenTreeRaw.fmt("{}\n", resolved.tree->showRaw(ctx));
+        opts.print.FlattenTreeRaw.fmt("{}\n", resolved.tree.showRaw(ctx));
     }
 
     if (opts.stopAfterPhase == options::Phase::NAMER || opts.stopAfterPhase == options::Phase::RESOLVER) {
@@ -868,7 +868,7 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
                 opts.print.NameTree.fmt("{}\n", named.tree->toStringWithTabs(*gs, 0));
             }
             if (opts.print.NameTreeRaw.enabled) {
-                opts.print.NameTreeRaw.fmt("{}\n", named.tree->showRaw(*gs));
+                opts.print.NameTreeRaw.fmt("{}\n", named.tree.showRaw(*gs));
             }
         }
 
@@ -921,7 +921,7 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
                 opts.print.ResolveTree.fmt("{}\n", resolved.tree->toString(*gs));
             }
             if (opts.print.ResolveTreeRaw.enabled) {
-                opts.print.ResolveTreeRaw.fmt("{}\n", resolved.tree->showRaw(*gs));
+                opts.print.ResolveTreeRaw.fmt("{}\n", resolved.tree.showRaw(*gs));
             }
         }
     }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -147,7 +147,7 @@ ast::TreePtr runDesugar(core::GlobalState &gs, core::FileRef file, unique_ptr<pa
         ast = ast::desugar::node2Tree(ctx, move(parseTree));
     }
     if (print.DesugarTree.enabled) {
-        print.DesugarTree.fmt("{}\n", ast->toStringWithTabs(gs, 0));
+        print.DesugarTree.fmt("{}\n", ast.toStringWithTabs(gs, 0));
     }
     if (print.DesugarTreeRaw.enabled) {
         print.DesugarTreeRaw.fmt("{}\n", ast.showRaw(gs));
@@ -201,7 +201,7 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
             }
         }
         if (print.RewriterTree.enabled) {
-            print.RewriterTree.fmt("{}\n", tree->toStringWithTabs(lgs, 0));
+            print.RewriterTree.fmt("{}\n", tree.toStringWithTabs(lgs, 0));
         }
         if (print.RewriterTreeRaw.enabled) {
             print.RewriterTreeRaw.fmt("{}\n", tree.showRaw(lgs));
@@ -261,7 +261,7 @@ indexOneWithPlugins(const options::Options &opts, core::GlobalState &gs, core::F
                 tree = runRewriter(gs, file, move(tree));
             }
             if (print.RewriterTree.enabled) {
-                print.RewriterTree.fmt("{}\n", tree->toStringWithTabs(gs, 0));
+                print.RewriterTree.fmt("{}\n", tree.toStringWithTabs(gs, 0));
             }
             if (print.RewriterTreeRaw.enabled) {
                 print.RewriterTreeRaw.fmt("{}\n", tree.showRaw(gs));
@@ -273,7 +273,7 @@ indexOneWithPlugins(const options::Options &opts, core::GlobalState &gs, core::F
             }
         }
         if (print.IndexTree.enabled) {
-            print.IndexTree.fmt("{}\n", tree->toStringWithTabs(gs, 0));
+            print.IndexTree.fmt("{}\n", tree.toStringWithTabs(gs, 0));
         }
         if (print.IndexTreeRaw.enabled) {
             print.IndexTreeRaw.fmt("{}\n", tree.showRaw(gs));
@@ -688,7 +688,7 @@ ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const 
     resolved = class_flatten::runOne(ctx, move(resolved));
 
     if (opts.print.FlattenTree.enabled || opts.print.AST.enabled) {
-        opts.print.FlattenTree.fmt("{}\n", resolved.tree->toString(ctx));
+        opts.print.FlattenTree.fmt("{}\n", resolved.tree.toString(ctx));
     }
     if (opts.print.FlattenTreeRaw.enabled || opts.print.ASTRaw.enabled) {
         opts.print.FlattenTreeRaw.fmt("{}\n", resolved.tree.showRaw(ctx));
@@ -742,7 +742,7 @@ vector<ast::ParsedFile> package(core::GlobalState &gs, vector<ast::ParsedFile> w
         what = packager::Packager::run(gs, workers, move(what));
         if (opts.print.Packager.enabled) {
             for (auto &f : what) {
-                opts.print.Packager.fmt("{}\n", f.tree->toStringWithTabs(gs, 0));
+                opts.print.Packager.fmt("{}\n", f.tree.toStringWithTabs(gs, 0));
             }
         }
     }
@@ -865,7 +865,7 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
 
         for (auto &named : what) {
             if (opts.print.NameTree.enabled) {
-                opts.print.NameTree.fmt("{}\n", named.tree->toStringWithTabs(*gs, 0));
+                opts.print.NameTree.fmt("{}\n", named.tree.toStringWithTabs(*gs, 0));
             }
             if (opts.print.NameTreeRaw.enabled) {
                 opts.print.NameTreeRaw.fmt("{}\n", named.tree.showRaw(*gs));
@@ -918,7 +918,7 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
     if (opts.print.ResolveTree.enabled || opts.print.ResolveTreeRaw.enabled) {
         for (auto &resolved : what) {
             if (opts.print.ResolveTree.enabled) {
-                opts.print.ResolveTree.fmt("{}\n", resolved.tree->toString(*gs));
+                opts.print.ResolveTree.fmt("{}\n", resolved.tree.toString(*gs));
             }
             if (opts.print.ResolveTreeRaw.enabled) {
                 opts.print.ResolveTreeRaw.fmt("{}\n", resolved.tree.showRaw(*gs));

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -554,7 +554,7 @@ public:
             staticField.owner = found.owner;
             staticField.name = found.name;
             staticField.asgnLoc = found.asgnLoc;
-            staticField.lhsLoc = asgn.lhs->loc;
+            staticField.lhsLoc = asgn.lhs.loc();
             staticField.isTypeAlias = true;
             return foundDefs->addStaticField(move(staticField));
         }
@@ -1328,7 +1328,7 @@ class TreeSymbolizer {
             }
             if (auto *uid = ast::cast_tree<ast::UnresolvedIdent>(node)) {
                 if (uid->kind != ast::UnresolvedIdent::Kind::Class || uid->name != core::Names::singleton()) {
-                    if (auto e = ctx.beginError(node->loc, core::errors::Namer::DynamicConstant)) {
+                    if (auto e = ctx.beginError(node.loc(), core::errors::Namer::DynamicConstant)) {
                         e.setHeader("Unsupported constant scope");
                     }
                 }
@@ -1338,7 +1338,7 @@ class TreeSymbolizer {
             } else if (node.isSelfReference()) {
                 // self::Foo
             } else {
-                if (auto e = ctx.beginError(node->loc, core::errors::Namer::DynamicConstant)) {
+                if (auto e = ctx.beginError(node.loc(), core::errors::Namer::DynamicConstant)) {
                     e.setHeader("Dynamic constant references are unsupported");
                 }
             }
@@ -1423,7 +1423,7 @@ class TreeSymbolizer {
             if (isValidAncestor(arg)) {
                 dest->emplace_back(arg.deepCopy());
             } else {
-                if (auto e = ctx.beginError(arg->loc, core::errors::Namer::AncestorNotConstant)) {
+                if (auto e = ctx.beginError(arg.loc(), core::errors::Namer::AncestorNotConstant)) {
                     e.setHeader("`{}` must only contain constant literals", send->fun.data(ctx)->show(ctx));
                 }
                 arg = ast::MK::EmptyTree();
@@ -1496,7 +1496,7 @@ public:
             /* Superclass is typeAlias in parent scope, mixins are typeAlias in inner scope */
             for (auto &anc : klass.ancestors) {
                 if (!isValidAncestor(anc)) {
-                    if (auto e = ctx.beginError(anc->loc, core::errors::Namer::AncestorNotConstant)) {
+                    if (auto e = ctx.beginError(anc.loc(), core::errors::Namer::AncestorNotConstant)) {
                         e.setHeader("Superclasses must only contain constant literals");
                     }
                     anc = ast::MK::EmptyTree();
@@ -1659,7 +1659,7 @@ public:
 
                 // one of fixed or bounds were provided
                 if (fixed != bounded) {
-                    asgn.lhs = ast::MK::Constant(asgn.lhs->loc, sym);
+                    asgn.lhs = ast::MK::Constant(asgn.lhs.loc(), sym);
 
                     // Leave it in the tree for the resolver to chew on.
                     return tree;

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -610,7 +610,7 @@ public:
         auto *send = ast::cast_tree<ast::Send>(asgn.rhs);
         if (send == nullptr) {
             fillAssign(ctx, asgn);
-        } else if (!send->recv->isSelfReference()) {
+        } else if (!send->recv.isSelfReference()) {
             handleAssignment(ctx, asgn);
         } else {
             switch (send->fun._id) {
@@ -1335,7 +1335,7 @@ class TreeSymbolizer {
                 // emitted via `class << self` blocks
             } else if (ast::isa_tree<ast::EmptyTree>(node)) {
                 // ::Foo
-            } else if (node->isSelfReference()) {
+            } else if (node.isSelfReference()) {
                 // self::Foo
             } else {
                 if (auto e = ctx.beginError(node->loc, core::errors::Namer::DynamicConstant)) {
@@ -1391,7 +1391,7 @@ class TreeSymbolizer {
         } else {
             return;
         }
-        if (!send->recv->isSelfReference()) {
+        if (!send->recv.isSelfReference()) {
             // ignore `something.include`
             return;
         }
@@ -1416,7 +1416,7 @@ class TreeSymbolizer {
             if (ast::isa_tree<ast::EmptyTree>(arg)) {
                 continue;
             }
-            if (arg->isSelfReference()) {
+            if (arg.isSelfReference()) {
                 dest->emplace_back(arg.deepCopy());
                 continue;
             }
@@ -1432,7 +1432,7 @@ class TreeSymbolizer {
     }
 
     bool isValidAncestor(ast::TreePtr &exp) {
-        if (ast::isa_tree<ast::EmptyTree>(exp) || exp->isSelfReference() || ast::isa_tree<ast::ConstantLit>(exp)) {
+        if (ast::isa_tree<ast::EmptyTree>(exp) || exp.isSelfReference() || ast::isa_tree<ast::ConstantLit>(exp)) {
             return true;
         }
         if (auto lit = ast::cast_tree<ast::UnresolvedConstantLit>(exp)) {
@@ -1472,7 +1472,7 @@ public:
     // This decides if we need to keep a node around incase the current LSP query needs type information for it
     bool shouldLeaveAncestorForIDE(const ast::TreePtr &anc) {
         // used in Desugar <-> resolver to signal classes that did not have explicit superclass
-        if (ast::isa_tree<ast::EmptyTree>(anc) || anc->isSelfReference()) {
+        if (ast::isa_tree<ast::EmptyTree>(anc) || anc.isSelfReference()) {
             return false;
         }
         auto rcl = ast::cast_tree<ast::ConstantLit>(anc);
@@ -1701,7 +1701,7 @@ public:
             return handleAssignment(ctx, std::move(tree));
         }
 
-        if (!send->recv->isSelfReference()) {
+        if (!send->recv.isSelfReference()) {
             return handleAssignment(ctx, std::move(tree));
         }
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -222,7 +222,7 @@ ast::TreePtr FullyQualifiedName::toLiteral(core::LocOffsets loc) const {
 ast::UnresolvedConstantLit *verifyConstant(core::MutableContext ctx, core::NameRef fun, ast::TreePtr &expr) {
     auto target = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
     if (target == nullptr) {
-        if (auto e = ctx.beginError(expr->loc, core::errors::Packager::InvalidImportOrExport)) {
+        if (auto e = ctx.beginError(expr.loc(), core::errors::Packager::InvalidImportOrExport)) {
             e.setHeader("Argument to `{}` must be a constant", fun.show(ctx));
         }
     }
@@ -256,7 +256,7 @@ struct PackageInfoFinder {
             send.fun != core::Names::exportMethods()) {
             for (const auto &arg : send.args) {
                 if (!ast::isa_tree<ast::Literal>(arg)) {
-                    if (auto e = ctx.beginError(arg->loc, core::errors::Packager::InvalidPackageExpression)) {
+                    if (auto e = ctx.beginError(arg.loc(), core::errors::Packager::InvalidPackageExpression)) {
                         e.setHeader("Invalid expression in package: Arguments to functions must be literals");
                     }
                 }
@@ -438,72 +438,72 @@ struct PackageInfoFinder {
     }
 
     ast::TreePtr preTransformIf(core::MutableContext ctx, ast::TreePtr original) {
-        illegalNode(ctx, original->loc, "`if`");
+        illegalNode(ctx, original.loc(), "`if`");
         return original;
     }
 
     ast::TreePtr preTransformWhile(core::MutableContext ctx, ast::TreePtr original) {
-        illegalNode(ctx, original->loc, "`while`");
+        illegalNode(ctx, original.loc(), "`while`");
         return original;
     }
 
     ast::TreePtr postTransformBreak(core::MutableContext ctx, ast::TreePtr original) {
-        illegalNode(ctx, original->loc, "`break`");
+        illegalNode(ctx, original.loc(), "`break`");
         return original;
     }
 
     ast::TreePtr postTransformRetry(core::MutableContext ctx, ast::TreePtr original) {
-        illegalNode(ctx, original->loc, "`retry`");
+        illegalNode(ctx, original.loc(), "`retry`");
         return original;
     }
 
     ast::TreePtr postTransformNext(core::MutableContext ctx, ast::TreePtr original) {
-        illegalNode(ctx, original->loc, "`next`");
+        illegalNode(ctx, original.loc(), "`next`");
         return original;
     }
 
     ast::TreePtr preTransformReturn(core::MutableContext ctx, ast::TreePtr original) {
-        illegalNode(ctx, original->loc, "`return`");
+        illegalNode(ctx, original.loc(), "`return`");
         return original;
     }
 
     ast::TreePtr preTransformRescueCase(core::MutableContext ctx, ast::TreePtr original) {
-        illegalNode(ctx, original->loc, "`rescue case`");
+        illegalNode(ctx, original.loc(), "`rescue case`");
         return original;
     }
 
     ast::TreePtr preTransformRescue(core::MutableContext ctx, ast::TreePtr original) {
-        illegalNode(ctx, original->loc, "`rescue`");
+        illegalNode(ctx, original.loc(), "`rescue`");
         return original;
     }
 
     ast::TreePtr preTransformAssign(core::MutableContext ctx, ast::TreePtr original) {
-        illegalNode(ctx, original->loc, "`=`");
+        illegalNode(ctx, original.loc(), "`=`");
         return original;
     }
 
     ast::TreePtr preTransformHash(core::MutableContext ctx, ast::TreePtr original) {
-        illegalNode(ctx, original->loc, "hash literals");
+        illegalNode(ctx, original.loc(), "hash literals");
         return original;
     }
 
     ast::TreePtr preTransformArray(core::MutableContext ctx, ast::TreePtr original) {
-        illegalNode(ctx, original->loc, "array literals");
+        illegalNode(ctx, original.loc(), "array literals");
         return original;
     }
 
     ast::TreePtr preTransformMethodDef(core::MutableContext ctx, ast::TreePtr original) {
-        illegalNode(ctx, original->loc, "method definitions");
+        illegalNode(ctx, original.loc(), "method definitions");
         return original;
     }
 
     ast::TreePtr preTransformBlock(core::MutableContext ctx, ast::TreePtr original) {
-        illegalNode(ctx, original->loc, "blocks");
+        illegalNode(ctx, original.loc(), "blocks");
         return original;
     }
 
     ast::TreePtr preTransformInsSeq(core::MutableContext ctx, ast::TreePtr original) {
-        illegalNode(ctx, original->loc, "`begin` and `end`");
+        illegalNode(ctx, original.loc(), "`begin` and `end`");
         return original;
     }
 };

--- a/plugin/SubprocessTextPlugin.cc
+++ b/plugin/SubprocessTextPlugin.cc
@@ -67,7 +67,7 @@ struct SpawningWalker {
 
             optional<string> output;
             {
-                string className = core::Loc(ctx.file, klass->name->loc).source(ctx);
+                string className = core::Loc(ctx.file, klass->name.loc()).source(ctx);
                 string_view shortName = send->fun.data(ctx)->shortName(ctx);
                 string sendSource = core::Loc(ctx.file, send->loc).source(ctx);
 

--- a/resolver/CorrectTypeAlias.cc
+++ b/resolver/CorrectTypeAlias.cc
@@ -31,9 +31,9 @@ void CorrectTypeAlias::eagerToLazy(core::Context ctx, core::ErrorBuilder &e, ast
         }
     }
 
-    auto *front = send->args.front().get();
-    auto *back = send->args.back().get();
-    core::Loc argsLoc{ctx.file, front->loc.join(back->loc)};
+    auto &front = send->args.front();
+    auto &back = send->args.back();
+    core::Loc argsLoc{ctx.file, front.loc().join(back.loc())};
 
     auto [start, end] = core::Loc(ctx.file, send->loc).position(ctx);
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -557,7 +557,7 @@ private:
                 return;
             }
             job.ancestor = cnst;
-        } else if (ancestor->isSelfReference()) {
+        } else if (ancestor.isSelfReference()) {
             auto loc = ancestor->loc;
             auto enclosingClass = ctx.owner.data(ctx)->enclosingClass(ctx);
             auto nw = ast::MK::UnresolvedConstant(loc, std::move(ancestor), enclosingClass.data(ctx)->name);
@@ -1275,7 +1275,7 @@ public:
         auto sym = id->symbol;
         auto data = sym.data(ctx);
         if (data->isTypeAlias() || data->isTypeMember()) {
-            ENFORCE(!data->isTypeMember() || send->recv->isSelfReference());
+            ENFORCE(!data->isTypeMember() || send->recv.isSelfReference());
 
             // This is for a special case that happens with the generation of
             // reflection.rbi: it re-creates the type aliases of the payload,
@@ -2183,7 +2183,7 @@ public:
                 default:
                     return tree;
             }
-        } else if (send.recv.get()->isSelfReference()) {
+        } else if (send.recv.isSelfReference()) {
             if (send.fun != core::Names::aliasMethod()) {
                 return tree;
             }
@@ -2305,7 +2305,7 @@ class ResolveMixesInClassMethodsWalk {
 public:
     ast::TreePtr postTransformSend(core::MutableContext ctx, ast::TreePtr tree) {
         auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
-        if (send.recv->isSelfReference() && send.fun == core::Names::mixesInClassMethods()) {
+        if (send.recv.isSelfReference() && send.fun == core::Names::mixesInClassMethods()) {
             processMixesInClassMethods(ctx, send);
         }
         return tree;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2318,7 +2318,7 @@ public:
     ast::TreePtr postTransformClassDef(core::MutableContext ctx, ast::TreePtr tree) {
         auto &original = ast::cast_tree_nonnull<ast::ClassDef>(tree);
         ENFORCE(original.symbol != core::Symbols::todo(), "These should have all been resolved: {}",
-                original.toString(ctx));
+                tree.toString(ctx));
         if (original.symbol == core::Symbols::root()) {
             ENFORCE(ctx.state.lookupStaticInitForFile(core::Loc(ctx.file, original.loc)).exists());
         } else {
@@ -2329,18 +2329,17 @@ public:
     ast::TreePtr postTransformMethodDef(core::MutableContext ctx, ast::TreePtr tree) {
         auto &original = ast::cast_tree_nonnull<ast::MethodDef>(tree);
         ENFORCE(original.symbol != core::Symbols::todo(), "These should have all been resolved: {}",
-                original.toString(ctx));
+                tree.toString(ctx));
         return tree;
     }
     ast::TreePtr postTransformUnresolvedConstantLit(core::MutableContext ctx, ast::TreePtr tree) {
-        auto &original = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(tree);
-        ENFORCE(false, "These should have all been removed: {}", original.toString(ctx));
+        ENFORCE(false, "These should have all been removed: {}", tree.toString(ctx));
         return tree;
     }
     ast::TreePtr postTransformUnresolvedIdent(core::MutableContext ctx, ast::TreePtr tree) {
         auto &original = ast::cast_tree_nonnull<ast::UnresolvedIdent>(tree);
         ENFORCE(original.kind != ast::UnresolvedIdent::Kind::Local, "{} should have been removed by local_vars",
-                original.toString(ctx));
+                tree.toString(ctx));
         return tree;
     }
     ast::TreePtr postTransformConstantLit(core::MutableContext ctx, ast::TreePtr tree) {

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -55,8 +55,8 @@ core::TypePtr getResultLiteral(core::Context ctx, ast::TreePtr &expr) {
     core::TypePtr result;
     typecase(
         expr.get(), [&](ast::Literal *lit) { result = lit->value; },
-        [&](ast::Expression *expr) {
-            if (auto e = ctx.beginError(expr->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+        [&](ast::Expression *e) {
+            if (auto e = ctx.beginError(expr.loc(), core::errors::Resolver::InvalidTypeDeclaration)) {
                 e.setHeader("Unsupported type literal");
             }
             result = core::Types::untypedUntracked();
@@ -162,20 +162,21 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
                             auto name = c->asSymbol(ctx);
                             auto &typeArgSpec = sig.enterTypeArgByName(name);
                             if (typeArgSpec.type) {
-                                if (auto e = ctx.beginError(arg->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                                if (auto e =
+                                        ctx.beginError(arg.loc(), core::errors::Resolver::InvalidMethodSignature)) {
                                     e.setHeader("Malformed signature; Type argument `{}` was specified twice",
                                                 name.show(ctx));
                                 }
                             }
                             typeArgSpec.type = core::make_type<core::TypeVar>(core::Symbols::todo());
-                            typeArgSpec.loc = core::Loc(ctx.file, arg->loc);
+                            typeArgSpec.loc = core::Loc(ctx.file, arg.loc());
                         } else {
-                            if (auto e = ctx.beginError(arg->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                            if (auto e = ctx.beginError(arg.loc(), core::errors::Resolver::InvalidMethodSignature)) {
                                 e.setHeader("Malformed signature; Type parameters are specified with symbols");
                             }
                         }
                     } else {
-                        if (auto e = ctx.beginError(arg->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                        if (auto e = ctx.beginError(arg.loc(), core::errors::Resolver::InvalidMethodSignature)) {
                             e.setHeader("Malformed signature; Type parameters are specified with symbols");
                         }
                     }
@@ -297,7 +298,7 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
                             core::NameRef name = lit->asSymbol(ctx);
                             auto resultAndBind =
                                 getResultTypeAndBindWithSelfTypeParams(ctx, value, *parent, args.withRebind());
-                            sig.argTypes.emplace_back(ParsedSig::ArgSpec{core::Loc(ctx.file, key->loc), name,
+                            sig.argTypes.emplace_back(ParsedSig::ArgSpec{core::Loc(ctx.file, key.loc()), name,
                                                                          resultAndBind.type, resultAndBind.rebind});
                         }
                     }
@@ -346,7 +347,7 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
                             e.replaceWith("Replace with `override`", core::Loc(ctx.file, send->loc), "override");
                         } else {
                             e.replaceWith("Replace with `override`", core::Loc(ctx.file, send->loc), "{}.override",
-                                          core::Loc(ctx.file, send->recv->loc).source(ctx));
+                                          core::Loc(ctx.file, send->recv.loc()).source(ctx));
                         }
                     }
                     break;
@@ -359,8 +360,8 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
                         if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
                             e.setHeader("`{}` does not accept keyword arguments", send->fun.show(ctx));
                             if (!send->hasKwSplat()) {
-                                auto start = send->args[send->numPosArgs]->loc;
-                                auto end = send->args.back()->loc;
+                                auto start = send->args[send->numPosArgs].loc();
+                                auto end = send->args.back().loc();
                                 core::Loc argsLoc(ctx.file, start.beginPos(), end.endPos());
                                 e.replaceWith("Wrap in braces to make a shape type", argsLoc, "{{{}}}",
                                               argsLoc.source(ctx));
@@ -379,7 +380,7 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
 
                     auto nil = ast::cast_tree<ast::Literal>(send->args[0]);
                     if (nil && nil->isNil(ctx)) {
-                        const auto loc = core::Loc(ctx.file, send->args[0]->loc);
+                        const auto loc = core::Loc(ctx.file, send->args[0].loc());
                         if (auto e = ctx.state.beginError(loc, core::errors::Resolver::InvalidMethodSignature)) {
                             e.setHeader("You probably meant `.returns(NilClass)`");
                             e.replaceWith("Replace with `NilClass`", loc, "NilClass");
@@ -644,7 +645,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                     keys.emplace_back(lit->value);
                     values.emplace_back(val);
                 } else {
-                    if (auto e = ctx.beginError(ktree->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                    if (auto e = ctx.beginError(ktree.loc(), core::errors::Resolver::InvalidTypeDeclaration)) {
                         e.setHeader("Malformed type declaration. Shape keys must be literals");
                     }
                 }
@@ -881,12 +882,12 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
             holders.reserve(s->args.size());
             for (auto &arg : s->args) {
                 core::TypeAndOrigins ty;
-                ty.origins.emplace_back(core::Loc(ctx.file, arg->loc));
+                ty.origins.emplace_back(core::Loc(ctx.file, arg.loc()));
                 ty.type = core::make_type<core::MetaType>(
                     getResultTypeWithSelfTypeParams(ctx, arg, sigBeingParsed, args.withoutSelfType()));
                 holders.emplace_back(make_unique<core::TypeAndOrigins>(move(ty)));
                 targs.emplace_back(holders.back().get());
-                argLocs.emplace_back(arg->loc);
+                argLocs.emplace_back(arg.loc());
             }
 
             core::SymbolRef corrected;
@@ -978,8 +979,8 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                 result.type = core::Types::untypedUntracked();
             }
         },
-        [&](ast::Expression *expr) {
-            if (auto e = ctx.beginError(expr->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+        [&](ast::Expression *e) {
+            if (auto e = ctx.beginError(expr.loc(), core::errors::Resolver::InvalidTypeDeclaration)) {
                 e.setHeader("Unsupported type syntax");
             }
             result.type = core::Types::untypedUntracked();

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -342,7 +342,7 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
                 case core::Names::implementation()._id:
                     if (auto e = ctx.beginError(send->loc, core::errors::Resolver::ImplementationDeprecated)) {
                         e.setHeader("Use of `{}` has been replaced by `{}`", "implementation", "override");
-                        if (send->recv->isSelfReference()) {
+                        if (send->recv.isSelfReference()) {
                             e.replaceWith("Replace with `override`", core::Loc(ctx.file, send->loc), "override");
                         } else {
                             e.replaceWith("Replace with `override`", core::Loc(ctx.file, send->loc), "{}.override",
@@ -420,7 +420,7 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
 
             // we only report this error if we haven't reported another unknown method error
             if (!recv && !reportedInvalidMethod) {
-                if (!send->recv->isSelfReference()) {
+                if (!send->recv.isSelfReference()) {
                     if (!sig.seen.proc) {
                         if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
                             e.setHeader("Malformed signature: `{}` being invoked on an invalid receiver",
@@ -969,7 +969,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
             result.type = core::Types::untypedUntracked();
         },
         [&](ast::Local *slf) {
-            if (slf->isSelfReference()) {
+            if (expr.isSelfReference()) {
                 result.type = ctxOwnerData->selfType(ctx);
             } else {
                 if (auto e = ctx.beginError(slf->loc, core::errors::Resolver::InvalidTypeDeclaration)) {

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -145,7 +145,7 @@ ast::TreePtr toWriterSigForName(core::MutableContext ctx, ast::Send *sharedSig, 
     ast::Send *cur = body;
     while (cur != nullptr) {
         auto recv = ast::cast_tree<ast::ConstantLit>(cur->recv);
-        if ((cur->recv->isSelfReference()) || (recv && recv->symbol == core::Symbols::Sorbet())) {
+        if ((cur->recv.isSelfReference()) || (recv && recv->symbol == core::Symbols::Sorbet())) {
             auto loc = resultType->loc;
             auto params = ast::MK::Send2(loc, move(cur->recv), core::Names::params(), ast::MK::Symbol(nameLoc, name),
                                          move(resultType));

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -32,7 +32,7 @@ pair<core::NameRef, core::LocOffsets> getName(core::MutableContext ctx, ast::Tre
             if (validAttr) {
                 res = nameRef;
             } else {
-                if (auto e = ctx.beginError(name->loc, core::errors::Rewriter::BadAttrArg)) {
+                if (auto e = ctx.beginError(name.loc(), core::errors::Rewriter::BadAttrArg)) {
                     e.setHeader("Bad attribute name \"{}\"", absl::CEscape(shortName));
                 }
                 res = core::Names::empty();
@@ -41,7 +41,7 @@ pair<core::NameRef, core::LocOffsets> getName(core::MutableContext ctx, ast::Tre
         }
     }
     if (!res.exists()) {
-        if (auto e = ctx.beginError(name->loc, core::errors::Rewriter::BadAttrArg)) {
+        if (auto e = ctx.beginError(name.loc(), core::errors::Rewriter::BadAttrArg)) {
             e.setHeader("arg must be a Symbol or String");
         }
     }
@@ -118,7 +118,7 @@ void ensureSafeSig(core::MutableContext ctx, const core::NameRef attrFun, ast::S
             if (auto e = ctx.beginError(sig->loc, core::errors::Rewriter::BadAttrType)) {
                 e.setHeader("The type for an `{}` cannot contain `{}`", attrFun.show(ctx), "type_parameters");
             }
-            body->args[0] = ast::MK::Untyped(body->args[0]->loc);
+            body->args[0] = ast::MK::Untyped(body->args[0].loc());
         }
         cur = ast::cast_tree<ast::Send>(cur->recv);
     }
@@ -146,7 +146,7 @@ ast::TreePtr toWriterSigForName(core::MutableContext ctx, ast::Send *sharedSig, 
     while (cur != nullptr) {
         auto recv = ast::cast_tree<ast::ConstantLit>(cur->recv);
         if ((cur->recv.isSelfReference()) || (recv && recv->symbol == core::Symbols::Sorbet())) {
-            auto loc = resultType->loc;
+            auto loc = resultType.loc();
             auto params = ast::MK::Send2(loc, move(cur->recv), core::Names::params(), ast::MK::Symbol(nameLoc, name),
                                          move(resultType));
             ast::cast_tree_nonnull<ast::Send>(params).numPosArgs = 0;

--- a/rewriter/ClassNew.cc
+++ b/rewriter/ClassNew.cc
@@ -55,7 +55,7 @@ vector<ast::TreePtr> ClassNew::run(core::MutableContext ctx, ast::Assign *asgn) 
     auto *block = ast::cast_tree<ast::Block>(send->block);
     if (block != nullptr && block->args.size() == 1) {
         auto blockArg = move(block->args[0]);
-        body.emplace_back(ast::MK::Assign(blockArg->loc, move(blockArg), asgn->lhs.deepCopy()));
+        body.emplace_back(ast::MK::Assign(blockArg.loc(), move(blockArg), asgn->lhs.deepCopy()));
     }
 
     if (send->block != nullptr) {

--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -93,7 +93,7 @@ vector<ast::TreePtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *send) 
 
     if (!skipGetter) {
         if (nilable) {
-            auto tyloc = type->loc;
+            auto tyloc = type.loc();
             type = ast::MK::Nilable(tyloc, move(type));
         }
         // def self.get_<prop>

--- a/rewriter/Flatfiles.cc
+++ b/rewriter/Flatfiles.cc
@@ -39,7 +39,7 @@ void handleFieldDefinition(core::MutableContext ctx, ast::TreePtr &stat, vector<
     if (auto send = ast::cast_tree<ast::Send>(stat)) {
         if ((send->fun != core::Names::from() && send->fun != core::Names::field() &&
              send->fun != core::Names::pattern()) ||
-            !send->recv->isSelfReference() || send->args.size() < 1) {
+            !send->recv.isSelfReference() || send->args.size() < 1) {
             return;
         }
         auto name = getFieldName(ctx, *send);

--- a/rewriter/Flatten.cc
+++ b/rewriter/Flatten.cc
@@ -390,7 +390,7 @@ public:
         auto insSeq = ast::cast_tree<ast::InsSeq>(tree);
         if (insSeq == nullptr) {
             ast::InsSeq::STATS_store stats;
-            tree = ast::make_tree<ast::InsSeq>(tree->loc, std::move(stats), std::move(tree));
+            tree = ast::make_tree<ast::InsSeq>(tree.loc(), std::move(stats), std::move(tree));
             return addTopLevelMethods(ctx, std::move(tree));
         }
 

--- a/rewriter/InterfaceWrapper.cc
+++ b/rewriter/InterfaceWrapper.cc
@@ -21,7 +21,7 @@ ast::TreePtr InterfaceWrapper::run(core::MutableContext ctx, ast::Send *send) {
     }
 
     if (!ast::isa_tree<ast::UnresolvedConstantLit>(send->recv)) {
-        if (auto e = ctx.beginError(send->recv->loc, core::errors::Rewriter::BadWrapInstance)) {
+        if (auto e = ctx.beginError(send->recv.loc(), core::errors::Rewriter::BadWrapInstance)) {
             e.setHeader("Unsupported wrap_instance() on a non-constant-literal");
         }
         return nullptr;

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -70,7 +70,7 @@ public:
     // we treat those the same way we treat classes
     ast::TreePtr preTransformSend(core::MutableContext ctx, ast::TreePtr tree) {
         auto *send = ast::cast_tree<ast::Send>(tree);
-        if (send->recv->isSelfReference() && send->args.size() == 1 && send->fun == core::Names::describe()) {
+        if (send->recv.isSelfReference() && send->args.size() == 1 && send->fun == core::Names::describe()) {
             classDepth++;
         }
         return tree;
@@ -78,7 +78,7 @@ public:
 
     ast::TreePtr postTransformSend(core::MutableContext ctx, ast::TreePtr tree) {
         auto *send = ast::cast_tree<ast::Send>(tree);
-        if (send->recv->isSelfReference() && send->args.size() == 1 && send->fun == core::Names::describe()) {
+        if (send->recv.isSelfReference() && send->args.size() == 1 && send->fun == core::Names::describe()) {
             classDepth--;
             if (classDepth == 0) {
                 movedConstants.emplace_back(move(tree));
@@ -240,7 +240,7 @@ ast::TreePtr runSingle(core::MutableContext ctx, ast::Send *send) {
 
     auto *block = ast::cast_tree<ast::Block>(send->block);
 
-    if (!send->recv->isSelfReference()) {
+    if (!send->recv.isSelfReference()) {
         return nullptr;
     }
 

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -110,7 +110,7 @@ public:
 };
 
 ast::TreePtr addSigVoid(ast::TreePtr expr) {
-    return ast::MK::InsSeq1(expr->loc, ast::MK::SigVoid(expr->loc, {}), std::move(expr));
+    return ast::MK::InsSeq1(expr.loc(), ast::MK::SigVoid(expr.loc(), {}), std::move(expr));
 }
 } // namespace
 
@@ -172,7 +172,7 @@ ast::TreePtr getIteratee(ast::TreePtr &exp) {
     if (canMoveIntoMethodDef(exp)) {
         return exp.deepCopy();
     } else {
-        return ast::MK::RaiseUnimplemented(exp->loc);
+        return ast::MK::RaiseUnimplemented(exp.loc());
     }
 }
 
@@ -209,7 +209,7 @@ ast::TreePtr runUnderEach(core::MutableContext ctx, core::NameRef eachName, ast:
         }
     }
     // if any of the above tests were not satisfied, then mark this statement as being invalid here
-    if (auto e = ctx.beginError(stmt->loc, core::errors::Rewriter::BadTestEach)) {
+    if (auto e = ctx.beginError(stmt.loc(), core::errors::Rewriter::BadTestEach)) {
         e.setHeader("Only valid `{}`-blocks can appear within `{}`", "it", eachName.show(ctx));
     }
 
@@ -247,7 +247,7 @@ ast::TreePtr runSingle(core::MutableContext ctx, ast::Send *send) {
     if ((send->fun == core::Names::testEach() || send->fun == core::Names::testEachHash()) && send->args.size() == 1) {
         if ((send->fun == core::Names::testEach() && block->args.size() != 1) ||
             (send->fun == core::Names::testEachHash() && block->args.size() != 2)) {
-            if (auto e = ctx.beginError(send->block->loc, core::errors::Rewriter::BadTestEach)) {
+            if (auto e = ctx.beginError(send->block.loc(), core::errors::Rewriter::BadTestEach)) {
                 e.setHeader("Wrong number of parameters for `{}` block: expected `{}`, got `{}`", send->fun.show(ctx),
                             1, block->args.size());
             }
@@ -261,7 +261,7 @@ ast::TreePtr runSingle(core::MutableContext ctx, ast::Send *send) {
         args.emplace_back(move(send->args.front()));
         return ast::MK::Send(
             send->loc, ast::MK::Self(send->loc), send->fun, 1, std::move(args), send->flags,
-            ast::MK::Block(send->block->loc,
+            ast::MK::Block(send->block.loc(),
                            prepareTestEachBody(ctx, send->fun, std::move(block->body), block->args, iteratee),
                            std::move(block->args)));
     }
@@ -283,10 +283,10 @@ ast::TreePtr runSingle(core::MutableContext ctx, ast::Send *send) {
 
     if (send->fun == core::Names::describe()) {
         ast::ClassDef::ANCESTORS_store ancestors;
-        ancestors.emplace_back(ast::MK::Self(arg->loc));
+        ancestors.emplace_back(ast::MK::Self(arg.loc()));
         ast::ClassDef::RHS_store rhs;
         rhs.emplace_back(prepareBody(ctx, std::move(block->body)));
-        auto name = ast::MK::UnresolvedConstant(arg->loc, ast::MK::EmptyTree(),
+        auto name = ast::MK::UnresolvedConstant(arg.loc(), ast::MK::EmptyTree(),
                                                 ctx.state.enterNameConstant("<describe '" + argString + "'>"));
         return ast::MK::Class(send->loc, core::Loc(ctx.file, send->loc), std::move(name), std::move(ancestors),
                               std::move(rhs));

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -143,7 +143,7 @@ string to_s(core::Context ctx, ast::TreePtr &arg) {
     if (argConstant != nullptr) {
         return argConstant->cnst.show(ctx);
     }
-    return arg->toString(ctx);
+    return arg.toString(ctx);
 }
 
 // This returns `true` for expressions which can be moved from class to method scope without changing their meaning, and

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -20,7 +20,7 @@ void ModuleFunction::run(core::MutableContext ctx, ast::ClassDef *cdef) {
     for (auto &stat : cdef->rhs) {
         if (auto send = ast::cast_tree<ast::Send>(stat)) {
             // we only care about sends if they're `module_function`
-            if (send->fun == core::Names::moduleFunction() && send->recv->isSelfReference()) {
+            if (send->fun == core::Names::moduleFunction() && send->recv.isSelfReference()) {
                 if (send->args.size() == 0) {
                     // a `module_function` with no args changes the way that every subsequent method definition works so
                     // we set this flag so we know that the rest of the defns should be rewritten

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -78,7 +78,7 @@ vector<ast::TreePtr> ModuleFunction::rewriteDefn(core::MutableContext ctx, const
         return stats;
     }
 
-    auto loc = expr->loc;
+    auto loc = expr.loc();
 
     // this creates a private copy of the method
     auto privateCopy = expr.deepCopy();
@@ -140,7 +140,7 @@ vector<ast::TreePtr> ModuleFunction::run(core::MutableContext ctx, ast::Send *se
             ast::cast_tree_nonnull<ast::MethodDef>(methodDef).flags.isSelfMethod = true;
             stats.emplace_back(std::move(methodDef));
         } else {
-            if (auto e = ctx.beginError(arg->loc, core::errors::Rewriter::BadModuleFunction)) {
+            if (auto e = ctx.beginError(arg.loc(), core::errors::Rewriter::BadModuleFunction)) {
                 e.setHeader("Bad argument to `{}`: must be a symbol, string, method definition, or nothing",
                             "module_function");
             }

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -230,7 +230,7 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
                 ret.computedByMethodNameLoc = lit->loc;
                 ret.computedByMethodName = lit->asSymbol(ctx);
             } else {
-                if (auto e = ctx.beginError(val->loc, core::errors::Rewriter::ComputedBySymbol)) {
+                if (auto e = ctx.beginError(val.loc(), core::errors::Rewriter::ComputedBySymbol)) {
                     e.setHeader("Value for `{}` must be a symbol literal", "computed_by");
                 }
             }
@@ -242,10 +242,10 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
             if (auto body = ASTUtil::thunkBody(ctx, ret.foreign)) {
                 ret.foreign = std::move(body);
             } else {
-                if (auto e = ctx.beginError(ret.foreign->loc, core::errors::Rewriter::PropForeignStrict)) {
+                if (auto e = ctx.beginError(ret.foreign.loc(), core::errors::Rewriter::PropForeignStrict)) {
                     e.setHeader("The argument to `{}` must be a lambda", "foreign:");
-                    e.replaceWith("Convert to lambda", core::Loc(ctx.file, ret.foreign->loc), "-> {{{}}}",
-                                  core::Loc(ctx.file, ret.foreign->loc).source(ctx));
+                    e.replaceWith("Convert to lambda", core::Loc(ctx.file, ret.foreign.loc()), "-> {{{}}}",
+                                  core::Loc(ctx.file, ret.foreign.loc()).source(ctx));
                 }
             }
         }

--- a/rewriter/SelfNew.cc
+++ b/rewriter/SelfNew.cc
@@ -6,7 +6,7 @@
 namespace sorbet::rewriter {
 
 ast::TreePtr SelfNew::run(core::MutableContext ctx, ast::Send *send) {
-    if (send->fun != core::Names::new_() || !send->recv->isSelfReference()) {
+    if (send->fun != core::Names::new_() || !send->recv.isSelfReference()) {
         return nullptr;
     }
 

--- a/rewriter/SigRewriter.cc
+++ b/rewriter/SigRewriter.cc
@@ -32,7 +32,7 @@ bool SigRewriter::run(core::MutableContext &ctx, ast::Send *send) {
         return false;
     }
 
-    if (!(send->recv->isSelfReference() || isTSigWithoutRuntime(send->recv))) {
+    if (!(send->recv.isSelfReference() || isTSigWithoutRuntime(send->recv))) {
         return false;
     }
 

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -78,34 +78,34 @@ vector<ast::TreePtr> processStat(core::MutableContext ctx, ast::ClassDef *klass,
 
     auto *rhs = ast::cast_tree<ast::Send>(asgn->rhs);
     if (rhs == nullptr) {
-        return badConst(ctx, stat->loc, klass->loc);
+        return badConst(ctx, stat.loc(), klass->loc);
     }
 
     if (rhs->fun != core::Names::selfNew() && rhs->fun != core::Names::let()) {
-        return badConst(ctx, stat->loc, klass->loc);
+        return badConst(ctx, stat.loc(), klass->loc);
     }
 
     if (rhs->fun == core::Names::selfNew() && !ast::MK::isMagicClass(rhs->recv)) {
-        return badConst(ctx, stat->loc, klass->loc);
+        return badConst(ctx, stat.loc(), klass->loc);
     }
 
     if (rhs->fun == core::Names::let()) {
         auto recv = ast::cast_tree<ast::UnresolvedConstantLit>(rhs->recv);
         if (recv == nullptr) {
-            return badConst(ctx, stat->loc, klass->loc);
+            return badConst(ctx, stat.loc(), klass->loc);
         }
 
         if (rhs->args.size() != 2) {
-            return badConst(ctx, stat->loc, klass->loc);
+            return badConst(ctx, stat.loc(), klass->loc);
         }
 
         auto arg0 = ast::cast_tree<ast::Send>(rhs->args[0]);
         if (arg0 == nullptr) {
-            return badConst(ctx, stat->loc, klass->loc);
+            return badConst(ctx, stat.loc(), klass->loc);
         }
 
         if (!ast::MK::isSelfNew(arg0)) {
-            return badConst(ctx, stat->loc, klass->loc);
+            return badConst(ctx, stat.loc(), klass->loc);
         }
     }
 
@@ -116,7 +116,7 @@ vector<ast::TreePtr> processStat(core::MutableContext ctx, ast::ClassDef *klass,
     // So we're good to process this thing as a new T::Enum value.
 
     if (fromWhere != FromWhere::Inside) {
-        if (auto e = ctx.beginError(stat->loc, core::errors::Rewriter::TEnumOutsideEnumsDo)) {
+        if (auto e = ctx.beginError(stat.loc(), core::errors::Rewriter::TEnumOutsideEnumsDo)) {
             e.setHeader("Definition of enum value `{}` must be within the `{}` block for this `{}`",
                         lhs->cnst.show(ctx), "enums do", "T::Enum");
             e.addErrorLine(klass->declLoc, "Enclosing definition here");
@@ -128,7 +128,7 @@ vector<ast::TreePtr> processStat(core::MutableContext ctx, ast::ClassDef *klass,
     ast::ClassDef::ANCESTORS_store parent;
     parent.emplace_back(klass->name.deepCopy());
     ast::ClassDef::RHS_store classRhs;
-    auto classDef = ast::MK::Class(stat->loc, core::Loc(ctx.file, stat->loc), classCnst.deepCopy(), std::move(parent),
+    auto classDef = ast::MK::Class(stat.loc(), core::Loc(ctx.file, stat.loc()), classCnst.deepCopy(), std::move(parent),
                                    std::move(classRhs));
 
     ast::Send::ARGS_store args;
@@ -149,10 +149,10 @@ vector<ast::TreePtr> processStat(core::MutableContext ctx, ast::ClassDef *klass,
     ast::Send::Flags flags = {};
     flags.isPrivateOk = true;
     auto singletonAsgn = ast::MK::Assign(
-        stat->loc, std::move(asgn->lhs),
+        stat.loc(), std::move(asgn->lhs),
         ast::MK::Send2(
-            stat->loc, ast::MK::Constant(stat->loc, core::Symbols::T()), core::Names::uncheckedLet(),
-            ast::MK::Send(stat->loc, classCnst.deepCopy(), core::Names::new_(), numPosArgs, std::move(args), flags),
+            stat.loc(), ast::MK::Constant(stat.loc(), core::Symbols::T()), core::Names::uncheckedLet(),
+            ast::MK::Send(stat.loc(), classCnst.deepCopy(), core::Names::new_(), numPosArgs, std::move(args), flags),
             std::move(classCnst)));
     vector<ast::TreePtr> result;
     result.emplace_back(std::move(classDef));

--- a/rewriter/TypeMembers.cc
+++ b/rewriter/TypeMembers.cc
@@ -20,7 +20,7 @@ void TypeMembers::run(core::MutableContext ctx, ast::ClassDef *cdef) {
         }
 
         auto rhs = ast::cast_tree<ast::Send>(assn->rhs);
-        if (!rhs || !rhs->recv->isSelfReference() || rhs->fun != core::Names::typeMember()) {
+        if (!rhs || !rhs->recv.isSelfReference() || rhs->fun != core::Names::typeMember()) {
             continue;
         }
 

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -239,7 +239,7 @@ ast::TreePtr ASTUtil::thunkBody(core::MutableContext ctx, ast::TreePtr &node) {
         return nullptr;
     }
     // Valid receivers for lambda/proc are either a self reference or `Kernel`
-    if (!send->recv->isSelfReference() && !isKernel(send->recv)) {
+    if (!send->recv.isSelfReference() && !isKernel(send->recv)) {
         return nullptr;
     }
     if (send->block == nullptr) {

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -243,7 +243,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         }
 
         handler.addObserved(*gs, "desugar-tree", [&]() { return desugared.tree->toString(*gs); });
-        handler.addObserved(*gs, "desugar-tree-raw", [&]() { return desugared.tree->showRaw(*gs); });
+        handler.addObserved(*gs, "desugar-tree-raw", [&]() { return desugared.tree.showRaw(*gs); });
 
         ast::ParsedFile localNamed;
 
@@ -259,13 +259,13 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             }
 
             handler.addObserved(*gs, "rewrite-tree", [&]() { return rewriten.tree->toString(*gs); });
-            handler.addObserved(*gs, "rewrite-tree-raw", [&]() { return rewriten.tree->showRaw(*gs); });
+            handler.addObserved(*gs, "rewrite-tree-raw", [&]() { return rewriten.tree.showRaw(*gs); });
 
             core::MutableContext ctx(*gs, core::Symbols::root(), desugared.file);
             localNamed = testSerialize(*gs, local_vars::LocalVars::run(ctx, move(rewriten)));
 
             handler.addObserved(*gs, "index-tree", [&]() { return localNamed.tree->toString(*gs); });
-            handler.addObserved(*gs, "index-tree-raw", [&]() { return localNamed.tree->showRaw(*gs); });
+            handler.addObserved(*gs, "index-tree-raw", [&]() { return localNamed.tree.showRaw(*gs); });
         } else {
             core::MutableContext ctx(*gs, core::Symbols::root(), desugared.file);
             localNamed = testSerialize(*gs, local_vars::LocalVars::run(ctx, move(desugared)));
@@ -298,7 +298,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         }
 
         handler.addObserved(*gs, "name-tree", [&]() { return namedTree.tree->toString(*gs); });
-        handler.addObserved(*gs, "name-tree-raw", [&]() { return namedTree.tree->showRaw(*gs); });
+        handler.addObserved(*gs, "name-tree-raw", [&]() { return namedTree.tree.showRaw(*gs); });
 
         tree = move(namedTree);
     }
@@ -338,7 +338,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     for (auto &resolvedTree : trees) {
         handler.addObserved(*gs, "resolve-tree", [&]() { return resolvedTree.tree->toString(*gs); });
-        handler.addObserved(*gs, "resolve-tree-raw", [&]() { return resolvedTree.tree->showRaw(*gs); });
+        handler.addObserved(*gs, "resolve-tree-raw", [&]() { return resolvedTree.tree.showRaw(*gs); });
     }
 
     // Simulate what pipeline.cc does: We want to start typeckecking big files first because it helps with better work
@@ -357,7 +357,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         resolvedTree = class_flatten::runOne(ctx, move(resolvedTree));
 
         handler.addObserved(*gs, "flatten-tree", [&]() { return resolvedTree.tree->toString(*gs); });
-        handler.addObserved(*gs, "flatten-tree-raw", [&]() { return resolvedTree.tree->showRaw(*gs); });
+        handler.addObserved(*gs, "flatten-tree-raw", [&]() { return resolvedTree.tree.showRaw(*gs); });
 
         // Don't run typecheck on RBI files.
         if (resolvedTree.file.data(ctx).isRBI()) {
@@ -495,17 +495,17 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         core::MutableContext ctx(*gs, core::Symbols::root(), f.file);
         ast::ParsedFile file = testSerialize(*gs, ast::ParsedFile{ast::desugar::node2Tree(ctx, move(nodes)), f.file});
         handler.addObserved(*gs, "desguar-tree", [&]() { return file.tree->toString(*gs); });
-        handler.addObserved(*gs, "desugar-tree-raw", [&]() { return file.tree->showRaw(*gs); });
+        handler.addObserved(*gs, "desugar-tree-raw", [&]() { return file.tree.showRaw(*gs); });
 
         // Rewriter pass
         file = testSerialize(*gs, ast::ParsedFile{rewriter::Rewriter::run(ctx, move(file.tree)), file.file});
         handler.addObserved(*gs, "rewrite-tree", [&]() { return file.tree->toString(*gs); });
-        handler.addObserved(*gs, "rewrite-tree-raw", [&]() { return file.tree->showRaw(*gs); });
+        handler.addObserved(*gs, "rewrite-tree-raw", [&]() { return file.tree.showRaw(*gs); });
 
         // local vars
         file = testSerialize(*gs, local_vars::LocalVars::run(ctx, move(file)));
         handler.addObserved(*gs, "index-tree", [&]() { return file.tree->toString(*gs); });
-        handler.addObserved(*gs, "index-tree-raw", [&]() { return file.tree->showRaw(*gs); });
+        handler.addObserved(*gs, "index-tree-raw", [&]() { return file.tree.showRaw(*gs); });
 
         newTrees.emplace_back(move(file));
     }
@@ -528,7 +528,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             tree = testSerialize(*gs, move(vTmp[0]));
 
             handler.addObserved(*gs, "name-tree", [&]() { return tree.tree->toString(*gs); });
-            handler.addObserved(*gs, "name-tree-raw", [&]() { return tree.tree->showRaw(*gs); });
+            handler.addObserved(*gs, "name-tree-raw", [&]() { return tree.tree.showRaw(*gs); });
         }
     }
 
@@ -537,7 +537,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     for (auto &resolvedTree : trees) {
         handler.addObserved(*gs, "resolve-tree", [&]() { return resolvedTree.tree->toString(*gs); });
-        handler.addObserved(*gs, "resolve-tree-raw", [&]() { return resolvedTree.tree->showRaw(*gs); });
+        handler.addObserved(*gs, "resolve-tree-raw", [&]() { return resolvedTree.tree.showRaw(*gs); });
     }
 
     handler.checkExpectations("[stress-incremental] ");

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -242,7 +242,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             desugared = testSerialize(*gs, ast::ParsedFile{ast::desugar::node2Tree(ctx, move(nodes)), file});
         }
 
-        handler.addObserved(*gs, "desugar-tree", [&]() { return desugared.tree->toString(*gs); });
+        handler.addObserved(*gs, "desugar-tree", [&]() { return desugared.tree.toString(*gs); });
         handler.addObserved(*gs, "desugar-tree-raw", [&]() { return desugared.tree.showRaw(*gs); });
 
         ast::ParsedFile localNamed;
@@ -258,13 +258,13 @@ TEST_CASE("PerPhaseTest") { // NOLINT
                     *gs, ast::ParsedFile{rewriter::Rewriter::run(ctx, move(desugared.tree)), desugared.file});
             }
 
-            handler.addObserved(*gs, "rewrite-tree", [&]() { return rewriten.tree->toString(*gs); });
+            handler.addObserved(*gs, "rewrite-tree", [&]() { return rewriten.tree.toString(*gs); });
             handler.addObserved(*gs, "rewrite-tree-raw", [&]() { return rewriten.tree.showRaw(*gs); });
 
             core::MutableContext ctx(*gs, core::Symbols::root(), desugared.file);
             localNamed = testSerialize(*gs, local_vars::LocalVars::run(ctx, move(rewriten)));
 
-            handler.addObserved(*gs, "index-tree", [&]() { return localNamed.tree->toString(*gs); });
+            handler.addObserved(*gs, "index-tree", [&]() { return localNamed.tree.toString(*gs); });
             handler.addObserved(*gs, "index-tree-raw", [&]() { return localNamed.tree.showRaw(*gs); });
         } else {
             core::MutableContext ctx(*gs, core::Symbols::root(), desugared.file);
@@ -281,7 +281,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         // Packager runs over all trees.
         trees = packager::Packager::run(*gs, *workers, move(trees));
         for (auto &tree : trees) {
-            handler.addObserved(*gs, "package-tree", [&]() { return tree.tree->toString(*gs); });
+            handler.addObserved(*gs, "package-tree", [&]() { return tree.tree.toString(*gs); });
         }
     }
 
@@ -297,7 +297,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             namedTree = testSerialize(*gs, move(vTmp[0]));
         }
 
-        handler.addObserved(*gs, "name-tree", [&]() { return namedTree.tree->toString(*gs); });
+        handler.addObserved(*gs, "name-tree", [&]() { return namedTree.tree.toString(*gs); });
         handler.addObserved(*gs, "name-tree-raw", [&]() { return namedTree.tree.showRaw(*gs); });
 
         tree = move(namedTree);
@@ -337,7 +337,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     handler.addObserved(*gs, "symbol-table-raw", [&]() { return gs->showRaw(); });
 
     for (auto &resolvedTree : trees) {
-        handler.addObserved(*gs, "resolve-tree", [&]() { return resolvedTree.tree->toString(*gs); });
+        handler.addObserved(*gs, "resolve-tree", [&]() { return resolvedTree.tree.toString(*gs); });
         handler.addObserved(*gs, "resolve-tree-raw", [&]() { return resolvedTree.tree.showRaw(*gs); });
     }
 
@@ -356,7 +356,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
         resolvedTree = class_flatten::runOne(ctx, move(resolvedTree));
 
-        handler.addObserved(*gs, "flatten-tree", [&]() { return resolvedTree.tree->toString(*gs); });
+        handler.addObserved(*gs, "flatten-tree", [&]() { return resolvedTree.tree.toString(*gs); });
         handler.addObserved(*gs, "flatten-tree-raw", [&]() { return resolvedTree.tree.showRaw(*gs); });
 
         // Don't run typecheck on RBI files.
@@ -494,17 +494,17 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
         core::MutableContext ctx(*gs, core::Symbols::root(), f.file);
         ast::ParsedFile file = testSerialize(*gs, ast::ParsedFile{ast::desugar::node2Tree(ctx, move(nodes)), f.file});
-        handler.addObserved(*gs, "desguar-tree", [&]() { return file.tree->toString(*gs); });
+        handler.addObserved(*gs, "desguar-tree", [&]() { return file.tree.toString(*gs); });
         handler.addObserved(*gs, "desugar-tree-raw", [&]() { return file.tree.showRaw(*gs); });
 
         // Rewriter pass
         file = testSerialize(*gs, ast::ParsedFile{rewriter::Rewriter::run(ctx, move(file.tree)), file.file});
-        handler.addObserved(*gs, "rewrite-tree", [&]() { return file.tree->toString(*gs); });
+        handler.addObserved(*gs, "rewrite-tree", [&]() { return file.tree.toString(*gs); });
         handler.addObserved(*gs, "rewrite-tree-raw", [&]() { return file.tree.showRaw(*gs); });
 
         // local vars
         file = testSerialize(*gs, local_vars::LocalVars::run(ctx, move(file)));
-        handler.addObserved(*gs, "index-tree", [&]() { return file.tree->toString(*gs); });
+        handler.addObserved(*gs, "index-tree", [&]() { return file.tree.toString(*gs); });
         handler.addObserved(*gs, "index-tree-raw", [&]() { return file.tree.showRaw(*gs); });
 
         newTrees.emplace_back(move(file));
@@ -514,7 +514,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     if (enablePackager) {
         trees = packager::Packager::runIncremental(*gs, move(trees));
         for (auto &tree : trees) {
-            handler.addObserved(*gs, "package-tree", [&]() { return tree.tree->toString(*gs); });
+            handler.addObserved(*gs, "package-tree", [&]() { return tree.tree.toString(*gs); });
         }
     }
 
@@ -527,7 +527,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             vTmp = move(namer::Namer::run(*gs, move(vTmp), *workers).result());
             tree = testSerialize(*gs, move(vTmp[0]));
 
-            handler.addObserved(*gs, "name-tree", [&]() { return tree.tree->toString(*gs); });
+            handler.addObserved(*gs, "name-tree", [&]() { return tree.tree.toString(*gs); });
             handler.addObserved(*gs, "name-tree-raw", [&]() { return tree.tree.showRaw(*gs); });
         }
     }
@@ -536,7 +536,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     trees = move(resolver::Resolver::runTreePasses(*gs, move(trees)).result());
 
     for (auto &resolvedTree : trees) {
-        handler.addObserved(*gs, "resolve-tree", [&]() { return resolvedTree.tree->toString(*gs); });
+        handler.addObserved(*gs, "resolve-tree", [&]() { return resolvedTree.tree.toString(*gs); });
         handler.addObserved(*gs, "resolve-tree-raw", [&]() { return resolvedTree.tree.showRaw(*gs); });
     }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
* Change `CFGBuilder::walk` to operate over `TreePtr` instead of `Expression *`
* Make `nodeName` a method declared on each concrete Tree, and dispatch on the `TreePtr` tag to decide which implementation to call
* Move `isSelfReference` to `TreePtr`
* Move `toString` and `showRaw` to `TreePtr`
* Move `loc` to individual nodes, and add `loc()` on `TreePtr`

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Continue removing methods from the Expression vtable, with the eventual goal of having it be completely empty.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
