### PR TITLE
Fix the DefaultArgs pass for deepCopy changes

### DIFF
--- a/rewriter/DefaultArgs.cc
+++ b/rewriter/DefaultArgs.cc
@@ -93,7 +93,7 @@ class DefaultArgsWalk {
                 if (!retType) {
                     return ast::MK::EmptyTree();
                 }
-                send->args[0] = retType->deepCopy();
+                send->args[0] = retType.deepCopy();
             }
 
             auto recv = ast::cast_tree<ast::Send>(send->recv);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Fix the merge race between the DefaultArgs pr and the deepCopy changes.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.