### PR TITLE
Updates Dir#[] signature to match documentation (fixes #1822)

### DIFF
--- a/rbi/core/dir.rbi
+++ b/rbi/core/dir.rbi
@@ -567,18 +567,10 @@ class Dir < Object
   # Equivalent to calling `Dir.glob([string,...], 0)`.
   sig do
     params(
-        pattern: T.any(String, T::Array[String]),
-        flags: Integer,
+        pattern: String,
+        base: T.nilable(String)
     )
     .returns(T::Array[String])
   end
-  sig do
-    params(
-        pattern: T.any(String, T::Array[String]),
-        flags: Integer,
-        blk: T.proc.params(arg0: String).returns(BasicObject),
-    )
-    .returns(NilClass)
-  end
-  def self.[](pattern, flags=T.unsafe(nil), &blk); end
+  def self.[](*pattern, base: nil); end
 end

--- a/rbi/core/dir.rbi
+++ b/rbi/core/dir.rbi
@@ -567,10 +567,11 @@ class Dir < Object
   # Equivalent to calling `Dir.glob([string,...], 0)`.
   sig do
     params(
-        pattern: String,
-        base: T.nilable(String)
+        pattern: T.any(String, Pathname),
+        base: T.nilable(T.any(String, Pathname)),
+        blk: T.nilable(T.proc.params(arg0: String).returns(BasicObject))
     )
     .returns(T::Array[String])
   end
-  def self.[](*pattern, base: nil); end
+  def self.[](*pattern, base: nil, &blk); end
 end

--- a/test/testdata/rbi/dir.rb
+++ b/test/testdata/rbi/dir.rb
@@ -6,4 +6,7 @@ sig {returns(T::Array[String])}
 def test_dir_brackets
   Dir['a', 'b']
   Dir['a', base: '.']
+  Dir['/*'] do |match|
+  end
+  Dir[Pathname.new('.')]
 end

--- a/test/testdata/rbi/dir.rb
+++ b/test/testdata/rbi/dir.rb
@@ -7,6 +7,7 @@ def test_dir_brackets
   Dir['a', 'b']
   Dir['a', base: '.']
   Dir['/*'] do |match|
+    T.assert_type!(match, String)
   end
   Dir[Pathname.new('.')]
 end

--- a/test/testdata/rbi/dir.rb
+++ b/test/testdata/rbi/dir.rb
@@ -1,0 +1,9 @@
+# typed: strict
+
+extend T::Sig
+
+sig {returns(T::Array[String])}
+def test_dir_brackets
+  Dir['a', 'b']
+  Dir['a', base: '.']
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

To fix #1822, where multiple string arguments caused a type checking error.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. The new test was failing because the signatures did not match the documentation for `Dir#[]`.
