### PR TITLE
`require_relative` accepts a String or a Pathname

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -1974,7 +1974,7 @@ module Kernel
   # If a file is loaded `true` is returned and false otherwise.
   sig do
     params(
-        feature: String,
+        feature: T.any(String, Pathname)
     )
     .returns(T::Boolean)
   end


### PR DESCRIPTION
Allows you to do things like `require_relative Rails.root.join("foo", "bar.rb")` without having to call `.to_s` on the end.
