### PR TITLE
Fix comment of T::Enum.values

### DIFF
--- a/rbi/core/enum.rbi
+++ b/rbi/core/enum.rbi
@@ -4,6 +4,8 @@ class T::Enum
   extend T::Props::CustomType
 
   ## Enum class methods ##
+
+  # All the values defined in the Enum class
   sig {returns(T::Array[T.attached_class])}
   def self.values; end
 


### PR DESCRIPTION
### Motivation
The comment about the section above the method is currently interpreted as the docs for it. It's also interpreted by Markdown parsers as a title :(

<img width="490" alt="Screen Shot 2020-07-09 at 6 38 08 PM" src="https://user-images.githubusercontent.com/104916/87104170-50442880-c214-11ea-901c-32d8961c705e.png"> 
