### PR TITLE
Desugar &. calls to use NilClass.===

### DIFF
--- a/test/testdata/desugar/blockpass.rb.desugar-tree.exp
+++ b/test/testdata/desugar/blockpass.rb.desugar-tree.exp
@@ -62,7 +62,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
       begin
         <assignTemp>$4 = <emptyTree>::<C CallsWithObject>
-        if <assignTemp>$4.==(nil)
+        if ::NilClass.===(<assignTemp>$4)
           nil
         else
           <assignTemp>$4.calls_with_object() do |<block-pass>$5|

--- a/test/testdata/desugar/csend.rb.desugar-tree.exp
+++ b/test/testdata/desugar/csend.rb.desugar-tree.exp
@@ -3,7 +3,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     begin
       begin
         <assignTemp>$2 = <self>.foo()
-        if <assignTemp>$2.==(nil)
+        if ::NilClass.===(<assignTemp>$2)
           nil
         else
           <assignTemp>$2.bar()
@@ -11,7 +11,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
       begin
         <assignTemp>$3 = <self>.foo()
-        if <assignTemp>$3.==(nil)
+        if ::NilClass.===(<assignTemp>$3)
           nil
         else
           <assignTemp>$3.bar() do |x|
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
       begin
         <assignTemp>$4 = <self>.foo()
-        if <assignTemp>$4.==(nil)
+        if ::NilClass.===(<assignTemp>$4)
           nil
         else
           <assignTemp>$4.bar=(5)
@@ -29,7 +29,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
       begin
         <assignTemp>$5 = <self>.foo()
-        if <assignTemp>$5.==(nil)
+        if ::NilClass.===(<assignTemp>$5)
           nil
         else
           begin
@@ -40,7 +40,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
       begin
         <assignTemp>$7 = <self>.foo()
-        if <assignTemp>$7.==(nil)
+        if ::NilClass.===(<assignTemp>$7)
           nil
         else
           begin
@@ -56,7 +56,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
       begin
         <assignTemp>$10 = <self>.foo()
-        if <assignTemp>$10.==(nil)
+        if ::NilClass.===(<assignTemp>$10)
           nil
         else
           begin
@@ -75,7 +75,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   begin
     <assignTemp>$2 = <emptyTree>::<C BasicObject>.new()
-    if <assignTemp>$2.==(nil)
+    if ::NilClass.===(<assignTemp>$2)
       nil
     else
       <assignTemp>$2.__id__()
@@ -92,7 +92,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def foo<<C <todo sym>>>(x, &<blk>)
       begin
         <assignTemp>$2 = x
-        if <assignTemp>$2.==(nil)
+        if ::NilClass.===(<assignTemp>$2)
           nil
         else
           <assignTemp>$2.|(true)

--- a/test/testdata/infer/control_flow/csend_and.rb
+++ b/test/testdata/infer/control_flow/csend_and.rb
@@ -7,7 +7,7 @@ class Test
     .returns(T.nilable(String))
   end
   def message(failures)
-    failure = failures&.first
+    failure = failures.first
     T.assert_type!(failure && failure['message'], T.nilable(String))
   end
 end

--- a/test/testdata/lsp/hover_ampersand_operations.rb
+++ b/test/testdata/lsp/hover_ampersand_operations.rb
@@ -18,13 +18,6 @@ def main
                     # ^ hover: sig {returns(String)}
 
   # Safenav
-  dog = Dog.new
-  breed = dog&.breed
-# ^ hover: T.nilable(String)
-        # ^ hover: Dog
-            # ^ hover: sig {returns(String)}
-             # ^ hover: sig {returns(String)}
-  
   maybeDog = T.let(nil, T.nilable(Dog))
   maybeBreed = maybeDog&.breed
 # ^ hover: T.nilable(String)

--- a/test/testdata/lsp/hover_ampersand_operations.rb
+++ b/test/testdata/lsp/hover_ampersand_operations.rb
@@ -18,6 +18,12 @@ def main
                     # ^ hover: sig {returns(String)}
 
   # Safenav
+  dog = Dog.new
+  breed = dog&.breed # error: This code is unreachable
+# ^ hover: String
+        # ^ hover: Dog
+            # ^ hover: sig {returns(String)}
+
   maybeDog = T.let(nil, T.nilable(Dog))
   maybeBreed = maybeDog&.breed
 # ^ hover: T.nilable(String)


### PR DESCRIPTION
This is an optimization that avoids potentially calling into an
arbitrary `==` for the object in which the safe navigation is being
used.

Fixes #3276