### PR TITLE
ruby27: Reject circular argument reference.

### DIFF
--- a/test/testdata/infer/overloads_test.rb
+++ b/test/testdata/infer/overloads_test.rb
@@ -34,7 +34,7 @@ class HasOverloads
     )
     .returns(Symbol)
   end
-  def overloaded(_=_, _1=_, _2=_);
+  def overloaded(_=_0, _1=_, _2=_);
     make_untyped
   end
 

--- a/test/whitequark/test_circular_argument_reference_error_0.rb
+++ b/test/whitequark/test_circular_argument_reference_error_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def m(foo = foo) end # error: circular argument reference foo

--- a/test/whitequark/test_circular_argument_reference_error_1.rb
+++ b/test/whitequark/test_circular_argument_reference_error_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def m(foo: foo) end # error: circular argument reference foo

--- a/test/whitequark/test_circular_argument_reference_error_2.rb
+++ b/test/whitequark/test_circular_argument_reference_error_2.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+m { |foo = foo| }  # error: circular argument reference foo

--- a/test/whitequark/test_circular_argument_reference_error_3.rb
+++ b/test/whitequark/test_circular_argument_reference_error_3.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+m { |foo: foo| }  # error: circular argument reference foo

--- a/test/whitequark/test_circular_argument_reference_error_4.rb
+++ b/test/whitequark/test_circular_argument_reference_error_4.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def m(foo = class << foo; end) end # error: circular argument reference foo

--- a/test/whitequark/test_circular_argument_reference_error_5.rb
+++ b/test/whitequark/test_circular_argument_reference_error_5.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def m(foo = def foo.m; end); end # error: circular argument reference foo

--- a/test/whitequark/test_circular_argument_reference_error_6.rb
+++ b/test/whitequark/test_circular_argument_reference_error_6.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+m { |foo = proc { 1 + foo }| }  # error: circular argument reference foo

--- a/third_party/parser/cc/grammars/typedruby.ypp
+++ b/third_party/parser/cc/grammars/typedruby.ypp
@@ -1598,6 +1598,7 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby27 &driver) {
                       driver.lex.cmdarg.push(false);
                       driver.lex.cond.push(false);
                       driver.lex.context.push(Context::State::DEF);
+                      driver.current_arg_stack.push("");
                     }
                     f_arglist bodystmt kEND
                     {
@@ -1607,6 +1608,7 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby27 &driver) {
                       driver.lex.cond.pop();
                       driver.lex.unextend();
                       driver.lex.context.pop();
+                      driver.current_arg_stack.pop();
                     }
                 | kDEF singleton dot_or_colon
                     {
@@ -1618,6 +1620,7 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby27 &driver) {
                       driver.lex.cmdarg.push(false);
                       driver.lex.cond.push(false);
                       driver.lex.context.push(Context::State::DEFS);
+                      driver.current_arg_stack.push("");
                     }
                     f_arglist bodystmt kEND
                     {
@@ -1628,6 +1631,7 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby27 &driver) {
                       driver.lex.cond.pop();
                       driver.lex.unextend();
                       driver.lex.context.pop();
+                      driver.current_arg_stack.pop();
                     }
                 | kBREAK
                     {
@@ -1909,6 +1913,7 @@ opt_block_args_tail:
  block_param_def: tPIPE opt_bv_decl tPIPE
                     {
                       $$ = driver.build.args(self, $1, $2, $3, true);
+                      driver.current_arg_stack.set("");
                       DIAGCHECK();
                     }
                 | tOROP
@@ -1920,6 +1925,7 @@ opt_block_args_tail:
                     {
                       auto &params = $2;
                       params->concat($3);
+                      driver.current_arg_stack.set("");
                       $$ = driver.build.args(self, $1, params, $4, true);
                       DIAGCHECK();
                     }
@@ -2751,11 +2757,13 @@ keyword_variable: kNIL
 
       f_arg_asgn: f_norm_arg
                     {
+                      driver.current_arg_stack.set($1[0].string());
                       $$ = $1;
                     }
 
       f_arg_item: f_arg_asgn
                     {
+                      driver.current_arg_stack.set("0");
                       $$ = driver.build.arg(self, $1);
                     }
                 | tLPAREN f_margs rparen
@@ -2782,15 +2790,18 @@ keyword_variable: kNIL
                         YYERROR;
                       }
                       driver.lex.declare(label->string());
+                      driver.current_arg_stack.set($1[0].string());
                       $$ = label;
                     }
 
             f_kw: f_label arg_value
                     {
+                      driver.current_arg_stack.set("");
                       $$ = driver.build.kwoptarg(self, $1, $2);
                     }
                 | f_label
                     {
+                      driver.current_arg_stack.set("");
                       $$ = driver.build.kwarg(self, $1);
                     }
 
@@ -2846,11 +2857,13 @@ keyword_variable: kNIL
 
            f_opt: f_arg_asgn tEQL arg_value
                     {
+                      driver.current_arg_stack.set("0");
                       $$ = driver.build.optarg(self, $1, $2, $3);
                     }
 
      f_block_opt: f_arg_asgn tEQL primary_value
                     {
+                      driver.current_arg_stack.set("0");
                       $$ = driver.build.optarg(self, $1, $2, $3);
                     }
 

--- a/third_party/parser/codegen/generate_diagnostics.cc
+++ b/third_party/parser/codegen/generate_diagnostics.cc
@@ -57,6 +57,7 @@ tuple<string, string> MESSAGES[] = {
     {"InvalidRegexp", "{}"},
     {"InvalidReturn", "Invalid return in class/module body"},
     {"CSendInLHSOfMAsgn", "&. inside multiple assignment destination"},
+    {"CircularArgumentReference", "circular argument reference {}"},
 
     // Parser warnings
     {"UselessElse", "else without rescue is useless"},

--- a/third_party/parser/include/ruby_parser/driver.hh
+++ b/third_party/parser/include/ruby_parser/driver.hh
@@ -117,12 +117,50 @@ public:
     }
 };
 
+/*
+ * Stack that holds names of current arguments,
+ * i.e. while parsing
+ *   def m1(a = (def m2(b = def m3(c = 1); end); end)); end
+ *                                   ^
+ * stack is [:a, :b, :c]
+ *
+ * Emulates `p->cur_arg` in MRI's parse.y
+ */
+class current_arg_stack {
+    std::vector<std::string> stack;
+
+public:
+    void push(std::string value) {
+        stack.push_back(value);
+    }
+
+    void set(std::string value) {
+        pop();
+        push(value);
+    }
+
+    void pop() {
+        if (!stack.empty()) {
+            stack.pop_back();
+        }
+    }
+
+    void reset() {
+        stack.clear();
+    }
+
+    std::string top() {
+        return stack.empty() ? "" : stack.back();
+    }
+};
+
 class base_driver {
 public:
     diagnostics_t diagnostics;
     const builder &build;
     lexer lex;
     mempool alloc;
+    current_arg_stack current_arg_stack;
 
     bool pending_error;
     size_t def_level;


### PR DESCRIPTION
### Motivation

Since https://github.com/ruby/ruby/pull/2569 circular argument references are considered errors instead of warning.

This pull-request reflects that change in Sorbet's parser.

### Test plan

See included automated tests.
