### PR TITLE
Allow NilClass for logdev

### DIFF
--- a/rbi/stdlib/logger.rbi
+++ b/rbi/stdlib/logger.rbi
@@ -429,7 +429,7 @@ class Logger
 
   sig do
     params(
-      logdev: T.any(String, IO, StringIO),
+      logdev: T.any(String, IO, NilClass),
       shift_age: Integer,
       shift_size: Integer,
       level: Integer,

--- a/rbi/stdlib/logger.rbi
+++ b/rbi/stdlib/logger.rbi
@@ -429,7 +429,7 @@ class Logger
 
   sig do
     params(
-      logdev: T.any(String, IO, NilClass),
+      logdev: T.any(String, IO, StringIO, NilClass),
       shift_age: Integer,
       shift_size: Integer,
       level: Integer,


### PR DESCRIPTION
Updating the RBI definition for `logdev` to be in accordance with its [documentation](https://github.com/ruby/logger/blob/master/lib/logger.rb#L351), which allows for `nil` as a parameter. 

Fixes #3149.
