### PR TITLE
Uniformize case for parser error messages

### DIFF
--- a/test/whitequark/test_return_in_class_0.rb
+++ b/test/whitequark/test_return_in_class_0.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-class A; return; end # error: Invalid return in class/module body
+class A; return; end # error: invalid return in class/module body

--- a/third_party/parser/codegen/generate_diagnostics.cc
+++ b/third_party/parser/codegen/generate_diagnostics.cc
@@ -55,7 +55,7 @@ tuple<string, string> MESSAGES[] = {
     {"MasgnAsCondition", "multiple assignment in conditional context"},
     {"BlockGivenToYield", "block given to yield"},
     {"InvalidRegexp", "{}"},
-    {"InvalidReturn", "Invalid return in class/module body"},
+    {"InvalidReturn", "invalid return in class/module body"},
     {"CSendInLHSOfMAsgn", "&. inside multiple assignment destination"},
 
     // Parser warnings
@@ -69,7 +69,7 @@ tuple<string, string> MESSAGES[] = {
     {"Clobbered", "clobbered by: {}"},
 
     // TypedRuby diagnostics
-    {"NotStaticCpathInGeninst", "Type name in generic instance must be a static constant path"},
+    {"NotStaticCpathInGeninst", "type name in generic instance must be a static constant path"},
 };
 
 void generateDclass() {


### PR DESCRIPTION
### Motivation

Those were the only errors in the whole file to start by a capitalized letter.

### Test plan

See included automated tests.
