### PR TITLE
Adds Array#intersection definition

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1485,6 +1485,31 @@ class Array < Object
   sig {returns(String)}
   def inspect(); end
 
+
+  # [`Set`](https://docs.ruby-lang.org/en/2.6.0/Set.html) Intersection ---
+  # Returns a new array containing unique elements common to the two arrays. The
+  # order is preserved from the original array.
+  #
+  # It compares elements using their
+  # [`hash`](https://docs.ruby-lang.org/en/2.6.0/Array.html#method-i-hash) and
+  # [`eql?`](https://docs.ruby-lang.org/en/2.6.0/Array.html#method-i-eql-3F)
+  # methods for efficiency.
+  #
+  # ```ruby
+  # [ 1, 1, 3, 5 ] & [ 3, 2, 1 ]                 #=> [ 1, 3 ]
+  # [ 'a', 'b', 'b', 'z' ] & [ 'a', 'b', 'c' ]   #=> [ 'a', 'b' ]
+  # ```
+  #
+  # See also
+  # [`Array#&`](https://docs.ruby-lang.org/en/2.7.0/Array.html#method-i-26).
+  sig do
+    params(
+      arrays: T::Array[T.untyped]
+    )
+    .returns(T::Array[Elem])
+  end
+  def intersection(*arrays); end
+
   # Returns a string created by converting each element of the array to a
   # string, separated by the given `separator`. If the `separator` is `nil`, it
   # uses current `$,`. If both the `separator` and `$,` are `nil`, it uses an


### PR DESCRIPTION
Adds method definition for `intersection` on Array, introduced by https://bugs.ruby-lang.org/issues/16155 in Ruby 2.7

### Motivation
Not having this defined throws undefined errors when the method is used on an Array with Ruby 2.7

Related: https://github.com/sorbet/sorbet/issues/2390

### Test plan
This definition and signature match similar methods already defined.

See included automated tests.
