### PR TITLE
Add definition for Enumerable#filter_map

### DIFF
--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -565,6 +565,24 @@ module Enumerable
   sig {returns(T::Enumerator[Elem])}
   def find_all(&blk); end
 
+  # Returns a new array containing the truthy results (everything except
+  # `false` or `nil`) of running the `block+ for every element in +enum+.
+  #
+  # If no block is given, an
+  # [`Enumerator`](https://docs.ruby-lang.org/en/2.6.0/Enumerator.html) is
+  # returned instead.
+  #
+  # ```ruby
+  # (1..10).filter_map { |i| i * 2 if i.even? } #=> [4, 8, 12, 16, 20]
+  # ```
+  sig do
+     type_parameters(:T)
+     .params(blk: T.proc.params(arg0: Elem).returns(T.any(NilClass, FalseClass, T.type_parameter(:T))))
+     .returns(T::Array[T.type_parameter(:T)])
+  end
+  sig {returns(T::Enumerator[Elem])}
+  def filter_map(&blk); end
+
   # Compares each entry in *enum* with *value* or passes to *block*. Returns the
   # index for the first for which the evaluated value is non-false. If no object
   # matches, returns `nil`

--- a/test/testdata/rbi/enumerable.rb
+++ b/test/testdata/rbi/enumerable.rb
@@ -19,6 +19,7 @@
 [1, 3, 20].sort_by {|n| [n.to_s, [1, 2]]}
 
 T.assert_type!([1].lazy, Enumerator::Lazy[Integer])
+T.assert_type!([1, 2].filter_map { |x| x.odd? ? x.to_f : x.to_s }, T::Array[T.any(Float, String)])
 
 # There are 3 different ways to call all?, any? and none?
 a = [1, 3, 20]


### PR DESCRIPTION
This method was added in Ruby 2.7.
See https://ruby-doc.org/core-2.7.1/Enumerable.html#method-i-filter_map.

### Motivation

The `filter_map` method was added in Ruby 2.7 and was not made available in Sorbet. Using it causes errors.

### Test plan

I added something. Does that test anything?
