### PR TITLE
Fix incorrect `json` sigs

### DIFF
--- a/rbi/stdlib/json.rbi
+++ b/rbi/stdlib/json.rbi
@@ -130,11 +130,12 @@ module JSON
   sig do
     params(
       obj: ::T.untyped,
-      args: ::T.untyped,
+      anIO: ::T.untyped,
+      limit: ::T.untyped,
     )
     .returns(::T.untyped)
   end
-  def self.dump(obj, *args); end
+  def self.dump(obj, anIO=T.unsafe(nil), limit=T.unsafe(nil)); end
 
   # The global default options for the
   # [`JSON.dump`](https://docs.ruby-lang.org/en/2.6.0/JSON.html#method-i-dump)
@@ -186,11 +187,11 @@ module JSON
   sig do
     params(
       obj: ::T.untyped,
-      args: ::T.untyped,
+      opts: ::T.untyped,
     )
     .returns(::T.untyped)
   end
-  def self.generate(obj, *args); end
+  def self.generate(obj, opts=T.unsafe(nil)); end
 
   # Returns the [`JSON`](https://docs.ruby-lang.org/en/2.6.0/JSON.html)
   # generator module that is used by
@@ -305,11 +306,11 @@ module JSON
   sig do
     params(
       obj: ::T.untyped,
-      args: ::T.untyped,
+      opts: ::T.untyped,
     )
     .returns(::T.untyped)
   end
-  def self.pretty_generate(obj, *args); end
+  def self.pretty_generate(obj, opts=T.unsafe(nil)); end
 
   sig do
     params(


### PR DESCRIPTION
We are trying to update to json 2.3 (from 1.8). We use tapioca. After updating `json` and re-running `tapioca` we got these 3 errors from `srb tc`:

```
sorbet/rbi/gems/json@2.3.1.rbi:31: Method JSON.dump redefined without matching argument count. Expected: 2, got: 3 https://srb.help/4010
    31 |  def self.dump(obj, anIO = _, limit = _); end
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    https://github.com/sorbet/sorbet/tree/576e1fe628309d57783b13d7d7c7e7c546060b49/rbi/stdlib/json.rbi#L137: Previous definition
     137 |  def self.dump(obj, *args); end
            ^^^^^^^^^^^^^^^^^^^^^^^^^

sorbet/rbi/gems/json@2.3.1.rbi:36: Method JSON.generate redefined with argument opts as a non-splat argument https://srb.help/4010
    36 |  def self.generate(obj, opts = _); end
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    https://github.com/sorbet/sorbet/tree/576e1fe628309d57783b13d7d7c7e7c546060b49/rbi/stdlib/json.rbi#L193: The corresponding argument args in the previous definition was a splat argument
     193 |  def self.generate(obj, *args); end
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

sorbet/rbi/gems/json@2.3.1.rbi:47: Method JSON.pretty_generate redefined with argument opts as a non-splat argument https://srb.help/4010
    47 |  def self.pretty_generate(obj, opts = _); end
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    https://github.com/sorbet/sorbet/tree/576e1fe628309d57783b13d7d7c7e7c546060b49/rbi/stdlib/json.rbi#L312: The corresponding argument args in the previous definition was a splat argument
     312 |  def self.pretty_generate(obj, *args); end
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

As far as I can tell, in every case tapioca's sig is correct, and matches the method sig in the json gem in versions [2.3.1](https://github.com/flori/json/blob/v2.3.1/lib/json/common.rb) and [1.8.6](https://github.com/flori/json/blob/v1.8.6/lib/json/common.rb). Therefore I am updating the rbis to match.
