### PR TITLE
runtime: Avoid allocation in T::Union#valid?

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/union.rb
+++ b/gems/sorbet-runtime/lib/types/types/union.rb
@@ -44,11 +44,7 @@ module T::Types
 
     # @override Base
     def valid?(obj)
-      @types.each do |type|
-        return true if type.valid?(obj)
-      end
-
-      false
+      @types.any? {|type| type.valid?(obj)}
     end
 
     # @override Base


### PR DESCRIPTION
Just use `any?` in `T::Union#valid?` instead of `each` with a `return false`.

Add tests that show that we now do zero allocations in `valid?` by default for T::Union and several other common runtime types.

### Motivation
I imagine the previous implementation of `valid?` was intended as an optimization, and in some older version of Ruby it might have been. But in Ruby 2.6, returning true from an inner block appears to require an allocation, while `Array#any?` has a direct C implementation which at the least shouldn't be slower than a manual loop: https://github.com/ruby/ruby/blob/a9a48e6a741f048766a2a287592098c4f6c7b7c7/array.c#L6191

### Test plan
See included automated tests.

(The test added for T::Union fails without this change.)