### PR TITLE
Flatten print of T.all

### DIFF
--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -154,114 +154,24 @@ string AndType::toStringWithTabs(const GlobalState &gs, int tabs) const {
                        rightBrace ? ")" : "");
 }
 
-/**
- * Metadata collected while traversing AndType for pretty-printing.
- */
-struct AndInfo {
-    /// True when the leaves of the AndType contains a NilClass.
-    bool containsNil{false};
+string showAnds(const GlobalState &, TypePtr, TypePtr);
 
-    /// True when the leaves of the AndType contains a FalseClass.
-    bool containsFalse{false};
-
-    /// True when the leaves of the AndType contains a TrueClass.
-    bool containsTrue{false};
-
-    /// True when the leaves of the AndType contains a type that is none of the
-    /// obove cases is present (Integer, for example).
-    bool containsOther{false};
-
-    /// True when there are more than one non-NilClass types present in the
-    /// leaves of the AndType.
-    bool containsMultiple{false};
-
-    bool isBoolean() const {
-        return containsTrue && containsFalse && !containsOther;
-    }
-
-    void markContainsMultiple() {
-        this->containsMultiple = true;
-    }
-
-    AndInfo() {}
-
-    static AndInfo nilInfo() {
-        AndInfo res;
-        res.containsNil = true;
-        return res;
-    }
-
-    static AndInfo trueInfo() {
-        AndInfo res;
-        res.containsTrue = true;
-        return res;
-    }
-
-    static AndInfo falseInfo() {
-        AndInfo res;
-        res.containsFalse = true;
-        return res;
-    }
-
-    static AndInfo otherInfo() {
-        AndInfo res;
-        res.containsOther = true;
-        return res;
-    }
-
-    static AndInfo merge(const AndInfo &left, const AndInfo &right) {
-        AndInfo res;
-        res.containsNil = left.containsNil || right.containsNil;
-        res.containsFalse = left.containsFalse || right.containsFalse;
-        res.containsTrue = left.containsTrue || right.containsTrue;
-        res.containsOther = left.containsOther || right.containsOther;
-        res.containsMultiple = left.containsMultiple || right.containsMultiple;
-        return res;
-    }
-};
-
-pair<AndInfo, optional<string>> showAnds(const GlobalState &, TypePtr, TypePtr);
-
-pair<AndInfo, optional<string>> showAndElem(const GlobalState &gs, TypePtr ty) {
-    if (auto classType = cast_type<ClassType>(ty.get())) {
-        if (classType->symbol == Symbols::NilClass()) {
-            return make_pair(AndInfo::nilInfo(), nullopt);
-        } else if (classType->symbol == Symbols::TrueClass()) {
-            return make_pair(AndInfo::trueInfo(), make_optional(classType->show(gs)));
-        } else if (classType->symbol == Symbols::FalseClass()) {
-            return make_pair(AndInfo::falseInfo(), make_optional(classType->show(gs)));
-        }
-    } else if (auto andType = cast_type<AndType>(ty.get())) {
+string showAndElem(const GlobalState &gs, TypePtr ty) {
+    if (auto andType = cast_type<AndType>(ty.get())) {
         return showAnds(gs, andType->left, andType->right);
     }
-
-    return make_pair(AndInfo::otherInfo(), make_optional(ty->show(gs)));
+    return ty->show(gs);
 }
 
-pair<AndInfo, optional<string>> showAnds(const GlobalState &gs, TypePtr left, TypePtr right) {
-    auto [leftInfo, leftStr] = showAndElem(gs, left);
-    auto [rightInfo, rightStr] = showAndElem(gs, right);
-
-    AndInfo merged = AndInfo::merge(leftInfo, rightInfo);
-
-    if (leftStr.has_value() && rightStr.has_value()) {
-        merged.markContainsMultiple();
-        return make_pair(merged, make_optional(fmt::format("{}, {}", *leftStr, *rightStr)));
-    } else if (leftStr.has_value()) {
-        return make_pair(merged, leftStr);
-    } else {
-        return make_pair(merged, rightStr);
-    }
+string showAnds(const GlobalState &gs, TypePtr left, TypePtr right) {
+    auto leftStr = showAndElem(gs, left);
+    auto rightStr = showAndElem(gs, right);
+    return fmt::format("{}, {}", leftStr, rightStr);
 }
 
 string AndType::show(const GlobalState &gs) const {
-    auto [info, str] = showAnds(gs, this->left, this->right);
-
-    if (info.containsMultiple) {
-        return fmt::format("T.all({})", *str);
-    } else {
-        return fmt::format("T.all({}, {})", this->left->show(gs), this->right->show(gs));
-    }
+    auto str = showAnds(gs, this->left, this->right);
+    return fmt::format("T.all({})", str);
 }
 
 string OrType::toStringWithTabs(const GlobalState &gs, int tabs) const {

--- a/test/testdata/infer/all_any.rb
+++ b/test/testdata/infer/all_any.rb
@@ -17,3 +17,6 @@ T.reveal_type(with_all) # error: Revealed type: `T.all(Foo, Bar)`
 
 with_all_more = T.let(T.unsafe(nil), T.all(Foo, Bar, Baz))
 T.reveal_type(with_all_more) # error: Revealed type: `T.all(Foo, Bar, Baz)`
+
+with_all_nested = T.let(T.unsafe(nil), T.all(Foo, T.all(Bar, Baz)))
+T.reveal_type(with_all_nested) # error: Revealed type: `T.all(Bar, Baz, Foo)`

--- a/test/testdata/infer/all_any.rb
+++ b/test/testdata/infer/all_any.rb
@@ -1,0 +1,19 @@
+# typed: true
+module Foo; end
+module Bar; end
+module Baz; end
+
+with_any = T.let(T.unsafe(nil), T.any(Foo, Bar))
+T.reveal_type(with_any) # error: Revealed type: `T.any(Foo, Bar)`
+
+with_any_more = T.let(T.unsafe(nil), T.any(Foo, Bar, Baz))
+T.reveal_type(with_any_more) # error: Revealed type: `T.any(Foo, Bar, Baz)`
+
+with_any_with_nilable = T.let(T.unsafe(nil), T.any(Foo, Bar, T.nilable(Baz)))
+T.reveal_type(with_any_with_nilable) # error: Revealed type: `T.nilable(T.any(Baz, Foo, Bar))`
+
+with_all = T.let(T.unsafe(nil), T.all(Foo, Bar))
+T.reveal_type(with_all) # error: Revealed type: `T.all(Foo, Bar)`
+
+with_all_more = T.let(T.unsafe(nil), T.all(Foo, Bar, Baz))
+T.reveal_type(with_all_more) # error: Revealed type: `T.all(Foo, Bar, Baz)`


### PR DESCRIPTION
This prevents types to be displayed as `T.all(T.all(A, B), C)`, and
uses the more natural `T.all(A, B, C)`.

This logic was being used for `T.any`, but not for `T.all`.

Fixes #1794

### Test plan
Added automated tests.
