### PR TITLE
runtime: avoid allocation in FixedArray#valid? and FixedHash#valid?

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/fixed_array.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_array.rb
@@ -19,8 +19,18 @@ module T::Types
 
     # @override Base
     def valid?(obj)
-      obj.is_a?(Array) && obj.length == @types.length &&
-        obj.zip(@types).all? {|item, type| type.valid?(item)}
+      if obj.is_a?(Array) && obj.length == @types.length
+        i = 0
+        while i < @types.length
+          if !@types[i].valid?(obj[i])
+            return false
+          end
+          i += 1
+        end
+        true
+      else
+        false
+      end
     end
 
     # @override Base

--- a/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
@@ -19,15 +19,8 @@ module T::Types
     # @override Base
     def valid?(obj)
       return false unless obj.is_a?(Hash)
-
-      @types.each do |key, type|
-        return false unless type.valid?(obj[key])
-      end
-
-      obj.each_key do |key|
-        return false unless @types[key]
-      end
-
+      return false if @types.any? {|key, type| !type.valid?(obj[key])}
+      return false if obj.any? {|key, _| !@types[key]}
       true
     end
 

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -192,6 +192,16 @@ module Opus::Types::Test
         msg = @type.error_message_for_obj(["hello", nil])
         assert_equal("Expected type [String, T::Boolean], got type [String, NilClass]", msg)
       end
+
+      it 'valid? does not allocate' do
+        arr = ["foo", false]
+        allocs_when_valid = counting_allocations {@type.valid?(arr)}
+        assert_equal(0, allocs_when_valid)
+
+        arr = [1, 2]
+        allocs_when_invalid = counting_allocations {@type.valid?(arr)}
+        assert_equal(0, allocs_when_invalid)
+      end
     end
 
     describe "FixedHash" do
@@ -227,6 +237,20 @@ module Opus::Types::Test
       it "fails validation if an extra field is present" do
         msg = @type.error_message_for_obj({a: "hello", b: true, d: "ohno"})
         assert_equal("Expected type {a: String, b: T::Boolean, c: T.nilable(Numeric)}, got type {a: String, b: TrueClass, d: String}", msg)
+      end
+
+      it 'valid? does not allocate' do
+        h = {a: 'foo', b: false, c: nil}
+        allocs_when_valid = counting_allocations {@type.valid?(h)}
+        assert_equal(0, allocs_when_valid)
+
+        h = {a: 'foo', b: 1, c: nil}
+        allocs_when_invalid_type = counting_allocations {@type.valid?(h)}
+        assert_equal(0, allocs_when_invalid_type)
+
+        h = {a: 'foo', b: false, c: nil, d: 'nope'}
+        allocs_when_invalid_key = counting_allocations {@type.valid?(h)}
+        assert_equal(0, allocs_when_invalid_key)
       end
     end
 


### PR DESCRIPTION
- Avoid using `zip` in `FixedArray#valid?` (in happy path) since it allocates O(N) times
- Avoid early return from blocks in `FixedHash#valid?` (which fortunately only happened in the unhappy path, but isn't hard to avoid using `Hash#any?`)

### Motivation
Followup to https://github.com/sorbet/sorbet/pull/3297 with same idea

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
