### PR TITLE
Singletons for T::Types::Untyped and similar classes

### DIFF
--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -37,12 +37,12 @@ module T
   # Matches any object. In the static checker, T.untyped allows any
   # method calls or operations.
   def self.untyped
-    T::Types::Untyped.new
+    T::Types::Untyped::Private::INSTANCE
   end
 
   # Indicates a function never returns (e.g. "Kernel#raise")
   def self.noreturn
-    T::Types::NoReturn.new
+    T::Types::NoReturn::Private::INSTANCE
   end
 
   # T.all(<Type>, <Type>, ...) -- matches an object that has all of the types listed
@@ -62,12 +62,12 @@ module T
 
   # Matches `self`:
   def self.self_type
-    T::Types::SelfType.new
+    T::Types::SelfType::Private::INSTANCE
   end
 
   # Matches the instance type in a singleton-class context
   def self.attached_class
-    T::Types::AttachedClassType.new
+    T::Types::AttachedClassType::Private::INSTANCE
   end
 
   # Matches any class that subclasses or includes the provided class

--- a/gems/sorbet-runtime/lib/types/types/attached_class.rb
+++ b/gems/sorbet-runtime/lib/types/types/attached_class.rb
@@ -29,5 +29,9 @@ module T::Types
         false
       end
     end
+
+    module Private
+      INSTANCE = AttachedClassType.new.freeze
+    end
   end
 end

--- a/gems/sorbet-runtime/lib/types/types/noreturn.rb
+++ b/gems/sorbet-runtime/lib/types/types/noreturn.rb
@@ -21,5 +21,9 @@ module T::Types
     private def subtype_of_single?(other)
       true
     end
+
+    module Private
+      INSTANCE = NoReturn.new.freeze
+    end
   end
 end

--- a/gems/sorbet-runtime/lib/types/types/self_type.rb
+++ b/gems/sorbet-runtime/lib/types/types/self_type.rb
@@ -27,5 +27,9 @@ module T::Types
           false
       end
     end
+
+    module Private
+      INSTANCE = SelfType.new.freeze
+    end
   end
 end

--- a/gems/sorbet-runtime/lib/types/types/untyped.rb
+++ b/gems/sorbet-runtime/lib/types/types/untyped.rb
@@ -21,5 +21,9 @@ module T::Types
     private def subtype_of_single?(other)
       true
     end
+
+    module Private
+      INSTANCE = Untyped.new.freeze
+    end
   end
 end


### PR DESCRIPTION
### Motivation
Fewer allocations & less memory use

(This mostly matters for T.untyped but the rest follow an ~identical pattern so it seemed cleaner to make them work the same too)

### Test plan
Existing tests
