### PR TITLE
Allow Symbol in Exception#initialize

### DIFF
--- a/rbi/core/exception.rbi
+++ b/rbi/core/exception.rbi
@@ -183,7 +183,7 @@ class Exception < Object
 
   sig do
     params(
-        arg0: T.any(String, NilClass),
+        arg0: T.any(String, Symbol, NilClass),
     )
     .void
   end

--- a/test/testdata/rbi/exception.rb
+++ b/test/testdata/rbi/exception.rb
@@ -3,3 +3,4 @@
 StandardError.new
 StandardError.new(nil)
 StandardError.new('msg')
+StandardError.new(:msg)


### PR DESCRIPTION
Even though `Exception#initialize` takes anything that can be turned
into a `String`, extending it to at least `Symbol` sounds like it would
unlock  some  of the most common usecases.

Fixes #2382