### PR TITLE
runtime: Best-effort one T::Types::Simple instance per module & one T.nilable(<mod>) per module

### DIFF
--- a/gems/sorbet-runtime/bench/tasks.rb
+++ b/gems/sorbet-runtime/bench/tasks.rb
@@ -6,6 +6,7 @@ require_relative 'setters'
 require_relative 'constructor'
 require_relative 'deserialize'
 require_relative 'prop_definition'
+require_relative 'typecheck'
 
 namespace :bench do
   task :getters do
@@ -28,5 +29,9 @@ namespace :bench do
     SorbetBenchmarks::PropDefinition.run
   end
 
-  task all: [:getters, :setters, :constructor, :deserialize, :prop_definition]
+  task :typecheck do
+    SorbetBenchmarks::Typecheck.run
+  end
+
+  task all: [:getters, :setters, :constructor, :deserialize, :prop_definition, :typecheck]
 end

--- a/gems/sorbet-runtime/bench/typecheck.rb
+++ b/gems/sorbet-runtime/bench/typecheck.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'benchmark'
+
+require_relative '../lib/sorbet-runtime'
+
+module SorbetBenchmarks
+  module Typecheck
+    extend T::Sig
+
+    class Example; end
+
+    def self.run
+      example = Example.new
+
+      result = Benchmark.measure do
+        1_000_000.times do
+          T.let(0, Integer)
+          T.let(1, Integer)
+        end
+      end
+      puts "T.let(..., Integer) twice, μs/iter"
+      puts result
+
+      result = Benchmark.measure do
+        1_000_000.times do
+          integer_param(0)
+          integer_param(1)
+        end
+      end
+      puts "sig {params(x: Integer).void} twice, μs/iter"
+      puts result
+
+      result = Benchmark.measure do
+        1_000_000.times do
+          T.let(nil, T.nilable(Integer))
+          T.let(1, T.nilable(Integer))
+        end
+      end
+      puts "T.let(..., T.nilable(Integer)) twice, μs/iter"
+      puts result
+
+      result = Benchmark.measure do
+        1_000_000.times do
+          nilable_integer_param(nil)
+          nilable_integer_param(1)
+        end
+      end
+      puts "sig {params(x: T.nilable(Integer)).void} twice, μs/iter"
+      puts result
+
+      result = Benchmark.measure do
+        1_000_000.times do
+          T.let(example, Example)
+          T.let(example, Example)
+        end
+      end
+      puts "T.let(..., Example) twice, μs/iter"
+      puts result
+
+      result = Benchmark.measure do
+        1_000_000.times do
+          application_class_param(example)
+          application_class_param(example)
+        end
+      end
+      puts "sig {params(x: Example).void} twice, μs/iter"
+      puts result
+
+      result = Benchmark.measure do
+        1_000_000.times do
+          T.let(nil, T.nilable(Example))
+          T.let(example, T.nilable(Example))
+        end
+      end
+      puts "T.let(..., T.nilable(Example)) twice, μs/iter"
+      puts result
+
+      result = Benchmark.measure do
+        1_000_000.times do
+          nilable_application_class_param(nil)
+          nilable_application_class_param(example)
+        end
+      end
+      puts "sig {params(x: T.nilable(Example)).void} twice, μs/iter"
+      puts result
+    end
+
+    sig {params(x: Integer).void}
+    def self.integer_param(x); end
+
+    sig {params(x: T.nilable(Integer)).void}
+    def self.nilable_integer_param(x); end
+
+    sig {params(x: Example).void}
+    def self.application_class_param(x); end
+
+    sig {params(x: T.nilable(Example)).void}
+    def self.nilable_application_class_param(x); end
+  end
+end

--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -26,12 +26,15 @@
 module T
   # T.any(<Type>, <Type>, ...) -- matches any of the types listed
   def self.any(type_a, type_b, *types)
-    T::Types::Union.new([type_a, type_b] + types)
+    type_a = T::Utils.coerce(type_a)
+    type_b = T::Utils.coerce(type_b)
+    types = types.map {|t| T::Utils.coerce(t)} if !types.empty?
+    T::Types::Union::Private::Pool.union_of_types(type_a, type_b, *types)
   end
 
   # Shorthand for T.any(type, NilClass)
   def self.nilable(type)
-    T::Types::Union.new([type, NilClass])
+    T::Types::Union::Private::Pool.union_of_types(T::Utils.coerce(type), T::Utils::Nilable::NIL_TYPE)
   end
 
   # Matches any object. In the static checker, T.untyped allows any

--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -29,7 +29,7 @@ module T
     type_a = T::Utils.coerce(type_a)
     type_b = T::Utils.coerce(type_b)
     types = types.map {|t| T::Utils.coerce(t)} if !types.empty?
-    T::Types::Union::Private::Pool.union_of_types(type_a, type_b, *types)
+    T::Types::Union::Private::Pool.union_of_types(type_a, type_b, types)
   end
 
   # Shorthand for T.any(type, NilClass)

--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -29,5 +29,23 @@ module T::Types
         false
       end
     end
+
+    class << self
+      alias_method :unpooled, :new
+      private :new
+    end
+
+    module Private
+      module Pool
+        def self.type_for_module(mod)
+          cached = mod.instance_variable_get(:@__as_sorbet_simple_type)
+          return cached if cached
+
+          type = Simple.unpooled(mod).freeze
+          mod.instance_variable_set(:@__as_sorbet_simple_type, type) unless mod.frozen?
+          type
+        end
+      end
+    end
   end
 end

--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -30,6 +30,10 @@ module T::Types
       end
     end
 
+    def to_nilable
+      @nilable ||= T::Types::Union.new([self, T::Utils::Nilable::NIL_TYPE])
+    end
+
     class << self
       alias_method :unpooled, :new
       private :new
@@ -41,7 +45,7 @@ module T::Types
           cached = mod.instance_variable_get(:@__as_sorbet_simple_type)
           return cached if cached
 
-          type = Simple.unpooled(mod).freeze
+          type = Simple.unpooled(mod)
           mod.instance_variable_set(:@__as_sorbet_simple_type, type) unless mod.frozen?
           type
         end

--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -34,18 +34,13 @@ module T::Types
       @nilable ||= T::Types::Union.new([self, T::Utils::Nilable::NIL_TYPE])
     end
 
-    class << self
-      alias_method :unpooled, :new
-      private :new
-    end
-
     module Private
       module Pool
         def self.type_for_module(mod)
           cached = mod.instance_variable_get(:@__as_sorbet_simple_type)
           return cached if cached
 
-          type = Simple.unpooled(mod)
+          type = Simple.new(mod)
           mod.instance_variable_set(:@__as_sorbet_simple_type, type) unless mod.frozen?
           type
         end

--- a/gems/sorbet-runtime/lib/types/types/union.rb
+++ b/gems/sorbet-runtime/lib/types/types/union.rb
@@ -54,8 +54,13 @@ module T::Types
 
     module Private
       module Pool
-        # Assumes arguments are T::Types::Base instances.
-        def self.union_of_types(type_a, type_b, *types)
+        EMPTY_ARRAY = [].freeze
+        private_constant :EMPTY_ARRAY
+
+        # @param type_a [T::Types::Base]
+        # @param type_b [T::Types::Base]
+        # @param types [Array] optional array of additional T::Types::Base instances
+        def self.union_of_types(type_a, type_b, types=EMPTY_ARRAY)
           if types.empty?
             # We aren't guaranteed to detect a simple `T.nilable(<Module>)` type here
             # in cases where there are duplicate types, nested unions, etc.

--- a/gems/sorbet-runtime/lib/types/types/union.rb
+++ b/gems/sorbet-runtime/lib/types/types/union.rb
@@ -54,12 +54,14 @@ module T::Types
 
     module Private
       module Pool
+        # Assumes arguments are T::Types::Base instances.
         def self.union_of_types(type_a, type_b, *types)
-          # We aren't guaranteed to detect a simple `T.nilable(<Module>)` type here
-          # in cases where NilClass is in `*types`, or there are duplicate types,
-          # or there are nested unions, etc. That's ok, because this is an optimization
-          # which isn't necessary for correctness.
           if types.empty?
+            # We aren't guaranteed to detect a simple `T.nilable(<Module>)` type here
+            # in cases where there are duplicate types, nested unions, etc.
+            #
+            # That's ok, because this is an optimization which isn't necessary for
+            # correctness.
             if type_b == T::Utils::Nilable::NIL_TYPE && type_a.is_a?(T::Types::Simple)
               type_a.to_nilable
             elsif type_a == T::Utils::Nilable::NIL_TYPE && type_b.is_a?(T::Types::Simple)
@@ -68,6 +70,8 @@ module T::Types
               Union.new([type_a, type_b])
             end
           else
+            # This can't be a `T.nilable(<Module>)` case unless there are duplicates,
+            # which is possible but unexpected.
             Union.new([type_a, type_b] + types)
           end
         end

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -21,7 +21,7 @@ module T::Utils
     elsif val == ::Range
       T::Range[T.untyped]
     elsif val.is_a?(Module)
-      T::Types::Simple.new(val) # rubocop:disable PrisonGuard/UseOpusTypesShortcut
+      T::Types::Simple::Private::Pool.type_for_module(val)
     elsif val.is_a?(::Array)
       T::Types::FixedArray.new(val) # rubocop:disable PrisonGuard/UseOpusTypesShortcut
     elsif val.is_a?(::Hash)
@@ -162,7 +162,7 @@ module T::Utils
     elsif classes.length > 1
       T::Types::Union.new(classes)
     else
-      T::Types::Simple.new(classes.first)
+      T::Types::Simple::Private::Pool.type_for_module(classes.first)
     end
   end
 

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -73,6 +73,14 @@ module Opus::Types::Test
         y = T::Types::Simple::Private::Pool.type_for_module(String)
         assert_equal(x.object_id, y.object_id)
       end
+
+      it 'does not blow up when pooling with frozen module' do
+        m = Module.new
+        m.freeze
+
+        x = T::Types::Simple::Private::Pool.type_for_module(m)
+        assert_instance_of(T::Types::Simple, x)
+      end
     end
 
     describe "Union" do

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -59,6 +59,20 @@ module Opus::Types::Test
         allocs_when_invalid = counting_allocations {@type.valid?(0.1)}
         assert_equal(0, allocs_when_invalid)
       end
+
+      it 'uses structural, not reference, equality' do
+        x = T::Types::Simple.new(String)
+        y = T::Types::Simple.new(String)
+        refute_equal(x.object_id, y.object_id)
+        assert_equal(x, y)
+        assert_equal(x.hash, y.hash)
+      end
+
+      it 'pools correctly' do
+        x = T::Types::Simple::Private::Pool.type_for_module(String)
+        y = T::Types::Simple::Private::Pool.type_for_module(String)
+        assert_equal(x.object_id, y.object_id)
+      end
     end
 
     describe "Union" do
@@ -108,6 +122,26 @@ module Opus::Types::Test
 
         allocs_when_invalid = counting_allocations {@type.valid?(0.1)}
         assert_equal(0, allocs_when_invalid)
+      end
+
+      it 'uses structural, not reference, equality' do
+        x = T::Types::Union.new([String, NilClass])
+        y = T::Types::Union.new([String, NilClass])
+        refute_equal(x.object_id, y.object_id)
+        assert_equal(x, y)
+        assert_equal(x.hash, y.hash)
+      end
+
+      it 'pools correctly for simple nilable types' do
+        x = T::Types::Union::Private::Pool.union_of_types(
+          T::Utils.coerce(String),
+          T::Utils.coerce(NilClass),
+        )
+        y = T::Types::Union::Private::Pool.union_of_types(
+          T::Utils.coerce(String),
+          T::Utils.coerce(NilClass),
+        )
+        assert_equal(x.object_id, y.object_id)
       end
     end
 


### PR DESCRIPTION
The basic idea here is:
1. For `T::Types::Simple`, we cache an instance on the module that we wrap, as an instance variable. We prefer to use this instance rather than construct a new one when using standard helpers.
2. For `T::Types::Union` uses that are a simple union of NilClass and a T::Types::Simple (ie, a simple T.nilable use), we cache an instance on the corresponding (cached) T::Types::Simple instance. We prefer to use this instance rather than construct a new one when using standard helpers.

I also added simple microbenchmarks for runtime typechecking.

Notably this does not _guarantee_ that only one equivalent instance of a T::Types::Simple or simple-nilable T::Union can exist. There are a couple of reasons that's difficult:
1. For T::Types::Simple, modules can be frozen. So we'd have to do the caching in something like a global Hash keyed by module instead. That'd be a little more complex and also I worry that would perform worse due to worse memory locality, although I admit I haven't tested.
2. For T::Types::Union, catching all possible ways that a simple-nilable union could define would require running after the `flat_map` and `uniq` logic currently in `initialize`, and I couldn't find a way of doing that which didn't reverse any gains in the benchmarks.

Since `new` on `T::Types::Simple` and `T::Types::Union` is public, for backwards compatibility we'd also have to override `new` instead of just adding a wrapper. That's doable but seems smellier.

I could be persuaded to reconsider the above reasoning and try to actually offer a uniqueness guarantee. It'd have the advantage of giving us cheaper equality and hash implementations. But those aren't hot paths, are they?

Another alternative would be to just hardcode constants for a handful of the most commonly-wrapped classes, like Integer, String, Float, Symbol etc. That seems like it would end up with less benefit for just as much complexity, though.

### Motivation
This is aiming to help with two things:
1. Total memory usage from `sig` definitions in a large codebase;
2. Runtime allocations from `T.let` uses (where type definitions aren't necessarily restricted to load-time like they are for `sig`).

I don't have memory usage data currently, but benchmarks before:
```
T.let(..., Integer) twice, μs/iter
  0.930970   0.000963   0.931933 (  0.932905)
sig {params(x: Integer).void} twice, μs/iter
  1.084934   0.001938   1.086872 (  1.087867)
T.let(..., T.nilable(Integer)) twice, μs/iter
  5.485798   0.003305   5.489103 (  5.491234)
sig {params(x: T.nilable(Integer)).void} twice, μs/iter
  1.981453   0.000917   1.982370 (  1.983042)
T.let(..., Example) twice, μs/iter
  0.814551   0.000244   0.814795 (  0.814936)
sig {params(x: Example).void} twice, μs/iter
  0.948986   0.000253   0.949239 (  0.949511)
T.let(..., T.nilable(Example)) twice, μs/iter
  5.453973   0.003054   5.457027 (  5.458655)
sig {params(x: T.nilable(Example)).void} twice, μs/iter
  2.053776   0.001400   2.055176 (  2.055702)
```

... vs after:
```
T.let(..., Integer) twice, μs/iter
  0.723203   0.000327   0.723530 (  0.723655)
sig {params(x: Integer).void} twice, μs/iter
  0.933413   0.001082   0.934495 (  0.934596)
T.let(..., T.nilable(Integer)) twice, μs/iter
  2.315996   0.000328   2.316324 (  2.316441)
sig {params(x: T.nilable(Integer)).void} twice, μs/iter
  1.862074   0.000523   1.862597 (  1.862729)
T.let(..., Example) twice, μs/iter
  0.704537   0.000083   0.704620 (  0.704666)
sig {params(x: Example).void} twice, μs/iter
  0.939468   0.000371   0.939839 (  0.940009)
T.let(..., T.nilable(Example)) twice, μs/iter
  2.398132   0.000883   2.399015 (  2.399266)
sig {params(x: T.nilable(Example)).void} twice, μs/iter
  1.943312   0.001264   1.944576 (  1.945432)
```

### Test plan
Existing tests plus benchmarks. Will also test in pay-server before merging.