### PR TITLE
Desugar inclusive ranges to a resolved constant

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1278,8 +1278,7 @@ TreePtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) {
                 result = std::move(res);
             },
             [&](parser::IRange *ret) {
-                core::NameRef range_name = core::Symbols::Range().data(dctx.ctx)->name;
-                TreePtr range = MK::UnresolvedConstant(loc, MK::EmptyTree(), range_name);
+                TreePtr range = MK::Constant(loc, core::Symbols::Range());
                 auto from = node2TreeImpl(dctx, std::move(ret->from));
                 auto to = node2TreeImpl(dctx, std::move(ret->to));
                 auto send = MK::Send2(loc, std::move(range), core::Names::new_(), std::move(from), std::move(to));

--- a/test/testdata/desugar/range.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/range.rb.desugar-tree-raw.exp
@@ -21,9 +21,9 @@ ClassDef{
               name = <U a>
             }
             rhs = Send{
-              recv = UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U Range>>
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = ::Range
               }
               fun = <U new>
               block = nullptr
@@ -96,9 +96,9 @@ ClassDef{
             }
             rhs = Send{
               recv = Send{
-                recv = UnresolvedConstantLit{
-                  scope = EmptyTree
-                  cnst = <C <U Range>>
+                recv = ConstantLit{
+                  orig = nullptr
+                  symbol = ::Range
                 }
                 fun = <U new>
                 block = nullptr
@@ -120,9 +120,9 @@ ClassDef{
             }
             rhs = Send{
               recv = Send{
-                recv = UnresolvedConstantLit{
-                  scope = EmptyTree
-                  cnst = <C <U Range>>
+                recv = ConstantLit{
+                  orig = nullptr
+                  symbol = ::Range
                 }
                 fun = <U new>
                 block = nullptr
@@ -227,9 +227,9 @@ ClassDef{
               name = <U g>
             }
             rhs = Send{
-              recv = UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U Range>>
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = ::Range
               }
               fun = <U new>
               block = nullptr

--- a/test/testdata/desugar/range_nested.rb
+++ b/test/testdata/desugar/range_nested.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+module Foo
+  class Range; end
+  T.reveal_type(0..1) # error: Revealed type: `T::Range[Integer]`
+  T.reveal_type(0...1) # error: Revealed type: `T::Range[Integer]`
+end

--- a/test/testdata/rewriter/flatfile_dsl.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/flatfile_dsl.rb.rewrite-tree.exp
@@ -76,7 +76,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.flatfile() do ||
       begin
-        <self>.from(<emptyTree>::<C Range>.new(1, 2), :"foo")
+        <self>.from(::Range.new(1, 2), :"foo")
         <self>.pattern(::Regexp.new("A-Za-z", 0), :"bar")
         <self>.field(:"baz")
       end


### PR DESCRIPTION
### Motivation

As we can see in this [example](https://sorbet.run/#%23%20typed%3A%20true%0A%0Amodule%20Foo%0A%20%20class%20Range%3B%20end%0A%20%20T.reveal_type(0..1)%0A%20%20T.reveal_type(0...1)%0Aend):

```ruby
# typed: true

module Foo
  class Range; end
  T.reveal_type(0..1) # Foo::Range
              # ^^^^ Wrong number of arguments for constructor. Expected: 0, got: 2
  T.reveal_type(0...1) # T::Range[Integer]
end
```

Inclusive ranges are desugared as an unresolved constant while the exclusive version is desugared properly.

This pull-request fixes that behavior to always return a resolved `::Range`:

```ruby
# typed: true

module Foo
  class Range; end
  T.reveal_type(0..1) # T::Range[Integer]
  T.reveal_type(0...1) # T::Range[Integer]
end
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
