### PR TITLE
Avoid allocation in the case where we have to strip kwargs from args array

### DIFF
--- a/gems/sorbet-runtime/bench/typecheck.rb
+++ b/gems/sorbet-runtime/bench/typecheck.rb
@@ -85,6 +85,15 @@ module SorbetBenchmarks
       end
       puts "sig {params(x: T.nilable(Example)).void} twice, μs/iter"
       puts result
+
+      result = Benchmark.measure do
+        1_000_000.times do
+          arg_plus_kwargs(:foo, x: 1, y: 2)
+          arg_plus_kwargs(:bar, x: 1)
+        end
+      end
+      puts "sig {params(s: Symbol, x: Integer, y: Integer).void} (with kwargs) twice, μs/iter"
+      puts result
     end
 
     sig {params(x: Integer).void}
@@ -98,5 +107,8 @@ module SorbetBenchmarks
 
     sig {params(x: T.nilable(Example)).void}
     def self.nilable_application_class_param(x); end
+
+    sig {params(s: Symbol, x: Integer, y: Integer).void}
+    def self.arg_plus_kwargs(s, x:, y: 0); end
   end
 end

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -146,9 +146,10 @@ class T::Private::Methods::Signature
     # can't) match the definition of the method we're validating. In addition, Ruby has a bug that
     # causes forwarding **kwargs to do the wrong thing: see https://bugs.ruby-lang.org/issues/10708
     # and https://bugs.ruby-lang.org/issues/11860.
-    if (args.length > @req_arg_count) && (!@kwarg_types.empty? || @has_keyrest) && args[-1].is_a?(Hash)
+    args_length = args.length
+    if (args_length > @req_arg_count) && (!@kwarg_types.empty? || @has_keyrest) && args[-1].is_a?(Hash)
       kwargs = args[-1]
-      args = args[0...-1]
+      args_length -= 1
     else
       kwargs = EMPTY_HASH
     end
@@ -156,19 +157,19 @@ class T::Private::Methods::Signature
     arg_types = @arg_types
 
     if @has_rest
-      arg_types += [[@rest_name, @rest_type]] * (args.length - @arg_types.length)
+      arg_types += [[@rest_name, @rest_type]] * (args_length - @arg_types.length)
 
-    elsif (args.length < @req_arg_count) || (args.length > @arg_types.length)
+    elsif (args_length < @req_arg_count) || (args_length > @arg_types.length)
       expected_str = @req_arg_count.to_s
       if @arg_types.length != @req_arg_count
         expected_str += "..#{@arg_types.length}"
       end
-      raise ArgumentError.new("wrong number of arguments (given #{args.length}, expected #{expected_str})")
+      raise ArgumentError.new("wrong number of arguments (given #{args_length}, expected #{expected_str})")
     end
 
     begin
       it = 0
-      while it < args.length
+      while it < args_length
         yield arg_types[it][0], args[it], arg_types[it][1]
         it += 1
       end


### PR DESCRIPTION
We don't need to actually re-assign `args` to a slice of itself, since all we do with it later is call `args.length` and then iterate through with a `while` loop. We can just pull `args.length` into a local variable and reduce it by one if needed. 

Also add a microbenchmark.

### Motivation
Save an allocation. Hard to see the effect in microbenchmarks but it's _maybe_ there, best of three before:
```
sig {params(s: Symbol, x: Integer, y: Integer).void} (with kwargs) twice, μs/iter
  2.895195   0.001551   2.896746 (  2.896965)
```

... and after:
```
sig {params(s: Symbol, x: Integer, y: Integer).void} (with kwargs) twice, μs/iter
  2.691076   0.000795   2.691871 (  2.691964)
```

### Test plan
I believe this should be covered by existing tests, and the benchmark should help us catch future regressions of the perf change.
