### PR TITLE
Avoid hitting slow path every time for aliased method

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -216,9 +216,6 @@ module T::Private::Methods
         &blk
       )
 
-      # Shouldn't happen
-      return if method_sig.nil?
-
       # Should be the same logic as CallValidation.wrap_method_if_needed but we
       # don't want that extra layer of indirection in the callstack
       if method_sig.mode == T::Private::Methods::Modes.abstract

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -265,21 +265,9 @@ module T::Private::Methods
         mod.send(:alias_method, method_name, original_name)
       end
     else
-      msg = "`sig` not present for method `#{method_name}` but you're trying to run it anyways. " \
+      raise "`sig` not present for method `#{method_name}` but you're trying to run it anyways. " \
         "This should only be executed if you used `alias_method` to grab a handle to a method after `sig`ing it, but that clearly isn't what you are doing. " \
-        "Maybe look to see if an exception was thrown in your `sig` lambda or somehow else your `sig` wasn't actually applied to the method. " \
-        "Contact #dev-productivity if you're really stuck."
-
-      new_new_method = mod.instance_method(method_name)
-      if new_method == new_new_method
-        # No way of recovering.
-        raise msg
-      else
-        # This shouldn't be reachable anymore, but historically we've handled this case,
-        # so soft-assert rather than exploding.
-        T::Configuration.soft_assert_handler(msg)
-        new_new_method.bind(obj).call(*args, &blk)
-      end
+        "Maybe look to see if an exception was thrown in your `sig` lambda or somehow else your `sig` wasn't actually applied to the method."
     end
 
     method_sig

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -36,18 +36,128 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     assert_equal("foo", klass.new.bar = "foo")
   end
 
-  it 'handles aliased methods' do
-    klass = Class.new do
-      extend T::Sig
-      extend T::Helpers
-      sig {returns(Symbol)}
-      def foo
-        :foo
+  describe 'aliasing' do
+    describe 'instance method' do
+      it 'handles alias_method with runtime checking' do
+        klass = Class.new do
+          extend T::Sig
+          extend T::Helpers
+          sig {returns(Symbol)}
+          def foo
+            :foo
+          end
+          alias_method :bar, :foo
+        end
+        assert_equal(:foo, klass.new.foo)
+        assert_equal(:foo, klass.new.bar)
       end
-      alias_method :bar, :foo
+
+      it 'handles alias_method without runtime checking' do
+        klass = Class.new do
+          extend T::Sig
+          extend T::Helpers
+          sig {returns(Symbol).checked(:never)}
+          def foo
+            :foo
+          end
+          alias_method :bar, :foo
+        end
+        assert_equal(:foo, klass.new.foo)
+        assert_equal(:foo, klass.new.bar)
+      end
+
+      it 'handles alias with runtime checking' do
+        klass = Class.new do
+          extend T::Sig
+          extend T::Helpers
+          sig {returns(Symbol)}
+          def foo
+            :foo
+          end
+          alias :bar :foo
+        end
+        assert_equal(:foo, klass.new.foo)
+        assert_equal(:foo, klass.new.bar)
+      end
+
+      it 'handles alias without runtime checking' do
+        klass = Class.new do
+          extend T::Sig
+          extend T::Helpers
+          sig {returns(Symbol).checked(:never)}
+          def foo
+            :foo
+          end
+          alias :bar :foo
+        end
+        assert_equal(:foo, klass.new.foo)
+        assert_equal(:foo, klass.new.bar)
+      end
     end
-    assert_equal(:foo, klass.new.foo)
-    assert_equal(:foo, klass.new.bar)
+
+    describe 'singleton method' do
+      it 'handles alias_method with runtime checking' do
+        klass = Class.new do
+          extend T::Sig
+          extend T::Helpers
+          sig {returns(Symbol)}
+          def self.foo
+            :foo
+          end
+          class << self
+            alias_method :bar, :foo
+          end
+        end
+        assert_equal(:foo, klass.foo)
+        assert_equal(:foo, klass.bar)
+      end
+
+      it 'handles alias_method without runtime checking' do
+        klass = Class.new do
+          extend T::Sig
+          extend T::Helpers
+          sig {returns(Symbol).checked(:never)}
+          def self.foo
+            :foo
+          end
+          class << self
+            alias_method :bar, :foo
+          end
+        end
+        assert_equal(:foo, klass.foo)
+        assert_equal(:foo, klass.bar)
+      end
+
+      it 'handles alias with runtime checking' do
+        klass = Class.new do
+          extend T::Sig
+          extend T::Helpers
+          def self.foo
+            :foo
+          end
+          class << self
+            alias :bar :foo
+          end
+        end
+        assert_equal(:foo, klass.foo)
+        assert_equal(:foo, klass.bar)
+      end
+
+      it 'handles alias without runtime checking' do
+        klass = Class.new do
+          extend T::Sig
+          extend T::Helpers
+          def self.foo
+            :foo
+          end
+          class << self
+            alias :bar :foo
+          end
+        end
+        assert_equal(:foo, klass.foo)
+        assert_equal(:foo, klass.bar)
+      end
+    end
   end
 
   it 'works for any_instance' do

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -48,23 +48,28 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         klass = Class.new do
           extend T::Sig
           extend T::Helpers
-          sig {returns(Symbol)}
-          def foo
-            :foo
+          sig {params(x: Symbol).returns(Symbol)}
+          def foo(x=:foo)
+            x
           end
           alias_method :bar, :foo
         end
         assert_equal(:foo, klass.new.foo)
         assert_equal(:foo, klass.new.bar)
+
+        # Should still validate
+        assert_raises(TypeError) do
+          klass.new.bar(1)
+        end
       end
 
       it 'handles alias_method without runtime checking' do
         klass = Class.new do
           extend T::Sig
           extend T::Helpers
-          sig {returns(Symbol).checked(:never)}
-          def foo
-            :foo
+          sig {params(x: Symbol).returns(Symbol).checked(:never)}
+          def foo(x=:foo)
+            x
           end
           alias_method :bar, :foo
         end
@@ -81,23 +86,28 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         klass = Class.new do
           extend T::Sig
           extend T::Helpers
-          sig {returns(Symbol)}
-          def foo
-            :foo
+          sig {params(x: Symbol).returns(Symbol)}
+          def foo(x=:foo)
+            x
           end
           alias :bar :foo
         end
         assert_equal(:foo, klass.new.foo)
         assert_equal(:foo, klass.new.bar)
+
+        # Should still validate
+        assert_raises(TypeError) do
+          klass.new.bar(1)
+        end
       end
 
       it 'handles alias without runtime checking' do
         klass = Class.new do
           extend T::Sig
           extend T::Helpers
-          sig {returns(Symbol).checked(:never)}
-          def foo
-            :foo
+          sig {params(x: Symbol).returns(Symbol).checked(:never)}
+          def foo(x=:foo)
+            x
           end
           alias :bar :foo
         end


### PR DESCRIPTION
In the edge case where we've called `alias` or `alias_method` after adding a `sig` to a method, we previously would hit the initial, slow `replace_method` wrapper every time - even if we used `checked(:never)` on the `sig`.

This avoids that by using `__callee__` plus `Method#original_name` to find the `Signature` object for the original method, if we've hit the alias, and then using that to generate a fast path more or less as we would have on the original method.

### Motivation
Least surprise: if `alias_method` isn't a performance problem for vanilla Ruby, Sorbet shouldn't make it one. We use it a couple of times in T::Props ourselves!

### Test plan
Expanded aliasing tests, also ran benchmarks and saw no notable change. (We don't bench this edge case, which seems fine.)
