### PR TITLE
Memoize name in T::Types::Simple to mitigate edge cases with slow Module#name

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -12,7 +12,11 @@ module T::Types
 
     # @override Base
     def name
-      @raw_type.name
+      # Memoize to mitigate pathological performance with anonymous modules (https://bugs.ruby-lang.org/issues/11119)
+      #
+      # `name` isn't normally a hot path for types, but it is used in initializing a T::Types::Union,
+      # and so in `T.nilable`, and so in runtime constructions like `x = T.let(nil, T.nilable(Integer))`.
+      @name ||= @raw_type.name.freeze
     end
 
     # @override Base


### PR DESCRIPTION
### Motivation
We hit the enum-initialization case often enough at runtime in pay-server for cases where Module#name allocates to show up in the allocation list. I'm not sure if we actually have a material negative impact from https://bugs.ruby-lang.org/issues/11119 but guarding against it seems low-cost.

### Test plan
Passing build.

I also double-checked that the magic number of instance variables before Ruby has to malloc to store an object is four; this only gets us to a max of three in T::Types::Simple. (Not sure this would be a big deal but it's the only way I could think of that this might regress performance.)