### PR TITLE
Expose libruby.2.x-static.a and libripper.2.x-static.a

### DIFF
--- a/third_party/ruby/build-ruby.bzl
+++ b/third_party/ruby/build-ruby.bzl
@@ -456,7 +456,7 @@ def _rubyfmt_static_deps_impl(ctx):
 
     libs = depset([ruby_info.static_libs])
 
-    return [DefaultInfo(files=libs)]
+    return [DefaultInfo(files = libs)]
 
 _rubyfmt_static_deps = rule(
     attrs = {

--- a/third_party/ruby/build-ruby.bzl
+++ b/third_party/ruby/build-ruby.bzl
@@ -95,10 +95,7 @@ run_cmd ./configure \
 run_cmd make V=1 -j8
 run_cmd make V=1 install
 
-echo $build_dir
-
 ruby_version=$(./miniruby -r ./rbconfig.rb -e 'puts "#{{RbConfig::CONFIG["MAJOR"]}}.#{{RbConfig::CONFIG["MINOR"]}}"')
-echo "ruby_version = $ruby_version"
 
 static_libs="$base/{static_libs}"
 mkdir -p "$static_libs"

--- a/third_party/ruby/build-ruby.bzl
+++ b/third_party/ruby/build-ruby.bzl
@@ -103,10 +103,10 @@ echo "ruby_version = $ruby_version"
 static_libs="$base/{static_libs}"
 mkdir -p "$static_libs"
 
-# from https://github.com/penelopezone/rubyfmt/blob/3051835cc28db04e9d9caf0c8430407ca0347e83/librubyfmt/build.rs#L34
-ar crus "libripper.$ruby_version-static.a" ext/ripper/ripper.o
+cp libruby*-static.a "$static_libs"
 
-cp "libruby.$ruby_version-static.a" "$static_libs"
+# from https://github.com/penelopezone/rubyfmt/blob/3051835cc28db04e9d9caf0c8430407ca0347e83/librubyfmt/build.rs#L34
+ar crs "libripper.$ruby_version-static.a" ext/ripper/ripper.o
 cp "libripper.$ruby_version-static.a" "$static_libs"
 
 internal_incdir="$base/{internal_incdir}"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Expose the static libs that are required for building https://github.com/penelopezone/rubyfmt as prework for integrating it into sorbet.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Prework for integrating https://github.com/penelopezone/rubyfmt.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The test will be building rubyfmt with the output of the `:rubyfmt-static-deps` target. I ran `bazel build @ruby_2_6//:rubyfmt-static-deps` on both osx and linux, and found the expected archives present in `bazel-bin/external/ruby_2_6/toolchain/static_libs/`.
