### PR TITLE
Fix the sig of the `<=>` operator across the core rbis

### DIFF
--- a/rbi/core/file.rbi
+++ b/rbi/core/file.rbi
@@ -1470,7 +1470,7 @@ class File::Stat < Object
   # ```
   sig do
     params(
-        other: File::Stat,
+        other: Object,
     )
     .returns(T.nilable(Integer))
   end

--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -86,7 +86,7 @@ class Module < Object
   # `other_module` is not a module, or if the two values are incomparable.
   sig do
     params(
-        other: Module,
+        other: Object,
     )
     .returns(T.nilable(Integer))
   end

--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -120,7 +120,7 @@ class String < Object
   # ```
   sig do
     params(
-        other: String,
+        other: Object,
     )
     .returns(T.nilable(Integer))
   end

--- a/rbi/core/symbol.rbi
+++ b/rbi/core/symbol.rbi
@@ -52,7 +52,7 @@ class Symbol < Object
   # See String#<=> for more information.
   sig do
     params(
-        other: Symbol,
+        other: Object,
     )
     .returns(T.nilable(Integer))
   end

--- a/rbi/core/time.rbi
+++ b/rbi/core/time.rbi
@@ -403,7 +403,7 @@ class Time < Object
   # ```
   sig do
     params(
-        other: Time,
+        other: Object,
     )
     .returns(T.nilable(Integer))
   end


### PR DESCRIPTION
### Motivation
I believe the sig of the `<=>` operator is too strict in some instances and is causing some valid code to not typecheck.

For [example](https://sorbet.run/#%23%20typed%3A%20strict%0A%0Aa%20%3D%20T.let(nil%2C%20T.nilable(String))%0Ab%20%3D%20T.let(nil%2C%20T.nilable(String))%0A%0Aa%20%3C%3D%3E%20b):

```ruby

# typed: strict

a = T.let(nil, T.nilable(String))
b = T.let(nil, T.nilable(String))

a <=> b


editor.rb:6: Expected String but found T.nilable(String) for argument other https://srb.help/7002
     6 |a <=> b
        ^^^^^^^
    https://github.com/sorbet/sorbet/tree/master/rbi/core/string.rbi#L123: Method String#<=> has specified other as String
     123 |        other: String,
                  ^^^^^
  Got T.nilable(String) originating from:
    editor.rb:4:
     4 |b = T.let(nil, T.nilable(String))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  Autocorrect: Use `-a` to autocorrect
    editor.rb:6: Replace with T.must(b)
     6 |a <=> b
              ^
Errors: 1
```

 It's possible that the sigs on these are more strict on purpose to force handling the class-mismatched case outside of the `<=>`, but it's not documented anywhere. If that's the case, please disregard this PR.

### Test plan
I'm not sure if these sigs are covered in tests or not. If they are I can update the specs, but I'd need to be pointed to where they live.
