### PR TITLE
Fix type members in REXML

### DIFF
--- a/rbi/stdlib/rexml.rbi
+++ b/rbi/stdlib/rexml.rbi
@@ -69,7 +69,7 @@ end
 class REXML::AttlistDecl < ::REXML::Child
   include(::Enumerable)
 
-  Elem = type_member(:out)
+  Elem = type_member(fixed: REXML::Attribute)
 
   # Create an
   # [`AttlistDecl`](https://docs.ruby-lang.org/en/2.6.0/REXML/AttlistDecl.html),
@@ -255,9 +255,9 @@ end
 # [`Attributes`](https://docs.ruby-lang.org/en/2.6.0/REXML/Attributes.html) of
 # an Element and provides operations for accessing elements in that set.
 class REXML::Attributes < ::Hash
-  K = type_member(:out)
-  V = type_member(:out)
-  Elem = type_member(:out)
+  K = type_member(fixed: String)
+  V = type_member(fixed: String)
+  Elem = type_member(fixed: REXML::Attribute)
 
   # Constructor
   # element
@@ -643,7 +643,7 @@ end
 class REXML::DocType < ::REXML::Parent
   include(::REXML::XMLTokens)
 
-  Elem = type_member(:out)
+  Elem = type_member(fixed: REXML::Child)
 
   DEFAULT_ENTITIES = T.let(T.unsafe(nil), T::Hash[T.untyped, T.untyped])
 
@@ -756,7 +756,7 @@ end
 # write a default declaration for you. See |DECLARATION| and |write|.
 class REXML::Document < ::REXML::Element
 
-  Elem = type_member(:out)
+  Elem = type_member(fixed: REXML::Child)
 
   # A convenient default [`XML`](https://docs.ruby-lang.org/en/2.6.0/XML.html)
   # declaration. If you want an
@@ -949,7 +949,7 @@ class REXML::Element < ::REXML::Parent
   include(::REXML::Namespace)
   include(::REXML::XMLTokens)
 
-  Elem = type_member(:out)
+  Elem = type_member(fixed: REXML::Child)
 
   UNDEFINED = T.let(T.unsafe(nil), String)
 
@@ -1499,7 +1499,7 @@ end
 class REXML::Elements
   include(::Enumerable)
 
-  Elem = type_member(:out)
+  Elem = type_member(fixed: REXML::Element)
 
   # Constructor
   # parent
@@ -2244,7 +2244,7 @@ end
 class REXML::Parent < ::REXML::Child
   include(::Enumerable)
 
-  Elem = type_member(:out)
+  Elem = type_member(fixed: REXML::Child)
 
   # Constructor @param parent if supplied, will be set as the parent of this
   # object
@@ -2977,7 +2977,7 @@ end
 class REXML::SyncEnumerator
   include(::Enumerable)
 
-  Elem = type_member(:out)
+  Elem = type_member(fixed: REXML::Element)
 
   # Creates a new
   # [`SyncEnumerator`](https://docs.ruby-lang.org/en/2.6.0/REXML/SyncEnumerator.html)


### PR DESCRIPTION
### Motivation

None of the classes from REXML are generic, we have to fix type members.

For [example](https://sorbet.run/#%23%20typed%3A%20true%0A%0Aclass%20Foo%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7B%20returns(REXML%3A%3ADocument)%20%7D%0A%20%20def%20foo%0A%20%20%20%20REXML%3A%3ADocument.new%0A%20%20end%0Aend) with `Document`:

```ruby
# typed: true

class Foo
  extend T::Sig

  sig { returns(REXML::Document) } # Error:  Malformed type declaration. Generic class without type arguments REXML::Document
  def foo
    REXML::Document.new
  end
end
```

With this PR, the previous snippet returns `No errors! Great job.`.

### Test plan

See included automated tests.