### PR TITLE
Fix handling of missing signatures to accept `checked(:never)`

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -260,7 +260,7 @@ module T::Private::Methods
         # Unchecked, so just make `alias_method` behave as if it had been called pre-sig.
         aliasing_mod.send(:alias_method, callee, original_method.name)
       end
-    else
+    elsif !method_sig && aliasing_method == original_method
       raise "`sig` not present for method `#{aliasing_method.name}` but you're trying to run it anyways. " \
         "This should only be executed if you used `alias_method` to grab a handle to a method after `sig`ing it, but that clearly isn't what you are doing. " \
         "Maybe look to see if an exception was thrown in your `sig` lambda or somehow else your `sig` wasn't actually applied to the method."


### PR DESCRIPTION
### Motivation

With sorbet-runtime `0.5.5848` the following snippet:

```ruby
require 'sorbet-runtime'

class Foo
  extend T::Sig

  sig { void }
  def bar
    puts [1, 2, 3].map(&method(:foo))
  end

  sig { params(x: Integer).returns(Integer).checked(:never) }
  def foo(x)
    -x
  end
end

Foo.new.bar
```

Will cause:

```
`sig` not present for method `foo` but you're trying to run it anyways. This should only be executed if you used `alias_method` to grab a handle to a method after `sig`ing it, but that clearly isn't what you are doing. Maybe look to see if an exception was thrown in your `sig` lambda or somehow else your `sig` wasn't actually applied to the method.
```

This regression was introduced in https://github.com/sorbet/sorbet/commit/1920057934cf7e1b65cf7d55d741a808de76cb97#diff-afe12100a816d1333caeabbe387089efR245 where the condition to raise got relaxed.

This PR puts back the original condition and add some tests to avoid further regression.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
