### PR TITLE
Add support for ruby 2.7 `**nil` syntax

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -608,6 +608,9 @@ string MethodDef::showRaw(const core::GlobalState &gs, int tabs) {
     if (this->flags.isRewriterSynthesized) {
         stringifiedFlags.emplace_back("rewriter");
     }
+    if (this->flags.isKwnil) {
+        stringifiedFlags.emplace_back("kwnil");
+    }
     fmt::format_to(buf, "flags = {{{}}}\n", fmt::join(stringifiedFlags, ", "));
 
     printTabs(buf, tabs + 1);

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -367,9 +367,10 @@ public:
     struct Flags {
         bool isSelfMethod : 1;
         bool isRewriterSynthesized : 1;
+        bool isKwnil : 1;
 
         // In C++20 we can replace this with bit field initialzers
-        Flags() : isSelfMethod(false), isRewriterSynthesized(false) {}
+        Flags() : isSelfMethod(false), isRewriterSynthesized(false), isKwnil(false) {}
     };
     CheckSize(Flags, 1, 1);
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -90,6 +90,7 @@ public:
         static constexpr u4 METHOD_OVERRIDE = 0x0000'1000;
         [[deprecated]] static constexpr u4 METHOD_IMPLEMENTATION = 0x0000'2000;
         static constexpr u4 METHOD_INCOMPATIBLE_OVERRIDE = 0x0000'4000;
+        static constexpr u4 METHOD_WITH_KWNIL = 0x0000'8000;
 
         // Type flags
         static constexpr u4 TYPE_COVARIANT = 0x0000'0010;
@@ -217,6 +218,11 @@ public:
     inline bool isOverride() const {
         ENFORCE_NO_TIMER(isMethod());
         return (flags & Symbol::Flags::METHOD_OVERRIDE) != 0;
+    }
+
+    inline bool isMethodWithKwnil() const {
+        ENFORCE(isMethod());
+        return (flags & Symbol::Flags::METHOD_WITH_KWNIL) != 0;
     }
 
     inline bool isCovariant() const {
@@ -389,6 +395,11 @@ public:
     inline void setGenericMethod() {
         ENFORCE(isMethod());
         flags |= Symbol::Flags::METHOD_GENERIC;
+    }
+
+    inline void setMethodWithKwnil() {
+        ENFORCE(isMethod());
+        flags |= Symbol::Flags::METHOD_WITH_KWNIL;
     }
 
     inline void setOverridable() {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -957,6 +957,10 @@ class SymbolDefiner {
         if (method.flags.isRewriterSynthesized) {
             sym.data(ctx)->setRewriterSynthesized();
         }
+
+        if (method.flags.isKwnil) {
+            sym.data(ctx)->setMethodWithKwnil();
+        }
         ENFORCE(ctx.state.lookupMethodSymbolWithHash(owner, method.name, method.argsHash).exists());
         return sym;
     }

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -723,6 +723,10 @@ public:
                                      std::move(value));
     }
 
+    unique_ptr<Node> kwnilarg(const token *dstar, const token *nil) {
+        return make_unique<Kwnilarg>(tokLoc(dstar).join(tokLoc(nil)));
+    }
+
     unique_ptr<Node> kwrestarg(const token *dstar, const token *name) {
         core::LocOffsets loc = tokLoc(dstar);
         core::NameRef nm;
@@ -1547,6 +1551,11 @@ ForeignPtr kwoptarg(SelfPtr builder, const token *name, ForeignPtr value) {
     return build->toForeign(build->kwoptarg(name, build->cast_node(value)));
 }
 
+ForeignPtr kwnilarg(SelfPtr builder, const token *dstar, const token *nil) {
+    auto build = cast_builder(builder);
+    return build->toForeign(build->kwnilarg(dstar, nil));
+}
+
 ForeignPtr kwrestarg(SelfPtr builder, const token *dstar, const token *name) {
     auto build = cast_builder(builder);
     return build->toForeign(build->kwrestarg(dstar, name));
@@ -1879,6 +1888,7 @@ struct ruby_parser::builder Builder::interface = {
     keywordZsuper,
     kwarg,
     kwoptarg,
+    kwnilarg,
     kwrestarg,
     kwsplat,
     line_literal,

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -310,6 +310,12 @@ NodeDef nodes[] = {
         "kwarg",
         vector<FieldDef>({{"name", FieldType::Name}}),
     },
+    // Keyword nil argument
+    {
+        "Kwnilarg",
+        "kwnilarg",
+        vector<FieldDef>(),
+    },
     // explicit `begin` keyword.
     // `kwbegin` is emitted _only_ for post-while and post-until loops
     // because they act differently

--- a/test/testdata/desugar/kwnil.desugar-tree-raw.exp
+++ b/test/testdata/desugar/kwnil.desugar-tree-raw.exp
@@ -1,0 +1,70 @@
+ClassDef{
+  kind = class
+  name = EmptyTree<<C <U <root>>>>
+  ancestors = [ConstantLit{
+      orig = nullptr
+      symbol = ::<todo sym>
+    }]
+  rhs = [
+    MethodDef{
+      flags = {kwnil}
+      name = <U f1><<C <U <todo sym>>>>
+      args = [BlockArg{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U <blk>>
+        } }]
+      rhs = EmptyTree
+    }
+
+    MethodDef{
+      flags = {kwnil}
+      name = <U f2><<C <U <todo sym>>>>
+      args = [RestArg{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U args>
+        } }, BlockArg{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U <blk>>
+        } }]
+      rhs = EmptyTree
+    }
+
+    MethodDef{
+      flags = {kwnil}
+      name = <U f3><<C <U <todo sym>>>>
+      args = [UnresolvedIdent{
+          kind = Local
+          name = <U a>
+        }, UnresolvedIdent{
+          kind = Local
+          name = <U b>
+        }, UnresolvedIdent{
+          kind = Local
+          name = <U c>
+        }, BlockArg{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U <blk>>
+        } }]
+      rhs = EmptyTree
+    }
+
+    MethodDef{
+      flags = {kwnil}
+      name = <U f4><<C <U <todo sym>>>>
+      args = [UnresolvedIdent{
+          kind = Local
+          name = <U a>
+        }, UnresolvedIdent{
+          kind = Local
+          name = <U b>
+        }, RestArg{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U c>
+        } }, BlockArg{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U <blk>>
+        } }]
+      rhs = EmptyTree
+    }
+  ]
+}

--- a/test/testdata/desugar/kwnil.desugar-tree.exp
+++ b/test/testdata/desugar/kwnil.desugar-tree.exp
@@ -1,0 +1,17 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def f1<<C <todo sym>>>(&<blk>)
+    <emptyTree>
+  end
+
+  def f2<<C <todo sym>>>(*args, &<blk>)
+    <emptyTree>
+  end
+
+  def f3<<C <todo sym>>>(a, b, c, &<blk>)
+    <emptyTree>
+  end
+
+  def f4<<C <todo sym>>>(a, b, *c, &<blk>)
+    <emptyTree>
+  end
+end

--- a/test/testdata/desugar/kwnil.rb
+++ b/test/testdata/desugar/kwnil.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+def f1(**nil); end
+def f2(*args, **nil); end
+def f3(a, b, c, **nil); end
+def f4(a, b, *c, **nil); end

--- a/test/testdata/desugar/kwnil.symbol-table-raw.exp
+++ b/test/testdata/desugar/kwnil.symbol-table-raw.exp
@@ -1,0 +1,21 @@
+class <C <U <root>>> < <C <U Object>> ()
+  class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/desugar/kwnil.rb start=3:1 end=6:29}
+      argument <blk><block> @ Loc {file=test/testdata/desugar/kwnil.rb start=??? end=???}
+  class <C <U Object>> < <C <U BasicObject>> (<C <U Kernel>>) @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed}
+    method <C <U Object>><U f1> : private (<blk>) @ Loc {file=test/testdata/desugar/kwnil.rb start=3:1 end=3:14}
+      argument <blk><block> @ Loc {file=test/testdata/desugar/kwnil.rb start=??? end=???}
+    method <C <U Object>><U f2> : private (args, <blk>) @ Loc {file=test/testdata/desugar/kwnil.rb start=4:1 end=4:21}
+      argument args<repeated> @ Loc {file=test/testdata/desugar/kwnil.rb start=4:9 end=4:13}
+      argument <blk><block> @ Loc {file=test/testdata/desugar/kwnil.rb start=??? end=???}
+    method <C <U Object>><U f3> : private (a, b, c, <blk>) @ Loc {file=test/testdata/desugar/kwnil.rb start=5:1 end=5:23}
+      argument a<> @ Loc {file=test/testdata/desugar/kwnil.rb start=5:8 end=5:9}
+      argument b<> @ Loc {file=test/testdata/desugar/kwnil.rb start=5:11 end=5:12}
+      argument c<> @ Loc {file=test/testdata/desugar/kwnil.rb start=5:14 end=5:15}
+      argument <blk><block> @ Loc {file=test/testdata/desugar/kwnil.rb start=??? end=???}
+    method <C <U Object>><U f4> : private (a, b, c, <blk>) @ Loc {file=test/testdata/desugar/kwnil.rb start=6:1 end=6:24}
+      argument a<> @ Loc {file=test/testdata/desugar/kwnil.rb start=6:8 end=6:9}
+      argument b<> @ Loc {file=test/testdata/desugar/kwnil.rb start=6:11 end=6:12}
+      argument c<repeated> @ Loc {file=test/testdata/desugar/kwnil.rb start=6:15 end=6:16}
+      argument <blk><block> @ Loc {file=test/testdata/desugar/kwnil.rb start=??? end=???}
+

--- a/test/testdata/infer/kwnil.rb
+++ b/test/testdata/infer/kwnil.rb
@@ -1,0 +1,167 @@
+# typed: true
+
+class A
+  def self.m1(**nil)
+  end
+
+  def self.m2(*a, **nil)
+  end
+
+  def self.m3(a, **nil)
+  end
+
+  def self.m4(a, b, c, **nil)
+  end
+
+  def self.m5(a, b, *rest, **nil)
+  end
+end
+
+def main
+  hash1 = {}
+  hash2 = {a: 10, b: 10}
+
+  A.m1
+  A.m1(*T.unsafe([]))
+  A.m1(*[1, 2])
+  A.m1(10) # error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1(nil) # error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1(10, a: 10) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `2`
+  A.m1(a: nil) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1(a: 10) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1(a: 10, b: 10) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1({}) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1({a: 10}) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1({a: 10, b: 10}) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1(**{}) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1(**{a: 10}) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1(**{a: 10, b: 10}) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^^^^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1(**hash1) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1(**hash2) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1(*[1, 2], **{}) # error: No keyword accepted for method `A.m1`
+  A.m1(*[1, 2], **{a: 10, b: 10}) # error: No keyword accepted for method `A.m1`
+  A.m1(*[1, 2], **hash1) # error: No keyword accepted for method `A.m1`
+  A.m1(*[1, 2], **hash2) # error: No keyword accepted for method `A.m1`
+
+  A.m2
+  A.m2(*T.unsafe([]))
+  A.m2(*[1, 2])
+  A.m2(10)
+  A.m2(nil)
+  A.m2(a: nil) # error: No keyword accepted for method `A.m2`
+  A.m2(a: 10) # error: No keyword accepted for method `A.m2`
+  A.m2(a: 10, b: 10) # error: No keyword accepted for method `A.m2`
+  A.m2({}) # error: No keyword accepted for method `A.m2`
+  A.m2({a: 10}) # error: No keyword accepted for method `A.m2`
+  A.m2({a: 10, b: 10}) # error: No keyword accepted for method `A.m2`
+  A.m2(**{}) # error: No keyword accepted for method `A.m2`
+  A.m2(**{a: 10}) # error: No keyword accepted for method `A.m2`
+  A.m2(**{a: 10, b: 10}) # error: No keyword accepted for method `A.m2`
+  A.m2(**hash1) # error: No keyword accepted for method `A.m2`
+  A.m2(**hash2) # error: No keyword accepted for method `A.m2`
+  A.m2(*[1, 2], **{}) # error: No keyword accepted for method `A.m2`
+  A.m2(*[1, 2], **{a: 10, b: 10}) # error: No keyword accepted for method `A.m2`
+  A.m2(*[1, 2], **hash1) # error: No keyword accepted for method `A.m2`
+  A.m2(*[1, 2], **hash2) # error: No keyword accepted for method `A.m2`
+
+  A.m3 # error: Not enough arguments provided for method `A.m3`. Expected: `1`, got: `0`
+  A.m3(*T.unsafe([]))
+  A.m3(*[1, 2])
+  A.m3(10)
+  A.m3(nil)
+  A.m3(a: nil) # error: No keyword accepted for method `A.m3`
+  A.m3(a: 10) # error: No keyword accepted for method `A.m3`
+  A.m3(a: 10, b: 10) # error: No keyword accepted for method `A.m3`
+  A.m3({}) # error: No keyword accepted for method `A.m3`
+  A.m3({a: 10}) # error: No keyword accepted for method `A.m3`
+  A.m3({a: 10, b: 10}) # error: No keyword accepted for method `A.m3`
+  A.m3(**{}) # error: No keyword accepted for method `A.m3`
+  A.m3(**{a: 10}) # error: No keyword accepted for method `A.m3`
+  A.m3(**{a: 10, b: 10}) # error: No keyword accepted for method `A.m3`
+  A.m3(**hash1) # error: No keyword accepted for method `A.m3`
+  A.m3(**hash2) # error: No keyword accepted for method `A.m3`
+  A.m3(*[1, 2], **{}) # error: No keyword accepted for method `A.m3`
+  A.m3(*[1, 2], **{a: 10, b: 10}) # error: No keyword accepted for method `A.m3`
+  A.m3(*[1, 2], **hash1) # error: No keyword accepted for method `A.m3`
+  A.m3(*[1, 2], **hash2) # error: No keyword accepted for method `A.m3`
+
+  A.m4 # error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `0`
+  A.m4(*T.unsafe([]))
+  A.m4(*[1, 2])
+  A.m4(10) # error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4(nil) # error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4(10, 10, nil)
+  A.m4(10, 10, nil, nil) # error: Too many arguments provided for method `A.m4`. Expected: `3`, got: `4`
+  A.m4(a: nil) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4(a: 10) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4(a: 10, b: 10) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4({}) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4({a: 10}) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4({a: 10, b: 10}) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4(**{}) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4(**{a: 10}) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4(**{a: 10, b: 10}) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^^^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4(**hash1) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4(**hash2) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4(*[1, 2], **{}) # error: No keyword accepted for method `A.m4`
+  A.m4(*[1, 2], **{a: 10, b: 10}) # error: No keyword accepted for method `A.m4`
+  A.m4(*[1, 2], **hash1) # error: No keyword accepted for method `A.m4`
+  A.m4(*[1, 2], **hash2) # error: No keyword accepted for method `A.m4`
+
+  A.m5 # error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `0`
+  A.m5(*T.unsafe([]))
+  A.m5(*[1, 2])
+  A.m5(10) # error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5(nil) # error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5(10, 10, nil)
+  A.m5(10, 10, nil, nil)
+  A.m5(a: nil) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5(a: 10) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5(a: 10, b: 10) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5({}) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5({a: 10}) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5({a: 10, b: 10}) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5(**{}) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5(**{a: 10}) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5(**{a: 10, b: 10}) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^^^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5(**hash1) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5(**hash2) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5(*[1, 2], **{}) # error: No keyword accepted for method `A.m5`
+  A.m5(*[1, 2], **{a: 10, b: 10}) # error: No keyword accepted for method `A.m5`
+  A.m5(*[1, 2], **hash1) # error: No keyword accepted for method `A.m5`
+  A.m5(*[1, 2], **hash2) # error: No keyword accepted for method `A.m5`
+end

--- a/test/testdata/infer/kwnil_redef.rb
+++ b/test/testdata/infer/kwnil_redef.rb
@@ -1,0 +1,20 @@
+# typed: true
+
+class A
+  def self.foo(*args, **nil)
+  end
+
+  def self.foo(*args, mode: false) # error: Method `A.foo` redefined without matching argument count. Expected: `1`, got: `2`
+  end
+end
+
+class B
+  def self.bar(*args, mode: false)
+  end
+
+  def self.bar(*args, **nil) # error: Method `B.bar` redefined without matching argument count. Expected: `2`, got: `1`
+  end
+end
+
+A.foo(mode: 10)
+B.bar(mode: 10) # error: No keyword accepted for method `B.bar`

--- a/test/testdata/infer/kwnil_sigs.rb
+++ b/test/testdata/infer/kwnil_sigs.rb
@@ -1,0 +1,177 @@
+# typed: strict
+
+class A
+  extend T::Sig
+
+  sig { void }
+  def self.m1(**nil)
+  end
+
+  sig { params(a: T.untyped).void }
+  def self.m2(*a, **nil)
+  end
+
+  sig { params(a: T.untyped).void }
+  def self.m3(a, **nil)
+  end
+
+  sig { params(a: T.untyped, b: T.untyped, c: T.untyped).void }
+  def self.m4(a, b, c, **nil)
+  end
+
+  sig { params(a: T.untyped, b: T.untyped, c: T.untyped).void }
+  def self.m5(a, b, *c, **nil)
+  end
+end
+
+extend T::Sig
+
+sig { void }
+def main
+  hash1 = {}
+  hash2 = {a: 10, b: 10}
+
+  A.m1
+  A.m1(*T.unsafe([]))
+  A.m1(*[1, 2])
+  A.m1(10) # error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1(nil) # error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1(10, a: 10) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `2`
+  A.m1(a: nil) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1(a: 10) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1(a: 10, b: 10) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1({}) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1({a: 10}) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1({a: 10, b: 10}) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1(**{}) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1(**{a: 10}) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1(**{a: 10, b: 10}) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^^^^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1(**hash1) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1(**hash2) # error: No keyword accepted for method `A.m1`
+# ^^^^^^^^^^^^^ error: Too many arguments provided for method `A.m1`. Expected: `0`, got: `1`
+  A.m1(*[1, 2], **{}) # error: No keyword accepted for method `A.m1`
+  A.m1(*[1, 2], **{a: 10, b: 10}) # error: No keyword accepted for method `A.m1`
+  A.m1(*[1, 2], **hash1) # error: No keyword accepted for method `A.m1`
+  A.m1(*[1, 2], **hash2) # error: No keyword accepted for method `A.m1`
+
+  A.m2
+  A.m2(*T.unsafe([]))
+  A.m2(*[1, 2])
+  A.m2(10)
+  A.m2(nil)
+  A.m2(a: nil) # error: No keyword accepted for method `A.m2`
+  A.m2(a: 10) # error: No keyword accepted for method `A.m2`
+  A.m2(a: 10, b: 10) # error: No keyword accepted for method `A.m2`
+  A.m2({}) # error: No keyword accepted for method `A.m2`
+  A.m2({a: 10}) # error: No keyword accepted for method `A.m2`
+  A.m2({a: 10, b: 10}) # error: No keyword accepted for method `A.m2`
+  A.m2(**{}) # error: No keyword accepted for method `A.m2`
+  A.m2(**{a: 10}) # error: No keyword accepted for method `A.m2`
+  A.m2(**{a: 10, b: 10}) # error: No keyword accepted for method `A.m2`
+  A.m2(**hash1) # error: No keyword accepted for method `A.m2`
+  A.m2(**hash2) # error: No keyword accepted for method `A.m2`
+  A.m2(*[1, 2], **{}) # error: No keyword accepted for method `A.m2`
+  A.m2(*[1, 2], **{a: 10, b: 10}) # error: No keyword accepted for method `A.m2`
+  A.m2(*[1, 2], **hash1) # error: No keyword accepted for method `A.m2`
+  A.m2(*[1, 2], **hash2) # error: No keyword accepted for method `A.m2`
+
+  A.m3 # error: Not enough arguments provided for method `A.m3`. Expected: `1`, got: `0`
+  A.m3(*T.unsafe([]))
+  A.m3(*[1, 2])
+  A.m3(10)
+  A.m3(nil)
+  A.m3(a: nil) # error: No keyword accepted for method `A.m3`
+  A.m3(a: 10) # error: No keyword accepted for method `A.m3`
+  A.m3(a: 10, b: 10) # error: No keyword accepted for method `A.m3`
+  A.m3({}) # error: No keyword accepted for method `A.m3`
+  A.m3({a: 10}) # error: No keyword accepted for method `A.m3`
+  A.m3({a: 10, b: 10}) # error: No keyword accepted for method `A.m3`
+  A.m3(**{}) # error: No keyword accepted for method `A.m3`
+  A.m3(**{a: 10}) # error: No keyword accepted for method `A.m3`
+  A.m3(**{a: 10, b: 10}) # error: No keyword accepted for method `A.m3`
+  A.m3(**hash1) # error: No keyword accepted for method `A.m3`
+  A.m3(**hash2) # error: No keyword accepted for method `A.m3`
+  A.m3(*[1, 2], **{}) # error: No keyword accepted for method `A.m3`
+  A.m3(*[1, 2], **{a: 10, b: 10}) # error: No keyword accepted for method `A.m3`
+  A.m3(*[1, 2], **hash1) # error: No keyword accepted for method `A.m3`
+  A.m3(*[1, 2], **hash2) # error: No keyword accepted for method `A.m3`
+
+  A.m4 # error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `0`
+  A.m4(*T.unsafe([]))
+  A.m4(*[1, 2])
+  A.m4(10) # error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4(nil) # error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4(10, 10, nil)
+  A.m4(10, 10, nil, nil) # error: Too many arguments provided for method `A.m4`. Expected: `3`, got: `4`
+  A.m4(a: nil) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4(a: 10) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4(a: 10, b: 10) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4({}) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4({a: 10}) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4({a: 10, b: 10}) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4(**{}) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4(**{a: 10}) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4(**{a: 10, b: 10}) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^^^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4(**hash1) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4(**hash2) # error: No keyword accepted for method `A.m4`
+# ^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m4`. Expected: `3`, got: `1`
+  A.m4(*[1, 2], **{}) # error: No keyword accepted for method `A.m4`
+  A.m4(*[1, 2], **{a: 10, b: 10}) # error: No keyword accepted for method `A.m4`
+  A.m4(*[1, 2], **hash1) # error: No keyword accepted for method `A.m4`
+  A.m4(*[1, 2], **hash2) # error: No keyword accepted for method `A.m4`
+
+  A.m5 # error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `0`
+  A.m5(*T.unsafe([]))
+  A.m5(*[1, 2])
+  A.m5(10) # error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5(nil) # error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5(10, 10, nil)
+  A.m5(10, 10, nil, nil)
+  A.m5(a: nil) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5(a: 10) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5(a: 10, b: 10) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5({}) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5({a: 10}) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5({a: 10, b: 10}) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5(**{}) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5(**{a: 10}) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5(**{a: 10, b: 10}) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^^^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5(**hash1) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5(**hash2) # error: No keyword accepted for method `A.m5`
+# ^^^^^^^^^^^^^ error: Not enough arguments provided for method `A.m5`. Expected: `2+`, got: `1`
+  A.m5(*[1, 2], **{}) # error: No keyword accepted for method `A.m5`
+  A.m5(*[1, 2], **{a: 10, b: 10}) # error: No keyword accepted for method `A.m5`
+  A.m5(*[1, 2], **hash1) # error: No keyword accepted for method `A.m5`
+  A.m5(*[1, 2], **hash2) # error: No keyword accepted for method `A.m5`
+end

--- a/test/testdata/parser/kwnil.parse-tree.exp
+++ b/test/testdata/parser/kwnil.parse-tree.exp
@@ -1,0 +1,65 @@
+Begin {
+  stmts = [
+    DefMethod {
+      name = <U f1>
+      args = Args {
+        args = [
+          Kwnilarg {
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U f2>
+      args = Args {
+        args = [
+          Restarg {
+            name = <U args>
+          }
+          Kwnilarg {
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U f3>
+      args = Args {
+        args = [
+          Arg {
+            name = <U a>
+          }
+          Arg {
+            name = <U b>
+          }
+          Arg {
+            name = <U c>
+          }
+          Kwnilarg {
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U f4>
+      args = Args {
+        args = [
+          Arg {
+            name = <U a>
+          }
+          Arg {
+            name = <U b>
+          }
+          Restarg {
+            name = <U c>
+          }
+          Kwnilarg {
+          }
+        ]
+      }
+      body = NULL
+    }
+  ]
+}

--- a/test/testdata/parser/kwnil.rb
+++ b/test/testdata/parser/kwnil.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+def f1(**nil); end
+def f2(*args, **nil); end
+def f3(a, b, c, **nil); end
+def f4(a, b, *c, **nil); end

--- a/test/testdata/parser/kwnil_errors.rb
+++ b/test/testdata/parser/kwnil_errors.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+def f1(**nil, **nil); end # error: unexpected token "**"
+def f2(*args, **kwargs, **nil); end # error: unexpected token "**"
+def f3(*args, a:, **nil); end # error: unexpected token "nil"
+def f4(a:, **nil); end # error: unexpected token "nil"
+def f5(**nil: 10); end # error: unexpected token tLABEL

--- a/test/whitequark/test_kwnilarg_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_kwnilarg_0.parse-tree-whitequark.exp
@@ -1,0 +1,3 @@
+s(:def, :f,
+  s(:args,
+    s(:kwnilarg)), nil)

--- a/test/whitequark/test_kwnilarg_0.rb
+++ b/test/whitequark/test_kwnilarg_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def f(**nil); end

--- a/test/whitequark/test_kwnilarg_1.parse-tree-whitequark.exp
+++ b/test/whitequark/test_kwnilarg_1.parse-tree-whitequark.exp
@@ -1,0 +1,4 @@
+s(:block,
+  s(:send, nil, :m),
+  s(:args,
+    s(:kwnilarg)), nil)

--- a/test/whitequark/test_kwnilarg_1.rb
+++ b/test/whitequark/test_kwnilarg_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+m { |**nil| }

--- a/test/whitequark/test_kwnilarg_2.parse-tree-whitequark.exp
+++ b/test/whitequark/test_kwnilarg_2.parse-tree-whitequark.exp
@@ -1,0 +1,5 @@
+s(:block,
+  s(:send,
+    s(:const, nil, :Kernel), :lambda),
+  s(:args,
+    s(:kwnilarg)), nil)

--- a/test/whitequark/test_kwnilarg_2.rb
+++ b/test/whitequark/test_kwnilarg_2.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+->(**nil) {}

--- a/third_party/parser/cc/grammars/typedruby.ypp
+++ b/third_party/parser/cc/grammars/typedruby.ypp
@@ -272,6 +272,7 @@ using namespace std::string_literals;
   f_marg_list
   f_margs
   f_optarg
+  f_no_kwarg
   f_rest_arg
   list_none
   mlhs_basic
@@ -1776,6 +1777,12 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby27 &driver) {
                       args->concat($2);
                       $$ = args;
                     }
+                | f_no_kwarg opt_f_block_arg
+                    {
+                      auto &args = $1;
+                      args->concat($2);
+                      $$ = args;
+                    }
                 | f_block_arg
                     {
                       $$ = $1;
@@ -2597,6 +2604,12 @@ keyword_variable: kNIL
                       args->concat($2);
                       $$ = args;
                     }
+                | f_no_kwarg opt_f_block_arg
+                    {
+                      auto &args = $1;
+                      args->concat($2);
+                      $$ = args;
+                    }
                 | f_block_arg
                     {
                       $$ = $1;
@@ -2826,6 +2839,11 @@ keyword_variable: kNIL
                     }
 
      kwrest_mark: tPOW | tDSTAR
+
+      f_no_kwarg: kwrest_mark kNIL
+                    {
+                      $$ = driver.alloc.node_list(driver.build.kwnilarg(self, $1, $2));
+                    }
 
         f_kwrest: kwrest_mark tIDENTIFIER
                     {

--- a/third_party/parser/include/ruby_parser/builder.hh
+++ b/third_party/parser/include/ruby_parser/builder.hh
@@ -71,6 +71,7 @@ struct builder {
 	ForeignPtr(*keywordZsuper)(SelfPtr builder, const token* keyword);
 	ForeignPtr(*kwarg)(SelfPtr builder, const token* name);
 	ForeignPtr(*kwoptarg)(SelfPtr builder, const token* name, ForeignPtr value);
+	ForeignPtr(*kwnilarg)(SelfPtr builder, const token* dstar, const token* nil);
 	ForeignPtr(*kwrestarg)(SelfPtr builder, const token* dstar, const token* name);
 	ForeignPtr(*kwsplat)(SelfPtr builder, const token* dstar, ForeignPtr arg);
 	ForeignPtr(*line_literal)(SelfPtr builder, const token* tok);


### PR DESCRIPTION
### Motivation

Ruby 2.7 [introduces the no-keyword-arguments syntax](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/#other-minor-changes-double-splat-nil) `**nil`.

You can use `**nil` in a method definition to explicitly mark that the method accepts no keyword arguments. Calling such methods with keyword arguments will result in an `ArgumentError`.

```ruby
def foo(*args, **nil)
end


foo(k: 1)
  #=> Ruby 2.7 or later: no keywords accepted (ArgumentError)
```

This pull request makes Sorbet support the `**nil` syntax and raise errors when keyword arguments are passed to methods that use it. See the many examples in `test/testdata/infer/kwnil.rb`.

### Approach

I wanted to avoid touching the way arguments were handled just for `**nil`, so I figured the easiest way was to just remove it completely from the args list.

1. During parsing, a node is created for `**nil` and added to the arguments list
2. During desugar, the node is removed from the args list and the method definition is tagged as using `**nil`
3. During namer, we move that information from the method definition to the symbol so it can be accessed during typing
4. Finally, during typing, that information is used to raise an error for any call with keyword arguments to a method symbol tagged `**nil` (I reused the `MethodArgumentCountMismatch` error)

### `**nil` in procs and lambda

With Ruby 2.7, you can also use `**nil` in procs and lambdas:

```ruby
m = ->(a, **nil) {}
m.call(10, b: 20) # ArgumentError (no keywords accepted)
```

While this PR changes the parser so it does not create a syntax error, the `**nil` is still not checked in procs and lambdas.
We can store the information in the block definition but then the call is a special case with `Proc.call` and I'm not sure how to get back the `**nil` tag from the block at this point.

### Test plan

See included automated tests.

This PR can be read commit by commit.