### PR TITLE
Fix return type for `Regexp::last_match`

### DIFF
--- a/rbi/core/regexp.rbi
+++ b/rbi/core/regexp.rbi
@@ -872,7 +872,7 @@ class Regexp < Object
   sig {returns(T.nilable(MatchData))}
   sig do
     params(
-        arg0: Integer,
+      arg0: T.any(Integer, Symbol),
     )
     .returns(T.nilable(String))
   end

--- a/rbi/core/regexp.rbi
+++ b/rbi/core/regexp.rbi
@@ -869,12 +869,12 @@ class Regexp < Object
   # Regexp.last_match(:lhs) #=> "var"
   # Regexp.last_match(:rhs) #=> "val"
   # ```
-  sig {returns(MatchData)}
+  sig {returns(T.nilable(MatchData))}
   sig do
     params(
         arg0: Integer,
     )
-    .returns(String)
+    .returns(T.nilable(String))
   end
   def self.last_match(arg0=T.unsafe(nil)); end
 


### PR DESCRIPTION
### Motivation

As shown in the documentation [a few lines above](https://github.com/sorbet/sorbet/blob/master/rbi/core/regexp.rbi#L865), the return type of `Regexp::last_match` can be `nil`:

```
[1] [shopify][development] pry(main)> "foo" =~ /\d/
=> nil
[2] [shopify][development] pry(main)> Regexp.last_match(1)
=> nil
```

### Test plan

See included automated tests.

cc. @paracycle @seachel 
