### PR TITLE
Make `srb` aware of `tapioca`

### DIFF
--- a/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/expected/err.log
+++ b/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/expected/err.log
@@ -1,0 +1,31 @@
+👋 Hey there! Heads up that this is not a release build of sorbet.
+Release builds are faster and more well-supported by the Sorbet team.
+Check out the README to learn how to build Sorbet in release mode.
+To forcibly silence this error, either pass --silence-dev-message,
+or set SORBET_SILENCE_DEV_MESSAGE=1 in your shell environment.
+
+lib/test.rb:3: Unable to resolve constant `Parlour` https://srb.help/5002
+     3 |FOO = Parlour # We expect `Parlour` to be undefined here since we didn't load any gem RBI
+              ^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    lib/test.rb:3: Replace with `Gem::RequestSet::Lockfile::Parser`
+     3 |FOO = Parlour # We expect `Parlour` to be undefined here since we didn't load any gem RBI
+              ^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    lib/test.rb:3: Replace with `JSON::Ext::Parser`
+     3 |FOO = Parlour # We expect `Parlour` to be undefined here since we didn't load any gem RBI
+              ^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    lib/test.rb:3: Replace with `Psych::Parser`
+     3 |FOO = Parlour # We expect `Parlour` to be undefined here since we didn't load any gem RBI
+              ^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/rubygems.rbi#L2819: Did you mean: `Gem::RequestSet::Lockfile::Parser`?
+    2819 |class Gem::RequestSet::Lockfile::Parser
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi#L974: Did you mean: `JSON::Ext::Parser`?
+     974 |class JSON::Ext::Parser
+          ^^^^^^^^^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi#L980: Did you mean: `Psych::Parser`?
+     980 |class Psych::Parser
+          ^^^^^^^^^^^^^^^^^^^
+Errors: 1

--- a/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/expected/sorbet/config
+++ b/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/expected/sorbet/config
@@ -1,0 +1,1 @@
+lib/test.rb

--- a/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/gems/0.0.0/gems/parlour-0.0.0/lib/parlour.rb
+++ b/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/gems/0.0.0/gems/parlour-0.0.0/lib/parlour.rb
@@ -1,0 +1,2 @@
+# typed: true
+

--- a/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/gems/0.0.0/gems/parlour-0.0.0/parlour.gemspec
+++ b/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/gems/0.0.0/gems/parlour-0.0.0/parlour.gemspec
@@ -1,0 +1,7 @@
+Gem::Specification.new do |s|
+  s.name        = 'parlour'
+  s.version     = '0.0.0'
+  s.summary     = 'parlour'
+  s.authors     = ['Sorbet Contributors']
+  s.files       = Dir.glob('lib/**/*')
+end

--- a/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/gems/0.0.0/gems/parlour-0.0.0/rbi/parlour.rbi
+++ b/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/gems/0.0.0/gems/parlour-0.0.0/rbi/parlour.rbi
@@ -1,0 +1,4 @@
+# typed: true
+
+module Parlour
+end

--- a/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/gems/0.0.0/gems/tapioca-0.0.0/lib/tapioca.rb
+++ b/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/gems/0.0.0/gems/tapioca-0.0.0/lib/tapioca.rb
@@ -1,0 +1,4 @@
+# typed: true
+
+module Tapioca
+end

--- a/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/gems/0.0.0/gems/tapioca-0.0.0/tapioca.gemspec
+++ b/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/gems/0.0.0/gems/tapioca-0.0.0/tapioca.gemspec
@@ -1,0 +1,7 @@
+Gem::Specification.new do |s|
+  s.name        = 'tapioca'
+  s.version     = '0.0.0'
+  s.summary     = 'tapioca'
+  s.authors     = ['Sorbet Contributors']
+  s.files       = Dir.glob('lib/**/*')
+end

--- a/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/src/Gemfile
+++ b/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/src/Gemfile
@@ -1,0 +1,2 @@
+gem 'tapioca', path: '../gems/0.0.0/gems/tapioca-0.0.0'
+gem 'parlour', path: '../gems/0.0.0/gems/parlour-0.0.0'

--- a/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/src/Gemfile.lock
+++ b/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/src/Gemfile.lock
@@ -1,0 +1,22 @@
+PATH
+  remote: ../gems/0.0.0/gems/parlour-0.0.0
+  specs:
+    parlour (0.0.0)
+
+PATH
+  remote: ../gems/0.0.0/gems/tapioca-0.0.0
+  specs:
+    tapioca (0.0.0)
+
+GEM
+  specs:
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  parlour!
+  tapioca!
+
+BUNDLED WITH
+   2.1.4

--- a/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/src/lib/test.rb
+++ b/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/src/lib/test.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+FOO = Parlour # We expect `Parlour` to be undefined here since we didn't load any gem RBI

--- a/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/src/sorbet/config
+++ b/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/src/sorbet/config
@@ -1,0 +1,1 @@
+lib/test.rb

--- a/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/src/test.sh
+++ b/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/src/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+bundle exec "$1" tc || exit 0

--- a/gems/sorbet/test/snapshot/partial/project-without-tapioca-but-rbis/expected/sorbet/config
+++ b/gems/sorbet/test/snapshot/partial/project-without-tapioca-but-rbis/expected/sorbet/config
@@ -1,0 +1,1 @@
+lib/test.rb

--- a/gems/sorbet/test/snapshot/partial/project-without-tapioca-but-rbis/gems/0.0.0/gems/parlour-0.0.0/lib/parlour.rb
+++ b/gems/sorbet/test/snapshot/partial/project-without-tapioca-but-rbis/gems/0.0.0/gems/parlour-0.0.0/lib/parlour.rb
@@ -1,0 +1,2 @@
+# typed: true
+

--- a/gems/sorbet/test/snapshot/partial/project-without-tapioca-but-rbis/gems/0.0.0/gems/parlour-0.0.0/parlour.gemspec
+++ b/gems/sorbet/test/snapshot/partial/project-without-tapioca-but-rbis/gems/0.0.0/gems/parlour-0.0.0/parlour.gemspec
@@ -1,0 +1,7 @@
+Gem::Specification.new do |s|
+  s.name        = 'parlour'
+  s.version     = '0.0.0'
+  s.summary     = 'parlour'
+  s.authors     = ['Sorbet Contributors']
+  s.files       = Dir.glob('lib/**/*')
+end

--- a/gems/sorbet/test/snapshot/partial/project-without-tapioca-but-rbis/gems/0.0.0/gems/parlour-0.0.0/rbi/parlour.rbi
+++ b/gems/sorbet/test/snapshot/partial/project-without-tapioca-but-rbis/gems/0.0.0/gems/parlour-0.0.0/rbi/parlour.rbi
@@ -1,0 +1,4 @@
+# typed: true
+
+module Parlour
+end

--- a/gems/sorbet/test/snapshot/partial/project-without-tapioca-but-rbis/src/Gemfile
+++ b/gems/sorbet/test/snapshot/partial/project-without-tapioca-but-rbis/src/Gemfile
@@ -1,0 +1,1 @@
+gem 'parlour', path: '../gems/0.0.0/gems/parlour-0.0.0'

--- a/gems/sorbet/test/snapshot/partial/project-without-tapioca-but-rbis/src/Gemfile.lock
+++ b/gems/sorbet/test/snapshot/partial/project-without-tapioca-but-rbis/src/Gemfile.lock
@@ -1,0 +1,16 @@
+PATH
+  remote: ../gems/0.0.0/gems/parlour-0.0.0
+  specs:
+    parlour (0.0.0)
+
+GEM
+  specs:
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  parlour!
+
+BUNDLED WITH
+   2.1.4

--- a/gems/sorbet/test/snapshot/partial/project-without-tapioca-but-rbis/src/lib/test.rb
+++ b/gems/sorbet/test/snapshot/partial/project-without-tapioca-but-rbis/src/lib/test.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+FOO = Parlour

--- a/gems/sorbet/test/snapshot/partial/project-without-tapioca-but-rbis/src/sorbet/config
+++ b/gems/sorbet/test/snapshot/partial/project-without-tapioca-but-rbis/src/sorbet/config
@@ -1,0 +1,1 @@
+lib/test.rb

--- a/gems/sorbet/test/snapshot/partial/project-without-tapioca-but-rbis/src/test.sh
+++ b/gems/sorbet/test/snapshot/partial/project-without-tapioca-but-rbis/src/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+bundle exec "$1" tc


### PR DESCRIPTION
### Motivation

One difference between `srb` and `tapioca` is the way they handle signatures coming from gems.

With `srb`, the developer of a gem [can provide a dir called `rbi/`](https://sorbet.org/docs/rbi#rbis-within-gems) that contains all the signatures they want to export.
When the end user runs `srb tc`, the content of the gem `rbi/` dir is [cached locally](https://github.com/sorbet/sorbet/blob/master/gems/sorbet/lib/find-gem-rbis.rb#L31-L43) then passed to sorbet along the other files to be typechecked in the project.

This approach brings at least two problems: 1) Sorbet does not come with a de-facto solution to copy signatures from the code to the `rbi/` folder, hence 2) there is a high probability for the `rbi/` folder to get desynchronized from the actual lib code.

`tapioca` tries to address this problem by automatically [copying code signatures to the RBI](https://github.com/Shopify/tapioca/blob/master/lib/tapioca/compilers/symbol_table/symbol_generator.rb#L491-L497) when it generates the RBIs for all the gems in the end user project. That way, the work is transferred from the gem developer to the gem user, and ultimately to `tapioca`. Since you likely run `tapioca` every time you change your Gemfile, you always get the up-to-date signatures from the gem code for free.

While still imperfect, this solution allows the whole RBI sharing to work without intervention from the developer nor the end user and avoid desynchronization. Also, since `tapioca` comes with an [exclusion list mechanism](https://github.com/Shopify/tapioca/blob/master/lib/tapioca/config.rb#L12) the end user can chose to completely ignore a gem RBI if they want.

Now comes the problem with the current `srb` behaviour. By always copying the `rbi/` folder, the RBI from the gem is always passed to Sorbet when one call `srb tc`. Which is then in conflict with the expected behaviour of a `tapioca` user.

To address this problem, @paracycle [proposed a new environment variable](https://github.com/sorbet/sorbet/pull/3121) controlling `srb` behaviour regarding gems RBIs: [`SRB_SKIP_GEM_RBIS`](https://github.com/sorbet/sorbet/blob/master/gems/sorbet/bin/srb#L50). While it solves the problem, it can be cumbersome for the end user that always have to remember to set this variable every time they use `tapioca` in a project that depends on gems with a `rbi/` folder. This problem is even bigger since `tapioca` started depending on the `parlour` gem which provides a [`rbi/` folder](https://github.com/AaronC81/parlour/tree/master/rbi) meaning that all `tapioca` users now need to set the environment variable.

With this pull-request, the idea is to make `srb` aware that `tapioca` is used in the project and copying the `rbi/` folder is not needed. The end user get the expected behaviour without changing environment variables and nothing changes if the project does not use `tapioca`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.