### PR TITLE
Fix regressions from #3317

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -255,7 +255,7 @@ module T::Private::Methods
       # Note, this logic is duplicated above, make sure to keep changes in sync.
       if method_sig.check_level == :always || (method_sig.check_level == :tests && T::Private::RuntimeLevels.check_tests?)
         # Checked, so copy the original signature to the aliased copy.
-        T::Private::Methods.unwrap_method(aliasing_mod, method_sig, aliasing_method)
+        T::Private::Methods.unwrap_method(aliasing_mod, method_sig, original_method)
       else
         # Unchecked, so just make `alias_method` behave as if it had been called pre-sig.
         aliasing_mod.send(:alias_method, callee, original_method.name)

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -254,8 +254,10 @@ module T::Private::Methods
       receiving_class = receiver.class
     elsif receiver.singleton_class <= original_method.owner
       receiving_class = receiver.singleton_class
+    elsif receiver.is_a?(Module) && receiver <= original_method.owner
+      receiving_class = receiver
     else
-      raise "#{receiver} is not related to #{original_method}, how did we get here?"
+      raise "#{receiver} is not related to #{original_method} - how did we get here?"
     end
 
     # Check for a case where `alias` or `alias_method` was called for a

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -208,7 +208,7 @@ module T::Private::Methods
     T::Private::ClassUtils.replace_method(mod, method_name) do |*args, &blk|
       method_sig = T::Private::Methods.maybe_run_sig_block_for_method(new_method)
       method_sig ||= T::Private::Methods._handle_missing_method_signature(
-        is_singleton_method ? self.singleton_class : self.class,
+        self,
         original_method,
         __callee__,
       )
@@ -242,16 +242,35 @@ module T::Private::Methods
     end
   end
 
-  def self._handle_missing_method_signature(klass, original_method, callee)
+  def self._handle_missing_method_signature(receiver, original_method, callee)
     method_sig = T::Private::Methods.signature_for_method(original_method)
+    if !method_sig
+      raise "`sig` not present for method `#{callee}` on #{receiver.inspect} but you're trying to run it anyways. " \
+        "This should only be executed if you used `alias_method` to grab a handle to a method after `sig`ing it, but that clearly isn't what you are doing. " \
+        "Maybe look to see if an exception was thrown in your `sig` lambda or somehow else your `sig` wasn't actually applied to the method."
+    end
 
-    aliasing_method = klass.instance_method(callee)
-    aliasing_mod = aliasing_method.owner
+    if receiver.class <= original_method.owner
+      receiving_class = receiver.class
+    elsif receiver.singleton_class <= original_method.owner
+      receiving_class = receiver.singleton_class
+    else
+      raise "#{receiver} is not related to #{original_method}, how did we get here?"
+    end
 
-    if method_sig && aliasing_method != original_method && aliasing_method.original_name == original_method.name
-      # We're handling a case where `alias` or `alias_method` was called for a
-      # method which had already had a `sig` applied.
-      #
+    # Check for a case where `alias` or `alias_method` was called for a
+    # method which had already had a `sig` applied. In that case, we want
+    # to avoid hitting this slow path again, by moving to a faster validator
+    # just like we did or will for the original method.
+    #
+    # If this isn't an `alias` or `alias_method` case, we're probably in the
+    # middle of some metaprogramming using a Method object, e.g. a pattern like
+    # `arr.map(&method(:foo))`. There's nothing really we can do to optimize
+    # that here.
+    receiving_method = receiving_class.instance_method(callee)
+    if receiving_method != original_method && receiving_method.original_name == original_method.name
+      aliasing_mod = receiving_method.owner
+
       # Note, this logic is duplicated above, make sure to keep changes in sync.
       if method_sig.check_level == :always || (method_sig.check_level == :tests && T::Private::RuntimeLevels.check_tests?)
         # Checked, so copy the original signature to the aliased copy.
@@ -260,10 +279,6 @@ module T::Private::Methods
         # Unchecked, so just make `alias_method` behave as if it had been called pre-sig.
         aliasing_mod.send(:alias_method, callee, original_method.name)
       end
-    else
-      raise "`sig` not present for method `#{aliasing_method.name}` but you're trying to run it anyways. " \
-        "This should only be executed if you used `alias_method` to grab a handle to a method after `sig`ing it, but that clearly isn't what you are doing. " \
-        "Maybe look to see if an exception was thrown in your `sig` lambda or somehow else your `sig` wasn't actually applied to the method."
     end
 
     method_sig

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -136,6 +136,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         assert_equal(:foo, subclass.new.foo)
         assert_equal(:foo, subclass.new.bar)
+        assert_equal(:foo, superclass.new.foo)
       end
 
       it 'handles alias to superclass method without runtime checking' do
@@ -239,6 +240,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         assert_equal(:foo, subclass.foo)
         assert_equal(:foo, subclass.bar)
+        assert_equal(:foo, superclass.foo)
       end
 
       it 'handles alias_method to superclass method without runtime checking' do

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -36,6 +36,24 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     assert_equal("foo", klass.new.bar = "foo")
   end
 
+  it 'handles module_function on including class' do
+    mod = Module.new do
+      extend T::Sig
+      extend T::Helpers
+      sig { params(foo: String).returns(String) }
+      module_function def foo(foo)
+        foo
+      end
+    end
+
+    klass = Class.new do
+      include mod
+    end
+
+    assert_equal('bar', klass.new.send(:foo, 'bar'))
+    assert_equal('bar', mod.foo('bar'))
+  end
+
   private def counting_allocations
     before = GC.stat[:total_allocated_objects]
     yield

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -154,6 +154,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         assert_equal(:foo, subclass.new.foo)
         assert_equal(:foo, subclass.new.bar)
+        assert_equal(:foo, superclass.new.foo)
       end
     end
 
@@ -258,6 +259,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         assert_equal(:foo, subclass.foo)
         assert_equal(:foo, subclass.bar)
+        assert_equal(:foo, superclass.foo)
       end
     end
   end

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -157,6 +157,44 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         assert_equal(:foo, subclass.new.bar)
         assert_equal(:foo, superclass.new.foo)
       end
+
+      it 'handles alias_method to included method with runtime checking' do
+        mod = Module.new do
+          extend T::Sig
+
+          sig {params(x: Symbol).returns(Symbol)}
+          def foo(x=:foo)
+            x
+          end
+        end
+
+        klass = Class.new do
+          include mod
+          alias_method :bar, :foo
+        end
+
+        assert_equal(:foo, klass.new.foo)
+        assert_equal(:foo, klass.new.bar)
+      end
+
+      it 'handles alias_method to included method without runtime checking' do
+        mod = Module.new do
+          extend T::Sig
+
+          sig {params(x: Symbol).returns(Symbol).checked(:never)}
+          def foo(x=:foo)
+            x
+          end
+        end
+
+        klass = Class.new do
+          include mod
+          alias_method :bar, :foo
+        end
+
+        assert_equal(:foo, klass.new.foo)
+        assert_equal(:foo, klass.new.bar)
+      end
     end
 
     describe 'singleton method' do
@@ -262,6 +300,100 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         assert_equal(:foo, subclass.foo)
         assert_equal(:foo, subclass.bar)
         assert_equal(:foo, superclass.foo)
+      end
+
+      it 'handles alias_method to extended method with runtime checking' do
+        mod = Module.new do
+          extend T::Sig
+
+          sig {params(x: Symbol).returns(Symbol)}
+          def foo(x=:foo)
+            x
+          end
+        end
+
+        klass = Class.new do
+          extend mod
+
+          class << self
+            alias_method :bar, :foo
+          end
+        end
+
+        assert_equal(:foo, klass.foo)
+        assert_equal(:foo, klass.bar)
+      end
+
+      it 'handles alias_method to extended method without runtime checking' do
+        mod = Module.new do
+          extend T::Sig
+
+          sig {params(x: Symbol).returns(Symbol).checked(:never)}
+          def foo(x=:foo)
+            x
+          end
+        end
+
+        klass = Class.new do
+          extend mod
+
+          class << self
+            alias_method :bar, :foo
+          end
+        end
+
+        assert_equal(:foo, klass.foo)
+        assert_equal(:foo, klass.bar)
+      end
+
+      it 'handles method reference without sig' do
+        klass = Class.new do
+          extend T::Sig
+          extend T::Helpers
+          def self.foo(arr)
+            arr.map(&method(:bar))
+          end
+          def self.bar(x)
+            -x
+          end
+        end
+        assert_equal([1, 2, 3], klass.foo([-1, -2, -3]))
+      end
+
+      it 'handles method reference with runtime checking' do
+        klass = Class.new do
+          extend T::Sig
+          extend T::Helpers
+          def self.foo(arr)
+            arr.map(&method(:bar))
+          end
+
+          sig { params(x: Integer).returns(Integer) }
+          def self.bar(x)
+            -x
+          end
+        end
+        assert_equal([1, 2, 3], klass.foo([-1, -2, -3]))
+        assert_raises(TypeError) do
+          klass.foo(["-1", "-2", "-3"])
+        end
+      end
+
+      it 'handles method reference without runtime checking' do
+        klass = Class.new do
+          extend T::Sig
+          extend T::Helpers
+          def self.foo(arr)
+            arr.map(&method(:bar))
+          end
+
+          sig { params(x: Integer).returns(Integer).checked(:never) }
+          def self.bar(x)
+            -x
+          end
+        end
+        assert_equal([1, 2, 3], klass.foo([-1, -2, -3]))
+        assert_equal(["-1", "-2", "-3"], klass.foo(["-1", "-2", "-3"]))
       end
     end
   end


### PR DESCRIPTION
### Motivation
This fixes three issues:
1. It pulls in the fix from #3327 by @Morriar 
2. It fixes another regression due to a typo which caused the aliasing method (ie, the one created with `alias_method`) to be used in place of the original method on the original superclass in some circumstances. Ruby doesn't allow this - it produces the "singleton method called for a different object" error on singleton methods and "bind argument must be an instance of ..." on instance methods.
3. It fixes yet another regression on handling of `extends` and `module_function` cases where the `is_singleton_method ? self.singleton_class : self.class` logic was not enough to determine the receiving class. 

### Test plan
See added tests. Also, I tested in pay-server, which I clearly should have done earlier.
