### PR TITLE
Resolve all instance variable warnings

### DIFF
--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -83,6 +83,7 @@ module T::Configuration
     raise error
   end
 
+  @inline_type_error_handler = nil
   def self.inline_type_error_handler(error)
     if @inline_type_error_handler
       @inline_type_error_handler.call(error)
@@ -123,6 +124,7 @@ module T::Configuration
     raise ArgumentError.new("#{location.path}:#{location.lineno}: Error interpreting `sig`:\n  #{error.message}\n\n")
   end
 
+  @sig_builder_error_handler = nil
   def self.sig_builder_error_handler(error, location)
     if @sig_builder_error_handler
       @sig_builder_error_handler.call(error, location)
@@ -173,6 +175,7 @@ module T::Configuration
     raise error
   end
 
+  @sig_validation_error_handler = nil
   def self.sig_validation_error_handler(error, opts={})
     if @sig_validation_error_handler
       @sig_validation_error_handler.call(error, opts)
@@ -219,6 +222,7 @@ module T::Configuration
     raise TypeError.new(opts[:pretty_message])
   end
 
+  @call_validation_error_handler = nil
   def self.call_validation_error_handler(signature, opts={})
     if @call_validation_error_handler
       @call_validation_error_handler.call(signature, opts)
@@ -251,6 +255,7 @@ module T::Configuration
     puts "#{str}, extra: #{extra}" # rubocop:disable PrisonGuard/NoBarePuts
   end
 
+  @log_info_handler = nil
   def self.log_info_handler(str, extra)
     if @log_info_handler
       @log_info_handler.call(str, extra)
@@ -285,6 +290,7 @@ module T::Configuration
     puts "#{str}, extra: #{extra}" # rubocop:disable PrisonGuard/NoBarePuts
   end
 
+  @soft_assert_handler = nil
   def self.soft_assert_handler(str, extra)
     if @soft_assert_handler
       @soft_assert_handler.call(str, extra)
@@ -319,6 +325,7 @@ module T::Configuration
     raise str
   end
 
+  @hard_assert_handler = nil
   def self.hard_assert_handler(str, extra={})
     if @hard_assert_handler
       @hard_assert_handler.call(str, extra)
@@ -359,6 +366,7 @@ module T::Configuration
     T::Enum
   }).freeze
 
+  @scalar_types = nil
   def self.scalar_types
     @scalar_types || @default_scalar_types
   end
@@ -389,10 +397,12 @@ module T::Configuration
   def self.disable_legacy_t_enum_migration_mode
     @legacy_t_enum_migration_mode = false
   end
+  @legacy_t_enum_migration_mode = false
   def self.legacy_t_enum_migration_mode?
-    @legacy_t_enum_migration_mode || false
+    @legacy_t_enum_migration_mode
   end
 
+  @sealed_violation_whitelist = nil
   # @param [Array] sealed_violation_whitelist An array of Regexp to validate
   #   whether inheriting /including a sealed module outside the defining module
   #   should be allowed. Useful to whitelist benign violations, like shim files

--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -280,14 +280,18 @@ class T::Enum
 
   sig {returns(T::Boolean)}
   def self.started_initializing?
-    @started_initializing = T.let(@started_initializing, T.nilable(T::Boolean))
-    @started_initializing ||= false
+    unless defined?(@started_initializing)
+      @started_initializing = T.let(false, T.nilable(T::Boolean))
+    end
+    T.must(@started_initializing)
   end
 
   sig {returns(T::Boolean)}
   def self.fully_initialized?
-    @fully_initialized = T.let(@fully_initialized, T.nilable(T::Boolean))
-    @fully_initialized ||= false
+    unless defined?(@fully_initialized)
+      @fully_initialized = T.let(false, T.nilable(T::Boolean))
+    end
+    T.must(@fully_initialized)
   end
 
   # Maintains the order in which values are defined
@@ -302,8 +306,8 @@ class T::Enum
   sig {params(blk: T.proc.void).void}
   def self.enums(&blk)
     raise "enums cannot be defined for T::Enum" if self == T::Enum
-    raise "Enum #{self} was already initialized" if @fully_initialized
-    raise "Enum #{self} is still initializing" if @started_initializing
+    raise "Enum #{self} was already initialized" if fully_initialized?
+    raise "Enum #{self} is still initializing" if started_initializing?
 
     @started_initializing = true
 

--- a/gems/sorbet-runtime/lib/types/private/abstract/data.rb
+++ b/gems/sorbet-runtime/lib/types/private/abstract/data.rb
@@ -12,7 +12,7 @@
 # modules that override the `hash` method with something completely broken.
 module T::Private::Abstract::Data
   def self.get(mod, key)
-    mod.instance_variable_get("@opus_abstract__#{key}") # rubocop:disable PrisonGuard/NoLurkyInstanceVariableAccess
+    mod.instance_variable_get("@opus_abstract__#{key}") if key?(mod, key) # rubocop:disable PrisonGuard/NoLurkyInstanceVariableAccess
   end
 
   def self.set(mod, key, value)

--- a/gems/sorbet-runtime/lib/types/props/constructor.rb
+++ b/gems/sorbet-runtime/lib/types/props/constructor.rb
@@ -20,7 +20,7 @@ module T::Props::Constructor::DecoratorMethods
     # Use `each_pair` rather than `count` because, as of Ruby 2.6, the latter delegates to Enumerator
     # and therefore allocates for each entry.
     result = 0
-    @props_without_defaults&.each_pair do |p, setter_proc|
+    props_without_defaults&.each_pair do |p, setter_proc|
       begin
         val = hash[p]
         instance.instance_exec(val, &setter_proc)

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -150,7 +150,7 @@ class T::Props::Decorator
     .checked(:never)
   end
   def prop_get(instance, prop, rules=prop_rules(prop))
-    val = instance.instance_variable_get(rules[:accessor_key])
+    val = instance.instance_variable_get(rules[:accessor_key]) if instance.instance_variable_defined?(rules[:accessor_key])
     if !val.nil?
       val
     else
@@ -172,7 +172,7 @@ class T::Props::Decorator
     .checked(:never)
   end
   def prop_get_if_set(instance, prop, rules=prop_rules(prop))
-    instance.instance_variable_get(rules[:accessor_key])
+    instance.instance_variable_get(rules[:accessor_key]) if instance.instance_variable_defined?(rules[:accessor_key])
   end
   alias_method :get, :prop_get_if_set # Alias for backwards compatibility
 

--- a/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
+++ b/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
@@ -37,7 +37,7 @@ module T::Props
 
     sig {returns(T::Boolean)}
     def self.lazy_evaluation_enabled?
-      !@lazy_evaluation_disabled
+      !defined?(@lazy_evaluation_disabled) || !@lazy_evaluation_disabled
     end
 
     module DecoratorMethods

--- a/gems/sorbet-runtime/lib/types/props/optional.rb
+++ b/gems/sorbet-runtime/lib/types/props/optional.rb
@@ -49,13 +49,13 @@ module T::Props::Optional::DecoratorMethods
     if default_setter
       @props_with_defaults ||= {}
       @props_with_defaults[prop] = default_setter
-      @props_without_defaults&.delete(prop) # Handle potential override
+      props_without_defaults&.delete(prop) # Handle potential override
 
       rules[DEFAULT_SETTER_RULE_KEY] = default_setter
     else
       @props_without_defaults ||= {}
       @props_without_defaults[prop] = rules.fetch(:setter_proc)
-      @props_with_defaults&.delete(prop) # Handle potential override
+      props_with_defaults&.delete(prop) # Handle potential override
     end
 
     super

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -35,7 +35,7 @@ module T::Props::Serializable
       end
     end
 
-    h.merge!(@_extra_props) if @_extra_props
+    h.merge!(@_extra_props) if defined?(@_extra_props)
     h
   end
 
@@ -121,8 +121,8 @@ module T::Props::Serializable
   private def with_existing_hash(changed_props, existing_hash:)
     serialized = existing_hash
     new_val = self.class.from_hash(serialized.merge(recursive_stringify_keys(changed_props)))
-    old_extra = self.instance_variable_get(:@_extra_props) # rubocop:disable PrisonGuard/NoLurkyInstanceVariableAccess
-    new_extra = new_val.instance_variable_get(:@_extra_props) # rubocop:disable PrisonGuard/NoLurkyInstanceVariableAccess
+    old_extra = self.instance_variable_get(:@_extra_props) if self.instance_variable_defined?(:@_extra_props) # rubocop:disable PrisonGuard/NoLurkyInstanceVariableAccess
+    new_extra = new_val.instance_variable_get(:@_extra_props) if new_val.instance_variable_defined?(:@_extra_props) # rubocop:disable PrisonGuard/NoLurkyInstanceVariableAccess
     if old_extra != new_extra
       difference =
         if old_extra
@@ -137,7 +137,8 @@ module T::Props::Serializable
 
   # Asserts if this property is missing during strict serialize
   private def required_prop_missing_from_serialize(prop)
-    if @_required_props_missing_from_deserialize&.include?(prop)
+    if defined?(@_required_props_missing_from_deserialize) &&
+      @_required_props_missing_from_deserialize&.include?(prop)
       # If the prop was already missing during deserialization, that means the application
       # code already had to deal with a nil value, which means we wouldn't be accomplishing
       # much by raising here (other than causing an unnecessary breakage).
@@ -289,7 +290,11 @@ module T::Props::Serializable::DecoratorMethods
   private_constant :EMPTY_EXTRA_PROPS
 
   def extra_props(instance)
-    instance.instance_variable_get(:@_extra_props) || EMPTY_EXTRA_PROPS
+    if instance.instance_variable_defined?(:@_extra_props)
+      instance.instance_variable_get(:@_extra_props)
+    else
+      instance.instance_variable_set(:@_extra_props, EMPTY_EXTRA_PROPS)
+    end
   end
 
   # @override T::Props::PrettyPrintable

--- a/gems/sorbet-runtime/lib/types/props/weak_constructor.rb
+++ b/gems/sorbet-runtime/lib/types/props/weak_constructor.rb
@@ -33,7 +33,7 @@ module T::Props::WeakConstructor::DecoratorMethods
     # Use `each_pair` rather than `count` because, as of Ruby 2.6, the latter delegates to Enumerator
     # and therefore allocates for each entry.
     result = 0
-    @props_without_defaults&.each_pair do |p, setter_proc|
+    props_without_defaults&.each_pair do |p, setter_proc|
       if hash.key?(p)
         instance.instance_exec(hash[p], &setter_proc)
         result += 1
@@ -54,7 +54,7 @@ module T::Props::WeakConstructor::DecoratorMethods
     # Use `each_pair` rather than `count` because, as of Ruby 2.6, the latter delegates to Enumerator
     # and therefore allocates for each entry.
     result = 0
-    @props_with_defaults&.each_pair do |p, default_struct|
+    props_with_defaults&.each_pair do |p, default_struct|
       if hash.key?(p)
         instance.instance_exec(hash[p], &default_struct.setter_proc)
         result += 1

--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -41,7 +41,7 @@ module T::Types
     module Private
       module Pool
         def self.type_for_module(mod)
-          cached = mod.instance_variable_get(:@__as_sorbet_simple_type)
+          cached = mod.instance_variable_get(:@__as_sorbet_simple_type) if mod.instance_variable_defined?(:@__as_sorbet_simple_type)
           return cached if cached
 
           type = Simple.new(mod)


### PR DESCRIPTION
This is a rebased version of @paracycle’s #3207, which appears to have gone stale. His original description is below.

----

This PR attempts to fix most of the Ruby warnings generated by `sorbet-runtime`. All the ones that can be identified by running the test suite are addressed, except for the ones that are dynamically triggered by the test suite itself.

Coincidentally, this investigation also lead to finding and fixing a memoization attempt using `||= false` which would be executed every time and defeat the aim to memoize the ivar.

### Motivation
Sorbet Runtime generates a lot of warnings like `warning: instance variable @foo not initialized` due to lazy initialization of various instance variables.

### Test plan
No extra automated tests, all the current ones pass.

Running the test suite using `RUBYOPT=-w bundle exec rake test` displays all the warnings that are generated during a test suite run.

There are still some `method redefinition` warnings left that this PR does not aim to fix.