### PR TITLE
Actually use fast path for alias_method when checked

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -272,15 +272,8 @@ module T::Private::Methods
     receiving_method = receiving_class.instance_method(callee)
     if receiving_method != original_method && receiving_method.original_name == original_method.name
       aliasing_mod = receiving_method.owner
-
-      # Note, this logic is duplicated above, make sure to keep changes in sync.
-      if method_sig.check_level == :always || (method_sig.check_level == :tests && T::Private::RuntimeLevels.check_tests?)
-        # Checked, so copy the original signature to the aliased copy.
-        T::Private::Methods.unwrap_method(aliasing_mod, method_sig, original_method)
-      else
-        # Unchecked, so just make `alias_method` behave as if it had been called pre-sig.
-        aliasing_mod.send(:alias_method, callee, original_method.name)
-      end
+      method_sig = method_sig.as_alias(callee)
+      unwrap_method(aliasing_mod, method_sig, original_method)
     end
 
     method_sig

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -297,7 +297,7 @@ module T::Private::Methods
         Signature.new_untyped(method: original_method)
       end
 
-    unwrap_method(hook_mod, signature, original_method)
+    unwrap_method(signature.method.owner, signature, original_method)
     signature
   end
 
@@ -349,8 +349,8 @@ module T::Private::Methods
     end
   end
 
-  def self.unwrap_method(hook_mod, signature, original_method)
-    maybe_wrapped_method = CallValidation.wrap_method_if_needed(signature.method.owner, signature, original_method)
+  def self.unwrap_method(mod, signature, original_method)
+    maybe_wrapped_method = CallValidation.wrap_method_if_needed(mod, signature, original_method)
     @signatures_by_method[method_to_key(maybe_wrapped_method)] = signature
   end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -12,9 +12,7 @@ module T::Private::Methods::CallValidation
   # @param method_sig [T::Private::Methods::Signature]
   # @return [UnboundMethod] the new wrapper method (or the original one if we didn't wrap it)
   def self.wrap_method_if_needed(mod, method_sig, original_method)
-    # Use `original_method.name` not `method_sig.method_name` to get visibility
-    # so that we handle aliases correctly (we want the visibility before aliasing).
-    original_visibility = visibility_method_name(mod, original_method.name)
+    original_visibility = visibility_method_name(mod, method_sig.method_name)
     if method_sig.mode == T::Private::Methods::Modes.abstract
       T::Private::ClassUtils.replace_method(mod, method_sig.method_name) do |*args, &blk|
         # TODO: write a cop to ensure that abstract methods have an empty body

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -12,7 +12,9 @@ module T::Private::Methods::CallValidation
   # @param method_sig [T::Private::Methods::Signature]
   # @return [UnboundMethod] the new wrapper method (or the original one if we didn't wrap it)
   def self.wrap_method_if_needed(mod, method_sig, original_method)
-    original_visibility = visibility_method_name(mod, method_sig.method_name)
+    # Use `original_method.name` not `method_sig.method_name` to get visibility
+    # so that we handle aliases correctly (we want the visibility before aliasing).
+    original_visibility = visibility_method_name(mod, original_method.name)
     if method_sig.mode == T::Private::Methods::Modes.abstract
       T::Private::ClassUtils.replace_method(mod, method_sig.method_name) do |*args, &blk|
         # TODO: write a cop to ensure that abstract methods have an empty body

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -121,6 +121,15 @@ class T::Private::Methods::Signature
     end
   end
 
+  attr_writer :method_name
+  protected :method_name=
+
+  def as_alias(alias_name)
+    new_sig = clone
+    new_sig.method_name = alias_name
+    new_sig
+  end
+
   def arg_count
     @arg_types.length
   end

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -79,6 +79,11 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         assert_raises(TypeError) do
           klass.new.bar(1)
         end
+
+        # Should use fast path
+        obj = klass.new
+        allocs = counting_allocations {obj.bar}
+        assert(allocs < 5)
       end
 
       it 'handles alias_method without runtime checking' do
@@ -117,6 +122,11 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         assert_raises(TypeError) do
           klass.new.bar(1)
         end
+
+        # Should use fast path
+        obj = klass.new
+        allocs = counting_allocations {obj.bar}
+        assert(allocs < 5)
       end
 
       it 'handles alias without runtime checking' do


### PR DESCRIPTION
When attempting to self-modify-away the initial slow wrapper for a method created via `alias` or `alias_method`, and calling into `unwrap_method`, pass a Signature object which has the alias as the `method_name`, instead of the original method name.

Before this PR, the `unwrap_method` call was actually just replacing the original method each time, and never affecting the alias. This worked but was unintentional.

With this PR, `unwrap_method` will actually do the right thing here for both checked and unchecked methods, so we can simplify.

### Motivation
Followup on https://github.com/sorbet/sorbet/pull/3317 which had the desired effect of allowing aliases to use the fast path for unchecked, but not for checked code.

https://github.com/sorbet/sorbet/pull/3317 has been much more of a journey than I expected - sorry for the churn! - but I do think we're ending up in a better place.

### Test plan
Added test assertions & also tested with pay-server, where I saw the expected decrease in allocations.