### PR TITLE
lsp_test_runner: Support tests that expect multiple definition locations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,19 @@ If a location should not report any definition or usage, then use the magic labe
 # ^ def: (nothing)
 ```
 
+If a location should report multiple definitions (e.g., a class or module opened
+in multiple files), then you can add a second `def` with the same name:
+
+```ruby
+class Foo
+  #   ^^^ def: foo
+end
+
+class Foo
+  #   ^^^ def: foo
+end
+```
+
 #### Testing "Go to Type Definition"
 
 This is somewhat similar to "Find Definition" above, but also slightly different

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -32,6 +32,10 @@ public:
     static std::unique_ptr<Range> makeRange(int sourceLine, int startChar = 0,
                                             int endChar = RangeAssertion::END_OF_LINE_POS);
 
+    static bool compareByRange(const std::shared_ptr<RangeAssertion> &a, const std::shared_ptr<RangeAssertion> &b) {
+        return a->cmp(*b) < 0;
+    }
+
     /**
      * Filters a vector of assertions and returns only ErrorAssertions.
      */
@@ -102,8 +106,9 @@ public:
     DefAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine, std::string_view symbol,
                  int version, bool isDefOfSelf);
 
-    void check(const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents, LSPWrapper &wrapper,
-               int &nextId, const Location &queryLoc);
+    static void check(const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents,
+                      LSPWrapper &wrapper, int &nextId, const Location &queryLoc,
+                      const std::vector<std::shared_ptr<DefAssertion>> &definitions);
 
     std::string toString() const override;
 };


### PR DESCRIPTION
lsp_test_runner: Support tests that expect multiple definition locations.

I also refactored some redundant location diffing logic to make code cleaner _and_ shorter. There is now a single helper function, `diffLocations`, that most position assertions use to diff expected and actual locations. As an added bonus, this change removes several places where we duplicated the same error message.

This change does not add new tests that exercise this behavior, as I believe those would surface bugs -- and I don't want to conflate bugfixes with this change. I'd rather introduce bugfixes in subsequent PRs. 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

go-to-def may return multiple definition locations. I noticed that we don't test this logic, and that we might also be ignoring definition locations that we want to report.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
