### PR TITLE
Introduce ENFORCE_FAST to speed up tests in debug builds

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -32,22 +32,32 @@ template <class E> using UnorderedSet = absl::flat_hash_set<E>;
 
 #define _MAYBE_ADD_COMMA(...) , ##__VA_ARGS__
 
+// A faster version of ENFORCE that does not emit a timer. Useful for checks that happen extremely frequently and
+// are O(1). Please avoid using unless ENFORCE shows up in profiles.
+#define ENFORCE_FAST(x, ...)                                                                                \
+    do {                                                                                                    \
+        if (::sorbet::debug_mode) {                                                                         \
+            if (!(x)) {                                                                                     \
+                ::sorbet::Exception::failInFuzzer();                                                        \
+                if (stopInDebugger()) {                                                                     \
+                    (void)!(x);                                                                             \
+                }                                                                                           \
+                ::sorbet::Exception::enforce_handler(#x, __FILE__, __LINE__ _MAYBE_ADD_COMMA(__VA_ARGS__)); \
+            }                                                                                               \
+        }                                                                                                   \
+    } while (false);
+
 // Used for cases like https://xkcd.com/2200/
 // where there is some assumption that you believe should always hold.
 // Please use this to explicitly write down what assumptions was the code written under.
 // One day they might be violated and you'll help the next person debug the issue.
-#define ENFORCE(x, ...)                                                                                           \
+// Emits a timer so that expensive checks show up in traces in debug builds.
+#define ENFORCE(...)                                                                                              \
     do {                                                                                                          \
         if (::sorbet::debug_mode) {                                                                               \
             auto __enforceTimer =                                                                                 \
                 ::sorbet::Timer(*(::spdlog::default_logger_raw()), "ENFORCE(" __FILE__ ":" QUOTED(__LINE__) ")"); \
-            if (!(x)) {                                                                                           \
-                ::sorbet::Exception::failInFuzzer();                                                              \
-                if (stopInDebugger()) {                                                                           \
-                    (void)!(x);                                                                                   \
-                }                                                                                                 \
-                ::sorbet::Exception::enforce_handler(#x, __FILE__, __LINE__ _MAYBE_ADD_COMMA(__VA_ARGS__));       \
-            }                                                                                                     \
+            ENFORCE_FAST(__VA_ARGS__);                                                                            \
         }                                                                                                         \
     } while (false);
 

--- a/common/common.h
+++ b/common/common.h
@@ -34,7 +34,7 @@ template <class E> using UnorderedSet = absl::flat_hash_set<E>;
 
 // A faster version of ENFORCE that does not emit a timer. Useful for checks that happen extremely frequently and
 // are O(1). Please avoid using unless ENFORCE shows up in profiles.
-#define ENFORCE_FAST(x, ...)                                                                                \
+#define ENFORCE_NO_TIMER(x, ...)                                                                            \
     do {                                                                                                    \
         if (::sorbet::debug_mode) {                                                                         \
             if (!(x)) {                                                                                     \
@@ -57,7 +57,7 @@ template <class E> using UnorderedSet = absl::flat_hash_set<E>;
         if (::sorbet::debug_mode) {                                                                               \
             auto __enforceTimer =                                                                                 \
                 ::sorbet::Timer(*(::spdlog::default_logger_raw()), "ENFORCE(" __FILE__ ":" QUOTED(__LINE__) ")"); \
-            ENFORCE_FAST(__VA_ARGS__);                                                                            \
+            ENFORCE_NO_TIMER(__VA_ARGS__);                                                                        \
         }                                                                                                         \
     } while (false);
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -868,19 +868,19 @@ SymbolRef GlobalState::findRenamedSymbol(SymbolRef owner, SymbolRef sym) const {
 }
 
 SymbolRef GlobalState::enterSymbol(Loc loc, SymbolRef owner, NameRef name, u4 flags) {
-    ENFORCE_FAST(owner.exists(), "entering symbol in to non-existing owner");
-    ENFORCE_FAST(name.exists(), "entering symbol with non-existing name");
+    ENFORCE_NO_TIMER(owner.exists(), "entering symbol in to non-existing owner");
+    ENFORCE_NO_TIMER(name.exists(), "entering symbol with non-existing name");
     SymbolData ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
     auto &store = ownerScope->members()[name];
     if (store.exists()) {
-        ENFORCE_FAST((store.data(*this)->flags & flags) == flags, "existing symbol has wrong flags");
+        ENFORCE_NO_TIMER((store.data(*this)->flags & flags) == flags, "existing symbol has wrong flags");
         counterInc("symbols.hit");
         return store;
     }
 
-    ENFORCE_FAST(!symbolTableFrozen);
+    ENFORCE_NO_TIMER(!symbolTableFrozen);
 
     SymbolRef ret = SymbolRef(this, symbols.size());
     store = ret; // DO NOT MOVE this assignment down. emplace_back on symbol invalidates `store`
@@ -1472,7 +1472,7 @@ void GlobalState::sanityCheck() const {
             continue;
         }
         const Name &nm = names[ent.second];
-        ENFORCE_FAST(ent.first == nm.hash(*this), "name hash table corruption");
+        ENFORCE_NO_TIMER(ent.first == nm.hash(*this), "name hash table corruption");
     }
 }
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -868,19 +868,19 @@ SymbolRef GlobalState::findRenamedSymbol(SymbolRef owner, SymbolRef sym) const {
 }
 
 SymbolRef GlobalState::enterSymbol(Loc loc, SymbolRef owner, NameRef name, u4 flags) {
-    ENFORCE(owner.exists(), "entering symbol in to non-existing owner");
-    ENFORCE(name.exists(), "entering symbol with non-existing name");
+    ENFORCE_FAST(owner.exists(), "entering symbol in to non-existing owner");
+    ENFORCE_FAST(name.exists(), "entering symbol with non-existing name");
     SymbolData ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
     auto &store = ownerScope->members()[name];
     if (store.exists()) {
-        ENFORCE((store.data(*this)->flags & flags) == flags, "existing symbol has wrong flags");
+        ENFORCE_FAST((store.data(*this)->flags & flags) == flags, "existing symbol has wrong flags");
         counterInc("symbols.hit");
         return store;
     }
 
-    ENFORCE(!symbolTableFrozen);
+    ENFORCE_FAST(!symbolTableFrozen);
 
     SymbolRef ret = SymbolRef(this, symbols.size());
     store = ret; // DO NOT MOVE this assignment down. emplace_back on symbol invalidates `store`
@@ -1472,7 +1472,7 @@ void GlobalState::sanityCheck() const {
             continue;
         }
         const Name &nm = names[ent.second];
-        ENFORCE(ent.first == nm.hash(*this), "name hash table corruption");
+        ENFORCE_FAST(ent.first == nm.hash(*this), "name hash table corruption");
     }
 }
 

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -153,21 +153,21 @@ void Name::sanityCheck(const GlobalState &gs) const {
     NameRef current = this->ref(gs);
     switch (this->kind) {
         case NameKind::UTF8:
-            ENFORCE_FAST(current == const_cast<GlobalState &>(gs).enterNameUTF8(this->raw.utf8),
-                         "Name table corrupted, re-entering UTF8 name gives different id");
+            ENFORCE_NO_TIMER(current == const_cast<GlobalState &>(gs).enterNameUTF8(this->raw.utf8),
+                             "Name table corrupted, re-entering UTF8 name gives different id");
             break;
         case NameKind::UNIQUE: {
-            ENFORCE_FAST(this->unique.original._id < current._id, "unique name id not bigger than original");
-            ENFORCE_FAST(this->unique.num > 0, "unique num == 0");
+            ENFORCE_NO_TIMER(this->unique.original._id < current._id, "unique name id not bigger than original");
+            ENFORCE_NO_TIMER(this->unique.num > 0, "unique num == 0");
             NameRef current2 = const_cast<GlobalState &>(gs).freshNameUnique(this->unique.uniqueNameKind,
                                                                              this->unique.original, this->unique.num);
-            ENFORCE_FAST(current == current2, "Name table corrupted, re-entering UNIQUE name gives different id");
+            ENFORCE_NO_TIMER(current == current2, "Name table corrupted, re-entering UNIQUE name gives different id");
             break;
         }
         case NameKind::CONSTANT:
-            ENFORCE_FAST(this->cnst.original._id < current._id, "constant name id not bigger than original");
-            ENFORCE_FAST(current == const_cast<GlobalState &>(gs).enterNameConstant(this->cnst.original),
-                         "Name table corrupted, re-entering CONSTANT name gives different id");
+            ENFORCE_NO_TIMER(this->cnst.original._id < current._id, "constant name id not bigger than original");
+            ENFORCE_NO_TIMER(current == const_cast<GlobalState &>(gs).enterNameConstant(this->cnst.original),
+                             "Name table corrupted, re-entering CONSTANT name gives different id");
             break;
     }
 }

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -153,21 +153,21 @@ void Name::sanityCheck(const GlobalState &gs) const {
     NameRef current = this->ref(gs);
     switch (this->kind) {
         case NameKind::UTF8:
-            ENFORCE(current == const_cast<GlobalState &>(gs).enterNameUTF8(this->raw.utf8),
-                    "Name table corrupted, re-entering UTF8 name gives different id");
+            ENFORCE_FAST(current == const_cast<GlobalState &>(gs).enterNameUTF8(this->raw.utf8),
+                         "Name table corrupted, re-entering UTF8 name gives different id");
             break;
         case NameKind::UNIQUE: {
-            ENFORCE(this->unique.original._id < current._id, "unique name id not bigger than original");
-            ENFORCE(this->unique.num > 0, "unique num == 0");
+            ENFORCE_FAST(this->unique.original._id < current._id, "unique name id not bigger than original");
+            ENFORCE_FAST(this->unique.num > 0, "unique num == 0");
             NameRef current2 = const_cast<GlobalState &>(gs).freshNameUnique(this->unique.uniqueNameKind,
                                                                              this->unique.original, this->unique.num);
-            ENFORCE(current == current2, "Name table corrupted, re-entering UNIQUE name gives different id");
+            ENFORCE_FAST(current == current2, "Name table corrupted, re-entering UNIQUE name gives different id");
             break;
         }
         case NameKind::CONSTANT:
-            ENFORCE(this->cnst.original._id < current._id, "constant name id not bigger than original");
-            ENFORCE(current == const_cast<GlobalState &>(gs).enterNameConstant(this->cnst.original),
-                    "Name table corrupted, re-entering CONSTANT name gives different id");
+            ENFORCE_FAST(this->cnst.original._id < current._id, "constant name id not bigger than original");
+            ENFORCE_FAST(current == const_cast<GlobalState &>(gs).enterNameConstant(this->cnst.original),
+                         "Name table corrupted, re-entering CONSTANT name gives different id");
             break;
     }
 }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -138,22 +138,22 @@ SymbolRef Symbol::ref(const GlobalState &gs) const {
 }
 
 SymbolData SymbolRef::data(GlobalState &gs) const {
-    ENFORCE(this->exists());
+    ENFORCE_FAST(this->exists());
     return dataAllowingNone(gs);
 }
 
 SymbolData SymbolRef::dataAllowingNone(GlobalState &gs) const {
-    ENFORCE(_id < gs.symbols.size());
+    ENFORCE_FAST(_id < gs.symbols.size());
     return SymbolData(gs.symbols[this->_id], gs);
 }
 
 const SymbolData SymbolRef::data(const GlobalState &gs) const {
-    ENFORCE(this->exists());
+    ENFORCE_FAST(this->exists());
     return dataAllowingNone(gs);
 }
 
 const SymbolData SymbolRef::dataAllowingNone(const GlobalState &gs) const {
-    ENFORCE(_id < gs.symbols.size());
+    ENFORCE_FAST(_id < gs.symbols.size());
     return SymbolData(const_cast<Symbol &>(gs.symbols[this->_id]), gs);
 }
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -138,22 +138,22 @@ SymbolRef Symbol::ref(const GlobalState &gs) const {
 }
 
 SymbolData SymbolRef::data(GlobalState &gs) const {
-    ENFORCE_FAST(this->exists());
+    ENFORCE_NO_TIMER(this->exists());
     return dataAllowingNone(gs);
 }
 
 SymbolData SymbolRef::dataAllowingNone(GlobalState &gs) const {
-    ENFORCE_FAST(_id < gs.symbols.size());
+    ENFORCE_NO_TIMER(_id < gs.symbols.size());
     return SymbolData(gs.symbols[this->_id], gs);
 }
 
 const SymbolData SymbolRef::data(const GlobalState &gs) const {
-    ENFORCE_FAST(this->exists());
+    ENFORCE_NO_TIMER(this->exists());
     return dataAllowingNone(gs);
 }
 
 const SymbolData SymbolRef::dataAllowingNone(const GlobalState &gs) const {
-    ENFORCE_FAST(_id < gs.symbols.size());
+    ENFORCE_NO_TIMER(_id < gs.symbols.size());
     return SymbolData(const_cast<Symbol &>(gs.symbols[this->_id]), gs);
 }
 
@@ -1086,20 +1086,20 @@ void Symbol::sanityCheck(const GlobalState &gs) const {
     if (current != Symbols::root()) {
         SymbolRef current2 =
             const_cast<GlobalState &>(gs).enterSymbol(this->loc(), this->owner, this->name, this->flags);
-        ENFORCE_FAST(current == current2);
+        ENFORCE_NO_TIMER(current == current2);
         for (auto &e : members()) {
-            ENFORCE_FAST(e.first.exists(), name.toString(gs) + " has a member symbol without a name");
-            ENFORCE_FAST(e.second.exists(), name.toString(gs) + "." + e.first.toString(gs) +
-                                                " corresponds to a core::Symbols::noSymbol()");
+            ENFORCE_NO_TIMER(e.first.exists(), name.toString(gs) + " has a member symbol without a name");
+            ENFORCE_NO_TIMER(e.second.exists(), name.toString(gs) + "." + e.first.toString(gs) +
+                                                    " corresponds to a core::Symbols::noSymbol()");
         }
     }
     if (this->isMethod()) {
         if (isa_type<AliasType>(this->resultType.get())) {
             // If we have an alias method, we should never look at it's arguments;
             // we should instead look at the arguments of whatever we're aliasing.
-            ENFORCE_FAST(this->arguments().empty(), this->show(gs));
+            ENFORCE_NO_TIMER(this->arguments().empty(), this->show(gs));
         } else {
-            ENFORCE_FAST(!this->arguments().empty(), this->show(gs));
+            ENFORCE_NO_TIMER(!this->arguments().empty(), this->show(gs));
         }
     }
 }
@@ -1281,7 +1281,7 @@ SymbolData::SymbolData(Symbol &ref, const GlobalState &gs) : DebugOnlyCheck(gs),
 SymbolDataDebugCheck::SymbolDataDebugCheck(const GlobalState &gs) : gs(gs), symbolCountAtCreation(gs.symbolsUsed()) {}
 
 void SymbolDataDebugCheck::check() const {
-    ENFORCE_FAST(symbolCountAtCreation == gs.symbolsUsed());
+    ENFORCE_NO_TIMER(symbolCountAtCreation == gs.symbolsUsed());
 }
 
 Symbol *SymbolData::operator->() {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1281,7 +1281,7 @@ SymbolData::SymbolData(Symbol &ref, const GlobalState &gs) : DebugOnlyCheck(gs),
 SymbolDataDebugCheck::SymbolDataDebugCheck(const GlobalState &gs) : gs(gs), symbolCountAtCreation(gs.symbolsUsed()) {}
 
 void SymbolDataDebugCheck::check() const {
-    ENFORCE(symbolCountAtCreation == gs.symbolsUsed());
+    ENFORCE_FAST(symbolCountAtCreation == gs.symbolsUsed());
 }
 
 Symbol *SymbolData::operator->() {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1086,20 +1086,20 @@ void Symbol::sanityCheck(const GlobalState &gs) const {
     if (current != Symbols::root()) {
         SymbolRef current2 =
             const_cast<GlobalState &>(gs).enterSymbol(this->loc(), this->owner, this->name, this->flags);
-        ENFORCE(current == current2);
+        ENFORCE_FAST(current == current2);
         for (auto &e : members()) {
-            ENFORCE(e.first.exists(), name.toString(gs) + " has a member symbol without a name");
-            ENFORCE(e.second.exists(),
-                    name.toString(gs) + "." + e.first.toString(gs) + " corresponds to a core::Symbols::noSymbol()");
+            ENFORCE_FAST(e.first.exists(), name.toString(gs) + " has a member symbol without a name");
+            ENFORCE_FAST(e.second.exists(), name.toString(gs) + "." + e.first.toString(gs) +
+                                                " corresponds to a core::Symbols::noSymbol()");
         }
     }
     if (this->isMethod()) {
         if (isa_type<AliasType>(this->resultType.get())) {
             // If we have an alias method, we should never look at it's arguments;
             // we should instead look at the arguments of whatever we're aliasing.
-            ENFORCE(this->arguments().empty(), this->show(gs));
+            ENFORCE_FAST(this->arguments().empty(), this->show(gs));
         } else {
-            ENFORCE(!this->arguments().empty(), this->show(gs));
+            ENFORCE_FAST(!this->arguments().empty(), this->show(gs));
         }
     }
 }

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -554,7 +554,7 @@ public:
     }
 
     SymbolRef rebind() const {
-        ENFORCE(isMethod());
+        ENFORCE_FAST(isMethod());
         return superClassOrRebind;
     }
 
@@ -563,7 +563,7 @@ public:
     TypePtr resultType;
 
     bool hasSig() const {
-        ENFORCE(isMethod());
+        ENFORCE_FAST(isMethod());
         return resultType != nullptr;
     }
 
@@ -580,12 +580,12 @@ public:
     };
 
     ArgumentsStore &arguments() {
-        ENFORCE(isMethod());
+        ENFORCE_FAST(isMethod());
         return arguments_;
     }
 
     const ArgumentsStore &arguments() const {
-        ENFORCE(isMethod());
+        ENFORCE_FAST(isMethod());
         return arguments_;
     }
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -190,52 +190,52 @@ public:
     }
 
     inline bool isOverloaded() const {
-        ENFORCE(isMethod());
+        ENFORCE_FAST(isMethod());
         return (flags & Symbol::Flags::METHOD_OVERLOADED) != 0;
     }
 
     inline bool isAbstract() const {
-        ENFORCE(isMethod());
+        ENFORCE_FAST(isMethod());
         return (flags & Symbol::Flags::METHOD_ABSTRACT) != 0;
     }
 
     inline bool isIncompatibleOverride() const {
-        ENFORCE(isMethod());
+        ENFORCE_FAST(isMethod());
         return (flags & Symbol::Flags::METHOD_INCOMPATIBLE_OVERRIDE) != 0;
     }
 
     inline bool isGenericMethod() const {
-        ENFORCE(isMethod());
+        ENFORCE_FAST(isMethod());
         return (flags & Symbol::Flags::METHOD_GENERIC) != 0;
     }
 
     inline bool isOverridable() const {
-        ENFORCE(isMethod());
+        ENFORCE_FAST(isMethod());
         return (flags & Symbol::Flags::METHOD_OVERRIDABLE) != 0;
     }
 
     inline bool isOverride() const {
-        ENFORCE(isMethod());
+        ENFORCE_FAST(isMethod());
         return (flags & Symbol::Flags::METHOD_OVERRIDE) != 0;
     }
 
     inline bool isCovariant() const {
-        ENFORCE(isTypeArgument() || isTypeMember());
+        ENFORCE_FAST(isTypeArgument() || isTypeMember());
         return (flags & Symbol::Flags::TYPE_COVARIANT) != 0;
     }
 
     inline bool isInvariant() const {
-        ENFORCE(isTypeArgument() || isTypeMember());
+        ENFORCE_FAST(isTypeArgument() || isTypeMember());
         return (flags & Symbol::Flags::TYPE_INVARIANT) != 0;
     }
 
     inline bool isContravariant() const {
-        ENFORCE(isTypeArgument() || isTypeMember());
+        ENFORCE_FAST(isTypeArgument() || isTypeMember());
         return (flags & Symbol::Flags::TYPE_CONTRAVARIANT) != 0;
     }
 
     inline bool isFixed() const {
-        ENFORCE(isTypeArgument() || isTypeMember());
+        ENFORCE_FAST(isTypeArgument() || isTypeMember());
         return (flags & Symbol::Flags::TYPE_FIXED) != 0;
     }
 
@@ -250,22 +250,22 @@ public:
     }
 
     inline bool isPublic() const {
-        ENFORCE(isMethod());
+        ENFORCE_FAST(isMethod());
         return !isProtected() && !isPrivate();
     }
 
     inline bool isProtected() const {
-        ENFORCE(isMethod());
+        ENFORCE_FAST(isMethod());
         return (flags & Symbol::Flags::METHOD_PROTECTED) != 0;
     }
 
     inline bool isPrivate() const {
-        ENFORCE(isMethod());
+        ENFORCE_FAST(isMethod());
         return (flags & Symbol::Flags::METHOD_PRIVATE) != 0;
     }
 
     inline bool isClassOrModuleModule() const {
-        ENFORCE(isClassOrModule());
+        ENFORCE_FAST(isClassOrModule());
         if (flags & Symbol::Flags::CLASS_OR_MODULE_MODULE)
             return true;
         if (flags & Symbol::Flags::CLASS_OR_MODULE_CLASS)
@@ -274,7 +274,7 @@ public:
     }
 
     inline bool isClassModuleSet() const {
-        ENFORCE(isClassOrModule());
+        ENFORCE_FAST(isClassOrModule());
         return flags & (Symbol::Flags::CLASS_OR_MODULE_MODULE | Symbol::Flags::CLASS_OR_MODULE_CLASS);
     }
 
@@ -288,22 +288,22 @@ public:
     }
 
     inline bool isClassOrModuleInterface() const {
-        ENFORCE(isClassOrModule());
+        ENFORCE_FAST(isClassOrModule());
         return (flags & Symbol::Flags::CLASS_OR_MODULE_INTERFACE) != 0;
     }
 
     inline bool isClassOrModuleLinearizationComputed() const {
-        ENFORCE(isClassOrModule());
+        ENFORCE_FAST(isClassOrModule());
         return (flags & Symbol::Flags::CLASS_OR_MODULE_LINEARIZATION_COMPUTED) != 0;
     }
 
     inline bool isClassOrModuleFinal() const {
-        ENFORCE(isClassOrModule());
+        ENFORCE_FAST(isClassOrModule());
         return (flags & Symbol::Flags::CLASS_OR_MODULE_FINAL) != 0;
     }
 
     inline bool isClassOrModuleSealed() const {
-        ENFORCE(isClassOrModule());
+        ENFORCE_FAST(isClassOrModule());
         return (flags & Symbol::Flags::CLASS_OR_MODULE_SEALED) != 0;
     }
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -118,12 +118,12 @@ public:
     TypePtr externalType(const GlobalState &gs) const;
 
     inline InlinedVector<SymbolRef, 4> &mixins() {
-        ENFORCE_FAST(isClassOrModule());
+        ENFORCE_NO_TIMER(isClassOrModule());
         return mixins_;
     }
 
     inline const InlinedVector<SymbolRef, 4> &mixins() const {
-        ENFORCE_FAST(isClassOrModule());
+        ENFORCE_NO_TIMER(isClassOrModule());
         return mixins_;
     }
 
@@ -190,52 +190,52 @@ public:
     }
 
     inline bool isOverloaded() const {
-        ENFORCE_FAST(isMethod());
+        ENFORCE_NO_TIMER(isMethod());
         return (flags & Symbol::Flags::METHOD_OVERLOADED) != 0;
     }
 
     inline bool isAbstract() const {
-        ENFORCE_FAST(isMethod());
+        ENFORCE_NO_TIMER(isMethod());
         return (flags & Symbol::Flags::METHOD_ABSTRACT) != 0;
     }
 
     inline bool isIncompatibleOverride() const {
-        ENFORCE_FAST(isMethod());
+        ENFORCE_NO_TIMER(isMethod());
         return (flags & Symbol::Flags::METHOD_INCOMPATIBLE_OVERRIDE) != 0;
     }
 
     inline bool isGenericMethod() const {
-        ENFORCE_FAST(isMethod());
+        ENFORCE_NO_TIMER(isMethod());
         return (flags & Symbol::Flags::METHOD_GENERIC) != 0;
     }
 
     inline bool isOverridable() const {
-        ENFORCE_FAST(isMethod());
+        ENFORCE_NO_TIMER(isMethod());
         return (flags & Symbol::Flags::METHOD_OVERRIDABLE) != 0;
     }
 
     inline bool isOverride() const {
-        ENFORCE_FAST(isMethod());
+        ENFORCE_NO_TIMER(isMethod());
         return (flags & Symbol::Flags::METHOD_OVERRIDE) != 0;
     }
 
     inline bool isCovariant() const {
-        ENFORCE_FAST(isTypeArgument() || isTypeMember());
+        ENFORCE_NO_TIMER(isTypeArgument() || isTypeMember());
         return (flags & Symbol::Flags::TYPE_COVARIANT) != 0;
     }
 
     inline bool isInvariant() const {
-        ENFORCE_FAST(isTypeArgument() || isTypeMember());
+        ENFORCE_NO_TIMER(isTypeArgument() || isTypeMember());
         return (flags & Symbol::Flags::TYPE_INVARIANT) != 0;
     }
 
     inline bool isContravariant() const {
-        ENFORCE_FAST(isTypeArgument() || isTypeMember());
+        ENFORCE_NO_TIMER(isTypeArgument() || isTypeMember());
         return (flags & Symbol::Flags::TYPE_CONTRAVARIANT) != 0;
     }
 
     inline bool isFixed() const {
-        ENFORCE_FAST(isTypeArgument() || isTypeMember());
+        ENFORCE_NO_TIMER(isTypeArgument() || isTypeMember());
         return (flags & Symbol::Flags::TYPE_FIXED) != 0;
     }
 
@@ -250,22 +250,22 @@ public:
     }
 
     inline bool isPublic() const {
-        ENFORCE_FAST(isMethod());
+        ENFORCE_NO_TIMER(isMethod());
         return !isProtected() && !isPrivate();
     }
 
     inline bool isProtected() const {
-        ENFORCE_FAST(isMethod());
+        ENFORCE_NO_TIMER(isMethod());
         return (flags & Symbol::Flags::METHOD_PROTECTED) != 0;
     }
 
     inline bool isPrivate() const {
-        ENFORCE_FAST(isMethod());
+        ENFORCE_NO_TIMER(isMethod());
         return (flags & Symbol::Flags::METHOD_PRIVATE) != 0;
     }
 
     inline bool isClassOrModuleModule() const {
-        ENFORCE_FAST(isClassOrModule());
+        ENFORCE_NO_TIMER(isClassOrModule());
         if (flags & Symbol::Flags::CLASS_OR_MODULE_MODULE)
             return true;
         if (flags & Symbol::Flags::CLASS_OR_MODULE_CLASS)
@@ -274,7 +274,7 @@ public:
     }
 
     inline bool isClassModuleSet() const {
-        ENFORCE_FAST(isClassOrModule());
+        ENFORCE_NO_TIMER(isClassOrModule());
         return flags & (Symbol::Flags::CLASS_OR_MODULE_MODULE | Symbol::Flags::CLASS_OR_MODULE_CLASS);
     }
 
@@ -288,22 +288,22 @@ public:
     }
 
     inline bool isClassOrModuleInterface() const {
-        ENFORCE_FAST(isClassOrModule());
+        ENFORCE_NO_TIMER(isClassOrModule());
         return (flags & Symbol::Flags::CLASS_OR_MODULE_INTERFACE) != 0;
     }
 
     inline bool isClassOrModuleLinearizationComputed() const {
-        ENFORCE_FAST(isClassOrModule());
+        ENFORCE_NO_TIMER(isClassOrModule());
         return (flags & Symbol::Flags::CLASS_OR_MODULE_LINEARIZATION_COMPUTED) != 0;
     }
 
     inline bool isClassOrModuleFinal() const {
-        ENFORCE_FAST(isClassOrModule());
+        ENFORCE_NO_TIMER(isClassOrModule());
         return (flags & Symbol::Flags::CLASS_OR_MODULE_FINAL) != 0;
     }
 
     inline bool isClassOrModuleSealed() const {
-        ENFORCE_FAST(isClassOrModule());
+        ENFORCE_NO_TIMER(isClassOrModule());
         return (flags & Symbol::Flags::CLASS_OR_MODULE_SEALED) != 0;
     }
 
@@ -539,7 +539,7 @@ public:
     SymbolRef superClassOrRebind; // method arugments store rebind here
 
     inline SymbolRef superClass() const {
-        ENFORCE_FAST(isClassOrModule());
+        ENFORCE_NO_TIMER(isClassOrModule());
         return superClassOrRebind;
     }
 
@@ -554,7 +554,7 @@ public:
     }
 
     SymbolRef rebind() const {
-        ENFORCE_FAST(isMethod());
+        ENFORCE_NO_TIMER(isMethod());
         return superClassOrRebind;
     }
 
@@ -563,7 +563,7 @@ public:
     TypePtr resultType;
 
     bool hasSig() const {
-        ENFORCE_FAST(isMethod());
+        ENFORCE_NO_TIMER(isMethod());
         return resultType != nullptr;
     }
 
@@ -580,12 +580,12 @@ public:
     };
 
     ArgumentsStore &arguments() {
-        ENFORCE_FAST(isMethod());
+        ENFORCE_NO_TIMER(isMethod());
         return arguments_;
     }
 
     const ArgumentsStore &arguments() const {
-        ENFORCE_FAST(isMethod());
+        ENFORCE_NO_TIMER(isMethod());
         return arguments_;
     }
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -118,12 +118,12 @@ public:
     TypePtr externalType(const GlobalState &gs) const;
 
     inline InlinedVector<SymbolRef, 4> &mixins() {
-        ENFORCE(isClassOrModule());
+        ENFORCE_FAST(isClassOrModule());
         return mixins_;
     }
 
     inline const InlinedVector<SymbolRef, 4> &mixins() const {
-        ENFORCE(isClassOrModule());
+        ENFORCE_FAST(isClassOrModule());
         return mixins_;
     }
 
@@ -539,7 +539,7 @@ public:
     SymbolRef superClassOrRebind; // method arugments store rebind here
 
     inline SymbolRef superClass() const {
-        ENFORCE(isClassOrModule());
+        ENFORCE_FAST(isClassOrModule());
         return superClassOrRebind;
     }
 

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -272,9 +272,9 @@ int maybeAddMixin(core::GlobalState &gs, core::SymbolRef forSym, InlinedVector<c
 // In order to obtain Ruby-side ancestors, one would need to walk superclass chain and concatenate `mixins`.
 // The algorithm is harder to explain than to code, so just follow code & tests if `testdata/resolver/linearization`
 ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, core::SymbolRef ofClass) {
-    ENFORCE_FAST(ofClass.exists());
+    ENFORCE_NO_TIMER(ofClass.exists());
     auto data = ofClass.data(gs);
-    ENFORCE_FAST(data->isClassOrModule());
+    ENFORCE_NO_TIMER(data->isClassOrModule());
     if (!data->isClassOrModuleLinearizationComputed()) {
         if (data->superClass().exists()) {
             computeClassLinearization(gs, data->superClass());
@@ -290,7 +290,7 @@ ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, 
                 newMixins.emplace_back(mixin);
                 continue;
             }
-            ENFORCE_FAST(mixin.data(gs)->isClassOrModule());
+            ENFORCE_NO_TIMER(mixin.data(gs)->isClassOrModule());
             ParentLinearizationInformation mixinLinearization = computeClassLinearization(gs, mixin);
 
             if (!mixin.data(gs)->isClassOrModuleModule()) {
@@ -320,7 +320,7 @@ ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, 
             }
         }
     }
-    ENFORCE_FAST(data->isClassOrModuleLinearizationComputed());
+    ENFORCE_NO_TIMER(data->isClassOrModuleLinearizationComputed());
     return ParentLinearizationInformation{data->mixins(), data->superClass(), ofClass};
 }
 

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -272,9 +272,9 @@ int maybeAddMixin(core::GlobalState &gs, core::SymbolRef forSym, InlinedVector<c
 // In order to obtain Ruby-side ancestors, one would need to walk superclass chain and concatenate `mixins`.
 // The algorithm is harder to explain than to code, so just follow code & tests if `testdata/resolver/linearization`
 ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, core::SymbolRef ofClass) {
-    ENFORCE(ofClass.exists());
+    ENFORCE_FAST(ofClass.exists());
     auto data = ofClass.data(gs);
-    ENFORCE(data->isClassOrModule());
+    ENFORCE_FAST(data->isClassOrModule());
     if (!data->isClassOrModuleLinearizationComputed()) {
         if (data->superClass().exists()) {
             computeClassLinearization(gs, data->superClass());
@@ -290,7 +290,7 @@ ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, 
                 newMixins.emplace_back(mixin);
                 continue;
             }
-            ENFORCE(mixin.data(gs)->isClassOrModule());
+            ENFORCE_FAST(mixin.data(gs)->isClassOrModule());
             ParentLinearizationInformation mixinLinearization = computeClassLinearization(gs, mixin);
 
             if (!mixin.data(gs)->isClassOrModuleModule()) {
@@ -320,7 +320,7 @@ ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, 
             }
         }
     }
-    ENFORCE(data->isClassOrModuleLinearizationComputed());
+    ENFORCE_FAST(data->isClassOrModuleLinearizationComputed());
     return ParentLinearizationInformation{data->mixins(), data->superClass(), ofClass};
 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Introduce ENFORCE_FAST to speed up tests in debug builds.

ENFORCE_FAST is equal to ENFORCE, except it doesn't create timers.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Timers were making debug test runs >50% slower locally. With these changes, test/testdata/lsp/definitions_and_usages takes less than half as much time as it used to (7s-8s to ~3.3s on my laptop).

* 7.37s - 8.12s Before optimizations
* 5.58s - 6.0s after SymbolRef::data/dataAllowingNone change
* 5.3 - 5.6 after resolver::computeClassLinearization change
* 4.0s - 4.4s after SymbolDataDebugCheck::check change
* 4.0s after Symbol::mixins(), superClass()
* 3.8s after Symbol::sanityCheck
* 3.5s after GS::enterSymbol >2.7%
* 3.4s after Symbol::arguments and a few others ~0.7%
* ~3.25s after Name::sanityCheck / gs::sanityCheck

Timers still show up prominently in profiles, and I know there's probably another ~500ms of savings to trim, but this is good enough for now and will speed up my workflow.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This change does not impact correctness.
