### PR TITLE
Better errors when the block param is mistyped

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1007,6 +1007,7 @@ ArgInfo ArgInfo::deepCopy() const {
     result.flags = this->flags;
     result.type = this->type;
     result.loc = this->loc;
+    result.typeLoc = this->typeLoc;
     result.name = this->name;
     result.rebind = this->rebind;
     return result;

--- a/core/Types.h
+++ b/core/Types.h
@@ -43,6 +43,7 @@ public:
     NameRef name;
     SymbolRef rebind;
     Loc loc;
+    Loc typeLoc;
     TypePtr type;
 
     /*

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -268,7 +268,7 @@ void validateBlockDefinition(const core::Context ctx, core::SymbolRef method) {
                                 arg.show(ctx));
                     e.addErrorLine(arg.typeLoc, "Parameter was defined as `{}`, but should be T.proc or Proc instead",
                                    blockType->show(ctx));
-                    e.replaceWith("Wrap in T.proc", arg.typeLoc, "T.proc({})", arg.typeLoc.source(ctx.state));
+                    e.replaceWith("Wrap in T.proc", arg.typeLoc, "T.proc.returns({})", arg.typeLoc.source(ctx.state));
                     arg.type = core::Types::untyped(ctx, method);
                 }
             }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1465,6 +1465,7 @@ private:
                 ENFORCE(spec->type != nullptr);
                 arg.type = spec->type;
                 arg.loc = spec->loc;
+                arg.typeLoc = spec->typeLoc;
                 arg.rebind = spec->rebind;
                 sig.argTypes.erase(spec);
             } else {

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -276,7 +276,8 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
                             core::NameRef name = lit->asSymbol(ctx);
                             auto resultAndBind =
                                 getResultTypeAndBindWithSelfTypeParams(ctx, value, *parent, args.withRebind());
-                            sig.argTypes.emplace_back(ParsedSig::ArgSpec{core::Loc(ctx.file, key->loc), name,
+                            sig.argTypes.emplace_back(ParsedSig::ArgSpec{core::Loc(ctx.file, key->loc),
+                                                                         core::Loc(ctx.file, value->loc), name,
                                                                          resultAndBind.type, resultAndBind.rebind});
                         }
                     }

--- a/resolver/type_syntax.h
+++ b/resolver/type_syntax.h
@@ -11,6 +11,7 @@ namespace sorbet::resolver {
 struct ParsedSig {
     struct ArgSpec {
         core::Loc loc;
+        core::Loc typeLoc;
         core::NameRef name;
         core::TypePtr type;
         core::SymbolRef rebind;

--- a/test/testdata/lsp/code_actions/invalid_block_parameter.A.rbedited
+++ b/test/testdata/lsp/code_actions/invalid_block_parameter.A.rbedited
@@ -5,7 +5,7 @@ class A
   extend T::Sig
 
   sig do
-    params(block: T.proc(String)).returns(String)
+    params(block: T.proc.returns(String)).returns(String)
                 # ^^^^^^ error: Malformed `sig`: block parameters should be defined as callable objects
                 # ^^^^^^ apply-code-action: [A] Wrap in T.proc
   end

--- a/test/testdata/lsp/code_actions/invalid_block_parameter.A.rbedited
+++ b/test/testdata/lsp/code_actions/invalid_block_parameter.A.rbedited
@@ -1,0 +1,15 @@
+# typed: true
+# exhaustive-apply-code-action: true
+
+class A
+  extend T::Sig
+
+  sig do
+    params(block: T.proc(String)).returns(String)
+                # ^^^^^^ error: Malformed `sig`: block parameters should be defined as callable objects
+                # ^^^^^^ apply-code-action: [A] Wrap in T.proc
+  end
+  def with_block(&block)
+    yield
+  end
+end

--- a/test/testdata/lsp/code_actions/invalid_block_parameter.rb
+++ b/test/testdata/lsp/code_actions/invalid_block_parameter.rb
@@ -1,0 +1,15 @@
+# typed: true
+# exhaustive-apply-code-action: true
+
+class A
+  extend T::Sig
+
+  sig do
+    params(block: String).returns(String)
+                # ^^^^^^ error: Malformed `sig`: block parameters should be defined as callable objects
+                # ^^^^^^ apply-code-action: [A] Wrap in T.proc
+  end
+  def with_block(&block)
+    yield
+  end
+end

--- a/test/testdata/resolver/block_definition_validation.rb
+++ b/test/testdata/resolver/block_definition_validation.rb
@@ -1,0 +1,13 @@
+# typed: strict
+
+class A
+  extend T::Sig
+
+  sig do
+    params(block: String).returns(String)
+         # ^^^^^ error: Malformed `sig`: block parameters should be defined as callable objects
+  end
+  def with_block(&block)
+    yield
+  end
+end


### PR DESCRIPTION
### Motivation
When the block parameter was not typed properly with T.proc or Proc, the error that the user would get is `Method call does not exist on... https://srb.help/7003` with an error pointing to the place where the block is called inside the method. Example: https://sorbet.run/#%23%20typed%3A%20true%0Aclass%20A%0A%20%20extend%20T%3A%3ASig%0A%20%20sig%20%7Bparams(x%3A%20Integer).returns(Integer)%7D%0A%20%20def%20bar(%26x)%0A%20%20%20%20yield%0A%20%20end%0Aend

This change should improve the experience and point to the place of the definition of the block argument type suggesting to wrap it into the `T.proc` or `Proc`.

### What changed
As a part of the solution there were two things that were done:
1. Added the loc for the place where argument type definition is happening
2. Added a validation that checks that the type parameter that is used for a block would be derived from Proc.
3. If the validation is failing there is also an autosuggestion to wrap the type provided in the `T.proc`

The first change also allows to address the following comment: https://github.com/sorbet/sorbet/blob/1af71480d0672e21ab09fa9d22ccd6b2c79c6246/infer/environment.cc#L1022
If the suggested approach in the PR to tracking the loc of the argument types is accepted, I would be glad to add a PR to implement the suggestion in the comment above.

### Current limitations
Technically it should be possible to have a sig like this `sig{type_parameters(:U).params(block: T.type_parameter(:U)).returns(T.type_parameter(:U)))}`. Which means that the passed in type of the block is returned back to the caller. However, it will currently won't work because of https://github.com/sorbet/sorbet/issues/2888.

I am trying to fix it in a separate PR, but until then this signature would not work

### Test plan
See included automated tests.
