### PR TITLE
Fix broken link to Rubocop rule

### DIFF
--- a/website/docs/procs.md
+++ b/website/docs/procs.md
@@ -194,5 +194,5 @@ end
 ```
 
 In general, you're better off avoiding `Proc.new` if you can. There's a
-[rubocop rule](https://www.rubocop.org/en/stable/cops_style/#styleproc) you can
-use to enforce this.
+[rubocop rule](https://docs.rubocop.org/rubocop/cops_style.html#styleproc) you
+can use to enforce this.


### PR DESCRIPTION
### Motivation
There's a broken link in the docs, making it difficult to find the Rubocop rule to enable. 


### Test plan
Manually confirm the new URL location.