### PR TITLE
Add overload for Array#sample for no-argument case

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -2202,6 +2202,7 @@ class Array < Object
   # a.sample(random: Random.new(1))     #=> 6
   # a.sample(4, random: Random.new(1))  #=> [6, 10, 9, 2]
   # ```
+  sig { returns(T.nilable(Elem)) }
   sig do
     params(
         arg0: Integer,


### PR DESCRIPTION
Before
``` ruby
T.reveal_type [3,5].sample
# Revealed type: T.nilable(T.any(Integer, T::Array[Integer]))
T.reveal_type [3,5].sample(2)
# Revealed type: T.nilable(T.any(Integer, T::Array[Integer]))
```

After
``` ruby
T.reveal_type [3,5].sample
# Revealed type: T.nilable(Integer)
T.reveal_type [3,5].sample(2)
# Revealed type: T.nilable(T.any(Integer, T::Array[Integer]))
```

[playground for fix](https://sorbet.run/#%23%20typed%3A%20strict%0A%0A%0Aclass%20Array%0A%20%20extend%20T%3A%3ASig%0A%20%20sig%20%7B%20returns%20T.nilable(Elem)%20%7D%0A%20%20sig%20do%0A%20%20%20%20params(%0A%20%20%20%20%20%20%20%20arg0%3A%20Integer%2C%0A%20%23%20%20%20%20%20%20%20random%3A%20Random%3A%3AFormatter%2C%0A%20%20%20%20)%0A%20%20%20%20.returns(T.any(T.nilable(Elem)%2C%20T%3A%3AArray%5BElem%5D))%0A%20%20end%0A%20%20def%20sample(arg0%3DT.unsafe(nil)%2C%20random%3A%20T.unsafe(nil))%3B%20end%0Aend%0A%0A%0AT.reveal_type%20%5B3%2C5%5D.sample%0AT.reveal_type%20%5B3%2C5%5D.sample(2)%0A%0A%0A%0A%0A%0A%0A%0A%0A%0A%0A%0A%0A%0A)


### Motivation
I couldn't do 
``` ruby
maby_empty_array.sample || default
```
when sorbet incorrectly thought `#sample` with no arguments could maybe return an array.

I saw that `first` worked, so then found out that you can overlaod sigs (which seems to be undocumented? but I didn't search the docs that hard, maybe you all use a different term)

[playground for example of problem](https://sorbet.run/#%23%20typed%3A%20strict%0Aclass%20F%0Aextend%20T%3A%3ASig%0A%0Asig%20%7B%20void%20%7D%0Adef%20initialize%0A%40populated%20%3D%20T.let%20%5B1%2C2%2C3%2C4%2C5%5D%2C%20T%3A%3AArray%5BInteger%5D%0A%40empty%20%3D%20T.let%20%5B%5D%2C%20T%3A%3AArray%5BInteger%5D%0Aend%0A%0Asig%20%7B%20returns%20Integer%20%7D%0Adef%20a%0A%20%20%40empty.sample%20%7C%7C%203%0Aend%0A%0Asig%20%7B%20returns%20Integer%20%7D%0Adef%20b%0A%20%20%40empty.first%20%7C%7C%203%0Aend%0A%0A%0Aend%0A%0A%0A%0A%0A)

### Test plan
I don’t know how to test this, and recent commits that altered built in sigs like #3296 and #3325 didn't have anything to go on 
