### PR TITLE
Also declare ivars for T.untyped attr writers

### DIFF
--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -66,7 +66,8 @@ bool isT(const ast::TreePtr &expr) {
 
 bool isTNilableOrUntyped(const ast::TreePtr &expr) {
     auto *send = ast::cast_tree_const<ast::Send>(expr);
-    return send != nullptr && (send->fun == core::Names::nilable() || send->fun == core::Names::untyped()) && isT(send->recv);
+    return send != nullptr && (send->fun == core::Names::nilable() || send->fun == core::Names::untyped()) &&
+           isT(send->recv);
 }
 
 bool hasNilableOrUntypedReturns(core::MutableContext ctx, ast::TreePtr &sharedSig) {

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -64,12 +64,12 @@ bool isT(const ast::TreePtr &expr) {
     return root != nullptr && root->symbol == core::Symbols::root();
 }
 
-bool isTNilable(const ast::TreePtr &expr) {
-    auto *nilable = ast::cast_tree_const<ast::Send>(expr);
-    return nilable != nullptr && nilable->fun == core::Names::nilable() && isT(nilable->recv);
+bool isTNilableOrUntyped(const ast::TreePtr &expr) {
+    auto *send = ast::cast_tree_const<ast::Send>(expr);
+    return send != nullptr && (send->fun == core::Names::nilable() || send->fun == core::Names::untyped()) && isT(send->recv);
 }
 
-bool hasNilableReturns(core::MutableContext ctx, ast::TreePtr &sharedSig) {
+bool hasNilableOrUntypedReturns(core::MutableContext ctx, ast::TreePtr &sharedSig) {
     ENFORCE(ASTUtil::castSig(sharedSig, core::Names::returns()),
             "We weren't given a send node that's a valid signature");
 
@@ -81,7 +81,7 @@ bool hasNilableReturns(core::MutableContext ctx, ast::TreePtr &sharedSig) {
     if (body.args.size() != 1) {
         return false;
     }
-    return isTNilable(body.args[0]);
+    return isTNilableOrUntyped(body.args[0]);
 }
 
 ast::TreePtr dupReturnsType(core::MutableContext ctx, ast::Send *sharedSig) {
@@ -212,7 +212,7 @@ vector<ast::TreePtr> AttrReader::run(core::MutableContext ctx, ast::Send *send, 
     }
 
     bool declareIvars = false;
-    if (sig != nullptr && hasNilableReturns(ctx, *prevStat)) {
+    if (sig != nullptr && hasNilableOrUntypedReturns(ctx, *prevStat)) {
         declareIvars = true;
     }
 

--- a/test/testdata/rewriter/attr_strict.rb
+++ b/test/testdata/rewriter/attr_strict.rb
@@ -7,14 +7,20 @@ class Test
   attr_accessor :non_nil_accessor # error-with-dupes: Use of undeclared variable `@non_nil_accessor`
   sig {returns(T.nilable(String))}
   attr_accessor :nilable_accessor
+  sig {returns(T.untyped)}
+  attr_accessor :untyped_accessor
 
   sig {returns(String)}
   attr_reader :non_nil_reader # error: Use of undeclared variable `@non_nil_reader`
   sig {returns(T.nilable(String))}
   attr_reader :nilable_reader # error: Use of undeclared variable `@nilable_reader`
+  sig {returns(T.untyped)}
+  attr_reader :untyped_reader # error: Use of undeclared variable `@untyped_reader`
 
   sig {params(non_nil_writer: String).returns(String)}
   attr_writer :non_nil_writer # error: Use of undeclared variable `@non_nil_writer`
   sig {params(nilable_writer: String).returns(T.nilable(String))}
   attr_writer :nilable_writer
+  sig {params(untyped_writer: T.untyped).returns(T.untyped)}
+  attr_writer :untyped_writer
 end


### PR DESCRIPTION
Declare ivars in the `AttrReader` rewriter pass for `T.untyped`, in addition to the existing behavior of declaring ivars for `T.nilable`.

Because this pass is purely syntactic, this doesn't fix other cases like `T.any(NilClass, Foo)` or type aliases, but at least it fixes the most surprising case. 🤷 

Fixes #3347 


### Motivation
#3347 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
