### PR TITLE
Return a proper error code when `srb` fails

### DIFF
--- a/gems/sorbet/bin/srb
+++ b/gems/sorbet/bin/srb
@@ -23,7 +23,7 @@ Options:
 For full help:
   https://sorbet.org
 EOF
-  exit 0
+  exit 1
 }
 
 subcommand=$1


### PR DESCRIPTION
### Motivation

In its current state, `srb` will return `0` even when the command is not found (or `sorbet/` does not exists):

```bash
$ srb
No sorbet/ directory found. Maybe you want to run 'srb init'?
$ echo $?
0

$ srb foo
Unknown subcommand `foo`
$ echo $?
0
```

This behaviour is not consistent with other commonly used tools that generally return `1` or any other value different than `0` when such a case arise:

```bash
$ git status
fatal: not a git repository (or any of the parent directories): .git
$ echo $?
128

$ git foo
git: 'foo' is not a git command. See 'git --help'.
$ echo $?
1
```

Because of this, when using `srb` through a script it makes it harder to differentiate between `0` returned because no type checking errors were found or because you mistyped `srb typcheck`.

This pull-request make `srb` return `1` if the command is not found or the `sorbet/` directory does not exist:

```bash
$ srb
No sorbet/ directory found. Maybe you want to run 'srb init'?
$ echo $?
1

$ srb foo
Unknown subcommand `foo`
$ echo $?
1
```

### Test plan

See included automated tests.
