### PR TITLE
Better detection of enumerable type from an instance

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
@@ -149,7 +149,8 @@ module T::Types
         # enumerating the object is a destructive operation and might hang.
         obj.class
       else
-        self.class.new(type_from_instances(obj))
+        # This is a specialized enumerable type, just return the class.
+        Object.instance_method(:class).bind(obj).call
       end
     end
 

--- a/gems/sorbet-runtime/test/types/method_validation.rb
+++ b/gems/sorbet-runtime/test/types/method_validation.rb
@@ -306,6 +306,28 @@ module Opus::Types::Test
         assert_empty(lines[3..-1])
       end
 
+      class TestEnumerable
+        include Enumerable
+
+        def each
+          yield "something"
+        end
+      end
+
+      it "raises a sensible error for custom enumerable validation errors" do
+        @mod.sig { returns(T::Array[String]) }
+        def @mod.foo
+          TestEnumerable.new
+        end
+
+        err = assert_raises(TypeError) do
+          @mod.foo
+        end
+        assert_match(
+          "Return value: Expected type T::Array[String], got Opus::Types::Test::MethodValidationTest::TestEnumerable",
+          err.message.lines[0])
+      end
+
       describe 'ranges' do
         describe 'return type is non-nilable integer' do
           it 'permits a range that has integers on start and end' do

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -309,6 +309,12 @@ module Opus::Types::Test
     end
 
     describe "TypedArray" do
+      class TestEnumerable
+        include Enumerable
+
+        def each; yield "something"; end
+      end
+
       it 'fails if value is not an array' do
         type = T::Array[Integer]
         value = 3
@@ -441,6 +447,14 @@ module Opus::Types::Test
 
         allocs_when_invalid = counting_allocations {type.valid?(invalid)}
         assert_equal(0, allocs_when_invalid)
+      end
+
+      it 'gives the right error when passed an unrelated enumerable' do
+        type = T::Array[String]
+        msg = check_error_message_for_obj(type, TestEnumerable.new)
+        assert_equal(
+          "Expected type T::Array[String], got Opus::Types::Test::TypesTest::TestEnumerable",
+          msg)
       end
     end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
When detecting the type of an enumerable from an instance, `TypedEnumerable` tries to match it to a couple of well-known enumerable classes (like `Array`, `Hash`, etc). The fallback case, however, tries to match it to the class of the type that the instance is being validated against, which does not make a lot sense. 

That behaviour means, if the instance is being compared against `T::Array[Foo]`, we would try to infer the type of the enumerable instance as a kind of `T::Array`. But, if it was being compared against a `T::Set[Foo]`, then the type of the instance would be inferred to be a `T::Set`. This leads to the problem outlined in #2808.

In reality, Sorbet should not try to infer the type based on what type the instance is being compared against, but should return the type of the instance as is.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixes: #2808 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
