### PR TITLE
Handle literal ranges the same way we handle other literal generics

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1278,19 +1278,17 @@ TreePtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) {
                 result = std::move(res);
             },
             [&](parser::IRange *ret) {
-                TreePtr range = MK::Constant(loc, core::Symbols::Range());
+                auto recv = MK::Constant(loc, core::Symbols::Magic());
                 auto from = node2TreeImpl(dctx, std::move(ret->from));
                 auto to = node2TreeImpl(dctx, std::move(ret->to));
-                auto send = MK::Send2(loc, std::move(range), core::Names::new_(), std::move(from), std::move(to));
+                auto send = MK::Send2(loc, std::move(recv), core::Names::buildRange(), std::move(from), std::move(to));
                 result = std::move(send);
             },
             [&](parser::ERange *ret) {
-                TreePtr range = MK::Constant(loc, core::Symbols::Range());
+                auto recv = MK::Constant(loc, core::Symbols::Magic());
                 auto from = node2TreeImpl(dctx, std::move(ret->from));
                 auto to = node2TreeImpl(dctx, std::move(ret->to));
-                auto true_ = MK::True(loc);
-                auto send = MK::Send3(loc, std::move(range), core::Names::new_(), std::move(from), std::move(to),
-                                      std::move(true_));
+                auto send = MK::Send2(loc, std::move(recv), core::Names::buildRange(), std::move(from), std::move(to));
                 result = std::move(send);
             },
             [&](parser::Regexp *regexpNode) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1282,7 +1282,8 @@ TreePtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) {
                 auto from = node2TreeImpl(dctx, std::move(ret->from));
                 auto to = node2TreeImpl(dctx, std::move(ret->to));
                 auto excludeEnd = MK::False(loc);
-                auto send = MK::Send3(loc, std::move(recv), core::Names::buildRange(), std::move(from), std::move(to), std::move(excludeEnd));
+                auto send = MK::Send3(loc, std::move(recv), core::Names::buildRange(), std::move(from), std::move(to),
+                                      std::move(excludeEnd));
                 result = std::move(send);
             },
             [&](parser::ERange *ret) {
@@ -1290,7 +1291,8 @@ TreePtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) {
                 auto from = node2TreeImpl(dctx, std::move(ret->from));
                 auto to = node2TreeImpl(dctx, std::move(ret->to));
                 auto excludeEnd = MK::True(loc);
-                auto send = MK::Send3(loc, std::move(recv), core::Names::buildRange(), std::move(from), std::move(to), std::move(excludeEnd));
+                auto send = MK::Send3(loc, std::move(recv), core::Names::buildRange(), std::move(from), std::move(to),
+                                      std::move(excludeEnd));
                 result = std::move(send);
             },
             [&](parser::Regexp *regexpNode) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1281,14 +1281,16 @@ TreePtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) {
                 auto recv = MK::Constant(loc, core::Symbols::Magic());
                 auto from = node2TreeImpl(dctx, std::move(ret->from));
                 auto to = node2TreeImpl(dctx, std::move(ret->to));
-                auto send = MK::Send2(loc, std::move(recv), core::Names::buildRange(), std::move(from), std::move(to));
+                auto excludeEnd = MK::False(loc);
+                auto send = MK::Send3(loc, std::move(recv), core::Names::buildRange(), std::move(from), std::move(to), std::move(excludeEnd));
                 result = std::move(send);
             },
             [&](parser::ERange *ret) {
                 auto recv = MK::Constant(loc, core::Symbols::Magic());
                 auto from = node2TreeImpl(dctx, std::move(ret->from));
                 auto to = node2TreeImpl(dctx, std::move(ret->to));
-                auto send = MK::Send2(loc, std::move(recv), core::Names::buildRange(), std::move(from), std::move(to));
+                auto excludeEnd = MK::True(loc);
+                auto send = MK::Send3(loc, std::move(recv), core::Names::buildRange(), std::move(from), std::move(to), std::move(excludeEnd));
                 result = std::move(send);
             },
             [&](parser::Regexp *regexpNode) {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -438,6 +438,23 @@ void GlobalState::initEmpty() {
         auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
         arg.flags.isBlock = true;
     }
+
+    // Synthesize <Magic>.<build-range>(from: T.untyped, to: T.untyped) => Range
+    method = enterMethodSymbol(Loc::none(), Symbols::MagicSingleton(), Names::buildRange());
+    {
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg0());
+        arg.type = Types::untyped(*this, method);
+    }
+    {
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg1());
+        arg.type = Types::untyped(*this, method);
+    }
+    method.data(*this)->resultType = Types::rangeOfUntyped();
+    {
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
+        arg.flags.isBlock = true;
+    }
+
     // Synthesize <Magic>.<splat>(a: Array) => Untyped
     method = enterMethodSymbol(Loc::none(), Symbols::MagicSingleton(), Names::splat());
     {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -449,6 +449,10 @@ void GlobalState::initEmpty() {
         auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg1());
         arg.type = Types::untyped(*this, method);
     }
+    {
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg2());
+        arg.type = Types::untyped(*this, method);
+    }
     method.data(*this)->resultType = Types::rangeOfUntyped();
     {
         auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -560,7 +560,7 @@ public:
     }
 
     static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 200;
-    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 29;
+    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 30;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 2;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 2;
     static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 99;

--- a/core/Types.h
+++ b/core/Types.h
@@ -111,6 +111,7 @@ public:
     static TypePtr Boolean();
     static TypePtr Object();
     static TypePtr arrayOfUntyped();
+    static TypePtr rangeOfUntyped();
     static TypePtr hashOfUntyped();
     static TypePtr procClass();
     static TypePtr classClass();
@@ -154,6 +155,7 @@ public:
 
     static TypePtr lubAll(const GlobalState &gs, std::vector<TypePtr> &elements);
     static TypePtr arrayOf(const GlobalState &gs, const TypePtr &elem);
+    static TypePtr rangeOf(const GlobalState &gs, const TypePtr &elem);
     static TypePtr hashOf(const GlobalState &gs, const TypePtr &elem);
     static TypePtr dropNil(const GlobalState &gs, const TypePtr &from);
 
@@ -217,6 +219,7 @@ public:
     }
 
     bool isUntyped() const;
+    bool isNilClass() const;
     core::SymbolRef untypedBlame() const;
     bool isBottom() const;
     virtual bool hasUntyped();

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -309,6 +309,7 @@ NameDef names[] = {
     {"buildHash", "<build-hash>"},
     {"buildKeywordArgs", "<build-keyword-args>"},
     {"buildArray", "<build-array>"},
+    {"buildRange", "<build-range>"},
     {"splat", "<splat>"},
     {"expandSplat", "<expand-splat>"},
     {"suggestType", "<suggest-type>"},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1363,6 +1363,34 @@ public:
     }
 } Magic_buildArray;
 
+class Magic_buildRange : public IntrinsicMethod {
+public:
+    void apply(const GlobalState &gs, DispatchArgs args, const Type *thisType, DispatchResult &res) const override {
+        ENFORCE(!args.args.empty(), "Magic_buildRange called without argument");
+
+        auto type_member = dropType(gs, args.args[0]->type);
+
+        if (args.args.size() > 1) {
+            auto other = dropType(gs, args.args[1]->type);
+            if (other != Types::untypedUntracked() && other != type_member) {
+                type_member = Types::untypedUntracked();
+            }
+        }
+
+        res.returnType = Types::rangeOf(gs, type_member);
+    }
+
+private:
+    static TypePtr dropType(const GlobalState &gs, const TypePtr type) {
+        auto t = Types::dropLiteral(type);
+        t = Types::dropNil(gs, t);
+        if (t->isBottom()) {
+            return Types::untypedUntracked();
+        }
+        return t;
+    }
+} Magic_buildRange;
+
 class Magic_expandSplat : public IntrinsicMethod {
     static TypePtr expandArray(const GlobalState &gs, const TypePtr &type, int expandTo) {
         if (auto *ot = cast_type<OrType>(type.get())) {
@@ -2265,6 +2293,7 @@ const vector<Intrinsic> intrinsicMethods{
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::buildHash(), &Magic_buildHashOrKeywordArgs},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::buildKeywordArgs(), &Magic_buildHashOrKeywordArgs},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::buildArray(), &Magic_buildArray},
+    {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::buildRange(), &Magic_buildRange},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::expandSplat(), &Magic_expandSplat},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::callWithSplat(), &Magic_callWithSplat},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::callWithBlock(), &Magic_callWithBlock},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1366,24 +1366,24 @@ public:
 class Magic_buildRange : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, DispatchArgs args, const Type *thisType, DispatchResult &res) const override {
-        ENFORCE(!args.args.empty(), "Magic_buildRange called without argument");
+        ENFORCE(args.args.size() == 2, "Magic_buildRange called without argument");
 
         auto rangeElemType = Types::dropLiteral(args.args[0]->type);
-        if (!rangeElemType->isNilClass()) {
+        auto firstArgIsNil = rangeElemType->isNilClass();
+        if (!firstArgIsNil) {
             rangeElemType = Types::dropNil(gs, rangeElemType);
         }
-
-        if (args.args.size() > 1) {
-            auto other = Types::dropLiteral(args.args[1]->type);
-            if (rangeElemType->isNilClass() && other->isNilClass()) {
+        auto other = Types::dropLiteral(args.args[1]->type);
+        auto secondArgIsNil = other->isNilClass();
+        if (firstArgIsNil) {
+            if (secondArgIsNil) {
                 rangeElemType = Types::untypedUntracked();
-            } else if (rangeElemType->isNilClass()) {
+            } else {
                 rangeElemType = Types::dropNil(gs, other);
-            } else if (other->isUntyped() || (!other->isNilClass() && !Types::equiv(gs, other, rangeElemType))) {
-                rangeElemType = Types::untypedUntracked();
             }
+        } else if (other->isUntyped() || (!secondArgIsNil && !Types::equiv(gs, other, rangeElemType))) {
+            rangeElemType = Types::untypedUntracked();
         }
-
         res.returnType = Types::rangeOf(gs, rangeElemType);
     }
 } Magic_buildRange;

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1382,7 +1382,7 @@ public:
                 rangeElemType = Types::dropNil(gs, other);
             }
         } else if (other->isUntyped() || (!secondArgIsNil && !Types::equiv(gs, other, rangeElemType))) {
-            rangeElemType = Types::any(gs, rangeElemType, other);
+            rangeElemType = Types::any(gs, rangeElemType, Types::dropNil(gs, other));
         }
         res.returnType = Types::rangeOf(gs, rangeElemType);
     }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1381,7 +1381,7 @@ public:
             } else {
                 rangeElemType = Types::dropNil(gs, other);
             }
-        } else if (other->isUntyped() || (!secondArgIsNil && !Types::equiv(gs, other, rangeElemType))) {
+        } else if (!secondArgIsNil) {
             rangeElemType = Types::any(gs, rangeElemType, Types::dropNil(gs, other));
         }
         res.returnType = Types::rangeOf(gs, rangeElemType);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1382,7 +1382,7 @@ public:
                 rangeElemType = Types::dropNil(gs, other);
             }
         } else if (other->isUntyped() || (!secondArgIsNil && !Types::equiv(gs, other, rangeElemType))) {
-            rangeElemType = Types::untypedUntracked();
+            rangeElemType = Types::any(gs, rangeElemType, other);
         }
         res.returnType = Types::rangeOf(gs, rangeElemType);
     }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1366,7 +1366,7 @@ public:
 class Magic_buildRange : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, DispatchArgs args, const Type *thisType, DispatchResult &res) const override {
-        ENFORCE(args.args.size() == 2, "Magic_buildRange called without argument");
+        ENFORCE(args.args.size() == 3, "Magic_buildRange called with missing arguments");
 
         auto rangeElemType = Types::dropLiteral(args.args[0]->type);
         auto firstArgIsNil = rangeElemType->isNilClass();

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -99,6 +99,12 @@ TypePtr Types::arrayOfUntyped() {
     return res;
 }
 
+TypePtr Types::rangeOfUntyped() {
+    static vector<TypePtr> targs{Types::untypedUntracked()};
+    static auto res = make_type<AppliedType>(Symbols::Range(), targs);
+    return res;
+}
+
 TypePtr Types::hashOfUntyped() {
     static vector<TypePtr> targs{Types::untypedUntracked(), Types::untypedUntracked(), Types::untypedUntracked()};
     static auto res = make_type<AppliedType>(Symbols::Hash(), targs);
@@ -274,6 +280,11 @@ TypePtr Types::arrayOf(const GlobalState &gs, const TypePtr &elem) {
     return make_type<AppliedType>(Symbols::Array(), targs);
 }
 
+TypePtr Types::rangeOf(const GlobalState &gs, const TypePtr &elem) {
+    vector<TypePtr> targs{move(elem)};
+    return make_type<AppliedType>(Symbols::Range(), targs);
+}
+
 TypePtr Types::hashOf(const GlobalState &gs, const TypePtr &elem) {
     vector<TypePtr> tupleArgs{Types::Symbol(), elem};
     vector<TypePtr> targs{Types::Symbol(), elem, TupleType::build(gs, tupleArgs)};
@@ -307,6 +318,11 @@ void ProxyType::_sanityCheck(const GlobalState &gs) {
 bool Type::isUntyped() const {
     auto *t = cast_type<ClassType>(this);
     return t != nullptr && t->symbol == Symbols::untyped();
+}
+
+bool Type::isNilClass() const {
+    auto *t = cast_type<ClassType>(this);
+    return t != nullptr && t->symbol == Symbols::NilClass();
 }
 
 core::SymbolRef Type::untypedBlame() const {

--- a/rbi/core/range.rbi
+++ b/rbi/core/range.rbi
@@ -102,18 +102,6 @@ class Range < Object
   extend T::Generic
   Elem = type_member(:out)
 
-  # Constructs a range using the given `begin` and `end`. If the `exclude_end`
-  # parameter is omitted or is `false`, the range will include the end object;
-  # otherwise, it will be excluded.
-  sig do
-    type_parameters(:U).params(
-      from: T.type_parameter(:U),
-      to: T.nilable(T.type_parameter(:U)),
-      exclude_end: T::Boolean
-    ).returns(T::Range[T.type_parameter(:U)])
-  end
-  def self.new(from, to, exclude_end=false); end
-
   # Returns `true` only if `obj` is a
   # [`Range`](https://docs.ruby-lang.org/en/2.6.0/Range.html), has equivalent
   # begin and end items (by comparing them with `==`), and has the same

--- a/rbi/core/range.rbi
+++ b/rbi/core/range.rbi
@@ -331,7 +331,7 @@ class Range < Object
   sig do
     params(
         _begin: Elem,
-        _end: Elem,
+        _end: T.nilable(Elem),
         exclude_end: T::Boolean,
     )
     .void

--- a/test/testdata/desugar/range.rb
+++ b/test/testdata/desugar/range.rb
@@ -17,6 +17,6 @@ def foo
     # testing for endless ranges
     g = (1..)
     h = Range.new(1, nil)
-    T.reveal_type(g) # error: Revealed type: `T::Range[Integer(1)]`
     T.reveal_type(h) # error: Revealed type: `T::Range[Integer(1)]`
+    T.reveal_type(g) # error: Revealed type: `T::Range[Integer]`
 end

--- a/test/testdata/desugar/range.rb
+++ b/test/testdata/desugar/range.rb
@@ -1,25 +1,148 @@
 # typed: true
 def foo
-    a = 1..2
-    b = Range.new(1, 2)
-    c = 1...2
-    d = Range.new(1, 2, true)
-    e = (1..42).first
-    f = ('a'..'z').last
+  untyped = T.let(42, T.untyped)
 
-    T.reveal_type(a) # error: Revealed type: `T::Range[Integer]`
-    T.reveal_type(b) # error: Revealed type: `T::Range[T.untyped]`
-    T.reveal_type(c) # error: Revealed type: `T::Range[Integer]`
-    T.reveal_type(d) # error: Revealed type: `T::Range[T.untyped]`
-    T.reveal_type(e) # error: Revealed type: `Integer`
-    T.reveal_type(f) # error: Revealed type: `String`
+  # Literal ranges
 
-    # testing for endless ranges
-    g = (1..)
-    h = Range.new(1, nil)
-    T.reveal_type(g) # error: Revealed type: `T::Range[Integer]`
-    T.reveal_type(h) # error: Revealed type: `T::Range[T.untyped]`
+  lr1 = 1..2
+  T.reveal_type(lr1) # error: Revealed type: `T::Range[Integer]`
 
-    i = (1.."a")
-    T.reveal_type(i) # error: Revealed type: `T::Range[T.untyped]`
+  lr2 = 1...2
+  T.reveal_type(lr2) # error: Revealed type: `T::Range[Integer]`
+
+  lr3 = 1..nil
+  T.reveal_type(lr3) # error: Revealed type: `T::Range[Integer]`
+
+  lr4 = 1...nil
+  T.reveal_type(lr4) # error: Revealed type: `T::Range[Integer]`
+
+  lr5 = (1..)
+  T.reveal_type(lr5) # error: Revealed type: `T::Range[Integer]`
+
+  lr6 = (1...)
+  T.reveal_type(lr6) # error: Revealed type: `T::Range[Integer]`
+
+  lr7 = (1.."a")
+  T.reveal_type(lr7) # error: Revealed type: `T::Range[T.untyped]`
+
+  lr8 = nil..42
+  T.reveal_type(lr8) # error: Revealed type: `T::Range[Integer]`
+
+  lr9 = nil...42
+  T.reveal_type(lr9) # error: Revealed type: `T::Range[Integer]`
+
+  lr10 = (nil..)
+  T.reveal_type(lr10) # error: Revealed type: `T::Range[T.untyped]`
+
+  lr11 = (nil...)
+  T.reveal_type(lr11) # error: Revealed type: `T::Range[T.untyped]`
+
+  lr12 = nil..nil
+  T.reveal_type(lr12) # error: Revealed type: `T::Range[T.untyped]`
+
+  lr13 = nil...nil
+  T.reveal_type(lr13) # error: Revealed type: `T::Range[T.untyped]`
+
+  lr14 = untyped..42
+  T.reveal_type(lr14) # error: Revealed type: `T::Range[T.untyped]`
+
+  lr15 = 1..untyped
+  T.reveal_type(lr15) # error: Revealed type: `T::Range[T.untyped]`
+
+  lr16 = untyped..untyped
+  T.reveal_type(lr16) # error: Revealed type: `T::Range[T.untyped]`
+
+  lr_first = (1..42).first
+  T.reveal_type(lr_first) # error: Revealed type: `Integer`
+
+  lr_last = ('a'..'z').last
+  T.reveal_type(lr_last) # error: Revealed type: `String`
+
+  # Range.new
+
+  rn1 = Range.new # error: Not enough arguments provided for method `Range#initialize`. Expected: `2..3`, got: `0`
+  T.reveal_type(rn1) # error: Revealed type: `T::Range[T.untyped]`
+
+  rn2 = Range.new(nil) # error: Not enough arguments provided for method `Range#initialize`. Expected: `2..3`, got: `1`
+  T.reveal_type(rn2) # error: Revealed type: `T::Range[T.untyped]`
+
+  rn3 = Range.new(1, 2)
+  T.reveal_type(rn3) # error: Revealed type: `T::Range[T.untyped]`
+
+  rn4 = Range.new(1, 2, true)
+  T.reveal_type(rn4) # error: Revealed type: `T::Range[T.untyped]`
+
+  rn5 = Range.new(1, nil)
+  T.reveal_type(rn5) # error: Revealed type: `T::Range[T.untyped]`
+
+  rn6 = Range.new(1, true)
+  T.reveal_type(rn6) # error: Revealed type: `T::Range[T.untyped]`
+
+  rn7 = Range.new(nil, 42)
+  T.reveal_type(rn7) # error: Revealed type: `T::Range[T.untyped]`
+
+  rn8 = Range.new(nil, nil)
+  T.reveal_type(rn8) # error: Revealed type: `T::Range[T.untyped]`
+
+  rn9 = Range.new(1, 'c')
+  T.reveal_type(rn9) # error: Revealed type: `T::Range[T.untyped]`
+
+  rn10 = Range.new(untyped, 42)
+  T.reveal_type(rn10) # error: Revealed type: `T::Range[T.untyped]`
+
+  rn11 = Range.new(1, untyped)
+  T.reveal_type(rn11) # error: Revealed type: `T::Range[T.untyped]`
+
+  rn12 = Range.new(untyped, untyped)
+  T.reveal_type(rn12) # error: Revealed type: `T::Range[T.untyped]`
+
+  rn_first = Range.new(1, 42).first
+  T.reveal_type(rn_first) # error: Revealed type: `T.untyped`
+
+  rn_last = Range.new('a', 'z').last
+  T.reveal_type(rn_last) # error: Revealed type: `T.untyped`
+
+  # T::Range[].new
+
+  tr1 = T::Range.new # error: Method `new` does not exist on `T.class_of(T::Range)`
+  T.reveal_type(tr1) # error: Revealed type: `T.untyped`
+
+  tr2 = T::Range[Integer].new # error: Not enough arguments provided for method `Range#initialize`. Expected: `2..3`, got: `0`
+  T.reveal_type(tr2) # error: Revealed type: `T::Range[Integer]`
+
+  tr3 = T::Range[Integer].new(1, 2)
+  T.reveal_type(tr3) # error: Revealed type: `T::Range[Integer]`
+
+  tr4 = T::Range[Integer].new(1, 2, true)
+  T.reveal_type(tr4) # error: Revealed type: `T::Range[Integer]`
+
+  tr5 = T::Range[Integer].new(1, nil)
+  T.reveal_type(tr5) # error: Revealed type: `T::Range[Integer]`
+
+  tr6 = T::Range[Integer].new(1, true) # error: Expected `T.nilable(Integer)` but found `TrueClass` for argument `_end`
+  T.reveal_type(tr6) # error: Revealed type: `T::Range[Integer]`
+
+  tr7 = T::Range[Integer].new(nil, 42) # error: Expected `Integer` but found `NilClass` for argument `_begin`
+  T.reveal_type(tr7) # error: Revealed type: `T::Range[Integer]`
+
+  tr8 = T::Range[Integer].new(nil, nil) # error: Expected `Integer` but found `NilClass` for argument `_begin`
+  T.reveal_type(tr8) # error: Revealed type: `T::Range[Integer]`
+
+  tr9 = T::Range[T.untyped].new(1, 'c')
+  T.reveal_type(tr9) # error: Revealed type: `T::Range[T.untyped]`
+
+  tr10 = T::Range[Integer].new(untyped, 42)
+  T.reveal_type(tr10) # error: Revealed type: `T::Range[Integer]`
+
+  tr11 = T::Range[Integer].new(1, untyped)
+  T.reveal_type(tr11) # error: Revealed type: `T::Range[Integer]`
+
+  tr12 = T::Range[Integer].new(untyped, untyped)
+  T.reveal_type(tr12) # error: Revealed type: `T::Range[Integer]`
+
+  tr_first = T::Range[Integer].new(1, 42).first
+  T.reveal_type(tr_first) # error: Revealed type: `Integer`
+
+  tr_last = T::Range[String].new('a', 'z').last
+  T.reveal_type(tr_last) # error: Revealed type: `String`
 end

--- a/test/testdata/desugar/range.rb
+++ b/test/testdata/desugar/range.rb
@@ -8,15 +8,15 @@ def foo
     f = ('a'..'z').last
 
     T.reveal_type(a) # error: Revealed type: `T::Range[Integer]`
-    T.reveal_type(b) # error: Revealed type: `T::Range[Integer]`
+    T.reveal_type(b) # error: Revealed type: `T::Range[T.untyped]`
     T.reveal_type(c) # error: Revealed type: `T::Range[Integer]`
-    T.reveal_type(d) # error: Revealed type: `T::Range[Integer]`
+    T.reveal_type(d) # error: Revealed type: `T::Range[T.untyped]`
     T.reveal_type(e) # error: Revealed type: `Integer`
     T.reveal_type(f) # error: Revealed type: `String`
 
     # testing for endless ranges
     g = (1..)
     h = Range.new(1, nil)
-    T.reveal_type(h) # error: Revealed type: `T::Range[Integer(1)]`
     T.reveal_type(g) # error: Revealed type: `T::Range[Integer]`
+    T.reveal_type(h) # error: Revealed type: `T::Range[T.untyped]`
 end

--- a/test/testdata/desugar/range.rb
+++ b/test/testdata/desugar/range.rb
@@ -19,4 +19,7 @@ def foo
     h = Range.new(1, nil)
     T.reveal_type(g) # error: Revealed type: `T::Range[Integer]`
     T.reveal_type(h) # error: Revealed type: `T::Range[T.untyped]`
+
+    i = (1.."a")
+    T.reveal_type(i) # error: Revealed type: `T::Range[T.untyped]`
 end

--- a/test/testdata/desugar/range.rb
+++ b/test/testdata/desugar/range.rb
@@ -23,7 +23,7 @@ def foo
   T.reveal_type(lr6) # error: Revealed type: `T::Range[Integer]`
 
   lr7 = (1.."a")
-  T.reveal_type(lr7) # error: Revealed type: `T::Range[T.untyped]`
+  T.reveal_type(lr7) # error: Revealed type: `T::Range[T.any(Integer, String)]`
 
   lr8 = nil..42
   T.reveal_type(lr8) # error: Revealed type: `T::Range[Integer]`

--- a/test/testdata/desugar/range.rb
+++ b/test/testdata/desugar/range.rb
@@ -1,6 +1,7 @@
 # typed: true
 def foo
   untyped = T.let(42, T.untyped)
+  nilable = T.let(42, T.nilable(Integer))
 
   # Literal ranges
 
@@ -51,6 +52,15 @@ def foo
 
   lr16 = untyped..untyped
   T.reveal_type(lr16) # error: Revealed type: `T::Range[T.untyped]`
+
+  lr17 = 1..nilable
+  T.reveal_type(lr17) # error: Revealed type: `T::Range[Integer]`
+
+  lr18 = nilable..1
+  T.reveal_type(lr18) # error: Revealed type: `T::Range[Integer]`
+
+  lr19 = nilable..nilable
+  T.reveal_type(lr19) # error: Revealed type: `T::Range[Integer]`
 
   lr_first = (1..42).first
   T.reveal_type(lr_first) # error: Revealed type: `Integer`

--- a/test/testdata/desugar/range.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/range.rb.desugar-tree-raw.exp
@@ -18,7 +18,34 @@ ClassDef{
           Assign{
             lhs = UnresolvedIdent{
               kind = Local
-              name = <U a>
+              name = <U untyped>
+            }
+            rhs = Send{
+              recv = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U T>>
+              }
+              fun = <U let>
+              block = nullptr
+              args = [
+                Literal{ value = 42 }
+                Send{
+                  recv = UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U T>>
+                  }
+                  fun = <U untyped>
+                  block = nullptr
+                  args = [
+                  ]
+                }
+              ]
+            }
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U lr1>
             }
             rhs = Send{
               recv = ConstantLit{
@@ -33,28 +60,24 @@ ClassDef{
               ]
             }
           }
-          Assign{
-            lhs = UnresolvedIdent{
-              kind = Local
-              name = <U b>
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
             }
-            rhs = Send{
-              recv = UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U Range>>
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U lr1>
               }
-              fun = <U new>
-              block = nullptr
-              args = [
-                Literal{ value = 1 }
-                Literal{ value = 2 }
-              ]
-            }
+            ]
           }
           Assign{
             lhs = UnresolvedIdent{
               kind = Local
-              name = <U c>
+              name = <U lr2>
             }
             rhs = Send{
               recv = ConstantLit{
@@ -69,29 +92,484 @@ ClassDef{
               ]
             }
           }
-          Assign{
-            lhs = UnresolvedIdent{
-              kind = Local
-              name = <U d>
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
             }
-            rhs = Send{
-              recv = UnresolvedConstantLit{
-                scope = EmptyTree
-                cnst = <C <U Range>>
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U lr2>
               }
-              fun = <U new>
-              block = nullptr
-              args = [
-                Literal{ value = 1 }
-                Literal{ value = 2 }
-                Literal{ value = true }
-              ]
-            }
+            ]
           }
           Assign{
             lhs = UnresolvedIdent{
               kind = Local
-              name = <U e>
+              name = <U lr3>
+            }
+            rhs = Send{
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = ::<Magic>
+              }
+              fun = <U <build-range>>
+              block = nullptr
+              args = [
+                Literal{ value = 1 }
+                Literal{ value = nil }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U lr3>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U lr4>
+            }
+            rhs = Send{
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = ::<Magic>
+              }
+              fun = <U <build-range>>
+              block = nullptr
+              args = [
+                Literal{ value = 1 }
+                Literal{ value = nil }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U lr4>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U lr5>
+            }
+            rhs = Send{
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = ::<Magic>
+              }
+              fun = <U <build-range>>
+              block = nullptr
+              args = [
+                Literal{ value = 1 }
+                EmptyTree
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U lr5>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U lr6>
+            }
+            rhs = Send{
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = ::<Magic>
+              }
+              fun = <U <build-range>>
+              block = nullptr
+              args = [
+                Literal{ value = 1 }
+                EmptyTree
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U lr6>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U lr7>
+            }
+            rhs = Send{
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = ::<Magic>
+              }
+              fun = <U <build-range>>
+              block = nullptr
+              args = [
+                Literal{ value = 1 }
+                Literal{ value = "a" }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U lr7>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U lr8>
+            }
+            rhs = Send{
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = ::<Magic>
+              }
+              fun = <U <build-range>>
+              block = nullptr
+              args = [
+                Literal{ value = nil }
+                Literal{ value = 42 }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U lr8>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U lr9>
+            }
+            rhs = Send{
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = ::<Magic>
+              }
+              fun = <U <build-range>>
+              block = nullptr
+              args = [
+                Literal{ value = nil }
+                Literal{ value = 42 }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U lr9>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U lr10>
+            }
+            rhs = Send{
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = ::<Magic>
+              }
+              fun = <U <build-range>>
+              block = nullptr
+              args = [
+                Literal{ value = nil }
+                EmptyTree
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U lr10>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U lr11>
+            }
+            rhs = Send{
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = ::<Magic>
+              }
+              fun = <U <build-range>>
+              block = nullptr
+              args = [
+                Literal{ value = nil }
+                EmptyTree
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U lr11>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U lr12>
+            }
+            rhs = Send{
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = ::<Magic>
+              }
+              fun = <U <build-range>>
+              block = nullptr
+              args = [
+                Literal{ value = nil }
+                Literal{ value = nil }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U lr12>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U lr13>
+            }
+            rhs = Send{
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = ::<Magic>
+              }
+              fun = <U <build-range>>
+              block = nullptr
+              args = [
+                Literal{ value = nil }
+                Literal{ value = nil }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U lr13>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U lr14>
+            }
+            rhs = Send{
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = ::<Magic>
+              }
+              fun = <U <build-range>>
+              block = nullptr
+              args = [
+                UnresolvedIdent{
+                  kind = Local
+                  name = <U untyped>
+                }
+                Literal{ value = 42 }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U lr14>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U lr15>
+            }
+            rhs = Send{
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = ::<Magic>
+              }
+              fun = <U <build-range>>
+              block = nullptr
+              args = [
+                Literal{ value = 1 }
+                UnresolvedIdent{
+                  kind = Local
+                  name = <U untyped>
+                }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U lr15>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U lr16>
+            }
+            rhs = Send{
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = ::<Magic>
+              }
+              fun = <U <build-range>>
+              block = nullptr
+              args = [
+                UnresolvedIdent{
+                  kind = Local
+                  name = <U untyped>
+                }
+                UnresolvedIdent{
+                  kind = Local
+                  name = <U untyped>
+                }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U lr16>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U lr_first>
             }
             rhs = Send{
               recv = Send{
@@ -112,10 +590,24 @@ ClassDef{
               ]
             }
           }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U lr_first>
+              }
+            ]
+          }
           Assign{
             lhs = UnresolvedIdent{
               kind = Local
-              name = <U f>
+              name = <U lr_last>
             }
             rhs = Send{
               recv = Send{
@@ -146,102 +638,140 @@ ClassDef{
             args = [
               UnresolvedIdent{
                 kind = Local
-                name = <U a>
-              }
-            ]
-          }
-          Send{
-            recv = UnresolvedConstantLit{
-              scope = EmptyTree
-              cnst = <C <U T>>
-            }
-            fun = <U reveal_type>
-            block = nullptr
-            args = [
-              UnresolvedIdent{
-                kind = Local
-                name = <U b>
-              }
-            ]
-          }
-          Send{
-            recv = UnresolvedConstantLit{
-              scope = EmptyTree
-              cnst = <C <U T>>
-            }
-            fun = <U reveal_type>
-            block = nullptr
-            args = [
-              UnresolvedIdent{
-                kind = Local
-                name = <U c>
-              }
-            ]
-          }
-          Send{
-            recv = UnresolvedConstantLit{
-              scope = EmptyTree
-              cnst = <C <U T>>
-            }
-            fun = <U reveal_type>
-            block = nullptr
-            args = [
-              UnresolvedIdent{
-                kind = Local
-                name = <U d>
-              }
-            ]
-          }
-          Send{
-            recv = UnresolvedConstantLit{
-              scope = EmptyTree
-              cnst = <C <U T>>
-            }
-            fun = <U reveal_type>
-            block = nullptr
-            args = [
-              UnresolvedIdent{
-                kind = Local
-                name = <U e>
-              }
-            ]
-          }
-          Send{
-            recv = UnresolvedConstantLit{
-              scope = EmptyTree
-              cnst = <C <U T>>
-            }
-            fun = <U reveal_type>
-            block = nullptr
-            args = [
-              UnresolvedIdent{
-                kind = Local
-                name = <U f>
+                name = <U lr_last>
               }
             ]
           }
           Assign{
             lhs = UnresolvedIdent{
               kind = Local
-              name = <U g>
+              name = <U rn1>
             }
             rhs = Send{
-              recv = ConstantLit{
-                orig = nullptr
-                symbol = ::<Magic>
+              recv = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U Range>>
               }
-              fun = <U <build-range>>
+              fun = <U new>
               block = nullptr
               args = [
-                Literal{ value = 1 }
-                EmptyTree
               ]
             }
           }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U rn1>
+              }
+            ]
+          }
           Assign{
             lhs = UnresolvedIdent{
               kind = Local
-              name = <U h>
+              name = <U rn2>
+            }
+            rhs = Send{
+              recv = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U Range>>
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+                Literal{ value = nil }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U rn2>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U rn3>
+            }
+            rhs = Send{
+              recv = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U Range>>
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+                Literal{ value = 1 }
+                Literal{ value = 2 }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U rn3>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U rn4>
+            }
+            rhs = Send{
+              recv = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U Range>>
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+                Literal{ value = 1 }
+                Literal{ value = 2 }
+                Literal{ value = true }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U rn4>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U rn5>
             }
             rhs = Send{
               recv = UnresolvedConstantLit{
@@ -266,9 +796,27 @@ ClassDef{
             args = [
               UnresolvedIdent{
                 kind = Local
-                name = <U g>
+                name = <U rn5>
               }
             ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U rn6>
+            }
+            rhs = Send{
+              recv = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U Range>>
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+                Literal{ value = 1 }
+                Literal{ value = true }
+              ]
+            }
           }
           Send{
             recv = UnresolvedConstantLit{
@@ -280,25 +828,920 @@ ClassDef{
             args = [
               UnresolvedIdent{
                 kind = Local
-                name = <U h>
+                name = <U rn6>
               }
             ]
           }
           Assign{
             lhs = UnresolvedIdent{
               kind = Local
-              name = <U i>
+              name = <U rn7>
             }
             rhs = Send{
-              recv = ConstantLit{
-                orig = nullptr
-                symbol = ::<Magic>
+              recv = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U Range>>
               }
-              fun = <U <build-range>>
+              fun = <U new>
+              block = nullptr
+              args = [
+                Literal{ value = nil }
+                Literal{ value = 42 }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U rn7>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U rn8>
+            }
+            rhs = Send{
+              recv = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U Range>>
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+                Literal{ value = nil }
+                Literal{ value = nil }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U rn8>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U rn9>
+            }
+            rhs = Send{
+              recv = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U Range>>
+              }
+              fun = <U new>
               block = nullptr
               args = [
                 Literal{ value = 1 }
-                Literal{ value = "a" }
+                Literal{ value = "c" }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U rn9>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U rn10>
+            }
+            rhs = Send{
+              recv = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U Range>>
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+                UnresolvedIdent{
+                  kind = Local
+                  name = <U untyped>
+                }
+                Literal{ value = 42 }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U rn10>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U rn11>
+            }
+            rhs = Send{
+              recv = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U Range>>
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+                Literal{ value = 1 }
+                UnresolvedIdent{
+                  kind = Local
+                  name = <U untyped>
+                }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U rn11>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U rn12>
+            }
+            rhs = Send{
+              recv = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U Range>>
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+                UnresolvedIdent{
+                  kind = Local
+                  name = <U untyped>
+                }
+                UnresolvedIdent{
+                  kind = Local
+                  name = <U untyped>
+                }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U rn12>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U rn_first>
+            }
+            rhs = Send{
+              recv = Send{
+                recv = UnresolvedConstantLit{
+                  scope = EmptyTree
+                  cnst = <C <U Range>>
+                }
+                fun = <U new>
+                block = nullptr
+                args = [
+                  Literal{ value = 1 }
+                  Literal{ value = 42 }
+                ]
+              }
+              fun = <U first>
+              block = nullptr
+              args = [
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U rn_first>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U rn_last>
+            }
+            rhs = Send{
+              recv = Send{
+                recv = UnresolvedConstantLit{
+                  scope = EmptyTree
+                  cnst = <C <U Range>>
+                }
+                fun = <U new>
+                block = nullptr
+                args = [
+                  Literal{ value = "a" }
+                  Literal{ value = "z" }
+                ]
+              }
+              fun = <U last>
+              block = nullptr
+              args = [
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U rn_last>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U tr1>
+            }
+            rhs = Send{
+              recv = UnresolvedConstantLit{
+                scope = UnresolvedConstantLit{
+                  scope = EmptyTree
+                  cnst = <C <U T>>
+                }
+                cnst = <C <U Range>>
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U tr1>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U tr2>
+            }
+            rhs = Send{
+              recv = Send{
+                recv = UnresolvedConstantLit{
+                  scope = UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U T>>
+                  }
+                  cnst = <C <U Range>>
+                }
+                fun = <U []>
+                block = nullptr
+                args = [
+                  UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U Integer>>
+                  }
+                ]
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U tr2>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U tr3>
+            }
+            rhs = Send{
+              recv = Send{
+                recv = UnresolvedConstantLit{
+                  scope = UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U T>>
+                  }
+                  cnst = <C <U Range>>
+                }
+                fun = <U []>
+                block = nullptr
+                args = [
+                  UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U Integer>>
+                  }
+                ]
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+                Literal{ value = 1 }
+                Literal{ value = 2 }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U tr3>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U tr4>
+            }
+            rhs = Send{
+              recv = Send{
+                recv = UnresolvedConstantLit{
+                  scope = UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U T>>
+                  }
+                  cnst = <C <U Range>>
+                }
+                fun = <U []>
+                block = nullptr
+                args = [
+                  UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U Integer>>
+                  }
+                ]
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+                Literal{ value = 1 }
+                Literal{ value = 2 }
+                Literal{ value = true }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U tr4>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U tr5>
+            }
+            rhs = Send{
+              recv = Send{
+                recv = UnresolvedConstantLit{
+                  scope = UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U T>>
+                  }
+                  cnst = <C <U Range>>
+                }
+                fun = <U []>
+                block = nullptr
+                args = [
+                  UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U Integer>>
+                  }
+                ]
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+                Literal{ value = 1 }
+                Literal{ value = nil }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U tr5>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U tr6>
+            }
+            rhs = Send{
+              recv = Send{
+                recv = UnresolvedConstantLit{
+                  scope = UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U T>>
+                  }
+                  cnst = <C <U Range>>
+                }
+                fun = <U []>
+                block = nullptr
+                args = [
+                  UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U Integer>>
+                  }
+                ]
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+                Literal{ value = 1 }
+                Literal{ value = true }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U tr6>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U tr7>
+            }
+            rhs = Send{
+              recv = Send{
+                recv = UnresolvedConstantLit{
+                  scope = UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U T>>
+                  }
+                  cnst = <C <U Range>>
+                }
+                fun = <U []>
+                block = nullptr
+                args = [
+                  UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U Integer>>
+                  }
+                ]
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+                Literal{ value = nil }
+                Literal{ value = 42 }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U tr7>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U tr8>
+            }
+            rhs = Send{
+              recv = Send{
+                recv = UnresolvedConstantLit{
+                  scope = UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U T>>
+                  }
+                  cnst = <C <U Range>>
+                }
+                fun = <U []>
+                block = nullptr
+                args = [
+                  UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U Integer>>
+                  }
+                ]
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+                Literal{ value = nil }
+                Literal{ value = nil }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U tr8>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U tr9>
+            }
+            rhs = Send{
+              recv = Send{
+                recv = UnresolvedConstantLit{
+                  scope = UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U T>>
+                  }
+                  cnst = <C <U Range>>
+                }
+                fun = <U []>
+                block = nullptr
+                args = [
+                  Send{
+                    recv = UnresolvedConstantLit{
+                      scope = EmptyTree
+                      cnst = <C <U T>>
+                    }
+                    fun = <U untyped>
+                    block = nullptr
+                    args = [
+                    ]
+                  }
+                ]
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+                Literal{ value = 1 }
+                Literal{ value = "c" }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U tr9>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U tr10>
+            }
+            rhs = Send{
+              recv = Send{
+                recv = UnresolvedConstantLit{
+                  scope = UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U T>>
+                  }
+                  cnst = <C <U Range>>
+                }
+                fun = <U []>
+                block = nullptr
+                args = [
+                  UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U Integer>>
+                  }
+                ]
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+                UnresolvedIdent{
+                  kind = Local
+                  name = <U untyped>
+                }
+                Literal{ value = 42 }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U tr10>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U tr11>
+            }
+            rhs = Send{
+              recv = Send{
+                recv = UnresolvedConstantLit{
+                  scope = UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U T>>
+                  }
+                  cnst = <C <U Range>>
+                }
+                fun = <U []>
+                block = nullptr
+                args = [
+                  UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U Integer>>
+                  }
+                ]
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+                Literal{ value = 1 }
+                UnresolvedIdent{
+                  kind = Local
+                  name = <U untyped>
+                }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U tr11>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U tr12>
+            }
+            rhs = Send{
+              recv = Send{
+                recv = UnresolvedConstantLit{
+                  scope = UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U T>>
+                  }
+                  cnst = <C <U Range>>
+                }
+                fun = <U []>
+                block = nullptr
+                args = [
+                  UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U Integer>>
+                  }
+                ]
+              }
+              fun = <U new>
+              block = nullptr
+              args = [
+                UnresolvedIdent{
+                  kind = Local
+                  name = <U untyped>
+                }
+                UnresolvedIdent{
+                  kind = Local
+                  name = <U untyped>
+                }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U tr12>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U tr_first>
+            }
+            rhs = Send{
+              recv = Send{
+                recv = Send{
+                  recv = UnresolvedConstantLit{
+                    scope = UnresolvedConstantLit{
+                      scope = EmptyTree
+                      cnst = <C <U T>>
+                    }
+                    cnst = <C <U Range>>
+                  }
+                  fun = <U []>
+                  block = nullptr
+                  args = [
+                    UnresolvedConstantLit{
+                      scope = EmptyTree
+                      cnst = <C <U Integer>>
+                    }
+                  ]
+                }
+                fun = <U new>
+                block = nullptr
+                args = [
+                  Literal{ value = 1 }
+                  Literal{ value = 42 }
+                ]
+              }
+              fun = <U first>
+              block = nullptr
+              args = [
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U tr_first>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U tr_last>
+            }
+            rhs = Send{
+              recv = Send{
+                recv = Send{
+                  recv = UnresolvedConstantLit{
+                    scope = UnresolvedConstantLit{
+                      scope = EmptyTree
+                      cnst = <C <U T>>
+                    }
+                    cnst = <C <U Range>>
+                  }
+                  fun = <U []>
+                  block = nullptr
+                  args = [
+                    UnresolvedConstantLit{
+                      scope = EmptyTree
+                      cnst = <C <U String>>
+                    }
+                  ]
+                }
+                fun = <U new>
+                block = nullptr
+                args = [
+                  Literal{ value = "a" }
+                  Literal{ value = "z" }
+                ]
+              }
+              fun = <U last>
+              block = nullptr
+              args = [
               ]
             }
           }
@@ -313,7 +1756,7 @@ ClassDef{
           args = [
             UnresolvedIdent{
               kind = Local
-              name = <U i>
+              name = <U tr_last>
             }
           ]
         }

--- a/test/testdata/desugar/range.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/range.rb.desugar-tree-raw.exp
@@ -23,9 +23,9 @@ ClassDef{
             rhs = Send{
               recv = ConstantLit{
                 orig = nullptr
-                symbol = ::Range
+                symbol = ::<Magic>
               }
-              fun = <U new>
+              fun = <U <build-range>>
               block = nullptr
               args = [
                 Literal{ value = 1 }
@@ -59,14 +59,13 @@ ClassDef{
             rhs = Send{
               recv = ConstantLit{
                 orig = nullptr
-                symbol = ::Range
+                symbol = ::<Magic>
               }
-              fun = <U new>
+              fun = <U <build-range>>
               block = nullptr
               args = [
                 Literal{ value = 1 }
                 Literal{ value = 2 }
-                Literal{ value = true }
               ]
             }
           }
@@ -98,9 +97,9 @@ ClassDef{
               recv = Send{
                 recv = ConstantLit{
                   orig = nullptr
-                  symbol = ::Range
+                  symbol = ::<Magic>
                 }
-                fun = <U new>
+                fun = <U <build-range>>
                 block = nullptr
                 args = [
                   Literal{ value = 1 }
@@ -122,9 +121,9 @@ ClassDef{
               recv = Send{
                 recv = ConstantLit{
                   orig = nullptr
-                  symbol = ::Range
+                  symbol = ::<Magic>
                 }
-                fun = <U new>
+                fun = <U <build-range>>
                 block = nullptr
                 args = [
                   Literal{ value = "a" }
@@ -229,9 +228,9 @@ ClassDef{
             rhs = Send{
               recv = ConstantLit{
                 orig = nullptr
-                symbol = ::Range
+                symbol = ::<Magic>
               }
-              fun = <U new>
+              fun = <U <build-range>>
               block = nullptr
               args = [
                 Literal{ value = 1 }

--- a/test/testdata/desugar/range.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/range.rb.desugar-tree-raw.exp
@@ -270,6 +270,38 @@ ClassDef{
               }
             ]
           }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U h>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U i>
+            }
+            rhs = Send{
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = ::<Magic>
+              }
+              fun = <U <build-range>>
+              block = nullptr
+              args = [
+                Literal{ value = 1 }
+                Literal{ value = "a" }
+              ]
+            }
+          }
         ],
         expr = Send{
           recv = UnresolvedConstantLit{
@@ -281,7 +313,7 @@ ClassDef{
           args = [
             UnresolvedIdent{
               kind = Local
-              name = <U h>
+              name = <U i>
             }
           ]
         }

--- a/test/testdata/desugar/range.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/range.rb.desugar-tree-raw.exp
@@ -88,6 +88,7 @@ ClassDef{
               args = [
                 Literal{ value = 1 }
                 Literal{ value = 2 }
+                Literal{ value = false }
               ]
             }
           }
@@ -120,6 +121,7 @@ ClassDef{
               args = [
                 Literal{ value = 1 }
                 Literal{ value = 2 }
+                Literal{ value = true }
               ]
             }
           }
@@ -152,6 +154,7 @@ ClassDef{
               args = [
                 Literal{ value = 1 }
                 Literal{ value = nil }
+                Literal{ value = false }
               ]
             }
           }
@@ -184,6 +187,7 @@ ClassDef{
               args = [
                 Literal{ value = 1 }
                 Literal{ value = nil }
+                Literal{ value = true }
               ]
             }
           }
@@ -216,6 +220,7 @@ ClassDef{
               args = [
                 Literal{ value = 1 }
                 EmptyTree
+                Literal{ value = false }
               ]
             }
           }
@@ -248,6 +253,7 @@ ClassDef{
               args = [
                 Literal{ value = 1 }
                 EmptyTree
+                Literal{ value = true }
               ]
             }
           }
@@ -280,6 +286,7 @@ ClassDef{
               args = [
                 Literal{ value = 1 }
                 Literal{ value = "a" }
+                Literal{ value = false }
               ]
             }
           }
@@ -312,6 +319,7 @@ ClassDef{
               args = [
                 Literal{ value = nil }
                 Literal{ value = 42 }
+                Literal{ value = false }
               ]
             }
           }
@@ -344,6 +352,7 @@ ClassDef{
               args = [
                 Literal{ value = nil }
                 Literal{ value = 42 }
+                Literal{ value = true }
               ]
             }
           }
@@ -376,6 +385,7 @@ ClassDef{
               args = [
                 Literal{ value = nil }
                 EmptyTree
+                Literal{ value = false }
               ]
             }
           }
@@ -408,6 +418,7 @@ ClassDef{
               args = [
                 Literal{ value = nil }
                 EmptyTree
+                Literal{ value = true }
               ]
             }
           }
@@ -440,6 +451,7 @@ ClassDef{
               args = [
                 Literal{ value = nil }
                 Literal{ value = nil }
+                Literal{ value = false }
               ]
             }
           }
@@ -472,6 +484,7 @@ ClassDef{
               args = [
                 Literal{ value = nil }
                 Literal{ value = nil }
+                Literal{ value = true }
               ]
             }
           }
@@ -507,6 +520,7 @@ ClassDef{
                   name = <U untyped>
                 }
                 Literal{ value = 42 }
+                Literal{ value = false }
               ]
             }
           }
@@ -542,6 +556,7 @@ ClassDef{
                   kind = Local
                   name = <U untyped>
                 }
+                Literal{ value = false }
               ]
             }
           }
@@ -580,6 +595,7 @@ ClassDef{
                   kind = Local
                   name = <U untyped>
                 }
+                Literal{ value = false }
               ]
             }
           }
@@ -615,6 +631,7 @@ ClassDef{
                   kind = Local
                   name = <U nilable>
                 }
+                Literal{ value = false }
               ]
             }
           }
@@ -650,6 +667,7 @@ ClassDef{
                   name = <U nilable>
                 }
                 Literal{ value = 1 }
+                Literal{ value = false }
               ]
             }
           }
@@ -688,6 +706,7 @@ ClassDef{
                   kind = Local
                   name = <U nilable>
                 }
+                Literal{ value = false }
               ]
             }
           }
@@ -721,6 +740,7 @@ ClassDef{
                 args = [
                   Literal{ value = 1 }
                   Literal{ value = 42 }
+                  Literal{ value = false }
                 ]
               }
               fun = <U first>
@@ -759,6 +779,7 @@ ClassDef{
                 args = [
                   Literal{ value = "a" }
                   Literal{ value = "z" }
+                  Literal{ value = false }
                 ]
               }
               fun = <U last>

--- a/test/testdata/desugar/range.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/range.rb.desugar-tree-raw.exp
@@ -45,6 +45,37 @@ ClassDef{
           Assign{
             lhs = UnresolvedIdent{
               kind = Local
+              name = <U nilable>
+            }
+            rhs = Send{
+              recv = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U T>>
+              }
+              fun = <U let>
+              block = nullptr
+              args = [
+                Literal{ value = 42 }
+                Send{
+                  recv = UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U T>>
+                  }
+                  fun = <U nilable>
+                  block = nullptr
+                  args = [
+                    UnresolvedConstantLit{
+                      scope = EmptyTree
+                      cnst = <C <U Integer>>
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
               name = <U lr1>
             }
             rhs = Send{
@@ -563,6 +594,114 @@ ClassDef{
               UnresolvedIdent{
                 kind = Local
                 name = <U lr16>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U lr17>
+            }
+            rhs = Send{
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = ::<Magic>
+              }
+              fun = <U <build-range>>
+              block = nullptr
+              args = [
+                Literal{ value = 1 }
+                UnresolvedIdent{
+                  kind = Local
+                  name = <U nilable>
+                }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U lr17>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U lr18>
+            }
+            rhs = Send{
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = ::<Magic>
+              }
+              fun = <U <build-range>>
+              block = nullptr
+              args = [
+                UnresolvedIdent{
+                  kind = Local
+                  name = <U nilable>
+                }
+                Literal{ value = 1 }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U lr18>
+              }
+            ]
+          }
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U lr19>
+            }
+            rhs = Send{
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = ::<Magic>
+              }
+              fun = <U <build-range>>
+              block = nullptr
+              args = [
+                UnresolvedIdent{
+                  kind = Local
+                  name = <U nilable>
+                }
+                UnresolvedIdent{
+                  kind = Local
+                  name = <U nilable>
+                }
+              ]
+            }
+          }
+          Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U lr19>
               }
             ]
           }

--- a/test/testdata/rewriter/flatfile_dsl.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/flatfile_dsl.rb.rewrite-tree.exp
@@ -76,7 +76,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.flatfile() do ||
       begin
-        <self>.from(::Range.new(1, 2), :"foo")
+        <self>.from(::<Magic>.<build-range>(1, 2), :"foo")
         <self>.pattern(::Regexp.new("A-Za-z", 0), :"bar")
         <self>.field(:"baz")
       end

--- a/test/testdata/rewriter/flatfile_dsl.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/flatfile_dsl.rb.rewrite-tree.exp
@@ -76,7 +76,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.flatfile() do ||
       begin
-        <self>.from(::<Magic>.<build-range>(1, 2), :"foo")
+        <self>.from(::<Magic>.<build-range>(1, 2, false), :"foo")
         <self>.pattern(::Regexp.new("A-Za-z", 0), :"bar")
         <self>.field(:"baz")
       end


### PR DESCRIPTION
### Motivation

Currently, literal ranges are desugared into calls to `Range.new` for historical reasons:

> @elliottt:
> yes, i think it's sort of accidental that Range.new has a more precise type right now
> looking at when it was first introduced, it was before generics existed in sorbet
> so i think it was just code-modded forwards, while types like Array and Hash got more attention

This means that the type of literal ranges is determined by the `Range.new` [signature](https://github.com/sorbet/sorbet/blob/master/rbi/core/range.rbi#L108-L115) which uses the type of the first argument.

This behaviour is 1) incoherent with other bare generics initialized through `new`: 

```ruby
T.reveal_type(Hash.new(a: 1, b: 2)) # Revealed type: T::Hash[T.untyped, T.untyped]
T.reveal_type(Array.new(1, 2)) # Revealed type: T::Array[T.untyped]
T.reveal_type(Range.new(1, 2)) # Revealed type: T::Range[Integer]
```

And 2) it's also brittle and leads to wrong types being inferred:

```ruby
T.reveal_type(Range.new(1)) # Revealed type: T::Range[Integer(1)]
```

^ it's not a range of literal `1`s, it's a `T::Range[Integer]`.
 
This pull request changes the way we handle literal ranges to use a similar approach than for literal arrays and hashes:

1. literal ranges are kept in the tree instead of being desugared away as `Range.new`
2. The range initialization is rewritten into a `Magic#buildRange`
3. The magic is used to attach an intrinsic for the return type figuring the return type

There is also two changes related to ranges:
1. Removing the duplicated signature for `Range::new` and keeping only `Range#initialize`
2. Fixing the test for incorrect `T::Range[Integer(1)]`

This will also be fixing the behaviour of the `T::Range[NilClass]` discussed in https://github.com/sorbet/sorbet/pull/3313#discussion_r459127000 once https://github.com/sorbet/sorbet/pull/3313 is merged.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
