### PR TITLE
Process Id returned from wait methods can be nil

### DIFF
--- a/rbi/core/process.rbi
+++ b/rbi/core/process.rbi
@@ -1026,7 +1026,7 @@ module Process
         pid: Integer,
         flags: Integer,
     )
-    .returns(Integer)
+    .returns(T.nilable(Integer))
   end
   def self.wait(pid=T.unsafe(nil), flags=T.unsafe(nil)); end
 
@@ -1119,7 +1119,7 @@ module Process
         pid: Integer,
         flags: Integer,
     )
-    .returns(Integer)
+    .returns(T.nilable(Integer))
   end
   def self.waitpid(pid=T.unsafe(nil), flags=T.unsafe(nil)); end
 
@@ -1141,7 +1141,7 @@ module Process
         pid: Integer,
         flags: Integer,
     )
-    .returns([Integer, Process::Status])
+    .returns(T.nilable([Integer, Process::Status]))
   end
   def self.waitpid2(pid=T.unsafe(nil), flags=T.unsafe(nil)); end
 end


### PR DESCRIPTION
There is a rare but valid case where a certain combination of `pid` values and `flags` to the `Process.wait` (and friends) will make a `nil` return value possible.

The [previous attempt at fixing the signature](https://github.com/sorbet/sorbet/pull/3115) had only done it for `Process.wait2` but it should be applied to `Process.wait`, `Process.waitpid` and `Process.waitpid2` as well.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Keeping the core library signatures real.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No automated tests.
