### PR TITLE
Make flow-sensitivity understand instance_of?

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -325,6 +325,7 @@ NameDef names[] = {
     {"unresolvedAncestors", "<unresolved-ancestors>"},
     {"defineTopClassOrModule", "<define-top-class-or-module>"},
 
+    {"instanceOf_p", "instance_of?"},
     {"isA_p", "is_a?"},
     {"kindOf_p", "kind_of?"},
     {"lessThan", "<"},

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -419,7 +419,8 @@ void Environment::updateKnowledge(core::Context ctx, core::LocalVariable local, 
         return;
     }
     // TODO(jez) We should probably update this to be aware of T::NonForcingConstants.non_forcing_is_a?
-    if (send->fun == core::Names::kindOf_p() || send->fun == core::Names::isA_p()) {
+    if (send->fun == core::Names::kindOf_p() || send->fun == core::Names::isA_p() ||
+        send->fun == core::Names::instanceOf_p()) {
         if (!knowledgeFilter.isNeeded(local)) {
             return;
         }

--- a/test/testdata/infer/control_flow/instance_of.rb
+++ b/test/testdata/infer/control_flow/instance_of.rb
@@ -1,0 +1,17 @@
+# typed: true
+
+class A; end;
+class B; end;
+class C; end;
+
+extend T::Sig
+
+sig {params(x: T.any(A, B, C)).void}
+def baz(x)
+  if x.instance_of?(A)
+    T.assert_type!(x, A)
+  end
+  if !x.instance_of?(A)
+    T.assert_type!(x, T.any(B, C))
+  end
+end


### PR DESCRIPTION
This makes sure that, after calling `instance_of?` on an object, Sorbet
knows about the type.

### Motivation
Fixes #48

### Test plan
Added automated tests.