### PR TITLE
Get better names for raw types

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -16,7 +16,7 @@ module T::Types
       #
       # `name` isn't normally a hot path for types, but it is used in initializing a T::Types::Union,
       # and so in `T.nilable`, and so in runtime constructions like `x = T.let(nil, T.nilable(Integer))`.
-      @name ||= @raw_type.name.freeze
+      @name ||= Module.instance_method(:name).bind(@raw_type).call.freeze
     end
 
     # @override Base

--- a/gems/sorbet-runtime/test/types/types_to_ruby.rb
+++ b/gems/sorbet-runtime/test/types/types_to_ruby.rb
@@ -2,6 +2,12 @@
 require_relative '../test_helper'
 
 class Opus::Types::Test::TypesToRubyTest < Critic::Unit::UnitTest
+  module TypeImpersonatingAnother
+    def self.name
+      "String"
+    end
+  end
+
   cases = [
     # Basic:
     [String, "String"],
@@ -10,6 +16,7 @@ class Opus::Types::Test::TypesToRubyTest < Critic::Unit::UnitTest
     [T::Types, "T::Types"],
     [self, "Opus::Types::Test::TypesToRubyTest"],
     [Symbol, "Symbol"],
+    [TypeImpersonatingAnother, "Opus::Types::Test::TypesToRubyTest::TypeImpersonatingAnother"],
 
     # Nilable:
     [T.nilable(String), "T.nilable(String)"],


### PR DESCRIPTION
Some types override the `Module#name` method to impersonate other types, but Sorbet checks for module (and ancestor) equivalance when checking for equality of types. Thus, if the types don't match, Sorbet ends up reporting a misleading name for such modules.

It is better to report the name that would have been returned by `Module#name` instead, by doing the bind/call trick.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Make `T::Types::Simple.new(Type).name` return the actual type name and not the overridden one.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
