### PR TITLE
Release binaries for macOS Big Sur (Darwin 20)

### DIFF
--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -33,7 +33,7 @@ sed -i.bak "s/0\\.0\\.0/${release_version}/" sorbet-static.gemspec
 if [[ "mac" == "$platform" ]]; then
     # Our binary should work on almost all OSes. The oldest v8 publishes is -14
     # so I'm going with that for now.
-    for i in {14..19}; do
+    for i in {14..20}; do
         sed -i.bak "s/Gem::Platform::CURRENT/'universal-darwin-$i'/" sorbet-static.gemspec
         gem build sorbet-static.gemspec
         mv sorbet-static.gemspec.bak sorbet-static.gemspec


### PR DESCRIPTION
### Motivation

This PR adds release binaries for Ruby on macOS Big Sur. Big Sur is Darwin 20 and so needs a new gem for it.

### Testing

The problem being fixed here isn't the compile but rather the needed gem being missing from Rubygems so there's little testing I can do here. I can however confirm that compiling and running Sorbet on macOS Big Sur does appear to still work.

---

⚠️  **Note about Apple Silicon:** system Ruby on Big Sur is now a universal x86_64 & arm64 binary. The changes here should work for system Ruby on x86_64, but arm64 support is still needed to natively support the new CPUs Apple will be phasing in. This is a separate task as it concerns the actual compile of the binary.

I can help out here where needed, but the likely first blocker there is the LLVM toolchain. Since I think the system toolchain isn't supported for building Sorbet, an update to LLVM 11 (when it releases - due soon) will likely be needed before macOS arm64 support can be added.

Note that the platform for both architectures is `universal-darwin-20`. That means that the goal will be a single binary containing both x86_64 and arm64 slices.

All this is a problem for another day however.