### PR TITLE
Fix signature for String#lines

### DIFF
--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -1250,11 +1250,12 @@ class String < Object
   # `each_line`.
   sig do
     params(
-        arg0: String,
+        separator: String,
+        chomp: T::Boolean,
     )
     .returns(T::Array[String])
   end
-  def lines(arg0=T.unsafe(nil)); end
+  def lines(separator = $/, chomp: false); end
 
   # If *integer* is greater than the length of *str*, returns a new `String` of
   # length *integer* with *str* left justified and padded with *padstr*;


### PR DESCRIPTION
### Motivation

Fixes: https://github.com/sorbet/sorbet/issues/1462.

Note that we can't port the same fix for methods in `IO` because they need overloads which do not support keyword arguments.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
