### PR TITLE
Fix signatures for Comparable methods

### DIFF
--- a/rbi/core/comparable.rbi
+++ b/rbi/core/comparable.rbi
@@ -37,12 +37,12 @@
 module Comparable
   # Compares two objects based on the receiver's `<=>` method, returning true if
   # it returns -1.
-  sig { params(other: T.untyped).returns(T::Boolean) }
+  sig { params(other: T.self_type).returns(T::Boolean) }
   def <(other); end
 
   # Compares two objects based on the receiver's `<=>` method, returning true if
   # it returns -1 or 0.
-  sig { params(other: T.untyped).returns(T::Boolean) }
+  sig { params(other: T.self_type).returns(T::Boolean) }
   def <=(other); end
 
   # Compares two objects based on the receiver's `<=>` method, returning true if
@@ -52,12 +52,12 @@ module Comparable
 
   # Compares two objects based on the receiver's `<=>` method, returning true if
   # it returns 1.
-  sig { params(other: T.untyped).returns(T::Boolean) }
+  sig { params(other: T.self_type).returns(T::Boolean) }
   def >(other); end
 
   # Compares two objects based on the receiver's `<=>` method, returning true if
   # it returns 0 or 1.
-  sig { params(other: T.untyped).returns(T::Boolean) }
+  sig { params(other: T.self_type).returns(T::Boolean) }
   def >=(other); end
 
   # Returns `false` if *obj* `<=>` *min* is less than zero or if *anObject*

--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -156,7 +156,8 @@ class Hash < Object
   # h2 < h1    #=> false
   # h1 < h1    #=> false
   # ```
-  def <(_); end
+  sig { params(other: T.self_type).returns(T::Boolean) }
+  def <(other); end
 
   # Returns `true` if *hash* is subset of *other* or equals to *other*.
   #
@@ -167,7 +168,8 @@ class Hash < Object
   # h2 <= h1   #=> false
   # h1 <= h1   #=> true
   # ```
-  def <=(_); end
+  sig { params(other: T.self_type).returns(T::Boolean) }
+  def <=(other); end
 
   # Equality---Two hashes are equal if they each contain the same number of keys
   # and if each key-value pair is equal to (according to `Object#==`) the
@@ -202,7 +204,8 @@ class Hash < Object
   # h2 > h1    #=> true
   # h1 > h1    #=> false
   # ```
-  def >(_); end
+  sig { params(other: T.self_type).returns(T::Boolean) }
+  def >(other); end
 
   # Returns `true` if *other* is subset of *hash* or equals to *hash*.
   #
@@ -213,7 +216,8 @@ class Hash < Object
   # h2 >= h1   #=> true
   # h1 >= h1   #=> true
   # ```
-  def >=(_); end
+  sig { params(other: T.self_type).returns(T::Boolean) }
+  def >=(other); end
 
   # Creates a new hash populated with the given objects.
   #

--- a/rbi/core/numeric.rbi
+++ b/rbi/core/numeric.rbi
@@ -146,7 +146,7 @@ class Numeric < Object
     params(
         arg0: Numeric,
     )
-    .returns(Integer)
+    .returns(T.nilable(Integer))
   end
   def <=>(arg0); end
 

--- a/rbi/core/numeric.rbi
+++ b/rbi/core/numeric.rbi
@@ -141,22 +141,6 @@ class Numeric < Object
   sig {returns(Numeric)}
   def -@(); end
 
-  sig do
-    params(
-        arg0: Numeric,
-    )
-    .returns(T::Boolean)
-  end
-  def <(arg0); end
-
-  sig do
-    params(
-        arg0: Numeric,
-    )
-    .returns(T::Boolean)
-  end
-  def <=(arg0); end
-
   # Returns zero if `number` equals `other`, otherwise returns `nil`.
   sig do
     params(
@@ -165,22 +149,6 @@ class Numeric < Object
     .returns(Integer)
   end
   def <=>(arg0); end
-
-  sig do
-    params(
-        arg0: Numeric,
-    )
-    .returns(T::Boolean)
-  end
-  def >(arg0); end
-
-  sig do
-    params(
-        arg0: Numeric,
-    )
-    .returns(T::Boolean)
-  end
-  def >=(arg0); end
 
   # Returns the absolute value of `num`.
   #

--- a/rbi/core/time.rbi
+++ b/rbi/core/time.rbi
@@ -364,22 +364,6 @@ class Time < Object
   end
   def -(arg0); end
 
-  sig do
-    params(
-        arg0: Time,
-    )
-    .returns(T::Boolean)
-  end
-  def <(arg0); end
-
-  sig do
-    params(
-        arg0: Time,
-    )
-    .returns(T::Boolean)
-  end
-  def <=(arg0); end
-
   # Comparison---Compares `time` with `other_time`.
   #
   # -1, 0, +1 or nil depending on whether `time` is less  than, equal to, or
@@ -408,22 +392,6 @@ class Time < Object
     .returns(T.nilable(Integer))
   end
   def <=>(other); end
-
-  sig do
-    params(
-        arg0: Time,
-    )
-    .returns(T::Boolean)
-  end
-  def >(arg0); end
-
-  sig do
-    params(
-        arg0: Time,
-    )
-    .returns(T::Boolean)
-  end
-  def >=(arg0); end
 
   # Returns a canonical string representation of *time*.
   #


### PR DESCRIPTION
### Motivation

Fixes https://github.com/sorbet/sorbet/issues/1048:

* Comparable enforce type for `other`
* Remove useless overloads that have no documentation attached
* Fix signatures for comparable overloads in Hash
* Fix return type for Numeric#<=>

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.