### PR TITLE
Fix missing RBI definitions for HTTP timeout errors

### DIFF
--- a/rbi/stdlib/net.rbi
+++ b/rbi/stdlib/net.rbi
@@ -2692,9 +2692,11 @@ class Net::HTTPFound < Net::HTTPRedirection
   HAS_BODY = ::T.unsafe(nil)
 end
 
-class Net::HTTPGatewayTimeOut < Net::HTTPServerError
+class Net::HTTPGatewayTimeout < Net::HTTPServerError
   HAS_BODY = ::T.unsafe(nil)
 end
+
+Net::HTTPGatewayTimeOut = Net::HTTPGatewayTimeout
 
 # [`HTTPGenericRequest`](https://docs.ruby-lang.org/en/2.6.0/Net/HTTPGenericRequest.html)
 # is the parent of the HTTPRequest class. Do not use this directly; use a
@@ -3178,9 +3180,11 @@ class Net::HTTPRequestHeaderFieldsTooLarge < Net::HTTPClientError
   HAS_BODY = ::T.unsafe(nil)
 end
 
-class Net::HTTPRequestTimeOut < Net::HTTPClientError
+class Net::HTTPRequestTimeout < Net::HTTPClientError
   HAS_BODY = ::T.unsafe(nil)
 end
+
+Net::HTTPRequestTimeOut = Net::HTTPRequestTimeout
 
 class Net::HTTPRequestURITooLong < Net::HTTPClientError
   HAS_BODY = ::T.unsafe(nil)


### PR DESCRIPTION
### Motivation

Fixes https://github.com/sorbet/sorbet/issues/2162.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
