### PR TITLE
Add Net::HTTPClientException to net RBI file

### DIFF
--- a/rbi/stdlib/net.rbi
+++ b/rbi/stdlib/net.rbi
@@ -3362,6 +3362,7 @@ end
 class Net::HTTPServerException < Net::ProtoServerError
   include ::Net::HTTPExceptions
 end
+Net::HTTPClientException = Net::HTTPServerException
 
 class Net::HTTPServiceUnavailable < Net::HTTPServerError
   HAS_BODY = ::T.unsafe(nil)


### PR DESCRIPTION
Apologies if I've done this the wrong way - the top of the RBI file indicates that it's auto-generated but I couldn't find the relevant scripts in the repository to run the specified command, and the [Sorbet documentation](https://sorbet.org/docs/faq#it-looks-like-sorbet-s-types-for-the-stdlib-are-wrong) tells me these stdlib RBI files are maintained by hand and that I should edit them myself.

### Motivation

Sorbet doesn't recognise `Net::HTTPClientException`. This is an alias for `Net::HTTPServerException`, which still exists but is deprecated due to incorrect naming.

[Reference for deprecation](https://bugs.ruby-lang.org/issues/14688)
[Code reference in Ruby source](https://github.com/ruby/ruby/blob/master/lib/net/http/exceptions.rb)


### Test plan

I haven't created new tests for this change as it's simply adding a constant to an RBI file.