### PR TITLE
Remove old encoding parser test

### DIFF
--- a/test/testdata/whitequark/parse_encoding.rb
+++ b/test/testdata/whitequark/parse_encoding.rb
@@ -1,3 +1,0 @@
-# typed: true
-
-__ENCODING__


### PR DESCRIPTION
### Motivation

https://github.com/sorbet/sorbet/pull/3319 moved the `parse_encoding.rb` test file out of the `disabled` directory and put it alone into https://github.com/sorbet/sorbet/tree/master/test/testdata/whitequark.

I believe this was an error and should have been moved to https://github.com/sorbet/sorbet/tree/master/test/whitequark instead.

But since the PR introduced a more exhaustive test for the desugarer (https://github.com/sorbet/sorbet/blob/master/test/testdata/desugar/parse_encoding.rb) and one was already present for the parser (https://github.com/sorbet/sorbet/blob/master/test/whitequark/test_ENCODING_0.rb), I think this file is now useless (and not really tested).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
