### PR TITLE
Fix output name for AttachedClass

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/attached_class.rb
+++ b/gems/sorbet-runtime/lib/types/types/attached_class.rb
@@ -12,7 +12,7 @@ module T::Types
 
     # @override Base
     def name
-      "AttachedClass"
+      "T.attached_class"
     end
 
     # @override Base

--- a/gems/sorbet-runtime/test/types/attached_class.rb
+++ b/gems/sorbet-runtime/test/types/attached_class.rb
@@ -67,5 +67,20 @@ module Opus::Types::Test
 
       assert_equal(Base.make.class, Integer)
     end
+
+    it 'can print its own name' do
+      class Base
+        extend T::Sig
+
+        sig {returns(T.attached_class)}
+        def self.make
+          Base.new
+        end
+      end
+
+      meth = Base.method(:make)
+      name = T::Private::Methods.signature_for_method(meth).return_type.to_s
+      assert_equal("T.attached_class", name)
+    end
   end
 end


### PR DESCRIPTION
### Motivation

The name returned by `sorbet-runtime` for the an attached class in the signature was `AttachedClass` which does not map on any existing class.

Let's return something the user (and tools like `tapioca`) can understand and use.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
