### PR TITLE
Fix autocorrect for T::Helpers methods

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -433,14 +433,8 @@ bool extendsTHelpers(const GlobalState &gs, core::SymbolRef enclosingClass) {
 /**
  * Make an autocorrection for adding `extend T::Helpers`, when needed.
  */
-optional<core::AutocorrectSuggestion> maybeSuggestExtendTHelpers(const GlobalState &gs, const Type *thisType,
+optional<core::AutocorrectSuggestion> maybeSuggestExtendTHelpers(const GlobalState &gs, core::SymbolRef enclosingClass,
                                                                  const Loc &call) {
-    auto *classType = cast_type<ClassType>(thisType);
-    if (classType == nullptr) {
-        return nullopt;
-    }
-
-    auto enclosingClass = classType->symbol.data(gs)->topAttachedClass(gs);
     if (extendsTHelpers(gs, enclosingClass)) {
         // No need to suggest here, because it already has 'extend T::Sig'
         return nullopt;
@@ -537,8 +531,9 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
                 // suggest adding `extend T::Helpers`.
                 if (args.name == core::Names::declareInterface() || args.name == core::Names::declareAbstract() ||
                     args.name == core::Names::declareFinal() || args.name == core::Names::declareSealed()) {
+                    auto attachedClass = symbol.data(gs)->attachedClass(gs);
                     if (auto suggestion =
-                            maybeSuggestExtendTHelpers(gs, thisType, core::Loc(args.locs.file, args.locs.call))) {
+                            maybeSuggestExtendTHelpers(gs, attachedClass, core::Loc(args.locs.file, args.locs.call))) {
                         e.addAutocorrect(std::move(*suggestion));
                     }
                 }

--- a/test/cli/autocorrect-helpers/autocorrect-helpers.out
+++ b/test/cli/autocorrect-helpers/autocorrect-helpers.out
@@ -1,0 +1,114 @@
+autocorrect-helpers.rb:4: Method `interface!` does not exist on `T.class_of(S1)` https://srb.help/7003
+     4 |  interface!
+          ^^^^^^^^^^
+  Autocorrect: Done
+    autocorrect-helpers.rb:4: Inserted `  extend T::Helpers
+`
+     4 |  interface!
+        ^
+
+autocorrect-helpers.rb:8: Method `abstract!` does not exist on `T.class_of(S2)` https://srb.help/7003
+     8 |  abstract!
+          ^^^^^^^^^
+  Autocorrect: Done
+    autocorrect-helpers.rb:8: Inserted `  extend T::Helpers
+`
+     8 |  abstract!
+        ^
+
+autocorrect-helpers.rb:12: Method `final!` does not exist on `T.class_of(S3)` https://srb.help/7003
+    12 |  final!
+          ^^^^^^
+  Autocorrect: Done
+    autocorrect-helpers.rb:12: Inserted `  extend T::Helpers
+`
+    12 |  final!
+        ^
+
+autocorrect-helpers.rb:16: Method `sealed!` does not exist on `T.class_of(S4)` https://srb.help/7003
+    16 |  sealed!
+          ^^^^^^^
+  Autocorrect: Done
+    autocorrect-helpers.rb:16: Inserted `  extend T::Helpers
+`
+    16 |  sealed!
+        ^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2135: Did you mean: `Kernel#select`?
+    2135 |  def select(read, write=T.unsafe(nil), error=T.unsafe(nil), timeout=T.unsafe(nil)); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+autocorrect-helpers.rb:20: Method `interface!` does not exist on `T.class_of(S5)` https://srb.help/7003
+    20 |  interface!
+          ^^^^^^^^^^
+  Autocorrect: Done
+    autocorrect-helpers.rb:20: Inserted `  extend T::Helpers
+`
+    20 |  interface!
+        ^
+
+autocorrect-helpers.rb:21: Method `final!` does not exist on `T.class_of(S5)` https://srb.help/7003
+    21 |  final!
+          ^^^^^^
+  Autocorrect: Done
+    autocorrect-helpers.rb:20: Inserted `  extend T::Helpers
+`
+    20 |  interface!
+        ^
+
+autocorrect-helpers.rb:25: Method `abstract!` does not exist on `T.class_of(S6)` https://srb.help/7003
+    25 |  abstract!
+          ^^^^^^^^^
+  Autocorrect: Done
+    autocorrect-helpers.rb:25: Inserted `  extend T::Helpers
+`
+    25 |  abstract!
+        ^
+
+autocorrect-helpers.rb:26: Method `sealed!` does not exist on `T.class_of(S6)` https://srb.help/7003
+    26 |  sealed!
+          ^^^^^^^
+  Autocorrect: Done
+    autocorrect-helpers.rb:25: Inserted `  extend T::Helpers
+`
+    25 |  abstract!
+        ^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2135: Did you mean: `Kernel#select`?
+    2135 |  def select(read, write=T.unsafe(nil), error=T.unsafe(nil), timeout=T.unsafe(nil)); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Errors: 8
+
+--------------------------------------------------------------------------
+
+# typed: true
+
+module S1
+  extend T::Helpers
+  interface!
+end
+
+class S2
+  extend T::Helpers
+  abstract!
+end
+
+class S3
+  extend T::Helpers
+  final!
+end
+
+class S4
+  extend T::Helpers
+  sealed!
+end
+
+module S5
+  extend T::Helpers
+  interface!
+  final!
+end
+
+class S6
+  extend T::Helpers
+  abstract!
+  sealed!
+end

--- a/test/cli/autocorrect-helpers/autocorrect-helpers.rb
+++ b/test/cli/autocorrect-helpers/autocorrect-helpers.rb
@@ -1,0 +1,27 @@
+# typed: true
+
+module S1
+  interface!
+end
+
+class S2
+  abstract!
+end
+
+class S3
+  final!
+end
+
+class S4
+  sealed!
+end
+
+module S5
+  interface!
+  final!
+end
+
+class S6
+  abstract!
+  sealed!
+end

--- a/test/cli/autocorrect-helpers/autocorrect-helpers.sh
+++ b/test/cli/autocorrect-helpers/autocorrect-helpers.sh
@@ -1,0 +1,18 @@
+tmp="$(mktemp -d)"
+infile="test/cli/autocorrect-helpers/autocorrect-helpers.rb"
+cp "$infile" "$tmp"
+
+cwd="$(pwd)"
+cd "$tmp" || exit 1
+
+"$cwd/main/sorbet" --silence-dev-message -a autocorrect-helpers.rb 2>&1
+
+echo
+echo --------------------------------------------------------------------------
+echo
+
+# Also cat the file, to make sure that 'extend' is only added once per class.
+cat autocorrect-helpers.rb
+
+rm autocorrect-helpers.rb
+rm "$tmp"


### PR DESCRIPTION
### Motivation

While there is [already code to suggest inserting `extend T::Helpers`](https://github.com/sorbet/sorbet/blob/master/core/types/calls.cc#L536-L544) when methods called `sealed!`, `final!`... are not found, Sorbet is actually [not suggesting the autocorrect](https://sorbet.run/#%23%20typed%3A%20true%0Amodule%20A%0A%20%20interface!%0Aend%0A%0Aclass%20B%0A%20%20sealed!%0Aend).

This is because the type passed to `maybeSuggestExtendTHelpers` is already the type of the attached class, while `maybeSuggestExtendTHelpers` tries to [extract it again](https://github.com/sorbet/sorbet/blob/master/core/types/calls.cc#L438-L443).

This PR fixes this problem by passing the attached class directly. See the associated test for an example.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
