### PR TITLE
Errors and autocorrects when `mixes_in_class_methods` is used without `extend T::Helpers`

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -530,7 +530,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
                 // catch the special case of `interface!`, `abstract!`, `final!`, or `sealed!` and
                 // suggest adding `extend T::Helpers`.
                 if (args.name == core::Names::declareInterface() || args.name == core::Names::declareAbstract() ||
-                    args.name == core::Names::declareFinal() || args.name == core::Names::declareSealed()) {
+                    args.name == core::Names::declareFinal() || args.name == core::Names::declareSealed() ||
+                    args.name == core::Names::mixesInClassMethods()) {
                     auto attachedClass = symbol.data(gs)->attachedClass(gs);
                     if (auto suggestion =
                             maybeSuggestExtendTHelpers(gs, attachedClass, core::Loc(args.locs.file, args.locs.call))) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2214,10 +2214,7 @@ class ResolveMixesInClassMethodsWalk {
         }
 
         if (send.args.size() != 1) {
-            if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidMixinDeclaration)) {
-                e.setHeader("Wrong number of arguments to `{}`: Expected: `{}`, got: `{}`",
-                            send.fun.data(ctx)->show(ctx), 1, send.args.size());
-            }
+            // The arity mismatch error will be emitted later by infer.
             return;
         }
         auto &front = send.args.front();
@@ -2258,7 +2255,6 @@ public:
         auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
         if (send.recv->isSelfReference() && send.fun == core::Names::mixesInClassMethods()) {
             processMixesInClassMethods(ctx, send);
-            return ast::MK::EmptyTree();
         }
         return tree;
     }

--- a/test/cli/autocorrect-helpers/autocorrect-helpers.out
+++ b/test/cli/autocorrect-helpers/autocorrect-helpers.out
@@ -75,7 +75,19 @@ autocorrect-helpers.rb:26: Method `sealed!` does not exist on `T.class_of(S6)` h
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2135: Did you mean: `Kernel#select`?
     2135 |  def select(read, write=T.unsafe(nil), error=T.unsafe(nil), timeout=T.unsafe(nil)); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 8
+
+autocorrect-helpers.rb:30: Method `mixes_in_class_methods` does not exist on `T.class_of(S7)` https://srb.help/7003
+    30 |  mixes_in_class_methods(S1)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    autocorrect-helpers.rb:30: Inserted `  extend T::Helpers
+`
+    30 |  mixes_in_class_methods(S1)
+        ^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#L1371: Did you mean: `Module#public_class_method`?
+    1371 |  def public_class_method(*arg0); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Errors: 9
 
 --------------------------------------------------------------------------
 
@@ -111,4 +123,9 @@ class S6
   extend T::Helpers
   abstract!
   sealed!
+end
+
+module S7
+  extend T::Helpers
+  mixes_in_class_methods(S1)
 end

--- a/test/cli/autocorrect-helpers/autocorrect-helpers.rb
+++ b/test/cli/autocorrect-helpers/autocorrect-helpers.rb
@@ -25,3 +25,7 @@ class S6
   abstract!
   sealed!
 end
+
+module S7
+  mixes_in_class_methods(S1)
+end

--- a/test/testdata/resolver/mixes_in_class_methods.rb
+++ b/test/testdata/resolver/mixes_in_class_methods.rb
@@ -1,6 +1,7 @@
 # typed: true
 module Mixin
   extend T::Sig
+  extend T::Helpers
 
   module ClassMethods
     def mixin_class_method
@@ -23,17 +24,20 @@ Test.new.mixin_method
 
 module Bad1
   extend T::Sig
-  mixes_in_class_methods # error: Wrong number of arguments to `mixes_in_class_methods`
+  extend T::Helpers
+  mixes_in_class_methods # error: Not enough arguments provided for method `T::Helpers#mixes_in_class_methods`. Expected: `1`, got: `0`
 end
 
 class Bad2
   extend T::Sig
+  extend T::Helpers
   module ClassMethods; end
   mixes_in_class_methods(ClassMethods) # error: can only be declared inside a module
 end
 
 module Bad3
   extend T::Sig
+  extend T::Helpers
 
   class ClassMethods; end
   mixes_in_class_methods(ClassMethods) # error: is a class, not a module
@@ -41,11 +45,13 @@ end
 
 module Bad4
   extend T::Sig
+  extend T::Helpers
 
   mixes_in_class_methods(0) # error: must be statically resolvable to a module
 end
 
 module Bad5
   extend T::Sig
+  extend T::Helpers
   mixes_in_class_methods(Bad5) # error: Must not pass your self
 end

--- a/test/testdata/resolver/mixes_in_class_methods.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/mixes_in_class_methods.rb.symbol-table-raw.exp
@@ -1,59 +1,59 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=2:1 end=51:4}
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=2:1 end=57:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=??? end=???}
-  module <C <U Bad1>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=24:1 end=24:12}
-  class <S <C <U Bad1>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> (<C <U Sig>>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=24:8 end=24:12}
-    type-member(+) <S <C <U Bad1>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Bad1>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Bad1) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=24:8 end=24:12}
-    method <S <C <U Bad1>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=24:1 end=27:4}
+  module <C <U Bad1>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=25:1 end=25:12}
+  class <S <C <U Bad1>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> (<C <U Helpers>>, <C <U Sig>>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=25:8 end=25:12}
+    type-member(+) <S <C <U Bad1>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Bad1>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Bad1) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=25:8 end=25:12}
+    method <S <C <U Bad1>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=25:1 end=29:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=??? end=???}
-  class <C <U Bad2>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=29:1 end=29:11}
-    module <C <U Bad2>><C <U ClassMethods>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=31:3 end=31:22}
-    class <C <U Bad2>><S <C <U ClassMethods>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=31:10 end=31:22}
-      type-member(+) <C <U Bad2>><S <C <U ClassMethods>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U Bad2>><S <C <U ClassMethods>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Bad2::ClassMethods) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=31:10 end=31:22}
-      method <C <U Bad2>><S <C <U ClassMethods>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=31:3 end=31:27}
+  class <C <U Bad2>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=31:1 end=31:11}
+    module <C <U Bad2>><C <U ClassMethods>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=34:3 end=34:22}
+    class <C <U Bad2>><S <C <U ClassMethods>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=34:10 end=34:22}
+      type-member(+) <C <U Bad2>><S <C <U ClassMethods>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U Bad2>><S <C <U ClassMethods>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Bad2::ClassMethods) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=34:10 end=34:22}
+      method <C <U Bad2>><S <C <U ClassMethods>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=34:3 end=34:27}
         argument <blk><block> @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=??? end=???}
-  class <S <C <U Bad2>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U Sig>>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=29:7 end=29:11}
-    type-member(+) <S <C <U Bad2>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Bad2>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Bad2) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=29:7 end=29:11}
-    method <S <C <U Bad2>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=29:1 end=33:4}
+  class <S <C <U Bad2>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U Helpers>>, <C <U Sig>>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=31:7 end=31:11}
+    type-member(+) <S <C <U Bad2>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Bad2>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Bad2) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=31:7 end=31:11}
+    method <S <C <U Bad2>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=31:1 end=36:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=??? end=???}
-  module <C <U Bad3>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=35:1 end=35:12}
-    class <C <U Bad3>><C <U ClassMethods>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=38:3 end=38:21}
-    class <C <U Bad3>><S <C <U ClassMethods>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=38:9 end=38:21}
-      type-member(+) <C <U Bad3>><S <C <U ClassMethods>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U Bad3>><S <C <U ClassMethods>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Bad3::ClassMethods) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=38:9 end=38:21}
-      method <C <U Bad3>><S <C <U ClassMethods>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=38:3 end=38:26}
+  module <C <U Bad3>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=38:1 end=38:12}
+    class <C <U Bad3>><C <U ClassMethods>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=42:3 end=42:21}
+    class <C <U Bad3>><S <C <U ClassMethods>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=42:9 end=42:21}
+      type-member(+) <C <U Bad3>><S <C <U ClassMethods>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U Bad3>><S <C <U ClassMethods>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Bad3::ClassMethods) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=42:9 end=42:21}
+      method <C <U Bad3>><S <C <U ClassMethods>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=42:3 end=42:26}
         argument <blk><block> @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=??? end=???}
-  class <S <C <U Bad3>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> (<C <U Sig>>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=35:8 end=35:12}
-    type-member(+) <S <C <U Bad3>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Bad3>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Bad3) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=35:8 end=35:12}
-    method <S <C <U Bad3>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=35:1 end=40:4}
+  class <S <C <U Bad3>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> (<C <U Helpers>>, <C <U Sig>>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=38:8 end=38:12}
+    type-member(+) <S <C <U Bad3>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Bad3>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Bad3) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=38:8 end=38:12}
+    method <S <C <U Bad3>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=38:1 end=44:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=??? end=???}
-  module <C <U Bad4>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=42:1 end=42:12}
-  class <S <C <U Bad4>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> (<C <U Sig>>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=42:8 end=42:12}
-    type-member(+) <S <C <U Bad4>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Bad4>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Bad4) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=42:8 end=42:12}
-    method <S <C <U Bad4>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=42:1 end=46:4}
+  module <C <U Bad4>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=46:1 end=46:12}
+  class <S <C <U Bad4>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> (<C <U Helpers>>, <C <U Sig>>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=46:8 end=46:12}
+    type-member(+) <S <C <U Bad4>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Bad4>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Bad4) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=46:8 end=46:12}
+    method <S <C <U Bad4>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=46:1 end=51:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=??? end=???}
-  module <C <U Bad5>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=48:1 end=48:12}
-  class <S <C <U Bad5>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> (<C <U Sig>>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=48:8 end=48:12}
-    type-member(+) <S <C <U Bad5>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Bad5>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Bad5) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=48:8 end=48:12}
-    method <S <C <U Bad5>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=48:1 end=51:4}
+  module <C <U Bad5>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=53:1 end=53:12}
+  class <S <C <U Bad5>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> (<C <U Helpers>>, <C <U Sig>>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=53:8 end=53:12}
+    type-member(+) <S <C <U Bad5>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Bad5>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Bad5) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=53:8 end=53:12}
+    method <S <C <U Bad5>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=53:1 end=57:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=??? end=???}
   module <C <U Mixin>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=2:1 end=2:13}
-    module <C <U Mixin>><C <U ClassMethods>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=5:3 end=5:22}
-      method <C <U Mixin>><C <U ClassMethods>><U mixin_class_method> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=6:5 end=6:27}
+    module <C <U Mixin>><C <U ClassMethods>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=6:3 end=6:22}
+      method <C <U Mixin>><C <U ClassMethods>><U mixin_class_method> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=7:5 end=7:27}
         argument <blk><block> @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=??? end=???}
-    class <C <U Mixin>><S <C <U ClassMethods>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=5:10 end=5:22}
-      type-member(+) <C <U Mixin>><S <C <U ClassMethods>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U Mixin>><S <C <U ClassMethods>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Mixin::ClassMethods) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=5:10 end=5:22}
-      method <C <U Mixin>><S <C <U ClassMethods>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=5:3 end=8:6}
+    class <C <U Mixin>><S <C <U ClassMethods>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=6:10 end=6:22}
+      type-member(+) <C <U Mixin>><S <C <U ClassMethods>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U Mixin>><S <C <U ClassMethods>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Mixin::ClassMethods) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=6:10 end=6:22}
+      method <C <U Mixin>><S <C <U ClassMethods>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=6:3 end=9:6}
         argument <blk><block> @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=??? end=???}
-    method <C <U Mixin>><U mixin_method> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=12:3 end=12:19}
+    method <C <U Mixin>><U mixin_method> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=13:3 end=13:19}
       argument <blk><block> @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=??? end=???}
-  class <S <C <U Mixin>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> (<C <U Sig>>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=2:8 end=2:13}
+  class <S <C <U Mixin>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> (<C <U Helpers>>, <C <U Sig>>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=2:8 end=2:13}
     type-member(+) <S <C <U Mixin>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Mixin>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Mixin) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=2:8 end=2:13}
-    method <S <C <U Mixin>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=2:1 end=14:4}
+    method <S <C <U Mixin>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=2:1 end=15:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=??? end=???}
-  class <C <U Test>> < <C <U Object>> (<C <U Mixin>>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=16:1 end=16:11}
-  class <S <C <U Test>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=16:7 end=16:11}
-    type-member(+) <S <C <U Test>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Test>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Test) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=16:7 end=16:11}
-    method <S <C <U Test>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=16:1 end=18:4}
+  class <C <U Test>> < <C <U Object>> (<C <U Mixin>>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=17:1 end=17:11}
+  class <S <C <U Test>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=17:7 end=17:11}
+    type-member(+) <S <C <U Test>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Test>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Test) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=17:7 end=17:11}
+    method <S <C <U Test>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=17:1 end=19:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/mixes_in_class_methods.rb start=??? end=???}
 

--- a/test/testdata/resolver/mixes_in_class_methods_twice.rb
+++ b/test/testdata/resolver/mixes_in_class_methods_twice.rb
@@ -10,6 +10,7 @@
 # actually fine. But if the class is different, that's an error.
 
 module A
+  extend T::Helpers
   module ClassMethods1; end
   module ClassMethods2; end
   mixes_in_class_methods(ClassMethods1)
@@ -17,6 +18,7 @@ module A
 end
 
 module B
+  extend T::Helpers
   module ClassMethods; end
   mixes_in_class_methods(ClassMethods)
   mixes_in_class_methods(ClassMethods) # explicitly not an error


### PR DESCRIPTION
### Motivation

Fixes #1805.

Please ignore the first commit as it is coming from #3381.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
