### PR TITLE
Fix Packager crash on typed: ignore files.

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -598,7 +598,11 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
 }
 
 ast::ParsedFile rewritePackagedFile(core::Context ctx, ast::ParsedFile file, core::NameRef packageMangledName) {
-    ctx.state.tracer().debug("Rewriting packaged file {}", file.file.data(ctx).path());
+    if (ast::isa_tree<ast::EmptyTree>(file.tree)) {
+        // Nothing to wrap. This occurs when a file is marked typed: Ignore.
+        return file;
+    }
+
     auto &rootKlass = ast::cast_tree_nonnull<ast::ClassDef>(file.tree);
     auto moduleWrapper =
         ast::MK::Module(core::LocOffsets::none(), core::Loc(ctx.file, core::LocOffsets::none()),

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -598,6 +598,7 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
 }
 
 ast::ParsedFile rewritePackagedFile(core::Context ctx, ast::ParsedFile file, core::NameRef packageMangledName) {
+    ctx.state.tracer().debug("Rewriting packaged file {}", file.file.data(ctx).path());
     auto &rootKlass = ast::cast_tree_nonnull<ast::ClassDef>(file.tree);
     auto moduleWrapper =
         ast::MK::Module(core::LocOffsets::none(), core::Loc(ctx.file, core::LocOffsets::none()),

--- a/test/testdata/packager/typed_ignore/__package.rb
+++ b/test/testdata/packager/typed_ignore/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# enable-packager: true
+
+class TypedIgnore < PackageSpec
+end
+

--- a/test/testdata/packager/typed_ignore/ignored.rb
+++ b/test/testdata/packager/typed_ignore/ignored.rb
@@ -1,0 +1,5 @@
+# typed: ignore
+# This file is parsed with an EmptyTree and shouldn't be wrapped in a package namespace by Packager.
+
+foobarbaz
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Fix Packager crash on typed: ignore files.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In `--stripe-packages` mode, Sorbet crashes on corpuses that contain `# typed: ignore` files.

This is because it assumes that every AST begins with a ClassDef containing the root scope. However, this is not true for `# typed: ignore` files, which have an EmptyTree.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
