### PR TITLE
Remove synthesizeExpr when making default args Cast

### DIFF
--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -200,7 +200,9 @@ public:
     core::TypePtr type;
     core::NameRef cast;
 
-    Cast(LocalRef value, const core::TypePtr &type, core::NameRef cast) : value(value), type(type), cast(cast) {}
+    Cast(LocalRef value, const core::TypePtr &type, core::NameRef cast) : value(value), type(type), cast(cast) {
+        ENFORCE(cast == core::Names::cast() || cast == core::Names::assertType() || cast == core::Names::let());
+    }
 
     virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -169,7 +169,7 @@ tuple<LocalRef, BasicBlock *, BasicBlock *> CFGBuilder::walkDefault(CFGContext c
 
     if (argInfo.type != nullptr) {
         auto tmp = cctx.newTemporary(core::Names::castTemp());
-        synthesizeExpr(defaultNext, tmp, defLoc, make_unique<Cast>(result, argInfo.type, core::Names::let()));
+        defaultNext->exprs.emplace_back(tmp, defLoc, make_unique<Cast>(result, argInfo.type, core::Names::let()));
         cctx.inWhat.minLoops[tmp.id()] = CFG::MIN_LOOP_LET;
     }
 

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1090,7 +1090,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
 
                 const core::TypeAndOrigins &ty = getAndFillTypeAndOrigin(ctx, c->value);
                 ENFORCE(c->cast != core::Names::uncheckedLet());
-                if (c->cast != core::Names::cast()) {
+                if (c->cast == core::Names::let() || c->cast == core::Names::assertType()) {
                     if (c->cast == core::Names::assertType() && ty.type->isUntyped()) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::CastTypeMismatch)) {
                             e.setHeader("The typechecker was unable to infer the type of the asserted value");

--- a/test/testdata/infer/default_let.rb
+++ b/test/testdata/infer/default_let.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+extend T::Sig
+
+sig {params(x: T.untyped).void}
+def foo(x = nil)
+end
+
+sig {params(x: Integer).void}
+def bar(x = Integer.new)
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This change should have zero user-visible impact.

There are two places in Sorbet where we use `synthesizeExpr` to make a
Cast instruction, but there's only one place where `isSynthetic` on a
Cast instruction is important.

This is the call site where it isn't important as far as I can tell.
There are some changes I need to make to this code for a future feature,
and this is pre-work that makes that change simpler.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.