### PR TITLE
CSV::Table uses a fixed type_member for Elem

### DIFF
--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -490,7 +490,7 @@ class CSV < Object
     )
     .returns(
       T.any(
-        CSV::Table[T.any(CSV::Row, T::Array[T.nilable(T.untyped)])],
+        CSV::Table,
         T::Array[T::Array[T.nilable(T.untyped)]],
       )
     )
@@ -1188,7 +1188,7 @@ class CSV::Table < Object
   include Enumerable
 
   extend T::Generic
-  Elem = type_member(:out)
+  Elem = type_member(:out, fixed: T.any(CSV::Row, T::Array[T.nilable(T.untyped)]))
 
   # Construct a new
   # [`CSV::Table`](https://docs.ruby-lang.org/en/2.6.0/CSV/Table.html) from
@@ -1211,7 +1211,7 @@ class CSV::Table < Object
   # *   empty?()
   # *   length()
   # *   size()
-  sig { params(array_of_rows: T::Array[CSV::Row], headers: T::Array[BasicObject]).returns(CSV::Table[T.any(CSV::Row, T::Array[T.nilable(T.untyped)])]) }
+  sig { params(array_of_rows: T::Array[CSV::Row], headers: T::Array[BasicObject]).returns(CSV::Table) }
   def self.new(array_of_rows, headers: nil); end
 
   # Adds a new row to the bottom end of this table. You can provide an
@@ -1230,7 +1230,7 @@ class CSV::Table < Object
   def <<(row_or_array); end
 
   # Returns `true` if all rows of this table ==() `other`'s rows.
-  sig { params(other: CSV::Table[T.any(CSV::Row, T::Array[T.nilable(T.untyped)])]).returns(T::Boolean) }
+  sig { params(other: CSV::Table).returns(T::Boolean) }
   def ==(other); end
 
   # In the default mixed mode, this method returns rows for index access and
@@ -1280,14 +1280,14 @@ class CSV::Table < Object
   # This method returns the duplicate table for chaining. Don't chain
   # destructive methods (like []=()) this way though, since you are working with
   # a duplicate.
-  sig { returns(CSV::Table[T::Array[T.nilable(T.untyped)]]) }
+  sig { returns(CSV::Table) }
   def by_col; end
 
   # Switches the mode of this table to column mode. All calls to indexing and
   # iteration methods will work with columns until the mode is changed again.
   #
   # This method returns the table and is safe to chain.
-  sig { returns(CSV::Table[T::Array[T.nilable(T.untyped)]]) }
+  sig { returns(CSV::Table) }
   def by_col!; end
 
   # Returns a duplicate table object, in mixed mode. This is handy for chaining
@@ -1297,7 +1297,7 @@ class CSV::Table < Object
   # This method returns the duplicate table for chaining. Don't chain
   # destructive methods (like []=()) this way though, since you are working with
   # a duplicate.
-  sig { returns(CSV::Table[T.any(CSV::Row, T::Array[T.nilable(T.untyped)])]) }
+  sig { returns(CSV::Table) }
   def by_col_or_row; end
 
   # Switches the mode of this table to mixed mode. All calls to indexing and
@@ -1306,7 +1306,7 @@ class CSV::Table < Object
   # reference while anything else is assumed to be column access by headers.
   #
   # This method returns the table and is safe to chain.
-  sig { returns(CSV::Table[T.any(CSV::Row, T::Array[T.nilable(T.untyped)])]) }
+  sig { returns(CSV::Table) }
   def by_col_or_row!; end
 
   # Returns a duplicate table object, in row mode. This is handy for chaining in
@@ -1316,14 +1316,14 @@ class CSV::Table < Object
   # This method returns the duplicate table for chaining. Don't chain
   # destructive methods (like []=()) this way though, since you are working with
   # a duplicate.
-  sig { returns(CSV::Table[CSV::Row]) }
+  sig { returns(CSV::Table) }
   def by_row; end
 
   # Switches the mode of this table to row mode. All calls to indexing and
   # iteration methods will work with rows until the mode is changed again.
   #
   # This method returns the table and is safe to chain.
-  sig { returns(CSV::Table[CSV::Row]) }
+  sig { returns(CSV::Table) }
   def by_row!; end
 
   # Removes and returns the indicated columns or rows. In the default mixed mode

--- a/test/testdata/rbi/csv.rb
+++ b/test/testdata/rbi/csv.rb
@@ -8,10 +8,10 @@ CSV.foreach('source.csv') do |row|
 end
 
 csv = CSV::Table.new([CSV::Row.new(['1', '2'], [1, 2]), CSV::Row.new(['1', '2'], [2, 3])])
-T.assert_type!(csv, CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])])
+T.assert_type!(csv, CSV::Table)
 
 csv = CSV::Table.new([CSV::Row.new(['1', '2'], [1, 2]), CSV::Row.new(['1', '2'], [2, 3])], headers: ['1', '2'])
-T.assert_type!(csv, CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])])
+T.assert_type!(csv, CSV::Table)
 
 CSV.parse("1,2,3\n3,,abc\n5,6,1") do |line|
   T.assert_type!(line, T.any(CSV::Row, T::Array[T.untyped]))
@@ -20,7 +20,7 @@ end
 csv = CSV.parse("1,2,3\n3,,abc\n5,6,1", { headers: true, converters: %i[numeric] })
 
 if csv.is_a?(CSV::Table)
-  T.assert_type!(csv << [1, {}, nil, '1'], CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])])
+  T.assert_type!(csv << [1, {}, nil, '1'], CSV::Table)
 
   T.assert_type!(csv == csv, T::Boolean)
 
@@ -30,12 +30,12 @@ if csv.is_a?(CSV::Table)
 
   T.assert_type!(csv[5] = CSV::Row.new(['1', '2'], [1, 2]), CSV::Row)
 
-  T.assert_type!(csv.by_col, CSV::Table[T::Array[T.nilable(BasicObject)]])
-  T.assert_type!(csv.by_col!, CSV::Table[T::Array[T.nilable(BasicObject)]])
-  T.assert_type!(csv.by_col_or_row, CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])])
-  T.assert_type!(csv.by_col_or_row!, CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])])
-  T.assert_type!(csv.by_row, CSV::Table[CSV::Row])
-  T.assert_type!(csv.by_row!, CSV::Table[CSV::Row])
+  T.assert_type!(csv.by_col, CSV::Table)
+  T.assert_type!(csv.by_col!, CSV::Table)
+  T.assert_type!(csv.by_col_or_row, CSV::Table)
+  T.assert_type!(csv.by_col_or_row!, CSV::Table)
+  T.assert_type!(csv.by_row, CSV::Table)
+  T.assert_type!(csv.by_row!, CSV::Table)
 
   T.assert_type!(csv.delete(0), T.any(T.nilable(CSV::Row), T::Array[T.nilable(BasicObject)], T::Array[T.nilable(CSV::Row)], T::Array[T::Array[T.nilable(BasicObject)]]))
   T.assert_type!(csv.delete(0, 1), T.any(T.nilable(CSV::Row), T::Array[T.nilable(BasicObject)], T::Array[T.nilable(CSV::Row)], T::Array[T::Array[T.nilable(BasicObject)]]))
@@ -62,8 +62,8 @@ if csv.is_a?(CSV::Table)
   end
 
   T.assert_type!(csv.dig(0), T.any(CSV::Row, T::Array[T.nilable(BasicObject)]))
-  T.assert_type!(csv.by_row.dig(0), CSV::Row)
-  T.assert_type!(csv.by_col.dig(0), T::Array[T.nilable(BasicObject)])
+  T.assert_type!(csv.by_row.dig(0), T.any(CSV::Row, T::Array[T.nilable(BasicObject)]))
+  T.assert_type!(csv.by_col.dig(0), T.any(CSV::Row, T::Array[T.nilable(BasicObject)]))
   T.let(csv.dig(0, 1), T.untyped)
 
   T.assert_type!(csv.headers, T::Array[BasicObject])
@@ -72,8 +72,8 @@ if csv.is_a?(CSV::Table)
 
   T.assert_type!(csv.mode, Symbol)
 
-  T.assert_type!(csv.push([[1, {}, nil, '1'], CSV::Row.new(['1', '2'], [1, 2])]), CSV::Table[T.any(CSV::Row, T::Array[T.nilable(BasicObject)])])
-  
+  T.assert_type!(csv.push([[1, {}, nil, '1'], CSV::Row.new(['1', '2'], [1, 2])]), CSV::Table)
+
   T.assert_type!(csv.to_a, T::Array[T::Array[T.nilable(BasicObject)]])
 
   T.assert_type!(csv.to_csv, String)
@@ -94,7 +94,7 @@ if csv.is_a?(CSV::Table)
   end
 
   # errors
-  csv.table # error: Method `table` does not exist on `CSV::Table[T.any(CSV::Row, T::Array[T.untyped])]`
+  csv.table # error: Method `table` does not exist on `CSV::Table`
 else
   T.assert_type!(csv, T::Array[T::Array[T.nilable(BasicObject)]])
 end


### PR DESCRIPTION
### Motivation

This a partial revert of https://github.com/sorbet/sorbet/pull/3122 which itself reverted https://github.com/sorbet/sorbet/pull/3156.

I agree with https://github.com/sorbet/sorbet/pull/3122, the type_member for `CSV::Table` should allow an union of rows and arrays.

But leaving the type member unfixed makes the type impossible to use.

```ruby
csv = T.cast(CSV.parse(string, headers: true), CSV::Table)
```

Will make sorbet-static complain that: `Malformed type declaration. Generic class without type arguments CSV::Table`

```ruby
csv = T.cast(CSV.parse(string, headers: true), CSV::Table[CSV::Row])
```

On the other hand will fail at runtime: `NoMethodError: undefined method '[]' for CSV::Table:Class`.

I beleive the correct implementation is to fix the type member:

```ruby
class CSV::Table < Object
  include Enumerable
  extend T::Generic
  Elem = type_member(:out, fixed: T.any(CSV::Row, T::Array[T.nilable(T.untyped)]))
end
```

And let the client cast the return value for methods returning the `Elem` type.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
