### PR TITLE
Rubyfmt integration

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -109,5 +109,7 @@ rust_repositories(
 load("@io_bazel_rules_rust//:workspace.bzl", "bazel_version")
 
 bazel_version(name = "bazel_version")
+
 load("//third_party/cargo:crates.bzl", "raze_fetch_remote_crates")
+
 raze_fetch_remote_crates()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -74,14 +74,6 @@ gemfile_lock_deps(
     ],
 )
 
-BAZEL_VERSION = "3.4.1"
-
-BAZEL_INSTALLER_VERSION_linux_SHA = "9808adad931ac652e8ff5022a74507c532250c2091d21d6aebc7064573669cc5"
-
-BAZEL_INSTALLER_VERSION_darwin_SHA = "b168b9c4186916cd07922b1155bca14eecc812729669f1fdbab141f3f4eee2a0"
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
 
 rust_repositories(
@@ -92,3 +84,9 @@ rust_repositories(
 load("@io_bazel_rules_rust//:workspace.bzl", "bazel_version")
 
 bazel_version(name = "bazel_version")
+
+BAZEL_VERSION = "3.4.1"
+
+BAZEL_INSTALLER_VERSION_linux_SHA = "9808adad931ac652e8ff5022a74507c532250c2091d21d6aebc7064573669cc5"
+
+BAZEL_INSTALLER_VERSION_darwin_SHA = "b168b9c4186916cd07922b1155bca14eecc812729669f1fdbab141f3f4eee2a0"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -82,7 +82,6 @@ BAZEL_INSTALLER_VERSION_darwin_SHA = "b168b9c4186916cd07922b1155bca14eecc8127296
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
 
 rust_repositories(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -83,22 +83,6 @@ BAZEL_INSTALLER_VERSION_darwin_SHA = "b168b9c4186916cd07922b1155bca14eecc8127296
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "io_bazel_rules_rust",
-    strip_prefix = "rules_rust-fdf9655ba95616e0314b4e0ebab40bb0c5fe005c",
-    urls = [
-        # Master branch as of 2019-10-07
-        "https://github.com/bazelbuild/rules_rust/archive/fdf9655ba95616e0314b4e0ebab40bb0c5fe005c.tar.gz",
-    ],
-)
-
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "9a737999532daca978a158f94e77e9af6a6a169709c0cee274f0a4c3359519bd",
-    strip_prefix = "bazel-skylib-1.0.0",
-    url = "https://github.com/bazelbuild/bazel-skylib/archive/1.0.0.tar.gz",
-)
-
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
 
 rust_repositories(
@@ -109,7 +93,3 @@ rust_repositories(
 load("@io_bazel_rules_rust//:workspace.bzl", "bazel_version")
 
 bazel_version(name = "bazel_version")
-
-load("//third_party/cargo:crates.bzl", "raze_fetch_remote_crates")
-
-raze_fetch_remote_crates()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -79,3 +79,35 @@ BAZEL_VERSION = "3.4.1"
 BAZEL_INSTALLER_VERSION_linux_SHA = "9808adad931ac652e8ff5022a74507c532250c2091d21d6aebc7064573669cc5"
 
 BAZEL_INSTALLER_VERSION_darwin_SHA = "b168b9c4186916cd07922b1155bca14eecc812729669f1fdbab141f3f4eee2a0"
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_bazel_rules_rust",
+    strip_prefix = "rules_rust-fdf9655ba95616e0314b4e0ebab40bb0c5fe005c",
+    urls = [
+        # Master branch as of 2019-10-07
+        "https://github.com/bazelbuild/rules_rust/archive/fdf9655ba95616e0314b4e0ebab40bb0c5fe005c.tar.gz",
+    ],
+)
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "9a737999532daca978a158f94e77e9af6a6a169709c0cee274f0a4c3359519bd",
+    strip_prefix = "bazel-skylib-1.0.0",
+    url = "https://github.com/bazelbuild/bazel-skylib/archive/1.0.0.tar.gz",
+)
+
+load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
+
+rust_repositories(
+    edition = "2018",
+    version = "1.46.0",
+)
+
+load("@io_bazel_rules_rust//:workspace.bzl", "bazel_version")
+
+bazel_version(name = "bazel_version")
+load("//third_party/cargo:crates.bzl", "raze_fetch_remote_crates")
+raze_fetch_remote_crates()

--- a/experimental/rubyfmt_c_main/BUILD
+++ b/experimental/rubyfmt_c_main/BUILD
@@ -9,6 +9,7 @@ cc_binary(
         "//conditions:default": [
             "-lcrypt",
             "-lrt",
+            "-lz",
         ],
     }),
     visibility = ["//visibility:public"],

--- a/experimental/rubyfmt_c_main/BUILD
+++ b/experimental/rubyfmt_c_main/BUILD
@@ -6,7 +6,11 @@ cc_binary(
     ],
     linkopts = select({
         "@com_stripe_ruby_typer//tools/config:darwin": ["-framework Foundation"],
-        "//conditions:default": ["-lcrypt", "-lgmp", "-lrt"],
+        "//conditions:default": [
+            "-lcrypt",
+            "-lgmp",
+            "-lrt",
+        ],
     }),
     visibility = ["//visibility:public"],
     deps = [

--- a/experimental/rubyfmt_c_main/BUILD
+++ b/experimental/rubyfmt_c_main/BUILD
@@ -10,6 +10,7 @@ cc_binary(
             "-lcrypt",
             "-lrt",
             "-lz",
+            "-lgmp",
         ],
     }),
     visibility = ["//visibility:public"],

--- a/experimental/rubyfmt_c_main/BUILD
+++ b/experimental/rubyfmt_c_main/BUILD
@@ -1,0 +1,17 @@
+cc_binary(
+    name = "main",
+    srcs = [
+        "main.c",
+        "rubyfmt.h",
+    ],
+    linkopts = select({
+        "@com_stripe_ruby_typer//tools/config:darwin": ["-framework Foundation"],
+        "//conditions:default": ["-lcrypt"],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        "@rubyfmt//:librubyfmt",
+        "@rubyfmt//:rubyfmt_macro_wrappers",
+        "@ruby_2_6//:rubyfmt-static-deps",
+    ],
+)

--- a/experimental/rubyfmt_c_main/BUILD
+++ b/experimental/rubyfmt_c_main/BUILD
@@ -10,8 +10,8 @@ cc_binary(
     }),
     visibility = ["//visibility:public"],
     deps = [
+        "@ruby_2_6//:rubyfmt-static-deps",
         "@rubyfmt//:librubyfmt",
         "@rubyfmt//:rubyfmt_macro_wrappers",
-        "@ruby_2_6//:rubyfmt-static-deps",
     ],
 )

--- a/experimental/rubyfmt_c_main/BUILD
+++ b/experimental/rubyfmt_c_main/BUILD
@@ -6,7 +6,7 @@ cc_binary(
     ],
     linkopts = select({
         "@com_stripe_ruby_typer//tools/config:darwin": ["-framework Foundation"],
-        "//conditions:default": ["-lcrypt"],
+        "//conditions:default": ["-lcrypt", "-lgmp", "-lrt"],
     }),
     visibility = ["//visibility:public"],
     deps = [

--- a/experimental/rubyfmt_c_main/BUILD
+++ b/experimental/rubyfmt_c_main/BUILD
@@ -8,7 +8,6 @@ cc_binary(
         "@com_stripe_ruby_typer//tools/config:darwin": ["-framework Foundation"],
         "//conditions:default": [
             "-lcrypt",
-            "-lgmp",
             "-lrt",
         ],
     }),

--- a/experimental/rubyfmt_c_main/main.c
+++ b/experimental/rubyfmt_c_main/main.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "rubyfmt.h"
+
+int main() {
+    unsigned char* ruby_source = (unsigned char*)"puts 'hi'\n";
+    int res = rubyfmt_init();
+    if (res != RUBYFMT_INIT_STATUS_OK) {
+        fprintf(stderr, "failed to init\n");
+        exit(1);
+    }
+    enum Rubyfmt_FormatError status = RUBYFMT_FORMAT_ERROR_OK;
+    RubyfmtString* out = rubyfmt_format_buffer(ruby_source, strlen((const char*)ruby_source)-1, &status);
+    if (status != 0) {
+        exit(status);
+    }
+
+    unsigned char* bytes = rubyfmt_string_ptr(out);
+    size_t len = rubyfmt_string_len(out);
+    fwrite(bytes, sizeof(char), len, stdout);
+    fflush(stdout);
+    rubyfmt_string_free(out);
+}

--- a/experimental/rubyfmt_c_main/rubyfmt.h
+++ b/experimental/rubyfmt_c_main/rubyfmt.h
@@ -1,0 +1,49 @@
+#ifndef RUBYFMT_H
+#define RUBYFMT_H
+
+int RUBYFMT_INIT_STATUS_OK = 0;
+int RUBYFMT_INIT_STATUS_ERROR = 1;
+
+enum Rubyfmt_FormatError {
+    RUBYFMT_FORMAT_ERROR_OK = 0,
+
+    // passed buffer contained a ruby syntax error. Non fatal, user should feel
+    // free to continue to call rubyfmt with non-error strings.
+    RUBYFMT_FORMAT_ERROR_SYNTAX_ERROR = 1,
+
+    // this error is fatal, the calling program should not continue to execute
+    // rubyfmt and you should report a bug with the file that crashed rubyfmt
+    RUBYFMT_FORMAT_ERROR_RIPPER_PARSE_FAILURE = 2,
+
+    // an error occured during IO within the function, should be impossible
+    // and most likely indicates a programming error within rubyfmt, please
+    // file a bug
+    RUBYFMT_FORMAT_ERROR_IO_ERROR = 3,
+
+    // some unknown ruby error occured during execution fo Rubyfmt. This indicates
+    // a programming error. Please file a bug report and terminate the process
+    // and restart.
+    RUBYFMT_OTHER_RUBY_ERROR = 4,
+};
+
+typedef struct _RubyfmtString RubyfmtString;
+
+// setup rubyfmt, call once per process. Will return non zero (RUBYFMT_INIT_STATUS_ERROR)
+// if initialization failed
+int rubyfmt_init();
+
+// ask rubyfmt to format the passed buffer. Must be utf-8 encoded, and len
+// bytes long. Returns NULL and populates the err pointer with non zero if
+// an error occurs
+RubyfmtString *rubyfmt_format_buffer(unsigned char *buf, size_t len, enum Rubyfmt_FormatError *err);
+
+// free a RubyfmtString after use
+void rubyfmt_string_free(RubyfmtString *);
+
+// Get a byte pointer from a RubyfmtString, is not a null terminated string,
+// but instead should be used with rubyfmt_string_len to get the number
+// of bytes in the string
+unsigned char *rubyfmt_string_ptr(const RubyfmtString *);
+size_t rubyfmt_string_len(const RubyfmtString *);
+
+#endif

--- a/third_party/cargo/BUILD
+++ b/third_party/cargo/BUILD
@@ -1,0 +1,71 @@
+"""
+@generated
+cargo-raze workspace build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = ["//visibility:public"])
+
+licenses([
+  "notice" # See individual crates for specific licenses
+])
+alias(
+    name = "backtrace",
+    actual = "@raze__backtrace__0_3_50//:backtrace",
+    tags = ["cargo-raze"],
+)
+alias(
+    name = "bytecount",
+    actual = "@raze__bytecount__0_6_0//:bytecount",
+    tags = ["cargo-raze"],
+)
+alias(
+    name = "cc",
+    actual = "@raze__cc__1_0_59//:cc",
+    tags = ["cargo-raze"],
+)
+alias(
+    name = "jemallocator",
+    actual = "@raze__jemallocator__0_3_2//:jemallocator",
+    tags = ["cargo-raze"],
+)
+alias(
+    name = "libc",
+    actual = "@raze__libc__0_2_77//:libc",
+    tags = ["cargo-raze"],
+)
+alias(
+    name = "log",
+    actual = "@raze__log__0_4_11//:log",
+    tags = ["cargo-raze"],
+)
+alias(
+    name = "proc_macro2",
+    actual = "@raze__proc_macro2__1_0_10//:proc_macro2",
+    tags = ["cargo-raze"],
+)
+alias(
+    name = "quote",
+    actual = "@raze__quote__1_0_3//:quote",
+    tags = ["cargo-raze"],
+)
+alias(
+    name = "serde",
+    actual = "@raze__serde__1_0_113//:serde",
+    tags = ["cargo-raze"],
+)
+alias(
+    name = "serde_json",
+    actual = "@raze__serde_json__1_0_57//:serde_json",
+    tags = ["cargo-raze"],
+)
+alias(
+    name = "simplelog",
+    actual = "@raze__simplelog__0_8_0//:simplelog",
+    tags = ["cargo-raze"],
+)
+alias(
+    name = "syn",
+    actual = "@raze__syn__1_0_17//:syn",
+    tags = ["cargo-raze"],
+)

--- a/third_party/cargo/BUILD
+++ b/third_party/cargo/BUILD
@@ -25,11 +25,6 @@ alias(
     tags = ["cargo-raze"],
 )
 alias(
-    name = "jemallocator",
-    actual = "@raze__jemallocator__0_3_2//:jemallocator",
-    tags = ["cargo-raze"],
-)
-alias(
     name = "libc",
     actual = "@raze__libc__0_2_77//:libc",
     tags = ["cargo-raze"],

--- a/third_party/cargo/BUILD
+++ b/third_party/cargo/BUILD
@@ -4,61 +4,73 @@ cargo-raze workspace build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = ["//visibility:public"])
 
 licenses([
-  "notice" # See individual crates for specific licenses
+    "notice",  # See individual crates for specific licenses
 ])
+
 alias(
     name = "backtrace",
     actual = "@raze__backtrace__0_3_50//:backtrace",
     tags = ["cargo-raze"],
 )
+
 alias(
     name = "bytecount",
     actual = "@raze__bytecount__0_6_0//:bytecount",
     tags = ["cargo-raze"],
 )
+
 alias(
     name = "cc",
     actual = "@raze__cc__1_0_59//:cc",
     tags = ["cargo-raze"],
 )
+
 alias(
     name = "libc",
     actual = "@raze__libc__0_2_77//:libc",
     tags = ["cargo-raze"],
 )
+
 alias(
     name = "log",
     actual = "@raze__log__0_4_11//:log",
     tags = ["cargo-raze"],
 )
+
 alias(
     name = "proc_macro2",
     actual = "@raze__proc_macro2__1_0_10//:proc_macro2",
     tags = ["cargo-raze"],
 )
+
 alias(
     name = "quote",
     actual = "@raze__quote__1_0_3//:quote",
     tags = ["cargo-raze"],
 )
+
 alias(
     name = "serde",
     actual = "@raze__serde__1_0_113//:serde",
     tags = ["cargo-raze"],
 )
+
 alias(
     name = "serde_json",
     actual = "@raze__serde_json__1_0_57//:serde_json",
     tags = ["cargo-raze"],
 )
+
 alias(
     name = "simplelog",
     actual = "@raze__simplelog__0_8_0//:simplelog",
     tags = ["cargo-raze"],
 )
+
 alias(
     name = "syn",
     actual = "@raze__syn__1_0_17//:syn",

--- a/third_party/cargo/Cargo.toml
+++ b/third_party/cargo/Cargo.toml
@@ -12,7 +12,6 @@ serde = { version = "1.0", features=["derive"] }
 serde_json = "1.0.40"
 bytecount = "0.6.0"
 backtrace = "0.3.45"
-jemallocator = { version = "0.3.0", features = ["disable_initial_exec_tls"] }
 libc = "0.2.68"
 log = { version = "0.4.8", features = ["max_level_debug", "release_max_level_warn"] }
 simplelog = "0.8"

--- a/third_party/cargo/Cargo.toml
+++ b/third_party/cargo/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "compile_with_bazel"
+version = "0.0.0"
+
+# Mandatory (or Cargo tooling is unhappy)
+[lib]
+path = "fake_lib.rs"
+
+[dependencies]
+# librubyfmt's dependencies
+serde = { version = "1.0", features=["derive"] }
+serde_json = "1.0.40"
+bytecount = "0.6.0"
+backtrace = "0.3.45"
+jemallocator = { version = "0.3.0", features = ["disable_initial_exec_tls"] }
+libc = "0.2.68"
+log = { version = "0.4.8", features = ["max_level_debug", "release_max_level_warn"] }
+simplelog = "0.8"
+# ripper deserialize's dependencies
+syn = { version = "=1.0.17", features = ["full"] }
+quote = "=1.0.3"
+proc-macro2 = "=1.0.10"
+[build-dependencies]
+cc = "1.0"
+
+[raze]
+# The WORKSPACE relative path to the Cargo.toml working directory.
+workspace_path = "//third_party/cargo"
+
+# The target to generate BUILD rules for.
+target = "x86_64-unknown-linux-gnu"
+
+genmode = "Remote"
+
+[raze.crates.syn.'1.0.17']
+additional_flags = [
+    "--cfg=use_proc_macro",
+]
+
+[raze.crates.proc-macro2.'1.0.10']
+additional_flags = [
+  "--cfg=use_proc_macro",
+]

--- a/third_party/cargo/Cargo.toml
+++ b/third_party/cargo/Cargo.toml
@@ -20,7 +20,7 @@ syn = { version = "=1.0.17", features = ["full"] }
 quote = "=1.0.3"
 proc-macro2 = "=1.0.10"
 [build-dependencies]
-cc = "1.0"
+cc = "=1.0.59"
 
 [raze]
 # The WORKSPACE relative path to the Cargo.toml working directory.

--- a/third_party/cargo/Cargo.toml
+++ b/third_party/cargo/Cargo.toml
@@ -41,3 +41,8 @@ additional_flags = [
 additional_flags = [
   "--cfg=use_proc_macro",
 ]
+
+[raze.crates.log.'0.4.11']
+additional_flags = [
+  "--cfg=atomic_cas",
+]

--- a/third_party/cargo/Cargo.toml
+++ b/third_party/cargo/Cargo.toml
@@ -31,11 +31,6 @@ target = "x86_64-unknown-linux-gnu"
 
 genmode = "Remote"
 
-[raze.crates.syn.'1.0.17']
-additional_flags = [
-    "--cfg=use_proc_macro",
-]
-
 [raze.crates.proc-macro2.'1.0.10']
 additional_flags = [
   "--cfg=use_proc_macro",

--- a/third_party/cargo/README.md
+++ b/third_party/cargo/README.md
@@ -1,0 +1,115 @@
+# Rust dependencies
+
+Rust dependencies are managed via [`cargo raze`](https://github.com/google/cargo-raze)
+which has a lot of sharp edges because cargo and bazel fundamentally want to
+manage dependencies in a different way. This guide both explains the baseline
+mechanics of what an ideal upgrade looks like, and what sharp edges you might
+encounter.
+
+## Raze's `Cargo.toml`
+
+Raze manages dependencies by reading `Cargo.toml` and `Cargo.lock` and then
+spitting out `.BUILD` files for each crate under the `remote` directory. This
+means that the `Cargo.toml` in this directory needs to contain the superset
+of dependencies that our Rust dependencies have. Today, there are two crates
+that have their dependencies vendored here:
+
+* `librubyfmt` - the Rubyfmt library crate
+* `ripper_deserialize` - a crate for making a Ruby C `VALUE` which represents a
+   ripper tree deserializable by serde.
+
+If you look at [`librubyfmt`'s Cargo.toml](https://github.com/penelopezone/rubyfmt/blob/trunk/librubyfmt/Cargo.toml#L11-L19)
+and [`ripper_deserialize`'s Cargo.toml](https://github.com/penelopezone/rubyfmt/blob/trunk/librubyfmt/ripper_deserialize/Cargo.toml#L9-L11)
+you will see that the `Cargo.toml` in this directory has dependencies that match,
+with comments outline which crate each dependency comes from.
+
+When `cargo raze` is run from this directory, this will cause crate `BUILD`
+files to be generated for each entry in that dependencies section.
+
+## Updating dependencies
+
+This will typically become relevant at Rubyfmt upgrade time. It is worth noting
+that Rubyfmt's dependencies change much more slowly than the library itself. In
+particular we have a very low expectation that our Rust dependencies will change
+for a good while going forward. Probably not until the 2021 edition, if we decide
+we need that.
+
+Say one of the above libraries' `Cargo.toml`s changes. The typical workflow would
+be:
+* to copy/paste the `[dependencies]` section from the Cargo.toml of that library to
+  this directory's `Cargo.toml`
+* run `cargo generate-lockfile` in this directory
+* run `./tools/scripts/cargo_raze.sh` in the top level of the repo (note: this
+  is not managed by bazel, you **must** have installed `cargo raze` in your local
+  rust toolchain for this to work)
+
+Rebuild rubyfmt to check everything is working.
+
+There are however some gotchas
+
+## The `raze.crates` section
+
+Cargo raze by default enables all features for the crates it pulls in. This
+means that most of the time things will "just work". However, some crates have
+configurations that are needed that are not part of the `features` section of
+their configuration. An example of this is:
+
+```
+[raze.crates.proc-macro2.'1.0.10']
+additional_flags = [
+  "--cfg=use_proc_macro",
+]
+```
+
+Without this, we get a nasty compilation error while trying to build librubyfmt:
+
+```
+    |
+108 |         Self::new2(stream.into())
+    |                    ^^^^^^^^^^^^^ the trait `std::convert::From<proc_macro::TokenStream>` is not implemented for `proc_macro2::TokenStream`
+    |
+    = help: the following implementations were found:
+              <proc_macro2::TokenStream as std::convert::From<proc_macro2::TokenTree>>
+    = note: required because of the requirements on the impl of `std::convert::Into<proc_macro2::TokenStream>` for `proc_macro::TokenStream`
+
+error[E0277]: the trait bound `proc_macro2::TokenStream: std::convert::From<proc_macro::TokenStream>` is not satisfied
+    --> external/raze__syn__1_0_17/src/parse.rs:1102:21
+     |
+1102 |         self.parse2(proc_macro2::TokenStream::from(tokens))
+     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::From<proc_macro::TokenStream>` is not implemented for `proc_macro2::TokenStream`
+     |
+     = help: the following implementations were found:
+               <proc_macro2::TokenStream as std::convert::From<proc_macro2::TokenTree>>
+     = note: required by `std::convert::From::from`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.
+```
+
+All Rubyfmt release tars (which vendor Ruby, and are the only ones which can
+be `http_archive`d for bazel builds in this repo) go through very extensive
+testing. It is unlikely to be a real error in Rubyfmt's build, but instead a
+missing rust compilation flag if you see an error like this.
+
+In order to fix it, the cleanest way to solve this is to look at the
+crate you're building (in this case, `proc_macro2`), and find it's compilation
+flags in a normal `cargo build` of `librubyfmt` or `ripper_deserialize`.
+
+You should:
+
+* `git clone https://github.com/penelopezone/rubyfmt`
+* `cd rubyfmt`
+* `git checkout v(matching tag to the http archive)`
+* `cd librubyfmt`
+* `cargo build -v`
+
+and see which flags are being omitted vs a bazel build.
+
+This process, for example, will not work for *really* complicated libraries like
+`jemallocator`, which I had to disable entirely for `librubyfmt` in bazel.
+`jemallocator`'s `build.rs` is too complicated to build in the bazel environment
+cleanly.
+
+Fortunately, Rubyfmt's dependencies change rarely, and so this is unlikely to be
+an ongoing problem.

--- a/third_party/cargo/add_crates_shas.rb
+++ b/third_party/cargo/add_crates_shas.rb
@@ -1,0 +1,25 @@
+require 'uri'
+require 'net/http'
+require 'digest'
+
+def main
+  data = ""
+  File.open("./crates.bzl").each_line do |line|
+    data << line
+    if line.include?("url = ")
+      url = line.split("\"")[1].split("\"")[0]
+      uri = URI(url)
+      res = Net::HTTP.get(uri)
+      hash = Digest::SHA256.hexdigest(res)
+      data << "        sha256 = \"#{hash}\",\n"
+    end
+  end
+
+  File.open("./crates.bzl", "w") do |fp|
+    fp.write(data)
+  end
+end
+
+if __FILE__ == $0
+  main
+end

--- a/third_party/cargo/crates.bzl
+++ b/third_party/cargo/crates.bzl
@@ -20,6 +20,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__addr2line__0_13_0",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/addr2line/addr2line-0.13.0.crate",
+        sha256 = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072",
         type = "tar.gz",
         strip_prefix = "addr2line-0.13.0",
         build_file = Label("//third_party/cargo/remote:addr2line-0.13.0.BUILD"),
@@ -28,6 +29,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__adler__0_2_3",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/adler/adler-0.2.3.crate",
+        sha256 = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e",
         type = "tar.gz",
         strip_prefix = "adler-0.2.3",
         build_file = Label("//third_party/cargo/remote:adler-0.2.3.BUILD"),
@@ -36,6 +38,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__autocfg__1_0_1",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/autocfg/autocfg-1.0.1.crate",
+        sha256 = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a",
         type = "tar.gz",
         strip_prefix = "autocfg-1.0.1",
         build_file = Label("//third_party/cargo/remote:autocfg-1.0.1.BUILD"),
@@ -44,6 +47,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__backtrace__0_3_50",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/backtrace/backtrace-0.3.50.crate",
+        sha256 = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293",
         type = "tar.gz",
         strip_prefix = "backtrace-0.3.50",
         build_file = Label("//third_party/cargo/remote:backtrace-0.3.50.BUILD"),
@@ -52,6 +56,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__bytecount__0_6_0",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/bytecount/bytecount-0.6.0.crate",
+        sha256 = "b0017894339f586ccb943b01b9555de56770c11cda818e7e3d8bd93f4ed7f46e",
         type = "tar.gz",
         strip_prefix = "bytecount-0.6.0",
         build_file = Label("//third_party/cargo/remote:bytecount-0.6.0.BUILD"),
@@ -60,6 +65,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__cc__1_0_59",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/cc/cc-1.0.59.crate",
+        sha256 = "66120af515773fb005778dc07c261bd201ec8ce50bd6e7144c927753fe013381",
         type = "tar.gz",
         strip_prefix = "cc-1.0.59",
         build_file = Label("//third_party/cargo/remote:cc-1.0.59.BUILD"),
@@ -68,6 +74,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__cfg_if__0_1_10",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/cfg-if/cfg-if-0.1.10.crate",
+        sha256 = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822",
         type = "tar.gz",
         strip_prefix = "cfg-if-0.1.10",
         build_file = Label("//third_party/cargo/remote:cfg-if-0.1.10.BUILD"),
@@ -76,6 +83,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__chrono__0_4_15",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/chrono/chrono-0.4.15.crate",
+        sha256 = "942f72db697d8767c22d46a598e01f2d3b475501ea43d0db4f16d90259182d0b",
         type = "tar.gz",
         strip_prefix = "chrono-0.4.15",
         build_file = Label("//third_party/cargo/remote:chrono-0.4.15.BUILD"),
@@ -84,6 +92,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__gimli__0_22_0",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/gimli/gimli-0.22.0.crate",
+        sha256 = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724",
         type = "tar.gz",
         strip_prefix = "gimli-0.22.0",
         build_file = Label("//third_party/cargo/remote:gimli-0.22.0.BUILD"),
@@ -92,6 +101,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__itoa__0_4_6",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/itoa/itoa-0.4.6.crate",
+        sha256 = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6",
         type = "tar.gz",
         strip_prefix = "itoa-0.4.6",
         build_file = Label("//third_party/cargo/remote:itoa-0.4.6.BUILD"),
@@ -100,6 +110,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__libc__0_2_77",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/libc/libc-0.2.77.crate",
+        sha256 = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235",
         type = "tar.gz",
         strip_prefix = "libc-0.2.77",
         build_file = Label("//third_party/cargo/remote:libc-0.2.77.BUILD"),
@@ -108,6 +119,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__log__0_4_11",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/log/log-0.4.11.crate",
+        sha256 = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b",
         type = "tar.gz",
         strip_prefix = "log-0.4.11",
         build_file = Label("//third_party/cargo/remote:log-0.4.11.BUILD"),
@@ -116,6 +128,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__miniz_oxide__0_4_2",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/miniz_oxide/miniz_oxide-0.4.2.crate",
+        sha256 = "c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9",
         type = "tar.gz",
         strip_prefix = "miniz_oxide-0.4.2",
         build_file = Label("//third_party/cargo/remote:miniz_oxide-0.4.2.BUILD"),
@@ -124,6 +137,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__num_integer__0_1_43",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/num-integer/num-integer-0.1.43.crate",
+        sha256 = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b",
         type = "tar.gz",
         strip_prefix = "num-integer-0.1.43",
         build_file = Label("//third_party/cargo/remote:num-integer-0.1.43.BUILD"),
@@ -132,6 +146,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__num_traits__0_2_12",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/num-traits/num-traits-0.2.12.crate",
+        sha256 = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611",
         type = "tar.gz",
         strip_prefix = "num-traits-0.2.12",
         build_file = Label("//third_party/cargo/remote:num-traits-0.2.12.BUILD"),
@@ -140,6 +155,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__object__0_20_0",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/object/object-0.20.0.crate",
+        sha256 = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5",
         type = "tar.gz",
         strip_prefix = "object-0.20.0",
         build_file = Label("//third_party/cargo/remote:object-0.20.0.BUILD"),
@@ -148,6 +164,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__proc_macro2__1_0_10",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/proc-macro2/proc-macro2-1.0.10.crate",
+        sha256 = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3",
         type = "tar.gz",
         strip_prefix = "proc-macro2-1.0.10",
         build_file = Label("//third_party/cargo/remote:proc-macro2-1.0.10.BUILD"),
@@ -156,6 +173,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__quote__1_0_3",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/quote/quote-1.0.3.crate",
+        sha256 = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f",
         type = "tar.gz",
         strip_prefix = "quote-1.0.3",
         build_file = Label("//third_party/cargo/remote:quote-1.0.3.BUILD"),
@@ -164,6 +182,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__rustc_demangle__0_1_16",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/rustc-demangle/rustc-demangle-0.1.16.crate",
+        sha256 = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783",
         type = "tar.gz",
         strip_prefix = "rustc-demangle-0.1.16",
         build_file = Label("//third_party/cargo/remote:rustc-demangle-0.1.16.BUILD"),
@@ -172,6 +191,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__ryu__1_0_5",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/ryu/ryu-1.0.5.crate",
+        sha256 = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e",
         type = "tar.gz",
         strip_prefix = "ryu-1.0.5",
         build_file = Label("//third_party/cargo/remote:ryu-1.0.5.BUILD"),
@@ -180,6 +200,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__serde__1_0_113",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/serde/serde-1.0.113.crate",
+        sha256 = "6135c78461981c79497158ef777264c51d9d0f4f3fc3a4d22b915900e42dac6a",
         type = "tar.gz",
         strip_prefix = "serde-1.0.113",
         build_file = Label("//third_party/cargo/remote:serde-1.0.113.BUILD"),
@@ -188,6 +209,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__serde_derive__1_0_113",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/serde_derive/serde_derive-1.0.113.crate",
+        sha256 = "93c5eaa17d0954cb481cdcfffe9d84fcfa7a1a9f2349271e678677be4c26ae31",
         type = "tar.gz",
         strip_prefix = "serde_derive-1.0.113",
         build_file = Label("//third_party/cargo/remote:serde_derive-1.0.113.BUILD"),
@@ -196,6 +218,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__serde_json__1_0_57",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/serde_json/serde_json-1.0.57.crate",
+        sha256 = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c",
         type = "tar.gz",
         strip_prefix = "serde_json-1.0.57",
         build_file = Label("//third_party/cargo/remote:serde_json-1.0.57.BUILD"),
@@ -204,6 +227,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__simplelog__0_8_0",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/simplelog/simplelog-0.8.0.crate",
+        sha256 = "2b2736f58087298a448859961d3f4a0850b832e72619d75adc69da7993c2cd3c",
         type = "tar.gz",
         strip_prefix = "simplelog-0.8.0",
         build_file = Label("//third_party/cargo/remote:simplelog-0.8.0.BUILD"),
@@ -212,6 +236,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__syn__1_0_17",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/syn/syn-1.0.17.crate",
+        sha256 = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03",
         type = "tar.gz",
         strip_prefix = "syn-1.0.17",
         build_file = Label("//third_party/cargo/remote:syn-1.0.17.BUILD"),
@@ -220,6 +245,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__termcolor__1_1_0",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/termcolor/termcolor-1.1.0.crate",
+        sha256 = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f",
         type = "tar.gz",
         strip_prefix = "termcolor-1.1.0",
         build_file = Label("//third_party/cargo/remote:termcolor-1.1.0.BUILD"),
@@ -228,6 +254,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__time__0_1_44",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/time/time-0.1.44.crate",
+        sha256 = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255",
         type = "tar.gz",
         strip_prefix = "time-0.1.44",
         build_file = Label("//third_party/cargo/remote:time-0.1.44.BUILD"),
@@ -236,6 +263,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__unicode_xid__0_2_1",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/unicode-xid/unicode-xid-0.2.1.crate",
+        sha256 = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564",
         type = "tar.gz",
         strip_prefix = "unicode-xid-0.2.1",
         build_file = Label("//third_party/cargo/remote:unicode-xid-0.2.1.BUILD"),
@@ -244,6 +272,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__wasi__0_10_0_wasi_snapshot_preview1",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/wasi/wasi-0.10.0+wasi-snapshot-preview1.crate",
+        sha256 = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f",
         type = "tar.gz",
         strip_prefix = "wasi-0.10.0+wasi-snapshot-preview1",
         build_file = Label("//third_party/cargo/remote:wasi-0.10.0+wasi-snapshot-preview1.BUILD"),
@@ -252,6 +281,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__winapi__0_3_9",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/winapi/winapi-0.3.9.crate",
+        sha256 = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
         type = "tar.gz",
         strip_prefix = "winapi-0.3.9",
         build_file = Label("//third_party/cargo/remote:winapi-0.3.9.BUILD"),
@@ -260,6 +290,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__winapi_i686_pc_windows_gnu__0_4_0",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/winapi-i686-pc-windows-gnu/winapi-i686-pc-windows-gnu-0.4.0.crate",
+        sha256 = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
         type = "tar.gz",
         strip_prefix = "winapi-i686-pc-windows-gnu-0.4.0",
         build_file = Label("//third_party/cargo/remote:winapi-i686-pc-windows-gnu-0.4.0.BUILD"),
@@ -268,6 +299,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__winapi_util__0_1_5",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/winapi-util/winapi-util-0.1.5.crate",
+        sha256 = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
         type = "tar.gz",
         strip_prefix = "winapi-util-0.1.5",
         build_file = Label("//third_party/cargo/remote:winapi-util-0.1.5.BUILD"),
@@ -276,6 +308,7 @@ def raze_fetch_remote_crates():
     _new_http_archive(
         name = "raze__winapi_x86_64_pc_windows_gnu__0_4_0",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/winapi-x86_64-pc-windows-gnu/winapi-x86_64-pc-windows-gnu-0.4.0.crate",
+        sha256 = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
         type = "tar.gz",
         strip_prefix = "winapi-x86_64-pc-windows-gnu-0.4.0",
         build_file = Label("//third_party/cargo/remote:winapi-x86_64-pc-windows-gnu-0.4.0.BUILD"),

--- a/third_party/cargo/crates.bzl
+++ b/third_party/cargo/crates.bzl
@@ -1,0 +1,307 @@
+"""
+@generated
+cargo-raze crate workspace functions
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+
+def _new_http_archive(name, **kwargs):
+    if not native.existing_rule(name):
+        http_archive(name=name, **kwargs)
+
+def _new_git_repository(name, **kwargs):
+    if not native.existing_rule(name):
+        new_git_repository(name=name, **kwargs)
+
+def raze_fetch_remote_crates():
+
+    _new_http_archive(
+        name = "raze__addr2line__0_13_0",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/addr2line/addr2line-0.13.0.crate",
+        type = "tar.gz",
+        strip_prefix = "addr2line-0.13.0",
+        build_file = Label("//third_party/cargo/remote:addr2line-0.13.0.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__adler__0_2_3",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/adler/adler-0.2.3.crate",
+        type = "tar.gz",
+        strip_prefix = "adler-0.2.3",
+        build_file = Label("//third_party/cargo/remote:adler-0.2.3.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__autocfg__1_0_1",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/autocfg/autocfg-1.0.1.crate",
+        type = "tar.gz",
+        strip_prefix = "autocfg-1.0.1",
+        build_file = Label("//third_party/cargo/remote:autocfg-1.0.1.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__backtrace__0_3_50",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/backtrace/backtrace-0.3.50.crate",
+        type = "tar.gz",
+        strip_prefix = "backtrace-0.3.50",
+        build_file = Label("//third_party/cargo/remote:backtrace-0.3.50.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__bytecount__0_6_0",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/bytecount/bytecount-0.6.0.crate",
+        type = "tar.gz",
+        strip_prefix = "bytecount-0.6.0",
+        build_file = Label("//third_party/cargo/remote:bytecount-0.6.0.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__cc__1_0_59",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/cc/cc-1.0.59.crate",
+        type = "tar.gz",
+        strip_prefix = "cc-1.0.59",
+        build_file = Label("//third_party/cargo/remote:cc-1.0.59.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__cfg_if__0_1_10",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/cfg-if/cfg-if-0.1.10.crate",
+        type = "tar.gz",
+        strip_prefix = "cfg-if-0.1.10",
+        build_file = Label("//third_party/cargo/remote:cfg-if-0.1.10.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__chrono__0_4_15",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/chrono/chrono-0.4.15.crate",
+        type = "tar.gz",
+        strip_prefix = "chrono-0.4.15",
+        build_file = Label("//third_party/cargo/remote:chrono-0.4.15.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__fs_extra__1_2_0",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/fs_extra/fs_extra-1.2.0.crate",
+        type = "tar.gz",
+        strip_prefix = "fs_extra-1.2.0",
+        build_file = Label("//third_party/cargo/remote:fs_extra-1.2.0.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__gimli__0_22_0",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/gimli/gimli-0.22.0.crate",
+        type = "tar.gz",
+        strip_prefix = "gimli-0.22.0",
+        build_file = Label("//third_party/cargo/remote:gimli-0.22.0.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__itoa__0_4_6",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/itoa/itoa-0.4.6.crate",
+        type = "tar.gz",
+        strip_prefix = "itoa-0.4.6",
+        build_file = Label("//third_party/cargo/remote:itoa-0.4.6.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__jemalloc_sys__0_3_2",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/jemalloc-sys/jemalloc-sys-0.3.2.crate",
+        type = "tar.gz",
+        strip_prefix = "jemalloc-sys-0.3.2",
+        build_file = Label("//third_party/cargo/remote:jemalloc-sys-0.3.2.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__jemallocator__0_3_2",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/jemallocator/jemallocator-0.3.2.crate",
+        type = "tar.gz",
+        strip_prefix = "jemallocator-0.3.2",
+        build_file = Label("//third_party/cargo/remote:jemallocator-0.3.2.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__libc__0_2_77",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/libc/libc-0.2.77.crate",
+        type = "tar.gz",
+        strip_prefix = "libc-0.2.77",
+        build_file = Label("//third_party/cargo/remote:libc-0.2.77.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__log__0_4_11",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/log/log-0.4.11.crate",
+        type = "tar.gz",
+        strip_prefix = "log-0.4.11",
+        build_file = Label("//third_party/cargo/remote:log-0.4.11.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__miniz_oxide__0_4_2",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/miniz_oxide/miniz_oxide-0.4.2.crate",
+        type = "tar.gz",
+        strip_prefix = "miniz_oxide-0.4.2",
+        build_file = Label("//third_party/cargo/remote:miniz_oxide-0.4.2.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__num_integer__0_1_43",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/num-integer/num-integer-0.1.43.crate",
+        type = "tar.gz",
+        strip_prefix = "num-integer-0.1.43",
+        build_file = Label("//third_party/cargo/remote:num-integer-0.1.43.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__num_traits__0_2_12",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/num-traits/num-traits-0.2.12.crate",
+        type = "tar.gz",
+        strip_prefix = "num-traits-0.2.12",
+        build_file = Label("//third_party/cargo/remote:num-traits-0.2.12.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__object__0_20_0",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/object/object-0.20.0.crate",
+        type = "tar.gz",
+        strip_prefix = "object-0.20.0",
+        build_file = Label("//third_party/cargo/remote:object-0.20.0.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__proc_macro2__1_0_10",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/proc-macro2/proc-macro2-1.0.10.crate",
+        type = "tar.gz",
+        strip_prefix = "proc-macro2-1.0.10",
+        build_file = Label("//third_party/cargo/remote:proc-macro2-1.0.10.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__quote__1_0_3",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/quote/quote-1.0.3.crate",
+        type = "tar.gz",
+        strip_prefix = "quote-1.0.3",
+        build_file = Label("//third_party/cargo/remote:quote-1.0.3.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__rustc_demangle__0_1_16",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/rustc-demangle/rustc-demangle-0.1.16.crate",
+        type = "tar.gz",
+        strip_prefix = "rustc-demangle-0.1.16",
+        build_file = Label("//third_party/cargo/remote:rustc-demangle-0.1.16.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__ryu__1_0_5",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/ryu/ryu-1.0.5.crate",
+        type = "tar.gz",
+        strip_prefix = "ryu-1.0.5",
+        build_file = Label("//third_party/cargo/remote:ryu-1.0.5.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__serde__1_0_113",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/serde/serde-1.0.113.crate",
+        type = "tar.gz",
+        strip_prefix = "serde-1.0.113",
+        build_file = Label("//third_party/cargo/remote:serde-1.0.113.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__serde_derive__1_0_113",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/serde_derive/serde_derive-1.0.113.crate",
+        type = "tar.gz",
+        strip_prefix = "serde_derive-1.0.113",
+        build_file = Label("//third_party/cargo/remote:serde_derive-1.0.113.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__serde_json__1_0_57",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/serde_json/serde_json-1.0.57.crate",
+        type = "tar.gz",
+        strip_prefix = "serde_json-1.0.57",
+        build_file = Label("//third_party/cargo/remote:serde_json-1.0.57.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__simplelog__0_8_0",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/simplelog/simplelog-0.8.0.crate",
+        type = "tar.gz",
+        strip_prefix = "simplelog-0.8.0",
+        build_file = Label("//third_party/cargo/remote:simplelog-0.8.0.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__syn__1_0_17",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/syn/syn-1.0.17.crate",
+        type = "tar.gz",
+        strip_prefix = "syn-1.0.17",
+        build_file = Label("//third_party/cargo/remote:syn-1.0.17.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__termcolor__1_1_0",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/termcolor/termcolor-1.1.0.crate",
+        type = "tar.gz",
+        strip_prefix = "termcolor-1.1.0",
+        build_file = Label("//third_party/cargo/remote:termcolor-1.1.0.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__time__0_1_44",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/time/time-0.1.44.crate",
+        type = "tar.gz",
+        strip_prefix = "time-0.1.44",
+        build_file = Label("//third_party/cargo/remote:time-0.1.44.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__unicode_xid__0_2_1",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/unicode-xid/unicode-xid-0.2.1.crate",
+        type = "tar.gz",
+        strip_prefix = "unicode-xid-0.2.1",
+        build_file = Label("//third_party/cargo/remote:unicode-xid-0.2.1.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__wasi__0_10_0_wasi_snapshot_preview1",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/wasi/wasi-0.10.0+wasi-snapshot-preview1.crate",
+        type = "tar.gz",
+        strip_prefix = "wasi-0.10.0+wasi-snapshot-preview1",
+        build_file = Label("//third_party/cargo/remote:wasi-0.10.0+wasi-snapshot-preview1.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__winapi__0_3_9",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/winapi/winapi-0.3.9.crate",
+        type = "tar.gz",
+        strip_prefix = "winapi-0.3.9",
+        build_file = Label("//third_party/cargo/remote:winapi-0.3.9.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__winapi_i686_pc_windows_gnu__0_4_0",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/winapi-i686-pc-windows-gnu/winapi-i686-pc-windows-gnu-0.4.0.crate",
+        type = "tar.gz",
+        strip_prefix = "winapi-i686-pc-windows-gnu-0.4.0",
+        build_file = Label("//third_party/cargo/remote:winapi-i686-pc-windows-gnu-0.4.0.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__winapi_util__0_1_5",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/winapi-util/winapi-util-0.1.5.crate",
+        type = "tar.gz",
+        strip_prefix = "winapi-util-0.1.5",
+        build_file = Label("//third_party/cargo/remote:winapi-util-0.1.5.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__winapi_x86_64_pc_windows_gnu__0_4_0",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/winapi-x86_64-pc-windows-gnu/winapi-x86_64-pc-windows-gnu-0.4.0.crate",
+        type = "tar.gz",
+        strip_prefix = "winapi-x86_64-pc-windows-gnu-0.4.0",
+        build_file = Label("//third_party/cargo/remote:winapi-x86_64-pc-windows-gnu-0.4.0.BUILD"),
+    )
+

--- a/third_party/cargo/crates.bzl
+++ b/third_party/cargo/crates.bzl
@@ -82,14 +82,6 @@ def raze_fetch_remote_crates():
     )
 
     _new_http_archive(
-        name = "raze__fs_extra__1_2_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/fs_extra/fs_extra-1.2.0.crate",
-        type = "tar.gz",
-        strip_prefix = "fs_extra-1.2.0",
-        build_file = Label("//third_party/cargo/remote:fs_extra-1.2.0.BUILD"),
-    )
-
-    _new_http_archive(
         name = "raze__gimli__0_22_0",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/gimli/gimli-0.22.0.crate",
         type = "tar.gz",
@@ -103,22 +95,6 @@ def raze_fetch_remote_crates():
         type = "tar.gz",
         strip_prefix = "itoa-0.4.6",
         build_file = Label("//third_party/cargo/remote:itoa-0.4.6.BUILD"),
-    )
-
-    _new_http_archive(
-        name = "raze__jemalloc_sys__0_3_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/jemalloc-sys/jemalloc-sys-0.3.2.crate",
-        type = "tar.gz",
-        strip_prefix = "jemalloc-sys-0.3.2",
-        build_file = Label("//third_party/cargo/remote:jemalloc-sys-0.3.2.BUILD"),
-    )
-
-    _new_http_archive(
-        name = "raze__jemallocator__0_3_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/jemallocator/jemallocator-0.3.2.crate",
-        type = "tar.gz",
-        strip_prefix = "jemallocator-0.3.2",
-        build_file = Label("//third_party/cargo/remote:jemallocator-0.3.2.BUILD"),
     )
 
     _new_http_archive(

--- a/third_party/cargo/crates.bzl
+++ b/third_party/cargo/crates.bzl
@@ -4,19 +4,19 @@ cargo-raze crate workspace functions
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 
 def _new_http_archive(name, **kwargs):
     if not native.existing_rule(name):
-        http_archive(name=name, **kwargs)
+        http_archive(name = name, **kwargs)
 
 def _new_git_repository(name, **kwargs):
     if not native.existing_rule(name):
-        new_git_repository(name=name, **kwargs)
+        new_git_repository(name = name, **kwargs)
 
 def raze_fetch_remote_crates():
-
     _new_http_archive(
         name = "raze__addr2line__0_13_0",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/addr2line/addr2line-0.13.0.crate",
@@ -280,4 +280,3 @@ def raze_fetch_remote_crates():
         strip_prefix = "winapi-x86_64-pc-windows-gnu-0.4.0",
         build_file = Label("//third_party/cargo/remote:winapi-x86_64-pc-windows-gnu-0.4.0.BUILD"),
     )
-

--- a/third_party/cargo/remote/addr2line-0.13.0.BUILD
+++ b/third_party/cargo/remote/addr2line-0.13.0.BUILD
@@ -1,0 +1,49 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "addr2line" with type "example" omitted
+
+rust_library(
+    name = "addr2line",
+    crate_type = "lib",
+    deps = [
+        "@raze__gimli__0_22_0//:gimli",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.13.0",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+
+# Unsupported target "correctness" with type "test" omitted
+# Unsupported target "output_equivalence" with type "test" omitted
+# Unsupported target "parse" with type "test" omitted

--- a/third_party/cargo/remote/addr2line-0.13.0.BUILD
+++ b/third_party/cargo/remote/addr2line-0.13.0.BUILD
@@ -4,43 +4,43 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # Apache-2.0 from expression "Apache-2.0 OR MIT"
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "addr2line" with type "example" omitted
 
 rust_library(
     name = "addr2line",
-    crate_type = "lib",
-    deps = [
-        "@raze__gimli__0_22_0//:gimli",
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.13.0",
     tags = ["cargo-raze"],
-    crate_features = [
+    version = "0.13.0",
+    deps = [
+        "@raze__gimli__0_22_0//:gimli",
     ],
 )
 

--- a/third_party/cargo/remote/adler-0.2.3.BUILD
+++ b/third_party/cargo/remote/adler-0.2.3.BUILD
@@ -4,41 +4,40 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "0BSD OR (MIT OR Apache-2.0)"
+    "notice",  # MIT from expression "0BSD OR (MIT OR Apache-2.0)"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
 
-
-
 rust_library(
     name = "adler",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.2.3",
     tags = ["cargo-raze"],
-    crate_features = [
+    version = "0.2.3",
+    deps = [
     ],
 )
 

--- a/third_party/cargo/remote/adler-0.2.3.BUILD
+++ b/third_party/cargo/remote/adler-0.2.3.BUILD
@@ -1,0 +1,45 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "0BSD OR (MIT OR Apache-2.0)"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+
+rust_library(
+    name = "adler",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.2.3",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+
+# Unsupported target "bench" with type "bench" omitted

--- a/third_party/cargo/remote/autocfg-1.0.1.BUILD
+++ b/third_party/cargo/remote/autocfg-1.0.1.BUILD
@@ -4,41 +4,40 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # Apache-2.0 from expression "Apache-2.0 OR MIT"
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
 
-
-
 rust_library(
     name = "autocfg",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "1.0.1",
     tags = ["cargo-raze"],
-    crate_features = [
+    version = "1.0.1",
+    deps = [
     ],
 )
 

--- a/third_party/cargo/remote/autocfg-1.0.1.BUILD
+++ b/third_party/cargo/remote/autocfg-1.0.1.BUILD
@@ -1,0 +1,49 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+
+rust_library(
+    name = "autocfg",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "1.0.1",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+
+# Unsupported target "integers" with type "example" omitted
+# Unsupported target "paths" with type "example" omitted
+# Unsupported target "rustflags" with type "test" omitted
+# Unsupported target "traits" with type "example" omitted
+# Unsupported target "versions" with type "example" omitted

--- a/third_party/cargo/remote/backtrace-0.3.50.BUILD
+++ b/third_party/cargo/remote/backtrace-0.3.50.BUILD
@@ -1,0 +1,64 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "accuracy" with type "test" omitted
+# Unsupported target "backtrace" with type "example" omitted
+
+rust_library(
+    name = "backtrace",
+    crate_type = "lib",
+    deps = [
+        "@raze__addr2line__0_13_0//:addr2line",
+        "@raze__cfg_if__0_1_10//:cfg_if",
+        "@raze__libc__0_2_77//:libc",
+        "@raze__miniz_oxide__0_4_2//:miniz_oxide",
+        "@raze__object__0_20_0//:object",
+        "@raze__rustc_demangle__0_1_16//:rustc_demangle",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.3.50",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "addr2line",
+        "default",
+        "gimli-symbolize",
+        "miniz_oxide",
+        "object",
+        "std",
+    ],
+)
+
+# Unsupported target "benchmarks" with type "bench" omitted
+# Unsupported target "concurrent-panics" with type "test" omitted
+# Unsupported target "long_fn_name" with type "test" omitted
+# Unsupported target "raw" with type "example" omitted
+# Unsupported target "skip_inner_frames" with type "test" omitted
+# Unsupported target "smoke" with type "test" omitted

--- a/third_party/cargo/remote/backtrace-0.3.50.BUILD
+++ b/third_party/cargo/remote/backtrace-0.3.50.BUILD
@@ -4,48 +4,32 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "accuracy" with type "test" omitted
 # Unsupported target "backtrace" with type "example" omitted
 
 rust_library(
     name = "backtrace",
-    crate_type = "lib",
-    deps = [
-        "@raze__addr2line__0_13_0//:addr2line",
-        "@raze__cfg_if__0_1_10//:cfg_if",
-        "@raze__libc__0_2_77//:libc",
-        "@raze__miniz_oxide__0_4_2//:miniz_oxide",
-        "@raze__object__0_20_0//:object",
-        "@raze__rustc_demangle__0_1_16//:rustc_demangle",
-    ],
     srcs = glob(["**/*.rs"]),
-    crate_root = "src/lib.rs",
-    edition = "2018",
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    version = "0.3.50",
-    tags = ["cargo-raze"],
     crate_features = [
         "addr2line",
         "default",
@@ -53,6 +37,22 @@ rust_library(
         "miniz_oxide",
         "object",
         "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = ["cargo-raze"],
+    version = "0.3.50",
+    deps = [
+        "@raze__addr2line__0_13_0//:addr2line",
+        "@raze__cfg_if__0_1_10//:cfg_if",
+        "@raze__libc__0_2_77//:libc",
+        "@raze__miniz_oxide__0_4_2//:miniz_oxide",
+        "@raze__object__0_20_0//:object",
+        "@raze__rustc_demangle__0_1_16//:rustc_demangle",
     ],
 )
 

--- a/third_party/cargo/remote/bytecount-0.6.0.BUILD
+++ b/third_party/cargo/remote/bytecount-0.6.0.BUILD
@@ -4,42 +4,42 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # Apache-2.0 from expression "Apache-2.0 OR MIT"
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "bench" with type "bench" omitted
 
 rust_library(
     name = "bytecount",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.6.0",
     tags = ["cargo-raze"],
-    crate_features = [
+    version = "0.6.0",
+    deps = [
     ],
 )
 

--- a/third_party/cargo/remote/bytecount-0.6.0.BUILD
+++ b/third_party/cargo/remote/bytecount-0.6.0.BUILD
@@ -1,0 +1,46 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "bench" with type "bench" omitted
+
+rust_library(
+    name = "bytecount",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.6.0",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+
+# Unsupported target "check" with type "test" omitted

--- a/third_party/cargo/remote/cc-1.0.59.BUILD
+++ b/third_party/cargo/remote/cc-1.0.59.BUILD
@@ -4,41 +4,40 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
 
-
-
 rust_library(
     name = "cc",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "1.0.59",
     tags = ["cargo-raze"],
-    crate_features = [
+    version = "1.0.59",
+    deps = [
     ],
 )
 
@@ -49,19 +48,19 @@ rust_binary(
     # Prefix bin name to disambiguate from (probable) collision with lib name
     # N.B.: The exact form of this is subject to change.
     name = "cargo_bin_gcc_shim",
-    deps = [
-        # Binaries get an implicit dependency on their crate's lib
-        ":cc",
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
     crate_root = "src/bin/gcc-shim.rs",
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "1.0.59",
     tags = ["cargo-raze"],
-    crate_features = [
+    version = "1.0.59",
+    deps = [
+        # Binaries get an implicit dependency on their crate's lib
+        ":cc",
     ],
 )
 

--- a/third_party/cargo/remote/cc-1.0.59.BUILD
+++ b/third_party/cargo/remote/cc-1.0.59.BUILD
@@ -1,0 +1,68 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+
+rust_library(
+    name = "cc",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "1.0.59",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+
+# Unsupported target "cc_env" with type "test" omitted
+# Unsupported target "cflags" with type "test" omitted
+# Unsupported target "cxxflags" with type "test" omitted
+rust_binary(
+    # Prefix bin name to disambiguate from (probable) collision with lib name
+    # N.B.: The exact form of this is subject to change.
+    name = "cargo_bin_gcc_shim",
+    deps = [
+        # Binaries get an implicit dependency on their crate's lib
+        ":cc",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/bin/gcc-shim.rs",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "1.0.59",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+
+# Unsupported target "test" with type "test" omitted

--- a/third_party/cargo/remote/cfg-if-0.1.10.BUILD
+++ b/third_party/cargo/remote/cfg-if-0.1.10.BUILD
@@ -4,41 +4,40 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
 
-
-
 rust_library(
     name = "cfg_if",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.1.10",
     tags = ["cargo-raze"],
-    crate_features = [
+    version = "0.1.10",
+    deps = [
     ],
 )
 

--- a/third_party/cargo/remote/cfg-if-0.1.10.BUILD
+++ b/third_party/cargo/remote/cfg-if-0.1.10.BUILD
@@ -1,0 +1,45 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+
+rust_library(
+    name = "cfg_if",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.1.10",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+
+# Unsupported target "xcrate" with type "test" omitted

--- a/third_party/cargo/remote/chrono-0.4.15.BUILD
+++ b/third_party/cargo/remote/chrono-0.4.15.BUILD
@@ -1,0 +1,54 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "chrono" with type "bench" omitted
+
+rust_library(
+    name = "chrono",
+    crate_type = "lib",
+    deps = [
+        "@raze__num_integer__0_1_43//:num_integer",
+        "@raze__num_traits__0_2_12//:num_traits",
+        "@raze__time__0_1_44//:time",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.4.15",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "clock",
+        "default",
+        "std",
+        "time",
+    ],
+)
+
+# Unsupported target "serde" with type "bench" omitted
+# Unsupported target "wasm" with type "test" omitted

--- a/third_party/cargo/remote/chrono-0.4.15.BUILD
+++ b/third_party/cargo/remote/chrono-0.4.15.BUILD
@@ -4,49 +4,49 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "chrono" with type "bench" omitted
 
 rust_library(
     name = "chrono",
-    crate_type = "lib",
-    deps = [
-        "@raze__num_integer__0_1_43//:num_integer",
-        "@raze__num_traits__0_2_12//:num_traits",
-        "@raze__time__0_1_44//:time",
-    ],
     srcs = glob(["**/*.rs"]),
-    crate_root = "src/lib.rs",
-    edition = "2015",
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    version = "0.4.15",
-    tags = ["cargo-raze"],
     crate_features = [
         "clock",
         "default",
         "std",
         "time",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = ["cargo-raze"],
+    version = "0.4.15",
+    deps = [
+        "@raze__num_integer__0_1_43//:num_integer",
+        "@raze__num_traits__0_2_12//:num_traits",
+        "@raze__time__0_1_44//:time",
     ],
 )
 

--- a/third_party/cargo/remote/fs_extra-1.2.0.BUILD
+++ b/third_party/cargo/remote/fs_extra-1.2.0.BUILD
@@ -4,43 +4,43 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT"
+    "notice",  # MIT from expression "MIT"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "dir" with type "test" omitted
 # Unsupported target "file" with type "test" omitted
 
 rust_library(
     name = "fs_extra",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "1.2.0",
     tags = ["cargo-raze"],
-    crate_features = [
+    version = "1.2.0",
+    deps = [
     ],
 )
 

--- a/third_party/cargo/remote/fs_extra-1.2.0.BUILD
+++ b/third_party/cargo/remote/fs_extra-1.2.0.BUILD
@@ -1,0 +1,47 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "dir" with type "test" omitted
+# Unsupported target "file" with type "test" omitted
+
+rust_library(
+    name = "fs_extra",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "1.2.0",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+
+# Unsupported target "lib" with type "test" omitted

--- a/third_party/cargo/remote/gimli-0.22.0.BUILD
+++ b/third_party/cargo/remote/gimli-0.22.0.BUILD
@@ -4,25 +4,25 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # Apache-2.0 from expression "Apache-2.0 OR MIT"
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "bench" with type "bench" omitted
 # Unsupported target "convert_self" with type "test" omitted
@@ -31,19 +31,19 @@ load(
 
 rust_library(
     name = "gimli",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "read",
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.22.0",
     tags = ["cargo-raze"],
-    crate_features = [
-        "read",
+    version = "0.22.0",
+    deps = [
     ],
 )
 

--- a/third_party/cargo/remote/gimli-0.22.0.BUILD
+++ b/third_party/cargo/remote/gimli-0.22.0.BUILD
@@ -1,0 +1,52 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "bench" with type "bench" omitted
+# Unsupported target "convert_self" with type "test" omitted
+# Unsupported target "dwarf-validate" with type "example" omitted
+# Unsupported target "dwarfdump" with type "example" omitted
+
+rust_library(
+    name = "gimli",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.22.0",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "read",
+    ],
+)
+
+# Unsupported target "parse_self" with type "test" omitted
+# Unsupported target "simple" with type "example" omitted
+# Unsupported target "simple_line" with type "example" omitted

--- a/third_party/cargo/remote/itoa-0.4.6.BUILD
+++ b/third_party/cargo/remote/itoa-0.4.6.BUILD
@@ -4,42 +4,42 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "bench" with type "bench" omitted
 
 rust_library(
     name = "itoa",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.4.6",
     tags = ["cargo-raze"],
-    crate_features = [
+    version = "0.4.6",
+    deps = [
     ],
 )
 

--- a/third_party/cargo/remote/itoa-0.4.6.BUILD
+++ b/third_party/cargo/remote/itoa-0.4.6.BUILD
@@ -1,0 +1,46 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "bench" with type "bench" omitted
+
+rust_library(
+    name = "itoa",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.4.6",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+
+# Unsupported target "test" with type "test" omitted

--- a/third_party/cargo/remote/jemalloc-sys-0.3.2.BUILD
+++ b/third_party/cargo/remote/jemalloc-sys-0.3.2.BUILD
@@ -4,46 +4,46 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "build-script-build" with type "custom-build" omitted
 
 rust_library(
     name = "jemalloc_sys",
-    crate_type = "lib",
-    deps = [
-        "@raze__libc__0_2_77//:libc",
-        "@jemalloc//:jemalloc_impl",
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "background_threads_runtime_support",
+        "disable_initial_exec_tls",
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.3.2",
     tags = ["cargo-raze"],
-    crate_features = [
-        "background_threads_runtime_support",
-        "disable_initial_exec_tls",
+    version = "0.3.2",
+    deps = [
+        "@jemalloc//:jemalloc_impl",
+        "@raze__libc__0_2_77//:libc",
     ],
 )
 

--- a/third_party/cargo/remote/jemalloc-sys-0.3.2.BUILD
+++ b/third_party/cargo/remote/jemalloc-sys-0.3.2.BUILD
@@ -1,0 +1,51 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "jemalloc_sys",
+    crate_type = "lib",
+    deps = [
+        "@raze__libc__0_2_77//:libc",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.3.2",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "background_threads_runtime_support",
+        "disable_initial_exec_tls",
+    ],
+)
+
+# Unsupported target "malloc_conf_empty" with type "test" omitted
+# Unsupported target "malloc_conf_set" with type "test" omitted
+# Unsupported target "unprefixed_malloc" with type "test" omitted

--- a/third_party/cargo/remote/jemalloc-sys-0.3.2.BUILD
+++ b/third_party/cargo/remote/jemalloc-sys-0.3.2.BUILD
@@ -31,6 +31,7 @@ rust_library(
     crate_type = "lib",
     deps = [
         "@raze__libc__0_2_77//:libc",
+        "@jemalloc//:jemalloc_impl",
     ],
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",

--- a/third_party/cargo/remote/jemallocator-0.3.2.BUILD
+++ b/third_party/cargo/remote/jemallocator-0.3.2.BUILD
@@ -1,0 +1,59 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "background_thread_defaults" with type "test" omitted
+# Unsupported target "background_thread_enabled" with type "test" omitted
+# Unsupported target "ffi" with type "test" omitted
+# Unsupported target "grow_in_place" with type "test" omitted
+
+rust_library(
+    name = "jemallocator",
+    crate_type = "lib",
+    deps = [
+        "@raze__jemalloc_sys__0_3_2//:jemalloc_sys",
+        "@raze__libc__0_2_77//:libc",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.3.2",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "background_threads_runtime_support",
+        "default",
+        "disable_initial_exec_tls",
+    ],
+)
+
+# Unsupported target "malloctl" with type "test" omitted
+# Unsupported target "roundtrip" with type "bench" omitted
+# Unsupported target "shrink_in_place" with type "test" omitted
+# Unsupported target "smoke" with type "test" omitted
+# Unsupported target "smoke_ffi" with type "test" omitted
+# Unsupported target "usable_size" with type "test" omitted

--- a/third_party/cargo/remote/jemallocator-0.3.2.BUILD
+++ b/third_party/cargo/remote/jemallocator-0.3.2.BUILD
@@ -4,25 +4,25 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "background_thread_defaults" with type "test" omitted
 # Unsupported target "background_thread_enabled" with type "test" omitted
@@ -31,23 +31,23 @@ load(
 
 rust_library(
     name = "jemallocator",
-    crate_type = "lib",
-    deps = [
-        "@raze__jemalloc_sys__0_3_2//:jemalloc_sys",
-        "@raze__libc__0_2_77//:libc",
-    ],
     srcs = glob(["**/*.rs"]),
-    crate_root = "src/lib.rs",
-    edition = "2015",
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    version = "0.3.2",
-    tags = ["cargo-raze"],
     crate_features = [
         "background_threads_runtime_support",
         "default",
         "disable_initial_exec_tls",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = ["cargo-raze"],
+    version = "0.3.2",
+    deps = [
+        "@raze__jemalloc_sys__0_3_2//:jemalloc_sys",
+        "@raze__libc__0_2_77//:libc",
     ],
 )
 

--- a/third_party/cargo/remote/libc-0.2.77.BUILD
+++ b/third_party/cargo/remote/libc-0.2.77.BUILD
@@ -4,45 +4,44 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "build-script-build" with type "custom-build" omitted
 # Unsupported target "const_fn" with type "test" omitted
 
 rust_library(
     name = "libc",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
-    crate_root = "src/lib.rs",
-    edition = "2015",
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    version = "0.2.77",
-    tags = ["cargo-raze"],
     crate_features = [
         "default",
         "std",
     ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = ["cargo-raze"],
+    version = "0.2.77",
+    deps = [
+    ],
 )
-

--- a/third_party/cargo/remote/libc-0.2.77.BUILD
+++ b/third_party/cargo/remote/libc-0.2.77.BUILD
@@ -1,0 +1,48 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+# Unsupported target "const_fn" with type "test" omitted
+
+rust_library(
+    name = "libc",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.2.77",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "default",
+        "std",
+    ],
+)
+

--- a/third_party/cargo/remote/log-0.4.11.BUILD
+++ b/third_party/cargo/remote/log-0.4.11.BUILD
@@ -1,0 +1,51 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+# Unsupported target "filters" with type "test" omitted
+
+rust_library(
+    name = "log",
+    crate_type = "lib",
+    deps = [
+        "@raze__cfg_if__0_1_10//:cfg_if",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.4.11",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "max_level_debug",
+        "release_max_level_warn",
+        "std",
+    ],
+)
+
+# Unsupported target "macros" with type "test" omitted

--- a/third_party/cargo/remote/log-0.4.11.BUILD
+++ b/third_party/cargo/remote/log-0.4.11.BUILD
@@ -38,6 +38,7 @@ rust_library(
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
+        "--cfg=atomic_cas",
     ],
     version = "0.4.11",
     tags = ["cargo-raze"],

--- a/third_party/cargo/remote/log-0.4.11.BUILD
+++ b/third_party/cargo/remote/log-0.4.11.BUILD
@@ -4,48 +4,48 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "build-script-build" with type "custom-build" omitted
 # Unsupported target "filters" with type "test" omitted
 
 rust_library(
     name = "log",
-    crate_type = "lib",
-    deps = [
-        "@raze__cfg_if__0_1_10//:cfg_if",
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "max_level_debug",
+        "release_max_level_warn",
+        "std",
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
         "--cfg=atomic_cas",
     ],
-    version = "0.4.11",
     tags = ["cargo-raze"],
-    crate_features = [
-        "max_level_debug",
-        "release_max_level_warn",
-        "std",
+    version = "0.4.11",
+    deps = [
+        "@raze__cfg_if__0_1_10//:cfg_if",
     ],
 )
 

--- a/third_party/cargo/remote/miniz_oxide-0.4.2.BUILD
+++ b/third_party/cargo/remote/miniz_oxide-0.4.2.BUILD
@@ -4,43 +4,42 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT"
+    "notice",  # MIT from expression "MIT"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "build-script-build" with type "custom-build" omitted
 
 rust_library(
     name = "miniz_oxide",
-    crate_type = "lib",
-    deps = [
-        "@raze__adler__0_2_3//:adler",
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.4.2",
     tags = ["cargo-raze"],
-    crate_features = [
+    version = "0.4.2",
+    deps = [
+        "@raze__adler__0_2_3//:adler",
     ],
 )
-

--- a/third_party/cargo/remote/miniz_oxide-0.4.2.BUILD
+++ b/third_party/cargo/remote/miniz_oxide-0.4.2.BUILD
@@ -1,0 +1,46 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "miniz_oxide",
+    crate_type = "lib",
+    deps = [
+        "@raze__adler__0_2_3//:adler",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.4.2",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+

--- a/third_party/cargo/remote/num-integer-0.1.43.BUILD
+++ b/third_party/cargo/remote/num-integer-0.1.43.BUILD
@@ -4,25 +4,25 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "average" with type "bench" omitted
 # Unsupported target "average" with type "test" omitted
@@ -31,19 +31,19 @@ load(
 
 rust_library(
     name = "num_integer",
-    crate_type = "lib",
-    deps = [
-        "@raze__num_traits__0_2_12//:num_traits",
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.1.43",
     tags = ["cargo-raze"],
-    crate_features = [
+    version = "0.1.43",
+    deps = [
+        "@raze__num_traits__0_2_12//:num_traits",
     ],
 )
 

--- a/third_party/cargo/remote/num-integer-0.1.43.BUILD
+++ b/third_party/cargo/remote/num-integer-0.1.43.BUILD
@@ -1,0 +1,51 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "average" with type "bench" omitted
+# Unsupported target "average" with type "test" omitted
+# Unsupported target "build-script-build" with type "custom-build" omitted
+# Unsupported target "gcd" with type "bench" omitted
+
+rust_library(
+    name = "num_integer",
+    crate_type = "lib",
+    deps = [
+        "@raze__num_traits__0_2_12//:num_traits",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.1.43",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+
+# Unsupported target "roots" with type "bench" omitted
+# Unsupported target "roots" with type "test" omitted

--- a/third_party/cargo/remote/num-traits-0.2.12.BUILD
+++ b/third_party/cargo/remote/num-traits-0.2.12.BUILD
@@ -4,43 +4,42 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "build-script-build" with type "custom-build" omitted
 # Unsupported target "cast" with type "test" omitted
 
 rust_library(
     name = "num_traits",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.2.12",
     tags = ["cargo-raze"],
-    crate_features = [
+    version = "0.2.12",
+    deps = [
     ],
 )
-

--- a/third_party/cargo/remote/num-traits-0.2.12.BUILD
+++ b/third_party/cargo/remote/num-traits-0.2.12.BUILD
@@ -1,0 +1,46 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+# Unsupported target "cast" with type "test" omitted
+
+rust_library(
+    name = "num_traits",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.2.12",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+

--- a/third_party/cargo/remote/object-0.20.0.BUILD
+++ b/third_party/cargo/remote/object-0.20.0.BUILD
@@ -4,25 +4,25 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # Apache-2.0 from expression "Apache-2.0 OR MIT"
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "integration" with type "test" omitted
 # Unsupported target "nm" with type "example" omitted
@@ -31,17 +31,7 @@ load(
 
 rust_library(
     name = "object",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
-    crate_root = "src/lib.rs",
-    edition = "2018",
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    version = "0.20.0",
-    tags = ["cargo-raze"],
     crate_features = [
         "coff",
         "elf",
@@ -49,6 +39,16 @@ rust_library(
         "pe",
         "read_core",
         "unaligned",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = ["cargo-raze"],
+    version = "0.20.0",
+    deps = [
     ],
 )
 

--- a/third_party/cargo/remote/object-0.20.0.BUILD
+++ b/third_party/cargo/remote/object-0.20.0.BUILD
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "integration" with type "test" omitted
+# Unsupported target "nm" with type "example" omitted
+# Unsupported target "objcopy" with type "example" omitted
+# Unsupported target "objdump" with type "example" omitted
+
+rust_library(
+    name = "object",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.20.0",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "coff",
+        "elf",
+        "macho",
+        "pe",
+        "read_core",
+        "unaligned",
+    ],
+)
+
+# Unsupported target "parse_self" with type "test" omitted

--- a/third_party/cargo/remote/proc-macro2-1.0.10.BUILD
+++ b/third_party/cargo/remote/proc-macro2-1.0.10.BUILD
@@ -1,0 +1,52 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+# Unsupported target "features" with type "test" omitted
+# Unsupported target "marker" with type "test" omitted
+
+rust_library(
+    name = "proc_macro2",
+    crate_type = "lib",
+    deps = [
+        "@raze__unicode_xid__0_2_1//:unicode_xid",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+        "--cfg=use_proc_macro",
+    ],
+    version = "1.0.10",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "default",
+        "proc-macro",
+    ],
+)
+
+# Unsupported target "test" with type "test" omitted

--- a/third_party/cargo/remote/proc-macro2-1.0.10.BUILD
+++ b/third_party/cargo/remote/proc-macro2-1.0.10.BUILD
@@ -4,25 +4,25 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "build-script-build" with type "custom-build" omitted
 # Unsupported target "features" with type "test" omitted
@@ -30,22 +30,22 @@ load(
 
 rust_library(
     name = "proc_macro2",
-    crate_type = "lib",
-    deps = [
-        "@raze__unicode_xid__0_2_1//:unicode_xid",
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "proc-macro",
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
         "--cfg=use_proc_macro",
     ],
-    version = "1.0.10",
     tags = ["cargo-raze"],
-    crate_features = [
-        "default",
-        "proc-macro",
+    version = "1.0.10",
+    deps = [
+        "@raze__unicode_xid__0_2_1//:unicode_xid",
     ],
 )
 

--- a/third_party/cargo/remote/quote-1.0.3.BUILD
+++ b/third_party/cargo/remote/quote-1.0.3.BUILD
@@ -1,0 +1,49 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "compiletest" with type "test" omitted
+
+rust_library(
+    name = "quote",
+    crate_type = "lib",
+    deps = [
+        "@raze__proc_macro2__1_0_10//:proc_macro2",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "1.0.3",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "default",
+        "proc-macro",
+    ],
+)
+
+# Unsupported target "test" with type "test" omitted

--- a/third_party/cargo/remote/quote-1.0.3.BUILD
+++ b/third_party/cargo/remote/quote-1.0.3.BUILD
@@ -4,45 +4,45 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "compiletest" with type "test" omitted
 
 rust_library(
     name = "quote",
-    crate_type = "lib",
-    deps = [
-        "@raze__proc_macro2__1_0_10//:proc_macro2",
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "proc-macro",
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "1.0.3",
     tags = ["cargo-raze"],
-    crate_features = [
-        "default",
-        "proc-macro",
+    version = "1.0.3",
+    deps = [
+        "@raze__proc_macro2__1_0_10//:proc_macro2",
     ],
 )
 

--- a/third_party/cargo/remote/rustc-demangle-0.1.16.BUILD
+++ b/third_party/cargo/remote/rustc-demangle-0.1.16.BUILD
@@ -4,41 +4,39 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
 
-
-
 rust_library(
     name = "rustc_demangle",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.1.16",
     tags = ["cargo-raze"],
-    crate_features = [
+    version = "0.1.16",
+    deps = [
     ],
 )
-

--- a/third_party/cargo/remote/rustc-demangle-0.1.16.BUILD
+++ b/third_party/cargo/remote/rustc-demangle-0.1.16.BUILD
@@ -1,0 +1,44 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+
+rust_library(
+    name = "rustc_demangle",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.1.16",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+

--- a/third_party/cargo/remote/ryu-1.0.5.BUILD
+++ b/third_party/cargo/remote/ryu-1.0.5.BUILD
@@ -4,25 +4,25 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # Apache-2.0 from expression "Apache-2.0 OR BSL-1.0"
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR BSL-1.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "bench" with type "bench" omitted
 # Unsupported target "build-script-build" with type "custom-build" omitted
@@ -34,18 +34,18 @@ load(
 
 rust_library(
     name = "ryu",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "1.0.5",
     tags = ["cargo-raze"],
-    crate_features = [
+    version = "1.0.5",
+    deps = [
     ],
 )
 

--- a/third_party/cargo/remote/ryu-1.0.5.BUILD
+++ b/third_party/cargo/remote/ryu-1.0.5.BUILD
@@ -1,0 +1,54 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # Apache-2.0 from expression "Apache-2.0 OR BSL-1.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "bench" with type "bench" omitted
+# Unsupported target "build-script-build" with type "custom-build" omitted
+# Unsupported target "common_test" with type "test" omitted
+# Unsupported target "d2s_table_test" with type "test" omitted
+# Unsupported target "d2s_test" with type "test" omitted
+# Unsupported target "exhaustive" with type "test" omitted
+# Unsupported target "f2s_test" with type "test" omitted
+
+rust_library(
+    name = "ryu",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "1.0.5",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+
+# Unsupported target "s2d_test" with type "test" omitted
+# Unsupported target "s2f_test" with type "test" omitted
+# Unsupported target "upstream_benchmark" with type "example" omitted

--- a/third_party/cargo/remote/serde-1.0.113.BUILD
+++ b/third_party/cargo/remote/serde-1.0.113.BUILD
@@ -4,35 +4,39 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "build-script-build" with type "custom-build" omitted
 
 rust_library(
     name = "serde",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "derive",
+        "serde_derive",
+        "std",
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2015",
     proc_macro_deps = [
         "@raze__serde_derive__1_0_113//:serde_derive",
@@ -40,13 +44,8 @@ rust_library(
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "1.0.113",
     tags = ["cargo-raze"],
-    crate_features = [
-        "default",
-        "derive",
-        "serde_derive",
-        "std",
+    version = "1.0.113",
+    deps = [
     ],
 )
-

--- a/third_party/cargo/remote/serde-1.0.113.BUILD
+++ b/third_party/cargo/remote/serde-1.0.113.BUILD
@@ -1,0 +1,52 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "serde",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    proc_macro_deps = [
+        "@raze__serde_derive__1_0_113//:serde_derive",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "1.0.113",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "default",
+        "derive",
+        "serde_derive",
+        "std",
+    ],
+)
+

--- a/third_party/cargo/remote/serde_derive-1.0.113.BUILD
+++ b/third_party/cargo/remote/serde_derive-1.0.113.BUILD
@@ -4,46 +4,45 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "build-script-build" with type "custom-build" omitted
 
 rust_library(
     name = "serde_derive",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
     crate_type = "proc-macro",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = ["cargo-raze"],
+    version = "1.0.113",
     deps = [
         "@raze__proc_macro2__1_0_10//:proc_macro2",
         "@raze__quote__1_0_3//:quote",
         "@raze__syn__1_0_17//:syn",
     ],
-    srcs = glob(["**/*.rs"]),
-    crate_root = "src/lib.rs",
-    edition = "2015",
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    version = "1.0.113",
-    tags = ["cargo-raze"],
-    crate_features = [
-        "default",
-    ],
 )
-

--- a/third_party/cargo/remote/serde_derive-1.0.113.BUILD
+++ b/third_party/cargo/remote/serde_derive-1.0.113.BUILD
@@ -1,0 +1,49 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "serde_derive",
+    crate_type = "proc-macro",
+    deps = [
+        "@raze__proc_macro2__1_0_10//:proc_macro2",
+        "@raze__quote__1_0_3//:quote",
+        "@raze__syn__1_0_17//:syn",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "1.0.113",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "default",
+    ],
+)
+

--- a/third_party/cargo/remote/serde_json-1.0.57.BUILD
+++ b/third_party/cargo/remote/serde_json-1.0.57.BUILD
@@ -1,0 +1,50 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "serde_json",
+    crate_type = "lib",
+    deps = [
+        "@raze__itoa__0_4_6//:itoa",
+        "@raze__ryu__1_0_5//:ryu",
+        "@raze__serde__1_0_113//:serde",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "1.0.57",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "default",
+        "std",
+    ],
+)
+

--- a/third_party/cargo/remote/serde_json-1.0.57.BUILD
+++ b/third_party/cargo/remote/serde_json-1.0.57.BUILD
@@ -4,47 +4,46 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "build-script-build" with type "custom-build" omitted
 
 rust_library(
     name = "serde_json",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
     crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = ["cargo-raze"],
+    version = "1.0.57",
     deps = [
         "@raze__itoa__0_4_6//:itoa",
         "@raze__ryu__1_0_5//:ryu",
         "@raze__serde__1_0_113//:serde",
     ],
-    srcs = glob(["**/*.rs"]),
-    crate_root = "src/lib.rs",
-    edition = "2018",
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    version = "1.0.57",
-    tags = ["cargo-raze"],
-    crate_features = [
-        "default",
-        "std",
-    ],
 )
-

--- a/third_party/cargo/remote/simplelog-0.8.0.BUILD
+++ b/third_party/cargo/remote/simplelog-0.8.0.BUILD
@@ -4,46 +4,45 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
 
-
-
 rust_library(
     name = "simplelog",
-    crate_type = "lib",
-    deps = [
-        "@raze__chrono__0_4_15//:chrono",
-        "@raze__log__0_4_11//:log",
-        "@raze__termcolor__1_1_0//:termcolor",
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "termcolor",
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.8.0",
     tags = ["cargo-raze"],
-    crate_features = [
-        "default",
-        "termcolor",
+    version = "0.8.0",
+    deps = [
+        "@raze__chrono__0_4_15//:chrono",
+        "@raze__log__0_4_11//:log",
+        "@raze__termcolor__1_1_0//:termcolor",
     ],
 )
 

--- a/third_party/cargo/remote/simplelog-0.8.0.BUILD
+++ b/third_party/cargo/remote/simplelog-0.8.0.BUILD
@@ -1,0 +1,50 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+
+rust_library(
+    name = "simplelog",
+    crate_type = "lib",
+    deps = [
+        "@raze__chrono__0_4_15//:chrono",
+        "@raze__log__0_4_11//:log",
+        "@raze__termcolor__1_1_0//:termcolor",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.8.0",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "default",
+        "termcolor",
+    ],
+)
+
+# Unsupported target "usage" with type "example" omitted

--- a/third_party/cargo/remote/syn-1.0.17.BUILD
+++ b/third_party/cargo/remote/syn-1.0.17.BUILD
@@ -1,0 +1,81 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+# Unsupported target "file" with type "bench" omitted
+# Unsupported target "rust" with type "bench" omitted
+
+rust_library(
+    name = "syn",
+    crate_type = "lib",
+    deps = [
+        "@raze__proc_macro2__1_0_10//:proc_macro2",
+        "@raze__quote__1_0_3//:quote",
+        "@raze__unicode_xid__0_2_1//:unicode_xid",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+        "--cfg=use_proc_macro",
+    ],
+    version = "1.0.17",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "clone-impls",
+        "default",
+        "derive",
+        "full",
+        "parsing",
+        "printing",
+        "proc-macro",
+        "quote",
+        "visit",
+    ],
+)
+
+# Unsupported target "test_asyncness" with type "test" omitted
+# Unsupported target "test_attribute" with type "test" omitted
+# Unsupported target "test_derive_input" with type "test" omitted
+# Unsupported target "test_expr" with type "test" omitted
+# Unsupported target "test_generics" with type "test" omitted
+# Unsupported target "test_grouping" with type "test" omitted
+# Unsupported target "test_ident" with type "test" omitted
+# Unsupported target "test_iterators" with type "test" omitted
+# Unsupported target "test_lit" with type "test" omitted
+# Unsupported target "test_meta" with type "test" omitted
+# Unsupported target "test_parse_buffer" with type "test" omitted
+# Unsupported target "test_pat" with type "test" omitted
+# Unsupported target "test_precedence" with type "test" omitted
+# Unsupported target "test_receiver" with type "test" omitted
+# Unsupported target "test_round_trip" with type "test" omitted
+# Unsupported target "test_should_parse" with type "test" omitted
+# Unsupported target "test_size" with type "test" omitted
+# Unsupported target "test_stmt" with type "test" omitted
+# Unsupported target "test_token_trees" with type "test" omitted
+# Unsupported target "test_visibility" with type "test" omitted
+# Unsupported target "zzz_stable" with type "test" omitted

--- a/third_party/cargo/remote/syn-1.0.17.BUILD
+++ b/third_party/cargo/remote/syn-1.0.17.BUILD
@@ -4,25 +4,25 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "build-script-build" with type "custom-build" omitted
 # Unsupported target "file" with type "bench" omitted
@@ -30,21 +30,7 @@ load(
 
 rust_library(
     name = "syn",
-    crate_type = "lib",
-    deps = [
-        "@raze__proc_macro2__1_0_10//:proc_macro2",
-        "@raze__quote__1_0_3//:quote",
-        "@raze__unicode_xid__0_2_1//:unicode_xid",
-    ],
     srcs = glob(["**/*.rs"]),
-    crate_root = "src/lib.rs",
-    edition = "2018",
-    rustc_flags = [
-        "--cap-lints=allow",
-        "--cfg=use_proc_macro",
-    ],
-    version = "1.0.17",
-    tags = ["cargo-raze"],
     crate_features = [
         "clone-impls",
         "default",
@@ -55,6 +41,20 @@ rust_library(
         "proc-macro",
         "quote",
         "visit",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+        "--cfg=use_proc_macro",
+    ],
+    tags = ["cargo-raze"],
+    version = "1.0.17",
+    deps = [
+        "@raze__proc_macro2__1_0_10//:proc_macro2",
+        "@raze__quote__1_0_3//:quote",
+        "@raze__unicode_xid__0_2_1//:unicode_xid",
     ],
 )
 

--- a/third_party/cargo/remote/syn-1.0.17.BUILD
+++ b/third_party/cargo/remote/syn-1.0.17.BUILD
@@ -47,7 +47,6 @@ rust_library(
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
-        "--cfg=use_proc_macro",
     ],
     tags = ["cargo-raze"],
     version = "1.0.17",

--- a/third_party/cargo/remote/termcolor-1.1.0.BUILD
+++ b/third_party/cargo/remote/termcolor-1.1.0.BUILD
@@ -4,41 +4,39 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "unencumbered", # Unlicense from expression "Unlicense OR MIT"
+    "unencumbered",  # Unlicense from expression "Unlicense OR MIT"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
 
-
-
 rust_library(
     name = "termcolor",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "1.1.0",
     tags = ["cargo-raze"],
-    crate_features = [
+    version = "1.1.0",
+    deps = [
     ],
 )
-

--- a/third_party/cargo/remote/termcolor-1.1.0.BUILD
+++ b/third_party/cargo/remote/termcolor-1.1.0.BUILD
@@ -1,0 +1,44 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "unencumbered", # Unlicense from expression "Unlicense OR MIT"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+
+rust_library(
+    name = "termcolor",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "1.1.0",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+

--- a/third_party/cargo/remote/time-0.1.44.BUILD
+++ b/third_party/cargo/remote/time-0.1.44.BUILD
@@ -1,0 +1,45 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+
+rust_library(
+    name = "time",
+    crate_type = "lib",
+    deps = [
+        "@raze__libc__0_2_77//:libc",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.1.44",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+

--- a/third_party/cargo/remote/time-0.1.44.BUILD
+++ b/third_party/cargo/remote/time-0.1.44.BUILD
@@ -4,42 +4,40 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
 
-
-
 rust_library(
     name = "time",
-    crate_type = "lib",
-    deps = [
-        "@raze__libc__0_2_77//:libc",
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.1.44",
     tags = ["cargo-raze"],
-    crate_features = [
+    version = "0.1.44",
+    deps = [
+        "@raze__libc__0_2_77//:libc",
     ],
 )
-

--- a/third_party/cargo/remote/unicode-xid-0.2.1.BUILD
+++ b/third_party/cargo/remote/unicode-xid-0.2.1.BUILD
@@ -4,43 +4,42 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "exhaustive_tests" with type "test" omitted
 
 rust_library(
     name = "unicode_xid",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.2.1",
     tags = ["cargo-raze"],
-    crate_features = [
-        "default",
+    version = "0.2.1",
+    deps = [
     ],
 )
-

--- a/third_party/cargo/remote/unicode-xid-0.2.1.BUILD
+++ b/third_party/cargo/remote/unicode-xid-0.2.1.BUILD
@@ -1,0 +1,46 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "exhaustive_tests" with type "test" omitted
+
+rust_library(
+    name = "unicode_xid",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.2.1",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "default",
+    ],
+)
+

--- a/third_party/cargo/remote/wasi-0.10.0+wasi-snapshot-preview1.BUILD
+++ b/third_party/cargo/remote/wasi-0.10.0+wasi-snapshot-preview1.BUILD
@@ -4,43 +4,41 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # Apache-2.0 from expression "Apache-2.0 OR (Apache-2.0 OR MIT)"
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR (Apache-2.0 OR MIT)"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
 
-
-
 rust_library(
     name = "wasi",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
-    crate_root = "src/lib.rs",
-    edition = "2018",
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    version = "0.10.0+wasi-snapshot-preview1",
-    tags = ["cargo-raze"],
     crate_features = [
         "default",
         "std",
     ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = ["cargo-raze"],
+    version = "0.10.0+wasi-snapshot-preview1",
+    deps = [
+    ],
 )
-

--- a/third_party/cargo/remote/wasi-0.10.0+wasi-snapshot-preview1.BUILD
+++ b/third_party/cargo/remote/wasi-0.10.0+wasi-snapshot-preview1.BUILD
@@ -1,0 +1,46 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # Apache-2.0 from expression "Apache-2.0 OR (Apache-2.0 OR MIT)"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+
+rust_library(
+    name = "wasi",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.10.0+wasi-snapshot-preview1",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "default",
+        "std",
+    ],
+)
+

--- a/third_party/cargo/remote/winapi-0.3.9.BUILD
+++ b/third_party/cargo/remote/winapi-0.3.9.BUILD
@@ -4,41 +4,31 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "build-script-build" with type "custom-build" omitted
 
 rust_library(
     name = "winapi",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
-    crate_root = "src/lib.rs",
-    edition = "2015",
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    version = "0.3.9",
-    tags = ["cargo-raze"],
     crate_features = [
         "consoleapi",
         "errhandlingapi",
@@ -56,5 +46,14 @@ rust_library(
         "winerror",
         "winnt",
     ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = ["cargo-raze"],
+    version = "0.3.9",
+    deps = [
+    ],
 )
-

--- a/third_party/cargo/remote/winapi-0.3.9.BUILD
+++ b/third_party/cargo/remote/winapi-0.3.9.BUILD
@@ -1,0 +1,60 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "winapi",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.3.9",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "consoleapi",
+        "errhandlingapi",
+        "fileapi",
+        "minwinbase",
+        "minwindef",
+        "ntdef",
+        "processenv",
+        "profileapi",
+        "std",
+        "sysinfoapi",
+        "timezoneapi",
+        "winbase",
+        "wincon",
+        "winerror",
+        "winnt",
+    ],
+)
+

--- a/third_party/cargo/remote/winapi-i686-pc-windows-gnu-0.4.0.BUILD
+++ b/third_party/cargo/remote/winapi-i686-pc-windows-gnu-0.4.0.BUILD
@@ -4,42 +4,41 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "build-script-build" with type "custom-build" omitted
 
 rust_library(
     name = "winapi_i686_pc_windows_gnu",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.4.0",
     tags = ["cargo-raze"],
-    crate_features = [
+    version = "0.4.0",
+    deps = [
     ],
 )
-

--- a/third_party/cargo/remote/winapi-i686-pc-windows-gnu-0.4.0.BUILD
+++ b/third_party/cargo/remote/winapi-i686-pc-windows-gnu-0.4.0.BUILD
@@ -1,0 +1,45 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "winapi_i686_pc_windows_gnu",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.4.0",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+

--- a/third_party/cargo/remote/winapi-util-0.1.5.BUILD
+++ b/third_party/cargo/remote/winapi-util-0.1.5.BUILD
@@ -4,41 +4,39 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "unencumbered", # Unlicense from expression "Unlicense OR MIT"
+    "unencumbered",  # Unlicense from expression "Unlicense OR MIT"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
 
-
-
 rust_library(
     name = "winapi_util",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.1.5",
     tags = ["cargo-raze"],
-    crate_features = [
+    version = "0.1.5",
+    deps = [
     ],
 )
-

--- a/third_party/cargo/remote/winapi-util-0.1.5.BUILD
+++ b/third_party/cargo/remote/winapi-util-0.1.5.BUILD
@@ -1,0 +1,44 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "unencumbered", # Unlicense from expression "Unlicense OR MIT"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+
+rust_library(
+    name = "winapi_util",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.1.5",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+

--- a/third_party/cargo/remote/winapi-x86_64-pc-windows-gnu-0.4.0.BUILD
+++ b/third_party/cargo/remote/winapi-x86_64-pc-windows-gnu-0.4.0.BUILD
@@ -4,42 +4,41 @@ cargo-raze crate build file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
 package(default_visibility = [
-  # Public for visibility by "@raze__crate__version//" targets.
-  #
-  # Prefer access through "//third_party/cargo", which limits external
-  # visibility to explicit Cargo.toml dependencies.
-  "//visibility:public",
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 load(
     "@io_bazel_rules_rust//rust:rust.bzl",
-    "rust_library",
     "rust_binary",
+    "rust_library",
     "rust_test",
 )
-
 
 # Unsupported target "build-script-build" with type "custom-build" omitted
 
 rust_library(
     name = "winapi_x86_64_pc_windows_gnu",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.4.0",
     tags = ["cargo-raze"],
-    crate_features = [
+    version = "0.4.0",
+    deps = [
     ],
 )
-

--- a/third_party/cargo/remote/winapi-x86_64-pc-windows-gnu-0.4.0.BUILD
+++ b/third_party/cargo/remote/winapi-x86_64-pc-windows-gnu-0.4.0.BUILD
@@ -1,0 +1,45 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "winapi_x86_64_pc_windows_gnu",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.4.0",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -143,6 +143,14 @@ package(default_visibility = ["//visibility:public"])
         strip_prefix = "bazel-compilation-database-0ae6349c52700f060c9a87c5ed2b04b75f94a26f",
     )
 
+    http_archive(
+            name = "rubyfmt",
+            strip_prefix = "rubyfmt-3051835cc28db04e9d9caf0c8430407ca0347e83",
+            urls = _github_public_urls("penelopezone/rubyfmt/archive/3051835cc28db04e9d9caf0c8430407ca0347e83.zip"),
+            sha256 = "1e0bc012fe7a52cead7f77d86e939c76e1b25dc1067e10908e33195c1e709203",
+            build_file = "//third_party/rubyfmt:rubyfmt.BUILD",
+            )
+
     # NOTE: using this branch:
     # https://github.com/DarkDimius/bazel-toolchain/tree/dp-srb-now
     http_archive(

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -296,6 +296,7 @@ package(default_visibility = ["//visibility:public"])
 
     http_archive(
         name = "io_bazel_rules_rust",
+        sha256 = "5ed804fcd10a506a5b8e9e59bc6b3b7f43bc30c87ce4670e6f78df43604894fd",
         strip_prefix = "rules_rust-fdf9655ba95616e0314b4e0ebab40bb0c5fe005c",
         urls = [
             # Master branch as of 2019-10-07

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -148,7 +148,7 @@ package(default_visibility = ["//visibility:public"])
     http_archive(
         name = "rubyfmt",
         urls = ["https://github.com/penelopezone/rubyfmt/releases/download/v0.4.0/rubyfmt-v0.4.0-sources.tar.gz"],
-        build_file = "//third_party/rubyfmt:rubyfmt.BUILD",
+        build_file = "@com_stripe_ruby_typer//third_party/rubyfmt:rubyfmt.BUILD",
         strip_prefix = "tmp/rubyfmt_source",
     )
 

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -312,8 +312,6 @@ package(default_visibility = ["//visibility:public"])
 
     raze_fetch_remote_crates()
 
-
-
 def _github_public_urls(path):
     """
     Produce a url list that works both with github, and stripe's internal artifact cache.

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -300,7 +300,7 @@ package(default_visibility = ["//visibility:public"])
         strip_prefix = "rules_rust-fdf9655ba95616e0314b4e0ebab40bb0c5fe005c",
 
         # Master branch as of 2019-10-07
-        urls = _github_public_urls("rules_rust/archive/fdf9655ba95616e0314b4e0ebab40bb0c5fe005c.tar.gz"),
+        urls = _github_public_urls("bazelbuild/rules_rust/archive/fdf9655ba95616e0314b4e0ebab40bb0c5fe005c.tar.gz"),
     )
 
     http_archive(

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -144,12 +144,11 @@ package(default_visibility = ["//visibility:public"])
         strip_prefix = "bazel-compilation-database-0ae6349c52700f060c9a87c5ed2b04b75f94a26f",
     )
 
-    new_git_repository(
+    http_archive(
         name = "rubyfmt",
-        remote = "https://github.com/penelopezone/rubyfmt",
-        commit = "f64f80ce80a5027106f689e76e6400abaa87d90f",
-        init_submodules = True,
+        urls = ["https://github.com/penelopezone/rubyfmt/releases/download/v0.4.0/rubyfmt-v0.4.0-sources.tar.gz"],
         build_file = "//third_party/rubyfmt:rubyfmt.BUILD",
+        strip_prefix = "tmp/rubyfmt_source",
     )
 
     # NOTE: using this branch:

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -1,5 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+load("//third_party/cargo:crates.bzl", "raze_fetch_remote_crates")
 
 # We define our externals here instead of directly in WORKSPACE
 def register_sorbet_dependencies():
@@ -292,6 +293,26 @@ package(default_visibility = ["//visibility:public"])
         path = "/usr",
         build_file = "@com_stripe_ruby_typer//third_party/openssl:linux.BUILD",
     )
+
+    http_archive(
+        name = "io_bazel_rules_rust",
+        strip_prefix = "rules_rust-fdf9655ba95616e0314b4e0ebab40bb0c5fe005c",
+        urls = [
+            # Master branch as of 2019-10-07
+            "https://github.com/bazelbuild/rules_rust/archive/fdf9655ba95616e0314b4e0ebab40bb0c5fe005c.tar.gz",
+        ],
+    )
+
+    http_archive(
+        name = "bazel_skylib",
+        sha256 = "9a737999532daca978a158f94e77e9af6a6a169709c0cee274f0a4c3359519bd",
+        strip_prefix = "bazel-skylib-1.0.0",
+        url = "https://github.com/bazelbuild/bazel-skylib/archive/1.0.0.tar.gz",
+    )
+
+    raze_fetch_remote_crates()
+
+
 
 def _github_public_urls(path):
     """

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -1,4 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 
 # We define our externals here instead of directly in WORKSPACE
 def register_sorbet_dependencies():
@@ -143,13 +144,13 @@ package(default_visibility = ["//visibility:public"])
         strip_prefix = "bazel-compilation-database-0ae6349c52700f060c9a87c5ed2b04b75f94a26f",
     )
 
-    http_archive(
-            name = "rubyfmt",
-            strip_prefix = "rubyfmt-3051835cc28db04e9d9caf0c8430407ca0347e83",
-            urls = _github_public_urls("penelopezone/rubyfmt/archive/3051835cc28db04e9d9caf0c8430407ca0347e83.zip"),
-            sha256 = "1e0bc012fe7a52cead7f77d86e939c76e1b25dc1067e10908e33195c1e709203",
-            build_file = "//third_party/rubyfmt:rubyfmt.BUILD",
-            )
+    new_git_repository(
+        name = "rubyfmt",
+        remote = "https://github.com/penelopezone/rubyfmt",
+        commit = "4869fd64be6e7dbeb0fb68684afb856eae450cf6",
+        init_submodules = True,
+        build_file = "//third_party/rubyfmt:rubyfmt.BUILD",
+    )
 
     # NOTE: using this branch:
     # https://github.com/DarkDimius/bazel-toolchain/tree/dp-srb-now

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -147,7 +147,7 @@ package(default_visibility = ["//visibility:public"])
     new_git_repository(
         name = "rubyfmt",
         remote = "https://github.com/penelopezone/rubyfmt",
-        commit = "4869fd64be6e7dbeb0fb68684afb856eae450cf6",
+        commit = "f64f80ce80a5027106f689e76e6400abaa87d90f",
         init_submodules = True,
         build_file = "//third_party/rubyfmt:rubyfmt.BUILD",
     )

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -145,13 +145,6 @@ package(default_visibility = ["//visibility:public"])
         strip_prefix = "bazel-compilation-database-0ae6349c52700f060c9a87c5ed2b04b75f94a26f",
     )
 
-    http_archive(
-        name = "rubyfmt",
-        urls = ["https://github.com/penelopezone/rubyfmt/releases/download/v0.4.0/rubyfmt-v0.4.0-sources.tar.gz"],
-        build_file = "@com_stripe_ruby_typer//third_party/rubyfmt:rubyfmt.BUILD",
-        strip_prefix = "tmp/rubyfmt_source",
-    )
-
     # NOTE: using this branch:
     # https://github.com/DarkDimius/bazel-toolchain/tree/dp-srb-now
     http_archive(
@@ -295,20 +288,26 @@ package(default_visibility = ["//visibility:public"])
     )
 
     http_archive(
+        name = "rubyfmt",
+        build_file = "@com_stripe_ruby_typer//third_party/rubyfmt:rubyfmt.BUILD",
+        strip_prefix = "tmp/rubyfmt_source",
+        urls = _github_public_urls("penelopezone/rubyfmt/releases/download/v0.4.0/rubyfmt-v0.4.0-sources.tar.gz"),
+    )
+
+    http_archive(
         name = "io_bazel_rules_rust",
         sha256 = "5ed804fcd10a506a5b8e9e59bc6b3b7f43bc30c87ce4670e6f78df43604894fd",
         strip_prefix = "rules_rust-fdf9655ba95616e0314b4e0ebab40bb0c5fe005c",
-        urls = [
-            # Master branch as of 2019-10-07
-            "https://github.com/bazelbuild/rules_rust/archive/fdf9655ba95616e0314b4e0ebab40bb0c5fe005c.tar.gz",
-        ],
+
+        # Master branch as of 2019-10-07
+        urls = _github_public_urls("rules_rust/archive/fdf9655ba95616e0314b4e0ebab40bb0c5fe005c.tar.gz"),
     )
 
     http_archive(
         name = "bazel_skylib",
         sha256 = "9a737999532daca978a158f94e77e9af6a6a169709c0cee274f0a4c3359519bd",
         strip_prefix = "bazel-skylib-1.0.0",
-        url = "https://github.com/bazelbuild/bazel-skylib/archive/1.0.0.tar.gz",
+        urls = _github_public_urls("bazelbuild/bazel-skylib/archive/1.0.0.tar.gz"),
     )
 
     raze_fetch_remote_crates()

--- a/third_party/ruby/build-ruby.bzl
+++ b/third_party/ruby/build-ruby.bzl
@@ -473,7 +473,6 @@ def _rubyfmt_static_deps_impl(ctx):
     build = []
 
     for file in libs:
-        print(file)
         library_to_link = cc_common.create_library_to_link(
             cc_toolchain = cc_toolchain,
             actions = ctx.actions,

--- a/third_party/ruby/build-ruby.bzl
+++ b/third_party/ruby/build-ruby.bzl
@@ -100,11 +100,11 @@ ruby_version=$(./miniruby -r ./rbconfig.rb -e 'puts "#{{RbConfig::CONFIG["MAJOR"
 static_libs="$base/{static_libs}"
 mkdir -p "$static_libs"
 
-cp libruby*-static.a "$static_libs"
+cp libruby*-static.a "$static_libs/libruby-static.a"
 
 # from https://github.com/penelopezone/rubyfmt/blob/3051835cc28db04e9d9caf0c8430407ca0347e83/librubyfmt/build.rs#L34
-ar crs "libripper.$ruby_version-static.a" ext/ripper/ripper.o
-cp "libripper.$ruby_version-static.a" "$static_libs"
+ar crs "libripper-static.a" ext/ripper/ripper.o
+cp "libripper-static.a" "$static_libs"
 
 internal_incdir="$base/{internal_incdir}"
 
@@ -190,8 +190,10 @@ def _build_ruby_impl(ctx):
 
     internal_incdir = ctx.actions.declare_directory("toolchain/internal_include")
     static_libs = ctx.actions.declare_file("toolchain/static_libs")
+    static_lib_ruby = ctx.actions.declare_file("toolchain/static_libs/libruby-static.a")
+    static_lib_ripper = ctx.actions.declare_file("toolchain/static_libs/libripper-static.a")
 
-    outputs = binaries + [libdir, incdir, sharedir, internal_incdir, static_libs]
+    outputs = binaries + [libdir, incdir, sharedir, internal_incdir, static_libs, static_lib_ruby, static_lib_ripper]
 
     # Build
     ctx.actions.run_shell(
@@ -207,6 +209,8 @@ def _build_ruby_impl(ctx):
             src_dir = src_dir,
             internal_incdir = internal_incdir.path,
             static_libs = static_libs.path,
+            static_lib_ruby = static_lib_ruby.path,
+            static_lib_ripper = static_lib_ripper.path,
             hdrs = " ".join(hdrs),
             libs = " ".join(libs),
             bundler = ctx.files.bundler[0].path,
@@ -224,10 +228,13 @@ def _build_ruby_impl(ctx):
             lib = libdir,
             share = sharedir,
             static_libs = static_libs,
+            static_lib_ruby = static_lib_ruby,
+            static_lib_ripper = static_lib_ripper,
         ),
         DefaultInfo(
             files = depset(outputs),
         ),
+        CcInfo(),
     ]
 
 _build_ruby = rule(
@@ -259,6 +266,7 @@ _build_ruby = rule(
     provides = [
         RubyInfo,
         DefaultInfo,
+        CcInfo,
     ],
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
     implementation = _build_ruby_impl,
@@ -451,16 +459,47 @@ _ruby_internal_headers = rule(
 def _rubyfmt_static_deps_impl(ctx):
     ruby_info = ctx.attr.ruby[RubyInfo]
 
-    libs = depset([ruby_info.static_libs])
+    libs = [ruby_info.static_lib_ruby, ruby_info.static_lib_ripper]
+    cc_toolchain = find_cpp_toolchain(ctx)
 
-    return [DefaultInfo(files = libs)]
+    cc_toolchain = ctx.attr._cc_toolchain[cc_common.CcToolchainInfo]
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+
+    build = []
+
+    for file in libs:
+        print(file)
+        library_to_link = cc_common.create_library_to_link(
+            cc_toolchain = cc_toolchain,
+            actions = ctx.actions,
+            feature_configuration = feature_configuration,
+            static_library = file,
+        )
+        build.append(library_to_link)
+
+    build = depset(build)
+    li = cc_common.create_linker_input(
+        owner = ctx.label,
+        libraries = build,
+    )
+    lc = cc_common.create_linking_context(linker_inputs = depset([li]))
+    return [CcInfo(linking_context = lc)]
 
 _rubyfmt_static_deps = rule(
     attrs = {
         "ruby": attr.label(
-            providers = [RubyInfo],
+            providers = [CcInfo],
+        ),
+        "_cc_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
         ),
     },
+    fragments = ["cpp"],
     implementation = _rubyfmt_static_deps_impl,
 )
 

--- a/third_party/rubyfmt/rubyfmt.BUILD
+++ b/third_party/rubyfmt/rubyfmt.BUILD
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_rust//rust:rust.bzl", "rust_library")
+
+rust_library(
+    name = "ripper_deserialize",
+    srcs = ["librubyfmt/ripper_deserialize/src/lib.rs"],
+    crate_type = "proc-macro",
+    edition = "2018",
+    deps = [
+        "@com_stripe_ruby_typer//third_party/cargo:proc_macro2",
+        "@com_stripe_ruby_typer//third_party/cargo:quote",
+        "@com_stripe_ruby_typer//third_party/cargo:syn",
+    ],
+)

--- a/third_party/rubyfmt/rubyfmt.BUILD
+++ b/third_party/rubyfmt/rubyfmt.BUILD
@@ -1,3 +1,5 @@
+package(default_visibility = ["//visibility:public"])
+
 load("@io_bazel_rules_rust//rust:rust.bzl", "rust_library")
 
 rust_library(
@@ -28,11 +30,17 @@ rust_library(
     deps = [
         "@com_stripe_ruby_typer//third_party/cargo:backtrace",
         "@com_stripe_ruby_typer//third_party/cargo:bytecount",
-        "@com_stripe_ruby_typer//third_party/cargo:jemallocator",
         "@com_stripe_ruby_typer//third_party/cargo:libc",
         "@com_stripe_ruby_typer//third_party/cargo:log",
         "@com_stripe_ruby_typer//third_party/cargo:serde",
         "@com_stripe_ruby_typer//third_party/cargo:serde_json",
         "@com_stripe_ruby_typer//third_party/cargo:simplelog",
     ],
+)
+
+cc_library(
+    name = "rubyfmt_macro_wrappers",
+    srcs = ["librubyfmt/src/rubyfmt.c"],
+    linkstatic = True,
+    deps = ["@ruby_2_6//:headers"],
 )

--- a/third_party/rubyfmt/rubyfmt.BUILD
+++ b/third_party/rubyfmt/rubyfmt.BUILD
@@ -11,3 +11,28 @@ rust_library(
         "@com_stripe_ruby_typer//third_party/cargo:syn",
     ],
 )
+
+rust_library(
+    name = "librubyfmt",
+    srcs = glob(["librubyfmt/src/**/*.rs"]),
+    crate_type = "staticlib",
+    data = [
+        "librubyfmt/rubyfmt_lib.rb",
+    ] + glob([
+        "librubyfmt/ruby_checkout/ruby-2.6.6/ext/ripper/lib/**/*.rb",
+    ]),
+    edition = "2018",
+    proc_macro_deps = [
+        ":ripper_deserialize",
+    ],
+    deps = [
+        "@com_stripe_ruby_typer//third_party/cargo:backtrace",
+        "@com_stripe_ruby_typer//third_party/cargo:bytecount",
+        "@com_stripe_ruby_typer//third_party/cargo:jemallocator",
+        "@com_stripe_ruby_typer//third_party/cargo:libc",
+        "@com_stripe_ruby_typer//third_party/cargo:log",
+        "@com_stripe_ruby_typer//third_party/cargo:serde",
+        "@com_stripe_ruby_typer//third_party/cargo:serde_json",
+        "@com_stripe_ruby_typer//third_party/cargo:simplelog",
+    ],
+)

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -53,6 +53,7 @@ compilation_database(
         "//main/pipeline:pipeline-orig",
         "//main/cache:cache-orig",
         "//infer:infer_test",
+        "//experimental/rubyfmt_c_main:main",
         "//emscripten:main",
         "//payload/text:empty",
         "//payload/binary:some",

--- a/tools/scripts/cargo_raze.sh
+++ b/tools/scripts/cargo_raze.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euxo pipefail
+cd "$(git rev-parse --show-toplevel)"
+(
+cd third_party/cargo && cargo raze
+)
+./tools/scripts/format_build_files.sh

--- a/tools/scripts/cargo_raze.sh
+++ b/tools/scripts/cargo_raze.sh
@@ -5,3 +5,7 @@ cd "$(git rev-parse --show-toplevel)"
 cd third_party/cargo && cargo raze
 )
 ./tools/scripts/format_build_files.sh
+(
+cd third_party/cargo && ruby add_crates_shas.rb
+)
+./tools/scripts/format_build_files.sh


### PR DESCRIPTION
adds a bazel build for rubyfmt. There's plenty I'd like some help on here:

1. the skylark changes I made to expose CcInfo seems hacky, I'm not sure if there's a better way to do it.
2. Rubyfmt's source had to be mangled a little to get this working, I'll need to provide some scripts to make it easier to update.
3. I had to remove jemalloc from rubyfmt. This impacts performance a little bit. It'd be nice to work out why the linking symbols were removed from `librubyfmt` during the final compilation.

I am also horrible at bazel, any style review on that would be lovely.

### Motivation
This is so we can integrate rubyfmt in to the sorbet lsp


### Test plan
./bazel run -s //experimental/rubyfmt_example_c_invocation:main
