### PR TITLE
Allow modules and classes to specify required ancestors

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1795,6 +1795,7 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     result->runningUnderAutogen = this->runningUnderAutogen;
     result->censorForSnapshotTests = this->censorForSnapshotTests;
     result->sleepInSlowPath = this->sleepInSlowPath;
+    result->requiresAncestorEnabled = this->requiresAncestorEnabled;
 
     if (keepId) {
         result->globalStateId = this->globalStateId;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -251,6 +251,8 @@ public:
 
     std::vector<std::unique_ptr<pipeline::semantic_extension::SemanticExtension>> semanticExtensions;
 
+    bool requiresAncestorEnabled = false;
+
 private:
     bool shouldReportErrorOn(Loc loc, ErrorClass what) const;
     struct DeepCloneHistoryEntry {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1303,10 +1303,12 @@ std::vector<Symbol::RequiredAncestor> Symbol::requiredAncestorsTransitiveInterna
 
 // All required ancestors by this class or module
 vector<Symbol::RequiredAncestor> Symbol::requiredAncestorsTransitive(const GlobalState &gs) const {
+    ENFORCE(gs.requiresAncestorEnabled);
     return readRequiredAncestorsInternal(gs, Names::requiredAncestorsLin());
 }
 
 void Symbol::computeRequiredAncestorLinearization(GlobalState &gs) {
+    ENFORCE(gs.requiresAncestorEnabled);
     ENFORCE(this->isClassOrModule(), "Symbol is not a class or module: {}", this->show(gs));
     std::vector<ClassOrModuleRef> seen;
     requiredAncestorsTransitiveInternal(gs, seen);

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1310,9 +1310,15 @@ vector<Symbol::RequiredAncestor> requiredAncestorsTransitiveInternal(const Globa
 
 // All required ancestors by this class or module
 vector<Symbol::RequiredAncestor> Symbol::requiredAncestorsTransitive(const GlobalState &gs) const {
+    return readRequiredAncestorsInternal(gs, Names::requiredAncestorsLin());
+}
+
+void Symbol::computeRequiredAncestorLinearization(GlobalState &gs) {
     ENFORCE(this->isClassOrModule(), "Symbol is not a class or module: {}", this->show(gs));
     std::vector<SymbolRef> seen;
-    return requiredAncestorsTransitiveInternal(gs, this->ref(gs), seen);
+    for (auto &req : requiredAncestorsTransitiveInternal(gs, this->ref(gs), seen)) {
+        recordRequiredAncestorInternal(gs, req, Names::requiredAncestorsLin());
+    }
 }
 
 SymbolRef Symbol::dealiasWithDefault(const GlobalState &gs, int depthLimit, SymbolRef def) const {

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -599,6 +599,8 @@ public:
         RequiredAncestor(SymbolRef origin, SymbolRef symbol, Loc loc) : origin(origin), symbol(symbol), loc(loc) {}
     };
 
+    void computeRequiredAncestorLinearization(GlobalState &gs);
+
     // Locally required ancestors by this class or module
     std::vector<RequiredAncestor> requiredAncestors(const GlobalState &gs) const;
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -724,6 +724,8 @@ private:
     // Read required ancestors for this class of module from a magic property
     std::vector<RequiredAncestor> readRequiredAncestorsInternal(const GlobalState &gs, NameRef prop) const;
 
+    std::vector<RequiredAncestor> requiredAncestorsTransitiveInternal(GlobalState &gs, std::vector<SymbolRef> &seen);
+
     SymbolRef findMemberTransitiveInternal(const GlobalState &gs, NameRef name, u4 mask, u4 flags,
                                            int maxDepth = 100) const;
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -716,6 +716,12 @@ private:
     InlinedVector<SymbolRef, 4> typeParams;
     InlinedVector<Loc, 2> locs_;
 
+    // Record a required ancestor for this class of module in a magic property
+    void recordRequiredAncestorInternal(GlobalState &gs, SymbolRef ancestor, Loc loc, NameRef prop);
+
+    // Read required ancestors for this class of module from a magic property
+    std::vector<RequiredAncestor> readRequiredAncestorsInternal(const GlobalState &gs, NameRef prop) const;
+
     SymbolRef findMemberTransitiveInternal(const GlobalState &gs, NameRef name, u4 mask, u4 flags,
                                            int maxDepth = 100) const;
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -592,6 +592,7 @@ public:
 
     // Associate a required ancestor with the loc it's required at
     struct RequiredAncestor {
+        SymbolRef origin; // Only used during transitive lookups
         SymbolRef symbol;
         Loc loc;
 
@@ -600,6 +601,9 @@ public:
 
     // Locally required ancestors by this class or module
     std::vector<RequiredAncestor> requiredAncestors(const GlobalState &gs) const;
+
+    // All required ancestors by this class or module
+    std::vector<RequiredAncestor> requiredAncestorsTransitive(const GlobalState &gs) const;
 
     // if dealiasing fails here, then we return Untyped instead
     SymbolRef dealias(const GlobalState &gs, int depthLimit = 42) const {

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -592,11 +592,11 @@ public:
 
     // Associate a required ancestor with the loc it's required at
     struct RequiredAncestor {
-        SymbolRef origin; // Only used during transitive lookups
-        SymbolRef symbol;
-        Loc loc;
+        SymbolRef origin; // The class or module that required `symbol`
+        SymbolRef symbol; // The symbol required
+        Loc loc;          // The location it was required at
 
-        RequiredAncestor(SymbolRef symbol, Loc loc) : symbol(symbol), loc(loc) {}
+        RequiredAncestor(SymbolRef origin, SymbolRef symbol, Loc loc) : origin(origin), symbol(symbol), loc(loc) {}
     };
 
     // Locally required ancestors by this class or module
@@ -717,7 +717,7 @@ private:
     InlinedVector<Loc, 2> locs_;
 
     // Record a required ancestor for this class of module in a magic property
-    void recordRequiredAncestorInternal(GlobalState &gs, SymbolRef ancestor, Loc loc, NameRef prop);
+    void recordRequiredAncestorInternal(GlobalState &gs, RequiredAncestor &ancestor, NameRef prop);
 
     // Read required ancestors for this class of module from a magic property
     std::vector<RequiredAncestor> readRequiredAncestorsInternal(const GlobalState &gs, NameRef prop) const;

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -587,6 +587,20 @@ public:
     const InlinedVector<Loc, 2> &sealedLocs(const GlobalState &gs) const;
     TypePtr sealedSubclassesToUnion(const GlobalState &ctx) const;
 
+    // Record a required ancestor for this class of module
+    void recordRequiredAncestor(GlobalState &gs, SymbolRef ancestor, Loc loc);
+
+    // Associate a required ancestor with the loc it's required at
+    struct RequiredAncestor {
+        SymbolRef symbol;
+        Loc loc;
+
+        RequiredAncestor(SymbolRef symbol, Loc loc) : symbol(symbol), loc(loc) {}
+    };
+
+    // Locally required ancestors by this class or module
+    std::vector<RequiredAncestor> requiredAncestors(const GlobalState &gs) const;
+
     // if dealiasing fails here, then we return Untyped instead
     SymbolRef dealias(const GlobalState &gs, int depthLimit = 42) const {
         return dealiasWithDefault(gs, depthLimit, Symbols::untyped());

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -588,15 +588,16 @@ public:
     TypePtr sealedSubclassesToUnion(const GlobalState &ctx) const;
 
     // Record a required ancestor for this class of module
-    void recordRequiredAncestor(GlobalState &gs, SymbolRef ancestor, Loc loc);
+    void recordRequiredAncestor(GlobalState &gs, ClassOrModuleRef ancestor, Loc loc);
 
     // Associate a required ancestor with the loc it's required at
     struct RequiredAncestor {
-        SymbolRef origin; // The class or module that required `symbol`
-        SymbolRef symbol; // The symbol required
-        Loc loc;          // The location it was required at
+        ClassOrModuleRef origin; // The class or module that required `symbol`
+        ClassOrModuleRef symbol; // The symbol required
+        Loc loc;                 // The location it was required at
 
-        RequiredAncestor(SymbolRef origin, SymbolRef symbol, Loc loc) : origin(origin), symbol(symbol), loc(loc) {}
+        RequiredAncestor(ClassOrModuleRef origin, ClassOrModuleRef symbol, Loc loc)
+            : origin(origin), symbol(symbol), loc(loc) {}
     };
 
     void computeRequiredAncestorLinearization(GlobalState &gs);
@@ -724,7 +725,8 @@ private:
     // Read required ancestors for this class of module from a magic property
     std::vector<RequiredAncestor> readRequiredAncestorsInternal(const GlobalState &gs, NameRef prop) const;
 
-    std::vector<RequiredAncestor> requiredAncestorsTransitiveInternal(GlobalState &gs, std::vector<SymbolRef> &seen);
+    std::vector<RequiredAncestor> requiredAncestorsTransitiveInternal(GlobalState &gs,
+                                                                      std::vector<ClassOrModuleRef> &seen);
 
     SymbolRef findMemberTransitiveInternal(const GlobalState &gs, NameRef name, u4 mask, u4 flags,
                                            int maxDepth = 100) const;

--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -67,6 +67,7 @@ constexpr ErrorClass AttachedClassAsParam{5058, StrictLevel::False};
 constexpr ErrorClass LazyResolve{5059, StrictLevel::False};
 constexpr ErrorClass GenericTypeParamBoundMismatch{5060, StrictLevel::False};
 constexpr ErrorClass PrivateConstantReferenced{5061, StrictLevel::True};
+constexpr ErrorClass InvalidRequiredAncestor{5062, StrictLevel::True};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -69,6 +69,7 @@ constexpr ErrorClass GenericTypeParamBoundMismatch{5060, StrictLevel::False};
 constexpr ErrorClass PrivateConstantReferenced{5061, StrictLevel::True};
 constexpr ErrorClass InvalidRequiredAncestor{5062, StrictLevel::True};
 constexpr ErrorClass UselessRequiredAncestor{5063, StrictLevel::True};
+constexpr ErrorClass UnsatisfiedRequiredAncestor{5064, StrictLevel::True};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -70,6 +70,7 @@ constexpr ErrorClass PrivateConstantReferenced{5061, StrictLevel::True};
 constexpr ErrorClass InvalidRequiredAncestor{5062, StrictLevel::True};
 constexpr ErrorClass UselessRequiredAncestor{5063, StrictLevel::True};
 constexpr ErrorClass UnsatisfiedRequiredAncestor{5064, StrictLevel::True};
+constexpr ErrorClass UnsatisfiableRequiredAncestor{5065, StrictLevel::True};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -68,6 +68,7 @@ constexpr ErrorClass LazyResolve{5059, StrictLevel::False};
 constexpr ErrorClass GenericTypeParamBoundMismatch{5060, StrictLevel::False};
 constexpr ErrorClass PrivateConstantReferenced{5061, StrictLevel::True};
 constexpr ErrorClass InvalidRequiredAncestor{5062, StrictLevel::True};
+constexpr ErrorClass UselessRequiredAncestor{5063, StrictLevel::True};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -71,6 +71,7 @@ constexpr ErrorClass InvalidRequiredAncestor{5062, StrictLevel::True};
 constexpr ErrorClass UselessRequiredAncestor{5063, StrictLevel::True};
 constexpr ErrorClass UnsatisfiedRequiredAncestor{5064, StrictLevel::True};
 constexpr ErrorClass UnsatisfiableRequiredAncestor{5065, StrictLevel::True};
+constexpr ErrorClass ExperimentalRequiredAncestor{5066, StrictLevel::False};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -281,6 +281,9 @@ NameDef names[] = {
     {"singleton", "<singleton class>"},
     {"attached", "<attached class>"},
 
+    // Requires ancestor
+    {"requiresAncestor", "requires_ancestor"},
+
     // This behaves like the above two names, in the sense that we use a member
     // on a class to lookup an associated symbol with some extra info.
     {"sealedSubclasses", "sealed_subclasses"},

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -283,6 +283,7 @@ NameDef names[] = {
 
     // Requires ancestor
     {"requiredAncestors", "<required-ancestor>"},
+    {"requiredAncestorsLin", "<required-ancestor-lin>"},
     {"requiresAncestor", "requires_ancestor"},
 
     // This behaves like the above two names, in the sense that we use a member

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -282,6 +282,7 @@ NameDef names[] = {
     {"attached", "<attached class>"},
 
     // Requires ancestor
+    {"requiredAncestors", "<required-ancestor>"},
     {"requiresAncestor", "requires_ancestor"},
 
     // This behaves like the above two names, in the sense that we use a member

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -517,7 +517,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
 
     SymbolRef mayBeOverloaded = symbol.data(gs)->findMemberTransitive(gs, args.name);
 
-    if (!mayBeOverloaded.exists()) {
+    if (!mayBeOverloaded.exists() && gs.requiresAncestorEnabled) {
         // Before raising any error, we look if the method exists in all required ancestors by this symbol
         auto ancestors = symbol.data(gs)->requiredAncestorsTransitive(gs);
         for (auto ancst : ancestors) {
@@ -570,7 +570,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 // suggest adding `extend T::Helpers`.
                 if (args.name == core::Names::declareInterface() || args.name == core::Names::declareAbstract() ||
                     args.name == core::Names::declareFinal() || args.name == core::Names::declareSealed() ||
-                    args.name == core::Names::mixesInClassMethods() || args.name == core::Names::requiresAncestor()) {
+                    args.name == core::Names::mixesInClassMethods() ||
+                    (args.name == core::Names::requiresAncestor() && gs.requiresAncestorEnabled)) {
                     auto attachedClass = symbol.data(gs)->attachedClass(gs);
                     if (auto suggestion =
                             maybeSuggestExtendTHelpers(gs, attachedClass, core::Loc(args.locs.file, args.locs.call))) {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -559,7 +559,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 // suggest adding `extend T::Helpers`.
                 if (args.name == core::Names::declareInterface() || args.name == core::Names::declareAbstract() ||
                     args.name == core::Names::declareFinal() || args.name == core::Names::declareSealed() ||
-                    args.name == core::Names::mixesInClassMethods()) {
+                    args.name == core::Names::mixesInClassMethods() || args.name == core::Names::requiresAncestor()) {
                     auto attachedClass = symbol.data(gs)->attachedClass(gs);
                     if (auto suggestion =
                             maybeSuggestExtendTHelpers(gs, attachedClass, core::Loc(args.locs.file, args.locs.call))) {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -518,6 +518,17 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
     SymbolRef mayBeOverloaded = symbol.data(gs)->findMemberTransitive(gs, args.name);
 
     if (!mayBeOverloaded.exists()) {
+        // Before raising any error, we look if the method exists in all required ancestors by this symbol
+        auto ancestors = symbol.data(gs)->requiredAncestorsTransitive(gs);
+        for (auto ancst : ancestors) {
+            mayBeOverloaded = ancst.symbol.data(gs)->findMemberTransitive(gs, args.name);
+            if (mayBeOverloaded.exists()) {
+                break;
+            }
+        }
+    }
+
+    if (!mayBeOverloaded.exists()) {
         if (args.name == Names::initialize()) {
             // Special-case initialize(). We should define this on
             // `BasicObject`, but our method-resolution order is wrong, and

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -543,7 +543,8 @@ void validateUnsatisfiableClassAncestors(core::Context ctx, const core::SymbolRe
 
     if (data->isClassOrModuleAbstract()) {
         for (auto ancst : requiredClasses) {
-            if (!sym.data(ctx)->derivesFrom(ctx, ancst.symbol) && !ancst.symbol.data(ctx)->derivesFrom(ctx, sym)) {
+            if (!sym.data(ctx)->derivesFrom(ctx, ancst.symbol) &&
+                !ancst.symbol.data(ctx)->derivesFrom(ctx, sym.asClassOrModuleRef())) {
                 if (auto e = ctx.state.beginError(data->loc(), core::errors::Resolver::UnsatisfiableRequiredAncestor)) {
                     e.setHeader("`{}` requires unrelated class `{}` making it impossible to inherit", data->show(ctx),
                                 ancst.symbol.data(ctx)->show(ctx));

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -691,12 +691,18 @@ public:
             // Only validateAbstract for this class if we haven't already (we already have if this
             // is a `class << self` ClassDef)
             validateAbstract(ctx, sym);
-            validateRequiredAncestors(ctx, sym);
+
+            if (ctx.state.requiresAncestorEnabled) {
+                validateRequiredAncestors(ctx, sym);
+            }
         }
         validateAbstract(ctx, singleton);
         validateFinal(ctx, sym, classDef);
         validateSealed(ctx, sym, classDef);
-        validateRequiredAncestors(ctx, singleton);
+
+        if (ctx.state.requiresAncestorEnabled) {
+            validateRequiredAncestors(ctx, singleton);
+        }
         return tree;
     }
 

--- a/gems/sorbet-runtime/lib/types/helpers.rb
+++ b/gems/sorbet-runtime/lib/types/helpers.rb
@@ -36,4 +36,21 @@ module T::Helpers
   def mixes_in_class_methods(mod, *mods)
     Private::Mixins.declare_mixes_in_class_methods(self, [mod].concat(mods))
   end
+
+  # Specify an inclusion or inheritance requirement for `self`.
+  #
+  # Example:
+  #
+  #   module MyHelper
+  #     extend T::Helpers
+  #
+  #     requires_ancestor Kernel
+  #   end
+  #
+  #   class MyClass < BasicObject # error: `MyClass` must include `Kernel` (required by `MyHelper`)
+  #     include MyHelper
+  #   end
+  #
+  # TODO: implement the checks in sorbet-runtime.
+  def requires_ancestor(mod, *mods); end
 end

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -42,7 +42,8 @@ unique_ptr<core::FileHash> computeFileHashForAST(unique_ptr<core::GlobalState> &
 
 // Note: lgs is an outparameter.
 core::FileRef makeEmptyGlobalStateForFile(spdlog::logger &logger, shared_ptr<core::File> forWhat,
-                                          unique_ptr<core::GlobalState> &lgs, const realmain::options::Options &hashingOpts) {
+                                          unique_ptr<core::GlobalState> &lgs,
+                                          const realmain::options::Options &hashingOpts) {
     lgs = make_unique<core::GlobalState>(
         (make_shared<core::ErrorQueue>(logger, logger, make_shared<core::NullFlusher>())));
     lgs->initEmpty();
@@ -56,7 +57,8 @@ core::FileRef makeEmptyGlobalStateForFile(spdlog::logger &logger, shared_ptr<cor
     }
 }
 
-unique_ptr<core::FileHash> computeFileHashForFile(shared_ptr<core::File> forWhat, spdlog::logger &logger, const realmain::options::Options &hashingOpts) {
+unique_ptr<core::FileHash> computeFileHashForFile(shared_ptr<core::File> forWhat, spdlog::logger &logger,
+                                                  const realmain::options::Options &hashingOpts) {
     Timer timeit(logger, "computeFileHash");
     unique_ptr<core::GlobalState> lgs;
     core::FileRef fref = makeEmptyGlobalStateForFile(logger, move(forWhat), /* out param */ lgs, hashingOpts);

--- a/hashing/hashing.h
+++ b/hashing/hashing.h
@@ -33,7 +33,7 @@ public:
     // Computes file hashes for the given files, and stores them in the files. If supplied, attempts to retrieve hashes
     // from the key-value store. Returns 'true' if it had to compute any file hashes.
     static void computeFileHashes(const std::vector<std::shared_ptr<core::File>> &files, spdlog::logger &logger,
-                                  WorkerPool &workers);
+                                  WorkerPool &workers, const realmain::options::Options &opts);
 
     /**
      * Parses and indexes the provided files using `gs` _and_ computes their hashes.

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -75,7 +75,7 @@ void LSPIndexer::computeFileHashes(const vector<shared_ptr<core::File>> &files, 
         return;
     }
 
-    hashing::Hashing::computeFileHashes(files, *config->logger, workers);
+    hashing::Hashing::computeFileHashes(files, *config->logger, workers, config->opts);
 }
 
 void LSPIndexer::computeFileHashes(const vector<shared_ptr<core::File>> &files) const {

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -23,7 +23,7 @@ void setRequiredLSPOptions(core::GlobalState &gs, options::Options &options) {
         gs.suppressErrorClass(sorbet::core::errors::Namer::MultipleBehaviorDefs.code);
     }
 
-    gs.requiresAncestorEnabled = true;
+    gs.requiresAncestorEnabled = options.requiresAncestorEnabled;
 
     // Ensure LSP is enabled.
     options.runLSP = true;

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -23,6 +23,8 @@ void setRequiredLSPOptions(core::GlobalState &gs, options::Options &options) {
         gs.suppressErrorClass(sorbet::core::errors::Namer::MultipleBehaviorDefs.code);
     }
 
+    gs.requiresAncestorEnabled = true;
+
     // Ensure LSP is enabled.
     options.runLSP = true;
 }

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -309,6 +309,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                     "Enable experimental LSP feature: Document Highlight");
     options.add_options("advanced")("enable-experimental-lsp-signature-help",
                                     "Enable experimental LSP feature: Signature Help");
+    options.add_options("advanced")("enable-experimental-requires-ancestor",
+                                    "Enable experimental `requires_ancestor` annotation");
 
     options.add_options("advanced")(
         "enable-all-experimental-lsp-features",
@@ -667,6 +669,8 @@ void readOptions(Options &opts,
         fast_sort(opts.inputFileNames);
         opts.inputFileNames.erase(unique(opts.inputFileNames.begin(), opts.inputFileNames.end()),
                                   opts.inputFileNames.end());
+
+        opts.requiresAncestorEnabled = raw["enable-experimental-requires-ancestor"].as<bool>();
 
         bool enableAllLSPFeatures = raw["enable-all-experimental-lsp-features"].as<bool>();
         opts.lspAllBetaFeaturesEnabled = enableAllLSPFeatures || raw["enable-all-beta-lsp-features"].as<bool>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -211,6 +211,9 @@ struct Options {
     bool lspDocumentFormatRubyfmtEnabled = false;
     bool lspSignatureHelpEnabled = false;
 
+    // Experimental feature `requires_ancestor`
+    bool requiresAncestorEnabled = false;
+
     std::string inlineInput; // passed via -e
     std::string debugLogFile;
     std::string webTraceFile;

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -514,7 +514,7 @@ int realmain(int argc, char *argv[]) {
 
         if (!opts.storeState.empty()) {
             // Compute file hashes for payload files (which aren't part of inputFiles) for LSP
-            hashing::Hashing::computeFileHashes(gs->getFiles(), *logger, *workers);
+            hashing::Hashing::computeFileHashes(gs->getFiles(), *logger, *workers, opts);
         }
 
         { inputFiles = pipeline::reserveFiles(gs, opts.inputFileNames); }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -442,6 +442,8 @@ int realmain(int argc, char *argv[]) {
     gs->semanticExtensions = move(extensions);
     vector<ast::ParsedFile> indexed;
 
+    gs->requiresAncestorEnabled = opts.requiresAncestorEnabled;
+
     logger->trace("building initial global state");
     unique_ptr<const OwnedKeyValueStore> kvstore = cache::maybeCreateKeyValueStore(opts);
     payload::createInitialGlobalState(gs, opts, kvstore);

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -87,7 +87,24 @@ module T::Helpers
   def final!; end
   sig {void}
   def sealed!; end
+
+  # We do not use signatures on the following methods as to not duplicate errors
+  # between the `namer` phase and typechecking for calls.
+  #
+  # With the following example:
+  #
+  # ```
+  # class A
+  #   requires_ancestor "A"
+  # end
+  # ```
+  #
+  # Using a signature would mean we would generate two errors:
+  # 1. error: `requires_ancestor` must only contain constant literals (from namer)
+  # 2. error: Expected `Module` but found `NilClass` for argument `mod` (from calls)
+
   def mixes_in_class_methods(mod, *mods); end
+  def requires_ancestor(mod, *mods); end
 end
 
 module T::Array

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -409,6 +409,9 @@ void Resolver::finalizeSymbols(core::GlobalState &gs) {
     for (int i = 1; i < gs.classAndModulesUsed(); ++i) {
         auto sym = core::ClassOrModuleRef(gs, i);
         resolveTypeMembers(gs, sym, typeAliases, resolved);
+
+        // Precompute the list of all required ancestors for this symbol
+        sym.data(gs)->computeRequiredAncestorLinearization(gs);
     }
 }
 

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -410,8 +410,10 @@ void Resolver::finalizeSymbols(core::GlobalState &gs) {
         auto sym = core::ClassOrModuleRef(gs, i);
         resolveTypeMembers(gs, sym, typeAliases, resolved);
 
-        // Precompute the list of all required ancestors for this symbol
-        sym.data(gs)->computeRequiredAncestorLinearization(gs);
+        if (gs.requiresAncestorEnabled) {
+            // Precompute the list of all required ancestors for this symbol
+            sym.data(gs)->computeRequiredAncestorLinearization(gs);
+        }
     }
 }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -683,7 +683,7 @@ private:
                 return;
             }
 
-            owner.data(gs)->recordRequiredAncestor(gs, id->symbol, argLoc);
+            owner.data(gs)->recordRequiredAncestor(gs, id->symbol.asClassOrModuleRef(), argLoc);
         }
     }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -851,12 +851,7 @@ public:
                 auto item = ClassMethodsResolutionItem{ctx.file, ctx.owner, &send};
                 this->todoClassMethods_.emplace_back(move(item));
             } else if (send.fun == core::Names::requiresAncestor()) {
-                if (!ctx.state.requiresAncestorEnabled) {
-                    if (auto e = ctx.beginError(send.loc, core::errors::Resolver::ExperimentalRequiredAncestor)) {
-                        e.setHeader("`{}` is an experimental feature. Use `{}` to enable it", "requires_ancestor",
-                                    "--enable-experimental-requires-ancestor");
-                    }
-                } else {
+                if (ctx.state.requiresAncestorEnabled) {
                     auto item = RequireAncestorResolutionItem{ctx.file, ctx.owner, &send};
                     this->todoRequiredAncestors_.emplace_back(move(item));
                 }
@@ -1019,6 +1014,8 @@ public:
         fast_sort(todoRequiredAncestors, [](const auto &lhs, const auto &rhs) -> bool {
             return locCompare(core::Loc(lhs.file, lhs.send->loc), core::Loc(rhs.file, rhs.send->loc));
         });
+
+        ENFORCE(todoRequiredAncestors.empty() || gs.requiresAncestorEnabled);
         fast_sort(trees, [](const auto &lhs, const auto &rhs) -> bool {
             return locCompare(core::Loc(lhs.file, lhs.tree.loc()), core::Loc(rhs.file, rhs.tree.loc()));
         });

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -652,6 +652,7 @@ private:
         auto owner = todo.owner;
         auto send = todo.send;
         auto loc = core::Loc(todo.file, send->loc);
+
         if (!owner.data(gs)->isClassOrModuleModule() && !owner.data(gs)->isClassOrModuleAbstract()) {
             if (auto e = gs.beginError(loc, core::errors::Resolver::InvalidRequiredAncestor)) {
                 e.setHeader("`{}` can only be declared inside a module or an abstract class", send->fun.show(gs));
@@ -681,6 +682,8 @@ private:
                 }
                 return;
             }
+
+            owner.data(gs)->recordRequiredAncestor(gs, id->symbol, argLoc);
         }
     }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -170,11 +170,24 @@ private:
         const ClassMethodsResolutionItem &operator=(const ClassMethodsResolutionItem &) = delete;
     };
 
+    struct RequireAncestorResolutionItem {
+        core::FileRef file;
+        core::SymbolRef owner;
+        ast::Send *send;
+
+        RequireAncestorResolutionItem(RequireAncestorResolutionItem &&) noexcept = default;
+        RequireAncestorResolutionItem &operator=(RequireAncestorResolutionItem &&rhs) noexcept = default;
+
+        RequireAncestorResolutionItem(const RequireAncestorResolutionItem &) = delete;
+        const RequireAncestorResolutionItem &operator=(const RequireAncestorResolutionItem &) = delete;
+    };
+
     vector<ResolutionItem> todo_;
     vector<AncestorResolutionItem> todoAncestors_;
     vector<ClassAliasResolutionItem> todoClassAliases_;
     vector<TypeAliasResolutionItem> todoTypeAliases_;
     vector<ClassMethodsResolutionItem> todoClassMethods_;
+    vector<RequireAncestorResolutionItem> todoRequiredAncestors_;
 
     static core::SymbolRef resolveLhs(core::Context ctx, shared_ptr<Nesting> nesting, core::NameRef name) {
         Nesting *scope = nesting.get();
@@ -635,6 +648,9 @@ private:
         }
     }
 
+    static void resolveRequiredAncestorsJob(core::GlobalState &gs, const RequireAncestorResolutionItem &todo) {
+    }
+
     static void tryRegisterSealedSubclass(core::MutableContext ctx, AncestorResolutionItem &job) {
         ENFORCE(job.ancestor->symbol.exists(), "Ancestor must exist, or we can't check whether it's sealed.");
         auto ancestorSym = job.ancestor->symbol.data(ctx)->dealias(ctx);
@@ -794,9 +810,14 @@ public:
 
     ast::ExpressionPtr postTransformSend(core::Context ctx, ast::ExpressionPtr tree) {
         auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
-        if (send.recv.isSelfReference() && send.fun == core::Names::mixesInClassMethods()) {
-            auto item = ClassMethodsResolutionItem{ctx.file, ctx.owner, &send};
-            this->todoClassMethods_.emplace_back(move(item));
+        if (send.recv.isSelfReference()) {
+            if (send.fun == core::Names::mixesInClassMethods()) {
+                auto item = ClassMethodsResolutionItem{ctx.file, ctx.owner, &send};
+                this->todoClassMethods_.emplace_back(move(item));
+            } else if (send.fun == core::Names::requiresAncestor()) {
+                auto item = RequireAncestorResolutionItem{ctx.file, ctx.owner, &send};
+                this->todoRequiredAncestors_.emplace_back(move(item));
+            }
         } else {
             auto recvAsConstantLit = ast::cast_tree<ast::ConstantLit>(send.recv);
             if (recvAsConstantLit != nullptr && recvAsConstantLit->symbol == core::Symbols::Magic() &&
@@ -847,6 +868,7 @@ public:
         vector<ClassAliasResolutionItem> todoClassAliases_;
         vector<TypeAliasResolutionItem> todoTypeAliases_;
         vector<ClassMethodsResolutionItem> todoClassMethods_;
+        vector<RequireAncestorResolutionItem> todoRequiredAncestors_;
         vector<ast::ParsedFile> trees;
     };
 
@@ -894,6 +916,7 @@ public:
                                          move(constants.todoClassAliases_),
                                          move(constants.todoTypeAliases_),
                                          move(constants.todoClassMethods_),
+                                         move(constants.todoRequiredAncestors_),
                                          move(partiallyResolvedTrees)};
                 auto computedTreesCount = result.trees.size();
                 resultq->push(move(result), computedTreesCount);
@@ -905,6 +928,7 @@ public:
         vector<ClassAliasResolutionItem> todoClassAliases;
         vector<TypeAliasResolutionItem> todoTypeAliases;
         vector<ClassMethodsResolutionItem> todoClassMethods;
+        vector<RequireAncestorResolutionItem> todoRequiredAncestors;
 
         {
             ResolveWalkResult threadResult;
@@ -925,6 +949,9 @@ public:
                     todoClassMethods.insert(todoClassMethods.end(),
                                             make_move_iterator(threadResult.todoClassMethods_.begin()),
                                             make_move_iterator(threadResult.todoClassMethods_.end()));
+                    todoRequiredAncestors.insert(todoRequiredAncestors.end(),
+                                                 make_move_iterator(threadResult.todoRequiredAncestors_.begin()),
+                                                 make_move_iterator(threadResult.todoRequiredAncestors_.end()));
                     trees.insert(trees.end(), make_move_iterator(threadResult.trees.begin()),
                                  make_move_iterator(threadResult.trees.end()));
                 }
@@ -944,6 +971,9 @@ public:
             return locCompare(core::Loc(lhs.file, (*lhs.rhs).loc()), core::Loc(rhs.file, (*rhs.rhs).loc()));
         });
         fast_sort(todoClassMethods, [](const auto &lhs, const auto &rhs) -> bool {
+            return locCompare(core::Loc(lhs.file, lhs.send->loc), core::Loc(rhs.file, rhs.send->loc));
+        });
+        fast_sort(todoRequiredAncestors, [](const auto &lhs, const auto &rhs) -> bool {
             return locCompare(core::Loc(lhs.file, lhs.send->loc), core::Loc(rhs.file, rhs.send->loc));
         });
         fast_sort(trees, [](const auto &lhs, const auto &rhs) -> bool {
@@ -1025,6 +1055,14 @@ public:
                 resolveClassMethodsJob(gs, todo);
             }
             todoClassMethods.clear();
+        }
+
+        {
+            Timer timeit(gs.tracer(), "resolver.requires_ancestor");
+            for (auto &todo : todoRequiredAncestors) {
+                resolveRequiredAncestorsJob(gs, todo);
+            }
+            todoRequiredAncestors.clear();
         }
 
         // We can no longer resolve new constants. All the code below reports errors

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -851,8 +851,15 @@ public:
                 auto item = ClassMethodsResolutionItem{ctx.file, ctx.owner, &send};
                 this->todoClassMethods_.emplace_back(move(item));
             } else if (send.fun == core::Names::requiresAncestor()) {
-                auto item = RequireAncestorResolutionItem{ctx.file, ctx.owner, &send};
-                this->todoRequiredAncestors_.emplace_back(move(item));
+                if (!ctx.state.requiresAncestorEnabled) {
+                    if (auto e = ctx.beginError(send.loc, core::errors::Resolver::ExperimentalRequiredAncestor)) {
+                        e.setHeader("`{}` is an experimental feature. Use `{}` to enable it", "requires_ancestor",
+                                    "--enable-experimental-requires-ancestor");
+                    }
+                } else {
+                    auto item = RequireAncestorResolutionItem{ctx.file, ctx.owner, &send};
+                    this->todoRequiredAncestors_.emplace_back(move(item));
+                }
             }
         } else {
             auto recvAsConstantLit = ast::cast_tree<ast::ConstantLit>(send.recv);

--- a/test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ancestor.out
+++ b/test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ancestor.out
@@ -1,0 +1,12 @@
+test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ancestor.rb:6: `requires_ancestor` is an experimental feature. Use `--enable-experimental-requires-ancestor` to enable it https://srb.help/5066
+     6 |  requires_ancestor Kernel
+          ^^^^^^^^^^^^^^^^^^^^^^^^
+Errors: 1
+--------------------------------------------------------------------------
+test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ancestor.rb:9: `Bar` must include `Kernel` (required by `Foo`) https://srb.help/5064
+     9 |class Bar < BasicObject
+        ^^^^^^^^^^^^^^^^^^^^^^^
+    test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ancestor.rb:6: required by `Foo` here
+     6 |  requires_ancestor Kernel
+                            ^^^^^^
+Errors: 1

--- a/test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ancestor.out
+++ b/test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ancestor.out
@@ -1,7 +1,4 @@
-test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ancestor.rb:6: `requires_ancestor` is an experimental feature. Use `--enable-experimental-requires-ancestor` to enable it https://srb.help/5066
-     6 |  requires_ancestor Kernel
-          ^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 1
+No errors! Great job.
 --------------------------------------------------------------------------
 test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ancestor.rb:9: `Bar` must include `Kernel` (required by `Foo`) https://srb.help/5064
      9 |class Bar < BasicObject

--- a/test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ancestor.rb
+++ b/test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ancestor.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+module Foo
+  extend T::Helpers
+
+  requires_ancestor Kernel
+end
+
+class Bar < BasicObject
+  include Foo
+end

--- a/test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ancestor.sh
+++ b/test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ancestor.sh
@@ -1,0 +1,6 @@
+main/sorbet --silence-dev-message test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ancestor.rb 2>&1
+
+echo --------------------------------------------------------------------------
+
+main/sorbet --silence-dev-message --enable-experimental-requires-ancestor \
+  test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ancestor.rb 2>&1

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -104,6 +104,9 @@ Usage:
       --enable-experimental-lsp-signature-help
                                 Enable experimental LSP feature: Signature
                                 Help
+      --enable-experimental-requires-ancestor
+                                Enable experimental `requires_ancestor`
+                                annotation
       --enable-all-experimental-lsp-features
                                 Enable every experimental LSP feature.
                                 (WARNING: can be crashy; for developer use only. End

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -38,6 +38,7 @@ const UnorderedMap<
         {"disable-fast-path", BooleanPropertyAssertion::make},
         {"disable-stress-incremental", BooleanPropertyAssertion::make},
         {"enable-packager", BooleanPropertyAssertion::make},
+        {"enable-experimental-requires-ancestor", BooleanPropertyAssertion::make},
         {"exhaustive-apply-code-action", BooleanPropertyAssertion::make},
         {"assert-fast-path", FastPathAssertion::make},
         {"assert-slow-path", BooleanPropertyAssertion::make},

--- a/test/lsp/lsp_test_runner.sh
+++ b/test/lsp/lsp_test_runner.sh
@@ -32,7 +32,10 @@ cleanup() {
 }
 trap cleanup exit
 
-main/sorbet --silence-dev-message --lsp --disable-watchman --enable-all-experimental-lsp-features --dir "$(dirname "$recfile")" < "$in_pipe" > "$out_pipe" &
+main/sorbet --silence-dev-message \
+    --enable-experimental-requires-ancestor \
+    --lsp --disable-watchman --enable-all-experimental-lsp-features \
+    --dir "$(dirname "$recfile")" < "$in_pipe" > "$out_pipe" &
 
 # This should be
 # exec {IN_FD}>"$in_pipe"

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -319,6 +319,8 @@ TEST_CASE("LSPTest") {
     {
         shared_ptr<realmain::options::Options> opts = make_shared<realmain::options::Options>();
         opts->noStdlib = BooleanPropertyAssertion::getValue("no-stdlib", assertions).value_or(false);
+        opts->requiresAncestorEnabled =
+            BooleanPropertyAssertion::getValue("enable-experimental-requires-ancestor", assertions).value_or(false);
         opts->stripePackages = BooleanPropertyAssertion::getValue("enable-packager", assertions).value_or(false);
         lspWrapper = SingleThreadedLSPWrapper::create("", move(opts));
         lspWrapper->enableAllExperimentalFeatures();

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -195,7 +195,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     auto assertions = RangeAssertion::parseAssertions(test.sourceFileContents);
 
-    gs->requiresAncestorEnabled = BooleanPropertyAssertion::getValue("enable-experimental-requires-ancestor", assertions).value_or(false);
+    gs->requiresAncestorEnabled =
+        BooleanPropertyAssertion::getValue("enable-experimental-requires-ancestor", assertions).value_or(false);
 
     if (BooleanPropertyAssertion::getValue("no-stdlib", assertions).value_or(false)) {
         gs->initEmpty();

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -190,11 +190,13 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         gs->semanticExtensions.emplace_back(provider->defaultInstance());
     }
 
-    gs->requiresAncestorEnabled = true;
     gs->censorForSnapshotTests = true;
     auto workers = WorkerPool::create(0, gs->tracer());
 
     auto assertions = RangeAssertion::parseAssertions(test.sourceFileContents);
+
+    gs->requiresAncestorEnabled = BooleanPropertyAssertion::getValue("enable-experimental-requires-ancestor", assertions).value_or(false);
+
     if (BooleanPropertyAssertion::getValue("no-stdlib", assertions).value_or(false)) {
         gs->initEmpty();
     } else {

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -190,6 +190,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         gs->semanticExtensions.emplace_back(provider->defaultInstance());
     }
 
+    gs->requiresAncestorEnabled = true;
     gs->censorForSnapshotTests = true;
     auto workers = WorkerPool::create(0, gs->tracer());
 

--- a/test/testdata/lsp/requires_ancestor.1.rbupdate
+++ b/test/testdata/lsp/requires_ancestor.1.rbupdate
@@ -1,0 +1,20 @@
+# typed: true
+# assert-slow-path: true
+
+module A
+  def foo_a; end
+end
+
+module B
+  extend T::Helpers
+
+  requires_ancestor A
+
+  def foo_b
+    foo_a
+  end
+end
+
+class C # error: `C` must include `A` (required by `B`)
+  include B
+end

--- a/test/testdata/lsp/requires_ancestor.2.rbupdate
+++ b/test/testdata/lsp/requires_ancestor.2.rbupdate
@@ -1,0 +1,20 @@
+# typed: true
+# assert-slow-path: true
+
+module A
+  def foo_a; end
+end
+
+module B
+  extend T::Helpers
+
+  # requires_ancestor A
+
+  def foo_b
+    foo_a # error: Method `foo_a` does not exist on `B`
+  end
+end
+
+class C
+  include B
+end

--- a/test/testdata/lsp/requires_ancestor.3.rbupdate
+++ b/test/testdata/lsp/requires_ancestor.3.rbupdate
@@ -15,8 +15,9 @@ module B
   end
 end
 
-class C # error: `C` must include `E` (required by `D`)
+class C
   include D
+  include E
 end
 
 module D

--- a/test/testdata/lsp/requires_ancestor.rb
+++ b/test/testdata/lsp/requires_ancestor.rb
@@ -1,0 +1,17 @@
+# typed: true
+
+module A
+  def foo_a; end
+end
+
+module B
+  extend T::Helpers
+
+  def foo_b
+    foo_a # error: Method `foo_a` does not exist on `B`
+  end
+end
+
+class C
+  include B
+end

--- a/test/testdata/lsp/requires_ancestor.rb
+++ b/test/testdata/lsp/requires_ancestor.rb
@@ -1,4 +1,5 @@
 # typed: true
+# enable-experimental-requires-ancestor: true
 
 module A
   def foo_a; end

--- a/test/testdata/resolver/requires_ancestor_calls_ancestors.rb
+++ b/test/testdata/resolver/requires_ancestor_calls_ancestors.rb
@@ -1,0 +1,214 @@
+# typed: true
+
+### Resolve calls on directly required module
+
+module Test1
+  module M1
+    extend T::Helpers
+    requires_ancestor M2
+
+    def m1
+      m2
+    end
+  end
+
+  module M2
+    def m2; end
+  end
+end
+
+### Resolve calls on module directly included by requirement
+
+module Test2
+  module M1
+    extend T::Helpers
+    requires_ancestor M3
+
+    def m1
+      m2
+      m3
+    end
+  end
+
+  module M2
+    def m2; end
+  end
+
+  module M3
+    include M2
+    def m3; end
+  end
+end
+
+### Resolve calls on module transitively included by requirement
+
+module Test3
+  module M1
+    extend T::Helpers
+    requires_ancestor M4
+
+    def m1
+      m2
+      m3
+      m4
+    end
+  end
+
+  module M2
+    def m2; end
+  end
+
+  module M3
+    include M2
+    def m3; end
+  end
+
+  module M4
+    include M3
+    def m4; end
+  end
+end
+
+### Resolve calls on transitively required modules
+
+module Test4
+  module M1
+    def m1; end
+  end
+
+  module M2
+    extend T::Helpers
+    requires_ancestor M1
+
+    def m2
+      m1
+    end
+  end
+
+  module M3
+    extend T::Helpers
+    requires_ancestor M2
+
+    def m3
+      m1
+      m2
+    end
+  end
+
+  module M4
+    extend T::Helpers
+    requires_ancestor M3
+
+    def m4
+      m1
+      m2
+      m3
+    end
+  end
+
+  class C1
+    include M1
+    include M2
+    include M3
+    include M4
+
+    def c1
+      m1
+      m2
+      m3
+      m4
+    end
+  end
+end
+
+### Resolve calls on directly included abstract class
+
+module Test5
+  module M1
+    extend T::Helpers
+    requires_ancestor C1
+
+    def m1
+      c1
+    end
+  end
+
+  class C1
+    extend T::Helpers
+    abstract!
+    def c1; end
+  end
+end
+
+### Resolve calls on directly included class
+
+module Test6
+  module M1
+    extend T::Helpers
+    requires_ancestor C2
+
+    def m1
+      c1
+    end
+  end
+
+  class C1
+    extend T::Helpers
+    abstract!
+    def c1; end
+  end
+
+  class C2 < C1
+  end
+end
+
+### Resolve calls on transitive superclasses
+
+module Test7
+  module M1
+    extend T::Helpers
+
+    requires_ancestor C3
+
+    def m1
+      c3
+    end
+  end
+
+  module M2
+    include M1
+
+    def m2
+      m1
+      c3
+    end
+  end
+
+  class C1
+    extend T::Helpers
+    abstract!
+    include M2
+
+    def c1
+      m1
+      m2
+      c3
+    end
+  end
+
+  class C2 < C1
+    extend T::Helpers
+    abstract!
+
+    def c2
+      m1
+      m2
+      c3
+      c1
+    end
+  end
+
+  class C3 < C2
+    def c3; end
+  end
+end

--- a/test/testdata/resolver/requires_ancestor_calls_ancestors.rb
+++ b/test/testdata/resolver/requires_ancestor_calls_ancestors.rb
@@ -1,4 +1,5 @@
 # typed: true
+# enable-experimental-requires-ancestor: true
 
 ### Resolve calls on directly required module
 

--- a/test/testdata/resolver/requires_ancestor_calls_types.rb
+++ b/test/testdata/resolver/requires_ancestor_calls_types.rb
@@ -1,0 +1,250 @@
+# typed: true
+
+module RA1
+  def foo; end
+end
+
+class RA2
+  def bar; end
+end
+
+### Resolve calls on implicit `self`
+
+module Test1
+  module M1
+    extend T::Helpers
+    requires_ancestor RA1
+
+    def m1
+      foo
+    end
+  end
+end
+
+### Resolve calls on explicit `self`
+
+module Test2
+  module M1
+    extend T::Helpers
+    requires_ancestor RA1
+
+    def m1
+      self.foo
+    end
+  end
+end
+
+### Resolve calls on `T.self_type`
+
+module Test3
+  module M1
+    extend T::Helpers
+    extend T::Sig
+    requires_ancestor RA1
+
+    def m1
+      get_me.foo
+      get_m1.foo
+    end
+
+    sig { returns(T.self_type) }
+    def get_me
+      self
+    end
+
+    sig { returns(M1) }
+    def get_m1
+      self
+    end
+  end
+end
+
+### Resolve calls on `T.any`
+
+module Test4
+  module M1
+    extend T::Helpers
+    extend T::Sig
+    requires_ancestor Kernel, RA1
+
+    def m1
+      any_m1_ra1.foo
+
+      m = any_m1_ra2
+      if m.is_a?(M1)
+        m.foo
+      else
+        m.bar
+      end
+    end
+
+    sig { returns(T.any(M1, RA1)) }
+    def any_m1_ra1
+      self
+    end
+
+    sig { returns(T.any(M1, RA2)) }
+    def any_m1_ra2
+      self
+    end
+  end
+end
+
+### Resolve calls on `T.all`
+
+module Test5
+  module M1
+    extend T::Helpers
+    extend T::Sig
+    requires_ancestor RA2
+    include RA1
+
+    def m1
+      all_m1_ra1.foo
+    end
+
+    sig { returns(T.all(M1, RA1)) }
+    def all_m1_ra1
+      self
+    end
+  end
+end
+
+### Resolve calls on `T.nilable`
+
+module Test6
+  module M1
+    extend T::Helpers
+    extend T::Sig
+    requires_ancestor RA1
+
+    def m1
+      m = m1?
+      m.foo if m
+      T.must(m).foo
+    end
+
+    sig { returns(T.nilable(M1)) }
+    def m1?
+      self
+    end
+  end
+end
+
+### Resolve calls on tuples
+
+module Test7
+  module M1
+    extend T::Helpers
+    extend T::Sig
+    requires_ancestor RA1, RA2
+
+    def m1
+      m = tuple
+      T.must(m.first).foo
+      T.must(m.last).bar
+    end
+
+    sig { returns([M1, M1]) }
+    def tuple
+      [self, self]
+    end
+  end
+end
+
+### Resolve calls on shapes
+
+module Test8
+  module M1
+    extend T::Helpers
+    extend T::Sig
+    requires_ancestor RA1, RA2
+
+    def m1
+      m = shape
+      m[:ra1].foo
+      m[:ra2].bar
+    end
+
+    sig { returns({ra1: M1, ra2: M1}) }
+    def shape
+      {ra1: self, ra2: self}
+    end
+  end
+end
+
+### Resolve calls on generics
+
+module Test9
+  module M1
+    extend T::Helpers
+    requires_ancestor RA1
+  end
+
+  class C1
+    extend T::Generic
+    extend T::Sig
+    Elem = type_member(upper: M1)
+
+    sig { params(m1: Elem).returns(Elem) }
+    def elem(m1)
+      m1.foo
+      m1
+    end
+  end
+
+  class C2
+    include M1
+    include RA1
+  end
+
+  def self.main
+    C1[M1].new.elem(C2.new).foo
+  end
+end
+
+### Resolve calls on singleton
+
+module Test10
+  module M1
+    extend T::Helpers
+    requires_ancestor RA1
+  end
+
+  module M2
+    extend M1
+    extend RA1
+    extend T::Sig
+
+    def self.m2
+      foo
+    end
+
+    def m2
+      T.attached_class.foo
+      T.class_of(M2).foo
+    end
+  end
+end
+
+### Resolve calls on struct types
+
+module Test11
+  module M1
+    extend T::Helpers
+    requires_ancestor RA1
+  end
+
+  class C1
+    include M1
+    include RA1
+  end
+
+  class S1 < T::Struct
+    prop :m1, M1
+  end
+
+  def self.main
+    S1.new(m1: C1.new).m1.foo
+  end
+end

--- a/test/testdata/resolver/requires_ancestor_calls_types.rb
+++ b/test/testdata/resolver/requires_ancestor_calls_types.rb
@@ -1,4 +1,5 @@
 # typed: true
+# enable-experimental-requires-ancestor: true
 
 module RA1
   def foo; end

--- a/test/testdata/resolver/requires_ancestor_disabled.rb
+++ b/test/testdata/resolver/requires_ancestor_disabled.rb
@@ -1,0 +1,44 @@
+# typed: true
+# enable-experimental-requires-ancestor: false
+
+### Does not suggest helper module if disabled
+
+module Test1
+  module M1
+    requires_ancestor M2 # error: Method `requires_ancestor` does not exist on `T.class_of(Test1::M1)`
+  end
+
+  module M2; end
+end
+
+### Does not resolve methods if disabled
+
+module Test2
+  module M1
+    extend T::Helpers
+    requires_ancestor M2
+
+    def m1
+      m2 # error: Method `m2` does not exist on `Test2::M1`
+    end
+  end
+
+  module M2
+    def m2; end
+  end
+end
+
+### Does not require ancestor if disabled
+
+module Test3
+  module M1
+    extend T::Helpers
+    requires_ancestor M2
+  end
+
+  module M2; end
+
+  module M3
+    include M1
+  end
+end

--- a/test/testdata/resolver/requires_ancestor_errors.rb
+++ b/test/testdata/resolver/requires_ancestor_errors.rb
@@ -1,0 +1,17 @@
+# typed: true
+
+module Helper1
+  requires_ancestor Object # error: Method `requires_ancestor` does not exist on `T.class_of(Helper1)`
+end
+
+module Helper2
+  extend T::Helpers
+
+  requires_ancestor # error: Not enough arguments provided for method `T::Helpers#requires_ancestor`. Expected: `1+`, got: `0`
+end
+
+module Helper3
+  extend T::Helpers
+
+  requires_ancestor NotFound # error: Unable to resolve constant `NotFound`
+end

--- a/test/testdata/resolver/requires_ancestor_errors.rb
+++ b/test/testdata/resolver/requires_ancestor_errors.rb
@@ -13,5 +13,35 @@ end
 module Helper3
   extend T::Helpers
 
-  requires_ancestor NotFound # error: Unable to resolve constant `NotFound`
+  requires_ancestor NotFound
+  #                 ^^^^^^^^ error: Argument to `requires_ancestor` must be statically resolvable to a class or a module
+  #                 ^^^^^^^^ error: Unable to resolve constant `NotFound`
+end
+
+class Helper4
+  extend T::Helpers
+
+  requires_ancestor Object # error: `requires_ancestor` can only be declared inside a module or an abstract class
+
+  class << self
+    extend T::Helpers
+    requires_ancestor String # error: `requires_ancestor` can only be declared inside a module or an abstract class
+  end
+end
+
+module Helper5
+  extend T::Helpers
+
+  requires_ancestor Object, "Object"
+  #                         ^^^^^^^^ error: Argument to `requires_ancestor` must be statically resolvable to a class or a module
+
+  requires_ancestor T.class_of(Object)
+  #                 ^^^^^^^^^^^^^^^^^^ error: Argument to `requires_ancestor` must be statically resolvable to a class or a module
+end
+
+module Helper6
+  extend T::Helpers
+
+  requires_ancestor Helper6
+  #                 ^^^^^^^ error: Must not pass yourself to `requires_ancestor`
 end

--- a/test/testdata/resolver/requires_ancestor_errors.rb
+++ b/test/testdata/resolver/requires_ancestor_errors.rb
@@ -45,3 +45,29 @@ module Helper6
   requires_ancestor Helper6
   #                 ^^^^^^^ error: Must not pass yourself to `requires_ancestor`
 end
+
+module Helper7
+  extend T::Helpers
+  include Kernel
+
+  requires_ancestor Kernel
+  #                 ^^^^^^ error: `Kernel` is already included by `Helper7`
+end
+
+class Helper8
+  extend T::Helpers
+
+  abstract!
+
+  requires_ancestor Object
+  #                 ^^^^^^ error: `Object` is already inherited by `Helper8`
+end
+
+class Helper9 < String
+  extend T::Helpers
+
+  abstract!
+
+  requires_ancestor String
+  #                 ^^^^^^ error: `String` is already inherited by `Helper9`
+end

--- a/test/testdata/resolver/requires_ancestor_errors.rb
+++ b/test/testdata/resolver/requires_ancestor_errors.rb
@@ -1,4 +1,5 @@
 # typed: true
+# enable-experimental-requires-ancestor: true
 
 module Helper1
   requires_ancestor Object # error: Method `requires_ancestor` does not exist on `T.class_of(Helper1)`

--- a/test/testdata/resolver/requires_ancestor_kernel.rb
+++ b/test/testdata/resolver/requires_ancestor_kernel.rb
@@ -1,0 +1,42 @@
+# typed: true
+
+module MyHelper
+  extend T::Helpers
+
+  requires_ancestor Kernel
+
+  def error(message)
+    puts "An error occurred: #{message}"
+    raise message
+  end
+end
+
+class MyTest1
+  include MyHelper
+
+  def test
+    error("test1")
+  end
+end
+
+class MyTest2 < BasicObject # error: `MyTest2` must include `Kernel` (required by `MyHelper`)
+  include MyHelper
+
+  def test
+    error("test2")
+  end
+end
+
+module MyTest3
+  include MyHelper
+end
+
+class MyTest4 < BasicObject
+  extend T::Helpers
+  include MyHelper
+
+  abstract!
+end
+
+class MyTest5 < MyTest4 # error: `MyTest5` must include `Kernel` (required by `MyHelper`)
+end

--- a/test/testdata/resolver/requires_ancestor_kernel.rb
+++ b/test/testdata/resolver/requires_ancestor_kernel.rb
@@ -1,4 +1,5 @@
 # typed: true
+# enable-experimental-requires-ancestor: true
 
 module MyHelper
   extend T::Helpers

--- a/test/testdata/resolver/requires_ancestor_lin.rb
+++ b/test/testdata/resolver/requires_ancestor_lin.rb
@@ -1,0 +1,282 @@
+# typed: true
+
+module R1; end
+module R2; end
+
+### Basic include
+
+module Test1
+  module M1
+    extend T::Helpers
+    requires_ancestor R1
+  end
+
+  class C1 # error: `Test1::C1` must include `R1` (required by `Test1::M1`)
+    include M1
+  end
+
+  class C2
+    include M1
+    include R1
+  end
+end
+
+### Abstract include
+
+module Test2
+  module M1
+    extend T::Helpers
+    requires_ancestor R1
+  end
+
+  module M2
+    extend T::Helpers
+    interface!
+    requires_ancestor R2
+  end
+
+  class C1
+    extend T::Helpers
+    abstract!
+    include M1
+    include M2
+  end
+
+   class C2 < C1
+ # ^^^^^^^^^^^^^ error: `Test2::C2` must include `R1` (required by `Test2::M1`)
+ # ^^^^^^^^^^^^^ error: `Test2::C2` must include `R2` (required by `Test2::M2`)
+   end
+
+  class C3 < C2
+    include R1
+    include R2
+  end
+end
+
+### Transitive requirement
+
+module Test3
+  module M1
+    extend T::Helpers
+    requires_ancestor R1
+  end
+
+  module M2
+    include M1
+  end
+
+  module M3
+    include M2
+  end
+
+  class C1 # error: `Test3::C1` must include `R1` (required by `Test3::M1`)
+    include M3
+  end
+
+  class C2 < C1 # error: `Test3::C2` must include `R1` (required by `Test3::M1`)
+  end
+
+  class C3
+    include M3
+    include R1
+  end
+end
+
+### Class requirement
+
+module Test4
+  module M1
+    extend T::Helpers
+    requires_ancestor C1
+  end
+
+  class C1
+    include M1
+  end
+
+  class C2 # error: `Test4::C2` must inherit `Test4::C1` (required by `Test4::M1`)
+    include M1
+  end
+
+  class C3 < C1
+  end
+end
+
+### Inherited requirement
+
+module Test5
+  module M1
+    extend T::Helpers
+    requires_ancestor C2
+  end
+
+  class C1
+    extend T::Helpers
+    abstract!
+  end
+
+  class C2 < C1
+    extend T::Helpers
+    abstract!
+  end
+
+  class C3 < C1 # error: `Test5::C3` must inherit `Test5::C2` (required by `Test5::M1`)
+    include M1
+  end
+
+  class C4 < C3 # error: `Test5::C4` must inherit `Test5::C2` (required by `Test5::M1`)
+  end
+
+  class C5 < C2
+    include M1
+  end
+
+  class C6 < C5
+  end
+end
+
+### Circular requirement
+
+module Test6
+  module M1
+    extend T::Helpers
+    requires_ancestor M2
+  end
+
+  module M2
+    extend T::Helpers
+    requires_ancestor M1
+  end
+
+  class C1 # error: `Test6::C1` must include `Test6::M2` (required by `Test6::M1`)
+    include M1
+  end
+
+  class C2 # error: `Test6::C2` must include `Test6::M1` (required by `Test6::M2`)
+    include M2
+  end
+
+  class C3
+    include M1, M2
+  end
+end
+
+### Circular requirement with inheritance
+
+module Test7
+  module M1
+    extend T::Helpers
+    requires_ancestor M2
+  end
+
+  module M2
+    extend T::Helpers
+    requires_ancestor C2
+  end
+
+  class C1
+    extend T::Helpers
+    abstract!
+    requires_ancestor M1
+  end
+
+  class C2 < C1
+    extend T::Helpers
+    abstract!
+  end
+
+  class C3 < C2
+# ^^^^^^^^^^^^^ error: `Test7::C3` must include `Test7::M1` (required by `Test7::C1`)
+# ^^^^^^^^^^^^^ error: `Test7::C3` must include `Test7::M2` (required by `Test7::M1`)
+  end
+
+  class C4 < C3
+# ^^^^^^^^^^^^^ error: `Test7::C4` must include `Test7::M1` (required by `Test7::C1`)
+# ^^^^^^^^^^^^^ error: `Test7::C4` must include `Test7::M2` (required by `Test7::M1`)
+  end
+
+  class C5 < C3
+    include M1
+    include M2
+  end
+end
+
+### Requirements from include
+
+module Test8
+  module M1
+    extend T::Helpers
+    requires_ancestor R1
+  end
+
+  module M2
+    include M1
+  end
+
+  class C1 # error: `Test8::C1` must include `R1` (required by `Test8::M1`)
+    include M2
+  end
+
+  class C2 < C1 # error: `Test8::C2` must include `R1` (required by `Test8::M1`)
+  end
+
+  class C3 < C2
+    include R1
+  end
+end
+
+### Requirements from extend
+
+module Test9
+  module M1
+    extend T::Helpers
+    requires_ancestor R1
+  end
+
+  module M2 # error: `T.class_of(Test9::M2)` must include `R1` (required by `Test9::M1`)
+    extend M1
+  end
+
+  class C1
+    include M2
+  end
+
+  class C2 < C1 # error: `T.class_of(Test9::C2)` must include `R1` (required by `Test9::M1`)
+    extend M1
+  end
+
+  class C3 < C2
+    extend R1
+  end
+
+  class C4 < C3
+  end
+
+  class C5 # error: `Test9::C5` must include `R1` (required by `Test9::M1`)
+    include M1
+  end
+
+  class C6
+    include M1
+    include R1
+  end
+
+  class C7
+    class << self # error: `T.class_of(Test9::C7)` must include `R1` (required by `Test9::M1`)
+      include M1
+    end
+  end
+
+  class C8
+    class << self
+      include M1
+      include R1
+    end
+  end
+
+  class C9
+    class << self # error: `T.class_of(T.class_of(Test9::C9))` must include `R1` (required by `Test9::M1`)
+      extend M1
+    end
+  end
+end

--- a/test/testdata/resolver/requires_ancestor_lin.rb
+++ b/test/testdata/resolver/requires_ancestor_lin.rb
@@ -1,4 +1,5 @@
 # typed: true
+# enable-experimental-requires-ancestor: true
 
 module R1; end
 module R2; end

--- a/test/testdata/resolver/requires_ancestor_no_subtyping.rb
+++ b/test/testdata/resolver/requires_ancestor_no_subtyping.rb
@@ -1,0 +1,41 @@
+# typed: true
+
+module RA
+  def foo; end
+end
+
+### Requiring ancestors does not create subtyping relationship
+
+module Test1
+  extend T::Sig
+
+  module M1
+    extend T::Helpers
+    requires_ancestor RA
+  end
+
+  class C1
+    include RA
+    include M1
+  end
+
+  sig { params(c1: C1).void }
+  def bar(c1)
+    c1.foo
+  end
+
+  sig { returns(M1) }
+  def m1
+    C1.new
+  end
+
+  sig { returns(C1) }
+  def c1
+    C1.new
+  end
+
+  def main
+    bar(m1) # error: Expected `Test1::C1` but found `Test1::M1` for argument `c1`
+    bar(c1)
+  end
+end

--- a/test/testdata/resolver/requires_ancestor_no_subtyping.rb
+++ b/test/testdata/resolver/requires_ancestor_no_subtyping.rb
@@ -1,4 +1,5 @@
 # typed: true
+# enable-experimental-requires-ancestor: true
 
 module RA
   def foo; end

--- a/test/testdata/resolver/requires_ancestor_object.rb
+++ b/test/testdata/resolver/requires_ancestor_object.rb
@@ -1,0 +1,23 @@
+# typed: true
+
+module Helper
+  extend T::Helpers
+
+  requires_ancestor Object
+
+  def get_my_class_name
+    self.class.name
+  end
+end
+
+class Foo
+  include Helper
+end
+
+class Bar < BasicObject # error: `Bar` must inherit `Object` (required by `Helper`)
+  include Helper
+end
+
+class Baz < Bar # error: `Baz` must inherit `Object` (required by `Helper`)
+  include Helper
+end

--- a/test/testdata/resolver/requires_ancestor_object.rb
+++ b/test/testdata/resolver/requires_ancestor_object.rb
@@ -1,4 +1,5 @@
 # typed: true
+# enable-experimental-requires-ancestor: true
 
 module Helper
   extend T::Helpers

--- a/test/testdata/resolver/requires_ancestor_unrelated_classes.rb
+++ b/test/testdata/resolver/requires_ancestor_unrelated_classes.rb
@@ -1,4 +1,5 @@
 # typed: true
+# enable-experimental-requires-ancestor: true
 
 class R1; end
 class R2 < R1; end

--- a/test/testdata/resolver/requires_ancestor_unrelated_classes.rb
+++ b/test/testdata/resolver/requires_ancestor_unrelated_classes.rb
@@ -1,0 +1,103 @@
+# typed: true
+
+class R1; end
+class R2 < R1; end
+class R3; end
+
+### Module requires unrelated classes
+
+module Test1
+  module M1
+    extend T::Helpers
+    requires_ancestor R1, R2
+  end
+
+  module M2 # error: `Test1::M2` requires unrelated classes `R1` and `R3` making it impossible to include
+    extend T::Helpers
+    requires_ancestor R1, R3
+  end
+end
+
+### Module requires unrelated classes from included modules
+
+module Test2
+  module M1
+    extend T::Helpers
+    requires_ancestor R1
+  end
+
+  module M2
+    extend T::Helpers
+    requires_ancestor R3
+  end
+
+  module M3 # error: `Test2::M3` requires unrelated classes `R3` and `R1` making it impossible to include
+    include M1
+    include M2
+  end
+end
+
+### Module requires unrelated classes from extended modules
+
+module Test3
+  module M1
+    extend T::Helpers
+    requires_ancestor R1
+  end
+
+  module M2
+    extend T::Helpers
+    requires_ancestor R3
+  end
+
+  module M3
+  #      ^^ error: `T.class_of(Test3::M3)` requires unrelated classes `R3` and `R1` making it impossible to inherit
+  #      ^^ error: `T.class_of(Test3::M3)` must inherit `R1` (required by `Test3::M1`)
+  #      ^^ error: `T.class_of(Test3::M3)` must inherit `R3` (required by `Test3::M2`)
+    extend M1, M2
+  end
+end
+
+### Abstract class requires unrelated classes
+
+module Test4
+  class C1
+# ^^^^^^^^ error: `Test4::C1` requires unrelated class `R2` making it impossible to inherit
+# ^^^^^^^^ error: `Test4::C1` requires unrelated class `R3` making it impossible to inherit
+# ^^^^^^^^ error: `Test4::C1` requires unrelated classes `R2` and `R3` making it impossible to inherit
+    extend T::Helpers
+    abstract!
+    requires_ancestor R2, R3
+  end
+
+  class C2 < C1
+# ^^^^^^^^^^^^^ error: `Test4::C2` requires unrelated class `R2` making it impossible to inherit
+# ^^^^^^^^^^^^^ error: `Test4::C2` requires unrelated class `R3` making it impossible to inherit
+# ^^^^^^^^^^^^^ error: `Test4::C2` requires unrelated classes `R2` and `R3` making it impossible to inherit
+    extend T::Helpers
+    abstract!
+  end
+end
+
+### Transitive unrelated classes from included modules
+
+module Test5
+  module M1
+    extend T::Helpers
+    requires_ancestor R2
+  end
+
+  module M2 # error: `Test5::M2` requires unrelated classes `R3` and `R2` making it impossible to include
+    extend T::Helpers
+    include M1
+    requires_ancestor R3
+  end
+
+  class C1 < R2
+# ^^^^^^^^^^^^^ error: `Test5::C1` requires unrelated class `R3` making it impossible to inherit
+# ^^^^^^^^^^^^^ error: `Test5::C1` requires unrelated classes `R3` and `R2` making it impossible to inherit
+    extend T::Helpers
+    abstract!
+    include M2
+  end
+end

--- a/test/testdata/resolver/requires_ancestor_unsupported_generics.rb
+++ b/test/testdata/resolver/requires_ancestor_unsupported_generics.rb
@@ -1,4 +1,5 @@
 # typed: true
+# enable-experimental-requires-ancestor: true
 
 ### Requiring generic classes or modules is not supported yet
 

--- a/test/testdata/resolver/requires_ancestor_unsupported_generics.rb
+++ b/test/testdata/resolver/requires_ancestor_unsupported_generics.rb
@@ -1,0 +1,27 @@
+# typed: true
+
+### Requiring generic classes or modules is not supported yet
+
+module Test1
+  module RA
+    extend T::Generic
+    E = type_member
+  end
+
+  module M # error: `Test1::M` can't require generic ancestor `Test1::RA` (unsupported)
+    extend T::Helpers
+    requires_ancestor RA
+  end
+end
+
+module Test2
+  class RA
+    extend T::Generic
+    E = type_member
+  end
+
+  module M # error: `Test2::M` can't require generic ancestor `Test2::RA` (unsupported)
+    extend T::Helpers
+    requires_ancestor RA
+  end
+end

--- a/website/docs/requires-ancestor.md
+++ b/website/docs/requires-ancestor.md
@@ -1,0 +1,154 @@
+---
+id: requires-ancestor
+title: Requiring Ancestors
+sidebar_label: Requiring Ancestors
+---
+
+It's not uncommon in Ruby to define helper modules that depends on other
+modules. For example, let's take the following helper which provides `say_error`
+method:
+
+```ruby
+# typed: true
+
+module MyHelper
+  def say_error(message):
+    raise "InternalError: #{message}" # error: Method `raise` does not exist on `MyHelper`
+  end
+end
+
+class MyClass
+  include MyHelper
+
+  def do_something(x)
+    say_error("some error") unless x
+    # ...
+  end
+end
+```
+
+If we run Sorbet on this example, we will get a type-checking error saying that
+the method `raise` does not exist on `MyHelper` since this method is defined on
+`Kernel`. Thanks to this error, Sorbet is protecting us against some edge-cases
+where we would try to include the `MyHelper` module in a class that does not
+include `Kernel`:
+
+```ruby
+class MyBaseClass < BasicObject
+  include MyHelper
+
+  def do_something(x)
+    say_error("some error") unless x
+    # ...
+  end
+end
+
+MyBaseClass.new.do_something(false) # runtime-error: in `say_error': undefined method `raise' for #<MyBaseClass> (NoMethodError)
+```
+
+This example would raise an error at runtime because the method `raise` is
+undefined for instances of `MyBaseClass` as it doesn't include `Kernel`.
+
+## Requiring Ancestors
+
+Sorbet provides the `requires_ancestor` method as a way to ensure that classes
+or modules including `MyHelper` will also include `Kernel`.
+
+Let's change our base example to use `requires_ancestor`:
+
+```ruby
+module MyHelper
+  extend T::Helpers
+
+  requires_ancestor Kernel
+
+  def say_error(message):
+    raise "InternalError: #{message}"
+  end
+end
+```
+
+This way we specify that any module including `MyHelper` must also include
+`Kernel` and Sorbet will display an error if it's not the case:
+
+```ruby
+class MyBaseClass < BasicObject # error: `MyBaseClass` must include `Kernel` (required by `MyHelper`)
+  include MyHelper
+end
+```
+
+`requires_ancestor` also works to require that a specific class must be
+inherited:
+
+```ruby
+module MyHelper
+  extend T::Helpers
+
+  requires_ancestor Object
+
+  def class_name
+    self.class.name
+  end
+end
+
+class MyBaseClass < BasicObject # error: `MyBaseClass` must inherit `Object` (required by `MyHelper`)
+  include MyHelper
+end
+```
+
+Note that requirements are transitive:
+
+```ruby
+class MyBaseClass2 < MyBaseClass # error: `MyBaseClass2` must inherit `Object` (required by `MyHelper`)
+  include MyHelper
+end
+```
+
+`requires_ancestor` can be used to require more than one ancestor:
+
+```ruby
+module Test
+  module TestAssertions
+    def assert_equal(x, y)
+      x == y
+    end
+  end
+
+  class TestBase
+    def test; end
+  end
+
+  class TestCase < TestBase
+    include TestAssertions
+  end
+end
+
+module MyLogger
+  def log_test_failed; end
+end
+
+module MyTestHelper
+  extend T::Helpers
+
+  requires_ancestor Test::TestAssertions, MyLogger
+
+  def assert_not_equal(x, y)
+    if assert_equal(x, y)
+      true
+    else
+      log_test_failed
+      false
+    end
+  end
+end
+
+class MyValidTest < Test::TestCase
+  include MyTestHelper
+  include MyLogger
+end
+
+class MyBrokenTest < Test::TestBase # error: `MyBrokenTest` must include `Test::TestAssertions` (required by `MyTestHelper`)
+                                    # error: `MyBrokenTest` must include `MyLogger` (required by `MyTestHelper`)
+  include MyTestHelper
+end
+```

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -47,7 +47,8 @@
     ],
     "Experimental Features": [
       "tuples",
-      "shapes"
+      "shapes",
+      "requires-ancestor"
     ]
   },
   "talks": {


### PR DESCRIPTION
### Motivation

(This coming from the documentation included in this pull-request)

It's not uncommon in Ruby to define helper modules that depends on other modules.
For example, let's take the following helper which provides `say_error` method:

```ruby
# typed: true

module MyHelper
  def say_error(message):
    raise "InternalError: #{message}" # error: Method `raise` does not exist on `MyHelper`
  end
end

class MyClass
  include MyHelper

  def do_something(x)
    say_error("some error") unless x
    # ...
  end
end
```

If we run Sorbet on this example, we will get a type-checking error saying that the method `raise`
does not exist on `MyHelper` since this method is defined on `Kernel`.
Thanks to this error, Sorbet is protecting us against some edge-cases where we would try to include
the `MyHelper` module in a class that does not include `Kernel`:

```ruby
class MyBaseClass < BasicObject
  include MyHelper

  def do_something(x)
    say_error("some error") unless x
    # ...
  end
end

MyBaseClass.new.do_something(false) # runtime-error: in `say_error': undefined method `raise' for #<MyBaseClass> (NoMethodError)
```

This example would raise an error at runtime because the method `raise` is undefined for instances of `MyBaseClass`
as it doesn't include `Kernel`.

## Requiring Ancestors

Sorbet provides the `requires_ancestor` method as a way to ensure that classes or modules including `MyHelper`
will also include `Kernel`.

Let's change our base example to use `requires_ancestor`:

```ruby
module MyHelper
  extend T::Helpers

  requires_ancestor Kernel

  def say_error(message):
    raise "InternalError: #{message}"
  end
end
```

This way we specify that any module including `MyHelper` must also include `Kernel`
and Sorbet will display an error if it's not the case:

```ruby
class MyBaseClass < BasicObject # error: `MyBaseClass` must include `Kernel` (required by `MyHelper`)
  include MyHelper
end
```

`requires_ancestor` also works to require that a specific class must be inherited:

```ruby
module MyHelper
  extend T::Helpers

  requires_ancestor Object

  def class_name
    self.class.name
  end
end

class MyBaseClass < BasicObject # error: `MyBaseClass` must inherit `Object` (required by `MyHelper`)
  include MyHelper
end
```

Note that requirements are transitive:

```ruby
class MyBaseClass2 < MyBaseClass # error: `MyBaseClass2` must inherit `Object` (required by `MyHelper`)
  include MyHelper
end
```

`requires_ancestor` can be used to require more than one ancestor:

```ruby
module Test
  module TestAssertions
    def assert_equal(x, y)
      x == y
    end
  end

  class TestBase
    def test; end
  end

  class TestCase < TestBase
    include TestAssertions
  end
end

module MyLogger
  def log_test_failed; end
end

module MyTestHelper
  extend T::Helpers

  requires_ancestor Test::TestAssertions, MyLogger

  def assert_not_equal(x, y)
    if assert_equal(x, y)
      true
    else
      log_test_failed
      false
    end
  end
end

class MyValidTest < Test::TestCase
  include MyTestHelper
  include MyLogger
end

class MyBrokenTest < Test::TestBase # error: `MyBrokenTest` must include `Test::TestAssertions` (required by `MyTestHelper`)
                                    # error: `MyBrokenTest` must include `MyLogger` (required by `MyTestHelper`)
  include MyTestHelper
end
```

### How it works?

1. A resolver job collects the required ancestors specified with `requires_ancestor X, Y` and stores them in a magic `<required-ancestor>` property.

2. The symbol can read the list of directly required ancestors from this magic `<required-ancestor>` property. Or compute recursively the list of all its ancestors on demand.

3. The definition validator will use both these lists to ensure all non-abstract classes do include all the ancestors their own includes require (and a few other sanity checks).

4. During calls validation, if a method called is not found, we also look into the required ancestors to see if the method exists before raising an error.

### But at what cost?

None if you don't use any `requires_ancestor` in your code.

If you do use them, you'll pay the price only where used:
* Cost some memory to store the magic "<required-ancestor>" property only for classes/modules that do use it.
* If a method is not found on a receiver, cost a bit to recursively look into all ancestors of the receiver if one of the required ancestors provides the method. So you pay only for NoMethod errors if you don't actually use the feature.

### Reviews

This pull-request can be read commit by commit.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests for more examples on how it works and the kind of errors it produces.

This should also provide an answer to https://github.com/sorbet/sorbet/issues/2236.