### PR TITLE
ruby27: Support forwarding arguments syntax

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -347,6 +347,11 @@ NameDef names[] = {
     {"min"},
     {"max"},
 
+    // Argument forwarding
+    {"fwdArgs", "<fwd-args>"},
+    {"fwdKwargs", "<fwd-kwargs>"},
+    {"fwdBlock", "<fwd-block>"},
+
     // Enumerable#flat_map has special-case logic in Infer
     {"flatMap", "flat_map"},
 

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -271,6 +271,18 @@ NodeDef nodes[] = {
         "for",
         vector<FieldDef>({{"vars", FieldType::Node}, {"expr", FieldType::Node}, {"body", FieldType::Node}}),
     },
+    // "..." argument forwarding in definition site
+    {
+        "ForwardArgs",
+        "forward_args",
+        vector<FieldDef>(),
+    },
+    // "..." argument forwarding in call site
+    {
+        "ForwardedArgs",
+        "forwarded_args",
+        vector<FieldDef>(),
+    },
     // float literal like "1.2"
     {
         "Float",

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2420,10 +2420,11 @@ private:
             if (l1._name == core::Names::fwdArgs() && l2._name == core::Names::fwdKwargs() &&
                 l3._name == core::Names::fwdBlock()) {
                 if (auto e = ctx.beginError(exprLoc, core::errors::Resolver::InvalidMethodSignature)) {
-                    e.setHeader("Unsupported `{}` for argument forwarding syntax. "
-                                "Rewrite the method as `def {}(*args, **kwargs, &blk)` to use a signature",
-                                "sig", method.data(ctx)->show(ctx));
+                    e.setHeader("Unsupported `{}` for argument forwarding syntax", "sig");
                     e.addErrorLine(methodInfo->loc(), "Method declares argument forwarding here");
+                    e.addErrorNote("Rewrite the method as `def {}(*args, **kwargs, &blk)` to use a signature",
+                                   method.data(ctx)->show(ctx));
+
                 }
                 return;
             }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2424,7 +2424,6 @@ private:
                     e.addErrorLine(methodInfo->loc(), "Method declares argument forwarding here");
                     e.addErrorNote("Rewrite the method as `def {}(*args, **kwargs, &blk)` to use a signature",
                                    method.data(ctx)->show(ctx));
-
                 }
                 return;
             }

--- a/test/testdata/desugar/forward_args.rb
+++ b/test/testdata/desugar/forward_args.rb
@@ -1,0 +1,19 @@
+# typed: true
+
+class Foo
+  def bar(a, b, k1:, k2:, &block); end
+
+  def foo(...)
+    T.unsafe(self).bar(...)
+  end
+
+  def foo2(*args, **kwargs, &block)
+    T.unsafe(self).bar(*args, **kwargs, &block)
+  end
+end
+
+Foo.new.foo
+Foo.new.foo(1, 2)
+Foo.new.foo(k1: 1, k2: 2)
+Foo.new.foo do puts "foo" end
+Foo.new.foo(1, 2, k1: 1, k2: 2) do puts "foo" end

--- a/test/testdata/desugar/forward_args.rb.desugar-tree.exp
+++ b/test/testdata/desugar/forward_args.rb.desugar-tree.exp
@@ -1,0 +1,29 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Foo><<C <todo sym>>> < (::<todo sym>)
+    def bar<<C <todo sym>>>(a, b, k1:, k2:, &block)
+      <emptyTree>
+    end
+
+    def foo<<C <todo sym>>>(*<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
+      ::<Magic>.<call-with-splat-and-block>(<emptyTree>::<C T>.unsafe(<self>), :bar, <fwd-args>.to_a().concat([<fwd-kwargs>.to_hash()]), nil, <fwd-block>)
+    end
+
+    def foo2<<C <todo sym>>>(*args, *kwargs:, &block)
+      ::<Magic>.<call-with-splat-and-block>(<emptyTree>::<C T>.unsafe(<self>), :bar, args.to_a().concat([kwargs.to_hash()]), nil, block)
+    end
+  end
+
+  <emptyTree>::<C Foo>.new().foo()
+
+  <emptyTree>::<C Foo>.new().foo(1, 2)
+
+  <emptyTree>::<C Foo>.new().foo(:k1, 1, :k2, 2)
+
+  <emptyTree>::<C Foo>.new().foo() do ||
+    <self>.puts("foo")
+  end
+
+  <emptyTree>::<C Foo>.new().foo(1, 2, :k1, 1, :k2, 2) do ||
+    <self>.puts("foo")
+  end
+end

--- a/test/testdata/resolver/forward_args.rb
+++ b/test/testdata/resolver/forward_args.rb
@@ -1,0 +1,98 @@
+# typed: true
+
+class Foo
+  extend T::Sig
+
+  sig do
+    params(
+      a: Integer,
+      b: String,
+      k1: Integer,
+      k2: String,
+      block: T.proc.params(x: Integer).returns(String)
+    ).returns(String)
+  end
+  def bar(a, b, k1:, k2:, &block)
+    return block.call(k1) if (b.length == a)
+    k2
+  end
+
+  sig do
+    params(
+      args: T::Array[T.untyped],
+      kargs: T::Hash[T.untyped, T.untyped],
+      block: T.untyped
+    ).returns(String)
+  end
+  def foo_orig(*args, **kargs, &block)
+    args_lit = [1, "2"]
+    hash_lit = {k1: 1, k2: "2"}
+    r1 = bar(1, "2", k1: 3, k2: "4") { "" }
+    T.reveal_type(r1) # error: Revealed type: `String`
+    r2 = bar(*T.unsafe(args), **kargs, &block)
+    T.reveal_type(r2) # error: Revealed type: `T.untyped`
+    r3 = bar(*T.unsafe(args), **T.unsafe(kargs)) { "" }
+    T.reveal_type(r3) # error: Revealed type: `T.untyped`
+    r4 = bar(*args_lit, hash_lit, &block)
+    T.reveal_type(r4) # error: Revealed type: `String`
+  end
+
+  sig do
+    params(
+      args: T::Array[T.untyped]
+    ).returns(String)
+  end # error: Unsupported `sig` for argument forwarding syntax. Rewrite the method as `def Foo#foo_fwd(*args, **kwargs, &blk)` to use a signature
+  def foo_fwd(...)
+    r1 = T.unsafe(self).bar(...)
+    T.reveal_type(r1) # error: Revealed type: `T.untyped`
+  end
+
+  sig do
+    params(
+      args: T.untyped,
+      kargs: T::Hash[T.untyped, T.untyped]
+    ).void
+  end # error: Unsupported `sig` for argument forwarding syntax. Rewrite the method as `def Foo#foo_fwd1(*args, **kwargs, &blk)` to use a signature
+  def foo_fwd1(...)
+  end
+
+  sig do
+    params(
+      a: T.untyped,
+      k: T::Hash[T.untyped, T.untyped],
+      b: T.untyped
+    ).void
+  end # error: Unsupported `sig` for argument forwarding syntax. Rewrite the method as `def Foo#foo_fwd2(*args, **kwargs, &blk)` to use a signature
+  def foo_fwd2(...)
+  end
+
+  def foo_fwd3(...)
+    puts args # error: Method `args` does not exist on `Foo`
+    puts kargs # error: Method `kargs` does not exist on `Foo`
+    puts block # error: Method `block` does not exist on `Foo`
+  end
+end
+
+Foo.new.foo_fwd
+Foo.new.foo_fwd(1, 2)
+Foo.new.foo_fwd(k1: 1, k2: 2)
+Foo.new.foo_fwd do puts "foo" end
+Foo.new.foo_fwd(1, 2, k1: 1, k2: 2) do puts "foo" end
+
+Foo.new.foo_fwd1 { 1}
+Foo.new.foo_fwd1(1, 2, 3, {}) { 1 }
+Foo.new.foo_fwd1("") { 1 }
+Foo.new.foo_fwd1(1, 2, 3, {a: 1}) { 1 }
+Foo.new.foo_fwd1(1, 2, 3, {}) { "" }
+
+Foo.new.foo_fwd2 { 1}
+Foo.new.foo_fwd2(1, 2, 3, {}) { 1 }
+Foo.new.foo_fwd2("") { 1 }
+Foo.new.foo_fwd2(1, 2, 3, {a: 1}) { 1 }
+Foo.new.foo_fwd2(1, 2, 3, {}) { "" }
+
+Foo.new.foo_fwd3 { 1}
+Foo.new.foo_fwd3(1, 2, 3, {}) { 1 }
+Foo.new.foo_fwd3("") { 1 }
+Foo.new.foo_fwd3(1, 2, 3, {a: 1}) { 1 }
+Foo.new.foo_fwd3(1, 2, 3, {}) { "" }

--- a/test/testdata/resolver/forward_args.rb
+++ b/test/testdata/resolver/forward_args.rb
@@ -41,7 +41,7 @@ class Foo
     params(
       args: T::Array[T.untyped]
     ).returns(String)
-  end # error: Unsupported `sig` for argument forwarding syntax. Rewrite the method as `def Foo#foo_fwd(*args, **kwargs, &blk)` to use a signature
+  end # error: Unsupported `sig` for argument forwarding syntax
   def foo_fwd(...)
     r1 = T.unsafe(self).bar(...)
     T.reveal_type(r1) # error: Revealed type: `T.untyped`
@@ -52,7 +52,7 @@ class Foo
       args: T.untyped,
       kargs: T::Hash[T.untyped, T.untyped]
     ).void
-  end # error: Unsupported `sig` for argument forwarding syntax. Rewrite the method as `def Foo#foo_fwd1(*args, **kwargs, &blk)` to use a signature
+  end # error: Unsupported `sig` for argument forwarding syntax
   def foo_fwd1(...)
   end
 
@@ -62,7 +62,7 @@ class Foo
       k: T::Hash[T.untyped, T.untyped],
       b: T.untyped
     ).void
-  end # error: Unsupported `sig` for argument forwarding syntax. Rewrite the method as `def Foo#foo_fwd2(*args, **kwargs, &blk)` to use a signature
+  end # error: Unsupported `sig` for argument forwarding syntax
   def foo_fwd2(...)
   end
 

--- a/test/whitequark/test_forward_args_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_forward_args_0.parse-tree-whitequark.exp
@@ -1,0 +1,4 @@
+s(:def, :foo,
+  s(:forward_args),
+  s(:send, nil, :bar,
+    s(:forwarded_args)))

--- a/test/whitequark/test_forward_args_0.rb
+++ b/test/whitequark/test_forward_args_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(...); bar(...); end

--- a/test/whitequark/test_forward_args_1.parse-tree-whitequark.exp
+++ b/test/whitequark/test_forward_args_1.parse-tree-whitequark.exp
@@ -1,0 +1,4 @@
+s(:def, :foo,
+  s(:forward_args),
+  s(:super,
+    s(:forwarded_args)))

--- a/test/whitequark/test_forward_args_1.rb
+++ b/test/whitequark/test_forward_args_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(...); super(...); end

--- a/test/whitequark/test_forward_args_10.rb
+++ b/test/whitequark/test_forward_args_10.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(...); yield(...); end # error: unexpected token ")"

--- a/test/whitequark/test_forward_args_11.rb
+++ b/test/whitequark/test_forward_args_11.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(...); return(...); end # error: unexpected token ")"

--- a/test/whitequark/test_forward_args_12.rb
+++ b/test/whitequark/test_forward_args_12.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(...); a = (...); end # error: unexpected token ")"

--- a/test/whitequark/test_forward_args_13.rb
+++ b/test/whitequark/test_forward_args_13.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(...); [...]; end # error: unexpected token "]"

--- a/test/whitequark/test_forward_args_14.rb
+++ b/test/whitequark/test_forward_args_14.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(...) bar[...]; end # error: unexpected token "]"

--- a/test/whitequark/test_forward_args_15.rb
+++ b/test/whitequark/test_forward_args_15.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(...) bar[...] = x; end # error: unexpected token "]"

--- a/test/whitequark/test_forward_args_16.rb
+++ b/test/whitequark/test_forward_args_16.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(...) defined?(...); end # error: unexpected token ")"

--- a/test/whitequark/test_forward_args_17.rb
+++ b/test/whitequark/test_forward_args_17.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo ...; end # error: unexpected token "..."

--- a/test/whitequark/test_forward_args_2.parse-tree-whitequark.exp
+++ b/test/whitequark/test_forward_args_2.parse-tree-whitequark.exp
@@ -1,0 +1,2 @@
+s(:def, :foo,
+  s(:forward_args), nil)

--- a/test/whitequark/test_forward_args_2.rb
+++ b/test/whitequark/test_forward_args_2.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(...); end

--- a/test/whitequark/test_forward_args_3.rb
+++ b/test/whitequark/test_forward_args_3.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(...) bar(...) { }; end # error: both block argument and literal block are passed

--- a/test/whitequark/test_forward_args_4.rb
+++ b/test/whitequark/test_forward_args_4.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+foo do |...| end # error: unexpected token "..."

--- a/test/whitequark/test_forward_args_5.rb
+++ b/test/whitequark/test_forward_args_5.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+foo { |...| } # error: unexpected token "..."

--- a/test/whitequark/test_forward_args_6.rb
+++ b/test/whitequark/test_forward_args_6.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(x,y,z); bar(...); end # error: unexpected token "..."

--- a/test/whitequark/test_forward_args_7.rb
+++ b/test/whitequark/test_forward_args_7.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(x,y,z); super(...); end # error: unexpected token "..."

--- a/test/whitequark/test_forward_args_8.rb
+++ b/test/whitequark/test_forward_args_8.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+->... {} # error: unexpected token "..."

--- a/test/whitequark/test_forward_args_9.rb
+++ b/test/whitequark/test_forward_args_9.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+->(...) {} # error: unexpected token "..."

--- a/third_party/parser/cc/grammars/typedruby.ypp
+++ b/third_party/parser/cc/grammars/typedruby.ypp
@@ -322,6 +322,7 @@ using namespace std::string_literals;
   xstring_contents
 
 %type <token>
+  args_forward
   blkarg_mark
   call_op
   cname
@@ -1279,7 +1280,12 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby27 &driver) {
                     {
                       $$ = driver.alloc.delimited_node_list($1, $2, $3);
                     }
-
+                | tLPAREN2 args_forward rparen
+                    {
+                      auto forwarded_args = driver.build.forwarded_args(self, $2);
+                      auto node_list = driver.alloc.node_list(forwarded_args);
+                      $$ = driver.alloc.delimited_node_list($1, node_list, $3);
+                    }
   opt_paren_args: // nothing
                     {
                       $$ = driver.alloc.delimited_node_list(nullptr, driver.alloc.node_list(), nullptr);
@@ -3060,6 +3066,12 @@ keyword_variable: kNIL
                       driver.lex.set_state_expr_value();
                       $$ = driver.build.args(self, $1, $2, $3, true);
                     }
+                | tLPAREN2 args_forward rparen
+                    {
+                      driver.lex.set_state_expr_value();
+                      driver.lex.declare_forward_args();
+                      $$ = driver.build.forward_args(self, $1, $2, $3);
+                    }
                 |   {
                       $<boolean>$ = driver.lex.in_kwarg;
                       driver.lex.in_kwarg = true;
@@ -3213,7 +3225,10 @@ keyword_variable: kNIL
                     {
                       $$ = driver.alloc.node_list();
                     }
-
+    args_forward: tDOT3
+                    {
+                      $$ = $1;
+                    }
        f_bad_arg: tCONSTANT
                     {
                       driver.diagnostics.emplace_back(dlevel::ERROR, dclass::ArgumentConst, $1);

--- a/third_party/parser/cc/lexer.rl
+++ b/third_party/parser/cc/lexer.rl
@@ -2833,6 +2833,14 @@ bool lexer::is_declared(const std::string& identifier) const {
   return env.find(identifier) != env.end();
 }
 
+void lexer::declare_forward_args() {
+  declare(FORWARD_ARGS);
+}
+
+bool lexer::is_declared_forward_args() {
+  return is_declared(FORWARD_ARGS);
+}
+
 optional_size lexer::dedentLevel() {
   // We erase @dedentLevel as a precaution to avoid accidentally
   // using a stale value.

--- a/third_party/parser/include/ruby_parser/builder.hh
+++ b/third_party/parser/include/ruby_parser/builder.hh
@@ -57,6 +57,8 @@ struct builder {
 	ForeignPtr(*float_)(SelfPtr builder, const token* tok);
 	ForeignPtr(*floatComplex)(SelfPtr builder, const token* tok);
 	ForeignPtr(*for_)(SelfPtr builder, const token* for_, ForeignPtr iterator, const token* in_, ForeignPtr iteratee, const token* do_, ForeignPtr body, const token* end);
+	ForeignPtr(*forward_args)(SelfPtr builder, const token* begin, const token* dots, const token* end);
+	ForeignPtr(*forwarded_args)(SelfPtr builder, const token* dots);
 	ForeignPtr(*gvar)(SelfPtr builder, const token* tok);
 	ForeignPtr(*hash_pattern)(SelfPtr builder, const token* begin, const node_list* kwargs, const token* end);
 	ForeignPtr(*ident)(SelfPtr builder, const token* tok);

--- a/third_party/parser/include/ruby_parser/lexer.hh
+++ b/third_party/parser/include/ruby_parser/lexer.hh
@@ -65,6 +65,8 @@ private:
     const char *te;
     int act;
 
+    const std::string FORWARD_ARGS = "FORWARD_ARGS";
+
     // State before =begin / =end block comment
     int cs_before_block_comment;
 
@@ -160,6 +162,8 @@ public:
     void unextend();
     void declare(const std::string &name);
     bool is_declared(const std::string &identifier) const;
+    void declare_forward_args();
+    bool is_declared_forward_args();
 
     optional_size dedentLevel();
 };


### PR DESCRIPTION
### Motivation

Ruby 2.7 introduced the argument forwarding syntax:

```rb
def foo(...)
  target(...)
end
```

And if I'm following [this documentation](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/) correctly, it would be comparable to...

```rb
def foo(*args, **kwargs, &block)
  target(*args, **kwargs, &block)
end
```

This PR imports the whitequark tests, updates the parser and introduces desugaring/resolving support for the forwarding syntax.

### Approach

1. During `parsing` we store `...` calls as a `FORWARD(ED)_ARG` node in the AST:

    ```
      DefMethod {
        name = <U foo>
        args = ForwardArgs {
        }
        body = Send {
          receiver = NULL
          method = <U bar>
          args = [
            ForwardedArgs {
            }
          ]
        }
      }
    ```

2. During `desugar` the `...` node are transformed into `*args, **kwargs, &block`:

    ```
    def foo<<C <todo sym>>>(*<args>, **<kargs>:, &<blk>)
      ::<Magic>.<call-with-splat-and-block>(<self>, :"bar", ::T.unsafe(<args>).to_a().concat([<kargs>.to_hash()]), <blk>)
    end
    ```

3. During `resolve`, nothing change regarding local variables and arguments resolution:

    ```
        MethodDef{
          flags = {}
          name = <U foo><<U foo>>
          args = [Local{
              localVariable = <U <args>>
            }, Local{
              localVariable = <U <kargs>>
            }, Local{
              localVariable = <U <blk>>
            }]
     ```

   But if a signature if provided we check that it contains the right parameters:

   ```rb
   sig do
    params(
      x: T.untyped
    ).returns(String)
   end # error: Malformed `sig` for argument forwarding. Signature must declare exactly `3` parameters named `args`, `kargs` and `block`
   def foo(...)
   end
   ```

   Then rename the `args` to `<args>` to match the desugared signature (and avoid someone using the `args` when it's not really declared:

    ```rb
    sig do
      params(
        args: Integer,
        kargs: T::Hash[Symbol, String],
        block: T.proc.returns(Integer)
      ).void
    end
    def foo(...)
      puts args # error: Method `args` does not exist on `Foo`
      puts kargs # error: Method `kargs` does not exist on `Foo`
      puts block # error: Method `block` does not exist on `Foo`
      target(...)
    end
    ```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
