### PR TITLE
ruby27: Add kwargs field to parser::Hash

### DIFF
--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -264,7 +264,9 @@ public:
     }
 
     unique_ptr<Node> associate(const token *begin, sorbet::parser::NodeVec pairs, const token *end) {
-        return make_unique<Hash>(collectionLoc(begin, pairs, end), std::move(pairs));
+        ENFORCE((begin == nullptr && end == nullptr) || (begin != nullptr && end != nullptr));
+        auto isKwargs = begin == nullptr && end == nullptr;
+        return make_unique<Hash>(collectionLoc(begin, pairs, end), isKwargs, std::move(pairs));
     }
 
     unique_ptr<Node> attrAsgn(unique_ptr<Node> receiver, const token *dot, const token *selector, bool masgn) {

--- a/test/testdata/parser/kwargs.rb
+++ b/test/testdata/parser/kwargs.rb
@@ -1,0 +1,6 @@
+# typed: false
+
+foo(x: 0)
+foo({x: 0})
+foo(**{x: 0})
+foo(**hash)

--- a/test/testdata/parser/kwargs.rb.parse-tree.exp
+++ b/test/testdata/parser/kwargs.rb.parse-tree.exp
@@ -1,0 +1,87 @@
+Begin {
+  stmts = [
+    Send {
+      receiver = NULL
+      method = <U foo>
+      args = [
+        Hash {
+          kwargs = true
+          pairs = [
+            Pair {
+              key = Symbol {
+                val = <U x>
+              }
+              value = Integer {
+                val = "0"
+              }
+            }
+          ]
+        }
+      ]
+    }
+    Send {
+      receiver = NULL
+      method = <U foo>
+      args = [
+        Hash {
+          kwargs = false
+          pairs = [
+            Pair {
+              key = Symbol {
+                val = <U x>
+              }
+              value = Integer {
+                val = "0"
+              }
+            }
+          ]
+        }
+      ]
+    }
+    Send {
+      receiver = NULL
+      method = <U foo>
+      args = [
+        Hash {
+          kwargs = true
+          pairs = [
+            Kwsplat {
+              expr = Hash {
+                kwargs = false
+                pairs = [
+                  Pair {
+                    key = Symbol {
+                      val = <U x>
+                    }
+                    value = Integer {
+                      val = "0"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+    Send {
+      receiver = NULL
+      method = <U foo>
+      args = [
+        Hash {
+          kwargs = true
+          pairs = [
+            Kwsplat {
+              expr = Send {
+                receiver = NULL
+                method = <U hash>
+                args = [
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/testdata/parser/misc.rb.parse-tree.exp
+++ b/test/testdata/parser/misc.rb.parse-tree.exp
@@ -321,6 +321,7 @@ Begin {
       body = NULL
     }
     Hash {
+      kwargs = false
       pairs = [
         Kwsplat {
           expr = LVar {
@@ -429,6 +430,7 @@ Begin {
       body = NULL
     }
     Hash {
+      kwargs = false
       pairs = [
         Pair {
           key = LVar {


### PR DESCRIPTION
This lets us model how Ruby 2.7 treats keyword args better.

Compare this (hash literal, mentions curly braces):

    ❯ ruby --dump=parsetree -e 'foo({x: 0})'
    ###########################################################
    ## Do NOT use this node dump for any purpose other than  ##
    ## debug and research.  Compatibility is not guaranteed. ##
    ###########################################################

    # @ NODE_SCOPE (line: 1, location: (1,0)-(1,11))
    # +- nd_tbl: (empty)
    # +- nd_args:
    # |   (null node)
    # +- nd_body:
    #     @ NODE_FCALL (line: 1, location: (1,0)-(1,11))*
    #     +- nd_mid: :foo
    #     +- nd_args:
    #         @ NODE_LIST (line: 1, location: (1,4)-(1,10))
    #         +- nd_alen: 1
    #         +- nd_head:
    #         |   @ NODE_HASH (line: 1, location: (1,4)-(1,10))
    #         |   +- nd_brace: 1 (hash literal)
    #         |   +- nd_head:
    #         |       @ NODE_LIST (line: 1, location: (1,5)-(1,9))
    #         |       +- nd_alen: 2
    #         |       +- nd_head:
    #         |       |   @ NODE_LIT (line: 1, location: (1,5)-(1,7))
    #         |       |   +- nd_lit: :x
    #         |       +- nd_head:
    #         |       |   @ NODE_LIT (line: 1, location: (1,8)-(1,9))
    #         |       |   +- nd_lit: 0
    #         |       +- nd_next:
    #         |           (null node)
    #         +- nd_next:
    #             (null node)

with this (keyword args, doesn't mention curly braces):

    ❯ ruby --dump=parsetree -e 'foo(x: 0)'
    ###########################################################
    ## Do NOT use this node dump for any purpose other than  ##
    ## debug and research.  Compatibility is not guaranteed. ##
    ###########################################################

    # @ NODE_SCOPE (line: 1, location: (1,0)-(1,9))
    # +- nd_tbl: (empty)
    # +- nd_args:
    # |   (null node)
    # +- nd_body:
    #     @ NODE_FCALL (line: 1, location: (1,0)-(1,9))*
    #     +- nd_mid: :foo
    #     +- nd_args:
    #         @ NODE_LIST (line: 1, location: (1,4)-(1,8))
    #         +- nd_alen: 1
    #         +- nd_head:
    #         |   @ NODE_HASH (line: 1, location: (1,4)-(1,8))
    #         |   +- nd_brace: 0 (keyword argument)
    #         |   +- nd_head:
    #         |       @ NODE_LIST (line: 1, location: (1,4)-(1,8))
    #         |       +- nd_alen: 2
    #         |       +- nd_head:
    #         |       |   @ NODE_LIT (line: 1, location: (1,4)-(1,6))
    #         |       |   +- nd_lit: :x
    #         |       +- nd_head:
    #         |       |   @ NODE_LIT (line: 1, location: (1,7)-(1,8))
    #         |       |   +- nd_lit: 0
    #         |       +- nd_next:
    #         |           (null node)
    #         +- nd_next:
    #             (null node)

Specifically, look for the `nd_brace` field on `NODE_HASH`.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

- [ ] TODO(jez) tests