### PR TITLE
Fix `hidden-methods` failure in Ruby 2.7

### DIFF
--- a/gems/sorbet/lib/serialize.rb
+++ b/gems/sorbet/lib/serialize.rb
@@ -337,6 +337,19 @@ class Sorbet::Private::Serialize
           uniq += 1
         end
       end
+
+      # Sanitize parameter names that are not valid.
+      # Ruby 2.7+ argument forwarding works by expanding `foo(...)`
+      # to `foo(**, ****, &&)`, in other words, to a rest parameter named
+      # `*`, a keyword rest parameter named `**` and a block argument named
+      # `&`. Those are all illegal parameter names which we should NOT
+      # generate. (Coincidentally, that is why Ruby 2.7+ uses those names,
+      # so that user code cannot mess with the forwarded arguments)
+      if ["*", "**", "&"].include?(name.to_s)
+        name = '_' + (uniq == 0 ? '' : uniq.to_s)
+        uniq += 1
+      end
+
       [kind, name]
     end
   end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Resolve: #2771

Due to the way argument forwarding is implemented in Ruby 2.7, at runtime Sorbet will see parameter names for the expanded method parameters that are invalid. This causes a failure in the hidden methods generation process since the output ends up being an invalid RBI file.

The fix is to sanitize the parameter names to be valid unique names so that we still capture the runtime method signature but also have valid parameter names as well.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No automated tests included since there is no framework to test `sorbet` gem under 2.7. However, there are [user reports of the fix working successfully in their codebase](https://stackoverflow.com/a/63855869/98634) with this patch
