### PR TITLE
Add `--print parse-tree-json-with-locs` option

### DIFF
--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -230,7 +230,7 @@ string Loc::showRaw(const GlobalState &gs) const {
     return fmt::format("Loc {{file={} start={}:{} end={}:{}}}", path, start.line, start.column, end.line, end.column);
 }
 
-string Loc::filePosToString(const GlobalState &gs) const {
+string Loc::filePosToString(const GlobalState &gs, bool showFull) const {
     stringstream buf;
     if (!file().exists()) {
         buf << "???";
@@ -251,7 +251,16 @@ string Loc::filePosToString(const GlobalState &gs) const {
                 buf << ":";
             }
             buf << pos.first.line;
-            // pos.second.line; is intentionally not printed so that iterm2 can open file name:line_number as links
+            if (showFull) {
+                buf << ":";
+                buf << pos.first.column;
+                buf << "-";
+                buf << pos.second.line;
+                buf << ":";
+                buf << pos.second.column;
+            } else {
+                // pos.second.line; is intentionally not printed so that iterm2 can open file name:line_number as links
+            }
         }
     }
     return buf.str();

--- a/core/Loc.h
+++ b/core/Loc.h
@@ -112,7 +112,7 @@ public:
         return toStringWithTabs(gs);
     }
     std::string showRaw(const GlobalState &gs) const;
-    std::string filePosToString(const GlobalState &gs) const;
+    std::string filePosToString(const GlobalState &gs, bool showFull = false) const;
     std::string source(const GlobalState &gs) const;
 
     bool operator==(const Loc &rhs) const;

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -560,7 +560,7 @@ public:
         bool showRaw = false;
         return toStringWithOptions(gs, 0, showFull, showRaw);
     }
-    std::string toJSON(const GlobalState &gs, int tabs = 0, bool showFull = false) const;
+    std::string toJSON(const GlobalState &gs, int tabs = 0) const;
     // Renders the full name of this Symbol in a form suitable for user display.
     std::string show(const GlobalState &gs) const;
 

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -31,6 +31,7 @@ struct PrintOptions {
 const vector<PrintOptions> print_options({
     {"parse-tree", &Printers::ParseTree},
     {"parse-tree-json", &Printers::ParseTreeJson},
+    {"parse-tree-json-with-locs", &Printers::ParseTreeJsonWithLocs},
     {"parse-tree-whitequark", &Printers::ParseTreeWhitequark},
     {"desugar-tree", &Printers::DesugarTree},
     {"desugar-tree-raw", &Printers::DesugarTreeRaw},
@@ -95,6 +96,7 @@ vector<reference_wrapper<PrinterConfig>> Printers::printers() {
     return vector<reference_wrapper<PrinterConfig>>({
         ParseTree,
         ParseTreeJson,
+        ParseTreeJsonWithLocs,
         ParseTreeWhitequark,
         DesugarTree,
         DesugarTreeRaw,

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -39,6 +39,7 @@ private:
 struct Printers {
     PrinterConfig ParseTree;
     PrinterConfig ParseTreeJson;
+    PrinterConfig ParseTreeJsonWithLocs;
     PrinterConfig ParseTreeWhitequark;
     PrinterConfig DesugarTree;
     PrinterConfig DesugarTreeRaw;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -131,6 +131,9 @@ unique_ptr<parser::Node> runParser(core::GlobalState &gs, core::FileRef file, co
     if (print.ParseTreeJson.enabled) {
         print.ParseTreeJson.fmt("{}\n", nodes->toJSON(gs, 0));
     }
+    if (print.ParseTreeJsonWithLocs.enabled) {
+        print.ParseTreeJson.fmt("{}\n", nodes->toJSONWithLocs(gs, file, 0));
+    }
     if (print.ParseTreeWhitequark.enabled) {
         print.ParseTreeWhitequark.fmt("{}\n", nodes->toWhitequark(gs, 0));
     }

--- a/parser/Node.cc
+++ b/parser/Node.cc
@@ -35,6 +35,15 @@ void Node::printNodeJSON(fmt::memory_buffer &to, const unique_ptr<Node> &node, c
     }
 }
 
+void Node::printNodeJSONWithLocs(fmt::memory_buffer &to, const unique_ptr<Node> &node, const core::GlobalState &gs,
+                                 core::FileRef file, int tabs) const {
+    if (node) {
+        fmt::format_to(to, "{}", node->toJSONWithLocs(gs, file, tabs));
+    } else {
+        fmt::format_to(to, "null");
+    }
+}
+
 void Node::printNodeWhitequark(fmt::memory_buffer &to, const unique_ptr<Node> &node, const core::GlobalState &gs,
                                int tabs) const {
     if (node) {

--- a/parser/Node.h
+++ b/parser/Node.h
@@ -16,6 +16,7 @@ public:
         return toStringWithTabs(gs);
     }
     virtual std::string toJSON(const core::GlobalState &gs, int tabs = 0) = 0;
+    virtual std::string toJSONWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) = 0;
     virtual std::string toWhitequark(const core::GlobalState &gs, int tabs = 0) = 0;
     virtual std::string nodeName() = 0;
     core::LocOffsets loc;
@@ -26,6 +27,8 @@ protected:
                    int tabs) const;
     void printNodeJSON(fmt::memory_buffer &to, const std::unique_ptr<Node> &node, const core::GlobalState &gs,
                        int tabs) const;
+    void printNodeJSONWithLocs(fmt::memory_buffer &to, const std::unique_ptr<Node> &node, const core::GlobalState &gs,
+                               core::FileRef file, int tabs) const;
     void printNodeWhitequark(fmt::memory_buffer &to, const std::unique_ptr<Node> &node, const core::GlobalState &gs,
                              int tabs) const;
 };

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -167,20 +167,21 @@ Usage:
 
  dev options:
   -p, --print type              Print: [parse-tree, parse-tree-json,
-                                parse-tree-whitequark, desugar-tree, desugar-tree-raw,
-                                rewrite-tree, rewrite-tree-raw, index-tree,
-                                index-tree-raw, name-tree, name-tree-raw,
-                                resolve-tree, resolve-tree-raw, flatten-tree,
-                                flatten-tree-raw, ast, ast-raw, cfg, cfg-raw,
-                                symbol-table, symbol-table-raw, symbol-table-json,
-                                symbol-table-proto, symbol-table-messagepack,
-                                symbol-table-full, symbol-table-full-raw,
-                                symbol-table-full-json, symbol-table-full-proto,
-                                symbol-table-full-messagepack, file-table-json,
-                                file-table-proto, file-table-messagepack,
-                                missing-constants, plugin-generated-code,
-                                autogen, autogen-msgpack, autogen-classlist,
-                                autogen-autoloader, autogen-subclasses, package-tree]
+                                parse-tree-json-with-locs, parse-tree-whitequark,
+                                desugar-tree, desugar-tree-raw, rewrite-tree,
+                                rewrite-tree-raw, index-tree, index-tree-raw,
+                                name-tree, name-tree-raw, resolve-tree,
+                                resolve-tree-raw, flatten-tree, flatten-tree-raw, ast,
+                                ast-raw, cfg, cfg-raw, symbol-table,
+                                symbol-table-raw, symbol-table-json, symbol-table-proto,
+                                symbol-table-messagepack, symbol-table-full,
+                                symbol-table-full-raw, symbol-table-full-json,
+                                symbol-table-full-proto,
+                                symbol-table-full-messagepack, file-table-json, file-table-proto,
+                                file-table-messagepack, missing-constants,
+                                plugin-generated-code, autogen, autogen-msgpack,
+                                autogen-classlist, autogen-autoloader,
+                                autogen-subclasses, package-tree]
       --autogen-subclasses-parent string
                                 Parent classes for which generate a list of
                                 subclasses. This option must be used in

--- a/test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs.out
+++ b/test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs.out
@@ -1,0 +1,132 @@
+{
+  "type" : "Module",
+  "loc" : "test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs1.rb:3:1-3:9",
+  "name" : {
+    "type" : "Const",
+    "scope" : null,
+    "name" : "A"
+  },
+  "body" : {
+    "type" : "Module",
+    "loc" : "test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs1.rb:4:3-4:11",
+    "name" : {
+      "type" : "Const",
+      "scope" : null,
+      "name" : "B"
+    },
+    "body" : {
+      "type" : "DefMethod",
+      "loc" : "test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs1.rb:5:5-5:12",
+      "name" : "foo",
+      "args" : null,
+      "body" : {
+        "type" : "String",
+        "val" : "foo"
+      }
+    }
+  }
+}
+{
+  "type" : "Class",
+  "loc" : "test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs2.rb:3:1-3:8",
+  "name" : {
+    "type" : "Const",
+    "scope" : null,
+    "name" : "C"
+  },
+  "superclass" : null,
+  "body" : {
+    "type" : "Begin",
+    "stmts" : [
+      {
+        "type" : "Send",
+        "receiver" : null,
+        "method" : "include",
+        "args" : [
+          {
+            "type" : "Const",
+            "scope" : null,
+            "name" : "A"
+          }
+        ]
+      },
+      {
+        "type" : "Send",
+        "receiver" : null,
+        "method" : "include",
+        "args" : [
+          {
+            "type" : "Const",
+            "scope" : null,
+            "name" : "B"
+          }
+        ]
+      },
+      {
+        "type" : "DefMethod",
+        "loc" : "test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs2.rb:7:3-7:10",
+        "name" : "bar",
+        "args" : null,
+        "body" : {
+          "type" : "Send",
+          "receiver" : null,
+          "method" : "foo",
+          "args" : [
+          ]
+        }
+      }
+    ]
+  }
+}
+{
+  "type" : "Class",
+  "loc" : "test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs3.rb:3:1-3:11",
+  "name" : {
+    "type" : "Const",
+    "scope" : null,
+    "name" : "Main"
+  },
+  "superclass" : null,
+  "body" : {
+    "type" : "DefMethod",
+    "loc" : "test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs3.rb:4:3-4:11",
+    "name" : "main",
+    "args" : null,
+    "body" : {
+      "type" : "Begin",
+      "stmts" : [
+        {
+          "type" : "Send",
+          "receiver" : {
+            "type" : "Const",
+            "scope" : null,
+            "name" : "A"
+          },
+          "method" : "new",
+          "args" : [
+          ]
+        },
+        {
+          "type" : "Send",
+          "receiver" : null,
+          "method" : "puts",
+          "args" : [
+            {
+              "type" : "Send",
+              "receiver" : {
+                "type" : "Send",
+                "receiver" : null,
+                "method" : "a",
+                "args" : [
+                ]
+              },
+              "method" : "foo",
+              "args" : [
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs.sh
+++ b/test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+main/sorbet \
+    --silence-dev-message \
+    --stop-after parser \
+    --no-error-count \
+    -p parse-tree-json-with-locs \
+    test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs1.rb \
+    test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs2.rb \
+    test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs3.rb 2>&1

--- a/test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs1.rb
+++ b/test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs1.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+module A
+  module B
+    def foo
+      "foo"
+    end
+  end
+end

--- a/test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs2.rb
+++ b/test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs2.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+class C
+  include A
+  include B
+
+  def bar; foo; end
+end

--- a/test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs3.rb
+++ b/test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs3.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+class Main
+  def main
+    A.new
+    puts a.foo
+  end
+end


### PR DESCRIPTION
### Motivation

Parsing Ruby code with Sorbet is tremendously fast which make `--print parse-tree-json` an interesting for tooling that needs to do some processing based on the AST content (linting, metrics collection, sky's the limit).

One problem when building tool using `--print parse-tree-json` is that it does not include location which limits the potential of the tool.

This PR introduces `--print parse-tree-json-with-locs` which include the location of each node (example extracted from the tests):

```
{
  "type" : "Module",
  "loc" : "test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs1.rb:3:1-3:9",
  "name" : {
    "type" : "Const",
    "scope" : null,
    "name" : "A"
  },
  "body" : {
    "type" : "Module",
    "loc" : "test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs1.rb:4:3-4:11",
    "name" : {
      "type" : "Const",
      "scope" : null,
      "name" : "B"
    },
    "body" : {
      "type" : "DefMethod",
      "loc" : "test/cli/parse-tree-json-with-locs/parse-tree-json-with-locs1.rb:5:5-5:12",
      "name" : "foo",
      "args" : null,
      "body" : {
        "type" : "String",
        "val" : "foo"
      }
    }
  }
}
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
