### PR TITLE
Allow method hooks to be disabled globally

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -23,6 +23,9 @@ module T::Private::Methods
   # enabling final checks for when those hooks are called. the 'hooks' here don't have anything to do with the 'hooks'
   # in installed_hooks.
   @old_hooks = nil
+  # this boolean flag indicates if new method additions will be processed or not. user code can
+  # disable further method additions from being processed by flipping this to false.
+  @method_hooks_disabled = false
 
   ARG_NOT_PROVIDED = Object.new
   PROC_TYPE = Object.new
@@ -171,7 +174,7 @@ module T::Private::Methods
 
   # Only public because it needs to get called below inside the replace_method blocks below.
   def self._on_method_added(hook_mod, method_name, is_singleton_method: false)
-    if T::Private::DeclState.current.skip_on_method_added
+    if @method_hooks_disabled || T::Private::DeclState.current.skip_on_method_added
       return
     end
 
@@ -468,6 +471,10 @@ module T::Private::Methods
       mod.extend(MethodHooks)
     end
     mod.extend(SingletonMethodHooks)
+  end
+
+  def self.disable_all_method_hooks
+    @method_hooks_disabled = true
   end
 
   # use this directly if you don't want/need to box up the method into an object to pass to method_to_key.

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -81,6 +81,11 @@ module T::Utils
     T::Private::Methods.run_all_sig_blocks
   end
 
+  # Stop searching for sigs. All method added hooks will be disabled.
+  def self.disable_method_hooks
+    T::Private::Methods.disable_all_method_hooks
+  end
+
   # Return the underlying type for a type alias. Otherwise returns type.
   def self.resolve_alias(type)
     case type

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -154,6 +154,7 @@ module T::Utils
   def self.coerce(val); end
   def self.resolve_alias(type); end
   def self.run_all_sig_blocks; end
+  def self.disable_method_hooks; end
   def self.signature_for_instance_method(mod, method_name); end
   def self.unwrap_nilable(type); end
   def self.wrap_method_with_call_validation_if_needed(mod, method_sig, original_method); end


### PR DESCRIPTION
Add a `T::Utils.disable_method_hooks` method to allow users to disable processing of method additions past that point.

### Motivation

Recently, we've had a case in our codebase where we experienced a 100% slowdown in an endpoint due to the addition of a signature in one of our Active Record models. My research into what caused the problem lead me to realize that the method was triggering many Active Record callback methods to be defined on the returned object for every call of the method. This was causing all those methods to trigger the method added hooks since Sorbet was activated on the model class, thus causing the slowdown.

While I am still investigating the root cause of the problem in our codebase (i.e. understanding why all those callback methods are being added in the first place), I also wanted to make Sorbet behaviour more deterministic in production by adding an optional method to disable method hooks.

Afterall, in production, we eager load our application, and unwrap all of our signatures after boot. Thus, we don't expect any methods with signatures to be defined after that point, and can safely disable the method hooks. The added `T::Utils.disable_method_hooks` method should allow us to do that.

### Test plan

I am not sure how to test this, since it changes global behaviour. I am open to suggestions.
