### PR TITLE
Fix Hash#rassoc parameter type

### DIFF
--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -980,7 +980,7 @@ class Hash < Object
     params(
         arg0: V,
     )
-    .returns(T::Array[T.any(K, V)])
+    .returns(T.nilable(T::Array[T.any(K, V)]))
   end
   def rassoc(arg0); end
 

--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -980,7 +980,7 @@ class Hash < Object
     params(
         arg0: V,
     )
-    .returns(T.nilable(T::Array[T.any(K, V)]))
+    .returns(T.nilable([K, V]))
   end
   def rassoc(arg0); end
 

--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -978,7 +978,7 @@ class Hash < Object
   # ```
   sig do
     params(
-        arg0: K,
+        arg0: V,
     )
     .returns(T::Array[T.any(K, V)])
   end


### PR DESCRIPTION
`Hash#rassoc` takes a value in the hash and returns the pair. The type signature expected a key rather than a value.

### Motivation
Caused [this incorrect type-checking failure](https://travis-ci.org/github/AaronC81/parlour/jobs/728444301) on Parlour.

### Test plan
N/A