### PR TITLE
Fix wrong signature for `StringScanner#scan`.

### DIFF
--- a/rbi/stdlib/strscan.rbi
+++ b/rbi/stdlib/strscan.rbi
@@ -526,16 +526,12 @@ class StringScanner < Object
   # p s.scan(/\w+/)   # -> "test"
   # p s.scan(/\w+/)   # -> nil
   # p s.scan(/\s+/)   # -> " "
-  # p s.scan(/\w+/)   # -> "string"
+  # p s.scan("str")   # -> "str"
+  # p s.scan(/\w+/)   # -> "ing"
   # p s.scan(/./)     # -> nil
   # ```
-  sig do
-    params(
-        arg0: Regexp,
-    )
-    .returns(String)
-  end
-  def scan(arg0); end
+  sig {params(pattern: T.any(Regexp, String)).returns(T.nilable(String))}
+  def scan(pattern); end
 
   # Tests whether the given `pattern` is matched from the current scan pointer.
   # Advances the scan pointer if `advance_pointer_p` is true. Returns the


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation

Current signature is wrong.
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The [documentation for Ruby 2.6.3](https://ruby-doc.org/stdlib-2.6.3/libdoc/strscan/rdoc/StringScanner.html#method-i-scan) includes a new line in the example passing `"str"` and already stated previously that is returns `nil` when nothing is matched.