### PR TITLE
RBI: Integer#divmod sig more accurate

### DIFF
--- a/rbi/core/integer.rbi
+++ b/rbi/core/integer.rbi
@@ -703,7 +703,13 @@ class Integer < Numeric
   # [`Numeric#divmod`](https://docs.ruby-lang.org/en/2.6.0/Numeric.html#method-i-divmod).
   sig do
     params(
-        arg0: T.any(Integer, Float, Rational, BigDecimal),
+        arg0: Integer,
+    )
+    .returns([Integer, Integer])
+  end
+  sig do
+    params(
+        arg0: T.any(Float, Rational, BigDecimal),
     )
     .returns([T.any(Integer, Float, Rational, BigDecimal), T.any(Integer, Float, Rational, BigDecimal)])
   end


### PR DESCRIPTION
This improves the signature of Integer#divmod to make it more accurate.
- Integer#div with an Integer argument always returns an Integer
- Integer#mod with an Integer argument always returns an Integer
- Hence Integer#divmod with an Integer argument should always return [Integer, Integer]

### Motivation

In the project I'm working at we use `Integer#divmod` in a few places.

### Test plan

I can add some tests if someone shows me:
- in which file they should be located;
- which other tests I can use as an example.