### PR TITLE
Split metrics for modules and classes count

### DIFF
--- a/test/cli/metrics-file/metrics-file.out
+++ b/test/cli/metrics-file/metrics-file.out
@@ -12,6 +12,12 @@ No errors! Great job.
    "value": 1
    "name": "ruby_typer.unknown..types.input.files.sigil.true",
    "value": 1
+   "name": "ruby_typer.unknown..types.input.modules.total",
+   "value": 1
+   "name": "ruby_typer.unknown..types.input.classes.total",
+   "value": 5
+   "name": "ruby_typer.unknown..types.input.methods.total",
+   "value": 8
 ------------------------------
 No errors! Great job.
 No error metrics reported.

--- a/test/cli/metrics-file/metrics-file.sh
+++ b/test/cli/metrics-file/metrics-file.sh
@@ -25,6 +25,9 @@ main/sorbet --silence-dev-message \
 grep -A1 "\"ruby_typer.unknown..types.input.files\"" metrics4.json
 grep -A1 "\"ruby_typer.unknown..types.input.files.sigil.false\"" metrics4.json
 grep -A1 "\"ruby_typer.unknown..types.input.files.sigil.true\"" metrics4.json
+grep -A1 "\"ruby_typer.unknown..types.input.modules.total\"" metrics4.json
+grep -A1 "\"ruby_typer.unknown..types.input.classes.total\"" metrics4.json
+grep -A1 "\"ruby_typer.unknown..types.input.methods.total\"" metrics4.json
 
 echo ------------------------------
 

--- a/test/cli/metrics-file/test.rb
+++ b/test/cli/metrics-file/test.rb
@@ -10,5 +10,8 @@ class Bar
   delegate :foo, to: :foo
 end
 
+module Baz
+end
+
 Foo.new.foo
 Bar.new.foo


### PR DESCRIPTION
### Motivation

Thanks to the `--metrics-file` option we can have metrics about a codebase in a few seconds. This is super cool to grasp the size of this codebase or to build tool using the output of this option.

One bothering detail is that the `types.input.classes.total` metric actually count both modules and classes.

For example, Be the following Ruby file:

```rb
# -- file.rb --
# typed: true

module A; end
class B; end
class C < B; end
```

Currently, computing the metrics for this file with `sorbet --metrics-file metrics.json file.rb` gives us:

```json
  ...
  {
   "name": "ruby_typer.unknown..singleton_classes",
   "value": 3
  },
  {
   "name": "ruby_typer.unknown..types.input.classes.total",
   "value": 6
  },
  ...
```

With this PR, we get instead:

```json
  ...
  {
   "name": "ruby_typer.unknown..singleton_classes",
   "value": 3
  },
  {
   "name": "ruby_typer.unknown..types.input.classes.total",
   "value": 5
  },
  {
   "name": "ruby_typer.unknown..types.input.modules.total",
   "value": 1
  }
```

**Warning**: If you're currently tracking the `types.input.classes.total` you might want to either track the new metrics or track the sum of the two metrics.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
