### PR TITLE
Penelope add exception base

### DIFF
--- a/rbi/core/exception.rbi
+++ b/rbi/core/exception.rbi
@@ -183,7 +183,7 @@ class Exception < Object
 
   sig do
     params(
-        arg0: T.any(String, Symbol, NilClass),
+        arg0: T.any(String, Symbol, NilClass, Exception),
     )
     .void
   end

--- a/test/testdata/rbi/exception.rb
+++ b/test/testdata/rbi/exception.rb
@@ -4,3 +4,5 @@ StandardError.new
 StandardError.new(nil)
 StandardError.new('msg')
 StandardError.new(:msg)
+ex = StandardError.new("bees")
+RuntimeError.new(ex)


### PR DESCRIPTION
This is to allow wrapping exceptions to be typed:

```
(penelope-add-exception-base)$ irb
irb(main):001:0> e = RuntimeError.new
=> #<RuntimeError: RuntimeError>
irb(main):002:0> Exception.new(e)
=> #<Exception: RuntimeError>
irb(main):003:0>
```

### Motivation
This corrects the issue where sorbet cannot correctly type exception wrapping at `strict` level: https://sorbet.run/#%23%20typed%3A%20strict%0Aclass%20MyError%20%3C%20RuntimeError%0Aend%0A%0Abegin%0A%20%20raise%20%22omg%22%0Arescue%20%3D%3E%20ex%0A%20%20MyError.new(ex)%0Aend


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
