### PR TITLE
Show singleton classes metrics in release build

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -924,7 +924,7 @@ SymbolRef Symbol::singletonClass(GlobalState &gs) {
     singleton = gs.enterClassSymbol(this->loc(), this->owner, singletonName);
     SymbolData singletonInfo = singleton.data(gs);
 
-    counterInc("singleton_classes");
+    prodCounterInc("singleton_classes");
     singletonInfo->members()[Names::attached()] = selfRef;
     singletonInfo->setSuperClass(Symbols::todo());
     singletonInfo->setIsModule(false);

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -924,7 +924,7 @@ SymbolRef Symbol::singletonClass(GlobalState &gs) {
     singleton = gs.enterClassSymbol(this->loc(), this->owner, singletonName);
     SymbolData singletonInfo = singleton.data(gs);
 
-    prodCounterInc("singleton_classes");
+    prodCounterInc("types.input.singleton_classes.total");
     singletonInfo->members()[Names::attached()] = selfRef;
     singletonInfo->setSuperClass(Symbols::todo());
     singletonInfo->setIsModule(false);

--- a/test/cli/metrics-file/metrics-file.out
+++ b/test/cli/metrics-file/metrics-file.out
@@ -16,7 +16,7 @@ No errors! Great job.
    "value": 1
    "name": "ruby_typer.unknown..types.input.classes.total",
    "value": 5
-   "name": "ruby_typer.unknown..singleton_classes",
+   "name": "ruby_typer.unknown..types.input.singleton_classes.total",
    "value": 3
    "name": "ruby_typer.unknown..types.input.methods.total",
    "value": 8

--- a/test/cli/metrics-file/metrics-file.out
+++ b/test/cli/metrics-file/metrics-file.out
@@ -16,6 +16,8 @@ No errors! Great job.
    "value": 1
    "name": "ruby_typer.unknown..types.input.classes.total",
    "value": 5
+   "name": "ruby_typer.unknown..singleton_classes",
+   "value": 3
    "name": "ruby_typer.unknown..types.input.methods.total",
    "value": 8
 ------------------------------

--- a/test/cli/metrics-file/metrics-file.sh
+++ b/test/cli/metrics-file/metrics-file.sh
@@ -27,6 +27,7 @@ grep -A1 "\"ruby_typer.unknown..types.input.files.sigil.false\"" metrics4.json
 grep -A1 "\"ruby_typer.unknown..types.input.files.sigil.true\"" metrics4.json
 grep -A1 "\"ruby_typer.unknown..types.input.modules.total\"" metrics4.json
 grep -A1 "\"ruby_typer.unknown..types.input.classes.total\"" metrics4.json
+grep -A1 "\"ruby_typer.unknown..singleton_classes\"" metrics4.json
 grep -A1 "\"ruby_typer.unknown..types.input.methods.total\"" metrics4.json
 
 echo ------------------------------

--- a/test/cli/metrics-file/metrics-file.sh
+++ b/test/cli/metrics-file/metrics-file.sh
@@ -27,7 +27,7 @@ grep -A1 "\"ruby_typer.unknown..types.input.files.sigil.false\"" metrics4.json
 grep -A1 "\"ruby_typer.unknown..types.input.files.sigil.true\"" metrics4.json
 grep -A1 "\"ruby_typer.unknown..types.input.modules.total\"" metrics4.json
 grep -A1 "\"ruby_typer.unknown..types.input.classes.total\"" metrics4.json
-grep -A1 "\"ruby_typer.unknown..singleton_classes\"" metrics4.json
+grep -A1 "\"ruby_typer.unknown..types.input.singleton_classes.total\"" metrics4.json
 grep -A1 "\"ruby_typer.unknown..types.input.methods.total\"" metrics4.json
 
 echo ------------------------------


### PR DESCRIPTION
### Motivation

Since #3441 Sorbet counts the classes processed but this metrics also includes all the singleton classes.

We have a metrics a separate for them: `singleton_classes` which is only displayed for debug builds.

This pull-request enables the `singleton_classes` metrics for release builds so the user can have a precise view of what their program actually contains.

### Test plan

See included automated tests.
