### PR TITLE
Fix crash when escaping JSON strings with UTF-8 characters

### DIFF
--- a/common/JSON.cc
+++ b/common/JSON.cc
@@ -37,7 +37,7 @@ string JSON::escape(string from) {
                 special = "\\t"sv;
                 break;
             default:
-                if (ch <= 0x1f) {
+                if (0x00 <= ch && ch <= 0x1f) {
                     string_view toAdd(from.data() + firstUnusedChar, currentChar - firstUnusedChar);
                     firstUnusedChar = currentChar + 1;
                     fmt::format_to(buf, "{}\\u{:04x}", toAdd, ch);

--- a/test/cli/parse-tree-json/parse-tree-json.out
+++ b/test/cli/parse-tree-json/parse-tree-json.out
@@ -1,0 +1,101 @@
+{
+  "type" : "Begin",
+  "stmts" : [
+    {
+      "type" : "Assign",
+      "lhs" : {
+        "type" : "GVarLhs",
+        "name" : "$global"
+      },
+      "rhs" : {
+        "type" : "Send",
+        "receiver" : {
+          "type" : "Integer",
+          "val" : "1"
+        },
+        "method" : "+",
+        "args" : [
+          {
+            "type" : "Integer",
+            "val" : "2"
+          }
+        ]
+      }
+    },
+    {
+      "type" : "Assign",
+      "lhs" : {
+        "type" : "IVarLhs",
+        "name" : "@a"
+      },
+      "rhs" : {
+        "type" : "Integer",
+        "val" : "1"
+      }
+    },
+    {
+      "type" : "Assign",
+      "lhs" : {
+        "type" : "CVarLhs",
+        "name" : "@@a"
+      },
+      "rhs" : {
+        "type" : "Integer",
+        "val" : "1"
+      }
+    },
+    {
+      "type" : "Assign",
+      "lhs" : {
+        "type" : "LVarLhs",
+        "name" : "a"
+      },
+      "rhs" : {
+        "type" : "Integer",
+        "val" : "2"
+      }
+    },
+    {
+      "type" : "Masgn",
+      "lhs" : {
+        "type" : "Mlhs",
+        "exprs" : [
+          {
+            "type" : "SplatLhs",
+            "var" : {
+              "type" : "LVarLhs",
+              "name" : "a"
+            }
+          }
+        ]
+      },
+      "rhs" : {
+        "type" : "Integer",
+        "val" : "1"
+      }
+    },
+    {
+      "type" : "Send",
+      "receiver" : null,
+      "method" : "puts",
+      "args" : [
+        {
+          "type" : "Integer",
+          "val" : "1"
+        },
+        {
+          "type" : "String",
+          "val" : "👋 a string"
+        },
+        {
+          "type" : "GVar",
+          "name" : "$global"
+        },
+        {
+          "type" : "NthRef",
+          "ref" : "1"
+        }
+      ]
+    }
+  ]
+}

--- a/test/cli/parse-tree-json/parse-tree-json.rb
+++ b/test/cli/parse-tree-json/parse-tree-json.rb
@@ -1,0 +1,6 @@
+$global = 1 + 2
+@a = 1
+@@a = 1
+a = 2
+*a = 1
+puts(1, "👋 a string", $global, $1)

--- a/test/cli/parse-tree-json/parse-tree-json.sh
+++ b/test/cli/parse-tree-json/parse-tree-json.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+main/sorbet \
+    --silence-dev-message \
+    --stop-after parser \
+    --no-error-count \
+    -p parse-tree-json \
+    test/cli/parse-tree-json/parse-tree-json.rb 2>&1


### PR DESCRIPTION
### Motivation

Running `sorbet --print parse-tree-json -e "'a👋a'"` with Sorbet's master results in a `Bus error: 10` error.

This is because when we escape the String with `JSON::escape` we iterate over each character of the string:

```cpp
string JSON::escape(string from) {
    //...
    for (auto ch : from) {
        switch (ch) {
            case '\\':
            // ...
```

For the `a👋a` string this mean we actually end up iterating over the code points of the UTF-8 chars:

```
61 -> a
fffffff0 -> 👋[0]
ffffff9f -> 👋[1]
ffffff91 -> 👋[2]
ffffff8b -> 👋[3]
61 -> a
```

This means that later when we will check if that character is a control character:

```cpp
                if (ch <= 0x1f) {
                    string_view toAdd(from.data() + firstUnusedChar, currentChar - firstUnusedChar);
                    firstUnusedChar = currentChar + 1;
                    fmt::format_to(buf, "{}\\u{:04x}", toAdd, ch);
                    break;
                }
```

The condition will be true and we will print the code-point resulting in the bus error.

We can avoid this by adding a guard on the lower bound:

```cpp
if (0x00 <= ch && ch <= 0x1f) {
```

### Test plan

We had no test for `parse-json` so I copied and adapted the `parse-whitequark` one.