### PR TITLE
Fix JSON::escape for control characters

### DIFF
--- a/common/JSON.cc
+++ b/common/JSON.cc
@@ -41,7 +41,6 @@ string JSON::escape(string from) {
                     string_view toAdd(from.data() + firstUnusedChar, currentChar - firstUnusedChar);
                     firstUnusedChar = currentChar + 1;
                     fmt::format_to(buf, "{}\\u{:04x}", toAdd, ch);
-                    break;
                 }
                 continue;
         }

--- a/test/cli/parse-tree-json/parse-tree-json.out
+++ b/test/cli/parse-tree-json/parse-tree-json.out
@@ -85,7 +85,7 @@
         },
         {
           "type" : "String",
-          "val" : "👋 a string"
+          "val" : "👋 a string \u0000 \u001b with control chars and emojis"
         },
         {
           "type" : "GVar",

--- a/test/cli/parse-tree-json/parse-tree-json.rb
+++ b/test/cli/parse-tree-json/parse-tree-json.rb
@@ -3,4 +3,4 @@ $global = 1 + 2
 @@a = 1
 a = 2
 *a = 1
-puts(1, "👋 a string", $global, $1)
+puts(1, "👋 a string \x00 \033 with control chars and emojis", $global, $1)


### PR DESCRIPTION
### Motivation

So this is actually unrelated to #3447 and its fix, it's a separate problem and this time with control characters:

```
$ sorbet --print parse-tree-json -e "\"\0\""
Bus error: 10
```

(and it needs to be a double-quoted string, with a single quote we have two literals `\` and `0`).

What is happening here is a logic problem in JSON::escape again:

```cpp
    for (auto ch : from) {
        currentChar++;
        string_view special;
        switch (ch) {
            // ...
            default:
                if (0x00 <= ch && ch <= 0x1f) {
                    string_view toAdd(from.data() + firstUnusedChar, currentChar - firstUnusedChar);
                    firstUnusedChar = currentChar + 1;
                    fmt::format_to(buf, "{}\\u{:04x}", toAdd, ch);
                    break;
                }
                continue;
        }
        string_view toAdd(from.data() + firstUnusedChar, currentChar - firstUnusedChar);
        firstUnusedChar = currentChar + 1;
        fmt::format_to(buf, "{}{}", toAdd, special);
    }
```

If `ch` is a control char:
1. we enter the `if`
2. we append the string from the last char we read to the current char
3. we `break`, and that's the problem. This means we skip over the `continue` (we're in a switch) and go to:
4. we read again the input string between bad indexes :(

The fix here is to remove the `break` so we do instead:
1. we enter the `if`
2. we append the string from the last char we read to the current char
3. go to the next char

### Test plan

I updated the CLI test for `parse-tree-json` so it uses control chars.