### PR TITLE
Proposal: clean printing options

### DIFF
--- a/gems/sorbet/lib/hidden-definition-finder.rb
+++ b/gems/sorbet/lib/hidden-definition-finder.rb
@@ -105,7 +105,8 @@ class Sorbet::Private::HiddenMethodFinder
       [
         File.realpath("#{__dir__}/../bin/srb"),
         'tc',
-        '--print=symbol-table-full-json',
+        '--print=symbol-tabl-json',
+        '--print-full',
         '--stdout-hup-hack',
         '--silence-dev-message',
         '--no-error-count',
@@ -125,7 +126,8 @@ class Sorbet::Private::HiddenMethodFinder
         'tc',
         # Make sure we don't load a sorbet/config in your cwd
         '--no-config',
-        '--print=symbol-table-full-json',
+        '--print=symbol-table-json',
+        '--print-full',
         # The hidden-definition serializer is not smart enough to put T::Enum
         # constants it discovers inside an `enums do` block. We probably want
         # to come up with a better long term solution here.

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -68,11 +68,6 @@ struct Printers {
     PrinterConfig SymbolTableProto;
     PrinterConfig SymbolTableMessagePack;
     PrinterConfig SymbolTableJson;
-    PrinterConfig SymbolTableFull;
-    PrinterConfig SymbolTableFullRaw;
-    PrinterConfig SymbolTableFullProto;
-    PrinterConfig SymbolTableFullMessagePack;
-    PrinterConfig SymbolTableFullJson;
     PrinterConfig FileTableJson;
     PrinterConfig FileTableProto;
     PrinterConfig FileTableMessagePack;
@@ -118,6 +113,8 @@ struct AutoloaderConfig {
 
 struct Options {
     Printers print;
+    bool printFull = false;
+
     AutoloaderConfig autoloaderConfig;
     Phase stopAfterPhase = Phase::INFERENCER;
     bool noStdlib = false;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1071,7 +1071,7 @@ ast::ParsedFilesOrCancelled typecheck(unique_ptr<core::GlobalState> &gs, vector<
 
 #ifndef SORBET_REALMAIN_MIN
         if (opts.print.SymbolTableJson.enabled) {
-            auto root = core::Proto::toProto(*gs, core::Symbols::root(), false);
+            auto root = core::Proto::toProto(*gs, core::Symbols::root(), opts.printFull);
             if (opts.print.SymbolTableJson.outputPath.empty()) {
                 core::Proto::toJSON(root, cout);
             } else {
@@ -1081,7 +1081,7 @@ ast::ParsedFilesOrCancelled typecheck(unique_ptr<core::GlobalState> &gs, vector<
             }
         }
         if (opts.print.SymbolTableProto.enabled) {
-            auto root = core::Proto::toProto(*gs, core::Symbols::root(), false);
+            auto root = core::Proto::toProto(*gs, core::Symbols::root(), opts.printFull);
             if (opts.print.SymbolTableProto.outputPath.empty()) {
                 root.SerializeToOstream(&cout);
             } else {
@@ -1091,7 +1091,7 @@ ast::ParsedFilesOrCancelled typecheck(unique_ptr<core::GlobalState> &gs, vector<
             }
         }
         if (opts.print.SymbolTableMessagePack.enabled) {
-            auto root = core::Proto::toProto(*gs, core::Symbols::root(), false);
+            auto root = core::Proto::toProto(*gs, core::Symbols::root(), opts.printFull);
             stringstream buf;
             core::Proto::toJSON(root, buf);
             auto str = buf.str();
@@ -1108,50 +1108,12 @@ ast::ParsedFilesOrCancelled typecheck(unique_ptr<core::GlobalState> &gs, vector<
                 Exception::raise("failed to write msgpack");
             }
         }
-        if (opts.print.SymbolTableFullJson.enabled) {
-            auto root = core::Proto::toProto(*gs, core::Symbols::root(), true);
-            if (opts.print.SymbolTableJson.outputPath.empty()) {
-                core::Proto::toJSON(root, cout);
-            } else {
-                stringstream buf;
-                core::Proto::toJSON(root, buf);
-                opts.print.SymbolTableJson.print(buf.str());
-            }
-        }
-        if (opts.print.SymbolTableFullProto.enabled) {
-            auto root = core::Proto::toProto(*gs, core::Symbols::root(), true);
-            if (opts.print.SymbolTableFullProto.outputPath.empty()) {
-                root.SerializeToOstream(&cout);
-            } else {
-                string buf;
-                root.SerializeToString(&buf);
-                opts.print.SymbolTableFullProto.print(buf);
-            }
-        }
-        if (opts.print.SymbolTableFullMessagePack.enabled) {
-            auto root = core::Proto::toProto(*gs, core::Symbols::root(), true);
-            stringstream buf;
-            core::Proto::toJSON(root, buf);
-            auto str = buf.str();
-            rapidjson::Document document;
-            document.Parse(str);
-            mpack_writer_t writer;
-            if (opts.print.SymbolTableFullMessagePack.outputPath.empty()) {
-                mpack_writer_init_stdfile(&writer, stdout, /* close when done */ false);
-            } else {
-                mpack_writer_init_filename(&writer, opts.print.SymbolTableFullMessagePack.outputPath.c_str());
-            }
-            json2msgpack::json2msgpack(document, &writer);
-            if (mpack_writer_destroy(&writer)) {
-                Exception::raise("failed to write msgpack");
-            }
-        }
 #endif
-        if (opts.print.SymbolTableFull.enabled) {
-            opts.print.SymbolTableFull.fmt("{}\n", gs->toStringFull());
+        if (opts.print.SymbolTable.enabled && opts.printFull) {
+            opts.print.SymbolTable.fmt("{}\n", gs->toStringFull());
         }
-        if (opts.print.SymbolTableFullRaw.enabled) {
-            opts.print.SymbolTableFullRaw.fmt("{}\n", gs->showRawFull());
+        if (opts.print.SymbolTableRaw.enabled && opts.printFull) {
+            opts.print.SymbolTableRaw.fmt("{}\n", gs->showRawFull());
         }
 
 #ifndef SORBET_REALMAIN_MIN

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -167,13 +167,12 @@ Usage:
                                 flatten-tree-raw, ast, ast-raw, cfg, cfg-raw,
                                 symbol-table, symbol-table-raw, symbol-table-json,
                                 symbol-table-proto, symbol-table-messagepack,
-                                symbol-table-full, symbol-table-full-raw,
-                                symbol-table-full-json, symbol-table-full-proto,
-                                symbol-table-full-messagepack, file-table-json,
-                                file-table-proto, file-table-messagepack,
-                                missing-constants, plugin-generated-code,
-                                autogen, autogen-msgpack, autogen-classlist,
-                                autogen-autoloader, autogen-subclasses, package-tree]
+                                file-table-json, file-table-proto,
+                                file-table-messagepack, missing-constants,
+                                plugin-generated-code, autogen, autogen-msgpack,
+                                autogen-classlist, autogen-autoloader,
+                                autogen-subclasses, package-tree]
+      --print-full              print full content (used with --print)
       --autogen-subclasses-parent string
                                 Parent classes for which generate a list of
                                 subclasses. This option must be used in

--- a/test/cli/phases/phases.out
+++ b/test/cli/phases/phases.out
@@ -9,6 +9,9 @@ Integer {
   "val" : "1"
 }
 --- parse-tree-json end ---
+--- parse-tree-whitequark start ---
+s(:int, "1")
+--- parse-tree-whitequark end ---
 --- desugar-tree start ---
 class <emptyTree><<C <root>>> < (::<todo sym>)
   1

--- a/test/cli/phases/phases.sh
+++ b/test/cli/phases/phases.sh
@@ -5,7 +5,7 @@ rm -rf out fileout
 mkdir -p out fileout
 
 # Make sure these options don't change output
-for p in parse-tree parse-tree-json desugar-tree desugar-tree-raw rewrite-tree rewrite-tree-raw index-tree index-tree-raw name-tree name-tree-raw resolve-tree resolve-tree-raw flatten-tree flatten-tree-raw ast ast-raw cfg cfg-raw symbol-table symbol-table-raw; do
+for p in parse-tree parse-tree-json parse-tree-whitequark desugar-tree desugar-tree-raw rewrite-tree rewrite-tree-raw index-tree index-tree-raw name-tree name-tree-raw resolve-tree resolve-tree-raw flatten-tree flatten-tree-raw ast ast-raw cfg cfg-raw symbol-table symbol-table-raw; do
     echo "--- $p start ---"
     main/sorbet --silence-dev-message --censor-for-snapshot-tests -p "$p" -e '1' | tee "out/$p"
     main/sorbet --silence-dev-message --censor-for-snapshot-tests -p "$p:fileout/$p" -e '1' > /dev/null
@@ -17,12 +17,21 @@ echo "--- checking diff ---"
 diff -r out fileout | sort
 
 echo "--- checking crashes ---"
-# Makes sure all these options don't crash us
-for p in symbol-table-json symbol-table-full symbol-table-full-raw symbol-table-full-json; do
+
+# Test --print symbol-table-* options don't crash
+for p in symbol-table symbol-table-json symbol-table-proto symbol-table-raw symbol-table-messagepack; do
+    main/sorbet --silence-dev-message -p "$p" -e '1' > /dev/null
+    main/sorbet --silence-dev-message -p "$p" --print-full -e '1' > /dev/null
+done
+
+# Test --print file-table-* options don't crash
+for p in file-table-json file-table-proto file-table-messagepack; do
     main/sorbet --silence-dev-message -p "$p" -e '1' > /dev/null
 done
 
+# Test --stop-after
 for p in init parser desugarer dsl namer resolver cfg inferencer; do
     main/sorbet --silence-dev-message --stop-after $p -e '1'
 done
+
 echo "--- checking crashes end ---"

--- a/test/cli/symbol-table-json-alias/symbol-table-json-alias.sh
+++ b/test/cli/symbol-table-json-alias/symbol-table-json-alias.sh
@@ -1,1 +1,1 @@
-main/sorbet test/cli/symbol-table-json-alias/symbol-table-json-alias.rb -p symbol-table-full-json | grep aliasTo -B 5 | head -n 5
+main/sorbet test/cli/symbol-table-json-alias/symbol-table-json-alias.rb -p symbol-table-json --print-full | grep aliasTo -B 5 | head -n 5


### PR DESCRIPTION
### Motivation

The way we currently handle the printer option is that we create one printer for each combination.

So for `symbol-table` we have the printer options:
* `symbol-table`
* `symbol-table-raw`
* `symbol-table-json`
* `symbol-table-proto`
* `symbol-table-messagepack`
* `symbol-table-full`
* `symbol-table-full-raw`
* `symbol-table-full-json`
* `symbol-table-full-proto`
* `symbol-table-full-messagepack`

This is just for the `symbol-table` and I'm about to add more variations with `with-locs`.

One solution would be to create options to configure how each base printer should work.
This PR gives an example with `--print-full`:

Instead of the those printers for `symbol-table`, we would "just" have:

* `symbol-table`
* `symbol-table-raw`
* `symbol-table-json`
* `symbol-table-proto`
* `symbol-table-messagepack`

Each can be decorated with `--print-full`:

```
$ sorbet --print symbol-table --print-full
...
$ sorbet --print symbol-table-json --print-full
...
$ sorbet --print resolve-tree --print-full
--print=resolve-tree does not support --print-full
```

With this approach we can do the same for `--print-format json`, `--print-locs` etc.

This will 1) remove code duplication where we print the things, 2) create a structure we can then pass around to the printing method to remove all the bare booleans used (@jez I know how much you hate them).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
