### PR TITLE
Update Etc.uname's type

### DIFF
--- a/rbi/stdlib/etc.rbi
+++ b/rbi/stdlib/etc.rbi
@@ -533,7 +533,7 @@ module Etc
   # #    :machine=>"i686"}
   # ```
   sig do
-    returns(String)
+    returns(T::Hash[Symbol, String])
   end
   def self.uname; end
 end

--- a/test/testdata/rbi/etc.rb
+++ b/test/testdata/rbi/etc.rb
@@ -4,3 +4,5 @@ T.reveal_type(Etc.getpwuid) # error: Revealed type: `T.nilable(Etc::Passwd)`
 T.reveal_type(Etc.getpwuid(10)) # error: Revealed type: `T.nilable(Etc::Passwd)`
 
 Etc.getpwuid("foo") # error: Expected `Integer` but found `String("foo")`
+
+T.reveal_type(Etc.uname) # error: Revealed type: `T::Hash[Symbol, String]`


### PR DESCRIPTION
### Motivation

The type signature of `Etc.uname` is not correct, so everything built on top of it will not pass type-checking. For example:

```
 Expected T.any(T::Range[Integer], Regexp) but found Symbol(:"sysname") for argument arg0 https://srb.help/7002
    39 |              name: uname[:sysname] || RbConfig::CONFIG["host_os"],
                                  ^^^^^^^^
    https://github.com/sorbet/sorbet/tree/b89eb263034e4b9754567c73e7983d0a87ffd34a/rbi/core/string.rbi#L264: Method String#[] (overload.1) has specified arg0 as T.any(T::Range[Integer], Regexp)
     264 |        arg0: T.any(T::Range[Integer], Regexp),
                  ^^^^
  Got Symbol(:"sysname") originating from:
    lib/sentry/scope.rb:39:
    39 |              name: uname[:sysname] || RbConfig::CONFIG["host_os"],
                                  ^^^^^^^^
```


### Test plan
I'm not sure if there's any test for it? If it is then the issue should have been spotted I think 🤔 
