### PR TITLE
Avoid mutating KnowledgeFact unless we have to.

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -217,13 +217,13 @@ KnowledgeFact &KnowledgeRef::mutate() {
 
 void KnowledgeRef::removeReferencesToVar(cfg::LocalRef var) {
     if (typeTestReferencesVar((*this)->yesTypeTests, var) || typeTestReferencesVar((*this)->noTypeTests, var)) {
-        auto &truthy = this->mutate();
-        truthy.yesTypeTests.erase(remove_if(truthy.yesTypeTests.begin(), truthy.yesTypeTests.end(),
-                                            [&](auto const &c) -> bool { return c.first == var; }),
-                                  truthy.yesTypeTests.end());
-        truthy.noTypeTests.erase(remove_if(truthy.noTypeTests.begin(), truthy.noTypeTests.end(),
-                                           [&](auto const &c) -> bool { return c.first == var; }),
-                                 truthy.noTypeTests.end());
+        auto &typeTests = this->mutate();
+        typeTests.yesTypeTests.erase(remove_if(typeTests.yesTypeTests.begin(), typeTests.yesTypeTests.end(),
+                                               [&](auto const &c) -> bool { return c.first == var; }),
+                                     typeTests.yesTypeTests.end());
+        typeTests.noTypeTests.erase(remove_if(typeTests.noTypeTests.begin(), typeTests.noTypeTests.end(),
+                                              [&](auto const &c) -> bool { return c.first == var; }),
+                                    typeTests.noTypeTests.end());
     }
 }
 

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -26,12 +26,7 @@ core::TypePtr dropConstructor(core::Context ctx, core::Loc loc, core::TypePtr tp
 
 bool typeTestReferencesVar(const InlinedVector<std::pair<cfg::LocalRef, core::TypePtr>, 1> &typeTest,
                            cfg::LocalRef var) {
-    for (auto &test : typeTest) {
-        if (test.first == var) {
-            return true;
-        }
-    }
-    return false;
+    return absl::c_any_of(typeTest, [var](auto &test) { return test.first == var; });
 }
 } // namespace
 
@@ -216,7 +211,7 @@ KnowledgeFact &KnowledgeRef::mutate() {
 }
 
 void KnowledgeRef::removeReferencesToVar(cfg::LocalRef var) {
-    if (typeTestReferencesVar((*this)->yesTypeTests, var) || typeTestReferencesVar((*this)->noTypeTests, var)) {
+    if (typeTestReferencesVar(knowledge->yesTypeTests, var) || typeTestReferencesVar(knowledge->noTypeTests, var)) {
         auto &typeTests = this->mutate();
         typeTests.yesTypeTests.erase(remove_if(typeTests.yesTypeTests.begin(), typeTests.yesTypeTests.end(),
                                                [&](auto const &c) -> bool { return c.first == var; }),

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -71,6 +71,7 @@ public:
     const KnowledgeFact *operator->() const;
 
     KnowledgeFact &mutate();
+    void removeReferencesToVar(cfg::LocalRef ref);
 
 private:
     std::shared_ptr<KnowledgeFact> knowledge;
@@ -89,6 +90,7 @@ public:
 
     static TestedKnowledge empty; // optimization
 
+    void removeReferencesToVar(cfg::LocalRef ref);
     void sanityCheck() const;
 };
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Avoid mutating KnowledgeFact unless we have to.

Before this change, we eagerly copied a KnowledgeFact if the KnowledgeFilter claims it is used when we call clearKnowledge. Now, we check if we have to mutate before we mutate. The resulting code is a bit cleaner and more self-documenting as well.

This results in a ~16% improvement in end-to-end typechecking runtime for a microbenchmark that has many local variables (which I modified from a similar file in Stripe's codebase); it typechecks in ~1s rather than ~1.2s.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Assumed covered by existing tests.
