### PR TITLE
RBI: Integer#round should always return an Integer

### DIFF
--- a/rbi/core/integer.rbi
+++ b/rbi/core/integer.rbi
@@ -1115,7 +1115,7 @@ class Integer < Numeric
     params(
         arg0: Numeric,
     )
-    .returns(Numeric)
+    .returns(Integer)
   end
   def round(arg0=T.unsafe(nil)); end
 


### PR DESCRIPTION
This improves the signature of Integer#round to make it more accurate. It should always return an Integer.

### Motivation

In the project I'm working at we use `T.any(Integer, Float, BigDecimal)#round` in a few places, and it is important for us that the return value of `#round` remains in `T.any(Integer, Float, BigDecimal)` and it should not expand to `Numeric`.

### Test plan

I can add some tests if someone shows me:
- in which file they should be located;
- which other tests I can use as an example.