### PR TITLE
RBI: Improve Hash#to_h signature accuracy

### DIFF
--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -1193,7 +1193,16 @@ class Hash < Object
   #
   # If a block is given, the results of the block on each pair of the receiver
   # will be used as pairs.
-  def to_h; end
+  sig do
+    type_parameters(:A, :B)
+      .params(
+        blk: T.proc.params(arg0: K, arg1: V)
+              .returns([T.type_parameter(:A), T.type_parameter(:B)])
+      )
+      .returns(T::Hash[T.type_parameter(:A), T.type_parameter(:B)])
+  end
+  sig {returns(T::Hash[K, V])}
+  def to_h(&blk); end
 
   # Returns `self`.
   sig {returns(T::Hash[K, V])}

--- a/test/testdata/rbi/hash.rb
+++ b/test/testdata/rbi/hash.rb
@@ -54,6 +54,10 @@ h3[nil] = "foo" # error: Expected `Integer` but found `NilClass` for argument `a
 h3[3] = nil # error: Expected `String` but found `NilClass` for argument `arg1`
 
 initial_hash = T.let({ a: 1.0, b: 3.0 }, T::Hash[Symbol, Float])
+hash_to_h_1 = initial_hash.to_h
+T.assert_type!(hash_to_h_1, T::Hash[Symbol, Float])
+hash_to_h_2 = initial_hash.to_h { |k, v| [k.to_s, v.to_d] }
+T.assert_type!(hash_to_h_2, T::Hash[String, BigDecimal])
 
 transformed_keys_hash = initial_hash.transform_keys(&:to_s)
 T.assert_type!(transformed_keys_hash, T::Hash[String, Float])


### PR DESCRIPTION
This improves the signature of Hash#to_h to make it more accurate.
- If called without arguments, it returns the same hash;
- If called with a block, it returns a new hash created from the return value of the block.

### Motivation

To avoid having to manually add these types in the project I'm working at.

### Test plan

See included automated tests.