### PR TITLE
Update Pathname#binwrite's signature

### DIFF
--- a/rbi/stdlib/pathname.rbi
+++ b/rbi/stdlib/pathname.rbi
@@ -417,10 +417,17 @@ class Pathname < Object
     params(
         arg0: String,
         offset: Integer,
+        external_encoding: String,
+        internal_encoding: String,
+        encoding: String,
+        textmode: BasicObject,
+        binmode: BasicObject,
+        autoclose: BasicObject,
+        mode: String,
     )
     .returns(Integer)
   end
-  def binwrite(arg0, offset=T.unsafe(nil)); end
+  def binwrite(arg0, offset=T.unsafe(nil), external_encoding: T.unsafe(nil), internal_encoding: T.unsafe(nil), encoding: T.unsafe(nil), textmode: T.unsafe(nil), binmode: T.unsafe(nil), autoclose: T.unsafe(nil), mode: T.unsafe(nil)); end
 
   # Returns the birth time for the file. If the platform doesn't have birthtime,
   # raises


### PR DESCRIPTION
### Motivation

`Pathname#binwrite`'s sig was missing `mode`. I tried to update it to match the actual sig but the documentation is hard to follow.

[`Pathname#binwrite`](https://ruby-doc.org/stdlib-2.7.1/libdoc/pathname/rdoc/Pathname.html#method-i-binwrite) says to refer to `File#binwrite` (which isn't present in [`File`](https://ruby-doc.org/core-2.7.1/File.html)), which means it's probably [`IO#binwrite`](https://ruby-doc.org/core-2.7.1/IO.html#method-c-binwrite) which says to refer to [`IO#write`](https://ruby-doc.org/core-2.7.1/IO.html#method-c-write). `IO#write` lists 4 arguments `encoding`, `mode`, `perm`, and `open_args`. 

However, Sorbet annotates `IO#binwrite` with several more arguments, and I tried then in `Pathname#binwrite` and they seem to be working, so I think the doc is wrong and Sorbet is right.

### Test plan

I have not included tests, I don't know how to test this.
