### PR TITLE
Partial ActiveSupport::Concern support through a rewriter

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -257,6 +257,8 @@ NameDef names[] = {
     {"ActiveRecord", "ActiveRecord", true},
     {"Migration", "Migration", true},
     {"Compatibility", "Compatibility", true},
+    {"ActiveSupport", "ActiveSupport", true},
+    {"Concern", "Concern", true},
 
     {"instance"},
     {"normal"},
@@ -286,6 +288,8 @@ NameDef names[] = {
     // Used to store arguments to a "mixes_in_class_methods()" call
     {"mixedInClassMethods", "<mixed_in_class_methods>"},
     {"mixesInClassMethods", "mixes_in_class_methods"},
+    {"ClassMethods", "ClassMethods", true},
+    {"classMethods", "class_methods"},
 
     {"blockTemp", "<block>"},
     {"blockRetrunType", "<block-return-type>"},

--- a/rewriter/Concern.cc
+++ b/rewriter/Concern.cc
@@ -1,0 +1,140 @@
+#include "rewriter/Concern.h"
+#include "ast/Helpers.h"
+#include "ast/ast.h"
+#include "core/Names.h"
+#include "core/core.h"
+
+using namespace std;
+
+namespace sorbet::rewriter {
+
+namespace {
+
+bool doesExtendConcern(core::MutableContext ctx, ast::ClassDef *klass) {
+    bool returnValue = false;
+    for (auto &stat : klass->rhs) {
+        typecase(
+            stat,
+            [&](ast::Send &send) {
+                if (send.fun != core::Names::extend()) {
+                    return;
+                }
+                auto &args = send.args;
+                if (args.empty()) {
+                    return;
+                }
+                auto *firstArg = ast::cast_tree<ast::UnresolvedConstantLit>(args.at(0));
+                if (firstArg == nullptr) {
+                    return;
+                }
+                auto *firstArgScope = ast::cast_tree<ast::UnresolvedConstantLit>(firstArg->scope);
+                if (firstArgScope == nullptr) {
+                    return;
+                }
+                auto *outerScope = ast::cast_tree<ast::UnresolvedConstantLit>(firstArgScope->scope);
+                if (outerScope != nullptr) {
+                    return;
+                }
+                if (firstArg->cnst != core::Names::Constants::Concern() ||
+                    firstArgScope->cnst != core::Names::Constants::ActiveSupport()) {
+                    return;
+                }
+
+                returnValue = true;
+            },
+            [&](const ast::ExpressionPtr &e) {});
+
+        if (returnValue) {
+            break;
+        }
+    }
+
+    return returnValue;
+}
+
+} // namespace
+
+// For a given ClassDef node the rewriter traverses the members (rhs) to identify `class_methods` calls
+// or `module ClassMethods` definitions. For the former it transforms it into Ruby code that Sorbet can understand.
+// It also handles cases where both `class_methods` and `module ClassMethods` are used.
+// Knowledge of `class_methods` and its source code will help you understand the steps taken here.
+// See https://api.rubyonrails.org/classes/ActiveSupport/Concern.html#method-i-class_methods.
+void Concern::run(core::MutableContext ctx, ast::ClassDef *klass) {
+    if (ctx.state.runningUnderAutogen) {
+        return;
+    }
+    if (!doesExtendConcern(ctx, klass)) {
+        return;
+    }
+
+    vector<ast::ExpressionPtr> stats;
+    ast::ExpressionPtr classMethodsNode;
+    for (auto &stat : klass->rhs) {
+        if (auto *send = ast::cast_tree<ast::Send>(stat)) {
+            if (send->fun == core::Names::classMethods()) { // class_methods do ... end
+                if (send->block == nullptr) {
+                    continue;
+                }
+                if (!send->recv.isSelfReference()) {
+                    continue;
+                }
+                if (classMethodsNode) {
+                    // ClassMethods module already exists. Let's add the block as one of its members
+                    auto *block = ast::cast_tree<ast::Block>(send->block);
+                    auto *classDef = ast::cast_tree<ast::ClassDef>(classMethodsNode);
+                    classDef->rhs.emplace_back(std::move(block->body));
+                } else {
+                    // We don't have a ClassMethods module yet. Let's create it and add the send definition to its
+                    // members
+                    auto loc = send->loc;
+                    ast::ClassDef::RHS_store rhs;
+                    auto *block = ast::cast_tree<ast::Block>(send->block);
+                    rhs.emplace_back(std::move(block->body));
+                    auto name =
+                        ast::MK::UnresolvedConstant(loc, ast::MK::EmptyTree(), core::Names::Constants::ClassMethods());
+                    classMethodsNode = ast::MK::Module(loc, loc, std::move(name), {}, std::move(rhs));
+                }
+                continue;
+            }
+        } else if (auto *mod = ast::cast_tree<ast::ClassDef>(stat)) {
+            auto name = ast::cast_tree<ast::UnresolvedConstantLit>(mod->name);
+            if (name && name->cnst == core::Names::Constants::ClassMethods()) {
+                if (classMethodsNode) {
+                    // ClassMethods module already exists. Let's add mod->rhs into existing module
+                    auto *classDef = ast::cast_tree<ast::ClassDef>(classMethodsNode);
+                    for (auto &elem : mod->rhs) {
+                        classDef->rhs.emplace_back(std::move(elem));
+                    }
+                } else {
+                    // We don't have a ClassMethods module yet. Let's use the defined module (mod)
+                    auto loc = mod->loc;
+                    classMethodsNode = ast::MK::Module(loc, loc, std::move(mod->name), {}, std::move(mod->rhs));
+                }
+                continue;
+            }
+        }
+        // Everything else that we are not interested in should be copied as is
+        stats.emplace_back(std::move(stat));
+    }
+
+    if (classMethodsNode) {
+        // Generate a Send { Magic.mixes_in_class_methods(ClassMethods) }
+        auto magic = ast::MK::Constant(klass->loc, core::Symbols::Magic());
+        auto classMethods =
+            ast::MK::UnresolvedConstant(klass->loc, ast::MK::EmptyTree(), core::Names::Constants::ClassMethods());
+        auto sendForMixes = ast::MK::Send2(klass->loc, std::move(magic), core::Names::mixesInClassMethods(),
+                                           ast::MK::Self(klass->loc), std::move(classMethods));
+        stats.emplace_back(std::move(sendForMixes));
+    }
+
+    klass->rhs.clear();
+    klass->rhs.reserve(stats.size());
+    if (classMethodsNode) {
+        klass->rhs.emplace_back(std::move(classMethodsNode));
+    }
+    for (auto &stat : stats) {
+        klass->rhs.emplace_back(std::move(stat));
+    }
+}
+
+}; // namespace sorbet::rewriter

--- a/rewriter/Concern.h
+++ b/rewriter/Concern.h
@@ -1,0 +1,37 @@
+#ifndef SORBET_REWRITER_CONCERN_H
+#define SORBET_REWRITER_CONCERN_H
+#include "ast/ast.h"
+
+namespace sorbet::rewriter {
+
+/**
+ * This class desugars things of the form
+ *
+ *    module Foo
+ *      extend ActiveSupport::Concern
+ *      class_methods do
+ *        def a_class_method
+ *        end
+ *      end
+ *    end
+ *
+ * into
+ *
+ *    module Foo
+ *      module ClassMethods
+ *        def a_class_method
+ *        end
+ *      end
+ *      <Magic>.mixes_in_class_methods(ClassMethods)
+ *    end
+ */
+class Concern final {
+public:
+    static void run(core::MutableContext ctx, ast::ClassDef *klass);
+
+    Concern() = delete;
+};
+
+} // namespace sorbet::rewriter
+
+#endif

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -7,6 +7,7 @@
 #include "rewriter/ClassNew.h"
 #include "rewriter/Cleanup.h"
 #include "rewriter/Command.h"
+#include "rewriter/Concern.h"
 #include "rewriter/DSLBuilder.h"
 #include "rewriter/DefDelegator.h"
 #include "rewriter/Delegate.h"
@@ -48,6 +49,7 @@ public:
         Prop::run(ctx, classDef);
         TypeMembers::run(ctx, classDef);
         Singleton::run(ctx, classDef);
+        Concern::run(ctx, classDef);
 
         for (auto &extension : ctx.state.semanticExtensions) {
             extension->run(ctx, classDef);

--- a/test/testdata/rewriter/concern.rb
+++ b/test/testdata/rewriter/concern.rb
@@ -1,0 +1,150 @@
+# typed: true
+module ActiveSupport::Concern
+  # Dummy definition
+end
+
+# Test with class_methods is used
+module Foo
+  extend ActiveSupport::Concern
+  class_methods do
+    def a_class_method
+    end
+  end
+
+  def instance_method
+  end
+end
+
+class A
+  include Foo
+end
+
+A.new.instance_method
+A.a_class_method
+A.new.a_class_method # error: Method `a_class_method` does not exist on `A`
+
+# Test with ClassMethods is used
+module Bar
+  extend ActiveSupport::Concern
+  module ClassMethods
+    def a_class_method
+    end
+
+    def another_class_method
+    end
+  end
+
+  def instance_method
+  end
+end
+
+class B
+  include Bar
+end
+
+B.new.instance_method
+B.a_class_method
+B.another_class_method
+B.new.a_class_method # error: Method `a_class_method` does not exist on `B`
+
+# Test with both `ClassMethods` and `class_methods` being used
+module Baz
+  extend ActiveSupport::Concern
+  module ClassMethods
+    def a_class_method
+    end
+  end
+
+  class_methods do
+    def a_class_method_2
+    end
+  end
+
+  def instance_method
+  end
+end
+
+class C
+  include Baz
+end
+
+C.new.instance_method
+C.a_class_method
+C.a_class_method_2
+
+# Same as above but used in different order
+module Qux
+  extend ActiveSupport::Concern
+  class_methods do
+    def a_class_method
+    end
+  end
+
+  module ClassMethods
+    def a_class_method_2
+    end
+  end
+
+  def instance_method
+  end
+end
+
+class D
+  include Qux
+end
+
+D.new.instance_method
+D.a_class_method
+D.a_class_method_2
+
+# Test no ClassMethods module
+module Quux
+  extend ActiveSupport::Concern
+  def instance_method
+  end
+end
+
+class E
+  include Quux
+end
+
+E.new.instance_method
+
+# Test without extend ActiveSupport::Concern
+module Corge
+  class_methods do # error: Method `class_methods` does not exist on `T.class_of(Corge)`
+    def a_class_method
+    end
+  end
+
+  def instance_method
+  end
+end
+
+class F
+  include Corge
+end
+
+F.new.instance_method
+F.a_class_method # error: Method `a_class_method` does not exist on `T.class_of(F)`
+
+# Test with double class_methods definition
+module Grault
+  extend ActiveSupport::Concern
+  class_methods do
+    def a_class_method
+    end
+  end
+
+  class_methods do
+    def another_class_method
+    end
+  end
+end
+
+class G
+  include Grault
+end
+
+G.a_class_method
+G.another_class_method

--- a/test/testdata/rewriter/concern.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/concern.rb.rewrite-tree.exp
@@ -1,0 +1,212 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C ActiveSupport>::<C Concern><<C <todo sym>>> < ()
+  end
+
+  module <emptyTree>::<C Foo><<C <todo sym>>> < ()
+    def instance_method<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    module <emptyTree>::<C ClassMethods><<C <todo sym>>> < ()
+      def a_class_method<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      ::Sorbet::Private::Static.keep_def(<self>, :a_class_method, :normal)
+    end
+
+    <self>.extend(<emptyTree>::<C ActiveSupport>::<C Concern>)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :instance_method, :normal)
+
+    ::<Magic>.mixes_in_class_methods(<self>, <emptyTree>::<C ClassMethods>)
+  end
+
+  class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
+    <self>.include(<emptyTree>::<C Foo>)
+  end
+
+  <emptyTree>::<C A>.new().instance_method()
+
+  <emptyTree>::<C A>.a_class_method()
+
+  <emptyTree>::<C A>.new().a_class_method()
+
+  module <emptyTree>::<C Bar><<C <todo sym>>> < ()
+    def instance_method<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    module <emptyTree>::<C ClassMethods><<C <todo sym>>> < ()
+      def a_class_method<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      def another_class_method<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      ::Sorbet::Private::Static.keep_def(<self>, :a_class_method, :normal)
+
+      ::Sorbet::Private::Static.keep_def(<self>, :another_class_method, :normal)
+    end
+
+    <self>.extend(<emptyTree>::<C ActiveSupport>::<C Concern>)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :instance_method, :normal)
+
+    ::<Magic>.mixes_in_class_methods(<self>, <emptyTree>::<C ClassMethods>)
+  end
+
+  class <emptyTree>::<C B><<C <todo sym>>> < (::<todo sym>)
+    <self>.include(<emptyTree>::<C Bar>)
+  end
+
+  <emptyTree>::<C B>.new().instance_method()
+
+  <emptyTree>::<C B>.a_class_method()
+
+  <emptyTree>::<C B>.another_class_method()
+
+  <emptyTree>::<C B>.new().a_class_method()
+
+  module <emptyTree>::<C Baz><<C <todo sym>>> < ()
+    def instance_method<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    module <emptyTree>::<C ClassMethods><<C <todo sym>>> < ()
+      def a_class_method<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      def a_class_method_2<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      ::Sorbet::Private::Static.keep_def(<self>, :a_class_method, :normal)
+
+      ::Sorbet::Private::Static.keep_def(<self>, :a_class_method_2, :normal)
+    end
+
+    <self>.extend(<emptyTree>::<C ActiveSupport>::<C Concern>)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :instance_method, :normal)
+
+    ::<Magic>.mixes_in_class_methods(<self>, <emptyTree>::<C ClassMethods>)
+  end
+
+  class <emptyTree>::<C C><<C <todo sym>>> < (::<todo sym>)
+    <self>.include(<emptyTree>::<C Baz>)
+  end
+
+  <emptyTree>::<C C>.new().instance_method()
+
+  <emptyTree>::<C C>.a_class_method()
+
+  <emptyTree>::<C C>.a_class_method_2()
+
+  module <emptyTree>::<C Qux><<C <todo sym>>> < ()
+    def instance_method<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    module <emptyTree>::<C ClassMethods><<C <todo sym>>> < ()
+      def a_class_method<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      def a_class_method_2<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      ::Sorbet::Private::Static.keep_def(<self>, :a_class_method, :normal)
+
+      ::Sorbet::Private::Static.keep_def(<self>, :a_class_method_2, :normal)
+    end
+
+    <self>.extend(<emptyTree>::<C ActiveSupport>::<C Concern>)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :instance_method, :normal)
+
+    ::<Magic>.mixes_in_class_methods(<self>, <emptyTree>::<C ClassMethods>)
+  end
+
+  class <emptyTree>::<C D><<C <todo sym>>> < (::<todo sym>)
+    <self>.include(<emptyTree>::<C Qux>)
+  end
+
+  <emptyTree>::<C D>.new().instance_method()
+
+  <emptyTree>::<C D>.a_class_method()
+
+  <emptyTree>::<C D>.a_class_method_2()
+
+  module <emptyTree>::<C Quux><<C <todo sym>>> < ()
+    def instance_method<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    <self>.extend(<emptyTree>::<C ActiveSupport>::<C Concern>)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :instance_method, :normal)
+  end
+
+  class <emptyTree>::<C E><<C <todo sym>>> < (::<todo sym>)
+    <self>.include(<emptyTree>::<C Quux>)
+  end
+
+  <emptyTree>::<C E>.new().instance_method()
+
+  module <emptyTree>::<C Corge><<C <todo sym>>> < ()
+    def a_class_method<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    def instance_method<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    <self>.class_methods() do ||
+      ::Sorbet::Private::Static.keep_def(<self>, :a_class_method, :normal)
+    end
+
+    ::Sorbet::Private::Static.keep_def(<self>, :instance_method, :normal)
+  end
+
+  class <emptyTree>::<C F><<C <todo sym>>> < (::<todo sym>)
+    <self>.include(<emptyTree>::<C Corge>)
+  end
+
+  <emptyTree>::<C F>.new().instance_method()
+
+  <emptyTree>::<C F>.a_class_method()
+
+  module <emptyTree>::<C Grault><<C <todo sym>>> < ()
+    module <emptyTree>::<C ClassMethods><<C <todo sym>>> < ()
+      def a_class_method<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      def another_class_method<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      ::Sorbet::Private::Static.keep_def(<self>, :a_class_method, :normal)
+
+      ::Sorbet::Private::Static.keep_def(<self>, :another_class_method, :normal)
+    end
+
+    <self>.extend(<emptyTree>::<C ActiveSupport>::<C Concern>)
+
+    ::<Magic>.mixes_in_class_methods(<self>, <emptyTree>::<C ClassMethods>)
+  end
+
+  class <emptyTree>::<C G><<C <todo sym>>> < (::<todo sym>)
+    <self>.include(<emptyTree>::<C Grault>)
+  end
+
+  <emptyTree>::<C G>.a_class_method()
+
+  <emptyTree>::<C G>.another_class_method()
+end


### PR DESCRIPTION
Blocked by: https://github.com/sorbet/sorbet/pull/3959

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Introduced ActiveSupport::Concern support. The rewriter supports using `class_methods` and `module ClassMethods` to include both instance methods and class methods into a class.

Rewriter works in 2 stages. First stage is triggering. We need to trigger the rewrite whenever `extend ActiveSupport::Concern` is found on the tree. Solution utilizes the existing tree traversal in `rewriter.cc` instead of doing an additional traversal inside the rewriter for performance reasons.

Second stage of the rewriter replaces nodes similar to other rewriters. It operates on a class definition and preserves the part of the body that is out of scope for the rewriter.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This is another step in enabling Sorbet to provide support for Rails constructs. In Rails projects ActiveSupport::Concern is heavily used since it simplifies the code: https://api.rubyonrails.org/classes/ActiveSupport/Concern.html#method-i-class_methods

Sorbet currently does not understand methods defined inside `class_methods` and those methods are not exposed to the class that includes the module.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. I tried to cover as many cases as I can think of. They are all in the same file for easier navigation.


To be merged after https://github.com/sorbet/sorbet/pull/3424