### PR TITLE
Fix rbi to reflect that Etc#getlogin can return nil

### DIFF
--- a/rbi/stdlib/etc.rbi
+++ b/rbi/stdlib/etc.rbi
@@ -320,7 +320,7 @@ module Etc
   # Etc.getlogin -> 'guest'
   # ```
   sig do
-    returns(String)
+    returns(T.nilable(String))
   end
   def self.getlogin; end
 

--- a/test/testdata/rbi/etc.rb
+++ b/test/testdata/rbi/etc.rb
@@ -6,3 +6,5 @@ T.reveal_type(Etc.getpwuid(10)) # error: Revealed type: `T.nilable(Etc::Passwd)`
 Etc.getpwuid("foo") # error: Expected `Integer` but found `String("foo")`
 
 T.reveal_type(Etc.uname) # error: Revealed type: `T::Hash[Symbol, String]`
+
+T.reveal_type(Etc.getlogin) # error: Revealed type: `T.nilable(String)`


### PR DESCRIPTION
Per the tin.

### Motivation
This RBI is wrong.

https://github.com/ruby/ruby/blob/48b94b791997881929c739c64f95ac30f3fd0bb9/ext/etc/etc.c#L80-L102

It's moderately annoying to get a repro but it does repro under the [runsc](https://github.com/google/gvisor) OCI runtime.

### Test plan

Updated `testdata`. This introduces one trivial type error in `pay-server`.