### PR TITLE
Added "User Defined Generics" documentation

### DIFF
--- a/website/docs/stdlib-generics.md
+++ b/website/docs/stdlib-generics.md
@@ -7,7 +7,8 @@ sidebar_label: Arrays & Hashes
 > TODO: This page is still a fragment. Contributions welcome!
 
 Sorbet supports generic types. The syntax looks likes `MyClass[Elem]`. For user
-defined generic classes, it's possible to make this valid Ruby syntax.
+defined generic classes, it's possible to make this valid Ruby syntax (see
+[User Defined Generics](user-defined-generics.md)).
 
 However, it's not possible to change the syntax for classes in the Ruby standard
 library that should be generic. To make up for this, we use wrappers in the `T`

--- a/website/docs/user-defined-generics.md
+++ b/website/docs/user-defined-generics.md
@@ -89,25 +89,26 @@ There are two ways to re-declare a type member:
   the type member, and this re-declaration must be fixed.
 
 ```ruby
-# Used like: Base[A, B]
 class Base
   extend T::Generic
   A = type_member
   B = type_member
 end
+base = Base[Integer, String].new
 
-# Usage is the same: Subtype[A, B]
 class Subtype < Base
   A = type_member
   B = type_member
 end
+subtype = Subtype[Integer, String].new
 
-# B has been fixed, so now only A can be specified: PartiallyFixedSubtype[A]
+# B has been fixed, so now only A can be specified
 # Any signatures which use B will treat B as String
 class PartiallyFixedSubtype < Subtype
   A = type_member
   B = type_member(fixed: String)
 end
+partially_fixed_subtype = PartiallyFixedSubtype[Integer].new
 
 # Both types are fixed, so FullyFixedSubtype takes no type parameters
 # A will be treated as Integer, and B as String
@@ -116,6 +117,7 @@ class FullyFixedSubtype < PartiallyFixedSubtype
   A = type_member(fixed: Integer)
   B = type_member(fixed: String)
 end
+fully_fixed_subtype = FullyFixedSubtype.new
 ```
 
 ## Variance

--- a/website/docs/user-defined-generics.md
+++ b/website/docs/user-defined-generics.md
@@ -48,6 +48,8 @@ class Pair
   extend T::Sig
   extend T::Generic
 
+  # The order here is important.
+  # The first use of `type_member` is the first type parameter, and so on.
   K = type_member
   V = type_member
 
@@ -64,6 +66,7 @@ class Pair
   attr_accessor :value
 end
 
+#      Pair[   K  ,    V   ]
 pair = Pair[String, Integer].new("foo", 2)
 T.reveal_type(pair) # Pair[String, Integer]
 T.reveal_type(pair.key) # String

--- a/website/docs/user-defined-generics.md
+++ b/website/docs/user-defined-generics.md
@@ -1,0 +1,161 @@
+---
+id: user-defined-generics
+title: User Defined Generics
+sidebar_label: User Defined Generics
+---
+
+You can define your own generic types, in addition to Sorbet's included
+[standard library generics](stdlib-generics.md) like `T::Array`.
+
+This is done by extending `T::Generic` in your class or module, and then 
+creating `type_member` constants for each type parameter that your type needs
+to have.
+
+Here's an example of creating a generic `Box` type, which has one type parameter
+and holds a value of that type:
+
+```ruby
+class Box
+  extend T::Sig
+  extend T::Generic
+
+  # This type has one type member, named "BoxedType"
+  BoxedType = type_member
+
+  sig { params(value: BoxedType).void }
+  def initialize(value)
+    @value = value
+  end
+
+  sig { returns(BoxedType) }
+  attr_accessor :value
+end
+
+# Omitted type members are set to T.untyped
+T.reveal_type(Box.new(3)) # Box[T.untyped]
+
+T.reveal_type(Box[Integer].new(3)) # Box[Integer]
+T.reveal_type(Box[Integer].new(3).value) # Integer
+
+T.reveal_type(Box[Integer].new("hello")) # error: Expected Integer but found String
+```
+
+You can define classes which accept multiple type parameters by using
+`type_member` several times, in order:
+
+```ruby
+class Pair
+  extend T::Sig
+  extend T::Generic
+
+  K = type_member
+  V = type_member
+
+  sig { params(key: K, value: V).void }
+  def initialize(key, value)
+    @key = key
+    @value = value
+  end
+
+  sig { returns(K) }
+  attr_accessor :key
+
+  sig { returns(V) }
+  attr_accessor :value
+end
+
+pair = Pair[String, Integer].new("foo", 2)
+T.reveal_type(pair) # Pair[String, Integer]
+T.reveal_type(pair.key) # String
+T.reveal_type(pair.value) # Integer
+```
+
+Using `[]` on a class would normally raise an exception, so extending
+`T::Generic` defines this as a method which simply returns your class.
+
+## Re-declaring Type Members
+
+If you inherit from a class, include a module, or extend a module which defines
+type members, then the type members must be re-declared in the child type.
+
+There are two ways to re-declare a type member:
+
+- **As a normal type member:** it must still be specified as a type parameter
+  when using the type (or left unspecified to use `T.untyped`), and will need to
+  be re-declared again in any child types.
+
+- **As a fixed type member:** it will take on a fixed value in this type, and
+  cannot be specified with a type parameter. Child types will need to re-declare
+  the type member, and this re-declaration must be fixed.
+
+```ruby
+# Used like: Base[A, B]
+class Base
+  extend T::Generic
+  A = type_member
+  B = type_member
+end
+
+# Usage is the same: Subtype[A, B]
+class Subtype < Base
+  A = type_member
+  B = type_member
+end
+
+# B has been fixed, so now only A can be specified: PartiallyFixedSubtype[A]
+# Any signatures which use B will treat B as String
+class PartiallyFixedSubtype < Subtype
+  A = type_member
+  B = type_member(fixed: String)
+end
+
+# Both types are fixed, so FullyFixedSubtype takes no type parameters
+# A will be treated as Integer, and B as String
+# (Even though the superclass fixed B to String, it must be fixed again)
+class FullyFixedSubtype < PartiallyFixedSubtype
+  A = type_member(fixed: Integer)
+  B = type_member(fixed: String)
+end
+```
+
+## Variance
+
+Type members on modules and interfaces may be invariant (default), covariant, or
+contravariant.
+
+| Variance      | Definition          | Allowed usage in `sig` | Allowed types                |
+| ------------- | ------------------- | ---------------------- | ---------------------------- |
+| Invariant     | `type_member`       | Any                    | Only exactly as specified    |
+| Covariant     | `type_member(:out)` | Return type            | As specified or more derived |
+| Contravariant | `type_member(:in)`  | Parameter type         | As specified or less derived |
+
+To demonstrate each variance, we can consider an interface `I` defined with one
+type parameter, and a class `A` which includes that interface.
+
+```ruby
+module I
+  extend T::Generic
+  Type = type_member # Variance goes here
+end
+
+class A
+  extend T::Generic
+  include I
+  Type = type_member
+end
+
+# === Invariant
+T.let(A[Object].new, I[BasicObject])  # error
+T.let(A[Object].new, I[Object])       # OK
+T.let(A[Object].new, I[Integer])      # error
+
+# === Covariant (type_member(:out))
+T.let(A[Object].new, I[BasicObject])  # OK - Object is more derived than BasicObject
+T.let(A[Object].new, I[Object])       # OK
+T.let(A[Object].new, I[Integer])      # error
+
+# === Contravariant (type_member(:in))
+T.let(A[Object].new, I[BasicObject])  # error
+T.let(A[Object].new, I[Object])       # OK
+T.let(A[Object].new, I[Integer])      # OK - Object is less derived than Integer
+```

--- a/website/docs/user-defined-generics.md
+++ b/website/docs/user-defined-generics.md
@@ -7,9 +7,9 @@ sidebar_label: User Defined Generics
 You can define your own generic types, in addition to Sorbet's included
 [standard library generics](stdlib-generics.md) like `T::Array`.
 
-This is done by extending `T::Generic` in your class or module, and then 
-creating `type_member` constants for each type parameter that your type needs
-to have.
+This is done by extending `T::Generic` in your class or module, and then
+creating `type_member` constants for each type parameter that your type needs to
+have.
 
 Here's an example of creating a generic `Box` type, which has one type parameter
 and holds a value of that type:

--- a/website/docs/user-defined-generics.md
+++ b/website/docs/user-defined-generics.md
@@ -80,7 +80,7 @@ type members, then the type members must be re-declared in the child type.
 
 There are two ways to re-declare a type member:
 
-- **As a normal type member:** it must still be specified as a type parameter
+- **As a variant type member:** it must still be specified as a type parameter
   when using the type (or left unspecified to use `T.untyped`), and will need to
   be re-declared again in any child types.
 
@@ -150,12 +150,12 @@ T.let(A[Object].new, I[Object])       # OK
 T.let(A[Object].new, I[Integer])      # error
 
 # === Covariant (type_member(:out))
-T.let(A[Object].new, I[BasicObject])  # OK - Object is more derived than BasicObject
+T.let(A[Object].new, I[BasicObject])  # OK - Object is a subtype of BasicObject
 T.let(A[Object].new, I[Object])       # OK
 T.let(A[Object].new, I[Integer])      # error
 
 # === Contravariant (type_member(:in))
 T.let(A[Object].new, I[BasicObject])  # error
 T.let(A[Object].new, I[Object])       # OK
-T.let(A[Object].new, I[Integer])      # OK - Object is less derived than Integer
+T.let(A[Object].new, I[Integer])      # OK - Object is a supertype of Integer
 ```

--- a/website/docs/user-defined-generics.md
+++ b/website/docs/user-defined-generics.md
@@ -164,3 +164,36 @@ T.let(A[Object].new, I[BasicObject])  # error
 T.let(A[Object].new, I[Object])       # OK
 T.let(A[Object].new, I[Integer])      # OK - Object is a supertype of Integer
 ```
+
+Making a type parameter covariant or contravariant places restrictions on where
+it can appear inside the module's method signatures:
+
+```ruby
+module I
+  extend T::Sig
+  extend T::Generic
+
+  Var = type_member
+  In = type_member(:in)
+  Out = type_member(:out)
+
+  # OK - variant type parameters can be used anywhere in a sig
+  sig { params(x: Var).returns(Var) }
+  def ok_var(x); Var.new; end
+
+  # OK - contravariant (:in) type parameters can be parameters 
+  #      covariant (:out) type parameters can be return types
+  sig { params(x: In).returns(Out) }
+  def ok_in_out(x); Out.new; end
+
+  # error - "type_member In was defined as :in but is used in an :out context"
+  #         cannot use contravariant (:in) type parameter as a return type
+  sig { params(x: In).returns(In) }
+  def error_returning_in(x); In.new; end
+
+  # error - "type_member In was defined as :in but is used in an :out context"
+  #         cannot use covariant (:out) type parameter as a function parameter type
+  sig { params(x: Out).returns(Out) }
+  def error_taking_out(x); Out.new; end
+end
+```

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -39,6 +39,7 @@
       "sealed",
       "class-of",
       "stdlib-generics",
+      "user-defined-generics",
       "self-type",
       "noreturn",
       "attached-class",


### PR DESCRIPTION
This adds the beginnings of documentation for user defined generic types. (Progress towards #1803.)

I don't know if "User Defined Generics" is the best title for this, since the principles also apply to any of the built-in generics, but I went with it to try to differentiate it from the `stdlib-generics.md` page. 

I'm also happy to add an unstable/subject to change/etc warning, if that is the case for generics.

### Motivation
As mentioned in the issue referenced above, generics are an important feature of Sorbet which come up a lot when dealing with RBIs or more advanced use cases of the type checker. Despite this, they don't appear to be documented anywhere currently, except with incidental uses of `type_member` in the documentation for `T.self_type` and in the error reference.

### Test plan
![image](https://user-images.githubusercontent.com/3321773/94999111-f8b51f00-05ae-11eb-8ed0-d9be5639b1f7.png)
