### PR TITLE
Fix some rbi issues with keyword arguments

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -551,12 +551,18 @@ void GlobalState::initEmpty() {
         auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
         arg.flags.isBlock = true;
     }
-    // Synthesize <Magic>.<self-new>(arg: *T.untyped) => T.untyped
+    // Synthesize <Magic>.<self-new>(arg: *T.untyped, kwargs: **T.untyped) => T.untyped
     method = enterMethodSymbol(Loc::none(), Symbols::MagicSingleton(), Names::selfNew());
     {
         auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg0());
         arg.type = Types::untyped(*this, method);
         arg.flags.isRepeated = true;
+    }
+    {
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg1());
+        arg.type = Types::untyped(*this, method);
+        arg.flags.isRepeated = true;
+        arg.flags.isKeyword = true;
     }
     method.data(*this)->resultType = Types::untyped(*this, method);
     {
@@ -627,8 +633,9 @@ void GlobalState::initEmpty() {
     method = enterMethodSymbol(Loc::none(), Symbols::DeclBuilderForProcsSingleton(), Names::params());
     {
         auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg0());
-        arg.flags.isDefault = true;
-        arg.type = Types::hashOfUntyped();
+        arg.flags.isKeyword = true;
+        arg.flags.isRepeated = true;
+        arg.type = Types::untyped(*this, method);
     }
     method.data(*this)->resultType = Types::declBuilderForProcsSingletonClass();
     {

--- a/rbi/core/class.rbi
+++ b/rbi/core/class.rbi
@@ -92,8 +92,8 @@ class Class < Module
   # Calls `allocate` to create a new object of *class*'s class, then invokes
   # that object's `initialize` method, passing it *args*. This is the method
   # that ends up getting called whenever an object is constructed using .new.
-  sig {params(args: T.untyped).returns(T.untyped)}
-  def new(*args); end
+  sig {params(args: T.untyped, kwargs: T.untyped).returns(T.untyped)}
+  def new(*args, **kwargs); end
 
   # Callback invoked whenever a subclass of the current class is created.
   #

--- a/rbi/sorbet/builder.rbi
+++ b/rbi/sorbet/builder.rbi
@@ -22,7 +22,7 @@ class T::Private::Methods::DeclBuilder
   def bind(claz); end
 
   sig {params(params: T.untyped).returns(T::Private::Methods::DeclBuilder)}
-  def params(params); end
+  def params(**params); end
 
   sig {params(type: T.untyped).returns(T::Private::Methods::DeclBuilder)}
   def returns(type); end

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -18,10 +18,10 @@ module T::Props
 end
 
 module T::Props::ClassMethods
-  sig {params(name: T.any(Symbol, String), cls_or_args: T.untyped, args: T::Hash[Symbol, T.untyped]).void}
-  def const(name, cls_or_args, args={}, &blk); end
+  sig {params(name: T.any(Symbol, String), cls_or_args: T.untyped, args: T.untyped).void}
+  def const(name, cls_or_args, **args, &blk); end
   sig {params(name: T.any(Symbol, String), cls: T.untyped, rules: T.untyped).void}
-  def prop(name, cls, rules = nil); end
+  def prop(name, cls, **rules); end
   def decorator; end
   def decorator_class; end
   def plugin(mod); end
@@ -120,7 +120,7 @@ module T::Props::WeakConstructor
 end
 
 module T::Props::Constructor
-  def initialize(hash = nil); end
+  def initialize(**hash); end
   include T::Props::WeakConstructor
 end
 

--- a/test/testdata/resolver/unnamed_proc_arguments.rb
+++ b/test/testdata/resolver/unnamed_proc_arguments.rb
@@ -6,4 +6,4 @@ T.let(nil, T.nilable(T.proc.params(x: Integer).void))
 # this one fails because the proc doesn't have named params
 T.let(nil, T.nilable(T.proc.params(Integer).void))
                    # ^^^^^^^^^^^^^^^^^^^^^^ error: `params` expects keyword arguments
-                   # ^^^^^^^^^^^^^^^^^^^^^^ error: Expected `T::Hash[T.untyped, T.untyped]` but found `T.class_of(Integer)`
+                   # ^^^^^^^^^^^^^^^^^^^^^^ error: Too many positional arguments provided


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
While working on refactoring our handling of keyword arguments to better support ruby 2.7, I noticed some issues with keyword arguments in some of our RBIs.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
