### PR TITLE
Add Pathname support to FileUtils.touch sig

### DIFF
--- a/rbi/stdlib/fileutils.rbi
+++ b/rbi/stdlib/fileutils.rbi
@@ -227,7 +227,7 @@ module FileUtils
   # ```
   sig do
     params(
-      list: T.any(String, T::Array[String]),
+      list: T.any(String, Pathname, T::Array[String]),
       noop: T.nilable(T::Boolean),
       verbose: T.nilable(T::Boolean),
       mtime: T.nilable(Time),


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I wanted to pass a Pathname to `FileUtils.touch` but Sorbet did not allow it.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

```ribu
➜ irb
irb(main):001:0> require "fileutils"; require "pathname";
=> true
irb(main):002:0> FileUtils.touch(Pathname.new("test-pathname"))
=> ["test-pathname"]
irb(main):003:0> `ls -al test-pathname`
=> "-rw-r--r--  1 qaisjp  staff  0  7 Oct 19:32 test-pathname\n"
irb(main):004:0>
```

### Input

[→ View on sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0Arequire%20%22pathname%22%0Arequire%20%22fileutils%22%0A%0AFileUtils.touch(Pathname.new(%22foobar%22)))

```ruby
# typed: true
require "pathname"
require "fileutils"

FileUtils.touch(Pathname.new("foobar"))
```

### Observed output

```
# typed: true
require "pathname"
require "fileutils"

FileUtils.touch(Pathname.new("foobar"))
editor.rb:5: Expected T.any(T::Array[String], String) but found Pathname for argument list https://srb.help/7002
     5 |FileUtils.touch(Pathname.new("foobar"))
                        ^^^^^^^^^^^^^^^^^^^^^^
    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/fileutils.rbi#L230: Method FileUtils.touch has specified list as T.any(T::Array[String], String)
     230 |      list: T.any(String, T::Array[String]),
                ^^^^
  Got Pathname originating from:
    editor.rb:5:
     5 |FileUtils.touch(Pathname.new("foobar"))
                        ^^^^^^^^^^^^^^^^^^^^^^
Errors: 1
```

### Expected behaviour

```
No errors! Great job.
```