### PR TITLE
Add `freeze` keyword arg for Psych load methods

### DIFF
--- a/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/expected/err.log
+++ b/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/expected/err.log
@@ -25,7 +25,7 @@ lib/test.rb:3: Unable to resolve constant `Parlour` https://srb.help/5002
     https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi#L974: Did you mean: `JSON::Ext::Parser`?
      974 |class JSON::Ext::Parser
           ^^^^^^^^^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi#L980: Did you mean: `Psych::Parser`?
-     980 |class Psych::Parser
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi#L982: Did you mean: `Psych::Parser`?
+     982 |class Psych::Parser
           ^^^^^^^^^^^^^^^^^^^
 Errors: 1

--- a/rbi/stdlib/psych.rbi
+++ b/rbi/stdlib/psych.rbi
@@ -246,10 +246,11 @@ module Psych
       filename: T.nilable(String),
       fallback: T.untyped,
       symbolize_names: T::Boolean,
+      freeze: T::Boolean,
     )
     .returns(T.untyped)
   end
-  def self.load(yaml, legacy_filename = T.unsafe(nil), filename: T.unsafe(nil), fallback: T.unsafe(nil), symbolize_names: T.unsafe(nil)); end
+  def self.load(yaml, legacy_filename = T.unsafe(nil), filename: T.unsafe(nil), fallback: T.unsafe(nil), symbolize_names: T.unsafe(nil), freeze: T.unsafe(nil)); end
 
   ###
   # Safely load the yaml string in +yaml+.  By default, only the following
@@ -308,10 +309,11 @@ module Psych
       filename: T.nilable(String),
       fallback: T.untyped,
       symbolize_names: T::Boolean,
+      freeze: T::Boolean,
     )
     .returns(T.untyped)
   end
-  def self.safe_load(yaml, legacy_permitted_classes = T.unsafe(nil), legacy_permitted_symbols = T.unsafe(nil), legacy_aliases = T.unsafe(nil), legacy_filename = T.unsafe(nil), permitted_classes: T.unsafe(nil), permitted_symbols: T.unsafe(nil), aliases: T.unsafe(nil), filename: T.unsafe(nil), fallback: T.unsafe(nil), symbolize_names: T.unsafe(nil)); end
+  def self.safe_load(yaml, legacy_permitted_classes = T.unsafe(nil), legacy_permitted_symbols = T.unsafe(nil), legacy_aliases = T.unsafe(nil), legacy_filename = T.unsafe(nil), permitted_classes: T.unsafe(nil), permitted_symbols: T.unsafe(nil), aliases: T.unsafe(nil), filename: T.unsafe(nil), fallback: T.unsafe(nil), symbolize_names: T.unsafe(nil), freeze: T.unsafe(nil)); end
 
   ###
   # Parse a YAML string in +yaml+.  Returns the Psych::Nodes::Document.


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The `freeze` parsing option was added almost a year ago in upstream PR: https://github.com/ruby/psych/pull/414 This commit reflects those changes in the RBI file.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No extra tests added.
