### PR TITLE
Fix Thread.join sig to reflect nil-ability

### DIFF
--- a/rbi/core/thread.rbi
+++ b/rbi/core/thread.rbi
@@ -448,8 +448,9 @@ class Thread < Object
   # tick...
   # tick...
   # ```
-  sig {params(limit: T.untyped).returns(Thread)}
-  def join(*limit); end
+  sig {params(limit: NilClass).returns(Thread)}
+  sig {params(limit: Numeric).returns(T.nilable(Thread))}
+  def join(limit=nil); end
 
   # Returns `true` if the given string (or symbol) exists as a fiber-local
   # variable.

--- a/rbi/core/thread.rbi
+++ b/rbi/core/thread.rbi
@@ -448,7 +448,7 @@ class Thread < Object
   # tick...
   # tick...
   # ```
-  sig {params(limit: NilClass).returns(Thread)}
+  sig {returns(Thread)}
   sig {params(limit: Numeric).returns(T.nilable(Thread))}
   def join(limit=nil); end
 


### PR DESCRIPTION
The return value of `Thread.join` was incorrectly specified as always being a `Thread`, but if `limit` is specifed, then the join operation may time-out and the return value will be nil. This can cause errors in code which correctly handles the nilable return value. See: https://github.com/sorbet/sorbet/issues/3499

I've used sig overloading (which I believe is allowed for stdlib types?) to reflect the behaviour of the std library (and minimise the number of incorrect type errors which will result from this change).

I've also typed the limit parameter as numeric (since it must be a number of seconds).

### Motivation
https://github.com/sorbet/sorbet/issues/3499

### Test plan
TODO: If reviewers are happy with this solution, then I'll add some tests based on the example in the issue.