### PR TITLE
Rename private, protected & public helper functions

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -669,9 +669,9 @@ string Symbol::toStringWithOptions(const GlobalState &gs, int tabs, bool showFul
 
     if (this->isClassOrModule() || this->isMethod()) {
         if (this->isMethod()) {
-            if (this->isPrivate()) {
+            if (this->isMethodPrivate()) {
                 fmt::format_to(buf, " : private");
-            } else if (this->isProtected()) {
+            } else if (this->isMethodProtected()) {
                 fmt::format_to(buf, " : protected");
             }
         }

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -249,17 +249,17 @@ public:
         Exception::raise("Should not happen");
     }
 
-    inline bool isPublic() const {
+    inline bool isMethodPublic() const {
         ENFORCE_NO_TIMER(isMethod());
-        return !isProtected() && !isPrivate();
+        return !isMethodProtected() && !isMethodPrivate();
     }
 
-    inline bool isProtected() const {
+    inline bool isMethodProtected() const {
         ENFORCE_NO_TIMER(isMethod());
         return (flags & Symbol::Flags::METHOD_PROTECTED) != 0;
     }
 
-    inline bool isPrivate() const {
+    inline bool isMethodPrivate() const {
         ENFORCE_NO_TIMER(isMethod());
         return (flags & Symbol::Flags::METHOD_PRIVATE) != 0;
     }

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -411,18 +411,18 @@ public:
         return (flags & Symbol::Flags::METHOD_FINAL) != 0;
     }
 
-    inline void setPublic() {
+    inline void setMethodPublic() {
         ENFORCE(isMethod());
         flags &= ~Symbol::Flags::METHOD_PRIVATE;
         flags &= ~Symbol::Flags::METHOD_PROTECTED;
     }
 
-    inline void setProtected() {
+    inline void setMethodProtected() {
         ENFORCE(isMethod());
         flags |= Symbol::Flags::METHOD_PROTECTED;
     }
 
-    inline void setPrivate() {
+    inline void setMethodPrivate() {
         ENFORCE(isMethod());
         flags |= Symbol::Flags::METHOD_PRIVATE;
     }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -259,13 +259,13 @@ void validateOverriding(const core::Context ctx, core::SymbolRef method) {
 
     // both of these match the behavior of the runtime checks, which will only allow public methods to be defined in
     // interfaces
-    if (klassData->isClassOrModuleInterface() && method.data(ctx)->isPrivate()) {
+    if (klassData->isClassOrModuleInterface() && method.data(ctx)->isMethodPrivate()) {
         if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::NonPublicAbstract)) {
             e.setHeader("Interface method `{}` cannot be private", method.show(ctx));
         }
     }
 
-    if (klassData->isClassOrModuleInterface() && method.data(ctx)->isProtected()) {
+    if (klassData->isClassOrModuleInterface() && method.data(ctx)->isMethodProtected()) {
         if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::NonPublicAbstract)) {
             e.setHeader("Interface method `{}` cannot be protected", method.show(ctx));
         }

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -142,9 +142,9 @@ string prettyDefForMethod(const core::GlobalState &gs, core::SymbolRef method) {
     auto methodData = method.data(gs);
 
     string visibility = "";
-    if (methodData->isPrivate()) {
+    if (methodData->isMethodPrivate()) {
         visibility = "private ";
-    } else if (methodData->isProtected()) {
+    } else if (methodData->isMethodProtected()) {
         visibility = "protected ";
     }
 

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -817,7 +817,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
             // Since each list is sorted by depth, taking the first elem dedups by depth within each name.
             auto similarMethod = similarMethods[0];
 
-            if (similarMethod.method.data(gs)->isPrivate() && !sendResp->isPrivateOk) {
+            if (similarMethod.method.data(gs)->isMethodPrivate() && !sendResp->isPrivateOk) {
                 continue;
             }
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -966,10 +966,10 @@ class SymbolDefiner {
         auto implicitlyPrivate = ctx.owner.data(ctx)->enclosingClass(ctx) == core::Symbols::root();
         if (implicitlyPrivate) {
             // Methods defined at the top level default to private (on Object)
-            symbol.data(ctx)->setPrivate();
+            symbol.data(ctx)->setMethodPrivate();
         } else {
             // All other methods default to public (their visibility might be changed later)
-            symbol.data(ctx)->setPublic();
+            symbol.data(ctx)->setMethodPublic();
         }
         return symbol;
     }
@@ -986,13 +986,13 @@ class SymbolDefiner {
             switch (mod.name._id) {
                 case core::Names::private_()._id:
                 case core::Names::privateClassMethod()._id:
-                    method.data(ctx)->setPrivate();
+                    method.data(ctx)->setMethodPrivate();
                     break;
                 case core::Names::protected_()._id:
-                    method.data(ctx)->setProtected();
+                    method.data(ctx)->setMethodProtected();
                     break;
                 case core::Names::public_()._id:
-                    method.data(ctx)->setPublic();
+                    method.data(ctx)->setMethodPublic();
                     break;
                 default:
                     break;


### PR DESCRIPTION
This is a purely structural change before adding support for checking calls to private methods. This was suggested by @jez in https://github.com/sorbet/sorbet/compare/jez-private-methods

### Test plan
Purely structural change, doesn't have any test impact.