### PR TITLE
Fix issue where Environment::clearKnowledge is accidentally quadratic in number of local variables

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -32,6 +32,9 @@ bool typeTestReferencesVar(const InlinedVector<std::pair<cfg::LocalRef, core::Ty
 
 void TypeTestReverseIndex::addToIndex(cfg::LocalRef from, cfg::LocalRef to) {
     auto &list = index[from];
+    // Maintain invariant: lists are sorted sets (no duplicate entries)
+    // lower_bound returns the first location that is >= to's ID, which is where `to` should be inserted if *it != to
+    // (uses binary search, O(log n))
     auto it =
         lower_bound(list.begin(), list.end(), to, [](const auto &a, const auto &b) -> bool { return a.id() < b.id(); });
     if (it == list.end() || *it != to) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -35,8 +35,7 @@ void TypeTestReverseIndex::addToIndex(cfg::LocalRef from, cfg::LocalRef to) {
     // Maintain invariant: lists are sorted sets (no duplicate entries)
     // lower_bound returns the first location that is >= to's ID, which is where `to` should be inserted if *it != to
     // (uses binary search, O(log n))
-    auto it =
-        lower_bound(list.begin(), list.end(), to, [](const auto &a, const auto &b) -> bool { return a.id() < b.id(); });
+    auto it = absl::c_lower_bound(list, to, [](const auto &a, const auto &b) -> bool { return a.id() < b.id(); });
     if (it == list.end() || *it != to) {
         list.insert(it, to);
     }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -57,6 +57,8 @@ void TypeTestReverseIndex::cloneFrom(const TypeTestReverseIndex &index) {
     this->index = index.index;
 }
 
+const InlinedVector<cfg::LocalRef, 1> TypeTestReverseIndex::empty;
+
 /**
  * Encode things that we know hold and don't hold.
  */

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -18,6 +18,7 @@
 namespace sorbet::infer {
 
 class TypeTestReverseIndex final {
+    // Note: vectors are sorted and are treated as sets.
     UnorderedMap<cfg::LocalRef, InlinedVector<cfg::LocalRef, 1>> index;
     const InlinedVector<cfg::LocalRef, 1> empty;
 

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -95,6 +95,7 @@ public:
 
     void replaceTruthy(cfg::LocalRef from, TypeTestReverseIndex &index, const KnowledgeRef &newTruthy);
     void replaceFalsy(cfg::LocalRef from, TypeTestReverseIndex &index, const KnowledgeRef &newFalsy);
+    void replace(cfg::LocalRef of, TypeTestReverseIndex &index, const TestedKnowledge &knowledge);
 
     std::string toString(const core::GlobalState &gs, const cfg::CFG &cfg) const;
 

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -17,7 +17,20 @@
 
 namespace sorbet::infer {
 
-using TypeTestReverseIndex = UnorderedMap<cfg::LocalRef, InlinedVector<cfg::LocalRef, 1>>;
+class TypeTestReverseIndex final {
+    UnorderedMap<cfg::LocalRef, InlinedVector<cfg::LocalRef, 1>> index;
+    const InlinedVector<cfg::LocalRef, 1> empty;
+
+public:
+    TypeTestReverseIndex() = default;
+    TypeTestReverseIndex(const TypeTestReverseIndex &rhs) = delete;
+    TypeTestReverseIndex(TypeTestReverseIndex &&rhs) = default;
+
+    void addToIndex(cfg::LocalRef from, cfg::LocalRef to);
+    const InlinedVector<cfg::LocalRef, 1> &get(cfg::LocalRef from) const;
+    void replace(cfg::LocalRef from, InlinedVector<cfg::LocalRef, 1> &&list);
+    void cloneFrom(const TypeTestReverseIndex &index);
+};
 
 class Environment;
 struct KnowledgeFact;

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -20,7 +20,7 @@ namespace sorbet::infer {
 class TypeTestReverseIndex final {
     // Note: vectors are sorted and are treated as sets.
     UnorderedMap<cfg::LocalRef, InlinedVector<cfg::LocalRef, 1>> index;
-    const InlinedVector<cfg::LocalRef, 1> empty;
+    static const InlinedVector<cfg::LocalRef, 1> empty;
 
 public:
     TypeTestReverseIndex() = default;

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -27,6 +27,9 @@ public:
     TypeTestReverseIndex(const TypeTestReverseIndex &rhs) = delete;
     TypeTestReverseIndex(TypeTestReverseIndex &&rhs) = default;
 
+    TypeTestReverseIndex &operator=(const TypeTestReverseIndex &rhs) = delete;
+    TypeTestReverseIndex &operator=(TypeTestReverseIndex &&rhs) = delete;
+
     void addToIndex(cfg::LocalRef from, cfg::LocalRef to);
     const InlinedVector<cfg::LocalRef, 1> &get(cfg::LocalRef from) const;
     void replace(cfg::LocalRef from, InlinedVector<cfg::LocalRef, 1> &&list);

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -202,11 +202,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
         }
         histogramInc("infer.environment.size", current.vars.size());
         for (auto &pair : current.vars) {
-            auto &k = pair.second.knowledge;
-            histogramInc("infer.knowledge.truthy.yes.size", k.truthy->yesTypeTests.size());
-            histogramInc("infer.knowledge.truthy.no.size", k.truthy->noTypeTests.size());
-            histogramInc("infer.knowledge.falsy.yes.size", k.falsy->yesTypeTests.size());
-            histogramInc("infer.knowledge.falsy.no.size", k.falsy->noTypeTests.size());
+            pair.second.knowledge.emitKnowledgeSizeMetric();
         }
     }
     if (startErrorCount == ctx.state.totalErrors()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Prior to this change:
* Environment::clearKnowledge iterated through all local variables (LocalRefs) in the environment to remove references to a variable in yes/no type tests (O(n) for n variables).
* Environment::clearKnowledge was called once per n local variable.

With this change:
* Environment maintains an index from local variable to a vector of local variables that contains that variable in its type tests.
  * Currently maintained as an overapproximation (e.g., it may contain variables that have since been mutated to no longer contain the variable).
* Environment::clearKnowledge iterates through only those local variables that may contain the variable in a type test (common case: none).

End result:
* Significant improvement in end-to-end typechecking time for files with many local variables or literals. Stripe had a couple of files internally that contained thousands of literals (numbers/strings/etc) that would take over a second to typecheck each. Now they typecheck 80%+ faster.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed++

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
