### PR TITLE
Error out on non-private calls to private methods

### DIFF
--- a/core/errors/infer.h
+++ b/core/errors/infer.h
@@ -35,6 +35,7 @@ constexpr ErrorClass UntypedConstantSuggestion{7027, StrictLevel::Strict};
 // constexpr ErrorClass GenericTypeParamBoundMismatch{7028, StrictLevel::False};
 // constexpr ErrorClass LazyResolve{7029, StrictLevel::True};
 constexpr ErrorClass MetaTypeDispatchCall{7030, StrictLevel::True};
+constexpr ErrorClass PrivateMethod{7031, StrictLevel::True};
 // N.B infer does not run for untyped call at all. StrictLevel::False here would be meaningless
 } // namespace sorbet::core::errors::Infer
 #endif

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -483,7 +483,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
                                   const Type *thisType, core::SymbolRef symbol, vector<TypePtr> &targs) {
     if (symbol == core::Symbols::untyped()) {
         return DispatchResult(Types::untyped(gs, thisType->untypedBlame()), std::move(args.selfType),
-                              Symbols::untyped());
+                              Symbols::noSymbol());
     } else if (symbol == Symbols::void_()) {
         if (auto e = gs.beginError(core::Loc(args.locs.file, args.locs.call), errors::Infer::UnknownMethod)) {
             e.setHeader("Can not call method `{}` on void type", args.name.data(gs)->show(gs));
@@ -510,7 +510,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args,
             }
             return result;
         } else if (args.name == core::Names::super()) {
-            return DispatchResult(Types::untypedUntracked(), std::move(args.selfType), Symbols::untyped());
+            return DispatchResult(Types::untypedUntracked(), std::move(args.selfType), Symbols::noSymbol());
         }
         auto result = DispatchResult(Types::untypedUntracked(), std::move(args.selfType), Symbols::noSymbol());
         // This is a hack. We want to always be able to build the error object

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -839,6 +839,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         it->main.method.data(ctx)->isMethodPrivate() && !send->isPrivateOk) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::PrivateMethod)) {
                             e.setHeader("Non-private call to private method `{}`", it->main.method.show(ctx));
+                            e.addErrorLine(it->main.method.data(ctx)->loc(), "Defined as");
                         }
                     }
 

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -833,7 +833,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     }
 
                     // The method here should always exists() and return true for `isMethod()`.
-                    // However, when initializing a class (e.g. `Object.new`), that is not the case. This guards against that.
+                    // However, when initializing a class (e.g. `Object.new`), that is not the case. This guards against
+                    // that.
                     if (it->main.method.exists() && it->main.method.data(ctx)->isMethod() &&
                         it->main.method.data(ctx)->isMethodPrivate() && !send->isPrivateOk) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::PrivateMethod)) {

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -143,7 +143,7 @@ vector<ast::TreePtr> processStat(core::MutableContext ctx, ast::ClassDef *klass,
         args.emplace_back(std::move(arg));
     }
 
-    ast::Send::Flags flags =  {};
+    ast::Send::Flags flags = {};
     flags.isPrivateOk = true;
     auto singletonAsgn = ast::MK::Assign(
         stat->loc, std::move(asgn->lhs),

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -143,12 +143,13 @@ vector<ast::TreePtr> processStat(core::MutableContext ctx, ast::ClassDef *klass,
         args.emplace_back(std::move(arg));
     }
 
+    ast::Send::Flags flags =  {};
+    flags.isPrivateOk = true;
     auto singletonAsgn = ast::MK::Assign(
         stat->loc, std::move(asgn->lhs),
         ast::MK::Send2(stat->loc, ast::MK::Constant(stat->loc, core::Symbols::T()), core::Names::uncheckedLet(),
-                       ast::MK::Send(stat->loc, classCnst.deepCopy(), core::Names::new_(), std::move(args)),
+                       ast::MK::Send(stat->loc, classCnst.deepCopy(), core::Names::new_(), std::move(args), flags),
                        std::move(classCnst)));
-
     vector<ast::TreePtr> result;
     result.emplace_back(std::move(classDef));
     result.emplace_back(std::move(singletonAsgn));

--- a/test/testdata/infer/private_class_methods.rb
+++ b/test/testdata/infer/private_class_methods.rb
@@ -1,0 +1,50 @@
+# typed: true
+
+# By these methods are defined on Object
+def self.bar; end
+
+class Test
+  def self.method_a; end
+  def self.method_b; end
+  private_class_method :method_b
+  private_class_method def self.method_c; end
+
+  class << self
+    def method_d; end
+    private :method_d
+
+    private def method_e; end
+
+    private
+
+    def method_f; end
+  end
+
+  module ClassMethods
+    def method_g; end
+    private :method_g
+
+    private def method_h; end
+
+    private
+
+    def method_i; end
+  end
+
+  extend ClassMethods
+end
+
+Object.bar # error: Non-private call to private method `Object.bar`
+
+Test.method_a
+Test.method_b # error: Non-private call to private method `Test.method_b`
+Test.method_c # error: Non-private call to private method `Test.method_c`
+Test.method_d # error: Non-private call to private method `Test.method_d`
+Test.method_e # error: Non-private call to private method `Test.method_e`
+Test.method_g # error: Non-private call to private method `Test::ClassMethods#method_g`
+Test.method_h # error: Non-private call to private method `Test::ClassMethods#method_h`
+
+# TODO: The following methods should contain errors. Sorbet currently does not support setting method
+# visibility using the private/protected keywords that affect the visibility of subsequent methods.
+Test.method_f
+Test.method_i

--- a/test/testdata/infer/private_class_methods.rb.symbol-table.exp
+++ b/test/testdata/infer/private_class_methods.rb.symbol-table.exp
@@ -1,0 +1,40 @@
+class ::<root> < ::Object ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/infer/private_class_methods.rb:4
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_class_methods.rb start=??? end=???}
+  class ::<Class:Object>[<AttachedClass>] < ::<Class:BasicObject> ()
+    method ::<Class:Object>#bar : private (<blk>) @ test/testdata/infer/private_class_methods.rb:4
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_class_methods.rb start=??? end=???}
+  class ::Test < ::Object () @ test/testdata/infer/private_class_methods.rb:6
+    module ::Test::ClassMethods < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/infer/private_class_methods.rb:23
+      method ::Test::ClassMethods#method_g : private (<blk>) @ test/testdata/infer/private_class_methods.rb:24
+        argument <blk><block> @ Loc {file=test/testdata/infer/private_class_methods.rb start=??? end=???}
+      method ::Test::ClassMethods#method_h : private (<blk>) @ test/testdata/infer/private_class_methods.rb:27
+        argument <blk><block> @ Loc {file=test/testdata/infer/private_class_methods.rb start=??? end=???}
+      method ::Test::ClassMethods#method_i (<blk>) @ test/testdata/infer/private_class_methods.rb:31
+        argument <blk><block> @ Loc {file=test/testdata/infer/private_class_methods.rb start=??? end=???}
+    class ::Test::<Class:ClassMethods>[<AttachedClass>] < ::Module () @ test/testdata/infer/private_class_methods.rb:23
+      type-member(+) ::Test::<Class:ClassMethods>::<AttachedClass> -> T.attached_class (of Test::ClassMethods) @ test/testdata/infer/private_class_methods.rb:23
+      method ::Test::<Class:ClassMethods>#<static-init> (<blk>) @ test/testdata/infer/private_class_methods.rb:23
+        argument <blk><block> @ Loc {file=test/testdata/infer/private_class_methods.rb start=??? end=???}
+  class ::<Class:Test>[<AttachedClass>] < ::<Class:Object> (ClassMethods) @ test/testdata/infer/private_class_methods.rb:12
+    type-member(+) ::<Class:Test>::<AttachedClass> -> T.attached_class (of Test) @ test/testdata/infer/private_class_methods.rb:6
+    method ::<Class:Test>#<static-init> (<blk>) @ test/testdata/infer/private_class_methods.rb:6
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_class_methods.rb start=??? end=???}
+    method ::<Class:Test>#method_a (<blk>) @ test/testdata/infer/private_class_methods.rb:7
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_class_methods.rb start=??? end=???}
+    method ::<Class:Test>#method_b : private (<blk>) @ test/testdata/infer/private_class_methods.rb:8
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_class_methods.rb start=??? end=???}
+    method ::<Class:Test>#method_c : private (<blk>) @ test/testdata/infer/private_class_methods.rb:10
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_class_methods.rb start=??? end=???}
+    method ::<Class:Test>#method_d : private (<blk>) @ test/testdata/infer/private_class_methods.rb:13
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_class_methods.rb start=??? end=???}
+    method ::<Class:Test>#method_e : private (<blk>) @ test/testdata/infer/private_class_methods.rb:16
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_class_methods.rb start=??? end=???}
+    method ::<Class:Test>#method_f (<blk>) @ test/testdata/infer/private_class_methods.rb:20
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_class_methods.rb start=??? end=???}
+  class ::<Class:<Class:Test>>[<AttachedClass>] < ::<Class:<Class:Object>> () @ test/testdata/infer/private_class_methods.rb:12
+    type-member(+) ::<Class:<Class:Test>>::<AttachedClass> -> T.attached_class (of T.class_of(Test)) @ test/testdata/infer/private_class_methods.rb:12
+    method ::<Class:<Class:Test>>#<static-init> (<blk>) @ test/testdata/infer/private_class_methods.rb:12
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_class_methods.rb start=??? end=???}
+

--- a/test/testdata/infer/private_methods.rb
+++ b/test/testdata/infer/private_methods.rb
@@ -1,0 +1,66 @@
+# typed: true
+
+class Test
+  def using_symbol
+    1
+  end
+  private :using_symbol
+
+  private def using_symbol_returned_by_def
+    2
+  end
+
+  private def splat_call(*args)
+    puts args
+  end
+
+  private def splat_and_block_call(foo, bar, &blk)
+  end
+
+  private def block_call(&blk)
+  end
+
+  def calling_private
+    using_symbol
+    self.using_symbol
+    assigned_self = self
+    assigned_self.using_symbol # error: Non-private call to private method `Test#using_symbol`
+  end
+
+  private
+  def subsequent_visibility
+    3
+  end
+end
+
+class TestChild < Test
+  def calling_private_in_parent
+    using_symbol
+    self.using_symbol
+    assigned_self = self
+    assigned_self.using_symbol # error: Non-private call to private method `Test#using_symbol`
+  end
+end
+
+Test.new.using_symbol # error: Non-private call to private method `Test#using_symbol`
+Test.new.using_symbol_returned_by_def # error: Non-private call to private method `Test#using_symbol_returned_by_def`
+Test.new.calling_private
+Test.new.using_symbol { 123 } # error: Non-private call to private method `Test#using_symbol`
+Test.new.block_call # error: Non-private call to private method `Test#block_call`
+Test.new.block_call { 123 } # error: Non-private call to private method `Test#block_call`
+Test.new.block_call(&:foo) # error: Non-private call to private method `Test#block_call`
+
+TestChild.new.using_symbol # error: Non-private call to private method `Test#using_symbol`
+
+T.unsafe(Test.new).using_symbol
+
+# TODO: The following methods should also error out. The do not currently do that since the the IR
+# of these calls are through the magic calls: splat-call, splat-and-block-call and block-call.
+# They don't contain the visibility information of the original method.
+Test.new.splat_call(*T.unsafe(nil))
+Test.new.splat_and_block_call(*[1, 'a'], &nil)
+Test.new.block_call(&nil)
+
+# TODO: The following method should contain an error. Sorbet currently does not support setting method
+# visibility using the private/protected keywords that affect the visibility of subsequent methods.
+Test.new.subsequent_visibility

--- a/test/testdata/infer/private_methods.rb
+++ b/test/testdata/infer/private_methods.rb
@@ -1,5 +1,7 @@
 # typed: true
 
+def foo; end
+
 class Test
   def using_symbol
     1
@@ -41,6 +43,8 @@ class TestChild < Test
     assigned_self.using_symbol # error: Non-private call to private method `Test#using_symbol`
   end
 end
+
+Object.new.foo # error: Non-private call to private method `Object#foo`
 
 Test.new.using_symbol # error: Non-private call to private method `Test#using_symbol`
 Test.new.using_symbol_returned_by_def # error: Non-private call to private method `Test#using_symbol_returned_by_def`

--- a/test/testdata/infer/private_methods.rb.symbol-table.exp
+++ b/test/testdata/infer/private_methods.rb.symbol-table.exp
@@ -1,0 +1,37 @@
+class ::<root> < ::Object ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/infer/private_methods.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_methods.rb start=??? end=???}
+  class ::Object < ::BasicObject (Kernel) @ https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#L27
+    method ::Object#foo : private (<blk>) @ test/testdata/infer/private_methods.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_methods.rb start=??? end=???}
+  class ::Test < ::Object () @ test/testdata/infer/private_methods.rb:5
+    method ::Test#block_call : private (blk) @ test/testdata/infer/private_methods.rb:22
+      argument blk<block> @ Loc {file=test/testdata/infer/private_methods.rb start=22:27 end=22:30}
+    method ::Test#calling_private (<blk>) @ test/testdata/infer/private_methods.rb:25
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_methods.rb start=??? end=???}
+    method ::Test#splat_and_block_call : private (foo, bar, blk) @ test/testdata/infer/private_methods.rb:19
+      argument foo<> @ Loc {file=test/testdata/infer/private_methods.rb start=19:36 end=19:39}
+      argument bar<> @ Loc {file=test/testdata/infer/private_methods.rb start=19:41 end=19:44}
+      argument blk<block> @ Loc {file=test/testdata/infer/private_methods.rb start=19:47 end=19:50}
+    method ::Test#splat_call : private (args, <blk>) @ test/testdata/infer/private_methods.rb:15
+      argument args<repeated> @ Loc {file=test/testdata/infer/private_methods.rb start=15:27 end=15:31}
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_methods.rb start=??? end=???}
+    method ::Test#subsequent_visibility (<blk>) @ test/testdata/infer/private_methods.rb:33
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_methods.rb start=??? end=???}
+    method ::Test#using_symbol : private (<blk>) @ test/testdata/infer/private_methods.rb:6
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_methods.rb start=??? end=???}
+    method ::Test#using_symbol_returned_by_def : private (<blk>) @ test/testdata/infer/private_methods.rb:11
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_methods.rb start=??? end=???}
+  class ::<Class:Test>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/infer/private_methods.rb:5
+    type-member(+) ::<Class:Test>::<AttachedClass> -> T.attached_class (of Test) @ test/testdata/infer/private_methods.rb:5
+    method ::<Class:Test>#<static-init> (<blk>) @ test/testdata/infer/private_methods.rb:5
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_methods.rb start=??? end=???}
+  class ::TestChild < ::Test () @ test/testdata/infer/private_methods.rb:38
+    method ::TestChild#calling_private_in_parent (<blk>) @ test/testdata/infer/private_methods.rb:39
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_methods.rb start=??? end=???}
+  class ::<Class:TestChild>[<AttachedClass>] < ::<Class:Test> () @ test/testdata/infer/private_methods.rb:38
+    type-member(+) ::<Class:TestChild>::<AttachedClass> -> T.attached_class (of TestChild) @ test/testdata/infer/private_methods.rb:38
+    method ::<Class:TestChild>#<static-init> (<blk>) @ test/testdata/infer/private_methods.rb:38
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_methods.rb start=??? end=???}
+

--- a/test/testdata/resolver/sig_generated.rb
+++ b/test/testdata/resolver/sig_generated.rb
@@ -2,6 +2,8 @@
 
 extend T::Sig
 
-sig {returns(NilClass).generated} # error: Malformed signature
+sig {returns(NilClass).generated}
+#    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Malformed signature: `generated` is invalid in this context
+#    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Non-private call to private method `Object#generated`
 def generated
 end


### PR DESCRIPTION
This will type-check private methods and ensure they can actually be called. Based off of https://github.com/sorbet/sorbet/compare/jez-private-methods

The following can still not be type-checked:
- splat/splat&block/block methods since they do not carry visibility information when being switched to the magic replacements.
- "subsequent visibility": using the private keyword, thus marking the following methods private.

I intend to work on those separately though.

### Motivation
Currently sorbet does not warn users about calling a private method on an object, instead a runtime error will occur. This will make sorbet error out  instead.


### Test plan
See included automated tests.
