### PR TITLE
Update copyright year

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -10,7 +10,7 @@ class Footer extends React.Component {
       <footer className="nav-footer" id="footer">
         <div className="wrapper">
           <p className="footer">
-            © 2019 Stripe{' · '}
+            © 2019-2020 Stripe{' · '}
             <a href={docUrl('adopting')}>Get started</a>
             {' · '}
             <a href={docUrl('overview')}>Docs</a>

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -6,11 +6,12 @@ class Footer extends React.Component {
     const {baseUrl, docsUrl} = siteConfig;
     const docsPart = `${docsUrl ? `${docsUrl}/` : ''}`;
     const docUrl = (doc) => `${baseUrl}${docsPart}${doc}`;
+    const currentYear = new Date().getFullYear();
     return (
       <footer className="nav-footer" id="footer">
         <div className="wrapper">
           <p className="footer">
-            © 2019-2020 Stripe{' · '}
+            © {currentYear} Stripe{' · '}
             <a href={docUrl('adopting')}>Get started</a>
             {' · '}
             <a href={docUrl('overview')}>Docs</a>


### PR DESCRIPTION
Update the copyright year in the site footer.

I'm not sure if this should be "2019-2020" or just "2020"? Or if we want to add a bit of JS that'll automatically display the current year? 🤷‍♂️

### Motivation

It was the wrong year :)

### Test plan

N/A