### PR TITLE
Fix invalid local attribution in type test reverse index.

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -505,8 +505,8 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         auto &whoKnows = getKnowledge(local);
         auto fnd = _vars.find(send->recv.variable);
         if (fnd != _vars.end()) {
-            whoKnows.replaceTruthy(fnd->first, typeTestsWithVar, fnd->second.knowledge.falsy());
-            whoKnows.replaceFalsy(fnd->first, typeTestsWithVar, fnd->second.knowledge.truthy());
+            whoKnows.replaceTruthy(local, typeTestsWithVar, fnd->second.knowledge.falsy());
+            whoKnows.replaceFalsy(local, typeTestsWithVar, fnd->second.knowledge.truthy());
             fnd->second.knowledge.truthy().addYesTypeTest(fnd->first, typeTestsWithVar, local,
                                                           core::Types::falsyTypes());
             fnd->second.knowledge.falsy().addNoTypeTest(fnd->first, typeTestsWithVar, local, core::Types::falsyTypes());


### PR DESCRIPTION
Fix invalid local attribution in type test reverse index.

whoKnows is the knowledge of `local` not `fnd->first`.

I'm not entirely sure how to craft a test file to exercise this bug.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is incorrect logic.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
