### PR TITLE
Allow to pass doctest specific options to each runner

### DIFF
--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -603,6 +603,6 @@ int main(int argc, char *argv[]) {
     sorbet::test::singleTest = res["single_test"].as<std::string>();
     sorbet::test::webTraceFile = res["web-trace-file"].as<std::string>();
 
-    doctest::Context context;
+    doctest::Context context(argc, argv);
     return context.run();
 }

--- a/test/parser_test_runner.cc
+++ b/test/parser_test_runner.cc
@@ -196,6 +196,6 @@ int main(int argc, char *argv[]) {
 
     sorbet::test::singleTest = res["single_test"].as<std::string>();
 
-    doctest::Context context;
+    doctest::Context context(argc, argv);
     return context.run();
 }

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -548,6 +548,6 @@ int main(int argc, char *argv[]) {
 
     sorbet::test::singleTest = res["single_test"].as<std::string>();
 
-    doctest::Context context;
+    doctest::Context context(argc, argv);
     return context.run();
 }

--- a/third_party/doctest.BUILD
+++ b/third_party/doctest.BUILD
@@ -1,7 +1,7 @@
 cc_library(
     name = "doctest",
     hdrs = glob(["doctest/**/*.h"]),
-    defines = ["DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL"],
+    defines = ["DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL", "DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS"],
     strip_include_prefix = "doctest",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
### Motivation
Use the [DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS](https://github.com/onqtam/doctest/blob/master/doc/markdown/configuration.md#doctest_config_no_unprefixed_options) define to allow passing doctest specific options (which are prefixed with "--dt-" to avoid colliding with any current/future custom command line flags the runner may have).

As a rationale, this allows to use options such as "--no-colors" (specified as "--dt-no-colors") to force disable escape sequences when doctest TTY recognition fails to work (which is the case if you are trying to debug from VSCode).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
None
