### PR TITLE
Add type definition Enumerable#tally and Module#const_source_location

### DIFF
--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -1569,7 +1569,7 @@ module Enumerable
   # ```ruby
   # ["a", "b", "c", "b"].tally  #=> {"a"=>1, "b"=>2, "c"=>1}
   # ```
-  sig {returns(T::Hash[T.nilable(Elem), Integer])}
+  sig {returns(T::Hash[Elem, Integer])}
   def tally(); end
 
   ### Implemented in C++

--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -1562,6 +1562,16 @@ module Enumerable
   sig {returns(T::Enumerator[Elem])}
   def take_while(&blk); end
 
+  # Tallies the collection, i.e., counts the occurrences of each element.
+  # Returns a hash with the elements of the collection as keys and the
+  # corresponding counts as values.
+  #
+  # ```ruby
+  # ["a", "b", "c", "b"].tally  #=> {"a"=>1, "b"=>2, "c"=>1}
+  # ```
+  sig {returns(T::Hash[T.nilable(Elem), Integer])}
+  def tally(); end
+
   ### Implemented in C++
 
   # Returns the result of interpreting *enum* as a list of `[key, value]` pairs.

--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -666,7 +666,7 @@ class Module < Object
     )
     .returns(T.nilable([String, Integer]))
   end
-  def const_source_location(sym, inherit=T.unsafe(nil)); end
+  def const_source_location(sym, inherit=true); end
 
   # Returns an array of the names of the constants accessible in *mod*. This
   # includes the names of constants in any included modules (example at start of

--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -620,6 +620,54 @@ class Module < Object
   end
   def const_set(arg0, arg1); end
 
+  # Returns the Ruby source filename and line number containing first definition of
+  # constant specified. If the named constant is not found, `nil` is returned.
+  # If the constant is found, but its source location can not be extracted (constant is defined in C code), empty array is returned.
+  #
+  # *inherit* specifies whether to lookup in `mod.ancestors` (`true` by default).
+  #
+  # ```ruby
+  # # test.rb
+  # class A
+  #   C1 = 1
+  # end
+  #
+  # module M
+  #   C2 = 2
+  # end
+  #
+  # class B < A
+  #   include M
+  #   C3 = 3
+  # end
+  #
+  # class A # continuation of A definition
+  # end
+  #
+  # p B.const_source_location('C3')           # => ["test.rb", 11]
+  # p B.const_source_location('C2')           # => ["test.rb", 6]
+  # p B.const_source_location('C1')           # => ["test.rb", 2]
+  #
+  # p B.const_source_location('C2', false)    # => nil  -- don't lookup in ancestors
+  #
+  # p Object.const_source_location('B')       # => ["test.rb", 9]
+  # p Object.const_source_location('A')       # => ["test.rb", 1]  -- note it is first entry, not "continuation"
+  #
+  # p B.const_source_location('A')            # => ["test.rb", 1]  -- because Object is in ancestors
+  # p M.const_source_location('A')            # => ["test.rb", 1]  -- Object is not ancestor, but additionally checked for modules
+  #
+  # p Object.const_source_location('A::C1')   # => ["test.rb", 2]  -- nesting is supported
+  # p Object.const_source_location('String')  # => []  -- constant is defined in C code
+  # ```
+  sig do
+    params(
+        sym: T.any(Symbol, String),
+        inherit: T::Boolean,
+    )
+    .returns(T.nilable([String, Integer]))
+  end
+  def const_source_location(sym, inherit=T.unsafe(nil)); end
+
   # Returns an array of the names of the constants accessible in *mod*. This
   # includes the names of constants in any included modules (example at start of
   # section), unless the *inherit* parameter is set to `false`.

--- a/test/cli/autocorrect-helpers/autocorrect-helpers.out
+++ b/test/cli/autocorrect-helpers/autocorrect-helpers.out
@@ -84,8 +84,8 @@ autocorrect-helpers.rb:30: Method `mixes_in_class_methods` does not exist on `T.
 `
     30 |  mixes_in_class_methods(S1)
         ^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#L1371: Did you mean: `Module#public_class_method`?
-    1371 |  def public_class_method(*arg0); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#L1419: Did you mean: `Module#public_class_method`?
+    1419 |  def public_class_method(*arg0); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 9
 

--- a/test/testdata/rbi/enumerable.rb
+++ b/test/testdata/rbi/enumerable.rb
@@ -20,6 +20,7 @@
 
 T.assert_type!([1].lazy, Enumerator::Lazy[Integer])
 T.assert_type!([1, 2].filter_map { |x| x.odd? ? x.to_f : x.to_s }, T::Array[T.any(Float, String)])
+T.assert_type!([1, 2, "3", nil].tally, T::Hash[T.nilable(T.any(Integer, String)), Integer])
 
 # There are 3 different ways to call all?, any? and none?
 a = [1, 3, 20]

--- a/test/testdata/rbi/module.rb
+++ b/test/testdata/rbi/module.rb
@@ -2,3 +2,8 @@
 
 String.module_eval { puts self }
 Enumerable.class_eval { |mod| puts mod }
+
+T.assert_type!(Module.const_source_location('IO'), T.nilable([String, Integer]))
+T.assert_type!(Module.const_source_location('Zlib'), T.nilable([String, Integer]))
+T.assert_type!(Module.const_source_location('Zlib', true), T.nilable([String, Integer]))
+T.assert_type!(Module.const_source_location(:Zlib, false), T.nilable([String, Integer]))


### PR DESCRIPTION
I added type definitions for the methods below.

- `Enumerable#tally`
- `Module#const_source_location`


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

By adding those definitions, Sorbet would get a bit more useful in Ruby 2.7.

Related: #2390

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I added test data and confirmed that `bazel test test --config=dbg` passed.