### PR TITLE
Implement dropSubtypesOf on sealed AppliedType

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1062,7 +1062,7 @@ TypePtr Symbol::sealedSubclassesToUnion(const GlobalState &gs) const {
     ENFORCE(lastClassType != nullptr, "Last element of sealedSubclasses must be ClassType");
     auto subclass = lastClassType->symbol.data(gs)->attachedClass(gs);
     ENFORCE(subclass.exists());
-    result = Types::any(gs, make_type<ClassType>(subclass), result);
+    result = Types::any(gs, subclass.data(gs)->externalType(gs), result);
 
     return result;
 }

--- a/test/testdata/infer/sealed_applied_FIX_ME.rb
+++ b/test/testdata/infer/sealed_applied_FIX_ME.rb
@@ -1,0 +1,33 @@
+# typed: strict
+
+class Parent
+  extend T::Helpers
+  extend T::Generic
+  sealed!
+  abstract!
+  A = type_member
+end
+
+class Child1 < Parent
+  A = type_member(lower: Integer)
+end
+
+class Child2 < Parent
+  A = type_member
+end
+
+extend T::Sig
+
+sig {params(x: Parent[String]).void}
+def foo(x)
+  case x
+  when Integer
+  when Child1
+    # This is wrong: the revealed type should not be allowed to exists, because
+    # `String` is not a super type of `Integer`, which is a lower bound of `Child1::A`
+    T.reveal_type(x) # error: Revealed type: `Child1[String]`
+  when Child2
+    T.reveal_type(x)
+  else T.absurd(x)
+  end
+end

--- a/test/testdata/infer/sealed_list.rb
+++ b/test/testdata/infer/sealed_list.rb
@@ -1,0 +1,46 @@
+# typed: true
+module List
+  extend T::Helpers
+  extend T::Generic
+  Elem = type_member(:out)
+  sealed!
+
+  class Cons
+    extend T::Generic
+    include List
+    Elem = type_member
+  end
+
+  class Nil
+    extend T::Generic
+    include List
+    Elem = type_member(fixed: T.noreturn)
+  end
+end
+
+extend T::Sig
+
+sig do
+  type_parameters(:U)
+    .params(xs: List[T.type_parameter(:U)])
+    .void
+end
+def foo(xs)
+  case xs
+  when List::Cons
+    T.reveal_type(xs)
+  when List::Nil
+    T.reveal_type(xs)
+  else
+    T.absurd(xs)
+  end
+end
+
+sig do
+  type_parameters(:U)
+    .params(xs: T.all(List[T.type_parameter(:U)], List::Cons[T.untyped]))
+    .void
+end
+def bar(xs)
+  T.reveal_type(xs)
+end


### PR DESCRIPTION
This implements exhaustiveness checking on sealed generic class
hierarchies, allowing for things like generic algebraic data types.



<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Closes #2572
Closes #1714


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.