### PR TITLE
LLDB debug configuration

### DIFF
--- a/.lldbinit
+++ b/.lldbinit
@@ -1,0 +1,2 @@
+command script import lldbinit.py
+

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "LSP Test - Debug active test",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/bazel-bin/test/lsp_test_runner",
+            "args": ["--single_test=${fileDirname}/${fileBasenameNoExtension}", "--dt-no-colors"],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "lldb",
+            "sourceFileMap": {
+                "${workspaceFolder}/bazel-sorbet": "${workspaceFolder}"
+            },
+            "setupCommands": [
+                {
+                    "description": "Load .lldb init",
+                    "text": "command source .lldbinit",
+                    "ignoreFailures": false
+                }
+            ]
+        }
+    ]
+}

--- a/lldbinit.py
+++ b/lldbinit.py
@@ -1,0 +1,24 @@
+if __name__ == "__main__":
+    print("Run only as script from LLDB... Not as standalone program!")
+
+try:
+    import lldb
+except:
+    pass
+
+import re
+import os
+
+# Bazel builds all binaries from a username-specific cache location
+# for lldb to work properly we need to map that path back to our main source
+project_root = os.path.dirname(os.path.realpath(__file__))
+bazel_workspace = os.path.realpath(os.path.join(project_root, "bazel-sorbet"))
+
+if not(os.path.isdir(bazel_workspace)):
+    print("You need to compile Sorbet first before loading this file")
+else:
+    print("Mapping %s to current working directory" % bazel_workspace)
+    source_map_command = 'settings set -- target.source-map "%s" "%s"' % (bazel_workspace, project_root)
+    ci = lldb.debugger.GetCommandInterpreter()
+    res = lldb.SBCommandReturnObject()
+    ci.HandleCommand(source_map_command, res)


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This PR adds some integration when working with LLDB.

Firstly, it creates an .lldbinit file which can be sourced to set up debug sessions properly. Specifically, it will load a Python script that will compute proper source mappings as Bazel builds all binaries from a username-specific cache location. Thus for LLDB output to make sense we need to map that path back to our main sources.

Secondly, it adds a sample VSCode debug launch.json to be able to debug LSP unit tests (which can be easily duplicated for other runners). Of note are the the two key additions to the configuration from the default templates aka `setupCommands` and `sourceFileMap`. The first one make sure that .lldbinit is properly sourced in the session (which will set a proper source map at the LLDB level). The second one will ensure that the VSCode *UI* correctly maps breakpoints/stacktrace information from LLDB to the workspace (why would it be not reading the LLDB source map setting and using that? no clue).

Note: depends on https://github.com/sorbet/sorbet/pull/3515

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No tests
