### PR TITLE
add moves for rvalue references in constructors

### DIFF
--- a/core/Files.cc
+++ b/core/Files.cc
@@ -99,8 +99,8 @@ StrictLevel File::fileSigil(string_view source) {
 }
 
 File::File(string &&path_, string &&source_, Type sourceType, u4 epoch)
-    : epoch(epoch), sourceType(sourceType), path_(path_), source_(source_), originalSigil(fileSigil(this->source_)),
-      strictLevel(originalSigil) {}
+    : epoch(epoch), sourceType(sourceType), path_(move(path_)), source_(move(source_)),
+      originalSigil(fileSigil(this->source_)), strictLevel(originalSigil) {}
 
 unique_ptr<File> File::deepCopy(GlobalState &gs) const {
     string sourceCopy = source_;

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -803,7 +803,7 @@ bool ShapeType::hasUntyped() {
     return false;
 };
 SendAndBlockLink::SendAndBlockLink(NameRef fun, vector<ArgInfo::ArgFlags> &&argFlags, int rubyBlockId)
-    : argFlags(argFlags), fun(fun), rubyBlockId(rubyBlockId) {}
+    : argFlags(move(argFlags)), fun(fun), rubyBlockId(rubyBlockId) {}
 
 shared_ptr<SendAndBlockLink> SendAndBlockLink::duplicate() {
     auto copy = *this;

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -304,9 +304,10 @@ LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<DidChangeTextDocumentParams>
         if (!config->isFileIgnored(localPath)) {
             string fileContents = changeParams->getSource(getFileContents(localPath));
             auto fileType = getFileType(localPath, config->opts);
-            auto file = make_shared<core::File>(string(localPath), move(fileContents), fileType, v);
+            auto &slot = openFiles[localPath];
+            auto file = make_shared<core::File>(move(localPath), move(fileContents), fileType, v);
             edit->updates.push_back(file);
-            openFiles[localPath] = move(file);
+            slot = move(file);
         }
     }
     return edit;
@@ -321,9 +322,10 @@ LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<DidOpenTextDocumentParams> o
         string localPath = config->remoteName2Local(uri);
         if (!config->isFileIgnored(localPath)) {
             auto fileType = getFileType(localPath, config->opts);
-            auto file = make_shared<core::File>(string(localPath), move(openParams->textDocument->text), fileType, v);
+            auto &slot = openFiles[localPath];
+            auto file = make_shared<core::File>(move(localPath), move(openParams->textDocument->text), fileType, v);
             edit->updates.push_back(file);
-            openFiles[localPath] = move(file);
+            slot = move(file);
         }
     }
     return edit;

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -340,8 +340,8 @@ LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<DidCloseTextDocumentParams> 
             openFiles.erase(localPath);
             // Use contents of file on disk.
             auto fileType = getFileType(localPath, config->opts);
-            edit->updates.push_back(
-                make_shared<core::File>(move(localPath), readFile(localPath, *config->opts.fs), fileType, v));
+            auto contents = readFile(localPath, *config->opts.fs);
+            edit->updates.push_back(make_shared<core::File>(move(localPath), move(contents), fileType, v));
         }
     }
     return edit;
@@ -357,8 +357,8 @@ LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<WatchmanQueryResponse> query
         // Editor contents supercede file system updates.
         if (!config->isFileIgnored(localPath) && !openFiles.contains(localPath)) {
             auto fileType = getFileType(localPath, config->opts);
-            edit->updates.push_back(
-                make_shared<core::File>(move(localPath), readFile(localPath, *config->opts.fs), fileType, v));
+            auto contents = readFile(localPath, *config->opts.fs);
+            edit->updates.push_back(make_shared<core::File>(move(localPath), move(contents), fileType, v));
         }
     }
     return edit;

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -340,8 +340,8 @@ LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<DidCloseTextDocumentParams> 
             openFiles.erase(localPath);
             // Use contents of file on disk.
             auto fileType = getFileType(localPath, config->opts);
-            auto contents = readFile(localPath, *config->opts.fs);
-            edit->updates.push_back(make_shared<core::File>(move(localPath), move(contents), fileType, v));
+            auto fileContents = readFile(localPath, *config->opts.fs);
+            edit->updates.push_back(make_shared<core::File>(move(localPath), move(fileContents), fileType, v));
         }
     }
     return edit;
@@ -357,8 +357,8 @@ LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<WatchmanQueryResponse> query
         // Editor contents supercede file system updates.
         if (!config->isFileIgnored(localPath) && !openFiles.contains(localPath)) {
             auto fileType = getFileType(localPath, config->opts);
-            auto contents = readFile(localPath, *config->opts.fs);
-            edit->updates.push_back(make_shared<core::File>(move(localPath), move(contents), fileType, v));
+            auto fileContents = readFile(localPath, *config->opts.fs);
+            edit->updates.push_back(make_shared<core::File>(move(localPath), move(fileContents), fileType, v));
         }
     }
     return edit;

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -304,7 +304,7 @@ LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<DidChangeTextDocumentParams>
         if (!config->isFileIgnored(localPath)) {
             string fileContents = changeParams->getSource(getFileContents(localPath));
             auto fileType = getFileType(localPath, config->opts);
-            auto file = make_shared<core::File>(move(localPath), move(fileContents), fileType, v);
+            auto file = make_shared<core::File>(string(localPath), move(fileContents), fileType, v);
             edit->updates.push_back(file);
             openFiles[localPath] = move(file);
         }
@@ -321,7 +321,7 @@ LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<DidOpenTextDocumentParams> o
         string localPath = config->remoteName2Local(uri);
         if (!config->isFileIgnored(localPath)) {
             auto fileType = getFileType(localPath, config->opts);
-            auto file = make_shared<core::File>(move(localPath), move(openParams->textDocument->text), fileType, v);
+            auto file = make_shared<core::File>(string(localPath), move(openParams->textDocument->text), fileType, v);
             edit->updates.push_back(file);
             openFiles[localPath] = move(file);
         }

--- a/test/helpers/expectations.cc
+++ b/test/helpers/expectations.cc
@@ -112,8 +112,8 @@ void populateSourceFileContents(Expectations &exp) {
     for (auto &file : exp.sourceFiles) {
         string filename = exp.folder + file;
         string fileContents = FileOps::read(filename);
-        exp.sourceFileContents[filename] =
-            make_shared<core::File>(move(filename), move(fileContents), core::File::Type::Normal);
+        auto &slot = exp.sourceFileContents[filename];
+        slot = make_shared<core::File>(move(filename), move(fileContents), core::File::Type::Normal);
     }
 }
 


### PR DESCRIPTION
Due to the wonders of C++, simply declaring rvalue reference arguments in your constructor is not enough to be maximally efficient; one must also `move` those arguments into the relevant places.  sorbet was not doing this in all places.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation

Small amounts of both efficiency and consistency.
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan

This is not a user-visible change; existing automated tests should be enough to cover this change.