### PR TITLE
Restrict T.absurd argument to variables

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -344,11 +344,20 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::Expression *what, BasicBlock 
                                 return;
                             }
 
-                            if (ast::isa_tree<ast::Send>(s->args[0])) {
-                                // Providing a send is the most common way T.absurd is misused
+                            if (!ast::isa_tree<ast::Local>(s->args[0]) &&
+                                !ast::isa_tree<ast::UnresolvedIdent>(s->args[0])) {
                                 if (auto e = cctx.ctx.beginError(s->loc, core::errors::CFG::MalformedTAbsurd)) {
-                                    e.setHeader("`{}` expects to be called on a variable, not a method call",
-                                                "T.absurd", s->args.size());
+                                    // Providing a send is the most common way T.absurd is misused, so we provide a
+                                    // little extra hint in the error message in this case.
+                                    //
+                                    // TODO(aprocter): Might be nice to caret the offending arg as a subsection of the
+                                    // main error.
+                                    if (ast::isa_tree<ast::Send>(s->args[0])) {
+                                        e.setHeader("`{}` expects to be called on a variable, not a method call",
+                                                    "T.absurd");
+                                    } else {
+                                        e.setHeader("`{}` expects to be called on a variable", "T.absurd");
+                                    }
                                 }
                                 ret = current;
                                 return;

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -348,10 +348,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::Expression *what, BasicBlock 
                                 !ast::isa_tree<ast::UnresolvedIdent>(s->args[0])) {
                                 if (auto e = cctx.ctx.beginError(s->loc, core::errors::CFG::MalformedTAbsurd)) {
                                     // Providing a send is the most common way T.absurd is misused, so we provide a
-                                    // little extra hint in the error message in this case.
-                                    //
-                                    // TODO(aprocter): Might be nice to caret the offending arg as a subsection of the
-                                    // main error.
+                                    // little extra hint in the error message in that case.
                                     if (ast::isa_tree<ast::Send>(s->args[0])) {
                                         e.setHeader("`{}` expects to be called on a variable, not a method call",
                                                     "T.absurd");

--- a/test/testdata/infer/exhaustiveness.rb
+++ b/test/testdata/infer/exhaustiveness.rb
@@ -150,11 +150,7 @@ end
 
 # --- trying to subvert normal usage ------------------------------------------
 
-def only_absurd_1
-  T.absurd(T.let(T.unsafe(nil), T.noreturn)) # error: This code is unreachable
-end
-
-def only_absurd_2
+def only_absurd
   temp1 = T.let(T.unsafe(nil), T.noreturn)
   T.absurd(temp1) # error: This code is unreachable
 end
@@ -183,7 +179,7 @@ end
 
 sig {params(x: Integer).void}
 def only_keyword_arg(x)
-  T.absurd(x: nil) if x.nil? # error: Control flow could reach `T.absurd` because the type `{x: NilClass}` wasn't handled
+  T.absurd(x: nil) if x.nil? # error: `T.absurd` expects to be called on a variable
 end
 
 sig {returns(T.any(Integer, String))}
@@ -192,11 +188,21 @@ def looks_like_a_variable
 end
 
 sig {void}
-def rejects_absurd_on_non_variable
+def rejects_absurd_on_method_call_that_looks_like_a_variable
   case looks_like_a_variable
   when Integer
   when String
   else
     T.absurd(looks_like_a_variable) # error: `T.absurd` expects to be called on a variable, not a method call
   end
+end
+
+sig{void}
+def rejects_absurd_on_integer_literal
+  T.absurd(42) # error: `T.absurd` expects to be called on a variable
+end
+
+sig{void}
+def rejects_absurd_on_list_literal
+  T.absurd([2,4,6,8]) # error: `T.absurd` expects to be called on a variable
 end

--- a/test/testdata/infer/exhaustiveness.rb
+++ b/test/testdata/infer/exhaustiveness.rb
@@ -160,6 +160,74 @@ def cant_call_only_absurd(x)
   T.absurd(x) # error: This code is unreachable
 end
 
+# --- reasonable usage on global, class, instance, and local variables --------
+$some_global = T.let(true, T::Boolean)
+
+sig {void}
+def absurd_not_reached_on_global_var
+  if $some_global
+    return
+  else
+    return
+  end
+
+  T.absurd($some_global)
+end
+
+sig {void}
+def absurd_reached_on_global_var
+  # Note T.nilable, because $some_global was not declared in this scope.
+  T.absurd($some_global) if !$some_global # error: Control flow could reach `T.absurd` because the type `T.nilable(FalseClass)` wasn't handled
+end
+
+class SomeClass
+  extend T::Sig
+
+  @@some_class_var = T.let(true, T::Boolean)
+
+  sig {void}
+  def initialize
+    @some_instance_var = T.let(true, T::Boolean)
+  end
+
+  sig {void}
+  def absurd_not_reached_on_class_var
+    if @@some_class_var
+      return
+    else
+      return
+    end
+
+    T.absurd(@@some_class_var)
+  end
+
+  sig {void}
+  def absurd_reached_on_class_var
+    T.absurd(@@some_class_var) if !@@some_class_var # error: Control flow could reach `T.absurd` because the type `FalseClass` wasn't handled
+  end
+
+  sig {void}
+  def absurd_not_reached_on_instance_var
+    if @some_instance_var
+      return
+    else
+      return
+    end
+
+    T.absurd(@some_instance_var)
+  end
+
+  sig {void}
+  def absurd_reached_on_instance_var
+    T.absurd(@some_instance_var) if !@some_instance_var # error: Control flow could reach `T.absurd` because the type `FalseClass` wasn't handled
+  end
+end
+
+sig {params(some_local_var: T::Boolean).void}
+def absurd_reached_on_local_var(some_local_var)
+  T.absurd(some_local_var) if !some_local_var # error: Control flow could reach `T.absurd` because the type `FalseClass` wasn't handled
+end
+
 # --- incorrect usage ---------------------------------------------------------
 
 sig {params(x: Integer).void}
@@ -200,9 +268,4 @@ end
 sig{void}
 def rejects_absurd_on_integer_literal
   T.absurd(42) # error: `T.absurd` expects to be called on a variable
-end
-
-sig{void}
-def rejects_absurd_on_list_literal
-  T.absurd([2,4,6,8]) # error: `T.absurd` expects to be called on a variable
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

See #3462.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Added some checks to `exhaustiveness.rb` that various kinds of non-variable expressions boink as expected.

Added some "positive" tests for all the allowed cases.
