### PR TITLE
Censor external locs consistently

### DIFF
--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -11,6 +11,35 @@
 namespace sorbet::core {
 
 using namespace std;
+
+constexpr auto EXTERNAL_PREFIX = "external/com_stripe_ruby_typer/"sv;
+constexpr auto URL_PREFIX = "https://github.com/sorbet/sorbet/tree/master/"sv;
+
+namespace {
+string censorFilePathForSnapshotTests(string_view orig) {
+    string_view result = orig;
+    if (absl::StartsWith(result, EXTERNAL_PREFIX)) {
+        // When running tests from outside of the sorbet repo, the files have a different path in the sandbox.
+        result.remove_prefix(EXTERNAL_PREFIX.size());
+    }
+
+    if (absl::StartsWith(result, URL_PREFIX)) {
+        // This is so that changing RBIs doesn't mean invalidating every symbol-table exp test.
+        result.remove_prefix(URL_PREFIX.size());
+        if (absl::StartsWith(result, EXTERNAL_PREFIX)) {
+            result.remove_prefix(EXTERNAL_PREFIX.size());
+        }
+    }
+
+    if (absl::StartsWith(orig, URL_PREFIX)) {
+        return fmt::format("{}{}", URL_PREFIX, result);
+    } else {
+        return string(result);
+    }
+}
+
+} // namespace
+
 LocOffsets LocOffsets::join(LocOffsets other) const {
     if (!this->exists()) {
         return other;
@@ -177,28 +206,19 @@ string Loc::showRaw(const GlobalState &gs) const {
         path = "???"sv;
     }
 
-    auto externalPrefix = "external/com_stripe_ruby_typer/"sv;
+    string censored;
     if (gs.censorForSnapshotTests) {
-        if (absl::StartsWith(path, externalPrefix)) {
-            // When running tests from outside of the sorbet repo, the files have a different path in the sandbox.
-            path.remove_prefix(externalPrefix.size());
+        censored = censorFilePathForSnapshotTests(path);
+        if (absl::StartsWith(path, URL_PREFIX)) {
+            return fmt::format("Loc {{file={} start=removed end=removed}}", censored);
         }
+        path = censored;
     }
 
     if (!exists()) {
         return fmt::format("Loc {{file={} start=??? end=???}}", path);
     }
 
-    auto urlPrefix = "https://github.com/sorbet/sorbet/tree/master/"sv;
-    if (gs.censorForSnapshotTests && absl::StartsWith(path, urlPrefix)) {
-        // This is so that changing RBIs doesn't mean invalidating every symbol-table exp test.
-        path.remove_prefix(urlPrefix.size());
-        if (absl::StartsWith(path, externalPrefix)) {
-            path.remove_prefix(externalPrefix.size());
-        }
-
-        return fmt::format("Loc {{file={}{} start=removed end=removed}}", urlPrefix, path);
-    }
     auto [start, end] = this->position(gs);
     return fmt::format("Loc {{file={} start={}:{} end={}:{}}}", path, start.line, start.column, end.line, end.column);
 }
@@ -209,15 +229,12 @@ string Loc::filePosToString(const GlobalState &gs) const {
         buf << "???";
     } else {
         auto path = gs.getPrintablePath(file().data(gs).path());
-        auto externalPrefix = "external/com_stripe_ruby_typer/"sv;
         if (gs.censorForSnapshotTests) {
-            if (absl::StartsWith(path, externalPrefix)) {
-                // When running tests from outside of the sorbet repo, the files have a different path in the sandbox.
-                path.remove_prefix(externalPrefix.size());
-            }
+            buf << censorFilePathForSnapshotTests(path);
+        } else {
+            buf << path;
         }
 
-        buf << path;
         if (exists()) {
             auto pos = position(gs);
             if (path.find("https://") == 0) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We were only removing the `external/` prefix from `symbol-table-raw` exp
files, not from `symbol-table` exp files.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested locally