### PR TITLE
Symbols.cc: Remove showRaw from membersStableOrderSlow

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1346,12 +1346,6 @@ vector<std::pair<NameRef, SymbolRef>> Symbol::membersStableOrderSlow(const Globa
         if (compareRaw != 0) {
             return compareRaw < 0;
         }
-        auto lhsSym = lhs.second.data(gs)->showRaw(gs);
-        auto rhsSym = rhs.second.data(gs)->showRaw(gs);
-        auto compareSym = lhsSym.compare(rhsSym);
-        if (compareSym != 0) {
-            return compareSym < 0;
-        }
         ENFORCE(false, "no stable sort");
         return 0;
     });


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We were recursively calling toStringWithOptions in toStringWithOptions
to just sort the members.

The list of members is a hash table; each key should be unique (a name).
These names should all have showRaw printings that don't collide with
each other.

So this showRaw call is purely redundant, and makes things like
completion, document_symbol, and symbol table prints/exports slower.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Snapshot tests don't change