### PR TITLE
avoid copies by using references in ranged-for loops

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -32,7 +32,7 @@ bool SymbolRef::operator!=(const SymbolRef &rhs) const {
 vector<TypePtr> Symbol::selfTypeArgs(const GlobalState &gs) const {
     ENFORCE(isClassOrModule()); // should be removed when we have generic methods
     vector<TypePtr> targs;
-    for (auto &tm : typeMembers()) {
+    for (auto tm : typeMembers()) {
         auto tmData = tm.data(gs);
         if (tmData->isFixed()) {
             auto *lambdaParam = cast_type<LambdaParam>(tmData->resultType.get());

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -32,7 +32,7 @@ bool SymbolRef::operator!=(const SymbolRef &rhs) const {
 vector<TypePtr> Symbol::selfTypeArgs(const GlobalState &gs) const {
     ENFORCE(isClassOrModule()); // should be removed when we have generic methods
     vector<TypePtr> targs;
-    for (auto tm : typeMembers()) {
+    for (auto &tm : typeMembers()) {
         auto tmData = tm.data(gs);
         if (tmData->isFixed()) {
             auto *lambdaParam = cast_type<LambdaParam>(tmData->resultType.get());
@@ -507,7 +507,7 @@ vector<Symbol::FuzzySearchResult> Symbol::findMemberFuzzyMatchConstant(const Glo
                 }
             }
         }
-        for (auto e : globalBest) {
+        for (auto &e : globalBest) {
             result.emplace_back(e);
         }
     }

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -172,7 +172,7 @@ com::stripe::rubytyper::Type::Literal Proto::toProto(const GlobalState &gs, cons
     return proto;
 }
 
-com::stripe::rubytyper::Type Proto::toProto(const GlobalState &gs, TypePtr typ) {
+com::stripe::rubytyper::Type Proto::toProto(const GlobalState &gs, const TypePtr &typ) {
     com::stripe::rubytyper::Type proto;
     typecase(
         typ.get(),
@@ -193,16 +193,16 @@ com::stripe::rubytyper::Type Proto::toProto(const GlobalState &gs, TypePtr typ) 
         [&](AppliedType *t) {
             proto.set_kind(com::stripe::rubytyper::Type::APPLIED);
             proto.mutable_applied()->set_symbol_full_name(t->klass.show(gs));
-            for (auto a : t->targs) {
+            for (auto &a : t->targs) {
                 *proto.mutable_applied()->add_type_args() = toProto(gs, a);
             }
         },
         [&](ShapeType *t) {
             proto.set_kind(com::stripe::rubytyper::Type::SHAPE);
-            for (auto k : t->keys) {
+            for (auto &k : t->keys) {
                 *proto.mutable_shape()->add_keys() = toProto(gs, k);
             }
-            for (auto v : t->values) {
+            for (auto &v : t->values) {
                 *proto.mutable_shape()->add_values() = toProto(gs, v);
             }
         },
@@ -212,7 +212,7 @@ com::stripe::rubytyper::Type Proto::toProto(const GlobalState &gs, TypePtr typ) 
         },
         [&](TupleType *t) {
             proto.set_kind(com::stripe::rubytyper::Type::TUPLE);
-            for (auto e : t->elems) {
+            for (auto &e : t->elems) {
                 *proto.mutable_tuple()->add_elems() = toProto(gs, e);
             }
         },

--- a/core/proto/proto.h
+++ b/core/proto/proto.h
@@ -23,7 +23,7 @@ public:
     static com::stripe::rubytyper::Symbol toProto(const GlobalState &gs, SymbolRef sym, bool showFull);
 
     static com::stripe::rubytyper::Type::Literal toProto(const GlobalState &gs, const LiteralType &lit);
-    static com::stripe::rubytyper::Type toProto(const GlobalState &gs, TypePtr typ);
+    static com::stripe::rubytyper::Type toProto(const GlobalState &gs, const TypePtr &typ);
 
     static com::stripe::rubytyper::Loc toProto(const GlobalState &gs, Loc loc);
     static com::stripe::rubytyper::FileTable filesToProto(const GlobalState &gs);

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -788,7 +788,7 @@ void SerializerImpl::unpickleGS(UnPickler &p, GlobalState &result) {
 
     UnorderedMap<string, FileRef> fileRefByPath;
     int i = 0;
-    for (auto f : files) {
+    for (auto &f : files) {
         if (f && !f->path().empty()) {
             fileRefByPath[string(f->path())] = FileRef(i);
         }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -380,14 +380,14 @@ TypePtr unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
     if (auto *shapeType = cast_type<ShapeType>(tp.get())) {
         vector<TypePtr> unwrappedValues;
         unwrappedValues.reserve(shapeType->values.size());
-        for (auto value : shapeType->values) {
+        for (auto &value : shapeType->values) {
             unwrappedValues.emplace_back(unwrapType(gs, loc, value));
         }
         return make_type<ShapeType>(Types::hashOfUntyped(), shapeType->keys, unwrappedValues);
     } else if (auto *tupleType = cast_type<TupleType>(tp.get())) {
         vector<TypePtr> unwrappedElems;
         unwrappedElems.reserve(tupleType->elems.size());
-        for (auto elem : tupleType->elems) {
+        for (auto &elem : tupleType->elems) {
             unwrappedElems.emplace_back(unwrapType(gs, loc, elem));
         }
         return TupleType::build(gs, unwrappedElems);

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -353,7 +353,7 @@ unique_ptr<SorbetWorkspaceEditParams>
 LSPPreprocessor::canonicalizeEdits(u4 v, unique_ptr<WatchmanQueryResponse> queryResponse) const {
     auto edit = make_unique<SorbetWorkspaceEditParams>();
     edit->epoch = v;
-    for (auto file : queryResponse->files) {
+    for (auto &file : queryResponse->files) {
         // Don't append rootPath if it is empty.
         string localPath = !config->rootPath.empty() ? absl::StrCat(config->rootPath, "/", file) : file;
         // Editor contents supercede file system updates.


### PR DESCRIPTION
One gotcha in C++ is that the convenient `for (auto x : iterable_thing)` expands to something that copies elements of `iterable_thing` into a variable named `x` for each iteration of the loop.  This is not so bad when you're iterating over a `std::vector<int32_t>`, but it results in a bunch of needless copies when iterating over a `std::vector<std::string>` or similar.  (If you are writing loops where you depend on the copying behavior...yuck.)

There is a [`clang-tidy` check for this footgun](https://clang.llvm.org/extra/clang-tidy/checks/performance-for-range-copy.html), but as we don't currently have `clang-tidy` enabled, I fixed a few cases manually.  I also fixed `Proto::toProto` to not copy its `typ` argument unnecessarily.  I did not exhaustively examine every eligible ranged-for loop because I didn't think it was worth it.

We could make a very limited linter for this sort of thing (match on the regex `for \(auto [A-Za-z0-9_]+ :` and disallow it), but that'd be far too restrictive: there are cases where you don't care if the value is copied.

### Motivation

Epsilon faster performance due to less copying.

### Test plan

This is not a user-visible change, and the existing tests should be sufficient.