### PR TITLE
Minor improvements to sorbet-runtime typecheck benchmarks

### DIFF
--- a/gems/sorbet-runtime/bench/typecheck.rb
+++ b/gems/sorbet-runtime/bench/typecheck.rb
@@ -11,90 +11,128 @@ module SorbetBenchmarks
 
     class Example; end
 
+    def self.time_block(name, iterations_of_block: 1_000_000, iterations_in_block: 2, &blk)
+      1_000.times(&blk) # warmup
+
+      GC.start
+      GC.disable
+
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      iterations_of_block.times(&blk)
+      duration_s = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0
+
+      GC.enable
+
+      ns_per_iter = duration_s * 1_000_000_000 / (iterations_of_block * iterations_in_block)
+      duration_str = ns_per_iter >= 1000 ? "#{(ns_per_iter / 1000).round(3)} μs" : "#{ns_per_iter.round(3)} ns"
+      puts "#{name}: #{duration_str}"
+    end
+
     def self.run
       example = Example.new
 
-      result = Benchmark.measure do
-        1_000_000.times do
-          T.let(0, Integer)
-          T.let(1, Integer)
-        end
+      time_block("Vanilla Ruby method call", iterations_in_block: 10) do
+        unchecked_param(0)
+        unchecked_param(1)
+        unchecked_param(2)
+        unchecked_param(3)
+        unchecked_param(nil)
+        unchecked_param(0)
+        unchecked_param(1)
+        unchecked_param(2)
+        unchecked_param(3)
+        unchecked_param(nil)
       end
-      puts "T.let(..., Integer) twice, μs/iter"
-      puts result
 
-      result = Benchmark.measure do
-        1_000_000.times do
-          integer_param(0)
-          integer_param(1)
-        end
+      time_block("Vanilla Ruby is_a?", iterations_in_block: 10) do
+        0.is_a?(Integer)
+        1.is_a?(Integer)
+        'str'.is_a?(Integer)
+        nil.is_a?(Integer)
+        false.is_a?(Integer)
+        0.is_a?(Integer)
+        1.is_a?(Integer)
+        'str'.is_a?(Integer)
+        nil.is_a?(Integer)
+        false.is_a?(Integer)
       end
-      puts "sig {params(x: Integer).void} twice, μs/iter"
-      puts result
 
-      result = Benchmark.measure do
-        1_000_000.times do
-          T.let(nil, T.nilable(Integer))
-          T.let(1, T.nilable(Integer))
-        end
+      type = T::Utils.coerce(Integer)
+      time_block("T::Types::Simple#valid?", iterations_in_block: 10) do
+        type.valid?(0)
+        type.valid?(1)
+        type.valid?(2)
+        type.valid?(3)
+        type.valid?(nil)
+        type.valid?(0)
+        type.valid?(1)
+        type.valid?(2)
+        type.valid?(3)
+        type.valid?(nil)
       end
-      puts "T.let(..., T.nilable(Integer)) twice, μs/iter"
-      puts result
 
-      result = Benchmark.measure do
-        1_000_000.times do
-          nilable_integer_param(nil)
-          nilable_integer_param(1)
-        end
+      type = T::Utils.coerce(T.nilable(Integer))
+      time_block("T::Types::Union#valid?", iterations_in_block: 10) do
+        type.valid?(0)
+        type.valid?(1)
+        type.valid?(2)
+        type.valid?(nil)
+        type.valid?(false)
+        type.valid?(0)
+        type.valid?(1)
+        type.valid?(2)
+        type.valid?(nil)
+        type.valid?(false)
       end
-      puts "sig {params(x: T.nilable(Integer)).void} twice, μs/iter"
-      puts result
 
-      result = Benchmark.measure do
-        1_000_000.times do
-          T.let(example, Example)
-          T.let(example, Example)
-        end
+      time_block("T.let(..., Integer)") do
+        T.let(0, Integer)
+        T.let(1, Integer)
       end
-      puts "T.let(..., Example) twice, μs/iter"
-      puts result
 
-      result = Benchmark.measure do
-        1_000_000.times do
-          application_class_param(example)
-          application_class_param(example)
-        end
+      time_block("sig {params(x: Integer).void}") do
+        integer_param(0)
+        integer_param(1)
       end
-      puts "sig {params(x: Example).void} twice, μs/iter"
-      puts result
 
-      result = Benchmark.measure do
-        1_000_000.times do
-          T.let(nil, T.nilable(Example))
-          T.let(example, T.nilable(Example))
-        end
+      time_block("T.let(..., T.nilable(Integer))") do
+        T.let(nil, T.nilable(Integer))
+        T.let(1, T.nilable(Integer))
       end
-      puts "T.let(..., T.nilable(Example)) twice, μs/iter"
-      puts result
 
-      result = Benchmark.measure do
-        1_000_000.times do
-          nilable_application_class_param(nil)
-          nilable_application_class_param(example)
-        end
+      time_block("sig {params(x: T.nilable(Integer)).void}") do
+        nilable_integer_param(nil)
+        nilable_integer_param(1)
       end
-      puts "sig {params(x: T.nilable(Example)).void} twice, μs/iter"
-      puts result
 
-      result = Benchmark.measure do
-        1_000_000.times do
-          arg_plus_kwargs(:foo, x: 1, y: 2)
-          arg_plus_kwargs(:bar, x: 1)
-        end
+      time_block("T.let(..., Example)") do
+        T.let(example, Example)
+        T.let(example, Example)
       end
-      puts "sig {params(s: Symbol, x: Integer, y: Integer).void} (with kwargs) twice, μs/iter"
-      puts result
+
+      time_block("sig {params(x: Example).void}") do
+        application_class_param(example)
+        application_class_param(example)
+      end
+
+      time_block("T.let(..., T.nilable(Example))") do
+        T.let(nil, T.nilable(Example))
+        T.let(example, T.nilable(Example))
+      end
+
+      time_block("sig {params(x: T.nilable(Example)).void}") do
+        nilable_application_class_param(nil)
+        nilable_application_class_param(example)
+      end
+
+      time_block("sig {params(s: Symbol, x: Integer, y: Integer).void} (with kwargs)") do
+        arg_plus_kwargs(:foo, x: 1, y: 2)
+        arg_plus_kwargs(:bar, x: 1)
+      end
     end
+
+    sig {params(x: Integer).void.checked(:never)}
+    def self.unchecked_param(x); end
 
     sig {params(x: Integer).void}
     def self.integer_param(x); end


### PR DESCRIPTION
- Add benchmarks for simple `valid?` and plain-Ruby `is_a?` and method calls (for comparison
- Instead of using Benchmark gem, just time directly so that we can output timing per iteration

### Motivation
Writing some documentation on performance & sorbet-runtime and wanted to have an easier reference

### Test plan
Ran `bundle exec rake bench:typecheck`:
```
Vanilla Ruby method call: 17.232 ns
Vanilla Ruby is_a?: 21.956 ns
T::Types::Simple#valid?: 42.017 ns
T::Types::Union#valid?: 146.213 ns
T.let(..., Integer): 378.44 ns
sig {params(x: Integer).void}: 440.225 ns
T.let(..., T.nilable(Integer)): 1.126 μs
sig {params(x: T.nilable(Integer)).void}: 958.921 ns
T.let(..., Example): 381.39 ns
sig {params(x: Example).void}: 420.27 ns
T.let(..., T.nilable(Example)): 1.115 μs
sig {params(x: T.nilable(Example)).void}: 958.978 ns
sig {params(s: Symbol, x: Integer, y: Integer).void} (with kwargs): 1.71 μs
```