### PR TITLE
core/Loc.h: Add a helper for debugging Locs

### DIFF
--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -169,6 +169,13 @@ string Loc::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return buf.str();
 }
 
+string LocOffsets::showRaw(const Context ctx) const {
+    return Loc(ctx.file, *this).showRaw(ctx);
+}
+string LocOffsets::showRaw(const MutableContext ctx) const {
+    return Loc(ctx.file, *this).showRaw(ctx);
+}
+
 string Loc::showRaw(const GlobalState &gs) const {
     string_view path;
     if (file().exists()) {

--- a/core/Loc.h
+++ b/core/Loc.h
@@ -8,6 +8,8 @@ namespace serialize {
 class SerializerImpl;
 }
 class GlobalState;
+class Context;
+class MutableContext;
 
 constexpr int INVALID_POS_LOC = 0xffffff;
 struct LocOffsets {
@@ -31,6 +33,9 @@ struct LocOffsets {
     LocOffsets copyWithZeroLength() const {
         return LocOffsets{beginPos(), beginPos()};
     }
+
+    std::string showRaw(const Context ctx) const;
+    std::string showRaw(const MutableContext ctx) const;
 };
 CheckSize(LocOffsets, 8, 4);
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It's annoying to have to create a Loc manually just to be able to
showRaw on it (now that core::LocOffsets split out from core::Loc, as of
PR #2737).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested in lldb

    (lldb) p klass->loc
    (const sorbet::core::LocOffsets) $1 = (beginLoc = 15, endLoc = 59)
    (lldb) p klass->loc.showRaw(ctx)
    (std::__1::string) $2 = "Loc {file=foo.rb start=3:1 end=5:4}"