### PR TITLE
`initial` parameter of `Enumerable#inject` can be of any type

### DIFF
--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -758,11 +758,11 @@ module Enumerable
     .returns(T.untyped)
   end
   sig do
-    params(
-        initial: Elem,
-        blk: T.proc.params(arg0: Elem, arg1: Elem).returns(Elem),
+    type_parameters(:Any).params(
+        initial: T.type_parameter(:Any),
+        blk: T.proc.params(arg0: T.type_parameter(:Any), arg1: Elem).returns(Elem),
     )
-    .returns(Elem)
+    .returns(T.type_parameter(:Any))
   end
   sig do
     params(


### PR DESCRIPTION

### Motivation

The current RBI for `Enumerable#inject` assumes that the `initial` parameter for the overload with a block given will always be of type `Enum`, but that is not always the case.

For example:

```ruby
[1,2,3].inject("") { |str, num| str << num.to_s }
```

is perfectly valid. The type of `str` should be `String` and the `inject` call should return a `String`, not an `Integer`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No automated tests.
