### PR TITLE
Compute Symbol::externalType serially.

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -61,7 +61,7 @@ TypePtr Symbol::externalType() const {
 
 TypePtr Symbol::unsafeComputeExternalType(GlobalState &gs) {
     ENFORCE_NO_TIMER(isClassOrModule());
-    if (resultType) {
+    if (resultType != nullptr) {
         return resultType;
     }
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -48,66 +48,64 @@ TypePtr Symbol::selfType(const GlobalState &gs) const {
     ENFORCE(isClassOrModule());
     // todo: in dotty it made sense to cache those.
     if (typeMembers().empty()) {
-        return externalType(gs);
+        return externalType();
     } else {
         return make_type<AppliedType>(ref(gs), selfTypeArgs(gs));
     }
 }
 
-TypePtr Symbol::externalType(const GlobalState &gs) const {
-    ENFORCE(isClassOrModule());
-    if (!resultType) {
-        // note that sometimes resultType is set externally to not be a result of this computation
-        // this happens e.g. in case this is a stub class
-        TypePtr newResultType;
-        auto ref = this->ref(gs);
-        if (typeMembers().empty()) {
-            newResultType = make_type<ClassType>(ref);
-        } else {
-            vector<TypePtr> targs;
-            targs.reserve(typeMembers().size());
+TypePtr Symbol::externalType() const {
+    ENFORCE_NO_TIMER(resultType);
+    return resultType;
+}
 
-            // Special-case covariant stdlib generics to have their types
-            // defaulted to `T.untyped`. This set *should not* grow over time.
-            bool isStdlibGeneric = ref == core::Symbols::Hash() || ref == core::Symbols::Array() ||
-                                   ref == core::Symbols::Set() || ref == core::Symbols::Range() ||
-                                   ref == core::Symbols::Enumerable() || ref == core::Symbols::Enumerator();
+TypePtr Symbol::unsafeComputeExternalType(GlobalState &gs) {
+    ENFORCE_NO_TIMER(isClassOrModule());
+    if (resultType) {
+        return resultType;
+    }
 
-            for (auto &tm : typeMembers()) {
-                auto tmData = tm.data(gs);
-                auto *lambdaParam = cast_type<LambdaParam>(tmData->resultType.get());
-                ENFORCE(lambdaParam != nullptr);
+    // note that sometimes resultType is set externally to not be a result of this computation
+    // this happens e.g. in case this is a stub class
+    auto ref = this->ref(gs);
+    if (typeMembers().empty()) {
+        resultType = make_type<ClassType>(ref);
+    } else {
+        vector<TypePtr> targs;
+        targs.reserve(typeMembers().size());
 
-                if (isStdlibGeneric) {
-                    // For backwards compatibility, instantiate stdlib generics
-                    // with T.untyped.
-                    targs.emplace_back(Types::untyped(gs, ref));
-                } else if (tmData->isFixed() || tmData->isCovariant()) {
-                    // Default fixed or covariant parameters to their upper
-                    // bound.
-                    targs.emplace_back(lambdaParam->upperBound);
-                } else if (tmData->isInvariant()) {
-                    // We instantiate Invariant type members as T.untyped as
-                    // this will behave a bit like a unification variable with
-                    // Types::glb.
-                    targs.emplace_back(Types::untyped(gs, ref));
-                } else {
-                    // The remaining case is a contravariant parameter, which
-                    // gets defaulted to its lower bound.
-                    targs.emplace_back(lambdaParam->lowerBound);
-                }
+        // Special-case covariant stdlib generics to have their types
+        // defaulted to `T.untyped`. This set *should not* grow over time.
+        bool isStdlibGeneric = ref == core::Symbols::Hash() || ref == core::Symbols::Array() ||
+                               ref == core::Symbols::Set() || ref == core::Symbols::Range() ||
+                               ref == core::Symbols::Enumerable() || ref == core::Symbols::Enumerator();
+
+        for (auto &tm : typeMembers()) {
+            auto tmData = tm.data(gs);
+            auto *lambdaParam = cast_type<LambdaParam>(tmData->resultType.get());
+            ENFORCE(lambdaParam != nullptr);
+
+            if (isStdlibGeneric) {
+                // For backwards compatibility, instantiate stdlib generics
+                // with T.untyped.
+                targs.emplace_back(Types::untyped(gs, ref));
+            } else if (tmData->isFixed() || tmData->isCovariant()) {
+                // Default fixed or covariant parameters to their upper
+                // bound.
+                targs.emplace_back(lambdaParam->upperBound);
+            } else if (tmData->isInvariant()) {
+                // We instantiate Invariant type members as T.untyped as
+                // this will behave a bit like a unification variable with
+                // Types::glb.
+                targs.emplace_back(Types::untyped(gs, ref));
+            } else {
+                // The remaining case is a contravariant parameter, which
+                // gets defaulted to its lower bound.
+                targs.emplace_back(lambdaParam->lowerBound);
             }
+        }
 
-            newResultType = make_type<AppliedType>(ref, move(targs));
-        }
-        {
-            // this method is supposed to be idempotent. The lines below implement "safe publication" of a value that is
-            // safe to be used in presence of multiple threads running this tion concurrently
-            auto mutableThis = const_cast<Symbol *>(this);
-            shared_ptr<core::Type> current(nullptr);
-            atomic_compare_exchange_weak(&mutableThis->resultType.store, &current, newResultType.store);
-        }
-        return externalType(gs);
+        resultType = make_type<AppliedType>(ref, targs);
     }
     return resultType;
 }

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -115,7 +115,12 @@ public:
     // (which must be isClassOrModule()), if instantiated without specific type
     // parameters, as seen from inside or outside of the class, respectively.
     TypePtr selfType(const GlobalState &gs) const;
-    TypePtr externalType(const GlobalState &gs) const;
+    TypePtr externalType() const;
+
+    // !! THREAD UNSAFE !! operation that computes the external type of this symbol.
+    // Do not call this method from multi-threaded contexts (which, honestly, shouldn't
+    // have access to a mutable GlobalState and thus shouldn't be able to call it).
+    TypePtr unsafeComputeExternalType(GlobalState &gs);
 
     inline InlinedVector<SymbolRef, 4> &mixins() {
         ENFORCE_NO_TIMER(isClassOrModule());

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -42,7 +42,6 @@ public:
     bool operator==(std::nullptr_t n) const {
         return store == nullptr;
     }
-    friend class Symbol;
 
     template <class T, class... Args> friend TypePtr make_type(Args &&... args);
 };

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -362,7 +362,7 @@ TypePtr unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
             return Types::untypedUntracked();
         }
 
-        return attachedClass.data(gs)->externalType(gs);
+        return attachedClass.data(gs)->externalType();
     }
 
     if (auto *appType = cast_type<AppliedType>(tp.get())) {
@@ -374,7 +374,7 @@ TypePtr unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
             return Types::untypedUntracked();
         }
 
-        return attachedClass.data(gs)->externalType(gs);
+        return attachedClass.data(gs)->externalType();
     }
 
     if (auto *shapeType = cast_type<ShapeType>(tp.get())) {
@@ -1147,7 +1147,7 @@ public:
         SymbolRef self = unwrapSymbol(args.thisType.get());
         auto singleton = self.data(gs)->lookupSingletonClass(gs);
         if (singleton.exists()) {
-            res.returnType = singleton.data(gs)->externalType(gs);
+            res.returnType = singleton.data(gs)->externalType();
         } else {
             res.returnType = Types::classClass();
         }
@@ -1169,7 +1169,7 @@ public:
                 return;
             }
         }
-        auto instanceTy = attachedClass.data(gs)->externalType(gs);
+        auto instanceTy = attachedClass.data(gs)->externalType();
         DispatchArgs innerArgs{Names::initialize(), args.locs,  args.args, instanceTy,
                                instanceTy,          instanceTy, args.block};
         auto dispatched = instanceTy->dispatchCall(gs, innerArgs);
@@ -1865,7 +1865,7 @@ public:
             // AttachedClass will only be missing on `T.untyped`
             ENFORCE(attachedClass.exists());
 
-            auto instanceTy = self.data(gs)->attachedClass(gs).data(gs)->externalType(gs);
+            auto instanceTy = self.data(gs)->attachedClass(gs).data(gs)->externalType();
             DispatchArgs innerArgs{Names::initialize(), sendLocs,   sendArgStore, instanceTy,
                                    instanceTy,          instanceTy, args.block};
             dispatched = instanceTy->dispatchCall(gs, innerArgs);
@@ -2255,7 +2255,7 @@ public:
             res.returnType = Types::Boolean();
             return;
         }
-        auto lhs = rc.data(gs)->externalType(gs);
+        auto lhs = rc.data(gs)->externalType();
         ENFORCE(!lhs->isUntyped(), "lhs of Module.=== must be typed");
         if (Types::isSubType(gs, rhs, lhs)) {
             res.returnType = Types::trueClass();

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -565,7 +565,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         auto &klassType = send->args[0].type;
         core::SymbolRef klass = core::Types::getRepresentedClass(ctx, klassType.get());
         if (klass.exists()) {
-            auto ty = klass.data(ctx)->externalType(ctx);
+            auto ty = klass.data(ctx)->externalType();
             if (!ty->isUntyped()) {
                 whoKnows.truthy().addYesTypeTest(local, typeTestsWithVar, send->recv.variable, ty);
                 whoKnows.falsy().addNoTypeTest(local, typeTestsWithVar, send->recv.variable, ty);
@@ -618,7 +618,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         // `when` against class literal
         core::SymbolRef representedClass = core::Types::getRepresentedClass(ctx, recvType.get());
         if (representedClass.exists()) {
-            auto representedType = representedClass.data(ctx)->externalType(ctx);
+            auto representedType = representedClass.data(ctx)->externalType();
             if (!representedType->isUntyped()) {
                 whoKnows.truthy().addYesTypeTest(local, typeTestsWithVar, send->args[0].variable, representedType);
                 whoKnows.falsy().addNoTypeTest(local, typeTestsWithVar, send->args[0].variable, representedType);
@@ -1031,7 +1031,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 if (data->isClassOrModule()) {
                     auto singletonClass = data->lookupSingletonClass(ctx);
                     ENFORCE(singletonClass.exists(), "Every class should have a singleton class by now.");
-                    tp.type = singletonClass.data(ctx)->externalType(ctx);
+                    tp.type = singletonClass.data(ctx)->externalType();
                     tp.origins.emplace_back(symbol.data(ctx)->loc());
                 } else if (data->isField() || (data->isStaticField() && !data->isTypeAlias()) || data->isTypeMember()) {
                     if (data->resultType.get() != nullptr) {
@@ -1229,7 +1229,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
             [&](cfg::LoadSelf *l) {
                 ENFORCE(l->link);
                 if (l->link->result->main.blockSpec.rebind.exists()) {
-                    tp.type = l->link->result->main.blockSpec.rebind.data(ctx)->externalType(ctx);
+                    tp.type = l->link->result->main.blockSpec.rebind.data(ctx)->externalType();
                     tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
 
                 } else {

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -86,7 +86,7 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
             tp.origins.emplace_back(symbol.data(ctx)->loc());
 
             if (symbol.data(ctx)->isClassOrModule()) {
-                tp.type = symbol.data(ctx)->lookupSingletonClass(ctx).data(ctx)->externalType(ctx);
+                tp.type = symbol.data(ctx)->lookupSingletonClass(ctx).data(ctx)->externalType();
             } else {
                 auto resultType = symbol.data(ctx)->resultType;
                 tp.type = resultType == nullptr ? core::Types::untyped(ctx, symbol) : resultType;

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -227,7 +227,7 @@ string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef consta
         if (!targetClass.data(gs)->attachedClass(gs).exists()) {
             targetClass = targetClass.data(gs)->lookupSingletonClass(gs);
         }
-        result = targetClass.data(gs)->externalType(gs);
+        result = targetClass.data(gs)->externalType();
     } else {
         auto resultType = constant.data(gs)->resultType;
         result = resultType == nullptr ? core::Types::untyped(gs, constant) : resultType;

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -158,6 +158,7 @@ void resolveTypeMembers(core::GlobalState &gs, core::SymbolRef sym,
 
     // If this class has no type members, fix attached class early.
     if (sym.data(gs)->typeMembers().empty()) {
+        sym.data(gs)->unsafeComputeExternalType(gs);
         auto singleton = sym.data(gs)->lookupSingletonClass(gs);
         if (singleton.exists()) {
             // AttachedClass doesn't exist on `T.untyped`, which is a problem
@@ -168,7 +169,7 @@ void resolveTypeMembers(core::GlobalState &gs, core::SymbolRef sym,
                 ENFORCE(lambdaParam != nullptr);
 
                 lambdaParam->lowerBound = core::Types::bottom();
-                lambdaParam->upperBound = sym.data(gs)->externalType(gs);
+                lambdaParam->upperBound = sym.data(gs)->externalType();
             }
         }
     }

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -536,7 +536,7 @@ core::TypePtr interpretTCombinator(core::MutableContext ctx, ast::Send *send, co
                 }
                 return core::Types::untypedUntracked();
             }
-            return singleton.data(ctx)->externalType(ctx);
+            return singleton.data(ctx)->externalType();
         }
         case core::Names::untyped()._id:
             return core::Types::untyped(ctx, args.untypedBlame);
@@ -698,7 +698,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                     result.type =
                         core::make_type<core::UnresolvedClassType>(unresolvedPath->first, move(unresolvedPath->second));
                 } else {
-                    result.type = sym.data(ctx)->externalType(ctx);
+                    result.type = sym.data(ctx)->externalType();
                 }
             } else if (sym.data(ctx)->isTypeMember()) {
                 auto symData = sym.data(ctx);

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -536,7 +536,7 @@ core::TypePtr interpretTCombinator(core::MutableContext ctx, ast::Send *send, co
                 }
                 return core::Types::untypedUntracked();
             }
-            return singleton.data(ctx)->externalType();
+            return singleton.data(ctx)->unsafeComputeExternalType(ctx);
         }
         case core::Names::untyped()._id:
             return core::Types::untyped(ctx, args.untypedBlame);
@@ -698,7 +698,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                     result.type =
                         core::make_type<core::UnresolvedClassType>(unresolvedPath->first, move(unresolvedPath->second));
                 } else {
-                    result.type = sym.data(ctx)->externalType();
+                    result.type = sym.data(ctx)->unsafeComputeExternalType(ctx);
                 }
             } else if (sym.data(ctx)->isTypeMember()) {
                 auto symData = sym.data(ctx);


### PR DESCRIPTION
Compute Symbol::externalType serially.

Delurks an atomic operation that 1) complicates an effort to use tagged pointers for TypedPtr and 2) is not actually needed!

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Makes it much simpler to transition to a tagged TypedPtr, and removes a lurky abstraction-breaking line of code.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
