### PR TITLE
constify methodHash when looking up method symbols

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -818,7 +818,7 @@ void GlobalState::preallocateTables(u4 classAndModulesSize, u4 methodsSize, u4 f
 
 constexpr decltype(GlobalState::STRINGS_PAGE_SIZE) GlobalState::STRINGS_PAGE_SIZE;
 
-SymbolRef GlobalState::lookupMethodSymbolWithHash(SymbolRef owner, NameRef name, vector<u4> methodHash) const {
+SymbolRef GlobalState::lookupMethodSymbolWithHash(SymbolRef owner, NameRef name, const vector<u4> &methodHash) const {
     ENFORCE(owner.exists(), "looking up symbol from non-existing owner");
     ENFORCE(name.exists(), "looking up symbol with non-existing name");
     SymbolData ownerScope = owner.dataAllowingNone(*this);

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -94,7 +94,7 @@ public:
     SymbolRef lookupMethodSymbol(SymbolRef owner, NameRef name) const {
         return lookupSymbolWithFlags(owner, name, Symbol::Flags::METHOD);
     }
-    SymbolRef lookupMethodSymbolWithHash(SymbolRef owner, NameRef name, std::vector<u4> methodHash) const;
+    SymbolRef lookupMethodSymbolWithHash(SymbolRef owner, NameRef name, const std::vector<u4> &methodHash) const;
     SymbolRef lookupStaticFieldSymbol(SymbolRef owner, NameRef name) const {
         return lookupSymbolWithFlags(owner, name, Symbol::Flags::STATIC_FIELD);
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

`GlobalState::lookupMethodSymbolWithHash` was taking the method hash by value, which caused unnecessary allocation and was completely unnecessary, since all we do is compare hashes for equality.  Taking it by `const&` makes the code clearer and more efficient.

### Motivation

Epsilon efficiency wins.

### Test plan

Not a user-visible change; existing tests should be sufficient.