### PR TITLE
Use an enum class for ShowOperation::Kind

### DIFF
--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -164,7 +164,7 @@ void LSPIndexer::initialize(LSPFileUpdates &updates, WorkerPool &workers) {
 
     vector<ast::ParsedFile> indexed;
     Timer timeit(config->logger, "initial_index");
-    ShowOperation op(*config, "Indexing", "Indexing files...");
+    ShowOperation op(*config, ShowOperation::Kind::Indexing);
     vector<core::FileRef> inputFiles;
     unique_ptr<const OwnedKeyValueStore> ownedKvstore = cache::ownIfUnchanged(*initialGS, move(kvstore));
     {

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -334,7 +334,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
             "runSlowPath can only be called from the typechecker thread.");
 
     auto &logger = config->logger;
-    unique_ptr<ShowOperation> slowPathOp = make_unique<ShowOperation>(*config, "SlowPathBlocking", "Typechecking...");
+    unique_ptr<ShowOperation> slowPathOp = make_unique<ShowOperation>(*config, ShowOperation::Kind::SlowPathBlocking);
     Timer timeit(logger, "slow_path");
     ENFORCE(!updates.canTakeFastPath || config->disableFastPath);
     ENFORCE(updates.updatedGS.has_value());
@@ -406,7 +406,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
             // Inform users that Sorbet should be responsive now.
             // Explicitly end previous operation before beginning next operation.
             slowPathOp = nullptr;
-            slowPathOp = make_unique<ShowOperation>(*config, "SlowPathNonBlocking", "Typechecking in background");
+            slowPathOp = make_unique<ShowOperation>(*config, ShowOperation::Kind::SlowPathNonBlocking);
         }
         // Report how long the slow path blocks preemption.
         timeit.clone("slow_path.blocking_time");

--- a/main/lsp/ShowOperation.cc
+++ b/main/lsp/ShowOperation.cc
@@ -8,16 +8,58 @@ namespace sorbet::realmain::lsp {
 using namespace std;
 
 namespace {
+
 unique_ptr<LSPMessage> makeShowOperation(std::string operationName, std::string description,
                                          SorbetOperationStatus status) {
     return make_unique<LSPMessage>(make_unique<NotificationMessage>(
         "2.0", LSPMethod::SorbetShowOperation,
         make_unique<SorbetShowOperationParams>(move(operationName), move(description), status)));
 }
+
+string_view kindToOperationName(ShowOperation::Kind kind) {
+    switch (kind) {
+        case ShowOperation::Kind::Indexing:
+            return "Indexing";
+            break;
+        case ShowOperation::Kind::SlowPathBlocking:
+            return "SlowPathBlocking";
+            break;
+        case ShowOperation::Kind::SlowPathNonBlocking:
+            return "SlowPathNonBlocking";
+            break;
+        case ShowOperation::Kind::References:
+            return "References";
+            break;
+        case ShowOperation::Kind::SymbolSearch:
+            return "SymbolSearch";
+            break;
+    }
+}
+
+string_view kindToDescription(ShowOperation::Kind kind) {
+    switch (kind) {
+        case ShowOperation::Kind::Indexing:
+            return "Indexing files...";
+            break;
+        case ShowOperation::Kind::SlowPathBlocking:
+            return "Typechecking...";
+            break;
+        case ShowOperation::Kind::SlowPathNonBlocking:
+            return "Typchecking in background";
+            break;
+        case ShowOperation::Kind::References:
+            return "Finding all references...";
+            break;
+        case ShowOperation::Kind::SymbolSearch:
+            return "Workspace symbol search...";
+            break;
+    }
+}
+
 } // namespace
 
-ShowOperation::ShowOperation(const LSPConfiguration &config, std::string operationName, std::string description)
-    : config(config), operationName(move(operationName)), description(move(description)) {
+ShowOperation::ShowOperation(const LSPConfiguration &config, Kind kind)
+    : config(config), kind(kind), operationName(kindToOperationName(kind)), description(kindToDescription(kind)) {
     if (config.getClientConfig().enableOperationNotifications) {
         config.output->write(makeShowOperation(this->operationName, this->description, SorbetOperationStatus::Start));
     }
@@ -29,3 +71,5 @@ ShowOperation::~ShowOperation() {
     }
 }
 } // namespace sorbet::realmain::lsp
+
+//

--- a/main/lsp/ShowOperation.cc
+++ b/main/lsp/ShowOperation.cc
@@ -20,19 +20,14 @@ string_view kindToOperationName(ShowOperation::Kind kind) {
     switch (kind) {
         case ShowOperation::Kind::Indexing:
             return "Indexing";
-            break;
         case ShowOperation::Kind::SlowPathBlocking:
             return "SlowPathBlocking";
-            break;
         case ShowOperation::Kind::SlowPathNonBlocking:
             return "SlowPathNonBlocking";
-            break;
         case ShowOperation::Kind::References:
             return "References";
-            break;
         case ShowOperation::Kind::SymbolSearch:
             return "SymbolSearch";
-            break;
     }
 }
 

--- a/main/lsp/ShowOperation.cc
+++ b/main/lsp/ShowOperation.cc
@@ -59,7 +59,7 @@ string_view kindToDescription(ShowOperation::Kind kind) {
 } // namespace
 
 ShowOperation::ShowOperation(const LSPConfiguration &config, Kind kind)
-    : config(config), kind(kind), operationName(kindToOperationName(kind)), description(kindToDescription(kind)) {
+    : config(config), operationName(kindToOperationName(kind)), description(kindToDescription(kind)) {
     if (config.getClientConfig().enableOperationNotifications) {
         config.output->write(makeShowOperation(this->operationName, this->description, SorbetOperationStatus::Start));
     }

--- a/main/lsp/ShowOperation.cc
+++ b/main/lsp/ShowOperation.cc
@@ -40,19 +40,14 @@ string_view kindToDescription(ShowOperation::Kind kind) {
     switch (kind) {
         case ShowOperation::Kind::Indexing:
             return "Indexing files...";
-            break;
         case ShowOperation::Kind::SlowPathBlocking:
             return "Typechecking...";
-            break;
         case ShowOperation::Kind::SlowPathNonBlocking:
             return "Typchecking in background";
-            break;
         case ShowOperation::Kind::References:
             return "Finding all references...";
-            break;
         case ShowOperation::Kind::SymbolSearch:
             return "Workspace symbol search...";
-            break;
     }
 }
 

--- a/main/lsp/ShowOperation.h
+++ b/main/lsp/ShowOperation.h
@@ -13,11 +13,19 @@ class LSPConfiguration;
  */
 class ShowOperation final {
     const LSPConfiguration &config;
+    const Kind kind;
     const std::string operationName;
     const std::string description;
 
 public:
-    ShowOperation(const LSPConfiguration &config, std::string operationName, std::string description);
+    enum class Kind {
+        Indexing = 1,
+        SlowPathBlocking,
+        SlowPathNonBlocking,
+        References,
+        SymbolSearch,
+    };
+    ShowOperation(const LSPConfiguration &config, Kind kind);
     ~ShowOperation();
 };
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/ShowOperation.h
+++ b/main/lsp/ShowOperation.h
@@ -13,7 +13,6 @@ class LSPConfiguration;
  */
 class ShowOperation final {
     const LSPConfiguration &config;
-    const Kind kind;
     const std::string operationName;
     const std::string description;
 

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -17,7 +17,7 @@ bool ReferencesTask::needsMultithreading(const LSPIndexer &indexer) const {
 
 unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentReferences);
-    ShowOperation op(config, "References", "Finding all references...");
+    ShowOperation op(config, ShowOperation::Kind::References);
 
     const core::GlobalState &gs = typechecker.state();
     auto result =

--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -331,7 +331,7 @@ bool WorkspaceSymbolsTask::isDelayable() const {
 unique_ptr<ResponseMessage> WorkspaceSymbolsTask::runRequest(LSPTypecheckerDelegate &typechecker) {
     Timer timeit(typechecker.state().tracer(), "LSPLoop::handleWorkspaceSymbols");
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::WorkspaceSymbol);
-    ShowOperation op(config, "References", "Workspace symbol search...");
+    ShowOperation op(config, ShowOperation::Kind::References);
     SymbolMatcher matcher(config, typechecker.state());
     response->result = matcher.doQuery(params->query);
     return response;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I wanted to be able to see what all the values of the `operationName`
were so that I could write code to handle them all in a Vim plugin.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.