### PR TITLE
Fix packaged behavior for `non_forcing_is_a?`

### DIFF
--- a/gems/sorbet-runtime/lib/types/non_forcing_constants.rb
+++ b/gems/sorbet-runtime/lib/types/non_forcing_constants.rb
@@ -30,25 +30,29 @@ module T::NonForcingConstants
 
         current_klass = Object
         current_prefix = ''
-      else
-        if current_klass.autoload?(part)
-          # There's an autoload registered for that constant, which means it's not
-          # yet loaded. `value` can't be an instance of something not yet loaded.
-          return false
-        end
 
-        # Sorbet guarantees that the string is an absolutely resolved name.
-        search_inheritance_chain = false
-        if !current_klass.const_defined?(part, search_inheritance_chain)
-          return false
-        end
+        # if this had a :: prefix, then there's no more loading to
+        # do---skip to the next one
+        next if part == ""
+      end
 
-        current_klass = current_klass.const_get(part)
-        current_prefix = "#{current_prefix}::#{part}"
+      if current_klass.autoload?(part)
+        # There's an autoload registered for that constant, which means it's not
+        # yet loaded. `value` can't be an instance of something not yet loaded.
+        return false
+      end
 
-        if !Module.===(current_klass)
-          raise ArgumentError.new("#{current_prefix} is not a class or module")
-        end
+      # Sorbet guarantees that the string is an absolutely resolved name.
+      search_inheritance_chain = false
+      if !current_klass.const_defined?(part, search_inheritance_chain)
+        return false
+      end
+
+      current_klass = current_klass.const_get(part)
+      current_prefix = "#{current_prefix}::#{part}"
+
+      if !Module.===(current_klass)
+        raise ArgumentError.new("#{current_prefix} is not a class or module")
       end
     end
 

--- a/gems/sorbet-runtime/test/types/non_forcing_constants.rb
+++ b/gems/sorbet-runtime/test/types/non_forcing_constants.rb
@@ -89,5 +89,20 @@ class Opus::Types::Test::NonForcingConstantsTest < Critic::Unit::UnitTest
       end
       assert_match(/is not a class or module/, exn.message)
     end
+
+    # These tests describe the /current/ behavior, but we expect this
+    # behavior to change once we have a runtime implementation of
+    # packages
+    describe 'packaged form' do
+      it "when exists but isn't is_a?" do
+        res = T::NonForcingConstants.non_forcing_is_a?(nil, 'Integer', package: "SomePackage")
+        assert_equal(false, res)
+      end
+
+      it "when exists and is_a?" do
+        res = T::NonForcingConstants.non_forcing_is_a?(0, 'Integer', package: "SomePackage")
+        assert_equal(true, res)
+      end
+    end
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This fixes the runtime behavior for the packaged equivalent of `non_forcing_is_a?`. This will need to be changed in the future to account for the runtime implementation of packages; right now it still treats them as though they're relative to `Object`, to match the WIP behavior in pay-server.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Added some tests to describe the current behavior, with a comment indicating so.
