### PR TITLE
add some const qualification around Type

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -224,7 +224,7 @@ public:
     bool isBottom() const;
     virtual bool hasUntyped();
     virtual bool isFullyDefined() = 0;
-    virtual int kind() = 0;
+    virtual int kind() const = 0;
     virtual TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc);
     unsigned int hash(const GlobalState &gs) const;
 };
@@ -266,7 +266,7 @@ class ClassType : public GroundType {
 public:
     SymbolRef symbol;
     ClassType(SymbolRef symbol);
-    virtual int kind() final;
+    virtual int kind() const final;
 
     virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const override;
     virtual std::string show(const GlobalState &gs) const override;
@@ -310,7 +310,7 @@ public:
 
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
-    virtual int kind() final;
+    virtual int kind() const final;
 };
 CheckSize(LambdaParam, 48, 8);
 
@@ -332,7 +332,7 @@ public:
 
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
-    virtual int kind() final;
+    virtual int kind() const final;
 };
 CheckSize(SelfTypeParam, 16, 8);
 
@@ -352,7 +352,7 @@ public:
 
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
-    virtual int kind() final;
+    virtual int kind() const final;
 };
 CheckSize(AliasType, 16, 8);
 
@@ -371,7 +371,7 @@ public:
 
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
-    virtual int kind() final;
+    virtual int kind() const final;
     virtual TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) override;
 
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
@@ -406,7 +406,7 @@ public:
 
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
-    virtual int kind() final;
+    virtual int kind() const final;
 };
 CheckSize(LiteralType, 24, 8);
 
@@ -428,7 +428,7 @@ public:
 
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
-    virtual int kind() final;
+    virtual int kind() const final;
     virtual TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) override;
     virtual TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) override;
 };
@@ -438,7 +438,7 @@ class OrType final : public GroundType {
 public:
     TypePtr left;
     TypePtr right;
-    virtual int kind() final;
+    virtual int kind() const final;
 
     virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
     virtual std::string show(const GlobalState &gs) const final;
@@ -492,7 +492,7 @@ class AndType final : public GroundType {
 public:
     TypePtr left;
     TypePtr right;
-    virtual int kind() final;
+    virtual int kind() const final;
 
     virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
     virtual std::string show(const GlobalState &gs) const final;
@@ -550,7 +550,7 @@ public:
 
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
-    virtual int kind() final;
+    virtual int kind() const final;
     virtual bool hasUntyped() override;
     virtual TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) override;
     virtual TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) override;
@@ -578,7 +578,7 @@ public:
 
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
-    virtual int kind() final;
+    virtual int kind() const final;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     virtual bool hasUntyped() override;
     virtual TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) override;
@@ -605,7 +605,7 @@ public:
 
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
-    virtual int kind() final;
+    virtual int kind() const final;
 
     virtual TypePtr getCallArguments(const GlobalState &gs, NameRef name) final;
 
@@ -642,7 +642,7 @@ public:
 
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
-    virtual int kind() final;
+    virtual int kind() const final;
     virtual TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) override;
     virtual TypePtr underlying() const override;
 };

--- a/core/Types.h
+++ b/core/Types.h
@@ -223,7 +223,7 @@ public:
     core::SymbolRef untypedBlame() const;
     bool isBottom() const;
     virtual bool hasUntyped();
-    virtual bool isFullyDefined() = 0;
+    virtual bool isFullyDefined() const = 0;
     virtual int kind() const = 0;
     virtual TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc);
     unsigned int hash(const GlobalState &gs) const;
@@ -278,7 +278,7 @@ public:
     void _sanityCheck(const GlobalState &gs) final;
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override final;
-    virtual bool isFullyDefined() final;
+    virtual bool isFullyDefined() const final;
     virtual bool hasUntyped() override final;
 };
 CheckSize(ClassType, 16, 8);
@@ -306,7 +306,7 @@ public:
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     virtual TypePtr getCallArguments(const GlobalState &gs, NameRef name) final;
     void _sanityCheck(const GlobalState &gs) final;
-    virtual bool isFullyDefined() final;
+    virtual bool isFullyDefined() const final;
 
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
@@ -328,7 +328,7 @@ public:
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     virtual TypePtr getCallArguments(const GlobalState &gs, NameRef name) final;
     void _sanityCheck(const GlobalState &gs) final;
-    virtual bool isFullyDefined() final;
+    virtual bool isFullyDefined() const final;
 
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
@@ -348,7 +348,7 @@ public:
 
     SymbolRef symbol;
     void _sanityCheck(const GlobalState &gs) final;
-    virtual bool isFullyDefined() final;
+    virtual bool isFullyDefined() const final;
 
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
@@ -367,7 +367,7 @@ public:
     virtual std::string show(const GlobalState &gs) const final;
     virtual std::string showValue(const GlobalState &gs) const final;
     virtual std::string typeName() const override;
-    virtual bool isFullyDefined() final;
+    virtual bool isFullyDefined() const final;
 
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
@@ -400,7 +400,7 @@ public:
     virtual std::string show(const GlobalState &gs) const final;
     virtual std::string showValue(const GlobalState &gs) const final;
     virtual std::string typeName() const override;
-    virtual bool isFullyDefined() final;
+    virtual bool isFullyDefined() const final;
 
     bool equals(const LiteralType &rhs) const;
 
@@ -422,7 +422,7 @@ public:
     virtual std::string typeName() const final;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     void _sanityCheck(const GlobalState &gs) final;
-    virtual bool isFullyDefined() final;
+    virtual bool isFullyDefined() const final;
     virtual TypePtr getCallArguments(const GlobalState &gs, NameRef name) final;
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
 
@@ -447,7 +447,7 @@ public:
     virtual TypePtr getCallArguments(const GlobalState &gs, NameRef name) final;
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
     void _sanityCheck(const GlobalState &gs) final;
-    virtual bool isFullyDefined() final;
+    virtual bool isFullyDefined() const final;
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
     virtual bool hasUntyped() override;
@@ -502,7 +502,7 @@ public:
     virtual TypePtr getCallArguments(const GlobalState &gs, NameRef name) final;
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
     void _sanityCheck(const GlobalState &gs) final;
-    virtual bool isFullyDefined() final;
+    virtual bool isFullyDefined() const final;
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
     virtual TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) override;
@@ -546,7 +546,7 @@ public:
     virtual std::string typeName() const override;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     void _sanityCheck(const GlobalState &gs) final;
-    virtual bool isFullyDefined() final;
+    virtual bool isFullyDefined() const final;
 
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
@@ -574,7 +574,7 @@ public:
     virtual std::string showWithMoreInfo(const GlobalState &gs) const final;
     virtual std::string typeName() const override;
     void _sanityCheck(const GlobalState &gs) final;
-    virtual bool isFullyDefined() final;
+    virtual bool isFullyDefined() const final;
 
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
@@ -601,7 +601,7 @@ public:
     virtual std::string typeName() const final;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     void _sanityCheck(const GlobalState &gs) final;
-    virtual bool isFullyDefined() final;
+    virtual bool isFullyDefined() const final;
 
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
@@ -638,7 +638,7 @@ public:
 
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     void _sanityCheck(const GlobalState &gs) final;
-    virtual bool isFullyDefined() final;
+    virtual bool isFullyDefined() const final;
 
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;

--- a/core/Types.h
+++ b/core/Types.h
@@ -222,7 +222,7 @@ public:
     bool isNilClass() const;
     core::SymbolRef untypedBlame() const;
     bool isBottom() const;
-    virtual bool hasUntyped();
+    virtual bool hasUntyped() const;
     virtual bool isFullyDefined() const = 0;
     virtual int kind() const = 0;
     virtual TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc);
@@ -279,7 +279,7 @@ public:
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override final;
     virtual bool isFullyDefined() const final;
-    virtual bool hasUntyped() override final;
+    virtual bool hasUntyped() const override final;
 };
 CheckSize(ClassType, 16, 8);
 
@@ -450,7 +450,7 @@ public:
     virtual bool isFullyDefined() const final;
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
-    virtual bool hasUntyped() override;
+    virtual bool hasUntyped() const override;
     virtual TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) override;
     virtual TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) override;
     virtual TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) override;
@@ -506,7 +506,7 @@ public:
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
     virtual TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) override;
-    virtual bool hasUntyped() override;
+    virtual bool hasUntyped() const override;
     virtual TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) override;
     virtual TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) override;
 
@@ -551,7 +551,7 @@ public:
     virtual TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                  const std::vector<TypePtr> &targs) override;
     virtual int kind() const final;
-    virtual bool hasUntyped() override;
+    virtual bool hasUntyped() const override;
     virtual TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) override;
     virtual TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) override;
     virtual TypePtr underlying() const override;
@@ -580,7 +580,7 @@ public:
                                  const std::vector<TypePtr> &targs) override;
     virtual int kind() const final;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
-    virtual bool hasUntyped() override;
+    virtual bool hasUntyped() const override;
     virtual TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) override;
     virtual TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) override;
 
@@ -610,7 +610,7 @@ public:
     virtual TypePtr getCallArguments(const GlobalState &gs, NameRef name) final;
 
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
-    virtual bool hasUntyped() override;
+    virtual bool hasUntyped() const override;
     virtual TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) override;
     virtual TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) override;
 };

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -1375,7 +1375,7 @@ void MetaType::_sanityCheck(const GlobalState &gs) {
     this->wrapped->sanityCheck(gs);
 }
 
-bool MetaType::isFullyDefined() {
+bool MetaType::isFullyDefined() const {
     return true; // this is kinda true but kinda false. it's false for subtyping but true for inferencer.
 }
 

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -750,15 +750,15 @@ bool SelfTypeParam::isFullyDefined() const {
     return true;
 }
 
-bool Type::hasUntyped() {
+bool Type::hasUntyped() const {
     return false;
 }
 
-bool ClassType::hasUntyped() {
+bool ClassType::hasUntyped() const {
     return isUntyped();
 }
 
-bool OrType::hasUntyped() {
+bool OrType::hasUntyped() const {
     return left->hasUntyped() || right->hasUntyped();
 }
 
@@ -767,7 +767,7 @@ TypePtr OrType::make_shared(const TypePtr &left, const TypePtr &right) {
     return res;
 }
 
-bool AndType::hasUntyped() {
+bool AndType::hasUntyped() const {
     return left->hasUntyped() || right->hasUntyped();
 }
 
@@ -776,7 +776,7 @@ TypePtr AndType::make_shared(const TypePtr &left, const TypePtr &right) {
     return res;
 }
 
-bool AppliedType::hasUntyped() {
+bool AppliedType::hasUntyped() const {
     for (auto &arg : this->targs) {
         if (arg->hasUntyped()) {
             return true;
@@ -785,7 +785,7 @@ bool AppliedType::hasUntyped() {
     return false;
 }
 
-bool TupleType::hasUntyped() {
+bool TupleType::hasUntyped() const {
     for (auto &arg : this->elems) {
         if (arg->hasUntyped()) {
             return true;
@@ -794,7 +794,7 @@ bool TupleType::hasUntyped() {
     return false;
 }
 
-bool ShapeType::hasUntyped() {
+bool ShapeType::hasUntyped() const {
     for (auto &arg : this->values) {
         if (arg->hasUntyped()) {
             return true;

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -488,55 +488,55 @@ void ClassType::_sanityCheck(const GlobalState &gs) {
     ENFORCE(this->symbol.exists());
 }
 
-int AppliedType::kind() {
+int AppliedType::kind() const {
     return 1;
 }
 
-int ClassType::kind() {
+int ClassType::kind() const {
     return 2;
 }
 
-int LiteralType::kind() {
+int LiteralType::kind() const {
     return 3;
 }
 
-int ShapeType::kind() {
+int ShapeType::kind() const {
     return 4;
 }
 
-int TupleType::kind() {
+int TupleType::kind() const {
     return 5;
 }
 
-int LambdaParam::kind() {
+int LambdaParam::kind() const {
     return 6;
 }
 
-int SelfTypeParam::kind() {
+int SelfTypeParam::kind() const {
     return 6;
 }
 
-int MetaType::kind() {
+int MetaType::kind() const {
     return 7;
 }
 
-int TypeVar::kind() {
+int TypeVar::kind() const {
     return 8;
 }
 
-int AliasType::kind() {
+int AliasType::kind() const {
     return 9;
 }
 
-int OrType::kind() {
+int OrType::kind() const {
     return 10;
 }
 
-int AndType::kind() {
+int AndType::kind() const {
     return 11;
 }
 
-int SelfType::kind() {
+int SelfType::kind() const {
     return 12;
 }
 

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -549,11 +549,11 @@ bool LiteralType::isFullyDefined() const {
 }
 
 bool ShapeType::isFullyDefined() const {
-    return absl::c_all_of(values, [](TypePtr t) { return t->isFullyDefined(); });
+    return absl::c_all_of(values, [](const TypePtr &t) { return t->isFullyDefined(); });
 }
 
 bool TupleType::isFullyDefined() const {
-    return absl::c_all_of(elems, [](TypePtr t) { return t->isFullyDefined(); });
+    return absl::c_all_of(elems, [](const TypePtr &t) { return t->isFullyDefined(); });
 }
 
 bool AliasType::isFullyDefined() const {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -540,31 +540,31 @@ int SelfType::kind() const {
     return 12;
 }
 
-bool ClassType::isFullyDefined() {
+bool ClassType::isFullyDefined() const {
     return true;
 }
 
-bool LiteralType::isFullyDefined() {
+bool LiteralType::isFullyDefined() const {
     return true;
 }
 
-bool ShapeType::isFullyDefined() {
+bool ShapeType::isFullyDefined() const {
     return absl::c_all_of(values, [](TypePtr t) { return t->isFullyDefined(); });
 }
 
-bool TupleType::isFullyDefined() {
+bool TupleType::isFullyDefined() const {
     return absl::c_all_of(elems, [](TypePtr t) { return t->isFullyDefined(); });
 }
 
-bool AliasType::isFullyDefined() {
+bool AliasType::isFullyDefined() const {
     return true;
 }
 
-bool AndType::isFullyDefined() {
+bool AndType::isFullyDefined() const {
     return this->left->isFullyDefined() && this->right->isFullyDefined();
 }
 
-bool OrType::isFullyDefined() {
+bool OrType::isFullyDefined() const {
     return this->left->isFullyDefined() && this->right->isFullyDefined();
 }
 
@@ -653,7 +653,7 @@ bool Types::isSubType(const GlobalState &gs, const TypePtr &t1, const TypePtr &t
     return isSubTypeUnderConstraint(gs, TypeConstraint::EmptyFrozenConstraint, t1, t2, UntypedMode::AlwaysCompatible);
 }
 
-bool TypeVar::isFullyDefined() {
+bool TypeVar::isFullyDefined() const {
     return false;
 }
 
@@ -673,7 +673,7 @@ void TypeVar::_sanityCheck(const GlobalState &gs) {
     ENFORCE(this->sym.exists());
 }
 
-bool AppliedType::isFullyDefined() {
+bool AppliedType::isFullyDefined() const {
     for (auto &targ : this->targs) {
         if (!targ->isFullyDefined()) {
             return false;
@@ -742,11 +742,11 @@ DispatchResult SelfTypeParam::dispatchCall(const GlobalState &gs, DispatchArgs a
 void LambdaParam::_sanityCheck(const GlobalState &gs) {}
 void SelfTypeParam::_sanityCheck(const GlobalState &gs) {}
 
-bool LambdaParam::isFullyDefined() {
+bool LambdaParam::isFullyDefined() const {
     return false;
 }
 
-bool SelfTypeParam::isFullyDefined() {
+bool SelfTypeParam::isFullyDefined() const {
     return true;
 }
 
@@ -841,7 +841,7 @@ string SelfType::typeName() const {
     return "SelfType";
 }
 
-bool SelfType::isFullyDefined() {
+bool SelfType::isFullyDefined() const {
     return false;
 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

`Type` has a number of methods that can be `const`-qualified and are unlikely to requiring modifying state in the future.  So let's let the compiler enforce that.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

More `const` is generally a good thing.

### Test plan

No user-visible effects, existing tests should be sufficient.