### PR TITLE
Enable pointing `srb rbi sorbet-typed` at a different repo

### DIFF
--- a/gems/sorbet/lib/fetch-rbis.rb
+++ b/gems/sorbet/lib/fetch-rbis.rb
@@ -19,7 +19,7 @@ class Sorbet::Private::FetchRBIs
   XDG_CACHE_HOME = ENV['XDG_CACHE_HOME'] || "#{ENV['HOME']}/.cache"
   RBI_CACHE_DIR = "#{XDG_CACHE_HOME}/sorbet/sorbet-typed"
 
-  SORBET_TYPED_REPO = 'https://github.com/sorbet/sorbet-typed.git'
+  SORBET_TYPED_REPO = ENV['SRB_SORBET_TYPED_REPO'] || 'https://github.com/sorbet/sorbet-typed.git'
   SORBET_TYPED_REVISION = ENV['SRB_SORBET_TYPED_REVISION'] || 'origin/master'
 
   HEADER = Sorbet::Private::Serialize.header(false, 'sorbet-typed')

--- a/gems/sorbet/lib/fetch-rbis.rb
+++ b/gems/sorbet/lib/fetch-rbis.rb
@@ -29,7 +29,12 @@ class Sorbet::Private::FetchRBIs
   # Ensure our cache is up-to-date
   T::Sig::WithoutRuntime.sig {void}
   def self.fetch_sorbet_typed
-    if !File.directory?(RBI_CACHE_DIR)
+    if File.directory?(RBI_CACHE_DIR)
+      remote = IO.popen(["git", "-C", RBI_CACHE_DIR, "config", "--get", "remote.origin.url"]) {|pipe| pipe.read}.strip
+      if remote != SORBET_TYPED_REPO
+        raise "Cached remote #{remote} does not match #{SORBET_TYPED_REPO}. Delete #{RBI_CACHE_DIR} and try again."
+      end
+    else
       IO.popen(["git", "clone", SORBET_TYPED_REPO, RBI_CACHE_DIR]) {|pipe| pipe.read}
       raise "Failed to git pull" if $?.exitstatus != 0
     end


### PR DESCRIPTION
Enable pointing `srb rbi sorbet-typed` at a different repo via an environment variable `SRB_SORBET_TYPED_REPO`. This goes along with the env variable that's already used to specify the revision (`SRB_SORBET_TYPED_REVISION`).

### Motivation

Our engineering org at Gusto has had multiple discussions on how best to maintain gem RBIs. There are two main options:
- use `sorbet-typed`
- maintain our own gem RBIs locally (manually and/or using `srb rbi gems` or `tapioca`)

We'd prefer to rely on (and contribute back to!) community maintained type definitions but the overhead (opening a PR and waiting for it to be approved/merged, particular by someone outside our org) is too high to be feasible. Our thought on an approach to keep overhead low while also contributing back to the community is:
- fork `sorbet/sorbet-typed` -> `gusto/sorbet-typed`
- point any of our repos using sorbet to run `srb rbi sorbet-typed` against our fork
- periodically open PRs against `sorbet/sorbet-typed` to upstream our changes and contribute back to the community (and obviously periodically pull from `sorbet/sorbet-typed` to pick up any community-added changes).

This PR enables this workflow for us.

### Test plan

Tested manually:

**Default works**
```
$ gems/sorbet/bin/srb-rbi sorbet-typed
Running command: sorbet-typed
Generating: sorbet/rbi/sorbet-typed/
remote: Enumerating objects: 18, done.
remote: Counting objects: 100% (18/18), done.
remote: Compressing objects: 100% (11/11), done.
remote: Total 13 (delta 5), reused 2 (delta 0), pack-reused 0
Unpacking objects: 100% (13/13), 2.99 KiB | 255.00 KiB/s, done.
From https://github.com/sorbet/sorbet-typed
   96db1f0..2133099  master     -> origin/master
```

**Using custom repo fails**
```
$ SRB_SORBET_TYPED_REPO=https://github.com/gusto/sorbet-typed.git gems/sorbet/bin/srb-rbi sorbet-typed
Running command: sorbet-typed
Generating: sorbet/rbi/sorbet-typed/
Traceback (most recent call last):
        4: from gems/sorbet/bin/srb-rbi:237:in `<main>'
        3: from gems/sorbet/bin/srb-rbi:224:in `main'
        2: from gems/sorbet/bin/srb-rbi:232:in `block in make_step'
        1: from ~/sorbet/gems/sorbet/lib/fetch-rbis.rb:110:in `main'
~/sorbet/gems/sorbet/lib/fetch-rbis.rb:35:in `fetch_sorbet_typed': Cached remote https://github.com/sorbet/sorbet-typed.git, does not match https://github.com/gusto/sorbet-typed.git. Delete ~/.cache/sorbet/sorbet-typed and try again. (RuntimeError)
```

**Removing cache and retrying works**
```
$ rm -rf ~/.cache/sorbet/sorbet-typed
$ SRB_SORBET_TYPED_REPO=https://github.com/gusto/sorbet-typed.git gems/sorbet/bin/srb-rbi sorbet-typed 
Running command: sorbet-typed
Generating: sorbet/rbi/sorbet-typed/
Cloning into '~/.cache/sorbet/sorbet-typed'...
warning: templates not found in ~/.git-templates
remote: Enumerating objects: 437, done.
remote: Total 437 (delta 0), reused 0 (delta 0), pack-reused 437
Receiving objects: 100% (437/437), 113.85 KiB | 1.28 MiB/s, done.
Resolving deltas: 100% (168/168), done.
```

**Default fails (as expected)**
```
$ gems/sorbet/bin/srb-rbi sorbet-typed 
Running command: sorbet-typed
Generating: sorbet/rbi/sorbet-typed/
Traceback (most recent call last):
        4: from gems/sorbet/bin/srb-rbi:237:in `<main>'
        3: from gems/sorbet/bin/srb-rbi:224:in `main'
        2: from gems/sorbet/bin/srb-rbi:232:in `block in make_step'
        1: from ~/sorbet/gems/sorbet/lib/fetch-rbis.rb:110:in `main'
~/sorbet/gems/sorbet/lib/fetch-rbis.rb:35:in `fetch_sorbet_typed': Cached remote https://github.com/gusto/sorbet-typed.git, does not match https://github.com/sorbet/sorbet-typed.git. Delete ~/.cache/sorbet/sorbet-typed and try again. (RuntimeError)
```