### PR TITLE
[WIP] Print package names as invalid constants

### DIFF
--- a/core/Names.cc
+++ b/core/Names.cc
@@ -306,7 +306,11 @@ NameRef NameRef::lookupMangledPackageName(const GlobalState &gs) const {
     ENFORCE(name->kind == NameKind::UTF8, "manglePackageName over non-utf8 name");
     auto parts = absl::StrSplit(name->raw.utf8, "::");
     string nameEq = absl::StrCat(absl::StrJoin(parts, "_"), "_Package");
-    return gs.lookupNameConstant(nameEq);
+    auto constantName = gs.lookupNameConstant(nameEq);
+    if (!constantName.exists()) {
+        return constantName;
+    }
+    return gs.lookupNameUnique(UniqueNameKind::Package, constantName, 1);
 }
 
 Name Name::deepCopy(const GlobalState &to) const {

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -100,6 +100,8 @@ string Name::toString(const GlobalState &gs) const {
                 return fmt::format("<Class:{}>", this->unique.original.data(gs)->show(gs));
             } else if (this->unique.uniqueNameKind == UniqueNameKind::Overload) {
                 return absl::StrCat(this->unique.original.data(gs)->show(gs), " (overload.", this->unique.num, ")");
+            } else if (this->unique.uniqueNameKind == UniqueNameKind::Package) {
+                return fmt::format("<pkg {}>", this->unique.original.data(gs)->toString(gs));
             }
             if (gs.censorForSnapshotTests && this->unique.uniqueNameKind == UniqueNameKind::Namer &&
                 this->unique.original == core::Names::staticInit()) {
@@ -123,6 +125,8 @@ string Name::show(const GlobalState &gs) const {
                 return absl::StrCat(this->unique.original.data(gs)->show(gs), " (overload.", this->unique.num, ")");
             } else if (this->unique.uniqueNameKind == UniqueNameKind::MangleRename) {
                 return this->unique.original.data(gs)->show(gs);
+            } else if (this->unique.uniqueNameKind == UniqueNameKind::Package) {
+                return fmt::format("<pkg {}>", this->unique.original.data(gs)->show(gs));
             } else if (this->unique.uniqueNameKind == UniqueNameKind::TEnum) {
                 // The entire goal of UniqueNameKind::TEnum is to have Name::show print the name as if on the
                 // original name, so that our T::Enum DSL-synthesized class names are kept as an implementation detail.
@@ -182,7 +186,8 @@ bool Name::isClassName(const GlobalState &gs) const {
         case NameKind::UNIQUE: {
             return (this->unique.uniqueNameKind == UniqueNameKind::Singleton ||
                     this->unique.uniqueNameKind == UniqueNameKind::MangleRename ||
-                    this->unique.uniqueNameKind == UniqueNameKind::TEnum) &&
+                    this->unique.uniqueNameKind == UniqueNameKind::TEnum ||
+                    this->unique.uniqueNameKind == UniqueNameKind::Package) &&
                    this->unique.original.data(gs)->isClassName(gs);
         }
         case NameKind::CONSTANT:

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -75,6 +75,9 @@ string Name::showRaw(const GlobalState &gs) const {
                 case UniqueNameKind::TEnum:
                     kind = "E";
                     break;
+                case UniqueNameKind::Package:
+                    kind = "Q";
+                    break;
             }
             if (gs.censorForSnapshotTests && this->unique.uniqueNameKind == UniqueNameKind::Namer &&
                 this->unique.original == core::Names::staticInit()) {

--- a/core/Names.h
+++ b/core/Names.h
@@ -52,6 +52,7 @@ enum class UniqueNameKind : u1 {
     ResolverMissingClass, // used by resolver when we want to enter a stub class into a static field. see
                           // test/resolver/stub_missing_class_alias.rb
     TEnum,
+    Package, // we never need multiple mangled versions of a package name, so num should always == 1
 };
 
 struct UniqueName final {

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -57,6 +57,9 @@ com::stripe::rubytyper::Name Proto::toProto(const GlobalState &gs, NameRef name)
                 case UniqueNameKind::TEnum:
                     protoName.set_unique(com::stripe::rubytyper::Name::OPUS_ENUM);
                     break;
+                case UniqueNameKind::Package:
+                    protoName.set_unique(com::stripe::rubytyper::Name::PACKAGE);
+                    break;
             }
             break;
         case NameKind::CONSTANT:

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -193,7 +193,8 @@ PackageName getPackageName(core::MutableContext ctx, ast::UnresolvedConstantLit 
 
     // Foo::Bar => Foo_Bar_Package
     auto mangledName = absl::StrCat(absl::StrJoin(pName.fullName.parts, "_", NameFormatter(ctx)), "_Package");
-    pName.mangledName = ctx.state.enterNameConstant(mangledName);
+    auto constName = ctx.state.enterNameConstant(ctx.state.enterNameUTF8(mangledName));
+    pName.mangledName = ctx.state.freshNameUnique(core::UniqueNameKind::Package, constName, 1);
 
     return pName;
 }

--- a/proto/Name.proto
+++ b/proto/Name.proto
@@ -24,6 +24,7 @@ message Name {
          RESOLVER_MISSING_CLASS = 10;
          OPUS_ENUM = 11;
          DEFAULT_ARG = 12;
+         PACKAGE = 13;
     };
 
     Kind kind = 1;

--- a/test/testdata/packager/export_imported/pass.package-tree.exp
+++ b/test/testdata/packager/export_imported/pass.package-tree.exp
@@ -2,25 +2,25 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C A><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(<emptyTree>::<C B>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C A_Package>::<C B>::<C BClass>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<pkg <C A_Package>>::<C B>::<C BClass>)
   end
 
-  module <emptyTree>::<C <PackageRegistry>>::<C A_Package><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C A_Package>><<C <todo sym>>> < ()
     module <emptyTree>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package>::<C BClass>
+      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<pkg <C B_Package>>::<C BClass>
     end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C B><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C B_Package>::<C BClass>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<pkg <C B_Package>>::<C BClass>)
   end
 
-  module <emptyTree>::<C <PackageRegistry>>::<C B_Package><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C B_Package>><<C <todo sym>>> < ()
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C B_Package><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C B_Package>><<C <todo sym>>> < ()
     class <emptyTree>::<C BClass><<C <todo sym>>> < (::<todo sym>)
     end
   end

--- a/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
@@ -18,31 +18,31 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.export(<self>.method())
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C A_Package>::<C REFERENCE>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<pkg <C A_Package>>::<C REFERENCE>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C A_Package>::<C AClass>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<pkg <C A_Package>>::<C AClass>)
 
-    <self>.export_methods(123, "hello", <self>.method(), <emptyTree>::<C <PackageRegistry>>::<C A_Package>::<C REFERENCE>, <emptyTree>::<C <PackageRegistry>>::<C A_Package>::<C AModule>, <emptyTree>::<C <PackageRegistry>>::<C A_Package>::<C AClass>)
+    <self>.export_methods(123, "hello", <self>.method(), <emptyTree>::<C <PackageRegistry>>::<pkg <C A_Package>>::<C REFERENCE>, <emptyTree>::<C <PackageRegistry>>::<pkg <C A_Package>>::<C AModule>, <emptyTree>::<C <PackageRegistry>>::<pkg <C A_Package>>::<C AClass>)
   end
 
-  module <emptyTree>::<C <PackageRegistry>>::<C A_Package>::<C <PackageMethods>><<C <todo sym>>> < ()
-    <self>.include(<emptyTree>::<C <PackageRegistry>>::<C A_Package>::<C REFERENCE>)
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C A_Package>>::<C <PackageMethods>><<C <todo sym>>> < ()
+    <self>.include(<emptyTree>::<C <PackageRegistry>>::<pkg <C A_Package>>::<C REFERENCE>)
 
-    <self>.include(<emptyTree>::<C <PackageRegistry>>::<C A_Package>::<C AModule>)
+    <self>.include(<emptyTree>::<C <PackageRegistry>>::<pkg <C A_Package>>::<C AModule>)
 
-    <self>.include(<emptyTree>::<C <PackageRegistry>>::<C A_Package>::<C AClass>)
+    <self>.include(<emptyTree>::<C <PackageRegistry>>::<pkg <C A_Package>>::<C AClass>)
   end
 
-  module <emptyTree>::<C <PackageRegistry>>::<C A_Package><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C A_Package>><<C <todo sym>>> < ()
     module <emptyTree>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package>::<C BClass>
+      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<pkg <C B_Package>>::<C BClass>
 
-      <self>.extend(<emptyTree>::<C <PackageRegistry>>::<C B_Package>::<C <PackageMethods>>)
+      <self>.extend(<emptyTree>::<C <PackageRegistry>>::<pkg <C B_Package>>::<C <PackageMethods>>)
     end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C A_Package><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C A_Package>><<C <todo sym>>> < ()
     <emptyTree>::<C REFERENCE> = <emptyTree>::<C ASecondClass>
 
     class <emptyTree>::<C ASecondClass><<C <todo sym>>> < (::<todo sym>)
@@ -81,27 +81,27 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C B><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(<emptyTree>::<C A>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C B_Package>::<C BClass>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<pkg <C B_Package>>::<C BClass>)
 
-    <self>.export_methods(<emptyTree>::<C <PackageRegistry>>::<C B_Package>::<C BModule>)
+    <self>.export_methods(<emptyTree>::<C <PackageRegistry>>::<pkg <C B_Package>>::<C BModule>)
   end
 
-  module <emptyTree>::<C <PackageRegistry>>::<C B_Package>::<C <PackageMethods>><<C <todo sym>>> < ()
-    <self>.include(<emptyTree>::<C <PackageRegistry>>::<C B_Package>::<C BModule>)
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C B_Package>>::<C <PackageMethods>><<C <todo sym>>> < ()
+    <self>.include(<emptyTree>::<C <PackageRegistry>>::<pkg <C B_Package>>::<C BModule>)
   end
 
-  module <emptyTree>::<C <PackageRegistry>>::<C B_Package><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C B_Package>><<C <todo sym>>> < ()
     module <emptyTree>::<C A><<C <todo sym>>> < ()
-      <emptyTree>::<C REFERENCE> = <emptyTree>::<C <PackageRegistry>>::<C A_Package>::<C REFERENCE>
+      <emptyTree>::<C REFERENCE> = <emptyTree>::<C <PackageRegistry>>::<pkg <C A_Package>>::<C REFERENCE>
 
-      <emptyTree>::<C AClass> = <emptyTree>::<C <PackageRegistry>>::<C A_Package>::<C AClass>
+      <emptyTree>::<C AClass> = <emptyTree>::<C <PackageRegistry>>::<pkg <C A_Package>>::<C AClass>
 
-      <self>.extend(<emptyTree>::<C <PackageRegistry>>::<C A_Package>::<C <PackageMethods>>)
+      <self>.extend(<emptyTree>::<C <PackageRegistry>>::<pkg <C A_Package>>::<C <PackageMethods>>)
     end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C B_Package><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C B_Package>><<C <todo sym>>> < ()
     class <emptyTree>::<C BClass><<C <todo sym>>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.returns(<emptyTree>::<C Integer>)

--- a/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
@@ -45,11 +45,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     @hello = <emptyTree>::<C T>.let(nil, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
   end
 
-  module <emptyTree>::<C <PackageRegistry>>::<C MyPackage_Package><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C MyPackage_Package>><<C <todo sym>>> < ()
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C MyPackage_Package><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C MyPackage_Package>><<C <todo sym>>> < ()
     class ::<root>::<C PackageSpec><<C <todo sym>>> < (::<todo sym>)
       def self.some_method<<C <todo sym>>>(x, &<blk>)
         <emptyTree>

--- a/test/testdata/packager/nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/nested_packages/pass.package-tree.exp
@@ -2,17 +2,17 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Package><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(<emptyTree>::<C Package>::<C Subpackage>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Package>::<C PackageClass>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<pkg <C Package_Package>>::<C PackageClass>)
   end
 
-  module <emptyTree>::<C <PackageRegistry>>::<C Package_Package><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C Package_Package>><<C <todo sym>>> < ()
     module <emptyTree>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
-      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package>::<C SubpackageClass>
+      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<pkg <C Package_Subpackage_Package>>::<C SubpackageClass>
     end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Package_Package><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C Package_Package>><<C <todo sym>>> < ()
     class <emptyTree>::<C PackageClass><<C <todo sym>>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.returns(<emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass>)
@@ -32,17 +32,17 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Package>::<C Subpackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(<emptyTree>::<C Package>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package>::<C SubpackageClass>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<pkg <C Package_Subpackage_Package>>::<C SubpackageClass>)
   end
 
-  module <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C Package_Subpackage_Package>><<C <todo sym>>> < ()
     module <emptyTree>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package>::<C PackageClass>
+      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<pkg <C Package_Package>>::<C PackageClass>
     end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C Package_Subpackage_Package>><<C <todo sym>>> < ()
     class <emptyTree>::<C SubpackageClass><<C <todo sym>>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.returns(<emptyTree>::<C Package>::<C PackageClass>)

--- a/test/testdata/packager/simple_package/pass.package-tree.exp
+++ b/test/testdata/packager/simple_package/pass.package-tree.exp
@@ -2,25 +2,25 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Project>::<C Bar><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(<emptyTree>::<C Project>::<C Foo>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package>::<C Bar>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<pkg <C Project_Bar_Package>>::<C Bar>)
 
-    <self>.export_methods(<emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package>::<C BarMethods>)
+    <self>.export_methods(<emptyTree>::<C <PackageRegistry>>::<pkg <C Project_Bar_Package>>::<C BarMethods>)
   end
 
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package>::<C <PackageMethods>><<C <todo sym>>> < ()
-    <self>.include(<emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package>::<C BarMethods>)
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C Project_Bar_Package>>::<C <PackageMethods>><<C <todo sym>>> < ()
+    <self>.include(<emptyTree>::<C <PackageRegistry>>::<pkg <C Project_Bar_Package>>::<C BarMethods>)
   end
 
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C Project_Bar_Package>><<C <todo sym>>> < ()
     module <emptyTree>::<C Project>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package>::<C Foo>
+      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<pkg <C Project_Foo_Package>>::<C Foo>
 
-      <self>.extend(<emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package>::<C <PackageMethods>>)
+      <self>.extend(<emptyTree>::<C <PackageRegistry>>::<pkg <C Project_Foo_Package>>::<C <PackageMethods>>)
     end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C Project_Bar_Package>><<C <todo sym>>> < ()
     class <emptyTree>::<C Bar><<C <todo sym>>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.params({:"value" => <emptyTree>::<C Integer>}).void()
@@ -37,7 +37,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C Project_Bar_Package>><<C <todo sym>>> < ()
     module <emptyTree>::<C BarMethods><<C <todo sym>>> < ()
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.returns(<emptyTree>::<C Project>::<C Foo>::<C Foo>)
@@ -67,25 +67,25 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Project>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(<emptyTree>::<C Project>::<C Bar>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package>::<C Foo>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<pkg <C Project_Foo_Package>>::<C Foo>)
 
-    <self>.export_methods(<emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package>::<C FooMethods>)
+    <self>.export_methods(<emptyTree>::<C <PackageRegistry>>::<pkg <C Project_Foo_Package>>::<C FooMethods>)
   end
 
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package>::<C <PackageMethods>><<C <todo sym>>> < ()
-    <self>.include(<emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package>::<C FooMethods>)
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C Project_Foo_Package>>::<C <PackageMethods>><<C <todo sym>>> < ()
+    <self>.include(<emptyTree>::<C <PackageRegistry>>::<pkg <C Project_Foo_Package>>::<C FooMethods>)
   end
 
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C Project_Foo_Package>><<C <todo sym>>> < ()
     module <emptyTree>::<C Project>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package>::<C Bar>
+      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<pkg <C Project_Bar_Package>>::<C Bar>
 
-      <self>.extend(<emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package>::<C <PackageMethods>>)
+      <self>.extend(<emptyTree>::<C <PackageRegistry>>::<pkg <C Project_Bar_Package>>::<C <PackageMethods>>)
     end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C Project_Foo_Package>><<C <todo sym>>> < ()
     class <emptyTree>::<C Foo><<C <todo sym>>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.params({:"value" => <emptyTree>::<C Integer>}).void()
@@ -102,7 +102,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<pkg <C Project_Foo_Package>><<C <todo sym>>> < ()
     module <emptyTree>::<C FooMethods><<C <todo sym>>> < ()
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.returns(<emptyTree>::<C Project>::<C Bar>::<C Bar>)


### PR DESCRIPTION
Prints package names as `<pkg PackageName>` instead of as `PackageName` in order to distinguish them from typical Ruby constants.


### Motivation
Distinguish package names from typical constants in the output. (Probably transitional, but it will make the temporary one-giant-package-mode a lot clearer.)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
