### PR TITLE
use real overloads for cast_tree*

### DIFF
--- a/ast/Helpers.cc
+++ b/ast/Helpers.cc
@@ -50,20 +50,20 @@ bool definesBehavior(const TreePtr &expr) {
 }
 
 bool BehaviorHelpers::checkClassDefinesBehavior(const TreePtr &expr) {
-    auto *klass = ast::cast_tree_const<ast::ClassDef>(expr);
+    auto *klass = ast::cast_tree<ast::ClassDef>(expr);
     ENFORCE(klass);
     return BehaviorHelpers::checkClassDefinesBehavior(*klass);
 }
 
 bool BehaviorHelpers::checkClassDefinesBehavior(const ast::ClassDef &klass) {
     for (auto &ancst : klass.ancestors) {
-        auto *cnst = ast::cast_tree_const<ast::ConstantLit>(ancst);
+        auto *cnst = ast::cast_tree<ast::ConstantLit>(ancst);
         if (cnst && cnst->original != nullptr) {
             return true;
         }
     }
     for (auto &ancst : klass.singletonAncestors) {
-        auto *cnst = ast::cast_tree_const<ast::ConstantLit>(ancst);
+        auto *cnst = ast::cast_tree<ast::ConstantLit>(ancst);
         if (cnst && cnst->original != nullptr) {
             return true;
         }

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -416,7 +416,7 @@ public:
     static ast::Local const *arg2Local(const ast::TreePtr &arg) {
         auto *cursor = &arg;
         while (true) {
-            if (auto *local = ast::cast_tree_const<ast::Local>(*cursor)) {
+            if (auto *local = ast::cast_tree<ast::Local>(*cursor)) {
                 // Buried deep within every argument is a Local
                 return local;
             }

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -364,15 +364,15 @@ ConstantLit::fullUnresolvedPath(const core::GlobalState &gs) const {
     auto *nested = this;
     {
         while (!nested->resolutionScopes.front().exists()) {
-            auto *orig = cast_tree_const<UnresolvedConstantLit>(nested->original);
+            auto *orig = cast_tree<UnresolvedConstantLit>(nested->original);
             ENFORCE(orig);
             namesFailedToResolve.emplace_back(orig->cnst);
-            nested = ast::cast_tree_const<ast::ConstantLit>(orig->scope);
+            nested = ast::cast_tree<ast::ConstantLit>(orig->scope);
             ENFORCE(nested);
             ENFORCE(nested->symbol == core::Symbols::StubModule());
             ENFORCE(!nested->resolutionScopes.empty());
         }
-        auto *orig = cast_tree_const<UnresolvedConstantLit>(nested->original);
+        auto *orig = cast_tree<UnresolvedConstantLit>(nested->original);
         ENFORCE(orig);
         namesFailedToResolve.emplace_back(orig->cnst);
         absl::c_reverse(namesFailedToResolve);

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -281,7 +281,7 @@ template <class To> To *cast_tree(TreePtr &what) {
     }
 }
 
-template <class To> To *cast_tree(const TreePtr &what) {
+template <class To> const To *cast_tree(const TreePtr &what) {
     if (isa_tree<To>(what)) {
         return reinterpret_cast<To *>(what.get());
     } else {

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -294,8 +294,8 @@ template <class To> To &cast_tree_nonnull(TreePtr &what) {
     return *reinterpret_cast<To *>(what.get());
 }
 
-template <class To> const To &cast_tree_nonnull_const(const TreePtr &what) {
-    ENFORCE(isa_tree<To>(what), "cast_tree_nonnull_const failed!");
+template <class To> const To &cast_tree_nonnull(const TreePtr &what) {
+    ENFORCE(isa_tree<To>(what), "cast_tree_nonnull failed!");
     return *reinterpret_cast<To *>(what.get());
 }
 

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -281,8 +281,7 @@ template <class To> To *cast_tree(TreePtr &what) {
     }
 }
 
-// A variant of cast_tree that preserves the const-ness (if const in, then const out)
-template <class To> To const *cast_tree_const(const TreePtr &what) {
+template <class To> To *cast_tree(const TreePtr &what) {
     if (isa_tree<To>(what)) {
         return reinterpret_cast<To *>(what.get());
     } else {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -32,7 +32,7 @@ struct DesugarContext final {
 };
 
 core::NameRef blockArg2Name(DesugarContext dctx, const BlockArg &blkArg) {
-    auto blkIdent = cast_tree_const<UnresolvedIdent>(blkArg.expr);
+    auto blkIdent = cast_tree<UnresolvedIdent>(blkArg.expr);
     ENFORCE(blkIdent != nullptr, "BlockArg must wrap UnresolvedIdent in desugar.");
     return blkIdent->name;
 }
@@ -178,7 +178,7 @@ TreePtr mergeStrings(DesugarContext dctx, core::LocOffsets loc, InlinedVector<Tr
                     if (isa_tree<EmptyTree>(expr))
                         return ""sv;
                     else
-                        return cast_tree_const<Literal>(expr)->asString(dctx.ctx).data(dctx.ctx)->shortName(dctx.ctx);
+                        return cast_tree<Literal>(expr)->asString(dctx.ctx).data(dctx.ctx)->shortName(dctx.ctx);
                 }))));
     }
 }
@@ -1325,7 +1325,7 @@ TreePtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) {
                 UnorderedMap<core::NameRef, core::LocOffsets> hashKeyStrings;
                 auto &gs = dctx.ctx.state;
                 for (auto &key : keys) {
-                    auto lit = ast::cast_tree_const<ast::Literal>(key);
+                    auto lit = ast::cast_tree<ast::Literal>(key);
                     if (lit == nullptr) {
                         continue;
                     }

--- a/class_flatten/class_flatten.cc
+++ b/class_flatten/class_flatten.cc
@@ -22,7 +22,7 @@ bool shouldExtract(core::Context ctx, const ast::TreePtr &what) {
         return false;
     }
 
-    if (auto *asgn = ast::cast_tree_const<ast::Assign>(what)) {
+    if (auto *asgn = ast::cast_tree<ast::Assign>(what)) {
         return !ast::isa_tree<ast::UnresolvedConstantLit>(asgn->lhs);
     }
 

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -349,13 +349,13 @@ void validateOverriding(const core::Context ctx, core::SymbolRef method) {
 core::LocOffsets getAncestorLoc(const core::GlobalState &gs, const ast::ClassDef *classDef,
                                 const core::SymbolRef ancestor) {
     for (const auto &anc : classDef->ancestors) {
-        const auto ancConst = ast::cast_tree_const<ast::ConstantLit>(anc);
+        const auto ancConst = ast::cast_tree<ast::ConstantLit>(anc);
         if (ancConst != nullptr && ancConst->symbol.data(gs)->dealias(gs) == ancestor) {
             return anc->loc;
         }
     }
     for (const auto &anc : classDef->singletonAncestors) {
-        const auto ancConst = ast::cast_tree_const<ast::ConstantLit>(anc);
+        const auto ancConst = ast::cast_tree<ast::ConstantLit>(anc);
         if (ancConst != nullptr && ancConst->symbol.data(gs)->dealias(gs) == ancestor) {
             return anc->loc;
         }
@@ -581,7 +581,7 @@ private:
 
 public:
     ast::TreePtr preTransformClassDef(core::Context ctx, ast::TreePtr tree) {
-        auto *classDef = ast::cast_tree_const<ast::ClassDef>(tree);
+        auto *classDef = ast::cast_tree<ast::ClassDef>(tree);
         auto sym = classDef->symbol;
         auto singleton = sym.data(ctx)->lookupSingletonClass(ctx);
         validateTStructNotGrandparent(ctx, sym);

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -522,7 +522,7 @@ public:
     }
 
     FoundDefinitionRef fillAssign(core::Context ctx, const ast::Assign &asgn) {
-        auto &lhs = ast::cast_tree_nonnull_const<ast::UnresolvedConstantLit>(asgn.lhs);
+        auto &lhs = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(asgn.lhs);
 
         FoundStaticField found;
         found.owner = getOwner();
@@ -584,7 +584,7 @@ public:
     }
 
     FoundDefinitionRef handleAssignment(core::Context ctx, const ast::Assign &asgn) {
-        auto &send = ast::cast_tree_nonnull_const<ast::Send>(asgn.rhs);
+        auto &send = ast::cast_tree_nonnull<ast::Send>(asgn.rhs);
         auto foundRef = fillAssign(ctx, asgn);
         ENFORCE(foundRef.kind() == DefinitionKind::StaticField);
         auto &staticField = foundRef.staticField(*foundDefs);

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -373,12 +373,12 @@ class SymbolFinder {
 
     // Returns index to foundDefs containing the given name. Recursively inserts class refs for its owners.
     FoundDefinitionRef squashNames(core::Context ctx, const ast::TreePtr &node) {
-        if (auto *id = ast::cast_tree_const<ast::ConstantLit>(node)) {
+        if (auto *id = ast::cast_tree<ast::ConstantLit>(node)) {
             // Already defined. Insert a foundname so we can reference it.
             auto sym = id->symbol.data(ctx)->dealias(ctx);
             ENFORCE(sym.exists());
             return foundDefs->addSymbol(sym);
-        } else if (auto constLit = ast::cast_tree_const<ast::UnresolvedConstantLit>(node)) {
+        } else if (auto constLit = ast::cast_tree<ast::UnresolvedConstantLit>(node)) {
             FoundClassRef found;
             found.owner = squashNames(ctx, constLit->scope);
             found.name = constLit->cnst;
@@ -535,8 +535,8 @@ public:
 
     FoundDefinitionRef handleTypeMemberDefinition(core::Context ctx, const ast::Send *send, const ast::Assign &asgn,
                                                   const ast::UnresolvedConstantLit *typeName) {
-        ENFORCE(ast::cast_tree_const<ast::UnresolvedConstantLit>(asgn.lhs) == typeName &&
-                ast::cast_tree_const<ast::Send>(asgn.rhs) ==
+        ENFORCE(ast::cast_tree<ast::UnresolvedConstantLit>(asgn.lhs) == typeName &&
+                ast::cast_tree<ast::Send>(asgn.rhs) ==
                     send); // this method assumes that `asgn` owns `send` and `typeName`
 
         FoundTypeMember found;
@@ -560,15 +560,15 @@ public:
         }
 
         if (!send->args.empty()) {
-            auto *lit = ast::cast_tree_const<ast::Literal>(send->args[0]);
+            auto *lit = ast::cast_tree<ast::Literal>(send->args[0]);
             if (lit != nullptr && lit->isSymbol(ctx)) {
                 found.varianceName = lit->asSymbol(ctx);
                 found.litLoc = lit->loc;
             }
 
-            if (auto *hash = ast::cast_tree_const<ast::Hash>(send->args.back())) {
+            if (auto *hash = ast::cast_tree<ast::Hash>(send->args.back())) {
                 for (auto &keyExpr : hash->keys) {
-                    auto key = ast::cast_tree_const<ast::Literal>(keyExpr);
+                    auto key = ast::cast_tree<ast::Literal>(keyExpr);
                     core::NameRef name;
                     if (key != nullptr && key->isSymbol(ctx)) {
                         switch (key->asSymbol(ctx)._id) {
@@ -1455,7 +1455,7 @@ public:
         if (ast::isa_tree<ast::EmptyTree>(anc) || anc->isSelfReference()) {
             return false;
         }
-        auto rcl = ast::cast_tree_const<ast::ConstantLit>(anc);
+        auto rcl = ast::cast_tree<ast::ConstantLit>(anc);
         if (rcl && rcl->symbol == core::Symbols::todo()) {
             return false;
         }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -212,7 +212,7 @@ private:
             core::SymbolRef result = resolveLhs(ctx, nesting, c.cnst);
             return result;
         }
-        if (auto *id = ast::cast_tree_const<ast::ConstantLit>(c.scope)) {
+        if (auto *id = ast::cast_tree<ast::ConstantLit>(c.scope)) {
             auto sym = id->symbol;
             if (sym.exists() && sym.data(ctx)->isTypeAlias() && !resolutionFailed) {
                 if (auto e = ctx.beginError(c.loc, core::errors::Resolver::ConstantInTypeAlias)) {
@@ -961,7 +961,7 @@ class ResolveTypeMembersWalk {
     }
 
     static bool isT(const ast::TreePtr &expr) {
-        auto *tMod = ast::cast_tree_const<ast::ConstantLit>(expr);
+        auto *tMod = ast::cast_tree<ast::ConstantLit>(expr);
         return tMod && tMod->symbol == core::Symbols::T();
     }
 
@@ -1892,7 +1892,7 @@ private:
 
         auto stringLoc = send.args[1]->loc;
 
-        auto *literalNode = ast::cast_tree_const<ast::Literal>(send.args[1]);
+        auto *literalNode = ast::cast_tree<ast::Literal>(send.args[1]);
         if (literalNode == nullptr) {
             if (auto e = ctx.beginError(stringLoc, core::errors::Resolver::LazyResolve)) {
                 e.setHeader("`{}` only accepts string literals", method);
@@ -1917,17 +1917,17 @@ private:
         optional<core::LocOffsets> packageLoc;
         if (send.args.size() == 3) {
             // this means we got the third package arg
-            auto *kwargs = ast::cast_tree_const<ast::Hash>(send.args[2]);
+            auto *kwargs = ast::cast_tree<ast::Hash>(send.args[2]);
             if (!kwargs || kwargs->keys.size() != 1) {
                 // Infer will report an error
                 return;
             }
-            auto *key = ast::cast_tree_const<ast::Literal>(kwargs->keys.front());
+            auto *key = ast::cast_tree<ast::Literal>(kwargs->keys.front());
             if (!key || !key->isSymbol(ctx) || key->asSymbol(ctx) != ctx.state.lookupNameUTF8("package")) {
                 return;
             }
 
-            auto *packageNode = ast::cast_tree_const<ast::Literal>(kwargs->values.front());
+            auto *packageNode = ast::cast_tree<ast::Literal>(kwargs->values.front());
             packageLoc = std::optional<core::LocOffsets>{send.args[2]->loc};
             if (packageNode == nullptr) {
                 if (auto e = ctx.beginError(send.args[2]->loc, core::errors::Resolver::LazyResolve)) {

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -52,7 +52,7 @@ pair<core::NameRef, core::LocOffsets> getName(core::MutableContext ctx, ast::Tre
 // either with no scope or with the root scope (i.e. `::T`). this might not actually refer to the `T` that we define for
 // users, but we don't know that information in the Rewriter passes.
 bool isT(const ast::TreePtr &expr) {
-    auto *t = ast::cast_tree_const<ast::UnresolvedConstantLit>(expr);
+    auto *t = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
     if (t == nullptr || t->cnst != core::Names::Constants::T()) {
         return false;
     }
@@ -60,12 +60,12 @@ bool isT(const ast::TreePtr &expr) {
     if (ast::isa_tree<ast::EmptyTree>(scope)) {
         return true;
     }
-    auto root = ast::cast_tree_const<ast::ConstantLit>(scope);
+    auto root = ast::cast_tree<ast::ConstantLit>(scope);
     return root != nullptr && root->symbol == core::Symbols::root();
 }
 
 bool isTNilableOrUntyped(const ast::TreePtr &expr) {
-    auto *send = ast::cast_tree_const<ast::Send>(expr);
+    auto *send = ast::cast_tree<ast::Send>(expr);
     return send != nullptr && (send->fun == core::Names::nilable() || send->fun == core::Names::untyped()) &&
            isT(send->recv);
 }

--- a/rewriter/Delegate.cc
+++ b/rewriter/Delegate.cc
@@ -8,21 +8,21 @@ using namespace std;
 namespace sorbet::rewriter {
 
 static bool literalSymbolEqual(const core::GlobalState &gs, const ast::TreePtr &node, core::NameRef name) {
-    if (auto lit = ast::cast_tree_const<ast::Literal>(node)) {
+    if (auto lit = ast::cast_tree<ast::Literal>(node)) {
         return lit->isSymbol(gs) && lit->asSymbol(gs) == name;
     }
     return false;
 }
 
 static bool isLiteralTrue(const core::GlobalState &gs, const ast::TreePtr &node) {
-    if (auto lit = ast::cast_tree_const<ast::Literal>(node)) {
+    if (auto lit = ast::cast_tree<ast::Literal>(node)) {
         return lit->isTrue(gs);
     }
     return false;
 }
 
 static optional<core::NameRef> stringOrSymbolNameRef(const core::GlobalState &gs, const ast::TreePtr &node) {
-    auto lit = ast::cast_tree_const<ast::Literal>(node);
+    auto lit = ast::cast_tree<ast::Literal>(node);
     if (!lit) {
         return nullopt;
     }
@@ -47,7 +47,7 @@ vector<ast::TreePtr> Delegate::run(core::MutableContext ctx, const ast::Send *se
         return empty;
     }
 
-    auto options = ast::cast_tree_const<ast::Hash>(send->args.back());
+    auto options = ast::cast_tree<ast::Hash>(send->args.back());
     if (!options) {
         return empty;
     }
@@ -92,7 +92,7 @@ vector<ast::TreePtr> Delegate::run(core::MutableContext ctx, const ast::Send *se
 
     vector<ast::TreePtr> methodStubs;
     for (int i = 0; i < send->args.size() - 1; i++) {
-        auto *lit = ast::cast_tree_const<ast::Literal>(send->args[i]);
+        auto *lit = ast::cast_tree<ast::Literal>(send->args[i]);
         if (!lit || !lit->isSymbol(ctx)) {
             return empty;
         }

--- a/rewriter/Initializer.cc
+++ b/rewriter/Initializer.cc
@@ -13,7 +13,7 @@ namespace {
 //
 // TODO: remove once https://github.com/sorbet/sorbet/issues/1715 is fixed
 bool isCopyableType(const ast::TreePtr &typeExpr) {
-    auto send = ast::cast_tree_const<ast::Send>(typeExpr);
+    auto send = ast::cast_tree<ast::Send>(typeExpr);
     if (send && send->fun == core::Names::typeParameter()) {
         return false;
     }
@@ -51,12 +51,12 @@ void maybeAddLet(core::MutableContext ctx, ast::TreePtr &expr,
 // exists; and otherwise returns a null pointer
 const ast::Hash *findParamHash(const ast::Send *send) {
     while (send && send->fun != core::Names::params()) {
-        send = ast::cast_tree_const<ast::Send>(send->recv);
+        send = ast::cast_tree<ast::Send>(send->recv);
     }
     if (!send || send->args.size() != 1) {
         return nullptr;
     }
-    return ast::cast_tree_const<ast::Hash>(send->args.front());
+    return ast::cast_tree<ast::Hash>(send->args.front());
 }
 
 } // namespace
@@ -74,13 +74,13 @@ void Initializer::run(core::MutableContext ctx, ast::MethodDef *methodDef, ast::
     if (sig == nullptr) {
         return;
     }
-    auto *block = ast::cast_tree_const<ast::Block>(sig->block);
+    auto *block = ast::cast_tree<ast::Block>(sig->block);
     if (block == nullptr) {
         return;
     }
 
     // walk through, find the `params()` invocation, and get its hash
-    auto *argHash = findParamHash(ast::cast_tree_const<ast::Send>(block->body));
+    auto *argHash = findParamHash(ast::cast_tree<ast::Send>(block->body));
     if (argHash == nullptr) {
         return;
     }
@@ -88,7 +88,7 @@ void Initializer::run(core::MutableContext ctx, ast::MethodDef *methodDef, ast::
     // build a lookup table that maps from names to the types they have
     UnorderedMap<core::NameRef, const ast::TreePtr *> argTypeMap;
     for (int i = 0; i < argHash->keys.size(); i++) {
-        auto *argName = ast::cast_tree_const<ast::Literal>(argHash->keys[i]);
+        auto *argName = ast::cast_tree<ast::Literal>(argHash->keys[i]);
         auto *argVal = &argHash->values[i];
         if (argName->isSymbol(ctx)) {
             argTypeMap[argName->asSymbol(ctx)] = argVal;

--- a/rewriter/Mattr.cc
+++ b/rewriter/Mattr.cc
@@ -7,14 +7,14 @@ using namespace std;
 namespace sorbet::rewriter {
 
 static bool literalSymbolEqual(const core::GlobalState &gs, const ast::TreePtr &node, core::NameRef name) {
-    if (auto lit = ast::cast_tree_const<ast::Literal>(node)) {
+    if (auto lit = ast::cast_tree<ast::Literal>(node)) {
         return lit->isSymbol(gs) && lit->asSymbol(gs) == name;
     }
     return false;
 }
 
 static bool isLiteralFalse(const core::GlobalState &gs, const ast::TreePtr &node) {
-    if (auto lit = ast::cast_tree_const<ast::Literal>(node)) {
+    if (auto lit = ast::cast_tree<ast::Literal>(node)) {
         return lit->isFalse(gs);
     }
     return false;
@@ -57,7 +57,7 @@ vector<ast::TreePtr> Mattr::run(core::MutableContext ctx, const ast::Send *send,
     if (send->args.empty()) {
         return empty;
     }
-    if (auto *options = ast::cast_tree_const<ast::Hash>(send->args.back())) {
+    if (auto *options = ast::cast_tree<ast::Hash>(send->args.back())) {
         symbolArgsBound--;
         for (int i = 0; i < options->keys.size(); i++) {
             auto &key = options->keys[i];
@@ -84,7 +84,7 @@ vector<ast::TreePtr> Mattr::run(core::MutableContext ctx, const ast::Send *send,
 
     vector<ast::TreePtr> result;
     for (int i = 0; i < symbolArgsBound; i++) {
-        auto *lit = ast::cast_tree_const<ast::Literal>(send->args[i]);
+        auto *lit = ast::cast_tree<ast::Literal>(send->args[i]);
         if (!lit || !lit->isSymbol(ctx)) {
             return empty;
         }

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -152,12 +152,12 @@ string to_s(core::Context ctx, ast::TreePtr &arg) {
 bool canMoveIntoMethodDef(const ast::TreePtr &exp) {
     if (ast::isa_tree<ast::Literal>(exp)) {
         return true;
-    } else if (auto *list = ast::cast_tree_const<ast::Array>(exp)) {
+    } else if (auto *list = ast::cast_tree<ast::Array>(exp)) {
         return absl::c_all_of(list->elems, [](auto &elem) { return canMoveIntoMethodDef(elem); });
-    } else if (auto *hash = ast::cast_tree_const<ast::Hash>(exp)) {
+    } else if (auto *hash = ast::cast_tree<ast::Hash>(exp)) {
         return absl::c_all_of(hash->keys, [](auto &elem) { return canMoveIntoMethodDef(elem); }) &&
                absl::c_all_of(hash->values, [](auto &elem) { return canMoveIntoMethodDef(elem); });
-    } else if (auto *send = ast::cast_tree_const<ast::Send>(exp)) {
+    } else if (auto *send = ast::cast_tree<ast::Send>(exp)) {
         return canMoveIntoMethodDef(send->recv) &&
                absl::c_all_of(send->args, [](auto &elem) { return canMoveIntoMethodDef(elem); });
     } else if (ast::isa_tree<ast::UnresolvedConstantLit>(exp)) {

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -71,7 +71,7 @@ void ModuleFunction::run(core::MutableContext ctx, ast::ClassDef *cdef) {
 vector<ast::TreePtr> ModuleFunction::rewriteDefn(core::MutableContext ctx, const ast::TreePtr &expr,
                                                  const ast::TreePtr *prevStat) {
     vector<ast::TreePtr> stats;
-    auto mdef = ast::cast_tree_const<ast::MethodDef>(expr);
+    auto mdef = ast::cast_tree<ast::MethodDef>(expr);
     // only do this rewrite to method defs that aren't self methods
     if (mdef == nullptr || mdef->flags.isSelfMethod) {
         stats.emplace_back(expr.deepCopy());
@@ -86,7 +86,7 @@ vector<ast::TreePtr> ModuleFunction::rewriteDefn(core::MutableContext ctx, const
 
     // as well as a public static copy of the method signature
     if (prevStat) {
-        if (auto *sig = ast::cast_tree_const<ast::Send>(*prevStat)) {
+        if (auto *sig = ast::cast_tree<ast::Send>(*prevStat)) {
             if (sig->fun == core::Names::sig()) {
                 stats.emplace_back(sig->deepCopy());
             }

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -163,7 +163,7 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
         if (send->args.empty()) {
             return nullopt;
         }
-        auto *sym = ast::cast_tree_const<ast::Literal>(send->args[0]);
+        auto *sym = ast::cast_tree<ast::Literal>(send->args[0]);
         if (!sym || !sym->isSymbol(ctx)) {
             return nullopt;
         }
@@ -192,7 +192,7 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
     // ----- Does the prop have any extra options? -----
     ast::TreePtr rulesTree;
     if (!send->args.empty()) {
-        if (auto back = ast::cast_tree_const<ast::Hash>(send->args.back())) {
+        if (auto back = ast::cast_tree<ast::Hash>(send->args.back())) {
             // Deep copy the rules hash so that we can destruct it at will to parse things,
             // without having to worry about whether we stole things from the tree.
             rulesTree = back->deepCopy();

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -14,14 +14,14 @@ namespace sorbet::rewriter {
 namespace {
 
 bool isKeywordInitKey(const core::GlobalState &gs, const ast::TreePtr &node) {
-    if (auto *lit = ast::cast_tree_const<ast::Literal>(node)) {
+    if (auto *lit = ast::cast_tree<ast::Literal>(node)) {
         return lit->isSymbol(gs) && lit->asSymbol(gs) == core::Names::keywordInit();
     }
     return false;
 }
 
 bool isLiteralTrue(const core::GlobalState &gs, const ast::TreePtr &node) {
-    if (auto *lit = ast::cast_tree_const<ast::Literal>(node)) {
+    if (auto *lit = ast::cast_tree<ast::Literal>(node)) {
         return lit->isTrue(gs);
     }
     return false;


### PR DESCRIPTION
`cast_tree` (resp. `cast_tree_nonnull`) comes in regular and `_const`-suffixed flavors.  But there's no real reason to have suffixed functions for this; regular C++ overloads will accomplish the same thing, at the small cost of making it slightly less obvious what kind of thing is being returned at the callsite.

This series also fixes, in passing, the code for `cast_tree_const`; it claimed to be returning `const` pointers, but wasn't actually doing anything of the sort.  Fortunately, making it live up to the code comments proved to be a simple code change, and not something more involved trying to change the users of `cast_tree_const`.

### Motivation

Better use of language features, more regular code (e.g. `cast_tree` and `cast_tree_nonnull` on `const TreePtr`s now are consistent).

### Test plan

No user-visible changes; existing tests should be sufficient.