### PR TITLE
Type check for private constants

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -701,6 +701,12 @@ string Symbol::toStringWithOptions(const GlobalState &gs, int tabs, bool showFul
                                return symb.argumentName(gs);
                            }));
         }
+
+        if (this->isClassOrModule() && this->isClassOrModulePrivate()) {
+            fmt::format_to(buf, " : private");
+        }
+    } else if (this->isStaticField() && this->isStaticFieldPrivate()) {
+        fmt::format_to(buf, " : private");
     }
     if (this->resultType && !isClassOrModule()) {
         string resultType;

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -77,6 +77,7 @@ public:
         static constexpr u4 CLASS_OR_MODULE_LINEARIZATION_COMPUTED = 0x0000'0100;
         static constexpr u4 CLASS_OR_MODULE_FINAL = 0x0000'0200;
         static constexpr u4 CLASS_OR_MODULE_SEALED = 0x0000'0400;
+        static constexpr u4 CLASS_OR_MODULE_PRIVATE = 0x0000'0800;
 
         // Method flags
         static constexpr u4 METHOD_PROTECTED = 0x0000'0010;
@@ -99,6 +100,7 @@ public:
 
         // Static Field flags
         static constexpr u4 STATIC_FIELD_TYPE_ALIAS = 0x0000'0010;
+        static constexpr u4 STATIC_FIELD_PRIVATE = 0x0000'0020;
     };
 
     Loc loc() const;
@@ -312,6 +314,16 @@ public:
         return (flags & Symbol::Flags::CLASS_OR_MODULE_SEALED) != 0;
     }
 
+    inline bool isClassOrModulePrivate() const {
+        ENFORCE_NO_TIMER(isClassOrModule());
+        return (flags & Symbol::Flags::CLASS_OR_MODULE_PRIVATE) != 0;
+    }
+
+    inline bool isStaticFieldPrivate() const {
+        ENFORCE_NO_TIMER(isStaticField());
+        return (flags & Symbol::Flags::STATIC_FIELD_PRIVATE) != 0;
+    }
+
     inline void setClassOrModule() {
         ENFORCE(!isStaticField() && !isField() && !isMethod() && !isTypeArgument() && !isTypeMember());
         flags |= Symbol::Flags::CLASS_OR_MODULE;
@@ -457,6 +469,11 @@ public:
         flags |= Symbol::Flags::CLASS_OR_MODULE_SEALED;
     }
 
+    inline void setClassOrModulePrivate() {
+        ENFORCE(isClassOrModule());
+        flags |= Symbol::Flags::CLASS_OR_MODULE_PRIVATE;
+    }
+
     inline void setTypeAlias() {
         ENFORCE(isStaticField());
         flags |= Symbol::Flags::STATIC_FIELD_TYPE_ALIAS;
@@ -467,6 +484,11 @@ public:
         // To make things nicer, we relax the ENFORCE here to also allow asking whether "some constant" is a type alias.
         ENFORCE(isClassOrModule() || isStaticField() || isTypeMember());
         return isStaticField() && (flags & Symbol::Flags::STATIC_FIELD_TYPE_ALIAS) != 0;
+    }
+
+    inline void setStaticFieldPrivate() {
+        ENFORCE(isStaticField());
+        flags |= Symbol::Flags::STATIC_FIELD_PRIVATE;
     }
 
     inline void setRewriterSynthesized() {

--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -66,6 +66,7 @@ constexpr ErrorClass StaticAbstractModuleMethod{5057, StrictLevel::False};
 constexpr ErrorClass AttachedClassAsParam{5058, StrictLevel::False};
 constexpr ErrorClass LazyResolve{5059, StrictLevel::False};
 constexpr ErrorClass GenericTypeParamBoundMismatch{5060, StrictLevel::False};
+constexpr ErrorClass PrivateConstantReferenced{5061, StrictLevel::True};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -149,6 +149,7 @@ NameDef names[] = {
     {"protected_", "protected"},
     {"public_", "public"},
     {"privateClassMethod", "private_class_method"},
+    {"privateConstant", "private_constant"},
     {"moduleFunction", "module_function"},
     {"aliasMethod", "alias_method"},
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1045,11 +1045,14 @@ class SymbolDefiner {
         auto owner = ctx.owner.data(ctx)->enclosingClass(ctx);
         auto constantNameRef = ctx.state.lookupNameConstant(mod.target);
         auto constant = ctx.state.lookupSymbol(owner, constantNameRef);
-        if (constant.exists() && mod.name._id == core::Names::privateConstant()._id) {
+        if (constant.exists() && mod.name == core::Names::privateConstant()) {
             if (constant.data(ctx)->isClassOrModule()) {
                 constant.data(ctx)->setClassOrModulePrivate();
             } else if (constant.data(ctx)->isStaticField()) {
                 constant.data(ctx)->setStaticFieldPrivate();
+            } else if (constant.data(ctx)->isTypeMember()) {
+                // Visibility on type members is special (even more restrictive than private),
+                // so we ignore requests to mark type members private.
             }
         }
     }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -136,7 +136,8 @@ struct Modifier {
     // The name of the modification.
     core::NameRef name;
     // For methods: The name of the method being modified.
-    core::NameRef methodName;
+    // For constants: The name of the constant being modified.
+    core::NameRef target;
 };
 
 class FoundDefinitions final {
@@ -480,8 +481,8 @@ public:
             methodModifier.owner = getOwner();
             methodModifier.loc = original.loc;
             methodModifier.name = original.fun;
-            methodModifier.methodName = unwrapLiteralToMethodName(ctx, original, original.args[0]);
-            if (methodModifier.methodName.exists()) {
+            methodModifier.target = unwrapLiteralToMethodName(ctx, original, original.args[0]);
+            if (methodModifier.target.exists()) {
                 foundDefs->addModifier(move(methodModifier));
             }
         }
@@ -988,7 +989,7 @@ class SymbolDefiner {
         if (mod.name._id == core::Names::privateClassMethod()._id) {
             owner = owner.data(ctx)->singletonClass(ctx);
         }
-        auto method = ctx.state.lookupMethodSymbol(owner, mod.methodName);
+        auto method = ctx.state.lookupMethodSymbol(owner, mod.target);
         if (method.exists()) {
             switch (mod.name._id) {
                 case core::Names::private_()._id:

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1362,8 +1362,6 @@ public:
                 case Modifier::Kind::ClassOrStaticField:
                     modifyConstant(ctx.withOwner(owner), modifier);
                     break;
-                default:
-                    Exception::raise("Found invalid modifier");
             }
         }
     }

--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -1266,7 +1266,7 @@ class Module < Object
   # Makes a list of existing constants private.
   sig do
     params(
-        arg0: Symbol,
+        arg0: T.any(Symbol, String),
     )
     .returns(T.self_type)
   end

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -246,7 +246,7 @@ private:
                 ((result.data(ctx)->isClassOrModule() && result.data(ctx)->isClassOrModulePrivate()) ||
                  (result.data(ctx)->isStaticField() && result.data(ctx)->isStaticFieldPrivate()))) {
                 if (auto e = ctx.beginError(c.loc, core::errors::Resolver::PrivateConstantReferenced)) {
-                    e.setHeader("private constant {} referenced", result.data(ctx)->show(ctx.state));
+                    e.setHeader("Non-private reference to private constant `{}` referenced", result.data(ctx)->show(ctx));
                 }
             }
             return result;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -246,7 +246,8 @@ private:
                 ((result.data(ctx)->isClassOrModule() && result.data(ctx)->isClassOrModulePrivate()) ||
                  (result.data(ctx)->isStaticField() && result.data(ctx)->isStaticFieldPrivate()))) {
                 if (auto e = ctx.beginError(c.loc, core::errors::Resolver::PrivateConstantReferenced)) {
-                    e.setHeader("Non-private reference to private constant `{}` referenced", result.data(ctx)->show(ctx));
+                    e.setHeader("Non-private reference to private constant `{}` referenced",
+                                result.data(ctx)->show(ctx));
                 }
             }
             return result;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -239,6 +239,16 @@ private:
             }
             core::SymbolRef resolved = id->symbol.data(ctx)->dealias(ctx);
             core::SymbolRef result = resolved.data(ctx)->findMember(ctx, c.cnst);
+
+            // Private constants are allowed to be resolved, when there is no scope set (the scope is checked above),
+            // otherwise we should error out:
+            if (result.exists() &&
+                ((result.data(ctx)->isClassOrModule() && result.data(ctx)->isClassOrModulePrivate()) ||
+                 (result.data(ctx)->isStaticField() && result.data(ctx)->isStaticFieldPrivate()))) {
+                if (auto e = ctx.beginError(c.loc, core::errors::Resolver::PrivateConstantReferenced)) {
+                    e.setHeader("private constant {} referenced", result.data(ctx)->show(ctx.state));
+                }
+            }
             return result;
         } else {
             if (!resolutionFailed) {

--- a/test/testdata/infer/private_constant.rb
+++ b/test/testdata/infer/private_constant.rb
@@ -49,9 +49,9 @@ module Foo
 
   def self.not_ok_private_usage
     ::Foo::A_PUBLIC_CONST
-    ::Foo::A_PRIVATE_CONST # error: private constant Foo::A_PRIVATE_CONST referenced
-    ::Foo::PrivateClass # error: private constant Foo::PrivateClass referenced
-    ::Foo::PrivateModule # error: private constant Foo::PrivateModule referenced
+    ::Foo::A_PRIVATE_CONST # error: Non-private reference to private constant `Foo::A_PRIVATE_CONST` referenced
+    ::Foo::PrivateClass # error: Non-private reference to private constant `Foo::PrivateClass` referenced
+    ::Foo::PrivateModule # error: Non-private reference to private constant `Foo::PrivateModule` referenced
   end
 
   sig { params(x: PrivateIntTypeAlias, y: PrivateInt).void }
@@ -66,10 +66,10 @@ end
 
 
 Foo::A_PUBLIC_CONST
-Foo::A_PRIVATE_CONST # error: private constant Foo::A_PRIVATE_CONST referenced
-Foo::PrivateClass # error: private constant Foo::PrivateClass referenced
-Foo::PrivateModule # error: private constant Foo::PrivateModule referenced
-Foo::PrivateModule::ClassInsidePrivateModule.also_ok_private_usage # error: private constant Foo::PrivateModule referenced
+Foo::A_PRIVATE_CONST # error: Non-private reference to private constant `Foo::A_PRIVATE_CONST` referenced
+Foo::PrivateClass # error: Non-private reference to private constant `Foo::PrivateClass` referenced
+Foo::PrivateModule # error: Non-private reference to private constant `Foo::PrivateModule` referenced
+Foo::PrivateModule::ClassInsidePrivateModule.also_ok_private_usage # error: Non-private reference to private constant `Foo::PrivateModule` referenced
 
 Foo.using_private_ints(1, 2)
 Foo.using_private_class(1) # error: Expected `Foo::PrivateClass` but found `Integer(1)` for argument `x`

--- a/test/testdata/infer/private_constant.rb
+++ b/test/testdata/infer/private_constant.rb
@@ -1,0 +1,22 @@
+# typed: true
+
+module Foo
+  A_PUBLIC_CONST = 'public'
+  A_PRIVATE_CONST = 'private'
+  private_constant :A_PRIVATE_CONST
+
+  ANOTHER_PRIVATE_CONST = true
+  private_constant 'ANOTHER_PRIVATE_CONST'
+
+  class PrivateClass; end
+  private_constant :PrivateClass
+
+  class AnotherPrivateClass; end
+  private_constant 'AnotherPrivateClass'
+
+  module PrivateModule; end
+  private_constant :PrivateModule
+
+  module AnotherPrivateModule; end
+  private_constant 'AnotherPrivateModule'
+end

--- a/test/testdata/infer/private_constant.rb
+++ b/test/testdata/infer/private_constant.rb
@@ -1,12 +1,20 @@
 # typed: true
 
 module Foo
+  extend T::Sig
+
   A_PUBLIC_CONST = 'public'
   A_PRIVATE_CONST = 'private'
   private_constant :A_PRIVATE_CONST
 
   ANOTHER_PRIVATE_CONST = true
   private_constant 'ANOTHER_PRIVATE_CONST'
+
+  PrivateIntTypeAlias = T.type_alias { Integer }
+  private_constant :PrivateIntTypeAlias
+
+  PrivateInt = Integer
+  private_constant :PrivateInt
 
   class PrivateClass; end
   private_constant :PrivateClass
@@ -45,6 +53,15 @@ module Foo
     ::Foo::PrivateClass # error: private constant Foo::PrivateClass referenced
     ::Foo::PrivateModule # error: private constant Foo::PrivateModule referenced
   end
+
+  sig { params(x: PrivateIntTypeAlias, y: PrivateInt).void }
+  def self.using_private_ints(x, y); end
+
+  sig { params(x: PrivateClass).void }
+  def self.using_private_class(x); end
+
+  sig { params(x: T.class_of(PrivateModule)).void }
+  def self.using_private_module(x); end
 end
 
 
@@ -53,3 +70,31 @@ Foo::A_PRIVATE_CONST # error: private constant Foo::A_PRIVATE_CONST referenced
 Foo::PrivateClass # error: private constant Foo::PrivateClass referenced
 Foo::PrivateModule # error: private constant Foo::PrivateModule referenced
 Foo::PrivateModule::ClassInsidePrivateModule.also_ok_private_usage # error: private constant Foo::PrivateModule referenced
+
+Foo.using_private_ints(1, 2)
+Foo.using_private_class(1) # error: Expected `Foo::PrivateClass` but found `Integer(1)` for argument `x`
+Foo.using_private_module(1) # error: Expected `T.class_of(Foo::PrivateModule)` but found `Integer(1)` for argument `x`
+
+extend T::Sig
+
+class PrivateTypeMember
+  extend T::Generic
+  extend T::Sig
+
+  Elem = type_member
+  private_constant :Elem
+
+  sig {params(x: Elem).void}
+  def foo(x); end
+
+  class B
+    extend T::Sig
+    sig {params(x: Elem).void}
+    #              ^^^^ error: `type_member` type `PrivateTypeMember::Elem` used outside of the class definition
+    def bar(x); end
+  end
+end
+
+sig {params(x: PrivateTypeMember::Elem).void}
+#              ^^^^^^^^^^^^^^^^^^^^^^^ error: `type_member` type `PrivateTypeMember::Elem` used outside of the class definition
+def foo(x); end

--- a/test/testdata/infer/private_constant.rb
+++ b/test/testdata/infer/private_constant.rb
@@ -14,9 +14,42 @@ module Foo
   class AnotherPrivateClass; end
   private_constant 'AnotherPrivateClass'
 
-  module PrivateModule; end
+  module PrivateModule
+    def self.ok_private_usage
+      A_PUBLIC_CONST
+      A_PRIVATE_CONST
+      PrivateClass
+      PrivateModule
+    end
+
+    class ClassInsidePrivateModule
+      def self.also_ok_private_usage; end
+    end
+  end
   private_constant :PrivateModule
 
   module AnotherPrivateModule; end
   private_constant 'AnotherPrivateModule'
+
+  def self.ok_private_usage
+    A_PUBLIC_CONST
+    A_PRIVATE_CONST
+    PrivateClass
+    PrivateModule.ok_private_usage
+    PrivateModule::ClassInsidePrivateModule.also_ok_private_usage
+  end
+
+  def self.not_ok_private_usage
+    ::Foo::A_PUBLIC_CONST
+    ::Foo::A_PRIVATE_CONST # error: private constant Foo::A_PRIVATE_CONST referenced
+    ::Foo::PrivateClass # error: private constant Foo::PrivateClass referenced
+    ::Foo::PrivateModule # error: private constant Foo::PrivateModule referenced
+  end
 end
+
+
+Foo::A_PUBLIC_CONST
+Foo::A_PRIVATE_CONST # error: private constant Foo::A_PRIVATE_CONST referenced
+Foo::PrivateClass # error: private constant Foo::PrivateClass referenced
+Foo::PrivateModule # error: private constant Foo::PrivateModule referenced
+Foo::PrivateModule::ClassInsidePrivateModule.also_ok_private_usage # error: private constant Foo::PrivateModule referenced

--- a/test/testdata/infer/private_constant.rb.symbol-table.exp
+++ b/test/testdata/infer/private_constant.rb.symbol-table.exp
@@ -11,10 +11,10 @@ class ::<root> < ::Object ()
       type-member(+) ::Foo::<Class:AnotherPrivateClass>::<AttachedClass> -> T.attached_class (of Foo::AnotherPrivateClass) @ test/testdata/infer/private_constant.rb:14
       method ::Foo::<Class:AnotherPrivateClass>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:14
         argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
-    module ::Foo::AnotherPrivateModule < ::Sorbet::Private::Static::ImplicitModuleSuperclass () : private @ test/testdata/infer/private_constant.rb:20
-    class ::Foo::<Class:AnotherPrivateModule>[<AttachedClass>] < ::Module () @ test/testdata/infer/private_constant.rb:20
-      type-member(+) ::Foo::<Class:AnotherPrivateModule>::<AttachedClass> -> T.attached_class (of Foo::AnotherPrivateModule) @ test/testdata/infer/private_constant.rb:20
-      method ::Foo::<Class:AnotherPrivateModule>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:20
+    module ::Foo::AnotherPrivateModule < ::Sorbet::Private::Static::ImplicitModuleSuperclass () : private @ test/testdata/infer/private_constant.rb:31
+    class ::Foo::<Class:AnotherPrivateModule>[<AttachedClass>] < ::Module () @ test/testdata/infer/private_constant.rb:31
+      type-member(+) ::Foo::<Class:AnotherPrivateModule>::<AttachedClass> -> T.attached_class (of Foo::AnotherPrivateModule) @ test/testdata/infer/private_constant.rb:31
+      method ::Foo::<Class:AnotherPrivateModule>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:31
         argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
     class ::Foo::PrivateClass < ::Object () : private @ test/testdata/infer/private_constant.rb:11
     class ::Foo::<Class:PrivateClass>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/infer/private_constant.rb:11
@@ -22,12 +22,25 @@ class ::<root> < ::Object ()
       method ::Foo::<Class:PrivateClass>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:11
         argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
     module ::Foo::PrivateModule < ::Sorbet::Private::Static::ImplicitModuleSuperclass () : private @ test/testdata/infer/private_constant.rb:17
+      class ::Foo::PrivateModule::ClassInsidePrivateModule < ::Object () @ test/testdata/infer/private_constant.rb:25
+      class ::Foo::PrivateModule::<Class:ClassInsidePrivateModule>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/infer/private_constant.rb:25
+        type-member(+) ::Foo::PrivateModule::<Class:ClassInsidePrivateModule>::<AttachedClass> -> T.attached_class (of Foo::PrivateModule::ClassInsidePrivateModule) @ test/testdata/infer/private_constant.rb:25
+        method ::Foo::PrivateModule::<Class:ClassInsidePrivateModule>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:25
+          argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
+        method ::Foo::PrivateModule::<Class:ClassInsidePrivateModule>#also_ok_private_usage (<blk>) @ test/testdata/infer/private_constant.rb:26
+          argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
     class ::Foo::<Class:PrivateModule>[<AttachedClass>] < ::Module () @ test/testdata/infer/private_constant.rb:17
       type-member(+) ::Foo::<Class:PrivateModule>::<AttachedClass> -> T.attached_class (of Foo::PrivateModule) @ test/testdata/infer/private_constant.rb:17
       method ::Foo::<Class:PrivateModule>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:17
         argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
+      method ::Foo::<Class:PrivateModule>#ok_private_usage (<blk>) @ test/testdata/infer/private_constant.rb:18
+        argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
   class ::<Class:Foo>[<AttachedClass>] < ::Module () @ test/testdata/infer/private_constant.rb:3
     type-member(+) ::<Class:Foo>::<AttachedClass> -> T.attached_class (of Foo) @ test/testdata/infer/private_constant.rb:3
     method ::<Class:Foo>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
+    method ::<Class:Foo>#not_ok_private_usage (<blk>) @ test/testdata/infer/private_constant.rb:42
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
+    method ::<Class:Foo>#ok_private_usage (<blk>) @ test/testdata/infer/private_constant.rb:34
       argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
 

--- a/test/testdata/infer/private_constant.rb.symbol-table.exp
+++ b/test/testdata/infer/private_constant.rb.symbol-table.exp
@@ -1,46 +1,79 @@
 class ::<root> < ::Object ()
-  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> (Sig)
     method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:3
       argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
   module ::Foo < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/infer/private_constant.rb:3
-    static-field ::Foo::ANOTHER_PRIVATE_CONST : private -> TrueClass @ test/testdata/infer/private_constant.rb:8
-    static-field ::Foo::A_PRIVATE_CONST : private -> String("private") @ test/testdata/infer/private_constant.rb:5
-    static-field ::Foo::A_PUBLIC_CONST -> String("public") @ test/testdata/infer/private_constant.rb:4
-    class ::Foo::AnotherPrivateClass < ::Object () : private @ test/testdata/infer/private_constant.rb:14
-    class ::Foo::<Class:AnotherPrivateClass>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/infer/private_constant.rb:14
-      type-member(+) ::Foo::<Class:AnotherPrivateClass>::<AttachedClass> -> T.attached_class (of Foo::AnotherPrivateClass) @ test/testdata/infer/private_constant.rb:14
-      method ::Foo::<Class:AnotherPrivateClass>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:14
+    static-field ::Foo::ANOTHER_PRIVATE_CONST : private -> TrueClass @ test/testdata/infer/private_constant.rb:10
+    static-field ::Foo::A_PRIVATE_CONST : private -> String("private") @ test/testdata/infer/private_constant.rb:7
+    static-field ::Foo::A_PUBLIC_CONST -> String("public") @ test/testdata/infer/private_constant.rb:6
+    class ::Foo::AnotherPrivateClass < ::Object () : private @ test/testdata/infer/private_constant.rb:22
+    class ::Foo::<Class:AnotherPrivateClass>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/infer/private_constant.rb:22
+      type-member(+) ::Foo::<Class:AnotherPrivateClass>::<AttachedClass> -> T.attached_class (of Foo::AnotherPrivateClass) @ test/testdata/infer/private_constant.rb:22
+      method ::Foo::<Class:AnotherPrivateClass>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:22
         argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
-    module ::Foo::AnotherPrivateModule < ::Sorbet::Private::Static::ImplicitModuleSuperclass () : private @ test/testdata/infer/private_constant.rb:31
-    class ::Foo::<Class:AnotherPrivateModule>[<AttachedClass>] < ::Module () @ test/testdata/infer/private_constant.rb:31
-      type-member(+) ::Foo::<Class:AnotherPrivateModule>::<AttachedClass> -> T.attached_class (of Foo::AnotherPrivateModule) @ test/testdata/infer/private_constant.rb:31
-      method ::Foo::<Class:AnotherPrivateModule>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:31
+    module ::Foo::AnotherPrivateModule < ::Sorbet::Private::Static::ImplicitModuleSuperclass () : private @ test/testdata/infer/private_constant.rb:39
+    class ::Foo::<Class:AnotherPrivateModule>[<AttachedClass>] < ::Module () @ test/testdata/infer/private_constant.rb:39
+      type-member(+) ::Foo::<Class:AnotherPrivateModule>::<AttachedClass> -> T.attached_class (of Foo::AnotherPrivateModule) @ test/testdata/infer/private_constant.rb:39
+      method ::Foo::<Class:AnotherPrivateModule>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:39
         argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
-    class ::Foo::PrivateClass < ::Object () : private @ test/testdata/infer/private_constant.rb:11
-    class ::Foo::<Class:PrivateClass>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/infer/private_constant.rb:11
-      type-member(+) ::Foo::<Class:PrivateClass>::<AttachedClass> -> T.attached_class (of Foo::PrivateClass) @ test/testdata/infer/private_constant.rb:11
-      method ::Foo::<Class:PrivateClass>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:11
+    class ::Foo::PrivateClass < ::Object () : private @ test/testdata/infer/private_constant.rb:19
+    class ::Foo::<Class:PrivateClass>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/infer/private_constant.rb:19
+      type-member(+) ::Foo::<Class:PrivateClass>::<AttachedClass> -> T.attached_class (of Foo::PrivateClass) @ test/testdata/infer/private_constant.rb:19
+      method ::Foo::<Class:PrivateClass>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:19
         argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
-    module ::Foo::PrivateModule < ::Sorbet::Private::Static::ImplicitModuleSuperclass () : private @ test/testdata/infer/private_constant.rb:17
-      class ::Foo::PrivateModule::ClassInsidePrivateModule < ::Object () @ test/testdata/infer/private_constant.rb:25
-      class ::Foo::PrivateModule::<Class:ClassInsidePrivateModule>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/infer/private_constant.rb:25
-        type-member(+) ::Foo::PrivateModule::<Class:ClassInsidePrivateModule>::<AttachedClass> -> T.attached_class (of Foo::PrivateModule::ClassInsidePrivateModule) @ test/testdata/infer/private_constant.rb:25
-        method ::Foo::PrivateModule::<Class:ClassInsidePrivateModule>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:25
+    static-field ::Foo::PrivateInt : private -> <Alias: ::Integer > @ test/testdata/infer/private_constant.rb:16
+    static-field-type-alias ::Foo::PrivateIntTypeAlias : private -> Integer @ test/testdata/infer/private_constant.rb:13
+    module ::Foo::PrivateModule < ::Sorbet::Private::Static::ImplicitModuleSuperclass () : private @ test/testdata/infer/private_constant.rb:25
+      class ::Foo::PrivateModule::ClassInsidePrivateModule < ::Object () @ test/testdata/infer/private_constant.rb:33
+      class ::Foo::PrivateModule::<Class:ClassInsidePrivateModule>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/infer/private_constant.rb:33
+        type-member(+) ::Foo::PrivateModule::<Class:ClassInsidePrivateModule>::<AttachedClass> -> T.attached_class (of Foo::PrivateModule::ClassInsidePrivateModule) @ test/testdata/infer/private_constant.rb:33
+        method ::Foo::PrivateModule::<Class:ClassInsidePrivateModule>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:33
           argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
-        method ::Foo::PrivateModule::<Class:ClassInsidePrivateModule>#also_ok_private_usage (<blk>) @ test/testdata/infer/private_constant.rb:26
+        method ::Foo::PrivateModule::<Class:ClassInsidePrivateModule>#also_ok_private_usage (<blk>) @ test/testdata/infer/private_constant.rb:34
           argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
-    class ::Foo::<Class:PrivateModule>[<AttachedClass>] < ::Module () @ test/testdata/infer/private_constant.rb:17
-      type-member(+) ::Foo::<Class:PrivateModule>::<AttachedClass> -> T.attached_class (of Foo::PrivateModule) @ test/testdata/infer/private_constant.rb:17
-      method ::Foo::<Class:PrivateModule>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:17
+    class ::Foo::<Class:PrivateModule>[<AttachedClass>] < ::Module () @ test/testdata/infer/private_constant.rb:25
+      type-member(+) ::Foo::<Class:PrivateModule>::<AttachedClass> -> T.attached_class (of Foo::PrivateModule) @ test/testdata/infer/private_constant.rb:25
+      method ::Foo::<Class:PrivateModule>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:25
         argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
-      method ::Foo::<Class:PrivateModule>#ok_private_usage (<blk>) @ test/testdata/infer/private_constant.rb:18
+      method ::Foo::<Class:PrivateModule>#ok_private_usage (<blk>) @ test/testdata/infer/private_constant.rb:26
         argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
-  class ::<Class:Foo>[<AttachedClass>] < ::Module () @ test/testdata/infer/private_constant.rb:3
+  class ::<Class:Foo>[<AttachedClass>] < ::Module (Sig) @ test/testdata/infer/private_constant.rb:3
     type-member(+) ::<Class:Foo>::<AttachedClass> -> T.attached_class (of Foo) @ test/testdata/infer/private_constant.rb:3
     method ::<Class:Foo>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:3
       argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
-    method ::<Class:Foo>#not_ok_private_usage (<blk>) @ test/testdata/infer/private_constant.rb:42
+    method ::<Class:Foo>#not_ok_private_usage (<blk>) @ test/testdata/infer/private_constant.rb:50
       argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
-    method ::<Class:Foo>#ok_private_usage (<blk>) @ test/testdata/infer/private_constant.rb:34
+    method ::<Class:Foo>#ok_private_usage (<blk>) @ test/testdata/infer/private_constant.rb:42
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
+    method ::<Class:Foo>#using_private_class (x, <blk>) -> Sorbet::Private::Static::Void @ test/testdata/infer/private_constant.rb:61
+      argument x<> -> Foo::PrivateClass @ Loc {file=test/testdata/infer/private_constant.rb start=60:16 end=60:17}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
+    method ::<Class:Foo>#using_private_ints (x, y, <blk>) -> Sorbet::Private::Static::Void @ test/testdata/infer/private_constant.rb:58
+      argument x<> -> Integer @ Loc {file=test/testdata/infer/private_constant.rb start=57:16 end=57:17}
+      argument y<> -> Integer @ Loc {file=test/testdata/infer/private_constant.rb start=57:40 end=57:41}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
+    method ::<Class:Foo>#using_private_module (x, <blk>) -> Sorbet::Private::Static::Void @ test/testdata/infer/private_constant.rb:64
+      argument x<> -> T.class_of(Foo::PrivateModule) @ Loc {file=test/testdata/infer/private_constant.rb start=63:16 end=63:17}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
+  class ::Object < ::BasicObject (Kernel) @ https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#L27
+    method ::Object#foo : private (x, <blk>) -> Sorbet::Private::Static::Void @ test/testdata/infer/private_constant.rb:100
+      argument x<> -> T.untyped @ Loc {file=test/testdata/infer/private_constant.rb start=98:13 end=98:14}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
+  class ::PrivateTypeMember[Elem] < ::Object () @ test/testdata/infer/private_constant.rb:80
+    class ::PrivateTypeMember::B < ::Object () @ test/testdata/infer/private_constant.rb:90
+      method ::PrivateTypeMember::B#bar (x, <blk>) -> Sorbet::Private::Static::Void @ test/testdata/infer/private_constant.rb:94
+        argument x<> -> T.untyped @ Loc {file=test/testdata/infer/private_constant.rb start=92:17 end=92:18}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
+    class ::PrivateTypeMember::<Class:B>[<AttachedClass>] < ::<Class:Object> (Sig) @ test/testdata/infer/private_constant.rb:90
+      type-member(+) ::PrivateTypeMember::<Class:B>::<AttachedClass> -> T.attached_class (of PrivateTypeMember::B) @ test/testdata/infer/private_constant.rb:90
+      method ::PrivateTypeMember::<Class:B>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:90
+        argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
+    type-member(=) ::PrivateTypeMember::Elem -> PrivateTypeMember::Elem @ test/testdata/infer/private_constant.rb:84
+    method ::PrivateTypeMember#foo (x, <blk>) -> Sorbet::Private::Static::Void @ test/testdata/infer/private_constant.rb:88
+      argument x<> -> PrivateTypeMember::Elem @ Loc {file=test/testdata/infer/private_constant.rb start=87:15 end=87:16}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
+  class ::<Class:PrivateTypeMember>[<AttachedClass>] < ::<Class:Object> (Sig, Generic, Helpers) @ test/testdata/infer/private_constant.rb:80
+    type-member(+) ::<Class:PrivateTypeMember>::<AttachedClass> -> T.attached_class (of PrivateTypeMember) @ test/testdata/infer/private_constant.rb:80
+    method ::<Class:PrivateTypeMember>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:80
       argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
 

--- a/test/testdata/infer/private_constant.rb.symbol-table.exp
+++ b/test/testdata/infer/private_constant.rb.symbol-table.exp
@@ -1,0 +1,33 @@
+class ::<root> < ::Object ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
+  module ::Foo < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/infer/private_constant.rb:3
+    static-field ::Foo::ANOTHER_PRIVATE_CONST : private -> TrueClass @ test/testdata/infer/private_constant.rb:8
+    static-field ::Foo::A_PRIVATE_CONST : private -> String("private") @ test/testdata/infer/private_constant.rb:5
+    static-field ::Foo::A_PUBLIC_CONST -> String("public") @ test/testdata/infer/private_constant.rb:4
+    class ::Foo::AnotherPrivateClass < ::Object () : private @ test/testdata/infer/private_constant.rb:14
+    class ::Foo::<Class:AnotherPrivateClass>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/infer/private_constant.rb:14
+      type-member(+) ::Foo::<Class:AnotherPrivateClass>::<AttachedClass> -> T.attached_class (of Foo::AnotherPrivateClass) @ test/testdata/infer/private_constant.rb:14
+      method ::Foo::<Class:AnotherPrivateClass>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:14
+        argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
+    module ::Foo::AnotherPrivateModule < ::Sorbet::Private::Static::ImplicitModuleSuperclass () : private @ test/testdata/infer/private_constant.rb:20
+    class ::Foo::<Class:AnotherPrivateModule>[<AttachedClass>] < ::Module () @ test/testdata/infer/private_constant.rb:20
+      type-member(+) ::Foo::<Class:AnotherPrivateModule>::<AttachedClass> -> T.attached_class (of Foo::AnotherPrivateModule) @ test/testdata/infer/private_constant.rb:20
+      method ::Foo::<Class:AnotherPrivateModule>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:20
+        argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
+    class ::Foo::PrivateClass < ::Object () : private @ test/testdata/infer/private_constant.rb:11
+    class ::Foo::<Class:PrivateClass>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/infer/private_constant.rb:11
+      type-member(+) ::Foo::<Class:PrivateClass>::<AttachedClass> -> T.attached_class (of Foo::PrivateClass) @ test/testdata/infer/private_constant.rb:11
+      method ::Foo::<Class:PrivateClass>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:11
+        argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
+    module ::Foo::PrivateModule < ::Sorbet::Private::Static::ImplicitModuleSuperclass () : private @ test/testdata/infer/private_constant.rb:17
+    class ::Foo::<Class:PrivateModule>[<AttachedClass>] < ::Module () @ test/testdata/infer/private_constant.rb:17
+      type-member(+) ::Foo::<Class:PrivateModule>::<AttachedClass> -> T.attached_class (of Foo::PrivateModule) @ test/testdata/infer/private_constant.rb:17
+      method ::Foo::<Class:PrivateModule>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:17
+        argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
+  class ::<Class:Foo>[<AttachedClass>] < ::Module () @ test/testdata/infer/private_constant.rb:3
+    type-member(+) ::<Class:Foo>::<AttachedClass> -> T.attached_class (of Foo) @ test/testdata/infer/private_constant.rb:3
+    method ::<Class:Foo>#<static-init> (<blk>) @ test/testdata/infer/private_constant.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
+


### PR DESCRIPTION
This adds support for type checking private constants statically:
```ruby
class Foo
  BAR = 123
  private_constant :BAR
end
Foo::BAR # error: private constant Foo::BAR referenced
```

### Motivation
This is currently not checked statically by sorbet.


### Test plan
See included automated tests.
