### PR TITLE
reduce copying of vectors when constructing types

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -98,7 +98,7 @@ TypePtr Symbol::externalType(const GlobalState &gs) const {
                 }
             }
 
-            newResultType = make_type<AppliedType>(ref, targs);
+            newResultType = make_type<AppliedType>(ref, move(targs));
         }
         {
             // this method is supposed to be idempotent. The lines below implement "safe publication" of a value that is

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -458,7 +458,7 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
             for (auto &value : values) {
                 value = unpickleType(p, gs);
             }
-            auto result = make_type<ShapeType>(underlying, keys, values);
+            auto result = make_type<ShapeType>(underlying, move(keys), move(values));
             return result;
         }
         case 7:
@@ -475,7 +475,7 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
             for (auto &t : targs) {
                 t = unpickleType(p, gs);
             }
-            return make_type<AppliedType>(klass, targs);
+            return make_type<AppliedType>(klass, move(targs));
         }
         case 10: {
             auto sym = SymbolRef::fromRaw(p.getU4());

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -970,7 +970,7 @@ TypePtr getMethodArguments(const GlobalState &gs, SymbolRef klass, NameRef name,
         }
         args.emplace_back(Types::resultTypeAsSeenFrom(gs, arg.type, data->owner, klass, targs));
     }
-    return TupleType::build(gs, args);
+    return TupleType::build(gs, move(args));
 }
 
 TypePtr ClassType::getCallArguments(const GlobalState &gs, NameRef name) {
@@ -1363,7 +1363,7 @@ public:
             }
         }
 
-        auto tuple = TupleType::build(gs, elems);
+        auto tuple = TupleType::build(gs, move(elems));
         if (isType) {
             tuple = make_type<MetaType>(move(tuple));
         }
@@ -1419,7 +1419,7 @@ class Magic_expandSplat : public IntrinsicMethod {
             types.resize(expandTo, Types::nilClass());
         }
 
-        return TupleType::build(gs, types);
+        return TupleType::build(gs, move(types));
     }
 
 public:
@@ -2168,7 +2168,7 @@ public:
             }
         }
 
-        res.returnType = Types::arrayOf(gs, TupleType::build(gs, unwrappedElems));
+        res.returnType = Types::arrayOf(gs, TupleType::build(gs, move(unwrappedElems)));
     }
 } Array_product;
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -383,14 +383,14 @@ TypePtr unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
         for (auto &value : shapeType->values) {
             unwrappedValues.emplace_back(unwrapType(gs, loc, value));
         }
-        return make_type<ShapeType>(Types::hashOfUntyped(), shapeType->keys, unwrappedValues);
+        return make_type<ShapeType>(Types::hashOfUntyped(), shapeType->keys, move(unwrappedValues));
     } else if (auto *tupleType = cast_type<TupleType>(tp.get())) {
         vector<TypePtr> unwrappedElems;
         unwrappedElems.reserve(tupleType->elems.size());
         for (auto &elem : tupleType->elems) {
             unwrappedElems.emplace_back(unwrapType(gs, loc, elem));
         }
-        return TupleType::build(gs, unwrappedElems);
+        return TupleType::build(gs, move(unwrappedElems));
     } else if (auto *litType = cast_type<LiteralType>(tp.get())) {
         if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
             e.setHeader("Unsupported usage of literal type");
@@ -1628,7 +1628,7 @@ private:
                 if (std::optional<int> procArity = Magic_callWithBlock::getArityForBlock(nonNilableBlockType)) {
                     vector<core::TypePtr> targs(*procArity + 1, core::Types::untypedUntracked());
                     auto procWithCorrectArity = core::Symbols::Proc(*procArity);
-                    passedInBlockType = make_type<core::AppliedType>(procWithCorrectArity, targs);
+                    passedInBlockType = make_type<core::AppliedType>(procWithCorrectArity, move(targs));
                 }
             } else if (auto e = gs.beginError(blockLoc, errors::Infer::MethodArgumentMismatch)) {
                 e.setHeader("Expected `{}` but found `{}` for block argument", blockPreType->show(gs),

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -321,7 +321,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                             } else if (!differ2) {
                                 result = t2;
                             } else {
-                                result = TupleType::build(gs, elemLubs);
+                                result = TupleType::build(gs, move(elemLubs));
                             }
                         } else {
                             result = Types::arrayOfUntyped();
@@ -676,7 +676,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         } else if (absl::c_equal(a2->elems, elemGlbs)) {
                             result = t2;
                         } else {
-                            result = TupleType::build(gs, elemGlbs);
+                            result = TupleType::build(gs, move(elemGlbs));
                         }
                     } else {
                         result = Types::bottom();

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -291,7 +291,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         } else if (!changedFromT1) {
             return t1s;
         } else {
-            return make_type<AppliedType>(a2->klass, newTargs);
+            return make_type<AppliedType>(a2->klass, move(newTargs));
         }
     }
 
@@ -364,7 +364,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                             } else if (!differ2) {
                                 result = t2;
                             } else {
-                                result = make_type<ShapeType>(Types::hashOfUntyped(), h2->keys, valueLubs);
+                                result = make_type<ShapeType>(Types::hashOfUntyped(), h2->keys, move(valueLubs));
                             }
                         } else {
                             result = Types::hashOfUntyped();
@@ -724,7 +724,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         } else if (canReuseT2) {
                             result = t2;
                         } else {
-                            result = make_type<ShapeType>(Types::hashOfUntyped(), h2->keys, valueLubs);
+                            result = make_type<ShapeType>(Types::hashOfUntyped(), h2->keys, move(valueLubs));
                         }
                     } else {
                         result = Types::bottom();
@@ -913,7 +913,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         } else if (absl::c_equal(a2->targs, newTargs) && a1->klass == a2->klass) {
             return ltr ? t1 : t2;
         } else {
-            return make_type<AppliedType>(a1->klass, newTargs);
+            return make_type<AppliedType>(a1->klass, move(newTargs));
         }
     }
     {

--- a/core/types/typemaps.cc
+++ b/core/types/typemaps.cc
@@ -177,7 +177,7 @@ TypePtr ShapeType::_instantiate(const GlobalState &gs, const InlinedVector<Symbo
             newValues[i] = this->values[i];
             i++;
         }
-        return make_type<ShapeType>(Types::hashOfUntyped(), this->keys, newValues);
+        return make_type<ShapeType>(Types::hashOfUntyped(), this->keys, move(newValues));
     }
     return nullptr;
 }
@@ -204,7 +204,7 @@ TypePtr ShapeType::_instantiate(const GlobalState &gs, const TypeConstraint &tc)
             newValues[i] = this->values[i];
             i++;
         }
-        return make_type<ShapeType>(Types::hashOfUntyped(), this->keys, newValues);
+        return make_type<ShapeType>(Types::hashOfUntyped(), this->keys, move(newValues));
     }
     return nullptr;
 }
@@ -231,7 +231,7 @@ TypePtr ShapeType::_approximate(const GlobalState &gs, const TypeConstraint &tc)
             newValues[i] = this->values[i];
             i++;
         }
-        return make_type<ShapeType>(Types::hashOfUntyped(), this->keys, newValues);
+        return make_type<ShapeType>(Types::hashOfUntyped(), this->keys, move(newValues));
     }
     return nullptr;
 }
@@ -352,7 +352,7 @@ TypePtr AppliedType::_instantiate(const GlobalState &gs, const InlinedVector<Sym
             newTargs[i] = this->targs[i];
             i++;
         }
-        return make_type<AppliedType>(this->klass, newTargs);
+        return make_type<AppliedType>(this->klass, move(newTargs));
     }
 
     return nullptr;
@@ -381,7 +381,7 @@ TypePtr AppliedType::_instantiate(const GlobalState &gs, const TypeConstraint &t
             newTargs[i] = this->targs[i];
             i++;
         }
-        return make_type<AppliedType>(this->klass, newTargs);
+        return make_type<AppliedType>(this->klass, move(newTargs));
     }
 
     return nullptr;
@@ -410,7 +410,7 @@ TypePtr AppliedType::_approximate(const GlobalState &gs, const TypeConstraint &t
             newTargs[i] = this->targs[i];
             i++;
         }
-        return make_type<AppliedType>(this->klass, newTargs);
+        return make_type<AppliedType>(this->klass, move(newTargs));
     }
 
     return nullptr;

--- a/core/types/typemaps.cc
+++ b/core/types/typemaps.cc
@@ -95,7 +95,7 @@ TypePtr TupleType::_instantiate(const GlobalState &gs, const InlinedVector<Symbo
             newElems[i] = this->elems[i];
             i++;
         }
-        return TupleType::build(gs, newElems);
+        return TupleType::build(gs, move(newElems));
     }
     return nullptr;
 }
@@ -122,7 +122,7 @@ TypePtr TupleType::_instantiate(const GlobalState &gs, const TypeConstraint &tc)
             newElems[i] = this->elems[i];
             i++;
         }
-        return TupleType::build(gs, newElems);
+        return TupleType::build(gs, move(newElems));
     }
     return nullptr;
 }
@@ -149,7 +149,7 @@ TypePtr TupleType::_approximate(const GlobalState &gs, const TypeConstraint &tc)
             newElems[i] = this->elems[i];
             i++;
         }
-        return TupleType::build(gs, newElems);
+        return TupleType::build(gs, move(newElems));
     }
     return nullptr;
 };

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -95,19 +95,19 @@ TypePtr Types::Float() {
 
 TypePtr Types::arrayOfUntyped() {
     static vector<TypePtr> targs{Types::untypedUntracked()};
-    static auto res = make_type<AppliedType>(Symbols::Array(), targs);
+    static auto res = make_type<AppliedType>(Symbols::Array(), move(targs));
     return res;
 }
 
 TypePtr Types::rangeOfUntyped() {
     static vector<TypePtr> targs{Types::untypedUntracked()};
-    static auto res = make_type<AppliedType>(Symbols::Range(), targs);
+    static auto res = make_type<AppliedType>(Symbols::Range(), move(targs));
     return res;
 }
 
 TypePtr Types::hashOfUntyped() {
     static vector<TypePtr> targs{Types::untypedUntracked(), Types::untypedUntracked(), Types::untypedUntracked()};
-    static auto res = make_type<AppliedType>(Symbols::Hash(), targs);
+    static auto res = make_type<AppliedType>(Symbols::Hash(), move(targs));
     return res;
 }
 
@@ -277,18 +277,18 @@ TypePtr Types::lubAll(const GlobalState &gs, vector<TypePtr> &elements) {
 
 TypePtr Types::arrayOf(const GlobalState &gs, const TypePtr &elem) {
     vector<TypePtr> targs{move(elem)};
-    return make_type<AppliedType>(Symbols::Array(), targs);
+    return make_type<AppliedType>(Symbols::Array(), move(targs));
 }
 
 TypePtr Types::rangeOf(const GlobalState &gs, const TypePtr &elem) {
     vector<TypePtr> targs{move(elem)};
-    return make_type<AppliedType>(Symbols::Range(), targs);
+    return make_type<AppliedType>(Symbols::Range(), move(targs));
 }
 
 TypePtr Types::hashOf(const GlobalState &gs, const TypePtr &elem) {
     vector<TypePtr> tupleArgs{Types::Symbol(), elem};
     vector<TypePtr> targs{Types::Symbol(), elem, TupleType::build(gs, tupleArgs)};
-    return make_type<AppliedType>(Symbols::Hash(), targs);
+    return make_type<AppliedType>(Symbols::Hash(), move(targs));
 }
 
 TypePtr Types::dropNil(const GlobalState &gs, const TypePtr &from) {
@@ -872,7 +872,7 @@ TypePtr Types::widen(const GlobalState &gs, const TypePtr &type) {
             for (const auto &t : appliedType->targs) {
                 newTargs.emplace_back(widen(gs, t));
             }
-            ret = make_type<AppliedType>(appliedType->klass, newTargs);
+            ret = make_type<AppliedType>(appliedType->klass, move(newTargs));
         },
         [&](Type *tp) { ret = type; });
     ENFORCE(ret);

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -885,12 +885,12 @@ TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &type) {
     TypePtr ret;
 
     auto unwrapTypeVector = [&](const std::vector<TypePtr> &elems) -> std::vector<TypePtr> {
-      std::vector<TypePtr> unwrapped;
-      unwrapped.reserve(elems.size());
-      for (auto &e : elems) {
-        unwrapped.emplace_back(unwrapSelfTypeParam(ctx, e));
-      }
-      return unwrapped;
+        std::vector<TypePtr> unwrapped;
+        unwrapped.reserve(elems.size());
+        for (auto &e : elems) {
+            unwrapped.emplace_back(unwrapSelfTypeParam(ctx, e));
+        }
+        return unwrapped;
     };
 
     typecase(
@@ -905,7 +905,8 @@ TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &type) {
             ret = OrType::make_shared(unwrapSelfTypeParam(ctx, orType->left), unwrapSelfTypeParam(ctx, orType->right));
         },
         [&](ShapeType *shape) {
-            ret = make_type<ShapeType>(unwrapSelfTypeParam(ctx, shape->underlying_), shape->keys, unwrapTypeVector(shape->values));
+            ret = make_type<ShapeType>(unwrapSelfTypeParam(ctx, shape->underlying_), shape->keys,
+                                       unwrapTypeVector(shape->values));
         },
         [&](TupleType *tuple) {
             ret = make_type<TupleType>(unwrapSelfTypeParam(ctx, tuple->underlying_), unwrapTypeVector(tuple->elems));

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -287,7 +287,7 @@ TypePtr Types::rangeOf(const GlobalState &gs, const TypePtr &elem) {
 
 TypePtr Types::hashOf(const GlobalState &gs, const TypePtr &elem) {
     vector<TypePtr> tupleArgs{Types::Symbol(), elem};
-    vector<TypePtr> targs{Types::Symbol(), elem, TupleType::build(gs, tupleArgs)};
+    vector<TypePtr> targs{Types::Symbol(), elem, TupleType::build(gs, move(tupleArgs))};
     return make_type<AppliedType>(Symbols::Hash(), move(targs));
 }
 

--- a/namer/configatron/configatron.cc
+++ b/namer/configatron/configatron.cc
@@ -154,7 +154,7 @@ void recurse(core::GlobalState &gs, const YAML::Node &node, shared_ptr<Path> pre
                 elemType = core::Types::bottom();
             }
             vector<core::TypePtr> elems{elemType};
-            prefix->setType(gs, core::make_type<core::AppliedType>(core::Symbols::Array(), elems));
+            prefix->setType(gs, core::make_type<core::AppliedType>(core::Symbols::Array(), move(elems)));
             break;
         }
         case YAML::NodeType::Map:

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1100,7 +1100,8 @@ class SymbolDefiner {
             // T.noreturn here represents the zero-length list of subclasses of this sealed class.
             // We will use T.any to record subclasses when they're resolved.
             vector<core::TypePtr> targs{core::Types::bottom()};
-            sealedSubclasses.data(ctx)->resultType = core::make_type<core::AppliedType>(core::Symbols::Set(), move(targs));
+            sealedSubclasses.data(ctx)->resultType =
+                core::make_type<core::AppliedType>(core::Symbols::Set(), move(targs));
         }
         if (fun == core::Names::declareInterface() || fun == core::Names::declareAbstract()) {
             symbolData->setClassOrModuleAbstract();

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1100,7 +1100,7 @@ class SymbolDefiner {
             // T.noreturn here represents the zero-length list of subclasses of this sealed class.
             // We will use T.any to record subclasses when they're resolved.
             vector<core::TypePtr> targs{core::Types::bottom()};
-            sealedSubclasses.data(ctx)->resultType = core::make_type<core::AppliedType>(core::Symbols::Set(), targs);
+            sealedSubclasses.data(ctx)->resultType = core::make_type<core::AppliedType>(core::Symbols::Set(), move(targs));
         }
         if (fun == core::Names::declareInterface() || fun == core::Names::declareAbstract()) {
             symbolData->setClassOrModuleAbstract();

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -601,7 +601,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
             for (auto &el : arr->elems) {
                 elems.emplace_back(getResultTypeWithSelfTypeParams(ctx, el, sigBeingParsed, args.withoutSelfType()));
             }
-            result.type = core::TupleType::build(ctx, elems);
+            result.type = core::TupleType::build(ctx, move(elems));
         },
         [&](ast::Hash *hash) {
             vector<core::TypePtr> keys;

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -621,7 +621,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                     }
                 }
             }
-            result.type = core::make_type<core::ShapeType>(core::Types::hashOfUntyped(), keys, values);
+            result.type = core::make_type<core::ShapeType>(core::Types::hashOfUntyped(), move(keys), move(values));
         },
         [&](ast::ConstantLit *i) {
             auto maybeAliased = i->symbol;
@@ -811,7 +811,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                 }
                 auto sym = core::Symbols::Proc(arity);
 
-                result.type = core::make_type<core::AppliedType>(sym, targs);
+                result.type = core::make_type<core::AppliedType>(sym, move(targs));
                 return;
             }
 


### PR DESCRIPTION
The constructor(s) of `core::{Applied,Shape,Tuple}Type` accepts "elements", a by-value `std::vector<TypePtr>`.  The constructors themselves will `move` this argument into the appropriate class member, but at the call sites, we often copy a vector to pass it to the appropriate constructor.  This copying is not great for two reasons: first is the unnecessary allocation, but secondly we also need to copy the contained `TypePtr` elements, which involves a bunch of atomic refcounting.

It would be better to `move` these vectors whenever possible, which these changes do.  (It's debatable whether these constructors should take `std::vector<TypePtr> &&` always, which would make copying explicit at call sites.)

### Motivation

Small efficiency wins, more consistent code.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
Covered by existing tests.