### PR TITLE
fix resolver crash when parent class has undeclared type parameters

### DIFF
--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -80,7 +80,7 @@ bool resolveTypeMember(core::GlobalState &gs, core::SymbolRef parent, core::Symb
         if (auto e = gs.beginError(data->loc(), core::errors::Resolver::ParentVarianceMismatch)) {
             e.setHeader("Type variance mismatch with parent `{}`", parent.data(gs)->show(gs));
         }
-        return true;
+        return false;
     }
     typeAliases[sym.classOrModuleIndex()].emplace_back(parentTypeMember, my);
     return true;

--- a/test/testdata/resolver/missing_generic_type.rb
+++ b/test/testdata/resolver/missing_generic_type.rb
@@ -1,0 +1,12 @@
+# typed: __STDLIB_INTERNAL
+
+class A # error: Type `Elem` declared by parent `Enumerable` must be re-declared in `A`
+# error: Missing definition for abstract method `Enumerable#each`
+  include Enumerable
+end
+
+class B < A # error: Missing definition for abstract method `Enumerable#each`
+  include Enumerable
+  extend T::Generic
+  Elem = type_member(fixed: T.untyped)
+end

--- a/test/testdata/resolver/missing_generic_type.rb
+++ b/test/testdata/resolver/missing_generic_type.rb
@@ -1,4 +1,5 @@
 # typed: __STDLIB_INTERNAL
+# disable-fast-path: true
 
 class A # error: Type `Elem` declared by parent `Enumerable` must be re-declared in `A`
 # error: Missing definition for abstract method `Enumerable#each`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

`resolveTypeMember` should return `false` if there was an error and `true` otherwise.  We were not correctly returning `false` in all cases.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #3107 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
