### PR TITLE
don't stop desugaring if we see a bogus DefS

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1003,9 +1003,6 @@ TreePtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) {
                             dctx.ctx.beginError(method->singleton->loc, core::errors::Desugar::InvalidSingletonDef)) {
                         e.setHeader("`{}` is only supported for `{}`", "def EXPRESSION.method", "def self.method");
                     }
-                    TreePtr res = MK::EmptyTree();
-                    result = std::move(res);
-                    return;
                 }
                 bool isSelf = true;
                 TreePtr res = buildMethod(dctx, method->loc, core::Loc(dctx.ctx.file, method->declLoc), method->name,

--- a/test/testdata/desugar/defs_not_self.rb.desugar-tree.exp
+++ b/test/testdata/desugar/defs_not_self.rb.desugar-tree.exp
@@ -1,3 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  <emptyTree>
+  def self.method<<C <todo sym>>>(&<blk>)
+    <emptyTree>
+  end
 end

--- a/test/testdata/desugar/defs_not_self_in_class.rb
+++ b/test/testdata/desugar/defs_not_self_in_class.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+class A
+  private_class_method def A.a  # error: `def EXPRESSION.method` is only supported for `def self.method`
+    5
+  end
+end

--- a/test/testdata/desugar/defs_not_self_in_class.rb.desugar-tree.exp
+++ b/test/testdata/desugar/defs_not_self_in_class.rb.desugar-tree.exp
@@ -1,0 +1,7 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
+    <self>.private_class_method(def self.a<<C <todo sym>>>(&<blk>)
+        5
+      end)
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

In desugar, when we ran into `def EXPRESSION.method` where `EXPRESSION` was not `self`, we issued an error...but we also dropped the entire method body and turned the whole method definition into the empty tree.  This is a reasonable thing to do, but in the motivating testcase, dropping the method body meant we were left with `private_class_method(<empty tree>)`, which the resolver was not expecting to see.

It seems reasonable to try and continue desugaring the rest of the method body; the `.exp` output indicates that we would silently replace `EXPRESSION` with `self` anyway.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #3394 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included tests.  I also need to test this against Stripe's codebase.