### PR TITLE
Fix hover (and other location queries) when looking up location with dead code

### DIFF
--- a/test/testdata/lsp/hover_methods_inside_block.rb
+++ b/test/testdata/lsp/hover_methods_inside_block.rb
@@ -1,0 +1,24 @@
+# typed: true
+
+module Foo
+  module Bar
+    module Baz
+      extend T::Sig
+      extend T::Helpers
+
+      sig {returns(T::Set[String])}
+      def enabled_methods
+        Set.new
+      end
+
+      sig {void}
+      def foo
+        errors = enabled_methods
+          .filter_map {|(_, foo)| foo}
+          .flat_map {|validation| validation.public_send(validation)} # error-with-dupes: This code is unreachable
+                                               # ^ hover: def public_send(arg0, *args); end
+        errors
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fix a case where a hover information was wrong because of flow-analysis.

See test for context around the problem. In there, we are trying to resolve a hover request on `public_send` which should show information about that method however in this scenario we instead would get hover information for `flat_map`.

Note how the file actually contains an error (signaled by the marker `error-with-dupes`), this error is intentional to reproduce the problem. It originates from the first block passed to `filter_map` where we are introducing a deconstruct of the argument which is an error (type String cannot be deconstructed this way). Sorbet CFG pass will thus mark the result injected into the `flat_map` block as a `T.noreturn` causing the first instruction of the block (the load of `validation`) to have an unreachable error set.

Now as to how this pertains to hover. Sorbet LSP requests (like hover information) are intertwined with the type checking pass. Specifically in this case the request is answered in `Environment::processBinding` where a typecase allow to distinguish the type of instruction and thus create a strongly-typed query response.

To get the correct information, `processBinding` needs to be called with the `Send` instruction representing the `public_send` call so that the logic can recognize it as a valid location and add it to the queue (multiple results will be added to the queue during a pass but the hover request will only pick the first one which corresponds to the "tightest" range possible). Since however the load instruction that comes before the send has been deemed as unreachable, the logic in `Inference::run` (for loop processing binding blocks expressions) will short-circuit because the environment was globally marked dead.

This means that our send never gets handled by `processBinding` thus never gets the chance to be added to the results queue. Since methods-calls-with-block range is defined to cover the entirety of the declaration, our `flat_map` call is indeed considered by the hover query as a match (because its overall spans include the requested location). Since nothing else tighter gets processed as explained, we thus get the `flat_map` hit deemed to be proper one.

The fix in this case is thus to disable that short-circuiting when (and only when) an LSP query is registered on the context as, in that case, we do not care about marking the graph with errors and would rather continue processing things exhaustively. This fixes the problem at hand by allowing the call to `public_send` to go through to `processBinding` thus allowing it to end up on the query results queue.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Added LSP test for hover case that was returning the wrong information.