### PR TITLE
TypePtr: Switch away from shared_ptr and tag Type pointer

### DIFF
--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -1,0 +1,75 @@
+#include "core/TypePtr.h"
+#include "core/Types.h"
+
+namespace sorbet::core {
+
+void TypePtr::deleteTagged(Tag tag, void *ptr) noexcept {
+    ENFORCE(ptr != nullptr);
+
+    switch (tag) {
+        case Tag::ClassType:
+            delete reinterpret_cast<ClassType *>(ptr);
+            break;
+
+        case Tag::LambdaParam:
+            delete reinterpret_cast<LambdaParam *>(ptr);
+            break;
+
+        case Tag::SelfTypeParam:
+            delete reinterpret_cast<SelfTypeParam *>(ptr);
+            break;
+
+        case Tag::AliasType:
+            delete reinterpret_cast<AliasType *>(ptr);
+            break;
+
+        case Tag::SelfType:
+            delete reinterpret_cast<SelfType *>(ptr);
+            break;
+
+        case Tag::LiteralType:
+            delete reinterpret_cast<LiteralType *>(ptr);
+            break;
+
+        case Tag::TypeVar:
+            delete reinterpret_cast<TypeVar *>(ptr);
+            break;
+
+        case Tag::OrType:
+            delete reinterpret_cast<OrType *>(ptr);
+            break;
+
+        case Tag::AndType:
+            delete reinterpret_cast<AndType *>(ptr);
+            break;
+
+        case Tag::ShapeType:
+            delete reinterpret_cast<ShapeType *>(ptr);
+            break;
+
+        case Tag::TupleType:
+            delete reinterpret_cast<TupleType *>(ptr);
+            break;
+
+        case Tag::AppliedType:
+            delete reinterpret_cast<AppliedType *>(ptr);
+            break;
+
+        case Tag::MetaType:
+            delete reinterpret_cast<MetaType *>(ptr);
+            break;
+
+        case Tag::BlamedUntyped:
+            delete reinterpret_cast<BlamedUntyped *>(ptr);
+            break;
+
+        case Tag::UnresolvedClassType:
+            delete reinterpret_cast<UnresolvedClassType *>(ptr);
+            break;
+
+        case Tag::UnresolvedAppliedType:
+            delete reinterpret_cast<UnresolvedAppliedType *>(ptr);
+            break;
+    }
+}
+} // namespace sorbet::core

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -52,7 +52,7 @@ private:
         return maskedPtr | val;
     }
 
-    explicit TypePtr(Tag tag, std::atomic<u4> *counter, void *expr) : counter(counter), store(tagPtr(tag, expr)) {
+    TypePtr(Tag tag, std::atomic<u4> *counter, void *expr) : counter(counter), store(tagPtr(tag, expr)) {
         if (counter != nullptr) {
             counter->fetch_add(1);
         }

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -4,25 +4,148 @@
 #include <memory>
 
 namespace sorbet::core {
-// using TypePtr = std::shared_ptr<Type>;
 class Type;
-class TypePtr {
-    std::shared_ptr<Type> store;
-    TypePtr(std::shared_ptr<Type> &&store);
+class TypePtr final {
+public:
+    // We store tagged pointers as 64-bit values.
+    using tagged_storage = u8;
+
+    enum class Tag {
+        ClassType = 1,
+        LambdaParam,
+        SelfTypeParam,
+        AliasType,
+        SelfType,
+        LiteralType,
+        TypeVar,
+        OrType,
+        AndType,
+        ShapeType,
+        TupleType,
+        AppliedType,
+        MetaType,
+        BlamedUntyped,
+        UnresolvedClassType,
+        UnresolvedAppliedType,
+    };
+
+    // A mapping from type to its corresponding tag.
+    template <typename T> struct TypeToTag;
+
+private:
+    std::atomic<u4> *counter;
+    tagged_storage store;
+
+    static constexpr tagged_storage TAG_MASK = 0xffff000000000007;
+
+    static constexpr tagged_storage PTR_MASK = ~TAG_MASK;
+
+    static tagged_storage tagPtr(Tag tag, void *expr) {
+        auto val = static_cast<tagged_storage>(tag);
+        if (val >= 8) {
+            // Store the tag in the upper 16 bits of the pointer, as it won't fit in the lower three bits.
+            val <<= 48;
+        }
+
+        auto maskedPtr = reinterpret_cast<tagged_storage>(expr) & PTR_MASK;
+
+        return maskedPtr | val;
+    }
+
+    explicit TypePtr(Tag tag, std::atomic<u4> *counter, void *expr) : counter(counter), store(tagPtr(tag, expr)) {
+        if (counter != nullptr) {
+            counter->fetch_add(1);
+        }
+    }
+    static void deleteTagged(Tag tag, void *ptr) noexcept;
+
+    // A version of release that doesn't mask the tag bits
+    tagged_storage releaseTagged() noexcept {
+        auto saved = store;
+        store = 0;
+        return saved;
+    }
+
+    std::atomic<u4> *releaseCounter() noexcept {
+        auto saved = counter;
+        counter = nullptr;
+        return saved;
+    }
+
+    void handleDelete() noexcept {
+        if (counter != nullptr) {
+            // fetch_sub returns value prior to subtract
+            const u4 counterVal = counter->fetch_sub(1) - 1;
+            if (counterVal == 0) {
+                deleteTagged(tag(), get());
+                delete counter;
+            }
+        }
+    }
 
 public:
-    TypePtr() = default;
-    TypePtr(TypePtr &&other) = default;
-    TypePtr(const TypePtr &other) = default;
-    TypePtr &operator=(TypePtr &&other) = default;
-    TypePtr &operator=(const TypePtr &other) = default;
-    explicit TypePtr(Type *ptr) : store(ptr) {}
-    TypePtr(std::nullptr_t n) : store(nullptr) {}
+    constexpr TypePtr() noexcept : counter(nullptr), store(0) {}
+
+    TypePtr(std::nullptr_t) noexcept : TypePtr() {}
+
+    TypePtr(TypePtr &&other) noexcept : counter(other.releaseCounter()), store(other.releaseTagged()){};
+
+    TypePtr(const TypePtr &other) noexcept : counter(other.counter), store(other.store) {
+        if (counter != nullptr) {
+            counter->fetch_add(1);
+        }
+    };
+
+    ~TypePtr() {
+        handleDelete();
+    }
+
+    TypePtr &operator=(TypePtr &&other) noexcept {
+        handleDelete();
+        counter = other.releaseCounter();
+        store = other.releaseTagged();
+        return *this;
+    };
+
+    TypePtr &operator=(const TypePtr &other) noexcept {
+        if (*this == other) {
+            return *this;
+        }
+
+        handleDelete();
+        counter = other.counter;
+        store = other.store;
+        if (counter != nullptr) {
+            counter->fetch_add(1);
+        }
+        return *this;
+    };
+
+    explicit TypePtr(Tag tag, void *expr) : TypePtr(tag, new std::atomic<u4>(), expr) {}
+
     operator bool() const {
         return (bool)store;
     }
+
+    Tag tag() const noexcept {
+        ENFORCE_NO_TIMER(store != 0);
+
+        auto value = reinterpret_cast<tagged_storage>(store) & TAG_MASK;
+        if (value <= 7) {
+            return static_cast<Tag>(value);
+        } else {
+            return static_cast<Tag>(value >> 48);
+        }
+    }
+
     Type *get() const {
-        return store.get();
+        auto val = store & PTR_MASK;
+        if constexpr (sizeof(void *) == 4) {
+            return reinterpret_cast<Type *>(val);
+        } else {
+            // sign extension for the upper 16 bits
+            return reinterpret_cast<Type *>((val << 16) >> 16);
+        }
     }
     Type *operator->() const {
         return get();
@@ -37,13 +160,14 @@ public:
         return store == other.store;
     }
     bool operator!=(std::nullptr_t n) const {
-        return store != nullptr;
+        return store != 0;
     }
     bool operator==(std::nullptr_t n) const {
-        return store == nullptr;
+        return store == 0;
     }
 
     template <class T, class... Args> friend TypePtr make_type(Args &&... args);
+    friend class TypePtrTestHelper;
 };
 CheckSize(TypePtr, 16, 8);
 } // namespace sorbet::core

--- a/core/Types.h
+++ b/core/Types.h
@@ -64,7 +64,7 @@ public:
 CheckSize(ArgInfo, 48, 8);
 
 template <class T, class... Args> TypePtr make_type(Args &&... args) {
-    return TypePtr(std::make_shared<T>(std::forward<Args>(args)...));
+    return TypePtr(TypePtr::TypeToTag<T>::value, new T(std::forward<Args>(args)...));
 }
 
 enum class UntypedMode {
@@ -246,6 +246,11 @@ template <class To> bool isa_type(Type *what) {
     return cast_type<To>(what) != nullptr;
 }
 
+#define TYPE(name)                                                                                             \
+    class name;                                                                                                \
+    template <> struct TypePtr::TypeToTag<name> { static constexpr TypePtr::Tag value = TypePtr::Tag::name; }; \
+    class __attribute__((aligned(8))) name
+
 class GroundType : public Type {};
 
 class ProxyType : public Type {
@@ -262,7 +267,7 @@ public:
 };
 CheckSize(ProxyType, 8, 8);
 
-class ClassType : public GroundType {
+TYPE(ClassType) : public GroundType {
 public:
     SymbolRef symbol;
     ClassType(SymbolRef symbol);
@@ -287,7 +292,7 @@ CheckSize(ClassType, 16, 8);
  * This is the type used to represent a use of a type_member or type_template in
  * a signature.
  */
-class LambdaParam final : public Type {
+TYPE(LambdaParam) final : public Type {
 public:
     SymbolRef definition;
 
@@ -314,7 +319,7 @@ public:
 };
 CheckSize(LambdaParam, 48, 8);
 
-class SelfTypeParam final : public Type {
+TYPE(SelfTypeParam) final : public Type {
 public:
     SymbolRef definition;
 
@@ -336,7 +341,7 @@ public:
 };
 CheckSize(SelfTypeParam, 16, 8);
 
-class AliasType final : public Type {
+TYPE(AliasType) final : public Type {
 public:
     AliasType(SymbolRef other);
     virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
@@ -360,7 +365,7 @@ CheckSize(AliasType, 16, 8);
  * It indicates that the method may(or will) return `self` or type that behaves equivalently
  * to self(e.g. in case of `.clone`).
  */
-class SelfType final : public Type {
+TYPE(SelfType) final : public Type {
 public:
     SelfType();
     virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
@@ -381,7 +386,7 @@ public:
 };
 CheckSize(SelfType, 8, 8);
 
-class LiteralType final : public ProxyType {
+TYPE(LiteralType) final : public ProxyType {
 public:
     union {
         const int64_t value;
@@ -413,7 +418,7 @@ CheckSize(LiteralType, 24, 8);
 /*
  * TypeVars are the used for the type parameters of generic methods.
  */
-class TypeVar final : public Type {
+TYPE(TypeVar) final : public Type {
 public:
     SymbolRef sym;
     TypeVar(SymbolRef sym);
@@ -434,7 +439,7 @@ public:
 };
 CheckSize(TypeVar, 16, 8);
 
-class OrType final : public GroundType {
+TYPE(OrType) final : public GroundType {
 public:
     TypePtr left;
     TypePtr right;
@@ -488,7 +493,7 @@ private:
 };
 CheckSize(OrType, 40, 8);
 
-class AndType final : public GroundType {
+TYPE(AndType) final : public GroundType {
 public:
     TypePtr left;
     TypePtr right;
@@ -533,7 +538,7 @@ private:
 };
 CheckSize(AndType, 40, 8);
 
-class ShapeType final : public ProxyType {
+TYPE(ShapeType) final : public ProxyType {
 public:
     std::vector<TypePtr> keys; // TODO: store sorted by whatever
     std::vector<TypePtr> values;
@@ -558,7 +563,7 @@ public:
 };
 CheckSize(ShapeType, 72, 8);
 
-class TupleType final : public ProxyType {
+TYPE(TupleType) final : public ProxyType {
 private:
     TupleType() = delete;
 
@@ -590,7 +595,7 @@ public:
 };
 CheckSize(TupleType, 48, 8);
 
-class AppliedType final : public Type {
+TYPE(AppliedType) final : public Type {
 public:
     SymbolRef klass;
     std::vector<TypePtr> targs;
@@ -624,7 +629,7 @@ CheckSize(AppliedType, 40, 8);
 //
 // These are used within the inferencer in places where we need to track
 // user-written types in the source code.
-class MetaType final : public ProxyType {
+TYPE(MetaType) final : public ProxyType {
 public:
     TypePtr wrapped;
 
@@ -745,13 +750,13 @@ struct DispatchResult {
           secondaryKind(secondaryKind){};
 };
 
-class BlamedUntyped final : public ClassType {
+TYPE(BlamedUntyped) final : public ClassType {
 public:
     const core::SymbolRef blame;
     BlamedUntyped(SymbolRef whoToBlame) : ClassType(core::Symbols::untyped()), blame(whoToBlame){};
 };
 
-class UnresolvedClassType final : public ClassType {
+TYPE(UnresolvedClassType) final : public ClassType {
 public:
     const core::SymbolRef scope;
     const std::vector<core::NameRef> names;
@@ -762,7 +767,7 @@ public:
     virtual std::string typeName() const final;
 };
 
-class UnresolvedAppliedType final : public ClassType {
+TYPE(UnresolvedAppliedType) final : public ClassType {
 public:
     const core::SymbolRef klass;
     const std::vector<TypePtr> targs;

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -33,8 +33,6 @@ TypePtr Types::dispatchCallWithoutBlock(const GlobalState &gs, const TypePtr &re
     return move(dispatched.returnType);
 }
 
-TypePtr::TypePtr(shared_ptr<Type> &&store) : store(move(store)){};
-
 TypePtr Types::top() {
     static auto res = make_type<ClassType>(Symbols::top());
     return res;
@@ -764,7 +762,7 @@ bool OrType::hasUntyped() const {
 }
 
 TypePtr OrType::make_shared(const TypePtr &left, const TypePtr &right) {
-    TypePtr res(new OrType(left, right));
+    TypePtr res(TypePtr::Tag::OrType, new OrType(left, right));
     return res;
 }
 
@@ -773,7 +771,7 @@ bool AndType::hasUntyped() const {
 }
 
 TypePtr AndType::make_shared(const TypePtr &left, const TypePtr &right) {
-    TypePtr res(new AndType(left, right));
+    TypePtr res(TypePtr::Tag::AndType, new AndType(left, right));
     return res;
 }
 


### PR DESCRIPTION
TypePtr: Switch away from shared_ptr

This PR essentially re-implements shared_ptr in TypePtr with tags. The tags are not yet used (that will come in the next PR!).

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This PR is broken off from https://github.com/sorbet/sorbet/pull/3569

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests! I wrote a suite of unit tests.
