### PR TITLE
Avoid Ruby 2.7 warning for numbered parameters

### DIFF
--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -73,8 +73,8 @@ To write a `sig` for this method, rename the method's parameters to have unique
 names:
 
 ```ruby
-sig {params(_1: String, _2: Integer).void} # ok
-def foo(_1, _2); end
+sig {params(_a: String, _b: Integer).void} # ok
+def foo(_a, _b); end
 ```
 
 ## 4002


### PR DESCRIPTION
Ruby 2.7 will warn "`_1' is reserved for numbered parameter; consider another name" if the advice is followed. See https://rubyreferences.github.io/rubychanges/2.7.html#numbered-block-parameters


### Motivation
I saw the warning after making this change https://github.com/aws/aws-sdk-ruby/pull/2426/files

### Test plan
Irb can demonstrate the issue:
```
irb(main):004:0> def foo(_1, _2); end
(irb):4: warning: `_1' is reserved for numbered parameter; consider another name
(irb):4: warning: `_2' is reserved for numbered parameter; consider another name
=> :foo
irb(main):005:0> def foo(_a, _b); end
=> :foo
```
