### PR TITLE
Speed up cold cache indexing by parallelizing tree walk

### DIFF
--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -10,7 +10,7 @@ class SubstWalk {
 private:
     const core::GlobalSubstitution &subst;
 
-    TreePtr substClassName(core::MutableContext ctx, TreePtr node) {
+    TreePtr substClassName(core::Context ctx, TreePtr node) {
         auto *constLit = cast_tree<UnresolvedConstantLit>(node);
         if (constLit == nullptr) { // uncommon case. something is strange
             if (isa_tree<EmptyTree>(node)) {
@@ -25,7 +25,7 @@ private:
         return make_tree<UnresolvedConstantLit>(constLit->loc, std::move(scope), cnst);
     }
 
-    TreePtr substArg(core::MutableContext ctx, TreePtr argp) {
+    TreePtr substArg(core::Context ctx, TreePtr argp) {
         Expression *arg = argp.get();
         while (arg != nullptr) {
             typecase(
@@ -44,7 +44,7 @@ private:
 public:
     SubstWalk(const core::GlobalSubstitution &subst) : subst(subst) {}
 
-    TreePtr preTransformClassDef(core::MutableContext ctx, TreePtr tree) {
+    TreePtr preTransformClassDef(core::Context ctx, TreePtr tree) {
         auto *original = cast_tree<ClassDef>(tree);
         original->name = substClassName(ctx, std::move(original->name));
         for (auto &anc : original->ancestors) {
@@ -53,7 +53,7 @@ public:
         return tree;
     }
 
-    TreePtr preTransformMethodDef(core::MutableContext ctx, TreePtr tree) {
+    TreePtr preTransformMethodDef(core::Context ctx, TreePtr tree) {
         auto *original = cast_tree<MethodDef>(tree);
         original->name = subst.substitute(original->name);
         for (auto &arg : original->args) {
@@ -62,7 +62,7 @@ public:
         return tree;
     }
 
-    TreePtr preTransformBlock(core::MutableContext ctx, TreePtr tree) {
+    TreePtr preTransformBlock(core::Context ctx, TreePtr tree) {
         auto *original = cast_tree<Block>(tree);
         for (auto &arg : original->args) {
             arg = substArg(ctx, std::move(arg));
@@ -70,22 +70,22 @@ public:
         return tree;
     }
 
-    TreePtr postTransformUnresolvedIdent(core::MutableContext ctx, TreePtr original) {
+    TreePtr postTransformUnresolvedIdent(core::Context ctx, TreePtr original) {
         cast_tree<UnresolvedIdent>(original)->name = subst.substitute(cast_tree<UnresolvedIdent>(original)->name);
         return original;
     }
 
-    TreePtr postTransformLocal(core::MutableContext ctx, TreePtr local) {
+    TreePtr postTransformLocal(core::Context ctx, TreePtr local) {
         cast_tree<Local>(local)->localVariable._name = subst.substitute(cast_tree<Local>(local)->localVariable._name);
         return local;
     }
 
-    TreePtr preTransformSend(core::MutableContext ctx, TreePtr original) {
+    TreePtr preTransformSend(core::Context ctx, TreePtr original) {
         cast_tree<Send>(original)->fun = subst.substitute(cast_tree<Send>(original)->fun);
         return original;
     }
 
-    TreePtr postTransformLiteral(core::MutableContext ctx, TreePtr tree) {
+    TreePtr postTransformLiteral(core::Context ctx, TreePtr tree) {
         auto *original = cast_tree<Literal>(tree);
         if (original->isString(ctx)) {
             auto nameRef = original->asString(ctx);
@@ -112,7 +112,7 @@ public:
         return tree;
     }
 
-    TreePtr postTransformUnresolvedConstantLit(core::MutableContext ctx, TreePtr tree) {
+    TreePtr postTransformUnresolvedConstantLit(core::Context ctx, TreePtr tree) {
         auto *original = cast_tree<UnresolvedConstantLit>(tree);
         original->cnst = subst.substitute(original->cnst);
         original->scope = substClassName(ctx, std::move(original->scope));
@@ -121,7 +121,7 @@ public:
 };
 } // namespace
 
-TreePtr Substitute::run(core::MutableContext ctx, const core::GlobalSubstitution &subst, TreePtr what) {
+TreePtr Substitute::run(core::Context ctx, const core::GlobalSubstitution &subst, TreePtr what) {
     if (subst.useFastPath()) {
         return what;
     }

--- a/ast/substitute/substitute.h
+++ b/ast/substitute/substitute.h
@@ -7,7 +7,7 @@
 namespace sorbet::ast {
 class Substitute {
 public:
-    static TreePtr run(core::MutableContext ctx, const core::GlobalSubstitution &subst, TreePtr what);
+    static TreePtr run(core::Context ctx, const core::GlobalSubstitution &subst, TreePtr what);
 };
 } // namespace sorbet::ast
 #endif // SORBET_SUBSTITUTE_H

--- a/common/concurrency/ConcurrentQueue.h
+++ b/common/concurrency/ConcurrentQueue.h
@@ -37,10 +37,15 @@ public:
     AbstractConcurrentBoundedQueue(const AbstractConcurrentBoundedQueue &other) = delete;
     AbstractConcurrentBoundedQueue(AbstractConcurrentBoundedQueue &&other) = delete;
 
-    inline void push(Elem &&elem, int count) noexcept {
-        _queue.enqueue(std::move(elem));
+    inline void reduceCapacity(int count) noexcept {
+        ENFORCE(count > 0);
         elementsLeftToPush.fetch_add(-count, std::memory_order_release);
         ENFORCE(elementsLeftToPush.load(std::memory_order_relaxed) >= 0);
+    }
+
+    inline void push(Elem &&elem, int count) noexcept {
+        _queue.enqueue(std::move(elem));
+        reduceCapacity(count);
     }
 
     inline DequeueResult try_pop(Elem &elem) noexcept {

--- a/common/concurrency/ConcurrentQueue.h
+++ b/common/concurrency/ConcurrentQueue.h
@@ -38,7 +38,6 @@ public:
     AbstractConcurrentBoundedQueue(AbstractConcurrentBoundedQueue &&other) = delete;
 
     inline void reduceCapacity(int count) noexcept {
-        ENFORCE(count > 0);
         elementsLeftToPush.fetch_add(-count, std::memory_order_release);
         ENFORCE(elementsLeftToPush.load(std::memory_order_relaxed) >= 0);
     }

--- a/core/Context.cc
+++ b/core/Context.cc
@@ -142,26 +142,28 @@ GlobalSubstitution::GlobalSubstitution(const GlobalState &from, GlobalState &to,
             }
         }
 
-        // Enforce that the symbol tables are the same
-        for (int i = 0; i < from.classAndModules.size(); ++i) {
-            ENFORCE(substitute(from.classAndModules[i].name) == from.classAndModules[i].name);
-            ENFORCE(from.classAndModules[i].name == to.classAndModules[i].name);
-        }
-        for (int i = 0; i < from.methods.size(); ++i) {
-            ENFORCE(substitute(from.methods[i].name) == from.methods[i].name);
-            ENFORCE(from.methods[i].name == to.methods[i].name);
-        }
-        for (int i = 0; i < from.fields.size(); ++i) {
-            ENFORCE(substitute(from.fields[i].name) == from.fields[i].name);
-            ENFORCE(from.fields[i].name == to.fields[i].name);
-        }
-        for (int i = 0; i < from.typeArguments.size(); ++i) {
-            ENFORCE(substitute(from.typeArguments[i].name) == from.typeArguments[i].name);
-            ENFORCE(from.typeArguments[i].name == to.typeArguments[i].name);
-        }
-        for (int i = 0; i < from.typeMembers.size(); ++i) {
-            ENFORCE(substitute(from.typeMembers[i].name) == from.typeMembers[i].name);
-            ENFORCE(from.typeMembers[i].name == to.typeMembers[i].name);
+        if (debug_mode) {
+            // Enforce that the symbol tables are the same
+            for (int i = 0; i < from.classAndModules.size(); ++i) {
+                ENFORCE(substitute(from.classAndModules[i].name) == from.classAndModules[i].name);
+                ENFORCE(from.classAndModules[i].name == to.classAndModules[i].name);
+            }
+            for (int i = 0; i < from.methods.size(); ++i) {
+                ENFORCE(substitute(from.methods[i].name) == from.methods[i].name);
+                ENFORCE(from.methods[i].name == to.methods[i].name);
+            }
+            for (int i = 0; i < from.fields.size(); ++i) {
+                ENFORCE(substitute(from.fields[i].name) == from.fields[i].name);
+                ENFORCE(from.fields[i].name == to.fields[i].name);
+            }
+            for (int i = 0; i < from.typeArguments.size(); ++i) {
+                ENFORCE(substitute(from.typeArguments[i].name) == from.typeArguments[i].name);
+                ENFORCE(from.typeArguments[i].name == to.typeArguments[i].name);
+            }
+            for (int i = 0; i < from.typeMembers.size(); ++i) {
+                ENFORCE(substitute(from.typeMembers[i].name) == from.typeMembers[i].name);
+                ENFORCE(from.typeMembers[i].name == to.typeMembers[i].name);
+            }
         }
     }
 

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -727,6 +727,11 @@ vector<ast::ParsedFile> index(unique_ptr<core::GlobalState> &gs, vector<core::Fi
         }
         ENFORCE(files.size() + pluginFileCount == ret.size());
     } else {
+        // Index larger files first to improve throughput
+        fast_sort(files, [&](const auto &lhs, const auto &rhs) -> bool {
+            // N.B.: Using `dataAllowingUnsafe` as file may be marked NotYetRead.
+            return lhs.dataAllowingUnsafe(*gs).source().size() > rhs.dataAllowingUnsafe(*gs).source().size();
+        });
         auto firstPass = indexSuppliedFiles(move(gs), files, opts, workers, kvstore);
         auto pluginPass = indexPluginFiles(move(firstPass), opts, workers, kvstore);
         gs = move(pluginPass.gs);

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -727,11 +727,6 @@ vector<ast::ParsedFile> index(unique_ptr<core::GlobalState> &gs, vector<core::Fi
         }
         ENFORCE(files.size() + pluginFileCount == ret.size());
     } else {
-        // Index larger files first to improve throughput
-        fast_sort(files, [&](const auto &lhs, const auto &rhs) -> bool {
-            // N.B.: Using `dataAllowingUnsafe` as file may be marked NotYetRead.
-            return lhs.dataAllowingUnsafe(*gs).source().size() > rhs.dataAllowingUnsafe(*gs).source().size();
-        });
         auto firstPass = indexSuppliedFiles(move(gs), files, opts, workers, kvstore);
         auto pluginPass = indexPluginFiles(move(firstPass), opts, workers, kvstore);
         gs = move(pluginPass.gs);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Speed up cold cache indexing by parallelizing tree walk.

The win would be larger if the main coordinating thread could begin the worker threads _before_ enqueueing work, as that would allow indexing threads that finish first to pick up tree walking work early. However, we cannot do this safely when multithreading is disabled; we lack a good primitive to handle this behavior. I hope to address that shortcoming in the future.

The win would also be larger if we decoupled _reading_ the files from _parsing_ the files, as that would let us sort the input files by size for better throughput.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This change is a slight win when typechecking large projects.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
