### PR TITLE
Send LSP message for early exits on errors

### DIFF
--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -22,7 +22,7 @@ string getRootPath(const shared_ptr<LSPOutput> &output, const options::Options &
     if (opts.rawInputDirNames.size() != 1) {
         auto msg = "Sorbet's language server requires a single input directory.";
         logger->error(msg);
-        auto params = make_unique<ShowMessageParams>(MessageType(1 /* error */), msg);
+        auto params = make_unique<ShowMessageParams>(MessageType::Error, msg);
         output->write(make_unique<LSPMessage>(
             make_unique<NotificationMessage>("2.0", LSPMethod::WindowShowMessage, move(params))));
         throw options::EarlyReturnWithCode(1);

--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -2,6 +2,8 @@
 #include "absl/strings/match.h"
 #include "absl/strings/str_replace.h"
 #include "common/FileOps.h"
+#include "main/lsp/LSPMessage.h"
+#include "main/lsp/LSPOutput.h"
 #include "main/lsp/json_types.h"
 
 using namespace std;
@@ -15,9 +17,14 @@ constexpr string_view httpsScheme = "https"sv;
 
 namespace {
 
-string getRootPath(const options::Options &opts, const shared_ptr<spdlog::logger> &logger) {
+string getRootPath(const shared_ptr<LSPOutput> &output, const options::Options &opts,
+                   const shared_ptr<spdlog::logger> &logger) {
     if (opts.rawInputDirNames.size() != 1) {
-        logger->error("Sorbet's language server requires a single input directory.");
+        auto msg = "Sorbet's language server requires a single input directory.";
+        logger->error(msg);
+        auto params = make_unique<ShowMessageParams>(MessageType(1 /* error */), msg);
+        output->write(make_unique<LSPMessage>(
+            make_unique<NotificationMessage>("2.0", LSPMethod::WindowShowMessage, move(params))));
         throw options::EarlyReturnWithCode(1);
     }
     return opts.rawInputDirNames.at(0);
@@ -35,7 +42,7 @@ MarkupKind getPreferredMarkupKind(vector<MarkupKind> formats) {
 LSPConfiguration::LSPConfiguration(const options::Options &opts, const shared_ptr<LSPOutput> &output,
                                    const shared_ptr<spdlog::logger> &logger, bool skipConfigatron, bool disableFastPath)
     : initialized(atomic<bool>(false)), opts(opts), output(output), logger(logger), skipConfigatron(skipConfigatron),
-      disableFastPath(disableFastPath), rootPath(getRootPath(opts, logger)) {}
+      disableFastPath(disableFastPath), rootPath(getRootPath(output, opts, logger)) {}
 
 void LSPConfiguration::assertHasClientConfig() const {
     if (!clientConfig) {

--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -123,7 +123,7 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(shared_ptr<LSPInput> inp
             auto msg = "Watchman support currently only works when Sorbet is run with a single input directory. If "
                        "Watchman is not needed, run Sorbet with `--disable-watchman`.";
             logger->error(msg);
-            auto params = make_unique<ShowMessageParams>(MessageType(1 /* error */), msg);
+            auto params = make_unique<ShowMessageParams>(MessageType::Error, msg);
             config->output->write(make_unique<LSPMessage>(
                 make_unique<NotificationMessage>("2.0", LSPMethod::WindowShowMessage, move(params))));
             throw options::EarlyReturnWithCode(1);
@@ -154,7 +154,7 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(shared_ptr<LSPInput> inp
                         messageQueue.terminate = true;
                         messageQueue.errorCode = watchmanExitCode;
                         if (watchmanExitCode != 0) {
-                            auto params = make_unique<ShowMessageParams>(MessageType(1 /* error */), msg);
+                            auto params = make_unique<ShowMessageParams>(MessageType::Error, msg);
                             config->output->write(make_unique<LSPMessage>(
                                 make_unique<NotificationMessage>("2.0", LSPMethod::WindowShowMessage, move(params))));
                         }

--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -146,12 +146,18 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(shared_ptr<LSPInput> inp
                     messageQueue.pendingRequests.push_back(move(msg));
                 }
             },
-            [&messageQueue, &messageQueueMutex, logger = logger](int watchmanExitCode) {
+            [&messageQueue, &messageQueueMutex, logger = logger, config = this->config](int watchmanExitCode,
+                                                                                        string const &msg) {
                 {
                     absl::MutexLock lck(&messageQueueMutex);
                     if (!messageQueue.terminate) {
                         messageQueue.terminate = true;
                         messageQueue.errorCode = watchmanExitCode;
+                        if (watchmanExitCode != 0) {
+                            auto params = make_unique<ShowMessageParams>(MessageType(1 /* error */), msg);
+                            config->output->write(make_unique<LSPMessage>(
+                                make_unique<NotificationMessage>("2.0", LSPMethod::WindowShowMessage, move(params))));
+                        }
                     }
                     logger->debug("Watchman terminating");
                 }

--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -3,7 +3,9 @@
 #include "common/Timer.h"
 #include "common/web_tracer_framework/tracing.h"
 #include "core/lsp/TypecheckEpochManager.h"
+#include "main/lsp/LSPConfiguration.h"
 #include "main/lsp/LSPInput.h"
+#include "main/lsp/LSPOutput.h"
 #include "main/lsp/LSPPreprocessor.h"
 #include "main/lsp/LSPTask.h"
 #include "main/lsp/json_types.h"
@@ -118,8 +120,12 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(shared_ptr<LSPInput> inp
     auto &logger = config->logger;
     if (!opts.disableWatchman) {
         if (opts.rawInputDirNames.size() != 1 || !opts.rawInputFileNames.empty()) {
-            logger->error("Watchman support currently only works when Sorbet is run with a single input directory. If "
-                          "Watchman is not needed, run Sorbet with `--disable-watchman`.");
+            auto msg = "Watchman support currently only works when Sorbet is run with a single input directory. If "
+                       "Watchman is not needed, run Sorbet with `--disable-watchman`.";
+            logger->error(msg);
+            auto params = make_unique<ShowMessageParams>(MessageType(1 /* error */), msg);
+            config->output->write(make_unique<LSPMessage>(
+                make_unique<NotificationMessage>("2.0", LSPMethod::WindowShowMessage, move(params))));
             throw options::EarlyReturnWithCode(1);
         }
 

--- a/main/lsp/watchman/WatchmanProcess.cc
+++ b/main/lsp/watchman/WatchmanProcess.cc
@@ -97,7 +97,7 @@ void WatchmanProcess::start() {
                 "detect changes to files made outside of your code editor.\nDon't need Watchman? Run Sorbet "
                 "with `--disable-watchman`.",
                 watchmanPath);
-            logger->info(msg);
+            logger->error(msg);
             exitWithCode(1, msg);
         } else {
             // The forked process failed to start, likely because Watchman wasn't found. Exit the process.

--- a/main/lsp/watchman/WatchmanProcess.h
+++ b/main/lsp/watchman/WatchmanProcess.h
@@ -18,7 +18,7 @@ private:
     const std::string workSpace;
     const std::vector<std::string> extensions;
     const std::function<void(std::unique_ptr<sorbet::realmain::lsp::WatchmanQueryResponse>)> processUpdate;
-    const std::function<void(int)> processExit;
+    const std::function<void(int, std::string const &)> processExit;
     const std::unique_ptr<Joinable> thread;
     // Mutex that must be held before reading or writing stopped.
     absl::Mutex mutex;
@@ -30,7 +30,7 @@ private:
      */
     void start();
 
-    void exitWithCode(int code);
+    void exitWithCode(int code, std::string const &);
 
     bool isStopped();
 
@@ -42,7 +42,7 @@ public:
     WatchmanProcess(std::shared_ptr<spdlog::logger> logger, std::string_view watchmanPath, std::string_view workSpace,
                     std::vector<std::string> extensions,
                     std::function<void(std::unique_ptr<sorbet::realmain::lsp::WatchmanQueryResponse>)> processUpdate,
-                    std::function<void(int)> processExit);
+                    std::function<void(int, std::string const &)> processExit);
 
     ~WatchmanProcess();
 

--- a/test/cli/lsp-requires-input-dir/lsp-requires-input-dir.out
+++ b/test/cli/lsp-requires-input-dir/lsp-requires-input-dir.out
@@ -1,1 +1,4 @@
 Sorbet's language server requires a single input directory.
+Content-Length: 139
+
+{"jsonrpc":"2.0","method":"window/showMessage","params":{"type":1,"message":"Sorbet's language server requires a single input directory."}}

--- a/test/cli/lsp-two-input-dirs/lsp-two-input-dirs.out
+++ b/test/cli/lsp-two-input-dirs/lsp-two-input-dirs.out
@@ -1,0 +1,3 @@
+Content-Length: 139
+
+{"jsonrpc":"2.0","method":"window/showMessage","params":{"type":1,"message":"Sorbet's language server requires a single input directory."}}

--- a/test/cli/lsp-two-input-dirs/lsp-two-input-dirs.sh
+++ b/test/cli/lsp-two-input-dirs/lsp-two-input-dirs.sh
@@ -1,0 +1,2 @@
+# Pass two directories (it doesn't matter what they are), and verify that we get the right error back
+main/sorbet --silence-dev-message --lsp --dir test/cli/lsp-two-input-dirs --dir test/cli 2>/dev/null


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Sends an LSP message (`window/showMessage`) before exiting due to errors.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

#3570 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
