### PR TITLE
Better error message when a variable is nil because it was uninitialized

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -667,7 +667,7 @@ class TypeAndOrigins final {
 public:
     TypePtr type;
     InlinedVector<Loc, 1> origins;
-    std::vector<ErrorLine> origins2Explanations(const GlobalState &gs) const;
+    std::vector<ErrorLine> origins2Explanations(const GlobalState &gs, const Loc &originForUninitialized) const;
     ~TypeAndOrigins() noexcept;
     TypeAndOrigins() = default;
     TypeAndOrigins(const TypeAndOrigins &) = default;
@@ -710,6 +710,7 @@ struct DispatchArgs {
     const TypePtr &fullType;
     const TypePtr &thisType;
     const std::shared_ptr<const SendAndBlockLink> &block;
+    const Loc &originForUninitialized;
 
     DispatchArgs withSelfRef(const TypePtr &newSelfRef);
     DispatchArgs withThisRef(const TypePtr &newThisRef);

--- a/core/Types.h
+++ b/core/Types.h
@@ -667,7 +667,7 @@ class TypeAndOrigins final {
 public:
     TypePtr type;
     InlinedVector<Loc, 1> origins;
-    std::vector<ErrorLine> origins2Explanations(const GlobalState &gs, const Loc &originForUninitialized) const;
+    std::vector<ErrorLine> origins2Explanations(const GlobalState &gs, Loc originForUninitialized) const;
     ~TypeAndOrigins() noexcept;
     TypeAndOrigins() = default;
     TypeAndOrigins(const TypeAndOrigins &) = default;
@@ -710,7 +710,7 @@ struct DispatchArgs {
     const TypePtr &fullType;
     const TypePtr &thisType;
     const std::shared_ptr<const SendAndBlockLink> &block;
-    const Loc &originForUninitialized;
+    Loc originForUninitialized;
 
     DispatchArgs withSelfRef(const TypePtr &newSelfRef);
     DispatchArgs withThisRef(const TypePtr &newThisRef);

--- a/core/TypesAndOrigins.cc
+++ b/core/TypesAndOrigins.cc
@@ -4,10 +4,32 @@
 using namespace std;
 namespace sorbet::core {
 
-// This sorts the underlying `origins`
-vector<ErrorLine> TypeAndOrigins::origins2Explanations(const GlobalState &gs) const {
+// This sorts the underlying `origins`.
+//
+// `originForUninitialized` is some local state that we pipe in here for the
+// sake of better error messages. Basically, when a variable takes on the type
+// `NilClass` due to its being uninitialized, we will assign a `Loc` for its
+// origin that corresponds to the enclosing `def` itself, rather than to a
+// specific initializing statement. `originForUninitialized` is that loc, and
+// we test for equality against it to decide whether to print a special error
+// message. Note that it is safe to pass `Loc::none()` as
+// `originForUninitialized` if the information is not easily available, but the
+// resulting messages may be a bit confusing.
+vector<ErrorLine> TypeAndOrigins::origins2Explanations(const GlobalState &gs, const Loc &originForUninitialized) const {
     vector<ErrorLine> result;
-    auto compare = [](Loc left, Loc right) {
+
+    auto compare = [&originForUninitialized](Loc left, Loc right) {
+        // Put "uninitialized" origins towards the end, since the overall
+        // message reads better that way.
+        if (originForUninitialized.exists()) {
+            if (left == originForUninitialized && right != originForUninitialized) {
+                return false;
+            }
+            if (left != originForUninitialized && right == originForUninitialized) {
+                return true;
+            }
+        }
+
         if (left.file() != right.file()) {
             return left.file().id() < right.file().id();
         }
@@ -27,7 +49,14 @@ vector<ErrorLine> TypeAndOrigins::origins2Explanations(const GlobalState &gs) co
             continue;
         }
         last = o;
-        result.emplace_back(o, "");
+
+        if (originForUninitialized.exists() && o == originForUninitialized) {
+            result.emplace_back(ErrorLine::from(
+                o, "Type may be `{}` since it depends on variables that are not necessarily initialized here:",
+                "NilClass"));
+        } else {
+            result.emplace_back(o, "");
+        }
     }
     return result;
 }

--- a/core/TypesAndOrigins.cc
+++ b/core/TypesAndOrigins.cc
@@ -52,7 +52,7 @@ vector<ErrorLine> TypeAndOrigins::origins2Explanations(const GlobalState &gs, Lo
         last = o;
 
         if (originForUninitialized.exists() && o == originForUninitialized) {
-            result.emplace_back(ErrorLine::from(o, "Type may be `{}` due to uninitialized variables in:", "NilClass"));
+            result.emplace_back(ErrorLine::from(o, "Possibly uninitialized (`{}`) in:", "NilClass"));
         } else {
             result.emplace_back(o, "");
         }

--- a/core/TypesAndOrigins.cc
+++ b/core/TypesAndOrigins.cc
@@ -12,13 +12,14 @@ namespace sorbet::core {
 // origin that corresponds to the enclosing `def` itself, rather than to a
 // specific initializing statement. `originForUninitialized` is that loc, and
 // we test for equality against it to decide whether to print a special error
-// message. Note that it is safe to pass `Loc::none()` as
-// `originForUninitialized` if the information is not easily available, but the
-// resulting messages may be a bit confusing.
-vector<ErrorLine> TypeAndOrigins::origins2Explanations(const GlobalState &gs, const Loc &originForUninitialized) const {
+// message. Note that it is reasonable to pass `Loc::none()` as
+// `originForUninitialized` only if the information is truly not applicable
+// (e.g. in "fake" dispatches used to generate signature suggestions). In other
+// cases, passing `Loc::none()` will result in confusing error messages.
+vector<ErrorLine> TypeAndOrigins::origins2Explanations(const GlobalState &gs, Loc originForUninitialized) const {
     vector<ErrorLine> result;
 
-    auto compare = [&originForUninitialized](Loc left, Loc right) {
+    auto compare = [originForUninitialized](Loc left, Loc right) {
         // Put "uninitialized" origins towards the end, since the overall
         // message reads better that way.
         if (originForUninitialized.exists()) {

--- a/core/TypesAndOrigins.cc
+++ b/core/TypesAndOrigins.cc
@@ -51,9 +51,7 @@ vector<ErrorLine> TypeAndOrigins::origins2Explanations(const GlobalState &gs, co
         last = o;
 
         if (originForUninitialized.exists() && o == originForUninitialized) {
-            result.emplace_back(ErrorLine::from(
-                o, "Type may be `{}` since it depends on variables that are not necessarily initialized here:",
-                "NilClass"));
+            result.emplace_back(ErrorLine::from(o, "Type may be `{}` due to uninitialized variables in:", "NilClass"));
         } else {
             result.emplace_back(o, "");
         }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -160,7 +160,8 @@ core::Loc smallestLocWithin(core::Loc callLoc, const core::TypeAndOrigins &argTp
 
 unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Loc callLoc, Loc receiverLoc,
                                SymbolRef inClass, SymbolRef method, const TypeAndOrigins &argTpe, const ArgInfo &argSym,
-                               const TypePtr &selfType, vector<TypePtr> &targs, Loc loc, bool mayBeSetter = false) {
+                               const TypePtr &selfType, vector<TypePtr> &targs, Loc loc, Loc ownerLoc,
+                               bool mayBeSetter = false) {
     TypePtr expectedType = Types::resultTypeAsSeenFrom(gs, argSym.type, method.data(gs)->owner, inClass, targs);
     if (!expectedType) {
         expectedType = Types::untyped(gs, method);
@@ -184,8 +185,8 @@ unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Lo
                                 argSym.argumentName(gs), expectedType->show(gs)),
             }));
         }
-        e.addErrorSection(
-            ErrorSection("Got " + argTpe.type->show(gs) + " originating from:", argTpe.origins2Explanations(gs)));
+        e.addErrorSection(ErrorSection("Got " + argTpe.type->show(gs) + " originating from:",
+                                       argTpe.origins2Explanations(gs, ownerLoc)));
         auto withoutNil = Types::approximateSubtract(gs, argTpe.type, Types::nilClass());
         if (!withoutNil->isBottom() &&
             Types::isSubTypeUnderConstraint(gs, constr, withoutNil, expectedType, UntypedMode::AlwaysCompatible)) {
@@ -678,10 +679,10 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args, core
         }
 
         auto offset = ait - args.args.begin();
-        if (auto e =
-                matchArgType(gs, *constr, core::Loc(args.locs.file, args.locs.call),
-                             core::Loc(args.locs.file, args.locs.receiver), symbol, method, *arg, spec, args.selfType,
-                             targs, core::Loc(args.locs.file, args.locs.args[offset]), args.args.size() == 1)) {
+        if (auto e = matchArgType(gs, *constr, core::Loc(args.locs.file, args.locs.call),
+                                  core::Loc(args.locs.file, args.locs.receiver), symbol, method, *arg, spec,
+                                  args.selfType, targs, core::Loc(args.locs.file, args.locs.args[offset]),
+                                  args.originForUninitialized, args.args.size() == 1)) {
             result.main.errors.emplace_back(std::move(e));
         }
 
@@ -763,8 +764,9 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args, core
                                 gs.beginError(core::Loc(args.locs.file, args.locs.call), errors::Infer::UntypedSplat)) {
                             e.setHeader("Passing a hash where the specific keys are unknown to a method taking keyword "
                                         "arguments");
-                            e.addErrorSection(ErrorSection("Got " + kwSplatType->show(gs) + " originating from:",
-                                                           kwSplatArg->origins2Explanations(gs)));
+                            e.addErrorSection(
+                                ErrorSection("Got " + kwSplatType->show(gs) + " originating from:",
+                                             kwSplatArg->origins2Explanations(gs, args.originForUninitialized)));
                             result.main.errors.emplace_back(e.build());
                         }
                         kwargs = Types::untypedUntracked();
@@ -797,7 +799,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args, core
                 if (auto e = matchArgType(gs, *constr, core::Loc(args.locs.file, args.locs.call),
                                           core::Loc(args.locs.file, args.locs.receiver), symbol, method,
                                           TypeAndOrigins{kwargs, {kwargsLoc}}, *pit, args.selfType, targs, kwargsLoc,
-                                          args.args.size() == 1)) {
+                                          args.originForUninitialized, args.args.size() == 1)) {
                     result.main.errors.emplace_back(std::move(e));
                 }
 
@@ -880,9 +882,10 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args, core
                         tpe.origins = {kwargsLoc};
                         auto offset = it - hash->keys.begin();
                         tpe.type = hash->values[offset];
-                        if (auto e = matchArgType(gs, *constr, core::Loc(args.locs.file, args.locs.call),
-                                                  core::Loc(args.locs.file, args.locs.receiver), symbol, method, tpe,
-                                                  spec, args.selfType, targs, Loc::none())) {
+                        if (auto e =
+                                matchArgType(gs, *constr, core::Loc(args.locs.file, args.locs.call),
+                                             core::Loc(args.locs.file, args.locs.receiver), symbol, method, tpe, spec,
+                                             args.selfType, targs, Loc::none(), args.originForUninitialized)) {
                             result.main.errors.emplace_back(std::move(e));
                         }
                     }
@@ -911,7 +914,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args, core
                 tpe.type = hash->values[offset];
                 if (auto e = matchArgType(gs, *constr, core::Loc(args.locs.file, args.locs.call),
                                           core::Loc(args.locs.file, args.locs.receiver), symbol, method, tpe, spec,
-                                          args.selfType, targs, Loc::none())) {
+                                          args.selfType, targs, Loc::none(), args.originForUninitialized)) {
                     result.main.errors.emplace_back(std::move(e));
                 }
             }
@@ -1111,8 +1114,15 @@ TypePtr AliasType::getCallArguments(const GlobalState &gs, NameRef name) {
 DispatchResult MetaType::dispatchCall(const GlobalState &gs, DispatchArgs args) {
     switch (args.name._id) {
         case Names::new_()._id: {
-            auto innerArgs = DispatchArgs{
-                Names::initialize(), args.locs, args.numPosArgs, args.args, wrapped, wrapped, wrapped, args.block};
+            auto innerArgs = DispatchArgs{Names::initialize(),
+                                          args.locs,
+                                          args.numPosArgs,
+                                          args.args,
+                                          wrapped,
+                                          wrapped,
+                                          wrapped,
+                                          args.block,
+                                          args.originForUninitialized};
             auto original = wrapped->dispatchCall(gs, innerArgs);
             original.returnType = wrapped;
             original.main.sendTp = wrapped;
@@ -1232,7 +1242,8 @@ public:
 
         if (auto e = gs.beginError(core::Loc(args.locs.file, args.locs.call), errors::Infer::RevealType)) {
             e.setHeader("Revealed type: `{}`", args.args[0]->type->showWithMoreInfo(gs));
-            e.addErrorSection(ErrorSection("From:", args.args[0]->origins2Explanations(gs)));
+            e.addErrorSection(
+                ErrorSection("From:", args.args[0]->origins2Explanations(gs, args.originForUninitialized)));
         }
         res.returnType = args.args[0]->type;
     }
@@ -1287,8 +1298,9 @@ public:
             }
         }
         auto instanceTy = attachedClass.data(gs)->externalType();
-        DispatchArgs innerArgs{Names::initialize(), args.locs,  args.numPosArgs, args.args,
-                               instanceTy,          instanceTy, instanceTy,      args.block};
+        DispatchArgs innerArgs{Names::initialize(), args.locs,  args.numPosArgs,
+                               args.args,           instanceTy, instanceTy,
+                               instanceTy,          args.block, args.originForUninitialized};
         auto dispatched = instanceTy->dispatchCall(gs, innerArgs);
 
         for (auto &err : res.main.errors) {
@@ -1451,8 +1463,8 @@ public:
         }
 
         auto recv = args.args[0]->type;
-        res = recv->dispatchCall(
-            gs, {core::Names::sig(), callLocs, numPosArgs, dispatchArgsArgs, recv, recv, recv, args.block});
+        res = recv->dispatchCall(gs, {core::Names::sig(), callLocs, numPosArgs, dispatchArgsArgs, recv, recv, recv,
+                                      args.block, args.originForUninitialized});
     }
 } SorbetPrivateStatic_sig;
 
@@ -1671,8 +1683,15 @@ public:
             posTuple, kwTuple, sendArgStore, core::Loc(args.locs.file, args.locs.args[2]));
         InlinedVector<LocOffsets, 2> sendArgLocs(sendArgs.size(), args.locs.args[2]);
         CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], sendArgLocs};
-        DispatchArgs innerArgs{
-            fn, sendLocs, numPosArgs, sendArgs, receiver->type, receiver->type, receiver->type, args.block};
+        DispatchArgs innerArgs{fn,
+                               sendLocs,
+                               numPosArgs,
+                               sendArgs,
+                               receiver->type,
+                               receiver->type,
+                               receiver->type,
+                               args.block,
+                               args.originForUninitialized};
         auto dispatched = receiver->type->dispatchCall(gs, innerArgs);
         for (auto &err : dispatched.main.errors) {
             res.main.errors.emplace_back(std::move(err));
@@ -1695,7 +1714,7 @@ class Magic_callWithBlock : public IntrinsicMethod {
 
 private:
     static TypePtr typeToProc(const GlobalState &gs, TypePtr blockType, core::FileRef file, LocOffsets callLoc,
-                              LocOffsets receiverLoc) {
+                              LocOffsets receiverLoc, const Loc &originForUninitialized) {
         auto nonNilBlockType = blockType;
         auto typeIsNilable = false;
         if (Types::isSubType(gs, Types::nilClass(), blockType)) {
@@ -1711,8 +1730,9 @@ private:
         InlinedVector<const TypeAndOrigins *, 2> sendArgs;
         InlinedVector<LocOffsets, 2> sendArgLocs;
         CallLocs sendLocs{file, callLoc, receiverLoc, sendArgLocs};
-        DispatchArgs innerArgs{to_proc,         sendLocs,        0,      sendArgs, nonNilBlockType,
-                               nonNilBlockType, nonNilBlockType, nullptr};
+        DispatchArgs innerArgs{to_proc,         sendLocs,        0,
+                               sendArgs,        nonNilBlockType, nonNilBlockType,
+                               nonNilBlockType, nullptr,         originForUninitialized};
         auto dispatched = nonNilBlockType->dispatchCall(gs, innerArgs);
         for (auto &err : dispatched.main.errors) {
             gs._error(std::move(err));
@@ -1893,14 +1913,21 @@ public:
         }
         CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], sendArgLocs};
 
-        TypePtr finalBlockType =
-            Magic_callWithBlock::typeToProc(gs, args.args[2]->type, args.locs.file, args.locs.call, args.locs.args[2]);
+        TypePtr finalBlockType = Magic_callWithBlock::typeToProc(gs, args.args[2]->type, args.locs.file, args.locs.call,
+                                                                 args.locs.args[2], args.originForUninitialized);
         std::optional<int> blockArity = Magic_callWithBlock::getArityForBlock(finalBlockType);
         auto link = make_shared<core::SendAndBlockLink>(fn, Magic_callWithBlock::argInfoByArity(blockArity), -1);
         res.main.constr = make_unique<TypeConstraint>();
 
-        DispatchArgs innerArgs{fn,  sendLocs, numPosArgs, sendArgs, receiver->type, receiver->type, receiver->type,
-                               link};
+        DispatchArgs innerArgs{fn,
+                               sendLocs,
+                               numPosArgs,
+                               sendArgs,
+                               receiver->type,
+                               receiver->type,
+                               receiver->type,
+                               link,
+                               args.originForUninitialized};
 
         Magic_callWithBlock::simulateCall(gs, receiver, innerArgs, link, finalBlockType,
                                           core::Loc(args.locs.file, args.locs.args[2]),
@@ -1976,14 +2003,21 @@ public:
         InlinedVector<LocOffsets, 2> sendArgLocs(sendArgs.size(), args.locs.args[2]);
         CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], sendArgLocs};
 
-        TypePtr finalBlockType =
-            Magic_callWithBlock::typeToProc(gs, args.args[4]->type, args.locs.file, args.locs.call, args.locs.args[4]);
+        TypePtr finalBlockType = Magic_callWithBlock::typeToProc(gs, args.args[4]->type, args.locs.file, args.locs.call,
+                                                                 args.locs.args[4], args.originForUninitialized);
         std::optional<int> blockArity = Magic_callWithBlock::getArityForBlock(finalBlockType);
         auto link = make_shared<core::SendAndBlockLink>(fn, Magic_callWithBlock::argInfoByArity(blockArity), -1);
         res.main.constr = make_unique<TypeConstraint>();
 
-        DispatchArgs innerArgs{fn,  sendLocs, numPosArgs, sendArgs, receiver->type, receiver->type, receiver->type,
-                               link};
+        DispatchArgs innerArgs{fn,
+                               sendLocs,
+                               numPosArgs,
+                               sendArgs,
+                               receiver->type,
+                               receiver->type,
+                               receiver->type,
+                               link,
+                               args.originForUninitialized};
 
         Magic_callWithBlock::simulateCall(gs, receiver, innerArgs, link, finalBlockType,
                                           core::Loc(args.locs.file, args.locs.args[4]),
@@ -2043,8 +2077,9 @@ public:
             // In the case that `self` is not a singleton class, we know that
             // this was a call to `new` outside of a self context. Dispatch to
             // an instance method named new, and see what happens.
-            DispatchArgs innerArgs{Names::new_(), sendLocs, numPosArgs, sendArgStore,
-                                   selfTy,        selfTy,   selfTy,     args.block};
+            DispatchArgs innerArgs{Names::new_(), sendLocs,   numPosArgs,
+                                   sendArgStore,  selfTy,     selfTy,
+                                   selfTy,        args.block, args.originForUninitialized};
             dispatched = selfTy->dispatchCall(gs, innerArgs);
             returnTy = dispatched.returnType;
         } else {
@@ -2056,8 +2091,9 @@ public:
             ENFORCE(attachedClass.exists());
 
             auto instanceTy = self.data(gs)->attachedClass(gs).data(gs)->externalType();
-            DispatchArgs innerArgs{Names::initialize(), sendLocs,   numPosArgs, sendArgStore,
-                                   instanceTy,          instanceTy, instanceTy, args.block};
+            DispatchArgs innerArgs{Names::initialize(), sendLocs,   numPosArgs,
+                                   sendArgStore,        instanceTy, instanceTy,
+                                   instanceTy,          args.block, args.originForUninitialized};
             dispatched = instanceTy->dispatchCall(gs, innerArgs);
 
             // The return type from dispatched is ignored, and we return
@@ -2441,9 +2477,8 @@ public:
         TypeAndOrigins myType{args.selfType, {core::Loc(args.locs.file, args.locs.receiver)}};
         InlinedVector<const TypeAndOrigins *, 2> innerArgs{&myType};
 
-        DispatchArgs dispatch{
-            core::Names::enumerableToH(), locs, 1, innerArgs, hash, hash, hash, nullptr,
-        };
+        DispatchArgs dispatch{core::Names::enumerableToH(), locs, 1, innerArgs, hash, hash, hash, nullptr,
+                              args.originForUninitialized};
         auto dispatched = hash->dispatchCall(gs, dispatch);
         for (auto &err : dispatched.main.errors) {
             res.main.errors.emplace_back(std::move(err));

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1714,7 +1714,7 @@ class Magic_callWithBlock : public IntrinsicMethod {
 
 private:
     static TypePtr typeToProc(const GlobalState &gs, TypePtr blockType, core::FileRef file, LocOffsets callLoc,
-                              LocOffsets receiverLoc, const Loc &originForUninitialized) {
+                              LocOffsets receiverLoc, Loc originForUninitialized) {
         auto nonNilBlockType = blockType;
         auto typeIsNilable = false;
         if (Types::isSubType(gs, Types::nilClass(), blockType)) {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -160,7 +160,7 @@ core::Loc smallestLocWithin(core::Loc callLoc, const core::TypeAndOrigins &argTp
 
 unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Loc callLoc, Loc receiverLoc,
                                SymbolRef inClass, SymbolRef method, const TypeAndOrigins &argTpe, const ArgInfo &argSym,
-                               const TypePtr &selfType, vector<TypePtr> &targs, Loc loc, Loc ownerLoc,
+                               const TypePtr &selfType, vector<TypePtr> &targs, Loc loc, Loc originForUninitialized,
                                bool mayBeSetter = false) {
     TypePtr expectedType = Types::resultTypeAsSeenFrom(gs, argSym.type, method.data(gs)->owner, inClass, targs);
     if (!expectedType) {
@@ -186,7 +186,7 @@ unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Lo
             }));
         }
         e.addErrorSection(ErrorSection("Got " + argTpe.type->show(gs) + " originating from:",
-                                       argTpe.origins2Explanations(gs, ownerLoc)));
+                                       argTpe.origins2Explanations(gs, originForUninitialized)));
         auto withoutNil = Types::approximateSubtract(gs, argTpe.type, Types::nilClass());
         if (!withoutNil->isBottom() &&
             Types::isSubTypeUnderConstraint(gs, constr, withoutNil, expectedType, UntypedMode::AlwaysCompatible)) {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -955,10 +955,10 @@ core::SymbolRef Types::getRepresentedClass(const GlobalState &gs, const core::Ty
 }
 
 DispatchArgs DispatchArgs::withSelfRef(const TypePtr &newSelfRef) {
-    return DispatchArgs{name, locs, numPosArgs, args, newSelfRef, fullType, newSelfRef, block};
+    return DispatchArgs{name, locs, numPosArgs, args, newSelfRef, fullType, newSelfRef, block, originForUninitialized};
 }
 
 DispatchArgs DispatchArgs::withThisRef(const TypePtr &newThisRef) {
-    return DispatchArgs{name, locs, numPosArgs, args, selfType, fullType, newThisRef, block};
+    return DispatchArgs{name, locs, numPosArgs, args, selfType, fullType, newThisRef, block, originForUninitialized};
 }
 } // namespace sorbet::core

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -89,8 +89,10 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
         snd->receiverLoc,
         snd->argLocs,
     };
-    core::DispatchArgs dispatchArgs{snd->fun,       locs,           snd->numPosArgs, args,
-                                    snd->recv.type, snd->recv.type, snd->recv.type,  snd->link};
+    auto originForUninitialized = core::Loc::none();
+    core::DispatchArgs dispatchArgs{snd->fun,       locs,           snd->numPosArgs,
+                                    args,           snd->recv.type, snd->recv.type,
+                                    snd->recv.type, snd->link,      originForUninitialized};
     auto dispatchInfo = snd->recv.type->dispatchCall(ctx, dispatchArgs);
 
     int i = -1;

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -89,6 +89,8 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
         snd->receiverLoc,
         snd->argLocs,
     };
+    // Since this is a "fake" dispatch and we are not going to display the errors anyway,
+    // core::Loc::none() should be okay here.
     auto originForUninitialized = core::Loc::none();
     core::DispatchArgs dispatchArgs{snd->fun,       locs,           snd->numPosArgs,
                                     args,           snd->recv.type, snd->recv.type,

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -952,8 +952,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     send->argLocs,
                 };
 
-                core::DispatchArgs dispatchArgs{send->fun,     locs,          send->numPosArgs, args,
-                                                recvType.type, recvType.type, recvType.type,    send->link};
+                core::DispatchArgs dispatchArgs{send->fun,     locs,          send->numPosArgs, args,    recvType.type,
+                                                recvType.type, recvType.type, send->link,       ownerLoc};
                 auto dispatched = recvType.type->dispatchCall(ctx, dispatchArgs);
 
                 auto it = &dispatched;
@@ -1158,7 +1158,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                             }));
                         e.addErrorSection(
                             core::ErrorSection("Got " + typeAndOrigin.type->show(ctx) + " originating from:",
-                                               typeAndOrigin.origins2Explanations(ctx)));
+                                               typeAndOrigin.origins2Explanations(ctx, ownerLoc)));
                     }
                 }
             },
@@ -1190,7 +1190,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         e.addErrorSection(core::ErrorSection("Expected " + expectedType->show(ctx)));
                         e.addErrorSection(
                             core::ErrorSection("Got " + typeAndOrigin.type->show(ctx) + " originating from:",
-                                               typeAndOrigin.origins2Explanations(ctx)));
+                                               typeAndOrigin.origins2Explanations(ctx, ownerLoc)));
                     }
                 }
 
@@ -1216,7 +1216,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         e.setHeader("Control flow could reach `{}` because the type `{}` wasn't handled", "T.absurd",
                                     typeAndOrigin.type->show(ctx));
                     }
-                    e.addErrorSection(core::ErrorSection("Originating from:", typeAndOrigin.origins2Explanations(ctx)));
+                    e.addErrorSection(
+                        core::ErrorSection("Originating from:", typeAndOrigin.origins2Explanations(ctx, ownerLoc)));
                 }
 
                 tp.type = core::Types::bottom();
@@ -1255,14 +1256,14 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::CastTypeMismatch)) {
                             e.setHeader("The typechecker was unable to infer the type of the asserted value");
                             e.addErrorSection(core::ErrorSection("Got " + ty.type->show(ctx) + " originating from:",
-                                                                 ty.origins2Explanations(ctx)));
+                                                                 ty.origins2Explanations(ctx, ownerLoc)));
                             e.addErrorSection(core::ErrorSection("You may need to add additional `sig` annotations"));
                         }
                     } else if (!core::Types::isSubType(ctx, ty.type, castType)) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::CastTypeMismatch)) {
                             e.setHeader("Argument does not have asserted type `{}`", castType->show(ctx));
                             e.addErrorSection(core::ErrorSection("Got " + ty.type->show(ctx) + " originating from:",
-                                                                 ty.origins2Explanations(ctx)));
+                                                                 ty.origins2Explanations(ctx, ownerLoc)));
                         }
                     }
                 } else if (!c->isSynthetic) {
@@ -1371,8 +1372,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                     e.replaceWith(fmt::format("Initialize as `{}`", suggest->show(ctx)), cur.origins[0],
                                                   "T.let({}, {})", cur.origins[0].source(ctx), suggest->show(ctx));
                                 } else {
-                                    e.addErrorSection(
-                                        core::ErrorSection("Original type from:", cur.origins2Explanations(ctx)));
+                                    e.addErrorSection(core::ErrorSection("Original type from:",
+                                                                         cur.origins2Explanations(ctx, ownerLoc)));
                                 }
                             }
 
@@ -1450,7 +1451,7 @@ core::TypeAndOrigins nilTypesWithOriginWithLoc(core::Loc loc) {
 }
 } // namespace
 
-Environment::Environment(core::Loc ownerLoc) : uninitialized(nilTypesWithOriginWithLoc(ownerLoc)) {}
+Environment::Environment(core::Loc ownerLoc) : uninitialized(nilTypesWithOriginWithLoc(ownerLoc)), ownerLoc(ownerLoc) {}
 
 TestedKnowledge TestedKnowledge::empty;
 } // namespace sorbet::infer

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -127,6 +127,8 @@ public:
 class Environment {
     const core::TypeAndOrigins uninitialized;
 
+    const core::Loc ownerLoc;
+
     /*
      * These four vectors represent the core state store of the environment,
      * modeling a map from local variables to (type, knowledge, known-truthy)

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -931,6 +931,8 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
 
             auto correctedSingleton = corrected.data(ctx)->singletonClass(ctx);
             auto ctype = core::make_type<core::ClassType>(correctedSingleton);
+            // In `dispatchArgs` this is ordinarily used to specify the origin tag for
+            // uninitialized variables. Inside of a signature we shouldn't need this:
             auto originForUninitialized = core::Loc::none();
             core::CallLocs locs{
                 ctx.file,

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -931,6 +931,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
 
             auto correctedSingleton = corrected.data(ctx)->singletonClass(ctx);
             auto ctype = core::make_type<core::ClassType>(correctedSingleton);
+            auto originForUninitialized = core::Loc::none();
             core::CallLocs locs{
                 ctx.file,
                 s->loc,
@@ -938,7 +939,8 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                 argLocs,
             };
             core::DispatchArgs dispatchArgs{
-                core::Names::squareBrackets(), locs, s->numPosArgs, targs, ctype, ctype, ctype, nullptr};
+                core::Names::squareBrackets(), locs, s->numPosArgs, targs, ctype, ctype, ctype, nullptr,
+                originForUninitialized};
             auto out = core::Types::dispatchCallWithoutBlock(ctx, ctype, dispatchArgs);
 
             if (out->isUntyped()) {

--- a/test/cli/errors/errors.out
+++ b/test/cli/errors/errors.out
@@ -38,15 +38,15 @@ test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` 
     .. |  sig {params(a: Integer).returns(Integer)}
                       ^
   Got T.nilable(Integer) originating from:
-    test/cli/errors/errors.rb:26:
-    .. |  def main(foo)
-          ^^^^^^^^^^^^^
     test/cli/errors/errors.rb:29:
     .. |          nil
                   ^^^
     test/cli/errors/errors.rb:31:
     .. |          2
                   ^
+    test/cli/errors/errors.rb:26: Type may be `NilClass` due to uninitialized variables in:
+    .. |  def main(foo)
+          ^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     test/cli/errors/errors.rb:33: Replace with `T.must(a)`
     .. |    bar(a)
@@ -92,15 +92,15 @@ test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` 
     .. |  sig {params(a: Integer).returns(Integer)}
                       ^
   Got T.nilable(Integer) originating from:
-    test/cli/errors/errors.rb:26:
-    .. |  def main(foo)
-          ^^^^^^^^^^^^^
     test/cli/errors/errors.rb:29:
     .. |          nil
                   ^^^
     test/cli/errors/errors.rb:31:
     .. |          2
                   ^
+    test/cli/errors/errors.rb:26: Type may be `NilClass` due to uninitialized variables in:
+    .. |  def main(foo)
+          ^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     test/cli/errors/errors.rb:33: Replace with `T.must(a)`
     .. |    bar(a)
@@ -146,15 +146,15 @@ test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` 
     .. |  sig {params(a: Integer).returns(Integer)}
                       ^
   Got T.nilable(Integer) originating from:
-    test/cli/errors/errors.rb:26:
-    .. |  def main(foo)
-          ^^^^^^^^^^^^^
     test/cli/errors/errors.rb:29:
     .. |          nil
                   ^^^
     test/cli/errors/errors.rb:31:
     .. |          2
                   ^
+    test/cli/errors/errors.rb:26: Type may be `NilClass` due to uninitialized variables in:
+    .. |  def main(foo)
+          ^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     test/cli/errors/errors.rb:33: Replace with `T.must(a)`
     .. |    bar(a)

--- a/test/cli/errors/errors.out
+++ b/test/cli/errors/errors.out
@@ -44,7 +44,7 @@ test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` 
     test/cli/errors/errors.rb:31:
     .. |          2
                   ^
-    test/cli/errors/errors.rb:26: Type may be `NilClass` due to uninitialized variables in:
+    test/cli/errors/errors.rb:26: Possibly uninitialized (`NilClass`) in:
     .. |  def main(foo)
           ^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
@@ -98,7 +98,7 @@ test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` 
     test/cli/errors/errors.rb:31:
     .. |          2
                   ^
-    test/cli/errors/errors.rb:26: Type may be `NilClass` due to uninitialized variables in:
+    test/cli/errors/errors.rb:26: Possibly uninitialized (`NilClass`) in:
     .. |  def main(foo)
           ^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
@@ -152,7 +152,7 @@ test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` 
     test/cli/errors/errors.rb:31:
     .. |          2
                   ^
-    test/cli/errors/errors.rb:26: Type may be `NilClass` due to uninitialized variables in:
+    test/cli/errors/errors.rb:26: Possibly uninitialized (`NilClass`) in:
     .. |  def main(foo)
           ^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect

--- a/test/cli/uninitialized-explanation/uninitialized-explanation.out
+++ b/test/cli/uninitialized-explanation/uninitialized-explanation.out
@@ -8,7 +8,7 @@ test/cli/uninitialized-explanation/uninitialized.rb:15: Expected `Integer` but f
     test/cli/uninitialized-explanation/uninitialized.rb:10:
     10 |    x = 1
                 ^
-    test/cli/uninitialized-explanation/uninitialized.rb:8: Type may be `NilClass` due to uninitialized variables in:
+    test/cli/uninitialized-explanation/uninitialized.rb:8: Possibly uninitialized (`NilClass`) in:
      8 |def uninitialized_loc_is_decl_loc
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect

--- a/test/cli/uninitialized-explanation/uninitialized-explanation.out
+++ b/test/cli/uninitialized-explanation/uninitialized-explanation.out
@@ -1,0 +1,18 @@
+test/cli/uninitialized-explanation/uninitialized.rb:15: Expected `Integer` but found `T.nilable(Integer)` for argument `x` https://srb.help/7002
+    15 |  takes_int(x)
+          ^^^^^^^^^^^^
+    test/cli/uninitialized-explanation/uninitialized.rb:5: Method `Object#takes_int` has specified `x` as `Integer`
+     5 |sig {params(x: Integer).void}
+                    ^
+  Got T.nilable(Integer) originating from:
+    test/cli/uninitialized-explanation/uninitialized.rb:10:
+    10 |    x = 1
+                ^
+    test/cli/uninitialized-explanation/uninitialized.rb:8: Type may be `NilClass` due to uninitialized variables in:
+     8 |def uninitialized_loc_is_decl_loc
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    test/cli/uninitialized-explanation/uninitialized.rb:15: Replace with `T.must(x)`
+    15 |  takes_int(x)
+                    ^
+Errors: 1

--- a/test/cli/uninitialized-explanation/uninitialized-explanation.sh
+++ b/test/cli/uninitialized-explanation/uninitialized-explanation.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+main/sorbet --silence-dev-message test/cli/uninitialized-explanation/uninitialized.rb 2>&1

--- a/test/cli/uninitialized-explanation/uninitialized.rb
+++ b/test/cli/uninitialized-explanation/uninitialized.rb
@@ -1,0 +1,16 @@
+# typed: true
+
+extend T::Sig
+
+sig {params(x: Integer).void}
+def takes_int(x); end
+
+def uninitialized_loc_is_decl_loc
+  if T.unsafe(nil)
+    x = 1
+  else
+    T.unsafe(self).raise "Unanalyzable raise"
+  end
+
+  takes_int(x)
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Addresses #1909.

Example input:

[→ View on sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0Asig%20%7Bparams(x%3A%20Integer).void%7D%0Adef%20takes_int(x)%3B%20end%0A%0Adef%20uninitialized_loc_is_decl_loc%0A%20%20if%20T.unsafe(nil)%0A%20%20%20%20x%20%3D%201%0A%20%20else%0A%20%20%20%20T.unsafe(self).raise%20%22Unanalyzable%20raise%22%0A%20%20end%0A%0A%20%20takes_int(x)%0Aend)

```ruby
# typed: true
extend T::Sig

sig {params(x: Integer).void}
def takes_int(x); end

def uninitialized_loc_is_decl_loc
  if T.unsafe(nil)
    x = 1
  else
    T.unsafe(self).raise "Unanalyzable raise"
  end

  takes_int(x)
end
```

Output before:

```
editor.rb:14: Expected Integer but found T.nilable(Integer) for argument x https://srb.help/7002
    14 |  takes_int(x)
          ^^^^^^^^^^^^
    editor.rb:4: Method Object#takes_int has specified x as Integer
     4 |sig {params(x: Integer).void}
                    ^
  Got T.nilable(Integer) originating from:
    editor.rb:7:
     7 |def uninitialized_loc_is_decl_loc
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    editor.rb:9:
     9 |    x = 1
                ^
  Autocorrect: Use `-a` to autocorrect
    editor.rb:14: Replace with T.must(x)
    14 |  takes_int(x)
                    ^
Errors: 1
```

Output after:

```
editor.rb:14: Expected Integer but found T.nilable(Integer) for argument x https://srb.help/7002
    14 |  takes_int(x)
          ^^^^^^^^^^^^
    editor.rb:4: Method Object#takes_int has specified x as Integer
     4 |sig {params(x: Integer).void}
                    ^
  Got T.nilable(Integer) originating from:
    editor.rb:9:
     9 |    x = 1
                ^
    editor.rb:7: Type may be NilClass due to uninitialized variables in:
     7 |def uninitialized_loc_is_decl_loc
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  Autocorrect: Use `-a` to autocorrect
    editor.rb:14: Replace with T.must(x)
    14 |  takes_int(x)
                    ^
Errors: 1
```

I couldn't find any way to do this without some slightly awkward plumbing into `origins2Explanations` and some other things up the call stack. Happy to revise if there's a better way!


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

See #1909


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Added a CLI test, and updated one existing CLI test that is affected by the change.