### PR TITLE
Basic autogen support for --stripe-packages

### DIFF
--- a/core/Files.cc
+++ b/core/Files.cc
@@ -177,6 +177,10 @@ bool File::isStdlib() const {
     return fileSigil(source()) == StrictLevel::Stdlib;
 }
 
+bool File::isPackage() const {
+    return absl::EndsWith(path(), "__package.rb");
+}
+
 vector<int> &File::lineBreaks() const {
     ENFORCE(this->sourceType != File::Type::TombStone);
     ENFORCE(this->sourceType != File::Type::NotYetRead);

--- a/core/Files.cc
+++ b/core/Files.cc
@@ -178,7 +178,7 @@ bool File::isStdlib() const {
 }
 
 bool File::isPackage() const {
-    return absl::EndsWith(path(), "__package.rb");
+    return sourceType == File::Type::Package;
 }
 
 vector<int> &File::lineBreaks() const {

--- a/core/Files.h
+++ b/core/Files.h
@@ -88,6 +88,7 @@ public:
     bool isPayload() const;
     bool isRBI() const;
     bool isStdlib() const;
+    bool isPackage() const;
 
     File(std::string &&path_, std::string &&source_, Type sourceType, u4 epoch = 0);
     File(File &&other) = delete;

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -221,10 +221,10 @@ public:
         // to the definition of the constant, because in that case we'll later on extend the location to cover the whole
         // class or assignment
         ref.definitionLoc = core::Loc(ctx.file, original->loc);
-        ref.name = constantName(ctx, original);
+        ref.name = QualifiedName::fromFullName(constantName(ctx, original));
         auto sym = original->symbol;
         if (!sym.data(ctx)->isClassOrModule() || sym != core::Symbols::StubModule()) {
-            ref.resolved = symbolName(ctx, sym);
+            ref.resolved = QualifiedName::fromFullName(symbolName(ctx, sym));
         }
         ref.is_resolved_statically = true;
         ref.is_defining_ref = false;

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -65,6 +65,11 @@ public:
         }
         scopeTypes.emplace_back(ScopeType::Class);
 
+        if (original.symbol.data(ctx)->owner == core::Symbols::PackageRegistry()) {
+            // this is a package, so do not enter a definition for it
+            return tree;
+        }
+
         // create a new `Definition`
         auto &def = defs.emplace_back();
         def.id = defs.size() - 1;

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -14,30 +14,25 @@ namespace sorbet::autogen {
 // different representation before using it. In this case, it takes the `autogen::ParsedFile` representation and
 // converts it to a `DefTree`, and then emits the autoloader files based on passed-in string fragments
 
-// `true` if the definition should have autoloads generated for it based on the `AutoloaderConfig`
 bool AutoloaderConfig::include(const NamedDefinition &nd) const {
     return !nd.qname.nameParts.empty() &&
            topLevelNamespaceRefs.find(nd.qname.nameParts[0]) != topLevelNamespaceRefs.end();
 }
 
-// `true` if the file should have autoloads generated for it (i.e. it's a ruby source file that's not ignored)
 bool AutoloaderConfig::includePath(string_view path) const {
     return absl::EndsWith(path, ".rb") &&
            !sorbet::FileOps::isFileIgnored("", fmt::format("/{}", path), absoluteIgnorePatterns,
                                            relativeIgnorePatterns);
 }
 
-// `true` if the file should be required based on the provided configuration
 bool AutoloaderConfig::includeRequire(core::NameRef req) const {
     return excludedRequireRefs.find(req) == excludedRequireRefs.end();
 }
 
-// `true` if the file name cannot be collapsed based on the provided configuration
 bool AutoloaderConfig::sameFileCollapsable(const vector<core::NameRef> &module) const {
     return nonCollapsableModuleNames.find(module) == nonCollapsableModuleNames.end();
 }
 
-// normalize the path relative to the provided prefixes
 string_view AutoloaderConfig::normalizePath(const core::GlobalState &gs, core::FileRef file) const {
     auto path = file.data(gs).path();
     for (const auto &prefix : stripPrefixes) {
@@ -48,8 +43,6 @@ string_view AutoloaderConfig::normalizePath(const core::GlobalState &gs, core::F
     return path;
 }
 
-// Convert the autoloader config passed in from `realmain` to this `AutoloaderConfig`. Much of this is about converting
-// `string`s to `NameRef`s
 AutoloaderConfig AutoloaderConfig::enterConfig(core::GlobalState &gs, const realmain::options::AutoloaderConfig &cfg) {
     AutoloaderConfig out;
     out.rootDir = cfg.rootDir;
@@ -74,8 +67,6 @@ AutoloaderConfig AutoloaderConfig::enterConfig(core::GlobalState &gs, const real
     return out;
 }
 
-// Convert an `autogen::DefinitionRef` to a `NamedDefinition`: this pulls the name, the parent definitions' name, the
-// requirements, the path, and the _depth_ of the path (which can short-circuit comparison against another path)
 NamedDefinition NamedDefinition::fromDef(const core::GlobalState &gs, ParsedFile &parsedFile, DefinitionRef def) {
     QualifiedName parentName;
     if (def.data(parsedFile).parent_ref.exists()) {
@@ -94,7 +85,6 @@ NamedDefinition NamedDefinition::fromDef(const core::GlobalState &gs, ParsedFile
     return {def.data(parsedFile), fullName, parentName, parsedFile.requires, parsedFile.tree.file, pathDepth};
 }
 
-// Used for sorting `NamedDefinition`
 bool NamedDefinition::preferredTo(const core::GlobalState &gs, const NamedDefinition &lhs, const NamedDefinition &rhs) {
     ENFORCE(lhs.qname == rhs.qname, "Can only compare definitions with same name");
     // Load defs with a parent name first since others will tend to depend on them.

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -27,17 +27,17 @@ bool AutoloaderConfig::includePath(string_view path) const {
                                            relativeIgnorePatterns);
 }
 
-// `true` if the file should be required
+// `true` if the file should be required based on the provided configuration
 bool AutoloaderConfig::includeRequire(core::NameRef req) const {
     return excludedRequireRefs.find(req) == excludedRequireRefs.end();
 }
 
-// `true` if collapsible (???)
+// `true` if the file name cannot be collapsed based on the provided configuration
 bool AutoloaderConfig::sameFileCollapsable(const vector<core::NameRef> &module) const {
     return nonCollapsableModuleNames.find(module) == nonCollapsableModuleNames.end();
 }
 
-// normalize the path relative to the prefixes (???)
+// normalize the path relative to the provided prefixes
 string_view AutoloaderConfig::normalizePath(const core::GlobalState &gs, core::FileRef file) const {
     auto path = file.data(gs).path();
     for (const auto &prefix : stripPrefixes) {
@@ -48,7 +48,8 @@ string_view AutoloaderConfig::normalizePath(const core::GlobalState &gs, core::F
     return path;
 }
 
-// Convert the autoloader config passed in from `realmain` to this `AutoloaderConfig`
+// Convert the autoloader config passed in from `realmain` to this `AutoloaderConfig`. Much of this is about converting
+// `string`s to `NameRef`s
 AutoloaderConfig AutoloaderConfig::enterConfig(core::GlobalState &gs, const realmain::options::AutoloaderConfig &cfg) {
     AutoloaderConfig out;
     out.rootDir = cfg.rootDir;

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -37,17 +37,23 @@ struct AutoloaderConfig {
     AutoloaderConfig &operator=(AutoloaderConfig &&) = default;
 };
 
+struct QualifiedName {
+    std::vector<core::NameRef> nameParts;
+    std::optional<core::NameRef> package;
+
+    static QualifiedName fromFullName(std::vector<core::NameRef> fullName);
+};
+
 struct NamedDefinition {
     static NamedDefinition fromDef(const core::GlobalState &, ParsedFile &, DefinitionRef);
     static bool preferredTo(const core::GlobalState &gs, const NamedDefinition &lhs, const NamedDefinition &rhs);
 
     Definition def;
-    std::vector<core::NameRef> nameParts;
-    std::vector<core::NameRef> parentName;
+    QualifiedName qname;
+    QualifiedName parentName;
     std::vector<core::NameRef> requires;
     core::FileRef fileRef;
     u4 pathDepth;
-    std::optional<core::NameRef> package;
 
     NamedDefinition() = default;
     NamedDefinition(const NamedDefinition &) = delete;
@@ -67,7 +73,7 @@ public:
     // rules.
     std::vector<NamedDefinition> namedDefs;
     std::unique_ptr<NamedDefinition> nonBehaviorDef;
-    std::vector<core::NameRef> nameParts;
+    QualifiedName qname;
 
     bool root() const;
     core::NameRef name() const;

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -47,6 +47,7 @@ struct NamedDefinition {
     std::vector<core::NameRef> requires;
     core::FileRef fileRef;
     u4 pathDepth;
+    std::optional<core::NameRef> package;
 
     NamedDefinition() = default;
     NamedDefinition(const NamedDefinition &) = delete;

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -37,13 +37,6 @@ struct AutoloaderConfig {
     AutoloaderConfig &operator=(AutoloaderConfig &&) = default;
 };
 
-struct QualifiedName {
-    std::vector<core::NameRef> nameParts;
-    std::optional<core::NameRef> package;
-
-    static QualifiedName fromFullName(std::vector<core::NameRef> fullName);
-};
-
 struct NamedDefinition {
     static NamedDefinition fromDef(const core::GlobalState &, ParsedFile &, DefinitionRef);
     static bool preferredTo(const core::GlobalState &gs, const NamedDefinition &lhs, const NamedDefinition &rhs);

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -10,14 +10,20 @@ namespace sorbet::autogen {
 // Contains same information as `realmain::options::AutoloaderConfig` except with `core::NameRef`s
 // instead of strings.
 struct AutoloaderConfig {
+    // Convert the autoloader config passed in from `realmain` to this `AutoloaderConfig`. Much of this is about
+    // converting `string`s to `NameRef`s
     static AutoloaderConfig enterConfig(core::GlobalState &gs, const realmain::options::AutoloaderConfig &cfg);
 
+    // `true` if the definition should have autoloads generated for it based on the `AutoloaderConfig`
     bool include(const NamedDefinition &) const;
+    // `true` if the file should have autoloads generated for it (i.e. it's a ruby source file that's not ignored)
     bool includePath(std::string_view path) const;
+    // `true` if the file should be required based on the provided configuration
     bool includeRequire(core::NameRef req) const;
     // Should definitions in this namespace be collapsed into their
     // parent if they all are from the same file?
     bool sameFileCollapsable(const std::vector<core::NameRef> &module) const;
+    // normalize the path relative to the provided prefixes
     std::string_view normalizePath(const core::GlobalState &gs, core::FileRef file) const;
 
     std::string rootDir;
@@ -38,7 +44,10 @@ struct AutoloaderConfig {
 };
 
 struct NamedDefinition {
+    // Convert an `autogen::DefinitionRef` to a `NamedDefinition`: this pulls the name, the parent definitions' name,
+    // the requirements, the path, and the _depth_ of the path (which can short-circuit comparison against another path)
     static NamedDefinition fromDef(const core::GlobalState &, ParsedFile &, DefinitionRef);
+    // Used for sorting `NamedDefinition`
     static bool preferredTo(const core::GlobalState &gs, const NamedDefinition &lhs, const NamedDefinition &rhs);
 
     Definition def;

--- a/main/autogen/data/definitions.h
+++ b/main/autogen/data/definitions.h
@@ -8,6 +8,15 @@ namespace sorbet::autogen {
 // The types defined here are simplified views of class and constant definitions in a Ruby codebase, which we use to
 // create static output information and autoloader files
 
+// A `QualifiedName` is a vector of namerefs that includes the fully-qualified name as well as an optional package name
+// (if we're running in `--stripe-packages` mode)
+struct QualifiedName {
+    std::vector<core::NameRef> nameParts;
+    std::optional<core::NameRef> package;
+
+    static QualifiedName fromFullName(std::vector<core::NameRef> fullName);
+};
+
 const u4 NONE_ID = (u4)-1;
 
 struct ParsedFile;
@@ -97,11 +106,11 @@ struct Reference {
     DefinitionRef scope;
 
     // its full qualified name
-    std::vector<core::NameRef> name;
+    QualifiedName name;
     // the full nesting of this constant. If it's a constant resolved from the root, this will be an empty vector
     std::vector<DefinitionRef> nesting;
     // the resolved name iff we have it from Sorbet
-    std::vector<core::NameRef> resolved;
+    QualifiedName resolved;
 
     // loc and definitionLoc will differ if this is a defining ref, otherwise they will be the same
     core::Loc loc;

--- a/main/autogen/data/definitions.h
+++ b/main/autogen/data/definitions.h
@@ -15,6 +15,22 @@ struct QualifiedName {
     std::optional<core::NameRef> package;
 
     static QualifiedName fromFullName(std::vector<core::NameRef> fullName);
+
+    bool empty() const {
+        return nameParts.empty();
+    }
+
+    u4 size() const {
+        return nameParts.size();
+    }
+
+    bool operator==(const QualifiedName &rhs) const {
+        return nameParts == rhs.nameParts && package == rhs.package;
+    }
+
+    core::NameRef name() const {
+        return nameParts.back();
+    }
 };
 
 const u4 NONE_ID = (u4)-1;

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -110,7 +110,7 @@ void MsgpackWriter::packReference(core::Context ctx, ParsedFile &pf, Reference &
     packRange(ref.loc.beginPos(), ref.loc.endPos());
 
     // resolved
-    if (ref.resolved.nameParts.empty()) {
+    if (ref.resolved.empty()) {
         mpack_write_nil(&writer);
     } else {
         packNames(ref.resolved.nameParts);

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -94,7 +94,7 @@ void MsgpackWriter::packReference(core::Context ctx, ParsedFile &pf, Reference &
     packDefinitionRef(ref.scope.id());
 
     // name
-    packNames(ref.name);
+    packNames(ref.name.nameParts);
 
     // nesting
     mpack_start_array(&writer, ref.nesting.size());
@@ -110,10 +110,10 @@ void MsgpackWriter::packReference(core::Context ctx, ParsedFile &pf, Reference &
     packRange(ref.loc.beginPos(), ref.loc.endPos());
 
     // resolved
-    if (ref.resolved.empty()) {
+    if (ref.resolved.nameParts.empty()) {
         mpack_write_nil(&writer);
     } else {
-        packNames(ref.resolved);
+        packNames(ref.resolved.nameParts);
     }
 
     // is_defining_ref

--- a/main/autogen/subclasses.cc
+++ b/main/autogen/subclasses.cc
@@ -54,7 +54,7 @@ optional<Subclasses::Map> Subclasses::listAllSubclasses(core::Context ctx, Parse
 
         // Get fully-qualified parent name as string
         string parentName =
-            fmt::format("{}", fmt::map_join(ref.resolved, "::", [&ctx](const core::NameRef &nm) -> string {
+            fmt::format("{}", fmt::map_join(ref.resolved.nameParts, "::", [&ctx](const core::NameRef &nm) -> string {
                             return nm.data(ctx)->show(ctx);
                         }));
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -531,7 +531,9 @@ int realmain(int argc, char *argv[]) {
             gs->suppressErrorClass(core::errors::Namer::ModuleKindRedefinition.code);
             gs->suppressErrorClass(core::errors::Resolver::StubConstant.code);
 
+            indexed = pipeline::package(*gs, move(indexed), opts, *workers);
             indexed = move(pipeline::name(*gs, move(indexed), opts, *workers).result());
+
             autogen::AutoloaderConfig autoloaderCfg;
             {
                 core::UnfreezeNameTable nameTableAccess(*gs);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -215,7 +215,7 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
             for (auto result = fileq->try_pop(idx); !result.done(); result = fileq->try_pop(idx)) {
                 ++n;
                 auto &tree = indexed[idx];
-                if (tree.file.data(gs).isRBI()) {
+                if (tree.file.data(gs).isRBI() || tree.file.data(gs).isPackage()) {
                     continue;
                 }
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -545,12 +545,11 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
     }
 
     // Sanity check: __package.rb files _must_ be typed: strict
-    // TODO: figure out why package files are being turned `false` under autogen?
-    // if (file.file.data(ctx).strictLevel < core::StrictLevel::Strict) {
-    //     if (auto e = ctx.beginError(core::LocOffsets{0, 0}, core::errors::Packager::PackageFileMustBeStrict)) {
-    //         e.setHeader("Package files must be at least `{}`", "# typed: strict");
-    //     }
-    // }
+    if (file.file.data(ctx).strictLevel < core::StrictLevel::Strict) {
+        if (auto e = ctx.beginError(core::LocOffsets{0, 0}, core::errors::Packager::PackageFileMustBeStrict)) {
+            e.setHeader("Package files must be at least `{}`", "# typed: strict");
+        }
+    }
 
     {
         UnorderedMap<core::NameRef, core::LocOffsets> importedNames;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -545,7 +545,7 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
     }
 
     // Sanity check: __package.rb files _must_ be typed: strict
-    if (file.file.data(ctx).strictLevel < core::StrictLevel::Strict) {
+    if (file.file.data(ctx).originalSigil < core::StrictLevel::Strict) {
         if (auto e = ctx.beginError(core::LocOffsets{0, 0}, core::errors::Packager::PackageFileMustBeStrict)) {
             e.setHeader("Package files must be at least `{}`", "# typed: strict");
         }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -545,11 +545,12 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
     }
 
     // Sanity check: __package.rb files _must_ be typed: strict
-    if (file.file.data(ctx).strictLevel < core::StrictLevel::Strict) {
-        if (auto e = ctx.beginError(core::LocOffsets{0, 0}, core::errors::Packager::PackageFileMustBeStrict)) {
-            e.setHeader("Package files must be at least `{}`", "# typed: strict");
-        }
-    }
+    // TODO: figure out why package files are being turned `false` under autogen?
+    // if (file.file.data(ctx).strictLevel < core::StrictLevel::Strict) {
+    //     if (auto e = ctx.beginError(core::LocOffsets{0, 0}, core::errors::Packager::PackageFileMustBeStrict)) {
+    //         e.setHeader("Package files must be at least `{}`", "# typed: strict");
+    //     }
+    // }
 
     {
         UnorderedMap<core::NameRef, core::LocOffsets> importedNames;

--- a/test/cli/autogen-pkg-autoloader/__package.rb
+++ b/test/cli/autogen-pkg-autoloader/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# frozen_string_literal: true
+
+class FakePackage < PackageSpec
+  export Yabba
+end

--- a/test/cli/autogen-pkg-autoloader/autogen-pkg-autoloader.out
+++ b/test/cli/autogen-pkg-autoloader/autogen-pkg-autoloader.out
@@ -1,0 +1,223 @@
+No errors! Great job.
+
+--- output/Foo.rb
+# frozen_string_literal: true
+# typed: true
+
+Opus::Require.on_autoload('Foo')
+
+module Foo
+end
+
+Opus::Require.autoload_map(Foo, {
+  Bar: "autoloader/Foo/Bar.rb",
+  Dabba: "autoloader/Foo/Dabba.rb",
+  Errors: "autoloader/Foo/Errors.rb",
+  TOP_LEVEL_CONST: "autoloader/Foo/TOP_LEVEL_CONST.rb",
+})
+
+--- output/Foo/Bar.rb
+# frozen_string_literal: true
+# typed: true
+
+Opus::Require.on_autoload('Foo::Bar')
+
+module Foo::Bar
+end
+
+Opus::Require.autoload_map(Foo::Bar, {
+  Jazz: "autoloader/Foo/Bar/Jazz.rb",
+  Quuz: "autoloader/Foo/Bar/Quuz.rb",
+})
+
+--- output/Foo/Bar/Jazz.rb
+# frozen_string_literal: true
+# typed: true
+
+require 'in_class'
+require 'in_method'
+require 'my_gem'
+Opus::Require.on_autoload('Foo::Bar::Jazz')
+
+class Foo::Bar::Jazz < Foo::Bar::Quuz
+end
+
+Opus::Require.for_autoload(Foo::Bar::Jazz, "test/cli/autogen-autoloader/foo.rb")
+
+--- output/Foo/Bar/Quuz.rb
+# frozen_string_literal: true
+# typed: true
+
+require 'in_class'
+require 'in_method'
+require 'my_gem'
+Opus::Require.on_autoload('Foo::Bar::Quuz')
+
+class Foo::Bar::Quuz
+end
+
+Opus::Require.for_autoload(Foo::Bar::Quuz, "test/cli/autogen-autoloader/foo.rb")
+
+--- output/Foo/Dabba.rb
+# frozen_string_literal: true
+# typed: true
+
+require 'in_class'
+require 'in_method'
+require 'my_gem'
+
+Opus::Require.for_autoload(nil, "test/cli/autogen-autoloader/foo.rb", [Foo, :Dabba])
+
+--- output/Foo/Errors.rb
+# frozen_string_literal: true
+# typed: true
+
+Opus::Require.on_autoload('Foo::Errors')
+
+module Foo::Errors
+end
+
+Opus::Require.autoload_map(Foo::Errors, {
+  BaseError: "autoloader/Foo/Errors/BaseError.rb",
+  MyError1: "autoloader/Foo/Errors/MyError1.rb",
+  MyError2: "autoloader/Foo/Errors/MyError2.rb",
+})
+
+--- output/Foo/Errors/BaseError.rb
+# frozen_string_literal: true
+# typed: true
+
+Opus::Require.on_autoload('Foo::Errors::BaseError')
+
+class Foo::Errors::BaseError < StandardError
+end
+
+Opus::Require.for_autoload(Foo::Errors::BaseError, "test/cli/autogen-autoloader/errors.rb")
+
+--- output/Foo/Errors/MyError1.rb
+# frozen_string_literal: true
+# typed: true
+
+Opus::Require.on_autoload('Foo::Errors::MyError1')
+
+class Foo::Errors::MyError1 < Foo::Errors::BaseError
+end
+
+Opus::Require.for_autoload(Foo::Errors::MyError1, "test/cli/autogen-autoloader/errors.rb")
+
+--- output/Foo/Errors/MyError2.rb
+# frozen_string_literal: true
+# typed: true
+
+Opus::Require.on_autoload('Foo::Errors::MyError2')
+
+class Foo::Errors::MyError2 < Foo::Errors::BaseError
+end
+
+Opus::Require.for_autoload(Foo::Errors::MyError2, "test/cli/autogen-autoloader/errors.rb")
+
+--- output/Foo/TOP_LEVEL_CONST.rb
+# frozen_string_literal: true
+# typed: true
+
+require 'in_class'
+require 'in_method'
+require 'my_gem'
+
+Opus::Require.for_autoload(nil, "test/cli/autogen-autoloader/foo.rb", [Foo, :TOP_LEVEL_CONST])
+
+--- output/Yabba.rb
+# frozen_string_literal: true
+# typed: true
+
+Opus::Require.on_autoload('Yabba')
+
+module Yabba
+end
+
+Opus::Require.autoload_map(Yabba, {
+  Dabba: "autoloader/Yabba/Dabba.rb",
+})
+
+--- output/Yabba/Dabba.rb
+# frozen_string_literal: true
+# typed: true
+
+Opus::Require.on_autoload('Yabba::Dabba')
+
+module Yabba::Dabba
+end
+
+Opus::Require.autoload_map(Yabba::Dabba, {
+  Bar2: "autoloader/Yabba/Dabba/Bar2.rb",
+  Jazz: "autoloader/Yabba/Dabba/Jazz.rb",
+  NoBehavior: "autoloader/Yabba/Dabba/NoBehavior.rb",
+  Quuz: "autoloader/Yabba/Dabba/Quuz.rb",
+})
+
+--- output/Yabba/Dabba/Bar2.rb
+# frozen_string_literal: true
+# typed: true
+
+Opus::Require.on_autoload('Yabba::Dabba::Bar2')
+
+class Yabba::Dabba::Bar2
+end
+
+Opus::Require.for_autoload(Yabba::Dabba::Bar2, "test/cli/autogen-autoloader/bar2.rb")
+
+--- output/Yabba/Dabba/Jazz.rb
+# frozen_string_literal: true
+# typed: true
+
+Opus::Require.on_autoload('Yabba::Dabba::Jazz')
+
+class Yabba::Dabba::Jazz
+end
+
+Opus::Require.autoload_map(Yabba::Dabba::Jazz, {
+  JazBaz: "autoloader/Yabba/Dabba/Jazz/JazBaz.rb",
+})
+
+--- output/Yabba/Dabba/Jazz/JazBaz.rb
+# frozen_string_literal: true
+# typed: true
+
+Opus::Require.on_autoload('Yabba::Dabba::Jazz::JazBaz')
+
+class Yabba::Dabba::Jazz::JazBaz
+end
+
+Opus::Require.for_autoload(Yabba::Dabba::Jazz::JazBaz, "test/cli/autogen-autoloader/bar.rb")
+
+--- output/Yabba/Dabba/NoBehavior.rb
+# frozen_string_literal: true
+# typed: true
+
+Opus::Require.on_autoload('Yabba::Dabba::NoBehavior')
+
+class Yabba::Dabba::NoBehavior
+end
+
+Opus::Require.for_autoload(Yabba::Dabba::NoBehavior, "test/cli/autogen-autoloader/bar2.rb")
+
+--- output/Yabba/Dabba/Quuz.rb
+# frozen_string_literal: true
+# typed: true
+
+Opus::Require.on_autoload('Yabba::Dabba::Quuz')
+
+class Yabba::Dabba::Quuz < AWS::String
+end
+
+Opus::Require.for_autoload(Yabba::Dabba::Quuz, "test/cli/autogen-autoloader/bar.rb")
+
+--- output/root.rb
+# frozen_string_literal: true
+# typed: true
+
+
+Opus::Require.autoload_map(Object, {
+  Foo: "autoloader/Foo.rb",
+  Yabba: "autoloader/Yabba.rb",
+})

--- a/test/cli/autogen-pkg-autoloader/autogen-pkg-autoloader.out
+++ b/test/cli/autogen-pkg-autoloader/autogen-pkg-autoloader.out
@@ -42,7 +42,7 @@ Opus::Require.on_autoload('Foo::Bar::Jazz')
 class Foo::Bar::Jazz < Foo::Bar::Quuz
 end
 
-Opus::Require.for_autoload(Foo::Bar::Jazz, "test/cli/autogen-autoloader/foo.rb")
+Opus::Require.for_autoload(Foo::Bar::Jazz, "test/cli/autogen-pkg-autoloader/foo.rb")
 
 --- output/Foo/Bar/Quuz.rb
 # frozen_string_literal: true
@@ -56,7 +56,7 @@ Opus::Require.on_autoload('Foo::Bar::Quuz')
 class Foo::Bar::Quuz
 end
 
-Opus::Require.for_autoload(Foo::Bar::Quuz, "test/cli/autogen-autoloader/foo.rb")
+Opus::Require.for_autoload(Foo::Bar::Quuz, "test/cli/autogen-pkg-autoloader/foo.rb")
 
 --- output/Foo/Dabba.rb
 # frozen_string_literal: true
@@ -66,7 +66,7 @@ require 'in_class'
 require 'in_method'
 require 'my_gem'
 
-Opus::Require.for_autoload(nil, "test/cli/autogen-autoloader/foo.rb", [Foo, :Dabba])
+Opus::Require.for_autoload(nil, "test/cli/autogen-pkg-autoloader/foo.rb", [Foo, :Dabba])
 
 --- output/Foo/Errors.rb
 # frozen_string_literal: true
@@ -92,7 +92,7 @@ Opus::Require.on_autoload('Foo::Errors::BaseError')
 class Foo::Errors::BaseError < StandardError
 end
 
-Opus::Require.for_autoload(Foo::Errors::BaseError, "test/cli/autogen-autoloader/errors.rb")
+Opus::Require.for_autoload(Foo::Errors::BaseError, "test/cli/autogen-pkg-autoloader/errors.rb")
 
 --- output/Foo/Errors/MyError1.rb
 # frozen_string_literal: true
@@ -103,7 +103,7 @@ Opus::Require.on_autoload('Foo::Errors::MyError1')
 class Foo::Errors::MyError1 < Foo::Errors::BaseError
 end
 
-Opus::Require.for_autoload(Foo::Errors::MyError1, "test/cli/autogen-autoloader/errors.rb")
+Opus::Require.for_autoload(Foo::Errors::MyError1, "test/cli/autogen-pkg-autoloader/errors.rb")
 
 --- output/Foo/Errors/MyError2.rb
 # frozen_string_literal: true
@@ -114,7 +114,7 @@ Opus::Require.on_autoload('Foo::Errors::MyError2')
 class Foo::Errors::MyError2 < Foo::Errors::BaseError
 end
 
-Opus::Require.for_autoload(Foo::Errors::MyError2, "test/cli/autogen-autoloader/errors.rb")
+Opus::Require.for_autoload(Foo::Errors::MyError2, "test/cli/autogen-pkg-autoloader/errors.rb")
 
 --- output/Foo/TOP_LEVEL_CONST.rb
 # frozen_string_literal: true
@@ -124,7 +124,7 @@ require 'in_class'
 require 'in_method'
 require 'my_gem'
 
-Opus::Require.for_autoload(nil, "test/cli/autogen-autoloader/foo.rb", [Foo, :TOP_LEVEL_CONST])
+Opus::Require.for_autoload(nil, "test/cli/autogen-pkg-autoloader/foo.rb", [Foo, :TOP_LEVEL_CONST])
 
 --- output/Yabba.rb
 # frozen_string_literal: true
@@ -164,7 +164,7 @@ Opus::Require.on_autoload('Yabba::Dabba::Bar2')
 class Yabba::Dabba::Bar2
 end
 
-Opus::Require.for_autoload(Yabba::Dabba::Bar2, "test/cli/autogen-autoloader/bar2.rb")
+Opus::Require.for_autoload(Yabba::Dabba::Bar2, "test/cli/autogen-pkg-autoloader/bar2.rb")
 
 --- output/Yabba/Dabba/Jazz.rb
 # frozen_string_literal: true
@@ -188,7 +188,7 @@ Opus::Require.on_autoload('Yabba::Dabba::Jazz::JazBaz')
 class Yabba::Dabba::Jazz::JazBaz
 end
 
-Opus::Require.for_autoload(Yabba::Dabba::Jazz::JazBaz, "test/cli/autogen-autoloader/bar.rb")
+Opus::Require.for_autoload(Yabba::Dabba::Jazz::JazBaz, "test/cli/autogen-pkg-autoloader/bar.rb")
 
 --- output/Yabba/Dabba/NoBehavior.rb
 # frozen_string_literal: true
@@ -199,7 +199,7 @@ Opus::Require.on_autoload('Yabba::Dabba::NoBehavior')
 class Yabba::Dabba::NoBehavior
 end
 
-Opus::Require.for_autoload(Yabba::Dabba::NoBehavior, "test/cli/autogen-autoloader/bar2.rb")
+Opus::Require.for_autoload(Yabba::Dabba::NoBehavior, "test/cli/autogen-pkg-autoloader/bar2.rb")
 
 --- output/Yabba/Dabba/Quuz.rb
 # frozen_string_literal: true
@@ -210,7 +210,7 @@ Opus::Require.on_autoload('Yabba::Dabba::Quuz')
 class Yabba::Dabba::Quuz < AWS::String
 end
 
-Opus::Require.for_autoload(Yabba::Dabba::Quuz, "test/cli/autogen-autoloader/bar.rb")
+Opus::Require.for_autoload(Yabba::Dabba::Quuz, "test/cli/autogen-pkg-autoloader/bar.rb")
 
 --- output/root.rb
 # frozen_string_literal: true

--- a/test/cli/autogen-pkg-autoloader/autogen-pkg-autoloader.sh
+++ b/test/cli/autogen-pkg-autoloader/autogen-pkg-autoloader.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -eu
+
+preamble="# frozen_string_literal: true
+# typed: true
+"
+
+rm -rf output
+mkdir -p output
+
+main/sorbet --silence-dev-message --stop-after=namer \
+  --stripe-packages \
+  -p autogen-autoloader:output \
+  --autogen-autoloader-modules={Foo,Yabba} \
+  --autogen-autoloader-exclude-require=byebug \
+  --autogen-autoloader-ignore=scripts/ \
+  --autogen-autoloader-preamble "$preamble" \
+  test/cli/autogen-pkg-autoloader/{foo,bar,bar2,errors,__package}.rb \
+  test/cli/autogen-pkg-autoloader/scripts/baz.rb 2>&1
+
+for file in $(find output -type f | sort); do
+  printf "\n--- %s\n" "$file"
+  cat "$file"
+done

--- a/test/cli/autogen-pkg-autoloader/bar.rb
+++ b/test/cli/autogen-pkg-autoloader/bar.rb
@@ -1,0 +1,16 @@
+# typed: true
+
+module Yabba
+  module Dabba
+    class Quuz < AWS::String
+      p 'x'
+    end
+
+    class Jazz
+      class JazBaz
+        VALUE = 1
+        p 'x'
+      end
+    end
+  end
+end

--- a/test/cli/autogen-pkg-autoloader/bar2.rb
+++ b/test/cli/autogen-pkg-autoloader/bar2.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+module Yabba::Dabba
+  class Bar2
+    p 'x'
+  end
+
+  class NoBehavior; end
+end

--- a/test/cli/autogen-pkg-autoloader/errors.rb
+++ b/test/cli/autogen-pkg-autoloader/errors.rb
@@ -1,0 +1,23 @@
+# typed: true
+
+module Foo
+  module Errors
+    class BaseError < StandardError
+      def foo
+        'hi'
+      end
+    end
+
+    class MyError1 < BaseError
+      def foo
+        '1'
+      end
+    end
+
+    class MyError2 < BaseError
+      def foo
+        '2'
+      end
+    end
+  end
+end

--- a/test/cli/autogen-pkg-autoloader/foo.rb
+++ b/test/cli/autogen-pkg-autoloader/foo.rb
@@ -1,0 +1,34 @@
+# typed: true
+
+require 'byebug'
+require 'my_gem'
+
+module Foo
+
+  # :Foo doesn't define behavior therefore this constant should get its own
+  # autoloader file.
+  TOP_LEVEL_CONST = some_method
+  # This should also happen for aliases.
+  Dabba = Yabba::Dabba
+
+  module Bar
+    class Quuz
+      p 'x'
+    end
+
+    class Jazz < Quuz
+      class JazBaz
+        p 'x'
+        require 'in_class'
+
+        def honk
+          require 'in_method'
+        end
+      end
+    end
+  end
+end
+
+module DontInclude
+  p 1
+end

--- a/test/cli/autogen-pkg-autoloader/inplace.rb
+++ b/test/cli/autogen-pkg-autoloader/inplace.rb
@@ -1,0 +1,3 @@
+module Foo
+  p 1
+end

--- a/test/cli/autogen-pkg-autoloader/scripts/baz.rb
+++ b/test/cli/autogen-pkg-autoloader/scripts/baz.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+# This file should be excluded
+require 'script_gem'
+
+module Foo::Baz
+  p 'x'
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
We currently do not run the `packager` when in `--autogen` mode at all. These changes allow us to run the packager but produce the same output as before by stripping off the package name when referring to constants, but also lays the groundwork for a separate "packaged autoloader" mode that generates autoloads suitable for packages.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Added a new CLI test to verify the output with `--stripe-packages`; this can be diff'ed against the output from the other autoloader CLI test to show that the only differences are in the file paths.
