### PR TITLE
lldbinit: Shorten message about source-maps

### DIFF
--- a/lldbinit.py
+++ b/lldbinit.py
@@ -17,7 +17,7 @@ bazel_workspace = os.path.realpath(os.path.join(project_root, "bazel-sorbet"))
 if not(os.path.isdir(bazel_workspace)):
     print("You need to compile Sorbet first before loading this file")
 else:
-    print("(lldb) Mapping ./bazel-sorbet paths to the project root")
+    print("(lldb) Mapping paths in ./bazel-sorbet to the project root")
     source_map_command = 'settings set -- target.source-map "%s" "%s"' % (bazel_workspace, project_root)
     ci = lldb.debugger.GetCommandInterpreter()
     res = lldb.SBCommandReturnObject()

--- a/lldbinit.py
+++ b/lldbinit.py
@@ -17,7 +17,7 @@ bazel_workspace = os.path.realpath(os.path.join(project_root, "bazel-sorbet"))
 if not(os.path.isdir(bazel_workspace)):
     print("You need to compile Sorbet first before loading this file")
 else:
-    print("Mapping %s to current working directory" % bazel_workspace)
+    print("(lldb) Mapping ./bazel-sorbet paths to the project root")
     source_map_command = 'settings set -- target.source-map "%s" "%s"' % (bazel_workspace, project_root)
     ci = lldb.debugger.GetCommandInterpreter()
     res = lldb.SBCommandReturnObject()


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Before

```
~/sorbet (master)
❯ lldb -- sorbet -e '0'
Mapping /private/var/tmp/_bazel_jez/491a13d243378e23690a7f8390a5c09f/execroot/com_stripe_ruby_typer to current working directory
(lldb) target create "sorbet"
Current executable set to 'sorbet' (x86_64).
(lldb) settings set -- target.run-args  "-e" "0"
(lldb)
```

After

```
~/sorbet (jez-lldb)  
❯ lldb -- sorbet -e '0'  
(lldb) Mapping paths in ./bazel-sorbet to the project root
(lldb) target create "sorbet"
Current executable set to 'sorbet' (x86_64).
(lldb) settings set -- target.run-args  "-e" "0"
(lldb) 
```


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.