### PR TITLE
fix crash in namer when redefining modules as static fields

### DIFF
--- a/test/testdata/namer/constant_redefinition/nested_module_then_constant.rb
+++ b/test/testdata/namer/constant_redefinition/nested_module_then_constant.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+module A::B::C
+  def foo; end
+end
+
+A::B = 1 # error: Redefining constant `B`

--- a/test/testdata/namer/constant_redefinition/nested_module_then_nonexistent_name.rb
+++ b/test/testdata/namer/constant_redefinition/nested_module_then_nonexistent_name.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+module A::B::C
+  def foo; end
+end
+
+  A::B = A::D
+# ^^^^^^^^^^^ error: Redefining constant `B`
+       # ^^^^ error: Unable to resolve constant `D`


### PR DESCRIPTION
In the example test cases, we would enter `A::B` into the symbol table as a static field.  But the name lookup during the symbol definition phase would find that static field when it was expecting to find a class/module, and problems would ensue.

Instead of indiscriminately looking for a matching symbol, we need to consider the context in which `squashNames` is being called, looking up classes or (dealiased) static fields as appropriate.

### Motivation

Fixes #3175.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
