### PR TITLE
Small cleanup in Trees.h

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -63,9 +63,6 @@ enum class Tag {
 // A mapping from tree type to its corresponding tag.
 template <typename T> struct TreeToTag;
 
-// A mapping from tag value to the tree it represents.
-template <Tag T> struct TagToTree;
-
 class Expression;
 
 class TreePtr {
@@ -94,7 +91,7 @@ private:
         return maskedPtr | val;
     }
 
-    explicit TreePtr(Tag tag, void *expr) : ptr(tagPtr(tag, expr)) {}
+    TreePtr(Tag tag, void *expr) : ptr(tagPtr(tag, expr)) {}
 
     static void deleteTagged(Tag tag, void *ptr) noexcept;
 
@@ -317,7 +314,6 @@ CheckSize(Declaration, 32, 8);
 #define TREE(name)                                                                  \
     class name;                                                                     \
     template <> struct TreeToTag<name> { static constexpr Tag value = Tag::name; }; \
-    template <> struct TagToTree<Tag::name> { using value = name; };                \
     class __attribute__((aligned(8))) name final
 
 TREE(ClassDef) : public Declaration {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
* Remove the `TagToTree` template, as it was unused
* Make the `TreePtr(tag, ptr)` private constructor not `explicit`, as that only makes sense for constructors with one argument

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Cleaning up.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
