### PR TITLE
Use tags in isa_type/cast_type. Introduces a const cast_type variant.

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1222,20 +1222,20 @@ string Literal::nodeName() {
 
 core::NameRef Literal::asString(const core::GlobalState &gs) const {
     ENFORCE(isString(gs));
-    auto t = core::cast_type<core::LiteralType>(value.get());
+    auto t = core::cast_type<core::LiteralType>(value);
     core::NameRef res(gs, t->value);
     return res;
 }
 
 core::NameRef Literal::asSymbol(const core::GlobalState &gs) const {
     ENFORCE(isSymbol(gs));
-    auto t = core::cast_type<core::LiteralType>(value.get());
+    auto t = core::cast_type<core::LiteralType>(value);
     core::NameRef res(gs, t->value);
     return res;
 }
 
 bool Literal::isSymbol(const core::GlobalState &gs) const {
-    auto t = core::cast_type<core::LiteralType>(value.get());
+    auto t = core::cast_type<core::LiteralType>(value);
     return t && t->derivesFrom(gs, core::Symbols::Symbol());
 }
 
@@ -1244,7 +1244,7 @@ bool Literal::isNil(const core::GlobalState &gs) const {
 }
 
 bool Literal::isString(const core::GlobalState &gs) const {
-    auto t = core::cast_type<core::LiteralType>(value.get());
+    auto t = core::cast_type<core::LiteralType>(value);
     return t && t->derivesFrom(gs, core::Symbols::String());
 }
 

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -318,7 +318,7 @@ TreePtr symbol2Proc(DesugarContext dctx, TreePtr expr) {
     ENFORCE(lit && lit->isSymbol(dctx.ctx));
 
     // &:foo => {|temp| temp.foo() }
-    core::NameRef name(dctx.ctx, core::cast_type<core::LiteralType>(lit->value.get())->value);
+    core::NameRef name(dctx.ctx, core::cast_type<core::LiteralType>(lit->value)->value);
     // `temp` does not refer to any specific source text, so give it a 0-length Loc so LSP ignores it.
     auto zeroLengthLoc = loc.copyWithZeroLength();
     TreePtr recv = MK::Local(zeroLengthLoc, temp);

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -95,7 +95,7 @@ string Literal::toString(const core::GlobalState &gs, const CFG &cfg) const {
     string res;
     typecase(
         this->value.get(), [&](core::LiteralType *l) { res = l->showValue(gs); },
-        [&](core::ClassType *l) {
+        [&](const core::ClassType *l) {
             if (l->symbol == core::Symbols::NilClass()) {
                 res = "nil";
             } else if (l->symbol == core::Symbols::FalseClass()) {
@@ -106,7 +106,7 @@ string Literal::toString(const core::GlobalState &gs, const CFG &cfg) const {
                 res = fmt::format("literal({})", this->value->toStringWithTabs(gs, 0));
             }
         },
-        [&](core::Type *t) { res = fmt::format("literal({})", this->value->toStringWithTabs(gs, 0)); });
+        [&](const core::Type *t) { res = fmt::format("literal({})", this->value->toStringWithTabs(gs, 0)); });
     return res;
 }
 

--- a/core/TypeConstraint.cc
+++ b/core/TypeConstraint.cc
@@ -16,7 +16,7 @@ void TypeConstraint::defineDomain(const GlobalState &gs, const InlinedVector<Sym
     // test/testdata/infer/generic_methods/countraints_crosstalk.rb
     for (const auto &tp : typeParams) {
         ENFORCE(tp.data(gs)->isTypeArgument());
-        auto typ = cast_type<TypeVar>(tp.data(gs)->resultType.get());
+        auto typ = cast_type<TypeVar>(tp.data(gs)->resultType);
         ENFORCE(typ != nullptr);
 
         if (tp.data(gs)->isCovariant()) {
@@ -97,7 +97,7 @@ bool TypeConstraint::solve(const GlobalState &gs) {
 
 bool TypeConstraint::rememberIsSubtype(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
     ENFORCE(!wasSolved);
-    if (auto t1p = cast_type<TypeVar>(t1.get())) {
+    if (auto t1p = cast_type<TypeVar>(t1)) {
         auto &entry = findUpperBound(t1p->sym);
         if (!entry) {
             entry = t2;
@@ -107,7 +107,7 @@ bool TypeConstraint::rememberIsSubtype(const GlobalState &gs, const TypePtr &t1,
             entry = AndType::make_shared(entry, t2);
         }
     } else {
-        auto t2p = cast_type<TypeVar>(t2.get());
+        auto t2p = cast_type<TypeVar>(t2);
         ENFORCE(t2p != nullptr);
         auto &entry = findLowerBound(t2p->sym);
         if (!entry) {
@@ -122,13 +122,13 @@ bool TypeConstraint::rememberIsSubtype(const GlobalState &gs, const TypePtr &t1,
 }
 
 bool TypeConstraint::isAlreadyASubType(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) const {
-    if (auto t1p = cast_type<TypeVar>(t1.get())) {
+    if (auto t1p = cast_type<TypeVar>(t1)) {
         if (!hasLowerBound(t1p->sym)) {
             return Types::isSubType(gs, Types::top(), t2);
         }
         return Types::isSubType(gs, findLowerBound(t1p->sym), t2);
     } else {
-        auto t2p = cast_type<TypeVar>(t2.get());
+        auto t2p = cast_type<TypeVar>(t2);
         ENFORCE(t2p != nullptr);
         if (!hasUpperBound(t2p->sym)) {
             return Types::isSubType(gs, t1, Types::bottom());

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -1,5 +1,8 @@
 #include "core/TypePtr.h"
+#include "core/SymbolRef.h"
 #include "core/Types.h"
+
+using namespace std;
 
 namespace sorbet::core {
 
@@ -72,4 +75,20 @@ void TypePtr::deleteTagged(Tag tag, void *ptr) noexcept {
             break;
     }
 }
+
+bool TypePtr::isUntyped() const {
+    auto *t = cast_type<ClassType>(*this);
+    return t != nullptr && t->symbol == Symbols::untyped();
+}
+
+bool TypePtr::isNilClass() const {
+    auto *t = cast_type<ClassType>(*this);
+    return t != nullptr && t->symbol == Symbols::NilClass();
+}
+
+bool TypePtr::isBottom() const {
+    auto *t = cast_type<ClassType>(*this);
+    return t != nullptr && t->symbol == Symbols::bottom();
+}
+
 } // namespace sorbet::core

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -166,6 +166,12 @@ public:
         return store == 0;
     }
 
+    bool isUntyped() const;
+
+    bool isNilClass() const;
+
+    bool isBottom() const;
+
     template <class T, class... Args> friend TypePtr make_type(Args &&... args);
     friend class TypePtrTestHelper;
 };

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -115,7 +115,7 @@ com::stripe::rubytyper::Symbol Proto::toProto(const GlobalState &gs, SymbolRef s
     }
 
     if (data->isStaticField()) {
-        if (auto type = core::cast_type<core::AliasType>(data->resultType.get())) {
+        if (auto type = core::cast_type<core::AliasType>(data->resultType)) {
             symbolProto.set_aliasto(type->symbol.rawId());
         }
     }
@@ -176,28 +176,28 @@ com::stripe::rubytyper::Type Proto::toProto(const GlobalState &gs, const TypePtr
     com::stripe::rubytyper::Type proto;
     typecase(
         typ.get(),
-        [&](ClassType *t) {
+        [&](const ClassType *t) {
             proto.set_kind(com::stripe::rubytyper::Type::CLASS);
             proto.set_class_full_name(t->symbol.show(gs));
         },
-        [&](AndType *t) {
+        [&](const AndType *t) {
             proto.set_kind(com::stripe::rubytyper::Type::AND);
             *proto.mutable_and_()->mutable_left() = toProto(gs, t->left);
             *proto.mutable_and_()->mutable_right() = toProto(gs, t->right);
         },
-        [&](OrType *t) {
+        [&](const OrType *t) {
             proto.set_kind(com::stripe::rubytyper::Type::OR);
             *proto.mutable_or_()->mutable_left() = toProto(gs, t->left);
             *proto.mutable_or_()->mutable_right() = toProto(gs, t->right);
         },
-        [&](AppliedType *t) {
+        [&](const AppliedType *t) {
             proto.set_kind(com::stripe::rubytyper::Type::APPLIED);
             proto.mutable_applied()->set_symbol_full_name(t->klass.show(gs));
             for (auto &a : t->targs) {
                 *proto.mutable_applied()->add_type_args() = toProto(gs, a);
             }
         },
-        [&](ShapeType *t) {
+        [&](const ShapeType *t) {
             proto.set_kind(com::stripe::rubytyper::Type::SHAPE);
             for (auto &k : t->keys) {
                 *proto.mutable_shape()->add_keys() = toProto(gs, k);
@@ -206,18 +206,18 @@ com::stripe::rubytyper::Type Proto::toProto(const GlobalState &gs, const TypePtr
                 *proto.mutable_shape()->add_values() = toProto(gs, v);
             }
         },
-        [&](LiteralType *t) {
+        [&](const LiteralType *t) {
             proto.set_kind(com::stripe::rubytyper::Type::LITERAL);
             *proto.mutable_literal() = toProto(gs, *t);
         },
-        [&](TupleType *t) {
+        [&](const TupleType *t) {
             proto.set_kind(com::stripe::rubytyper::Type::TUPLE);
             for (auto &e : t->elems) {
                 *proto.mutable_tuple()->add_elems() = toProto(gs, e);
             }
         },
         // TODO later: add more types
-        [&](Type *t) { proto.set_kind(com::stripe::rubytyper::Type::UNKNOWN); });
+        [&](const Type *t) { proto.set_kind(com::stripe::rubytyper::Type::UNKNOWN); });
     return proto;
 }
 

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -57,7 +57,7 @@ string LiteralType::show(const GlobalState &gs) const {
 }
 
 string LiteralType::showValue(const GlobalState &gs) const {
-    SymbolRef undSymbol = cast_type<ClassType>(this->underlying().get())->symbol;
+    SymbolRef undSymbol = cast_type<ClassType>(this->underlying())->symbol;
     if (undSymbol == Symbols::String()) {
         return fmt::format("\"{}\"", absl::CEscape(NameRef(gs, this->value).show(gs)));
     } else if (undSymbol == Symbols::Symbol()) {
@@ -124,9 +124,9 @@ string ShapeType::show(const GlobalState &gs) const {
         } else {
             fmt::format_to(buf, ", ");
         }
-        SymbolRef undSymbol = cast_type<ClassType>(cast_type<LiteralType>(key.get())->underlying().get())->symbol;
+        SymbolRef undSymbol = cast_type<ClassType>(cast_type<LiteralType>(key)->underlying())->symbol;
         if (undSymbol == Symbols::Symbol()) {
-            fmt::format_to(buf, "{}: {}", NameRef(gs, cast_type<LiteralType>(key.get())->value).show(gs),
+            fmt::format_to(buf, "{}: {}", NameRef(gs, cast_type<LiteralType>(key)->value).show(gs),
                            (*valueIterator)->show(gs));
         } else {
             fmt::format_to(buf, "{} => {}", key->show(gs), (*valueIterator)->show(gs));
@@ -146,24 +146,24 @@ string AliasType::show(const GlobalState &gs) const {
 }
 
 string AndType::toStringWithTabs(const GlobalState &gs, int tabs) const {
-    bool leftBrace = isa_type<OrType>(this->left.get());
-    bool rightBrace = isa_type<OrType>(this->right.get());
+    bool leftBrace = isa_type<OrType>(this->left);
+    bool rightBrace = isa_type<OrType>(this->right);
 
     return fmt::format("{}{}{} & {}{}{}", leftBrace ? "(" : "", this->left->toStringWithTabs(gs, tabs + 2),
                        leftBrace ? ")" : "", rightBrace ? "(" : "", this->right->toStringWithTabs(gs, tabs + 2),
                        rightBrace ? ")" : "");
 }
 
-string showAnds(const GlobalState &, TypePtr, TypePtr);
+string showAnds(const GlobalState &, const TypePtr &, const TypePtr &);
 
-string showAndElem(const GlobalState &gs, TypePtr ty) {
-    if (auto andType = cast_type<AndType>(ty.get())) {
+string showAndElem(const GlobalState &gs, const TypePtr &ty) {
+    if (auto andType = cast_type<AndType>(ty)) {
         return showAnds(gs, andType->left, andType->right);
     }
     return ty->show(gs);
 }
 
-string showAnds(const GlobalState &gs, TypePtr left, TypePtr right) {
+string showAnds(const GlobalState &gs, const TypePtr &left, const TypePtr &right) {
     auto leftStr = showAndElem(gs, left);
     auto rightStr = showAndElem(gs, right);
     return fmt::format("{}, {}", leftStr, rightStr);
@@ -175,8 +175,8 @@ string AndType::show(const GlobalState &gs) const {
 }
 
 string OrType::toStringWithTabs(const GlobalState &gs, int tabs) const {
-    bool leftBrace = isa_type<AndType>(this->left.get());
-    bool rightBrace = isa_type<AndType>(this->right.get());
+    bool leftBrace = isa_type<AndType>(this->left);
+    bool rightBrace = isa_type<AndType>(this->right);
 
     return fmt::format("{}{}{} | {}{}{}", leftBrace ? "(" : "", this->left->toStringWithTabs(gs, tabs + 2),
                        leftBrace ? ")" : "", rightBrace ? "(" : "", this->right->toStringWithTabs(gs, tabs + 2),
@@ -249,10 +249,10 @@ struct OrInfo {
     }
 };
 
-pair<OrInfo, optional<string>> showOrs(const GlobalState &, TypePtr, TypePtr);
+pair<OrInfo, optional<string>> showOrs(const GlobalState &, const TypePtr &, const TypePtr &);
 
-pair<OrInfo, optional<string>> showOrElem(const GlobalState &gs, TypePtr ty) {
-    if (auto classType = cast_type<ClassType>(ty.get())) {
+pair<OrInfo, optional<string>> showOrElem(const GlobalState &gs, const TypePtr &ty) {
+    if (auto classType = cast_type<ClassType>(ty)) {
         if (classType->symbol == Symbols::NilClass()) {
             return make_pair(OrInfo::nilInfo(), nullopt);
         } else if (classType->symbol == Symbols::TrueClass()) {
@@ -260,14 +260,14 @@ pair<OrInfo, optional<string>> showOrElem(const GlobalState &gs, TypePtr ty) {
         } else if (classType->symbol == Symbols::FalseClass()) {
             return make_pair(OrInfo::falseInfo(), make_optional(classType->show(gs)));
         }
-    } else if (auto orType = cast_type<OrType>(ty.get())) {
+    } else if (auto orType = cast_type<OrType>(ty)) {
         return showOrs(gs, orType->left, orType->right);
     }
 
     return make_pair(OrInfo::otherInfo(), make_optional(ty->show(gs)));
 }
 
-pair<OrInfo, optional<string>> showOrs(const GlobalState &gs, TypePtr left, TypePtr right) {
+pair<OrInfo, optional<string>> showOrs(const GlobalState &gs, const TypePtr &left, const TypePtr &right) {
     auto [leftInfo, leftStr] = showOrElem(gs, left);
     auto [rightInfo, rightStr] = showOrElem(gs, right);
 

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -38,14 +38,14 @@ TypePtr Types::any(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
 }
 
 const TypePtr underlying(const TypePtr &t1) {
-    if (auto *f = cast_type<ProxyType>(t1.get())) {
+    if (auto *f = cast_type<ProxyType>(t1)) {
         return f->underlying();
     }
     return t1;
 }
 
 void fillInOrComponents(InlinedVector<TypePtr, 4> &orComponents, const TypePtr &type) {
-    auto *o = cast_type<OrType>(type.get());
+    auto *o = cast_type<OrType>(type);
     if (o == nullptr) {
         orComponents.emplace_back(type);
     } else {
@@ -55,7 +55,7 @@ void fillInOrComponents(InlinedVector<TypePtr, 4> &orComponents, const TypePtr &
 }
 
 TypePtr filterOrComponents(const TypePtr &originalType, const InlinedVector<Type *, 4> &typeFilter) {
-    auto *o = cast_type<OrType>(originalType.get());
+    auto *o = cast_type<OrType>(originalType);
     if (o == nullptr) {
         if (absl::c_linear_search(typeFilter, originalType.get())) {
             return nullptr;
@@ -80,7 +80,7 @@ TypePtr filterOrComponents(const TypePtr &originalType, const InlinedVector<Type
 TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
     InlinedVector<TypePtr, 4> originalOrComponents;
     InlinedVector<Type *, 4> typesConsumed;
-    auto *o1 = cast_type<OrType>(t1.get());
+    auto *o1 = cast_type<OrType>(t1);
     ENFORCE(o1 != nullptr);
     fillInOrComponents(originalOrComponents, o1->left);
     fillInOrComponents(originalOrComponents, o1->right);
@@ -114,7 +114,7 @@ TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr 
 }
 
 TypePtr glbDistributeAnd(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
-    auto *a1 = cast_type<AndType>(t1.get());
+    auto *a1 = cast_type<AndType>(t1);
     ENFORCE(t1 != nullptr);
     TypePtr n1 = Types::all(gs, a1->left, t2);
     if (n1.get() == a1->left.get()) {
@@ -148,7 +148,7 @@ TypePtr glbDistributeAnd(const GlobalState &gs, const TypePtr &t1, const TypePtr
 
 // only keep knowledge in t1 that is not already present in t2. Return the same reference if unchaged
 TypePtr dropLubComponents(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
-    if (auto *a1 = cast_type<AndType>(t1.get())) {
+    if (auto *a1 = cast_type<AndType>(t1)) {
         auto a1a = dropLubComponents(gs, a1->left, t2);
         auto a1b = dropLubComponents(gs, a1->right, t2);
         auto subl = Types::isSubType(gs, a1a, t2);
@@ -159,7 +159,7 @@ TypePtr dropLubComponents(const GlobalState &gs, const TypePtr &t1, const TypePt
         if (a1a != a1->left || a1b != a1->right) {
             return Types::all(gs, a1a, a1b);
         }
-    } else if (auto *o1 = cast_type<OrType>(t1.get())) {
+    } else if (auto *o1 = cast_type<OrType>(t1)) {
         auto subl = Types::isSubType(gs, o1->left, t2);
         auto subr = Types::isSubType(gs, o1->right, t2);
         if (subl && subr) {
@@ -183,7 +183,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         return lub(gs, t2, t1);
     }
 
-    if (auto *mayBeSpecial1 = cast_type<ClassType>(t1.get())) {
+    if (auto *mayBeSpecial1 = cast_type<ClassType>(t1)) {
         if (mayBeSpecial1->symbol == Symbols::untyped()) {
             categoryCounterInc("lub", "<untyped");
             return t1;
@@ -198,7 +198,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         }
     }
 
-    if (auto *mayBeSpecial2 = cast_type<ClassType>(t2.get())) {
+    if (auto *mayBeSpecial2 = cast_type<ClassType>(t2)) {
         if (mayBeSpecial2->symbol == Symbols::untyped()) {
             categoryCounterInc("lub", "untyped>");
             return t2;
@@ -213,10 +213,10 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         }
     }
 
-    if (auto *o2 = cast_type<OrType>(t2.get())) { // 3, 5, 6
+    if (auto *o2 = cast_type<OrType>(t2)) { // 3, 5, 6
         categoryCounterInc("lub", "or>");
         return lubDistributeOr(gs, t2, t1);
-    } else if (auto *a2 = cast_type<AndType>(t2.get())) { // 2, 4
+    } else if (auto *a2 = cast_type<AndType>(t2)) { // 2, 4
         categoryCounterInc("lub", "and>");
         auto t1d = underlying(t1);
         auto t2filtered = dropLubComponents(gs, t2, t1d);
@@ -224,13 +224,13 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             return lub(gs, t1, t2filtered);
         }
         return OrType::make_shared(t1, t2filtered);
-    } else if (isa_type<OrType>(t1.get())) {
+    } else if (isa_type<OrType>(t1)) {
         categoryCounterInc("lub", "<or");
         return lubDistributeOr(gs, t1, t2);
     }
 
-    if (auto *a1 = cast_type<AppliedType>(t1.get())) {
-        auto *a2 = cast_type<AppliedType>(t2.get());
+    if (auto *a1 = cast_type<AppliedType>(t1)) {
+        auto *a2 = cast_type<AppliedType>(t2);
         if (a2 == nullptr) {
             if (isSubType(gs, t2, t1)) {
                 return t1;
@@ -273,7 +273,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                 if (!Types::equiv(gs, a1->targs[i], a2->targs[j])) {
                     return OrType::make_shared(t1s, t2s);
                 }
-                if (a1->targs[i]->isUntyped()) {
+                if (a1->targs[i].isUntyped()) {
                     newTargs.emplace_back(a1->targs[i]);
                 } else {
                     newTargs.emplace_back(a2->targs[j]);
@@ -295,16 +295,16 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         }
     }
 
-    if (auto *p1 = cast_type<ProxyType>(t1.get())) {
+    if (auto *p1 = cast_type<ProxyType>(t1)) {
         categoryCounterInc("lub", "<proxy");
-        if (auto *p2 = cast_type<ProxyType>(t2.get())) {
+        if (auto *p2 = cast_type<ProxyType>(t2)) {
             categoryCounterInc("lub", "proxy>");
             // both are proxy
             TypePtr result;
             typecase(
                 p1,
-                [&](TupleType *a1) { // Warning: this implements COVARIANT arrays
-                    if (auto *a2 = cast_type<TupleType>(p2)) {
+                [&](const TupleType *a1) { // Warning: this implements COVARIANT arrays
+                    if (auto *a2 = cast_type<TupleType>(t2)) {
                         if (a1->elems.size() == a2->elems.size()) { // lub arrays only if they have same element count
                             vector<TypePtr> elemLubs;
                             int i = -1;
@@ -330,8 +330,8 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         result = lub(gs, p1->underlying(), p2->underlying());
                     }
                 },
-                [&](ShapeType *h1) { // Warning: this implements COVARIANT hashes
-                    if (auto *h2 = cast_type<ShapeType>(p2)) {
+                [&](const ShapeType *h1) { // Warning: this implements COVARIANT hashes
+                    if (auto *h2 = cast_type<ShapeType>(t2)) {
                         if (h2->keys.size() == h1->keys.size()) {
                             // have enough keys.
                             int i = -1;
@@ -341,12 +341,12 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                             bool differ2 = false;
                             for (auto &el2 : h2->keys) {
                                 ++i;
-                                auto el2l = cast_type<LiteralType>(el2.get());
-                                auto *u2 = cast_type<ClassType>(el2l->underlying().get());
+                                auto el2l = cast_type<LiteralType>(el2);
+                                auto *u2 = cast_type<ClassType>(el2l->underlying());
                                 ENFORCE(u2 != nullptr);
                                 auto fnd = absl::c_find_if(h1->keys, [&](auto &candidate) -> bool {
-                                    auto el1l = cast_type<LiteralType>(candidate.get());
-                                    ClassType *u1 = cast_type<ClassType>(el1l->underlying().get());
+                                    auto el1l = cast_type<LiteralType>(candidate);
+                                    auto *u1 = cast_type<ClassType>(el1l->underlying());
                                     return el1l->value == el2l->value && u1->symbol == u2->symbol; // from lambda
                                 });
                                 if (fnd != h1->keys.end()) {
@@ -373,10 +373,10 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         result = lub(gs, p1->underlying(), p2->underlying());
                     }
                 },
-                [&](LiteralType *l1) {
-                    if (auto *l2 = cast_type<LiteralType>(p2)) {
-                        auto *u1 = cast_type<ClassType>(l1->underlying().get());
-                        auto *u2 = cast_type<ClassType>(l2->underlying().get());
+                [&](const LiteralType *l1) {
+                    if (auto *l2 = cast_type<LiteralType>(t2)) {
+                        auto *u1 = cast_type<ClassType>(l1->underlying());
+                        auto *u2 = cast_type<ClassType>(l2->underlying());
                         ENFORCE(u1 != nullptr && u2 != nullptr);
                         if (u1->symbol == u2->symbol) {
                             if (l1->value == l2->value) {
@@ -391,8 +391,8 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         result = lub(gs, p1->underlying(), p2->underlying());
                     }
                 },
-                [&](MetaType *m1) {
-                    if (auto *m2 = cast_type<MetaType>(p2)) {
+                [&](const MetaType *m1) {
+                    if (auto *m2 = cast_type<MetaType>(t2)) {
                         if (Types::equiv(gs, m1->wrapped, m2->wrapped)) {
                             result = t1;
                             return;
@@ -403,7 +403,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             ENFORCE(result.get() != nullptr);
             return result;
         } else {
-            bool allowProxyInLub = isa_type<TupleType>(p1) || isa_type<ShapeType>(p1);
+            bool allowProxyInLub = isa_type<TupleType>(t1) || isa_type<ShapeType>(t1);
             // only 1st is proxy
             TypePtr und = p1->underlying();
             if (isSubType(gs, und, t2)) {
@@ -414,9 +414,9 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                 return lub(gs, t2, und);
             }
         }
-    } else if (auto *p2 = cast_type<ProxyType>(t2.get())) {
+    } else if (auto *p2 = cast_type<ProxyType>(t2)) {
         // only 2nd is proxy
-        bool allowProxyInLub = isa_type<TupleType>(p2) || isa_type<ShapeType>(p2);
+        bool allowProxyInLub = isa_type<TupleType>(t2) || isa_type<ShapeType>(t2);
         // only 1st is proxy
         TypePtr und = p2->underlying();
         if (isSubType(gs, und, t1)) {
@@ -429,20 +429,20 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
     }
 
     {
-        if (isa_type<LambdaParam>(t1.get()) || isa_type<LambdaParam>(t2.get())) {
+        if (isa_type<LambdaParam>(t1) || isa_type<LambdaParam>(t2)) {
             return OrType::make_shared(t1, t2);
         }
     }
 
     {
-        if (isa_type<TypeVar>(t1.get()) || isa_type<TypeVar>(t2.get())) {
+        if (isa_type<TypeVar>(t1) || isa_type<TypeVar>(t2)) {
             return OrType::make_shared(t1, t2);
         }
     }
 
     {
-        auto *s1 = cast_type<SelfTypeParam>(t1.get());
-        auto *s2 = cast_type<SelfTypeParam>(t2.get());
+        auto *s1 = cast_type<SelfTypeParam>(t1);
+        auto *s2 = cast_type<SelfTypeParam>(t2);
 
         if (s1 != nullptr || s2 != nullptr) {
             if (s1 == nullptr || s2 == nullptr || s2->definition != s1->definition) {
@@ -454,8 +454,8 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
     }
 
     {
-        auto *self1 = cast_type<SelfType>(t1.get());
-        auto *self2 = cast_type<SelfType>(t2.get());
+        auto *self1 = cast_type<SelfType>(t1);
+        auto *self2 = cast_type<SelfType>(t2);
 
         if (self1 != nullptr || self2 != nullptr) {
             if (self1 == nullptr || self2 == nullptr) {
@@ -471,10 +471,8 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
 }
 
 TypePtr lubGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
-    auto *g1 = cast_type<GroundType>(t1.get());
-    auto *g2 = cast_type<GroundType>(t2.get());
-    ENFORCE(g1 != nullptr);
-    ENFORCE(g2 != nullptr);
+    ENFORCE(isa_type<GroundType>(t1));
+    ENFORCE(isa_type<GroundType>(t2));
 
     //    if (g1->kind() > g2->kind()) { // force the relation to be symmentric and half the implementation
     //        return lubGround(gs, t2, t1);
@@ -498,8 +496,8 @@ TypePtr lubGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
     TypePtr result;
 
     // 1 :-)
-    auto *c1 = cast_type<ClassType>(t1.get());
-    auto *c2 = cast_type<ClassType>(t2.get());
+    auto *c1 = cast_type<ClassType>(t1);
+    auto *c2 = cast_type<ClassType>(t2);
     categoryCounterInc("lub", "<class>");
     ENFORCE(c1 != nullptr && c2 != nullptr);
 
@@ -518,12 +516,10 @@ TypePtr lubGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
 }
 
 TypePtr glbGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
-    auto *g1 = cast_type<GroundType>(t1.get());
-    auto *g2 = cast_type<GroundType>(t2.get());
-    ENFORCE(g1 != nullptr);
-    ENFORCE(g2 != nullptr);
+    ENFORCE(isa_type<GroundType>(t1));
+    ENFORCE(isa_type<GroundType>(t2));
 
-    if (g1->kind() > g2->kind()) { // force the relation to be symmentric and half the implementation
+    if (t1->kind() > t2->kind()) { // force the relation to be symmentric and half the implementation
         return glbGround(gs, t2, t1);
     }
     /** this implementation makes a bet that types are small and very likely to be collapsable.
@@ -544,8 +540,8 @@ TypePtr glbGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
 
     TypePtr result;
     // 1 :-)
-    auto *c1 = cast_type<ClassType>(t1.get());
-    auto *c2 = cast_type<ClassType>(t2.get());
+    auto *c1 = cast_type<ClassType>(t1);
+    auto *c2 = cast_type<ClassType>(t2);
     ENFORCE(c1 != nullptr && c2 != nullptr);
     categoryCounterInc("glb", "<class>");
 
@@ -597,7 +593,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         return t1;
     }
 
-    if (auto *mayBeSpecial1 = cast_type<ClassType>(t1.get())) {
+    if (auto *mayBeSpecial1 = cast_type<ClassType>(t1)) {
         if (mayBeSpecial1->symbol == Symbols::top()) {
             categoryCounterInc("glb", "<top");
             return t2;
@@ -605,7 +601,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         if (mayBeSpecial1->symbol == Symbols::untyped()) {
             // This case is to prefer `T.untyped` to top, so that
             // `glb(T.untyped,<any>)` will reduce to `T.untyped`.
-            if (auto *mayBeSpecial2 = cast_type<ClassType>(t2.get())) {
+            if (auto *mayBeSpecial2 = cast_type<ClassType>(t2)) {
                 if (mayBeSpecial2->symbol == Symbols::top()) {
                     categoryCounterInc("glb", "top>");
                     return t1;
@@ -620,7 +616,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         }
     }
 
-    if (auto *mayBeSpecial2 = cast_type<ClassType>(t2.get())) {
+    if (auto *mayBeSpecial2 = cast_type<ClassType>(t2)) {
         if (mayBeSpecial2->symbol == Symbols::top()) {
             categoryCounterInc("glb", "top>");
             return t1;
@@ -638,24 +634,24 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
     if (t1->kind() > t2->kind()) { // force the relation to be symmentric and half the implementation
         return glb(gs, t2, t1);
     }
-    if (isa_type<AndType>(t1.get())) { // 4, 5
+    if (isa_type<AndType>(t1)) { // 4, 5
         categoryCounterInc("glb", "<and");
         return glbDistributeAnd(gs, t1, t2);
-    } else if (isa_type<AndType>(t2.get())) { // 2
+    } else if (isa_type<AndType>(t2)) { // 2
         categoryCounterInc("glb", "and>");
         return glbDistributeAnd(gs, t2, t1);
     }
 
-    if (auto *p1 = cast_type<ProxyType>(t1.get())) {
-        if (auto *p2 = cast_type<ProxyType>(t2.get())) {
+    if (auto *p1 = cast_type<ProxyType>(t1)) {
+        if (auto *p2 = cast_type<ProxyType>(t2)) {
             if (typeid(*p1) != typeid(*p2)) {
                 return Types::bottom();
             }
             TypePtr result;
             typecase(
                 p1,
-                [&](TupleType *a1) { // Warning: this implements COVARIANT arrays
-                    auto *a2 = cast_type<TupleType>(p2);
+                [&](const TupleType *a1) { // Warning: this implements COVARIANT arrays
+                    auto *a2 = cast_type<TupleType>(t2);
                     ENFORCE(a2 != nullptr);
                     if (a1->elems.size() == a2->elems.size()) { // lub arrays only if they have same element count
                         vector<TypePtr> elemGlbs;
@@ -665,7 +661,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         for (auto &el2 : a2->elems) {
                             ++i;
                             auto glbe = glb(gs, a1->elems[i], el2);
-                            if (glbe->isBottom()) {
+                            if (glbe.isBottom()) {
                                 result = Types::bottom();
                                 return;
                             }
@@ -683,8 +679,8 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                     }
 
                 },
-                [&](ShapeType *h1) { // Warning: this implements COVARIANT hashes
-                    auto *h2 = cast_type<ShapeType>(p2);
+                [&](const ShapeType *h1) { // Warning: this implements COVARIANT hashes
+                    auto *h2 = cast_type<ShapeType>(t2);
                     ENFORCE(h2 != nullptr);
                     if (h2->keys.size() == h1->keys.size()) {
                         // have enough keys.
@@ -695,19 +691,19 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         bool canReuseT2 = true;
                         for (auto &el2 : h2->keys) {
                             ++i;
-                            auto el2l = cast_type<LiteralType>(el2.get());
-                            auto *u2 = cast_type<ClassType>(el2l->underlying().get());
+                            auto el2l = cast_type<LiteralType>(el2);
+                            auto *u2 = cast_type<ClassType>(el2l->underlying());
                             ENFORCE(u2 != nullptr);
                             auto fnd = absl::c_find_if(h1->keys, [&](auto &candidate) -> bool {
-                                auto el1l = cast_type<LiteralType>(candidate.get());
-                                ClassType *u1 = cast_type<ClassType>(el1l->underlying().get());
+                                auto el1l = cast_type<LiteralType>(candidate);
+                                auto *u1 = cast_type<ClassType>(el1l->underlying());
                                 return el1l->value == el2l->value && u1->symbol == u2->symbol; // from lambda
                             });
                             if (fnd != h1->keys.end()) {
                                 auto left = h1->values[fnd - h1->keys.begin()];
                                 auto right = h2->values[i];
                                 auto glbe = glb(gs, left, right);
-                                if (glbe->isBottom()) {
+                                if (glbe.isBottom()) {
                                     result = Types::bottom();
                                     return;
                                 }
@@ -731,11 +727,11 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                     }
 
                 },
-                [&](LiteralType *l1) {
-                    auto *l2 = cast_type<LiteralType>(p2);
+                [&](const LiteralType *l1) {
+                    auto *l2 = cast_type<LiteralType>(t2);
                     ENFORCE(l2 != nullptr);
-                    auto *u1 = cast_type<ClassType>(l1->underlying().get());
-                    auto *u2 = cast_type<ClassType>(l2->underlying().get());
+                    auto *u1 = cast_type<ClassType>(l1->underlying());
+                    auto *u2 = cast_type<ClassType>(l2->underlying());
                     ENFORCE(u1 != nullptr && u2 != nullptr);
                     if (u1->symbol == u2->symbol) {
                         if (l1->value == l2->value) {
@@ -747,8 +743,8 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         result = Types::bottom();
                     }
                 },
-                [&](MetaType *m1) {
-                    auto *m2 = cast_type<MetaType>(p2);
+                [&](const MetaType *m1) {
+                    auto *m2 = cast_type<MetaType>(t2);
                     ENFORCE(m2 != nullptr);
                     if (Types::equiv(gs, m1->wrapped, m2->wrapped)) {
                         result = t1;
@@ -766,7 +762,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                 return Types::bottom();
             }
         }
-    } else if (isa_type<ProxyType>(t2.get())) {
+    } else if (isa_type<ProxyType>(t2)) {
         // only 1st is proxy
         if (Types::isSubType(gs, t2, t1)) {
             return t2;
@@ -775,7 +771,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         }
     }
 
-    if (auto *o2 = cast_type<OrType>(t2.get())) { // 3, 6
+    if (auto *o2 = cast_type<OrType>(t2)) { // 3, 6
         bool collapseInLeft = Types::isAsSpecificAs(gs, t1, t2);
         if (collapseInLeft) {
             categoryCounterInc("glb", "Zor");
@@ -788,26 +784,26 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             return t2;
         }
 
-        if (isa_type<ClassType>(t1.get()) || isa_type<AppliedType>(t1.get())) {
+        if (isa_type<ClassType>(t1) || isa_type<AppliedType>(t1)) {
             auto lft = Types::all(gs, t1, o2->left);
-            if (Types::isAsSpecificAs(gs, lft, o2->right) && !lft->isBottom()) {
+            if (Types::isAsSpecificAs(gs, lft, o2->right) && !lft.isBottom()) {
                 categoryCounterInc("glb", "ZZZorClass");
                 return lft;
             }
             auto rght = Types::all(gs, t1, o2->right);
-            if (Types::isAsSpecificAs(gs, rght, o2->left) && !rght->isBottom()) {
+            if (Types::isAsSpecificAs(gs, rght, o2->left) && !rght.isBottom()) {
                 categoryCounterInc("glb", "ZZZZorClass");
                 return rght;
             }
-            if (lft->isBottom()) {
+            if (lft.isBottom()) {
                 return rght;
             }
-            if (rght->isBottom()) {
+            if (rght.isBottom()) {
                 return lft;
             }
         }
 
-        if (auto *o1 = cast_type<OrType>(t1.get())) { // 6
+        if (auto *o1 = cast_type<OrType>(t1)) { // 6
             auto t11 = Types::all(gs, o1->left, o2->left);
             auto t12 = Types::all(gs, o1->left, o2->right);
             auto t21 = Types::all(gs, o1->right, o2->left);
@@ -829,7 +825,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             if (t22 == o1->right || t22 == o2->right) {
                 score++;
             }
-            if (t11->isBottom() || t12->isBottom() || t21->isBottom() || t22->isBottom()) {
+            if (t11.isBottom() || t12.isBottom() || t21.isBottom() || t22.isBottom()) {
                 score++;
             }
 
@@ -841,10 +837,10 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         return AndType::make_shared(t1, t2);
     }
 
-    if (auto *a1 = cast_type<AppliedType>(t1.get())) {
-        auto *a2 = cast_type<AppliedType>(t2.get());
+    if (auto *a1 = cast_type<AppliedType>(t1)) {
+        auto *a2 = cast_type<AppliedType>(t2);
         if (a2 == nullptr) {
-            auto *c2 = cast_type<ClassType>(t2.get());
+            auto *c2 = cast_type<ClassType>(t2);
             if (a1->klass.data(gs)->isClassOrModuleModule() || c2 == nullptr) {
                 return AndType::make_shared(t1, t2);
             }
@@ -897,7 +893,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                     if (!Types::equiv(gs, a1->targs[j], a2->targs[i])) {
                         return AndType::make_shared(t1, t2);
                     }
-                    if (a1->targs[j]->isUntyped()) {
+                    if (a1->targs[j].isUntyped()) {
                         newTargs.emplace_back(a2->targs[i]);
                     } else {
                         newTargs.emplace_back(a1->targs[j]);
@@ -917,13 +913,13 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         }
     }
     {
-        if (isa_type<TypeVar>(t1.get()) || isa_type<TypeVar>(t2.get())) {
+        if (isa_type<TypeVar>(t1) || isa_type<TypeVar>(t2)) {
             return AndType::make_shared(t1, t2);
         }
     }
     {
-        auto *s1 = cast_type<SelfTypeParam>(t1.get());
-        auto *s2 = cast_type<SelfTypeParam>(t2.get());
+        auto *s1 = cast_type<SelfTypeParam>(t1);
+        auto *s2 = cast_type<SelfTypeParam>(t2);
 
         if (s1 != nullptr || s2 != nullptr) {
             if (s1 == nullptr || s2 == nullptr || s2->definition != s1->definition) {
@@ -935,8 +931,8 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
     }
 
     {
-        auto *self1 = cast_type<SelfType>(t1.get());
-        auto *self2 = cast_type<SelfType>(t2.get());
+        auto *self1 = cast_type<SelfType>(t1);
+        auto *self2 = cast_type<SelfType>(t2);
 
         if (self1 != nullptr || self2 != nullptr) {
             if (self1 == nullptr || self2 == nullptr) {
@@ -956,30 +952,30 @@ bool classSymbolIsAsGoodAs(const GlobalState &gs, SymbolRef c1, SymbolRef c2) {
 }
 
 void compareToUntyped(const GlobalState &gs, TypeConstraint &constr, const TypePtr &ty, const TypePtr &blame) {
-    ENFORCE(blame->isUntyped());
-    if (auto *p = cast_type<ProxyType>(ty.get())) {
+    ENFORCE(blame.isUntyped());
+    if (auto *p = cast_type<ProxyType>(ty)) {
         compareToUntyped(gs, constr, p->underlying(), blame);
     }
 
-    if (auto *t = cast_type<AppliedType>(ty.get())) {
+    if (auto *t = cast_type<AppliedType>(ty)) {
         for (auto &targ : t->targs) {
             compareToUntyped(gs, constr, targ, blame);
         }
-    } else if (auto *t = cast_type<ShapeType>(ty.get())) {
+    } else if (auto *t = cast_type<ShapeType>(ty)) {
         for (auto &val : t->values) {
             compareToUntyped(gs, constr, val, blame);
         }
-    } else if (auto *t = cast_type<TupleType>(ty.get())) {
+    } else if (auto *t = cast_type<TupleType>(ty)) {
         for (auto &val : t->elems) {
             compareToUntyped(gs, constr, val, blame);
         }
-    } else if (auto *t = cast_type<OrType>(ty.get())) {
+    } else if (auto *t = cast_type<OrType>(ty)) {
         compareToUntyped(gs, constr, t->left, blame);
         compareToUntyped(gs, constr, t->right, blame);
-    } else if (auto *t = cast_type<AndType>(ty.get())) {
+    } else if (auto *t = cast_type<AndType>(ty)) {
         compareToUntyped(gs, constr, t->left, blame);
         compareToUntyped(gs, constr, t->right, blame);
-    } else if (auto *t = cast_type<TypeVar>(ty.get())) {
+    } else if (auto *t = cast_type<TypeVar>(ty)) {
         constr.rememberIsSubtype(gs, ty, blame);
     }
 }
@@ -995,7 +991,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
         return true;
     }
 
-    if (isa_type<TypeVar>(t1.get()) || isa_type<TypeVar>(t2.get())) {
+    if (isa_type<TypeVar>(t1) || isa_type<TypeVar>(t2)) {
         if (constr.isSolved()) {
             return constr.isAlreadyASubType(gs, t1, t2);
         } else {
@@ -1003,7 +999,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
         }
     }
 
-    if (auto *mayBeSpecial1 = cast_type<ClassType>(t1.get())) {
+    if (auto *mayBeSpecial1 = cast_type<ClassType>(t1)) {
         if (mayBeSpecial1->symbol == Symbols::untyped()) {
             if (!constr.isSolved()) {
                 compareToUntyped(gs, constr, t2, t1);
@@ -1014,7 +1010,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
             return true;
         }
         if (mayBeSpecial1->symbol == Symbols::top()) {
-            if (auto *mayBeSpecial2 = cast_type<ClassType>(t2.get())) {
+            if (auto *mayBeSpecial2 = cast_type<ClassType>(t2)) {
                 return mayBeSpecial2->symbol == Symbols::top() || mayBeSpecial2->symbol == Symbols::untyped();
             } else {
                 return false;
@@ -1022,7 +1018,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
         }
     }
 
-    if (auto *mayBeSpecial2 = cast_type<ClassType>(t2.get())) {
+    if (auto *mayBeSpecial2 = cast_type<ClassType>(t2)) {
         if (mayBeSpecial2->symbol == Symbols::untyped()) {
             if (!constr.isSolved()) {
                 compareToUntyped(gs, constr, t1, t2);
@@ -1037,11 +1033,11 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
         }
     }
     //    ENFORCE(!isa_type<LambdaParam>(t1.get())); // sandly, this is false in Resolver, as we build
-    //    original signatures using lub ENFORCE(cast_type<LambdaParam>(t2.get()) == nullptr);
+    //    original signatures using lub ENFORCE(cast_type<LambdaParam>(t2) == nullptr);
 
     {
-        auto *lambda1 = cast_type<LambdaParam>(t1.get());
-        auto *lambda2 = cast_type<LambdaParam>(t2.get());
+        auto *lambda1 = cast_type<LambdaParam>(t1);
+        auto *lambda2 = cast_type<LambdaParam>(t2);
         if (lambda1 != nullptr || lambda2 != nullptr) {
             // This should only be reachable in resolver.
             if (lambda1 == nullptr || lambda2 == nullptr) {
@@ -1052,19 +1048,19 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
     }
 
     {
-        auto *self1 = cast_type<SelfTypeParam>(t1.get());
-        auto *self2 = cast_type<SelfTypeParam>(t2.get());
+        auto *self1 = cast_type<SelfTypeParam>(t1);
+        auto *self2 = cast_type<SelfTypeParam>(t2);
         if (self1 != nullptr || self2 != nullptr) {
             // NOTE: SelfTypeParam is used both with LambdaParam and TypeVar, so
             // we can only check bounds when a LambdaParam is present.
             if (self1 == nullptr) {
-                if (auto *lambdaParam = cast_type<LambdaParam>(self2->definition.data(gs)->resultType.get())) {
+                if (auto *lambdaParam = cast_type<LambdaParam>(self2->definition.data(gs)->resultType)) {
                     return Types::isSubTypeUnderConstraint(gs, constr, t1, lambdaParam->lowerBound, mode);
                 } else {
                     return false;
                 }
             } else if (self2 == nullptr) {
-                if (auto *lambdaParam = cast_type<LambdaParam>(self1->definition.data(gs)->resultType.get())) {
+                if (auto *lambdaParam = cast_type<LambdaParam>(self1->definition.data(gs)->resultType)) {
                     return Types::isSubTypeUnderConstraint(gs, constr, lambdaParam->upperBound, t2, mode);
                 } else {
                     return false;
@@ -1074,8 +1070,8 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                     return true;
                 }
 
-                auto *lambda1 = cast_type<LambdaParam>(self1->definition.data(gs)->resultType.get());
-                auto *lambda2 = cast_type<LambdaParam>(self2->definition.data(gs)->resultType.get());
+                auto *lambda1 = cast_type<LambdaParam>(self1->definition.data(gs)->resultType);
+                auto *lambda2 = cast_type<LambdaParam>(self2->definition.data(gs)->resultType);
                 return lambda1 && lambda2 &&
                        Types::isSubTypeUnderConstraint(gs, constr, lambda1->upperBound, lambda2->lowerBound, mode);
             }
@@ -1083,8 +1079,8 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
     }
 
     {
-        auto *self1 = cast_type<SelfType>(t1.get());
-        auto *self2 = cast_type<SelfType>(t2.get());
+        auto *self1 = cast_type<SelfType>(t1);
+        auto *self2 = cast_type<SelfType>(t2);
         if (self1 != nullptr || self2 != nullptr) {
             if (self1 == nullptr || self2 == nullptr) {
                 return false;
@@ -1093,11 +1089,11 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
         }
     }
 
-    if (auto *a1 = cast_type<AppliedType>(t1.get())) {
-        auto *a2 = cast_type<AppliedType>(t2.get());
+    if (auto *a1 = cast_type<AppliedType>(t1)) {
+        auto *a2 = cast_type<AppliedType>(t2);
         bool result;
         if (a2 == nullptr) {
-            if (auto *c2 = cast_type<ClassType>(t2.get())) {
+            if (auto *c2 = cast_type<ClassType>(t2)) {
                 return classSymbolIsAsGoodAs(gs, a1->klass, c2->symbol);
             }
             return false;
@@ -1141,21 +1137,21 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
         }
         return result;
     }
-    if (isa_type<AppliedType>(t2.get())) {
-        if (auto *pt = cast_type<ProxyType>(t1.get())) {
+    if (isa_type<AppliedType>(t2)) {
+        if (auto *pt = cast_type<ProxyType>(t1)) {
             return Types::isSubTypeUnderConstraint(gs, constr, pt->underlying(), t2, mode);
         }
         return false;
     }
 
-    if (auto *p1 = cast_type<ProxyType>(t1.get())) {
-        if (auto *p2 = cast_type<ProxyType>(t2.get())) {
+    if (auto *p1 = cast_type<ProxyType>(t1)) {
+        if (auto *p2 = cast_type<ProxyType>(t2)) {
             bool result;
             // TODO: simply compare as memory regions
             typecase(
                 p1,
-                [&](TupleType *a1) { // Warning: this implements COVARIANT arrays
-                    auto *a2 = cast_type<TupleType>(p2);
+                [&](const TupleType *a1) { // Warning: this implements COVARIANT arrays
+                    auto *a2 = cast_type<TupleType>(t2);
                     result = a2 != nullptr && a1->elems.size() >= a2->elems.size();
                     if (result) {
                         int i = -1;
@@ -1168,8 +1164,8 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                         }
                     }
                 },
-                [&](ShapeType *h1) { // Warning: this implements COVARIANT hashes
-                    auto *h2 = cast_type<ShapeType>(p2);
+                [&](const ShapeType *h1) { // Warning: this implements COVARIANT hashes
+                    auto *h2 = cast_type<ShapeType>(t2);
                     result = h2 != nullptr && h2->keys.size() <= h1->keys.size();
                     if (!result) {
                         return;
@@ -1178,12 +1174,12 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                     int i = -1;
                     for (auto &el2 : h2->keys) {
                         ++i;
-                        auto el2l = cast_type<LiteralType>(el2.get());
-                        auto *u2 = cast_type<ClassType>(el2l->underlying().get());
+                        auto el2l = cast_type<LiteralType>(el2);
+                        auto *u2 = cast_type<ClassType>(el2l->underlying());
                         ENFORCE(u2 != nullptr);
                         auto fnd = absl::c_find_if(h1->keys, [&](auto &candidate) -> bool {
-                            auto el1l = cast_type<LiteralType>(candidate.get());
-                            ClassType *u1 = cast_type<ClassType>(el1l->underlying().get());
+                            auto el1l = cast_type<LiteralType>(candidate);
+                            auto *u1 = cast_type<ClassType>(el1l->underlying());
                             return el1l->value == el2l->value && u1->symbol == u2->symbol; // from lambda
                         });
                         result = fnd != h1->keys.end() &&
@@ -1194,20 +1190,20 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                         }
                     }
                 },
-                [&](LiteralType *l1) {
-                    auto *l2 = cast_type<LiteralType>(p2);
+                [&](const LiteralType *l1) {
+                    auto *l2 = cast_type<LiteralType>(t2);
                     if (l2 == nullptr) {
                         // is a literal a subtype of a different kind of proxy
                         result = false;
                         return;
                     }
-                    auto *u1 = cast_type<ClassType>(l1->underlying().get());
-                    auto *u2 = cast_type<ClassType>(l2->underlying().get());
+                    auto *u1 = cast_type<ClassType>(l1->underlying());
+                    auto *u2 = cast_type<ClassType>(l2->underlying());
                     ENFORCE(u1 != nullptr && u2 != nullptr);
                     result = l2 != nullptr && u1->symbol == u2->symbol && l1->value == l2->value;
                 },
-                [&](MetaType *m1) {
-                    auto *m2 = cast_type<MetaType>(p2);
+                [&](const MetaType *m1) {
+                    auto *m2 = cast_type<MetaType>(t2);
                     if (m2 == nullptr) {
                         // is a literal a subtype of a different kind of proxy
                         result = false;
@@ -1223,12 +1219,12 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
             TypePtr und = p1->underlying();
             return isSubTypeUnderConstraintSingle(gs, constr, mode, und, t2);
         }
-    } else if (isa_type<ProxyType>(t2.get())) {
+    } else if (isa_type<ProxyType>(t2)) {
         // non-proxies are never subtypes of proxies.
         return false;
     } else {
-        if (auto *c1 = cast_type<ClassType>(t1.get())) {
-            if (auto *c2 = cast_type<ClassType>(t2.get())) {
+        if (auto *c1 = cast_type<ClassType>(t1)) {
+            if (auto *c2 = cast_type<ClassType>(t2)) {
                 return classSymbolIsAsGoodAs(gs, c1->symbol, c2->symbol);
             }
         }
@@ -1255,28 +1251,28 @@ bool Types::isSubTypeUnderConstraint(const GlobalState &gs, TypeConstraint &cons
 
     // Note: order of cases here matters! We can't loose "and" information in t1 early and we can't
     // loose "or" information in t2 early.
-    if (auto *o1 = cast_type<OrType>(t1.get())) { // 7, 8, 9
+    if (auto *o1 = cast_type<OrType>(t1)) { // 7, 8, 9
         return Types::isSubTypeUnderConstraint(gs, constr, o1->left, t2, mode) &&
                Types::isSubTypeUnderConstraint(gs, constr, o1->right, t2, mode);
     }
 
-    if (auto *a2 = cast_type<AndType>(t2.get())) { // 2, 5
+    if (auto *a2 = cast_type<AndType>(t2)) { // 2, 5
         return Types::isSubTypeUnderConstraint(gs, constr, t1, a2->left, mode) &&
                Types::isSubTypeUnderConstraint(gs, constr, t1, a2->right, mode);
     }
 
-    auto *a1 = cast_type<AndType>(t1.get());
-    auto *o2 = cast_type<OrType>(t2.get());
+    auto *a1 = cast_type<AndType>(t1);
+    auto *o2 = cast_type<OrType>(t2);
 
     if (a1 != nullptr) {
         // If the left is an And of an Or, then we can reorder it to be an Or of
         // an And, which lets us recurse on smaller types
         auto l = a1->left;
         auto r = a1->right;
-        if (isa_type<OrType>(r.get())) {
+        if (isa_type<OrType>(r)) {
             swap(r, l);
         }
-        auto *a2o = cast_type<OrType>(l.get());
+        auto *a2o = cast_type<OrType>(l);
         if (a2o != nullptr) {
             // This handles `(A | B) & C` -> `(A & C) | (B & C)`
 
@@ -1291,10 +1287,10 @@ bool Types::isSubTypeUnderConstraint(const GlobalState &gs, TypeConstraint &cons
         // an Or, which lets us recurse on smaller types
         auto l = o2->left;
         auto r = o2->right;
-        if (isa_type<AndType>(r.get())) {
+        if (isa_type<AndType>(r)) {
             swap(r, l);
         }
-        auto *o2a = cast_type<AndType>(l.get());
+        auto *o2a = cast_type<AndType>(l);
         if (o2a != nullptr) {
             // This handles `(A & B) | C` -> `(A | C) & (B | C)`
 
@@ -1371,7 +1367,7 @@ string MetaType::typeName() const {
 }
 
 void MetaType::_sanityCheck(const GlobalState &gs) {
-    ENFORCE(!core::isa_type<MetaType>(wrapped.get()));
+    ENFORCE(!core::isa_type<MetaType>(wrapped));
     this->wrapped->sanityCheck(gs);
 }
 

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -43,7 +43,7 @@ Signature decomposeSignature(const core::GlobalState &gs, core::SymbolRef method
 
 // This returns true if `sub` is a subtype of `super`, but it also returns true if either one is `nullptr` or if either
 // one is not fully defined. This is really just a useful helper function for this module: do not use it elsewhere.
-bool checkSubtype(const core::Context ctx, core::TypePtr sub, core::TypePtr super) {
+bool checkSubtype(const core::Context ctx, const core::TypePtr &sub, const core::TypePtr &super) {
     if (sub == nullptr || super == nullptr) {
         return true;
     }

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -67,41 +67,41 @@ private:
 
     VarianceValidator(const core::Loc loc) : loc(loc) {}
 
-    void validate(const core::Context ctx, const Polarity polarity, const core::TypePtr type) {
+    void validate(const core::Context ctx, const Polarity polarity, const core::TypePtr &type) {
         typecase(
-            type.get(), [&](core::ClassType *klass) {},
+            type.get(), [&](const core::ClassType *klass) {},
 
-            [&](core::LiteralType *lit) {},
+            [&](const core::LiteralType *lit) {},
 
-            [&](core::SelfType *self) {},
+            [&](const core::SelfType *self) {},
 
-            [&](core::SelfTypeParam *sp) {},
+            [&](const core::SelfTypeParam *sp) {},
 
-            [&](core::TypeVar *tvar) {},
+            [&](const core::TypeVar *tvar) {},
 
-            [&](core::OrType *any) {
+            [&](const core::OrType *any) {
                 validate(ctx, polarity, any->left);
                 validate(ctx, polarity, any->right);
             },
 
-            [&](core::AndType *all) {
+            [&](const core::AndType *all) {
                 validate(ctx, polarity, all->left);
                 validate(ctx, polarity, all->right);
             },
 
-            [&](core::ShapeType *shape) {
+            [&](const core::ShapeType *shape) {
                 for (auto value : shape->values) {
                     validate(ctx, polarity, value);
                 }
             },
 
-            [&](core::TupleType *tuple) {
+            [&](const core::TupleType *tuple) {
                 for (auto value : tuple->elems) {
                     validate(ctx, polarity, value);
                 }
             },
 
-            [&](core::AppliedType *app) {
+            [&](const core::AppliedType *app) {
                 auto members = app->klass.data(ctx)->typeMembers();
                 auto params = app->targs;
 
@@ -136,7 +136,7 @@ private:
             },
 
             // This is where the actual variance checks are done.
-            [&](core::LambdaParam *param) {
+            [&](const core::LambdaParam *param) {
                 auto paramData = param->definition.data(ctx);
 
                 ENFORCE(paramData->isTypeMember());
@@ -166,7 +166,7 @@ private:
                 }
             },
 
-            [&](core::AliasType *alias) {
+            [&](const core::AliasType *alias) {
                 auto aliasSym = alias->symbol.data(ctx)->dealias(ctx);
 
                 // This can be introduced by `module_function`, which in its
@@ -179,14 +179,14 @@ private:
                 }
             },
 
-            [&](core::Type *skipped) {
+            [&](const core::Type *skipped) {
                 Exception::raise("Unexpected type in variance checking: {}", skipped->toString(ctx));
             });
     }
 
 public:
     static void validatePolarity(const core::Loc loc, const core::Context ctx, const Polarity polarity,
-                                 const core::TypePtr type) {
+                                 const core::TypePtr &type) {
         VarianceValidator validator(loc);
         return validator.validate(ctx, polarity, type);
     }

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -112,7 +112,7 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
         while (iter != nullptr) {
             if (iter->main.method.exists() && iter->main.method != core::Symbols::untyped()) {
                 auto argType = extractArgType(ctx, *snd, iter->main, i);
-                if (argType && !argType->isUntyped()) {
+                if (argType && !argType.isUntyped()) {
                     if (!thisType) {
                         thisType = argType;
                     } else {
@@ -320,7 +320,7 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
             guessedReturnType = core::Types::untypedUntracked();
         }
 
-        guessedSomethingUseful |= !guessedReturnType->isUntyped();
+        guessedSomethingUseful |= !guessedReturnType.isUntyped();
     } else {
         guessedReturnType = methodReturnType;
     }
@@ -346,12 +346,12 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
     fmt::memory_buffer ss;
     if (closestMethod.exists()) {
         auto closestReturnType = closestMethod.data(ctx)->resultType;
-        if (closestReturnType && !closestReturnType->isUntyped()) {
+        if (closestReturnType && !closestReturnType.isUntyped()) {
             guessedReturnType = closestReturnType;
         }
 
         for (const auto &arg : closestMethod.data(ctx)->arguments()) {
-            if (arg.type && !arg.type->isUntyped()) {
+            if (arg.type && !arg.type.isUntyped()) {
                 guessedArgumentTypes[arg.name] = arg.type;
             }
         }
@@ -401,8 +401,8 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
             core::TypePtr chosenType;
 
             auto oldType = argSym.type;
-            if (!oldType || oldType->isUntyped()) {
-                if (!argType || argType->isBottom()) {
+            if (!oldType || oldType.isUntyped()) {
+                if (!argType || argType.isBottom()) {
                     chosenType = core::Types::untypedUntracked();
                 } else {
                     guessedSomethingUseful = true;
@@ -422,7 +422,7 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
 
     bool suggestsVoid = methodSymbol.data(ctx)->name == core::Names::initialize() ||
                         (core::Types::isSubType(ctx, core::Types::void_(), guessedReturnType) &&
-                         !guessedReturnType->isUntyped() && !guessedReturnType->isBottom());
+                         !guessedReturnType.isUntyped() && !guessedReturnType.isBottom());
 
     if (suggestsVoid) {
         fmt::format_to(ss, "void}}");

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -13,8 +13,8 @@ namespace sorbet::infer {
 
 namespace {
 core::TypePtr dropConstructor(core::Context ctx, core::Loc loc, core::TypePtr tp) {
-    if (auto *mt = core::cast_type<core::MetaType>(tp.get())) {
-        if (!mt->wrapped->isUntyped()) {
+    if (auto *mt = core::cast_type<core::MetaType>(tp)) {
+        if (!mt->wrapped.isUntyped()) {
             if (auto e = ctx.state.beginError(loc, core::errors::Infer::BareTypeUsage)) {
                 e.setHeader("Unsupported usage of bare type");
             }
@@ -169,7 +169,7 @@ KnowledgeRef KnowledgeRef::under(core::Context ctx, const Environment &env, core
             // file effectively exist to support this feature.
 
             auto type = state.typeAndOrigins.type;
-            if (isNeeded && !type->isUntyped() && !core::isa_type<core::MetaType>(type.get())) {
+            if (isNeeded && !type.isUntyped() && !core::isa_type<core::MetaType>(type)) {
                 // Direct mutation of `yesTypeTests` rather than going through `addYesTypeTest`.
                 // This is fine since `copy` is unmoored from a particular environment.
                 copy.mutate().yesTypeTests.emplace_back(local, type);
@@ -178,7 +178,7 @@ KnowledgeRef KnowledgeRef::under(core::Context ctx, const Environment &env, core
             auto &second = fnd->second;
             auto &typeAndOrigin = state.typeAndOrigins;
             auto combinedType = core::Types::all(ctx, typeAndOrigin.type, second);
-            if (combinedType->isBottom()) {
+            if (combinedType.isBottom()) {
                 copy.markDead();
                 break;
             }
@@ -220,11 +220,11 @@ void KnowledgeFact::sanityCheck() const {
     }
     for (auto &a : yesTypeTests) {
         ENFORCE(a.second.get() != nullptr);
-        ENFORCE(!a.second->isUntyped());
+        ENFORCE(!a.second.isUntyped());
     }
     for (auto &a : noTypeTests) {
         ENFORCE(a.second.get() != nullptr);
-        ENFORCE(!a.second->isUntyped());
+        ENFORCE(!a.second.isUntyped());
     }
 }
 
@@ -266,12 +266,12 @@ KnowledgeFact &KnowledgeRef::mutate() {
 void KnowledgeRef::addYesTypeTest(cfg::LocalRef of, TypeTestReverseIndex &index, cfg::LocalRef ref,
                                   core::TypePtr type) {
     index.addToIndex(ref, of);
-    this->mutate().yesTypeTests.emplace_back(ref, type);
+    this->mutate().yesTypeTests.emplace_back(ref, move(type));
 }
 
 void KnowledgeRef::addNoTypeTest(cfg::LocalRef of, TypeTestReverseIndex &index, cfg::LocalRef ref, core::TypePtr type) {
     index.addToIndex(ref, of);
-    this->mutate().noTypeTests.emplace_back(ref, type);
+    this->mutate().noTypeTests.emplace_back(ref, move(type));
 }
 
 void KnowledgeRef::markDead() {
@@ -563,10 +563,10 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         }
         auto &whoKnows = getKnowledge(local);
         auto &klassType = send->args[0].type;
-        core::SymbolRef klass = core::Types::getRepresentedClass(ctx, klassType.get());
+        core::SymbolRef klass = core::Types::getRepresentedClass(ctx, klassType);
         if (klass.exists()) {
             auto ty = klass.data(ctx)->externalType();
-            if (!ty->isUntyped()) {
+            if (!ty.isUntyped()) {
                 whoKnows.truthy().addYesTypeTest(local, typeTestsWithVar, send->recv.variable, ty);
                 whoKnows.falsy().addNoTypeTest(local, typeTestsWithVar, send->recv.variable, ty);
             }
@@ -587,20 +587,20 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
 
         ENFORCE(argType.get() != nullptr);
         ENFORCE(recvType.get() != nullptr);
-        if (!argType->isUntyped()) {
+        if (!argType.isUntyped()) {
             truthy.addYesTypeTest(local, typeTestsWithVar, send->recv.variable, argType);
         }
-        if (!recvType->isUntyped()) {
+        if (!recvType.isUntyped()) {
             truthy.addYesTypeTest(local, typeTestsWithVar, send->args[0].variable, recvType);
         }
-        if (auto s = core::cast_type<core::ClassType>(argType.get())) {
+        if (auto s = core::cast_type<core::ClassType>(argType)) {
             // check if s is a singleton. in this case we can learn that
             // a failed comparison means that type test would also fail
             if (isSingleton(ctx, s->symbol)) {
                 falsy.addNoTypeTest(local, typeTestsWithVar, send->recv.variable, argType);
             }
         }
-        if (auto s = core::cast_type<core::ClassType>(recvType.get())) {
+        if (auto s = core::cast_type<core::ClassType>(recvType)) {
             // check if s is a singleton. in this case we can learn that
             // a failed comparison means that type test would also fail
             if (isSingleton(ctx, s->symbol)) {
@@ -616,17 +616,17 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         const auto &recvType = send->recv.type;
 
         // `when` against class literal
-        core::SymbolRef representedClass = core::Types::getRepresentedClass(ctx, recvType.get());
+        core::SymbolRef representedClass = core::Types::getRepresentedClass(ctx, recvType);
         if (representedClass.exists()) {
             auto representedType = representedClass.data(ctx)->externalType();
-            if (!representedType->isUntyped()) {
+            if (!representedType.isUntyped()) {
                 whoKnows.truthy().addYesTypeTest(local, typeTestsWithVar, send->args[0].variable, representedType);
                 whoKnows.falsy().addNoTypeTest(local, typeTestsWithVar, send->args[0].variable, representedType);
             }
         }
 
         // `when` against singleton
-        if (auto s = core::cast_type<core::ClassType>(recvType.get())) {
+        if (auto s = core::cast_type<core::ClassType>(recvType)) {
             // check if s is a singleton. in this case we can learn that
             // a failed comparison means that type test would also fail
             if (isSingleton(ctx, s->symbol)) {
@@ -640,12 +640,12 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         const auto &recvKlass = send->recv.type;
         const auto &argType = send->args[0].type;
 
-        if (auto *argClass = core::cast_type<core::ClassType>(argType.get())) {
+        if (auto *argClass = core::cast_type<core::ClassType>(argType)) {
             if (!recvKlass->derivesFrom(ctx, core::Symbols::Class()) ||
                 !argClass->symbol.data(ctx)->derivesFrom(ctx, core::Symbols::Class())) {
                 return;
             }
-        } else if (auto *argClass = core::cast_type<core::AppliedType>(argType.get())) {
+        } else if (auto *argClass = core::cast_type<core::AppliedType>(argType)) {
             if (!recvKlass->derivesFrom(ctx, core::Symbols::Class()) ||
                 !argClass->klass.data(ctx)->derivesFrom(ctx, core::Symbols::Class())) {
                 return;
@@ -690,11 +690,11 @@ void Environment::assumeKnowledge(core::Context ctx, bool isTrue, cfg::LocalRef 
 
         core::TypeAndOrigins tp = getTypeAndOrigin(ctx, cond);
         tp.origins.emplace_back(loc);
-        if (tp.type->isUntyped()) {
+        if (tp.type.isUntyped()) {
             tp.type = core::Types::falsyTypes();
         } else {
             tp.type = core::Types::all(ctx, tp.type, core::Types::falsyTypes());
-            if (tp.type->isBottom()) {
+            if (tp.type.isBottom()) {
                 isDead = true;
                 return;
             }
@@ -705,7 +705,7 @@ void Environment::assumeKnowledge(core::Context ctx, bool isTrue, cfg::LocalRef 
         tp.origins.emplace_back(loc);
         tp.type = core::Types::dropSubtypesOf(ctx, core::Types::dropSubtypesOf(ctx, tp.type, core::Symbols::NilClass()),
                                               core::Symbols::FalseClass());
-        if (tp.type->isBottom()) {
+        if (tp.type.isBottom()) {
             isDead = true;
             return;
         }
@@ -732,7 +732,7 @@ void Environment::assumeKnowledge(core::Context ctx, bool isTrue, cfg::LocalRef 
             tp.type = glbbed;
         }
         setTypeAndOrigin(typeTested.first, tp);
-        if (tp.type->isBottom()) {
+        if (tp.type.isBottom()) {
             isDead = true;
             return;
         }
@@ -745,10 +745,10 @@ void Environment::assumeKnowledge(core::Context ctx, bool isTrue, cfg::LocalRef 
         core::TypeAndOrigins tp = getTypeAndOrigin(ctx, typeTested.first);
         tp.origins.emplace_back(loc);
 
-        if (!tp.type->isUntyped()) {
+        if (!tp.type.isUntyped()) {
             tp.type = core::Types::approximateSubtract(ctx, tp.type, typeTested.second);
             setTypeAndOrigin(typeTested.first, tp);
-            if (tp.type->isBottom()) {
+            if (tp.type.isBottom()) {
                 isDead = true;
                 return;
             }
@@ -866,11 +866,11 @@ void Environment::populateFrom(core::Context ctx, const Environment &other) {
     this->pinnedTypes = other.pinnedTypes;
 }
 
-core::TypePtr Environment::getReturnType(core::Context ctx, core::TypePtr procType) {
+core::TypePtr Environment::getReturnType(core::Context ctx, const core::TypePtr &procType) {
     if (!procType->derivesFrom(ctx, core::Symbols::Proc())) {
         return core::Types::untypedUntracked();
     }
-    auto *applied = core::cast_type<core::AppliedType>(procType.get());
+    auto *applied = core::cast_type<core::AppliedType>(procType);
     if (applied == nullptr || applied->targs.empty()) {
         return core::Types::untypedUntracked();
     }
@@ -878,17 +878,17 @@ core::TypePtr Environment::getReturnType(core::Context ctx, core::TypePtr procTy
     return applied->targs.front();
 }
 
-core::TypePtr flattenArrays(core::Context ctx, core::TypePtr type) {
+core::TypePtr flattenArrays(core::Context ctx, const core::TypePtr &type) {
     core::TypePtr result;
 
     typecase(
         type.get(),
 
-        [&](core::OrType *o) {
+        [&](const core::OrType *o) {
             result = core::Types::any(ctx, flattenArrays(ctx, o->left), flattenArrays(ctx, o->right));
         },
 
-        [&](core::AppliedType *a) {
+        [&](const core::AppliedType *a) {
             if (a->klass != core::Symbols::Array()) {
                 result = type;
                 return;
@@ -897,13 +897,14 @@ core::TypePtr flattenArrays(core::Context ctx, core::TypePtr type) {
             result = a->targs.front();
         },
 
-        [&](core::TupleType *t) { result = t->elementType(); },
+        [&](const core::TupleType *t) { result = t->elementType(); },
 
-        [&](core::Type *t) { result = std::move(type); });
+        [&](const core::Type *t) { result = std::move(type); });
     return result;
 }
 
-core::TypePtr flatmapHack(core::Context ctx, core::TypePtr receiver, core::TypePtr returnType, core::NameRef fun) {
+core::TypePtr flatmapHack(core::Context ctx, const core::TypePtr &receiver, const core::TypePtr &returnType,
+                          core::NameRef fun) {
     if (fun != core::Names::flatMap()) {
         return returnType;
     }
@@ -911,7 +912,7 @@ core::TypePtr flatmapHack(core::Context ctx, core::TypePtr receiver, core::TypeP
         return returnType;
     }
 
-    if (!receiver->isUntyped() && receiver->derivesFrom(ctx, core::Symbols::Enumerator_Lazy())) {
+    if (!receiver.isUntyped() && receiver->derivesFrom(ctx, core::Symbols::Enumerator_Lazy())) {
         return returnType;
     }
 
@@ -1039,7 +1040,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                             if (data->isFixed()) {
                                 // pick the upper bound here, as
                                 // isFixed() => lowerBound == upperBound.
-                                auto lambdaParam = core::cast_type<core::LambdaParam>(data->resultType.get());
+                                auto lambdaParam = core::cast_type<core::LambdaParam>(data->resultType);
                                 ENFORCE(lambdaParam != nullptr);
                                 tp.type = core::make_type<core::MetaType>(lambdaParam->upperBound);
                             } else {
@@ -1126,7 +1127,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 // rule doesn't apply. We don't model the distinction accurately
                 // yet.
                 auto &blkArgs = insn->link->argFlags;
-                auto *tuple = core::cast_type<core::TupleType>(params.get());
+                auto *tuple = core::cast_type<core::TupleType>(params);
                 if (blkArgs.size() > 1 && !blkArgs.front().isRepeated && tuple && tuple->elems.size() == 1 &&
                     tuple->elems.front()->derivesFrom(ctx, core::Symbols::Array())) {
                     tp.type = std::move(tuple->elems.front());
@@ -1210,7 +1211,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 const core::TypeAndOrigins &typeAndOrigin = getTypeAndOrigin(ctx, i->what.variable);
 
                 if (auto e = ctx.beginError(bind.loc, core::errors::Infer::NotExhaustive)) {
-                    if (typeAndOrigin.type->isUntyped()) {
+                    if (typeAndOrigin.type.isUntyped()) {
                         e.setHeader("Control flow could reach `{}` because argument was `{}`", "T.absurd", "T.untyped");
                     } else {
                         e.setHeader("Control flow could reach `{}` because the type `{}` wasn't handled", "T.absurd",
@@ -1252,7 +1253,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 const core::TypeAndOrigins &ty = getAndFillTypeAndOrigin(ctx, c->value);
                 ENFORCE(c->cast != core::Names::uncheckedLet());
                 if (c->cast != core::Names::cast()) {
-                    if (c->cast == core::Names::assertType() && ty.type->isUntyped()) {
+                    if (c->cast == core::Names::assertType() && ty.type.isUntyped()) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::CastTypeMismatch)) {
                             e.setHeader("The typechecker was unable to infer the type of the asserted value");
                             e.addErrorSection(core::ErrorSection("Got " + ty.type->show(ctx) + " originating from:",
@@ -1267,11 +1268,11 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         }
                     }
                 } else if (!c->isSynthetic) {
-                    if (castType->isUntyped()) {
+                    if (castType.isUntyped()) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::InvalidCast)) {
                             e.setHeader("Please use `T.unsafe(...)` to cast to T.untyped");
                         }
-                    } else if (!ty.type->isUntyped() && core::Types::isSubType(ctx, ty.type, castType)) {
+                    } else if (!ty.type.isUntyped() && core::Types::isSubType(ctx, ty.type, castType)) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::InvalidCast)) {
                             e.setHeader("Useless cast: inferred type `{}` is already a subtype of `{}`",
                                         ty.type->show(ctx), castType->show(ctx));
@@ -1337,7 +1338,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         }
                         break;
                     default: {
-                        if (!asGoodAs || (tp.type->isUntyped() && !cur.type->isUntyped())) {
+                        if (!asGoodAs || (tp.type.isUntyped() && !cur.type.isUntyped())) {
                             if (auto ident = cfg::cast_instruction<cfg::Ident>(bind.value.get())) {
                                 // See cfg/builder/builder_walk.cc for an explanation of why this is here.
                                 if (ident->what.data(inWhat)._name == core::Names::blockBreakAssign()) {

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -192,7 +192,7 @@ class Environment {
 
     // Extract the return value type from a proc. This should potentially be a
     // method on `Type` or otherwise handled there.
-    core::TypePtr getReturnType(core::Context ctx, core::TypePtr procType);
+    core::TypePtr getReturnType(core::Context ctx, const core::TypePtr &procType);
 
     void cloneFrom(const Environment &rhs);
 

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -155,7 +155,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                                            knowledgeFilter, *constr, methodReturnType);
                 if (cfg::isa_instruction<cfg::Send>(bind.value.get())) {
                     totalSendCount++;
-                    if (bind.bind.type && !bind.bind.type->isUntyped()) {
+                    if (bind.bind.type && !bind.bind.type.isUntyped()) {
                         typedSendCount++;
                     } else if (bind.bind.type->hasUntyped()) {
                         DEBUG_ONLY(histogramInc("untyped.sources", bind.bind.type->untypedBlame().rawId()););
@@ -166,7 +166,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                 }
                 ENFORCE(bind.bind.type);
                 bind.bind.type->sanityCheck(ctx);
-                if (bind.bind.type->isBottom()) {
+                if (bind.bind.type.isBottom()) {
                     current.isDead = true;
                     madeBlockDead = core::Loc(ctx.file, bind.loc);
                 }

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -89,10 +89,10 @@ bool hasSimilarName(const core::GlobalState &gs, core::NameRef name, std::string
 bool hideSymbol(const core::GlobalState &gs, core::SymbolRef sym);
 std::unique_ptr<MarkupContent> formatRubyMarkup(MarkupKind markupKind, std::string_view rubyMarkup,
                                                 std::optional<std::string_view> explanation);
-std::string prettyTypeForMethod(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver,
-                                core::TypePtr retType, const core::TypeConstraint *constraint);
+std::string prettyTypeForMethod(const core::GlobalState &gs, core::SymbolRef method, const core::TypePtr &receiver,
+                                const core::TypePtr &retType, const core::TypeConstraint *constraint);
 std::string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef constant);
-core::TypePtr getResultType(const core::GlobalState &gs, core::TypePtr type, core::SymbolRef inWhat,
+core::TypePtr getResultType(const core::GlobalState &gs, const core::TypePtr &type, core::SymbolRef inWhat,
                             core::TypePtr receiver, const core::TypeConstraint *constr);
 SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef sym);
 

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -68,7 +68,7 @@ constexpr int MAX_PRETTY_SIG_ARGS = 4;
 // iff a `def` would be this wide or wider, expand it to be a multi-line def.
 constexpr int MAX_PRETTY_WIDTH = 80;
 
-string prettySigForMethod(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver,
+string prettySigForMethod(const core::GlobalState &gs, core::SymbolRef method, const core::TypePtr &receiver,
                           core::TypePtr retType, const core::TypeConstraint *constraint) {
     ENFORCE(method.exists());
     ENFORCE(method.data(gs)->dealias(gs) == method);
@@ -210,8 +210,8 @@ string prettyDefForMethod(const core::GlobalState &gs, core::SymbolRef method) {
     return result;
 }
 
-string prettyTypeForMethod(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiver,
-                           core::TypePtr retType, const core::TypeConstraint *constraint) {
+string prettyTypeForMethod(const core::GlobalState &gs, core::SymbolRef method, const core::TypePtr &receiver,
+                           const core::TypePtr &retType, const core::TypeConstraint *constraint) {
     return fmt::format("{}\n{}", prettySigForMethod(gs, method.data(gs)->dealias(gs), receiver, retType, constraint),
                        prettyDefForMethod(gs, method));
 }
@@ -240,13 +240,13 @@ string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef consta
     return result->showWithMoreInfo(gs);
 }
 
-core::TypePtr getResultType(const core::GlobalState &gs, core::TypePtr type, core::SymbolRef inWhat,
+core::TypePtr getResultType(const core::GlobalState &gs, const core::TypePtr &type, core::SymbolRef inWhat,
                             core::TypePtr receiver, const core::TypeConstraint *constr) {
     auto resultType = type;
-    if (auto *proxy = core::cast_type<core::ProxyType>(receiver.get())) {
+    if (auto *proxy = core::cast_type<core::ProxyType>(receiver)) {
         receiver = proxy->underlying();
     }
-    if (auto *applied = core::cast_type<core::AppliedType>(receiver.get())) {
+    if (auto *applied = core::cast_type<core::AppliedType>(receiver)) {
         /* instantiate generic classes */
         resultType = core::Types::resultTypeAsSeenFrom(gs, resultType, inWhat.data(gs)->enclosingClass(gs),
                                                        applied->klass, applied->targs);

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -166,19 +166,19 @@ SimilarMethodsByName mergeSimilarMethods(SimilarMethodsByName left, SimilarMetho
     return result;
 }
 
-SimilarMethodsByName similarMethodsForReceiver(const core::GlobalState &gs, const core::TypePtr receiver,
+SimilarMethodsByName similarMethodsForReceiver(const core::GlobalState &gs, const core::TypePtr &receiver,
                                                string_view prefix) {
     auto result = SimilarMethodsByName{};
 
     typecase(
-        receiver.get(), [&](core::ClassType *type) { result = similarMethodsForClass(gs, type->symbol, prefix); },
-        [&](core::AppliedType *type) { result = similarMethodsForClass(gs, type->klass, prefix); },
-        [&](core::AndType *type) {
+        receiver.get(), [&](const core::ClassType *type) { result = similarMethodsForClass(gs, type->symbol, prefix); },
+        [&](const core::AppliedType *type) { result = similarMethodsForClass(gs, type->klass, prefix); },
+        [&](const core::AndType *type) {
             result = mergeSimilarMethods(similarMethodsForReceiver(gs, type->left, prefix),
                                          similarMethodsForReceiver(gs, type->right, prefix));
         },
-        [&](core::ProxyType *type) { result = similarMethodsForReceiver(gs, type->underlying(), prefix); },
-        [&](core::Type *type) { return; });
+        [&](const core::ProxyType *type) { result = similarMethodsForReceiver(gs, type->underlying(), prefix); },
+        [&](const core::Type *type) { return; });
 
     return result;
 }
@@ -237,7 +237,7 @@ vector<core::LocalVariable> allSimilarLocals(const core::GlobalState &gs, const 
     return result;
 }
 
-string methodSnippet(const core::GlobalState &gs, core::SymbolRef method, core::TypePtr receiverType,
+string methodSnippet(const core::GlobalState &gs, core::SymbolRef method, const core::TypePtr &receiverType,
                      const core::TypeConstraint *constraint) {
     fmt::memory_buffer result;
     fmt::format_to(result, "{}", method.data(gs)->name.data(gs)->shortName(gs));
@@ -276,10 +276,10 @@ string methodSnippet(const core::GlobalState &gs, core::SymbolRef method, core::
     auto &blkArg = method.data(gs)->arguments().back();
     ENFORCE(blkArg.flags.isBlock);
 
-    auto hasBlockType = blkArg.type != nullptr && !blkArg.type->isUntyped();
+    auto hasBlockType = blkArg.type != nullptr && !blkArg.type.isUntyped();
     if (hasBlockType && !core::Types::isSubType(gs, core::Types::nilClass(), blkArg.type)) {
         string blkArgs;
-        if (auto *appliedType = core::cast_type<core::AppliedType>(blkArg.type.get())) {
+        if (auto *appliedType = core::cast_type<core::AppliedType>(blkArg.type)) {
             if (appliedType->targs.size() >= 2) {
                 // The first element in targs is the return type.
                 auto targs_it = appliedType->targs.begin();
@@ -536,9 +536,9 @@ unique_ptr<CompletionItem> trySuggestSig(LSPTypecheckerDelegate &typechecker,
     }
 
     core::SymbolRef receiverSym;
-    if (auto classType = core::cast_type<core::ClassType>(receiverType.get())) {
+    if (auto classType = core::cast_type<core::ClassType>(receiverType)) {
         receiverSym = classType->symbol;
-    } else if (auto appliedType = core::cast_type<core::AppliedType>(receiverType.get())) {
+    } else if (auto appliedType = core::cast_type<core::AppliedType>(receiverType)) {
         receiverSym = appliedType->klass;
     } else {
         // receiverType is not a simple type. This can happen for any number of strange and uncommon reasons, like:
@@ -641,7 +641,7 @@ CompletionTask::CompletionTask(const LSPConfiguration &config, MessageId id, uni
 
 unique_ptr<CompletionItem>
 CompletionTask::getCompletionItemForMethod(LSPTypecheckerDelegate &typechecker, core::SymbolRef maybeAlias,
-                                           core::TypePtr receiverType, const core::TypeConstraint *constraint,
+                                           const core::TypePtr &receiverType, const core::TypeConstraint *constraint,
                                            core::Loc queryLoc, string_view prefix, size_t sortIdx) const {
     const auto &gs = typechecker.state();
     ENFORCE(maybeAlias.exists());

--- a/main/lsp/requests/completion.h
+++ b/main/lsp/requests/completion.h
@@ -14,7 +14,7 @@ class CompletionTask final : public LSPRequestTask {
                               std::vector<std::unique_ptr<CompletionItem>> &items) const;
 
     std::unique_ptr<CompletionItem> getCompletionItemForMethod(LSPTypecheckerDelegate &typechecker,
-                                                               core::SymbolRef what, core::TypePtr receiverType,
+                                                               core::SymbolRef what, const core::TypePtr &receiverType,
                                                                const core::TypeConstraint *constraint,
                                                                core::Loc queryLoc, std::string_view prefix,
                                                                size_t sortIdx) const;

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -37,7 +37,7 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &t
                 auto sendResp = resp->isSend();
                 auto start = sendResp->dispatchResult.get();
                 while (start != nullptr) {
-                    if (start->main.method.exists() && !start->main.receiver->isUntyped()) {
+                    if (start->main.method.exists() && !start->main.receiver.isUntyped()) {
                         addLocIfExists(gs, result, start->main.method.data(gs)->loc());
                     }
                     start = start->secondary.get();

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -78,7 +78,7 @@ unique_ptr<ResponseMessage> DocumentHighlightTask::runRequest(LSPTypecheckerDele
                 auto start = sendResp->dispatchResult.get();
                 vector<unique_ptr<DocumentHighlight>> highlights;
                 while (start != nullptr) {
-                    if (start->main.method.exists() && !start->main.receiver->isUntyped()) {
+                    if (start->main.method.exists() && !start->main.receiver.isUntyped()) {
                         highlights =
                             getHighlightsToSymbolInFile(typechecker, uri, start->main.method, move(highlights));
                     }

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -65,7 +65,7 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
         if (auto sendResp = resp->isSend()) {
             auto retType = sendResp->dispatchResult->returnType;
             auto start = sendResp->dispatchResult.get();
-            if (start != nullptr && start->main.method.exists() && !start->main.receiver->isUntyped()) {
+            if (start != nullptr && start->main.method.exists() && !start->main.receiver.isUntyped()) {
                 auto loc = start->main.method.data(gs)->loc();
                 if (loc.exists()) {
                     documentation = findDocumentation(loc.file().data(gs).source(), loc.beginPos());

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -58,7 +58,7 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &t
                 auto start = sendResp->dispatchResult.get();
                 vector<unique_ptr<Location>> locations;
                 while (start != nullptr) {
-                    if (start->main.method.exists() && !start->main.receiver->isUntyped()) {
+                    if (start->main.method.exists() && !start->main.receiver.isUntyped()) {
                         locations = getReferencesToSymbol(typechecker, start->main.method, move(locations));
                     }
                     start = start->secondary.get();

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -8,15 +8,15 @@ using namespace std;
 namespace sorbet::realmain::lsp {
 
 namespace {
-vector<core::Loc> locsForType(const core::GlobalState &gs, core::TypePtr type) {
+vector<core::Loc> locsForType(const core::GlobalState &gs, const core::TypePtr &type) {
     vector<core::Loc> result;
-    if (type->isUntyped()) {
+    if (type.isUntyped()) {
         return result;
     }
     typecase(
-        type.get(), [&](core::ClassType *t) { result.emplace_back(t->symbol.data(gs)->loc()); },
-        [&](core::AppliedType *t) { result.emplace_back(t->klass.data(gs)->loc()); },
-        [&](core::OrType *t) {
+        type.get(), [&](const core::ClassType *t) { result.emplace_back(t->symbol.data(gs)->loc()); },
+        [&](const core::AppliedType *t) { result.emplace_back(t->klass.data(gs)->loc()); },
+        [&](const core::OrType *t) {
             for (auto loc : locsForType(gs, t->left)) {
                 result.emplace_back(loc);
             }
@@ -24,7 +24,7 @@ vector<core::Loc> locsForType(const core::GlobalState &gs, core::TypePtr type) {
                 result.emplace_back(loc);
             }
         },
-        [&](core::AndType *t) {
+        [&](const core::AndType *t) {
             for (auto loc : locsForType(gs, t->left)) {
                 result.emplace_back(loc);
             }

--- a/namer/configatron/configatron.cc
+++ b/namer/configatron/configatron.cc
@@ -97,7 +97,7 @@ struct Path {
         return children.emplace_back(make_shared<Path>(this, string(name)));
     }
 
-    void setType(core::GlobalState &gs, core::TypePtr tp) {
+    void setType(core::GlobalState &gs, const core::TypePtr &tp) {
         if (myType) {
             myType = core::Types::any(gs, myType, tp);
         } else {

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -165,7 +165,7 @@ void resolveTypeMembers(core::GlobalState &gs, core::SymbolRef sym,
             // with RuntimeProfiled.
             auto attachedClass = singleton.data(gs)->findMember(gs, core::Names::Constants::AttachedClass());
             if (attachedClass.exists()) {
-                auto *lambdaParam = core::cast_type<core::LambdaParam>(attachedClass.data(gs)->resultType.get());
+                auto *lambdaParam = core::cast_type<core::LambdaParam>(attachedClass.data(gs)->resultType);
                 ENFORCE(lambdaParam != nullptr);
 
                 lambdaParam->lowerBound = core::Types::bottom();

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -427,7 +427,7 @@ private:
         core::TypePtr resultType = uaSym.data(ctx)->resultType;
         if (!resultType) {
             uaSym.data(ctx)->resultType = core::TupleType::build(ctx, {ancestorType});
-        } else if (auto tt = core::cast_type<core::TupleType>(resultType.get())) {
+        } else if (auto tt = core::cast_type<core::TupleType>(resultType)) {
             tt->elems.push_back(ancestorType);
         } else {
             ENFORCE(false);
@@ -965,14 +965,14 @@ class ResolveTypeMembersWalk {
         return tMod && tMod->symbol == core::Symbols::T();
     }
 
-    static bool isTodo(core::TypePtr type) {
-        auto *todo = core::cast_type<core::ClassType>(type.get());
+    static bool isTodo(const core::TypePtr &type) {
+        auto *todo = core::cast_type<core::ClassType>(type);
         return todo != nullptr && todo->symbol == core::Symbols::todo();
     }
 
     static bool isLHSResolved(core::MutableContext ctx, core::SymbolRef sym) {
         if (sym.data(ctx)->isTypeMember()) {
-            auto *lambdaParam = core::cast_type<core::LambdaParam>(sym.data(ctx)->resultType.get());
+            auto *lambdaParam = core::cast_type<core::LambdaParam>(sym.data(ctx)->resultType);
             ENFORCE(lambdaParam != nullptr);
 
             // both bounds are set to todo in the namer, so it's sufficient to
@@ -1000,7 +1000,7 @@ class ResolveTypeMembersWalk {
         auto parentMember = owner.data(ctx)->superClass().data(ctx)->findMember(ctx, data->name);
         if (parentMember.exists()) {
             if (parentMember.data(ctx)->isTypeMember()) {
-                parentType = core::cast_type<core::LambdaParam>(parentMember.data(ctx)->resultType.get());
+                parentType = core::cast_type<core::LambdaParam>(parentMember.data(ctx)->resultType);
                 ENFORCE(parentType != nullptr);
             } else if (auto e = ctx.beginError(rhs->loc, core::errors::Resolver::ParentTypeBoundsMismatch)) {
                 const auto parentShow = parentMember.data(ctx)->show(ctx);
@@ -1012,7 +1012,7 @@ class ResolveTypeMembersWalk {
         // Initialize the resultType to a LambdaParam with default bounds
         auto lambdaParam = core::make_type<core::LambdaParam>(lhs, core::Types::bottom(), core::Types::top());
         data->resultType = lambdaParam;
-        auto *memberType = core::cast_type<core::LambdaParam>(lambdaParam.get());
+        auto *memberType = core::cast_type<core::LambdaParam>(lambdaParam);
 
         // When no args are supplied, this implies that the upper and lower
         // bounds of the type parameter are top and bottom.
@@ -1102,7 +1102,7 @@ class ResolveTypeMembersWalk {
             return;
         }
 
-        auto *lambdaParam = core::cast_type<core::LambdaParam>(attachedClass.data(ctx)->resultType.get());
+        auto *lambdaParam = core::cast_type<core::LambdaParam>(attachedClass.data(ctx)->resultType);
         ENFORCE(lambdaParam != nullptr);
 
         if (isTodo(lambdaParam->lowerBound)) {
@@ -1401,7 +1401,7 @@ private:
                 if (typeSpec.type) {
                     auto name = ctx.state.freshNameUnique(core::UniqueNameKind::TypeVarName, typeSpec.name, 1);
                     auto sym = ctx.state.enterTypeArgument(typeSpec.loc, method, name, core::Variance::CoVariant);
-                    auto asTypeVar = core::cast_type<core::TypeVar>(typeSpec.type.get());
+                    auto asTypeVar = core::cast_type<core::TypeVar>(typeSpec.type);
                     ENFORCE(asTypeVar != nullptr);
                     asTypeVar->sym = sym;
                     sym.data(ctx)->resultType = typeSpec.type;
@@ -1895,7 +1895,7 @@ private:
             return;
         }
 
-        auto literal = core::cast_type<core::LiteralType>(literalNode->value.get());
+        auto literal = core::cast_type<core::LiteralType>(literalNode->value);
         if (literal == nullptr) {
             if (auto e = ctx.beginError(stringLoc, core::errors::Resolver::LazyResolve)) {
                 e.setHeader("`{}` only accepts string literals", method);
@@ -1908,7 +1908,7 @@ private:
             return;
         }
 
-        core::LiteralType *package = nullptr;
+        const core::LiteralType *package = nullptr;
         optional<core::LocOffsets> packageLoc;
         if (send.hasKwArgs()) {
             // this means we got the third package arg
@@ -1926,7 +1926,7 @@ private:
                 return;
             }
 
-            package = core::cast_type<core::LiteralType>(packageNode->value.get());
+            package = core::cast_type<core::LiteralType>(packageNode->value);
             if (package == nullptr || package->literalKind != core::LiteralType::LiteralTypeKind::String) {
                 // Infer will report a type error
                 return;
@@ -2068,7 +2068,7 @@ public:
                     asgn.rhs = ast::MK::Send1(loc, ast::MK::Constant(loc, core::Symbols::Magic()),
                                               core::Names::suggestType(), move(rhs));
                 }
-            } else if (!core::isa_type<core::AliasType>(data->resultType.get())) {
+            } else if (!core::isa_type<core::AliasType>(data->resultType)) {
                 // If we've already resolved a temporary constant, we still want to run resolveConstantType to
                 // report errors (e.g. so that a stand-in untyped value won't suppress errors in subsequent
                 // typechecking runs) but we only want to run this on constants that are value-level and not class

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -215,10 +215,10 @@ ParsedSig parseSigWithSelfTypeParams(core::MutableContext ctx, ast::Send *sigSen
 
                     bool validBind = false;
                     auto bind = getResultTypeWithSelfTypeParams(ctx, send->args.front(), *parent, args);
-                    if (auto classType = core::cast_type<core::ClassType>(bind.get())) {
+                    if (auto classType = core::cast_type<core::ClassType>(bind)) {
                         sig.bind = classType->symbol;
                         validBind = true;
-                    } else if (auto appType = core::cast_type<core::AppliedType>(bind.get())) {
+                    } else if (auto appType = core::cast_type<core::AppliedType>(bind)) {
                         // When `T.proc.bind` is used with `T.class_of`, pass it
                         // through as long as it only has the AttachedClass type
                         // member.
@@ -640,7 +640,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                 auto val = getResultTypeWithSelfTypeParams(ctx, vtree, sigBeingParsed, args.withoutSelfType());
                 auto lit = ast::cast_tree<ast::Literal>(ktree);
                 if (lit && (lit->isSymbol(ctx) || lit->isString(ctx))) {
-                    ENFORCE(core::cast_type<core::LiteralType>(lit->value.get()));
+                    ENFORCE(core::isa_type<core::LiteralType>(lit->value));
                     keys.emplace_back(lit->value);
                     values.emplace_back(val);
                 } else {
@@ -669,7 +669,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
             // times as wanted, and assigned into different constants each time. As much as possible, we
             // want there to be one name for every type; making an alias for a type should always be
             // syntactically declared with T.type_alias.
-            if (auto resultType = core::cast_type<core::ClassType>(maybeAliased.data(ctx)->resultType.get())) {
+            if (auto resultType = core::cast_type<core::ClassType>(maybeAliased.data(ctx)->resultType)) {
                 if (resultType->symbol.data(ctx)->derivesFrom(ctx, core::Symbols::T_Enum())) {
                     result.type = maybeAliased.data(ctx)->resultType;
                     return;
@@ -945,7 +945,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                 originForUninitialized};
             auto out = core::Types::dispatchCallWithoutBlock(ctx, ctype, dispatchArgs);
 
-            if (out->isUntyped()) {
+            if (out.isUntyped()) {
                 // Using a generic untyped type here will lead to incorrect handling of global state hashing,
                 // where we won't see difference between types with generic arguments.
                 // Thus, while normally we would treat these as untyped, in `sig`s we treat them as proper types, so
@@ -958,7 +958,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                 result.type = core::make_type<core::UnresolvedAppliedType>(correctedSingleton, move(targPtrs));
                 return;
             }
-            if (auto *mt = core::cast_type<core::MetaType>(out.get())) {
+            if (auto *mt = core::cast_type<core::MetaType>(out)) {
                 result.type = mt->wrapped;
                 return;
             }

--- a/rewriter/Rails.cc
+++ b/rewriter/Rails.cc
@@ -43,7 +43,7 @@ void Rails::run(core::MutableContext ctx, ast::ClassDef *cdef) {
     if (!arg) {
         return;
     }
-    auto value = core::cast_type<core::LiteralType>(arg->value.get());
+    auto value = core::cast_type<core::LiteralType>(arg->value);
     if (value->literalKind != core::LiteralType::LiteralTypeKind::Float) {
         return;
     }


### PR DESCRIPTION
Use tags in isa_type/cast_type. Introduces a const cast_type variant.

Convert all callsites to use these methods, and:
* Use `const` where possible
* Avoid copying `TypePtrs` where applicable by changing method parameters to accept a `const TypePtr &`
* Move a few simple methods onto `TypePtr`

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Broken off from https://github.com/sorbet/sorbet/pull/3569

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
