### PR TITLE
Froydnj lsp code reduction

### DIFF
--- a/main/lsp/tools/generate_lsp_messages.h
+++ b/main/lsp/tools/generate_lsp_messages.h
@@ -247,7 +247,8 @@ public:
         // Create new scope for temp var.
         fmt::format_to(out, "{{\n");
         fmt::format_to(out, "rapidjson::Value strCopy;\n");
-        fmt::format_to(out, "strCopy.SetString({0}.c_str(), {0}.length(), {1});\n", from, ALLOCATOR_VAR);
+        fmt::format_to(out, "const std::string &tmpStr = {0};\n", from);
+        fmt::format_to(out, "strCopy.SetString(tmpStr.c_str(), tmpStr.length(), {0});\n", ALLOCATOR_VAR);
         assign(out, "strCopy");
         fmt::format_to(out, "}}\n");
     }

--- a/main/lsp/tools/generate_lsp_messages.h
+++ b/main/lsp/tools/generate_lsp_messages.h
@@ -526,7 +526,7 @@ public:
         }
         fmt::format_to(out, "}};\n");
         fmt::format_to(out, "{0} get{0}(std::string_view value);\n", typeName);
-        fmt::format_to(out, "std::string convert{0}ToString({0} kind);", typeName);
+        fmt::format_to(out, "const std::string &convert{0}ToString({0} kind);", typeName);
     }
 
     void emitDefinition(fmt::memory_buffer &out) {
@@ -546,7 +546,7 @@ public:
         fmt::format_to(out, "}}\n");
         fmt::format_to(out, "return it->second;\n");
         fmt::format_to(out, "}}\n");
-        fmt::format_to(out, "std::string convert{0}ToString({0} kind) {{\n", typeName);
+        fmt::format_to(out, "const std::string &convert{0}ToString({0} kind) {{\n", typeName);
         fmt::format_to(out, "switch (kind) {{\n");
         for (std::string_view value : enumValues) {
             fmt::format_to(out, "case {}:\n", enumVar(value));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
These changes make serializing enums more efficient by calling into conversion functions less and making the conversion functions themselves more efficient.  It might make the compiler do slightly less work in other cases.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Epsilon efficiency improvements.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests should be sufficient.
