### PR TITLE
Split apart and fully comment `autogen.{cc,h}`

### DIFF
--- a/main/autogen/BUILD
+++ b/main/autogen/BUILD
@@ -3,13 +3,11 @@ cc_library(
     srcs = [
         "autogen.cc",
         "autoloader.cc",
-        "msgpack.cc",
         "subclasses.cc",
     ],
     hdrs = [
         "autogen.h",
         "autoloader.h",
-        "msgpack.h",
         "subclasses.h",
     ],
     linkstatic = select({
@@ -21,8 +19,8 @@ cc_library(
         "//ast",
         "//ast/treemap",
         "//core",
+        "//main/autogen/data",
         "//main/options",
         "@com_github_d_bahr_crcpp",
-        "@com_github_ludocode_mpack",
     ],
 )

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -10,6 +10,8 @@
 using namespace std;
 namespace sorbet::autogen {
 
+// The `AutogenWalk` class converts the internal Sorbet representation (of symbols and constants and everything) into a
+// simplified set of `ParsedFile`s which contain a set of `Definition`s and a set of `Reference`s.
 class AutogenWalk {
     vector<Definition> defs;
     vector<Reference> refs;
@@ -22,6 +24,7 @@ class AutogenWalk {
 
     UnorderedMap<void *, ReferenceRef> refMap;
 
+    // Convert a symbol name into a fully qualified name
     vector<core::NameRef> symbolName(core::Context ctx, core::SymbolRef sym) {
         vector<core::NameRef> out;
         while (sym.exists() && sym != core::Symbols::root()) {
@@ -32,6 +35,7 @@ class AutogenWalk {
         return out;
     }
 
+    // Convert a constant literal into a fully qualified name
     vector<core::NameRef> constantName(core::Context ctx, ast::ConstantLit *cnst) {
         vector<core::NameRef> out;
         while (cnst != nullptr && cnst->original != nullptr) {
@@ -61,37 +65,53 @@ public:
         }
         scopeTypes.emplace_back(ScopeType::Class);
 
-        // cerr << "preTransformClassDef(" << original->toString(ctx) << ")\n";
-
+        // create a new `Definition`
         auto &def = defs.emplace_back();
         def.id = defs.size() - 1;
+
+        // mark it as being either a `Class` or a `Module`
         if (original.kind == ast::ClassDef::Kind::Class) {
             def.type = Definition::Type::Class;
         } else {
             def.type = Definition::Type::Module;
         }
+
+        // is it (recursively) empty?
         def.is_empty =
             absl::c_all_of(original.rhs, [](auto &tree) { return sorbet::ast::BehaviorHelpers::checkEmptyDeep(tree); });
+        // does it define behavior?
         def.defines_behavior = sorbet::ast::BehaviorHelpers::checkClassDefinesBehavior(tree);
 
         // TODO: ref.parent_of, def.parent_ref
         // TODO: expression_range
+
+        // we're 'pre-traversing' the constant literal here (instead of waiting for the walk to get to it naturally)
+        // which means that we'll have entered in a `Reference` for it already.
         original.name = ast::TreeMap::apply(ctx, *this, move(original.name));
+        // ...find the reference we just created for it
         auto it = refMap.find(original.name.get());
         ENFORCE(it != refMap.end());
+        // ...so we can use that reference as the 'defining reference'
         def.defining_ref = it->second;
+        // update that reference with the relevant metadata so we know 1. it's the defining ref and 2. it encompasses
+        // the entire class, not just the constant name
         refs[it->second.id()].is_defining_ref = true;
         refs[it->second.id()].definitionLoc = core::Loc(ctx.file, original.loc);
 
         auto ait = original.ancestors.begin();
+        // if this is a class, then the first ancestor is the parent class
         if (original.kind == ast::ClassDef::Kind::Class && !original.ancestors.empty()) {
-            // Handle the superclass at outer scope
+            // we need to do name resolution for that class "outside" of the class body, so handle this before we've
+            // modified the current scoping
             *ait = ast::TreeMap::apply(ctx, *this, move(*ait));
             ++ait;
         }
-        // Then push a scope
+
+        // The rest of the ancestors are all references inside the class body (i.e. uses of `include` or `extend`) so
+        // add the current class to the scoping
         nesting.emplace_back(def.id);
 
+        // ...and then run the treemap over all the includes and extends
         for (; ait != original.ancestors.end(); ++ait) {
             *ait = ast::TreeMap::apply(ctx, *this, move(*ait));
         }
@@ -99,21 +119,26 @@ public:
             ancst = ast::TreeMap::apply(ctx, *this, move(ancst));
         }
 
+        // and now that we've processed all the ancestors, we should have created references for them all, so traverse
+        // them once again...
         for (auto &ancst : original.ancestors) {
             auto *cnst = ast::cast_tree<ast::ConstantLit>(ancst);
             if (cnst == nullptr || cnst->original == nullptr) {
-                // Don't include synthetic ancestors
+                // ignore them if they're not statically-known ancestors (i.e. not constants)
                 continue;
             }
 
+            // ...find the references
             auto it = refMap.find(ancst.get());
             if (it == refMap.end()) {
                 continue;
             }
+            // if it's the parent class, then we can set the parent_ref of the `Definition`
             if (original.kind == ast::ClassDef::Kind::Class && &ancst == &original.ancestors.front()) {
                 // superclass
                 def.parent_ref = it->second;
             }
+            // otherwise, make sure we know the ref is the parent of this `Definition`
             refs[it->second.id()].parent_of = def.id;
         }
 
@@ -124,9 +149,12 @@ public:
         auto &original = ast::cast_tree_nonnull<ast::ClassDef>(tree);
 
         if (!ast::isa_tree<ast::ConstantLit>(original.name)) {
+            // if the name of the class wasn't a constant, then we didn't run the `preTransformClassDef` step anyway, so
+            // just skip it
             return tree;
         }
 
+        // remove the stuff added to handle the class scope here
         nesting.pop_back();
         scopeTypes.pop_back();
 
@@ -143,6 +171,7 @@ public:
         return block;
     }
 
+    // `true` if the constant is fully qualified and can be traced back to the root scope, `false` otherwise
     bool isCBaseConstant(ast::ConstantLit *cnst) {
         while (cnst != nullptr && cnst->original != nullptr) {
             auto &original = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(cnst->original);
@@ -158,17 +187,24 @@ public:
         auto *original = ast::cast_tree<ast::ConstantLit>(tree);
 
         if (!ignoring.empty()) {
+            // this is either a constant in a `keepForIde` node (in which case we don't care) or it was an `include` or
+            // an `extend` which already got handled in `preTransformClassDef` (in which case don't handle it again)
             return tree;
         }
         if (original->original == nullptr) {
             return tree;
         }
 
+        // Create a new `Reference`
         auto &ref = refs.emplace_back();
         ref.id = refs.size() - 1;
+
+        // if it's a constant we can resolve from the root...
         if (isCBaseConstant(original)) {
+            // then its scope is easy
             ref.scope = nesting.front();
         } else {
+            // otherwise we need to figure out how it's nested in the current scope and mark that
             ref.nesting = nesting;
             reverse(ref.nesting.begin(), ref.nesting.end());
             ref.nesting.pop_back();
@@ -176,8 +212,9 @@ public:
         }
         ref.loc = core::Loc(ctx.file, original->loc);
 
-        // This will get overridden if this loc is_defining_ref at the point
-        // where we set that flag.
+        // the reference location is the location of constant, but this might get updated if the reference corresponds
+        // to the definition of the constant, because in that case we'll later on extend the location to cover the whole
+        // class or assignment
         ref.definitionLoc = core::Loc(ctx.file, original->loc);
         ref.name = constantName(ctx, original);
         auto sym = original->symbol;
@@ -192,6 +229,7 @@ public:
         if (!defs.empty() && !nesting.empty() && defs.back().id._id != nesting.back()._id) {
             ref.parentKind = ClassKind::Class;
         }
+        // now, add it to the refmap
         refMap[tree.get()] = ref.id;
         return tree;
     }
@@ -199,27 +237,39 @@ public:
     ast::TreePtr postTransformAssign(core::Context ctx, ast::TreePtr tree) {
         auto &original = ast::cast_tree_nonnull<ast::Assign>(tree);
 
+        // autogen only cares about constant assignments/definitions, so bail otherwise
         auto *lhs = ast::cast_tree<ast::ConstantLit>(original.lhs);
         if (lhs == nullptr || lhs->original == nullptr) {
             return tree;
         }
 
+        // Create the Definition for it
         auto &def = defs.emplace_back();
         def.id = defs.size() - 1;
+
+        // if the RHS is _also_ a constant, then this is an alias
         auto *rhs = ast::cast_tree<ast::ConstantLit>(original.rhs);
         if (rhs && rhs->symbol.exists() && !rhs->symbol.data(ctx)->isTypeAlias()) {
             def.type = Definition::Type::Alias;
+            // since this is a `post`- method, then we've already created a `Reference` for the constant on the
+            // RHS. Mark this `Definition` as an alias for it.
             ENFORCE(refMap.count(original.rhs.get()));
             def.aliased_ref = refMap[original.rhs.get()];
         } else {
+            // if the RHS _isn't_ just a constant literal, then this is a constant definition.
             def.type = Definition::Type::Casgn;
         }
+
+        // We also should already have a `Reference` for the name of this constant (because this is running after the
+        // pre-traversal of the constant) so find that
         ENFORCE(refMap.count(original.lhs.get()));
         auto &ref = refs[refMap[original.lhs.get()].id()];
+        // ...and mark that this is the defining ref for that one
         def.defining_ref = ref.id;
         ref.is_defining_ref = true;
         ref.definitionLoc = core::Loc(ctx.file, original.loc);
 
+        // Constant definitions always count as non-empty behavior-defining definitions
         def.defines_behavior = true;
         def.is_empty = false;
 
@@ -238,6 +288,7 @@ public:
              (original->fun == core::Names::include() || original->fun == core::Names::extend()))) {
             ignoring.emplace_back(original);
         }
+        // This means it's a `require`; mark it as such
         if (original->flags.isPrivateOk && original->fun == core::Names::require() && original->args.size() == 1) {
             auto *lit = ast::cast_tree<ast::Literal>(original->args.front());
             if (lit && lit->isString(ctx)) {
@@ -246,8 +297,10 @@ public:
         }
         return tree;
     }
+
     ast::TreePtr postTransformSend(core::Context ctx, ast::TreePtr tree) {
         auto *original = ast::cast_tree<ast::Send>(tree);
+        // if this send was something we were ignoring (i.e. a `keepForIde` or an `include` or `require`) then pop this
         if (!ignoring.empty() && ignoring.back() == original) {
             ignoring.pop_back();
         }
@@ -265,6 +318,8 @@ public:
     }
 };
 
+// Convert a Sorbet `ParsedFile` into an Autogen `ParsedFile` by walking it as above and also recording the checksum of
+// the current file
 ParsedFile Autogen::generate(core::Context ctx, ast::ParsedFile tree) {
     AutogenWalk walk;
     tree.tree = ast::TreeMap::apply(ctx, walk, move(tree.tree));

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -4,20 +4,11 @@
 #include "ast/treemap/treemap.h"
 #include "common/formatting.h"
 #include "main/autogen/autoloader.h"
-#include "main/autogen/msgpack.h"
 
 #include "CRC.h"
 
 using namespace std;
 namespace sorbet::autogen {
-
-const Definition &DefinitionRef::data(const ParsedFile &pf) const {
-    return pf.defs[_id];
-}
-
-const Reference &ReferenceRef::data(const ParsedFile &pf) const {
-    return pf.refs[_id];
-}
 
 class AutogenWalk {
     vector<Definition> defs;
@@ -283,116 +274,6 @@ ParsedFile Autogen::generate(core::Context ctx, ast::ParsedFile tree) {
     pf.cksum = CRC::Calculate(src.data(), src.size(), CRC::CRC_32());
     pf.tree = move(tree);
     return pf;
-}
-
-vector<core::NameRef> ParsedFile::showFullName(const core::GlobalState &gs, DefinitionRef id) const {
-    auto &def = id.data(*this);
-    if (!def.defining_ref.exists()) {
-        return {};
-    }
-    auto &ref = def.defining_ref.data(*this);
-    auto scope = showFullName(gs, ref.scope);
-    scope.insert(scope.end(), ref.name.begin(), ref.name.end());
-    return scope;
-}
-
-string ParsedFile::toString(const core::GlobalState &gs) const {
-    fmt::memory_buffer out;
-    auto nameToString = [&](const auto &nm) -> string { return nm.data(gs)->show(gs); };
-
-    fmt::format_to(out,
-                   "# ParsedFile: {}\n"
-                   "requires: [{}]\n"
-                   "## defs:\n",
-                   path, fmt::map_join(requires, ", ", nameToString));
-
-    for (auto &def : defs) {
-        string_view type;
-        switch (def.type) {
-            case Definition::Type::Module:
-                type = "module"sv;
-                break;
-            case Definition::Type::Class:
-                type = "class"sv;
-                break;
-            case Definition::Type::Casgn:
-                type = "casgn"sv;
-                break;
-            case Definition::Type::Alias:
-                type = "alias"sv;
-                break;
-        }
-
-        fmt::format_to(out,
-                       "[def id={}]\n"
-                       " type={}\n"
-                       " defines_behavior={}\n"
-                       " is_empty={}\n",
-                       def.id.id(), type, (int)def.defines_behavior, (int)def.is_empty);
-
-        if (def.defining_ref.exists()) {
-            auto &ref = def.defining_ref.data(*this);
-            fmt::format_to(out, " defining_ref=[{}]\n", fmt::map_join(ref.name, " ", nameToString));
-        }
-        if (def.parent_ref.exists()) {
-            auto &ref = def.parent_ref.data(*this);
-            fmt::format_to(out, " parent_ref=[{}]\n", fmt::map_join(ref.name, " ", nameToString));
-        }
-        if (def.aliased_ref.exists()) {
-            auto &ref = def.aliased_ref.data(*this);
-            fmt::format_to(out, " aliased_ref=[{}]\n", fmt::map_join(ref.name, " ", nameToString));
-        }
-    }
-    fmt::format_to(out, "## refs:\n");
-    for (auto &ref : refs) {
-        vector<string> nestingStrings;
-        for (auto &scope : ref.nesting) {
-            auto fullScopeName = showFullName(gs, scope);
-            nestingStrings.emplace_back(fmt::format("[{}]", fmt::map_join(fullScopeName, " ", nameToString)));
-        }
-
-        auto refFullName = showFullName(gs, ref.scope);
-        fmt::format_to(out,
-                       "[ref id={}]\n"
-                       " scope=[{}]\n"
-                       " name=[{}]\n"
-                       " nesting=[{}]\n"
-                       " resolved=[{}]\n"
-                       " loc={}\n"
-                       " is_defining_ref={}\n",
-
-                       ref.id.id(), fmt::map_join(refFullName, " ", nameToString),
-                       fmt::map_join(ref.name, " ", nameToString), fmt::join(nestingStrings, " "),
-                       fmt::map_join(ref.resolved, " ", nameToString), ref.loc.filePosToString(gs),
-                       (int)ref.is_defining_ref);
-
-        if (ref.parent_of.exists()) {
-            auto parentOfFullName = showFullName(gs, ref.parent_of);
-            fmt::format_to(out, " parent_of=[{}]\n", fmt::map_join(parentOfFullName, " ", nameToString));
-        }
-    }
-    return to_string(out);
-}
-
-string ParsedFile::toMsgpack(core::Context ctx, int version) {
-    MsgpackWriter write(version);
-    return write.pack(ctx, *this);
-}
-
-vector<string> ParsedFile::listAllClasses(core::Context ctx) {
-    vector<string> out;
-
-    for (auto &def : defs) {
-        if (def.type != Definition::Type::Class) {
-            continue;
-        }
-        vector<core::NameRef> names = showFullName(ctx, def.id);
-        out.emplace_back(fmt::format("{}", fmt::map_join(names, "::", [&ctx](const core::NameRef &nm) -> string_view {
-                                         return nm.data(ctx)->shortName(ctx);
-                                     })));
-    }
-
-    return out;
 }
 
 } // namespace sorbet::autogen

--- a/main/autogen/autogen.h
+++ b/main/autogen/autogen.h
@@ -1,103 +1,10 @@
 #ifndef AUTOGEN_H
 #define AUTOGEN_H
 
-#include "ast/ast.h"
+#include "main/autogen/data/definitions.h"
 #include "main/options/options.h"
 
 namespace sorbet::autogen {
-
-const u4 NONE_ID = (u4)-1;
-
-struct ParsedFile;
-struct Reference;
-struct Definition;
-
-struct AutoloaderConfig;
-struct NamedDefinition;
-class DefTree;
-
-enum class ClassKind { Class, Module };
-
-struct DefinitionRef {
-    u4 _id;
-
-    DefinitionRef() : _id(NONE_ID){};
-    DefinitionRef(u4 id) : _id(id) {}
-
-    u4 id() const {
-        return _id;
-    }
-
-    bool exists() const {
-        return _id != NONE_ID;
-    }
-
-    const Definition &data(const ParsedFile &pf) const;
-};
-
-struct ReferenceRef {
-    u4 _id;
-    ReferenceRef() : _id(NONE_ID){};
-    ReferenceRef(u4 id) : _id(id) {}
-
-    u4 id() const {
-        return _id;
-    }
-
-    bool exists() const {
-        return _id != NONE_ID;
-    }
-
-    const Reference &data(const ParsedFile &pf) const;
-};
-
-struct Definition {
-    enum class Type : u8 { Module, Class, Casgn, Alias };
-
-    DefinitionRef id;
-
-    Type type;
-    bool defines_behavior;
-    bool is_empty;
-
-    ReferenceRef parent_ref;
-    ReferenceRef aliased_ref;
-    ReferenceRef defining_ref;
-};
-
-struct Reference {
-    ReferenceRef id;
-
-    DefinitionRef scope;
-    std::vector<core::NameRef> name;
-    std::vector<DefinitionRef> nesting;
-    std::vector<core::NameRef> resolved;
-
-    core::Loc loc;
-    core::Loc definitionLoc;
-    bool is_resolved_statically;
-    bool is_defining_ref;
-
-    ClassKind parentKind = ClassKind::Module;
-
-    DefinitionRef parent_of;
-};
-
-struct ParsedFile {
-    friend class MsgpackWriter;
-
-    ast::ParsedFile tree;
-    u4 cksum;
-    std::string path;
-    std::vector<Definition> defs;
-    std::vector<Reference> refs;
-    std::vector<core::NameRef> requires;
-
-    std::string toString(const core::GlobalState &gs) const;
-    std::string toMsgpack(core::Context ctx, int version);
-    std::vector<core::NameRef> showFullName(const core::GlobalState &gs, DefinitionRef id) const;
-    std::vector<std::string> listAllClasses(core::Context ctx);
-};
 
 class Autogen final {
 public:

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -1,7 +1,7 @@
 #ifndef AUTOGEN_AUTOLOADER_H
 #define AUTOGEN_AUTOLOADER_H
 #include "ast/ast.h"
-#include "main/autogen/autogen.h"
+#include "main/autogen/data/definitions.h"
 #include "main/options/options.h"
 #include <string_view>
 

--- a/main/autogen/data/BUILD
+++ b/main/autogen/data/BUILD
@@ -1,0 +1,21 @@
+cc_library(
+    name = "data",
+    srcs = [
+        "definitions.cc",
+        "msgpack.cc",
+    ],
+    hdrs = [
+        "definitions.h",
+        "msgpack.h",
+    ],
+    linkstatic = select({
+        "//tools/config:linkshared": 0,
+        "//conditions:default": 1,
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//ast",
+        "//core",
+        "@com_github_ludocode_mpack",
+    ],
+)

--- a/main/autogen/data/definitions.cc
+++ b/main/autogen/data/definitions.cc
@@ -1,0 +1,129 @@
+#include "main/autogen/data/definitions.h"
+#include "ast/ast.h"
+#include "common/formatting.h"
+#include "core/GlobalState.h"
+#include "main/autogen/data/msgpack.h"
+
+using namespace std;
+
+namespace sorbet::autogen {
+
+const Definition &DefinitionRef::data(const ParsedFile &pf) const {
+    return pf.defs[_id];
+}
+
+const Reference &ReferenceRef::data(const ParsedFile &pf) const {
+    return pf.refs[_id];
+}
+
+vector<core::NameRef> ParsedFile::showFullName(const core::GlobalState &gs, DefinitionRef id) const {
+    auto &def = id.data(*this);
+    if (!def.defining_ref.exists()) {
+        return {};
+    }
+    auto &ref = def.defining_ref.data(*this);
+    auto scope = showFullName(gs, ref.scope);
+    scope.insert(scope.end(), ref.name.begin(), ref.name.end());
+    return scope;
+}
+
+string ParsedFile::toString(const core::GlobalState &gs) const {
+    fmt::memory_buffer out;
+    auto nameToString = [&](const auto &nm) -> string { return nm.data(gs)->show(gs); };
+
+    fmt::format_to(out,
+                   "# ParsedFile: {}\n"
+                   "requires: [{}]\n"
+                   "## defs:\n",
+                   path, fmt::map_join(requires, ", ", nameToString));
+
+    for (auto &def : defs) {
+        string_view type;
+        switch (def.type) {
+            case Definition::Type::Module:
+                type = "module"sv;
+                break;
+            case Definition::Type::Class:
+                type = "class"sv;
+                break;
+            case Definition::Type::Casgn:
+                type = "casgn"sv;
+                break;
+            case Definition::Type::Alias:
+                type = "alias"sv;
+                break;
+        }
+
+        fmt::format_to(out,
+                       "[def id={}]\n"
+                       " type={}\n"
+                       " defines_behavior={}\n"
+                       " is_empty={}\n",
+                       def.id.id(), type, (int)def.defines_behavior, (int)def.is_empty);
+
+        if (def.defining_ref.exists()) {
+            auto &ref = def.defining_ref.data(*this);
+            fmt::format_to(out, " defining_ref=[{}]\n", fmt::map_join(ref.name, " ", nameToString));
+        }
+        if (def.parent_ref.exists()) {
+            auto &ref = def.parent_ref.data(*this);
+            fmt::format_to(out, " parent_ref=[{}]\n", fmt::map_join(ref.name, " ", nameToString));
+        }
+        if (def.aliased_ref.exists()) {
+            auto &ref = def.aliased_ref.data(*this);
+            fmt::format_to(out, " aliased_ref=[{}]\n", fmt::map_join(ref.name, " ", nameToString));
+        }
+    }
+    fmt::format_to(out, "## refs:\n");
+    for (auto &ref : refs) {
+        vector<string> nestingStrings;
+        for (auto &scope : ref.nesting) {
+            auto fullScopeName = showFullName(gs, scope);
+            nestingStrings.emplace_back(fmt::format("[{}]", fmt::map_join(fullScopeName, " ", nameToString)));
+        }
+
+        auto refFullName = showFullName(gs, ref.scope);
+        fmt::format_to(out,
+                       "[ref id={}]\n"
+                       " scope=[{}]\n"
+                       " name=[{}]\n"
+                       " nesting=[{}]\n"
+                       " resolved=[{}]\n"
+                       " loc={}\n"
+                       " is_defining_ref={}\n",
+
+                       ref.id.id(), fmt::map_join(refFullName, " ", nameToString),
+                       fmt::map_join(ref.name, " ", nameToString), fmt::join(nestingStrings, " "),
+                       fmt::map_join(ref.resolved, " ", nameToString), ref.loc.filePosToString(gs),
+                       (int)ref.is_defining_ref);
+
+        if (ref.parent_of.exists()) {
+            auto parentOfFullName = showFullName(gs, ref.parent_of);
+            fmt::format_to(out, " parent_of=[{}]\n", fmt::map_join(parentOfFullName, " ", nameToString));
+        }
+    }
+    return to_string(out);
+}
+
+vector<string> ParsedFile::listAllClasses(core::Context ctx) {
+    vector<string> out;
+
+    for (auto &def : defs) {
+        if (def.type != Definition::Type::Class) {
+            continue;
+        }
+        vector<core::NameRef> names = showFullName(ctx, def.id);
+        out.emplace_back(fmt::format("{}", fmt::map_join(names, "::", [&ctx](const core::NameRef &nm) -> string_view {
+                                         return nm.data(ctx)->shortName(ctx);
+                                     })));
+    }
+
+    return out;
+}
+
+string ParsedFile::toMsgpack(core::Context ctx, int version) {
+    MsgpackWriter write(version);
+    return write.pack(ctx, *this);
+}
+
+} // namespace sorbet::autogen

--- a/main/autogen/data/definitions.cc
+++ b/main/autogen/data/definitions.cc
@@ -8,14 +8,19 @@ using namespace std;
 
 namespace sorbet::autogen {
 
+// Find the `Definition` associated with this `DefinitionRef`
 const Definition &DefinitionRef::data(const ParsedFile &pf) const {
     return pf.defs[_id];
 }
 
+// Find the `Reference` associated with this `ReferenceRef`
 const Reference &ReferenceRef::data(const ParsedFile &pf) const {
     return pf.refs[_id];
 }
 
+// Show the full qualified name of this `Definition`, if possible. (If for some reason there is no actual `defining_ref`
+// for this `DefinitionRef` (e.g. if this is called _during_ an `AutogenWalk` traversal and the defining ref has not yet
+// been set) then this will return an empty vector.
 vector<core::NameRef> ParsedFile::showFullName(const core::GlobalState &gs, DefinitionRef id) const {
     auto &def = id.data(*this);
     if (!def.defining_ref.exists()) {
@@ -27,6 +32,7 @@ vector<core::NameRef> ParsedFile::showFullName(const core::GlobalState &gs, Defi
     return scope;
 }
 
+// Pretty-print a `ParsedFile`, including all definitions and references and the pieces of metadata associated with them
 string ParsedFile::toString(const core::GlobalState &gs) const {
     fmt::memory_buffer out;
     auto nameToString = [&](const auto &nm) -> string { return nm.data(gs)->show(gs); };
@@ -105,6 +111,7 @@ string ParsedFile::toString(const core::GlobalState &gs) const {
     return to_string(out);
 }
 
+// List every class name defined in this `ParsedFile`.
 vector<string> ParsedFile::listAllClasses(core::Context ctx) {
     vector<string> out;
 
@@ -121,6 +128,7 @@ vector<string> ParsedFile::listAllClasses(core::Context ctx) {
     return out;
 }
 
+// Convert this parsedfile to a msgpack representation
 string ParsedFile::toMsgpack(core::Context ctx, int version) {
     MsgpackWriter write(version);
     return write.pack(ctx, *this);

--- a/main/autogen/data/definitions.h
+++ b/main/autogen/data/definitions.h
@@ -23,6 +23,7 @@ class DefTree;
 
 enum class ClassKind { Class, Module };
 
+// A reference to a specific `Definition` inside of a `ParsedFile`.
 struct DefinitionRef {
     u4 _id;
 
@@ -40,6 +41,7 @@ struct DefinitionRef {
     const Definition &data(const ParsedFile &pf) const;
 };
 
+// A reference to a specific `Reference` inside of a `ParsedFile`.
 struct ReferenceRef {
     u4 _id;
     ReferenceRef() : _id(NONE_ID){};
@@ -56,46 +58,85 @@ struct ReferenceRef {
     const Reference &data(const ParsedFile &pf) const;
 };
 
+// A constant definition---a class, module, constant definition, or constant alias---along with relevant metadata
 struct Definition {
     enum class Type : u8 { Module, Class, Casgn, Alias };
 
+    // the reference to this definition. Once `AutogenWalk` is completed and a full `ParsedFile` has been created, it
+    // should always be the case that
+    //   definition.id.data(pf) == definition
     DefinitionRef id;
 
+    // is this a class, module, constant, or alias
     Type type;
+    // does this define behavior? (i.e. is it a casgn or class, not simply a namespace?)
     bool defines_behavior;
+    // does it contain other things?
     bool is_empty;
 
+    // if this is a class, then `parent_ref` will be the reference to the parent class; otherwise it will be undefined
     ReferenceRef parent_ref;
+
+    // if this is an alias, then `aliased_ref` will be the reference it is an alias for; otherwise it will be undefined
     ReferenceRef aliased_ref;
+
+    // which ref is the one that corresponds to this definition? I (gdritter) _believe_ that this will always be defined
+    // once `AutogenWalk` has completed; please update this comment if that ever turns out to be false
     ReferenceRef defining_ref;
 };
 
+// A `Reference` corresponds to a simple use of a constant name in a file. After a `ParsedFile` has been created, every
+// constant use should have a `Reference` corresponding to it _unless_ it appears in a `keep_for_ide` call.
 struct Reference {
+    // the reference to this reference. Once `AutogenWalk` is completed and a full `ParsedFile` has been created, it
+    // should always be the case that
+    //   reference.id.data(pf) == reference
     ReferenceRef id;
 
+    // In which class or module was this reference used?
     DefinitionRef scope;
+
+    // its full qualified name
     std::vector<core::NameRef> name;
+    // the full nesting of this constant. If it's a constant resolved from the root, this will be an empty vector
     std::vector<DefinitionRef> nesting;
+    // the resolved name iff we have it from Sorbet
     std::vector<core::NameRef> resolved;
 
+    // loc and definitionLoc will differ if this is a defining ref, otherwise they will be the same
     core::Loc loc;
     core::Loc definitionLoc;
+
+    // this is always true
+    // TODO(gdritter): delete this, of course
     bool is_resolved_statically;
+    // `true` if this is the appearance of the constant name associated with a definition: i.e. the name of a class or
+    // module or the LHS of a casgn
     bool is_defining_ref;
 
+    // Iff this is a class, then this will be `ClassKind::Class`, otherwise `ClassKind::Module`
     ClassKind parentKind = ClassKind::Module;
 
+    // If this is a ref used in an `include` or `extend`, then this will point to the definition of the class in which
+    // this is being `include`d or `extend`ed
     DefinitionRef parent_of;
 };
 
+// A `ParsedFile` contains all the `Definition`s and `References` used in a particular file
 struct ParsedFile {
     friend class MsgpackWriter;
 
+    // the original file AST from Sorbet
     ast::ParsedFile tree;
+    // the checksum of this file
     u4 cksum;
+    // the path on disk to this file
     std::string path;
+    // every statically-known constant defined by this file
     std::vector<Definition> defs;
+    // every static constant usage in this file
     std::vector<Reference> refs;
+    // every required gem in this file
     std::vector<core::NameRef> requires;
 
     std::string toString(const core::GlobalState &gs) const;

--- a/main/autogen/data/definitions.h
+++ b/main/autogen/data/definitions.h
@@ -1,0 +1,108 @@
+#ifndef AUTOGEN_DEFINITIONS_H
+#define AUTOGEN_DEFINITIONS_H
+
+#include "ast/ast.h"
+
+namespace sorbet::autogen {
+
+// The types defined here are simplified views of class and constant definitions in a Ruby codebase, which we use to
+// create static output information and autoloader files
+
+const u4 NONE_ID = (u4)-1;
+
+struct ParsedFile;
+struct Reference;
+struct Definition;
+
+struct DefinitionRef;
+struct ReferenceRef;
+
+struct AutoloaderConfig;
+struct NamedDefinition;
+class DefTree;
+
+enum class ClassKind { Class, Module };
+
+struct DefinitionRef {
+    u4 _id;
+
+    DefinitionRef() : _id(NONE_ID){};
+    DefinitionRef(u4 id) : _id(id) {}
+
+    u4 id() const {
+        return _id;
+    }
+
+    bool exists() const {
+        return _id != NONE_ID;
+    }
+
+    const Definition &data(const ParsedFile &pf) const;
+};
+
+struct ReferenceRef {
+    u4 _id;
+    ReferenceRef() : _id(NONE_ID){};
+    ReferenceRef(u4 id) : _id(id) {}
+
+    u4 id() const {
+        return _id;
+    }
+
+    bool exists() const {
+        return _id != NONE_ID;
+    }
+
+    const Reference &data(const ParsedFile &pf) const;
+};
+
+struct Definition {
+    enum class Type : u8 { Module, Class, Casgn, Alias };
+
+    DefinitionRef id;
+
+    Type type;
+    bool defines_behavior;
+    bool is_empty;
+
+    ReferenceRef parent_ref;
+    ReferenceRef aliased_ref;
+    ReferenceRef defining_ref;
+};
+
+struct Reference {
+    ReferenceRef id;
+
+    DefinitionRef scope;
+    std::vector<core::NameRef> name;
+    std::vector<DefinitionRef> nesting;
+    std::vector<core::NameRef> resolved;
+
+    core::Loc loc;
+    core::Loc definitionLoc;
+    bool is_resolved_statically;
+    bool is_defining_ref;
+
+    ClassKind parentKind = ClassKind::Module;
+
+    DefinitionRef parent_of;
+};
+
+struct ParsedFile {
+    friend class MsgpackWriter;
+
+    ast::ParsedFile tree;
+    u4 cksum;
+    std::string path;
+    std::vector<Definition> defs;
+    std::vector<Reference> refs;
+    std::vector<core::NameRef> requires;
+
+    std::string toString(const core::GlobalState &gs) const;
+    std::string toMsgpack(core::Context ctx, int version);
+    std::vector<core::NameRef> showFullName(const core::GlobalState &gs, DefinitionRef id) const;
+    std::vector<std::string> listAllClasses(core::Context ctx);
+};
+
+} // namespace sorbet::autogen
+#endif // AUTOGEN_DEFINITIONS_H

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -1,8 +1,8 @@
 // has to go first because it violates our poisons
 #include "mpack/mpack.h"
 
-#include "main/autogen/autogen.h"
-#include "main/autogen/msgpack.h"
+#include "main/autogen/data/definitions.h"
+#include "main/autogen/data/msgpack.h"
 
 using namespace std;
 namespace sorbet::autogen {

--- a/main/autogen/data/msgpack.h
+++ b/main/autogen/data/msgpack.h
@@ -3,7 +3,7 @@
 // has to go first because it violates our poisons
 #include "mpack/mpack.h"
 
-#include "main/autogen/autogen.h"
+#include "main/autogen/data/definitions.h"
 
 namespace sorbet::autogen {
 

--- a/main/autogen/subclasses.h
+++ b/main/autogen/subclasses.h
@@ -1,7 +1,7 @@
 #ifndef AUTOGEN_SUBCLASSES_H
 #define AUTOGEN_SUBCLASSES_H
 #include "common/common.h"
-#include "main/autogen/autogen.h"
+#include "main/autogen/data/definitions.h"
 
 namespace sorbet::autogen {
 

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -77,6 +77,7 @@ compilation_database(
         "//main/autogen:autogen",
         "//main/options:options",
         "//third_party/licenses:licenses",
+        "//main/autogen/data:data",
         "//definition_validator:definition_validator",
         "//core/serialize:serialize_test",
         "//core/serialize:serialize",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
The `autogen` code is a mess. This does a little move/split to make it clearer and adds a _ton_ of comments to clarify what's going on.

1. take the autogen `ParsedFile`/`Definition`/`Reference` declarations (which are by and large an implementation detail of `autogen` itself, not a public API) and move them to `main/autogen/data/*`, leaving only the external interface to autogen in `autogen.{h,cc}`.
2. since the msgpack code is used only by those definitions, move that to `main/autogen/data` as well.
3. fix up the build and imports
4. _thoroughly comment all of `autogen.cc` and other files used here_. Doing this gave me ideas for further cleanup that will avoid some of the action-at-a-distance needed in that traversal, but I didn't want to roll semantic changes into this code-moving-and-commenting PR.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
