### PR TITLE
Re-do "Emit better error message when assignment precedes T.let declaration"

### DIFF
--- a/core/errors/infer.h
+++ b/core/errors/infer.h
@@ -37,6 +37,7 @@ constexpr ErrorClass UntypedConstantSuggestion{7027, StrictLevel::Strict};
 constexpr ErrorClass MetaTypeDispatchCall{7030, StrictLevel::True};
 constexpr ErrorClass PrivateMethod{7031, StrictLevel::True};
 constexpr ErrorClass GenericArgumentKeywordArgs{7032, StrictLevel::True};
+constexpr ErrorClass PinnedVariableAssignedBeforeLet{7033, StrictLevel::True};
 // N.B infer does not run for untyped call at all. StrictLevel::False here would be meaningless
 } // namespace sorbet::core::errors::Infer
 #endif

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1331,10 +1331,10 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                             if (auto e =
                                     ctx.beginError(bind.loc, core::errors::Infer::PinnedVariableAssignedBeforeLet)) {
                                 e.setHeader("Assignment to a variable declared via `{}` occurs before the `{}` "
-                                            "declaration has been reached",
-                                            "let", "let");
+                                            "declaration",
+                                            "T.let", "T.let");
                                 if (tp.origins.size() == 1) {
-                                    e.replaceWith(fmt::format("Use `{}` at initial assignment", "let"), tp.origins[0],
+                                    e.replaceWith(fmt::format("Use `{}` at initial assignment", "T.let"), tp.origins[0],
                                                   "T.let({}, {})", tp.origins[0].source(ctx),
                                                   core::Types::dropLiteral(tp.type)->show(ctx));
                                 }

--- a/test/testdata/infer/let.rb
+++ b/test/testdata/infer/let.rb
@@ -12,11 +12,11 @@ class TestLet
   end
 
   def test_assign_before_let
-    x = "foo" # error: Assignment to a variable declared via `let` occurs before the `let` declaration has been reached
+    x = "foo" # error: Assignment to a variable declared via `T.let` occurs before the `T.let` declaration
     x = T.let("bar", String)
   end
 
-  def test_default_param_before_let(x = "foo") # error: Assignment to a variable declared via `let` occurs before the `let` declaration has been reached
+  def test_default_param_before_let(x = "foo") # error: Assignment to a variable declared via `T.let` occurs before the `T.let` declaration
     x = T.let("bar", String)
   end
 end

--- a/test/testdata/infer/let.rb
+++ b/test/testdata/infer/let.rb
@@ -10,4 +10,13 @@ class TestLet
     # apparent where to do so.
     0 + T.let(1, Integer)
   end
+
+  def test_assign_before_let
+    x = "foo" # error: Assignment to a variable declared via `let` occurs before the `let` declaration has been reached
+    x = T.let("bar", String)
+  end
+
+  def test_default_param_before_let(x = "foo") # error: Assignment to a variable declared via `let` occurs before the `let` declaration has been reached
+    x = T.let("bar", String)
+  end
 end

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -989,23 +989,23 @@ See [Exhaustiveness Checking](exhaustiveness.md) for more information.
 
 ## 7033
 
-A variable is being assigned to before its type is declared with `T.let`. Sorbet
-does not support this. For example:
+A local variable given an annotated type using `T.let` must not be assigned to
+before the assignment with the `T.let`. For example:
 
 ```ruby
 # typed: true
 
-x = "foo"                  # <-- this will produce an error
+x = "foo"                  # error: Assignment occurs before the `T.let`
 x = T.let("bar", String)
 ```
 
-To fix this issue, first make sure that the error is not caused by, say, copying
-and pasting a code snippet whose variable names conflict with existing code.
-Then wrap the first assignment's expression with `T.let`:
+Sometimes this error is caused when reusing a variable that was not meant to be
+reused. If both assignments are intentional, fix this by moving the `T.let` to
+the first assignment (and optionally removing the `T.let` from the second):
 
 ```ruby
 # typed: true
 
-x = T.let("foo", String)   # <-- this will no longer produce an error
-x = T.let("bar", String)   # <-- optionally, can replace this with `x = "bar"'
+x = T.let("foo", String)   # ok: First assignment to `x` uses `T.let`
+x = T.let("bar", String)   # optional: Replace with `x = "bar"`
 ```

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -986,3 +986,26 @@ See [Exhaustiveness Checking](exhaustiveness.md) for more information.
 [report an issue]: https://github.com/sorbet/sorbet/issues
 
 <script src="/js/error-reference.js"></script>
+
+## 7033
+
+A variable is being assigned to before its type is declared with `T.let`. Sorbet
+does not support this. For example:
+
+```ruby
+# typed: true
+
+x = "foo"                  # <-- this will produce an error
+x = T.let("bar", String)
+```
+
+To fix this issue, first make sure that the error is not caused by, say, copying
+and pasting a code snippet whose variable names conflict with existing code.
+Then wrap the first assignment's expression with `T.let`:
+
+```ruby
+# typed: true
+
+x = T.let("foo", String)   # <-- this will no longer produce an error
+x = T.let("bar", String)   # <-- optionally, can replace this with `x = "bar"'
+```


### PR DESCRIPTION
_(Re-do of #3590, which was reverted at #3595 because I forgot to run some internal tests.)_

Partially addresses an issue reported at #3482. If a `let`-less assignment to a variable came _before_ it was "declared" with `let`, info on the declared type would be missing, so we would default to treating the declared type as `NilClass` even if that was not the eventually declared type, which resulted in confusing error messages. With this change we check if the type info was missing rather than accepting the default, and produce a more reasonable error message.

It would be nice if we could add some signposts to the error message pointing out the `let` that conflicts with the assignment, but I think that's probably out of reach without some major work.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
See #3482

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
