### PR TITLE
Stop using typecase for Types.

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1,6 +1,5 @@
 #include "ast/Trees.h"
 #include "common/formatting.h"
-#include "common/typecase.h"
 #include "core/Symbols.h"
 #include <sstream>
 #include <utility>
@@ -850,22 +849,21 @@ string Literal::showRaw(const core::GlobalState &gs, int tabs) {
 }
 
 string Literal::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
-    string res;
-    typecase(
-        this->value.get(), [&](core::LiteralType *l) { res = l->showValue(gs); },
-        [&](core::ClassType *l) {
-            if (l->symbol == core::Symbols::NilClass()) {
-                res = "nil";
-            } else if (l->symbol == core::Symbols::FalseClass()) {
-                res = "false";
-            } else if (l->symbol == core::Symbols::TrueClass()) {
-                res = "true";
-            } else {
-                res = "literal(" + this->value->toStringWithTabs(gs, tabs) + ")";
-            }
-        },
-        [&](core::Type *t) { res = "literal(" + this->value->toStringWithTabs(gs, tabs) + ")"; });
-    return res;
+    if (auto *l = core::cast_type<core::LiteralType>(this->value)) {
+        return l->showValue(gs);
+    } else if (auto *l = core::cast_type<core::ClassType>(this->value)) {
+        if (l->symbol == core::Symbols::NilClass()) {
+            return "nil";
+        } else if (l->symbol == core::Symbols::FalseClass()) {
+            return "false";
+        } else if (l->symbol == core::Symbols::TrueClass()) {
+            return "true";
+        } else {
+            return "literal(" + this->value->toStringWithTabs(gs, tabs) + ")";
+        }
+    } else {
+        return "literal(" + this->value->toStringWithTabs(gs, tabs) + ")";
+    }
 }
 
 string Assign::toStringWithTabs(const core::GlobalState &gs, int tabs) const {

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -1,7 +1,6 @@
 #include "Instructions.h"
 
 #include "common/formatting.h"
-#include "common/typecase.h"
 #include "core/Names.h"
 #include "core/TypeConstraint.h"
 #include <utility>
@@ -92,22 +91,21 @@ Literal::Literal(const core::TypePtr &value) : value(move(value)) {
 }
 
 string Literal::toString(const core::GlobalState &gs, const CFG &cfg) const {
-    string res;
-    typecase(
-        this->value.get(), [&](core::LiteralType *l) { res = l->showValue(gs); },
-        [&](const core::ClassType *l) {
-            if (l->symbol == core::Symbols::NilClass()) {
-                res = "nil";
-            } else if (l->symbol == core::Symbols::FalseClass()) {
-                res = "false";
-            } else if (l->symbol == core::Symbols::TrueClass()) {
-                res = "true";
-            } else {
-                res = fmt::format("literal({})", this->value->toStringWithTabs(gs, 0));
-            }
-        },
-        [&](const core::Type *t) { res = fmt::format("literal({})", this->value->toStringWithTabs(gs, 0)); });
-    return res;
+    if (auto *l = core::cast_type<core::LiteralType>(this->value)) {
+        return l->showValue(gs);
+    } else if (auto *l = core::cast_type<core::ClassType>(this->value)) {
+        if (l->symbol == core::Symbols::NilClass()) {
+            return "nil";
+        } else if (l->symbol == core::Symbols::FalseClass()) {
+            return "false";
+        } else if (l->symbol == core::Symbols::TrueClass()) {
+            return "true";
+        } else {
+            return fmt::format("literal({})", this->value->toStringWithTabs(gs, 0));
+        }
+    } else {
+        return fmt::format("literal({})", this->value->toStringWithTabs(gs, 0));
+    }
 }
 
 string Literal::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -6,7 +6,6 @@
 #include "absl/strings/str_cat.h"
 #include "common/Counters_impl.h"
 #include "common/Random.h"
-#include "common/typecase.h"
 #include "core/Names.h"
 
 using namespace std;
@@ -174,50 +173,75 @@ com::stripe::rubytyper::Type::Literal Proto::toProto(const GlobalState &gs, cons
 
 com::stripe::rubytyper::Type Proto::toProto(const GlobalState &gs, const TypePtr &typ) {
     com::stripe::rubytyper::Type proto;
-    typecase(
-        typ.get(),
-        [&](const ClassType *t) {
+    switch (typ.tag()) {
+        case TypePtr::Tag::BlamedUntyped:
+        case TypePtr::Tag::UnresolvedAppliedType:
+        case TypePtr::Tag::UnresolvedClassType:
+        case TypePtr::Tag::ClassType: {
+            auto &t = core::cast_type_nonnull<core::ClassType>(typ);
             proto.set_kind(com::stripe::rubytyper::Type::CLASS);
-            proto.set_class_full_name(t->symbol.show(gs));
-        },
-        [&](const AndType *t) {
+            proto.set_class_full_name(t.symbol.show(gs));
+            break;
+        }
+        case TypePtr::Tag::AndType: {
+            auto &t = core::cast_type_nonnull<core::AndType>(typ);
             proto.set_kind(com::stripe::rubytyper::Type::AND);
-            *proto.mutable_and_()->mutable_left() = toProto(gs, t->left);
-            *proto.mutable_and_()->mutable_right() = toProto(gs, t->right);
-        },
-        [&](const OrType *t) {
+            *proto.mutable_and_()->mutable_left() = toProto(gs, t.left);
+            *proto.mutable_and_()->mutable_right() = toProto(gs, t.right);
+            break;
+        }
+        case TypePtr::Tag::OrType: {
+            auto &t = core::cast_type_nonnull<core::OrType>(typ);
             proto.set_kind(com::stripe::rubytyper::Type::OR);
-            *proto.mutable_or_()->mutable_left() = toProto(gs, t->left);
-            *proto.mutable_or_()->mutable_right() = toProto(gs, t->right);
-        },
-        [&](const AppliedType *t) {
+            *proto.mutable_or_()->mutable_left() = toProto(gs, t.left);
+            *proto.mutable_or_()->mutable_right() = toProto(gs, t.right);
+            break;
+        }
+        case TypePtr::Tag::AppliedType: {
+            auto &t = core::cast_type_nonnull<core::AppliedType>(typ);
             proto.set_kind(com::stripe::rubytyper::Type::APPLIED);
-            proto.mutable_applied()->set_symbol_full_name(t->klass.show(gs));
-            for (auto &a : t->targs) {
+            proto.mutable_applied()->set_symbol_full_name(t.klass.show(gs));
+            for (auto &a : t.targs) {
                 *proto.mutable_applied()->add_type_args() = toProto(gs, a);
             }
-        },
-        [&](const ShapeType *t) {
+            break;
+        }
+        case TypePtr::Tag::ShapeType: {
+            auto &t = core::cast_type_nonnull<core::ShapeType>(typ);
             proto.set_kind(com::stripe::rubytyper::Type::SHAPE);
-            for (auto &k : t->keys) {
+            for (auto &k : t.keys) {
                 *proto.mutable_shape()->add_keys() = toProto(gs, k);
             }
-            for (auto &v : t->values) {
+            for (auto &v : t.values) {
                 *proto.mutable_shape()->add_values() = toProto(gs, v);
             }
-        },
-        [&](const LiteralType *t) {
+            break;
+        }
+        case TypePtr::Tag::LiteralType: {
+            auto &t = core::cast_type_nonnull<core::LiteralType>(typ);
             proto.set_kind(com::stripe::rubytyper::Type::LITERAL);
-            *proto.mutable_literal() = toProto(gs, *t);
-        },
-        [&](const TupleType *t) {
+            *proto.mutable_literal() = toProto(gs, t);
+            break;
+        }
+        case TypePtr::Tag::TupleType: {
+            auto &t = core::cast_type_nonnull<core::TupleType>(typ);
             proto.set_kind(com::stripe::rubytyper::Type::TUPLE);
-            for (auto &e : t->elems) {
+            for (auto &e : t.elems) {
                 *proto.mutable_tuple()->add_elems() = toProto(gs, e);
             }
-        },
-        // TODO later: add more types
-        [&](const Type *t) { proto.set_kind(com::stripe::rubytyper::Type::UNKNOWN); });
+            break;
+        }
+        case TypePtr::Tag::AliasType:
+        case TypePtr::Tag::LambdaParam:
+        case TypePtr::Tag::SelfType:
+        case TypePtr::Tag::SelfTypeParam:
+        case TypePtr::Tag::TypeVar:
+        case TypePtr::Tag::MetaType: {
+            // TODO later: add more types
+            proto.set_kind(com::stripe::rubytyper::Type::UNKNOWN);
+            break;
+        }
+    }
     return proto;
 }
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2,7 +2,6 @@
 #include "absl/strings/str_split.h"
 #include "common/common.h"
 #include "common/sort.h"
-#include "common/typecase.h"
 #include "core/GlobalState.h"
 #include "core/Names.h"
 #include "core/Symbols.h"
@@ -1147,18 +1146,19 @@ DispatchResult MetaType::dispatchCall(const GlobalState &gs, DispatchArgs args) 
 
 SymbolRef unwrapSymbol(const TypePtr &type) {
     SymbolRef result;
-    const Type *rawTypePtr = type.get();
+    const TypePtr *typePtr = &type;
+    TypePtr tempHolder;
     while (!result.exists()) {
-        typecase(
-            rawTypePtr,
-
-            [&](const ClassType *klass) { result = klass->symbol; },
-
-            [&](const AppliedType *app) { result = app->klass; },
-
-            [&](const ProxyType *proxy) { rawTypePtr = proxy->underlying().get(); },
-
-            [&](const Type *ty) { ENFORCE(false, "Unexpected type: {}", ty->typeName()); });
+        if (auto *klass = cast_type<ClassType>(*typePtr)) {
+            result = klass->symbol;
+        } else if (auto *app = cast_type<AppliedType>(*typePtr)) {
+            result = app->klass;
+        } else if (auto *proxy = cast_type<ProxyType>(*typePtr)) {
+            tempHolder = proxy->underlying();
+            typePtr = &tempHolder;
+        } else {
+            ENFORCE(false, "Unexpected type: {}", (*typePtr)->typeName());
+        }
     }
     return result;
 }
@@ -2320,30 +2320,22 @@ class Array_flatten : public IntrinsicMethod {
         }
         const int newDepth = depth - 1;
 
-        TypePtr result;
-        typecase(
-            type.get(),
-
-            // This only shows up because t->elementType() for tuples returns an OrType of all its elements.
-            // So to properly handle nested tuples, we have to descend into the OrType's.
-            [&](const OrType *o) {
-                result = Types::any(gs, recursivelyFlattenArrays(gs, o->left, newDepth),
-                                    recursivelyFlattenArrays(gs, o->right, newDepth));
-            },
-
-            [&](const AppliedType *a) {
-                if (a->klass != Symbols::Array()) {
-                    result = type;
-                    return;
-                }
-                ENFORCE(a->targs.size() == 1);
-                result = recursivelyFlattenArrays(gs, a->targs.front(), newDepth);
-            },
-
-            [&](const TupleType *t) { result = recursivelyFlattenArrays(gs, t->elementType(), newDepth); },
-
-            [&](const Type *t) { result = std::move(type); });
-        return result;
+        // This only shows up because t->elementType() for tuples returns an OrType of all its elements.
+        // So to properly handle nested tuples, we have to descend into the OrType's.
+        if (auto *o = cast_type<OrType>(type)) {
+            return Types::any(gs, recursivelyFlattenArrays(gs, o->left, newDepth),
+                              recursivelyFlattenArrays(gs, o->right, newDepth));
+        } else if (auto *a = cast_type<AppliedType>(type)) {
+            if (a->klass != Symbols::Array()) {
+                return type;
+            }
+            ENFORCE(a->targs.size() == 1);
+            return recursivelyFlattenArrays(gs, a->targs.front(), newDepth);
+        } else if (auto *t = cast_type<TupleType>(type)) {
+            return recursivelyFlattenArrays(gs, t->elementType(), newDepth);
+        } else {
+            return type;
+        }
     }
 
 public:

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -4,7 +4,6 @@
 #include "ast/treemap/treemap.h"
 #include "common/concurrency/ConcurrentQueue.h"
 #include "common/sort.h"
-#include "common/typecase.h"
 #include "core/ErrorCollector.h"
 #include "core/ErrorQueue.h"
 #include "core/Unfreeze.h"

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -3,7 +3,6 @@
 #include "common/concurrency/WorkerPool.h"
 #include "common/kvstore/KeyValueStore.h"
 #include "common/statsd/statsd.h"
-#include "common/typecase.h"
 #include "common/web_tracer_framework/tracing.h"
 #include "core/errors/internal.h"
 #include "core/errors/namer.h"

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -6,7 +6,6 @@
 #include "ast/treemap/treemap.h"
 #include "common/formatting.h"
 #include "common/sort.h"
-#include "common/typecase.h"
 #include "core/lsp/QueryResponse.h"
 #include "main/lsp/LocalVarFinder.h"
 #include "main/lsp/NextMethodFinder.h"
@@ -168,19 +167,18 @@ SimilarMethodsByName mergeSimilarMethods(SimilarMethodsByName left, SimilarMetho
 
 SimilarMethodsByName similarMethodsForReceiver(const core::GlobalState &gs, const core::TypePtr &receiver,
                                                string_view prefix) {
-    auto result = SimilarMethodsByName{};
-
-    typecase(
-        receiver.get(), [&](const core::ClassType *type) { result = similarMethodsForClass(gs, type->symbol, prefix); },
-        [&](const core::AppliedType *type) { result = similarMethodsForClass(gs, type->klass, prefix); },
-        [&](const core::AndType *type) {
-            result = mergeSimilarMethods(similarMethodsForReceiver(gs, type->left, prefix),
-                                         similarMethodsForReceiver(gs, type->right, prefix));
-        },
-        [&](const core::ProxyType *type) { result = similarMethodsForReceiver(gs, type->underlying(), prefix); },
-        [&](const core::Type *type) { return; });
-
-    return result;
+    if (auto *type = core::cast_type<core::ClassType>(receiver)) {
+        return similarMethodsForClass(gs, type->symbol, prefix);
+    } else if (auto *type = core::cast_type<core::AppliedType>(receiver)) {
+        return similarMethodsForClass(gs, type->klass, prefix);
+    } else if (auto *type = core::cast_type<core::AndType>(receiver)) {
+        return mergeSimilarMethods(similarMethodsForReceiver(gs, type->left, prefix),
+                                   similarMethodsForReceiver(gs, type->right, prefix));
+    } else if (auto *type = core::cast_type<core::ProxyType>(receiver)) {
+        return similarMethodsForReceiver(gs, type->underlying(), prefix);
+    } else {
+        return {};
+    }
 }
 
 // Walk a core::DispatchResult to find methods similar to `prefix` on any of its DispatchComponents' receivers.

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -1,5 +1,4 @@
 #include "main/lsp/requests/type_definition.h"
-#include "common/typecase.h"
 #include "core/lsp/QueryResponse.h"
 #include "main/lsp/json_types.h"
 
@@ -13,25 +12,25 @@ vector<core::Loc> locsForType(const core::GlobalState &gs, const core::TypePtr &
     if (type.isUntyped()) {
         return result;
     }
-    typecase(
-        type.get(), [&](const core::ClassType *t) { result.emplace_back(t->symbol.data(gs)->loc()); },
-        [&](const core::AppliedType *t) { result.emplace_back(t->klass.data(gs)->loc()); },
-        [&](const core::OrType *t) {
-            for (auto loc : locsForType(gs, t->left)) {
-                result.emplace_back(loc);
-            }
-            for (auto loc : locsForType(gs, t->right)) {
-                result.emplace_back(loc);
-            }
-        },
-        [&](const core::AndType *t) {
-            for (auto loc : locsForType(gs, t->left)) {
-                result.emplace_back(loc);
-            }
-            for (auto loc : locsForType(gs, t->right)) {
-                result.emplace_back(loc);
-            }
-        });
+    if (auto *t = core::cast_type<core::ClassType>(type)) {
+        result.emplace_back(t->symbol.data(gs)->loc());
+    } else if (auto *t = core::cast_type<core::AppliedType>(type)) {
+        result.emplace_back(t->klass.data(gs)->loc());
+    } else if (auto *t = core::cast_type<core::OrType>(type)) {
+        for (auto loc : locsForType(gs, t->left)) {
+            result.emplace_back(loc);
+        }
+        for (auto loc : locsForType(gs, t->right)) {
+            result.emplace_back(loc);
+        }
+    } else if (auto *t = core::cast_type<core::AndType>(type)) {
+        for (auto loc : locsForType(gs, t->left)) {
+            result.emplace_back(loc);
+        }
+        for (auto loc : locsForType(gs, t->right)) {
+            result.emplace_back(loc);
+        }
+    }
     return result;
 }
 } // namespace

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -9,7 +9,6 @@
 #include "common/concurrency/ConcurrentQueue.h"
 #include "common/concurrency/WorkerPool.h"
 #include "common/sort.h"
-#include "common/typecase.h"
 #include "core/Context.h"
 #include "core/Names.h"
 #include "core/Symbols.h"


### PR DESCRIPTION
Instead, use a sequence of if/else casts that leverage tags _or_ use a switch statement on tags.

Why not use a switch statement everywhere? Unfortunately, we are using the class hierarchy for some types. For example, `ClassType` has separate subtypes. Same with `GroundType` and `ProxyType`. So a `switch` author would need to know about that, and I think that might make the code a little harder to grok. 

Note that `typecase` does this sort of if/else check, except with `fast_cast`, so this should still be strictly better.

This avoids using `fast_cast` for determining castability, which uses typeid/dynamic casts.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Broken off from https://github.com/sorbet/sorbet/pull/3569

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
