### PR TITLE
use moves for strings during LSP serialization

### DIFF
--- a/main/lsp/tools/generate_lsp_messages.h
+++ b/main/lsp/tools/generate_lsp_messages.h
@@ -58,9 +58,10 @@ public:
     virtual BaseKind getJSONBaseKind() const = 0;
 
     /**
-     * Returns `true` if the underlying C++ type cannot be copied and must be moved.
+     * Returns `true` if the underlying C++ type would prefer to be moved rather than
+     * copied where possible.
      */
-    virtual bool cannotBeCopied() const {
+    virtual bool wantMove() const {
         return false;
     }
 
@@ -351,8 +352,8 @@ public:
         return fmt::format("Array<{}>", componentType->getJSONType());
     }
 
-    bool cannotBeCopied() const {
-        return componentType->cannotBeCopied();
+    bool wantMove() const {
+        return componentType->wantMove();
     }
 
     void emitFromJSONValue(fmt::memory_buffer &out, std::string_view from, AssignLambda assign,
@@ -598,8 +599,8 @@ public:
         return fmt::format("({})?", innerType->getJSONType());
     }
 
-    bool cannotBeCopied() const {
-        return innerType->cannotBeCopied();
+    bool wantMove() const {
+        return innerType->wantMove();
     }
 
     void emitFromJSONValue(fmt::memory_buffer &out, std::string_view from, AssignLambda assign,
@@ -664,7 +665,7 @@ public:
         return typeName;
     }
 
-    bool cannotBeCopied() const {
+    bool wantMove() const {
         return true;
     }
 
@@ -715,7 +716,7 @@ public:
                                              return fmt::format("{} {}", field->type->getCPPType(), field->cppName);
                                          }),
                            fmt::map_join(reqFields, ", ", [](auto field) -> std::string {
-                               if (field->type->cannotBeCopied()) {
+                               if (field->type->wantMove()) {
                                    return fmt::format("{}(move({}))", field->cppName, field->cppName);
                                }
                                return fmt::format("{}({})", field->cppName, field->cppName);
@@ -741,7 +742,7 @@ public:
         }
         fmt::format_to(out, "{} rv = std::make_unique<{}>({});\n", getCPPType(), typeName,
                        fmt::map_join(reqFields, ", ", [](auto field) -> std::string {
-                           if (field->type->cannotBeCopied()) {
+                           if (field->type->wantMove()) {
                                return fmt::format("move({})", field->cppName);
                            } else {
                                return field->cppName;
@@ -827,9 +828,9 @@ public:
             "{}", fmt::map_join(variants, " | ", [](auto variant) -> std::string { return variant->getJSONType(); }));
     }
 
-    bool cannotBeCopied() const {
+    bool wantMove() const {
         for (auto &variant : variants) {
-            if (variant->cannotBeCopied()) {
+            if (variant->wantMove()) {
                 return true;
             }
         }

--- a/main/lsp/tools/generate_lsp_messages.h
+++ b/main/lsp/tools/generate_lsp_messages.h
@@ -254,6 +254,10 @@ public:
         fmt::format_to(out, "}}\n");
     }
 
+    bool wantMove() const {
+        return true;
+    }
+
     BaseKind getCPPBaseKind() const {
         return BaseKind::StringKind;
     }
@@ -288,6 +292,10 @@ private:
 
 public:
     JSONStringConstantType(std::string_view value) : value(std::string(value)) {}
+
+    bool wantMove() const {
+        return true;
+    }
 
     BaseKind getCPPBaseKind() const {
         return BaseKind::StringKind;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
For LSP objects that had string members, during deserialization from JSON values, we would:

1. Allocate a string when converting from the rapidJSON field
2. Allocate a string to call the constructor for the object, because the object takes the string by value
3. Allocate a string to store in the object, because we copied the by-value string into the field

The last two steps should be completely unnecessary.  You can imagine this gets worse when you have a member that is an array of strings, as the last two steps copy the involved `std::vector`.

Since we already had all the machinery to deal with `std::unique_ptr`, the change for strings is conceptually simple.  I debated having two separate functions (`cannotBeCopied` and `wantMove`), but ultimately decided that for this application, one function should be sufficient...at least for now.

cc @jvilk-stripe 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Epsilon efficiency improvements.
### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing test coverage should be sufficient.