### PR TITLE
Typecase function that uses tags on tagged pointer

### DIFF
--- a/ast/ArgParsing.cc
+++ b/ast/ArgParsing.cc
@@ -11,31 +11,31 @@ namespace {
 ParsedArg parseArg(const ast::TreePtr &arg) {
     ParsedArg parsedArg;
 
-    typecase(
-        arg.get(),
-        [&](const ast::RestArg *rest) {
-            parsedArg = parseArg(rest->expr);
+    tagTypecase(
+        arg,
+        [&](const ast::RestArg &rest) {
+            parsedArg = parseArg(rest.expr);
             parsedArg.flags.isRepeated = true;
         },
-        [&](const ast::KeywordArg *kw) {
-            parsedArg = parseArg(kw->expr);
+        [&](const ast::KeywordArg &kw) {
+            parsedArg = parseArg(kw.expr);
             parsedArg.flags.isKeyword = true;
         },
-        [&](const ast::OptionalArg *opt) {
-            parsedArg = parseArg(opt->expr);
+        [&](const ast::OptionalArg &opt) {
+            parsedArg = parseArg(opt.expr);
             parsedArg.flags.isDefault = true;
         },
-        [&](const ast::BlockArg *blk) {
-            parsedArg = parseArg(blk->expr);
+        [&](const ast::BlockArg &blk) {
+            parsedArg = parseArg(blk.expr);
             parsedArg.flags.isBlock = true;
         },
-        [&](const ast::ShadowArg *shadow) {
-            parsedArg = parseArg(shadow->expr);
+        [&](const ast::ShadowArg &shadow) {
+            parsedArg = parseArg(shadow.expr);
             parsedArg.flags.isShadow = true;
         },
-        [&](const ast::Local *local) {
-            parsedArg.local = local->localVariable;
-            parsedArg.loc = local->loc;
+        [&](const ast::Local &local) {
+            parsedArg.local = local.localVariable;
+            parsedArg.loc = local.loc;
         });
 
     return parsedArg;
@@ -43,13 +43,13 @@ ParsedArg parseArg(const ast::TreePtr &arg) {
 
 TreePtr getDefaultValue(TreePtr arg) {
     TreePtr default_;
-    typecase(
-        arg.get(), [&](ast::RestArg *rest) { default_ = getDefaultValue(move(rest->expr)); },
-        [&](ast::KeywordArg *kw) { default_ = getDefaultValue(move(kw->expr)); },
-        [&](ast::OptionalArg *opt) { default_ = move(opt->default_); },
-        [&](ast::BlockArg *blk) { default_ = getDefaultValue(move(blk->expr)); },
-        [&](ast::ShadowArg *shadow) { default_ = getDefaultValue(move(shadow->expr)); },
-        [&](ast::Local *local) {
+    tagTypecase(
+        arg, [&](ast::RestArg &rest) { default_ = getDefaultValue(move(rest.expr)); },
+        [&](ast::KeywordArg &kw) { default_ = getDefaultValue(move(kw.expr)); },
+        [&](ast::OptionalArg &opt) { default_ = move(opt.default_); },
+        [&](ast::BlockArg &blk) { default_ = getDefaultValue(move(blk.expr)); },
+        [&](ast::ShadowArg &shadow) { default_ = getDefaultValue(move(shadow.expr)); },
+        [&](ast::Local &local) {
             // No default.
         });
     ENFORCE(default_ != nullptr);

--- a/ast/ArgParsing.cc
+++ b/ast/ArgParsing.cc
@@ -11,7 +11,7 @@ namespace {
 ParsedArg parseArg(const ast::TreePtr &arg) {
     ParsedArg parsedArg;
 
-    tagTypecase(
+    typecase(
         arg,
         [&](const ast::RestArg &rest) {
             parsedArg = parseArg(rest.expr);
@@ -43,7 +43,7 @@ ParsedArg parseArg(const ast::TreePtr &arg) {
 
 TreePtr getDefaultValue(TreePtr arg) {
     TreePtr default_;
-    tagTypecase(
+    typecase(
         arg, [&](ast::RestArg &rest) { default_ = getDefaultValue(move(rest.expr)); },
         [&](ast::KeywordArg &kw) { default_ = getDefaultValue(move(kw.expr)); },
         [&](ast::OptionalArg &opt) { default_ = move(opt.default_); },

--- a/ast/Helpers.cc
+++ b/ast/Helpers.cc
@@ -45,7 +45,7 @@ bool definesBehavior(const TreePtr &expr) {
         [&](const ast::MethodDef &methodDef) { result = !methodDef.flags.isRewriterSynthesized; },
         [&](const ast::Literal &methodDef) { result = false; },
 
-        [&](const ast::Expression &klass) { result = true; });
+        [&](const TreePtr &klass) { result = true; });
     return result;
 }
 
@@ -90,7 +90,7 @@ bool BehaviorHelpers::checkEmptyDeep(const TreePtr &expr) {
                      checkEmptyDeep(seq.expr);
         },
 
-        [&](const ast::Expression &klass) { result = false; });
+        [&](const TreePtr &klass) { result = false; });
     return result;
 }
 

--- a/ast/Helpers.cc
+++ b/ast/Helpers.cc
@@ -10,7 +10,7 @@ bool definesBehavior(const TreePtr &expr) {
     }
     bool result = true;
 
-    tagTypecase(
+    typecase(
         expr,
 
         [&](const ast::ClassDef &klass) {
@@ -74,7 +74,7 @@ bool BehaviorHelpers::checkClassDefinesBehavior(const ast::ClassDef &klass) {
 bool BehaviorHelpers::checkEmptyDeep(const TreePtr &expr) {
     bool result = false;
 
-    tagTypecase(
+    typecase(
         expr,
 
         [&](const ast::Send &send) {

--- a/ast/Helpers.cc
+++ b/ast/Helpers.cc
@@ -10,11 +10,11 @@ bool definesBehavior(const TreePtr &expr) {
     }
     bool result = true;
 
-    typecase(
-        expr.get(),
+    tagTypecase(
+        expr,
 
-        [&](ast::ClassDef *klass) {
-            auto *id = ast::cast_tree<ast::UnresolvedIdent>(klass->name);
+        [&](const ast::ClassDef &klass) {
+            auto *id = ast::cast_tree<ast::UnresolvedIdent>(klass.name);
             if (id && id->name == core::Names::singleton()) {
                 // class << self; We consider this
                 // behavior-defining. We could opt to recurse inside
@@ -27,25 +27,25 @@ bool definesBehavior(const TreePtr &expr) {
             }
         },
 
-        [&](ast::Assign *asgn) {
-            if (ast::isa_tree<ast::ConstantLit>(asgn->lhs)) {
+        [&](const ast::Assign &asgn) {
+            if (ast::isa_tree<ast::ConstantLit>(asgn.lhs)) {
                 result = false;
             } else {
                 result = true;
             }
         },
 
-        [&](ast::InsSeq *seq) {
-            result = absl::c_any_of(seq->stats, [](auto &child) { return definesBehavior(child); }) ||
-                     definesBehavior(seq->expr);
+        [&](const ast::InsSeq &seq) {
+            result = absl::c_any_of(seq.stats, [](auto &child) { return definesBehavior(child); }) ||
+                     definesBehavior(seq.expr);
         },
 
         // Ignore code synthesized by Rewriter pass.
-        [&](ast::Send *send) { result = !send->flags.isRewriterSynthesized; },
-        [&](ast::MethodDef *methodDef) { result = !methodDef->flags.isRewriterSynthesized; },
-        [&](ast::Literal *methodDef) { result = false; },
+        [&](const ast::Send &send) { result = !send.flags.isRewriterSynthesized; },
+        [&](const ast::MethodDef &methodDef) { result = !methodDef.flags.isRewriterSynthesized; },
+        [&](const ast::Literal &methodDef) { result = false; },
 
-        [&](ast::Expression *klass) { result = true; });
+        [&](const ast::Expression &klass) { result = true; });
     return result;
 }
 
@@ -74,23 +74,23 @@ bool BehaviorHelpers::checkClassDefinesBehavior(const ast::ClassDef &klass) {
 bool BehaviorHelpers::checkEmptyDeep(const TreePtr &expr) {
     bool result = false;
 
-    typecase(
-        expr.get(),
+    tagTypecase(
+        expr,
 
-        [&](ast::Send *send) {
-            result = send->fun == core::Names::keepForIde() || send->fun == core::Names::keepDef() ||
-                     send->fun == core::Names::keepSelfDef() || send->fun == core::Names::include() ||
-                     send->fun == core::Names::extend();
+        [&](const ast::Send &send) {
+            result = send.fun == core::Names::keepForIde() || send.fun == core::Names::keepDef() ||
+                     send.fun == core::Names::keepSelfDef() || send.fun == core::Names::include() ||
+                     send.fun == core::Names::extend();
         },
 
-        [&](ast::EmptyTree *) { result = true; },
+        [&](const ast::EmptyTree &) { result = true; },
 
-        [&](ast::InsSeq *seq) {
-            result = absl::c_all_of(seq->stats, [](auto &child) { return checkEmptyDeep(child); }) &&
-                     checkEmptyDeep(seq->expr);
+        [&](const ast::InsSeq &seq) {
+            result = absl::c_all_of(seq.stats, [](auto &child) { return checkEmptyDeep(child); }) &&
+                     checkEmptyDeep(seq.expr);
         },
 
-        [&](ast::Expression *klass) { result = false; });
+        [&](const ast::Expression &klass) { result = false; });
     return result;
 }
 

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -451,7 +451,7 @@ public:
                 [&](const class ShadowArg &shadow) { cursor = &shadow.expr; },
                 // ENFORCES are last so that we don't pay the price of casting in the fast path.
                 [&](const UnresolvedIdent &opt) { ENFORCE(false, "Namer should have created a Local for this arg."); },
-                [&](const Expression &expr) { ENFORCE(false, "Unexpected node type in argument position."); });
+                [&](const TreePtr &expr) { ENFORCE(false, "Unexpected node type in argument position."); });
         }
     }
 };

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -443,7 +443,7 @@ public:
             }
 
             // Recurse into structure to find the Local
-            tagTypecase(
+            typecase(
                 *cursor, [&](const class RestArg &rest) { cursor = &rest.expr; },
                 [&](const class KeywordArg &kw) { cursor = &kw.expr; },
                 [&](const class OptionalArg &opt) { cursor = &opt.expr; },

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -443,14 +443,15 @@ public:
             }
 
             // Recurse into structure to find the Local
-            typecase(
-                cursor->get(), [&](class RestArg *rest) { cursor = &rest->expr; },
-                [&](class KeywordArg *kw) { cursor = &kw->expr; }, [&](class OptionalArg *opt) { cursor = &opt->expr; },
-                [&](class BlockArg *blk) { cursor = &blk->expr; },
-                [&](class ShadowArg *shadow) { cursor = &shadow->expr; },
+            tagTypecase(
+                *cursor, [&](const class RestArg &rest) { cursor = &rest.expr; },
+                [&](const class KeywordArg &kw) { cursor = &kw.expr; },
+                [&](const class OptionalArg &opt) { cursor = &opt.expr; },
+                [&](const class BlockArg &blk) { cursor = &blk.expr; },
+                [&](const class ShadowArg &shadow) { cursor = &shadow.expr; },
                 // ENFORCES are last so that we don't pay the price of casting in the fast path.
-                [&](UnresolvedIdent *opt) { ENFORCE(false, "Namer should have created a Local for this arg."); },
-                [&](Expression *expr) { ENFORCE(false, "Unexpected node type in argument position."); });
+                [&](const UnresolvedIdent &opt) { ENFORCE(false, "Namer should have created a Local for this arg."); },
+                [&](const Expression &expr) { ENFORCE(false, "Unexpected node type in argument position."); });
         }
     }
 };

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1012,20 +1012,20 @@ string Literal::showRaw(const core::GlobalState &gs, int tabs) {
 
 string Literal::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     string res;
-    typecase(
-        this->value.get(), [&](core::LiteralType *l) { res = l->showValue(gs); },
-        [&](core::ClassType *l) {
-            if (l->symbol == core::Symbols::NilClass()) {
+    tagTypecase(
+        this->value, [&](const core::LiteralType &l) { res = l.showValue(gs); },
+        [&](const core::ClassType &l) {
+            if (l.symbol == core::Symbols::NilClass()) {
                 res = "nil";
-            } else if (l->symbol == core::Symbols::FalseClass()) {
+            } else if (l.symbol == core::Symbols::FalseClass()) {
                 res = "false";
-            } else if (l->symbol == core::Symbols::TrueClass()) {
+            } else if (l.symbol == core::Symbols::TrueClass()) {
                 res = "true";
             } else {
                 res = "literal(" + this->value->toStringWithTabs(gs, tabs) + ")";
             }
         },
-        [&](core::Type *t) { res = "literal(" + this->value->toStringWithTabs(gs, tabs) + ")"; });
+        [&](const core::TypePtr &t) { res = "literal(" + this->value->toStringWithTabs(gs, tabs) + ")"; });
     return res;
 }
 

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1012,7 +1012,7 @@ string Literal::showRaw(const core::GlobalState &gs, int tabs) {
 
 string Literal::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     string res;
-    tagTypecase(
+    typecase(
         this->value, [&](const core::LiteralType &l) { res = l.showValue(gs); },
         [&](const core::ClassType &l) {
             if (l.symbol == core::Symbols::NilClass()) {

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -70,6 +70,26 @@ public:
     // We store tagged pointers as 64-bit values.
     using tagged_storage = u8;
 
+    // Required for tagTypecase
+    template <class To> static bool isa(const TreePtr &tree);
+    template <> inline bool isa<Expression>(const TreePtr &tree) {
+        return true;
+    }
+    template <> inline bool isa<TreePtr>(const TreePtr &tree) {
+        return true;
+    }
+
+    template <class To> static const To &cast_nonnull(const TreePtr &tree);
+    template <> inline const Expression &cast_nonnull<Expression>(const TreePtr &tree) {
+        return *tree.get();
+    }
+    template <> inline const TreePtr &cast_nonnull<TreePtr>(const TreePtr &tree) {
+        return tree;
+    }
+    template <class To> static To &cast_nonnull(TreePtr &tree) {
+        return const_cast<To &>(cast_nonnull<To>(static_cast<const TreePtr &>(tree)));
+    }
+
 private:
     static constexpr tagged_storage TAG_MASK = 0xffff000000000007;
 
@@ -299,6 +319,14 @@ template <class To> To &cast_tree_nonnull(TreePtr &what) {
 template <class To> const To &cast_tree_nonnull(const TreePtr &what) {
     ENFORCE(isa_tree<To>(what), "cast_tree_nonnull failed!");
     return *reinterpret_cast<To *>(what.get());
+}
+
+template <class To> inline bool TreePtr::isa(const TreePtr &what) {
+    return isa_tree<To>(what);
+}
+
+template <class To> inline To const &TreePtr::cast_nonnull(const TreePtr &what) {
+    return cast_tree_nonnull<To>(what);
 }
 
 #define TREE(name)                                                                  \

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -70,7 +70,7 @@ public:
     // We store tagged pointers as 64-bit values.
     using tagged_storage = u8;
 
-    // Required for tagTypecase
+    // Required for typecase
     template <class To> static bool isa(const TreePtr &tree);
     template <> inline bool isa<Expression>(const TreePtr &tree) {
         return true;

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -72,20 +72,7 @@ public:
 
     // Required for typecase
     template <class To> static bool isa(const TreePtr &tree);
-    template <> inline bool isa<Expression>(const TreePtr &tree) {
-        return true;
-    }
-    template <> inline bool isa<TreePtr>(const TreePtr &tree) {
-        return true;
-    }
-
     template <class To> static const To &cast_nonnull(const TreePtr &tree);
-    template <> inline const Expression &cast_nonnull<Expression>(const TreePtr &tree) {
-        return *tree.get();
-    }
-    template <> inline const TreePtr &cast_nonnull<TreePtr>(const TreePtr &tree) {
-        return tree;
-    }
     template <class To> static To &cast_nonnull(TreePtr &tree) {
         return const_cast<To &>(cast_nonnull<To>(static_cast<const TreePtr &>(tree)));
     }
@@ -327,6 +314,19 @@ template <class To> inline bool TreePtr::isa(const TreePtr &what) {
 
 template <class To> inline To const &TreePtr::cast_nonnull(const TreePtr &what) {
     return cast_tree_nonnull<To>(what);
+}
+
+template <> inline bool TreePtr::isa<Expression>(const TreePtr &tree) {
+    return true;
+}
+template <> inline bool TreePtr::isa<TreePtr>(const TreePtr &tree) {
+    return true;
+}
+template <> inline const Expression &TreePtr::cast_nonnull<Expression>(const TreePtr &tree) {
+    return *tree.get();
+}
+template <> inline const TreePtr &TreePtr::cast_nonnull<TreePtr>(const TreePtr &tree) {
+    return tree;
 }
 
 #define TREE(name)                                                                  \

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -72,9 +72,9 @@ public:
 
     // Required for typecase
     template <class To> static bool isa(const TreePtr &tree);
-    template <class To> static const To &cast_nonnull(const TreePtr &tree);
-    template <class To> static To &cast_nonnull(TreePtr &tree) {
-        return const_cast<To &>(cast_nonnull<To>(static_cast<const TreePtr &>(tree)));
+    template <class To> static const To &cast(const TreePtr &tree);
+    template <class To> static To &cast(TreePtr &tree) {
+        return const_cast<To &>(cast<To>(static_cast<const TreePtr &>(tree)));
     }
 
 private:
@@ -312,17 +312,15 @@ template <class To> inline bool TreePtr::isa(const TreePtr &what) {
     return isa_tree<To>(what);
 }
 
-template <class To> inline To const &TreePtr::cast_nonnull(const TreePtr &what) {
+template <class To> inline To const &TreePtr::cast(const TreePtr &what) {
     return cast_tree_nonnull<To>(what);
 }
 
 template <> inline bool TreePtr::isa<TreePtr>(const TreePtr &tree) {
     return true;
 }
-template <> inline const Expression &TreePtr::cast_nonnull<Expression>(const TreePtr &tree) {
-    return *tree.get();
-}
-template <> inline const TreePtr &TreePtr::cast_nonnull<TreePtr>(const TreePtr &tree) {
+
+template <> inline const TreePtr &TreePtr::cast<TreePtr>(const TreePtr &tree) {
     return tree;
 }
 

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -316,9 +316,6 @@ template <class To> inline To const &TreePtr::cast_nonnull(const TreePtr &what) 
     return cast_tree_nonnull<To>(what);
 }
 
-template <> inline bool TreePtr::isa<Expression>(const TreePtr &tree) {
-    return true;
-}
 template <> inline bool TreePtr::isa<TreePtr>(const TreePtr &tree) {
     return true;
 }

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -28,7 +28,7 @@ private:
     TreePtr substArg(core::MutableContext ctx, TreePtr argp) {
         TreePtr *arg = &argp;
         while (arg != nullptr) {
-            tagTypecase(
+            typecase(
                 *arg, [&](RestArg &rest) { arg = &rest.expr; }, [&](KeywordArg &kw) { arg = &kw.expr; },
                 [&](OptionalArg &opt) { arg = &opt.expr; }, [&](BlockArg &opt) { arg = &opt.expr; },
                 [&](ShadowArg &opt) { arg = &opt.expr; },

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -26,17 +26,17 @@ private:
     }
 
     TreePtr substArg(core::MutableContext ctx, TreePtr argp) {
-        Expression *arg = argp.get();
+        TreePtr *arg = &argp;
         while (arg != nullptr) {
-            typecase(
-                arg, [&](RestArg *rest) { arg = rest->expr.get(); }, [&](KeywordArg *kw) { arg = kw->expr.get(); },
-                [&](OptionalArg *opt) { arg = opt->expr.get(); }, [&](BlockArg *opt) { arg = opt->expr.get(); },
-                [&](ShadowArg *opt) { arg = opt->expr.get(); },
-                [&](Local *local) {
-                    local->localVariable._name = subst.substitute(local->localVariable._name);
+            tagTypecase(
+                *arg, [&](RestArg &rest) { arg = &rest.expr; }, [&](KeywordArg &kw) { arg = &kw.expr; },
+                [&](OptionalArg &opt) { arg = &opt.expr; }, [&](BlockArg &opt) { arg = &opt.expr; },
+                [&](ShadowArg &opt) { arg = &opt.expr; },
+                [&](Local &local) {
+                    local.localVariable._name = subst.substitute(local.localVariable._name);
                     arg = nullptr;
                 },
-                [&](UnresolvedIdent *nm) { Exception::raise("UnresolvedIdent remaining after local_vars"); });
+                [&](const UnresolvedIdent &nm) { Exception::raise("UnresolvedIdent remaining after local_vars"); });
         }
         return argp;
     }

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -93,20 +93,20 @@ Literal::Literal(const core::TypePtr &value) : value(move(value)) {
 
 string Literal::toString(const core::GlobalState &gs, const CFG &cfg) const {
     string res;
-    typecase(
-        this->value.get(), [&](core::LiteralType *l) { res = l->showValue(gs); },
-        [&](const core::ClassType *l) {
-            if (l->symbol == core::Symbols::NilClass()) {
+    tagTypecase(
+        this->value, [&](const core::LiteralType &l) { res = l.showValue(gs); },
+        [&](const core::ClassType &l) {
+            if (l.symbol == core::Symbols::NilClass()) {
                 res = "nil";
-            } else if (l->symbol == core::Symbols::FalseClass()) {
+            } else if (l.symbol == core::Symbols::FalseClass()) {
                 res = "false";
-            } else if (l->symbol == core::Symbols::TrueClass()) {
+            } else if (l.symbol == core::Symbols::TrueClass()) {
                 res = "true";
             } else {
                 res = fmt::format("literal({})", this->value->toStringWithTabs(gs, 0));
             }
         },
-        [&](const core::Type *t) { res = fmt::format("literal({})", this->value->toStringWithTabs(gs, 0)); });
+        [&](const core::TypePtr &t) { res = fmt::format("literal({})", this->value->toStringWithTabs(gs, 0)); });
     return res;
 }
 

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -93,7 +93,7 @@ Literal::Literal(const core::TypePtr &value) : value(move(value)) {
 
 string Literal::toString(const core::GlobalState &gs, const CFG &cfg) const {
     string res;
-    tagTypecase(
+    typecase(
         this->value, [&](const core::LiteralType &l) { res = l.showValue(gs); },
         [&](const core::ClassType &l) {
             if (l.symbol == core::Symbols::NilClass()) {

--- a/cfg/builder/builder.h
+++ b/cfg/builder/builder.h
@@ -10,7 +10,7 @@ public:
     static std::unique_ptr<CFG> buildFor(core::Context ctx, ast::MethodDef &md);
 
 private:
-    static BasicBlock *walk(CFGContext cctx, const ast::TreePtr &what, BasicBlock *current);
+    static BasicBlock *walk(CFGContext cctx, ast::TreePtr &what, BasicBlock *current);
     static void fillInTopoSorts(core::Context ctx, CFG &cfg);
     static void dealias(core::Context ctx, CFG &cfg);
     static void simplify(core::Context ctx, CFG &cfg);
@@ -26,7 +26,7 @@ private:
     static void unconditionalJump(BasicBlock *from, BasicBlock *to, CFG &inWhat, core::LocOffsets loc);
     static void jumpToDead(BasicBlock *from, CFG &inWhat, core::LocOffsets loc);
     static void synthesizeExpr(BasicBlock *bb, LocalRef var, core::LocOffsets loc, std::unique_ptr<Instruction> inst);
-    static BasicBlock *walkHash(CFGContext cctx, ast::Hash *h, BasicBlock *current, core::NameRef method);
+    static BasicBlock *walkHash(CFGContext cctx, ast::Hash &h, BasicBlock *current, core::NameRef method);
     static std::tuple<LocalRef, BasicBlock *, BasicBlock *>
     walkDefault(CFGContext cctx, int argIndex, const core::ArgInfo &argInfo, LocalRef argLocal, core::LocOffsets argLoc,
                 ast::TreePtr &def, BasicBlock *presentCont, BasicBlock *defaultCont);

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -190,7 +190,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::TreePtr &what, BasicBlock *cu
 
     try {
         BasicBlock *ret = nullptr;
-        tagTypecase(
+        typecase(
             what,
             [&](ast::While &a) {
                 auto headerBlock = cctx.inWhat.freshBlock(cctx.loops + 1, current->rubyBlockId);

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -53,10 +53,10 @@ LocalRef global2Local(CFGContext cctx, core::SymbolRef what) {
     return alias;
 }
 
-LocalRef unresolvedIdent2Local(CFGContext cctx, ast::UnresolvedIdent *id) {
+LocalRef unresolvedIdent2Local(CFGContext cctx, const ast::UnresolvedIdent &id) {
     core::SymbolRef klass;
 
-    switch (id->kind) {
+    switch (id.kind) {
         case ast::UnresolvedIdent::Kind::Class:
             klass = cctx.ctx.owner.data(cctx.ctx)->enclosingClass(cctx.ctx);
             while (klass.data(cctx.ctx)->attachedClass(cctx.ctx).exists()) {
@@ -76,17 +76,17 @@ LocalRef unresolvedIdent2Local(CFGContext cctx, ast::UnresolvedIdent *id) {
     }
     ENFORCE(klass.data(cctx.ctx)->isClassOrModule());
 
-    auto sym = klass.data(cctx.ctx)->findMemberTransitive(cctx.ctx, id->name);
+    auto sym = klass.data(cctx.ctx)->findMemberTransitive(cctx.ctx, id.name);
     if (!sym.exists()) {
-        auto fnd = cctx.discoveredUndeclaredFields.find(id->name);
+        auto fnd = cctx.discoveredUndeclaredFields.find(id.name);
         if (fnd == cctx.discoveredUndeclaredFields.end()) {
-            if (id->kind != ast::UnresolvedIdent::Kind::Global) {
-                if (auto e = cctx.ctx.beginError(id->loc, core::errors::CFG::UndeclaredVariable)) {
-                    e.setHeader("Use of undeclared variable `{}`", id->name.show(cctx.ctx));
+            if (id.kind != ast::UnresolvedIdent::Kind::Global) {
+                if (auto e = cctx.ctx.beginError(id.loc, core::errors::CFG::UndeclaredVariable)) {
+                    e.setHeader("Use of undeclared variable `{}`", id.name.show(cctx.ctx));
                 }
             }
-            auto ret = cctx.newTemporary(id->name);
-            cctx.discoveredUndeclaredFields[id->name] = ret;
+            auto ret = cctx.newTemporary(id.name);
+            cctx.discoveredUndeclaredFields[id.name] = ret;
             return ret;
         }
         return fnd->second;
@@ -116,25 +116,25 @@ void CFGBuilder::synthesizeExpr(BasicBlock *bb, LocalRef var, core::LocOffsets l
     inserted.value->isSynthetic = true;
 }
 
-BasicBlock *CFGBuilder::walkHash(CFGContext cctx, ast::Hash *h, BasicBlock *current, core::NameRef method) {
+BasicBlock *CFGBuilder::walkHash(CFGContext cctx, ast::Hash &h, BasicBlock *current, core::NameRef method) {
     InlinedVector<cfg::LocalRef, 2> vars;
     InlinedVector<core::LocOffsets, 2> locs;
-    for (int i = 0; i < h->keys.size(); i++) {
+    for (int i = 0; i < h.keys.size(); i++) {
         LocalRef keyTmp = cctx.newTemporary(core::Names::hashTemp());
         LocalRef valTmp = cctx.newTemporary(core::Names::hashTemp());
-        current = walk(cctx.withTarget(keyTmp), h->keys[i], current);
-        current = walk(cctx.withTarget(valTmp), h->values[i], current);
+        current = walk(cctx.withTarget(keyTmp), h.keys[i], current);
+        current = walk(cctx.withTarget(valTmp), h.values[i], current);
         vars.emplace_back(keyTmp);
         vars.emplace_back(valTmp);
-        locs.emplace_back(h->keys[i].loc());
-        locs.emplace_back(h->values[i].loc());
+        locs.emplace_back(h.keys[i].loc());
+        locs.emplace_back(h.values[i].loc());
     }
     LocalRef magic = cctx.newTemporary(core::Names::magic());
     synthesizeExpr(current, magic, core::LocOffsets::none(), make_unique<Alias>(core::Symbols::Magic()));
 
     auto isPrivateOk = false;
-    current->exprs.emplace_back(cctx.target, h->loc,
-                                make_unique<Send>(magic, method, h->loc, vars.size(), vars, locs, isPrivateOk));
+    current->exprs.emplace_back(cctx.target, h.loc,
+                                make_unique<Send>(magic, method, h.loc, vars.size(), vars, locs, isPrivateOk));
     return current;
 }
 
@@ -180,7 +180,7 @@ tuple<LocalRef, BasicBlock *, BasicBlock *> CFGBuilder::walkDefault(CFGContext c
 /** Convert `what` into a cfg, by starting to evaluate it in `current` inside method defined by `inWhat`.
  * store result of evaluation into `target`. Returns basic block in which evaluation should proceed.
  */
-BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlock *current) {
+BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::TreePtr &what, BasicBlock *current) {
     /** Try to pay additional attention not to duplicate any part of tree.
      * Though this may lead to more effictient and a better CFG if it was to be actually compiled into code
      * This will lead to duplicate typechecking and may lead to exponential explosion of typechecking time
@@ -190,32 +190,32 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlo
 
     try {
         BasicBlock *ret = nullptr;
-        typecase(
-            what.get(),
-            [&](ast::While *a) {
+        tagTypecase(
+            what,
+            [&](ast::While &a) {
                 auto headerBlock = cctx.inWhat.freshBlock(cctx.loops + 1, current->rubyBlockId);
                 // breakNotCalledBlock is only entered if break is not called in
                 // the loop body
                 auto breakNotCalledBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyBlockId);
                 auto continueBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyBlockId);
-                unconditionalJump(current, headerBlock, cctx.inWhat, a->loc);
+                unconditionalJump(current, headerBlock, cctx.inWhat, a.loc);
 
                 LocalRef condSym = cctx.newTemporary(core::Names::whileTemp());
                 auto headerEnd =
-                    walk(cctx.withTarget(condSym).withLoopScope(headerBlock, continueBlock), a->cond, headerBlock);
+                    walk(cctx.withTarget(condSym).withLoopScope(headerBlock, continueBlock), a.cond, headerBlock);
                 auto bodyBlock = cctx.inWhat.freshBlock(cctx.loops + 1, current->rubyBlockId);
-                conditionalJump(headerEnd, condSym, bodyBlock, breakNotCalledBlock, cctx.inWhat, a->cond.loc());
+                conditionalJump(headerEnd, condSym, bodyBlock, breakNotCalledBlock, cctx.inWhat, a.cond.loc());
                 // finishHeader
                 LocalRef bodySym = cctx.newTemporary(core::Names::statTemp());
 
                 auto body = walk(cctx.withTarget(bodySym)
                                      .withLoopScope(headerBlock, continueBlock)
                                      .withBlockBreakTarget(cctx.target),
-                                 a->body, bodyBlock);
-                unconditionalJump(body, headerBlock, cctx.inWhat, a->loc);
+                                 a.body, bodyBlock);
+                unconditionalJump(body, headerBlock, cctx.inWhat, a.loc);
 
-                synthesizeExpr(breakNotCalledBlock, cctx.target, a->loc, make_unique<Literal>(core::Types::nilClass()));
-                unconditionalJump(breakNotCalledBlock, continueBlock, cctx.inWhat, a->loc);
+                synthesizeExpr(breakNotCalledBlock, cctx.target, a.loc, make_unique<Literal>(core::Types::nilClass()));
+                unconditionalJump(breakNotCalledBlock, continueBlock, cctx.inWhat, a.loc);
                 ret = continueBlock;
 
                 /*
@@ -238,23 +238,23 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlo
                  *
                  */
             },
-            [&](ast::Return *a) {
+            [&](ast::Return &a) {
                 LocalRef retSym = cctx.newTemporary(core::Names::returnTemp());
-                auto cont = walk(cctx.withTarget(retSym), a->expr, current);
-                cont->exprs.emplace_back(cctx.target, a->loc, make_unique<Return>(retSym)); // dead assign.
-                jumpToDead(cont, cctx.inWhat, a->loc);
+                auto cont = walk(cctx.withTarget(retSym), a.expr, current);
+                cont->exprs.emplace_back(cctx.target, a.loc, make_unique<Return>(retSym)); // dead assign.
+                jumpToDead(cont, cctx.inWhat, a.loc);
                 ret = cctx.inWhat.deadBlock();
             },
-            [&](ast::If *a) {
+            [&](ast::If &a) {
                 LocalRef ifSym = cctx.newTemporary(core::Names::ifTemp());
                 ENFORCE(ifSym.exists(), "ifSym does not exist");
-                auto cont = walk(cctx.withTarget(ifSym), a->cond, current);
+                auto cont = walk(cctx.withTarget(ifSym), a.cond, current);
                 auto thenBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyBlockId);
                 auto elseBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyBlockId);
-                conditionalJump(cont, ifSym, thenBlock, elseBlock, cctx.inWhat, a->cond.loc());
+                conditionalJump(cont, ifSym, thenBlock, elseBlock, cctx.inWhat, a.cond.loc());
 
-                auto thenEnd = walk(cctx, a->thenp, thenBlock);
-                auto elseEnd = walk(cctx, a->elsep, elseBlock);
+                auto thenEnd = walk(cctx, a.thenp, thenBlock);
+                auto elseEnd = walk(cctx, a.elsep, elseBlock);
                 if (thenEnd != cctx.inWhat.deadBlock() || elseEnd != cctx.inWhat.deadBlock()) {
                     if (thenEnd == cctx.inWhat.deadBlock()) {
                         ret = elseEnd;
@@ -262,37 +262,39 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlo
                         ret = thenEnd;
                     } else {
                         ret = cctx.inWhat.freshBlock(cctx.loops, current->rubyBlockId);
-                        unconditionalJump(thenEnd, ret, cctx.inWhat, a->loc);
-                        unconditionalJump(elseEnd, ret, cctx.inWhat, a->loc);
+                        unconditionalJump(thenEnd, ret, cctx.inWhat, a.loc);
+                        unconditionalJump(elseEnd, ret, cctx.inWhat, a.loc);
                     }
                 } else {
                     ret = cctx.inWhat.deadBlock();
                 }
             },
-            [&](ast::Literal *a) {
-                current->exprs.emplace_back(cctx.target, a->loc, make_unique<Literal>(a->value));
+            [&](const ast::Literal &a) {
+                current->exprs.emplace_back(cctx.target, a.loc, make_unique<Literal>(a.value));
                 ret = current;
             },
-            [&](ast::UnresolvedIdent *id) {
+            [&](const ast::UnresolvedIdent &id) {
                 LocalRef loc = unresolvedIdent2Local(cctx, id);
                 ENFORCE(loc.exists());
-                current->exprs.emplace_back(cctx.target, id->loc, make_unique<Ident>(loc));
+                current->exprs.emplace_back(cctx.target, id.loc, make_unique<Ident>(loc));
 
                 ret = current;
             },
-            [&](ast::UnresolvedConstantLit *a) { Exception::raise("Should have been eliminated by namer/resolver"); },
-            [&](ast::ConstantLit *a) {
+            [&](const ast::UnresolvedConstantLit &a) {
+                Exception::raise("Should have been eliminated by namer/resolver");
+            },
+            [&](ast::ConstantLit &a) {
                 auto aliasName = cctx.newTemporary(core::Names::cfgAlias());
-                if (a->symbol == core::Symbols::StubModule()) {
-                    current->exprs.emplace_back(aliasName, a->loc, make_unique<Alias>(core::Symbols::untyped()));
+                if (a.symbol == core::Symbols::StubModule()) {
+                    current->exprs.emplace_back(aliasName, a.loc, make_unique<Alias>(core::Symbols::untyped()));
                 } else {
-                    current->exprs.emplace_back(aliasName, a->loc, make_unique<Alias>(a->symbol));
+                    current->exprs.emplace_back(aliasName, a.loc, make_unique<Alias>(a.symbol));
                 }
 
-                synthesizeExpr(current, cctx.target, a->loc, make_unique<Ident>(aliasName));
+                synthesizeExpr(current, cctx.target, a.loc, make_unique<Ident>(aliasName));
 
-                if (a->original) {
-                    auto *orig = ast::cast_tree<ast::UnresolvedConstantLit>(a->original);
+                if (a.original) {
+                    auto *orig = ast::cast_tree<ast::UnresolvedConstantLit>(a.original);
                     if (ast::isa_tree<ast::ConstantLit>(orig->scope)) {
                         LocalRef deadSym = cctx.newTemporary(core::Names::keepForIde());
                         current = walk(cctx.withTarget(deadSym), orig->scope, current);
@@ -301,64 +303,64 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlo
 
                 ret = current;
             },
-            [&](ast::Local *a) {
-                current->exprs.emplace_back(cctx.target, a->loc,
-                                            make_unique<Ident>(cctx.inWhat.enterLocal(a->localVariable)));
+            [&](const ast::Local &a) {
+                current->exprs.emplace_back(cctx.target, a.loc,
+                                            make_unique<Ident>(cctx.inWhat.enterLocal(a.localVariable)));
                 ret = current;
             },
-            [&](ast::Assign *a) {
+            [&](ast::Assign &a) {
                 LocalRef lhs;
-                if (auto lhsIdent = ast::cast_tree<ast::ConstantLit>(a->lhs)) {
+                if (auto lhsIdent = ast::cast_tree<ast::ConstantLit>(a.lhs)) {
                     lhs = global2Local(cctx, lhsIdent->symbol);
-                } else if (auto lhsLocal = ast::cast_tree<ast::Local>(a->lhs)) {
+                } else if (auto lhsLocal = ast::cast_tree<ast::Local>(a.lhs)) {
                     lhs = cctx.inWhat.enterLocal(lhsLocal->localVariable);
-                } else if (auto ident = ast::cast_tree<ast::UnresolvedIdent>(a->lhs)) {
-                    lhs = unresolvedIdent2Local(cctx, ident);
+                } else if (auto ident = ast::cast_tree<ast::UnresolvedIdent>(a.lhs)) {
+                    lhs = unresolvedIdent2Local(cctx, *ident);
                     ENFORCE(lhs.exists());
                 } else {
                     Exception::raise("should never be reached");
                 }
 
-                auto rhsCont = walk(cctx.withTarget(lhs), a->rhs, current);
-                rhsCont->exprs.emplace_back(cctx.target, a->loc, make_unique<Ident>(lhs));
+                auto rhsCont = walk(cctx.withTarget(lhs), a.rhs, current);
+                rhsCont->exprs.emplace_back(cctx.target, a.loc, make_unique<Ident>(lhs));
                 ret = rhsCont;
             },
-            [&](ast::InsSeq *a) {
-                for (auto &exp : a->stats) {
+            [&](ast::InsSeq &a) {
+                for (auto &exp : a.stats) {
                     LocalRef temp = cctx.newTemporary(core::Names::statTemp());
                     current = walk(cctx.withTarget(temp), exp, current);
                 }
-                ret = walk(cctx, a->expr, current);
+                ret = walk(cctx, a.expr, current);
             },
-            [&](ast::Send *s) {
+            [&](ast::Send &s) {
                 LocalRef recv;
 
-                if (s->fun == core::Names::absurd()) {
-                    if (auto cnst = ast::cast_tree<ast::ConstantLit>(s->recv)) {
+                if (s.fun == core::Names::absurd()) {
+                    if (auto cnst = ast::cast_tree<ast::ConstantLit>(s.recv)) {
                         if (cnst->symbol == core::Symbols::T()) {
-                            if (s->hasKwArgs()) {
-                                if (auto e = cctx.ctx.beginError(s->loc, core::errors::CFG::MalformedTAbsurd)) {
+                            if (s.hasKwArgs()) {
+                                if (auto e = cctx.ctx.beginError(s.loc, core::errors::CFG::MalformedTAbsurd)) {
                                     e.setHeader("`{}` does not accept keyword arguments", "T.absurd");
                                 }
                                 ret = current;
                                 return;
                             }
 
-                            if (s->numPosArgs != 1) {
-                                if (auto e = cctx.ctx.beginError(s->loc, core::errors::CFG::MalformedTAbsurd)) {
+                            if (s.numPosArgs != 1) {
+                                if (auto e = cctx.ctx.beginError(s.loc, core::errors::CFG::MalformedTAbsurd)) {
                                     e.setHeader("`{}` expects exactly one argument but got `{}`", "T.absurd",
-                                                s->numPosArgs);
+                                                s.numPosArgs);
                                 }
                                 ret = current;
                                 return;
                             }
 
-                            if (!ast::isa_tree<ast::Local>(s->args[0]) &&
-                                !ast::isa_tree<ast::UnresolvedIdent>(s->args[0])) {
-                                if (auto e = cctx.ctx.beginError(s->loc, core::errors::CFG::MalformedTAbsurd)) {
+                            if (!ast::isa_tree<ast::Local>(s.args[0]) &&
+                                !ast::isa_tree<ast::UnresolvedIdent>(s.args[0])) {
+                                if (auto e = cctx.ctx.beginError(s.loc, core::errors::CFG::MalformedTAbsurd)) {
                                     // Providing a send is the most common way T.absurd is misused, so we provide a
                                     // little extra hint in the error message in that case.
-                                    if (ast::isa_tree<ast::Send>(s->args[0])) {
+                                    if (ast::isa_tree<ast::Send>(s.args[0])) {
                                         e.setHeader("`{}` expects to be called on a variable, not a method call",
                                                     "T.absurd");
                                     } else {
@@ -370,8 +372,8 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlo
                             }
 
                             auto temp = cctx.newTemporary(core::Names::statTemp());
-                            current = walk(cctx.withTarget(temp), s->args[0], current);
-                            current->exprs.emplace_back(cctx.target, s->loc, make_unique<TAbsurd>(temp));
+                            current = walk(cctx.withTarget(temp), s.args[0], current);
+                            current->exprs.emplace_back(cctx.target, s.loc, make_unique<TAbsurd>(temp));
                             ret = current;
                             return;
                         }
@@ -379,14 +381,14 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlo
                 }
 
                 recv = cctx.newTemporary(core::Names::statTemp());
-                current = walk(cctx.withTarget(recv), s->recv, current);
+                current = walk(cctx.withTarget(recv), s.recv, current);
 
                 InlinedVector<LocalRef, 2> args;
                 InlinedVector<core::LocOffsets, 2> argLocs;
-                auto [posEnd, kwEnd] = s->kwArgsRange();
+                auto [posEnd, kwEnd] = s.kwArgsRange();
                 int argIdx = 0;
                 for (; argIdx < posEnd; ++argIdx) {
-                    auto &exp = s->args[argIdx];
+                    auto &exp = s.args[argIdx];
                     LocalRef temp = cctx.newTemporary(core::Names::statTemp());
                     current = walk(cctx.withTarget(temp), exp, current);
                     args.emplace_back(temp);
@@ -394,8 +396,8 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlo
                 }
 
                 for (; argIdx < kwEnd; argIdx += 2) {
-                    auto &key = s->args[argIdx];
-                    auto &val = s->args[argIdx + 1];
+                    auto &key = s.args[argIdx];
+                    auto &val = s.args[argIdx + 1];
                     LocalRef keyTmp = cctx.newTemporary(core::Names::hashTemp());
                     LocalRef valTmp = cctx.newTemporary(core::Names::hashTemp());
                     current = walk(cctx.withTarget(keyTmp), key, current);
@@ -406,18 +408,18 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlo
                     argLocs.emplace_back(val.loc());
                 }
 
-                if (s->hasKwSplat()) {
-                    auto &exp = s->args.back();
+                if (s.hasKwSplat()) {
+                    auto &exp = s.args.back();
                     LocalRef temp = cctx.newTemporary(core::Names::statTemp());
                     current = walk(cctx.withTarget(temp), exp, current);
                     args.emplace_back(temp);
                     argLocs.emplace_back(exp.loc());
                 }
 
-                if (s->block != nullptr) {
+                if (s.block != nullptr) {
                     auto newRubyBlockId = ++cctx.inWhat.maxRubyBlockId;
                     vector<ast::ParsedArg> blockArgs =
-                        ast::ArgParsing::parseArgs(ast::cast_tree<ast::Block>(s->block)->args);
+                        ast::ArgParsing::parseArgs(ast::cast_tree<ast::Block>(s.block)->args);
                     vector<core::ArgInfo::ArgFlags> argFlags;
                     for (auto &e : blockArgs) {
                         auto &target = argFlags.emplace_back();
@@ -426,12 +428,12 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlo
                         target.isDefault = e.flags.isDefault;
                         target.isShadow = e.flags.isShadow;
                     }
-                    auto link = make_shared<core::SendAndBlockLink>(s->fun, move(argFlags), newRubyBlockId);
-                    auto send = make_unique<Send>(recv, s->fun, s->recv.loc(), s->numPosArgs, args, argLocs,
-                                                  !!s->flags.isPrivateOk, link);
+                    auto link = make_shared<core::SendAndBlockLink>(s.fun, move(argFlags), newRubyBlockId);
+                    auto send = make_unique<Send>(recv, s.fun, s.recv.loc(), s.numPosArgs, args, argLocs,
+                                                  !!s.flags.isPrivateOk, link);
                     LocalRef sendTemp = cctx.newTemporary(core::Names::blockPreCallTemp());
                     auto solveConstraint = make_unique<SolveConstraint>(link, sendTemp);
-                    current->exprs.emplace_back(sendTemp, s->loc, move(send));
+                    current->exprs.emplace_back(sendTemp, s.loc, move(send));
                     LocalRef restoreSelf = cctx.newTemporary(core::Names::selfRestore());
                     synthesizeExpr(current, restoreSelf, core::LocOffsets::none(),
                                    make_unique<Ident>(LocalRef::selfVariable()));
@@ -445,9 +447,9 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlo
 
                     LocalRef argTemp = cctx.newTemporary(core::Names::blkArg());
                     LocalRef idxTmp = cctx.newTemporary(core::Names::blkArg());
-                    bodyBlock->exprs.emplace_back(LocalRef::selfVariable(), s->loc,
+                    bodyBlock->exprs.emplace_back(LocalRef::selfVariable(), s.loc,
                                                   make_unique<LoadSelf>(link, LocalRef::selfVariable()));
-                    bodyBlock->exprs.emplace_back(argTemp, s->block.loc(), make_unique<LoadYieldParams>(link));
+                    bodyBlock->exprs.emplace_back(argTemp, s.block.loc(), make_unique<LoadYieldParams>(link));
 
                     for (int i = 0; i < blockArgs.size(); ++i) {
                         auto &arg = blockArgs[i];
@@ -476,32 +478,32 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlo
                         auto isPrivateOk = false;
                         bodyBlock->exprs.emplace_back(argLoc, arg.loc,
                                                       make_unique<Send>(argTemp, core::Names::squareBrackets(),
-                                                                        s->block.loc(), idxVec.size(), idxVec, locs,
+                                                                        s.block.loc(), idxVec.size(), idxVec, locs,
                                                                         isPrivateOk));
                     }
 
                     conditionalJump(headerBlock, LocalRef::blockCall(), bodyBlock, solveConstraintBlock, cctx.inWhat,
-                                    s->loc);
+                                    s.loc);
 
-                    unconditionalJump(current, headerBlock, cctx.inWhat, s->loc);
+                    unconditionalJump(current, headerBlock, cctx.inWhat, s.loc);
 
                     LocalRef blockrv = cctx.newTemporary(core::Names::blockReturnTemp());
                     auto blockLast = walk(cctx.withTarget(blockrv)
                                               .withBlockBreakTarget(cctx.target)
                                               .withLoopScope(headerBlock, postBlock, true)
                                               .withSendAndBlockLink(link),
-                                          ast::cast_tree<ast::Block>(s->block)->body, bodyBlock);
+                                          ast::cast_tree<ast::Block>(s.block)->body, bodyBlock);
                     if (blockLast != cctx.inWhat.deadBlock()) {
                         LocalRef dead = cctx.newTemporary(core::Names::blockReturnTemp());
-                        synthesizeExpr(blockLast, dead, s->block.loc(), make_unique<BlockReturn>(link, blockrv));
+                        synthesizeExpr(blockLast, dead, s.block.loc(), make_unique<BlockReturn>(link, blockrv));
                     }
 
-                    unconditionalJump(blockLast, headerBlock, cctx.inWhat, s->loc);
-                    unconditionalJump(solveConstraintBlock, postBlock, cctx.inWhat, s->loc);
+                    unconditionalJump(blockLast, headerBlock, cctx.inWhat, s.loc);
+                    unconditionalJump(solveConstraintBlock, postBlock, cctx.inWhat, s.loc);
 
-                    solveConstraintBlock->exprs.emplace_back(cctx.target, s->loc, move(solveConstraint));
+                    solveConstraintBlock->exprs.emplace_back(cctx.target, s.loc, move(solveConstraint));
                     current = postBlock;
-                    synthesizeExpr(current, LocalRef::selfVariable(), s->loc, make_unique<Ident>(restoreSelf));
+                    synthesizeExpr(current, LocalRef::selfVariable(), s.loc, make_unique<Ident>(restoreSelf));
 
                     /*
                      * This code:
@@ -523,41 +525,41 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlo
                      *
                      */
                 } else {
-                    current->exprs.emplace_back(cctx.target, s->loc,
-                                                make_unique<Send>(recv, s->fun, s->recv.loc(), s->numPosArgs, args,
-                                                                  argLocs, !!s->flags.isPrivateOk));
+                    current->exprs.emplace_back(cctx.target, s.loc,
+                                                make_unique<Send>(recv, s.fun, s.recv.loc(), s.numPosArgs, args,
+                                                                  argLocs, !!s.flags.isPrivateOk));
                 }
 
                 ret = current;
             },
 
-            [&](ast::Block *a) { Exception::raise("should never encounter a bare Block"); },
+            [&](const ast::Block &a) { Exception::raise("should never encounter a bare Block"); },
 
-            [&](ast::Next *a) {
+            [&](ast::Next &a) {
                 LocalRef exprSym = cctx.newTemporary(core::Names::nextTemp());
-                auto afterNext = walk(cctx.withTarget(exprSym), a->expr, current);
+                auto afterNext = walk(cctx.withTarget(exprSym), a.expr, current);
                 if (afterNext != cctx.inWhat.deadBlock() && cctx.isInsideRubyBlock) {
                     LocalRef dead = cctx.newTemporary(core::Names::nextTemp());
                     ENFORCE(cctx.link.get() != nullptr);
-                    afterNext->exprs.emplace_back(dead, a->loc, make_unique<BlockReturn>(cctx.link, exprSym));
+                    afterNext->exprs.emplace_back(dead, a.loc, make_unique<BlockReturn>(cctx.link, exprSym));
                 }
 
                 if (cctx.nextScope == nullptr) {
-                    if (auto e = cctx.ctx.beginError(a->loc, core::errors::CFG::NoNextScope)) {
+                    if (auto e = cctx.ctx.beginError(a.loc, core::errors::CFG::NoNextScope)) {
                         e.setHeader("No `{}` block around `{}`", "do", "next");
                     }
                     // I guess just keep going into deadcode?
-                    unconditionalJump(afterNext, cctx.inWhat.deadBlock(), cctx.inWhat, a->loc);
+                    unconditionalJump(afterNext, cctx.inWhat.deadBlock(), cctx.inWhat, a.loc);
                 } else {
-                    unconditionalJump(afterNext, cctx.nextScope, cctx.inWhat, a->loc);
+                    unconditionalJump(afterNext, cctx.nextScope, cctx.inWhat, a.loc);
                 }
 
                 ret = cctx.inWhat.deadBlock();
             },
 
-            [&](ast::Break *a) {
+            [&](ast::Break &a) {
                 LocalRef exprSym = cctx.newTemporary(core::Names::returnTemp());
-                auto afterBreak = walk(cctx.withTarget(exprSym), a->expr, current);
+                auto afterBreak = walk(cctx.withTarget(exprSym), a.expr, current);
 
                 // Here, since cctx.blockBreakTarget refers to something outside of the block,
                 // it will show up on the pinned variables list (with type of NilClass).
@@ -572,13 +574,13 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlo
 
                 // This is a temporary hack until we change how pining works to handle this case.
                 auto blockBreakAssign = cctx.newTemporary(core::Names::blockBreakAssign());
-                afterBreak->exprs.emplace_back(blockBreakAssign, a->loc, make_unique<Ident>(exprSym));
-                afterBreak->exprs.emplace_back(cctx.blockBreakTarget, a->loc, make_unique<Ident>(blockBreakAssign));
+                afterBreak->exprs.emplace_back(blockBreakAssign, a.loc, make_unique<Ident>(exprSym));
+                afterBreak->exprs.emplace_back(cctx.blockBreakTarget, a.loc, make_unique<Ident>(blockBreakAssign));
 
                 // call intrinsic for break
                 auto magic = cctx.newTemporary(core::Names::magic());
                 auto ignored = cctx.newTemporary(core::Names::blockBreak());
-                synthesizeExpr(afterBreak, magic, a->loc, make_unique<Alias>(core::Symbols::Magic()));
+                synthesizeExpr(afterBreak, magic, a.loc, make_unique<Alias>(core::Symbols::Magic()));
                 InlinedVector<LocalRef, 2> args{exprSym};
                 InlinedVector<core::LocOffsets, 2> locs{core::LocOffsets::none()};
                 auto isPrivateOk = false;
@@ -588,24 +590,24 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlo
                                                  args.size(), args, locs, isPrivateOk));
 
                 if (cctx.breakScope == nullptr) {
-                    if (auto e = cctx.ctx.beginError(a->loc, core::errors::CFG::NoNextScope)) {
+                    if (auto e = cctx.ctx.beginError(a.loc, core::errors::CFG::NoNextScope)) {
                         e.setHeader("No `{}` block around `{}`", "do", "break");
                     }
                     // I guess just keep going into deadcode?
-                    unconditionalJump(afterBreak, cctx.inWhat.deadBlock(), cctx.inWhat, a->loc);
+                    unconditionalJump(afterBreak, cctx.inWhat.deadBlock(), cctx.inWhat, a.loc);
                 } else {
-                    unconditionalJump(afterBreak, cctx.breakScope, cctx.inWhat, a->loc);
+                    unconditionalJump(afterBreak, cctx.breakScope, cctx.inWhat, a.loc);
                 }
                 ret = cctx.inWhat.deadBlock();
             },
 
-            [&](ast::Retry *a) {
+            [&](const ast::Retry &a) {
                 if (cctx.rescueScope == nullptr) {
-                    if (auto e = cctx.ctx.beginError(a->loc, core::errors::CFG::NoNextScope)) {
+                    if (auto e = cctx.ctx.beginError(a.loc, core::errors::CFG::NoNextScope)) {
                         e.setHeader("No `{}` block around `{}`", "begin", "retry");
                     }
                     // I guess just keep going into deadcode?
-                    unconditionalJump(current, cctx.inWhat.deadBlock(), cctx.inWhat, a->loc);
+                    unconditionalJump(current, cctx.inWhat.deadBlock(), cctx.inWhat, a.loc);
                 } else {
                     auto magic = cctx.newTemporary(core::Names::magic());
                     synthesizeExpr(current, magic, core::LocOffsets::none(),
@@ -617,12 +619,12 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlo
                     synthesizeExpr(current, retryTemp, core::LocOffsets::none(),
                                    make_unique<Send>(magic, core::Names::retry(), what.loc(), args.size(), args,
                                                      argLocs, isPrivateOk));
-                    unconditionalJump(current, cctx.rescueScope, cctx.inWhat, a->loc);
+                    unconditionalJump(current, cctx.rescueScope, cctx.inWhat, a.loc);
                 }
                 ret = cctx.inWhat.deadBlock();
             },
 
-            [&](ast::Rescue *a) {
+            [&](ast::Rescue &a) {
                 auto bodyRubyBlockId = ++cctx.inWhat.maxRubyBlockId;
                 auto handlersRubyBlockId = bodyRubyBlockId + CFG::HANDLERS_BLOCK_OFFSET;
                 auto ensureRubyBlockId = bodyRubyBlockId + CFG::ENSURE_BLOCK_OFFSET;
@@ -630,7 +632,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlo
                 cctx.inWhat.maxRubyBlockId = elseRubyBlockId;
 
                 auto rescueHeaderBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyBlockId);
-                unconditionalJump(current, rescueHeaderBlock, cctx.inWhat, a->loc);
+                unconditionalJump(current, rescueHeaderBlock, cctx.inWhat, a.loc);
                 cctx.rescueScope = rescueHeaderBlock;
 
                 // We have a simplified view of the control flow here but in
@@ -645,24 +647,24 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlo
                 auto bodyBlock = cctx.inWhat.freshBlock(cctx.loops, bodyRubyBlockId);
                 auto exceptionValue = cctx.newTemporary(core::Names::exceptionValue());
                 synthesizeExpr(rescueHeaderBlock, exceptionValue, what.loc(), make_unique<GetCurrentException>());
-                conditionalJump(rescueHeaderBlock, exceptionValue, rescueHandlersBlock, bodyBlock, cctx.inWhat, a->loc);
+                conditionalJump(rescueHeaderBlock, exceptionValue, rescueHandlersBlock, bodyBlock, cctx.inWhat, a.loc);
 
                 // cctx.loops += 1; // should formally be here but this makes us report a lot of false errors
-                bodyBlock = walk(cctx, a->body, bodyBlock);
+                bodyBlock = walk(cctx, a.body, bodyBlock);
 
                 // else is only executed if body didn't raise an exception
                 auto elseBody = cctx.inWhat.freshBlock(cctx.loops, elseRubyBlockId);
                 synthesizeExpr(bodyBlock, exceptionValue, what.loc(), make_unique<GetCurrentException>());
-                conditionalJump(bodyBlock, exceptionValue, rescueHandlersBlock, elseBody, cctx.inWhat, a->loc);
+                conditionalJump(bodyBlock, exceptionValue, rescueHandlersBlock, elseBody, cctx.inWhat, a.loc);
 
-                elseBody = walk(cctx, a->else_, elseBody);
+                elseBody = walk(cctx, a.else_, elseBody);
                 auto ensureBody = cctx.inWhat.freshBlock(cctx.loops, ensureRubyBlockId);
-                unconditionalJump(elseBody, ensureBody, cctx.inWhat, a->loc);
+                unconditionalJump(elseBody, ensureBody, cctx.inWhat, a.loc);
 
                 auto magic = cctx.newTemporary(core::Names::magic());
                 synthesizeExpr(current, magic, core::LocOffsets::none(), make_unique<Alias>(core::Symbols::Magic()));
 
-                for (auto &expr : a->rescueCases) {
+                for (auto &expr : a.rescueCases) {
                     auto *rescueCase = ast::cast_tree<ast::RescueCase>(expr);
                     auto caseBody = cctx.inWhat.freshBlock(cctx.loops, handlersRubyBlockId);
                     auto &exceptions = rescueCase->exceptions;
@@ -717,64 +719,64 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlo
                     }
 
                     caseBody = walk(cctx, rescueCase->body, caseBody);
-                    unconditionalJump(caseBody, ensureBody, cctx.inWhat, a->loc);
+                    unconditionalJump(caseBody, ensureBody, cctx.inWhat, a.loc);
                 }
 
                 // This magic local remembers if none of the `rescue`s match,
                 // and if so, after the ensure runs, we should jump to dead
                 // since in Ruby the exception would propagate up the statck.
                 auto gotoDeadTemp = cctx.newTemporary(core::Names::gotoDeadTemp());
-                synthesizeExpr(rescueHandlersBlock, gotoDeadTemp, a->loc,
+                synthesizeExpr(rescueHandlersBlock, gotoDeadTemp, a.loc,
                                make_unique<Literal>(core::Types::trueClass()));
-                unconditionalJump(rescueHandlersBlock, ensureBody, cctx.inWhat, a->loc);
+                unconditionalJump(rescueHandlersBlock, ensureBody, cctx.inWhat, a.loc);
 
                 auto throwAway = cctx.newTemporary(core::Names::throwAwayTemp());
-                ensureBody = walk(cctx.withTarget(throwAway), a->ensure, ensureBody);
+                ensureBody = walk(cctx.withTarget(throwAway), a.ensure, ensureBody);
                 ret = cctx.inWhat.freshBlock(cctx.loops, current->rubyBlockId);
-                conditionalJump(ensureBody, gotoDeadTemp, cctx.inWhat.deadBlock(), ret, cctx.inWhat, a->loc);
+                conditionalJump(ensureBody, gotoDeadTemp, cctx.inWhat.deadBlock(), ret, cctx.inWhat, a.loc);
             },
 
-            [&](ast::Hash *h) { ret = walkHash(cctx, h, current, core::Names::buildHash()); },
+            [&](ast::Hash &h) { ret = walkHash(cctx, h, current, core::Names::buildHash()); },
 
-            [&](ast::Array *a) {
+            [&](ast::Array &a) {
                 InlinedVector<LocalRef, 2> vars;
                 InlinedVector<core::LocOffsets, 2> locs;
-                for (auto &elem : a->elems) {
+                for (auto &elem : a.elems) {
                     LocalRef tmp = cctx.newTemporary(core::Names::arrayTemp());
                     current = walk(cctx.withTarget(tmp), elem, current);
                     vars.emplace_back(tmp);
-                    locs.emplace_back(a->loc);
+                    locs.emplace_back(a.loc);
                 }
                 LocalRef magic = cctx.newTemporary(core::Names::magic());
                 synthesizeExpr(current, magic, core::LocOffsets::none(), make_unique<Alias>(core::Symbols::Magic()));
                 auto isPrivateOk = false;
                 current->exprs.emplace_back(
-                    cctx.target, a->loc,
-                    make_unique<Send>(magic, core::Names::buildArray(), a->loc, vars.size(), vars, locs, isPrivateOk));
+                    cctx.target, a.loc,
+                    make_unique<Send>(magic, core::Names::buildArray(), a.loc, vars.size(), vars, locs, isPrivateOk));
                 ret = current;
             },
 
-            [&](ast::Cast *c) {
+            [&](ast::Cast &c) {
                 LocalRef tmp = cctx.newTemporary(core::Names::castTemp());
-                current = walk(cctx.withTarget(tmp), c->arg, current);
-                if (c->cast == core::Names::uncheckedLet()) {
-                    current->exprs.emplace_back(cctx.target, c->loc, make_unique<Ident>(tmp));
+                current = walk(cctx.withTarget(tmp), c.arg, current);
+                if (c.cast == core::Names::uncheckedLet()) {
+                    current->exprs.emplace_back(cctx.target, c.loc, make_unique<Ident>(tmp));
                 } else {
-                    current->exprs.emplace_back(cctx.target, c->loc, make_unique<Cast>(tmp, c->type, c->cast));
+                    current->exprs.emplace_back(cctx.target, c.loc, make_unique<Cast>(tmp, c.type, c.cast));
                 }
-                if (c->cast == core::Names::let()) {
+                if (c.cast == core::Names::let()) {
                     cctx.inWhat.minLoops[cctx.target.id()] = CFG::MIN_LOOP_LET;
                 }
 
                 ret = current;
             },
 
-            [&](ast::EmptyTree *n) { ret = current; },
+            [&](const ast::EmptyTree &n) { ret = current; },
 
-            [&](ast::ClassDef *c) { Exception::raise("Should have been removed by FlattenWalk"); },
-            [&](ast::MethodDef *c) { Exception::raise("Should have been removed by FlattenWalk"); },
+            [&](const ast::ClassDef &c) { Exception::raise("Should have been removed by FlattenWalk"); },
+            [&](const ast::MethodDef &c) { Exception::raise("Should have been removed by FlattenWalk"); },
 
-            [&](ast::Expression *n) { Exception::raise("Unimplemented AST Node: {}", what.nodeName()); });
+            [&](const ast::Expression &n) { Exception::raise("Unimplemented AST Node: {}", what.nodeName()); });
 
         // For, Rescue,
         // Symbol, Array,

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -776,7 +776,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::TreePtr &what, BasicBlock *cu
             [&](const ast::ClassDef &c) { Exception::raise("Should have been removed by FlattenWalk"); },
             [&](const ast::MethodDef &c) { Exception::raise("Should have been removed by FlattenWalk"); },
 
-            [&](const ast::Expression &n) { Exception::raise("Unimplemented AST Node: {}", what.nodeName()); });
+            [&](const ast::TreePtr &n) { Exception::raise("Unimplemented AST Node: {}", what.nodeName()); });
 
         // For, Rescue,
         // Symbol, Array,

--- a/common/typecase.h
+++ b/common/typecase.h
@@ -83,7 +83,7 @@ template <typename Base, typename FUNC> bool typecaseHelper(Base &base, FUNC &&f
     // We specialize (const and non-const) references
     using ArgType = typename std::remove_const<typename std::remove_reference<typename traits::arg_type>::type>::type;
     if (Base::template isa<ArgType>(base)) {
-        func(Base::template cast_nonnull<ArgType>(base));
+        func(Base::template cast<ArgType>(base));
         return true;
     } else {
         return false;

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -35,10 +35,10 @@ public:
     // Required for typecase.
     template <class To> static bool isa(const TypePtr &what);
 
-    template <class To> static To const &cast_nonnull(const TypePtr &what);
+    template <class To> static To const &cast(const TypePtr &what);
 
-    template <class To> static To &cast_nonnull(TypePtr &what) {
-        return const_cast<To &>(cast_nonnull<To>(static_cast<const TypePtr &>(what)));
+    template <class To> static To &cast(TypePtr &what) {
+        return const_cast<To &>(cast<To>(static_cast<const TypePtr &>(what)));
     }
 
 private:

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -34,14 +34,8 @@ public:
 
     // Required for typecase.
     template <class To> static bool isa(const TypePtr &what);
-    template <> inline bool isa<TypePtr>(const TypePtr &what) {
-        return true;
-    }
 
     template <class To> static To const &cast_nonnull(const TypePtr &what);
-    template <> inline TypePtr const &cast_nonnull<TypePtr>(const TypePtr &what) {
-        return what;
-    }
 
     template <class To> static To &cast_nonnull(TypePtr &what) {
         return const_cast<To &>(cast_nonnull<To>(static_cast<const TypePtr &>(what)));

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -32,7 +32,7 @@ public:
     // A mapping from type to its corresponding tag.
     template <typename T> struct TypeToTag;
 
-    // Required for tagTypecase.
+    // Required for typecase.
     template <class To> static bool isa(const TypePtr &what);
     template <> inline bool isa<TypePtr>(const TypePtr &what) {
         return true;

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -32,6 +32,21 @@ public:
     // A mapping from type to its corresponding tag.
     template <typename T> struct TypeToTag;
 
+    // Required for tagTypecase.
+    template <class To> static bool isa(const TypePtr &what);
+    template <> inline bool isa<TypePtr>(const TypePtr &what) {
+        return true;
+    }
+
+    template <class To> static To const &cast_nonnull(const TypePtr &what);
+    template <> inline TypePtr const &cast_nonnull<TypePtr>(const TypePtr &what) {
+        return what;
+    }
+
+    template <class To> static To &cast_nonnull(TypePtr &what) {
+        return const_cast<To &>(cast_nonnull<To>(static_cast<const TypePtr &>(what)));
+    }
+
 private:
     std::atomic<u4> *counter;
     tagged_storage store;

--- a/core/Types.h
+++ b/core/Types.h
@@ -300,7 +300,7 @@ template <class To> To const &cast_type_nonnull(const TypePtr &what) {
     return *reinterpret_cast<const To *>(what.get());
 }
 
-// Simple forwarders defined on TypePtr which make `tagTypecase` work.
+// Simple forwarders defined on TypePtr which make `typecase` work.
 template <class To> inline bool TypePtr::isa(const TypePtr &what) {
     return isa_type<To>(what);
 }

--- a/core/Types.h
+++ b/core/Types.h
@@ -301,6 +301,15 @@ template <class To> To const &cast_type_nonnull(const TypePtr &what) {
     return *reinterpret_cast<const To *>(what.get());
 }
 
+// Simple forwarders defined on TypePtr which make `tagTypecase` work.
+template <class To> inline bool TypePtr::isa(const TypePtr &what) {
+    return isa_type<To>(what);
+}
+
+template <class To> inline To const &TypePtr::cast_nonnull(const TypePtr &what) {
+    return cast_type_nonnull<To>(what);
+}
+
 #define TYPE(name)                                                                                             \
     class name;                                                                                                \
     template <> struct TypePtr::TypeToTag<name> { static constexpr TypePtr::Tag value = TypePtr::Tag::name; }; \

--- a/core/Types.h
+++ b/core/Types.h
@@ -305,7 +305,7 @@ template <class To> inline bool TypePtr::isa(const TypePtr &what) {
     return isa_type<To>(what);
 }
 
-template <class To> inline To const &TypePtr::cast_nonnull(const TypePtr &what) {
+template <class To> inline To const &TypePtr::cast(const TypePtr &what) {
     return cast_type_nonnull<To>(what);
 }
 
@@ -313,7 +313,7 @@ template <> inline bool TypePtr::isa<TypePtr>(const TypePtr &what) {
     return true;
 }
 
-template <> inline TypePtr const &TypePtr::cast_nonnull<TypePtr>(const TypePtr &what) {
+template <> inline TypePtr const &TypePtr::cast<TypePtr>(const TypePtr &what) {
     return what;
 }
 

--- a/core/Types.h
+++ b/core/Types.h
@@ -309,6 +309,14 @@ template <class To> inline To const &TypePtr::cast_nonnull(const TypePtr &what) 
     return cast_type_nonnull<To>(what);
 }
 
+template <> inline bool TypePtr::isa<TypePtr>(const TypePtr &what) {
+    return true;
+}
+
+template <> inline TypePtr const &TypePtr::cast_nonnull<TypePtr>(const TypePtr &what) {
+    return what;
+}
+
 #define TYPE(name)                                                                                             \
     class name;                                                                                                \
     template <> struct TypePtr::TypeToTag<name> { static constexpr TypePtr::Tag value = TypePtr::Tag::name; }; \

--- a/core/Types.h
+++ b/core/Types.h
@@ -227,36 +227,31 @@ public:
 };
 CheckSize(Type, 8, 8);
 
-template <class To> To const *cast_type(const TypePtr &what) {
-    if (what != nullptr && what.tag() == TypePtr::TypeToTag<To>::value) {
-        return reinterpret_cast<To const *>(what.get());
-    } else {
-        return nullptr;
-    }
+template <class To> bool isa_type(const TypePtr &what) {
+    return what != nullptr && what.tag() == TypePtr::TypeToTag<To>::value;
 }
 
 // Specializations to handle the class hierarchy.
-
 class ClassType;
-template <> inline const ClassType *cast_type<ClassType>(const TypePtr &what) {
+template <> inline bool isa_type<ClassType>(const TypePtr &what) {
     if (what == nullptr) {
-        return nullptr;
+        return false;
     }
     switch (what.tag()) {
         case TypePtr::Tag::ClassType:
         case TypePtr::Tag::BlamedUntyped:
         case TypePtr::Tag::UnresolvedClassType:
         case TypePtr::Tag::UnresolvedAppliedType:
-            return reinterpret_cast<const ClassType *>(what.get());
+            return true;
         default:
-            return nullptr;
+            return false;
     }
 }
 
 class GroundType;
-template <> inline const GroundType *cast_type<GroundType>(const TypePtr &what) {
+template <> inline bool isa_type<GroundType>(const TypePtr &what) {
     if (what == nullptr) {
-        return nullptr;
+        return false;
     }
     switch (what.tag()) {
         case TypePtr::Tag::ClassType:
@@ -265,30 +260,34 @@ template <> inline const GroundType *cast_type<GroundType>(const TypePtr &what) 
         case TypePtr::Tag::UnresolvedAppliedType:
         case TypePtr::Tag::OrType:
         case TypePtr::Tag::AndType:
-            return reinterpret_cast<const GroundType *>(what.get());
+            return true;
         default:
-            return nullptr;
+            return false;
     }
 }
 
 class ProxyType;
-template <> inline const ProxyType *cast_type<ProxyType>(const TypePtr &what) {
+template <> inline bool isa_type<ProxyType>(const TypePtr &what) {
     if (what == nullptr) {
-        return nullptr;
+        return false;
     }
     switch (what.tag()) {
         case TypePtr::Tag::LiteralType:
         case TypePtr::Tag::ShapeType:
         case TypePtr::Tag::TupleType:
         case TypePtr::Tag::MetaType:
-            return reinterpret_cast<const ProxyType *>(what.get());
+            return true;
         default:
-            return nullptr;
+            return false;
     }
 }
 
-template <class To> bool isa_type(const TypePtr &what) {
-    return cast_type<To>(what) != nullptr;
+template <class To> To const *cast_type(const TypePtr &what) {
+    if (isa_type<To>(what)) {
+        return reinterpret_cast<To const *>(what.get());
+    } else {
+        return nullptr;
+    }
 }
 
 template <class To> To *cast_type(TypePtr &what) {

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -166,7 +166,7 @@ com::stripe::rubytyper::Type::Literal Proto::toProto(const GlobalState &gs, cons
 
 com::stripe::rubytyper::Type Proto::toProto(const GlobalState &gs, const TypePtr &typ) {
     com::stripe::rubytyper::Type proto;
-    tagTypecase(
+    typecase(
         typ,
         [&](const ClassType &t) {
             proto.set_kind(com::stripe::rubytyper::Type::CLASS);

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -166,50 +166,50 @@ com::stripe::rubytyper::Type::Literal Proto::toProto(const GlobalState &gs, cons
 
 com::stripe::rubytyper::Type Proto::toProto(const GlobalState &gs, const TypePtr &typ) {
     com::stripe::rubytyper::Type proto;
-    typecase(
-        typ.get(),
-        [&](const ClassType *t) {
+    tagTypecase(
+        typ,
+        [&](const ClassType &t) {
             proto.set_kind(com::stripe::rubytyper::Type::CLASS);
-            proto.set_class_full_name(t->symbol.show(gs));
+            proto.set_class_full_name(t.symbol.show(gs));
         },
-        [&](const AndType *t) {
+        [&](const AndType &t) {
             proto.set_kind(com::stripe::rubytyper::Type::AND);
-            *proto.mutable_and_()->mutable_left() = toProto(gs, t->left);
-            *proto.mutable_and_()->mutable_right() = toProto(gs, t->right);
+            *proto.mutable_and_()->mutable_left() = toProto(gs, t.left);
+            *proto.mutable_and_()->mutable_right() = toProto(gs, t.right);
         },
-        [&](const OrType *t) {
+        [&](const OrType &t) {
             proto.set_kind(com::stripe::rubytyper::Type::OR);
-            *proto.mutable_or_()->mutable_left() = toProto(gs, t->left);
-            *proto.mutable_or_()->mutable_right() = toProto(gs, t->right);
+            *proto.mutable_or_()->mutable_left() = toProto(gs, t.left);
+            *proto.mutable_or_()->mutable_right() = toProto(gs, t.right);
         },
-        [&](const AppliedType *t) {
+        [&](const AppliedType &t) {
             proto.set_kind(com::stripe::rubytyper::Type::APPLIED);
-            proto.mutable_applied()->set_symbol_full_name(t->klass.show(gs));
-            for (auto &a : t->targs) {
+            proto.mutable_applied()->set_symbol_full_name(t.klass.show(gs));
+            for (auto &a : t.targs) {
                 *proto.mutable_applied()->add_type_args() = toProto(gs, a);
             }
         },
-        [&](const ShapeType *t) {
+        [&](const ShapeType &t) {
             proto.set_kind(com::stripe::rubytyper::Type::SHAPE);
-            for (auto &k : t->keys) {
+            for (auto &k : t.keys) {
                 *proto.mutable_shape()->add_keys() = toProto(gs, k);
             }
-            for (auto &v : t->values) {
+            for (auto &v : t.values) {
                 *proto.mutable_shape()->add_values() = toProto(gs, v);
             }
         },
-        [&](const LiteralType *t) {
+        [&](const LiteralType &t) {
             proto.set_kind(com::stripe::rubytyper::Type::LITERAL);
-            *proto.mutable_literal() = toProto(gs, *t);
+            *proto.mutable_literal() = toProto(gs, t);
         },
-        [&](const TupleType *t) {
+        [&](const TupleType &t) {
             proto.set_kind(com::stripe::rubytyper::Type::TUPLE);
-            for (auto &e : t->elems) {
+            for (auto &e : t.elems) {
                 *proto.mutable_tuple()->add_elems() = toProto(gs, e);
             }
         },
         // TODO later: add more types
-        [&](const Type *t) { proto.set_kind(com::stripe::rubytyper::Type::UNKNOWN); });
+        [&](const TypePtr &t) { proto.set_kind(com::stripe::rubytyper::Type::UNKNOWN); });
     return proto;
 }
 

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -4,7 +4,6 @@
 #include "ast/Helpers.h"
 #include "common/Timer.h"
 #include "common/sort.h"
-#include "common/typecase.h"
 #include "core/Error.h"
 #include "core/GlobalState.h"
 #include "core/NameHash.h"

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1160,7 +1160,7 @@ SymbolRef unwrapSymbol(const TypePtr &type) {
     SymbolRef result;
     TypePtr typePtr = type;
     while (!result.exists()) {
-        tagTypecase(
+        typecase(
             typePtr,
 
             [&](const ClassType &klass) { result = klass.symbol; },
@@ -2332,7 +2332,7 @@ class Array_flatten : public IntrinsicMethod {
         const int newDepth = depth - 1;
 
         TypePtr result;
-        tagTypecase(
+        typecase(
             type,
 
             // This only shows up because t->elementType() for tuples returns an OrType of all its elements.

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -301,19 +301,19 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             categoryCounterInc("lub", "proxy>");
             // both are proxy
             TypePtr result;
-            typecase(
-                p1,
-                [&](const TupleType *a1) { // Warning: this implements COVARIANT arrays
+            tagTypecase(
+                t1,
+                [&](const TupleType &a1) { // Warning: this implements COVARIANT arrays
                     if (auto *a2 = cast_type<TupleType>(t2)) {
-                        if (a1->elems.size() == a2->elems.size()) { // lub arrays only if they have same element count
+                        if (a1.elems.size() == a2->elems.size()) { // lub arrays only if they have same element count
                             vector<TypePtr> elemLubs;
                             int i = -1;
                             bool differ1 = false;
                             bool differ2 = false;
                             for (auto &el2 : a2->elems) {
                                 ++i;
-                                auto &inserted = elemLubs.emplace_back(lub(gs, a1->elems[i], el2));
-                                differ1 = differ1 || inserted != a1->elems[i];
+                                auto &inserted = elemLubs.emplace_back(lub(gs, a1.elems[i], el2));
+                                differ1 = differ1 || inserted != a1.elems[i];
                                 differ2 = differ2 || inserted != el2;
                             }
                             if (!differ1) {
@@ -330,9 +330,9 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         result = lub(gs, p1->underlying(), p2->underlying());
                     }
                 },
-                [&](const ShapeType *h1) { // Warning: this implements COVARIANT hashes
+                [&](const ShapeType &h1) { // Warning: this implements COVARIANT hashes
                     if (auto *h2 = cast_type<ShapeType>(t2)) {
-                        if (h2->keys.size() == h1->keys.size()) {
+                        if (h2->keys.size() == h1.keys.size()) {
                             // have enough keys.
                             int i = -1;
                             vector<TypePtr> valueLubs;
@@ -344,15 +344,15 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                                 auto el2l = cast_type<LiteralType>(el2);
                                 auto *u2 = cast_type<ClassType>(el2l->underlying());
                                 ENFORCE(u2 != nullptr);
-                                auto fnd = absl::c_find_if(h1->keys, [&](auto &candidate) -> bool {
+                                auto fnd = absl::c_find_if(h1.keys, [&](auto &candidate) -> bool {
                                     auto el1l = cast_type<LiteralType>(candidate);
                                     auto *u1 = cast_type<ClassType>(el1l->underlying());
                                     return el1l->value == el2l->value && u1->symbol == u2->symbol; // from lambda
                                 });
-                                if (fnd != h1->keys.end()) {
+                                if (fnd != h1.keys.end()) {
                                     auto &inserted = valueLubs.emplace_back(
-                                        lub(gs, h1->values[fnd - h1->keys.begin()], h2->values[i]));
-                                    differ1 = differ1 || inserted != h1->values[fnd - h1->keys.begin()];
+                                        lub(gs, h1.values[fnd - h1.keys.begin()], h2->values[i]));
+                                    differ1 = differ1 || inserted != h1.values[fnd - h1.keys.begin()];
                                     differ2 = differ2 || inserted != h2->values[i];
                                 } else {
                                     result = Types::hashOfUntyped();
@@ -373,27 +373,26 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         result = lub(gs, p1->underlying(), p2->underlying());
                     }
                 },
-                [&](const LiteralType *l1) {
+                [&](const LiteralType &l1) {
                     if (auto *l2 = cast_type<LiteralType>(t2)) {
-                        auto *u1 = cast_type<ClassType>(l1->underlying());
-                        auto *u2 = cast_type<ClassType>(l2->underlying());
-                        ENFORCE(u1 != nullptr && u2 != nullptr);
-                        if (u1->symbol == u2->symbol) {
-                            if (l1->value == l2->value) {
+                        auto &u1 = cast_type_nonnull<ClassType>(l1.underlying());
+                        auto &u2 = cast_type_nonnull<ClassType>(l2->underlying());
+                        if (u1.symbol == u2.symbol) {
+                            if (l1.value == l2->value) {
                                 result = t1;
                             } else {
-                                result = l1->underlying();
+                                result = l1.underlying();
                             }
                         } else {
-                            result = lubGround(gs, l1->underlying(), l2->underlying());
+                            result = lubGround(gs, l1.underlying(), l2->underlying());
                         }
                     } else {
                         result = lub(gs, p1->underlying(), p2->underlying());
                     }
                 },
-                [&](const MetaType *m1) {
+                [&](const MetaType &m1) {
                     if (auto *m2 = cast_type<MetaType>(t2)) {
-                        if (Types::equiv(gs, m1->wrapped, m2->wrapped)) {
+                        if (Types::equiv(gs, m1.wrapped, m2->wrapped)) {
                             result = t1;
                             return;
                         }
@@ -644,32 +643,31 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
 
     if (auto *p1 = cast_type<ProxyType>(t1)) {
         if (auto *p2 = cast_type<ProxyType>(t2)) {
-            if (typeid(*p1) != typeid(*p2)) {
+            if (t1.tag() != t2.tag()) {
                 return Types::bottom();
             }
             TypePtr result;
-            typecase(
-                p1,
-                [&](const TupleType *a1) { // Warning: this implements COVARIANT arrays
-                    auto *a2 = cast_type<TupleType>(t2);
-                    ENFORCE(a2 != nullptr);
-                    if (a1->elems.size() == a2->elems.size()) { // lub arrays only if they have same element count
+            tagTypecase(
+                t1,
+                [&](const TupleType &a1) { // Warning: this implements COVARIANT arrays
+                    auto &a2 = cast_type_nonnull<TupleType>(t2);
+                    if (a1.elems.size() == a2.elems.size()) { // lub arrays only if they have same element count
                         vector<TypePtr> elemGlbs;
-                        elemGlbs.reserve(a2->elems.size());
+                        elemGlbs.reserve(a2.elems.size());
 
                         int i = -1;
-                        for (auto &el2 : a2->elems) {
+                        for (auto &el2 : a2.elems) {
                             ++i;
-                            auto glbe = glb(gs, a1->elems[i], el2);
+                            auto glbe = glb(gs, a1.elems[i], el2);
                             if (glbe.isBottom()) {
                                 result = Types::bottom();
                                 return;
                             }
                             elemGlbs.emplace_back(glbe);
                         }
-                        if (absl::c_equal(a1->elems, elemGlbs)) {
+                        if (absl::c_equal(a1.elems, elemGlbs)) {
                             result = t1;
-                        } else if (absl::c_equal(a2->elems, elemGlbs)) {
+                        } else if (absl::c_equal(a2.elems, elemGlbs)) {
                             result = t2;
                         } else {
                             result = TupleType::build(gs, move(elemGlbs));
@@ -679,29 +677,28 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                     }
 
                 },
-                [&](const ShapeType *h1) { // Warning: this implements COVARIANT hashes
-                    auto *h2 = cast_type<ShapeType>(t2);
-                    ENFORCE(h2 != nullptr);
-                    if (h2->keys.size() == h1->keys.size()) {
+                [&](const ShapeType &h1) { // Warning: this implements COVARIANT hashes
+                    auto &h2 = cast_type_nonnull<ShapeType>(t2);
+                    if (h2.keys.size() == h1.keys.size()) {
                         // have enough keys.
                         int i = -1;
                         vector<TypePtr> valueLubs;
-                        valueLubs.reserve(h2->keys.size());
+                        valueLubs.reserve(h2.keys.size());
                         bool canReuseT1 = true;
                         bool canReuseT2 = true;
-                        for (auto &el2 : h2->keys) {
+                        for (auto &el2 : h2.keys) {
                             ++i;
                             auto el2l = cast_type<LiteralType>(el2);
                             auto *u2 = cast_type<ClassType>(el2l->underlying());
                             ENFORCE(u2 != nullptr);
-                            auto fnd = absl::c_find_if(h1->keys, [&](auto &candidate) -> bool {
+                            auto fnd = absl::c_find_if(h1.keys, [&](auto &candidate) -> bool {
                                 auto el1l = cast_type<LiteralType>(candidate);
                                 auto *u1 = cast_type<ClassType>(el1l->underlying());
                                 return el1l->value == el2l->value && u1->symbol == u2->symbol; // from lambda
                             });
-                            if (fnd != h1->keys.end()) {
-                                auto left = h1->values[fnd - h1->keys.begin()];
-                                auto right = h2->values[i];
+                            if (fnd != h1.keys.end()) {
+                                auto left = h1.values[fnd - h1.keys.begin()];
+                                auto right = h2.values[i];
                                 auto glbe = glb(gs, left, right);
                                 if (glbe.isBottom()) {
                                     result = Types::bottom();
@@ -720,21 +717,20 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         } else if (canReuseT2) {
                             result = t2;
                         } else {
-                            result = make_type<ShapeType>(Types::hashOfUntyped(), h2->keys, move(valueLubs));
+                            result = make_type<ShapeType>(Types::hashOfUntyped(), h2.keys, move(valueLubs));
                         }
                     } else {
                         result = Types::bottom();
                     }
 
                 },
-                [&](const LiteralType *l1) {
-                    auto *l2 = cast_type<LiteralType>(t2);
-                    ENFORCE(l2 != nullptr);
-                    auto *u1 = cast_type<ClassType>(l1->underlying());
-                    auto *u2 = cast_type<ClassType>(l2->underlying());
+                [&](const LiteralType &l1) {
+                    auto &l2 = cast_type_nonnull<LiteralType>(t2);
+                    auto *u1 = cast_type<ClassType>(l1.underlying());
+                    auto *u2 = cast_type<ClassType>(l2.underlying());
                     ENFORCE(u1 != nullptr && u2 != nullptr);
                     if (u1->symbol == u2->symbol) {
-                        if (l1->value == l2->value) {
+                        if (l1.value == l2.value) {
                             result = t1;
                         } else {
                             result = Types::bottom();
@@ -743,10 +739,10 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         result = Types::bottom();
                     }
                 },
-                [&](const MetaType *m1) {
+                [&](const MetaType &m1) {
                     auto *m2 = cast_type<MetaType>(t2);
                     ENFORCE(m2 != nullptr);
-                    if (Types::equiv(gs, m1->wrapped, m2->wrapped)) {
+                    if (Types::equiv(gs, m1.wrapped, m2->wrapped)) {
                         result = t1;
                     } else {
                         result = Types::bottom();
@@ -1148,25 +1144,25 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
         if (auto *p2 = cast_type<ProxyType>(t2)) {
             bool result;
             // TODO: simply compare as memory regions
-            typecase(
-                p1,
-                [&](const TupleType *a1) { // Warning: this implements COVARIANT arrays
+            tagTypecase(
+                t1,
+                [&](const TupleType &a1) { // Warning: this implements COVARIANT arrays
                     auto *a2 = cast_type<TupleType>(t2);
-                    result = a2 != nullptr && a1->elems.size() >= a2->elems.size();
+                    result = a2 != nullptr && a1.elems.size() >= a2->elems.size();
                     if (result) {
                         int i = -1;
                         for (auto &el2 : a2->elems) {
                             ++i;
-                            result = Types::isSubTypeUnderConstraint(gs, constr, a1->elems[i], el2, mode);
+                            result = Types::isSubTypeUnderConstraint(gs, constr, a1.elems[i], el2, mode);
                             if (!result) {
                                 break;
                             }
                         }
                     }
                 },
-                [&](const ShapeType *h1) { // Warning: this implements COVARIANT hashes
+                [&](const ShapeType &h1) { // Warning: this implements COVARIANT hashes
                     auto *h2 = cast_type<ShapeType>(t2);
-                    result = h2 != nullptr && h2->keys.size() <= h1->keys.size();
+                    result = h2 != nullptr && h2->keys.size() <= h1.keys.size();
                     if (!result) {
                         return;
                     }
@@ -1177,32 +1173,32 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                         auto el2l = cast_type<LiteralType>(el2);
                         auto *u2 = cast_type<ClassType>(el2l->underlying());
                         ENFORCE(u2 != nullptr);
-                        auto fnd = absl::c_find_if(h1->keys, [&](auto &candidate) -> bool {
+                        auto fnd = absl::c_find_if(h1.keys, [&](auto &candidate) -> bool {
                             auto el1l = cast_type<LiteralType>(candidate);
                             auto *u1 = cast_type<ClassType>(el1l->underlying());
                             return el1l->value == el2l->value && u1->symbol == u2->symbol; // from lambda
                         });
-                        result = fnd != h1->keys.end() &&
-                                 Types::isSubTypeUnderConstraint(gs, constr, h1->values[fnd - h1->keys.begin()],
+                        result = fnd != h1.keys.end() &&
+                                 Types::isSubTypeUnderConstraint(gs, constr, h1.values[fnd - h1.keys.begin()],
                                                                  h2->values[i], mode);
                         if (!result) {
                             return;
                         }
                     }
                 },
-                [&](const LiteralType *l1) {
+                [&](const LiteralType &l1) {
                     auto *l2 = cast_type<LiteralType>(t2);
                     if (l2 == nullptr) {
                         // is a literal a subtype of a different kind of proxy
                         result = false;
                         return;
                     }
-                    auto *u1 = cast_type<ClassType>(l1->underlying());
+                    auto *u1 = cast_type<ClassType>(l1.underlying());
                     auto *u2 = cast_type<ClassType>(l2->underlying());
                     ENFORCE(u1 != nullptr && u2 != nullptr);
-                    result = l2 != nullptr && u1->symbol == u2->symbol && l1->value == l2->value;
+                    result = l2 != nullptr && u1->symbol == u2->symbol && l1.value == l2->value;
                 },
-                [&](const MetaType *m1) {
+                [&](const MetaType &m1) {
                     auto *m2 = cast_type<MetaType>(t2);
                     if (m2 == nullptr) {
                         // is a literal a subtype of a different kind of proxy
@@ -1210,7 +1206,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                         return;
                     }
 
-                    result = Types::equiv(gs, m1->wrapped, m2->wrapped);
+                    result = Types::equiv(gs, m1.wrapped, m2->wrapped);
                 });
             return result;
             // both are proxy

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -301,7 +301,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             categoryCounterInc("lub", "proxy>");
             // both are proxy
             TypePtr result;
-            tagTypecase(
+            typecase(
                 t1,
                 [&](const TupleType &a1) { // Warning: this implements COVARIANT arrays
                     if (auto *a2 = cast_type<TupleType>(t2)) {
@@ -647,7 +647,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                 return Types::bottom();
             }
             TypePtr result;
-            tagTypecase(
+            typecase(
                 t1,
                 [&](const TupleType &a1) { // Warning: this implements COVARIANT arrays
                     auto &a2 = cast_type_nonnull<TupleType>(t2);
@@ -1144,7 +1144,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
         if (auto *p2 = cast_type<ProxyType>(t2)) {
             bool result;
             // TODO: simply compare as memory regions
-            tagTypecase(
+            typecase(
                 t1,
                 [&](const TupleType &a1) { // Warning: this implements COVARIANT arrays
                     auto *a2 = cast_type<TupleType>(t2);

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -151,7 +151,7 @@ TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from, Symbol
         return from;
     }
 
-    tagTypecase(
+    typecase(
         from,
         [&](const OrType &o) {
             auto lhs = dropSubtypesOf(gs, o.left, klass);
@@ -219,7 +219,7 @@ TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from, Symbol
 
 bool Types::canBeTruthy(const GlobalState &gs, const TypePtr &what) {
     bool isTruthy = true;
-    tagTypecase(
+    typecase(
         what, [&](const OrType &o) { isTruthy = canBeTruthy(gs, o.left) || canBeTruthy(gs, o.right); },
         [&](const AndType &a) { isTruthy = canBeTruthy(gs, a.left) && canBeTruthy(gs, a.right); },
         [&](const ClassType &c) {
@@ -249,7 +249,7 @@ bool Types::canBeFalsy(const GlobalState &gs, const TypePtr &what) {
 
 TypePtr Types::approximateSubtract(const GlobalState &gs, const TypePtr &from, const TypePtr &what) {
     TypePtr result;
-    tagTypecase(
+    typecase(
         what, [&](const ClassType &c) { result = Types::dropSubtypesOf(gs, from, c.symbol); },
         [&](const AppliedType &c) { result = Types::dropSubtypesOf(gs, from, c.klass); },
         [&](const OrType &o) {
@@ -837,7 +837,7 @@ void SelfType::_sanityCheck(const GlobalState &gs) {}
 TypePtr Types::widen(const GlobalState &gs, const TypePtr &type) {
     ENFORCE(type != nullptr);
     TypePtr ret;
-    tagTypecase(
+    typecase(
         type, [&](const AndType &andType) { ret = all(gs, widen(gs, andType.left), widen(gs, andType.right)); },
         [&](const OrType &orType) { ret = any(gs, widen(gs, orType.left), widen(gs, orType.right)); },
         [&](const ProxyType &proxy) { ret = Types::widen(gs, proxy.underlying()); },
@@ -868,7 +868,7 @@ TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &type) {
         return unwrapped;
     };
 
-    tagTypecase(
+    typecase(
         type, [&](const ClassType &klass) { ret = type; }, [&](const TypeVar &tv) { ret = type; },
         [&](const LambdaParam &tv) { ret = type; }, [&](const SelfType &self) { ret = type; },
         [&](const LiteralType &lit) { ret = type; },

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -68,7 +68,7 @@ private:
     VarianceValidator(const core::Loc loc) : loc(loc) {}
 
     void validate(const core::Context ctx, const Polarity polarity, const core::TypePtr &type) {
-        tagTypecase(
+        typecase(
             type, [&](const core::ClassType &klass) {},
 
             [&](const core::LiteralType &lit) {},

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -68,42 +68,42 @@ private:
     VarianceValidator(const core::Loc loc) : loc(loc) {}
 
     void validate(const core::Context ctx, const Polarity polarity, const core::TypePtr &type) {
-        typecase(
-            type.get(), [&](const core::ClassType *klass) {},
+        tagTypecase(
+            type, [&](const core::ClassType &klass) {},
 
-            [&](const core::LiteralType *lit) {},
+            [&](const core::LiteralType &lit) {},
 
-            [&](const core::SelfType *self) {},
+            [&](const core::SelfType &self) {},
 
-            [&](const core::SelfTypeParam *sp) {},
+            [&](const core::SelfTypeParam &sp) {},
 
-            [&](const core::TypeVar *tvar) {},
+            [&](const core::TypeVar &tvar) {},
 
-            [&](const core::OrType *any) {
-                validate(ctx, polarity, any->left);
-                validate(ctx, polarity, any->right);
+            [&](const core::OrType &any) {
+                validate(ctx, polarity, any.left);
+                validate(ctx, polarity, any.right);
             },
 
-            [&](const core::AndType *all) {
-                validate(ctx, polarity, all->left);
-                validate(ctx, polarity, all->right);
+            [&](const core::AndType &all) {
+                validate(ctx, polarity, all.left);
+                validate(ctx, polarity, all.right);
             },
 
-            [&](const core::ShapeType *shape) {
-                for (auto value : shape->values) {
+            [&](const core::ShapeType &shape) {
+                for (auto value : shape.values) {
                     validate(ctx, polarity, value);
                 }
             },
 
-            [&](const core::TupleType *tuple) {
-                for (auto value : tuple->elems) {
+            [&](const core::TupleType &tuple) {
+                for (auto value : tuple.elems) {
                     validate(ctx, polarity, value);
                 }
             },
 
-            [&](const core::AppliedType *app) {
-                auto members = app->klass.data(ctx)->typeMembers();
-                auto params = app->targs;
+            [&](const core::AppliedType &app) {
+                auto members = app.klass.data(ctx)->typeMembers();
+                auto params = app.targs;
 
                 ENFORCE(members.size() == params.size(),
                         fmt::format("types should be fully saturated, but there are {} members and {} params",
@@ -136,8 +136,8 @@ private:
             },
 
             // This is where the actual variance checks are done.
-            [&](const core::LambdaParam *param) {
-                auto paramData = param->definition.data(ctx);
+            [&](const core::LambdaParam &param) {
+                auto paramData = param.definition.data(ctx);
 
                 ENFORCE(paramData->isTypeMember());
 
@@ -166,8 +166,8 @@ private:
                 }
             },
 
-            [&](const core::AliasType *alias) {
-                auto aliasSym = alias->symbol.data(ctx)->dealias(ctx);
+            [&](const core::AliasType &alias) {
+                auto aliasSym = alias.symbol.data(ctx)->dealias(ctx);
 
                 // This can be introduced by `module_function`, which in its
                 // current implementation will alias an instance method as a
@@ -175,11 +175,11 @@ private:
                 if (aliasSym.data(ctx)->isMethod()) {
                     validateMethod(ctx, polarity, aliasSym);
                 } else {
-                    Exception::raise("Unexpected type alias: {}", alias->toString(ctx));
+                    Exception::raise("Unexpected type alias: {}", alias.toString(ctx));
                 }
             },
 
-            [&](const core::Type *skipped) {
+            [&](const core::TypePtr &skipped) {
                 Exception::raise("Unexpected type in variance checking: {}", skipped->toString(ctx));
             });
     }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -881,7 +881,7 @@ core::TypePtr Environment::getReturnType(core::Context ctx, const core::TypePtr 
 core::TypePtr flattenArrays(core::Context ctx, const core::TypePtr &type) {
     core::TypePtr result;
 
-    tagTypecase(
+    typecase(
         type,
 
         [&](const core::OrType &o) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -881,25 +881,25 @@ core::TypePtr Environment::getReturnType(core::Context ctx, const core::TypePtr 
 core::TypePtr flattenArrays(core::Context ctx, const core::TypePtr &type) {
     core::TypePtr result;
 
-    typecase(
-        type.get(),
+    tagTypecase(
+        type,
 
-        [&](const core::OrType *o) {
-            result = core::Types::any(ctx, flattenArrays(ctx, o->left), flattenArrays(ctx, o->right));
+        [&](const core::OrType &o) {
+            result = core::Types::any(ctx, flattenArrays(ctx, o.left), flattenArrays(ctx, o.right));
         },
 
-        [&](const core::AppliedType *a) {
-            if (a->klass != core::Symbols::Array()) {
+        [&](const core::AppliedType &a) {
+            if (a.klass != core::Symbols::Array()) {
                 result = type;
                 return;
             }
-            ENFORCE(a->targs.size() == 1);
-            result = a->targs.front();
+            ENFORCE(a.targs.size() == 1);
+            result = a.targs.front();
         },
 
-        [&](const core::TupleType *t) { result = t->elementType(); },
+        [&](const core::TupleType &t) { result = t.elementType(); },
 
-        [&](const core::Type *t) { result = std::move(type); });
+        [&](const core::TypePtr &t) { result = std::move(type); });
     return result;
 }
 

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -44,7 +44,7 @@ class LocalNameInserter {
     NamedArg nameArg(ast::TreePtr arg) {
         NamedArg named;
 
-        tagTypecase(
+        typecase(
             arg,
             [&](ast::UnresolvedIdent &nm) {
                 named.name = nm.name;

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -44,43 +44,43 @@ class LocalNameInserter {
     NamedArg nameArg(ast::TreePtr arg) {
         NamedArg named;
 
-        typecase(
-            arg.get(),
-            [&](ast::UnresolvedIdent *nm) {
-                named.name = nm->name;
+        tagTypecase(
+            arg,
+            [&](ast::UnresolvedIdent &nm) {
+                named.name = nm.name;
                 named.local = enterLocal(named.name);
                 named.loc = arg.loc();
                 named.expr = ast::make_tree<ast::Local>(arg.loc(), named.local);
             },
-            [&](ast::RestArg *rest) {
-                named = nameArg(move(rest->expr));
+            [&](ast::RestArg &rest) {
+                named = nameArg(move(rest.expr));
                 named.expr = ast::MK::RestArg(arg.loc(), move(named.expr));
                 named.flags.repeated = true;
             },
-            [&](ast::KeywordArg *kw) {
-                named = nameArg(move(kw->expr));
+            [&](ast::KeywordArg &kw) {
+                named = nameArg(move(kw.expr));
                 named.expr = ast::MK::KeywordArg(arg.loc(), move(named.expr));
                 named.flags.keyword = true;
             },
-            [&](ast::OptionalArg *opt) {
-                named = nameArg(move(opt->expr));
-                named.expr = ast::MK::OptionalArg(arg.loc(), move(named.expr), move(opt->default_));
+            [&](ast::OptionalArg &opt) {
+                named = nameArg(move(opt.expr));
+                named.expr = ast::MK::OptionalArg(arg.loc(), move(named.expr), move(opt.default_));
             },
-            [&](ast::BlockArg *blk) {
-                named = nameArg(move(blk->expr));
+            [&](ast::BlockArg &blk) {
+                named = nameArg(move(blk.expr));
                 named.expr = ast::MK::BlockArg(arg.loc(), move(named.expr));
                 named.flags.block = true;
             },
-            [&](ast::ShadowArg *shadow) {
-                named = nameArg(move(shadow->expr));
+            [&](ast::ShadowArg &shadow) {
+                named = nameArg(move(shadow.expr));
                 named.expr = ast::MK::ShadowArg(arg.loc(), move(named.expr));
                 named.flags.shadow = true;
             },
-            [&](ast::Local *local) {
-                named.name = local->localVariable._name;
+            [&](const ast::Local &local) {
+                named.name = local.localVariable._name;
                 named.local = enterLocal(named.name);
                 named.loc = arg.loc();
-                named.expr = ast::make_tree<ast::Local>(local->loc, named.local);
+                named.expr = ast::make_tree<ast::Local>(local.loc, named.local);
             });
 
         return named;

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -4,7 +4,6 @@
 #include "ast/treemap/treemap.h"
 #include "common/concurrency/ConcurrentQueue.h"
 #include "common/sort.h"
-#include "common/typecase.h"
 #include "core/ErrorCollector.h"
 #include "core/ErrorQueue.h"
 #include "core/Unfreeze.h"

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -3,7 +3,6 @@
 #include "common/concurrency/WorkerPool.h"
 #include "common/kvstore/KeyValueStore.h"
 #include "common/statsd/statsd.h"
-#include "common/typecase.h"
 #include "common/web_tracer_framework/tracing.h"
 #include "core/errors/internal.h"
 #include "core/errors/namer.h"

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -170,15 +170,15 @@ SimilarMethodsByName similarMethodsForReceiver(const core::GlobalState &gs, cons
                                                string_view prefix) {
     auto result = SimilarMethodsByName{};
 
-    typecase(
-        receiver.get(), [&](const core::ClassType *type) { result = similarMethodsForClass(gs, type->symbol, prefix); },
-        [&](const core::AppliedType *type) { result = similarMethodsForClass(gs, type->klass, prefix); },
-        [&](const core::AndType *type) {
-            result = mergeSimilarMethods(similarMethodsForReceiver(gs, type->left, prefix),
-                                         similarMethodsForReceiver(gs, type->right, prefix));
+    tagTypecase(
+        receiver, [&](const core::ClassType &type) { result = similarMethodsForClass(gs, type.symbol, prefix); },
+        [&](const core::AppliedType &type) { result = similarMethodsForClass(gs, type.klass, prefix); },
+        [&](const core::AndType &type) {
+            result = mergeSimilarMethods(similarMethodsForReceiver(gs, type.left, prefix),
+                                         similarMethodsForReceiver(gs, type.right, prefix));
         },
-        [&](const core::ProxyType *type) { result = similarMethodsForReceiver(gs, type->underlying(), prefix); },
-        [&](const core::Type *type) { return; });
+        [&](const core::ProxyType &type) { result = similarMethodsForReceiver(gs, type.underlying(), prefix); },
+        [&](const core::TypePtr &type) { return; });
 
     return result;
 }

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -170,7 +170,7 @@ SimilarMethodsByName similarMethodsForReceiver(const core::GlobalState &gs, cons
                                                string_view prefix) {
     auto result = SimilarMethodsByName{};
 
-    tagTypecase(
+    typecase(
         receiver, [&](const core::ClassType &type) { result = similarMethodsForClass(gs, type.symbol, prefix); },
         [&](const core::AppliedType &type) { result = similarMethodsForClass(gs, type.klass, prefix); },
         [&](const core::AndType &type) {

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -13,7 +13,7 @@ vector<core::Loc> locsForType(const core::GlobalState &gs, const core::TypePtr &
     if (type.isUntyped()) {
         return result;
     }
-    tagTypecase(
+    typecase(
         type, [&](const core::ClassType &t) { result.emplace_back(t.symbol.data(gs)->loc()); },
         [&](const core::AppliedType &t) { result.emplace_back(t.klass.data(gs)->loc()); },
         [&](const core::OrType &t) {

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -13,22 +13,22 @@ vector<core::Loc> locsForType(const core::GlobalState &gs, const core::TypePtr &
     if (type.isUntyped()) {
         return result;
     }
-    typecase(
-        type.get(), [&](const core::ClassType *t) { result.emplace_back(t->symbol.data(gs)->loc()); },
-        [&](const core::AppliedType *t) { result.emplace_back(t->klass.data(gs)->loc()); },
-        [&](const core::OrType *t) {
-            for (auto loc : locsForType(gs, t->left)) {
+    tagTypecase(
+        type, [&](const core::ClassType &t) { result.emplace_back(t.symbol.data(gs)->loc()); },
+        [&](const core::AppliedType &t) { result.emplace_back(t.klass.data(gs)->loc()); },
+        [&](const core::OrType &t) {
+            for (auto loc : locsForType(gs, t.left)) {
                 result.emplace_back(loc);
             }
-            for (auto loc : locsForType(gs, t->right)) {
+            for (auto loc : locsForType(gs, t.right)) {
                 result.emplace_back(loc);
             }
         },
-        [&](const core::AndType *t) {
-            for (auto loc : locsForType(gs, t->left)) {
+        [&](const core::AndType &t) {
+            for (auto loc : locsForType(gs, t.left)) {
                 result.emplace_back(loc);
             }
-            for (auto loc : locsForType(gs, t->right)) {
+            for (auto loc : locsForType(gs, t.right)) {
                 result.emplace_back(loc);
             }
         });

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -9,7 +9,6 @@
 #include "common/concurrency/ConcurrentQueue.h"
 #include "common/concurrency/WorkerPool.h"
 #include "common/sort.h"
-#include "common/typecase.h"
 #include "core/Context.h"
 #include "core/Names.h"
 #include "core/Symbols.h"

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1749,7 +1749,7 @@ private:
 
             [&](const ast::EmptyTree &e) { stat.reset(nullptr); },
 
-            [&](const ast::Expression &e) {});
+            [&](const ast::TreePtr &e) {});
     }
 
     // Resolve the type of the rhs of a constant declaration. This logic is
@@ -1770,7 +1770,7 @@ private:
                 result = cast.type;
             },
             [&](const ast::InsSeq &outer) { result = resolveConstantType(ctx, outer.expr, ofSym); },
-            [&](const ast::Expression &expr) {});
+            [&](const ast::TreePtr &expr) {});
         return result;
     }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1568,7 +1568,7 @@ private:
     }
 
     void processStatement(core::MutableContext ctx, ast::TreePtr &stat, InlinedVector<ast::Send *, 1> &lastSigs) {
-        tagTypecase(
+        typecase(
             stat,
 
             [&](ast::Send &send) {
@@ -1759,7 +1759,7 @@ private:
     // type (once we have generics) will be nontrivial.
     core::TypePtr resolveConstantType(core::Context ctx, const ast::TreePtr &expr, core::SymbolRef ofSym) {
         core::TypePtr result;
-        tagTypecase(
+        typecase(
             expr, [&](const ast::Literal &a) { result = a.value; },
             [&](const ast::Cast &cast) {
                 if (cast.cast != core::Names::let() && cast.cast != core::Names::uncheckedLet()) {

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -55,7 +55,7 @@ core::TypePtr getResultLiteral(core::Context ctx, const ast::TreePtr &expr) {
     core::TypePtr result;
     typecase(
         expr, [&](const ast::Literal &lit) { result = lit.value; },
-        [&](const ast::Expression &e) {
+        [&](const ast::TreePtr &e) {
             if (auto e = ctx.beginError(expr.loc(), core::errors::Resolver::InvalidTypeDeclaration)) {
                 e.setHeader("Unsupported type literal");
             }
@@ -978,7 +978,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
                 result.type = core::Types::untypedUntracked();
             }
         },
-        [&](const ast::Expression &e) {
+        [&](const ast::TreePtr &e) {
             if (auto e = ctx.beginError(expr.loc(), core::errors::Resolver::InvalidTypeDeclaration)) {
                 e.setHeader("Unsupported type syntax");
             }

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -53,7 +53,7 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::MutableContext ctx
 
 core::TypePtr getResultLiteral(core::Context ctx, const ast::TreePtr &expr) {
     core::TypePtr result;
-    tagTypecase(
+    typecase(
         expr, [&](const ast::Literal &lit) { result = lit.value; },
         [&](const ast::Expression &e) {
             if (auto e = ctx.beginError(expr.loc(), core::errors::Resolver::InvalidTypeDeclaration)) {
@@ -622,7 +622,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
     ENFORCE(ctxOwnerData->isClassOrModule(), "getResultTypeAndBind wasn't called with a class owner");
 
     TypeSyntax::ResultType result;
-    tagTypecase(
+    typecase(
         expr,
         [&](const ast::Array &arr) {
             vector<core::TypePtr> elems;

--- a/resolver/type_syntax.h
+++ b/resolver/type_syntax.h
@@ -70,8 +70,9 @@ struct TypeSyntaxArgs {
 
 class TypeSyntax {
 public:
-    static bool isSig(core::Context ctx, ast::Send *send);
-    static ParsedSig parseSig(core::MutableContext ctx, ast::Send *send, const ParsedSig *parent, TypeSyntaxArgs args);
+    static bool isSig(core::Context ctx, const ast::Send &send);
+    static ParsedSig parseSig(core::MutableContext ctx, const ast::Send &send, const ParsedSig *parent,
+                              TypeSyntaxArgs args);
 
     struct ResultType {
         core::TypePtr type;

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -52,81 +52,81 @@ public:
         ast::TreePtr *prevStat = nullptr;
         UnorderedMap<void *, vector<ast::TreePtr>> replaceNodes;
         for (auto &stat : classDef->rhs) {
-            typecase(
-                stat.get(),
-                [&](ast::Assign *assign) {
+            tagTypecase(
+                stat,
+                [&](ast::Assign &assign) {
                     vector<ast::TreePtr> nodes;
 
-                    nodes = Struct::run(ctx, assign);
+                    nodes = Struct::run(ctx, &assign);
                     if (!nodes.empty()) {
                         replaceNodes[stat.get()] = std::move(nodes);
                         return;
                     }
 
-                    nodes = ClassNew::run(ctx, assign);
+                    nodes = ClassNew::run(ctx, &assign);
                     if (!nodes.empty()) {
                         replaceNodes[stat.get()] = std::move(nodes);
                         return;
                     }
 
-                    nodes = Regexp::run(ctx, assign);
+                    nodes = Regexp::run(ctx, &assign);
                     if (!nodes.empty()) {
                         replaceNodes[stat.get()] = std::move(nodes);
                         return;
                     }
                 },
 
-                [&](ast::Send *send) {
+                [&](ast::Send &send) {
                     vector<ast::TreePtr> nodes;
 
-                    nodes = MixinEncryptedProp::run(ctx, send);
+                    nodes = MixinEncryptedProp::run(ctx, &send);
                     if (!nodes.empty()) {
                         replaceNodes[stat.get()] = std::move(nodes);
                         return;
                     }
 
-                    nodes = Minitest::run(ctx, send);
+                    nodes = Minitest::run(ctx, &send);
                     if (!nodes.empty()) {
                         replaceNodes[stat.get()] = move(nodes);
                         return;
                     }
 
-                    nodes = DSLBuilder::run(ctx, send);
+                    nodes = DSLBuilder::run(ctx, &send);
                     if (!nodes.empty()) {
                         replaceNodes[stat.get()] = std::move(nodes);
                         return;
                     }
 
-                    nodes = Private::run(ctx, send);
+                    nodes = Private::run(ctx, &send);
                     if (!nodes.empty()) {
                         replaceNodes[stat.get()] = std::move(nodes);
                         return;
                     }
 
-                    nodes = Delegate::run(ctx, send);
+                    nodes = Delegate::run(ctx, &send);
                     if (!nodes.empty()) {
                         replaceNodes[stat.get()] = std::move(nodes);
                         return;
                     }
 
                     // This one is different: it gets an extra prevStat argument.
-                    nodes = AttrReader::run(ctx, send, prevStat);
+                    nodes = AttrReader::run(ctx, &send, prevStat);
                     if (!nodes.empty()) {
                         replaceNodes[stat.get()] = std::move(nodes);
                         return;
                     }
 
                     // This one is also a little different: it gets the ClassDef kind
-                    nodes = Mattr::run(ctx, send, classDef->kind);
+                    nodes = Mattr::run(ctx, &send, classDef->kind);
                     if (!nodes.empty()) {
                         replaceNodes[stat.get()] = std::move(nodes);
                         return;
                     }
                 },
 
-                [&](ast::MethodDef *mdef) { Initializer::run(ctx, mdef, prevStat); },
+                [&](ast::MethodDef &mdef) { Initializer::run(ctx, &mdef, prevStat); },
 
-                [&](ast::Expression *e) {});
+                [&](const ast::Expression &e) {});
 
             prevStat = &stat;
         }

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -52,7 +52,7 @@ public:
         ast::TreePtr *prevStat = nullptr;
         UnorderedMap<void *, vector<ast::TreePtr>> replaceNodes;
         for (auto &stat : classDef->rhs) {
-            tagTypecase(
+            typecase(
                 stat,
                 [&](ast::Assign &assign) {
                     vector<ast::TreePtr> nodes;

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -126,7 +126,7 @@ public:
 
                 [&](ast::MethodDef &mdef) { Initializer::run(ctx, &mdef, prevStat); },
 
-                [&](const ast::Expression &e) {});
+                [&](const ast::TreePtr &e) {});
 
             prevStat = &stat;
         }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Adds a `typecase()` function that uses tags on tagged pointer. Now we can use `typecase()` with tagged pointers, which uses `tag()` to determine if a cast is legal!

I have made the specialization work with both `TypePtr` and `TreePtr`. To make the same code work with both types, those types had to implement the following interface:

* `isa<T>` static template function. These forward to `isa_type`/`isa_tree`, respectively, with some specializations to support casting to `TypePtr`/`TreePtr`/`Expression`.
* `cast_nonnull<T>` static template function. These forward to `cast_type_nonnull`/`cast_tree_nonnull`, respectively, with some specializations.

One change to the interface is that lambdas are called with a _reference type_, which I think is cleaner anyway. Hence the big diff with shallow changes.

The tagged `typecase` version takes a reference type rather than a pointer type, letting the existing (non-tagged) version coexist peacefully with it. I added in a friendly `static_assert` that checks for `.tag()` and complains if you use the wrong version. No one will be able to use the non-tagged typecase on `TypePtr`/`TreePtr`.

I've verified via godbolt that this typecase implementation optimizes into a simple jump table: https://godbolt.org/z/76MEhM

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

To have our cake and eat it too! (https://github.com/sorbet/sorbet/pull/3599 but without removing typecase)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.