### PR TITLE
AST: Make declLoc a LocOffsets rather than a Loc.

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -219,8 +219,8 @@ public:
         return make_tree<ast::Literal>(loc, core::make_type<core::LiteralType>(core::Symbols::String(), value));
     }
 
-    static TreePtr Method(core::LocOffsets loc, core::Loc declLoc, core::NameRef name, MethodDef::ARGS_store args,
-                          TreePtr rhs) {
+    static TreePtr Method(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
+                          MethodDef::ARGS_store args, TreePtr rhs) {
         if (args.empty() || (!isa_tree<ast::Local>(args.back()) && !isa_tree<ast::BlockArg>(args.back()))) {
             auto blkLoc = core::LocOffsets::none();
             args.emplace_back(make_tree<ast::BlockArg>(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
@@ -229,39 +229,39 @@ public:
         return make_tree<MethodDef>(loc, declLoc, core::Symbols::todo(), name, std::move(args), std::move(rhs), flags);
     }
 
-    static TreePtr SyntheticMethod(core::LocOffsets loc, core::Loc declLoc, core::NameRef name,
+    static TreePtr SyntheticMethod(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
                                    MethodDef::ARGS_store args, TreePtr rhs) {
         auto mdef = Method(loc, declLoc, name, std::move(args), std::move(rhs));
         cast_tree<MethodDef>(mdef)->flags.isRewriterSynthesized = true;
         return mdef;
     }
 
-    static TreePtr SyntheticMethod0(core::LocOffsets loc, core::Loc declLoc, core::NameRef name, TreePtr rhs) {
+    static TreePtr SyntheticMethod0(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name, TreePtr rhs) {
         MethodDef::ARGS_store args;
         return SyntheticMethod(loc, declLoc, name, std::move(args), std::move(rhs));
     }
 
-    static TreePtr SyntheticMethod1(core::LocOffsets loc, core::Loc declLoc, core::NameRef name, TreePtr arg0,
+    static TreePtr SyntheticMethod1(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name, TreePtr arg0,
                                     TreePtr rhs) {
         MethodDef::ARGS_store args;
         args.emplace_back(std::move(arg0));
         return SyntheticMethod(loc, declLoc, name, std::move(args), std::move(rhs));
     }
 
-    static TreePtr ClassOrModule(core::LocOffsets loc, core::Loc declLoc, TreePtr name,
+    static TreePtr ClassOrModule(core::LocOffsets loc, core::LocOffsets declLoc, TreePtr name,
                                  ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs, ClassDef::Kind kind) {
         return make_tree<ClassDef>(loc, declLoc, core::Symbols::todo(), std::move(name), std::move(ancestors),
                                    std::move(rhs), kind);
     }
 
-    static TreePtr Class(core::LocOffsets loc, core::Loc declLoc, TreePtr name, ClassDef::ANCESTORS_store ancestors,
-                         ClassDef::RHS_store rhs) {
+    static TreePtr Class(core::LocOffsets loc, core::LocOffsets declLoc, TreePtr name,
+                         ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs) {
         return MK::ClassOrModule(loc, declLoc, std::move(name), std::move(ancestors), std::move(rhs),
                                  ClassDef::Kind::Class);
     }
 
-    static TreePtr Module(core::LocOffsets loc, core::Loc declLoc, TreePtr name, ClassDef::ANCESTORS_store ancestors,
-                          ClassDef::RHS_store rhs) {
+    static TreePtr Module(core::LocOffsets loc, core::LocOffsets declLoc, TreePtr name,
+                          ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs) {
         return MK::ClassOrModule(loc, declLoc, std::move(name), std::move(ancestors), std::move(rhs),
                                  ClassDef::Kind::Module);
     }

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -374,7 +374,7 @@ bool isa_declaration(const TreePtr &what) {
  * Desugar string concatenation into series of .to_s calls and string concatenations
  */
 
-ClassDef::ClassDef(core::LocOffsets loc, core::Loc declLoc, core::SymbolRef symbol, TreePtr name,
+ClassDef::ClassDef(core::LocOffsets loc, core::LocOffsets declLoc, core::SymbolRef symbol, TreePtr name,
                    ANCESTORS_store ancestors, RHS_store rhs, ClassDef::Kind kind)
     : loc(loc), declLoc(declLoc), symbol(symbol), kind(kind), rhs(std::move(rhs)), name(std::move(name)),
       ancestors(std::move(ancestors)) {
@@ -384,7 +384,7 @@ ClassDef::ClassDef(core::LocOffsets loc, core::Loc declLoc, core::SymbolRef symb
     _sanityCheck();
 }
 
-MethodDef::MethodDef(core::LocOffsets loc, core::Loc declLoc, core::SymbolRef symbol, core::NameRef name,
+MethodDef::MethodDef(core::LocOffsets loc, core::LocOffsets declLoc, core::SymbolRef symbol, core::NameRef name,
                      ARGS_store args, TreePtr rhs, Flags flags)
     : loc(loc), declLoc(declLoc), symbol(symbol), rhs(std::move(rhs)), args(std::move(args)), name(name), flags(flags) {
     categoryCounterInc("trees", "methoddef");

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -309,7 +309,7 @@ template <class To> const To &cast_tree_nonnull(const TreePtr &what) {
 TREE(ClassDef) : public Expression {
 public:
     const core::LocOffsets loc;
-    core::Loc declLoc;
+    core::LocOffsets declLoc;
     core::SymbolRef symbol;
 
     enum class Kind : u1 {
@@ -330,8 +330,8 @@ public:
     ANCESTORS_store ancestors;
     ANCESTORS_store singletonAncestors;
 
-    ClassDef(core::LocOffsets loc, core::Loc declLoc, core::SymbolRef symbol, TreePtr name, ANCESTORS_store ancestors,
-             RHS_store rhs, ClassDef::Kind kind);
+    ClassDef(core::LocOffsets loc, core::LocOffsets declLoc, core::SymbolRef symbol, TreePtr name,
+             ANCESTORS_store ancestors, RHS_store rhs, ClassDef::Kind kind);
 
     TreePtr deepCopy() const;
 
@@ -341,12 +341,12 @@ public:
 
     void _sanityCheck();
 };
-CheckSize(ClassDef, 136, 8);
+CheckSize(ClassDef, 128, 8);
 
 TREE(MethodDef) : public Expression {
 public:
     const core::LocOffsets loc;
-    core::Loc declLoc;
+    core::LocOffsets declLoc;
     core::SymbolRef symbol;
 
     TreePtr rhs;
@@ -367,8 +367,8 @@ public:
 
     Flags flags;
 
-    MethodDef(core::LocOffsets loc, core::Loc declLoc, core::SymbolRef symbol, core::NameRef name, ARGS_store args,
-              TreePtr rhs, Flags flags);
+    MethodDef(core::LocOffsets loc, core::LocOffsets declLoc, core::SymbolRef symbol, core::NameRef name,
+              ARGS_store args, TreePtr rhs, Flags flags);
 
     TreePtr deepCopy() const;
 

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -269,8 +269,7 @@ private:
         // We intentionally do not walk v->ancestors nor v->singletonAncestors.
         // They are guaranteed to be simple trees in the desugarer.
         for (auto &def : cast_tree<ClassDef>(v)->rhs) {
-            def = mapIt(std::move(def),
-                        ctx.withOwner(cast_tree<ClassDef>(v)->symbol).withFile(cast_tree<ClassDef>(v)->declLoc.file()));
+            def = mapIt(std::move(def), ctx.withOwner(cast_tree<ClassDef>(v)->symbol).withFile(ctx.file));
         }
 
         if constexpr (HAS_MEMBER_postTransformClassDef<FUNC>::value) {
@@ -292,9 +291,8 @@ private:
                 optArg->default_ = mapIt(std::move(optArg->default_), ctx.withOwner(cast_tree<MethodDef>(v)->symbol));
             }
         }
-        cast_tree<MethodDef>(v)->rhs =
-            mapIt(std::move(cast_tree<MethodDef>(v)->rhs),
-                  ctx.withOwner(cast_tree<MethodDef>(v)->symbol).withFile(cast_tree<MethodDef>(v)->declLoc.file()));
+        cast_tree<MethodDef>(v)->rhs = mapIt(std::move(cast_tree<MethodDef>(v)->rhs),
+                                             ctx.withOwner(cast_tree<MethodDef>(v)->symbol).withFile(ctx.file));
 
         if constexpr (HAS_MEMBER_postTransformMethodDef<FUNC>::value) {
             return PostPonePostTransform_MethodDef<FUNC, CTX, HAS_MEMBER_postTransformMethodDef<FUNC>::value>::call(

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -12,7 +12,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
     ENFORCE(md.symbol.exists());
     ENFORCE(!md.symbol.data(ctx)->isOverloaded());
     unique_ptr<CFG> res(new CFG); // private constructor
-    res->file = md.declLoc.file();
+    res->file = ctx.file;
     res->symbol = md.symbol.data(ctx)->dealiasMethod(ctx);
     u4 temporaryCounter = 1;
     UnorderedMap<core::SymbolRef, LocalRef> aliases;

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -10,7 +10,8 @@ ast::TreePtr DefLocSaver::postTransformMethodDef(core::Context ctx, ast::TreePtr
     auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
 
     const core::lsp::Query &lspQuery = ctx.state.lspQuery;
-    bool lspQueryMatch = lspQuery.matchesLoc(methodDef.declLoc) || lspQuery.matchesSymbol(methodDef.symbol);
+    bool lspQueryMatch =
+        lspQuery.matchesLoc(core::Loc(ctx.file, methodDef.declLoc)) || lspQuery.matchesSymbol(methodDef.symbol);
 
     if (lspQueryMatch) {
         // Query matches against the method definition as a whole.
@@ -39,9 +40,10 @@ ast::TreePtr DefLocSaver::postTransformMethodDef(core::Context ctx, ast::TreePtr
         }
 
         tp.type = symbolData->resultType;
-        tp.origins.emplace_back(methodDef.declLoc);
+        tp.origins.emplace_back(core::Loc(ctx.file, methodDef.declLoc));
         core::lsp::QueryResponse::pushQueryResponse(
-            ctx, core::lsp::DefinitionResponse(methodDef.symbol, methodDef.declLoc, methodDef.name, tp));
+            ctx, core::lsp::DefinitionResponse(methodDef.symbol, core::Loc(ctx.file, methodDef.declLoc), methodDef.name,
+                                               tp));
     }
 
     return tree;

--- a/main/lsp/LocalVarFinder.cc
+++ b/main/lsp/LocalVarFinder.cc
@@ -53,8 +53,9 @@ ast::TreePtr LocalVarFinder::preTransformClassDef(core::Context ctx, ast::TreePt
     ENFORCE(classDef.symbol.exists());
     ENFORCE(classDef.symbol != core::Symbols::todo());
 
-    auto currentMethod = classDef.symbol == core::Symbols::root() ? ctx.state.lookupStaticInitForFile(classDef.declLoc)
-                                                                  : ctx.state.lookupStaticInitForClass(classDef.symbol);
+    auto currentMethod = classDef.symbol == core::Symbols::root()
+                             ? ctx.state.lookupStaticInitForFile(core::Loc(ctx.file, classDef.declLoc))
+                             : ctx.state.lookupStaticInitForClass(classDef.symbol);
 
     this->methodStack.emplace_back(currentMethod);
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -363,7 +363,7 @@ struct PackageInfoFinder {
 
         // Use the loc of the `export_methods` call so `include` errors goes to the right place.
         classDef.rhs.emplace_back(ast::MK::Module(
-            exportMethodsLoc, core::Loc(ctx.file, exportMethodsLoc),
+            exportMethodsLoc, exportMethodsLoc,
             name2Expr(core::Names::Constants::PackageMethods(),
                       name2Expr(this->info->name.mangledName, name2Expr(core::Names::Constants::PackageRegistry()))),
             {}, std::move(includeStatements)));
@@ -580,7 +580,7 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
                 // Create a module for the imported package that sets up constant references to exported items.
                 // Use proper loc information on the module name so that `import Foo` displays in the results of LSP
                 // Find All References on `Foo`.
-                importedPackages.emplace_back(ast::MK::Module(imported.loc, core::Loc(ctx.file, imported.loc),
+                importedPackages.emplace_back(ast::MK::Module(imported.loc, imported.loc,
                                                               imported.fullName.toLiteral(imported.loc), {},
                                                               std::move(exportedItemsCopy)));
             }
@@ -588,7 +588,7 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
     }
 
     auto packageNamespace =
-        ast::MK::Module(core::LocOffsets::none(), core::Loc(ctx.file, core::LocOffsets::none()),
+        ast::MK::Module(core::LocOffsets::none(), core::LocOffsets::none(),
                         name2Expr(package->name.mangledName, name2Expr(core::Names::Constants::PackageRegistry())), {},
                         std::move(importedPackages));
 
@@ -605,7 +605,7 @@ ast::ParsedFile rewritePackagedFile(core::Context ctx, ast::ParsedFile file, cor
 
     auto &rootKlass = ast::cast_tree_nonnull<ast::ClassDef>(file.tree);
     auto moduleWrapper =
-        ast::MK::Module(core::LocOffsets::none(), core::Loc(ctx.file, core::LocOffsets::none()),
+        ast::MK::Module(core::LocOffsets::none(), core::LocOffsets::none(),
                         name2Expr(packageMangledName, name2Expr(core::Names::Constants::PackageRegistry())), {},
                         std::move(rootKlass.rhs));
     rootKlass.rhs.clear();

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1599,7 +1599,7 @@ private:
                 if (debug_mode) {
                     bool hasSig = !lastSigs.empty();
                     bool rewriten = mdef->flags.isRewriterSynthesized;
-                    bool isRBI = mdef->declLoc.file().data(ctx).isRBI();
+                    bool isRBI = ctx.file.data(ctx).isRBI();
                     if (hasSig) {
                         categoryCounterInc("method.sig", "true");
                     } else {

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -245,8 +245,7 @@ vector<ast::TreePtr> AttrReader::run(core::MutableContext ctx, ast::Send *send, 
                 }
             }
 
-            stats.emplace_back(
-                ast::MK::SyntheticMethod0(loc, core::Loc(ctx.file, loc), name, ast::MK::Instance(argLoc, varName)));
+            stats.emplace_back(ast::MK::SyntheticMethod0(loc, loc, name, ast::MK::Instance(argLoc, varName)));
         }
     }
 
@@ -279,8 +278,7 @@ vector<ast::TreePtr> AttrReader::run(core::MutableContext ctx, ast::Send *send, 
             } else {
                 body = ast::MK::Assign(loc, ast::MK::Instance(argLoc, varName), ast::MK::Local(loc, name));
             }
-            stats.emplace_back(ast::MK::SyntheticMethod1(loc, core::Loc(ctx.file, loc), setName,
-                                                         ast::MK::Local(argLoc, name), move(body)));
+            stats.emplace_back(ast::MK::SyntheticMethod1(loc, loc, setName, ast::MK::Local(argLoc, name), move(body)));
         }
     }
 

--- a/rewriter/ClassNew.cc
+++ b/rewriter/ClassNew.cc
@@ -78,8 +78,7 @@ vector<ast::TreePtr> ClassNew::run(core::MutableContext ctx, ast::Assign *asgn) 
     }
 
     vector<ast::TreePtr> stats;
-    stats.emplace_back(
-        ast::MK::Class(loc, core::Loc(ctx.file, loc), std::move(asgn->lhs), std::move(ancestors), std::move(body)));
+    stats.emplace_back(ast::MK::Class(loc, loc, std::move(asgn->lhs), std::move(ancestors), std::move(body)));
     return stats;
 }
 

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -86,8 +86,8 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
         newArgs.emplace_back(arg.deepCopy());
     }
 
-    auto selfCall = ast::MK::SyntheticMethod(call->loc, core::Loc(ctx.file, call->loc), call->name, std::move(newArgs),
-                                             ast::MK::UntypedNil(call->loc));
+    auto selfCall =
+        ast::MK::SyntheticMethod(call->loc, call->loc, call->name, std::move(newArgs), ast::MK::UntypedNil(call->loc));
     ast::cast_tree<ast::MethodDef>(selfCall)->flags.isSelfMethod = true;
 
     klass->rhs.insert(klass->rhs.begin() + i + 1, sig->deepCopy());

--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -85,8 +85,7 @@ vector<ast::TreePtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *send) 
             auto default_ = ast::MK::UntypedNil(loc);
             arg = ast::MK::OptionalArg(loc, move(arg), move(default_));
         }
-        auto defSelfProp =
-            ast::MK::SyntheticMethod1(loc, core::Loc(ctx.file, loc), name, move(arg), ast::MK::EmptyTree());
+        auto defSelfProp = ast::MK::SyntheticMethod1(loc, loc, name, move(arg), ast::MK::EmptyTree());
         ast::cast_tree<ast::MethodDef>(defSelfProp)->flags.isSelfMethod = true;
         stats.emplace_back(move(defSelfProp));
     }
@@ -99,15 +98,13 @@ vector<ast::TreePtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *send) 
         // def self.get_<prop>
         core::NameRef getName = ctx.state.enterNameUTF8("get_" + name.data(ctx)->show(ctx));
         stats.emplace_back(ast::MK::Sig0(loc, ASTUtil::dupType(type)));
-        auto defSelfGetProp =
-            ast::MK::SyntheticMethod(loc, core::Loc(ctx.file, loc), getName, {}, ast::MK::RaiseUnimplemented(loc));
+        auto defSelfGetProp = ast::MK::SyntheticMethod(loc, loc, getName, {}, ast::MK::RaiseUnimplemented(loc));
         ast::cast_tree<ast::MethodDef>(defSelfGetProp)->flags.isSelfMethod = true;
         stats.emplace_back(move(defSelfGetProp));
 
         // def <prop>()
         stats.emplace_back(ast::MK::Sig0(loc, ASTUtil::dupType(type)));
-        stats.emplace_back(
-            ast::MK::SyntheticMethod(loc, core::Loc(ctx.file, loc), name, {}, ast::MK::RaiseUnimplemented(loc)));
+        stats.emplace_back(ast::MK::SyntheticMethod(loc, loc, name, {}, ast::MK::RaiseUnimplemented(loc)));
     }
 
     return stats;

--- a/rewriter/Delegate.cc
+++ b/rewriter/Delegate.cc
@@ -124,8 +124,7 @@ vector<ast::TreePtr> Delegate::run(core::MutableContext ctx, const ast::Send *se
         args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
         args.emplace_back(ast::make_tree<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
 
-        methodStubs.push_back(
-            ast::MK::SyntheticMethod(loc, core::Loc(ctx.file, loc), methodName, std::move(args), ast::MK::EmptyTree()));
+        methodStubs.push_back(ast::MK::SyntheticMethod(loc, loc, methodName, std::move(args), ast::MK::EmptyTree()));
     }
 
     return methodStubs;

--- a/rewriter/Flatfiles.cc
+++ b/rewriter/Flatfiles.cc
@@ -48,14 +48,13 @@ void handleFieldDefinition(core::MutableContext ctx, ast::TreePtr &stat, vector<
         }
 
         methods.emplace_back(ast::MK::Sig0(send->loc, ast::MK::Untyped(send->loc)));
-        methods.emplace_back(
-            ast::MK::SyntheticMethod0(send->loc, core::Loc(ctx.file, send->loc), *name, ast::MK::Nil(send->loc)));
+        methods.emplace_back(ast::MK::SyntheticMethod0(send->loc, send->loc, *name, ast::MK::Nil(send->loc)));
         auto var = ast::MK::Local(send->loc, core::Names::arg0());
         auto setName = name->addEq(ctx);
         methods.emplace_back(ast::MK::Sig1(send->loc, ast::MK::Symbol(send->loc, core::Names::arg0()),
                                            ast::MK::Untyped(send->loc), ast::MK::Untyped(send->loc)));
-        methods.emplace_back(ast::MK::SyntheticMethod1(send->loc, core::Loc(ctx.file, send->loc), setName, move(var),
-                                                       ast::MK::Nil(send->loc)));
+        methods.emplace_back(
+            ast::MK::SyntheticMethod1(send->loc, send->loc, setName, move(var), ast::MK::Nil(send->loc)));
     }
 }
 

--- a/rewriter/Mattr.cc
+++ b/rewriter/Mattr.cc
@@ -93,8 +93,7 @@ vector<ast::TreePtr> Mattr::run(core::MutableContext ctx, const ast::Send *send,
         auto loc = lit->loc;
         if (doReaders) {
             auto sig = ast::MK::Sig0(loc, ast::MK::Untyped(loc));
-            auto def =
-                ast::MK::SyntheticMethod0(loc, core::Loc(ctx.file, loc), lit->asSymbol(ctx), ast::MK::EmptyTree());
+            auto def = ast::MK::SyntheticMethod0(loc, loc, lit->asSymbol(ctx), ast::MK::EmptyTree());
             ast::cast_tree_nonnull<ast::MethodDef>(def).flags.isSelfMethod = true;
             if (instanceReader) {
                 addInstanceCounterPart(result, sig, def);
@@ -105,7 +104,7 @@ vector<ast::TreePtr> Mattr::run(core::MutableContext ctx, const ast::Send *send,
         if (doWriters) {
             auto sig = ast::MK::Sig1(loc, ast::MK::Symbol(loc, core::Names::arg0()), ast::MK::Untyped(loc),
                                      ast::MK::Untyped(loc));
-            auto def = ast::MK::SyntheticMethod1(loc, core::Loc(ctx.file, loc), lit->asSymbol(ctx).addEq(ctx),
+            auto def = ast::MK::SyntheticMethod1(loc, loc, lit->asSymbol(ctx).addEq(ctx),
                                                  ast::MK::Local(loc, core::Names::arg0()), ast::MK::EmptyTree());
             ast::cast_tree_nonnull<ast::MethodDef>(def).flags.isSelfMethod = true;
             if (instanceWriter) {
@@ -119,8 +118,7 @@ vector<ast::TreePtr> Mattr::run(core::MutableContext ctx, const ast::Send *send,
             // from being generated.
             auto sig = ast::MK::Sig0(
                 loc, ast::MK::UnresolvedConstant(loc, ast::MK::T(loc), core::Names::Constants::Boolean()));
-            auto def = ast::MK::SyntheticMethod0(loc, core::Loc(ctx.file, loc), lit->asSymbol(ctx).addQuestion(ctx),
-                                                 ast::MK::False(loc));
+            auto def = ast::MK::SyntheticMethod0(loc, loc, lit->asSymbol(ctx).addQuestion(ctx), ast::MK::False(loc));
             ast::cast_tree_nonnull<ast::MethodDef>(def).flags.isSelfMethod = true;
             if (instanceReader && instancePredicate) {
                 addInstanceCounterPart(result, sig, def);

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -202,8 +202,7 @@ ast::TreePtr runUnderEach(core::MutableContext ctx, core::NameRef eachName, ast:
             auto blk = ast::MK::Block(send->loc, move(body), std::move(new_args));
             auto each = ast::MK::Send0Block(send->loc, iteratee.deepCopy(), core::Names::each(), move(blk));
             // put that into a method def named the appropriate thing
-            auto method = addSigVoid(
-                ast::MK::SyntheticMethod0(send->loc, core::Loc(ctx.file, send->loc), move(name), move(each)));
+            auto method = addSigVoid(ast::MK::SyntheticMethod0(send->loc, send->loc, move(name), move(each)));
             // add back any moved constants
             return constantMover.addConstantsToExpression(send->loc, move(method));
         }
@@ -270,8 +269,8 @@ ast::TreePtr runSingle(core::MutableContext ctx, ast::Send *send) {
         auto name = send->fun == core::Names::after() ? core::Names::afterAngles() : core::Names::initialize();
         ConstantMover constantMover;
         block->body = ast::TreeMap::apply(ctx, constantMover, move(block->body));
-        auto method = addSigVoid(ast::MK::SyntheticMethod0(send->loc, core::Loc(ctx.file, send->loc), name,
-                                                           prepareBody(ctx, std::move(block->body))));
+        auto method =
+            addSigVoid(ast::MK::SyntheticMethod0(send->loc, send->loc, name, prepareBody(ctx, std::move(block->body))));
         return constantMover.addConstantsToExpression(send->loc, move(method));
     }
 
@@ -288,14 +287,13 @@ ast::TreePtr runSingle(core::MutableContext ctx, ast::Send *send) {
         rhs.emplace_back(prepareBody(ctx, std::move(block->body)));
         auto name = ast::MK::UnresolvedConstant(arg.loc(), ast::MK::EmptyTree(),
                                                 ctx.state.enterNameConstant("<describe '" + argString + "'>"));
-        return ast::MK::Class(send->loc, core::Loc(ctx.file, send->loc), std::move(name), std::move(ancestors),
-                              std::move(rhs));
+        return ast::MK::Class(send->loc, send->loc, std::move(name), std::move(ancestors), std::move(rhs));
     } else if (send->fun == core::Names::it()) {
         ConstantMover constantMover;
         block->body = ast::TreeMap::apply(ctx, constantMover, move(block->body));
         auto name = ctx.state.enterNameUTF8("<it '" + argString + "'>");
-        auto method = addSigVoid(ast::MK::SyntheticMethod0(send->loc, core::Loc(ctx.file, send->loc), std::move(name),
-                                                           prepareBody(ctx, std::move(block->body))));
+        auto method = addSigVoid(
+            ast::MK::SyntheticMethod0(send->loc, send->loc, std::move(name), prepareBody(ctx, std::move(block->body))));
         method = ast::MK::InsSeq1(send->loc, send->args.front().deepCopy(), move(method));
         return constantMover.addConstantsToExpression(send->loc, move(method));
     }

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -135,8 +135,7 @@ vector<ast::TreePtr> ModuleFunction::run(core::MutableContext ctx, ast::Send *se
             ast::MethodDef::ARGS_store args;
             args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
             args.emplace_back(ast::make_tree<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
-            auto methodDef = ast::MK::SyntheticMethod(loc, core::Loc(ctx.file, loc), methodName, std::move(args),
-                                                      ast::MK::EmptyTree());
+            auto methodDef = ast::MK::SyntheticMethod(loc, loc, methodName, std::move(args), ast::MK::EmptyTree());
             ast::cast_tree_nonnull<ast::MethodDef>(methodDef).flags.isSelfMethod = true;
             stats.emplace_back(std::move(methodDef));
         } else {

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -407,8 +407,8 @@ vector<ast::TreePtr> processProp(core::MutableContext ctx, PropInfo &ret, PropCo
 
         ast::TreePtr arg =
             ast::MK::RestArg(nameLoc, ast::MK::KeywordArg(nameLoc, ast::MK::Local(nameLoc, core::Names::opts())));
-        nodes.emplace_back(ast::MK::SyntheticMethod1(loc, core::Loc(ctx.file, loc), fkMethod, std::move(arg),
-                                                     ast::MK::RaiseUnimplemented(loc)));
+        nodes.emplace_back(
+            ast::MK::SyntheticMethod1(loc, loc, fkMethod, std::move(arg), ast::MK::RaiseUnimplemented(loc)));
 
         // sig {params(opts: T.untyped).returns($foreign)}
         nodes.emplace_back(ast::MK::Sig1(loc, ast::MK::Symbol(nameLoc, core::Names::opts()), ast::MK::Untyped(loc),
@@ -421,8 +421,8 @@ vector<ast::TreePtr> processProp(core::MutableContext ctx, PropInfo &ret, PropCo
         auto fkMethodBang = ctx.state.enterNameUTF8(name.data(ctx)->show(ctx) + "_!");
         ast::TreePtr arg2 =
             ast::MK::RestArg(nameLoc, ast::MK::KeywordArg(nameLoc, ast::MK::Local(nameLoc, core::Names::opts())));
-        nodes.emplace_back(ast::MK::SyntheticMethod1(loc, core::Loc(ctx.file, loc), fkMethodBang, std::move(arg2),
-                                                     ast::MK::RaiseUnimplemented(loc)));
+        nodes.emplace_back(
+            ast::MK::SyntheticMethod1(loc, loc, fkMethodBang, std::move(arg2), ast::MK::RaiseUnimplemented(loc)));
     }
 
     return nodes;
@@ -505,8 +505,8 @@ vector<ast::TreePtr> mkTypedInitialize(core::MutableContext ctx, core::LocOffset
 
     vector<ast::TreePtr> result;
     result.emplace_back(ast::MK::SigVoid(klassLoc, std::move(sigArgs)));
-    result.emplace_back(ast::MK::SyntheticMethod(klassLoc, core::Loc(ctx.file, klassLoc), core::Names::initialize(),
-                                                 std::move(args), std::move(body)));
+    result.emplace_back(
+        ast::MK::SyntheticMethod(klassLoc, klassLoc, core::Names::initialize(), std::move(args), std::move(body)));
     return result;
 }
 

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -106,10 +106,9 @@ vector<ast::TreePtr> Struct::run(core::MutableContext ctx, ast::Assign *asgn) {
         }
         newArgs.emplace_back(ast::MK::OptionalArg(symLoc, move(argName), ast::MK::Nil(symLoc)));
 
-        body.emplace_back(
-            ast::MK::SyntheticMethod0(symLoc, core::Loc(ctx.file, symLoc), name, ast::MK::RaiseUnimplemented(loc)));
-        body.emplace_back(ast::MK::SyntheticMethod1(symLoc, core::Loc(ctx.file, symLoc), name.addEq(ctx),
-                                                    ast::MK::Local(symLoc, name), ast::MK::RaiseUnimplemented(loc)));
+        body.emplace_back(ast::MK::SyntheticMethod0(symLoc, symLoc, name, ast::MK::RaiseUnimplemented(loc)));
+        body.emplace_back(ast::MK::SyntheticMethod1(symLoc, symLoc, name.addEq(ctx), ast::MK::Local(symLoc, name),
+                                                    ast::MK::RaiseUnimplemented(loc)));
     }
 
     // Elem = type_member(fixed: T.untyped)
@@ -139,16 +138,15 @@ vector<ast::TreePtr> Struct::run(core::MutableContext ctx, ast::Assign *asgn) {
     }
 
     body.emplace_back(ast::MK::SigVoid(loc, std::move(sigArgs)));
-    body.emplace_back(ast::MK::SyntheticMethod(loc, core::Loc(ctx.file, loc), core::Names::initialize(),
-                                               std::move(newArgs), ast::MK::RaiseUnimplemented(loc)));
+    body.emplace_back(ast::MK::SyntheticMethod(loc, loc, core::Names::initialize(), std::move(newArgs),
+                                               ast::MK::RaiseUnimplemented(loc)));
 
     ast::ClassDef::ANCESTORS_store ancestors;
     ancestors.emplace_back(ast::MK::UnresolvedConstant(loc, ast::MK::Constant(loc, core::Symbols::root()),
                                                        core::Names::Constants::Struct()));
 
     vector<ast::TreePtr> stats;
-    stats.emplace_back(
-        ast::MK::Class(loc, core::Loc(ctx.file, loc), std::move(asgn->lhs), std::move(ancestors), std::move(body)));
+    stats.emplace_back(ast::MK::Class(loc, loc, std::move(asgn->lhs), std::move(ancestors), std::move(body)));
     return stats;
 }
 

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -119,7 +119,7 @@ vector<ast::TreePtr> processStat(core::MutableContext ctx, ast::ClassDef *klass,
         if (auto e = ctx.beginError(stat.loc(), core::errors::Rewriter::TEnumOutsideEnumsDo)) {
             e.setHeader("Definition of enum value `{}` must be within the `{}` block for this `{}`",
                         lhs->cnst.show(ctx), "enums do", "T::Enum");
-            e.addErrorLine(klass->declLoc, "Enclosing definition here");
+            e.addErrorLine(core::Loc(ctx.file, klass->declLoc), "Enclosing definition here");
         }
     }
 
@@ -128,8 +128,8 @@ vector<ast::TreePtr> processStat(core::MutableContext ctx, ast::ClassDef *klass,
     ast::ClassDef::ANCESTORS_store parent;
     parent.emplace_back(klass->name.deepCopy());
     ast::ClassDef::RHS_store classRhs;
-    auto classDef = ast::MK::Class(stat.loc(), core::Loc(ctx.file, stat.loc()), classCnst.deepCopy(), std::move(parent),
-                                   std::move(classRhs));
+    auto classDef =
+        ast::MK::Class(stat.loc(), stat.loc(), classCnst.deepCopy(), std::move(parent), std::move(classRhs));
 
     ast::Send::ARGS_store args;
     auto first = true;
@@ -187,11 +187,10 @@ void TEnum::run(core::MutableContext ctx, ast::ClassDef *klass) {
     klass->rhs.clear();
     klass->rhs.reserve(oldRHS.size());
     auto loc = klass->declLoc;
-    klass->rhs.emplace_back(ast::MK::Send1(loc.offsets(), ast::MK::Self(loc.offsets()), core::Names::extend(),
-                                           ast::MK::Constant(loc.offsets(), core::Symbols::T_Helpers())));
-    klass->rhs.emplace_back(
-        ast::MK::Send0(loc.offsets(), ast::MK::Self(loc.offsets()), core::Names::declareAbstract()));
-    klass->rhs.emplace_back(ast::MK::Send0(loc.offsets(), ast::MK::Self(loc.offsets()), core::Names::declareSealed()));
+    klass->rhs.emplace_back(ast::MK::Send1(loc, ast::MK::Self(loc), core::Names::extend(),
+                                           ast::MK::Constant(loc, core::Symbols::T_Helpers())));
+    klass->rhs.emplace_back(ast::MK::Send0(loc, ast::MK::Self(loc), core::Names::declareAbstract()));
+    klass->rhs.emplace_back(ast::MK::Send0(loc, ast::MK::Self(loc), core::Names::declareSealed()));
     for (auto &stat : oldRHS) {
         if (auto enumsDo = asEnumsDo(stat)) {
             auto &block = ast::cast_tree_nonnull<ast::Block>(enumsDo->block);

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -205,13 +205,12 @@ ast::TreePtr ASTUtil::mkKwArgsHash(const ast::Send *send) {
 }
 
 ast::TreePtr ASTUtil::mkGet(core::Context ctx, core::LocOffsets loc, core::NameRef name, ast::TreePtr rhs) {
-    return ast::MK::SyntheticMethod0(loc, core::Loc(ctx.file, loc), name, move(rhs));
+    return ast::MK::SyntheticMethod0(loc, loc, name, move(rhs));
 }
 
 ast::TreePtr ASTUtil::mkSet(core::Context ctx, core::LocOffsets loc, core::NameRef name, core::LocOffsets argLoc,
                             ast::TreePtr rhs) {
-    return ast::MK::SyntheticMethod1(loc, core::Loc(ctx.file, loc), name, ast::MK::Local(argLoc, core::Names::arg0()),
-                                     move(rhs));
+    return ast::MK::SyntheticMethod1(loc, loc, name, ast::MK::Local(argLoc, core::Names::arg0()), move(rhs));
 }
 
 ast::TreePtr ASTUtil::mkNilable(core::LocOffsets loc, ast::TreePtr type) {

--- a/test/hello-test.cc
+++ b/test/hello-test.cc
@@ -153,16 +153,16 @@ TEST_CASE("CountTrees") {
     args.emplace_back(std::move(arg));
 
     ast::MethodDef::Flags flags;
-    auto methodDef =
-        ast::make_tree<ast::MethodDef>(loc.offsets(), loc, methodSym, name, std::move(args), std::move(rhs), flags);
+    auto methodDef = ast::make_tree<ast::MethodDef>(loc.offsets(), loc.offsets(), methodSym, name, std::move(args),
+                                                    std::move(rhs), flags);
     auto emptyTree = ast::MK::EmptyTree();
     auto cnst = ast::make_tree<ast::UnresolvedConstantLit>(loc.offsets(), std::move(emptyTree), name);
 
     ast::ClassDef::RHS_store classrhs;
     classrhs.emplace_back(std::move(methodDef));
-    auto tree =
-        ast::make_tree<ast::ClassDef>(loc.offsets(), loc, classSym, std::move(cnst), ast::ClassDef::ANCESTORS_store(),
-                                      std::move(classrhs), ast::ClassDef::Kind::Class);
+    auto tree = ast::make_tree<ast::ClassDef>(loc.offsets(), loc.offsets(), classSym, std::move(cnst),
+                                              ast::ClassDef::ANCESTORS_store(), std::move(classrhs),
+                                              ast::ClassDef::Kind::Class);
     Counter c;
     sorbet::core::MutableContext ctx(cb, core::Symbols::root(), loc.file());
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

AST: Make declLoc a LocOffsets rather than a Loc. Now all locs in trees are not dependent on FileRef.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

* Unblocks a Sorbet file hashing optimization that avoids re-parsing the file for hashing.
* Reduces LSP memory consumption a little bit (LSP holds all ASTs in memory).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
