### PR TITLE
`URI.regexp` returns `Regexp` not `String` array

### DIFF
--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -468,7 +468,7 @@ module URI
     params(
         schemes: T::Array[T.untyped],
     )
-    .returns(T::Array[String])
+    .returns(Regexp)
   end
   def self.regexp(schemes=T.unsafe(nil)); end
 


### PR DESCRIPTION
As documented in the description of the `URI.regexp` method, the return value of the method is always a `Regexp` instance, regardless of the values passed into the `schemes` parameter.


### Motivation

With the current method definition valid code like the one below will cause errors with type-checking:

```ruby
body = "Some text that includes a URI: https://stripe.com"
URI.regexp.match?(body) #=> true
```

### Test plan

No automated tests.
