### PR TITLE
remove support for boolean types from LiteralType

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -725,7 +725,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::TreePtr &what, BasicBlo
                 // since in Ruby the exception would propagate up the statck.
                 auto gotoDeadTemp = cctx.newTemporary(core::Names::gotoDeadTemp());
                 synthesizeExpr(rescueHandlersBlock, gotoDeadTemp, a->loc,
-                               make_unique<Literal>(core::make_type<core::LiteralType>(true)));
+                               make_unique<Literal>(core::Types::trueClass()));
                 unconditionalJump(rescueHandlersBlock, ensureBody, cctx.inWhat, a->loc);
 
                 auto throwAway = cctx.newTemporary(core::Names::throwAwayTemp());

--- a/core/Types.h
+++ b/core/Types.h
@@ -448,12 +448,11 @@ public:
         const double floatval;
     };
 
-    enum class LiteralTypeKind : u1 { Integer, String, Symbol, True, False, Float };
+    enum class LiteralTypeKind : u1 { Integer, String, Symbol, Float };
     const LiteralTypeKind literalKind;
     LiteralType(int64_t val);
     LiteralType(double val);
     LiteralType(SymbolRef klass, NameRef val);
-    LiteralType(bool val);
     virtual TypePtr underlying() const override;
 
     virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -156,14 +156,6 @@ com::stripe::rubytyper::Type::Literal Proto::toProto(const GlobalState &gs, cons
             proto.set_kind(com::stripe::rubytyper::Type::Literal::SYMBOL);
             proto.set_symbol(NameRef(gs, lit.value).show(gs));
             break;
-        case LiteralType::LiteralTypeKind::True:
-            proto.set_kind(com::stripe::rubytyper::Type::Literal::TRUE);
-            proto.set_bool_(true);
-            break;
-        case LiteralType::LiteralTypeKind::False:
-            proto.set_kind(com::stripe::rubytyper::Type::Literal::FALSE);
-            proto.set_bool_(false);
-            break;
         case LiteralType::LiteralTypeKind::Float:
             proto.set_kind(com::stripe::rubytyper::Type::Literal::FLOAT);
             proto.set_float_(lit.floatval);

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -452,10 +452,6 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
                     return make_type<LiteralType>(Symbols::String(), core::NameRef(NameRef::WellKnown{}, value));
                 case LiteralType::LiteralTypeKind::Symbol:
                     return make_type<LiteralType>(Symbols::Symbol(), core::NameRef(NameRef::WellKnown{}, value));
-                case LiteralType::LiteralTypeKind::True:
-                    return make_type<LiteralType>(true);
-                case LiteralType::LiteralTypeKind::False:
-                    return make_type<LiteralType>(false);
             }
             Exception::notImplemented();
         }

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -327,11 +327,6 @@ LiteralType::LiteralType(SymbolRef klass, NameRef val)
     ENFORCE(klass == Symbols::String() || klass == Symbols::Symbol());
 }
 
-LiteralType::LiteralType(bool val)
-    : value(val ? 1 : 0), literalKind(val ? LiteralTypeKind::True : LiteralTypeKind::False) {
-    categoryCounterInc("types.allocated", "literaltype");
-}
-
 TypePtr LiteralType::underlying() const {
     switch (literalKind) {
         case LiteralTypeKind::Integer:
@@ -342,10 +337,6 @@ TypePtr LiteralType::underlying() const {
             return Types::String();
         case LiteralTypeKind::Symbol:
             return Types::Symbol();
-        case LiteralTypeKind::True:
-            return Types::trueClass();
-        case LiteralTypeKind::False:
-            return Types::falseClass();
     }
     Exception::raise("should never be reached");
 }

--- a/infer/test/infer_test.cc
+++ b/infer/test/infer_test.cc
@@ -57,7 +57,7 @@ TEST_CASE("Infer") {
         auto intClass = core::make_type<core::ClassType>(core::Symbols::Integer());
         auto floatLit = core::make_type<core::LiteralType>(1.0f);
         auto floatClass = core::make_type<core::ClassType>(core::Symbols::Float());
-        auto trueLit = core::make_type<core::LiteralType>(true);
+        auto trueLit = core::Types::trueClass();
         auto trueClass = core::make_type<core::ClassType>(core::Symbols::TrueClass());
         auto stringLit = core::make_type<core::LiteralType>(core::Symbols::String(), core::Names::assignTemp());
         auto stringClass = core::make_type<core::ClassType>(core::Symbols::String());

--- a/proto/Type.proto
+++ b/proto/Type.proto
@@ -23,7 +23,8 @@ message Type {
             INTEGER = 0;
             STRING = 1;
             SYMBOL = 2;
-            // skip a few
+            // TRUE = 3;
+            // FALSE = 4;
             FLOAT = 5;
         }
 

--- a/proto/Type.proto
+++ b/proto/Type.proto
@@ -23,8 +23,7 @@ message Type {
             INTEGER = 0;
             STRING = 1;
             SYMBOL = 2;
-            TRUE = 3;
-            FALSE = 4;
+            // skip a few
             FLOAT = 5;
         }
 

--- a/test/testdata/cfg/dealias_with_return.rb.cfg.exp
+++ b/test/testdata/cfg/dealias_with_return.rb.cfg.exp
@@ -42,7 +42,7 @@ subgraph "cluster_::Object#a" {
 
     "bb::Object#a_7" -> "bb::Object#a_6" [style="bold"];
     "bb::Object#a_8" [
-        label = "block[id=8, rubyBlockId=2]()\l<gotoDeadTemp>$11: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2]()\l<gotoDeadTemp>$11: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#a_8" -> "bb::Object#a_6" [style="bold"];

--- a/test/testdata/cfg/rescue.rb.cfg.exp
+++ b/test/testdata/cfg/rescue.rb.cfg.exp
@@ -49,7 +49,7 @@ subgraph "cluster_::Object#main" {
 
     "bb::Object#main_7" -> "bb::Object#main_6" [style="bold"];
     "bb::Object#main_8" [
-        label = "block[id=8, rubyBlockId=2](<self>: Object, <returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$12: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2](<self>: Object, <returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$12: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#main_8" -> "bb::Object#main_6" [style="bold"];

--- a/test/testdata/cfg/rescue_complex.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_complex.rb.cfg.exp
@@ -187,7 +187,7 @@ subgraph "cluster_::TestRescue#multiple_rescue" {
 
     "bb::TestRescue#multiple_rescue_9" -> "bb::TestRescue#multiple_rescue_6" [style="bold"];
     "bb::TestRescue#multiple_rescue_10" [
-        label = "block[id=10, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$16: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=10, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$16: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#multiple_rescue_10" -> "bb::TestRescue#multiple_rescue_6" [style="bold"];
@@ -255,7 +255,7 @@ subgraph "cluster_::TestRescue#multiple_rescue_classes" {
     "bb::TestRescue#multiple_rescue_classes_8" -> "bb::TestRescue#multiple_rescue_classes_9" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_classes_9" [
-        label = "block[id=9, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$13: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=9, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$13: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#multiple_rescue_classes_9" -> "bb::TestRescue#multiple_rescue_classes_6" [style="bold"];
@@ -316,7 +316,7 @@ subgraph "cluster_::TestRescue#parse_rescue_ensure" {
 
     "bb::TestRescue#parse_rescue_ensure_7" -> "bb::TestRescue#parse_rescue_ensure_6" [style="bold"];
     "bb::TestRescue#parse_rescue_ensure_8" [
-        label = "block[id=8, rubyBlockId=2](<self>: TestRescue, <returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2](<self>: TestRescue, <returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_ensure_8" -> "bb::TestRescue#parse_rescue_ensure_6" [style="bold"];
@@ -377,7 +377,7 @@ subgraph "cluster_::TestRescue#parse_bug_rescue_empty_else" {
 
     "bb::TestRescue#parse_bug_rescue_empty_else_7" -> "bb::TestRescue#parse_bug_rescue_empty_else_6" [style="bold"];
     "bb::TestRescue#parse_bug_rescue_empty_else_8" [
-        label = "block[id=8, rubyBlockId=2]()\l<gotoDeadTemp>$9: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2]()\l<gotoDeadTemp>$9: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_bug_rescue_empty_else_8" -> "bb::TestRescue#parse_bug_rescue_empty_else_6" [style="bold"];
@@ -438,7 +438,7 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12686" {
 
     "bb::TestRescue#parse_ruby_bug_12686_7" -> "bb::TestRescue#parse_ruby_bug_12686_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12686_8" [
-        label = "block[id=8, rubyBlockId=2](<self>: TestRescue, <statTemp>$4: T.untyped)\l<gotoDeadTemp>$12: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2](<self>: TestRescue, <statTemp>$4: T.untyped)\l<gotoDeadTemp>$12: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12686_8" -> "bb::TestRescue#parse_ruby_bug_12686_6" [style="bold"];
@@ -499,7 +499,7 @@ subgraph "cluster_::TestRescue#parse_rescue_mod" {
 
     "bb::TestRescue#parse_rescue_mod_7" -> "bb::TestRescue#parse_rescue_mod_6" [style="bold"];
     "bb::TestRescue#parse_rescue_mod_8" [
-        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_mod_8" -> "bb::TestRescue#parse_rescue_mod_6" [style="bold"];
@@ -560,7 +560,7 @@ subgraph "cluster_::TestRescue#parse_resbody_list_var" {
 
     "bb::TestRescue#parse_resbody_list_var_7" -> "bb::TestRescue#parse_resbody_list_var_6" [style="bold"];
     "bb::TestRescue#parse_resbody_list_var_8" [
-        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_resbody_list_var_8" -> "bb::TestRescue#parse_resbody_list_var_6" [style="bold"];
@@ -621,7 +621,7 @@ subgraph "cluster_::TestRescue#parse_rescue_else_ensure" {
 
     "bb::TestRescue#parse_rescue_else_ensure_7" -> "bb::TestRescue#parse_rescue_else_ensure_6" [style="bold"];
     "bb::TestRescue#parse_rescue_else_ensure_8" [
-        label = "block[id=8, rubyBlockId=2](<self>: TestRescue, <returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$12: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2](<self>: TestRescue, <returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$12: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_else_ensure_8" -> "bb::TestRescue#parse_rescue_else_ensure_6" [style="bold"];
@@ -682,7 +682,7 @@ subgraph "cluster_::TestRescue#parse_rescue" {
 
     "bb::TestRescue#parse_rescue_7" -> "bb::TestRescue#parse_rescue_6" [style="bold"];
     "bb::TestRescue#parse_rescue_8" [
-        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_8" -> "bb::TestRescue#parse_rescue_6" [style="bold"];
@@ -743,7 +743,7 @@ subgraph "cluster_::TestRescue#parse_resbody_var" {
 
     "bb::TestRescue#parse_resbody_var_7" -> "bb::TestRescue#parse_resbody_var_6" [style="bold"];
     "bb::TestRescue#parse_resbody_var_8" [
-        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_resbody_var_8" -> "bb::TestRescue#parse_resbody_var_6" [style="bold"];
@@ -804,7 +804,7 @@ subgraph "cluster_::TestRescue#parse_resbody_var_1" {
 
     "bb::TestRescue#parse_resbody_var_1_7" -> "bb::TestRescue#parse_resbody_var_1_6" [style="bold"];
     "bb::TestRescue#parse_resbody_var_1_8" [
-        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$13: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$13: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_resbody_var_1_8" -> "bb::TestRescue#parse_resbody_var_1_6" [style="bold"];
@@ -865,7 +865,7 @@ subgraph "cluster_::TestRescue#parse_rescue_mod_op_assign" {
 
     "bb::TestRescue#parse_rescue_mod_op_assign_7" -> "bb::TestRescue#parse_rescue_mod_op_assign_6" [style="bold"];
     "bb::TestRescue#parse_rescue_mod_op_assign_8" [
-        label = "block[id=8, rubyBlockId=2](<statTemp>$3: NilClass, <statTemp>$4: T.untyped)\l<gotoDeadTemp>$13: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2](<statTemp>$3: NilClass, <statTemp>$4: T.untyped)\l<gotoDeadTemp>$13: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_mod_op_assign_8" -> "bb::TestRescue#parse_rescue_mod_op_assign_6" [style="bold"];
@@ -926,7 +926,7 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402" {
 
     "bb::TestRescue#parse_ruby_bug_12402_7" -> "bb::TestRescue#parse_ruby_bug_12402_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_8" [
-        label = "block[id=8, rubyBlockId=2](foo: NilClass)\l<gotoDeadTemp>$12: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2](foo: NilClass)\l<gotoDeadTemp>$12: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_8" -> "bb::TestRescue#parse_ruby_bug_12402_6" [style="bold"];
@@ -987,7 +987,7 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402_1" {
 
     "bb::TestRescue#parse_ruby_bug_12402_1_7" -> "bb::TestRescue#parse_ruby_bug_12402_1_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_1_8" [
-        label = "block[id=8, rubyBlockId=2](<statTemp>$3: NilClass, <statTemp>$4: NilClass)\l<gotoDeadTemp>$14: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2](<statTemp>$3: NilClass, <statTemp>$4: NilClass)\l<gotoDeadTemp>$14: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_1_8" -> "bb::TestRescue#parse_ruby_bug_12402_1_6" [style="bold"];
@@ -1048,7 +1048,7 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402_2" {
 
     "bb::TestRescue#parse_ruby_bug_12402_2_7" -> "bb::TestRescue#parse_ruby_bug_12402_2_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_2_8" [
-        label = "block[id=8, rubyBlockId=2]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass)\l<gotoDeadTemp>$22: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass)\l<gotoDeadTemp>$22: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_2_8" -> "bb::TestRescue#parse_ruby_bug_12402_2_6" [style="bold"];

--- a/test/testdata/cfg/rescue_else_block.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_else_block.rb.cfg.exp
@@ -56,7 +56,7 @@ subgraph "cluster_::Object#foo" {
 
     "bb::Object#foo_10" -> "bb::Object#foo_9" [style="bold"];
     "bb::Object#foo_11" [
-        label = "block[id=11, rubyBlockId=2](<returnMethodTemp>$2: T.nilable(Integer))\l<gotoDeadTemp>$10: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=11, rubyBlockId=2](<returnMethodTemp>$2: T.nilable(Integer))\l<gotoDeadTemp>$10: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#foo_11" -> "bb::Object#foo_9" [style="bold"];

--- a/test/testdata/cfg/rescue_expression.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_expression.rb.cfg.exp
@@ -49,7 +49,7 @@ subgraph "cluster_::Object#foo" {
 
     "bb::Object#foo_7" -> "bb::Object#foo_6" [style="bold"];
     "bb::Object#foo_8" [
-        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$15: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$15: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#foo_8" -> "bb::Object#foo_6" [style="bold"];

--- a/test/testdata/cfg/rescue_two_return.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_two_return.rb.cfg.exp
@@ -30,7 +30,7 @@ subgraph "cluster_::Object#foo" {
 
     "bb::Object#foo_4" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_6" [
-        label = "block[id=6, rubyBlockId=3](<self>: Object, <gotoDeadTemp>$12: TrueClass(true))\l<gotoDeadTemp>$12: TrueClass(true)\l"
+        label = "block[id=6, rubyBlockId=3](<self>: Object, <gotoDeadTemp>$12: TrueClass)\l<gotoDeadTemp>$12: TrueClass\l"
     ];
 
     "bb::Object#foo_6" -> "bb::Object#foo_1" [style="bold"];
@@ -42,7 +42,7 @@ subgraph "cluster_::Object#foo" {
 
     "bb::Object#foo_7" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_8" [
-        label = "block[id=8, rubyBlockId=2](<self>: Object)\l<gotoDeadTemp>$12: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2](<self>: Object)\l<gotoDeadTemp>$12: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#foo_8" -> "bb::Object#foo_6" [style="bold"];

--- a/test/testdata/cfg/rescue_var_expression.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_var_expression.rb.cfg.exp
@@ -49,7 +49,7 @@ subgraph "cluster_::Object#foo" {
 
     "bb::Object#foo_7" -> "bb::Object#foo_6" [style="bold"];
     "bb::Object#foo_8" [
-        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$16: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$16: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#foo_8" -> "bb::Object#foo_6" [style="bold"];

--- a/test/testdata/cfg/rescue_with_return.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_with_return.rb.cfg.exp
@@ -42,7 +42,7 @@ subgraph "cluster_::Object#a" {
 
     "bb::Object#a_7" -> "bb::Object#a_6" [style="bold"];
     "bb::Object#a_8" [
-        label = "block[id=8, rubyBlockId=2]()\l<gotoDeadTemp>$10: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2]()\l<gotoDeadTemp>$10: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#a_8" -> "bb::Object#a_6" [style="bold"];

--- a/test/testdata/cfg/retry.rb.cfg.exp
+++ b/test/testdata/cfg/retry.rb.cfg.exp
@@ -66,7 +66,7 @@ subgraph "cluster_::Object#main" {
 
     "bb::Object#main_10" -> "bb::Object#main_2" [style="bold"];
     "bb::Object#main_11" [
-        label = "block[id=11, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$24: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=11, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$24: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#main_11" -> "bb::Object#main_9" [style="bold"];

--- a/test/testdata/cfg/retry_multiple.rb.cfg.exp
+++ b/test/testdata/cfg/retry_multiple.rb.cfg.exp
@@ -90,7 +90,7 @@ subgraph "cluster_::Object#main" {
 
     "bb::Object#main_15" -> "bb::Object#main_2" [style="bold"];
     "bb::Object#main_16" [
-        label = "block[id=16, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$46: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=16, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$46: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#main_16" -> "bb::Object#main_12" [style="bold"];

--- a/test/testdata/cfg/retry_nested.rb.cfg.exp
+++ b/test/testdata/cfg/retry_nested.rb.cfg.exp
@@ -97,7 +97,7 @@ subgraph "cluster_::Object#main" {
 
     "bb::Object#main_16" -> "bb::Object#main_5" [style="bold"];
     "bb::Object#main_17" [
-        label = "block[id=17, rubyBlockId=6](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$42: T.class_of(<Magic>))\l<gotoDeadTemp>$40: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=17, rubyBlockId=6](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$42: T.class_of(<Magic>))\l<gotoDeadTemp>$40: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#main_17" -> "bb::Object#main_15" [style="bold"];
@@ -126,7 +126,7 @@ subgraph "cluster_::Object#main" {
 
     "bb::Object#main_21" -> "bb::Object#main_2" [style="bold"];
     "bb::Object#main_22" [
-        label = "block[id=22, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$53: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=22, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$53: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#main_22" -> "bb::Object#main_20" [style="bold"];

--- a/test/testdata/cfg/uaf1.rb.cfg.exp
+++ b/test/testdata/cfg/uaf1.rb.cfg.exp
@@ -84,7 +84,7 @@ subgraph "cluster_::A#initialize" {
 
     "bb::A#initialize_11" -> "bb::A#initialize_10" [style="bold"];
     "bb::A#initialize_12" [
-        label = "block[id=12, rubyBlockId=3](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$9: T.nilable(Integer))\louterLoops: 1\l<gotoDeadTemp>$16: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=12, rubyBlockId=3](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$9: T.nilable(Integer))\louterLoops: 1\l<gotoDeadTemp>$16: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::A#initialize_12" -> "bb::A#initialize_10" [style="bold"];

--- a/test/testdata/desugar/ensure_without_rescue.rb.cfg.exp
+++ b/test/testdata/desugar/ensure_without_rescue.rb.cfg.exp
@@ -18,7 +18,7 @@ subgraph "cluster_::Object#main" {
 
     "bb::Object#main_1" -> "bb::Object#main_1" [style="bold"];
     "bb::Object#main_3" [
-        label = "block[id=3, rubyBlockId=2](<self>: Object, <returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$6: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=3, rubyBlockId=2](<self>: Object, <returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$6: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#main_3" -> "bb::Object#main_6" [style="bold"];

--- a/test/testdata/infer/control_flow/complex_implication_1.rb.cfg.exp
+++ b/test/testdata/infer/control_flow/complex_implication_1.rb.cfg.exp
@@ -67,7 +67,7 @@ subgraph "cluster_::ModuleMethods#instrumented_request" {
 
     "bb::ModuleMethods#instrumented_request_7" -> "bb::ModuleMethods#instrumented_request_6" [style="bold"];
     "bb::ModuleMethods#instrumented_request_8" [
-        label = "block[id=8, rubyBlockId=2](final_attempt: T.untyped, foo: T.untyped)\l<gotoDeadTemp>$10: TrueClass(true) = true\l<unconditional>\l"
+        label = "block[id=8, rubyBlockId=2](final_attempt: T.untyped, foo: T.untyped)\l<gotoDeadTemp>$10: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::ModuleMethods#instrumented_request_8" -> "bb::ModuleMethods#instrumented_request_6" [style="bold"];


### PR DESCRIPTION
We had two different ways of representing this information and we weren't always consistent in picking which one.  This version of the representation at least makes everything consistent.  This representation of `true` and `false` is also slightly smaller.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Consistency.  No more confusion when looking at `sorbet_llvm` code and wondering why `LiteralTypeKind::{True,False}` aren't being handled.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing automated tests should be sufficient.