### PR TITLE
Fix **kwargs splat

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -763,14 +763,20 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args, core
                     absl::c_copy(hash->keys, back_inserter(keys));
                     absl::c_copy(hash->values, back_inserter(values));
                     kwargs = make_type<ShapeType>(Types::hashOfUntyped(), move(keys), move(values));
-                    --aend;
+                    if (implicitKwsplat) {
+                        --aend;
+                    }
                 } else {
                     if (kwSplatType.isUntyped()) {
                         // Allow an untyped arg to satisfy all kwargs
-                        --aend;
+                        if (implicitKwsplat) {
+                            --aend;
+                        }
                         kwargs = Types::untypedUntracked();
                     } else if (kwSplatType->derivesFrom(gs, Symbols::Hash())) {
-                        --aend;
+                        if (implicitKwsplat) {
+                            --aend;
+                        }
                         if (auto e =
                                 gs.beginError(core::Loc(args.locs.file, args.locs.call), errors::Infer::UntypedSplat)) {
                             e.setHeader("Passing a hash where the specific keys are unknown to a method taking keyword "

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -769,14 +769,10 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args, core
                 } else {
                     if (kwSplatType.isUntyped()) {
                         // Allow an untyped arg to satisfy all kwargs
-                        if (implicitKwsplat) {
-                            --aend;
-                        }
+                        --aend;
                         kwargs = Types::untypedUntracked();
                     } else if (kwSplatType->derivesFrom(gs, Symbols::Hash())) {
-                        if (implicitKwsplat) {
-                            --aend;
-                        }
+                        --aend;
                         if (auto e =
                                 gs.beginError(core::Loc(args.locs.file, args.locs.call), errors::Infer::UntypedSplat)) {
                             e.setHeader("Passing a hash where the specific keys are unknown to a method taking keyword "

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2321,6 +2321,12 @@ public:
     }
 } Shape_merge;
 
+class Shape_to_hash : public IntrinsicMethod {
+    void apply(const GlobalState &gs, DispatchArgs args, DispatchResult &res) const override {
+        res.returnType = args.selfType;
+    }
+} Shape_to_hash;
+
 class Array_flatten : public IntrinsicMethod {
     // Flattens a (nested) array all way down to its (inner) element type, stopping if we hit the depth limit first.
     static TypePtr recursivelyFlattenArrays(const GlobalState &gs, const TypePtr &type, const int64_t depth) {
@@ -2594,6 +2600,7 @@ const vector<Intrinsic> intrinsicMethods{
     {Symbols::Tuple(), Intrinsic::Kind::Instance, Names::concat(), &Tuple_concat},
 
     {Symbols::Shape(), Intrinsic::Kind::Instance, Names::merge(), &Shape_merge},
+    {Symbols::Shape(), Intrinsic::Kind::Instance, Names::toHash(), &Shape_to_hash},
 
     {Symbols::Array(), Intrinsic::Kind::Instance, Names::flatten(), &Array_flatten},
     {Symbols::Array(), Intrinsic::Kind::Instance, Names::product(), &Array_product},

--- a/rbi/sorbet/sorbet.rbi
+++ b/rbi/sorbet/sorbet.rbi
@@ -90,6 +90,7 @@ class Sorbet::Private::Static::Shape < Hash
   Elem = type_member(:out)
 
   def merge(other); end
+  def to_hash(); end
 end
 
 class Sorbet::Private::Static::ENVClass

--- a/test/cli/error-kwarg-hash-without-splat/error-kwarg-hash-without-splat.out
+++ b/test/cli/error-kwarg-hash-without-splat/error-kwarg-hash-without-splat.out
@@ -1,19 +1,5 @@
-test/cli/error-kwarg-hash-without-splat/goodsplat.rb:15: Passing a hash where the specific keys are unknown to a method taking keyword arguments https://srb.help/7019
-    15 |takes_kwargs(99, **arghash)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Got T::Hash[T.untyped, T.untyped] originating from:
-    test/cli/error-kwarg-hash-without-splat/goodsplat.rb:15:
-    15 |takes_kwargs(99, **arghash)
-                         ^^^^^^^^^
-Errors: 1
-test/cli/error-kwarg-hash-without-splat/goodsplat.rb:15: Passing a hash where the specific keys are unknown to a method taking keyword arguments https://srb.help/7019
-    15 |takes_kwargs(99, **arghash)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Got T::Hash[T.untyped, T.untyped] originating from:
-    test/cli/error-kwarg-hash-without-splat/goodsplat.rb:15:
-    15 |takes_kwargs(99, **arghash)
-                         ^^^^^^^^^
-Errors: 1
+No errors! Great job.
+No errors! Great job.
 test/cli/error-kwarg-hash-without-splat/badsplat.rb:10: Keyword argument hash without `**` is deprecated https://srb.help/7033
     10 |takes_kwargs(99, arghash)
                          ^^^^^^^

--- a/test/cli/error-kwarg-hash-without-splat/goodsplat.rb
+++ b/test/cli/error-kwarg-hash-without-splat/goodsplat.rb
@@ -7,9 +7,4 @@ def takes_kwargs(x, y:)
 end
 
 arghash = {y: 42}
-
-# NOTE: This currently fails with "Passing a hash where the specific keys are
-# unknown to a method taking keyword arguments". This is a bug in Sorbet. Once
-# that bug is fixed, goodsplat.rb should exhibit no errors, so the expected
-# output of this test will need to be updated and this comment removed.
 takes_kwargs(99, **arghash)

--- a/test/testdata/infer/kwargs_splat.rb
+++ b/test/testdata/infer/kwargs_splat.rb
@@ -1,0 +1,35 @@
+# typed: true
+
+require 'sorbet-runtime'
+
+extend T::Sig
+
+sig {params(x: Integer, y: Integer, z: String).void}
+def f(x, y:, z:)
+  puts x
+  puts y
+  puts z
+end
+
+sig {params(x: Integer, y: Integer, z: String, w: Float).void}
+def g(x, y:, z:, w:)
+  puts x
+  puts y
+  puts z
+  puts w
+end
+
+shaped_hash = {y: 3, z: "hi mom"}
+f(3, shaped_hash)
+f(3, **shaped_hash)
+g(3, **shaped_hash, w: 2.0)
+
+untyped_hash = T.let(shaped_hash, T.untyped)
+f(3, untyped_hash)
+f(3, **untyped_hash)
+g(3, **untyped_hash, w: 2.0)
+
+untyped_values_hash = T.let(shaped_hash, T::Hash[Symbol, T.untyped])
+f(3, untyped_values_hash) # error: Passing a hash where the specific keys are unknown to a method taking keyword arguments
+f(3, **untyped_values_hash) # error: Passing a hash where the specific keys are unknown to a method taking keyword arguments
+g(3, **untyped_values_hash, w: 2.0) # error: Passing a hash where the specific keys are unknown to a method taking keyword arguments

--- a/test/testdata/infer/shape_to_hash.rb
+++ b/test/testdata/infer/shape_to_hash.rb
@@ -1,0 +1,36 @@
+# typed: true
+
+class A
+  extend T::Sig
+
+  class WhateverAReturnsFromToHash ; end
+
+  sig {returns(WhateverAReturnsFromToHash)}
+  def to_hash 
+    WhateverAReturnsFromToHash.new
+  end
+end
+
+foo = {x: "hello", y: 333, z: A.new}
+T.reveal_type(foo) # error: Revealed type: `{x: String("hello"), y: Integer(333), z: A}`
+T.reveal_type(foo.to_hash) # error: Revealed type: `{x: String("hello"), y: Integer(333), z: A}`
+
+bar = {x: "yolo", y: 209, z: "hello again"}
+
+if T.unsafe(false)
+  baz = foo
+else
+  baz = bar
+end
+
+T.reveal_type(baz) # error: Revealed type: `{x: String, y: Integer, z: T.any(A, String)}`
+T.reveal_type(baz.to_hash) # error: Revealed type: `{x: String, y: Integer, z: T.any(A, String)}`
+
+if T.unsafe(false)
+  qux = baz
+else
+  qux = A.new
+end
+
+T.reveal_type(qux) # error: Revealed type: `T.any(A, {x: String, y: Integer, z: T.any(A, String)})`
+T.reveal_type(qux.to_hash) # error: Revealed type: `T.any(A::WhateverAReturnsFromToHash, {x: String, y: Integer, z: T.any(A, String)})`


### PR DESCRIPTION
This fixes `**kwargs` splats. Specifically:

- Updates `Shape#to_hash` to an intrinsic that keeps the shape rather than falling back to `T::Hash[Symbol, T.untyped]` (or whatever it was).
- Fixes a bug in the `dispatchCallSymbol` logic when `**` splats are in use.

Example:

[→ View on sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0A%0Aextend%20T%3A%3ASig%0A%0Asig%20%7Bparams(x%3A%20Integer%2C%20y%3A%20Integer%2C%20z%3A%20String).void%7D%0Adef%20f(x%2C%20y%3A%2C%20z%3A)%0A%20%20puts%20x%0A%20%20puts%20y%0A%20%20puts%20z%0Aend%0A%0Asig%20%7Bparams(x%3A%20Integer%2C%20y%3A%20Integer%2C%20z%3A%20String%2C%20w%3A%20Float).void%7D%0Adef%20g(x%2C%20y%3A%2C%20z%3A%2C%20w%3A)%0A%20%20puts%20x%0A%20%20puts%20y%0A%20%20puts%20z%0A%20%20puts%20w%0Aend%0A%0Ashaped_hash%20%3D%20%7By%3A%203%2C%20z%3A%20%22hi%20mom%22%7D%0Af(3%2C%20**shaped_hash)%0Ag(3%2C%20**shaped_hash%2C%20w%3A%202.0))

```ruby
# typed: true

extend T::Sig

sig {params(x: Integer, y: Integer, z: String).void}
def f(x, y:, z:)
  puts x
  puts y
  puts z
end

sig {params(x: Integer, y: Integer, z: String, w: Float).void}
def g(x, y:, z:, w:)
  puts x
  puts y
  puts z
  puts w
end

shaped_hash = {y: 3, z: "hi mom"}
f(3, **shaped_hash)
g(3, **shaped_hash, w: 2.0)
```

Before this change, the example fails with:

```
editor.rb:21: Passing a hash where the specific keys are unknown to a method taking keyword arguments https://srb.help/7019
    21 |f(3, **shaped_hash)
        ^^^^^^^^^^^^^^^^^^^
  Got T::Hash[T.untyped, T.untyped] originating from:
    editor.rb:21:
    21 |f(3, **shaped_hash)
             ^^^^^^^^^^^^^

editor.rb:22: Passing a hash where the specific keys are unknown to a method taking keyword arguments https://srb.help/7019
    22 |g(3, **shaped_hash, w: 2.0)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  Got T::Hash[T.untyped, T.untyped] originating from:
    editor.rb:22:
    22 |g(3, **shaped_hash, w: 2.0)
             ^^^^^^^^^^^^^^^^^^^^^
Errors: 2
```

After this change, the example passes.

### Motivation
`**`-less kwarg hashes are deprecated in Ruby 2.7 and will be an error in Ruby 3.0, so we'll need to support them properly. (See also #3608, which adds a flag to make `**`-less kwarg hashes an error, and issues an autocorrect.)


### Test plan

See included automated tests.
