### PR TITLE
Fix Numeric#truncate signature to support optional ndigits arg

### DIFF
--- a/rbi/core/numeric.rbi
+++ b/rbi/core/numeric.rbi
@@ -622,7 +622,13 @@ class Numeric < Object
   # [`Float`](https://docs.ruby-lang.org/en/2.6.0/Float.html) and invoking
   # [`Float#truncate`](https://docs.ruby-lang.org/en/2.6.0/Float.html#method-i-truncate).
   sig {returns(Integer)}
-  def truncate(); end
+  sig do
+    params(
+      arg0: Integer
+    )
+    .returns(T.any(Integer, Float))
+  end
+  def truncate(arg0=T.unsafe(nil)); end
 
   # Returns `true` if `num` has a zero value.
   sig {returns(T::Boolean)}


### PR DESCRIPTION
Fix the type signature of `Numeric#truncate` to match Ruby's
documentation.
https://docs.ruby-lang.org/en/2.6.0/Numeric.html#method-i-truncate

The new signature adds support to optional `ndigits` argument and
expands the return types to `Integer` and `Float` when the argument
is given. When not `ndigits` is not present, the method returns
always `Integer`.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Currently, the `Numeric#truncate` signature does not support the optional argument `ndigits` as described in the documentation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

RBI change
