### PR TITLE
Block in `Pathname#descend` is optional

### DIFF
--- a/rbi/stdlib/pathname.rbi
+++ b/rbi/stdlib/pathname.rbi
@@ -574,6 +574,7 @@ class Pathname < Object
     )
     .returns(T.untyped)
   end
+  sig {returns(T::Enumerator[Pathname])}
   def descend(&blk); end
 
   # See


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The block argument of `Pathname#descend` is optional and if not supplied, returns an Enumerator of Pathname objects. [This example](https://sorbet.run/#%23%20typed%3A%20true%0A%0APathname.new(%22a%2Fb%2Fc%2Fd%2Fe%2Ff%22).descend%0A%0A) should type-check properly.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No extra automated tests.
