### PR TITLE
Inline Type::hasUntyped and isFullyDefined into TypePtr methods

### DIFF
--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -226,27 +226,42 @@ bool TypePtr::hasUntyped() const {
         case Tag::UnresolvedClassType:
         case Tag::ClassType: {
             auto &c = cast_type_nonnull<ClassType>(*this);
-            return c.hasUntyped();
+            return c.symbol == Symbols::untyped();
         }
         case Tag::OrType: {
             auto &o = cast_type_nonnull<OrType>(*this);
-            return o.hasUntyped();
+            return o.left.hasUntyped() || o.right.hasUntyped();
         }
         case Tag::AndType: {
             auto &a = cast_type_nonnull<AndType>(*this);
-            return a.hasUntyped();
+            return a.left.hasUntyped() || a.right.hasUntyped();
         }
         case Tag::AppliedType: {
             auto &app = cast_type_nonnull<AppliedType>(*this);
-            return app.hasUntyped();
+            for (auto &arg : app.targs) {
+                if (arg.hasUntyped()) {
+                    return true;
+                }
+            }
+            return false;
         }
         case Tag::TupleType: {
             auto &tuple = cast_type_nonnull<TupleType>(*this);
-            return tuple.hasUntyped();
+            for (auto &arg : tuple.elems) {
+                if (arg.hasUntyped()) {
+                    return true;
+                }
+            }
+            return false;
         }
         case Tag::ShapeType: {
             auto &shape = cast_type_nonnull<ShapeType>(*this);
-            return shape.hasUntyped();
+            for (auto &arg : shape.values) {
+                if (arg.hasUntyped()) {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 }

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -183,23 +183,28 @@ bool TypePtr::isFullyDefined() const {
         // Composite types
         case Tag::ShapeType: {
             auto &shape = cast_type_nonnull<ShapeType>(*this);
-            return shape.isFullyDefined();
+            return absl::c_all_of(shape.values, [](const TypePtr &t) { return t.isFullyDefined(); });
         }
         case Tag::TupleType: {
             auto &tuple = cast_type_nonnull<TupleType>(*this);
-            return tuple.isFullyDefined();
+            return absl::c_all_of(tuple.elems, [](const TypePtr &t) { return t.isFullyDefined(); });
         }
         case Tag::AndType: {
             auto &andType = cast_type_nonnull<AndType>(*this);
-            return andType.isFullyDefined();
+            return andType.left.isFullyDefined() && andType.right.isFullyDefined();
         }
         case Tag::OrType: {
             auto &orType = cast_type_nonnull<OrType>(*this);
-            return orType.isFullyDefined();
+            return orType.left.isFullyDefined() && orType.right.isFullyDefined();
         }
         case Tag::AppliedType: {
             auto &app = cast_type_nonnull<AppliedType>(*this);
-            return app.isFullyDefined();
+            for (auto &targ : app.targs) {
+                if (!targ.isFullyDefined()) {
+                    return false;
+                }
+            }
+            return true;
         }
     }
 }

--- a/core/Types.h
+++ b/core/Types.h
@@ -336,7 +336,6 @@ public:
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
     void _sanityCheck(const GlobalState &gs) final;
-    bool hasUntyped() const;
 };
 CheckSize(ClassType, 16, 8);
 
@@ -468,7 +467,6 @@ public:
     void _sanityCheck(const GlobalState &gs) final;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
-    bool hasUntyped() const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const;
@@ -521,7 +519,6 @@ public:
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
     TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const;
-    bool hasUntyped() const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
 
@@ -562,7 +559,6 @@ public:
     void _sanityCheck(const GlobalState &gs) final;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
-    bool hasUntyped() const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
     virtual TypePtr underlying() const override;
@@ -587,7 +583,6 @@ public:
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
-    bool hasUntyped() const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
 
@@ -613,7 +608,6 @@ public:
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
 
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
-    bool hasUntyped() const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
 };

--- a/core/Types.h
+++ b/core/Types.h
@@ -466,7 +466,6 @@ public:
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
     void _sanityCheck(const GlobalState &gs) final;
-    bool isFullyDefined() const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
     bool hasUntyped() const;
@@ -519,7 +518,6 @@ public:
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
     void _sanityCheck(const GlobalState &gs) final;
-    bool isFullyDefined() const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
     TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const;
@@ -562,7 +560,6 @@ public:
     virtual std::string show(const GlobalState &gs) const final;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     void _sanityCheck(const GlobalState &gs) final;
-    bool isFullyDefined() const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
     bool hasUntyped() const;
@@ -587,7 +584,6 @@ public:
     virtual std::string show(const GlobalState &gs) const final;
     virtual std::string showWithMoreInfo(const GlobalState &gs) const final;
     void _sanityCheck(const GlobalState &gs) final;
-    bool isFullyDefined() const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
@@ -611,7 +607,6 @@ public:
     virtual std::string show(const GlobalState &gs) const final;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     void _sanityCheck(const GlobalState &gs) final;
-    bool isFullyDefined() const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1102,17 +1102,15 @@ TypePtr getMethodArguments(const GlobalState &gs, SymbolRef klass, NameRef name,
 }
 
 TypePtr ClassType::getCallArguments(const GlobalState &gs, NameRef name) const {
-    if (hasUntyped()) {
+    if (symbol == core::Symbols::untyped()) {
         return Types::untyped(gs, Symbols::noSymbol());
     }
     return getMethodArguments(gs, symbol, name, vector<TypePtr>{});
 }
 
 TypePtr BlamedUntyped::getCallArguments(const GlobalState &gs, NameRef name) const {
-    if (hasUntyped()) {
-        return Types::untyped(gs, blame);
-    }
-    return ClassType::getCallArguments(gs, name);
+    // BlamedUntyped are always untyped.
+    return Types::untyped(gs, blame);
 }
 
 TypePtr AppliedType::getCallArguments(const GlobalState &gs, NameRef name) const {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -177,7 +177,7 @@ TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from, Symbol
         },
         [&](const ClassType &c) {
             auto cdata = c.symbol.data(gs);
-            if (c.hasUntyped()) {
+            if (c.symbol == core::Symbols::untyped()) {
                 result = from;
             } else if (c.symbol == klass || c.derivesFrom(gs, klass)) {
                 result = Types::bottom();
@@ -601,53 +601,14 @@ DispatchResult SelfTypeParam::dispatchCall(const GlobalState &gs, DispatchArgs a
 void LambdaParam::_sanityCheck(const GlobalState &gs) {}
 void SelfTypeParam::_sanityCheck(const GlobalState &gs) {}
 
-bool ClassType::hasUntyped() const {
-    return this->symbol == Symbols::untyped();
-}
-
-bool OrType::hasUntyped() const {
-    return left.hasUntyped() || right.hasUntyped();
-}
-
 TypePtr OrType::make_shared(const TypePtr &left, const TypePtr &right) {
     TypePtr res(TypePtr::Tag::OrType, new OrType(left, right));
     return res;
 }
 
-bool AndType::hasUntyped() const {
-    return left.hasUntyped() || right.hasUntyped();
-}
-
 TypePtr AndType::make_shared(const TypePtr &left, const TypePtr &right) {
     TypePtr res(TypePtr::Tag::AndType, new AndType(left, right));
     return res;
-}
-
-bool AppliedType::hasUntyped() const {
-    for (auto &arg : this->targs) {
-        if (arg.hasUntyped()) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool TupleType::hasUntyped() const {
-    for (auto &arg : this->elems) {
-        if (arg.hasUntyped()) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool ShapeType::hasUntyped() const {
-    for (auto &arg : this->values) {
-        if (arg.hasUntyped()) {
-            return true;
-        }
-    }
-    return false;
 }
 
 SendAndBlockLink::SendAndBlockLink(NameRef fun, vector<ArgInfo::ArgFlags> &&argFlags, int rubyBlockId)

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -453,22 +453,6 @@ void ClassType::_sanityCheck(const GlobalState &gs) {
     ENFORCE(this->symbol.exists());
 }
 
-bool ShapeType::isFullyDefined() const {
-    return absl::c_all_of(values, [](const TypePtr &t) { return t.isFullyDefined(); });
-}
-
-bool TupleType::isFullyDefined() const {
-    return absl::c_all_of(elems, [](const TypePtr &t) { return t.isFullyDefined(); });
-}
-
-bool AndType::isFullyDefined() const {
-    return this->left.isFullyDefined() && this->right.isFullyDefined();
-}
-
-bool OrType::isFullyDefined() const {
-    return this->left.isFullyDefined() && this->right.isFullyDefined();
-}
-
 /** Returns type parameters of what reordered in the order of type parameters of asIf
  * If some typeArgs are not present, return NoSymbol
  * */
@@ -564,15 +548,6 @@ TypeVar::TypeVar(SymbolRef sym) : sym(sym) {
 
 void TypeVar::_sanityCheck(const GlobalState &gs) {
     ENFORCE(this->sym.exists());
-}
-
-bool AppliedType::isFullyDefined() const {
-    for (auto &targ : this->targs) {
-        if (!targ.isFullyDefined()) {
-            return false;
-        }
-    }
-    return true;
 }
 
 void AppliedType::_sanityCheck(const GlobalState &gs) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Inline Type::hasUntyped and isFullyDefined into TypePtr methods.

These methods are trivial and recursive (e.g., composite types call the method on the types they contain). It's easier to understand them within the context of one big switch statement than distributed between different methods.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Simplify code.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
