### PR TITLE
Better error message for &. on non-nilable receiver

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1041,7 +1041,8 @@ TreePtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) {
                     loc, make_unique<parser::LVar>(recvLoc, tempRecv), csend->method, std::move(csend->args));
                 auto send = node2TreeImpl(dctx, std::move(sendNode));
 
-                TreePtr nil = MK::Nil(zeroLengthLoc);
+                TreePtr nil = MK::Send1(zeroLengthRecvLoc, ast::MK::Constant(zeroLengthLoc, core::Symbols::Magic()),
+                                        core::Names::nilForSafeNavigation(), MK::Local(zeroLengthRecvLoc, tempRecv));
                 auto iff = MK::If(zeroLengthLoc, std::move(cond), std::move(nil), std::move(send));
                 auto res = MK::InsSeq1(zeroLengthLoc, std::move(assgn), std::move(iff));
                 result = std::move(res);

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -563,6 +563,17 @@ void GlobalState::initEmpty() {
         auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
         arg.flags.isBlock = true;
     }
+    // Synthesize <Magic>.<nil-for-safe-navigation>(recv: T.untyped) => NilClass
+    method = enterMethodSymbol(Loc::none(), Symbols::MagicSingleton(), Names::nilForSafeNavigation());
+    {
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg0());
+        arg.type = Types::untyped(*this, method);
+    }
+    method.data(*this)->resultType = Types::nilClass();
+    {
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
+        arg.flags.isBlock = true;
+    }
     // Synthesize <Magic>.<string-interpolate>(arg: *T.untyped) => String
     method = enterMethodSymbol(Loc::none(), Symbols::MagicSingleton(), Names::stringInterpolate());
     {

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -560,7 +560,7 @@ public:
     }
 
     static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 200;
-    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 30;
+    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 31;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 1;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 2;
     static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 99;

--- a/core/errors/infer.h
+++ b/core/errors/infer.h
@@ -38,6 +38,7 @@ constexpr ErrorClass MetaTypeDispatchCall{7030, StrictLevel::True};
 constexpr ErrorClass PrivateMethod{7031, StrictLevel::True};
 constexpr ErrorClass GenericArgumentKeywordArgs{7032, StrictLevel::True};
 constexpr ErrorClass KeywordArgHashWithoutSplat{7033, StrictLevel::True};
+constexpr ErrorClass UnnecessarySafeNavigation{7034, StrictLevel::True};
 // N.B infer does not run for untyped call at all. StrictLevel::False here would be meaningless
 } // namespace sorbet::core::errors::Infer
 #endif

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -326,6 +326,7 @@ NameDef names[] = {
     {"retry", "<retry>"},
     {"unresolvedAncestors", "<unresolved-ancestors>"},
     {"defineTopClassOrModule", "<define-top-class-or-module>"},
+    {"nilForSafeNavigation", "<nil-for-safe-navigation>"},
 
     {"isA_p", "is_a?"},
     {"kindOf_p", "kind_of?"},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2130,6 +2130,14 @@ public:
     }
 } Magic_selfNew;
 
+class Magic_nilForSafeNavigation : public IntrinsicMethod {
+public:
+    void apply(const GlobalState &gs, DispatchArgs args, DispatchResult &res) const override {
+        ENFORCE(args.args.size() == 1);
+        res.returnType = Types::nilClass();
+    }
+} Magic_nilForSafeNavigation;
+
 class DeclBuilderForProcs_void : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, DispatchArgs args, DispatchResult &res) const override {
@@ -2583,6 +2591,7 @@ const vector<Intrinsic> intrinsicMethods{
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::callWithSplatAndBlock(), &Magic_callWithSplatAndBlock},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::suggestType(), &Magic_suggestUntypedConstantType},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::selfNew(), &Magic_selfNew},
+    {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::nilForSafeNavigation(), &Magic_nilForSafeNavigation},
 
     {Symbols::DeclBuilderForProcsSingleton(), Intrinsic::Kind::Instance, Names::void_(), &DeclBuilderForProcs_void},
     {Symbols::DeclBuilderForProcsSingleton(), Intrinsic::Kind::Instance, Names::returns(),

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2130,14 +2130,6 @@ public:
     }
 } Magic_selfNew;
 
-class Magic_nilForSafeNavigation : public IntrinsicMethod {
-public:
-    void apply(const GlobalState &gs, DispatchArgs args, DispatchResult &res) const override {
-        ENFORCE(args.args.size() == 1);
-        res.returnType = Types::nilClass();
-    }
-} Magic_nilForSafeNavigation;
-
 class DeclBuilderForProcs_void : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, DispatchArgs args, DispatchResult &res) const override {
@@ -2591,7 +2583,6 @@ const vector<Intrinsic> intrinsicMethods{
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::callWithSplatAndBlock(), &Magic_callWithSplatAndBlock},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::suggestType(), &Magic_suggestUntypedConstantType},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::selfNew(), &Magic_selfNew},
-    {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::nilForSafeNavigation(), &Magic_nilForSafeNavigation},
 
     {Symbols::DeclBuilderForProcsSingleton(), Intrinsic::Kind::Instance, Names::void_(), &DeclBuilderForProcs_void},
     {Symbols::DeclBuilderForProcsSingleton(), Intrinsic::Kind::Instance, Names::returns(),

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -127,8 +127,6 @@ public:
 class Environment {
     const core::TypeAndOrigins uninitialized;
 
-    const core::Loc ownerLoc;
-
     /*
      * These four vectors represent the core state store of the environment,
      * modeling a map from local variables to (type, knowledge, known-truthy)
@@ -203,6 +201,8 @@ public:
 
     bool isDead = false;
     cfg::BasicBlock *bb;
+
+    const core::Loc ownerLoc;
 
     const UnorderedMap<cfg::LocalRef, VariableState> &vars() const {
         return _vars;

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -127,6 +127,8 @@ public:
 class Environment {
     const core::TypeAndOrigins uninitialized;
 
+    const core::Loc ownerLoc;
+
     /*
      * These four vectors represent the core state store of the environment,
      * modeling a map from local variables to (type, knowledge, known-truthy)
@@ -202,8 +204,6 @@ public:
     bool isDead = false;
     cfg::BasicBlock *bb;
 
-    const core::Loc ownerLoc;
-
     const UnorderedMap<cfg::LocalRef, VariableState> &vars() const {
         return _vars;
     }
@@ -242,6 +242,10 @@ public:
 
     void ensureGoodCondition(core::Context ctx, cfg::LocalRef cond) {}
     void ensureGoodAssignTarget(core::Context ctx, cfg::LocalRef target) {}
+
+    core::Loc locForUninitialized() const {
+        return ownerLoc;
+    }
 };
 
 } // namespace sorbet::infer

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -128,6 +128,21 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
             bb->firstDeadInstructionIdx = 0;
             // this block is unreachable.
             if (!bb->exprs.empty()) {
+                // This is a bit complicated:
+                //
+                //   1. If the block consists only of synthetic bindings or T.absurd, we don't
+                //      want to issue an error.
+                //   2. If the block contains a send of the form <Magic>.<nil-for-safe-navigation>(x),
+                //      we want to issue an UnnecessarySafeNavigationError, extracting
+                //      type-and-origin info from x. (This magic form is inserted by the desugarer
+                //      for a "safe navigation" operation, e.g., `x&.foo`.)
+                //   3. Otherwise, we want to issue a DeadBranchInferencer error, taking the first
+                //      (non-synthetic, non-"T.absurd") instruction in the block as the loc of the
+                //      error.
+                cfg::Instruction *unreachableInstruction = nullptr;
+                core::LocOffsets locForUnreachable;
+                bool dueToSafeNavigation = false;
+
                 for (auto &expr : bb->exprs) {
                     if (expr.value->isSynthetic) {
                         continue;
@@ -135,10 +150,39 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                     if (cfg::isa_instruction<cfg::TAbsurd>(expr.value.get())) {
                         continue;
                     }
-                    if (auto e = ctx.beginError(expr.loc, core::errors::Infer::DeadBranchInferencer)) {
+
+                    auto send = cfg::cast_instruction<cfg::Send>(expr.value.get());
+                    if (send != nullptr && send->fun == core::Names::nilForSafeNavigation()) {
+                        unreachableInstruction = expr.value.get();
+                        locForUnreachable = expr.loc;
+                        dueToSafeNavigation = true;
+                        break;
+                    } else if (unreachableInstruction == nullptr) {
+                        unreachableInstruction = expr.value.get();
+                        locForUnreachable = expr.loc;
+                    }
+                }
+
+                if (unreachableInstruction != nullptr) {
+                    auto send = cfg::cast_instruction<cfg::Send>(unreachableInstruction);
+
+                    if (dueToSafeNavigation && send != nullptr) {
+                        if (auto e =
+                                ctx.beginError(locForUnreachable, core::errors::Infer::UnnecessarySafeNavigation)) {
+                            e.setHeader("Used `{}` accessor on a receiver which can never be nil", "&.");
+
+                            // Just a failsafe check; args.size() should always be 1.
+                            if (send->args.size() > 0) {
+                                auto ty = current.getAndFillTypeAndOrigin(ctx, send->args[0]);
+                                e.addErrorSection(
+                                    core::ErrorSection(core::ErrorColors::format("Type of receiver is `{}`, from:",
+                                                                                 ty.type->toString(ctx)),
+                                                       ty.origins2Explanations(ctx, current.ownerLoc)));
+                            }
+                        }
+                    } else if (auto e = ctx.beginError(locForUnreachable, core::errors::Infer::DeadBranchInferencer)) {
                         e.setHeader("This code is unreachable");
                     }
-                    break;
                 }
             }
             continue;

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -176,7 +176,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                                 auto ty = current.getAndFillTypeAndOrigin(ctx, send->args[0]);
                                 e.addErrorSection(core::ErrorSection(
                                     core::ErrorColors::format("Type of receiver is `{}`, from:", ty.type->show(ctx)),
-                                    ty.origins2Explanations(ctx, current.ownerLoc)));
+                                    ty.origins2Explanations(ctx, current.locForUninitialized())));
                             }
                         }
                     } else if (auto e = ctx.beginError(locForUnreachable, core::errors::Infer::DeadBranchInferencer)) {

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -174,10 +174,9 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                             // Just a failsafe check; args.size() should always be 1.
                             if (send->args.size() > 0) {
                                 auto ty = current.getAndFillTypeAndOrigin(ctx, send->args[0]);
-                                e.addErrorSection(
-                                    core::ErrorSection(core::ErrorColors::format("Type of receiver is `{}`, from:",
-                                                                                 ty.type->toString(ctx)),
-                                                       ty.origins2Explanations(ctx, current.ownerLoc)));
+                                e.addErrorSection(core::ErrorSection(
+                                    core::ErrorColors::format("Type of receiver is `{}`, from:", ty.type->show(ctx)),
+                                    ty.origins2Explanations(ctx, current.ownerLoc)));
                             }
                         }
                     } else if (auto e = ctx.beginError(locForUnreachable, core::errors::Infer::DeadBranchInferencer)) {

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -169,7 +169,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                     if (dueToSafeNavigation && send != nullptr) {
                         if (auto e =
                                 ctx.beginError(locForUnreachable, core::errors::Infer::UnnecessarySafeNavigation)) {
-                            e.setHeader("Used `{}` accessor on a receiver which can never be nil", "&.");
+                            e.setHeader("Used `{}` operator on a receiver which can never be nil", "&.");
 
                             // Just a failsafe check; args.size() should always be 1.
                             if (send->args.size() > 0) {

--- a/test/testdata/desugar/blockpass.rb
+++ b/test/testdata/desugar/blockpass.rb
@@ -45,7 +45,6 @@ def foo(&blk)
     calls_with_object(&HasToProc.new)
     calls_with_object {|*args| HasToProc.new.to_proc.call(*args)}
     CallsWithObject.calls_with_object(&:meth)
-    CallsWithObject&.calls_with_object(&:meth)
     CallsWithObjectChild.calls_with_object(&:meth)
     calls_arg_with_object(HasMeth.new, &:meth)
     calls_arg_with_object(HasMeth.new) {|x| x.meth}

--- a/test/testdata/desugar/blockpass.rb
+++ b/test/testdata/desugar/blockpass.rb
@@ -45,6 +45,7 @@ def foo(&blk)
     calls_with_object(&HasToProc.new)
     calls_with_object {|*args| HasToProc.new.to_proc.call(*args)}
     CallsWithObject.calls_with_object(&:meth)
+    CallsWithObject&.calls_with_object(&:meth) # error: Used `&.` operator on a receiver which can never be nil
     CallsWithObjectChild.calls_with_object(&:meth)
     calls_arg_with_object(HasMeth.new, &:meth)
     calls_arg_with_object(HasMeth.new) {|x| x.meth}

--- a/test/testdata/desugar/blockpass.rb.desugar-tree.exp
+++ b/test/testdata/desugar/blockpass.rb.desugar-tree.exp
@@ -60,11 +60,21 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C CallsWithObject>.calls_with_object() do |<block-pass>$3|
         <block-pass>$3.meth()
       end
-      <emptyTree>::<C CallsWithObjectChild>.calls_with_object() do |<block-pass>$4|
-        <block-pass>$4.meth()
+      begin
+        <assignTemp>$4 = <emptyTree>::<C CallsWithObject>
+        if ::NilClass.===(<assignTemp>$4)
+          ::<Magic>.<nil-for-safe-navigation>(<assignTemp>$4)
+        else
+          <assignTemp>$4.calls_with_object() do |<block-pass>$5|
+            <block-pass>$5.meth()
+          end
+        end
       end
-      <self>.calls_arg_with_object(<emptyTree>::<C HasMeth>.new()) do |<block-pass>$5|
-        <block-pass>$5.meth()
+      <emptyTree>::<C CallsWithObjectChild>.calls_with_object() do |<block-pass>$6|
+        <block-pass>$6.meth()
+      end
+      <self>.calls_arg_with_object(<emptyTree>::<C HasMeth>.new()) do |<block-pass>$7|
+        <block-pass>$7.meth()
       end
       <self>.calls_arg_with_object(<emptyTree>::<C HasMeth>.new()) do |x|
         x.meth()

--- a/test/testdata/desugar/blockpass.rb.desugar-tree.exp
+++ b/test/testdata/desugar/blockpass.rb.desugar-tree.exp
@@ -60,21 +60,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C CallsWithObject>.calls_with_object() do |<block-pass>$3|
         <block-pass>$3.meth()
       end
-      begin
-        <assignTemp>$4 = <emptyTree>::<C CallsWithObject>
-        if ::NilClass.===(<assignTemp>$4)
-          nil
-        else
-          <assignTemp>$4.calls_with_object() do |<block-pass>$5|
-            <block-pass>$5.meth()
-          end
-        end
+      <emptyTree>::<C CallsWithObjectChild>.calls_with_object() do |<block-pass>$4|
+        <block-pass>$4.meth()
       end
-      <emptyTree>::<C CallsWithObjectChild>.calls_with_object() do |<block-pass>$6|
-        <block-pass>$6.meth()
-      end
-      <self>.calls_arg_with_object(<emptyTree>::<C HasMeth>.new()) do |<block-pass>$7|
-        <block-pass>$7.meth()
+      <self>.calls_arg_with_object(<emptyTree>::<C HasMeth>.new()) do |<block-pass>$5|
+        <block-pass>$5.meth()
       end
       <self>.calls_arg_with_object(<emptyTree>::<C HasMeth>.new()) do |x|
         x.meth()

--- a/test/testdata/desugar/csend.rb.desugar-tree.exp
+++ b/test/testdata/desugar/csend.rb.desugar-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       begin
         <assignTemp>$2 = <self>.foo()
         if ::NilClass.===(<assignTemp>$2)
-          nil
+          ::<Magic>.<nil-for-safe-navigation>(<assignTemp>$2)
         else
           <assignTemp>$2.bar()
         end
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       begin
         <assignTemp>$3 = <self>.foo()
         if ::NilClass.===(<assignTemp>$3)
-          nil
+          ::<Magic>.<nil-for-safe-navigation>(<assignTemp>$3)
         else
           <assignTemp>$3.bar() do |x|
             x
@@ -22,7 +22,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       begin
         <assignTemp>$4 = <self>.foo()
         if ::NilClass.===(<assignTemp>$4)
-          nil
+          ::<Magic>.<nil-for-safe-navigation>(<assignTemp>$4)
         else
           <assignTemp>$4.bar=(5)
         end
@@ -30,7 +30,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       begin
         <assignTemp>$5 = <self>.foo()
         if ::NilClass.===(<assignTemp>$5)
-          nil
+          ::<Magic>.<nil-for-safe-navigation>(<assignTemp>$5)
         else
           begin
             bar$6 = <assignTemp>$5
@@ -41,7 +41,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       begin
         <assignTemp>$7 = <self>.foo()
         if ::NilClass.===(<assignTemp>$7)
-          nil
+          ::<Magic>.<nil-for-safe-navigation>(<assignTemp>$7)
         else
           begin
             bar$8 = <assignTemp>$7
@@ -57,7 +57,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       begin
         <assignTemp>$10 = <self>.foo()
         if ::NilClass.===(<assignTemp>$10)
-          nil
+          ::<Magic>.<nil-for-safe-navigation>(<assignTemp>$10)
         else
           begin
             bar$11 = <assignTemp>$10
@@ -76,7 +76,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   begin
     <assignTemp>$2 = <emptyTree>::<C BasicObject>.new()
     if ::NilClass.===(<assignTemp>$2)
-      nil
+      ::<Magic>.<nil-for-safe-navigation>(<assignTemp>$2)
     else
       <assignTemp>$2.__id__()
     end
@@ -93,7 +93,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       begin
         <assignTemp>$2 = x
         if ::NilClass.===(<assignTemp>$2)
-          nil
+          ::<Magic>.<nil-for-safe-navigation>(<assignTemp>$2)
         else
           <assignTemp>$2.|(true)
         end

--- a/test/testdata/infer/nil_safe_navigation.rb
+++ b/test/testdata/infer/nil_safe_navigation.rb
@@ -4,7 +4,7 @@ extend T::Sig
 
 sig {params(x: Integer, y: T.nilable(Integer)).void}
 def foo(x, y)
-  puts x&.to_s       # error: Used `&.` accessor on a receiver which can never be nil
+  puts x&.to_s       # error: Used `&.` operator on a receiver which can never be nil
   puts x.to_s
 
   puts y&.to_s

--- a/test/testdata/infer/nil_safe_navigation.rb
+++ b/test/testdata/infer/nil_safe_navigation.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+extend T::Sig
+
+sig {params(x: Integer, y: T.nilable(Integer)).void}
+def foo(x, y)
+  puts x&.to_s       # error: Used `&.` accessor on a receiver which can never be nil
+  puts x.to_s
+
+  puts y&.to_s
+  puts y.to_s
+end

--- a/test/testdata/lsp/hover_ampersand_operations.rb
+++ b/test/testdata/lsp/hover_ampersand_operations.rb
@@ -19,7 +19,7 @@ def main
 
   # Safenav
   dog = Dog.new
-  breed = dog&.breed # error: This code is unreachable
+  breed = dog&.breed # error: Used `&.` accessor on a receiver which can never be nil
 # ^ hover: String
         # ^ hover: Dog
             # ^ hover: sig {returns(String)}

--- a/test/testdata/lsp/hover_ampersand_operations.rb
+++ b/test/testdata/lsp/hover_ampersand_operations.rb
@@ -19,7 +19,7 @@ def main
 
   # Safenav
   dog = Dog.new
-  breed = dog&.breed # error: Used `&.` accessor on a receiver which can never be nil
+  breed = dog&.breed # error: Used `&.` operator on a receiver which can never be nil
 # ^ hover: String
         # ^ hover: Dog
             # ^ hover: sig {returns(String)}

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -988,8 +988,8 @@ See [Exhaustiveness Checking](exhaustiveness.md) for more information.
 ## 7034
 
 Sorbet detected that the safe navigation operator (`&.`) was being used on a
-receiver that can never be nil. Replace the offending occurrence of `&.` with
-a normal method call (`.`).
+receiver that can never be nil. Replace the offending occurrence of `&.` with a
+normal method call (`.`).
 
 ```ruby
 # typed: true

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -989,9 +989,9 @@ See [Exhaustiveness Checking](exhaustiveness.md) for more information.
 
 ## 7034
 
-Sorbet detected that the safe navigation operator `&.` was being used on a
+Sorbet detected that the safe navigation operator (`&.`) was being used on a
 receiver that can never be nil. Replace the offending occurrence of `&.` with
-`.`.
+a normal method call (`.`).
 
 ```ruby
 # typed: true

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -985,8 +985,6 @@ See [Exhaustiveness Checking](exhaustiveness.md) for more information.
 
 [report an issue]: https://github.com/sorbet/sorbet/issues
 
-<script src="/js/error-reference.js"></script>
-
 ## 7034
 
 Sorbet detected that the safe navigation operator (`&.`) was being used on a
@@ -1006,3 +1004,5 @@ def foo(x, y)
   puts y&.to_s  # no error: y may be nil
 end
 ```
+
+<script src="/js/error-reference.js"></script>

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -986,3 +986,23 @@ See [Exhaustiveness Checking](exhaustiveness.md) for more information.
 [report an issue]: https://github.com/sorbet/sorbet/issues
 
 <script src="/js/error-reference.js"></script>
+
+## 7034
+
+Sorbet detected that the safe navigation operator `&.` was being used on a
+receiver that can never be nil. Replace the offending occurrence of `&.` with
+`.`.
+
+```ruby
+# typed: true
+
+extend T::Sig
+
+sig {params(x: Integer, y: T.nilable(Integer)).void}
+def foo(x, y)
+  puts x&.to_s  # error: x can never be nil
+  puts x.to_s   # no error
+
+  puts y&.to_s  # no error: y may be nil
+end
+```


### PR DESCRIPTION
This adds a less confusing error message for cases where `&.` ("safe navigation") is used on a receiver that is not nilable. (Currently this shows up as a "code is unreachable" error inside the if-then-else generated by the desugarer.)

Implementation is as @DarkDimius outlines in #36, with the very slight difference that the "magic send" winds up being the second instruction in the block, not the first. (First instruction is an `alias` for the `<Magic>` class constant.)

Example:

```ruby
# typed: true

extend T::Sig

if T.unsafe(false)
  foo = "hi"
else
  foo = 33
end

bar = foo&.to_s
```

Before:

```
editor.rb:11: This code is unreachable https://srb.help/7006
    11 |bar = foo&.to_s
              ^
Errors: 1
```

After:

```
editor.rb:11: Used &. operator on a receiver which can never be nil https://srb.help/7034
    11 |bar = foo&.to_s
              ^
  Type of receiver is String | Integer, from:
    editor.rb:6:
     6 |  foo = "hi"
                ^^^^
    editor.rb:8:
     8 |  foo = 33
                ^^
Errors: 1
```


### Motivation

The weird error message in this case is a pretty common source of confusion among users.


### Test plan

See included automated tests.
