### PR TITLE
Update Integer#[] signature to support Ruby 2.7 features

### DIFF
--- a/rbi/core/integer.rbi
+++ b/rbi/core/integer.rbi
@@ -477,6 +477,14 @@ class Integer < Numeric
   # 50.downto(0) {|n| print a[n] }
   # #=> 000101110110100000111000011110010100111100010111001
   # ```
+  #
+  # Range operations n[i, len] and n[i..j] are naturally extended.
+  # - `n[i, len]` equals to `(n >> i) & ((1 << len) - 1)`.
+  # - `n[i..j]` equals to `(n >> i) & ((1 << (j - i + 1)) - 1)`.
+  # - `n[i...j]`` equals to `(n >> i) & ((1 << (j - i)) - 1)`.
+  # - `n[i..]`` equals to `(n >> i)`.
+  # - `n[..j]` is zero if `n & ((1 << (j + 1)) - 1)` is zero. Otherwise, raises an `ArgumentError`.
+  # - `n[...j]` is zero if `n & ((1 << j) - 1)` is zero. Otherwise, raises an `ArgumentError`.
   sig do
     params(
         arg0: Integer,
@@ -501,7 +509,20 @@ class Integer < Numeric
     )
     .returns(Integer)
   end
-  def [](arg0); end
+  sig do
+    params(
+        arg0: T::Range[T.any(Integer, Float, Rational)],
+    )
+    .returns(Integer)
+  end
+  sig do
+    params(
+        arg0: Numeric,
+        arg1: Numeric,
+    )
+    .returns(Integer)
+  end
+  def [](arg0, arg1=T.unsafe(nil)); end
 
   # Bitwise EXCLUSIVE OR.
   sig do

--- a/test/testdata/rbi/integer.rb
+++ b/test/testdata/rbi/integer.rb
@@ -1,0 +1,22 @@
+# typed: strict
+
+# Integer#[] accepts Integer index
+T.assert_type!(5[1], Integer)
+
+# Integer#[] accepts Integer index and length arguments
+T.assert_type!(5[1, 3], Integer)
+
+# Integer#[] accepts Float index and length arguments
+T.assert_type!(5[1.0, 3.0], Integer)
+
+# Integer#[] accepts Integer Range as argument
+T.assert_type!(5[1..2], Integer)
+
+# Integer#[] accepts Float Range as argument
+T.assert_type!(5[1.0..2.0], Integer)
+
+# Integer#[] accepts beginless Range as argument
+T.assert_type!(5[nil..2], Integer)
+
+# Integer#[] accepts endless Range as argument
+T.assert_type!(5[1..nil], Integer)


### PR DESCRIPTION
Add support for bit reference (`Integer#[]`) using index and length
as arguments or a Range.
Example:
```ruby
0b01001101[2, 4] # => 3
0b01001101[2..5] # => 3
```
https://bugs.ruby-lang.org/issues/8842

Method Documentation:
https://ruby-doc.org/core-2.7.1/Integer.html#method-i-5B-5D

Related to Issue #2390

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Improve method's signature to support Ruby 2.7 features (bit reference with range).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

https://github.com/sorbet/sorbet/issues/2390