### PR TITLE
Fix "deterined" typo in faq.md

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -164,7 +164,7 @@ out-of-bounds. If you would rather raise an exception than handle `nil`, use the
 
 Sorbet can't know what the "parent method" is 100% of the time. For example,
 when calling `super` from a method defined in a module, the `super` method will
-be deterined only once we know which class or module this module has been mixed
+be determined only once we know which class or module this module has been mixed
 into. That's a lot of words, so here's an example:
 
 <a href="https://sorbet.run/#%23%20typed%3A%20true%0Amodule%20MyModule%0A%20%20sig%20%7Breturns(Integer)%7D%0A%20%20def%20foo%0A%20%20%20%20%23%20Can't%20know%20super%20until%20we%20know%20which%20module%20we're%20mixed%20into%0A%20%20%20%20res%20%3D%20super%0A%20%20%20%20T.reveal_type(res)%0A%20%20%20%20res%0A%20%20end%0Aend%0A%0Amodule%20ParentModule1%0A%20%20sig%20%7Breturns(Integer)%7D%0A%20%20def%20foo%0A%20%20%20%200%0A%20%20end%0Aend%0A%0Amodule%20ParentModule2%0A%20%20sig%20%7Breturns(String)%7D%0A%20%20def%20foo%0A%20%20%20%20''%0A%20%20end%0Aend%0A%0Aclass%20MyClass1%0A%20%20include%20ParentModule1%0A%20%20include%20MyModule%0Aend%0A%0Aclass%20MyClass2%0A%20%20include%20ParentModule2%0A%20%20include%20MyModule%0Aend%0A%0AMyClass1.new.foo%0AMyClass2.new.foo%0A">→


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

https://sorbet.org/docs/faq#it-looks-like-sorbets-types-for-the-stdlib-are-wrong

> [...] the super method will be **deterined** only once we know which class or module this module has been mixed into.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It is misspelt

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I did not test it
