### PR TITLE
Method rename support (initial implementation)

### DIFF
--- a/main/lsp/requests/prepare_rename.cc
+++ b/main/lsp/requests/prepare_rename.cc
@@ -50,13 +50,18 @@ unique_ptr<ResponseMessage> PrepareRenameTask::runRequest(LSPTypecheckerDelegate
         auto &queryResponses = result.responses;
         if (!queryResponses.empty()) {
             auto resp = move(queryResponses[0]);
-            // Only supports rename requests from constants and class definitions.
+            // We support rename requests from constants, class definitions, and methods.
             if (auto constResp = resp->isConstant()) {
                 response->result = getPrepareRenameResult(gs, constResp->symbol);
             } else if (auto defResp = resp->isDefinition()) {
                 if (defResp->symbol.data(gs)->isClassOrModule()) {
                     response->result = getPrepareRenameResult(gs, defResp->symbol);
+                } else if (defResp->symbol.data(gs)->isMethod()) {
+                    response->result = getPrepareRenameResult(gs, defResp->symbol);
                 }
+            } else if (auto sendResp = resp->isSend()) {
+                auto method = sendResp->dispatchResult->main.method;
+                response->result = getPrepareRenameResult(gs, method);
             }
         }
     }

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -7,7 +7,6 @@
 #include "main/lsp/ShowOperation.h"
 #include "main/lsp/json_types.h"
 #include "main/lsp/lsp.h"
-#include <iostream>
 #include <stdio.h>
 using namespace std;
 
@@ -126,7 +125,6 @@ public:
         } else { // send
             newsrc = replaceMethodNameInSend(source);
         }
-        cout << "MethodRename: old/new: " << source << "/" << newsrc << "\n";
         edits[location->uri].push_back(make_unique<TextEdit>(move(location->range), newsrc));
     }
 

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -158,7 +158,6 @@ RenameTask::getRenameEdits(LSPTypecheckerDelegate &typechecker, core::SymbolRef 
     const core::GlobalState &gs = typechecker.state();
     auto symbolData = symbol.data(gs);
     auto originalName = symbolData->name.show(gs);
-    auto we = make_unique<WorkspaceEdit>();
     unique_ptr<Renamer> renamer;
 
     vector<core::SymbolRef> symbolsToRename;
@@ -188,7 +187,6 @@ RenameTask::getRenameEdits(LSPTypecheckerDelegate &typechecker, core::SymbolRef 
         renamer = make_unique<ConstRenamer>(originalName, newName);
         symbolsToRename.push_back(symbol);
     }
-    UnorderedMap<string, vector<unique_ptr<TextEdit>>> edits;
 
     for (auto sym : symbolsToRename) {
         vector<unique_ptr<Location>> references = getReferencesToSymbol(typechecker, sym);

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -1,6 +1,7 @@
 #include "main/lsp/requests/rename.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_join.h"
+#include "absl/strings/str_replace.h"
 #include "absl/strings/str_split.h"
 #include "core/lsp/QueryResponse.h"
 #include "main/lsp/ShowOperation.h"
@@ -29,37 +30,135 @@ bool isValidRenameLocation(const core::SymbolRef &symbol, const core::GlobalStat
                 fmt::format("Renaming constants defined in {} files is not supported; symbol {} is defined at {}",
                             filetype, symbol.data(gs)->name.show(gs), loc.filePosToString(gs));
             response->error = make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest, error);
-
             return false;
         }
     }
     return true;
 }
+
+// Replaces originalName with newName in the last dotted component if the string is of the form x.y.z; otherwise does a
+// simple ReplaceAll.
+std::string replaceLastDotted(std::string_view input, std::string_view originalName, std::string_view newName) {
+    if (absl::StrContains(input, ".")) {
+        std::vector<std::string> dotted = absl::StrSplit(input, ".");
+        // TODO: check for exactly one match
+        dotted[dotted.size() - 1] = absl::StrReplaceAll(dotted[dotted.size() - 1], {{originalName, newName}});
+        return absl::StrJoin(dotted, ".");
+    }
+    return absl::StrReplaceAll(input, {{originalName, newName}});
+}
+
+// Checks if s is a subclass of root, and updates isSubclass, visited, and subclasses vectors.
+bool updateSubclass(const core::GlobalState &gs, core::SymbolRef root, core::SymbolRef s, vector<bool> &isSubclass,
+                    vector<bool> &visited, vector<core::SymbolRef> &subclasses) {
+    if (visited[s.rawId()] == true) {
+        return isSubclass[s.rawId()];
+    }
+    visited[s.rawId()] = true;
+    if (s.rawId() == root.rawId()) {
+        subclasses.push_back(s);
+        isSubclass[s.rawId()] = true;
+        return true;
+    }
+    auto super = s.data(gs)->superClass();
+    if (super.exists()) {
+        if (updateSubclass(gs, root, super, isSubclass, visited, subclasses)) {
+            subclasses.push_back(s);
+            isSubclass[super.rawId()] = true;
+            return true;
+        }
+    }
+    isSubclass[s.rawId()] = false;
+    return false;
+}
+
+// Returns all subclasses of root (including root)
+vector<core::SymbolRef> getSubclasses(LSPTypecheckerDelegate &typechecker, core::SymbolRef root) {
+    const core::GlobalState &gs = typechecker.state();
+    vector<bool> isSubclass(gs.classAndModulesUsed());
+    vector<bool> visited(gs.classAndModulesUsed());
+    vector<core::SymbolRef> subclasses;
+    for (u4 i = 1; i < gs.classAndModulesUsed(); ++i) {
+        auto s = core::SymbolRef(&gs, core::SymbolRef::Kind::ClassOrModule, i);
+        updateSubclass(gs, root, s, isSubclass, visited, subclasses);
+    }
+    return subclasses;
+}
+
+// Follow superClass links to find the root of a class hierarchy.
+core::SymbolRef findRootSuperclass(const core::GlobalState &gs, core::SymbolRef klass) {
+    auto root = klass;
+    while (true) {
+        auto tmp = root.data(gs)->superClass();
+        ENFORCE(tmp.exists()); // everything derives from Kernel::Object
+        // TODO is there a better way to do this check for the base object class?
+        if (!tmp.exists() || tmp.data(gs)->show(gs) == "Object") {
+            break;
+        }
+        root = tmp;
+    }
+    return root;
+}
+
 } // namespace
 
 variant<JSONNullObject, unique_ptr<WorkspaceEdit>>
 RenameTask::getRenameEdits(LSPTypecheckerDelegate &typechecker, core::SymbolRef symbol, std::string_view newName) {
     const core::GlobalState &gs = typechecker.state();
-    vector<unique_ptr<Location>> references = getReferencesToSymbol(typechecker, symbol);
-    auto originalName = symbol.data(gs)->name.toString(gs);
+    auto symbolData = symbol.data(gs);
+    auto originalName = symbolData->name.show(gs);
     auto we = make_unique<WorkspaceEdit>();
 
-    UnorderedMap<string, vector<unique_ptr<TextEdit>>> edits;
-    for (auto &location : references) {
-        // Get text at location.
-        auto fref = config.uri2FileRef(gs, location->uri);
-        if (fref.data(gs).isPayload()) {
-            // We don't support renaming things in payload files.
-            return JSONNullObject();
+    vector<core::SymbolRef> symbolsToRename;
+    if (symbolData->isMethod()) {
+        // We have to check for methods as part of a class hierarchy: Follow superClass() links till we find the root;
+        // then find the full tree; then look for methods with the same name as ours; then find all references to all
+        // those methods and rename them.
+        auto symbolClass = symbolData->enclosingClass(gs);
+        auto root = findRootSuperclass(gs, symbolClass);
+        auto subclasses = getSubclasses(typechecker, root);
+
+        // find the target method definition in each subclass
+        for (auto c : subclasses) {
+            auto classSymbol = c.data(gs);
+            auto member = classSymbol->findMember(gs, symbol.data(gs)->name);
+            if (member.exists()) {
+                symbolsToRename.push_back(member);
+            }
         }
-
-        auto loc = location->range->toLoc(gs, fref);
-        auto source = loc.source(gs);
-        std::vector<std::string> strs = absl::StrSplit(source, "::");
-        strs[strs.size() - 1] = string(newName);
-        edits[location->uri].push_back(make_unique<TextEdit>(move(location->range), absl::StrJoin(strs, "::")));
+    } else {
+        symbolsToRename.push_back(symbol);
     }
+    UnorderedMap<string, vector<unique_ptr<TextEdit>>> edits;
 
+    // TODO is it possible to do one query with many symbols, and would that be faster?
+    for (auto sym : symbolsToRename) {
+        vector<unique_ptr<Location>> references = getReferencesToSymbol(typechecker, sym);
+
+        for (auto &location : references) {
+            // Get text at location.
+            auto fref = config.uri2FileRef(gs, location->uri);
+            if (fref.data(gs).isPayload()) {
+                // We don't support renaming things in payload files.
+                return JSONNullObject();
+            }
+
+            auto loc = location->range->toLoc(gs, fref);
+            auto source = loc.source(gs);
+
+            if (absl::StrContains(source, "::")) {
+                std::vector<std::string> strs = absl::StrSplit(source, "::");
+
+                strs[strs.size() - 1] = replaceLastDotted(strs[strs.size() - 1], originalName, newName);
+
+                auto newsrc = absl::StrJoin(strs, "::");
+                edits[location->uri].push_back(make_unique<TextEdit>(move(location->range), newsrc));
+            } else {
+                auto newsrc = replaceLastDotted(source, originalName, newName);
+                edits[location->uri].push_back(make_unique<TextEdit>(move(location->range), newsrc));
+            }
+        }
+    }
     vector<unique_ptr<TextDocumentEdit>> textDocEdits;
     for (auto &item : edits) {
         // TODO: Version.
@@ -92,13 +191,6 @@ unique_ptr<ResponseMessage> RenameTask::runRequest(LSPTypecheckerDelegate &typec
         return response;
     }
 
-    // Sanity check the text.
-    if (islower(params->newName[0])) {
-        response->error = make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest,
-                                                     "Constant names must begin with an uppercase letter.");
-        return response;
-    }
-
     ShowOperation op(config, ShowOperation::Kind::Rename);
 
     auto result = queryByLoc(typechecker, params->textDocument->uri, *params->position, LSPMethod::TextDocumentRename);
@@ -114,15 +206,24 @@ unique_ptr<ResponseMessage> RenameTask::runRequest(LSPTypecheckerDelegate &typec
             auto resp = move(queryResponses[0]);
             // Only supports rename requests from constants and class definitions.
             if (auto constResp = resp->isConstant()) {
+                // Sanity check the text.
+                if (islower(params->newName[0])) {
+                    response->error = make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest,
+                                                                 "Constant names must begin with an uppercase letter.");
+                    return response;
+                }
                 if (isValidRenameLocation(constResp->symbol, gs, response)) {
                     response->result = getRenameEdits(typechecker, constResp->symbol, params->newName);
                 }
             } else if (auto defResp = resp->isDefinition()) {
-                if (defResp->symbol.data(gs)->isClassOrModule()) {
+                if (defResp->symbol.data(gs)->isClassOrModule() || defResp->symbol.data(gs)->isMethod()) {
                     if (isValidRenameLocation(defResp->symbol, gs, response)) {
                         response->result = getRenameEdits(typechecker, defResp->symbol, params->newName);
                     }
                 }
+            } else if (auto sendResp = resp->isSend()) {
+                auto method = sendResp->dispatchResult->main.method;
+                response->result = getRenameEdits(typechecker, method, params->newName);
             }
         }
     }

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -120,7 +120,7 @@ public:
         auto source = loc.source(gs);
         string newsrc;
         if (absl::StartsWith(source, "def ") || absl::StartsWith(source, "attr_reader") ||
-            absl::StartsWith(source, "attr_accessor")) {
+            absl::StartsWith(source, "attr_writer") || absl::StartsWith(source, "attr_accessor")) {
             newsrc = replaceMethodNameInDef(source);
         } else { // send
             newsrc = replaceMethodNameInSend(source);
@@ -138,6 +138,7 @@ private:
             if (send[i] == ' ' || send[i] == '(') {
                 methodExpr = send.substr(0, i);
                 args = send.substr(i, send.size() - i);
+                break;
             }
         }
         // no args passed

--- a/main/lsp/requests/rename.h
+++ b/main/lsp/requests/rename.h
@@ -9,7 +9,7 @@ class RenameParams;
 class RenameTask final : public LSPRequestTask {
     std::unique_ptr<RenameParams> params;
     absl::variant<JSONNullObject, std::unique_ptr<WorkspaceEdit>>
-    getRenameEdits(LSPTypecheckerDelegate &typechecker, core::SymbolRef symbol, std::string_view newName);
+    getRenameEdits(LSPTypecheckerDelegate &typechecker, core::SymbolRef symbol, std::string newName);
 
 public:
     RenameTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<RenameParams> params);

--- a/test/testdata/lsp/rename/method_attr.A.rbedited
+++ b/test/testdata/lsp/rename/method_attr.A.rbedited
@@ -1,0 +1,10 @@
+# typed: true
+# frozen_string_literal: true
+
+class Foo
+  attr_reader :baz
+end
+
+f = Foo.new
+f.baz
+# ^ apply-rename: [A] newName: baz

--- a/test/testdata/lsp/rename/method_attr.rb
+++ b/test/testdata/lsp/rename/method_attr.rb
@@ -1,0 +1,10 @@
+# typed: true
+# frozen_string_literal: true
+
+class Foo
+  attr_reader :bar
+end
+
+f = Foo.new
+f.bar
+# ^ apply-rename: [A] newName: baz

--- a/test/testdata/lsp/rename/method_class_hierarchy.A.rbedited
+++ b/test/testdata/lsp/rename/method_class_hierarchy.A.rbedited
@@ -2,18 +2,28 @@
 # frozen_string_literal: true
 
 class Base
+  # does not contain method foo
+end
+
+class BaseWithMethod < Base
   def bar
   end
 end
 
-class A < Base
+class A < BaseWithMethod
   def bar
 #     ^ apply-rename: [A] newName: bar
   end
 end
 
-class B < Base
+class B < BaseWithMethod
   def bar
+  end
+end
+
+class C < Base
+  def foo
+    # this one should not be renamed!
   end
 end
 

--- a/test/testdata/lsp/rename/method_class_hierarchy.A.rbedited
+++ b/test/testdata/lsp/rename/method_class_hierarchy.A.rbedited
@@ -1,0 +1,20 @@
+# typed: true
+# frozen_string_literal: true
+
+class Base
+  def bar
+  end
+end
+
+class A < Base
+  def bar
+#     ^ apply-rename: [A] newName: bar
+  end
+end
+
+class B < Base
+  def bar
+  end
+end
+
+A.new.bar

--- a/test/testdata/lsp/rename/method_class_hierarchy.rb
+++ b/test/testdata/lsp/rename/method_class_hierarchy.rb
@@ -1,0 +1,20 @@
+# typed: true
+# frozen_string_literal: true
+
+class Base
+  def foo
+  end
+end
+
+class A < Base
+  def foo
+#     ^ apply-rename: [A] newName: bar
+  end
+end
+
+class B < Base
+  def foo
+  end
+end
+
+A.new.foo

--- a/test/testdata/lsp/rename/method_class_hierarchy.rb
+++ b/test/testdata/lsp/rename/method_class_hierarchy.rb
@@ -2,18 +2,28 @@
 # frozen_string_literal: true
 
 class Base
+  # does not contain method foo
+end
+
+class BaseWithMethod < Base
   def foo
   end
 end
 
-class A < Base
+class A < BaseWithMethod
   def foo
 #     ^ apply-rename: [A] newName: bar
   end
 end
 
-class B < Base
+class B < BaseWithMethod
   def foo
+  end
+end
+
+class C < Base
+  def foo
+    # this one should not be renamed!
   end
 end
 

--- a/test/testdata/lsp/rename/method_class_method.A.rbedited
+++ b/test/testdata/lsp/rename/method_class_method.A.rbedited
@@ -1,0 +1,15 @@
+# typed: true
+# frozen_string_literal: true
+
+class Foo
+  def self.bar
+#          ^ apply-rename: [A] newName: bar
+  end
+
+  def foo
+    # this is a separate method
+  end
+end
+
+Foo.bar
+Foo.new.foo

--- a/test/testdata/lsp/rename/method_class_method.rb
+++ b/test/testdata/lsp/rename/method_class_method.rb
@@ -1,0 +1,15 @@
+# typed: true
+# frozen_string_literal: true
+
+class Foo
+  def self.foo
+#          ^ apply-rename: [A] newName: bar
+  end
+
+  def foo
+    # this is a separate method
+  end
+end
+
+Foo.foo
+Foo.new.foo

--- a/test/testdata/lsp/rename/method_names.A.rbedited
+++ b/test/testdata/lsp/rename/method_names.A.rbedited
@@ -1,0 +1,35 @@
+# typed: strict
+# frozen_string_literal: true
+
+class C1
+  extend T::Sig
+
+  sig { returns(C1) }
+  def m2
+#     ^ apply-rename: [A] newName: m2
+    self
+  end
+
+  sig { returns(String) }
+  def x
+    "hello, world"
+  end
+end
+
+class C2
+  extend T::Sig
+
+  # this one isn't being renamed
+  sig { returns(C1) }
+  def m1
+    C1.new
+  end
+end
+
+c2 = C2.new
+# only the second m1 should change
+puts c2.m1.m2.x
+
+c1 = C1.new
+# both first and second m1 should change
+puts c1.m2.m2.x

--- a/test/testdata/lsp/rename/method_names.rb
+++ b/test/testdata/lsp/rename/method_names.rb
@@ -1,0 +1,35 @@
+# typed: strict
+# frozen_string_literal: true
+
+class C1
+  extend T::Sig
+
+  sig { returns(C1) }
+  def m1
+#     ^ apply-rename: [A] newName: m2
+    self
+  end
+
+  sig { returns(String) }
+  def x
+    "hello, world"
+  end
+end
+
+class C2
+  extend T::Sig
+
+  # this one isn't being renamed
+  sig { returns(C1) }
+  def m1
+    C1.new
+  end
+end
+
+c2 = C2.new
+# only the second m1 should change
+puts c2.m1.m1.x
+
+c1 = C1.new
+# both first and second m1 should change
+puts c1.m1.m1.x

--- a/test/testdata/lsp/rename/method_simple.A.rbedited
+++ b/test/testdata/lsp/rename/method_simple.A.rbedited
@@ -1,0 +1,25 @@
+# typed: true
+# frozen_string_literal: true
+
+module M
+  class Foo
+    def baz(a=1)
+#     ^ apply-rename: [A] newName: baz
+    end
+
+    def caller
+      baz(1)
+    end
+  end
+end
+
+f = M::Foo.new
+f.baz(2)
+f.baz
+
+M::Foo.new.baz 3
+
+class Unrelated
+  # this should be left unchanged
+  def bar; end
+end

--- a/test/testdata/lsp/rename/method_simple.A.rbedited
+++ b/test/testdata/lsp/rename/method_simple.A.rbedited
@@ -10,11 +10,15 @@ module M
     def caller
       baz(1)
     end
+
+    def x
+      42
+    end
   end
 end
 
 f = M::Foo.new
-f.baz(2)
+f.baz(f.x)
 f.baz
 
 M::Foo.new.baz 3

--- a/test/testdata/lsp/rename/method_simple.rb
+++ b/test/testdata/lsp/rename/method_simple.rb
@@ -1,0 +1,25 @@
+# typed: true
+# frozen_string_literal: true
+
+module M
+  class Foo
+    def bar(a=1)
+#     ^ apply-rename: [A] newName: baz
+    end
+
+    def caller
+      bar(1)
+    end
+  end
+end
+
+f = M::Foo.new
+f.bar(2)
+f.bar
+
+M::Foo.new.bar 3
+
+class Unrelated
+  # this should be left unchanged
+  def bar; end
+end

--- a/test/testdata/lsp/rename/method_simple.rb
+++ b/test/testdata/lsp/rename/method_simple.rb
@@ -10,11 +10,15 @@ module M
     def caller
       bar(1)
     end
+
+    def x
+      42
+    end
   end
 end
 
 f = M::Foo.new
-f.bar(2)
+f.bar(f.x)
 f.bar
 
 M::Foo.new.bar 3


### PR DESCRIPTION
Implements a first cut of method rename support, building on the constant rename work. This implementation supports subclasses but doesn't handle union types, mixins, and probably more cases.

The goal of this change is to enable method renames in experimental mode and gather some user feedback about which missing bits are most important.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We have lots of user demand for refactoring features, and we think method renames would one of the useful ones.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
