### PR TITLE
Support go-to-def / go-to-type-def / hover doc strings for classes/modules opened in multiple files

### DIFF
--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -26,13 +26,21 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &t
             auto resp = move(queryResponses[0]);
 
             // Only support go-to-definition on constants and fields in untyped files.
-            if (resp->isConstant() || resp->isField() || (fileIsTyped && (resp->isIdent() || resp->isLiteral()))) {
+            if (auto c = resp->isConstant()) {
+                auto sym = c->symbol;
+                for (auto loc : sym.data(gs)->locs()) {
+                    addLocIfExists(gs, result, loc);
+                }
+            } else if (resp->isField() || (fileIsTyped && (resp->isIdent() || resp->isLiteral()))) {
                 auto retType = resp->getTypeAndOrigins();
                 for (auto &originLoc : retType.origins) {
                     addLocIfExists(gs, result, originLoc);
                 }
             } else if (fileIsTyped && resp->isDefinition()) {
-                addLocIfExists(gs, result, resp->isDefinition()->termLoc);
+                auto sym = resp->isDefinition()->symbol;
+                for (auto loc : sym.data(gs)->locs()) {
+                    addLocIfExists(gs, result, loc);
+                }
             } else if (fileIsTyped && resp->isSend()) {
                 auto sendResp = resp->isSend();
                 auto start = sendResp->dispatchResult.get();

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -14,8 +14,17 @@ vector<core::Loc> locsForType(const core::GlobalState &gs, const core::TypePtr &
         return result;
     }
     typecase(
-        type, [&](const core::ClassType &t) { result.emplace_back(t.symbol.data(gs)->loc()); },
-        [&](const core::AppliedType &t) { result.emplace_back(t.klass.data(gs)->loc()); },
+        type,
+        [&](const core::ClassType &t) {
+            for (auto loc : t.symbol.data(gs)->locs()) {
+                result.emplace_back(loc);
+            }
+        },
+        [&](const core::AppliedType &t) {
+            for (auto loc : t.klass.data(gs)->locs()) {
+                result.emplace_back(loc);
+            }
+        },
         [&](const core::OrType &t) {
             for (auto loc : locsForType(gs, t.left)) {
                 result.emplace_back(loc);

--- a/test/testdata/lsp/definitions_multiple__a.rb
+++ b/test/testdata/lsp/definitions_multiple__a.rb
@@ -1,12 +1,17 @@
 # typed: true
 
+# Documentation 2
 class MyCommand
   #   ^^^^^^^^^ def: MyCommand
   #   ^^^^^^^^^ type-def: MyCommand
+  #   ^^^^^^^^^ hover: Documentation 1
+  #   ^^^^^^^^^ hover: Documentation 2
 end
 
 def main
   MyCommand.new
 # ^^^^^^^^^ usage: MyCommand
 #           ^^^ type: MyCommand
+# ^^^^^^^^^ hover: Documentation 1
+# ^^^^^^^^^ hover: Documentation 2
 end

--- a/test/testdata/lsp/definitions_multiple__a.rb
+++ b/test/testdata/lsp/definitions_multiple__a.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+class MyCommand
+  #   ^^^^^^^^^ def: MyCommand
+  #   ^^^^^^^^^ type-def: MyCommand
+end
+
+def main
+  MyCommand.new
+# ^^^^^^^^^ usage: MyCommand
+#           ^^^ type: MyCommand
+end

--- a/test/testdata/lsp/definitions_multiple__b.rb
+++ b/test/testdata/lsp/definitions_multiple__b.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+class MyCommand
+  #   ^^^^^^^^^ def: MyCommand
+  #   ^^^^^^^^^ type-def: MyCommand
+
+end

--- a/test/testdata/lsp/definitions_multiple__b.rb
+++ b/test/testdata/lsp/definitions_multiple__b.rb
@@ -1,7 +1,10 @@
 # typed: true
 
+# Documentation 1
 class MyCommand
   #   ^^^^^^^^^ def: MyCommand
   #   ^^^^^^^^^ type-def: MyCommand
+  #   ^^^^^^^^^ hover: Documentation 1
+  #   ^^^^^^^^^ hover: Documentation 2
 
 end

--- a/test/testdata/lsp/hover.rb
+++ b/test/testdata/lsp/hover.rb
@@ -5,8 +5,8 @@ class BigFoo; extend T::Sig
 
 # The docs for FOO_CONSTANT
   FOO_CONSTANT = 1
-# ^^^^^^^^^^^^ The docs for FOO_CONSTANT
-# ^^^^^^^^^^^^ Integer(1)
+# ^^^^^^^^^^^^ hover: The docs for FOO_CONSTANT
+# ^^^^^^^^^^^^ hover: Integer(1)
 
   # Docs for Bar#static_variable
   @@static_variable = T.let('asdf', String)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Support go-to-def / go-to-type-def / hover doc strings for classes/modules opened in multiple files.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These features previously only reported/used a single definition site.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
