### PR TITLE
Move remaining Type methods to TypePtr + introduce standard CALL_MEMBER/HAS_MEMBER helpers

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -44,6 +44,7 @@ namespace sorbet::ast {
 #define CASE_STATEMENT(CASE_BODY, T) \
     case Tag::T: {                   \
         CASE_BODY(T)                 \
+        break;                       \
     }
 
 #define GENERATE_TAG_SWITCH(tag, CASE_BODY)              \

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -83,12 +83,10 @@ namespace sorbet::ast {
 void TreePtr::deleteTagged(Tag tag, void *ptr) noexcept {
     ENFORCE(ptr != nullptr);
 #define DELETE_TYPE(T)                                      \
-    if (tag == Tag::EmptyTree) {                            \
+    if (tag != Tag::EmptyTree) {                            \
         /* explicitly not deleting the empty tree pointer*/ \
-        break;                                              \
-    }                                                       \
-    delete reinterpret_cast<T *>(ptr);                      \
-    break;
+        delete reinterpret_cast<T *>(ptr);                  \
+    }
 
     GENERATE_TAG_SWITCH(tag, DELETE_TYPE)
 

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -41,126 +41,57 @@ using namespace std;
 
 namespace sorbet::ast {
 
+#define CASE_STATEMENT(CASE_BODY, T) \
+    case Tag::T: {                   \
+        CASE_BODY(T)                 \
+    }
+
+#define GENERATE_TAG_SWITCH(tag, CASE_BODY)              \
+    switch (tag) {                                       \
+        CASE_STATEMENT(CASE_BODY, EmptyTree)             \
+        CASE_STATEMENT(CASE_BODY, Send)                  \
+        CASE_STATEMENT(CASE_BODY, ClassDef)              \
+        CASE_STATEMENT(CASE_BODY, MethodDef)             \
+        CASE_STATEMENT(CASE_BODY, If)                    \
+        CASE_STATEMENT(CASE_BODY, While)                 \
+        CASE_STATEMENT(CASE_BODY, Break)                 \
+        CASE_STATEMENT(CASE_BODY, Retry)                 \
+        CASE_STATEMENT(CASE_BODY, Next)                  \
+        CASE_STATEMENT(CASE_BODY, Return)                \
+        CASE_STATEMENT(CASE_BODY, RescueCase)            \
+        CASE_STATEMENT(CASE_BODY, Rescue)                \
+        CASE_STATEMENT(CASE_BODY, Local)                 \
+        CASE_STATEMENT(CASE_BODY, UnresolvedIdent)       \
+        CASE_STATEMENT(CASE_BODY, RestArg)               \
+        CASE_STATEMENT(CASE_BODY, KeywordArg)            \
+        CASE_STATEMENT(CASE_BODY, OptionalArg)           \
+        CASE_STATEMENT(CASE_BODY, BlockArg)              \
+        CASE_STATEMENT(CASE_BODY, ShadowArg)             \
+        CASE_STATEMENT(CASE_BODY, Assign)                \
+        CASE_STATEMENT(CASE_BODY, Cast)                  \
+        CASE_STATEMENT(CASE_BODY, Hash)                  \
+        CASE_STATEMENT(CASE_BODY, Array)                 \
+        CASE_STATEMENT(CASE_BODY, Literal)               \
+        CASE_STATEMENT(CASE_BODY, UnresolvedConstantLit) \
+        CASE_STATEMENT(CASE_BODY, ConstantLit)           \
+        CASE_STATEMENT(CASE_BODY, ZSuperArgs)            \
+        CASE_STATEMENT(CASE_BODY, Block)                 \
+        CASE_STATEMENT(CASE_BODY, InsSeq)                \
+    }
+
 void TreePtr::deleteTagged(Tag tag, void *ptr) noexcept {
     ENFORCE(ptr != nullptr);
+#define DELETE_TYPE(T)                                      \
+    if (tag == Tag::EmptyTree) {                            \
+        /* explicitly not deleting the empty tree pointer*/ \
+        break;                                              \
+    }                                                       \
+    delete reinterpret_cast<T *>(ptr);                      \
+    break;
 
-    switch (tag) {
-        case Tag::EmptyTree:
-            // explicitly not deleting the empty tree pointer
-            break;
+    GENERATE_TAG_SWITCH(tag, DELETE_TYPE)
 
-        case Tag::Send:
-            delete reinterpret_cast<Send *>(ptr);
-            break;
-
-        case Tag::ClassDef:
-            delete reinterpret_cast<ClassDef *>(ptr);
-            break;
-
-        case Tag::MethodDef:
-            delete reinterpret_cast<MethodDef *>(ptr);
-            break;
-
-        case Tag::If:
-            delete reinterpret_cast<If *>(ptr);
-            break;
-
-        case Tag::While:
-            delete reinterpret_cast<While *>(ptr);
-            break;
-
-        case Tag::Break:
-            delete reinterpret_cast<Break *>(ptr);
-            break;
-
-        case Tag::Retry:
-            delete reinterpret_cast<Retry *>(ptr);
-            break;
-
-        case Tag::Next:
-            delete reinterpret_cast<Next *>(ptr);
-            break;
-
-        case Tag::Return:
-            delete reinterpret_cast<Return *>(ptr);
-            break;
-
-        case Tag::RescueCase:
-            delete reinterpret_cast<RescueCase *>(ptr);
-            break;
-
-        case Tag::Rescue:
-            delete reinterpret_cast<Rescue *>(ptr);
-            break;
-
-        case Tag::Local:
-            delete reinterpret_cast<Local *>(ptr);
-            break;
-
-        case Tag::UnresolvedIdent:
-            delete reinterpret_cast<UnresolvedIdent *>(ptr);
-            break;
-
-        case Tag::RestArg:
-            delete reinterpret_cast<RestArg *>(ptr);
-            break;
-
-        case Tag::KeywordArg:
-            delete reinterpret_cast<KeywordArg *>(ptr);
-            break;
-
-        case Tag::OptionalArg:
-            delete reinterpret_cast<OptionalArg *>(ptr);
-            break;
-
-        case Tag::BlockArg:
-            delete reinterpret_cast<BlockArg *>(ptr);
-            break;
-
-        case Tag::ShadowArg:
-            delete reinterpret_cast<ShadowArg *>(ptr);
-            break;
-
-        case Tag::Assign:
-            delete reinterpret_cast<Assign *>(ptr);
-            break;
-
-        case Tag::Cast:
-            delete reinterpret_cast<Cast *>(ptr);
-            break;
-
-        case Tag::Hash:
-            delete reinterpret_cast<Hash *>(ptr);
-            break;
-
-        case Tag::Array:
-            delete reinterpret_cast<Array *>(ptr);
-            break;
-
-        case Tag::Literal:
-            delete reinterpret_cast<Literal *>(ptr);
-            break;
-
-        case Tag::UnresolvedConstantLit:
-            delete reinterpret_cast<UnresolvedConstantLit *>(ptr);
-            break;
-
-        case Tag::ConstantLit:
-            delete reinterpret_cast<ConstantLit *>(ptr);
-            break;
-
-        case Tag::ZSuperArgs:
-            delete reinterpret_cast<ZSuperArgs *>(ptr);
-            break;
-
-        case Tag::Block:
-            delete reinterpret_cast<Block *>(ptr);
-            break;
-
-        case Tag::InsSeq:
-            delete reinterpret_cast<InsSeq *>(ptr);
-            break;
-    }
+#undef DELETE_TYPE
 }
 
 string TreePtr::nodeName() const {
@@ -168,40 +99,8 @@ string TreePtr::nodeName() const {
 
     ENFORCE(ptr != nullptr);
 
-#define NODE_NAME(name) \
-    case Tag::name:     \
-        return reinterpret_cast<name *>(ptr)->nodeName();
-    switch (tag()) {
-        NODE_NAME(EmptyTree)
-        NODE_NAME(Send)
-        NODE_NAME(ClassDef)
-        NODE_NAME(MethodDef)
-        NODE_NAME(If)
-        NODE_NAME(While)
-        NODE_NAME(Break)
-        NODE_NAME(Retry)
-        NODE_NAME(Next)
-        NODE_NAME(Return)
-        NODE_NAME(RescueCase)
-        NODE_NAME(Rescue)
-        NODE_NAME(Local)
-        NODE_NAME(UnresolvedIdent)
-        NODE_NAME(RestArg)
-        NODE_NAME(KeywordArg)
-        NODE_NAME(OptionalArg)
-        NODE_NAME(BlockArg)
-        NODE_NAME(ShadowArg)
-        NODE_NAME(Assign)
-        NODE_NAME(Cast)
-        NODE_NAME(Hash)
-        NODE_NAME(Array)
-        NODE_NAME(Literal)
-        NODE_NAME(UnresolvedConstantLit)
-        NODE_NAME(ConstantLit)
-        NODE_NAME(ZSuperArgs)
-        NODE_NAME(Block)
-        NODE_NAME(InsSeq)
-    }
+#define NODE_NAME(name) return reinterpret_cast<name *>(ptr)->nodeName();
+    GENERATE_TAG_SWITCH(tag(), NODE_NAME)
 #undef NODE_NAME
 }
 
@@ -210,40 +109,8 @@ string TreePtr::showRaw(const core::GlobalState &gs, int tabs) {
 
     ENFORCE(ptr != nullptr);
 
-#define SHOW_RAW(name) \
-    case Tag::name:    \
-        return reinterpret_cast<name *>(ptr)->showRaw(gs, tabs);
-    switch (tag()) {
-        SHOW_RAW(EmptyTree)
-        SHOW_RAW(Send)
-        SHOW_RAW(ClassDef)
-        SHOW_RAW(MethodDef)
-        SHOW_RAW(If)
-        SHOW_RAW(While)
-        SHOW_RAW(Break)
-        SHOW_RAW(Retry)
-        SHOW_RAW(Next)
-        SHOW_RAW(Return)
-        SHOW_RAW(RescueCase)
-        SHOW_RAW(Rescue)
-        SHOW_RAW(Local)
-        SHOW_RAW(UnresolvedIdent)
-        SHOW_RAW(RestArg)
-        SHOW_RAW(KeywordArg)
-        SHOW_RAW(OptionalArg)
-        SHOW_RAW(BlockArg)
-        SHOW_RAW(ShadowArg)
-        SHOW_RAW(Assign)
-        SHOW_RAW(Cast)
-        SHOW_RAW(Hash)
-        SHOW_RAW(Array)
-        SHOW_RAW(Literal)
-        SHOW_RAW(UnresolvedConstantLit)
-        SHOW_RAW(ConstantLit)
-        SHOW_RAW(ZSuperArgs)
-        SHOW_RAW(Block)
-        SHOW_RAW(InsSeq)
-    }
+#define SHOW_RAW(name) return reinterpret_cast<name *>(ptr)->showRaw(gs, tabs);
+    GENERATE_TAG_SWITCH(tag(), SHOW_RAW)
 #undef SHOW_RAW
 }
 
@@ -252,40 +119,8 @@ core::LocOffsets TreePtr::loc() const {
 
     ENFORCE(ptr != nullptr);
 
-#define CASE(name)  \
-    case Tag::name: \
-        return reinterpret_cast<name *>(ptr)->loc;
-    switch (tag()) {
-        CASE(EmptyTree)
-        CASE(Send)
-        CASE(ClassDef)
-        CASE(MethodDef)
-        CASE(If)
-        CASE(While)
-        CASE(Break)
-        CASE(Retry)
-        CASE(Next)
-        CASE(Return)
-        CASE(RescueCase)
-        CASE(Rescue)
-        CASE(Local)
-        CASE(UnresolvedIdent)
-        CASE(RestArg)
-        CASE(KeywordArg)
-        CASE(OptionalArg)
-        CASE(BlockArg)
-        CASE(ShadowArg)
-        CASE(Assign)
-        CASE(Cast)
-        CASE(Hash)
-        CASE(Array)
-        CASE(Literal)
-        CASE(UnresolvedConstantLit)
-        CASE(ConstantLit)
-        CASE(ZSuperArgs)
-        CASE(Block)
-        CASE(InsSeq)
-    }
+#define CASE(name) return reinterpret_cast<name *>(ptr)->loc;
+    GENERATE_TAG_SWITCH(tag(), CASE)
 #undef CASE
 }
 
@@ -294,40 +129,8 @@ string TreePtr::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
 
     ENFORCE(ptr != nullptr);
 
-#define CASE(name)  \
-    case Tag::name: \
-        return reinterpret_cast<name *>(ptr)->toStringWithTabs(gs, tabs);
-    switch (tag()) {
-        CASE(EmptyTree)
-        CASE(Send)
-        CASE(ClassDef)
-        CASE(MethodDef)
-        CASE(If)
-        CASE(While)
-        CASE(Break)
-        CASE(Retry)
-        CASE(Next)
-        CASE(Return)
-        CASE(RescueCase)
-        CASE(Rescue)
-        CASE(Local)
-        CASE(UnresolvedIdent)
-        CASE(RestArg)
-        CASE(KeywordArg)
-        CASE(OptionalArg)
-        CASE(BlockArg)
-        CASE(ShadowArg)
-        CASE(Assign)
-        CASE(Cast)
-        CASE(Hash)
-        CASE(Array)
-        CASE(Literal)
-        CASE(UnresolvedConstantLit)
-        CASE(ConstantLit)
-        CASE(ZSuperArgs)
-        CASE(Block)
-        CASE(InsSeq)
-    }
+#define CASE(name) return reinterpret_cast<name *>(ptr)->toStringWithTabs(gs, tabs);
+    GENERATE_TAG_SWITCH(tag(), CASE)
 #undef CASE
 }
 

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1401,7 +1401,7 @@ bool Literal::isSymbol(const core::GlobalState &gs) const {
 }
 
 bool Literal::isNil(const core::GlobalState &gs) const {
-    return value->derivesFrom(gs, core::Symbols::NilClass());
+    return value.derivesFrom(gs, core::Symbols::NilClass());
 }
 
 bool Literal::isString(const core::GlobalState &gs) const {
@@ -1410,11 +1410,11 @@ bool Literal::isString(const core::GlobalState &gs) const {
 }
 
 bool Literal::isTrue(const core::GlobalState &gs) const {
-    return value->derivesFrom(gs, core::Symbols::TrueClass());
+    return value.derivesFrom(gs, core::Symbols::TrueClass());
 }
 
 bool Literal::isFalse(const core::GlobalState &gs) const {
-    return value->derivesFrom(gs, core::Symbols::FalseClass());
+    return value.derivesFrom(gs, core::Symbols::FalseClass());
 }
 
 string UnresolvedConstantLit::nodeName() {

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1022,10 +1022,10 @@ string Literal::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
             } else if (l.symbol == core::Symbols::TrueClass()) {
                 res = "true";
             } else {
-                res = "literal(" + this->value->toStringWithTabs(gs, tabs) + ")";
+                res = "literal(" + this->value.toStringWithTabs(gs, tabs) + ")";
             }
         },
-        [&](const core::TypePtr &t) { res = "literal(" + this->value->toStringWithTabs(gs, tabs) + ")"; });
+        [&](const core::TypePtr &t) { res = "literal(" + this->value.toStringWithTabs(gs, tabs) + ")"; });
     return res;
 }
 
@@ -1163,7 +1163,7 @@ string Send::showRaw(const core::GlobalState &gs, int tabs) {
 string Cast::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     fmt::format_to(buf, "T.{}", this->cast.toString(gs));
-    fmt::format_to(buf, "({}, {})", this->arg.toStringWithTabs(gs, tabs), this->type->toStringWithTabs(gs, tabs));
+    fmt::format_to(buf, "({}, {})", this->arg.toStringWithTabs(gs, tabs), this->type.toStringWithTabs(gs, tabs));
 
     return fmt::to_string(buf);
 }
@@ -1176,7 +1176,7 @@ string Cast::showRaw(const core::GlobalState &gs, int tabs) {
     printTabs(buf, tabs + 2);
     fmt::format_to(buf, "arg = {}\n", this->arg.showRaw(gs, tabs + 2));
     printTabs(buf, tabs + 2);
-    fmt::format_to(buf, "type = {},\n", this->type->toString(gs));
+    fmt::format_to(buf, "type = {},\n", this->type.toString(gs));
     printTabs(buf, tabs);
     fmt::format_to(buf, "}}\n");
 

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -70,8 +70,8 @@ public:
     TreePtr postTransformInsSeq(core::MutableContext ctx, TreePtr original);
 };
 
-// NOTE: Implementations don't have to use MutableContext (they can use Context too), but we use MutableContext
-// in these preprocessor templates to detect if the type has a function that can be called with a MutableContext.
+// NOTE: Implementations must use a context type parameter that `MutableContext` is convertable to.
+// That is, either `Context` or `MutableContext`.
 #define GENERATE_HAS_MEMBER_VISITOR(X) \
     GENERATE_HAS_MEMBER(X, std::declval<core::MutableContext>(), std::declval<TreePtr>())
 

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -2,6 +2,7 @@
 #define SORBET_TREEMAP_H
 
 #include "ast/Trees.h"
+#include "common/has_member.h"
 #include "core/Context.h"
 #include "core/GlobalState.h"
 #include "core/errors/internal.h"
@@ -69,80 +70,59 @@ public:
     TreePtr postTransformInsSeq(core::MutableContext ctx, TreePtr original);
 };
 
-/**
- * GENERATE_HAS_MEMBER(att)  // Creates 'has_member_att'.
- * `HAS_MEMBER_att<C>::value` can be used to statically test if C has a member att
- */
-#define GENERATE_HAS_MEMBER(X)                                                          \
-    template <typename T> class HAS_MEMBER_##X {                                        \
-        struct Fallback {                                                               \
-            int X;                                                                      \
-        };                                                                              \
-        struct Derived : T, Fallback {};                                                \
-                                                                                        \
-        template <typename U, U> struct Check;                                          \
-                                                                                        \
-        using ArrayOfOne = char[1];                                                     \
-        using ArrayOfTwo = char[2];                                                     \
-                                                                                        \
-        template <typename U> static ArrayOfOne &func(Check<int Fallback::*, &U::X> *); \
-        template <typename U> static ArrayOfTwo &func(...);                             \
-                                                                                        \
-    public:                                                                             \
-        using type = HAS_MEMBER_##X;                                                    \
-        static constexpr std::size_t value = sizeof(func<Derived>(0)) == 2;             \
-    };
+#define GENERATE_HAS_MEMBER_VISITOR(X) \
+    GENERATE_HAS_MEMBER(X, std::declval<core::MutableContext>(), std::declval<TreePtr>())
 
-GENERATE_HAS_MEMBER(preTransformExpression);
-GENERATE_HAS_MEMBER(preTransformClassDef);
-GENERATE_HAS_MEMBER(preTransformMethodDef);
-GENERATE_HAS_MEMBER(preTransformIf);
-GENERATE_HAS_MEMBER(preTransformWhile);
-GENERATE_HAS_MEMBER(preTransformBreak);
-GENERATE_HAS_MEMBER(preTransformRetry);
-GENERATE_HAS_MEMBER(preTransformNext);
-GENERATE_HAS_MEMBER(preTransformReturn);
-GENERATE_HAS_MEMBER(preTransformRescueCase);
-GENERATE_HAS_MEMBER(preTransformRescue);
-GENERATE_HAS_MEMBER(preTransformAssign);
-GENERATE_HAS_MEMBER(preTransformSend);
-GENERATE_HAS_MEMBER(preTransformHash);
-GENERATE_HAS_MEMBER(preTransformArray);
-GENERATE_HAS_MEMBER(preTransformBlock);
-GENERATE_HAS_MEMBER(preTransformInsSeq);
+GENERATE_HAS_MEMBER_VISITOR(preTransformExpression);
+GENERATE_HAS_MEMBER_VISITOR(preTransformClassDef);
+GENERATE_HAS_MEMBER_VISITOR(preTransformMethodDef);
+GENERATE_HAS_MEMBER_VISITOR(preTransformIf);
+GENERATE_HAS_MEMBER_VISITOR(preTransformWhile);
+GENERATE_HAS_MEMBER_VISITOR(preTransformBreak);
+GENERATE_HAS_MEMBER_VISITOR(preTransformRetry);
+GENERATE_HAS_MEMBER_VISITOR(preTransformNext);
+GENERATE_HAS_MEMBER_VISITOR(preTransformReturn);
+GENERATE_HAS_MEMBER_VISITOR(preTransformRescueCase);
+GENERATE_HAS_MEMBER_VISITOR(preTransformRescue);
+GENERATE_HAS_MEMBER_VISITOR(preTransformAssign);
+GENERATE_HAS_MEMBER_VISITOR(preTransformSend);
+GENERATE_HAS_MEMBER_VISITOR(preTransformHash);
+GENERATE_HAS_MEMBER_VISITOR(preTransformArray);
+GENERATE_HAS_MEMBER_VISITOR(preTransformBlock);
+GENERATE_HAS_MEMBER_VISITOR(preTransformInsSeq);
 
 // used to check for ABSENCE of method
-GENERATE_HAS_MEMBER(preTransformUnresolvedIdent);
-GENERATE_HAS_MEMBER(preTransformLocal);
-GENERATE_HAS_MEMBER(preTransformUnresolvedConstantLit);
-GENERATE_HAS_MEMBER(preTransformConstantLit);
-GENERATE_HAS_MEMBER(preTransformLiteral);
-GENERATE_HAS_MEMBER(preTransformCast);
+GENERATE_HAS_MEMBER_VISITOR(preTransformUnresolvedIdent);
+GENERATE_HAS_MEMBER_VISITOR(preTransformLocal);
+GENERATE_HAS_MEMBER_VISITOR(preTransformUnresolvedConstantLit);
+GENERATE_HAS_MEMBER_VISITOR(preTransformConstantLit);
+GENERATE_HAS_MEMBER_VISITOR(preTransformLiteral);
+GENERATE_HAS_MEMBER_VISITOR(preTransformCast);
 
-GENERATE_HAS_MEMBER(postTransformClassDef);
-GENERATE_HAS_MEMBER(postTransformMethodDef);
-GENERATE_HAS_MEMBER(postTransformIf);
-GENERATE_HAS_MEMBER(postTransformWhile);
-GENERATE_HAS_MEMBER(postTransformBreak);
-GENERATE_HAS_MEMBER(postTransformRetry);
-GENERATE_HAS_MEMBER(postTransformNext);
-GENERATE_HAS_MEMBER(postTransformReturn);
-GENERATE_HAS_MEMBER(postTransformRescueCase);
-GENERATE_HAS_MEMBER(postTransformRescue);
-GENERATE_HAS_MEMBER(postTransformUnresolvedIdent);
-GENERATE_HAS_MEMBER(postTransformAssign);
-GENERATE_HAS_MEMBER(postTransformSend);
-GENERATE_HAS_MEMBER(postTransformHash);
-GENERATE_HAS_MEMBER(postTransformLocal);
-GENERATE_HAS_MEMBER(postTransformArray);
-GENERATE_HAS_MEMBER(postTransformLiteral);
-GENERATE_HAS_MEMBER(postTransformUnresolvedConstantLit);
-GENERATE_HAS_MEMBER(postTransformConstantLit);
-GENERATE_HAS_MEMBER(postTransformArraySplat);
-GENERATE_HAS_MEMBER(postTransformHashSplat);
-GENERATE_HAS_MEMBER(postTransformBlock);
-GENERATE_HAS_MEMBER(postTransformInsSeq);
-GENERATE_HAS_MEMBER(postTransformCast);
+GENERATE_HAS_MEMBER_VISITOR(postTransformClassDef);
+GENERATE_HAS_MEMBER_VISITOR(postTransformMethodDef);
+GENERATE_HAS_MEMBER_VISITOR(postTransformIf);
+GENERATE_HAS_MEMBER_VISITOR(postTransformWhile);
+GENERATE_HAS_MEMBER_VISITOR(postTransformBreak);
+GENERATE_HAS_MEMBER_VISITOR(postTransformRetry);
+GENERATE_HAS_MEMBER_VISITOR(postTransformNext);
+GENERATE_HAS_MEMBER_VISITOR(postTransformReturn);
+GENERATE_HAS_MEMBER_VISITOR(postTransformRescueCase);
+GENERATE_HAS_MEMBER_VISITOR(postTransformRescue);
+GENERATE_HAS_MEMBER_VISITOR(postTransformUnresolvedIdent);
+GENERATE_HAS_MEMBER_VISITOR(postTransformAssign);
+GENERATE_HAS_MEMBER_VISITOR(postTransformSend);
+GENERATE_HAS_MEMBER_VISITOR(postTransformHash);
+GENERATE_HAS_MEMBER_VISITOR(postTransformLocal);
+GENERATE_HAS_MEMBER_VISITOR(postTransformArray);
+GENERATE_HAS_MEMBER_VISITOR(postTransformLiteral);
+GENERATE_HAS_MEMBER_VISITOR(postTransformUnresolvedConstantLit);
+GENERATE_HAS_MEMBER_VISITOR(postTransformConstantLit);
+GENERATE_HAS_MEMBER_VISITOR(postTransformArraySplat);
+GENERATE_HAS_MEMBER_VISITOR(postTransformHashSplat);
+GENERATE_HAS_MEMBER_VISITOR(postTransformBlock);
+GENERATE_HAS_MEMBER_VISITOR(postTransformInsSeq);
+GENERATE_HAS_MEMBER_VISITOR(postTransformCast);
 
 #define GENERATE_POSTPONE_PRECLASS(X)                                                   \
                                                                                         \
@@ -252,17 +232,17 @@ private:
 
     FUNC &func;
 
-    static_assert(!HAS_MEMBER_preTransformUnresolvedIdent<FUNC>::value, "use post*Transform instead");
-    static_assert(!HAS_MEMBER_preTransformLiteral<FUNC>::value, "use post*Transform instead");
-    static_assert(!HAS_MEMBER_preTransformUnresolvedConstantLit<FUNC>::value, "use post*Transform instead");
-    static_assert(!HAS_MEMBER_preTransformConstantLit<FUNC>::value, "use post*Transform instead");
-    static_assert(!HAS_MEMBER_preTransformLocal<FUNC>::value, "use post*Transform instead");
+    static_assert(!HAS_MEMBER_preTransformUnresolvedIdent<FUNC>(), "use post*Transform instead");
+    static_assert(!HAS_MEMBER_preTransformLiteral<FUNC>(), "use post*Transform instead");
+    static_assert(!HAS_MEMBER_preTransformUnresolvedConstantLit<FUNC>(), "use post*Transform instead");
+    static_assert(!HAS_MEMBER_preTransformConstantLit<FUNC>(), "use post*Transform instead");
+    static_assert(!HAS_MEMBER_preTransformLocal<FUNC>(), "use post*Transform instead");
 
     TreeMapper(FUNC &func) : func(func) {}
 
     TreePtr mapClassDef(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformClassDef<FUNC>::value) {
-            v = PostPonePreTransform_ClassDef<FUNC, CTX, HAS_MEMBER_preTransformClassDef<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_preTransformClassDef<FUNC>()) {
+            v = PostPonePreTransform_ClassDef<FUNC, CTX, HAS_MEMBER_preTransformClassDef<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
 
@@ -272,16 +252,16 @@ private:
             def = mapIt(std::move(def), ctx.withOwner(cast_tree<ClassDef>(v)->symbol).withFile(ctx.file));
         }
 
-        if constexpr (HAS_MEMBER_postTransformClassDef<FUNC>::value) {
-            return PostPonePostTransform_ClassDef<FUNC, CTX, HAS_MEMBER_postTransformClassDef<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformClassDef<FUNC>()) {
+            return PostPonePostTransform_ClassDef<FUNC, CTX, HAS_MEMBER_postTransformClassDef<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
         return v;
     }
 
     TreePtr mapMethodDef(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformMethodDef<FUNC>::value) {
-            v = PostPonePreTransform_MethodDef<FUNC, CTX, HAS_MEMBER_preTransformMethodDef<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_preTransformMethodDef<FUNC>()) {
+            v = PostPonePreTransform_MethodDef<FUNC, CTX, HAS_MEMBER_preTransformMethodDef<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
 
@@ -294,8 +274,8 @@ private:
         cast_tree<MethodDef>(v)->rhs = mapIt(std::move(cast_tree<MethodDef>(v)->rhs),
                                              ctx.withOwner(cast_tree<MethodDef>(v)->symbol).withFile(ctx.file));
 
-        if constexpr (HAS_MEMBER_postTransformMethodDef<FUNC>::value) {
-            return PostPonePostTransform_MethodDef<FUNC, CTX, HAS_MEMBER_postTransformMethodDef<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformMethodDef<FUNC>()) {
+            return PostPonePostTransform_MethodDef<FUNC, CTX, HAS_MEMBER_postTransformMethodDef<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
 
@@ -303,82 +283,81 @@ private:
     }
 
     TreePtr mapIf(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformIf<FUNC>::value) {
-            v = PostPonePreTransform_If<FUNC, CTX, HAS_MEMBER_preTransformIf<FUNC>::value>::call(ctx, std::move(v),
-                                                                                                 func);
+        if constexpr (HAS_MEMBER_preTransformIf<FUNC>()) {
+            v = PostPonePreTransform_If<FUNC, CTX, HAS_MEMBER_preTransformIf<FUNC>()>::call(ctx, std::move(v), func);
         }
         cast_tree<If>(v)->cond = mapIt(std::move(cast_tree<If>(v)->cond), ctx);
         cast_tree<If>(v)->thenp = mapIt(std::move(cast_tree<If>(v)->thenp), ctx);
         cast_tree<If>(v)->elsep = mapIt(std::move(cast_tree<If>(v)->elsep), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformIf<FUNC>::value) {
-            return PostPonePostTransform_If<FUNC, CTX, HAS_MEMBER_postTransformIf<FUNC>::value>::call(ctx, std::move(v),
-                                                                                                      func);
+        if constexpr (HAS_MEMBER_postTransformIf<FUNC>()) {
+            return PostPonePostTransform_If<FUNC, CTX, HAS_MEMBER_postTransformIf<FUNC>()>::call(ctx, std::move(v),
+                                                                                                 func);
         }
         return v;
     }
 
     TreePtr mapWhile(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformWhile<FUNC>::value) {
-            v = PostPonePreTransform_While<FUNC, CTX, HAS_MEMBER_preTransformWhile<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_preTransformWhile<FUNC>()) {
+            v = PostPonePreTransform_While<FUNC, CTX, HAS_MEMBER_preTransformWhile<FUNC>()>::call(ctx, std::move(v),
+                                                                                                  func);
         }
         cast_tree<While>(v)->cond = mapIt(std::move(cast_tree<While>(v)->cond), ctx);
         cast_tree<While>(v)->body = mapIt(std::move(cast_tree<While>(v)->body), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformWhile<FUNC>::value) {
-            return PostPonePostTransform_While<FUNC, CTX, HAS_MEMBER_postTransformWhile<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformWhile<FUNC>()) {
+            return PostPonePostTransform_While<FUNC, CTX, HAS_MEMBER_postTransformWhile<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
         return v;
     }
 
     TreePtr mapBreak(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformBreak<FUNC>::value) {
-            return PostPonePreTransform_Break<FUNC, CTX, HAS_MEMBER_preTransformBreak<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_preTransformBreak<FUNC>()) {
+            return PostPonePreTransform_Break<FUNC, CTX, HAS_MEMBER_preTransformBreak<FUNC>()>::call(ctx, std::move(v),
+                                                                                                     func);
         }
 
         cast_tree<Break>(v)->expr = mapIt(std::move(cast_tree<Break>(v)->expr), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformBreak<FUNC>::value) {
-            return PostPonePostTransform_Break<FUNC, CTX, HAS_MEMBER_postTransformBreak<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformBreak<FUNC>()) {
+            return PostPonePostTransform_Break<FUNC, CTX, HAS_MEMBER_postTransformBreak<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
         return v;
     }
     TreePtr mapRetry(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_postTransformRetry<FUNC>::value) {
-            return PostPonePostTransform_Retry<FUNC, CTX, HAS_MEMBER_postTransformRetry<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformRetry<FUNC>()) {
+            return PostPonePostTransform_Retry<FUNC, CTX, HAS_MEMBER_postTransformRetry<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
         return v;
     }
 
     TreePtr mapNext(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformNext<FUNC>::value) {
-            return PostPonePreTransform_Next<FUNC, CTX, HAS_MEMBER_preTransformNext<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_preTransformNext<FUNC>()) {
+            return PostPonePreTransform_Next<FUNC, CTX, HAS_MEMBER_preTransformNext<FUNC>()>::call(ctx, std::move(v),
+                                                                                                   func);
         }
 
         cast_tree<Next>(v)->expr = mapIt(std::move(cast_tree<Next>(v)->expr), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformNext<FUNC>::value) {
-            return PostPonePostTransform_Next<FUNC, CTX, HAS_MEMBER_postTransformNext<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_postTransformNext<FUNC>()) {
+            return PostPonePostTransform_Next<FUNC, CTX, HAS_MEMBER_postTransformNext<FUNC>()>::call(ctx, std::move(v),
+                                                                                                     func);
         }
         return v;
     }
 
     TreePtr mapReturn(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformReturn<FUNC>::value) {
-            v = PostPonePreTransform_Return<FUNC, CTX, HAS_MEMBER_preTransformReturn<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_preTransformReturn<FUNC>()) {
+            v = PostPonePreTransform_Return<FUNC, CTX, HAS_MEMBER_preTransformReturn<FUNC>()>::call(ctx, std::move(v),
+                                                                                                    func);
         }
         cast_tree<Return>(v)->expr = mapIt(std::move(cast_tree<Return>(v)->expr), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformReturn<FUNC>::value) {
-            return PostPonePostTransform_Return<FUNC, CTX, HAS_MEMBER_postTransformReturn<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformReturn<FUNC>()) {
+            return PostPonePostTransform_Return<FUNC, CTX, HAS_MEMBER_postTransformReturn<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
 
@@ -386,8 +365,8 @@ private:
     }
 
     TreePtr mapRescueCase(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformRescueCase<FUNC>::value) {
-            v = PostPonePreTransform_RescueCase<FUNC, CTX, HAS_MEMBER_preTransformRescueCase<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_preTransformRescueCase<FUNC>()) {
+            v = PostPonePreTransform_RescueCase<FUNC, CTX, HAS_MEMBER_preTransformRescueCase<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
 
@@ -399,17 +378,17 @@ private:
 
         cast_tree<RescueCase>(v)->body = mapIt(std::move(cast_tree<RescueCase>(v)->body), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformRescueCase<FUNC>::value) {
-            return PostPonePostTransform_RescueCase<FUNC, CTX, HAS_MEMBER_postTransformRescueCase<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformRescueCase<FUNC>()) {
+            return PostPonePostTransform_RescueCase<FUNC, CTX, HAS_MEMBER_postTransformRescueCase<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
 
         return v;
     }
     TreePtr mapRescue(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformRescue<FUNC>::value) {
-            v = PostPonePreTransform_Rescue<FUNC, CTX, HAS_MEMBER_preTransformRescue<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_preTransformRescue<FUNC>()) {
+            v = PostPonePreTransform_Rescue<FUNC, CTX, HAS_MEMBER_preTransformRescue<FUNC>()>::call(ctx, std::move(v),
+                                                                                                    func);
         }
 
         cast_tree<Rescue>(v)->body = mapIt(std::move(cast_tree<Rescue>(v)->body), ctx);
@@ -423,8 +402,8 @@ private:
         cast_tree<Rescue>(v)->else_ = mapIt(std::move(cast_tree<Rescue>(v)->else_), ctx);
         cast_tree<Rescue>(v)->ensure = mapIt(std::move(cast_tree<Rescue>(v)->ensure), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformRescue<FUNC>::value) {
-            return PostPonePostTransform_Rescue<FUNC, CTX, HAS_MEMBER_postTransformRescue<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformRescue<FUNC>()) {
+            return PostPonePostTransform_Rescue<FUNC, CTX, HAS_MEMBER_postTransformRescue<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
 
@@ -432,24 +411,24 @@ private:
     }
 
     TreePtr mapUnresolvedIdent(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_postTransformUnresolvedIdent<FUNC>::value) {
+        if constexpr (HAS_MEMBER_postTransformUnresolvedIdent<FUNC>()) {
             return PostPonePostTransform_UnresolvedIdent<
-                FUNC, CTX, HAS_MEMBER_postTransformUnresolvedIdent<FUNC>::value>::call(ctx, std::move(v), func);
+                FUNC, CTX, HAS_MEMBER_postTransformUnresolvedIdent<FUNC>()>::call(ctx, std::move(v), func);
         }
         return v;
     }
 
     TreePtr mapAssign(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformAssign<FUNC>::value) {
-            v = PostPonePreTransform_Assign<FUNC, CTX, HAS_MEMBER_preTransformAssign<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_preTransformAssign<FUNC>()) {
+            v = PostPonePreTransform_Assign<FUNC, CTX, HAS_MEMBER_preTransformAssign<FUNC>()>::call(ctx, std::move(v),
+                                                                                                    func);
         }
 
         cast_tree<Assign>(v)->lhs = mapIt(std::move(cast_tree<Assign>(v)->lhs), ctx);
         cast_tree<Assign>(v)->rhs = mapIt(std::move(cast_tree<Assign>(v)->rhs), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformAssign<FUNC>::value) {
-            return PostPonePostTransform_Assign<FUNC, CTX, HAS_MEMBER_postTransformAssign<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformAssign<FUNC>()) {
+            return PostPonePostTransform_Assign<FUNC, CTX, HAS_MEMBER_postTransformAssign<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
 
@@ -457,9 +436,9 @@ private:
     }
 
     TreePtr mapSend(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformSend<FUNC>::value) {
-            v = PostPonePreTransform_Send<FUNC, CTX, HAS_MEMBER_preTransformSend<FUNC>::value>::call(ctx, std::move(v),
-                                                                                                     func);
+        if constexpr (HAS_MEMBER_preTransformSend<FUNC>()) {
+            v = PostPonePreTransform_Send<FUNC, CTX, HAS_MEMBER_preTransformSend<FUNC>()>::call(ctx, std::move(v),
+                                                                                                func);
         }
         cast_tree<Send>(v)->recv = mapIt(std::move(cast_tree<Send>(v)->recv), ctx);
         for (auto &arg : cast_tree<Send>(v)->args) {
@@ -473,18 +452,18 @@ private:
             cast_tree<Send>(v)->block = std::move(nblock);
         }
 
-        if constexpr (HAS_MEMBER_postTransformSend<FUNC>::value) {
-            return PostPonePostTransform_Send<FUNC, CTX, HAS_MEMBER_postTransformSend<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_postTransformSend<FUNC>()) {
+            return PostPonePostTransform_Send<FUNC, CTX, HAS_MEMBER_postTransformSend<FUNC>()>::call(ctx, std::move(v),
+                                                                                                     func);
         }
 
         return v;
     }
 
     TreePtr mapHash(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformHash<FUNC>::value) {
-            v = PostPonePreTransform_Hash<FUNC, CTX, HAS_MEMBER_preTransformHash<FUNC>::value>::call(ctx, std::move(v),
-                                                                                                     func);
+        if constexpr (HAS_MEMBER_preTransformHash<FUNC>()) {
+            v = PostPonePreTransform_Hash<FUNC, CTX, HAS_MEMBER_preTransformHash<FUNC>()>::call(ctx, std::move(v),
+                                                                                                func);
         }
         for (auto &key : cast_tree<Hash>(v)->keys) {
             key = mapIt(std::move(key), ctx);
@@ -494,57 +473,57 @@ private:
             value = mapIt(std::move(value), ctx);
         }
 
-        if constexpr (HAS_MEMBER_postTransformArray<FUNC>::value) {
-            return PostPonePostTransform_Hash<FUNC, CTX, HAS_MEMBER_postTransformHash<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_postTransformArray<FUNC>()) {
+            return PostPonePostTransform_Hash<FUNC, CTX, HAS_MEMBER_postTransformHash<FUNC>()>::call(ctx, std::move(v),
+                                                                                                     func);
         }
         return v;
     }
 
     TreePtr mapArray(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformArray<FUNC>::value) {
-            v = PostPonePreTransform_Array<FUNC, CTX, HAS_MEMBER_preTransformArray<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_preTransformArray<FUNC>()) {
+            v = PostPonePreTransform_Array<FUNC, CTX, HAS_MEMBER_preTransformArray<FUNC>()>::call(ctx, std::move(v),
+                                                                                                  func);
         }
         for (auto &elem : cast_tree<Array>(v)->elems) {
             elem = mapIt(std::move(elem), ctx);
         }
 
-        if constexpr (HAS_MEMBER_postTransformArray<FUNC>::value) {
-            return PostPonePostTransform_Array<FUNC, CTX, HAS_MEMBER_postTransformArray<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformArray<FUNC>()) {
+            return PostPonePostTransform_Array<FUNC, CTX, HAS_MEMBER_postTransformArray<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
         return v;
     }
 
     TreePtr mapLiteral(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_postTransformLiteral<FUNC>::value) {
-            return PostPonePostTransform_Literal<FUNC, CTX, HAS_MEMBER_postTransformLiteral<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformLiteral<FUNC>()) {
+            return PostPonePostTransform_Literal<FUNC, CTX, HAS_MEMBER_postTransformLiteral<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
         return v;
     }
 
     TreePtr mapUnresolvedConstantLit(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_postTransformUnresolvedConstantLit<FUNC>::value) {
+        if constexpr (HAS_MEMBER_postTransformUnresolvedConstantLit<FUNC>()) {
             return PostPonePostTransform_UnresolvedConstantLit<
-                FUNC, CTX, HAS_MEMBER_postTransformUnresolvedConstantLit<FUNC>::value>::call(ctx, std::move(v), func);
+                FUNC, CTX, HAS_MEMBER_postTransformUnresolvedConstantLit<FUNC>()>::call(ctx, std::move(v), func);
         }
         return v;
     }
 
     TreePtr mapConstantLit(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_postTransformConstantLit<FUNC>::value) {
-            return PostPonePostTransform_ConstantLit<FUNC, CTX, HAS_MEMBER_postTransformConstantLit<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformConstantLit<FUNC>()) {
+            return PostPonePostTransform_ConstantLit<FUNC, CTX, HAS_MEMBER_postTransformConstantLit<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
         return v;
     }
 
     TreePtr mapBlock(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformBlock<FUNC>::value) {
-            v = PostPonePreTransform_Block<FUNC, CTX, HAS_MEMBER_preTransformBlock<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_preTransformBlock<FUNC>()) {
+            v = PostPonePreTransform_Block<FUNC, CTX, HAS_MEMBER_preTransformBlock<FUNC>()>::call(ctx, std::move(v),
+                                                                                                  func);
         }
 
         for (auto &arg : cast_tree<Block>(v)->args) {
@@ -555,17 +534,17 @@ private:
         }
         cast_tree<Block>(v)->body = mapIt(std::move(cast_tree<Block>(v)->body), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformBlock<FUNC>::value) {
-            return PostPonePostTransform_Block<FUNC, CTX, HAS_MEMBER_postTransformBlock<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformBlock<FUNC>()) {
+            return PostPonePostTransform_Block<FUNC, CTX, HAS_MEMBER_postTransformBlock<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
         return v;
     }
 
     TreePtr mapInsSeq(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformInsSeq<FUNC>::value) {
-            v = PostPonePreTransform_InsSeq<FUNC, CTX, HAS_MEMBER_preTransformInsSeq<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_preTransformInsSeq<FUNC>()) {
+            v = PostPonePreTransform_InsSeq<FUNC, CTX, HAS_MEMBER_preTransformInsSeq<FUNC>()>::call(ctx, std::move(v),
+                                                                                                    func);
         }
 
         for (auto &stat : cast_tree<InsSeq>(v)->stats) {
@@ -574,8 +553,8 @@ private:
 
         cast_tree<InsSeq>(v)->expr = mapIt(std::move(cast_tree<InsSeq>(v)->expr), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformInsSeq<FUNC>::value) {
-            return PostPonePostTransform_InsSeq<FUNC, CTX, HAS_MEMBER_postTransformInsSeq<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformInsSeq<FUNC>()) {
+            return PostPonePostTransform_InsSeq<FUNC, CTX, HAS_MEMBER_postTransformInsSeq<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
 
@@ -583,23 +562,23 @@ private:
     }
 
     TreePtr mapLocal(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_postTransformLocal<FUNC>::value) {
-            return PostPonePostTransform_Local<FUNC, CTX, HAS_MEMBER_postTransformLocal<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformLocal<FUNC>()) {
+            return PostPonePostTransform_Local<FUNC, CTX, HAS_MEMBER_postTransformLocal<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
         return v;
     }
 
     TreePtr mapCast(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformCast<FUNC>::value) {
-            v = PostPonePreTransform_Cast<FUNC, CTX, HAS_MEMBER_preTransformCast<FUNC>::value>::call(ctx, std::move(v),
-                                                                                                     func);
+        if constexpr (HAS_MEMBER_preTransformCast<FUNC>()) {
+            v = PostPonePreTransform_Cast<FUNC, CTX, HAS_MEMBER_preTransformCast<FUNC>()>::call(ctx, std::move(v),
+                                                                                                func);
         }
         cast_tree<Cast>(v)->arg = mapIt(std::move(cast_tree<Cast>(v)->arg), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformCast<FUNC>::value) {
-            return PostPonePostTransform_Cast<FUNC, CTX, HAS_MEMBER_postTransformCast<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_postTransformCast<FUNC>()) {
+            return PostPonePostTransform_Cast<FUNC, CTX, HAS_MEMBER_postTransformCast<FUNC>()>::call(ctx, std::move(v),
+                                                                                                     func);
         }
 
         return v;
@@ -613,8 +592,8 @@ private:
 
         try {
             // TODO: reorder by frequency
-            if constexpr (HAS_MEMBER_preTransformExpression<FUNC>::value) {
-                what = PostPonePreTransform_Expression<FUNC, CTX, HAS_MEMBER_preTransformExpression<FUNC>::value>::call(
+            if constexpr (HAS_MEMBER_preTransformExpression<FUNC>()) {
+                what = PostPonePreTransform_Expression<FUNC, CTX, HAS_MEMBER_preTransformExpression<FUNC>()>::call(
                     ctx, std::move(what), func);
             }
 
@@ -749,17 +728,17 @@ private:
 
     FUNC &func;
 
-    static_assert(!HAS_MEMBER_preTransformUnresolvedIdent<FUNC>::value, "use post*Transform instead");
-    static_assert(!HAS_MEMBER_preTransformLiteral<FUNC>::value, "use post*Transform instead");
-    static_assert(!HAS_MEMBER_preTransformUnresolvedConstantLit<FUNC>::value, "use post*Transform instead");
-    static_assert(!HAS_MEMBER_preTransformConstantLit<FUNC>::value, "use post*Transform instead");
-    static_assert(!HAS_MEMBER_preTransformLocal<FUNC>::value, "use post*Transform instead");
+    static_assert(!HAS_MEMBER_preTransformUnresolvedIdent<FUNC>(), "use post*Transform instead");
+    static_assert(!HAS_MEMBER_preTransformLiteral<FUNC>(), "use post*Transform instead");
+    static_assert(!HAS_MEMBER_preTransformUnresolvedConstantLit<FUNC>(), "use post*Transform instead");
+    static_assert(!HAS_MEMBER_preTransformConstantLit<FUNC>(), "use post*Transform instead");
+    static_assert(!HAS_MEMBER_preTransformLocal<FUNC>(), "use post*Transform instead");
 
     ShallowMapper(FUNC &func) : func(func) {}
 
     TreePtr mapClassDef(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformClassDef<FUNC>::value) {
-            v = PostPonePreTransform_ClassDef<FUNC, CTX, HAS_MEMBER_preTransformClassDef<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_preTransformClassDef<FUNC>()) {
+            v = PostPonePreTransform_ClassDef<FUNC, CTX, HAS_MEMBER_preTransformClassDef<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
 
@@ -769,16 +748,16 @@ private:
             def = mapIt(std::move(def), ctx.withOwner(cast_tree<ClassDef>(v)->symbol));
         }
 
-        if constexpr (HAS_MEMBER_postTransformClassDef<FUNC>::value) {
-            return PostPonePostTransform_ClassDef<FUNC, CTX, HAS_MEMBER_postTransformClassDef<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformClassDef<FUNC>()) {
+            return PostPonePostTransform_ClassDef<FUNC, CTX, HAS_MEMBER_postTransformClassDef<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
         return v;
     }
 
     TreePtr mapMethodDef(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformMethodDef<FUNC>::value) {
-            v = PostPonePreTransform_MethodDef<FUNC, CTX, HAS_MEMBER_preTransformMethodDef<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_preTransformMethodDef<FUNC>()) {
+            v = PostPonePreTransform_MethodDef<FUNC, CTX, HAS_MEMBER_preTransformMethodDef<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
 
@@ -790,8 +769,8 @@ private:
         }
         // because this is a ShallowMap, we do not map over the body of the method
 
-        if constexpr (HAS_MEMBER_postTransformMethodDef<FUNC>::value) {
-            return PostPonePostTransform_MethodDef<FUNC, CTX, HAS_MEMBER_postTransformMethodDef<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformMethodDef<FUNC>()) {
+            return PostPonePostTransform_MethodDef<FUNC, CTX, HAS_MEMBER_postTransformMethodDef<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
 
@@ -799,82 +778,81 @@ private:
     }
 
     TreePtr mapIf(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformIf<FUNC>::value) {
-            v = PostPonePreTransform_If<FUNC, CTX, HAS_MEMBER_preTransformIf<FUNC>::value>::call(ctx, std::move(v),
-                                                                                                 func);
+        if constexpr (HAS_MEMBER_preTransformIf<FUNC>()) {
+            v = PostPonePreTransform_If<FUNC, CTX, HAS_MEMBER_preTransformIf<FUNC>()>::call(ctx, std::move(v), func);
         }
         cast_tree<If>(v)->cond = mapIt(std::move(cast_tree<If>(v)->cond), ctx);
         cast_tree<If>(v)->thenp = mapIt(std::move(cast_tree<If>(v)->thenp), ctx);
         cast_tree<If>(v)->elsep = mapIt(std::move(cast_tree<If>(v)->elsep), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformIf<FUNC>::value) {
-            return PostPonePostTransform_If<FUNC, CTX, HAS_MEMBER_postTransformIf<FUNC>::value>::call(ctx, std::move(v),
-                                                                                                      func);
+        if constexpr (HAS_MEMBER_postTransformIf<FUNC>()) {
+            return PostPonePostTransform_If<FUNC, CTX, HAS_MEMBER_postTransformIf<FUNC>()>::call(ctx, std::move(v),
+                                                                                                 func);
         }
         return v;
     }
 
     TreePtr mapWhile(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformWhile<FUNC>::value) {
-            v = PostPonePreTransform_While<FUNC, CTX, HAS_MEMBER_preTransformWhile<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_preTransformWhile<FUNC>()) {
+            v = PostPonePreTransform_While<FUNC, CTX, HAS_MEMBER_preTransformWhile<FUNC>()>::call(ctx, std::move(v),
+                                                                                                  func);
         }
         cast_tree<While>(v)->cond = mapIt(std::move(cast_tree<While>(v)->cond), ctx);
         cast_tree<While>(v)->body = mapIt(std::move(cast_tree<While>(v)->body), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformWhile<FUNC>::value) {
-            return PostPonePostTransform_While<FUNC, CTX, HAS_MEMBER_postTransformWhile<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformWhile<FUNC>()) {
+            return PostPonePostTransform_While<FUNC, CTX, HAS_MEMBER_postTransformWhile<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
         return v;
     }
 
     TreePtr mapBreak(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformBreak<FUNC>::value) {
-            return PostPonePreTransform_Break<FUNC, CTX, HAS_MEMBER_preTransformBreak<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_preTransformBreak<FUNC>()) {
+            return PostPonePreTransform_Break<FUNC, CTX, HAS_MEMBER_preTransformBreak<FUNC>()>::call(ctx, std::move(v),
+                                                                                                     func);
         }
 
         cast_tree<Break>(v)->expr = mapIt(std::move(cast_tree<Break>(v)->expr), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformBreak<FUNC>::value) {
-            return PostPonePostTransform_Break<FUNC, CTX, HAS_MEMBER_postTransformBreak<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformBreak<FUNC>()) {
+            return PostPonePostTransform_Break<FUNC, CTX, HAS_MEMBER_postTransformBreak<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
         return v;
     }
     TreePtr mapRetry(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_postTransformRetry<FUNC>::value) {
-            return PostPonePostTransform_Retry<FUNC, CTX, HAS_MEMBER_postTransformRetry<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformRetry<FUNC>()) {
+            return PostPonePostTransform_Retry<FUNC, CTX, HAS_MEMBER_postTransformRetry<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
         return v;
     }
 
     TreePtr mapNext(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformNext<FUNC>::value) {
-            return PostPonePreTransform_Next<FUNC, CTX, HAS_MEMBER_preTransformNext<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_preTransformNext<FUNC>()) {
+            return PostPonePreTransform_Next<FUNC, CTX, HAS_MEMBER_preTransformNext<FUNC>()>::call(ctx, std::move(v),
+                                                                                                   func);
         }
 
         cast_tree<Next>(v)->expr = mapIt(std::move(cast_tree<Next>(v)->expr), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformNext<FUNC>::value) {
-            return PostPonePostTransform_Next<FUNC, CTX, HAS_MEMBER_postTransformNext<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_postTransformNext<FUNC>()) {
+            return PostPonePostTransform_Next<FUNC, CTX, HAS_MEMBER_postTransformNext<FUNC>()>::call(ctx, std::move(v),
+                                                                                                     func);
         }
         return v;
     }
 
     TreePtr mapReturn(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformReturn<FUNC>::value) {
-            v = PostPonePreTransform_Return<FUNC, CTX, HAS_MEMBER_preTransformReturn<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_preTransformReturn<FUNC>()) {
+            v = PostPonePreTransform_Return<FUNC, CTX, HAS_MEMBER_preTransformReturn<FUNC>()>::call(ctx, std::move(v),
+                                                                                                    func);
         }
         cast_tree<Return>(v)->expr = mapIt(std::move(cast_tree<Return>(v)->expr), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformReturn<FUNC>::value) {
-            return PostPonePostTransform_Return<FUNC, CTX, HAS_MEMBER_postTransformReturn<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformReturn<FUNC>()) {
+            return PostPonePostTransform_Return<FUNC, CTX, HAS_MEMBER_postTransformReturn<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
 
@@ -882,8 +860,8 @@ private:
     }
 
     TreePtr mapRescueCase(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformRescueCase<FUNC>::value) {
-            v = PostPonePreTransform_RescueCase<FUNC, CTX, HAS_MEMBER_preTransformRescueCase<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_preTransformRescueCase<FUNC>()) {
+            v = PostPonePreTransform_RescueCase<FUNC, CTX, HAS_MEMBER_preTransformRescueCase<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
 
@@ -895,17 +873,17 @@ private:
 
         cast_tree<RescueCase>(v)->body = mapIt(std::move(cast_tree<RescueCase>(v)->body), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformRescueCase<FUNC>::value) {
-            return PostPonePostTransform_RescueCase<FUNC, CTX, HAS_MEMBER_postTransformRescueCase<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformRescueCase<FUNC>()) {
+            return PostPonePostTransform_RescueCase<FUNC, CTX, HAS_MEMBER_postTransformRescueCase<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
 
         return v;
     }
     TreePtr mapRescue(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformRescue<FUNC>::value) {
-            v = PostPonePreTransform_Rescue<FUNC, CTX, HAS_MEMBER_preTransformRescue<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_preTransformRescue<FUNC>()) {
+            v = PostPonePreTransform_Rescue<FUNC, CTX, HAS_MEMBER_preTransformRescue<FUNC>()>::call(ctx, std::move(v),
+                                                                                                    func);
         }
 
         cast_tree<Rescue>(v)->body = mapIt(std::move(cast_tree<Rescue>(v)->body), ctx);
@@ -919,8 +897,8 @@ private:
         cast_tree<Rescue>(v)->else_ = mapIt(std::move(cast_tree<Rescue>(v)->else_), ctx);
         cast_tree<Rescue>(v)->ensure = mapIt(std::move(cast_tree<Rescue>(v)->ensure), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformRescue<FUNC>::value) {
-            return PostPonePostTransform_Rescue<FUNC, CTX, HAS_MEMBER_postTransformRescue<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformRescue<FUNC>()) {
+            return PostPonePostTransform_Rescue<FUNC, CTX, HAS_MEMBER_postTransformRescue<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
 
@@ -928,24 +906,24 @@ private:
     }
 
     TreePtr mapUnresolvedIdent(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_postTransformUnresolvedIdent<FUNC>::value) {
+        if constexpr (HAS_MEMBER_postTransformUnresolvedIdent<FUNC>()) {
             return PostPonePostTransform_UnresolvedIdent<
-                FUNC, CTX, HAS_MEMBER_postTransformUnresolvedIdent<FUNC>::value>::call(ctx, std::move(v), func);
+                FUNC, CTX, HAS_MEMBER_postTransformUnresolvedIdent<FUNC>()>::call(ctx, std::move(v), func);
         }
         return v;
     }
 
     TreePtr mapAssign(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformAssign<FUNC>::value) {
-            v = PostPonePreTransform_Assign<FUNC, CTX, HAS_MEMBER_preTransformAssign<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_preTransformAssign<FUNC>()) {
+            v = PostPonePreTransform_Assign<FUNC, CTX, HAS_MEMBER_preTransformAssign<FUNC>()>::call(ctx, std::move(v),
+                                                                                                    func);
         }
 
         cast_tree<Assign>(v)->lhs = mapIt(std::move(cast_tree<Assign>(v)->lhs), ctx);
         cast_tree<Assign>(v)->rhs = mapIt(std::move(cast_tree<Assign>(v)->rhs), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformAssign<FUNC>::value) {
-            return PostPonePostTransform_Assign<FUNC, CTX, HAS_MEMBER_postTransformAssign<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformAssign<FUNC>()) {
+            return PostPonePostTransform_Assign<FUNC, CTX, HAS_MEMBER_postTransformAssign<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
 
@@ -953,9 +931,9 @@ private:
     }
 
     TreePtr mapSend(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformSend<FUNC>::value) {
-            v = PostPonePreTransform_Send<FUNC, CTX, HAS_MEMBER_preTransformSend<FUNC>::value>::call(ctx, std::move(v),
-                                                                                                     func);
+        if constexpr (HAS_MEMBER_preTransformSend<FUNC>()) {
+            v = PostPonePreTransform_Send<FUNC, CTX, HAS_MEMBER_preTransformSend<FUNC>()>::call(ctx, std::move(v),
+                                                                                                func);
         }
         cast_tree<Send>(v)->recv = mapIt(std::move(cast_tree<Send>(v)->recv), ctx);
         for (auto &arg : cast_tree<Send>(v)->args) {
@@ -969,18 +947,18 @@ private:
             cast_tree<Send>(v)->block = std::move(nblock);
         }
 
-        if constexpr (HAS_MEMBER_postTransformSend<FUNC>::value) {
-            return PostPonePostTransform_Send<FUNC, CTX, HAS_MEMBER_postTransformSend<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_postTransformSend<FUNC>()) {
+            return PostPonePostTransform_Send<FUNC, CTX, HAS_MEMBER_postTransformSend<FUNC>()>::call(ctx, std::move(v),
+                                                                                                     func);
         }
 
         return v;
     }
 
     TreePtr mapHash(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformHash<FUNC>::value) {
-            v = PostPonePreTransform_Hash<FUNC, CTX, HAS_MEMBER_preTransformHash<FUNC>::value>::call(ctx, std::move(v),
-                                                                                                     func);
+        if constexpr (HAS_MEMBER_preTransformHash<FUNC>()) {
+            v = PostPonePreTransform_Hash<FUNC, CTX, HAS_MEMBER_preTransformHash<FUNC>()>::call(ctx, std::move(v),
+                                                                                                func);
         }
         for (auto &key : cast_tree<Hash>(v)->keys) {
             key = mapIt(std::move(key), ctx);
@@ -990,57 +968,57 @@ private:
             value = mapIt(std::move(value), ctx);
         }
 
-        if constexpr (HAS_MEMBER_postTransformArray<FUNC>::value) {
-            return PostPonePostTransform_Hash<FUNC, CTX, HAS_MEMBER_postTransformHash<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_postTransformArray<FUNC>()) {
+            return PostPonePostTransform_Hash<FUNC, CTX, HAS_MEMBER_postTransformHash<FUNC>()>::call(ctx, std::move(v),
+                                                                                                     func);
         }
         return v;
     }
 
     TreePtr mapArray(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformArray<FUNC>::value) {
-            v = PostPonePreTransform_Array<FUNC, CTX, HAS_MEMBER_preTransformArray<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_preTransformArray<FUNC>()) {
+            v = PostPonePreTransform_Array<FUNC, CTX, HAS_MEMBER_preTransformArray<FUNC>()>::call(ctx, std::move(v),
+                                                                                                  func);
         }
         for (auto &elem : cast_tree<Array>(v)->elems) {
             elem = mapIt(std::move(elem), ctx);
         }
 
-        if constexpr (HAS_MEMBER_postTransformArray<FUNC>::value) {
-            return PostPonePostTransform_Array<FUNC, CTX, HAS_MEMBER_postTransformArray<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformArray<FUNC>()) {
+            return PostPonePostTransform_Array<FUNC, CTX, HAS_MEMBER_postTransformArray<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
         return v;
     }
 
     TreePtr mapLiteral(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_postTransformLiteral<FUNC>::value) {
-            return PostPonePostTransform_Literal<FUNC, CTX, HAS_MEMBER_postTransformLiteral<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformLiteral<FUNC>()) {
+            return PostPonePostTransform_Literal<FUNC, CTX, HAS_MEMBER_postTransformLiteral<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
         return v;
     }
 
     TreePtr mapUnresolvedConstantLit(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_postTransformUnresolvedConstantLit<FUNC>::value) {
+        if constexpr (HAS_MEMBER_postTransformUnresolvedConstantLit<FUNC>()) {
             return PostPonePostTransform_UnresolvedConstantLit<
-                FUNC, CTX, HAS_MEMBER_postTransformUnresolvedConstantLit<FUNC>::value>::call(ctx, std::move(v), func);
+                FUNC, CTX, HAS_MEMBER_postTransformUnresolvedConstantLit<FUNC>()>::call(ctx, std::move(v), func);
         }
         return v;
     }
 
     TreePtr mapConstantLit(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_postTransformConstantLit<FUNC>::value) {
-            return PostPonePostTransform_ConstantLit<FUNC, CTX, HAS_MEMBER_postTransformConstantLit<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformConstantLit<FUNC>()) {
+            return PostPonePostTransform_ConstantLit<FUNC, CTX, HAS_MEMBER_postTransformConstantLit<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
         return v;
     }
 
     TreePtr mapBlock(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformBlock<FUNC>::value) {
-            v = PostPonePreTransform_Block<FUNC, CTX, HAS_MEMBER_preTransformBlock<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_preTransformBlock<FUNC>()) {
+            v = PostPonePreTransform_Block<FUNC, CTX, HAS_MEMBER_preTransformBlock<FUNC>()>::call(ctx, std::move(v),
+                                                                                                  func);
         }
 
         for (auto &arg : cast_tree<Block>(v)->args) {
@@ -1051,17 +1029,17 @@ private:
         }
         cast_tree<Block>(v)->body = mapIt(std::move(cast_tree<Block>(v)->body), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformBlock<FUNC>::value) {
-            return PostPonePostTransform_Block<FUNC, CTX, HAS_MEMBER_postTransformBlock<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformBlock<FUNC>()) {
+            return PostPonePostTransform_Block<FUNC, CTX, HAS_MEMBER_postTransformBlock<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
         return v;
     }
 
     TreePtr mapInsSeq(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformInsSeq<FUNC>::value) {
-            v = PostPonePreTransform_InsSeq<FUNC, CTX, HAS_MEMBER_preTransformInsSeq<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_preTransformInsSeq<FUNC>()) {
+            v = PostPonePreTransform_InsSeq<FUNC, CTX, HAS_MEMBER_preTransformInsSeq<FUNC>()>::call(ctx, std::move(v),
+                                                                                                    func);
         }
 
         for (auto &stat : cast_tree<InsSeq>(v)->stats) {
@@ -1070,8 +1048,8 @@ private:
 
         cast_tree<InsSeq>(v)->expr = mapIt(std::move(cast_tree<InsSeq>(v)->expr), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformInsSeq<FUNC>::value) {
-            return PostPonePostTransform_InsSeq<FUNC, CTX, HAS_MEMBER_postTransformInsSeq<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformInsSeq<FUNC>()) {
+            return PostPonePostTransform_InsSeq<FUNC, CTX, HAS_MEMBER_postTransformInsSeq<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
 
@@ -1079,23 +1057,23 @@ private:
     }
 
     TreePtr mapLocal(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_postTransformLocal<FUNC>::value) {
-            return PostPonePostTransform_Local<FUNC, CTX, HAS_MEMBER_postTransformLocal<FUNC>::value>::call(
+        if constexpr (HAS_MEMBER_postTransformLocal<FUNC>()) {
+            return PostPonePostTransform_Local<FUNC, CTX, HAS_MEMBER_postTransformLocal<FUNC>()>::call(
                 ctx, std::move(v), func);
         }
         return v;
     }
 
     TreePtr mapCast(TreePtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformCast<FUNC>::value) {
-            v = PostPonePreTransform_Cast<FUNC, CTX, HAS_MEMBER_preTransformCast<FUNC>::value>::call(ctx, std::move(v),
-                                                                                                     func);
+        if constexpr (HAS_MEMBER_preTransformCast<FUNC>()) {
+            v = PostPonePreTransform_Cast<FUNC, CTX, HAS_MEMBER_preTransformCast<FUNC>()>::call(ctx, std::move(v),
+                                                                                                func);
         }
         cast_tree<Cast>(v)->arg = mapIt(std::move(cast_tree<Cast>(v)->arg), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformCast<FUNC>::value) {
-            return PostPonePostTransform_Cast<FUNC, CTX, HAS_MEMBER_postTransformCast<FUNC>::value>::call(
-                ctx, std::move(v), func);
+        if constexpr (HAS_MEMBER_postTransformCast<FUNC>()) {
+            return PostPonePostTransform_Cast<FUNC, CTX, HAS_MEMBER_postTransformCast<FUNC>()>::call(ctx, std::move(v),
+                                                                                                     func);
         }
 
         return v;
@@ -1109,8 +1087,8 @@ private:
 
         try {
             // TODO: reorder by frequency
-            if constexpr (HAS_MEMBER_preTransformExpression<FUNC>::value) {
-                what = PostPonePreTransform_Expression<FUNC, CTX, HAS_MEMBER_preTransformExpression<FUNC>::value>::call(
+            if constexpr (HAS_MEMBER_preTransformExpression<FUNC>()) {
+                what = PostPonePreTransform_Expression<FUNC, CTX, HAS_MEMBER_preTransformExpression<FUNC>()>::call(
                     ctx, std::move(what), func);
             }
 

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -111,7 +111,7 @@ string Literal::toString(const core::GlobalState &gs, const CFG &cfg) const {
 }
 
 string Literal::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
-    return fmt::format("Literal {{ value = {} }}", this->value->show(gs));
+    return fmt::format("Literal {{ value = {} }}", this->value.show(gs));
 }
 
 Ident::Ident(LocalRef what) : what(what) {
@@ -208,7 +208,7 @@ string Cast::toString(const core::GlobalState &gs, const CFG &cfg) const {
 string Cast::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
     return fmt::format("Cast {{\n{0}&nbsp;cast = T.{1},\n{0}&nbsp;value = {2},\n{0}&nbsp;type = {3},\n{0}}}",
                        spacesForTabLevel(tabs), this->cast.data(gs)->show(gs), this->value.showRaw(gs, cfg, tabs + 1),
-                       this->type->show(gs));
+                       this->type.show(gs));
 }
 
 string TAbsurd::toString(const core::GlobalState &gs, const CFG &cfg) const {
@@ -224,7 +224,7 @@ string VariableUseSite::toString(const core::GlobalState &gs, const CFG &cfg) co
     if (this->variable == LocalRef::unconditional() || this->type == nullptr) {
         return this->variable.toString(gs, cfg);
     } else {
-        return fmt::format("{}: {}", this->variable.toString(gs, cfg), this->type->show(gs));
+        return fmt::format("{}: {}", this->variable.toString(gs, cfg), this->type.show(gs));
     }
 }
 
@@ -233,7 +233,7 @@ string VariableUseSite::showRaw(const core::GlobalState &gs, const CFG &cfg, int
         return fmt::format("VariableUseSite {{ variable = {} }}", this->variable.showRaw(gs, cfg));
     } else {
         return fmt::format("VariableUseSite {{\n{0}&nbsp;variable = {1},\n{0}&nbsp;type = {2},\n{0}}}",
-                           spacesForTabLevel(tabs), this->variable.showRaw(gs, cfg), this->type->show(gs));
+                           spacesForTabLevel(tabs), this->variable.showRaw(gs, cfg), this->type.show(gs));
     }
 }
 

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -103,10 +103,10 @@ string Literal::toString(const core::GlobalState &gs, const CFG &cfg) const {
             } else if (l.symbol == core::Symbols::TrueClass()) {
                 res = "true";
             } else {
-                res = fmt::format("literal({})", this->value->toStringWithTabs(gs, 0));
+                res = fmt::format("literal({})", this->value.toStringWithTabs(gs, 0));
             }
         },
-        [&](const core::TypePtr &t) { res = fmt::format("literal({})", this->value->toStringWithTabs(gs, 0)); });
+        [&](const core::TypePtr &t) { res = fmt::format("literal({})", this->value.toStringWithTabs(gs, 0)); });
     return res;
 }
 
@@ -202,7 +202,7 @@ string GetCurrentException::showRaw(const core::GlobalState &gs, const CFG &cfg,
 }
 
 string Cast::toString(const core::GlobalState &gs, const CFG &cfg) const {
-    return fmt::format("cast({}, {});", this->value.toString(gs, cfg), this->type->toString(gs));
+    return fmt::format("cast({}, {});", this->value.toString(gs, cfg), this->type.toString(gs));
 }
 
 string Cast::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {

--- a/common/has_member.h
+++ b/common/has_member.h
@@ -29,6 +29,41 @@ template <class> struct sfinae_true : std::true_type {};
         return decltype(__HAS_MEMBER_##name::__has_##name<T>(0)){};                                        \
     }
 
+/**
+ * Given a method name, a default statement to run, and a list of argument types, do the following:
+ * - Generate `HAS_MEMBER_method_name` to statically detect if method is defined on a class.
+ * - Generate `CALL_MEMBER_method_name<T>` to call method `method_name` on object `T` if it exists otherwise return
+ * `default_behavior`.
+ *
+ * Example:
+ *
+ * GENERATE_CALL_MEMBER(toString, return "", std::declval<const core::GlobalState &>())
+ * CALL_MEMBER_toString<core::NameRef>::call(name, gs); // calls name.toString(gs)
+ * CALL_MEMBER_toString<int>::call(10, gs); // returns ""
+ */
+#define GENERATE_CALL_MEMBER(method_name, default_behavior, arg_types...)               \
+    GENERATE_HAS_MEMBER(method_name, arg_types)                                         \
+    template <typename T, bool has> class CALL_MEMBER_impl_##method_name {              \
+    public:                                                                             \
+        template <class... Args> static decltype(auto) call(T &self, Args &&... args) { \
+            Exception::raise("should never be called");                                 \
+        };                                                                              \
+    };                                                                                  \
+    template <typename T> class CALL_MEMBER_impl_##method_name<T, true> {               \
+    public:                                                                             \
+        template <class... Args> static decltype(auto) call(T &self, Args &&... args) { \
+            return self.method_name(std::forward<Args>(args)...);                       \
+        };                                                                              \
+    };                                                                                  \
+    template <typename T> class CALL_MEMBER_impl_##method_name<T, false> {              \
+    public:                                                                             \
+        template <class... Args> static decltype(auto) call(T &self, Args &&... args) { \
+            default_behavior;                                                           \
+        };                                                                              \
+    };                                                                                  \
+    template <typename T>                                                               \
+    class CALL_MEMBER_##method_name : public CALL_MEMBER_impl_##method_name<T, HAS_MEMBER_##method_name<T>()> {};
+
 } // namespace sorbet
 
 #endif

--- a/common/has_member.h
+++ b/common/has_member.h
@@ -1,5 +1,5 @@
-#ifndef SORBET_COMMON_HAS_METHOD_H
-#define SORBET_COMMON_HAS_METHOD_H
+#ifndef SORBET_COMMON_HAS_MEMBER_H
+#define SORBET_COMMON_HAS_MEMBER_H
 
 #include <typeinfo>
 

--- a/common/has_member.h
+++ b/common/has_member.h
@@ -1,0 +1,34 @@
+#ifndef SORBET_COMMON_HAS_METHOD_H
+#define SORBET_COMMON_HAS_METHOD_H
+
+#include <typeinfo>
+
+namespace sorbet {
+
+template <class> struct sfinae_true : std::true_type {};
+
+/**
+ * GENERATE_HAS_MEMBER(name, arg_types...) creates HAS_MEMBER_name<T>() which can be used to statically test if class
+ * `T` contains a method `name` that accepts arguments `arg_types`.
+ *
+ * Example:
+ *
+ * GENERATE_HAS_MEMBER(toString, std::declval<const core::GlobalState &>())
+ * static_assert(HAS_MEMBER_toString<core::NameRef>());
+ * static_assert(!HAS_MEMBER_toString<std::string>());
+ *
+ * Adapted from https://stackoverflow.com/a/9154394
+ */
+#define GENERATE_HAS_MEMBER(name, arg_types...)                                                            \
+    namespace __HAS_MEMBER_##name {                                                                        \
+        template <class T>                                                                                 \
+        static constexpr auto __has_##name(int)->sfinae_true<decltype(std::declval<T>().name(arg_types))>; \
+        template <class> static constexpr auto __has_##name(long)->std::false_type;                        \
+    };                                                                                                     \
+    template <class T> constexpr bool HAS_MEMBER_##name() {                                                \
+        return decltype(__HAS_MEMBER_##name::__has_##name<T>(0)){};                                        \
+    }
+
+} // namespace sorbet
+
+#endif

--- a/common/typecase.h
+++ b/common/typecase.h
@@ -3,6 +3,7 @@
 
 #include "common/Exception.h"
 #include "common/common.h"
+#include "common/has_member.h"
 #include <functional>
 #include <string>
 #include <typeinfo>
@@ -37,16 +38,6 @@ struct argtype_extractor<ReturnType (ClassType::*)(ArgType) const> {
     using arg_type = ArgType;
 };
 
-namespace Sfinae {
-// Check if .tag() exists (from https://stackoverflow.com/a/9154394)
-// Indicates that type is a tagged pointer.
-template <class> struct sfinae_true : std::true_type {};
-
-template <class T> static auto test_has_tag(int) -> sfinae_true<decltype(std::declval<T>().tag())>;
-template <class> static auto test_has_tag(long) -> std::false_type;
-template <class T> struct has_tag : decltype(test_has_tag<T>(0)) {};
-} // namespace Sfinae
-
 // fast_cast-based typecase
 
 template <typename Base, typename FUNC> bool typecaseHelper(Base *base, FUNC &&func) {
@@ -61,8 +52,10 @@ template <typename Base, typename FUNC> bool typecaseHelper(Base *base, FUNC &&f
     }
 }
 
+GENERATE_HAS_MEMBER(tag)
+
 template <typename Base, typename... Subclasses> void typecase(Base *base, Subclasses &&... funcs) {
-    static_assert(Sfinae::has_tag<Base>() != true,
+    static_assert(HAS_MEMBER_tag<Base>() != true,
                   "For tagged pointers, please call typecase on a reference to the object not a pointer.");
     bool done = false;
 
@@ -91,7 +84,7 @@ template <typename Base, typename FUNC> bool typecaseHelper(Base &base, FUNC &&f
 }
 
 template <typename Base, typename... Subclasses> void typecase(Base &base, Subclasses &&... funcs) {
-    static_assert(Sfinae::has_tag<Base>() == true,
+    static_assert(HAS_MEMBER_tag<Base>() == true,
                   "typecase used on reference type without .tag()! Did you mean to use it on a pointer type?");
     bool done = false;
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -707,7 +707,7 @@ string Symbol::toStringWithOptions(const GlobalState &gs, int tabs, bool showFul
         if (showRaw) {
             resultType = absl::StrReplaceAll(this->resultType.toStringWithTabs(gs, tabs), {{"\n", " "}});
         } else {
-            resultType = this->resultType->show(gs);
+            resultType = this->resultType.show(gs);
         }
         fmt::format_to(buf, " -> {}", resultType);
     }
@@ -795,7 +795,7 @@ string ArgInfo::toString(const GlobalState &gs) const {
     }
     fmt::format_to(buf, "<{}>", fmt::join(flagTexts, ", "));
     if (this->type) {
-        fmt::format_to(buf, " -> {}", this->type->show(gs));
+        fmt::format_to(buf, " -> {}", this->type.show(gs));
     }
 
     fmt::format_to(buf, " @ {}", loc.showRaw(gs));

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -705,7 +705,7 @@ string Symbol::toStringWithOptions(const GlobalState &gs, int tabs, bool showFul
     if (this->resultType && !isClassOrModule()) {
         string resultType;
         if (showRaw) {
-            resultType = absl::StrReplaceAll(this->resultType->toStringWithTabs(gs, tabs), {{"\n", " "}});
+            resultType = absl::StrReplaceAll(this->resultType.toStringWithTabs(gs, tabs), {{"\n", " "}});
         } else {
             resultType = this->resultType->show(gs);
         }
@@ -1212,7 +1212,7 @@ SymbolRef Symbol::enclosingClass(const GlobalState &gs) const {
 
 u4 Symbol::hash(const GlobalState &gs) const {
     u4 result = _hash(name.data(gs)->shortName(gs));
-    result = mix(result, !this->resultType ? 0 : this->resultType->hash(gs));
+    result = mix(result, !this->resultType ? 0 : this->resultType.hash(gs));
     result = mix(result, this->flags);
     result = mix(result, this->owner._id);
     result = mix(result, this->superClassOrRebind._id);
@@ -1233,7 +1233,7 @@ u4 Symbol::hash(const GlobalState &gs) const {
         if (!type) {
             type = Types::untypedUntracked();
         }
-        result = mix(result, type->hash(gs));
+        result = mix(result, type.hash(gs));
         result = mix(result, _hash(arg.name.data(gs)->shortName(gs)));
     }
     for (const auto &e : typeParams) {
@@ -1261,7 +1261,7 @@ u4 Symbol::methodShapeHash(const GlobalState &gs) const {
         // This is a synthetic method that encodes the superclasses of its owning class in its return type.
         // If the return type changes, we must take the slow path.
         ENFORCE(resultType);
-        result = mix(result, resultType->hash(gs));
+        result = mix(result, resultType.hash(gs));
     }
 
     return result;

--- a/core/TypeConstraint.cc
+++ b/core/TypeConstraint.cc
@@ -249,17 +249,17 @@ std::string TypeConstraint::toString(const core::GlobalState &gs) const {
     fmt::format_to(buf, "upperBounds: [{}]\n",
                    fmt::map_join(
                        this->upperBounds.begin(), this->upperBounds.end(), ", ", [&gs](auto pair) -> auto {
-                           return fmt::format("{}: {}", pair.first.toString(gs), pair.second->show(gs));
+                           return fmt::format("{}: {}", pair.first.toString(gs), pair.second.show(gs));
                        }));
     fmt::format_to(buf, "lowerBounds: [{}]\n",
                    fmt::map_join(
                        this->lowerBounds.begin(), this->lowerBounds.end(), ", ", [&gs](auto pair) -> auto {
-                           return fmt::format("{}: {}", pair.first.toString(gs), pair.second->show(gs));
+                           return fmt::format("{}: {}", pair.first.toString(gs), pair.second.show(gs));
                        }));
     fmt::format_to(buf, "solution: [{}]\n",
                    fmt::map_join(
                        this->solution.begin(), this->solution.end(), ", ", [&gs](auto pair) -> auto {
-                           return fmt::format("{}: {}", pair.first.toString(gs), pair.second->show(gs));
+                           return fmt::format("{}: {}", pair.first.toString(gs), pair.second.show(gs));
                        }));
     return to_string(buf);
 }

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -533,4 +533,37 @@ std::string TypePtr::showWithMoreInfo(const GlobalState &gs) const {
     }
 }
 
+bool TypePtr::derivesFrom(const GlobalState &gs, SymbolRef klass) const {
+    switch (tag()) {
+        case Tag::LiteralType:
+            return cast_type_nonnull<LiteralType>(*this).derivesFrom(gs, klass);
+        case Tag::ShapeType:
+            return cast_type_nonnull<ShapeType>(*this).derivesFrom(gs, klass);
+        case Tag::TupleType:
+            return cast_type_nonnull<TupleType>(*this).derivesFrom(gs, klass);
+        case Tag::BlamedUntyped:
+        case Tag::UnresolvedClassType:
+        case Tag::UnresolvedAppliedType:
+        case Tag::ClassType:
+            return cast_type_nonnull<ClassType>(*this).derivesFrom(gs, klass);
+        case Tag::OrType:
+            return cast_type_nonnull<OrType>(*this).derivesFrom(gs, klass);
+        case Tag::AndType:
+            return cast_type_nonnull<AndType>(*this).derivesFrom(gs, klass);
+        case Tag::AliasType:
+            return cast_type_nonnull<AliasType>(*this).derivesFrom(gs, klass);
+        case Tag::MetaType:
+            return cast_type_nonnull<MetaType>(*this).derivesFrom(gs, klass);
+        case Tag::TypeVar:
+            return cast_type_nonnull<TypeVar>(*this).derivesFrom(gs, klass);
+        case Tag::AppliedType:
+            return cast_type_nonnull<AppliedType>(*this).derivesFrom(gs, klass);
+        case Tag::LambdaParam:
+            return cast_type_nonnull<LambdaParam>(*this).derivesFrom(gs, klass);
+        case Tag::SelfTypeParam:
+            return cast_type_nonnull<SelfTypeParam>(*this).derivesFrom(gs, klass);
+        case Tag::SelfType:
+            return cast_type_nonnull<SelfType>(*this).derivesFrom(gs, klass);
+    }
+}
 } // namespace sorbet::core

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -55,9 +55,7 @@ GENERATE_CALL_MEMBER(_approximate, return nullptr, declval<const GlobalState &>(
 void TypePtr::deleteTagged(Tag tag, void *ptr) noexcept {
     ENFORCE(ptr != nullptr);
 
-#define DELETE_TYPE(T)                 \
-    delete reinterpret_cast<T *>(ptr); \
-    break;
+#define DELETE_TYPE(T) delete reinterpret_cast<T *>(ptr);
 
     GENERATE_TAG_SWITCH(tag, DELETE_TYPE)
 

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -1,4 +1,5 @@
 #include "core/TypePtr.h"
+#include "core/Hashing.h"
 #include "core/Symbols.h"
 #include "core/Types.h"
 
@@ -444,6 +445,47 @@ void TypePtr::_sanityCheck(const GlobalState &gs) const {
         case Tag::AliasType:
             return cast_type_nonnull<AliasType>(*this)._sanityCheck(gs);
     }
+}
+
+string TypePtr::toStringWithTabs(const GlobalState &gs, int tabs) const {
+    switch (tag()) {
+        case Tag::BlamedUntyped:
+            return cast_type_nonnull<BlamedUntyped>(*this).toStringWithTabs(gs, tabs);
+        case Tag::UnresolvedAppliedType:
+            return cast_type_nonnull<UnresolvedAppliedType>(*this).toStringWithTabs(gs, tabs);
+        case Tag::UnresolvedClassType:
+            return cast_type_nonnull<UnresolvedClassType>(*this).toStringWithTabs(gs, tabs);
+        case Tag::ClassType:
+            return cast_type_nonnull<ClassType>(*this).toStringWithTabs(gs, tabs);
+        case Tag::TypeVar:
+            return cast_type_nonnull<TypeVar>(*this).toStringWithTabs(gs, tabs);
+        case Tag::LiteralType:
+            return cast_type_nonnull<LiteralType>(*this).toStringWithTabs(gs, tabs);
+        case Tag::SelfTypeParam:
+            return cast_type_nonnull<SelfTypeParam>(*this).toStringWithTabs(gs, tabs);
+        case Tag::SelfType:
+            return cast_type_nonnull<SelfType>(*this).toStringWithTabs(gs, tabs);
+        case Tag::TupleType:
+            return cast_type_nonnull<TupleType>(*this).toStringWithTabs(gs, tabs);
+        case Tag::ShapeType:
+            return cast_type_nonnull<ShapeType>(*this).toStringWithTabs(gs, tabs);
+        case Tag::OrType:
+            return cast_type_nonnull<OrType>(*this).toStringWithTabs(gs, tabs);
+        case Tag::AndType:
+            return cast_type_nonnull<AndType>(*this).toStringWithTabs(gs, tabs);
+        case Tag::AppliedType:
+            return cast_type_nonnull<AppliedType>(*this).toStringWithTabs(gs, tabs);
+        case Tag::LambdaParam:
+            return cast_type_nonnull<LambdaParam>(*this).toStringWithTabs(gs, tabs);
+        case Tag::MetaType:
+            return cast_type_nonnull<MetaType>(*this).toStringWithTabs(gs, tabs);
+        case Tag::AliasType:
+            return cast_type_nonnull<AliasType>(*this).toStringWithTabs(gs, tabs);
+    }
+}
+
+unsigned int TypePtr::hash(const GlobalState &gs) const {
+    return _hash(this->toString(gs)); // TODO: make something better
 }
 
 } // namespace sorbet::core

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -9,6 +9,7 @@ using namespace std;
 #define CASE_STATEMENT(CASE_BODY, T) \
     case TypePtr::Tag::T: {          \
         CASE_BODY(T)                 \
+        break;                       \
     }
 
 #define GENERATE_TAG_SWITCH(tag, CASE_BODY)              \

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -1,80 +1,66 @@
 #include "core/TypePtr.h"
+#include "common/has_member.h"
 #include "core/Hashing.h"
 #include "core/Symbols.h"
 #include "core/Types.h"
 
 using namespace std;
 
+#define CASE_STATEMENT(CASE_BODY, T) \
+    case TypePtr::Tag::T: {          \
+        CASE_BODY(T)                 \
+    }
+
+#define GENERATE_TAG_SWITCH(tag, CASE_BODY)              \
+    switch (tag) {                                       \
+        CASE_STATEMENT(CASE_BODY, ClassType)             \
+        CASE_STATEMENT(CASE_BODY, LambdaParam)           \
+        CASE_STATEMENT(CASE_BODY, SelfTypeParam)         \
+        CASE_STATEMENT(CASE_BODY, AliasType)             \
+        CASE_STATEMENT(CASE_BODY, SelfType)              \
+        CASE_STATEMENT(CASE_BODY, LiteralType)           \
+        CASE_STATEMENT(CASE_BODY, TypeVar)               \
+        CASE_STATEMENT(CASE_BODY, OrType)                \
+        CASE_STATEMENT(CASE_BODY, AndType)               \
+        CASE_STATEMENT(CASE_BODY, ShapeType)             \
+        CASE_STATEMENT(CASE_BODY, TupleType)             \
+        CASE_STATEMENT(CASE_BODY, AppliedType)           \
+        CASE_STATEMENT(CASE_BODY, MetaType)              \
+        CASE_STATEMENT(CASE_BODY, BlamedUntyped)         \
+        CASE_STATEMENT(CASE_BODY, UnresolvedClassType)   \
+        CASE_STATEMENT(CASE_BODY, UnresolvedAppliedType) \
+    }
+
 namespace sorbet::core {
+
+namespace {
+GENERATE_CALL_MEMBER(showWithMoreInfo, return self.show(std::forward<Args>(args)...),
+                     std::declval<const GlobalState &>())
+
+GENERATE_CALL_MEMBER(dispatchCall,
+                     Exception::raise("should never happen: dispatchCall on {}",
+                                      TypePtr::tagToString(TypePtr::TypeToTag<typename remove_const<T>::type>::value));
+                     return DispatchResult{};, std::declval<const GlobalState &>(), std::declval<DispatchArgs>())
+
+GENERATE_CALL_MEMBER(_instantiate, return nullptr, std::declval<const GlobalState &>(),
+                     std::declval<const TypeConstraint &>())
+
+GENERATE_CALL_MEMBER(_replaceSelfType, return nullptr, declval<const GlobalState &>(), declval<const TypePtr &>())
+
+GENERATE_CALL_MEMBER(_approximate, return nullptr, declval<const GlobalState &>(), declval<const TypeConstraint &>())
+
+} // namespace
 
 void TypePtr::deleteTagged(Tag tag, void *ptr) noexcept {
     ENFORCE(ptr != nullptr);
 
-    switch (tag) {
-        case Tag::ClassType:
-            delete reinterpret_cast<ClassType *>(ptr);
-            break;
+#define DELETE_TYPE(T)                 \
+    delete reinterpret_cast<T *>(ptr); \
+    break;
 
-        case Tag::LambdaParam:
-            delete reinterpret_cast<LambdaParam *>(ptr);
-            break;
+    GENERATE_TAG_SWITCH(tag, DELETE_TYPE)
 
-        case Tag::SelfTypeParam:
-            delete reinterpret_cast<SelfTypeParam *>(ptr);
-            break;
-
-        case Tag::AliasType:
-            delete reinterpret_cast<AliasType *>(ptr);
-            break;
-
-        case Tag::SelfType:
-            delete reinterpret_cast<SelfType *>(ptr);
-            break;
-
-        case Tag::LiteralType:
-            delete reinterpret_cast<LiteralType *>(ptr);
-            break;
-
-        case Tag::TypeVar:
-            delete reinterpret_cast<TypeVar *>(ptr);
-            break;
-
-        case Tag::OrType:
-            delete reinterpret_cast<OrType *>(ptr);
-            break;
-
-        case Tag::AndType:
-            delete reinterpret_cast<AndType *>(ptr);
-            break;
-
-        case Tag::ShapeType:
-            delete reinterpret_cast<ShapeType *>(ptr);
-            break;
-
-        case Tag::TupleType:
-            delete reinterpret_cast<TupleType *>(ptr);
-            break;
-
-        case Tag::AppliedType:
-            delete reinterpret_cast<AppliedType *>(ptr);
-            break;
-
-        case Tag::MetaType:
-            delete reinterpret_cast<MetaType *>(ptr);
-            break;
-
-        case Tag::BlamedUntyped:
-            delete reinterpret_cast<BlamedUntyped *>(ptr);
-            break;
-
-        case Tag::UnresolvedClassType:
-            delete reinterpret_cast<UnresolvedClassType *>(ptr);
-            break;
-
-        case Tag::UnresolvedAppliedType:
-            delete reinterpret_cast<UnresolvedAppliedType *>(ptr);
-            break;
-    }
+#undef DELETE_TYPE
 }
 
 bool TypePtr::isUntyped() const {
@@ -125,41 +111,14 @@ int TypePtr::kind() const {
     }
 }
 
+std::string TypePtr::tagToString(Tag tag) {
+#define TYPE_TO_STRING(T) return #T;
+    GENERATE_TAG_SWITCH(tag, TYPE_TO_STRING)
+#undef TYPE_TO_STRING
+}
+
 std::string TypePtr::typeName() const {
-    switch (tag()) {
-        case Tag::AppliedType:
-            return "AppliedType";
-        case Tag::BlamedUntyped:
-            return "BlamedUntyped";
-        case Tag::UnresolvedAppliedType:
-            return "UnresolvedAppliedType";
-        case Tag::UnresolvedClassType:
-            return "UnresolvedClassType";
-        case Tag::ClassType:
-            return "ClassType";
-        case Tag::LiteralType:
-            return "LiteralType";
-        case Tag::ShapeType:
-            return "ShapeType";
-        case Tag::TupleType:
-            return "TupleType";
-        case Tag::LambdaParam:
-            return "LambdaParam";
-        case Tag::SelfTypeParam:
-            return "SelfTypeParam";
-        case Tag::MetaType:
-            return "MetaType";
-        case Tag::TypeVar:
-            return "TypeVar";
-        case Tag::AliasType:
-            return "AliasType";
-        case Tag::OrType:
-            return "OrType";
-        case Tag::AndType:
-            return "AndType";
-        case Tag::SelfType:
-            return "SelfType";
-    }
+    return TypePtr::tagToString(tag());
 }
 
 bool TypePtr::isFullyDefined() const {
@@ -297,88 +256,22 @@ TypePtr TypePtr::getCallArguments(const GlobalState &gs, NameRef name) const {
 }
 
 TypePtr TypePtr::_approximate(const GlobalState &gs, const TypeConstraint &tc) const {
-    switch (tag()) {
-        case Tag::MetaType:
-            return cast_type_nonnull<MetaType>(*this)._approximate(gs, tc);
-        case Tag::TypeVar:
-            return cast_type_nonnull<TypeVar>(*this)._approximate(gs, tc);
-        case Tag::TupleType:
-            return cast_type_nonnull<TupleType>(*this)._approximate(gs, tc);
-        case Tag::ShapeType:
-            return cast_type_nonnull<ShapeType>(*this)._approximate(gs, tc);
-        case Tag::OrType:
-            return cast_type_nonnull<OrType>(*this)._approximate(gs, tc);
-        case Tag::AndType:
-            return cast_type_nonnull<AndType>(*this)._approximate(gs, tc);
-        case Tag::AppliedType:
-            return cast_type_nonnull<AppliedType>(*this)._approximate(gs, tc);
-
-        case Tag::UnresolvedClassType:
-        case Tag::UnresolvedAppliedType:
-        case Tag::BlamedUntyped:
-        case Tag::LiteralType:
-        case Tag::AliasType:
-        case Tag::SelfTypeParam:
-        case Tag::SelfType:
-        case Tag::LambdaParam:
-        case Tag::ClassType:
-            return nullptr;
-    }
+#define _APPROXIMATE(T) return CALL_MEMBER__approximate<const T>::call(cast_type_nonnull<T>(*this), gs, tc);
+    GENERATE_TAG_SWITCH(tag(), _APPROXIMATE)
+#undef _APPROXIMATE
 }
 
 TypePtr TypePtr::_replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const {
-    switch (tag()) {
-        case Tag::SelfType:
-            return cast_type_nonnull<SelfType>(*this)._replaceSelfType(gs, receiver);
-        case Tag::OrType:
-            return cast_type_nonnull<OrType>(*this)._replaceSelfType(gs, receiver);
-        case Tag::AndType:
-            return cast_type_nonnull<AndType>(*this)._replaceSelfType(gs, receiver);
-
-        case Tag::UnresolvedClassType:
-        case Tag::UnresolvedAppliedType:
-        case Tag::BlamedUntyped:
-        case Tag::LiteralType:
-        case Tag::AliasType:
-        case Tag::SelfTypeParam:
-        case Tag::LambdaParam:
-        case Tag::ClassType:
-        case Tag::ShapeType:
-        case Tag::TypeVar:
-        case Tag::TupleType:
-        case Tag::AppliedType:
-        case Tag::MetaType:
-            return nullptr;
-    }
+#define _REPLACE_SELF_TYPE(T) \
+    return CALL_MEMBER__replaceSelfType<const T>::call(cast_type_nonnull<T>(*this), gs, receiver);
+    GENERATE_TAG_SWITCH(tag(), _REPLACE_SELF_TYPE)
+#undef _REPLACE_SELF_TYPE
 }
 
 TypePtr TypePtr::_instantiate(const GlobalState &gs, const TypeConstraint &tc) const {
-    switch (tag()) {
-        case Tag::TypeVar:
-            return cast_type_nonnull<TypeVar>(*this)._instantiate(gs, tc);
-        case Tag::TupleType:
-            return cast_type_nonnull<TupleType>(*this)._instantiate(gs, tc);
-        case Tag::ShapeType:
-            return cast_type_nonnull<ShapeType>(*this)._instantiate(gs, tc);
-        case Tag::OrType:
-            return cast_type_nonnull<OrType>(*this)._instantiate(gs, tc);
-        case Tag::AndType:
-            return cast_type_nonnull<AndType>(*this)._instantiate(gs, tc);
-        case Tag::AppliedType:
-            return cast_type_nonnull<AppliedType>(*this)._instantiate(gs, tc);
-
-        case Tag::UnresolvedClassType:
-        case Tag::UnresolvedAppliedType:
-        case Tag::BlamedUntyped:
-        case Tag::LiteralType:
-        case Tag::AliasType:
-        case Tag::SelfType:
-        case Tag::SelfTypeParam:
-        case Tag::LambdaParam:
-        case Tag::ClassType:
-        case Tag::MetaType:
-            return nullptr;
-    }
+#define _INSTANTIATE(T) return CALL_MEMBER__instantiate<const T>::call(cast_type_nonnull<T>(*this), gs, tc);
+    GENERATE_TAG_SWITCH(tag(), _INSTANTIATE)
+#undef _INSTANTIATE
 }
 
 TypePtr TypePtr::_instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
@@ -414,74 +307,15 @@ TypePtr TypePtr::_instantiate(const GlobalState &gs, const InlinedVector<SymbolR
 }
 
 void TypePtr::_sanityCheck(const GlobalState &gs) const {
-    switch (tag()) {
-        case Tag::BlamedUntyped:
-        case Tag::UnresolvedAppliedType:
-        case Tag::UnresolvedClassType:
-        case Tag::ClassType:
-            return cast_type_nonnull<ClassType>(*this)._sanityCheck(gs);
-        case Tag::TypeVar:
-            return cast_type_nonnull<TypeVar>(*this)._sanityCheck(gs);
-        case Tag::LiteralType:
-            return cast_type_nonnull<LiteralType>(*this)._sanityCheck(gs);
-        case Tag::SelfTypeParam:
-            return cast_type_nonnull<SelfTypeParam>(*this)._sanityCheck(gs);
-        case Tag::SelfType:
-            return cast_type_nonnull<SelfType>(*this)._sanityCheck(gs);
-        case Tag::TupleType:
-            return cast_type_nonnull<TupleType>(*this)._sanityCheck(gs);
-        case Tag::ShapeType:
-            return cast_type_nonnull<ShapeType>(*this)._sanityCheck(gs);
-        case Tag::OrType:
-            return cast_type_nonnull<OrType>(*this)._sanityCheck(gs);
-        case Tag::AndType:
-            return cast_type_nonnull<AndType>(*this)._sanityCheck(gs);
-        case Tag::AppliedType:
-            return cast_type_nonnull<AppliedType>(*this)._sanityCheck(gs);
-        case Tag::LambdaParam:
-            return cast_type_nonnull<LambdaParam>(*this)._sanityCheck(gs);
-        case Tag::MetaType:
-            return cast_type_nonnull<MetaType>(*this)._sanityCheck(gs);
-        case Tag::AliasType:
-            return cast_type_nonnull<AliasType>(*this)._sanityCheck(gs);
-    }
+#define SANITY_CHECK(T) return cast_type_nonnull<T>(*this)._sanityCheck(gs);
+    GENERATE_TAG_SWITCH(tag(), SANITY_CHECK)
+#undef SANITY_CHECK
 }
 
 string TypePtr::toStringWithTabs(const GlobalState &gs, int tabs) const {
-    switch (tag()) {
-        case Tag::BlamedUntyped:
-            return cast_type_nonnull<BlamedUntyped>(*this).toStringWithTabs(gs, tabs);
-        case Tag::UnresolvedAppliedType:
-            return cast_type_nonnull<UnresolvedAppliedType>(*this).toStringWithTabs(gs, tabs);
-        case Tag::UnresolvedClassType:
-            return cast_type_nonnull<UnresolvedClassType>(*this).toStringWithTabs(gs, tabs);
-        case Tag::ClassType:
-            return cast_type_nonnull<ClassType>(*this).toStringWithTabs(gs, tabs);
-        case Tag::TypeVar:
-            return cast_type_nonnull<TypeVar>(*this).toStringWithTabs(gs, tabs);
-        case Tag::LiteralType:
-            return cast_type_nonnull<LiteralType>(*this).toStringWithTabs(gs, tabs);
-        case Tag::SelfTypeParam:
-            return cast_type_nonnull<SelfTypeParam>(*this).toStringWithTabs(gs, tabs);
-        case Tag::SelfType:
-            return cast_type_nonnull<SelfType>(*this).toStringWithTabs(gs, tabs);
-        case Tag::TupleType:
-            return cast_type_nonnull<TupleType>(*this).toStringWithTabs(gs, tabs);
-        case Tag::ShapeType:
-            return cast_type_nonnull<ShapeType>(*this).toStringWithTabs(gs, tabs);
-        case Tag::OrType:
-            return cast_type_nonnull<OrType>(*this).toStringWithTabs(gs, tabs);
-        case Tag::AndType:
-            return cast_type_nonnull<AndType>(*this).toStringWithTabs(gs, tabs);
-        case Tag::AppliedType:
-            return cast_type_nonnull<AppliedType>(*this).toStringWithTabs(gs, tabs);
-        case Tag::LambdaParam:
-            return cast_type_nonnull<LambdaParam>(*this).toStringWithTabs(gs, tabs);
-        case Tag::MetaType:
-            return cast_type_nonnull<MetaType>(*this).toStringWithTabs(gs, tabs);
-        case Tag::AliasType:
-            return cast_type_nonnull<AliasType>(*this).toStringWithTabs(gs, tabs);
-    }
+#define TO_STRING_WITH_TABS(T) return cast_type_nonnull<T>(*this).toStringWithTabs(gs, tabs);
+    GENERATE_TAG_SWITCH(tag(), TO_STRING_WITH_TABS)
+#undef TO_STRING_WITH_TABS
 }
 
 unsigned int TypePtr::hash(const GlobalState &gs) const {
@@ -489,114 +323,27 @@ unsigned int TypePtr::hash(const GlobalState &gs) const {
 }
 
 std::string TypePtr::show(const GlobalState &gs) const {
-    switch (tag()) {
-        case Tag::UnresolvedAppliedType:
-            return cast_type_nonnull<UnresolvedAppliedType>(*this).show(gs);
-        case Tag::UnresolvedClassType:
-            return cast_type_nonnull<UnresolvedClassType>(*this).show(gs);
-        case Tag::BlamedUntyped:
-        case Tag::ClassType:
-            return cast_type_nonnull<ClassType>(*this).show(gs);
-        case Tag::TypeVar:
-            return cast_type_nonnull<TypeVar>(*this).show(gs);
-        case Tag::LiteralType:
-            return cast_type_nonnull<LiteralType>(*this).show(gs);
-        case Tag::SelfTypeParam:
-            return cast_type_nonnull<SelfTypeParam>(*this).show(gs);
-        case Tag::SelfType:
-            return cast_type_nonnull<SelfType>(*this).show(gs);
-        case Tag::TupleType:
-            return cast_type_nonnull<TupleType>(*this).show(gs);
-        case Tag::ShapeType:
-            return cast_type_nonnull<ShapeType>(*this).show(gs);
-        case Tag::OrType:
-            return cast_type_nonnull<OrType>(*this).show(gs);
-        case Tag::AndType:
-            return cast_type_nonnull<AndType>(*this).show(gs);
-        case Tag::AppliedType:
-            return cast_type_nonnull<AppliedType>(*this).show(gs);
-        case Tag::LambdaParam:
-            return cast_type_nonnull<LambdaParam>(*this).show(gs);
-        case Tag::MetaType:
-            return cast_type_nonnull<MetaType>(*this).show(gs);
-        case Tag::AliasType:
-            return cast_type_nonnull<AliasType>(*this).show(gs);
-    }
+#define SHOW(T) return cast_type_nonnull<T>(*this).show(gs);
+    GENERATE_TAG_SWITCH(tag(), SHOW)
+#undef SHOW
 }
 
 std::string TypePtr::showWithMoreInfo(const GlobalState &gs) const {
-    switch (tag()) {
-        case Tag::TupleType:
-            return cast_type_nonnull<TupleType>(*this).showWithMoreInfo(gs);
-        default:
-            return show(gs);
-    }
+#define SHOW_WITH_MORE_INFO(T) return CALL_MEMBER_showWithMoreInfo<const T>::call(cast_type_nonnull<T>(*this), gs);
+    GENERATE_TAG_SWITCH(tag(), SHOW_WITH_MORE_INFO)
+#undef SHOW_WITH_MORE_INFO
 }
 
 bool TypePtr::derivesFrom(const GlobalState &gs, SymbolRef klass) const {
-    switch (tag()) {
-        case Tag::LiteralType:
-            return cast_type_nonnull<LiteralType>(*this).derivesFrom(gs, klass);
-        case Tag::ShapeType:
-            return cast_type_nonnull<ShapeType>(*this).derivesFrom(gs, klass);
-        case Tag::TupleType:
-            return cast_type_nonnull<TupleType>(*this).derivesFrom(gs, klass);
-        case Tag::BlamedUntyped:
-        case Tag::UnresolvedClassType:
-        case Tag::UnresolvedAppliedType:
-        case Tag::ClassType:
-            return cast_type_nonnull<ClassType>(*this).derivesFrom(gs, klass);
-        case Tag::OrType:
-            return cast_type_nonnull<OrType>(*this).derivesFrom(gs, klass);
-        case Tag::AndType:
-            return cast_type_nonnull<AndType>(*this).derivesFrom(gs, klass);
-        case Tag::AliasType:
-            return cast_type_nonnull<AliasType>(*this).derivesFrom(gs, klass);
-        case Tag::MetaType:
-            return cast_type_nonnull<MetaType>(*this).derivesFrom(gs, klass);
-        case Tag::TypeVar:
-            return cast_type_nonnull<TypeVar>(*this).derivesFrom(gs, klass);
-        case Tag::AppliedType:
-            return cast_type_nonnull<AppliedType>(*this).derivesFrom(gs, klass);
-        case Tag::LambdaParam:
-            return cast_type_nonnull<LambdaParam>(*this).derivesFrom(gs, klass);
-        case Tag::SelfTypeParam:
-            return cast_type_nonnull<SelfTypeParam>(*this).derivesFrom(gs, klass);
-        case Tag::SelfType:
-            return cast_type_nonnull<SelfType>(*this).derivesFrom(gs, klass);
-    }
+#define DERIVES_FROM(T) return cast_type_nonnull<T>(*this).derivesFrom(gs, klass);
+    GENERATE_TAG_SWITCH(tag(), DERIVES_FROM)
+#undef DERIVES_FROM
 }
 
 DispatchResult TypePtr::dispatchCall(const GlobalState &gs, DispatchArgs args) const {
-    switch (tag()) {
-        case Tag::LiteralType:
-            return cast_type_nonnull<LiteralType>(*this).dispatchCall(gs, move(args));
-        case Tag::OrType:
-            return cast_type_nonnull<OrType>(*this).dispatchCall(gs, move(args));
-        case Tag::AndType:
-            return cast_type_nonnull<AndType>(*this).dispatchCall(gs, move(args));
-        case Tag::ShapeType:
-            return cast_type_nonnull<ShapeType>(*this).dispatchCall(gs, move(args));
-        case Tag::TupleType:
-            return cast_type_nonnull<TupleType>(*this).dispatchCall(gs, move(args));
-        case Tag::BlamedUntyped:
-        case Tag::UnresolvedAppliedType:
-        case Tag::UnresolvedClassType:
-        case Tag::ClassType:
-            return cast_type_nonnull<ClassType>(*this).dispatchCall(gs, move(args));
-        case Tag::AppliedType:
-            return cast_type_nonnull<AppliedType>(*this).dispatchCall(gs, move(args));
-        case Tag::MetaType:
-            return cast_type_nonnull<MetaType>(*this).dispatchCall(gs, move(args));
-        case Tag::SelfTypeParam:
-            return cast_type_nonnull<SelfTypeParam>(*this).dispatchCall(gs, move(args));
-
-        case Tag::TypeVar:
-        case Tag::LambdaParam:
-        case Tag::SelfType:
-        case Tag::AliasType:
-            Exception::raise("should never happen: dispatchCall on `{}`", typeName());
-    }
+#define DISPATCH_CALL(T) return CALL_MEMBER_dispatchCall<const T>::call(cast_type_nonnull<T>(*this), gs, args);
+    GENERATE_TAG_SWITCH(tag(), DISPATCH_CALL)
+#undef DISPATCH_CALL
 }
 
 } // namespace sorbet::core

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -412,4 +412,38 @@ TypePtr TypePtr::_instantiate(const GlobalState &gs, const InlinedVector<SymbolR
     }
 }
 
+void TypePtr::_sanityCheck(const GlobalState &gs) const {
+    switch (tag()) {
+        case Tag::BlamedUntyped:
+        case Tag::UnresolvedAppliedType:
+        case Tag::UnresolvedClassType:
+        case Tag::ClassType:
+            return cast_type_nonnull<ClassType>(*this)._sanityCheck(gs);
+        case Tag::TypeVar:
+            return cast_type_nonnull<TypeVar>(*this)._sanityCheck(gs);
+        case Tag::LiteralType:
+            return cast_type_nonnull<LiteralType>(*this)._sanityCheck(gs);
+        case Tag::SelfTypeParam:
+            return cast_type_nonnull<SelfTypeParam>(*this)._sanityCheck(gs);
+        case Tag::SelfType:
+            return cast_type_nonnull<SelfType>(*this)._sanityCheck(gs);
+        case Tag::TupleType:
+            return cast_type_nonnull<TupleType>(*this)._sanityCheck(gs);
+        case Tag::ShapeType:
+            return cast_type_nonnull<ShapeType>(*this)._sanityCheck(gs);
+        case Tag::OrType:
+            return cast_type_nonnull<OrType>(*this)._sanityCheck(gs);
+        case Tag::AndType:
+            return cast_type_nonnull<AndType>(*this)._sanityCheck(gs);
+        case Tag::AppliedType:
+            return cast_type_nonnull<AppliedType>(*this)._sanityCheck(gs);
+        case Tag::LambdaParam:
+            return cast_type_nonnull<LambdaParam>(*this)._sanityCheck(gs);
+        case Tag::MetaType:
+            return cast_type_nonnull<MetaType>(*this)._sanityCheck(gs);
+        case Tag::AliasType:
+            return cast_type_nonnull<AliasType>(*this)._sanityCheck(gs);
+    }
+}
+
 } // namespace sorbet::core

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -566,4 +566,37 @@ bool TypePtr::derivesFrom(const GlobalState &gs, SymbolRef klass) const {
             return cast_type_nonnull<SelfType>(*this).derivesFrom(gs, klass);
     }
 }
+
+DispatchResult TypePtr::dispatchCall(const GlobalState &gs, DispatchArgs args) const {
+    switch (tag()) {
+        case Tag::LiteralType:
+            return cast_type_nonnull<LiteralType>(*this).dispatchCall(gs, move(args));
+        case Tag::OrType:
+            return cast_type_nonnull<OrType>(*this).dispatchCall(gs, move(args));
+        case Tag::AndType:
+            return cast_type_nonnull<AndType>(*this).dispatchCall(gs, move(args));
+        case Tag::ShapeType:
+            return cast_type_nonnull<ShapeType>(*this).dispatchCall(gs, move(args));
+        case Tag::TupleType:
+            return cast_type_nonnull<TupleType>(*this).dispatchCall(gs, move(args));
+        case Tag::BlamedUntyped:
+        case Tag::UnresolvedAppliedType:
+        case Tag::UnresolvedClassType:
+        case Tag::ClassType:
+            return cast_type_nonnull<ClassType>(*this).dispatchCall(gs, move(args));
+        case Tag::AppliedType:
+            return cast_type_nonnull<AppliedType>(*this).dispatchCall(gs, move(args));
+        case Tag::MetaType:
+            return cast_type_nonnull<MetaType>(*this).dispatchCall(gs, move(args));
+        case Tag::SelfTypeParam:
+            return cast_type_nonnull<SelfTypeParam>(*this).dispatchCall(gs, move(args));
+
+        case Tag::TypeVar:
+        case Tag::LambdaParam:
+        case Tag::SelfType:
+        case Tag::AliasType:
+            Exception::raise("should never happen: dispatchCall on `{}`", typeName());
+    }
+}
+
 } // namespace sorbet::core

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -488,4 +488,49 @@ unsigned int TypePtr::hash(const GlobalState &gs) const {
     return _hash(this->toString(gs)); // TODO: make something better
 }
 
+std::string TypePtr::show(const GlobalState &gs) const {
+    switch (tag()) {
+        case Tag::UnresolvedAppliedType:
+            return cast_type_nonnull<UnresolvedAppliedType>(*this).show(gs);
+        case Tag::UnresolvedClassType:
+            return cast_type_nonnull<UnresolvedClassType>(*this).show(gs);
+        case Tag::BlamedUntyped:
+        case Tag::ClassType:
+            return cast_type_nonnull<ClassType>(*this).show(gs);
+        case Tag::TypeVar:
+            return cast_type_nonnull<TypeVar>(*this).show(gs);
+        case Tag::LiteralType:
+            return cast_type_nonnull<LiteralType>(*this).show(gs);
+        case Tag::SelfTypeParam:
+            return cast_type_nonnull<SelfTypeParam>(*this).show(gs);
+        case Tag::SelfType:
+            return cast_type_nonnull<SelfType>(*this).show(gs);
+        case Tag::TupleType:
+            return cast_type_nonnull<TupleType>(*this).show(gs);
+        case Tag::ShapeType:
+            return cast_type_nonnull<ShapeType>(*this).show(gs);
+        case Tag::OrType:
+            return cast_type_nonnull<OrType>(*this).show(gs);
+        case Tag::AndType:
+            return cast_type_nonnull<AndType>(*this).show(gs);
+        case Tag::AppliedType:
+            return cast_type_nonnull<AppliedType>(*this).show(gs);
+        case Tag::LambdaParam:
+            return cast_type_nonnull<LambdaParam>(*this).show(gs);
+        case Tag::MetaType:
+            return cast_type_nonnull<MetaType>(*this).show(gs);
+        case Tag::AliasType:
+            return cast_type_nonnull<AliasType>(*this).show(gs);
+    }
+}
+
+std::string TypePtr::showWithMoreInfo(const GlobalState &gs) const {
+    switch (tag()) {
+        case Tag::TupleType:
+            return cast_type_nonnull<TupleType>(*this).showWithMoreInfo(gs);
+        default:
+            return show(gs);
+    }
+}
+
 } // namespace sorbet::core

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -220,6 +220,11 @@ public:
         return toStringWithTabs(gs);
     }
 
+    // User visible type. Should exactly match what the user can write.
+    std::string show(const GlobalState &gs) const;
+    // Like show, but can include extra info. Does not necessarily match what the user can type.
+    std::string showWithMoreInfo(const GlobalState &gs) const;
+
     unsigned int hash(const GlobalState &gs) const;
 
     template <class T, class... Args> friend TypePtr make_type(Args &&... args);

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -215,6 +215,13 @@ public:
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
 
+    std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
+    std::string toString(const GlobalState &gs) const {
+        return toStringWithTabs(gs);
+    }
+
+    unsigned int hash(const GlobalState &gs) const;
+
     template <class T, class... Args> friend TypePtr make_type(Args &&... args);
     friend class TypePtrTestHelper;
 };

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -201,7 +201,7 @@ public:
     bool hasUntyped() const;
 
     void sanityCheck(const GlobalState &gs) const {
-        if (!debug_mode)
+        if constexpr (!debug_mode)
             return;
         _sanityCheck(gs);
     }

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -8,6 +8,8 @@
 namespace sorbet::core {
 class Type;
 class TypeConstraint;
+struct DispatchResult;
+struct DispatchArgs;
 
 class TypePtr final {
 public:
@@ -228,6 +230,8 @@ public:
     bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
 
     unsigned int hash(const GlobalState &gs) const;
+
+    DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) const;
 
     template <class T, class... Args> friend TypePtr make_type(Args &&... args);
     friend class TypePtrTestHelper;

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -47,6 +47,8 @@ public:
         return const_cast<To &>(cast<To>(static_cast<const TypePtr &>(what)));
     }
 
+    static std::string tagToString(Tag tag);
+
 private:
     std::atomic<u4> *counter;
     tagged_storage store;

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -225,6 +225,8 @@ public:
     // Like show, but can include extra info. Does not necessarily match what the user can type.
     std::string showWithMoreInfo(const GlobalState &gs) const;
 
+    bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
+
     unsigned int hash(const GlobalState &gs) const;
 
     template <class T, class... Args> friend TypePtr make_type(Args &&... args);

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -96,6 +96,8 @@ private:
         }
     }
 
+    void _sanityCheck(const GlobalState &gs) const;
+
 public:
     constexpr TypePtr() noexcept : counter(nullptr), store(0) {}
 
@@ -193,6 +195,12 @@ public:
     bool isFullyDefined() const;
 
     bool hasUntyped() const;
+
+    void sanityCheck(const GlobalState &gs) const {
+        if (!debug_mode)
+            return;
+        _sanityCheck(gs);
+    }
 
     core::SymbolRef untypedBlame() const;
 

--- a/core/Types.h
+++ b/core/Types.h
@@ -189,8 +189,6 @@ public:
     Type() = default;
     Type(const Type &obj) = delete;
     virtual ~Type() = default;
-
-    virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) = 0;
 };
 CheckSize(Type, 8, 8);
 
@@ -297,7 +295,7 @@ public:
     virtual TypePtr underlying() const = 0;
     ProxyType() = default;
 
-    virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) override;
+    DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) const;
     bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
 
     void _sanityCheck(const GlobalState &gs) const;
@@ -311,7 +309,7 @@ public:
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
-    virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) override final;
+    DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) const;
 
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
     bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
@@ -338,7 +336,6 @@ public:
 
     bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
 
-    virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     void _sanityCheck(const GlobalState &gs) const;
 
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
@@ -356,7 +353,7 @@ public:
 
     bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
 
-    virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
+    DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) const;
     void _sanityCheck(const GlobalState &gs) const;
 };
 CheckSize(SelfTypeParam, 16, 8);
@@ -366,7 +363,6 @@ public:
     AliasType(SymbolRef other);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
-    virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
 
     SymbolRef symbol;
@@ -387,7 +383,6 @@ public:
 
     TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const;
 
-    virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     void _sanityCheck(const GlobalState &gs) const;
     bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
 };
@@ -424,7 +419,6 @@ public:
     TypeVar(SymbolRef sym);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
-    virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     void _sanityCheck(const GlobalState &gs) const;
 
     bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
@@ -441,7 +435,7 @@ public:
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
-    virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
+    DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) const;
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
     bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
     void _sanityCheck(const GlobalState &gs) const;
@@ -491,7 +485,7 @@ public:
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
-    virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
+    DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) const;
 
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
     bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
@@ -535,7 +529,7 @@ public:
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
-    virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
+    DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) const;
     void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
@@ -562,7 +556,7 @@ public:
     void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
-    virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
+    DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
 
@@ -580,7 +574,7 @@ public:
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
-    virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
+    DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) const;
     void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
@@ -612,7 +606,7 @@ public:
 
     bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
 
-    virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
+    DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) const;
     void _sanityCheck(const GlobalState &gs) const;
 
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;

--- a/core/Types.h
+++ b/core/Types.h
@@ -203,12 +203,6 @@ public:
 
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) = 0;
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const = 0;
-    virtual void _sanityCheck(const GlobalState &gs) = 0;
-    void sanityCheck(const GlobalState &gs) {
-        if (!debug_mode)
-            return;
-        _sanityCheck(gs);
-    }
 
     unsigned int hash(const GlobalState &gs) const;
 };
@@ -320,7 +314,7 @@ public:
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) override;
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const override;
 
-    void _sanityCheck(const GlobalState &gs) override;
+    void _sanityCheck(const GlobalState &gs) const;
 };
 CheckSize(ProxyType, 8, 8);
 
@@ -335,7 +329,7 @@ public:
 
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
-    void _sanityCheck(const GlobalState &gs) final;
+    void _sanityCheck(const GlobalState &gs) const;
 };
 CheckSize(ClassType, 16, 8);
 
@@ -359,7 +353,7 @@ public:
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
 
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
-    void _sanityCheck(const GlobalState &gs) final;
+    void _sanityCheck(const GlobalState &gs) const;
 
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
@@ -377,7 +371,7 @@ public:
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
 
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
-    void _sanityCheck(const GlobalState &gs) final;
+    void _sanityCheck(const GlobalState &gs) const;
 };
 CheckSize(SelfTypeParam, 16, 8);
 
@@ -390,7 +384,7 @@ public:
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
 
     SymbolRef symbol;
-    void _sanityCheck(const GlobalState &gs) final;
+    void _sanityCheck(const GlobalState &gs) const;
 };
 CheckSize(AliasType, 16, 8);
 
@@ -408,7 +402,7 @@ public:
     TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const;
 
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
-    void _sanityCheck(const GlobalState &gs) final;
+    void _sanityCheck(const GlobalState &gs) const;
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
 };
 CheckSize(SelfType, 8, 8);
@@ -445,7 +439,7 @@ public:
     virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
     virtual std::string show(const GlobalState &gs) const final;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
-    void _sanityCheck(const GlobalState &gs) final;
+    void _sanityCheck(const GlobalState &gs) const;
 
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
 
@@ -464,7 +458,7 @@ public:
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
-    void _sanityCheck(const GlobalState &gs) final;
+    void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
@@ -515,7 +509,7 @@ public:
 
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
-    void _sanityCheck(const GlobalState &gs) final;
+    void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
     TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const;
@@ -556,7 +550,7 @@ public:
     virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
     virtual std::string show(const GlobalState &gs) const final;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
-    void _sanityCheck(const GlobalState &gs) final;
+    void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
@@ -579,7 +573,7 @@ public:
     virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
     virtual std::string show(const GlobalState &gs) const final;
     virtual std::string showWithMoreInfo(const GlobalState &gs) const final;
-    void _sanityCheck(const GlobalState &gs) final;
+    void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
@@ -601,7 +595,7 @@ public:
     virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
     virtual std::string show(const GlobalState &gs) const final;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
-    void _sanityCheck(const GlobalState &gs) final;
+    void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
 
@@ -633,7 +627,7 @@ public:
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
 
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
-    void _sanityCheck(const GlobalState &gs) final;
+    void _sanityCheck(const GlobalState &gs) const;
 
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
     virtual TypePtr underlying() const override;

--- a/core/Types.h
+++ b/core/Types.h
@@ -191,7 +191,6 @@ public:
     virtual ~Type() = default;
 
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) = 0;
-    virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const = 0;
 };
 CheckSize(Type, 8, 8);
 
@@ -299,7 +298,7 @@ public:
     ProxyType() = default;
 
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) override;
-    virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const override;
+    bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
 
     void _sanityCheck(const GlobalState &gs) const;
 };
@@ -315,7 +314,7 @@ public:
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) override final;
 
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
-    virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
+    bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
     void _sanityCheck(const GlobalState &gs) const;
 };
 CheckSize(ClassType, 16, 8);
@@ -337,7 +336,7 @@ public:
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
 
-    virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
+    bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
 
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     void _sanityCheck(const GlobalState &gs) const;
@@ -355,7 +354,7 @@ public:
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
 
-    virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
+    bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
 
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     void _sanityCheck(const GlobalState &gs) const;
@@ -368,7 +367,7 @@ public:
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
-    virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
+    bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
 
     SymbolRef symbol;
     void _sanityCheck(const GlobalState &gs) const;
@@ -390,7 +389,7 @@ public:
 
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     void _sanityCheck(const GlobalState &gs) const;
-    virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
+    bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
 };
 CheckSize(SelfType, 8, 8);
 
@@ -428,7 +427,7 @@ public:
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     void _sanityCheck(const GlobalState &gs) const;
 
-    virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
+    bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
 
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
@@ -444,7 +443,7 @@ public:
     std::string show(const GlobalState &gs) const;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
-    virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
+    bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
     void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
@@ -495,7 +494,7 @@ public:
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
 
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
-    virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
+    bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
     void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
@@ -588,7 +587,7 @@ public:
 
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
 
-    virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
+    bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
 };
@@ -611,7 +610,7 @@ public:
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
 
-    virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
+    bool derivesFrom(const GlobalState &gs, SymbolRef klass) const;
 
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     void _sanityCheck(const GlobalState &gs) const;

--- a/core/Types.h
+++ b/core/Types.h
@@ -189,11 +189,6 @@ public:
     Type() = default;
     Type(const Type &obj) = delete;
     virtual ~Type() = default;
-    // Internal printer.
-    virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const = 0;
-    std::string toString(const GlobalState &gs) const {
-        return toStringWithTabs(gs);
-    }
     // User visible type. Should exactly match what the user can write.
     virtual std::string show(const GlobalState &gs) const = 0;
     // Like show, but can include extra info. Does not necessarily match what the user can type.
@@ -203,8 +198,6 @@ public:
 
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) = 0;
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const = 0;
-
-    unsigned int hash(const GlobalState &gs) const;
 };
 CheckSize(Type, 8, 8);
 
@@ -323,7 +316,7 @@ public:
     SymbolRef symbol;
     ClassType(SymbolRef symbol);
 
-    virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const override;
+    std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     virtual std::string show(const GlobalState &gs) const override;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) override final;
 
@@ -347,7 +340,7 @@ public:
     TypePtr upperBound;
 
     LambdaParam(SymbolRef definition, TypePtr lower, TypePtr upper);
-    virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
+    std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     virtual std::string show(const GlobalState &gs) const final;
 
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
@@ -365,7 +358,7 @@ public:
     SymbolRef definition;
 
     SelfTypeParam(const SymbolRef definition);
-    virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
+    std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     virtual std::string show(const GlobalState &gs) const final;
 
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
@@ -378,7 +371,7 @@ CheckSize(SelfTypeParam, 16, 8);
 TYPE(AliasType) final : public Type {
 public:
     AliasType(SymbolRef other);
-    virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
+    std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     virtual std::string show(const GlobalState &gs) const final;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
@@ -395,7 +388,7 @@ CheckSize(AliasType, 16, 8);
 TYPE(SelfType) final : public Type {
 public:
     SelfType();
-    virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
+    std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     virtual std::string show(const GlobalState &gs) const final;
     virtual std::string showValue(const GlobalState &gs) const final;
 
@@ -421,7 +414,7 @@ public:
     LiteralType(SymbolRef klass, NameRef val);
     virtual TypePtr underlying() const override;
 
-    virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
+    std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     virtual std::string show(const GlobalState &gs) const final;
     virtual std::string showValue(const GlobalState &gs) const final;
 
@@ -436,7 +429,7 @@ TYPE(TypeVar) final : public Type {
 public:
     SymbolRef sym;
     TypeVar(SymbolRef sym);
-    virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
+    std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     virtual std::string show(const GlobalState &gs) const final;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     void _sanityCheck(const GlobalState &gs) const;
@@ -453,7 +446,7 @@ public:
     TypePtr left;
     TypePtr right;
 
-    virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
+    std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     virtual std::string show(const GlobalState &gs) const final;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
@@ -503,7 +496,7 @@ public:
     TypePtr left;
     TypePtr right;
 
-    virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
+    std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     virtual std::string show(const GlobalState &gs) const final;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
 
@@ -547,7 +540,7 @@ public:
     ShapeType();
     ShapeType(TypePtr underlying, std::vector<TypePtr> keys, std::vector<TypePtr> values);
 
-    virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
+    std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     virtual std::string show(const GlobalState &gs) const final;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     void _sanityCheck(const GlobalState &gs) const;
@@ -570,7 +563,7 @@ public:
     TupleType(TypePtr underlying, std::vector<TypePtr> elements);
     static TypePtr build(const GlobalState &gs, std::vector<TypePtr> elements);
 
-    virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
+    std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     virtual std::string show(const GlobalState &gs) const final;
     virtual std::string showWithMoreInfo(const GlobalState &gs) const final;
     void _sanityCheck(const GlobalState &gs) const;
@@ -592,7 +585,7 @@ public:
     std::vector<TypePtr> targs;
     AppliedType(SymbolRef klass, std::vector<TypePtr> targs);
 
-    virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
+    std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     virtual std::string show(const GlobalState &gs) const final;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     void _sanityCheck(const GlobalState &gs) const;
@@ -621,7 +614,7 @@ public:
 
     MetaType(const TypePtr &wrapped);
 
-    virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
+    std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     virtual std::string show(const GlobalState &gs) const final;
 
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
@@ -747,7 +740,7 @@ public:
     const std::vector<core::NameRef> names;
     UnresolvedClassType(SymbolRef scope, std::vector<core::NameRef> names)
         : ClassType(core::Symbols::untyped()), scope(scope), names(names){};
-    virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
+    std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     virtual std::string show(const GlobalState &gs) const final;
 };
 
@@ -757,7 +750,7 @@ public:
     const std::vector<TypePtr> targs;
     UnresolvedAppliedType(SymbolRef klass, std::vector<TypePtr> targs)
         : ClassType(core::Symbols::untyped()), klass(klass), targs(std::move(targs)){};
-    virtual std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const final;
+    std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     virtual std::string show(const GlobalState &gs) const final;
 };
 

--- a/core/Types.h
+++ b/core/Types.h
@@ -189,12 +189,6 @@ public:
     Type() = default;
     Type(const Type &obj) = delete;
     virtual ~Type() = default;
-    // User visible type. Should exactly match what the user can write.
-    virtual std::string show(const GlobalState &gs) const = 0;
-    // Like show, but can include extra info. Does not necessarily match what the user can type.
-    virtual std::string showWithMoreInfo(const GlobalState &gs) const {
-        return show(gs);
-    }
 
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) = 0;
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const = 0;
@@ -317,7 +311,7 @@ public:
     ClassType(SymbolRef symbol);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    virtual std::string show(const GlobalState &gs) const override;
+    std::string show(const GlobalState &gs) const;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) override final;
 
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
@@ -341,7 +335,7 @@ public:
 
     LambdaParam(SymbolRef definition, TypePtr lower, TypePtr upper);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    virtual std::string show(const GlobalState &gs) const final;
+    std::string show(const GlobalState &gs) const;
 
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
 
@@ -359,7 +353,7 @@ public:
 
     SelfTypeParam(const SymbolRef definition);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    virtual std::string show(const GlobalState &gs) const final;
+    std::string show(const GlobalState &gs) const;
 
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
 
@@ -372,7 +366,7 @@ TYPE(AliasType) final : public Type {
 public:
     AliasType(SymbolRef other);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    virtual std::string show(const GlobalState &gs) const final;
+    std::string show(const GlobalState &gs) const;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
 
@@ -389,7 +383,7 @@ TYPE(SelfType) final : public Type {
 public:
     SelfType();
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    virtual std::string show(const GlobalState &gs) const final;
+    std::string show(const GlobalState &gs) const;
     virtual std::string showValue(const GlobalState &gs) const final;
 
     TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const;
@@ -415,7 +409,7 @@ public:
     virtual TypePtr underlying() const override;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    virtual std::string show(const GlobalState &gs) const final;
+    std::string show(const GlobalState &gs) const;
     virtual std::string showValue(const GlobalState &gs) const final;
 
     bool equals(const LiteralType &rhs) const;
@@ -430,7 +424,7 @@ public:
     SymbolRef sym;
     TypeVar(SymbolRef sym);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    virtual std::string show(const GlobalState &gs) const final;
+    std::string show(const GlobalState &gs) const;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     void _sanityCheck(const GlobalState &gs) const;
 
@@ -447,7 +441,7 @@ public:
     TypePtr right;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    virtual std::string show(const GlobalState &gs) const final;
+    std::string show(const GlobalState &gs) const;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
@@ -497,7 +491,7 @@ public:
     TypePtr right;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    virtual std::string show(const GlobalState &gs) const final;
+    std::string show(const GlobalState &gs) const;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
 
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
@@ -541,7 +535,7 @@ public:
     ShapeType(TypePtr underlying, std::vector<TypePtr> keys, std::vector<TypePtr> values);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    virtual std::string show(const GlobalState &gs) const final;
+    std::string show(const GlobalState &gs) const;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
@@ -564,8 +558,8 @@ public:
     static TypePtr build(const GlobalState &gs, std::vector<TypePtr> elements);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    virtual std::string show(const GlobalState &gs) const final;
-    virtual std::string showWithMoreInfo(const GlobalState &gs) const final;
+    std::string show(const GlobalState &gs) const;
+    std::string showWithMoreInfo(const GlobalState &gs) const;
     void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
@@ -586,7 +580,7 @@ public:
     AppliedType(SymbolRef klass, std::vector<TypePtr> targs);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    virtual std::string show(const GlobalState &gs) const final;
+    std::string show(const GlobalState &gs) const;
     virtual DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) final;
     void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
@@ -615,7 +609,7 @@ public:
     MetaType(const TypePtr &wrapped);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    virtual std::string show(const GlobalState &gs) const final;
+    std::string show(const GlobalState &gs) const;
 
     virtual bool derivesFrom(const GlobalState &gs, SymbolRef klass) const final;
 
@@ -741,7 +735,7 @@ public:
     UnresolvedClassType(SymbolRef scope, std::vector<core::NameRef> names)
         : ClassType(core::Symbols::untyped()), scope(scope), names(names){};
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    virtual std::string show(const GlobalState &gs) const final;
+    std::string show(const GlobalState &gs) const;
 };
 
 TYPE(UnresolvedAppliedType) final : public ClassType {
@@ -751,7 +745,7 @@ public:
     UnresolvedAppliedType(SymbolRef klass, std::vector<TypePtr> targs)
         : ClassType(core::Symbols::untyped()), klass(klass), targs(std::move(targs)){};
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    virtual std::string show(const GlobalState &gs) const final;
+    std::string show(const GlobalState &gs) const;
 };
 
 } // namespace sorbet::core

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -172,16 +172,16 @@ unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Lo
     if (auto e = gs.beginError(smallestLocWithin(callLoc, argTpe), errors::Infer::MethodArgumentMismatch)) {
         if (mayBeSetter && isSetter(gs, method.data(gs)->name)) {
             e.setHeader("Assigning a value to `{}` that does not match expected type `{}`", argSym.argumentName(gs),
-                        expectedType->show(gs));
+                        expectedType.show(gs));
         } else {
-            e.setHeader("Expected `{}` but found `{}` for argument `{}`", expectedType->show(gs), argTpe.type->show(gs),
+            e.setHeader("Expected `{}` but found `{}` for argument `{}`", expectedType.show(gs), argTpe.type.show(gs),
                         argSym.argumentName(gs));
             e.addErrorSection(ErrorSection({
                 ErrorLine::from(argSym.loc, "Method `{}` has specified `{}` as `{}`", method.data(gs)->show(gs),
-                                argSym.argumentName(gs), expectedType->show(gs)),
+                                argSym.argumentName(gs), expectedType.show(gs)),
             }));
         }
-        e.addErrorSection(ErrorSection("Got " + argTpe.type->show(gs) + " originating from:",
+        e.addErrorSection(ErrorSection("Got " + argTpe.type.show(gs) + " originating from:",
                                        argTpe.origins2Explanations(gs, originForUninitialized)));
         auto withoutNil = Types::approximateSubtract(gs, argTpe.type, Types::nilClass());
         if (!withoutNil.isBottom() &&
@@ -523,10 +523,10 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args, core
         // errors list of the result so that the caller can deal with the error.
         auto e = gs.beginError(core::Loc(args.locs.file, args.locs.call), errors::Infer::UnknownMethod);
         if (e) {
-            string thisStr = args.thisType->show(gs);
+            string thisStr = args.thisType.show(gs);
             if (args.fullType.get() != args.thisType.get()) {
                 e.setHeader("Method `{}` does not exist on `{}` component of `{}`", args.name.data(gs)->show(gs),
-                            thisStr, args.fullType->show(gs));
+                            thisStr, args.fullType.show(gs));
             } else {
                 e.setHeader("Method `{}` does not exist on `{}`", args.name.data(gs)->show(gs), thisStr);
 
@@ -772,7 +772,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args, core
                             e.setHeader("Passing a hash where the specific keys are unknown to a method taking keyword "
                                         "arguments");
                             e.addErrorSection(
-                                ErrorSection("Got " + kwSplatType->show(gs) + " originating from:",
+                                ErrorSection("Got " + kwSplatType.show(gs) + " originating from:",
                                              kwSplatArg->origins2Explanations(gs, args.originForUninitialized)));
                             result.main.errors.emplace_back(e.build());
                         }
@@ -833,7 +833,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args, core
                     e.setHeader(
                         "Not enough arguments provided for method `{}` on `{}` component of `{}`. Expected: `{}`, got: "
                         "`{}`",
-                        data->show(gs), args.thisType->show(gs), args.fullType->show(gs), prettyArity(gs, method),
+                        data->show(gs), args.thisType.show(gs), args.fullType.show(gs), prettyArity(gs, method),
                         posArgs); // TODO: should use position and print the source tree, not the cfg one.
                 } else {
                     e.setHeader("Not enough arguments provided for method `{}`. Expected: `{}`, got: `{}`",
@@ -1142,7 +1142,7 @@ DispatchResult MetaType::dispatchCall(const GlobalState &gs, DispatchArgs args) 
             auto loc = core::Loc(args.locs.file, args.locs.call);
             if (auto e = gs.beginError(loc, errors::Infer::MetaTypeDispatchCall)) {
                 e.setHeader("Call to method `{}` on `{}` mistakes a type for a value", args.name.data(gs)->show(gs),
-                            this->wrapped->show(gs));
+                            this->wrapped.show(gs));
                 if (args.name == core::Names::tripleEq()) {
                     if (auto appliedType = cast_type<AppliedType>(this->wrapped)) {
                         e.addErrorSection(
@@ -1197,14 +1197,14 @@ public:
         const auto loc = core::Loc(args.locs.file, args.locs.call);
         if (!args.args[0]->type.isFullyDefined()) {
             if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
-                e.setHeader("T.must() applied to incomplete type `{}`", args.args[0]->type->show(gs));
+                e.setHeader("T.must() applied to incomplete type `{}`", args.args[0]->type.show(gs));
             }
             return;
         }
         auto ret = Types::approximateSubtract(gs, args.args[0]->type, Types::nilClass());
         if (ret == args.args[0]->type) {
             if (auto e = gs.beginError(loc, errors::Infer::InvalidCast)) {
-                e.setHeader("T.must(): Expected a `T.nilable` type, got: `{}`", args.args[0]->type->show(gs));
+                e.setHeader("T.must(): Expected a `T.nilable` type, got: `{}`", args.args[0]->type.show(gs));
                 const auto locWithoutTMust = Loc{loc.file(), loc.beginPos() + 7, loc.endPos() - 1};
                 e.replaceWith("Remove `T.must`", loc, "{}", locWithoutTMust.source(gs));
             }
@@ -1259,7 +1259,7 @@ public:
         }
 
         if (auto e = gs.beginError(core::Loc(args.locs.file, args.locs.call), errors::Infer::RevealType)) {
-            e.setHeader("Revealed type: `{}`", args.args[0]->type->showWithMoreInfo(gs));
+            e.setHeader("Revealed type: `{}`", args.args[0]->type.showWithMoreInfo(gs));
             e.addErrorSection(
                 ErrorSection("From:", args.args[0]->origins2Explanations(gs, args.originForUninitialized)));
         }
@@ -1420,11 +1420,11 @@ public:
                 if (!Types::isSubType(gs, argType, memType->upperBound)) {
                     validBounds = false;
                     if (auto e = gs.beginError(loc, errors::Resolver::GenericTypeParamBoundMismatch)) {
-                        auto argStr = argType->show(gs);
+                        auto argStr = argType.show(gs);
                         e.setHeader("`{}` is not a subtype of upper bound of type member `{}`", argStr,
                                     memData->showFullName(gs));
                         e.addErrorLine(memData->loc(), "`{}` is `{}` bounded by `{}` here", memData->showFullName(gs),
-                                       "upper", memType->upperBound->show(gs));
+                                       "upper", memType->upperBound.show(gs));
                     }
                 }
 
@@ -1432,11 +1432,11 @@ public:
                     validBounds = false;
 
                     if (auto e = gs.beginError(loc, errors::Resolver::GenericTypeParamBoundMismatch)) {
-                        auto argStr = argType->show(gs);
+                        auto argStr = argType.show(gs);
                         e.setHeader("`{}` is not a supertype of lower bound of type member `{}`", argStr,
                                     memData->showFullName(gs));
                         e.addErrorLine(memData->loc(), "`{}` is `{}` bounded by `{}` here", memData->showFullName(gs),
-                                       "lower", memType->lowerBound->show(gs));
+                                       "lower", memType->lowerBound.show(gs));
                     }
                 }
 
@@ -1800,7 +1800,7 @@ private:
         ENFORCE(bspec.flags.isBlock);
         e.addErrorSection(ErrorSection({
             ErrorLine::from(bspec.loc, "Method `{}` has specified `{}` as `{}`", dispatchComp.method.data(gs)->show(gs),
-                            bspec.argumentName(gs), blockType->show(gs)),
+                            bspec.argumentName(gs), blockType.show(gs)),
         }));
     }
 
@@ -1826,7 +1826,7 @@ private:
                 // raise an error in strict mode.
                 // This could occur, for example, when using Method#to_proc, since we type it as returning a `Proc`.
                 if (auto e = gs.beginError(blockLoc, errors::Infer::ProcArityUnknown)) {
-                    e.setHeader("Cannot use a `{}` with unknown arity as a `{}`", "Proc", blockPreType->show(gs));
+                    e.setHeader("Cannot use a `{}` with unknown arity as a `{}`", "Proc", blockPreType.show(gs));
                     if (!dispatched.secondary) {
                         Magic_callWithBlock::showLocationOfArgDefn(gs, e, blockPreType, dispatched.main);
                     }
@@ -1841,8 +1841,8 @@ private:
                     passedInBlockType = make_type<core::AppliedType>(procWithCorrectArity, move(targs));
                 }
             } else if (auto e = gs.beginError(blockLoc, errors::Infer::MethodArgumentMismatch)) {
-                e.setHeader("Expected `{}` but found `{}` for block argument", blockPreType->show(gs),
-                            passedInBlockType->show(gs));
+                e.setHeader("Expected `{}` but found `{}` for block argument", blockPreType.show(gs),
+                            passedInBlockType.show(gs));
                 if (!dispatched.secondary) {
                     Magic_callWithBlock::showLocationOfArgDefn(gs, e, blockPreType, dispatched.main);
                 }
@@ -2054,8 +2054,8 @@ public:
             e.setHeader("Constants must have type annotations with `{}` when specifying `{}`", "T.let",
                         "# typed: strict");
             if (!ty.isUntyped() && loc.exists()) {
-                e.replaceWith(fmt::format("Initialize as `{}`", ty->show(gs)), loc, "T.let({}, {})", loc.source(gs),
-                              ty->show(gs));
+                e.replaceWith(fmt::format("Initialize as `{}`", ty.show(gs)), loc, "T.let({}, {})", loc.source(gs),
+                              ty.show(gs));
             }
         }
         res.returnType = move(ty);
@@ -2373,7 +2373,7 @@ public:
         } else if (auto *tuple = cast_type<TupleType>(args.thisType)) {
             element = tuple->elementType();
         } else {
-            ENFORCE(false, "Array#flatten on unexpected type: {}", args.selfType->show(gs));
+            ENFORCE(false, "Array#flatten on unexpected type: {}", args.selfType.show(gs));
         }
 
         int64_t depth;
@@ -2426,7 +2426,7 @@ public:
         } else {
             // We will have only dispatched to this intrinsic when we knew the receiver.
             // Did we register this intrinsic on the wrong symbol?
-            ENFORCE(false, "Array#product on unexpected receiver type: {}", args.selfType->show(gs));
+            ENFORCE(false, "Array#product on unexpected receiver type: {}", args.selfType.show(gs));
             res.returnType = Types::untypedUntracked();
             return;
         }
@@ -2461,7 +2461,7 @@ public:
         } else if (auto *tuple = cast_type<TupleType>(args.thisType)) {
             element = tuple->elementType();
         } else {
-            ENFORCE(false, "Array#compact on unexpected type: {}", args.selfType->show(gs));
+            ENFORCE(false, "Array#compact on unexpected type: {}", args.selfType.show(gs));
         }
         auto ret = Types::approximateSubtract(gs, element, Types::nilClass());
         res.returnType = Types::arrayOf(gs, ret);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -670,7 +670,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args, core
             break;
         }
         if (ait + 1 == aend && hasKwargs && (spec.flags.isDefault || spec.flags.isRepeated) &&
-            Types::approximate(gs, arg->type, *constr)->derivesFrom(gs, Symbols::Hash())) {
+            Types::approximate(gs, arg->type, *constr).derivesFrom(gs, Symbols::Hash())) {
             break;
         }
 
@@ -765,7 +765,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, DispatchArgs args, core
                         // Allow an untyped arg to satisfy all kwargs
                         --aend;
                         kwargs = Types::untypedUntracked();
-                    } else if (kwSplatType->derivesFrom(gs, Symbols::Hash())) {
+                    } else if (kwSplatType.derivesFrom(gs, Symbols::Hash())) {
                         --aend;
                         if (auto e =
                                 gs.beginError(core::Loc(args.locs.file, args.locs.call), errors::Infer::UntypedSplat)) {
@@ -1570,7 +1570,7 @@ class Magic_expandSplat : public IntrinsicMethod {
 
         auto *tuple = cast_type<TupleType>(type);
         if (tuple == nullptr && core::Types::approximate(gs, type, core::TypeConstraint::EmptyFrozenConstraint)
-                                    ->derivesFrom(gs, Symbols::Array())) {
+                                    .derivesFrom(gs, Symbols::Array())) {
             // If this is an array and not a tuple, just pass it through. We
             // can't say anything about the elements.
             return type;
@@ -1597,8 +1597,8 @@ public:
         auto val = args.args.front()->type;
         auto *beforeLit = cast_type<LiteralType>(args.args[1]->type);
         auto *afterLit = cast_type<LiteralType>(args.args[2]->type);
-        if (!(beforeLit->underlying()->derivesFrom(gs, Symbols::Integer()) &&
-              afterLit->underlying()->derivesFrom(gs, Symbols::Integer()))) {
+        if (!(beforeLit->underlying().derivesFrom(gs, Symbols::Integer()) &&
+              afterLit->underlying().derivesFrom(gs, Symbols::Integer()))) {
             res.returnType = Types::untypedUntracked();
             return;
         }
@@ -2171,7 +2171,7 @@ public:
         if (args.args.size() == 1) {
             lit = cast_type<LiteralType>(args.args.front()->type);
         }
-        if (!lit || !lit->underlying()->derivesFrom(gs, Symbols::Integer())) {
+        if (!lit || !lit->underlying().derivesFrom(gs, Symbols::Integer())) {
             return;
         }
 

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -45,7 +45,7 @@ string UnresolvedAppliedType::toStringWithTabs(const GlobalState &gs, int tabs) 
 
 string UnresolvedAppliedType::show(const GlobalState &gs) const {
     return fmt::format("{}[{}] (unresolved)", this->klass.data(gs)->show(gs),
-                       fmt::map_join(targs, ", ", [&](auto targ) { return targ->show(gs); }));
+                       fmt::map_join(targs, ", ", [&](auto targ) { return targ.show(gs); }));
 }
 
 string LiteralType::toStringWithTabs(const GlobalState &gs, int tabs) const {
@@ -53,7 +53,7 @@ string LiteralType::toStringWithTabs(const GlobalState &gs, int tabs) const {
 }
 
 string LiteralType::show(const GlobalState &gs) const {
-    return fmt::format("{}({})", this->underlying()->show(gs), showValue(gs));
+    return fmt::format("{}({})", this->underlying().show(gs), showValue(gs));
 }
 
 string LiteralType::showValue(const GlobalState &gs) const {
@@ -90,8 +90,7 @@ string TupleType::toStringWithTabs(const GlobalState &gs, int tabs) const {
 }
 
 string TupleType::show(const GlobalState &gs) const {
-    return fmt::format("[{}]",
-                       fmt::map_join(this->elems, ", ", [&](const auto &el) -> string { return el->show(gs); }));
+    return fmt::format("[{}]", fmt::map_join(this->elems, ", ", [&](const auto &el) -> string { return el.show(gs); }));
 }
 
 string TupleType::showWithMoreInfo(const GlobalState &gs) const {
@@ -127,9 +126,9 @@ string ShapeType::show(const GlobalState &gs) const {
         SymbolRef undSymbol = cast_type<ClassType>(cast_type<LiteralType>(key)->underlying())->symbol;
         if (undSymbol == Symbols::Symbol()) {
             fmt::format_to(buf, "{}: {}", NameRef(gs, cast_type<LiteralType>(key)->value).show(gs),
-                           (*valueIterator)->show(gs));
+                           (*valueIterator).show(gs));
         } else {
-            fmt::format_to(buf, "{} => {}", key->show(gs), (*valueIterator)->show(gs));
+            fmt::format_to(buf, "{} => {}", key.show(gs), (*valueIterator).show(gs));
         }
         ++valueIterator;
     }
@@ -160,7 +159,7 @@ string showAndElem(const GlobalState &gs, const TypePtr &ty) {
     if (auto andType = cast_type<AndType>(ty)) {
         return showAnds(gs, andType->left, andType->right);
     }
-    return ty->show(gs);
+    return ty.show(gs);
 }
 
 string showAnds(const GlobalState &gs, const TypePtr &left, const TypePtr &right) {
@@ -264,7 +263,7 @@ pair<OrInfo, optional<string>> showOrElem(const GlobalState &gs, const TypePtr &
         return showOrs(gs, orType->left, orType->right);
     }
 
-    return make_pair(OrInfo::otherInfo(), make_optional(ty->show(gs)));
+    return make_pair(OrInfo::otherInfo(), make_optional(ty.show(gs)));
 }
 
 pair<OrInfo, optional<string>> showOrs(const GlobalState &gs, const TypePtr &left, const TypePtr &right) {
@@ -374,7 +373,7 @@ string AppliedType::show(const GlobalState &gs) const {
             fmt::format_to(buf, "{}",
                            fmt::map_join(
                                targs_it, this->targs.end(), ", ", [&](auto targ) -> auto {
-                                   return fmt::format("arg{}: {}", arg_num++, targ->show(gs));
+                                   return fmt::format("arg{}: {}", arg_num++, targ.show(gs));
                                }));
 
             if (*procArity > 0) {
@@ -384,7 +383,7 @@ string AppliedType::show(const GlobalState &gs) const {
             if (return_type == core::Types::void_()) {
                 fmt::format_to(buf, ".void");
             } else {
-                fmt::format_to(buf, ".returns({})", return_type->show(gs));
+                fmt::format_to(buf, ".returns({})", return_type.show(gs));
             }
             return to_string(buf);
         } else {
@@ -410,7 +409,7 @@ string AppliedType::show(const GlobalState &gs) const {
     }
 
     if (!targs.empty()) {
-        fmt::format_to(buf, "[{}]", fmt::map_join(targs, ", ", [&](auto targ) { return targ->show(gs); }));
+        fmt::format_to(buf, "[{}]", fmt::map_join(targs, ", ", [&](auto targ) { return targ.show(gs); }));
     }
     return to_string(buf);
 }

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -49,7 +49,7 @@ string UnresolvedAppliedType::show(const GlobalState &gs) const {
 }
 
 string LiteralType::toStringWithTabs(const GlobalState &gs, int tabs) const {
-    return fmt::format("{}({})", this->underlying()->toStringWithTabs(gs, tabs), showValue(gs));
+    return fmt::format("{}({})", this->underlying().toStringWithTabs(gs, tabs), showValue(gs));
 }
 
 string LiteralType::show(const GlobalState &gs) const {
@@ -83,7 +83,7 @@ string TupleType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     int i = -1;
     for (auto &el : this->elems) {
         i++;
-        fmt::format_to(buf, "{}{} = {}\n", nestedTabs, i, el->toStringWithTabs(gs, tabs + 3));
+        fmt::format_to(buf, "{}{} = {}\n", nestedTabs, i, el.toStringWithTabs(gs, tabs + 3));
     }
     fmt::format_to(buf, "{}}}", thisTabs);
     return to_string(buf);
@@ -105,8 +105,8 @@ string ShapeType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     fmt::format_to(buf, "ShapeType {{\n");
     auto valueIterator = this->values.begin();
     for (auto &el : this->keys) {
-        fmt::format_to(buf, "{}{} => {}\n", nestedTabs, el->toStringWithTabs(gs, tabs + 2),
-                       (*valueIterator)->toStringWithTabs(gs, tabs + 3));
+        fmt::format_to(buf, "{}{} => {}\n", nestedTabs, el.toStringWithTabs(gs, tabs + 2),
+                       (*valueIterator).toStringWithTabs(gs, tabs + 3));
         ++valueIterator;
     }
     fmt::format_to(buf, "{}}}", thisTabs);
@@ -149,8 +149,8 @@ string AndType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     bool leftBrace = isa_type<OrType>(this->left);
     bool rightBrace = isa_type<OrType>(this->right);
 
-    return fmt::format("{}{}{} & {}{}{}", leftBrace ? "(" : "", this->left->toStringWithTabs(gs, tabs + 2),
-                       leftBrace ? ")" : "", rightBrace ? "(" : "", this->right->toStringWithTabs(gs, tabs + 2),
+    return fmt::format("{}{}{} & {}{}{}", leftBrace ? "(" : "", this->left.toStringWithTabs(gs, tabs + 2),
+                       leftBrace ? ")" : "", rightBrace ? "(" : "", this->right.toStringWithTabs(gs, tabs + 2),
                        rightBrace ? ")" : "");
 }
 
@@ -178,8 +178,8 @@ string OrType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     bool leftBrace = isa_type<AndType>(this->left);
     bool rightBrace = isa_type<AndType>(this->right);
 
-    return fmt::format("{}{}{} | {}{}{}", leftBrace ? "(" : "", this->left->toStringWithTabs(gs, tabs + 2),
-                       leftBrace ? ")" : "", rightBrace ? "(" : "", this->right->toStringWithTabs(gs, tabs + 2),
+    return fmt::format("{}{}{} | {}{}{}", leftBrace ? "(" : "", this->left.toStringWithTabs(gs, tabs + 2),
+                       leftBrace ? ")" : "", rightBrace ? "(" : "", this->right.toStringWithTabs(gs, tabs + 2),
                        rightBrace ? ")" : "");
 }
 
@@ -330,7 +330,7 @@ string AppliedType::toStringWithTabs(const GlobalState &gs, int tabs) const {
         if (i < this->klass.data(gs)->typeMembers().size()) {
             auto tyMem = this->klass.data(gs)->typeMembers()[i];
             fmt::format_to(buf, "{}{} = {}\n", twiceNestedTabs, tyMem.data(gs)->name.showRaw(gs),
-                           targ->toStringWithTabs(gs, tabs + 3));
+                           targ.toStringWithTabs(gs, tabs + 3));
         } else {
             // this happens if we try to print type before resolver has processed stdlib
             fmt::format_to(buf, "{}EARLY_TYPE_MEMBER\n", twiceNestedTabs);
@@ -417,11 +417,11 @@ string AppliedType::show(const GlobalState &gs) const {
 
 string LambdaParam::toStringWithTabs(const GlobalState &gs, int tabs) const {
     auto defName = this->definition.data(gs)->toStringFullName(gs);
-    auto upperStr = this->upperBound->toString(gs);
+    auto upperStr = this->upperBound.toString(gs);
     if (this->definition.data(gs)->isFixed()) {
         return fmt::format("LambdaParam({}, fixed={})", defName, upperStr);
     } else {
-        auto lowerStr = this->lowerBound->toString(gs);
+        auto lowerStr = this->lowerBound.toString(gs);
         return fmt::format("LambdaParam({}, lower={}, upper={})", defName, lowerStr, upperStr);
     }
 }

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -1319,7 +1319,7 @@ bool Types::equivNoUntyped(const GlobalState &gs, const TypePtr &t1, const TypeP
 }
 
 bool ProxyType::derivesFrom(const GlobalState &gs, SymbolRef klass) const {
-    return underlying()->derivesFrom(gs, klass);
+    return underlying().derivesFrom(gs, klass);
 }
 
 bool ClassType::derivesFrom(const GlobalState &gs, SymbolRef klass) const {
@@ -1330,11 +1330,11 @@ bool ClassType::derivesFrom(const GlobalState &gs, SymbolRef klass) const {
 }
 
 bool OrType::derivesFrom(const GlobalState &gs, SymbolRef klass) const {
-    return left->derivesFrom(gs, klass) && right->derivesFrom(gs, klass);
+    return left.derivesFrom(gs, klass) && right.derivesFrom(gs, klass);
 }
 
 bool AndType::derivesFrom(const GlobalState &gs, SymbolRef klass) const {
-    return left->derivesFrom(gs, klass) || right->derivesFrom(gs, klass);
+    return left.derivesFrom(gs, klass) || right.derivesFrom(gs, klass);
 }
 
 bool AliasType::derivesFrom(const GlobalState &gs, SymbolRef klass) const {

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -32,7 +32,7 @@ TypePtr Types::any(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
     //            "we do pointer comparisons in order to see if one is subtype of another " + t1->toString(gs) +
     //                " was lubbing with " + t2->toString(gs) + " got " + ret->toString(gs));
 
-    ret->sanityCheck(gs);
+    ret.sanityCheck(gs);
 
     return ret;
 }
@@ -563,7 +563,7 @@ TypePtr glbGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
 }
 TypePtr Types::all(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
     auto ret = glb(gs, t1, t2);
-    ret->sanityCheck(gs);
+    ret.sanityCheck(gs);
 
     SLOW_ENFORCE(Types::isSubType(gs, ret, t1), "\n{}\nis not a subtype of\n{}\nwas glbbing with\n{}",
                  ret->toString(gs), t1->toString(gs), t2->toString(gs));
@@ -1341,7 +1341,7 @@ bool AliasType::derivesFrom(const GlobalState &gs, SymbolRef klass) const {
     Exception::raise("AliasType.derivesfrom");
 }
 
-void AliasType::_sanityCheck(const GlobalState &gs) {
+void AliasType::_sanityCheck(const GlobalState &gs) const {
     ENFORCE(this->symbol.exists());
 }
 
@@ -1353,9 +1353,9 @@ string MetaType::show(const GlobalState &gs) const {
     return "<Type: " + wrapped->show(gs) + ">";
 }
 
-void MetaType::_sanityCheck(const GlobalState &gs) {
+void MetaType::_sanityCheck(const GlobalState &gs) const {
     ENFORCE(!core::isa_type<MetaType>(wrapped));
-    this->wrapped->sanityCheck(gs);
+    this->wrapped.sanityCheck(gs);
 }
 
 bool MetaType::derivesFrom(const GlobalState &gs, SymbolRef klass) const {

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -15,9 +15,9 @@ TypePtr lubGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
 TypePtr Types::any(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
     auto ret = lub(gs, t1, t2);
     SLOW_ENFORCE(Types::isSubType(gs, t1, ret), "\n{}\nis not a super type of\n{}\nwas lubbing with {}",
-                 ret->toString(gs), t1->toString(gs), t2->toString(gs));
+                 ret.toString(gs), t1.toString(gs), t2.toString(gs));
     SLOW_ENFORCE(Types::isSubType(gs, t2, ret), "\n{}\nis not a super type of\n{}\nwas lubbing with {}",
-                 ret->toString(gs), t2->toString(gs), t1->toString(gs));
+                 ret.toString(gs), t2.toString(gs), t1.toString(gs));
 
     //  TODO: @dmitry, reenable
     //    ENFORCE(t1->hasUntyped() || t2->hasUntyped() || ret->hasUntyped() || // check if this test makes sense
@@ -565,11 +565,11 @@ TypePtr Types::all(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
     auto ret = glb(gs, t1, t2);
     ret.sanityCheck(gs);
 
-    SLOW_ENFORCE(Types::isSubType(gs, ret, t1), "\n{}\nis not a subtype of\n{}\nwas glbbing with\n{}",
-                 ret->toString(gs), t1->toString(gs), t2->toString(gs));
+    SLOW_ENFORCE(Types::isSubType(gs, ret, t1), "\n{}\nis not a subtype of\n{}\nwas glbbing with\n{}", ret.toString(gs),
+                 t1.toString(gs), t2.toString(gs));
 
     SLOW_ENFORCE(Types::isSubType(gs, ret, t2), "\n{}\n is not a subtype of\n{}\nwas glbbing with\n{}",
-                 ret->toString(gs), t2->toString(gs), t1->toString(gs));
+                 ret.toString(gs), t2.toString(gs), t1.toString(gs));
     //  TODO: @dmitry, reenable
     //    ENFORCE(t1->hasUntyped() || t2->hasUntyped() || ret->hasUntyped() || // check if this test makes sense
     //                !Types::isSubTypeUnderConstraint(gs, t1, t2) || ret == t1 || ret->isUntyped(),

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -1350,7 +1350,7 @@ string MetaType::toStringWithTabs(const GlobalState &gs, int tabs) const {
 }
 
 string MetaType::show(const GlobalState &gs) const {
-    return "<Type: " + wrapped->show(gs) + ">";
+    return "<Type: " + wrapped.show(gs) + ">";
 }
 
 void MetaType::_sanityCheck(const GlobalState &gs) const {

--- a/core/types/typemaps.cc
+++ b/core/types/typemaps.cc
@@ -1,7 +1,6 @@
 #include "absl/base/casts.h"
 #include "common/common.h"
 #include "core/Context.h"
-#include "core/Hashing.h"
 #include "core/Names.h"
 #include "core/TypeConstraint.h"
 #include "core/Types.h"
@@ -453,10 +452,6 @@ TypePtr AndType::_replaceSelfType(const GlobalState &gs, const TypePtr &receiver
         return Types::all(gs, left, right);
     }
     return nullptr;
-}
-
-unsigned int Type::hash(const GlobalState &gs) const {
-    return _hash(this->toString(gs)); // TODO: make something better
 }
 
 } // namespace sorbet::core

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -22,7 +22,7 @@ namespace sorbet::core {
 using namespace std;
 
 TypePtr Types::dispatchCallWithoutBlock(const GlobalState &gs, const TypePtr &recv, DispatchArgs args) {
-    auto dispatched = recv->dispatchCall(gs, move(args));
+    auto dispatched = recv.dispatchCall(gs, move(args));
     auto link = &dispatched;
     while (link != nullptr) {
         for (auto &err : link->main.errors) {
@@ -588,14 +588,9 @@ bool SelfTypeParam::derivesFrom(const GlobalState &gs, SymbolRef klass) const {
     return false;
 }
 
-DispatchResult LambdaParam::dispatchCall(const GlobalState &gs, DispatchArgs args) {
-    Exception::raise(
-        "LambdaParam::dispatchCall not implemented, not clear what it should do. Let's see this fire first.");
-}
-
-DispatchResult SelfTypeParam::dispatchCall(const GlobalState &gs, DispatchArgs args) {
+DispatchResult SelfTypeParam::dispatchCall(const GlobalState &gs, DispatchArgs args) const {
     auto untypedUntracked = Types::untypedUntracked();
-    return untypedUntracked->dispatchCall(gs, args.withThisRef(untypedUntracked));
+    return untypedUntracked.dispatchCall(gs, args.withThisRef(untypedUntracked));
 }
 
 void LambdaParam::_sanityCheck(const GlobalState &gs) const {}
@@ -647,10 +642,6 @@ AppliedType::AppliedType(SymbolRef klass, vector<TypePtr> targs) : klass(klass),
 }
 
 bool SelfType::derivesFrom(const GlobalState &gs, SymbolRef klass) const {
-    Exception::raise("should never happen");
-}
-
-DispatchResult SelfType::dispatchCall(const GlobalState &gs, DispatchArgs args) {
     Exception::raise("should never happen");
 }
 

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -308,9 +308,9 @@ ClassType::ClassType(SymbolRef symbol) : symbol(symbol) {
     ENFORCE(symbol.exists());
 }
 
-void ProxyType::_sanityCheck(const GlobalState &gs) {
+void ProxyType::_sanityCheck(const GlobalState &gs) const {
     ENFORCE(isa_type<ClassType>(this->underlying()) || isa_type<AppliedType>(this->underlying()));
-    this->underlying()->sanityCheck(gs);
+    this->underlying().sanityCheck(gs);
 }
 
 LiteralType::LiteralType(int64_t val) : value(val), literalKind(LiteralTypeKind::Integer) {
@@ -371,7 +371,7 @@ OrType::OrType(const TypePtr &left, const TypePtr &right) : left(move(left)), ri
     categoryCounterInc("types.allocated", "ortype");
 }
 
-void TupleType::_sanityCheck(const GlobalState &gs) {
+void TupleType::_sanityCheck(const GlobalState &gs) const {
     ProxyType::_sanityCheck(gs);
     auto *applied = cast_type<AppliedType>(this->underlying());
     ENFORCE(applied);
@@ -396,14 +396,14 @@ TypePtr TupleType::underlying() const {
     return this->underlying_;
 }
 
-void ShapeType::_sanityCheck(const GlobalState &gs) {
+void ShapeType::_sanityCheck(const GlobalState &gs) const {
     ProxyType::_sanityCheck(gs);
     ENFORCE(this->values.size() == this->keys.size());
     for (auto &v : this->keys) {
-        v->_sanityCheck(gs);
+        v.sanityCheck(gs);
     }
     for (auto &e : this->values) {
-        e->_sanityCheck(gs);
+        e.sanityCheck(gs);
     }
 }
 
@@ -411,9 +411,9 @@ AliasType::AliasType(SymbolRef other) : symbol(other) {
     categoryCounterInc("types.allocated", "aliastype");
 }
 
-void AndType::_sanityCheck(const GlobalState &gs) {
-    left->_sanityCheck(gs);
-    right->_sanityCheck(gs);
+void AndType::_sanityCheck(const GlobalState &gs) const {
+    left.sanityCheck(gs);
+    right.sanityCheck(gs);
     /*
      * This is no longer true. Now we can construct types such as:
      * ShapeType(1 => 1), AppliedType{Array, Integer}
@@ -433,9 +433,9 @@ void AndType::_sanityCheck(const GlobalState &gs) {
     //            left->toString(gs));
 }
 
-void OrType::_sanityCheck(const GlobalState &gs) {
-    left->_sanityCheck(gs);
-    right->_sanityCheck(gs);
+void OrType::_sanityCheck(const GlobalState &gs) const {
+    left.sanityCheck(gs);
+    right.sanityCheck(gs);
     //    ENFORCE(!isa_type<ProxyType>(left.get()));
     //    ENFORCE(!isa_type<ProxyType>(right.get()));
     ENFORCE(!left.isUntyped());
@@ -449,7 +449,7 @@ void OrType::_sanityCheck(const GlobalState &gs) {
     //            left->toString(gs));
 }
 
-void ClassType::_sanityCheck(const GlobalState &gs) {
+void ClassType::_sanityCheck(const GlobalState &gs) const {
     ENFORCE(this->symbol.exists());
 }
 
@@ -546,11 +546,11 @@ TypeVar::TypeVar(SymbolRef sym) : sym(sym) {
     categoryCounterInc("types.allocated", "typevar");
 }
 
-void TypeVar::_sanityCheck(const GlobalState &gs) {
+void TypeVar::_sanityCheck(const GlobalState &gs) const {
     ENFORCE(this->sym.exists());
 }
 
-void AppliedType::_sanityCheck(const GlobalState &gs) {
+void AppliedType::_sanityCheck(const GlobalState &gs) const {
     ENFORCE(this->klass.data(gs)->isClassOrModule());
     ENFORCE(this->klass != Symbols::untyped());
 
@@ -561,7 +561,7 @@ void AppliedType::_sanityCheck(const GlobalState &gs) {
                     this->klass.classOrModuleIndex() <= Symbols::last_proc().classOrModuleIndex(),
             this->klass.data(gs)->name.showRaw(gs));
     for (auto &targ : this->targs) {
-        targ->sanityCheck(gs);
+        targ.sanityCheck(gs);
     }
 }
 
@@ -598,8 +598,8 @@ DispatchResult SelfTypeParam::dispatchCall(const GlobalState &gs, DispatchArgs a
     return untypedUntracked->dispatchCall(gs, args.withThisRef(untypedUntracked));
 }
 
-void LambdaParam::_sanityCheck(const GlobalState &gs) {}
-void SelfTypeParam::_sanityCheck(const GlobalState &gs) {}
+void LambdaParam::_sanityCheck(const GlobalState &gs) const {}
+void SelfTypeParam::_sanityCheck(const GlobalState &gs) const {}
 
 TypePtr OrType::make_shared(const TypePtr &left, const TypePtr &right) {
     TypePtr res(TypePtr::Tag::OrType, new OrType(left, right));
@@ -654,7 +654,7 @@ DispatchResult SelfType::dispatchCall(const GlobalState &gs, DispatchArgs args) 
     Exception::raise("should never happen");
 }
 
-void SelfType::_sanityCheck(const GlobalState &gs) {}
+void SelfType::_sanityCheck(const GlobalState &gs) const {}
 
 TypePtr Types::widen(const GlobalState &gs, const TypePtr &type) {
     ENFORCE(type != nullptr);

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -212,8 +212,8 @@ TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from, Symbol
         },
         [&](const TypePtr &) { result = from; });
     SLOW_ENFORCE(Types::isSubType(gs, result, from),
-                 "dropSubtypesOf({}, {}) returned {}, which is not a subtype of the input", from->toString(gs),
-                 klass.data(gs)->showFullName(gs), result->toString(gs));
+                 "dropSubtypesOf({}, {}) returned {}, which is not a subtype of the input", from.toString(gs),
+                 klass.data(gs)->showFullName(gs), result.toString(gs));
     return result;
 }
 
@@ -721,7 +721,7 @@ TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &type) {
             }
         },
         [&](const TypePtr &tp) {
-            ENFORCE(false, "Unhandled case: {}", type->toString(ctx));
+            ENFORCE(false, "Unhandled case: {}", type.toString(ctx));
             Exception::notImplemented();
         });
 

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -519,7 +519,7 @@ TypePtr Types::resultTypeAsSeenFrom(const GlobalState &gs, const TypePtr &what, 
 }
 
 TypePtr Types::getProcReturnType(const GlobalState &gs, const TypePtr &procType) {
-    if (!procType->derivesFrom(gs, Symbols::Proc())) {
+    if (!procType.derivesFrom(gs, Symbols::Proc())) {
         return Types::untypedUntracked();
     }
     auto *applied = cast_type<AppliedType>(procType);
@@ -731,7 +731,7 @@ TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &type) {
 }
 
 core::SymbolRef Types::getRepresentedClass(const GlobalState &gs, const TypePtr &ty) {
-    if (!ty->derivesFrom(gs, core::Symbols::Module())) {
+    if (!ty.derivesFrom(gs, core::Symbols::Module())) {
         return core::Symbols::noSymbol();
     }
     core::SymbolRef singleton;

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -83,11 +83,11 @@ void matchPositional(const core::Context ctx, absl::InlinedVector<reference_wrap
         if (!checkSubtype(ctx, superArgType, methodArgType)) {
             if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
                 e.setHeader("Parameter `{}` of type `{}` not compatible with type of {} method `{}`",
-                            methodArgs[idx].get().show(ctx), methodArgType->show(ctx),
-                            supermethodKind(ctx, superMethod), superMethod.data(ctx)->show(ctx));
+                            methodArgs[idx].get().show(ctx), methodArgType.show(ctx), supermethodKind(ctx, superMethod),
+                            superMethod.data(ctx)->show(ctx));
                 e.addErrorLine(superMethod.data(ctx)->loc(),
                                "The super method parameter `{}` was declared here with type `{}`",
-                               superArgs[idx].get().show(ctx), superArgType->show(ctx));
+                               superArgs[idx].get().show(ctx), superArgType.show(ctx));
             }
         }
         idx++;
@@ -156,11 +156,11 @@ void validateCompatibleOverride(const core::Context ctx, core::SymbolRef superMe
                     if (auto e =
                             ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
                         e.setHeader("Keyword parameter `{}` of type `{}` not compatible with type of {} method `{}`",
-                                    corresponding->get().show(ctx), corresponding->get().type->show(ctx),
+                                    corresponding->get().show(ctx), corresponding->get().type.show(ctx),
                                     supermethodKind(ctx, superMethod), superMethod.data(ctx)->show(ctx));
                         e.addErrorLine(superMethod.data(ctx)->loc(),
                                        "The corresponding parameter `{}` was declared here with type `{}`",
-                                       req.get().show(ctx), req.get().type->show(ctx));
+                                       req.get().show(ctx), req.get().type.show(ctx));
                     }
                 }
             } else {
@@ -184,11 +184,11 @@ void validateCompatibleOverride(const core::Context ctx, core::SymbolRef superMe
                     if (auto e =
                             ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
                         e.setHeader("Keyword parameter `{}` of type `{}` not compatible with type of {} method `{}`",
-                                    corresponding->get().show(ctx), corresponding->get().type->show(ctx),
+                                    corresponding->get().show(ctx), corresponding->get().type.show(ctx),
                                     supermethodKind(ctx, superMethod), superMethod.data(ctx)->show(ctx));
                         e.addErrorLine(superMethod.data(ctx)->loc(),
                                        "The super method parameter `{}` was declared here with type `{}`",
-                                       opt.get().show(ctx), opt.get().type->show(ctx));
+                                       opt.get().show(ctx), opt.get().type.show(ctx));
                     }
                 }
             }
@@ -205,11 +205,11 @@ void validateCompatibleOverride(const core::Context ctx, core::SymbolRef superMe
         } else if (!checkSubtype(ctx, leftRest->get().type, right.kw.rest->get().type)) {
             if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
                 e.setHeader("Parameter **`{}` of type `{}` not compatible with type of {} method `{}`",
-                            right.kw.rest->get().show(ctx), right.kw.rest->get().type->show(ctx),
+                            right.kw.rest->get().show(ctx), right.kw.rest->get().type.show(ctx),
                             supermethodKind(ctx, superMethod), superMethod.data(ctx)->show(ctx));
                 e.addErrorLine(superMethod.data(ctx)->loc(),
                                "The super method parameter **`{}` was declared here with type `{}`",
-                               left.kw.rest->get().show(ctx), left.kw.rest->get().type->show(ctx));
+                               left.kw.rest->get().show(ctx), left.kw.rest->get().type.show(ctx));
             }
         }
     }
@@ -241,10 +241,10 @@ void validateCompatibleOverride(const core::Context ctx, core::SymbolRef superMe
 
         if (!checkSubtype(ctx, methodReturn, superReturn)) {
             if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
-                e.setHeader("Return type `{}` does not match return type of {} method `{}`", methodReturn->show(ctx),
+                e.setHeader("Return type `{}` does not match return type of {} method `{}`", methodReturn.show(ctx),
                             supermethodKind(ctx, superMethod), superMethod.data(ctx)->show(ctx));
                 e.addErrorLine(superMethod.data(ctx)->loc(), "Super method defined here with return type `{}`",
-                               superReturn->show(ctx));
+                               superReturn.show(ctx));
             }
         }
     }

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -175,12 +175,12 @@ private:
                 if (aliasSym.data(ctx)->isMethod()) {
                     validateMethod(ctx, polarity, aliasSym);
                 } else {
-                    Exception::raise("Unexpected type alias: {}", alias.toString(ctx));
+                    Exception::raise("Unexpected type alias: {}", type.toString(ctx));
                 }
             },
 
             [&](const core::TypePtr &skipped) {
-                Exception::raise("Unexpected type in variance checking: {}", skipped->toString(ctx));
+                Exception::raise("Unexpected type in variance checking: {}", skipped.toString(ctx));
             });
     }
 

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -412,7 +412,7 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
                 // TODO: maybe combine the old and new types in some way?
                 chosenType = oldType;
             }
-            fmt::format_to(ss, "{}: {}", argSym.argumentName(ctx), chosenType->show(ctx));
+            fmt::format_to(ss, "{}: {}", argSym.argumentName(ctx), chosenType.show(ctx));
         }
         fmt::format_to(ss, ").");
     }
@@ -427,7 +427,7 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
     if (suggestsVoid) {
         fmt::format_to(ss, "void}}");
     } else {
-        fmt::format_to(ss, "returns({})}}", guessedReturnType->show(ctx));
+        fmt::format_to(ss, "returns({})}}", guessedReturnType.show(ctx));
     }
 
     auto [replacementLoc, padding] = loc.findStartOfLine(ctx);

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -95,7 +95,7 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
     core::DispatchArgs dispatchArgs{snd->fun,       locs,           snd->numPosArgs,
                                     args,           snd->recv.type, snd->recv.type,
                                     snd->recv.type, snd->link,      originForUninitialized};
-    auto dispatchInfo = snd->recv.type->dispatchCall(ctx, dispatchArgs);
+    auto dispatchInfo = snd->recv.type.dispatchCall(ctx, dispatchArgs);
 
     int i = -1;
 

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -955,7 +955,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
 
                 core::DispatchArgs dispatchArgs{send->fun,     locs,          send->numPosArgs, args,    recvType.type,
                                                 recvType.type, recvType.type, send->link,       ownerLoc};
-                auto dispatched = recvType.type->dispatchCall(ctx, dispatchArgs);
+                auto dispatched = recvType.type.dispatchCall(ctx, dispatchArgs);
 
                 auto it = &dispatched;
                 while (it != nullptr) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1152,13 +1152,13 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         auto ownerData = ctx.owner.data(ctx);
                         e.setHeader("Returning value that does not conform to method result type");
                         e.addErrorSection(core::ErrorSection(
-                            "Expected " + methodReturnType->show(ctx),
+                            "Expected " + methodReturnType.show(ctx),
                             {
                                 core::ErrorLine::from(ownerData->loc(), "Method `{}` has return type `{}`",
-                                                      ownerData->name.show(ctx), methodReturnType->show(ctx)),
+                                                      ownerData->name.show(ctx), methodReturnType.show(ctx)),
                             }));
                         e.addErrorSection(
-                            core::ErrorSection("Got " + typeAndOrigin.type->show(ctx) + " originating from:",
+                            core::ErrorSection("Got " + typeAndOrigin.type.show(ctx) + " originating from:",
                                                typeAndOrigin.origins2Explanations(ctx, ownerLoc)));
                     }
                 }
@@ -1188,9 +1188,9 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
 
                     if (auto e = ctx.beginError(bind.loc, core::errors::Infer::ReturnTypeMismatch)) {
                         e.setHeader("Returning value that does not conform to block result type");
-                        e.addErrorSection(core::ErrorSection("Expected " + expectedType->show(ctx)));
+                        e.addErrorSection(core::ErrorSection("Expected " + expectedType.show(ctx)));
                         e.addErrorSection(
-                            core::ErrorSection("Got " + typeAndOrigin.type->show(ctx) + " originating from:",
+                            core::ErrorSection("Got " + typeAndOrigin.type.show(ctx) + " originating from:",
                                                typeAndOrigin.origins2Explanations(ctx, ownerLoc)));
                     }
                 }
@@ -1215,7 +1215,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         e.setHeader("Control flow could reach `{}` because argument was `{}`", "T.absurd", "T.untyped");
                     } else {
                         e.setHeader("Control flow could reach `{}` because the type `{}` wasn't handled", "T.absurd",
-                                    typeAndOrigin.type->show(ctx));
+                                    typeAndOrigin.type.show(ctx));
                     }
                     e.addErrorSection(
                         core::ErrorSection("Originating from:", typeAndOrigin.origins2Explanations(ctx, ownerLoc)));
@@ -1256,14 +1256,14 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     if (c->cast == core::Names::assertType() && ty.type.isUntyped()) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::CastTypeMismatch)) {
                             e.setHeader("The typechecker was unable to infer the type of the asserted value");
-                            e.addErrorSection(core::ErrorSection("Got " + ty.type->show(ctx) + " originating from:",
+                            e.addErrorSection(core::ErrorSection("Got " + ty.type.show(ctx) + " originating from:",
                                                                  ty.origins2Explanations(ctx, ownerLoc)));
                             e.addErrorSection(core::ErrorSection("You may need to add additional `sig` annotations"));
                         }
                     } else if (!core::Types::isSubType(ctx, ty.type, castType)) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::CastTypeMismatch)) {
-                            e.setHeader("Argument does not have asserted type `{}`", castType->show(ctx));
-                            e.addErrorSection(core::ErrorSection("Got " + ty.type->show(ctx) + " originating from:",
+                            e.setHeader("Argument does not have asserted type `{}`", castType.show(ctx));
+                            e.addErrorSection(core::ErrorSection("Got " + ty.type.show(ctx) + " originating from:",
                                                                  ty.origins2Explanations(ctx, ownerLoc)));
                         }
                     }
@@ -1275,7 +1275,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     } else if (!ty.type.isUntyped() && core::Types::isSubType(ctx, ty.type, castType)) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::InvalidCast)) {
                             e.setHeader("Useless cast: inferred type `{}` is already a subtype of `{}`",
-                                        ty.type->show(ctx), castType->show(ctx));
+                                        ty.type.show(ctx), castType.show(ctx));
                         }
                     }
                 }
@@ -1311,7 +1311,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                             if (auto e = ctx.beginError(bind.loc, core::errors::Infer::FieldReassignmentTypeMismatch)) {
                                 e.setHeader(
                                     "Reassigning field with a value of wrong type: `{}` is not a subtype of `{}`",
-                                    tp.type->show(ctx), cur.type->show(ctx));
+                                    tp.type.show(ctx), cur.type.show(ctx));
                             }
                             tp = cur;
                         }
@@ -1322,7 +1322,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                     ctx.beginError(bind.loc, core::errors::Infer::GlobalReassignmentTypeMismatch)) {
                                 e.setHeader(
                                     "Reassigning global with a value of wrong type: `{}` is not a subtype of `{}`",
-                                    tp.type->show(ctx), cur.type->show(ctx));
+                                    tp.type.show(ctx), cur.type.show(ctx));
                             }
                             tp = cur;
                         }
@@ -1332,7 +1332,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                             if (auto e = ctx.beginError(bind.loc, core::errors::Infer::PinnedVariableMismatch)) {
                                 e.setHeader("Incompatible assignment to variable declared via `{}`: `{}` is not a "
                                             "subtype of `{}`",
-                                            "let", tp.type->show(ctx), cur.type->show(ctx));
+                                            "let", tp.type.show(ctx), cur.type.show(ctx));
                             }
                             tp = cur;
                         }
@@ -1356,10 +1356,10 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                             }
                             if (auto e = ctx.beginError(bind.loc, core::errors::Infer::PinnedVariableMismatch)) {
                                 e.setHeader("Changing the type of a variable in a loop is not permitted");
+                                e.addErrorSection(core::ErrorSection(
+                                    core::ErrorColors::format("Existing variable has type: `{}`", cur.type.show(ctx))));
                                 e.addErrorSection(core::ErrorSection(core::ErrorColors::format(
-                                    "Existing variable has type: `{}`", cur.type->show(ctx))));
-                                e.addErrorSection(core::ErrorSection(core::ErrorColors::format(
-                                    "Attempting to change type to: `{}`\n", tp.type->show(ctx))));
+                                    "Attempting to change type to: `{}`\n", tp.type.show(ctx))));
 
                                 if (cur.origins.size() == 1) {
                                     // NOTE(nelhage): We assume that if there is
@@ -1370,8 +1370,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                     // other source (e.g. a function argument)
                                     auto suggest =
                                         core::Types::any(ctx, dropConstructor(ctx, tp.origins[0], tp.type), cur.type);
-                                    e.replaceWith(fmt::format("Initialize as `{}`", suggest->show(ctx)), cur.origins[0],
-                                                  "T.let({}, {})", cur.origins[0].source(ctx), suggest->show(ctx));
+                                    e.replaceWith(fmt::format("Initialize as `{}`", suggest.show(ctx)), cur.origins[0],
+                                                  "T.let({}, {})", cur.origins[0].source(ctx), suggest.show(ctx));
                                 } else {
                                     e.addErrorSection(core::ErrorSection("Original type from:",
                                                                          cur.origins2Explanations(ctx, ownerLoc)));

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -765,7 +765,7 @@ void Environment::mergeWith(core::Context ctx, const Environment &other, core::L
         auto &thisTO = pair.second.typeAndOrigins;
         if (thisTO.type.get() != nullptr) {
             thisTO.type = core::Types::any(ctx, thisTO.type, otherTO.type);
-            thisTO.type->sanityCheck(ctx);
+            thisTO.type.sanityCheck(ctx);
             for (auto origin : otherTO.origins) {
                 if (!absl::c_linear_search(thisTO.origins, origin)) {
                     thisTO.origins.emplace_back(origin);
@@ -841,7 +841,7 @@ void Environment::computePins(core::Context ctx, const vector<Environment> &envs
                             tp.origins.emplace_back(origin);
                         }
                     }
-                    tp.type->sanityCheck(ctx);
+                    tp.type.sanityCheck(ctx);
                 } else {
                     tp = otherPin->second;
                 }
@@ -1285,7 +1285,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
             });
 
         ENFORCE(tp.type.get() != nullptr, "Inferencer did not assign type: {}", bind.value->toString(ctx, inWhat));
-        tp.type->sanityCheck(ctx);
+        tp.type.sanityCheck(ctx);
 
         if (checkFullyDefined && !tp.type.isFullyDefined()) {
             if (auto e = ctx.beginError(bind.loc, core::errors::Infer::IncompleteType)) {
@@ -1435,7 +1435,7 @@ void Environment::setUninitializedVarsToNil(const core::Context &ctx, core::Loc 
             uninitialized.second.typeAndOrigins.type = core::Types::nilClass();
             uninitialized.second.typeAndOrigins.origins.emplace_back(origin);
         } else {
-            uninitialized.second.typeAndOrigins.type->sanityCheck(ctx);
+            uninitialized.second.typeAndOrigins.type.sanityCheck(ctx);
         }
     }
 }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -641,12 +641,12 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         const auto &argType = send->args[0].type;
 
         if (auto *argClass = core::cast_type<core::ClassType>(argType)) {
-            if (!recvKlass->derivesFrom(ctx, core::Symbols::Class()) ||
+            if (!recvKlass.derivesFrom(ctx, core::Symbols::Class()) ||
                 !argClass->symbol.data(ctx)->derivesFrom(ctx, core::Symbols::Class())) {
                 return;
             }
         } else if (auto *argClass = core::cast_type<core::AppliedType>(argType)) {
-            if (!recvKlass->derivesFrom(ctx, core::Symbols::Class()) ||
+            if (!recvKlass.derivesFrom(ctx, core::Symbols::Class()) ||
                 !argClass->klass.data(ctx)->derivesFrom(ctx, core::Symbols::Class())) {
                 return;
             }
@@ -867,7 +867,7 @@ void Environment::populateFrom(core::Context ctx, const Environment &other) {
 }
 
 core::TypePtr Environment::getReturnType(core::Context ctx, const core::TypePtr &procType) {
-    if (!procType->derivesFrom(ctx, core::Symbols::Proc())) {
+    if (!procType.derivesFrom(ctx, core::Symbols::Proc())) {
         return core::Types::untypedUntracked();
     }
     auto *applied = core::cast_type<core::AppliedType>(procType);
@@ -908,11 +908,11 @@ core::TypePtr flatmapHack(core::Context ctx, const core::TypePtr &receiver, cons
     if (fun != core::Names::flatMap()) {
         return returnType;
     }
-    if (!receiver->derivesFrom(ctx, core::Symbols::Enumerable())) {
+    if (!receiver.derivesFrom(ctx, core::Symbols::Enumerable())) {
         return returnType;
     }
 
-    if (!receiver.isUntyped() && receiver->derivesFrom(ctx, core::Symbols::Enumerator_Lazy())) {
+    if (!receiver.isUntyped() && receiver.derivesFrom(ctx, core::Symbols::Enumerator_Lazy())) {
         return returnType;
     }
 
@@ -1129,7 +1129,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 auto &blkArgs = insn->link->argFlags;
                 auto *tuple = core::cast_type<core::TupleType>(params);
                 if (blkArgs.size() > 1 && !blkArgs.front().isRepeated && tuple && tuple->elems.size() == 1 &&
-                    tuple->elems.front()->derivesFrom(ctx, core::Symbols::Array())) {
+                    tuple->elems.front().derivesFrom(ctx, core::Symbols::Array())) {
                     tp.type = std::move(tuple->elems.front());
                 } else if (params == nullptr) {
                     tp.type = core::Types::untypedUntracked();

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -233,11 +233,11 @@ string KnowledgeFact::toString(const core::GlobalState &gs, const cfg::CFG &cfg)
 
     for (auto &el : yesTypeTests) {
         buf1.emplace_back(
-            fmt::format("    {} to be {}\n", el.first.showRaw(gs, cfg), el.second->toStringWithTabs(gs, 0)));
+            fmt::format("    {} to be {}\n", el.first.showRaw(gs, cfg), el.second.toStringWithTabs(gs, 0)));
     }
     for (auto &el : noTypeTests) {
         buf2.emplace_back(
-            fmt::format("    {} NOT to be {}\n", el.first.showRaw(gs, cfg), el.second->toStringWithTabs(gs, 0)));
+            fmt::format("    {} NOT to be {}\n", el.first.showRaw(gs, cfg), el.second.toStringWithTabs(gs, 0)));
     }
     fast_sort(buf1);
     fast_sort(buf2);
@@ -383,7 +383,7 @@ string Environment::toString(const core::GlobalState &gs, const cfg::CFG &cfg) c
         if (var.data(cfg)._name == core::Names::debugEnvironmentTemp()) {
             continue;
         }
-        fmt::format_to(buf, "{}: {}{}\n{}\n", var.showRaw(gs, cfg), state.typeAndOrigins.type->toStringWithTabs(gs, 0),
+        fmt::format_to(buf, "{}: {}{}\n{}\n", var.showRaw(gs, cfg), state.typeAndOrigins.type.toStringWithTabs(gs, 0),
                        state.knownTruthy ? " (and truthy)\n" : "", state.knowledge.toString(gs, cfg));
     }
     return to_string(buf);

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -175,7 +175,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                             if (send->args.size() > 0) {
                                 auto ty = current.getAndFillTypeAndOrigin(ctx, send->args[0]);
                                 e.addErrorSection(core::ErrorSection(
-                                    core::ErrorColors::format("Type of receiver is `{}`, from:", ty.type->show(ctx)),
+                                    core::ErrorColors::format("Type of receiver is `{}`, from:", ty.type.show(ctx)),
                                     ty.origins2Explanations(ctx, current.locForUninitialized())));
                             }
                         }

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -208,7 +208,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                     }
                 }
                 ENFORCE(bind.bind.type);
-                bind.bind.type->sanityCheck(ctx);
+                bind.bind.type.sanityCheck(ctx);
                 if (bind.bind.type.isBottom()) {
                     current.isDead = true;
                     madeBlockDead = core::Loc(ctx.file, bind.loc);

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -81,7 +81,7 @@ string prettySigForMethod(const core::GlobalState &gs, core::SymbolRef method, c
         retType = getResultType(gs, method.data(gs)->resultType, method, receiver, constraint);
     }
     string methodReturnType =
-        (retType == core::Types::void_()) ? "void" : absl::StrCat("returns(", retType->show(gs), ")");
+        (retType == core::Types::void_()) ? "void" : absl::StrCat("returns(", retType.show(gs), ")");
     vector<string> typeAndArgNames;
 
     vector<string> flags;
@@ -105,7 +105,7 @@ string prettySigForMethod(const core::GlobalState &gs, core::SymbolRef method, c
             if (!argSym.isSyntheticBlockArgument()) {
                 typeAndArgNames.emplace_back(
                     absl::StrCat(argSym.argumentName(gs), ": ",
-                                 getResultType(gs, argSym.type, method, receiver, constraint)->show(gs)));
+                                 getResultType(gs, argSym.type, method, receiver, constraint).show(gs)));
             }
         }
     }
@@ -237,7 +237,7 @@ string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef consta
         // By wrapping the type in `MetaType`, it displays as `<Type: Foo>` rather than `Foo`.
         result = core::make_type<core::MetaType>(result);
     }
-    return result->showWithMoreInfo(gs);
+    return result.showWithMoreInfo(gs);
 }
 
 core::TypePtr getResultType(const core::GlobalState &gs, const core::TypePtr &type, core::SymbolRef inWhat,

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -260,7 +260,7 @@ string methodSnippet(const core::GlobalState &gs, core::SymbolRef method, const 
             fmt::format_to(argBuf, "{}: ", argSym.name.data(gs)->shortName(gs));
         }
         if (argSym.type) {
-            auto resultType = getResultType(gs, argSym.type, method, receiverType, constraint)->show(gs);
+            auto resultType = getResultType(gs, argSym.type, method, receiverType, constraint).show(gs);
             fmt::format_to(argBuf, "${{{}:{}}}", nextTabstop++, resultType);
         } else {
             fmt::format_to(argBuf, "${{{}}}", nextTabstop++);
@@ -286,7 +286,7 @@ string methodSnippet(const core::GlobalState &gs, core::SymbolRef method, const 
                 targs_it++;
                 blkArgs = fmt::format(" |{}|", fmt::map_join(targs_it, appliedType->targs.end(), ", ", [&](auto targ) {
                                           auto resultType = getResultType(gs, targ, method, receiverType, constraint);
-                                          return fmt::format("${{{}:{}}}", nextTabstop++, resultType->show(gs));
+                                          return fmt::format("${{{}:{}}}", nextTabstop++, resultType.show(gs));
                                       }));
             }
         }

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -91,7 +91,7 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
             }
             if (sendResp->dispatchResult->main.method.exists() && sendResp->dispatchResult->main.method.isSynthetic()) {
                 // For synthetic methods, just show the return type
-                typeString = retType->showWithMoreInfo(gs);
+                typeString = retType.showWithMoreInfo(gs);
             } else {
                 typeString = methodInfoString(gs, retType, *sendResp->dispatchResult, constraint);
             }
@@ -105,7 +105,7 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
             if (!retType) {
                 retType = core::Types::untypedUntracked();
             }
-            typeString = retType->showWithMoreInfo(gs);
+            typeString = retType.showWithMoreInfo(gs);
         }
 
         // Sort so documentation order is deterministic.

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -37,7 +37,7 @@ void addSignatureHelpItem(const core::GlobalState &gs, core::SymbolRef method,
         }
         parameter->documentation = getResultType(gs, arg.type, method, resp.dispatchResult->main.receiver,
                                                  resp.dispatchResult->main.constr.get())
-                                       ->show(gs);
+                                       .show(gs);
         parameters.push_back(move(parameter));
         i += 1;
     }

--- a/namer/configatron/configatron.cc
+++ b/namer/configatron/configatron.cc
@@ -75,7 +75,7 @@ struct Path {
     string show(core::GlobalState &gs) const {
         fmt::memory_buffer buf;
         if (myType) {
-            fmt::format_to(buf, "{} -> {}", toString(), myType->toString(gs));
+            fmt::format_to(buf, "{} -> {}", toString(), myType.toString(gs));
         }
         fmt::format_to(buf, "{}",
                        fmt::map_join(children, "", [&](const auto &child) -> string { return child->show(gs); }));

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1150,13 +1150,13 @@ class ResolveTypeMembersWalk {
             if (!core::Types::isSubType(ctx, parentType->lowerBound, memberType->lowerBound)) {
                 if (auto e = ctx.beginError(rhs->loc, core::errors::Resolver::ParentTypeBoundsMismatch)) {
                     e.setHeader("parent lower bound `{}` is not a subtype of lower bound `{}`",
-                                parentType->lowerBound->show(ctx), memberType->lowerBound->show(ctx));
+                                parentType->lowerBound.show(ctx), memberType->lowerBound.show(ctx));
                 }
             }
             if (!core::Types::isSubType(ctx, memberType->upperBound, parentType->upperBound)) {
                 if (auto e = ctx.beginError(rhs->loc, core::errors::Resolver::ParentTypeBoundsMismatch)) {
                     e.setHeader("upper bound `{}` is not a subtype of parent upper bound `{}`",
-                                memberType->upperBound->show(ctx), parentType->upperBound->show(ctx));
+                                memberType->upperBound.show(ctx), parentType->upperBound.show(ctx));
                 }
             }
         }
@@ -1166,8 +1166,8 @@ class ResolveTypeMembersWalk {
         // is fixed.
         if (!core::Types::isSubType(ctx, memberType->lowerBound, memberType->upperBound)) {
             if (auto e = ctx.beginError(rhs->loc, core::errors::Resolver::InvalidTypeMemberBounds)) {
-                e.setHeader("`{}` is not a subtype of `{}`", memberType->lowerBound->show(ctx),
-                            memberType->upperBound->show(ctx));
+                e.setHeader("`{}` is not a subtype of `{}`", memberType->lowerBound.show(ctx),
+                            memberType->upperBound.show(ctx));
             }
         }
 

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -62,7 +62,7 @@ core::TypePtr getResultLiteral(core::Context ctx, const ast::TreePtr &expr) {
             result = core::Types::untypedUntracked();
         });
     ENFORCE(result.get() != nullptr);
-    result->sanityCheck(ctx);
+    result.sanityCheck(ctx);
     return result;
 }
 
@@ -985,7 +985,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
             result.type = core::Types::untypedUntracked();
         });
     ENFORCE(result.type.get() != nullptr);
-    result.type->sanityCheck(ctx);
+    result.type.sanityCheck(ctx);
     return result;
 }
 } // namespace


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Move remaining Type methods to TypePtr + introduce standard CALL_MEMBER/HAS_MEMBER helpers.

This PR does a few things (I can land them separately if desired!):

* Moves remaining Type methods to TypePtr.
* Introduces a non-class-based `GENERATE_HAS_MEMBER` macro and uses it in `treemap.h` and in `typecase`
* Introduces GENERATE_CALL_MEMBER and uses it + other macro helpers to reduce boilerplate in TreePtr.cc.
* Use similar macro helpers to reduce boilerplate in Trees.cc.
* Migrate treemap.h to use GENERATE_CALL_MEMBER.

Once this lands, a follow-up PR will delete the Type class. Then we can start inlining certain types in to TypePtr.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

First part is taken from https://github.com/sorbet/sorbet/pull/3569

The remaining changes reduce boilerplate and introduces standardized metaprogramming utils.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
