### PR TITLE
Display better errors from rename test

### DIFF
--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -1362,11 +1362,10 @@ void ApplyRenameAssertion::check(const UnorderedMap<std::string, std::shared_ptr
         string expectedEditedFileContents = expectedEditedFiles[expectedEditedFilePath];
 
         {
-            INFO(fmt::format("The expected (rbedited) file contents for this rename did not match the actual file "
-                             "contents post-edit of {} ",
-                             expectedEditedFilePath));
-            // TODO: change this to CHECK_EQ_DIFF for better user experience
-            CHECK_EQ(expectedEditedFileContents, actualEditedFileContents);
+            CHECK_EQ_DIFF(
+                expectedEditedFileContents, actualEditedFileContents,
+                fmt::format("The expected (rbedited) file contents for {} did not match the actual post-edit contents",
+                            filePath));
         }
     }
 }

--- a/test/testdata/lsp/rename/constant__class_reference.rb
+++ b/test/testdata/lsp/rename/constant__class_reference.rb
@@ -1,0 +1,6 @@
+# typed: true
+# frozen_string_literal: true
+
+require_relative './rename__class_definition.rb'
+
+foo = Foo::Foo.new


### PR DESCRIPTION
Add missing test data file


### Motivation
Provide clear failure message from rename test with filename and diff of expected vs actual contents

### Test plan
See included automated tests.
