### PR TITLE
Move ResolveMixesInClassMethods AST pass to ResolveConstants.

### DIFF
--- a/docs/namer-resolver-pipeline.md
+++ b/docs/namer-resolver-pipeline.md
@@ -87,12 +87,6 @@ For a fuller picture of Sorbet's pipeline, see [pipeline.md](pipeline.md).
 │                                                   │ ast::Expression │                                                   │
 │                                                   └─────────────────┘                                                   │
 │                                                            │                                                            │
-│                                                            │ resolveMixesInClassMethods                                 │
-│                                                            ▼                                                            │
-│                                                   ┌─────────────────┐                                                   │
-│                                                   │ ast::Expression │                                                   │
-│                                                   └─────────────────┘                                                   │
-│                                                            │                                                            │
 │                                                            │ ResolveTypeMembersWalk                                     │
 │                                                            ▼                                                            │
 │                                                   ┌─────────────────┐                                                   │

--- a/resolver/resolver.h
+++ b/resolver/resolver.h
@@ -27,8 +27,6 @@ private:
     static void finalizeSymbols(core::GlobalState &gs);
     static void computeLinearization(core::GlobalState &gs);
     static ast::ParsedFilesOrCancelled resolveSigs(core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
-    static ast::ParsedFilesOrCancelled resolveMixesInClassMethods(core::GlobalState &gs,
-                                                                  std::vector<ast::ParsedFile> trees);
     static void sanityCheck(core::GlobalState &gs, std::vector<ast::ParsedFile> &trees);
 };
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Move ResolveMixesInClassMethods AST pass to ResolveConstants.

Converts a serial AST walk into a parallel AST walk that collects work to perform serially, which fits the ResolveConstants pattern.

* Question: Does this have any impact on autogen? Autogen previously did not run `resolveMixesInClassMethods`. It looks like it's working fine, though.
* Answer: From chatting w/ team, autogen doesn't consume method information, so it should not impact it. The additional runtime to `resolveConstants` with this new change is negligible; the new timer for `resolver.mixes_in_class_methods` doesn't show up with --counters since it completes within a handful of milliseconds!


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed!

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
