### PR TITLE
Compute external types during incremental resolver.

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2384,6 +2384,14 @@ public:
         return tree;
     }
 };
+
+void computeExternalTypes(core::GlobalState &gs) {
+    Timer timeit(gs.tracer(), "resolver.computeExternalType");
+    // Ensure all symbols have `externalType` computed.
+    for (u4 i = 1; i < gs.classAndModulesUsed(); i++) {
+        core::SymbolRef(gs, core::SymbolRef::Kind::ClassOrModule, i).data(gs)->unsafeComputeExternalType(gs);
+    }
+}
 }; // namespace
 
 ast::ParsedFilesOrCancelled Resolver::run(core::GlobalState &gs, vector<ast::ParsedFile> trees, WorkerPool &workers) {
@@ -2432,14 +2440,6 @@ ast::ParsedFilesOrCancelled Resolver::resolveSigs(core::GlobalState &gs, vector<
     }
 
     return trees;
-}
-
-void Resolver::computeExternalTypes(core::GlobalState &gs) {
-    Timer timeit(gs.tracer(), "resolver.computeExternalType");
-    // Ensure all symbols have `externalType` computed.
-    for (u4 i = 1; i < gs.classAndModulesUsed(); i++) {
-        core::SymbolRef(gs, core::SymbolRef::Kind::ClassOrModule, i).data(gs)->unsafeComputeExternalType(gs);
-    }
 }
 
 void Resolver::sanityCheck(core::GlobalState &gs, vector<ast::ParsedFile> &trees) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2458,7 +2458,7 @@ ast::ParsedFilesOrCancelled Resolver::runIncremental(core::GlobalState &gs, vect
     trees = ResolveConstantsWalk::resolveConstants(gs, std::move(trees), *workers);
     computeLinearization(gs);
     trees = ResolveTypeMembersWalk::run(gs, std::move(trees));
-    // computeExternalTypes(gs);
+    computeExternalTypes(gs);
     auto result = resolveSigs(gs, std::move(trees));
     if (!result.hasResult()) {
         return result;

--- a/resolver/resolver.h
+++ b/resolver/resolver.h
@@ -26,7 +26,6 @@ private:
     static void finalizeAncestors(core::GlobalState &gs);
     static void finalizeSymbols(core::GlobalState &gs);
     static void computeLinearization(core::GlobalState &gs);
-    static void computeExternalTypes(core::GlobalState &gs);
     static ast::ParsedFilesOrCancelled resolveSigs(core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
     static void sanityCheck(core::GlobalState &gs, std::vector<ast::ParsedFile> &trees);
 };

--- a/resolver/resolver.h
+++ b/resolver/resolver.h
@@ -26,6 +26,7 @@ private:
     static void finalizeAncestors(core::GlobalState &gs);
     static void finalizeSymbols(core::GlobalState &gs);
     static void computeLinearization(core::GlobalState &gs);
+    static void computeExternalTypes(core::GlobalState &gs);
     static ast::ParsedFilesOrCancelled resolveSigs(core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
     static void sanityCheck(core::GlobalState &gs, std::vector<ast::ParsedFile> &trees);
 };


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Compute external types during incremental resolver.

May resolve an LSP crash in features that use externalType() to pretty print information to user.

I was unable to reproduce the crash in a test, unfortunately. :( In order to do so, I'd need to induce the following conditions:

* incrementalResolver creates a new class or module symbol
* incrementalResolver does not compute the external type via `unsafeComputeExternalType()`
* LSP references the class in a constant reference which the test hovers over

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Users were crashing at this line of code, which suggests that `externalType()` returned nullptr:
https://github.com/sorbet/sorbet/blob/master/main/lsp/lsp_helpers.cc#L240

I know there are some cases where the fast path / incremental resolver may end up adding new symbols to the symbol table, so my guess is that the user found themselves in a state where LSP tried to view the external type of a symbol created on the incremental path.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I could not reproduce the crash in a test. Ideas appreciated!
