### PR TITLE
Rename Resolver::runTreePasses to Resolver::runIncremental.

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -320,7 +320,7 @@ vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, vector<ast::Pa
             core::UnfreezeSymbolTable symbolTable(gs);
             core::UnfreezeNameTable nameTable(gs);
 
-            auto result = sorbet::resolver::Resolver::runTreePasses(gs, move(what));
+            auto result = sorbet::resolver::Resolver::runIncremental(gs, move(what));
             // incrementalResolve is not cancelable.
             ENFORCE(result.hasResult());
             what = move(result.result());

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2451,7 +2451,7 @@ void Resolver::sanityCheck(core::GlobalState &gs, vector<ast::ParsedFile> &trees
     }
 }
 
-ast::ParsedFilesOrCancelled Resolver::runTreePasses(core::GlobalState &gs, vector<ast::ParsedFile> trees) {
+ast::ParsedFilesOrCancelled Resolver::runIncremental(core::GlobalState &gs, vector<ast::ParsedFile> trees) {
     auto workers = WorkerPool::create(0, gs.tracer());
     trees = ResolveConstantsWalk::resolveConstants(gs, std::move(trees), *workers);
     computeLinearization(gs);

--- a/resolver/resolver.h
+++ b/resolver/resolver.h
@@ -16,7 +16,7 @@ public:
     /** Only runs tree passes, used for incremental changes that do not affect global state. Assumes that `run` was
      * called on a tree that contains same definitions before (LSP uses heuristics that should only have false negatives
      * to find this) */
-    static ast::ParsedFilesOrCancelled runTreePasses(core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
+    static ast::ParsedFilesOrCancelled runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
 
     // used by autogen only
     static std::vector<ast::ParsedFile> runConstantResolution(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -533,7 +533,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     }
 
     // resolver
-    trees = move(resolver::Resolver::runTreePasses(*gs, move(trees)).result());
+    trees = move(resolver::Resolver::runIncremental(*gs, move(trees)).result());
 
     for (auto &resolvedTree : trees) {
         handler.addObserved(*gs, "resolve-tree", [&]() { return resolvedTree.tree.toString(*gs); });


### PR DESCRIPTION
Rename Resolver::runTreePasses to Resolver::runIncremental.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The old name was confusing.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by CI.
