### PR TITLE
Implements rewriter for `Forwardable#def_delegator`

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -175,6 +175,7 @@ NameDef names[] = {
     {"merchantProp", "merchant_prop"},
     {"encryptedProp", "encrypted_prop"},
     {"array"},
+    {"defDelegator", "def_delegator"},
     {"delegate"},
     {"type"},
     {"optional"},

--- a/rewriter/DefDelegator.cc
+++ b/rewriter/DefDelegator.cc
@@ -1,0 +1,74 @@
+#include "rewriter/DefDelegator.h"
+#include "ast/Helpers.h"
+#include "core/GlobalState.h"
+#include "rewriter/Util.h"
+#include <optional>
+
+using namespace std;
+
+namespace sorbet::rewriter {
+
+vector<ast::TreePtr> DefDelegator::run(core::MutableContext ctx, const ast::Send *send) {
+    vector<ast::TreePtr> empty;
+    auto loc = send->loc;
+
+    if (send->fun != core::Names::defDelegator()) {
+        return empty;
+    }
+
+    // This method takes 2..3 positional arguments and no keyword args:
+    // `def_delegator(accessor, method, ali = method)`
+    if (!(send->numPosArgs == 2 || send->numPosArgs == 3)) {
+        return empty;
+    }
+
+    if (send->hasKwArgs()) {
+        return empty;
+    }
+
+    auto *accessor = ast::cast_tree<ast::Literal>(send->args[0]);
+    auto *method = ast::cast_tree<ast::Literal>(send->args[1]);
+
+    if (!accessor || !(accessor->isSymbol(ctx) || accessor->isString(ctx))) {
+        return empty;
+    }
+
+    if (!method || !method->isSymbol(ctx)) {
+        return empty;
+    }
+
+    core::NameRef methodName = method->asSymbol(ctx);
+
+    if (send->numPosArgs == 3) {
+        auto *alias = ast::cast_tree<ast::Literal>(send->args[2]);
+
+        if (!alias || !alias->isSymbol(ctx)) {
+            return empty;
+        }
+
+        methodName = alias->asSymbol(ctx);
+    }
+
+    vector<ast::TreePtr> methodStubs;
+
+    // sig {params(arg0: T.untyped, blk: Proc).returns(T.untyped)}
+    ast::Send::ARGS_store sigArgs;
+    sigArgs.emplace_back(ast::MK::Symbol(loc, core::Names::arg0()));
+    sigArgs.emplace_back(ast::MK::Untyped(loc));
+
+    sigArgs.emplace_back(ast::MK::Symbol(loc, core::Names::blkArg()));
+    sigArgs.emplace_back(ast::MK::Nilable(loc, ast::MK::Constant(loc, core::Symbols::Proc())));
+
+    methodStubs.push_back(ast::MK::Sig(loc, std::move(sigArgs), ast::MK::Untyped(loc)));
+
+    // def $methodName(*arg0, &blk); end
+    ast::MethodDef::ARGS_store args;
+    args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
+    args.emplace_back(ast::make_tree<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
+
+    methodStubs.push_back(ast::MK::SyntheticMethod(loc, loc, methodName, std::move(args), ast::MK::EmptyTree()));
+
+    return methodStubs;
+}
+
+} // namespace sorbet::rewriter

--- a/rewriter/DefDelegator.h
+++ b/rewriter/DefDelegator.h
@@ -16,11 +16,11 @@ namespace sorbet::rewriter {
  * into
  *
  *    class MyClass
- *      sig {params(arg0: T.untyped).returns(T.untyped)}
- *      def foo(*arg0); end
+ *      sig {params(arg0: T.untyped, blk: T.nilable(Proc)).returns(T.untyped)}
+ *      def foo(*arg0, &blk); end
  *
- *      sig {params(arg0: T.untyped).returns(T.untyped)}
- *      def aliased_bar(*arg0); end
+ *      sig {params(arg0: T.untyped, blk: T.nilable(Proc)).returns(T.untyped)}
+ *      def aliased_bar(*arg0, &blk); end
  *    end
  */
 class DefDelegator final {

--- a/rewriter/DefDelegator.h
+++ b/rewriter/DefDelegator.h
@@ -1,0 +1,35 @@
+#ifndef SORBET_REWRITER_DEF_DELEGATOR_H
+#define SORBET_REWRITER_DEF_DELEGATOR_H
+#include "ast/ast.h"
+
+namespace sorbet::rewriter {
+
+/**
+ * This class implements Forwardable#def_delegator
+ * by desugaring things of the form
+ *
+ *    class MyClass
+ *      def_delegator :thing, :foo
+ *      def_delegator :thing, :bar, :aliased_bar
+ *    end
+ *
+ * into
+ *
+ *    class MyClass
+ *      sig {params(arg0: T.untyped).returns(T.untyped)}
+ *      def foo(*arg0); end
+ *
+ *      sig {params(arg0: T.untyped).returns(T.untyped)}
+ *      def aliased_bar(*arg0); end
+ *    end
+ */
+class DefDelegator final {
+public:
+    static std::vector<ast::TreePtr> run(core::MutableContext ctx, const ast::Send *send);
+
+    DefDelegator() = delete;
+};
+
+} // namespace sorbet::rewriter
+
+#endif

--- a/rewriter/Delegate.h
+++ b/rewriter/Delegate.h
@@ -15,11 +15,11 @@ namespace sorbet::rewriter {
  * into
  *
  *    class MyClass
- *      sig {params(arg0: T.untyped).returns(T.untyped)}
- *      def foo(*arg0); end
+ *      sig {params(arg0: T.untyped, blk: T.nilable(Proc)).returns(T.untyped)}
+ *      def foo(*arg0, &blk); end
  *
- *      sig {params(arg0: T.untyped).returns(T.untyped)}
- *      def bar(*arg0); end
+ *      sig {params(arg0: T.untyped, blk: T.nilable(Proc)).returns(T.untyped)}
+ *      def bar(*arg0, &blk); end
  *    end
  */
 class Delegate final {

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -8,6 +8,7 @@
 #include "rewriter/Cleanup.h"
 #include "rewriter/Command.h"
 #include "rewriter/DSLBuilder.h"
+#include "rewriter/DefDelegator.h"
 #include "rewriter/Delegate.h"
 #include "rewriter/Flatfiles.h"
 #include "rewriter/Flatten.h"
@@ -98,6 +99,12 @@ public:
                     }
 
                     nodes = Private::run(ctx, &send);
+                    if (!nodes.empty()) {
+                        replaceNodes[stat.get()] = std::move(nodes);
+                        return;
+                    }
+
+                    nodes = DefDelegator::run(ctx, &send);
                     if (!nodes.empty()) {
                         replaceNodes[stat.get()] = std::move(nodes);
                         return;

--- a/test/testdata/rewriter/def_delegator.rb
+++ b/test/testdata/rewriter/def_delegator.rb
@@ -36,6 +36,11 @@ class WorksWithoutExtendingTSig
   def_delegator :thing, :bar, :aliased_bar
 end
 
+class ErrorsWhenMissingForwardable
+  def_delegator :thing, :foo # error: Method `def_delegator` does not exist
+  def_delegator :thing, :bar, :aliased_bar # error: Method `def_delegator` does not exist
+end
+
 class IgnoredUsages
   extend Forwardable
 

--- a/test/testdata/rewriter/def_delegator.rb
+++ b/test/testdata/rewriter/def_delegator.rb
@@ -1,0 +1,52 @@
+# typed: strict
+
+class GoodUsages
+  extend T::Sig
+  extend Forwardable
+
+  def_delegator :thing, :foo
+  def_delegator :thing, :bar, :aliased_bar
+
+  sig {void}
+  def usages
+    foo {}
+    foo(1, 2)
+    foo(1, 2) {}
+    foo(1, 2, hey: true)
+    foo(1, 2, hey: true) {}
+    foo(hey: true)
+    foo(hey: true) {}
+
+    aliased_bar {}
+    aliased_bar(1, 2)
+    aliased_bar(1, 2) {}
+    aliased_bar(1, 2, hey: true)
+    aliased_bar(1, 2, hey: true) {}
+    aliased_bar(hey: true)
+    aliased_bar(hey: true) {}
+
+    bar # error: Method `bar` does not exist
+  end
+end
+
+class WorksWithoutExtendingTSig
+  def_delegator :thing, :foo
+  def_delegator :thing, :bar, :aliased_bar
+end
+
+class IgnoredUsages
+  extend Forwardable
+
+  local = 0
+  not_def_delegator :thing, :foo # error: Method `not_def_delegator` does not exist
+  def_delegator # error: Not enough arguments provided for method Forwardable#def_delegator. Expected: 2..3, got: 0
+  def_delegator :thing # error: Not enough arguments provided for method Forwardable#def_delegator. Expected: 2..3, got: 0
+  def_delegator :thing, :foo, :bar, :baz # error: Too many arguments provided for method Forwardable#def_delegator. Expected: 2..3, got: 4
+  def_delegator :thing, :foo, :bar, kwarg: :thing # error: Too many arguments provided for method Forwardable#def_delegator. Expected: 2..3, got: 4
+  def_delegator :thing, kwarg: :thing # error: Expected Symbol but found {kwarg: Symbol(:"thing")} for argument method
+  def_delegator :foo, kwarg1: :thing, kwarg2: local # error: Expected Symbol but found {kwarg1: Symbol(:"thing"), kwarg2: Integer(0)} for argument method
+  def_delegator :foo, local => :thing # error: Expected Symbol but found {} for argument method
+  def_delegator 234, :foo # error: Expected T.any(Symbol, String) but found Integer(234) for argument accessor
+  def_delegator :thing => :thing # error: Method `def_delegator` does not exist
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Not enough arguments provided for method Forwardable#def_delegator. Expected: 2..3, got: 1
+end

--- a/test/testdata/rewriter/def_delegator.rb
+++ b/test/testdata/rewriter/def_delegator.rb
@@ -30,6 +30,8 @@ class GoodUsages
 end
 
 class WorksWithoutExtendingTSig
+  extend Forwardable
+
   def_delegator :thing, :foo
   def_delegator :thing, :bar, :aliased_bar
 end
@@ -39,14 +41,25 @@ class IgnoredUsages
 
   local = 0
   not_def_delegator :thing, :foo # error: Method `not_def_delegator` does not exist
-  def_delegator # error: Not enough arguments provided for method Forwardable#def_delegator. Expected: 2..3, got: 0
-  def_delegator :thing # error: Not enough arguments provided for method Forwardable#def_delegator. Expected: 2..3, got: 0
-  def_delegator :thing, :foo, :bar, :baz # error: Too many arguments provided for method Forwardable#def_delegator. Expected: 2..3, got: 4
-  def_delegator :thing, :foo, :bar, kwarg: :thing # error: Too many arguments provided for method Forwardable#def_delegator. Expected: 2..3, got: 4
-  def_delegator :thing, kwarg: :thing # error: Expected Symbol but found {kwarg: Symbol(:"thing")} for argument method
-  def_delegator :foo, kwarg1: :thing, kwarg2: local # error: Expected Symbol but found {kwarg1: Symbol(:"thing"), kwarg2: Integer(0)} for argument method
-  def_delegator :foo, local => :thing # error: Expected Symbol but found {} for argument method
-  def_delegator 234, :foo # error: Expected T.any(Symbol, String) but found Integer(234) for argument accessor
-  def_delegator :thing => :thing # error: Method `def_delegator` does not exist
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Not enough arguments provided for method Forwardable#def_delegator. Expected: 2..3, got: 1
+  def_delegator # error: Not enough arguments provided for method `Forwardable#def_delegator`
+  def_delegator :thing # error: Not enough arguments provided for method `Forwardable#def_delegator`
+  def_delegator :thing, :foo, :bar, :baz # error: Too many arguments provided for method `Forwardable#def_delegator`
+  def_delegator :thing, :foo, :bar, kwarg: :thing # error: Too many arguments provided for method `Forwardable#def_delegator`
+  def_delegator :thing, kwarg: :thing # error: Expected `Symbol` but found `{kwarg: Symbol(:thing)}` for argument `method`
+  def_delegator :foo, kwarg1: :thing, kwarg2: local # error: Expected `Symbol` but found `{kwarg1: Symbol(:thing), kwarg2: Integer(0)}` for argument `method`
+  def_delegator :foo, local => :thing # error: Expected `Symbol` but found `{}` for argument `method`
+  def_delegator 234, :foo # error: Expected `T.any(Symbol, String)` but found `Integer(234)` for argument `accessor`
+  def_delegator :thing => :foo # error: Not enough arguments provided for method `Forwardable#def_delegator
+              # ^^^^^^^^^^^^^^ error: Expected `T.any(Symbol, String)` but found `{thing: Symbol(:foo)}` for argument `accessor`
+end
+
+class EnumerableUsage
+  extend T::Generic
+  extend Forwardable
+
+  include Enumerable
+
+  Elem = type_member
+
+  def_delegator :thing, :each
 end

--- a/test/testdata/rewriter/def_delegator.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/def_delegator.rb.rewrite-tree.exp
@@ -1,0 +1,117 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C GoodUsages><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:"arg0", ::T.untyped(), :"<blk>", ::T.nilable(::Proc)).returns(::T.untyped())
+    end
+
+    def foo<<C <todo sym>>>(*arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:"arg0", ::T.untyped(), :"<blk>", ::T.nilable(::Proc)).returns(::T.untyped())
+    end
+
+    def aliased_bar<<C <todo sym>>>(*arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.void()
+    end
+
+    def usages<<C <todo sym>>>(&<blk>)
+      begin
+        <self>.foo() do ||
+          <emptyTree>
+        end
+        <self>.foo(1, 2)
+        <self>.foo(1, 2) do ||
+          <emptyTree>
+        end
+        <self>.foo(1, 2, :"hey", true)
+        <self>.foo(1, 2, :"hey", true) do ||
+          <emptyTree>
+        end
+        <self>.foo(:"hey", true)
+        <self>.foo(:"hey", true) do ||
+          <emptyTree>
+        end
+        <self>.aliased_bar() do ||
+          <emptyTree>
+        end
+        <self>.aliased_bar(1, 2)
+        <self>.aliased_bar(1, 2) do ||
+          <emptyTree>
+        end
+        <self>.aliased_bar(1, 2, :"hey", true)
+        <self>.aliased_bar(1, 2, :"hey", true) do ||
+          <emptyTree>
+        end
+        <self>.aliased_bar(:"hey", true)
+        <self>.aliased_bar(:"hey", true) do ||
+          <emptyTree>
+        end
+        <self>.bar()
+      end
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    <self>.extend(<emptyTree>::<C Forwardable>)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"foo")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"aliased_bar")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"usages")
+  end
+
+  class <emptyTree>::<C WorksWithoutExtendingTSig><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:"arg0", ::T.untyped(), :"<blk>", ::T.nilable(::Proc)).returns(::T.untyped())
+    end
+
+    def foo<<C <todo sym>>>(*arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:"arg0", ::T.untyped(), :"<blk>", ::T.nilable(::Proc)).returns(::T.untyped())
+    end
+
+    def aliased_bar<<C <todo sym>>>(*arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"foo")
+
+    ::Sorbet::Private::Static.keep_def(<self>, :"aliased_bar")
+  end
+
+  class <emptyTree>::<C IgnoredUsages><<C <todo sym>>> < (::<todo sym>)
+    <self>.extend(<emptyTree>::<C Forwardable>)
+
+    local = 0
+
+    <self>.not_def_delegator(:"thing", :"foo")
+
+    <self>.def_delegator()
+
+    <self>.def_delegator(:"thing")
+
+    <self>.def_delegator(:"thing", :"foo", :"bar", :"baz")
+
+    <self>.def_delegator(:"thing", :"foo", :"bar", :"kwarg", :"thing")
+
+    <self>.def_delegator(:"thing", :"kwarg", :"thing")
+
+    <self>.def_delegator(:"foo", :"kwarg1", :"thing", :"kwarg2", local)
+
+    <self>.def_delegator(:"foo", local, :"thing")
+
+    <self>.def_delegator(234, :"foo")
+
+    <self>.def_delegator(:"thing", :"thing")
+  end
+end

--- a/test/testdata/rewriter/def_delegator.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/def_delegator.rb.rewrite-tree.exp
@@ -1,7 +1,7 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C GoodUsages><<C <todo sym>>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:"arg0", ::T.untyped(), :"<blk>", ::T.nilable(::Proc)).returns(::T.untyped())
+      <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
     def foo<<C <todo sym>>>(*arg0, &<blk>)
@@ -9,7 +9,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:"arg0", ::T.untyped(), :"<blk>", ::T.nilable(::Proc)).returns(::T.untyped())
+      <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
     def aliased_bar<<C <todo sym>>>(*arg0, &<blk>)
@@ -29,12 +29,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.foo(1, 2) do ||
           <emptyTree>
         end
-        <self>.foo(1, 2, :"hey", true)
-        <self>.foo(1, 2, :"hey", true) do ||
+        <self>.foo(1, 2, :hey, true)
+        <self>.foo(1, 2, :hey, true) do ||
           <emptyTree>
         end
-        <self>.foo(:"hey", true)
-        <self>.foo(:"hey", true) do ||
+        <self>.foo(:hey, true)
+        <self>.foo(:hey, true) do ||
           <emptyTree>
         end
         <self>.aliased_bar() do ||
@@ -44,12 +44,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.aliased_bar(1, 2) do ||
           <emptyTree>
         end
-        <self>.aliased_bar(1, 2, :"hey", true)
-        <self>.aliased_bar(1, 2, :"hey", true) do ||
+        <self>.aliased_bar(1, 2, :hey, true)
+        <self>.aliased_bar(1, 2, :hey, true) do ||
           <emptyTree>
         end
-        <self>.aliased_bar(:"hey", true)
-        <self>.aliased_bar(:"hey", true) do ||
+        <self>.aliased_bar(:hey, true)
+        <self>.aliased_bar(:hey, true) do ||
           <emptyTree>
         end
         <self>.bar()
@@ -60,16 +60,16 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.extend(<emptyTree>::<C Forwardable>)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :"foo")
+    ::Sorbet::Private::Static.keep_def(<self>, :foo)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :"aliased_bar")
+    ::Sorbet::Private::Static.keep_def(<self>, :aliased_bar)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :"usages")
+    ::Sorbet::Private::Static.keep_def(<self>, :usages)
   end
 
   class <emptyTree>::<C WorksWithoutExtendingTSig><<C <todo sym>>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:"arg0", ::T.untyped(), :"<blk>", ::T.nilable(::Proc)).returns(::T.untyped())
+      <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
     def foo<<C <todo sym>>>(*arg0, &<blk>)
@@ -77,16 +77,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:"arg0", ::T.untyped(), :"<blk>", ::T.nilable(::Proc)).returns(::T.untyped())
+      <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
     def aliased_bar<<C <todo sym>>>(*arg0, &<blk>)
       <emptyTree>
     end
 
-    ::Sorbet::Private::Static.keep_def(<self>, :"foo")
+    <self>.extend(<emptyTree>::<C Forwardable>)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :"aliased_bar")
+    ::Sorbet::Private::Static.keep_def(<self>, :foo)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :aliased_bar)
   end
 
   class <emptyTree>::<C IgnoredUsages><<C <todo sym>>> < (::<todo sym>)
@@ -94,24 +96,44 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     local = 0
 
-    <self>.not_def_delegator(:"thing", :"foo")
+    <self>.not_def_delegator(:thing, :foo)
 
     <self>.def_delegator()
 
-    <self>.def_delegator(:"thing")
+    <self>.def_delegator(:thing)
 
-    <self>.def_delegator(:"thing", :"foo", :"bar", :"baz")
+    <self>.def_delegator(:thing, :foo, :bar, :baz)
 
-    <self>.def_delegator(:"thing", :"foo", :"bar", :"kwarg", :"thing")
+    <self>.def_delegator(:thing, :foo, :bar, :kwarg, :thing)
 
-    <self>.def_delegator(:"thing", :"kwarg", :"thing")
+    <self>.def_delegator(:thing, :kwarg, :thing)
 
-    <self>.def_delegator(:"foo", :"kwarg1", :"thing", :"kwarg2", local)
+    <self>.def_delegator(:foo, :kwarg1, :thing, :kwarg2, local)
 
-    <self>.def_delegator(:"foo", local, :"thing")
+    <self>.def_delegator(:foo, local, :thing)
 
-    <self>.def_delegator(234, :"foo")
+    <self>.def_delegator(234, :foo)
 
-    <self>.def_delegator(:"thing", :"thing")
+    <self>.def_delegator(:thing, :foo)
+  end
+
+  class <emptyTree>::<C EnumerableUsage><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
+    end
+
+    def each<<C <todo sym>>>(*arg0, &<blk>)
+      <emptyTree>
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Generic>)
+
+    <self>.extend(<emptyTree>::<C Forwardable>)
+
+    <self>.include(<emptyTree>::<C Enumerable>)
+
+    <emptyTree>::<C Elem> = <self>.type_member()
+
+    ::Sorbet::Private::Static.keep_def(<self>, :each)
   end
 end

--- a/test/testdata/rewriter/def_delegator.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/def_delegator.rb.rewrite-tree.exp
@@ -5,7 +5,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo<<C <todo sym>>>(*arg0, &<blk>)
-      <emptyTree>
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -13,7 +13,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def aliased_bar<<C <todo sym>>>(*arg0, &<blk>)
-      <emptyTree>
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::Sorbet::Private::Static.sig(<self>) do ||
@@ -62,7 +62,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :foo)
 
+    <self>.def_delegator(:thing, :foo)
+
     ::Sorbet::Private::Static.keep_def(<self>, :aliased_bar)
+
+    <self>.def_delegator(:thing, :bar, :aliased_bar)
 
     ::Sorbet::Private::Static.keep_def(<self>, :usages)
   end
@@ -73,7 +77,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo<<C <todo sym>>>(*arg0, &<blk>)
-      <emptyTree>
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -81,14 +85,44 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def aliased_bar<<C <todo sym>>>(*arg0, &<blk>)
-      <emptyTree>
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
     <self>.extend(<emptyTree>::<C Forwardable>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :foo)
 
+    <self>.def_delegator(:thing, :foo)
+
     ::Sorbet::Private::Static.keep_def(<self>, :aliased_bar)
+
+    <self>.def_delegator(:thing, :bar, :aliased_bar)
+  end
+
+  class <emptyTree>::<C ErrorsWhenMissingForwardable><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
+    end
+
+    def foo<<C <todo sym>>>(*arg0, &<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
+    end
+
+    def aliased_bar<<C <todo sym>>>(*arg0, &<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::Sorbet::Private::Static.keep_def(<self>, :foo)
+
+    <self>.def_delegator(:thing, :foo)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :aliased_bar)
+
+    <self>.def_delegator(:thing, :bar, :aliased_bar)
   end
 
   class <emptyTree>::<C IgnoredUsages><<C <todo sym>>> < (::<todo sym>)
@@ -123,7 +157,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def each<<C <todo sym>>>(*arg0, &<blk>)
-      <emptyTree>
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
     <self>.extend(<emptyTree>::<C T>::<C Generic>)
@@ -135,5 +169,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C Elem> = <self>.type_member()
 
     ::Sorbet::Private::Static.keep_def(<self>, :each)
+
+    <self>.def_delegator(:thing, :each)
   end
 end


### PR DESCRIPTION
Implements `Forwardable#def_delegator` by desugaring things of the form

```ruby
class MyClass
  def_delegator :thing, :foo
  def_delegator :thing, :bar, :aliased_bar
end
```

into

```ruby
class MyClass
  sig {params(arg0: T.untyped, blk: T.nilable(Proc)).returns(T.untyped)}
  def foo(*arg0, &blk); end

  sig {params(arg0: T.untyped, blk: T.nilable(Proc)).returns(T.untyped)}
  def aliased_bar(*arg0, &blk); end
end
```

Some notes:
- This is similar to the rewriter that already exists for ActiveSupport's `Module#delegate`.
- There's also a `Forwardable#def_delegators` (plural) that this PR does not handle since the usage is different enough that it likely warrants its own rewriter.

### Motivation

Enable usage of `Forwardable#def_delegator` (a ruby stdlib construct) with sorbet:

[→ View on sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0Aclass%20A%0A%20%20extend%20Forwardable%0A%0A%20%20def_delegator%20%3Athing%2C%20%3Afoo%0Aend%0A%0AA.new.foo%20%23%20Method%20foo%20does%20not%20exist%20on%20A)
```ruby
class A
  extend Forwardable

  def_delegator :thing, :foo
end

A.new.foo # error: Method foo does not exist on A (but the method does exist!)
```

### Test plan

See included automated tests.
