### PR TITLE
Delete Type, GroundType, and ProxyType classes

### DIFF
--- a/common/typecase.h
+++ b/common/typecase.h
@@ -94,7 +94,7 @@ template <typename Base, typename... Subclasses> void typecase(Base &base, Subcl
         if (!base) {
             sorbet::Exception::raise("nullptr passed to typecase");
         }
-        sorbet::Exception::raise("not handled typecase case: {}", demangle(typeid(*base).name()));
+        sorbet::Exception::raise("not handled typecase case: {}", base.tag());
     }
 }
 

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -214,6 +214,9 @@ public:
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
 
+    // If this TypePtr `is_proxy_type`, returns its underlying type.
+    TypePtr underlying() const;
+
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string toString(const GlobalState &gs) const {
         return toStringWithTabs(gs);

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -102,6 +102,16 @@ private:
 
     void _sanityCheck(const GlobalState &gs) const;
 
+    void *get() const {
+        auto val = store & PTR_MASK;
+        if constexpr (sizeof(void *) == 4) {
+            return reinterpret_cast<void *>(val);
+        } else {
+            // sign extension for the upper 16 bits
+            return reinterpret_cast<void *>((val << 16) >> 16);
+        }
+    }
+
 public:
     constexpr TypePtr() noexcept : counter(nullptr), store(0) {}
 
@@ -157,21 +167,6 @@ public:
         }
     }
 
-    Type *get() const {
-        auto val = store & PTR_MASK;
-        if constexpr (sizeof(void *) == 4) {
-            return reinterpret_cast<Type *>(val);
-        } else {
-            // sign extension for the upper 16 bits
-            return reinterpret_cast<Type *>((val << 16) >> 16);
-        }
-    }
-    Type *operator->() const {
-        return get();
-    }
-    Type &operator*() const {
-        return *get();
-    }
     bool operator!=(const TypePtr &other) const {
         return store != other.store;
     }
@@ -236,6 +231,8 @@ public:
     DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) const;
 
     template <class T, class... Args> friend TypePtr make_type(Args &&... args);
+    template <class To> friend To const *cast_type(const TypePtr &what);
+    template <class To> friend To const &cast_type_nonnull(const TypePtr &what);
     friend class TypePtrTestHelper;
 };
 CheckSize(TypePtr, 16, 8);

--- a/core/Types.h
+++ b/core/Types.h
@@ -205,8 +205,7 @@ template <> inline bool isa_type<ClassType>(const TypePtr &what) {
     }
 }
 
-class GroundType;
-template <> inline bool isa_type<GroundType>(const TypePtr &what) {
+inline bool is_ground_type(const TypePtr &what) {
     if (what == nullptr) {
         return false;
     }
@@ -279,8 +278,6 @@ template <> inline TypePtr const &TypePtr::cast<TypePtr>(const TypePtr &what) {
     template <> struct TypePtr::TypeToTag<name> { static constexpr TypePtr::Tag value = TypePtr::Tag::name; }; \
     class __attribute__((aligned(8))) name
 
-class GroundType {};
-
 class ProxyType {
 public:
     // TODO: use shared pointers that use inline counter
@@ -294,7 +291,7 @@ public:
 };
 CheckSize(ProxyType, 8, 8);
 
-TYPE(ClassType) : public GroundType {
+TYPE(ClassType) {
 public:
     SymbolRef symbol;
     ClassType(SymbolRef symbol);
@@ -420,7 +417,7 @@ public:
 };
 CheckSize(TypeVar, 8, 8);
 
-TYPE(OrType) final : public GroundType {
+TYPE(OrType) final {
 public:
     TypePtr left;
     TypePtr right;
@@ -470,7 +467,7 @@ private:
 };
 CheckSize(OrType, 32, 8);
 
-TYPE(AndType) final : public GroundType {
+TYPE(AndType) final {
 public:
     TypePtr left;
     TypePtr right;

--- a/core/Types.h
+++ b/core/Types.h
@@ -217,7 +217,16 @@ inline bool is_ground_type(const TypePtr &what) {
         case TypePtr::Tag::OrType:
         case TypePtr::Tag::AndType:
             return true;
-        default:
+        case TypePtr::Tag::LiteralType:
+        case TypePtr::Tag::ShapeType:
+        case TypePtr::Tag::TupleType:
+        case TypePtr::Tag::MetaType:
+        case TypePtr::Tag::LambdaParam:
+        case TypePtr::Tag::SelfTypeParam:
+        case TypePtr::Tag::SelfType:
+        case TypePtr::Tag::AliasType:
+        case TypePtr::Tag::AppliedType:
+        case TypePtr::Tag::TypeVar:
             return false;
     }
 }
@@ -232,7 +241,18 @@ inline bool is_proxy_type(const TypePtr &what) {
         case TypePtr::Tag::TupleType:
         case TypePtr::Tag::MetaType:
             return true;
-        default:
+        case TypePtr::Tag::ClassType:
+        case TypePtr::Tag::BlamedUntyped:
+        case TypePtr::Tag::UnresolvedClassType:
+        case TypePtr::Tag::UnresolvedAppliedType:
+        case TypePtr::Tag::OrType:
+        case TypePtr::Tag::AndType:
+        case TypePtr::Tag::LambdaParam:
+        case TypePtr::Tag::SelfTypeParam:
+        case TypePtr::Tag::SelfType:
+        case TypePtr::Tag::AliasType:
+        case TypePtr::Tag::AppliedType:
+        case TypePtr::Tag::TypeVar:
             return false;
     }
 }

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -147,7 +147,11 @@ public:
         return ptr.store;
     }
 
-    static TypePtr create(TypePtr::Tag tag, Type *type) {
+    static void *get(const TypePtr &ptr) {
+        return ptr.get();
+    }
+
+    static TypePtr create(TypePtr::Tag tag, void *type) {
         return TypePtr(tag, type);
     }
 };
@@ -203,7 +207,7 @@ TEST_SUITE("TypePtr") {
             auto rawPtr = new ClassType(Symbols::untyped());
             auto ptr = TypePtrTestHelper::create(TypePtr::Tag::ClassType, rawPtr);
             CHECK_EQ(TypePtr::Tag::ClassType, ptr.tag());
-            CHECK_EQ(rawPtr, ptr.get());
+            CHECK_EQ(rawPtr, TypePtrTestHelper::get(ptr));
         }
 
         // This tag is > 8
@@ -211,7 +215,7 @@ TEST_SUITE("TypePtr") {
             auto rawPtr = new BlamedUntyped(Symbols::untyped());
             auto ptr = TypePtrTestHelper::create(TypePtr::Tag::BlamedUntyped, rawPtr);
             CHECK_EQ(TypePtr::Tag::BlamedUntyped, ptr.tag());
-            CHECK_EQ(rawPtr, ptr.get());
+            CHECK_EQ(rawPtr, TypePtrTestHelper::get(ptr));
         }
     }
 }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -520,7 +520,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
         auto e = gs.beginError(core::Loc(args.locs.file, args.locs.call), errors::Infer::UnknownMethod);
         if (e) {
             string thisStr = args.thisType.show(gs);
-            if (args.fullType.get() != args.thisType.get()) {
+            if (args.fullType != args.thisType) {
                 e.setHeader("Method `{}` does not exist on `{}` component of `{}`", args.name.data(gs)->show(gs),
                             thisStr, args.fullType.show(gs));
             } else {
@@ -825,7 +825,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
         if (!(pit->flags.isKeyword || pit->flags.isDefault || pit->flags.isRepeated || pit->flags.isBlock)) {
             if (auto e = gs.beginError(core::Loc(args.locs.file, args.locs.call),
                                        errors::Infer::MethodArgumentCountMismatch)) {
-                if (args.fullType.get() != args.thisType.get()) {
+                if (args.fullType != args.thisType) {
                     e.setHeader(
                         "Not enough arguments provided for method `{}` on `{}` component of `{}`. Expected: `{}`, got: "
                         "`{}`",

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -470,8 +470,8 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
 }
 
 TypePtr lubGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
-    ENFORCE(isa_type<GroundType>(t1));
-    ENFORCE(isa_type<GroundType>(t2));
+    ENFORCE(is_ground_type(t1));
+    ENFORCE(is_ground_type(t2));
 
     //    if (g1->kind() > g2->kind()) { // force the relation to be symmentric and half the implementation
     //        return lubGround(gs, t2, t1);
@@ -515,8 +515,8 @@ TypePtr lubGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
 }
 
 TypePtr glbGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
-    ENFORCE(isa_type<GroundType>(t1));
-    ENFORCE(isa_type<GroundType>(t2));
+    ENFORCE(is_ground_type(t1));
+    ENFORCE(is_ground_type(t2));
 
     if (t1.kind() > t1.kind()) { // force the relation to be symmentric and half the implementation
         return glbGround(gs, t2, t1);

--- a/core/types/typemaps.cc
+++ b/core/types/typemaps.cc
@@ -10,7 +10,7 @@ namespace sorbet::core {
 
 TypePtr Types::instantiate(const GlobalState &gs, const TypePtr &what, const InlinedVector<SymbolRef, 4> &params,
                            const vector<TypePtr> &targs) {
-    ENFORCE(what.get());
+    ENFORCE(what != nullptr);
     auto t = what._instantiate(gs, params, targs);
     if (t) {
         return t;
@@ -23,7 +23,7 @@ TypePtr Types::instantiate(const GlobalState &gs, const TypePtr &what, const Typ
     if (tc.isEmpty()) {
         return what;
     }
-    ENFORCE(what.get());
+    ENFORCE(what != nullptr);
     auto t = what._instantiate(gs, tc);
     if (t) {
         return t;
@@ -32,7 +32,7 @@ TypePtr Types::instantiate(const GlobalState &gs, const TypePtr &what, const Typ
 }
 
 TypePtr Types::approximate(const GlobalState &gs, const TypePtr &what, const TypeConstraint &tc) {
-    ENFORCE(what.get());
+    ENFORCE(what != nullptr);
     auto t = what._approximate(gs, tc);
     if (t) {
         return t;
@@ -412,7 +412,7 @@ TypePtr LambdaParam::_instantiate(const GlobalState &gs, const InlinedVector<Sym
 }
 
 TypePtr Types::replaceSelfType(const GlobalState &gs, const TypePtr &what, const TypePtr &receiver) {
-    ENFORCE(what.get());
+    ENFORCE(what != nullptr);
     auto t = what._replaceSelfType(gs, receiver);
     if (t) {
         return t;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -145,7 +145,7 @@ KnowledgeRef KnowledgeRef::under(core::Context ctx, const Environment &env, core
         auto fnd = absl::c_find_if(copy->yesTypeTests, [&](auto const &e) -> bool { return e.first == local; });
         if (fnd == copy->yesTypeTests.end()) {
             // add info from env to knowledge
-            ENFORCE(state.typeAndOrigins.type.get() != nullptr);
+            ENFORCE(state.typeAndOrigins.type != nullptr);
             // This handles code snippets such as
             //
             //    if (...)
@@ -219,11 +219,11 @@ void KnowledgeFact::sanityCheck() const {
         return;
     }
     for (auto &a : yesTypeTests) {
-        ENFORCE(a.second.get() != nullptr);
+        ENFORCE(a.second != nullptr);
         ENFORCE(!a.second.isUntyped());
     }
     for (auto &a : noTypeTests) {
-        ENFORCE(a.second.get() != nullptr);
+        ENFORCE(a.second != nullptr);
         ENFORCE(!a.second.isUntyped());
     }
 }
@@ -395,7 +395,7 @@ bool Environment::hasType(core::Context ctx, cfg::LocalRef symbol) const {
         return false;
     }
     // We don't distinguish between nullptr and "not set"
-    return fnd->second.typeAndOrigins.type.get() != nullptr;
+    return fnd->second.typeAndOrigins.type != nullptr;
 }
 
 const core::TypeAndOrigins &Environment::getTypeAndOrigin(core::Context ctx, cfg::LocalRef symbol) const {
@@ -403,7 +403,7 @@ const core::TypeAndOrigins &Environment::getTypeAndOrigin(core::Context ctx, cfg
     if (fnd == _vars.end()) {
         return uninitialized;
     }
-    ENFORCE(fnd->second.typeAndOrigins.type.get() != nullptr);
+    ENFORCE(fnd->second.typeAndOrigins.type != nullptr);
     return fnd->second.typeAndOrigins;
 }
 
@@ -430,10 +430,10 @@ void Environment::propagateKnowledge(core::Context ctx, cfg::LocalRef to, cfg::L
         toState.knownTruthy = fromState.knownTruthy;
         auto &toKnowledge = toState.knowledge;
         auto &fromKnowledge = fromState.knowledge;
-        if (fromState.typeAndOrigins.type.get() == nullptr) {
+        if (fromState.typeAndOrigins.type == nullptr) {
             fromState.typeAndOrigins.type = core::Types::nilClass();
         }
-        if (toState.typeAndOrigins.type.get() == nullptr) {
+        if (toState.typeAndOrigins.type == nullptr) {
             toState.typeAndOrigins.type = core::Types::nilClass();
         }
 
@@ -585,8 +585,8 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         auto &truthy = funIsEq ? whoKnows.truthy() : whoKnows.falsy();
         auto &falsy = funIsEq ? whoKnows.falsy() : whoKnows.truthy();
 
-        ENFORCE(argType.get() != nullptr);
-        ENFORCE(recvType.get() != nullptr);
+        ENFORCE(argType != nullptr);
+        ENFORCE(recvType != nullptr);
         if (!argType.isUntyped()) {
             truthy.addYesTypeTest(local, typeTestsWithVar, send->recv.variable, argType);
         }
@@ -662,7 +662,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
 }
 
 void Environment::setTypeAndOrigin(cfg::LocalRef symbol, const core::TypeAndOrigins &typeAndOrigins) {
-    ENFORCE(typeAndOrigins.type.get() != nullptr);
+    ENFORCE(typeAndOrigins.type != nullptr);
     _vars[symbol].typeAndOrigins = typeAndOrigins;
 }
 
@@ -763,7 +763,7 @@ void Environment::mergeWith(core::Context ctx, const Environment &other, core::L
         auto var = pair.first;
         const auto &otherTO = other.getTypeAndOrigin(ctx, var);
         auto &thisTO = pair.second.typeAndOrigins;
-        if (thisTO.type.get() != nullptr) {
+        if (thisTO.type != nullptr) {
             thisTO.type = core::Types::any(ctx, thisTO.type, otherTO.type);
             thisTO.type.sanityCheck(ctx);
             for (auto origin : otherTO.origins) {
@@ -1035,7 +1035,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     tp.type = singletonClass.data(ctx)->externalType();
                     tp.origins.emplace_back(symbol.data(ctx)->loc());
                 } else if (data->isField() || (data->isStaticField() && !data->isTypeAlias()) || data->isTypeMember()) {
-                    if (data->resultType.get() != nullptr) {
+                    if (data->resultType != nullptr) {
                         if (data->isTypeMember()) {
                             if (data->isFixed()) {
                                 // pick the upper bound here, as
@@ -1060,7 +1060,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         tp.type = core::Types::untyped(ctx, symbol);
                     }
                 } else if (data->isTypeAlias()) {
-                    ENFORCE(data->resultType.get() != nullptr);
+                    ENFORCE(data->resultType != nullptr);
                     tp.origins.emplace_back(data->loc());
                     tp.type = core::make_type<core::MetaType>(data->resultType);
                 } else {
@@ -1284,7 +1284,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 }
             });
 
-        ENFORCE(tp.type.get() != nullptr, "Inferencer did not assign type: {}", bind.value->toString(ctx, inWhat));
+        ENFORCE(tp.type != nullptr, "Inferencer did not assign type: {}", bind.value->toString(ctx, inWhat));
         tp.type.sanityCheck(ctx);
 
         if (checkFullyDefined && !tp.type.isFullyDefined()) {
@@ -1431,7 +1431,7 @@ void Environment::initializeBasicBlockArgs(const cfg::BasicBlock &bb) {
 
 void Environment::setUninitializedVarsToNil(const core::Context &ctx, core::Loc origin) {
     for (auto &uninitialized : _vars) {
-        if (uninitialized.second.typeAndOrigins.type.get() == nullptr) {
+        if (uninitialized.second.typeAndOrigins.type == nullptr) {
             uninitialized.second.typeAndOrigins.type = core::Types::nilClass();
             uninitialized.second.typeAndOrigins.origins.emplace_back(origin);
         } else {

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -243,8 +243,8 @@ string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef consta
 core::TypePtr getResultType(const core::GlobalState &gs, const core::TypePtr &type, core::SymbolRef inWhat,
                             core::TypePtr receiver, const core::TypeConstraint *constr) {
     auto resultType = type;
-    if (auto *proxy = core::cast_type<core::ProxyType>(receiver)) {
-        receiver = proxy->underlying();
+    if (core::is_proxy_type(receiver)) {
+        receiver = receiver.underlying();
     }
     if (auto *applied = core::cast_type<core::AppliedType>(receiver)) {
         /* instantiate generic classes */

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -177,8 +177,11 @@ SimilarMethodsByName similarMethodsForReceiver(const core::GlobalState &gs, cons
             result = mergeSimilarMethods(similarMethodsForReceiver(gs, type.left, prefix),
                                          similarMethodsForReceiver(gs, type.right, prefix));
         },
-        [&](const core::ProxyType &type) { result = similarMethodsForReceiver(gs, type.underlying(), prefix); },
-        [&](const core::TypePtr &type) { return; });
+        [&](const core::TypePtr &type) {
+            if (is_proxy_type(receiver)) {
+                result = similarMethodsForReceiver(gs, receiver.underlying(), prefix);
+            }
+        });
 
     return result;
 }

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -61,7 +61,7 @@ core::TypePtr getResultLiteral(core::Context ctx, const ast::TreePtr &expr) {
             }
             result = core::Types::untypedUntracked();
         });
-    ENFORCE(result.get() != nullptr);
+    ENFORCE(result != nullptr);
     result.sanityCheck(ctx);
     return result;
 }
@@ -984,7 +984,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::MutableConte
             }
             result.type = core::Types::untypedUntracked();
         });
-    ENFORCE(result.type.get() != nullptr);
+    ENFORCE(result.type != nullptr);
     result.type.sanityCheck(ctx);
     return result;
 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Delete Type, GroundType, and ProxyType classes.

I believe the ProxyType deletion may be the most controversial, as we were getting some amount of mileage from that abstraction. I'm happy to remove it from this PR if that is the case.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Reduce the size of Type objects and eliminate virtual dispatch where possible.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
