### PR TITLE
Parallelize ResolverTypeMembersWalk

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1462,7 +1462,7 @@ public:
             }
         }
 
-        // Sort items for deterministic execution.
+        // Put files into a consistent order for subsequent passes.
         fast_sort(combined.files, [](auto &a, auto &b) -> bool { return a.file.id() < b.file.id(); });
 
         for (auto &job : combined.todoAttachedClassItems) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Parallelize ResolverTypeMembersWalk. Walk the ASTs in parallel, collect work, perform work serially.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed! Walking every AST in the project on a single thread does not scale well.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
