### PR TITLE
Add a rewrite pass for `include Singleton`

### DIFF
--- a/rewriter/Singleton.cc
+++ b/rewriter/Singleton.cc
@@ -1,0 +1,58 @@
+#include "rewriter/Singleton.h"
+#include "ast/Helpers.h"
+#include "core/GlobalState.h"
+
+using namespace std;
+
+namespace sorbet::rewriter {
+
+namespace {
+
+bool isSingleton(const ast::TreePtr &expr) {
+    if (auto *sym = ast::cast_tree<ast::UnresolvedConstantLit>(expr)) {
+        return sym->cnst == core::Names::Constants::Singleton();
+    }
+    return false;
+}
+
+} // namespace
+
+std::vector<ast::TreePtr> Singleton::run(core::MutableContext ctx, const ast::Send *send) {
+    vector<ast::TreePtr> stmts{};
+
+    if (!send->recv.isSelfReference()) {
+        return stmts;
+    }
+
+    if (send->fun != core::Names::include()) {
+        return stmts;
+    }
+
+    if (send->args.size() != 1) {
+        return stmts;
+    }
+
+    if (!isSingleton(send->args.front())) {
+        return stmts;
+    }
+
+    auto loc = send->loc;
+
+    {
+        auto sig = ast::MK::Sig0(loc, ast::MK::Send0(loc, ast::MK::T(loc), core::Names::attachedClass()));
+        ast::cast_tree_nonnull<ast::Send>(sig).args.emplace_back(ast::MK::Symbol(loc, core::Names::final_()));
+        stmts.emplace_back(std::move(sig));
+    }
+
+    {
+        auto method = ast::MK::SyntheticMethod0(loc, loc, core::Names::instance(), ast::MK::RaiseUnimplemented(loc));
+        ast::cast_tree_nonnull<ast::MethodDef>(method).flags.isSelfMethod = true;
+        stmts.emplace_back(std::move(method));
+    }
+
+    stmts.emplace_back(send->deepCopy());
+
+    return stmts;
+}
+
+} // namespace sorbet::rewriter

--- a/rewriter/Singleton.h
+++ b/rewriter/Singleton.h
@@ -20,7 +20,7 @@ namespace sorbet::rewriter {
  * ```
  * class Foo
  *
- *   sig(:final) {returns(T.attached_class)}
+ *   sig {returns(T.attached_class)}
  *   def self.instance
  *     raise "Not implemented"
  *   end
@@ -31,7 +31,7 @@ namespace sorbet::rewriter {
  */
 class Singleton final {
 public:
-    static std::vector<ast::TreePtr> run(core::MutableContext ctx, const ast::Send *send);
+    static void run(core::MutableContext ctx, ast::ClassDef *cdef);
 
     Singleton() = delete;
 };

--- a/rewriter/Singleton.h
+++ b/rewriter/Singleton.h
@@ -1,0 +1,41 @@
+#ifndef SORBET_REWRITER_SINGLETON_H
+#define SORBET_REWRITER_SINGLETON_H
+
+#include "ast/ast.h"
+
+namespace sorbet::rewriter {
+
+/**
+ * Rewrite uses of the `Singleton` module to include the `self.instance` method, with a type signature that gives sorbet
+ * more information.
+ *
+ * ```
+ * class Foo
+ *   include Singleton
+ * end
+ * ```
+ *
+ * Is rewritten to
+ *
+ * ```
+ * class Foo
+ *
+ *   sig(:final) {returns(T.attached_class)}
+ *   def self.instance
+ *     raise "Not implemented"
+ *   end
+ *
+ *   include Singleton
+ * end
+ * ```
+ */
+class Singleton final {
+public:
+    static std::vector<ast::TreePtr> run(core::MutableContext ctx, const ast::Send *send);
+
+    Singleton() = delete;
+};
+
+} // namespace sorbet::rewriter
+
+#endif

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -45,6 +45,7 @@ public:
         Flatfiles::run(ctx, classDef);
         Prop::run(ctx, classDef);
         TypeMembers::run(ctx, classDef);
+        Singleton::run(ctx, classDef);
 
         for (auto &extension : ctx.state.semanticExtensions) {
             extension->run(ctx, classDef);
@@ -119,12 +120,6 @@ public:
 
                     // This one is also a little different: it gets the ClassDef kind
                     nodes = Mattr::run(ctx, &send, classDef->kind);
-                    if (!nodes.empty()) {
-                        replaceNodes[stat.get()] = std::move(nodes);
-                        return;
-                    }
-
-                    nodes = Singleton::run(ctx, &send);
                     if (!nodes.empty()) {
                         replaceNodes[stat.get()] = std::move(nodes);
                         return;

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -23,6 +23,7 @@
 #include "rewriter/Regexp.h"
 #include "rewriter/SelfNew.h"
 #include "rewriter/SigRewriter.h"
+#include "rewriter/Singleton.h"
 #include "rewriter/Struct.h"
 #include "rewriter/TEnum.h"
 #include "rewriter/TypeMembers.h"
@@ -118,6 +119,12 @@ public:
 
                     // This one is also a little different: it gets the ClassDef kind
                     nodes = Mattr::run(ctx, &send, classDef->kind);
+                    if (!nodes.empty()) {
+                        replaceNodes[stat.get()] = std::move(nodes);
+                        return;
+                    }
+
+                    nodes = Singleton::run(ctx, &send);
                     if (!nodes.empty()) {
                         replaceNodes[stat.get()] = std::move(nodes);
                         return;

--- a/test/testdata/rewriter/singleton.rb
+++ b/test/testdata/rewriter/singleton.rb
@@ -1,0 +1,21 @@
+# typed: true
+
+class A
+  include Singleton
+end
+
+# Singleton supports inheritence, turning the sub-class into a singleton as well.
+class B < A; end
+
+T.reveal_type(A.instance) # error: Revealed type: `A`
+T.reveal_type(B.instance) # error: Revealed type: `B`
+
+class C
+  include Singleton
+  extend T::Helpers
+  final!
+end
+
+T.reveal_type(C.instance) # error: Revealed type: `C`
+
+class D < C; end # error: `C` was declared as final

--- a/test/testdata/rewriter/singleton.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/singleton.rb.rewrite-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime, :"final") do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.returns(::T.attached_class())
     end
 
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
-    ::Sorbet::Private::Static.keep_self_def(<self>, :"instance")
+    ::Sorbet::Private::Static.keep_self_def(<self>, :instance)
 
     <self>.include(<emptyTree>::<C Singleton>)
   end
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(<emptyTree>::<C B>.instance())
 
   class <emptyTree>::<C C><<C <todo sym>>> < (::<todo sym>)
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime, :"final") do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime, :final) do ||
       <self>.returns(::T.attached_class())
     end
 
@@ -29,7 +29,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
-    ::Sorbet::Private::Static.keep_self_def(<self>, :"instance")
+    ::Sorbet::Private::Static.keep_self_def(<self>, :instance)
 
     <self>.include(<emptyTree>::<C Singleton>)
 

--- a/test/testdata/rewriter/singleton.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/singleton.rb.rewrite-tree.exp
@@ -1,0 +1,45 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime, :"final") do ||
+      <self>.returns(::T.attached_class())
+    end
+
+    def self.instance<<C <todo sym>>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :"instance")
+
+    <self>.include(<emptyTree>::<C Singleton>)
+  end
+
+  class <emptyTree>::<C B><<C <todo sym>>> < (<emptyTree>::<C A>)
+  end
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C A>.instance())
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C B>.instance())
+
+  class <emptyTree>::<C C><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime, :"final") do ||
+      <self>.returns(::T.attached_class())
+    end
+
+    def self.instance<<C <todo sym>>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :"instance")
+
+    <self>.include(<emptyTree>::<C Singleton>)
+
+    <self>.extend(<emptyTree>::<C T>::<C Helpers>)
+
+    <self>.final!()
+  end
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C C>.instance())
+
+  class <emptyTree>::<C D><<C <todo sym>>> < (<emptyTree>::<C C>)
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This introduces a rewrite pass that adds a signature and method definition for `self.instance` when classes `include Singleton`. The rewrite takes a definition like:

```ruby
class A
  include Singleton
end
```

and turns it into:

```ruby
class A
  sig {returns(T.attached_class)}
  def self.instance
    raise "Sorbet rewriter pass partially unimplemented"
  end

  include Singleton
end
```

When the class is marked `final!` the generated `self.instance` method will have a signature that is also marked final.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Allowing singleton classes to also be marked as `final!`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
