### PR TITLE
Do not produce unreported errors for AndType::dispatchCall.

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -677,9 +677,9 @@ struct DispatchArgs {
     const TypePtr &thisType;
     const std::shared_ptr<const SendAndBlockLink> &block;
     Loc originForUninitialized;
-    // Special option used for AndType::dispatchCall: Do not produce dispatch-related errors while evaluating the call.
-    // AndTypes only require one of their component types to handle the call, so failure is the common case -- and
-    // producing good error messages is expensive!
+    // Do not produce dispatch-related errors while evaluating the call. This is a performance optimization, as there
+    // are cases where we call dispatchCall with no intention of showing the errors to the user. Producing those
+    // unreported errors is expensive!
     bool suppressErrors = false;
 
     DispatchArgs withSelfRef(const TypePtr &newSelfRef) const;

--- a/core/Types.h
+++ b/core/Types.h
@@ -677,9 +677,14 @@ struct DispatchArgs {
     const TypePtr &thisType;
     const std::shared_ptr<const SendAndBlockLink> &block;
     Loc originForUninitialized;
+    // Special option used for AndType::dispatchCall: Do not produce dispatch-related errors while evaluating the call.
+    // AndTypes only require one of their component types to handle the call, so failure is the common case -- and
+    // producing good error messages is expensive!
+    bool suppressErrors = false;
 
     DispatchArgs withSelfRef(const TypePtr &newSelfRef) const;
     DispatchArgs withThisRef(const TypePtr &newThisRef) const;
+    DispatchArgs withErrorsSuppressed() const;
 };
 
 struct DispatchComponent {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -741,10 +741,17 @@ core::SymbolRef Types::getRepresentedClass(const GlobalState &gs, const TypePtr 
 }
 
 DispatchArgs DispatchArgs::withSelfRef(const TypePtr &newSelfRef) const {
-    return DispatchArgs{name, locs, numPosArgs, args, newSelfRef, fullType, newSelfRef, block, originForUninitialized};
+    return DispatchArgs{
+        name, locs, numPosArgs, args, newSelfRef, fullType, newSelfRef, block, originForUninitialized, suppressErrors};
 }
 
 DispatchArgs DispatchArgs::withThisRef(const TypePtr &newThisRef) const {
-    return DispatchArgs{name, locs, numPosArgs, args, selfType, fullType, newThisRef, block, originForUninitialized};
+    return DispatchArgs{
+        name, locs, numPosArgs, args, selfType, fullType, newThisRef, block, originForUninitialized, suppressErrors};
+}
+
+DispatchArgs DispatchArgs::withErrorsSuppressed() const {
+    return DispatchArgs{name, locs, numPosArgs, args, selfType, fullType, thisType, block, originForUninitialized,
+                        true};
 }
 } // namespace sorbet::core


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Do not produce unreported errors for AndType::dispatchCall.

Failure is the common case, and these errors are expensive to produce.

If all components in an AndType fail, re-dispatch the call with errors enabled.

Question:
* Are there any other places where we throw out errors? Could we change DispatchCall so that it doesn't force the caller to report errors?

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Levenstein distance was showing up as super hot on profiles, and I tracked it to the (unreported) errors produced in AndType::dispatchCall.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
