### PR TITLE
handle subtyping for AndType and TypeVars more carefully

### DIFF
--- a/test/testdata/infer/bug_generics_pr3642.rb
+++ b/test/testdata/infer/bug_generics_pr3642.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+# typed: strict
+extend T::Sig
+
+sig do
+  type_parameters(:U)
+    .params(
+      f: T.proc.params(x: T.type_parameter(:U)).void,
+      x: T.type_parameter(:U)
+    )
+    .void
+end
+def foo(f, x)
+end
+
+f = T.let(
+  proc {|x| nil},
+  T.proc.params(x: T.any(String, Integer)).void
+)
+
+foo(f, 0)

--- a/test/testdata/infer/generic_all.rb
+++ b/test/testdata/infer/generic_all.rb
@@ -1,0 +1,66 @@
+# typed: true
+
+module One
+  extend T::Sig
+
+  module A; end
+
+  module B; end
+
+  sig {params(x: Integer).returns(T.all(A, B))}
+  def return_ab(x)
+    return_ab(x)
+  end
+
+  def main
+    ab_list = [1,2,3].map {|i| return_ab(i)}
+    T.reveal_type(ab_list) # error: Revealed type: `T::Array[T.all(One::A, One::B)]`
+  end
+end
+
+module Two
+  extend T::Sig
+
+  class Parent; end
+  module Interface; end
+  class Child < Parent
+    include Interface
+  end
+
+  def bar
+    x = T.let([[:child, Child.new]], T::Array[[Symbol, T.all(Interface, Parent)]])
+    T.reveal_type(x.to_h) # error: Revealed type: `T::Hash[Symbol, T.all(Two::Interface, Two::Parent)]`
+  end
+end
+
+module Three
+  module WhateverInterface; end
+  module WhyInterface; end
+  module HelpInterface; end
+
+  class Test
+    include WhateverInterface
+    include WhyInterface
+    include HelpInterface
+  end
+
+  class A
+    extend T::Sig
+
+    Everything = T.type_alias do 
+      T.all(
+        WhateverInterface,
+        WhyInterface,
+        HelpInterface,
+      )
+    end
+    sig {returns(T::Array[Everything])}
+    def something
+      arr = T.let([Test.new], T::Array[Everything])
+      results = arr.map do |elem|
+        elem
+      end
+      results
+    end
+  end
+end


### PR DESCRIPTION
When we were determining subtyping relations for (`AndType`, `TypeVar`), we were only considering half of the `AndType` in `isSubTypeUnderConstraint` -> `isSubTypeUnderConstraintSingle` -> `TypeConstraint::rememberIsSubtype`.

This is almost certainly not the most elegant way to solve this, but it makes a certain amount of intuitive sense to me, and all the other ways of addressing this didn't seem to work -- suggestions welcome!  It's possible that this needs to be some kind of interface directly on `TypeConstraint`, but I'm not sure what that would look like, nor do I understand why only checking for one-half of the `AndType` even worked before.  (The standard library RBIs have cases where one runs into (`Symbol & U`, `U`) being passed into `isSubTypeUnderConstraint`, at least, so maybe that's part of it.)

### Motivation

Fixes #884.

### Test plan

See included automated tests, which include all of the provided testcases from the above issue.