### PR TITLE
Block in `Pathname#ascend` is optional

### DIFF
--- a/rbi/stdlib/pathname.rbi
+++ b/rbi/stdlib/pathname.rbi
@@ -375,6 +375,7 @@ class Pathname < Object
     )
     .returns(T.untyped)
   end
+  sig {returns(T::Enumerator[Pathname])}
   def ascend(&blk); end
 
   # Returns the last access time for the file.


### PR DESCRIPTION
Shamelessly plagiarised from #3617 except for `Pathname#ascend`.
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The block argument of `Pathname#ascend` is optional and if not supplied, returns an Enumerator of Pathname objects. [This example](https://sorbet.run/#%23%20typed%3A%20true%0A%0APathname.new(%22a%2Fb%2Fc%2Fd%2Fe%2Ff%22).ascend%0A%0A) should type-check properly.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No extra automated tests.


