### PR TITLE
don't needlessly allocate in _instantiate and _approximate

### DIFF
--- a/core/types/typemaps.cc
+++ b/core/types/typemaps.cc
@@ -57,15 +57,15 @@ TypePtr TypeVar::_approximate(const GlobalState &gs, const TypeConstraint &tc) c
 }
 
 namespace {
-template <typename... TransformArgs>
-optional<vector<TypePtr>> mungeArgs(const vector<TypePtr> &elems,
-                                    TypePtr (TypePtr::*method)(const TransformArgs &...) const,
-                                    const TransformArgs &... transformArgs) {
+template <typename... MethodArgs>
+optional<vector<TypePtr>> mungeElems(const vector<TypePtr> &elems,
+                                     TypePtr (TypePtr::*method)(const MethodArgs &...) const,
+                                     const MethodArgs &... methodArgs) {
     optional<vector<TypePtr>> newArgs;
     int i = -1;
     for (auto &e : elems) {
         ++i;
-        auto t = (e.*method)(transformArgs...);
+        auto t = (e.*method)(methodArgs...);
         if (!newArgs.has_value() && !t) {
             continue;
         }
@@ -92,7 +92,7 @@ optional<vector<TypePtr>> mungeArgs(const vector<TypePtr> &elems,
 
 TypePtr TupleType::_instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                 const vector<TypePtr> &targs) const {
-    optional<vector<TypePtr>> newElems = mungeArgs(this->elems, &TypePtr::_instantiate, gs, params, targs);
+    optional<vector<TypePtr>> newElems = mungeElems(this->elems, &TypePtr::_instantiate, gs, params, targs);
     if (!newElems) {
         return nullptr;
     }
@@ -100,7 +100,7 @@ TypePtr TupleType::_instantiate(const GlobalState &gs, const InlinedVector<Symbo
 }
 
 TypePtr TupleType::_instantiate(const GlobalState &gs, const TypeConstraint &tc) const {
-    optional<vector<TypePtr>> newElems = mungeArgs(this->elems, &TypePtr::_instantiate, gs, tc);
+    optional<vector<TypePtr>> newElems = mungeElems(this->elems, &TypePtr::_instantiate, gs, tc);
     if (!newElems) {
         return nullptr;
     }
@@ -108,7 +108,7 @@ TypePtr TupleType::_instantiate(const GlobalState &gs, const TypeConstraint &tc)
 }
 
 TypePtr TupleType::_approximate(const GlobalState &gs, const TypeConstraint &tc) const {
-    optional<vector<TypePtr>> newElems = mungeArgs(this->elems, &TypePtr::_approximate, gs, tc);
+    optional<vector<TypePtr>> newElems = mungeElems(this->elems, &TypePtr::_approximate, gs, tc);
     if (!newElems) {
         return nullptr;
     }
@@ -117,7 +117,7 @@ TypePtr TupleType::_approximate(const GlobalState &gs, const TypeConstraint &tc)
 
 TypePtr ShapeType::_instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                 const vector<TypePtr> &targs) const {
-    optional<vector<TypePtr>> newValues = mungeArgs(this->values, &TypePtr::_instantiate, gs, params, targs);
+    optional<vector<TypePtr>> newValues = mungeElems(this->values, &TypePtr::_instantiate, gs, params, targs);
     if (!newValues) {
         return nullptr;
     }
@@ -125,7 +125,7 @@ TypePtr ShapeType::_instantiate(const GlobalState &gs, const InlinedVector<Symbo
 }
 
 TypePtr ShapeType::_instantiate(const GlobalState &gs, const TypeConstraint &tc) const {
-    optional<vector<TypePtr>> newValues = mungeArgs(this->values, &TypePtr::_instantiate, gs, tc);
+    optional<vector<TypePtr>> newValues = mungeElems(this->values, &TypePtr::_instantiate, gs, tc);
     if (!newValues) {
         return nullptr;
     }
@@ -133,7 +133,7 @@ TypePtr ShapeType::_instantiate(const GlobalState &gs, const TypeConstraint &tc)
 }
 
 TypePtr ShapeType::_approximate(const GlobalState &gs, const TypeConstraint &tc) const {
-    optional<vector<TypePtr>> newValues = mungeArgs(this->values, &TypePtr::_approximate, gs, tc);
+    optional<vector<TypePtr>> newValues = mungeElems(this->values, &TypePtr::_approximate, gs, tc);
     if (!newValues) {
         return nullptr;
     }
@@ -234,7 +234,7 @@ TypePtr AndType::_approximate(const GlobalState &gs, const TypeConstraint &tc) c
 
 TypePtr AppliedType::_instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                                   const vector<TypePtr> &targs) const {
-    optional<vector<TypePtr>> newTargs = mungeArgs(this->targs, &TypePtr::_instantiate, gs, params, targs);
+    optional<vector<TypePtr>> newTargs = mungeElems(this->targs, &TypePtr::_instantiate, gs, params, targs);
     if (!newTargs) {
         return nullptr;
     }
@@ -242,7 +242,7 @@ TypePtr AppliedType::_instantiate(const GlobalState &gs, const InlinedVector<Sym
 }
 
 TypePtr AppliedType::_instantiate(const GlobalState &gs, const TypeConstraint &tc) const {
-    optional<vector<TypePtr>> newTargs = mungeArgs(this->targs, &TypePtr::_instantiate, gs, tc);
+    optional<vector<TypePtr>> newTargs = mungeElems(this->targs, &TypePtr::_instantiate, gs, tc);
     if (!newTargs) {
         return nullptr;
     }
@@ -250,7 +250,7 @@ TypePtr AppliedType::_instantiate(const GlobalState &gs, const TypeConstraint &t
 }
 
 TypePtr AppliedType::_approximate(const GlobalState &gs, const TypeConstraint &tc) const {
-    optional<vector<TypePtr>> newTargs = mungeArgs(this->targs, &TypePtr::_approximate, gs, tc);
+    optional<vector<TypePtr>> newTargs = mungeElems(this->targs, &TypePtr::_approximate, gs, tc);
     if (!newTargs) {
         return nullptr;
     }

--- a/core/types/typemaps.cc
+++ b/core/types/typemaps.cc
@@ -60,21 +60,21 @@ namespace {
 
 template <typename... MethodArgs>
 optional<vector<TypePtr>> instantiateElems(const vector<TypePtr> &elems, const MethodArgs &... methodArgs) {
-    optional<vector<TypePtr>> newArgs;
+    optional<vector<TypePtr>> newElems;
     int i = -1;
     for (auto &e : elems) {
         ++i;
         auto t = e._instantiate(methodArgs...);
-        if (!newArgs.has_value() && !t) {
+        if (!newElems.has_value() && !t) {
             continue;
         }
 
-        if (!newArgs.has_value()) {
+        if (!newElems.has_value()) {
             // Oops, need to fixup all the elements that should be there.
-            newArgs.emplace();
-            newArgs->reserve(elems.size());
+            newElems.emplace();
+            newElems->reserve(elems.size());
             for (int j = 0; j < i; ++j) {
-                newArgs->emplace_back(elems[j]);
+                newElems->emplace_back(elems[j]);
             }
         }
 
@@ -82,29 +82,29 @@ optional<vector<TypePtr>> instantiateElems(const vector<TypePtr> &elems, const M
             t = e;
         }
 
-        ENFORCE(newArgs->size() == i);
-        newArgs->emplace_back(move(t));
+        ENFORCE(newElems->size() == i);
+        newElems->emplace_back(move(t));
     }
-    return newArgs;
+    return newElems;
 }
 
 optional<vector<TypePtr>> approximateElems(const vector<TypePtr> &elems, const GlobalState &gs,
                                            const TypeConstraint &tc) {
-    optional<vector<TypePtr>> newArgs;
+    optional<vector<TypePtr>> newElems;
     int i = -1;
     for (auto &e : elems) {
         ++i;
         auto t = e._approximate(gs, tc);
-        if (!newArgs.has_value() && !t) {
+        if (!newElems.has_value() && !t) {
             continue;
         }
 
-        if (!newArgs.has_value()) {
+        if (!newElems.has_value()) {
             // Oops, need to fixup all the elements that should be there.
-            newArgs.emplace();
-            newArgs->reserve(elems.size());
+            newElems.emplace();
+            newElems->reserve(elems.size());
             for (int j = 0; j < i; ++j) {
-                newArgs->emplace_back(elems[j]);
+                newElems->emplace_back(elems[j]);
             }
         }
 
@@ -112,10 +112,10 @@ optional<vector<TypePtr>> approximateElems(const vector<TypePtr> &elems, const G
             t = e;
         }
 
-        ENFORCE(newArgs->size() == i);
-        newArgs->emplace_back(move(t));
+        ENFORCE(newElems->size() == i);
+        newElems->emplace_back(move(t));
     }
-    return newArgs;
+    return newElems;
 }
 } // anonymous namespace
 

--- a/core/types/typemaps.cc
+++ b/core/types/typemaps.cc
@@ -84,7 +84,7 @@ optional<vector<TypePtr>> mungeArgs(const vector<TypePtr> &elems,
         }
 
         ENFORCE(newArgs->size() == i);
-        newArgs->emplace_back(t);
+        newArgs->emplace_back(move(t));
     }
     return newArgs;
 }


### PR DESCRIPTION
There's a TODO (effectively nine TODOs) in typemaps.cc that we shouldn't allocate new vectors in `_instantiate` and `_approximate` unless we actually needed to.  This PR makes that change, and commons up all the logic so we only have to implement it once, possibly making it a little more readable in the process.

### Motivation

Epsilon efficiency improvements, more readable code.

### Test plan

Existing automated tests should be sufficient.