### PR TITLE
Call parameters "params" not "arguments"

### DIFF
--- a/ast/ArgParsing.h
+++ b/ast/ArgParsing.h
@@ -5,7 +5,7 @@ namespace sorbet::ast {
 struct ParsedArg {
     core::LocOffsets loc;
     core::LocalVariable local;
-    core::ArgInfo::ArgFlags flags;
+    core::ParamInfo::ArgFlags flags;
 };
 class ArgParsing {
 public:

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -550,12 +550,12 @@ string MethodDef::toStringWithTabs(const core::GlobalState &gs, int tabs) const 
             fmt::format_to(buf, "{}", a.toStringWithTabs(gs, tabs + 1));
         }
     } else {
-        for (auto &a : data->params()) {
+        for (auto &p : data->params()) {
             if (!first) {
                 fmt::format_to(buf, ", ");
             }
             first = false;
-            fmt::format_to(buf, "{}", a.argumentName(gs));
+            fmt::format_to(buf, "{}", p.argumentName(gs));
         }
     }
     fmt::format_to(buf, ")\n");

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -550,7 +550,7 @@ string MethodDef::toStringWithTabs(const core::GlobalState &gs, int tabs) const 
             fmt::format_to(buf, "{}", a.toStringWithTabs(gs, tabs + 1));
         }
     } else {
-        for (auto &a : data->arguments()) {
+        for (auto &a : data->params()) {
             if (!first) {
                 fmt::format_to(buf, ", ");
             }

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -169,7 +169,7 @@ string LoadArg::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) c
     return fmt::format("LoadArg {{ argument = {} }}", this->argument(gs).argumentName(gs));
 }
 
-const core::ArgInfo &LoadArg::argument(const core::GlobalState &gs) const {
+const core::ParamInfo &LoadArg::argument(const core::GlobalState &gs) const {
     return this->method.data(gs)->arguments()[this->argId];
 }
 
@@ -181,7 +181,7 @@ string ArgPresent::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs
     return fmt::format("ArgPresent {{ argument = {} }}", this->argument(gs).argumentName(gs));
 }
 
-const core::ArgInfo &ArgPresent::argument(const core::GlobalState &gs) const {
+const core::ParamInfo &ArgPresent::argument(const core::GlobalState &gs) const {
     return this->method.data(gs)->arguments()[this->argId];
 }
 

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -170,7 +170,7 @@ string LoadArg::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) c
 }
 
 const core::ParamInfo &LoadArg::argument(const core::GlobalState &gs) const {
-    return this->method.data(gs)->arguments()[this->argId];
+    return this->method.data(gs)->params()[this->argId];
 }
 
 string ArgPresent::toString(const core::GlobalState &gs, const CFG &cfg) const {
@@ -182,7 +182,7 @@ string ArgPresent::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs
 }
 
 const core::ParamInfo &ArgPresent::argument(const core::GlobalState &gs) const {
-    return this->method.data(gs)->arguments()[this->argId];
+    return this->method.data(gs)->params()[this->argId];
 }
 
 string LoadYieldParams::toString(const core::GlobalState &gs, const CFG &cfg) const {

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -162,7 +162,7 @@ public:
         categoryCounterInc("cfg", "loadarg");
     };
 
-    const core::ArgInfo &argument(const core::GlobalState &gs) const;
+    const core::ParamInfo &argument(const core::GlobalState &gs) const;
     virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
@@ -177,7 +177,7 @@ public:
         categoryCounterInc("cfg", "argpresent");
     }
 
-    const core::ArgInfo &argument(const core::GlobalState &gs) const;
+    const core::ParamInfo &argument(const core::GlobalState &gs) const;
     virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };

--- a/cfg/builder/builder.h
+++ b/cfg/builder/builder.h
@@ -28,7 +28,7 @@ private:
     static void synthesizeExpr(BasicBlock *bb, LocalRef var, core::LocOffsets loc, std::unique_ptr<Instruction> inst);
     static BasicBlock *walkHash(CFGContext cctx, ast::Hash &h, BasicBlock *current, core::NameRef method);
     static std::tuple<LocalRef, BasicBlock *, BasicBlock *>
-    walkDefault(CFGContext cctx, int argIndex, const core::ArgInfo &argInfo, LocalRef argLocal, core::LocOffsets argLoc,
+    walkDefault(CFGContext cctx, int argIndex, const core::ParamInfo &argInfo, LocalRef argLocal, core::LocOffsets argLoc,
                 ast::TreePtr &def, BasicBlock *presentCont, BasicBlock *defaultCont);
     static BasicBlock *joinBlocks(CFGContext cctx, BasicBlock *a, BasicBlock *b);
 };

--- a/cfg/builder/builder.h
+++ b/cfg/builder/builder.h
@@ -28,8 +28,8 @@ private:
     static void synthesizeExpr(BasicBlock *bb, LocalRef var, core::LocOffsets loc, std::unique_ptr<Instruction> inst);
     static BasicBlock *walkHash(CFGContext cctx, ast::Hash &h, BasicBlock *current, core::NameRef method);
     static std::tuple<LocalRef, BasicBlock *, BasicBlock *>
-    walkDefault(CFGContext cctx, int argIndex, const core::ParamInfo &argInfo, LocalRef argLocal, core::LocOffsets argLoc,
-                ast::TreePtr &def, BasicBlock *presentCont, BasicBlock *defaultCont);
+    walkDefault(CFGContext cctx, int argIndex, const core::ParamInfo &argInfo, LocalRef argLocal,
+                core::LocOffsets argLoc, ast::TreePtr &def, BasicBlock *presentCont, BasicBlock *defaultCont);
     static BasicBlock *joinBlocks(CFGContext cctx, BasicBlock *a, BasicBlock *b);
 };
 

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -39,7 +39,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
         BasicBlock *presentCont = entry;
         BasicBlock *defaultCont = nullptr;
 
-        auto &argInfos = md.symbol.data(ctx)->arguments();
+        auto &argInfos = md.symbol.data(ctx)->params();
         bool isAbstract = md.symbol.data(ctx)->isAbstract();
         bool seenKeyword = false;
         int i = -1;

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -39,7 +39,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
         BasicBlock *presentCont = entry;
         BasicBlock *defaultCont = nullptr;
 
-        auto &argInfos = md.symbol.data(ctx)->params();
+        auto &paramInfos = md.symbol.data(ctx)->params();
         bool isAbstract = md.symbol.data(ctx)->isAbstract();
         bool seenKeyword = false;
         int i = -1;
@@ -47,7 +47,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
             i++;
             auto *a = ast::MK::arg2Local(argExpr);
             auto local = res->enterLocal(a->localVariable);
-            auto &argInfo = argInfos[i];
+            auto &argInfo = paramInfos[i];
 
             seenKeyword = seenKeyword || argInfo.flags.isKeyword;
 

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -146,7 +146,7 @@ BasicBlock *CFGBuilder::joinBlocks(CFGContext cctx, BasicBlock *a, BasicBlock *b
 }
 
 tuple<LocalRef, BasicBlock *, BasicBlock *> CFGBuilder::walkDefault(CFGContext cctx, int argIndex,
-                                                                    const core::ArgInfo &argInfo, LocalRef argLocal,
+                                                                    const core::ParamInfo &argInfo, LocalRef argLocal,
                                                                     core::LocOffsets argLoc, ast::TreePtr &def,
                                                                     BasicBlock *presentCont, BasicBlock *defaultCont) {
     auto defLoc = def.loc();
@@ -420,7 +420,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::TreePtr &what, BasicBlock *cu
                     auto newRubyBlockId = ++cctx.inWhat.maxRubyBlockId;
                     vector<ast::ParsedArg> blockArgs =
                         ast::ArgParsing::parseArgs(ast::cast_tree<ast::Block>(s.block)->args);
-                    vector<core::ArgInfo::ArgFlags> argFlags;
+                    vector<core::ParamInfo::ArgFlags> argFlags;
                     for (auto &e : blockArgs) {
                         auto &target = argFlags.emplace_back();
                         target.isKeyword = e.flags.isKeyword;

--- a/class_flatten/class_flatten.cc
+++ b/class_flatten/class_flatten.cc
@@ -96,9 +96,9 @@ public:
             // available to the containing static-init
             replacement = ast::MK::DefineTopClassOrModule(classDef->declLoc, classDef->symbol);
         }
-        ENFORCE(!sym.data(ctx)->arguments().empty(), "<static-init> method should already have a block arg symbol: {}",
+        ENFORCE(!sym.data(ctx)->params().empty(), "<static-init> method should already have a block arg symbol: {}",
                 sym.data(ctx)->show(ctx));
-        ENFORCE(sym.data(ctx)->arguments().back().flags.isBlock,
+        ENFORCE(sym.data(ctx)->params().back().flags.isBlock,
                 "Last argument symbol is not a block arg: {}" + sym.data(ctx)->show(ctx));
 
         // Synthesize a block argument for this <static-init> block. This is rather fiddly,

--- a/class_flatten/class_flatten.cc
+++ b/class_flatten/class_flatten.cc
@@ -96,10 +96,10 @@ public:
             // available to the containing static-init
             replacement = ast::MK::DefineTopClassOrModule(classDef->declLoc, classDef->symbol);
         }
-        ENFORCE(!sym.data(ctx)->params().empty(), "<static-init> method should already have a block arg symbol: {}",
+        ENFORCE(!sym.data(ctx)->params().empty(), "<static-init> method should already have a block ParamInfo: {}",
                 sym.data(ctx)->show(ctx));
         ENFORCE(sym.data(ctx)->params().back().flags.isBlock,
-                "Last argument symbol is not a block arg: {}" + sym.data(ctx)->show(ctx));
+                "Last ParamInfo is not a block param: {}" + sym.data(ctx)->show(ctx));
 
         // Synthesize a block argument for this <static-init> block. This is rather fiddly,
         // because we have to know exactly what invariants desugar and namer set up about

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1083,10 +1083,10 @@ SymbolRef GlobalState::enterNewMethodOverload(Loc sigLoc, SymbolRef original, co
     auto owner = original.data(*this)->owner;
     SymbolRef res = enterMethodSymbol(loc, owner, name);
     ENFORCE(res != original);
-    if (res.data(*this)->arguments().size() != original.data(*this)->arguments().size()) {
-        ENFORCE(res.data(*this)->arguments().empty());
-        res.data(*this)->arguments().reserve(original.data(*this)->arguments().size());
-        const auto &originalArguments = original.data(*this)->arguments();
+    if (res.data(*this)->params().size() != original.data(*this)->params().size()) {
+        ENFORCE(res.data(*this)->params().empty());
+        res.data(*this)->params().reserve(original.data(*this)->params().size());
+        const auto &originalArguments = original.data(*this)->params();
         int i = -1;
         for (auto &arg : originalArguments) {
             i += 1;
@@ -1179,12 +1179,12 @@ ParamInfo &GlobalState::enterMethodArgumentSymbol(Loc loc, SymbolRef owner, Name
     ENFORCE(name.exists(), "entering symbol with non-existing name");
     SymbolData ownerScope = owner.dataAllowingNone(*this);
 
-    for (auto &arg : ownerScope->arguments()) {
+    for (auto &arg : ownerScope->params()) {
         if (arg.name == name) {
             return arg;
         }
     }
-    auto &store = ownerScope->arguments().emplace_back();
+    auto &store = ownerScope->params().emplace_back();
 
     ENFORCE(!symbolTableFrozen);
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1173,7 +1173,7 @@ SymbolRef GlobalState::enterStaticFieldSymbol(Loc loc, SymbolRef owner, NameRef 
     return ret;
 }
 
-ArgInfo &GlobalState::enterMethodArgumentSymbol(Loc loc, SymbolRef owner, NameRef name) {
+ParamInfo &GlobalState::enterMethodArgumentSymbol(Loc loc, SymbolRef owner, NameRef name) {
     ENFORCE(owner.exists(), "entering symbol in to non-existing owner");
     ENFORCE(owner.data(*this)->isMethod(), "entering method argument symbol into not-a-method");
     ENFORCE(name.exists(), "entering symbol with non-existing name");

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1086,21 +1086,21 @@ SymbolRef GlobalState::enterNewMethodOverload(Loc sigLoc, SymbolRef original, co
     if (res.data(*this)->params().size() != original.data(*this)->params().size()) {
         ENFORCE(res.data(*this)->params().empty());
         res.data(*this)->params().reserve(original.data(*this)->params().size());
-        const auto &originalArguments = original.data(*this)->params();
+        const auto &originalParams = original.data(*this)->params();
         int i = -1;
-        for (auto &arg : originalArguments) {
+        for (auto &param : originalParams) {
             i += 1;
-            Loc loc = arg.loc;
+            Loc loc = param.loc;
             if (!absl::c_linear_search(argsToKeep, i)) {
-                if (arg.flags.isBlock) {
+                if (param.flags.isBlock) {
                     loc = Loc::none();
                 } else {
                     continue;
                 }
             }
-            NameRef nm = arg.name;
+            NameRef nm = param.name;
             auto &newArg = enterMethodArgumentSymbol(loc, res, nm);
-            newArg = arg.deepCopy();
+            newArg = param.deepCopy();
             newArg.loc = loc;
         }
     }
@@ -1179,9 +1179,9 @@ ParamInfo &GlobalState::enterMethodArgumentSymbol(Loc loc, SymbolRef owner, Name
     ENFORCE(name.exists(), "entering symbol with non-existing name");
     SymbolData ownerScope = owner.dataAllowingNone(*this);
 
-    for (auto &arg : ownerScope->params()) {
-        if (arg.name == name) {
-            return arg;
+    for (auto &param : ownerScope->params()) {
+        if (param.name == name) {
+            return param;
         }
     }
     auto &store = ownerScope->params().emplace_back();

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -80,7 +80,7 @@ public:
                                      const std::vector<int> &argsToKeep);
     SymbolRef enterFieldSymbol(Loc loc, SymbolRef owner, NameRef name);
     SymbolRef enterStaticFieldSymbol(Loc loc, SymbolRef owner, NameRef name);
-    ArgInfo &enterMethodArgumentSymbol(Loc loc, SymbolRef owner, NameRef name);
+    ParamInfo &enterMethodArgumentSymbol(Loc loc, SymbolRef owner, NameRef name);
 
     SymbolRef lookupSymbol(SymbolRef owner, NameRef name) const {
         return lookupSymbolWithFlags(owner, name, 0);

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -246,7 +246,7 @@ string SymbolRef::show(const GlobalState &gs) const {
     return dataAllowingNone(gs)->show(gs);
 }
 
-TypePtr ArgInfo::argumentTypeAsSeenByImplementation(Context ctx, core::TypeConstraint &constr) const {
+TypePtr ParamInfo::argumentTypeAsSeenByImplementation(Context ctx, core::TypeConstraint &constr) const {
     auto owner = ctx.owner;
     auto klass = owner.data(ctx)->enclosingClass(ctx);
     ENFORCE(klass.data(ctx)->isClassOrModule());
@@ -770,11 +770,11 @@ string Symbol::toStringWithOptions(const GlobalState &gs, int tabs, bool showFul
     return to_string(buf);
 }
 
-string ArgInfo::show(const GlobalState &gs) const {
+string ParamInfo::show(const GlobalState &gs) const {
     return fmt::format("{}", this->argumentName(gs));
 }
 
-string ArgInfo::toString(const GlobalState &gs) const {
+string ParamInfo::toString(const GlobalState &gs) const {
     fmt::memory_buffer buf;
     fmt::format_to(buf, "argument {}", show(gs));
     vector<string_view> flagTexts;
@@ -851,7 +851,7 @@ string Symbol::show(const GlobalState &gs) const {
                        this->name.data(gs)->show(gs));
 }
 
-string ArgInfo::argumentName(const GlobalState &gs) const {
+string ParamInfo::argumentName(const GlobalState &gs) const {
     if (flags.isKeyword) {
         return (string)name.data(gs)->shortName(gs);
     } else {
@@ -1058,13 +1058,13 @@ SymbolRef Symbol::dealiasWithDefault(const GlobalState &gs, int depthLimit, Symb
     return this->ref(gs);
 }
 
-bool ArgInfo::isSyntheticBlockArgument() const {
+bool ParamInfo::isSyntheticBlockArgument() const {
     // Every block argument that we synthesize in desugar or enter manually into global state uses Loc::none().
     return flags.isBlock && !loc.exists();
 }
 
-ArgInfo ArgInfo::deepCopy() const {
-    ArgInfo result;
+ParamInfo ParamInfo::deepCopy() const {
+    ParamInfo result;
     result.flags = this->flags;
     result.type = this->type;
     result.loc = this->loc;
@@ -1073,7 +1073,7 @@ ArgInfo ArgInfo::deepCopy() const {
     return result;
 }
 
-u1 ArgInfo::ArgFlags::toU1() const {
+u1 ParamInfo::ArgFlags::toU1() const {
     u1 flags = 0;
     if (isKeyword) {
         flags += 1;
@@ -1093,7 +1093,7 @@ u1 ArgInfo::ArgFlags::toU1() const {
     return flags;
 }
 
-void ArgInfo::ArgFlags::setFromU1(u1 flags) {
+void ParamInfo::ArgFlags::setFromU1(u1 flags) {
     isKeyword = flags & 1;
     isRepeated = flags & 2;
     isDefault = flags & 4;

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1270,14 +1270,14 @@ u4 Symbol::methodShapeHash(const GlobalState &gs) const {
 vector<u4> Symbol::methodArgumentHash(const GlobalState &gs) const {
     vector<u4> result;
     result.reserve(params().size());
-    for (const auto &e : params()) {
+    for (const auto &p : params()) {
         u4 arg = 0;
         // Changing name of keyword arg is a shape change.
-        if (e.flags.isKeyword) {
-            arg = mix(arg, _hash(e.name.data(gs)->shortName(gs)));
+        if (p.flags.isKeyword) {
+            arg = mix(arg, _hash(p.name.data(gs)->shortName(gs)));
         }
         // Changing an argument from e.g. keyword to position-based is a shape change.
-        result.push_back(mix(arg, e.flags.toU1()));
+        result.push_back(mix(arg, p.flags.toU1()));
     }
     return result;
 }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -697,7 +697,7 @@ string Symbol::toStringWithOptions(const GlobalState &gs, int tabs, bool showFul
                            }));
 
         } else {
-            fmt::format_to(buf, " ({})", fmt::map_join(this->arguments(), ", ", [&](const auto &symb) {
+            fmt::format_to(buf, " ({})", fmt::map_join(this->params(), ", ", [&](const auto &symb) {
                                return symb.argumentName(gs);
                            }));
         }
@@ -759,7 +759,7 @@ string Symbol::toStringWithOptions(const GlobalState &gs, int tabs, bool showFul
         fmt::format_to(buf, "{}", move(str));
     }
     if (isMethod()) {
-        for (auto &arg : arguments()) {
+        for (auto &arg : params()) {
             auto str = arg.toString(gs);
             ENFORCE(!str.empty());
             printTabs(buf, tabs + 1);
@@ -1182,9 +1182,9 @@ void Symbol::sanityCheck(const GlobalState &gs) const {
         if (isa_type<AliasType>(this->resultType)) {
             // If we have an alias method, we should never look at it's arguments;
             // we should instead look at the arguments of whatever we're aliasing.
-            ENFORCE_NO_TIMER(this->arguments().empty(), this->show(gs));
+            ENFORCE_NO_TIMER(this->params().empty(), this->show(gs));
         } else {
-            ENFORCE_NO_TIMER(!this->arguments().empty(), this->show(gs));
+            ENFORCE_NO_TIMER(!this->params().empty(), this->show(gs));
         }
     }
 }
@@ -1269,8 +1269,8 @@ u4 Symbol::methodShapeHash(const GlobalState &gs) const {
 
 vector<u4> Symbol::methodArgumentHash(const GlobalState &gs) const {
     vector<u4> result;
-    result.reserve(arguments().size());
-    for (const auto &e : arguments()) {
+    result.reserve(params().size());
+    for (const auto &e : params()) {
         u4 arg = 0;
         // Changing name of keyword arg is a shape change.
         if (e.flags.isKeyword) {

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -574,8 +574,8 @@ public:
 
     UnorderedMap<NameRef, SymbolRef> members_;
 
-    using ArgumentsStore = InlinedVector<ParamInfo, core::SymbolRef::EXPECTED_METHOD_ARGS_COUNT>;
-    ArgumentsStore arguments_;
+    using ParamsStore = InlinedVector<ParamInfo, core::SymbolRef::EXPECTED_METHOD_ARGS_COUNT>;
+    ParamsStore arguments_;
 
     UnorderedMap<NameRef, SymbolRef> &members() {
         return members_;
@@ -584,12 +584,12 @@ public:
         return members_;
     };
 
-    ArgumentsStore &arguments() {
+    ParamsStore &arguments() {
         ENFORCE_NO_TIMER(isMethod());
         return arguments_;
     }
 
-    const ArgumentsStore &arguments() const {
+    const ParamsStore &arguments() const {
         ENFORCE_NO_TIMER(isMethod());
         return arguments_;
     }

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -584,12 +584,12 @@ public:
         return members_;
     };
 
-    ParamsStore &arguments() {
+    ParamsStore &params() {
         ENFORCE_NO_TIMER(isMethod());
         return arguments_;
     }
 
-    const ParamsStore &arguments() const {
+    const ParamsStore &params() const {
         ENFORCE_NO_TIMER(isMethod());
         return arguments_;
     }

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -574,7 +574,7 @@ public:
 
     UnorderedMap<NameRef, SymbolRef> members_;
 
-    using ArgumentsStore = InlinedVector<ArgInfo, core::SymbolRef::EXPECTED_METHOD_ARGS_COUNT>;
+    using ArgumentsStore = InlinedVector<ParamInfo, core::SymbolRef::EXPECTED_METHOD_ARGS_COUNT>;
     ArgumentsStore arguments_;
 
     UnorderedMap<NameRef, SymbolRef> &members() {

--- a/core/Types.h
+++ b/core/Types.h
@@ -24,7 +24,7 @@ class TypeVar;
 class SendAndBlockLink;
 class TypeAndOrigins;
 
-class ArgInfo {
+class ParamInfo {
 public:
     struct ArgFlags {
         bool isKeyword = false;
@@ -55,13 +55,13 @@ public:
     std::string toString(const GlobalState &gs) const;
     std::string show(const GlobalState &gs) const;
     std::string argumentName(const GlobalState &gs) const;
-    ArgInfo(const ArgInfo &) = delete;
-    ArgInfo() = default;
-    ArgInfo(ArgInfo &&) noexcept = default;
-    ArgInfo &operator=(ArgInfo &&) noexcept = default;
-    ArgInfo deepCopy() const;
+    ParamInfo(const ParamInfo &) = delete;
+    ParamInfo() = default;
+    ParamInfo(ParamInfo &&) noexcept = default;
+    ParamInfo &operator=(ParamInfo &&) noexcept = default;
+    ParamInfo deepCopy() const;
 };
-CheckSize(ArgInfo, 48, 8);
+CheckSize(ParamInfo, 48, 8);
 
 template <class T, class... Args> TypePtr make_type(Args &&... args) {
     return TypePtr(TypePtr::TypeToTag<T>::value, new T(std::forward<Args>(args)...));
@@ -619,12 +619,12 @@ class SendAndBlockLink {
 
 public:
     SendAndBlockLink(SendAndBlockLink &&) = default;
-    std::vector<ArgInfo::ArgFlags> argFlags;
+    std::vector<ParamInfo::ArgFlags> argFlags;
     core::NameRef fun;
     int rubyBlockId;
     std::shared_ptr<DispatchResult> result;
 
-    SendAndBlockLink(NameRef fun, std::vector<ArgInfo::ArgFlags> &&argFlags, int rubyBlockId);
+    SendAndBlockLink(NameRef fun, std::vector<ParamInfo::ArgFlags> &&argFlags, int rubyBlockId);
     std::optional<int> fixedArity() const;
     std::shared_ptr<SendAndBlockLink> duplicate();
 };
@@ -694,7 +694,7 @@ struct DispatchComponent {
     TypePtr sendTp;
     TypePtr blockReturnType;
     TypePtr blockPreType;
-    ArgInfo blockSpec; // used only by LoadSelf to change type of self inside method.
+    ParamInfo blockSpec; // used only by LoadSelf to change type of self inside method.
     std::unique_ptr<TypeConstraint> constr;
 };
 
@@ -709,7 +709,7 @@ struct DispatchResult {
     DispatchResult(TypePtr returnType, TypePtr receiverType, core::SymbolRef method)
         : returnType(returnType),
           main(DispatchComponent{
-              std::move(receiverType), method, {}, std::move(returnType), nullptr, nullptr, ArgInfo{}, nullptr}){};
+              std::move(receiverType), method, {}, std::move(returnType), nullptr, nullptr, ParamInfo{}, nullptr}){};
     DispatchResult(TypePtr returnType, DispatchComponent comp)
         : returnType(std::move(returnType)), main(std::move(comp)){};
     DispatchResult(TypePtr returnType, DispatchComponent comp, std::unique_ptr<DispatchResult> secondary,

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -66,7 +66,7 @@ com::stripe::rubytyper::Name Proto::toProto(const GlobalState &gs, NameRef name)
     return protoName;
 }
 
-com::stripe::rubytyper::Symbol::ArgumentInfo Proto::toProto(const GlobalState &gs, const ArgInfo &arg) {
+com::stripe::rubytyper::Symbol::ArgumentInfo Proto::toProto(const GlobalState &gs, const ParamInfo &arg) {
     com::stripe::rubytyper::Symbol::ArgumentInfo argProto;
     *argProto.mutable_name() = toProto(gs, arg.name);
     argProto.set_iskeyword(arg.flags.isKeyword);

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -104,7 +104,7 @@ com::stripe::rubytyper::Symbol Proto::toProto(const GlobalState &gs, SymbolRef s
                 symbolProto.add_mixins(thing.rawId());
             }
         } else {
-            for (auto &thing : data->arguments()) {
+            for (auto &thing : data->params()) {
                 *symbolProto.add_arguments() = toProto(gs, thing);
             }
         }

--- a/core/proto/proto.h
+++ b/core/proto/proto.h
@@ -19,7 +19,7 @@ public:
 
     static com::stripe::rubytyper::Name toProto(const GlobalState &gs, NameRef name);
 
-    static com::stripe::rubytyper::Symbol::ArgumentInfo toProto(const GlobalState &gs, const ArgInfo &arg);
+    static com::stripe::rubytyper::Symbol::ArgumentInfo toProto(const GlobalState &gs, const ParamInfo &arg);
     static com::stripe::rubytyper::Symbol toProto(const GlobalState &gs, SymbolRef sym, bool showFull);
 
     static com::stripe::rubytyper::Type::Literal toProto(const GlobalState &gs, const LiteralType &lit);

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -547,8 +547,8 @@ void SerializerImpl::pickle(Pickler &p, const Symbol &what) {
     }
     if (what.isMethod()) {
         p.putU4(what.params().size());
-        for (const auto &a : what.params()) {
-            pickle(p, a);
+        for (const auto &param : what.params()) {
+            pickle(p, param);
         }
     }
     p.putU4(what.members().size());

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -546,8 +546,8 @@ void SerializerImpl::pickle(Pickler &p, const Symbol &what) {
         p.putU4(s.rawId());
     }
     if (what.isMethod()) {
-        p.putU4(what.arguments().size());
-        for (const auto &a : what.arguments()) {
+        p.putU4(what.params().size());
+        for (const auto &a : what.params()) {
             pickle(p, a);
         }
     }
@@ -594,7 +594,7 @@ Symbol SerializerImpl::unpickleSymbol(UnPickler &p, const GlobalState *gs) {
     if (result.isMethod()) {
         int argsSize = p.getU4();
         for (int i = 0; i < argsSize; i++) {
-            result.arguments().emplace_back(unpickleArgInfo(p, gs));
+            result.params().emplace_back(unpickleArgInfo(p, gs));
         }
     }
     int membersSize = p.getU4();

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -30,7 +30,7 @@ public:
     static void pickle(Pickler &p, const File &what);
     static void pickle(Pickler &p, const Name &what);
     static void pickle(Pickler &p, const TypePtr &what);
-    static void pickle(Pickler &p, const ArgInfo &a);
+    static void pickle(Pickler &p, const ParamInfo &a);
     static void pickle(Pickler &p, const Symbol &what);
     static void pickle(Pickler &p, const ast::TreePtr &what);
     static void pickle(Pickler &p, core::LocOffsets loc);
@@ -40,7 +40,7 @@ public:
     static shared_ptr<File> unpickleFile(UnPickler &p);
     static Name unpickleName(UnPickler &p, GlobalState &gs);
     static TypePtr unpickleType(UnPickler &p, const GlobalState *gs);
-    static ArgInfo unpickleArgInfo(UnPickler &p, const GlobalState *gs);
+    static ParamInfo unpickleArgInfo(UnPickler &p, const GlobalState *gs);
     static Symbol unpickleSymbol(UnPickler &p, const GlobalState *gs);
     static void unpickleGS(UnPickler &p, GlobalState &result);
     static u4 unpickleGSUUID(UnPickler &p);
@@ -509,7 +509,7 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
     }
 }
 
-void SerializerImpl::pickle(Pickler &p, const ArgInfo &a) {
+void SerializerImpl::pickle(Pickler &p, const ParamInfo &a) {
     p.putU4(a.name._id);
     p.putU4(a.rebind.rawId());
     pickle(p, a.loc);
@@ -517,8 +517,8 @@ void SerializerImpl::pickle(Pickler &p, const ArgInfo &a) {
     pickle(p, a.type);
 }
 
-ArgInfo SerializerImpl::unpickleArgInfo(UnPickler &p, const GlobalState *gs) {
-    ArgInfo result;
+ParamInfo SerializerImpl::unpickleArgInfo(UnPickler &p, const GlobalState *gs) {
+    ParamInfo result;
     result.name = core::NameRef(*gs, p.getU4());
     result.rebind = core::SymbolRef::fromRaw(p.getU4());
     result.loc = unpickleLoc(p);

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -616,7 +616,7 @@ TypePtr AndType::make_shared(const TypePtr &left, const TypePtr &right) {
     return res;
 }
 
-SendAndBlockLink::SendAndBlockLink(NameRef fun, vector<ArgInfo::ArgFlags> &&argFlags, int rubyBlockId)
+SendAndBlockLink::SendAndBlockLink(NameRef fun, vector<ParamInfo::ArgFlags> &&argFlags, int rubyBlockId)
     : argFlags(move(argFlags)), fun(fun), rubyBlockId(rubyBlockId) {}
 
 shared_ptr<SendAndBlockLink> SendAndBlockLink::duplicate() {

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -23,19 +23,19 @@ struct Signature {
 
 Signature decomposeSignature(const core::GlobalState &gs, core::SymbolRef method) {
     Signature sig;
-    for (auto &arg : method.data(gs)->params()) {
-        if (arg.flags.isBlock) {
-            sig.syntheticBlk = arg.isSyntheticBlockArgument();
+    for (auto &param : method.data(gs)->params()) {
+        if (param.flags.isBlock) {
+            sig.syntheticBlk = param.isSyntheticBlockArgument();
             continue;
         }
 
-        auto &dst = arg.flags.isKeyword ? sig.kw : sig.pos;
-        if (arg.flags.isRepeated) {
-            dst.rest = std::optional<reference_wrapper<const core::ParamInfo>>{arg};
-        } else if (arg.flags.isDefault) {
-            dst.optional.push_back(arg);
+        auto &dst = param.flags.isKeyword ? sig.kw : sig.pos;
+        if (param.flags.isRepeated) {
+            dst.rest = std::optional<reference_wrapper<const core::ParamInfo>>{param};
+        } else if (param.flags.isDefault) {
+            dst.optional.push_back(param);
         } else {
-            dst.required.push_back(arg);
+            dst.required.push_back(param);
         }
     }
     return sig;
@@ -69,7 +69,8 @@ string supermethodKind(const core::Context ctx, core::SymbolRef method) {
 
 // This walks two positional argument lists to ensure that they're compatibly typed (i.e. that every argument in the
 // implementing method is either the same or a supertype of the abstract or overridable definition)
-void matchPositional(const core::Context ctx, absl::InlinedVector<reference_wrapper<const core::ParamInfo>, 4> &superArgs,
+void matchPositional(const core::Context ctx,
+                     absl::InlinedVector<reference_wrapper<const core::ParamInfo>, 4> &superArgs,
                      core::SymbolRef superMethod,
                      absl::InlinedVector<reference_wrapper<const core::ParamInfo>, 4> &methodArgs,
                      core::SymbolRef method) {

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -23,7 +23,7 @@ struct Signature {
 
 Signature decomposeSignature(const core::GlobalState &gs, core::SymbolRef method) {
     Signature sig;
-    for (auto &arg : method.data(gs)->arguments()) {
+    for (auto &arg : method.data(gs)->params()) {
         if (arg.flags.isBlock) {
             sig.syntheticBlk = arg.isSyntheticBlockArgument();
             continue;

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -14,9 +14,9 @@ namespace sorbet::definition_validator {
 
 struct Signature {
     struct {
-        absl::InlinedVector<reference_wrapper<const core::ArgInfo>, 4> required;
-        absl::InlinedVector<reference_wrapper<const core::ArgInfo>, 4> optional;
-        std::optional<reference_wrapper<const core::ArgInfo>> rest;
+        absl::InlinedVector<reference_wrapper<const core::ParamInfo>, 4> required;
+        absl::InlinedVector<reference_wrapper<const core::ParamInfo>, 4> optional;
+        std::optional<reference_wrapper<const core::ParamInfo>> rest;
     } pos, kw;
     bool syntheticBlk;
 } left, right;
@@ -31,7 +31,7 @@ Signature decomposeSignature(const core::GlobalState &gs, core::SymbolRef method
 
         auto &dst = arg.flags.isKeyword ? sig.kw : sig.pos;
         if (arg.flags.isRepeated) {
-            dst.rest = std::optional<reference_wrapper<const core::ArgInfo>>{arg};
+            dst.rest = std::optional<reference_wrapper<const core::ParamInfo>>{arg};
         } else if (arg.flags.isDefault) {
             dst.optional.push_back(arg);
         } else {
@@ -69,9 +69,9 @@ string supermethodKind(const core::Context ctx, core::SymbolRef method) {
 
 // This walks two positional argument lists to ensure that they're compatibly typed (i.e. that every argument in the
 // implementing method is either the same or a supertype of the abstract or overridable definition)
-void matchPositional(const core::Context ctx, absl::InlinedVector<reference_wrapper<const core::ArgInfo>, 4> &superArgs,
+void matchPositional(const core::Context ctx, absl::InlinedVector<reference_wrapper<const core::ParamInfo>, 4> &superArgs,
                      core::SymbolRef superMethod,
-                     absl::InlinedVector<reference_wrapper<const core::ArgInfo>, 4> &methodArgs,
+                     absl::InlinedVector<reference_wrapper<const core::ParamInfo>, 4> &methodArgs,
                      core::SymbolRef method) {
     auto idx = 0;
     auto maxLen = min(superArgs.size(), methodArgs.size());

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -200,7 +200,7 @@ public:
         // context.
         const Polarity negated = negatePolarity(polarity);
 
-        for (auto &arg : methodData->arguments()) {
+        for (auto &arg : methodData->params()) {
             if (arg.type != nullptr) {
                 validatePolarity(arg.loc, ctx, negated, arg.type);
             }

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -200,9 +200,9 @@ public:
         // context.
         const Polarity negated = negatePolarity(polarity);
 
-        for (auto &arg : methodData->params()) {
-            if (arg.type != nullptr) {
-                validatePolarity(arg.loc, ctx, negated, arg.type);
+        for (auto &param : methodData->params()) {
+            if (param.type != nullptr) {
+                validatePolarity(param.loc, ctx, negated, param.type);
             }
         }
 

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -325,7 +325,7 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
         guessedReturnType = methodReturnType;
     }
 
-    auto isBadArg = [&](const core::ArgInfo &arg) -> bool {
+    auto isBadArg = [&](const core::ParamInfo &arg) -> bool {
         return
             // runtime does not support rest args and key-rest args
             arg.flags.isRepeated ||

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -58,7 +58,7 @@ optional<core::AutocorrectSuggestion::Edit> maybeSuggestExtendTSig(core::Context
 
 core::TypePtr extractArgType(core::Context ctx, cfg::Send &send, core::DispatchComponent &component, int argId) {
     ENFORCE(component.method.exists() && component.method != core::Symbols::untyped());
-    const auto &args = component.method.data(ctx)->arguments();
+    const auto &args = component.method.data(ctx)->params();
     if (argId >= args.size()) {
         return nullptr;
     }
@@ -333,7 +333,7 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
             // sometimes variable does not have a name e.g. `def initialize (*)`
             arg.name.data(ctx)->shortName(ctx).empty();
     };
-    bool hasBadArg = absl::c_any_of(methodSymbol.data(ctx)->arguments(), isBadArg);
+    bool hasBadArg = absl::c_any_of(methodSymbol.data(ctx)->params(), isBadArg);
     if (hasBadArg) {
         return nullopt;
     }
@@ -350,7 +350,7 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
             guessedReturnType = closestReturnType;
         }
 
-        for (const auto &arg : closestMethod.data(ctx)->arguments()) {
+        for (const auto &arg : closestMethod.data(ctx)->params()) {
             if (arg.type && !arg.type.isUntyped()) {
                 guessedArgumentTypes[arg.name] = arg.type;
             }
@@ -366,9 +366,9 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
 
     fmt::format_to(ss, "sig {{");
 
-    ENFORCE(!methodSymbol.data(ctx)->arguments().empty(), "There should always be at least one arg (the block arg).");
-    bool onlyArgumentIsBlkArg = methodSymbol.data(ctx)->arguments().size() == 1 &&
-                                methodSymbol.data(ctx)->arguments()[0].isSyntheticBlockArgument();
+    ENFORCE(!methodSymbol.data(ctx)->params().empty(), "There should always be at least one arg (the block arg).");
+    bool onlyArgumentIsBlkArg = methodSymbol.data(ctx)->params().size() == 1 &&
+                                methodSymbol.data(ctx)->params()[0].isSyntheticBlockArgument();
 
     if (methodSymbol.data(ctx)->name != core::Names::initialize()) {
         // Only need override / implementation if the parent has a sig
@@ -383,7 +383,7 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
         fmt::format_to(ss, "params(");
 
         bool first = true;
-        for (auto &argSym : methodSymbol.data(ctx)->arguments()) {
+        for (auto &argSym : methodSymbol.data(ctx)->params()) {
             // WARNING: This is doing raw string equality--don't cargo cult this!
             // You almost certainly want to compare NameRef's for equality instead.
             // We need to compare strings here because we're running with a frozen global state

--- a/main/BUILD
+++ b/main/BUILD
@@ -36,6 +36,7 @@ cc_binary(
     ],
 )
 
+# TODO(jez) Can we build payload in parallel?
 cc_binary(
     name = "sorbet-orig",
     srcs = [

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -16,21 +16,21 @@ ast::TreePtr DefLocSaver::postTransformMethodDef(core::Context ctx, ast::TreePtr
     if (lspQueryMatch) {
         // Query matches against the method definition as a whole.
         auto &symbolData = methodDef.symbol.data(ctx);
-        auto &argTypes = symbolData->params();
+        auto &paramTypes = symbolData->params();
         core::TypeAndOrigins tp;
 
-        // Check if it matches against a specific argument. If it does, send that instead;
+        // Check if it matches against a specific param. If it does, send that instead;
         // it's more specific.
-        const int numArgs = methodDef.args.size();
+        const int numParams = methodDef.args.size();
 
-        ENFORCE(numArgs == argTypes.size());
-        for (int i = 0; i < numArgs; i++) {
+        ENFORCE(numParams == paramTypes.size());
+        for (int i = 0; i < numParams; i++) {
             auto &arg = methodDef.args[i];
-            auto &argType = argTypes[i];
+            auto &paramType = paramTypes[i];
             auto *localExp = ast::MK::arg2Local(arg);
             // localExp should never be null, but guard against the possibility.
             if (localExp && lspQuery.matchesLoc(core::Loc(ctx.file, localExp->loc))) {
-                tp.type = argType.type;
+                tp.type = paramType.type;
                 tp.origins.emplace_back(core::Loc(ctx.file, localExp->loc));
                 core::lsp::QueryResponse::pushQueryResponse(
                     ctx, core::lsp::IdentResponse(core::Loc(ctx.file, localExp->loc), localExp->localVariable, tp,

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -16,7 +16,7 @@ ast::TreePtr DefLocSaver::postTransformMethodDef(core::Context ctx, ast::TreePtr
     if (lspQueryMatch) {
         // Query matches against the method definition as a whole.
         auto &symbolData = methodDef.symbol.data(ctx);
-        auto &argTypes = symbolData->arguments();
+        auto &argTypes = symbolData->params();
         core::TypeAndOrigins tp;
 
         // Check if it matches against a specific argument. If it does, send that instead;

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -100,7 +100,7 @@ string prettySigForMethod(const core::GlobalState &gs, core::SymbolRef method, c
         if (sym->isOverride()) {
             flags.emplace_back("override");
         }
-        for (auto &argSym : method.data(gs)->arguments()) {
+        for (auto &argSym : method.data(gs)->params()) {
             // Don't display synthetic arguments (like blk).
             if (!argSym.isSyntheticBlockArgument()) {
                 typeAndArgNames.emplace_back(
@@ -160,7 +160,7 @@ string prettyDefForMethod(const core::GlobalState &gs, core::SymbolRef method) {
         methodNamePrefix = "self.";
     }
     vector<string> prettyArgs;
-    const auto &arguments = methodData->dealias(gs).data(gs)->arguments();
+    const auto &arguments = methodData->dealias(gs).data(gs)->params();
     ENFORCE(!arguments.empty(), "Should have at least a block arg");
     for (const auto &argSym : arguments) {
         // Don't display synthetic arguments (like blk).

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -247,7 +247,7 @@ string methodSnippet(const core::GlobalState &gs, core::SymbolRef method, const 
     auto nextTabstop = 1;
 
     vector<string> typeAndArgNames;
-    for (auto &argSym : method.data(gs)->arguments()) {
+    for (auto &argSym : method.data(gs)->params()) {
         fmt::memory_buffer argBuf;
         if (argSym.flags.isBlock) {
             // Blocks are handled below
@@ -275,8 +275,8 @@ string methodSnippet(const core::GlobalState &gs, core::SymbolRef method, const 
         fmt::format_to(result, "({})", fmt::join(typeAndArgNames, ", "));
     }
 
-    ENFORCE(!method.data(gs)->arguments().empty());
-    auto &blkArg = method.data(gs)->arguments().back();
+    ENFORCE(!method.data(gs)->params().empty());
+    auto &blkArg = method.data(gs)->params().back();
     ENFORCE(blkArg.flags.isBlock);
 
     auto hasBlockType = blkArg.type != nullptr && !blkArg.type.isUntyped();

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -20,7 +20,7 @@ void addSignatureHelpItem(const core::GlobalState &gs, core::SymbolRef method,
     vector<unique_ptr<ParameterInformation>> parameters;
     // Documentation is set to be a markdown element that highlights which parameter you are currently typing in.
     string methodDocumentation = "(";
-    auto &args = method.data(gs)->arguments();
+    auto &args = method.data(gs)->params();
     int i = 0;
     for (const auto &arg : args) {
         // label field is populated with the name of the variable.

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -786,7 +786,7 @@ class SymbolDefiner {
         bool inShadows = false;
         bool intrinsic = isIntrinsic(methodData);
         bool swapArgs = intrinsic && (methodData->arguments().size() == 1);
-        core::ArgInfo swappedArg;
+        core::ParamInfo swappedArg;
         if (swapArgs) {
             // When we're filling in an intrinsic method, we want to overwrite the block arg that used
             // to exist with the block arg that we got from desugaring the method def in the RBI files.

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -71,7 +71,7 @@ TEST_CASE("namer tests") {
         auto methodSym = objectScope->members().at(gs.enterNameUTF8("hello_world"));
         const auto &symbol = methodSym.data(gs);
         REQUIRE_EQ(core::Symbols::Object(), symbol->owner);
-        REQUIRE_EQ(1, symbol->arguments().size());
+        REQUIRE_EQ(1, symbol->params().size());
     }
 
     SUBCASE("Idempotent") { // NOLINT

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1513,7 +1513,7 @@ class ResolveSignaturesWalk {
 private:
     std::vector<int> nestedBlockCounts;
 
-    ast::Local const *getArgLocal(core::Context ctx, const core::ArgInfo &argSym, const ast::MethodDef &mdef, int pos,
+    ast::Local const *getArgLocal(core::Context ctx, const core::ParamInfo &argSym, const ast::MethodDef &mdef, int pos,
                                   bool isOverloaded) {
         if (!isOverloaded) {
             return ast::MK::arg2Local(mdef.args[pos]);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1521,10 +1521,10 @@ private:
             // we cannot rely on method and symbol arguments being aligned, as method could have more arguments.
             // we roundtrip through original symbol that is stored in mdef.
             auto internalNameToLookFor = argSym.name;
-            auto originalArgIt = absl::c_find_if(mdef.symbol.data(ctx)->arguments(),
+            auto originalArgIt = absl::c_find_if(mdef.symbol.data(ctx)->params(),
                                                  [&](const auto &arg) { return arg.name == internalNameToLookFor; });
-            ENFORCE(originalArgIt != mdef.symbol.data(ctx)->arguments().end());
-            auto realPos = originalArgIt - mdef.symbol.data(ctx)->arguments().begin();
+            ENFORCE(originalArgIt != mdef.symbol.data(ctx)->params().end());
+            auto realPos = originalArgIt - mdef.symbol.data(ctx)->params().begin();
             return ast::MK::arg2Local(mdef.args[realPos]);
         }
     }
@@ -1532,7 +1532,7 @@ private:
     void fillInInfoFromSig(core::MutableContext ctx, core::SymbolRef method, core::LocOffsets exprLoc, ParsedSig sig,
                            bool isOverloaded, const ast::MethodDef &mdef) {
         ENFORCE(isOverloaded || mdef.symbol == method);
-        ENFORCE(isOverloaded || method.data(ctx)->arguments().size() == mdef.args.size());
+        ENFORCE(isOverloaded || method.data(ctx)->params().size() == mdef.args.size());
 
         if (!sig.seen.returns && !sig.seen.void_) {
             if (auto e = ctx.beginError(exprLoc, core::errors::Resolver::InvalidMethodSignature)) {
@@ -1589,7 +1589,7 @@ private:
         auto methodInfo = method.data(ctx);
         methodInfo->resultType = sig.returns;
         int i = -1;
-        for (auto &arg : methodInfo->arguments()) {
+        for (auto &arg : methodInfo->params()) {
             ++i;
             auto local = getArgLocal(ctx, arg, mdef, i, isOverloaded);
             auto treeArgName = local->localVariable._name;
@@ -1876,7 +1876,7 @@ private:
                             local = ast::cast_tree<ast::Local>(arg);
                         }
 
-                        auto &info = mdef.symbol.data(ctx)->arguments()[argIdx];
+                        auto &info = mdef.symbol.data(ctx)->params()[argIdx];
                         if (info.flags.isKeyword) {
                             args.emplace_back(ast::MK::Symbol(local->loc, info.name));
                             args.emplace_back(local->deepCopy());

--- a/test/cli/arity-messages/arity-messages.out
+++ b/test/cli/arity-messages/arity-messages.out
@@ -4,7 +4,7 @@ test/cli/arity-messages/arity-messages.rb:4: Too many positional arguments provi
     test/cli/arity-messages/arity-messages.rb:3: `foo` defined here
      3 |def foo(x: nil); end
         ^^^^^^^^^^^^^^^
-    test/cli/arity-messages/arity-messages.rb:4: `Object#foo` has optional keyword arguments. Did you mean to provide a value for `x`?
+    test/cli/arity-messages/arity-messages.rb:4: `Object#foo` has optional keyword parameters. Did you mean to provide a value for `x`?
      4 |foo 1
         ^^^^^
 
@@ -18,7 +18,7 @@ test/cli/arity-messages/arity-messages.rb:8: Too many positional arguments provi
     test/cli/arity-messages/arity-messages.rb:7: `bar` defined here
      7 |def bar(x: nil, y: nil); end
         ^^^^^^^^^^^^^^^^^^^^^^^
-    test/cli/arity-messages/arity-messages.rb:8: `Object#bar` has optional keyword arguments. Did you mean to provide a value for `y`?
+    test/cli/arity-messages/arity-messages.rb:8: `Object#bar` has optional keyword parameters. Did you mean to provide a value for `y`?
      8 |bar(5, x: 8)
         ^^^^^^^^^^^^
 
@@ -28,7 +28,7 @@ test/cli/arity-messages/arity-messages.rb:9: Too many positional arguments provi
     test/cli/arity-messages/arity-messages.rb:7: `bar` defined here
      7 |def bar(x: nil, y: nil); end
         ^^^^^^^^^^^^^^^^^^^^^^^
-    test/cli/arity-messages/arity-messages.rb:9: `Object#bar` has optional keyword arguments. Did you mean to provide a value for `x`?
+    test/cli/arity-messages/arity-messages.rb:9: `Object#bar` has optional keyword parameters. Did you mean to provide a value for `x`?
      9 |bar(5, 8)
         ^^^^^^^^^
 
@@ -38,7 +38,7 @@ test/cli/arity-messages/arity-messages.rb:12: Too many positional arguments prov
     test/cli/arity-messages/arity-messages.rb:11: `baz` defined here
     11 |def baz(x: nil); end
         ^^^^^^^^^^^^^^^
-    test/cli/arity-messages/arity-messages.rb:12: `Object#baz` has optional keyword arguments. Did you mean to provide a value for `x`?
+    test/cli/arity-messages/arity-messages.rb:12: `Object#baz` has optional keyword parameters. Did you mean to provide a value for `x`?
     12 |baz 7
         ^^^^^
 
@@ -66,7 +66,7 @@ test/cli/arity-messages/arity-messages.rb:21: Too many positional arguments prov
     test/cli/arity-messages/arity-messages.rb:20: `qaadr` defined here
     20 |def qaadr(e: 1); end
         ^^^^^^^^^^^^^^^
-    test/cli/arity-messages/arity-messages.rb:21: `Object#qaadr` has optional keyword arguments. Did you mean to provide a value for `e`?
+    test/cli/arity-messages/arity-messages.rb:21: `Object#qaadr` has optional keyword parameters. Did you mean to provide a value for `e`?
     21 |qaadr({a: 1}, {b: 2}, {c: 3})
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -90,7 +90,7 @@ test/cli/arity-messages/arity-messages.rb:30: Too many positional arguments prov
     test/cli/arity-messages/arity-messages.rb:29: `paperino` defined here
     29 |def paperino(x, y: nil, **kwargs); end
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    test/cli/arity-messages/arity-messages.rb:30: `Object#paperino` has optional keyword arguments. Did you mean to provide a value for `y`?
+    test/cli/arity-messages/arity-messages.rb:30: `Object#paperino` has optional keyword parameters. Did you mean to provide a value for `y`?
     30 |paperino(2, 3, z: 4)
         ^^^^^^^^^^^^^^^^^^^^
 Errors: 12


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When reading `dispatchCallSymbol`, it's really annoying to keep track whether a
variable refers to something at the method call site or the method definition
site.

I want to fix this by being more intentional with our variable names.
We should call the things at the definition site "parameters", because that's
what they are. Arguments are the things at the call site.

This PR starts by renaming `Symbol::arguments` to `Symbol::params`, and fixes
up some variable names.

It doesn't eradicate the problem, but it is a good first start


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.