### PR TITLE
reduce copying in QualifiedName::fromFullName

### DIFF
--- a/main/autogen/data/definitions.cc
+++ b/main/autogen/data/definitions.cc
@@ -10,12 +10,11 @@ namespace sorbet::autogen {
 
 QualifiedName QualifiedName::fromFullName(vector<core::NameRef> name) {
     if (name.size() < 3 || name.front() != core::Names::Constants::PackageRegistry()) {
-        return {name, nullopt};
+        return {move(name), nullopt};
     }
     auto pkgName = std::optional<core::NameRef>{name[1]};
-    name.erase(name.begin());
-    name.erase(name.begin());
-    return {name, pkgName};
+    name.erase(name.begin(), name.begin() + 2);
+    return {move(name), pkgName};
 }
 
 // Find the `Definition` associated with this `DefinitionRef`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
We can do a better job of re-using the passed-in vector in `QualifiedName::fromFullName`.  The compiler is unable to merge the two `erase` calls, so we should help it out.

I tried looking a little farther afield to see if we could avoid the O(N) `erase` call, replacing it with a decrease in the vector length, by storing names reversed in most cases, but I think this runs into too much duplication and complexity.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Epsilon efficiency improvements.

### Test plan

Existing automated tests should be sufficient.