### PR TITLE
Small definition validator cleanup/optimization

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -12,6 +12,7 @@ using namespace std;
 
 namespace sorbet::definition_validator {
 
+namespace {
 struct Signature {
     struct {
         absl::InlinedVector<reference_wrapper<const core::ArgInfo>, 4> required;
@@ -611,6 +612,7 @@ public:
         return tree;
     }
 };
+} // namespace
 
 ast::ParsedFile runOne(core::Context ctx, ast::ParsedFile tree) {
     Timer timeit(ctx.state.tracer(), "validateSymbols");


### PR DESCRIPTION
 Small definition validator cleanup/optimization.

* Don't call `bestNonRBIFile` unless we encounter a sealed class.
* Put most of validator into anonymous namespace.
* Use `cast_type_nonnull` in tree walk.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speedup. I noticed `bestNonRBIFile` shows up in profiles, and discovered we could avoid calling it most of the time.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
