### PR TITLE
Stop trying to detect a keyword args hash while processing positional args

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -695,10 +695,6 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
         if (spec.flags.isKeyword) {
             break;
         }
-        if (ait + 1 == aend && hasKwargs && (spec.flags.isDefault || spec.flags.isRepeated) &&
-            Types::approximate(gs, arg->type, *constr).derivesFrom(gs, Symbols::Hash())) {
-            break;
-        }
 
         auto offset = ait - args.args.begin();
         if (auto e = matchArgType(gs, *constr, core::Loc(args.locs.file, args.locs.call),

--- a/test/testdata/infer/kwargs.rb
+++ b/test/testdata/infer/kwargs.rb
@@ -14,3 +14,17 @@ end
 # Each repeated argument is checked as element type
 A.foo(x: 1, y: 2, z: '') # error: Expected `Integer` but found `String("")` for argument `kwargs`
 A.foo(x: 1, y: 2, z: 3)
+
+
+class B
+  extend T::Sig
+
+  sig {params(y: T::Hash[String,String], z: String).void}
+  def self.foo(y={}, z:)
+  end
+end
+
+# There is some tricky logic in dispatchCallSymbol to handle the case where a final positional hash argument is used for
+# keyword args. For the following case, the hash should be used for the defaulted positional arg, /not/ the implicit
+# keyword args hash.
+B.foo({ "a" => "foo" }) # error: Missing required keyword argument `z`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Before we inlined keyword arguments into the Send node, we would break out of positional argument processing early when a final hash argument was detected. That logic is at odds with the current implementation of keyword args, yielding the bug in #3647. Removing it fixes the issue, as the case it handles is now explicitly encoded in the AST.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixes #3647.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
