### PR TITLE
`Pathname.glob` can take a `Pathname`.

### DIFF
--- a/rbi/stdlib/pathname.rbi
+++ b/rbi/stdlib/pathname.rbi
@@ -244,7 +244,7 @@ class Pathname < Object
   # [`Dir.glob`](https://docs.ruby-lang.org/en/2.6.0/Dir.html#method-c-glob).
   sig do
     params(
-        p1: String,
+        p1: T.any(String, Pathname),
         p2: String,
     )
     .returns(T::Array[Pathname])


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

```ruby
require "pathname"
Pathname.glob(Pathname.new("*.md"))
```

does not type-check currently, but runs as expected.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

N/A
