### PR TITLE
Argument for `Pathname#children` is optional.

### DIFF
--- a/rbi/stdlib/pathname.rbi
+++ b/rbi/stdlib/pathname.rbi
@@ -477,7 +477,7 @@ class Pathname < Object
     )
     .returns(T::Array[Pathname])
   end
-  def children(with_directory); end
+  def children(with_directory=T.unsafe(nil)); end
 
   # Changes file permissions.
   #


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

```ruby
require "pathname"
Pathname.pwd.children
```

does not type-check currently, but runs as expected.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

N/A
