### PR TITLE
Show all method flags in symbol-table output

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -673,10 +673,32 @@ string Symbol::toStringWithOptions(const GlobalState &gs, int tabs, bool showFul
 
     if (this->isClassOrModule() || this->isMethod()) {
         if (this->isMethod()) {
+            auto methodFlags = InlinedVector<string, 3>{};
+
             if (this->isMethodPrivate()) {
-                fmt::format_to(buf, " : private");
+                methodFlags.emplace_back("private");
             } else if (this->isMethodProtected()) {
-                fmt::format_to(buf, " : protected");
+                methodFlags.emplace_back("protected");
+            }
+
+            if (this->isAbstract()) {
+                methodFlags.emplace_back("abstract");
+            }
+            if (this->isOverridable()) {
+                methodFlags.emplace_back("overridable");
+            }
+            if (this->isOverride()) {
+                methodFlags.emplace_back("override");
+            }
+            if (this->isIncompatibleOverride()) {
+                methodFlags.emplace_back("allow_incompatible");
+            }
+            if (this->isFinalMethod()) {
+                methodFlags.emplace_back("final");
+            }
+
+            if (!methodFlags.empty()) {
+                fmt::format_to(buf, " : {}", fmt::map_join(methodFlags, "|", [](const auto &flag) { return flag; }));
             }
         }
 

--- a/test/testdata/resolver/allow_incompatible.rb
+++ b/test/testdata/resolver/allow_incompatible.rb
@@ -1,0 +1,21 @@
+# typed: true
+
+class AbstractClass
+  extend T::Sig
+  extend T::Helpers
+  abstract!
+
+  sig {abstract.returns(Object)}
+  def self.foo; end
+
+  sig {abstract.returns(Object)}
+  def bar; end
+end
+
+class ImplEnabling < AbstractClass
+  sig {override(allow_incompatible: false).params(x: Integer).returns(Object)}
+  def self.foo(x); end # error: `AbstractClass.foo` must accept no more than `0` required argument(s)
+
+  sig {override(allow_incompatible: true).params(x: Integer).returns(Object)}
+  def bar(x); end
+end

--- a/test/testdata/resolver/allow_incompatible.rb.symbol-table.exp
+++ b/test/testdata/resolver/allow_incompatible.rb.symbol-table.exp
@@ -1,0 +1,25 @@
+class ::<root> < ::Object ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible.rb start=??? end=???}
+  class ::AbstractClass < ::Object () @ test/testdata/resolver/allow_incompatible.rb:3
+    method ::AbstractClass#bar (<blk>) -> Object @ test/testdata/resolver/allow_incompatible.rb:12
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible.rb start=??? end=???}
+  class ::<Class:AbstractClass>[<AttachedClass>] < ::<Class:Object> (Helpers, Sig) @ test/testdata/resolver/allow_incompatible.rb:3
+    type-member(+) ::<Class:AbstractClass>::<AttachedClass> -> T.attached_class (of AbstractClass) @ test/testdata/resolver/allow_incompatible.rb:3
+    method ::<Class:AbstractClass>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible.rb start=??? end=???}
+    method ::<Class:AbstractClass>#foo (<blk>) -> Object @ test/testdata/resolver/allow_incompatible.rb:9
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible.rb start=??? end=???}
+  class ::ImplEnabling < ::AbstractClass () @ test/testdata/resolver/allow_incompatible.rb:15
+    method ::ImplEnabling#bar (x, <blk>) -> Object @ test/testdata/resolver/allow_incompatible.rb:20
+      argument x<> -> Integer @ Loc {file=test/testdata/resolver/allow_incompatible.rb start=19:50 end=19:51}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible.rb start=??? end=???}
+  class ::<Class:ImplEnabling>[<AttachedClass>] < ::<Class:AbstractClass> () @ test/testdata/resolver/allow_incompatible.rb:15
+    type-member(+) ::<Class:ImplEnabling>::<AttachedClass> -> T.attached_class (of ImplEnabling) @ test/testdata/resolver/allow_incompatible.rb:15
+    method ::<Class:ImplEnabling>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible.rb:15
+      argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible.rb start=??? end=???}
+    method ::<Class:ImplEnabling>#foo (x, <blk>) -> Object @ test/testdata/resolver/allow_incompatible.rb:17
+      argument x<> -> Integer @ Loc {file=test/testdata/resolver/allow_incompatible.rb start=16:51 end=16:52}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible.rb start=??? end=???}
+

--- a/test/testdata/resolver/allow_incompatible.rb.symbol-table.exp
+++ b/test/testdata/resolver/allow_incompatible.rb.symbol-table.exp
@@ -3,23 +3,23 @@ class ::<root> < ::Object ()
     method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible.rb:3
       argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible.rb start=??? end=???}
   class ::AbstractClass < ::Object () @ test/testdata/resolver/allow_incompatible.rb:3
-    method ::AbstractClass#bar (<blk>) -> Object @ test/testdata/resolver/allow_incompatible.rb:12
+    method ::AbstractClass#bar : abstract (<blk>) -> Object @ test/testdata/resolver/allow_incompatible.rb:12
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible.rb start=??? end=???}
   class ::<Class:AbstractClass>[<AttachedClass>] < ::<Class:Object> (Helpers, Sig) @ test/testdata/resolver/allow_incompatible.rb:3
     type-member(+) ::<Class:AbstractClass>::<AttachedClass> -> T.attached_class (of AbstractClass) @ test/testdata/resolver/allow_incompatible.rb:3
     method ::<Class:AbstractClass>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible.rb:3
       argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible.rb start=??? end=???}
-    method ::<Class:AbstractClass>#foo (<blk>) -> Object @ test/testdata/resolver/allow_incompatible.rb:9
+    method ::<Class:AbstractClass>#foo : abstract (<blk>) -> Object @ test/testdata/resolver/allow_incompatible.rb:9
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible.rb start=??? end=???}
   class ::ImplEnabling < ::AbstractClass () @ test/testdata/resolver/allow_incompatible.rb:15
-    method ::ImplEnabling#bar (x, <blk>) -> Object @ test/testdata/resolver/allow_incompatible.rb:20
+    method ::ImplEnabling#bar : override|allow_incompatible (x, <blk>) -> Object @ test/testdata/resolver/allow_incompatible.rb:20
       argument x<> -> Integer @ Loc {file=test/testdata/resolver/allow_incompatible.rb start=19:50 end=19:51}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible.rb start=??? end=???}
   class ::<Class:ImplEnabling>[<AttachedClass>] < ::<Class:AbstractClass> () @ test/testdata/resolver/allow_incompatible.rb:15
     type-member(+) ::<Class:ImplEnabling>::<AttachedClass> -> T.attached_class (of ImplEnabling) @ test/testdata/resolver/allow_incompatible.rb:15
     method ::<Class:ImplEnabling>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible.rb:15
       argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible.rb start=??? end=???}
-    method ::<Class:ImplEnabling>#foo (x, <blk>) -> Object @ test/testdata/resolver/allow_incompatible.rb:17
+    method ::<Class:ImplEnabling>#foo : override (x, <blk>) -> Object @ test/testdata/resolver/allow_incompatible.rb:17
       argument x<> -> Integer @ Loc {file=test/testdata/resolver/allow_incompatible.rb start=16:51 end=16:52}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible.rb start=??? end=???}
 

--- a/test/testdata/resolver/final_method.rb.symbol-table.exp
+++ b/test/testdata/resolver/final_method.rb.symbol-table.exp
@@ -1,0 +1,102 @@
+class ::<root> < ::Object ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  class ::C < ::Object () @ test/testdata/resolver/final_method.rb:33
+    method ::C#foo (<blk>) -> Sorbet::Private::Static::Void @ test/testdata/resolver/final_method.rb:36
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  class ::<Class:C>[<AttachedClass>] < ::<Class:Object> (Sig) @ test/testdata/resolver/final_method.rb:33
+    type-member(+) ::<Class:C>::<AttachedClass> -> T.attached_class (of C) @ test/testdata/resolver/final_method.rb:33
+    method ::<Class:C>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:33
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+    method ::<Class:C>#bar (<blk>) -> Sorbet::Private::Static::Void @ test/testdata/resolver/final_method.rb:38
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  module ::ExtendAgain < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/resolver/final_method.rb:91
+  class ::<Class:ExtendAgain>[<AttachedClass>] < ::Module (M1) @ test/testdata/resolver/final_method.rb:91
+    type-member(+) ::<Class:ExtendAgain>::<AttachedClass> -> T.attached_class (of ExtendAgain) @ test/testdata/resolver/final_method.rb:91
+    method ::<Class:ExtendAgain>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:91
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  module ::IncludeAgain < ::Sorbet::Private::Static::ImplicitModuleSuperclass (M1) @ test/testdata/resolver/final_method.rb:86
+  class ::<Class:IncludeAgain>[<AttachedClass>] < ::Module () @ test/testdata/resolver/final_method.rb:86
+    type-member(+) ::<Class:IncludeAgain>::<AttachedClass> -> T.attached_class (of IncludeAgain) @ test/testdata/resolver/final_method.rb:86
+    method ::<Class:IncludeAgain>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:86
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  module ::M1 < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/resolver/final_method.rb:46
+    method ::M1#foo (<blk>) -> Sorbet::Private::Static::Void @ test/testdata/resolver/final_method.rb:49
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  class ::<Class:M1>[<AttachedClass>] < ::Module (Sig) @ test/testdata/resolver/final_method.rb:46
+    type-member(+) ::<Class:M1>::<AttachedClass> -> T.attached_class (of M1) @ test/testdata/resolver/final_method.rb:46
+    method ::<Class:M1>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:46
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  module ::M2 < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/resolver/final_method.rb:52
+    method ::M2#foo (<blk>) -> Sorbet::Private::Static::Void @ test/testdata/resolver/final_method.rb:55
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  class ::<Class:M2>[<AttachedClass>] < ::Module (Sig) @ test/testdata/resolver/final_method.rb:52
+    type-member(+) ::<Class:M2>::<AttachedClass> -> T.attached_class (of M2) @ test/testdata/resolver/final_method.rb:52
+    method ::<Class:M2>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:52
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  class ::OverrideDoubleExtend < ::Object () @ test/testdata/resolver/final_method.rb:73
+  class ::<Class:OverrideDoubleExtend>[<AttachedClass>] < ::<Class:Object> (M2, M1) @ test/testdata/resolver/final_method.rb:73
+    type-member(+) ::<Class:OverrideDoubleExtend>::<AttachedClass> -> T.attached_class (of OverrideDoubleExtend) @ test/testdata/resolver/final_method.rb:73
+    method ::<Class:OverrideDoubleExtend>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:73
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  class ::OverrideDoubleInclude < ::Object (M2, M1) @ test/testdata/resolver/final_method.rb:68
+  class ::<Class:OverrideDoubleInclude>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/resolver/final_method.rb:68
+    type-member(+) ::<Class:OverrideDoubleInclude>::<AttachedClass> -> T.attached_class (of OverrideDoubleInclude) @ test/testdata/resolver/final_method.rb:68
+    method ::<Class:OverrideDoubleInclude>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:68
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  class ::OverrideExtend < ::Object () @ test/testdata/resolver/final_method.rb:63
+  class ::<Class:OverrideExtend>[<AttachedClass>] < ::<Class:Object> (M1) @ test/testdata/resolver/final_method.rb:63
+    type-member(+) ::<Class:OverrideExtend>::<AttachedClass> -> T.attached_class (of OverrideExtend) @ test/testdata/resolver/final_method.rb:63
+    method ::<Class:OverrideExtend>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:63
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+    method ::<Class:OverrideExtend>#foo (<blk>) @ test/testdata/resolver/final_method.rb:65
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  class ::OverrideInclude < ::Object (M1) @ test/testdata/resolver/final_method.rb:58
+    method ::OverrideInclude#foo (<blk>) @ test/testdata/resolver/final_method.rb:60
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  class ::<Class:OverrideInclude>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/resolver/final_method.rb:58
+    type-member(+) ::<Class:OverrideInclude>::<AttachedClass> -> T.attached_class (of OverrideInclude) @ test/testdata/resolver/final_method.rb:58
+    method ::<Class:OverrideInclude>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:58
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  class ::OverrideInherit < ::C () @ test/testdata/resolver/final_method.rb:41
+    method ::OverrideInherit#foo (<blk>) @ test/testdata/resolver/final_method.rb:42
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  class ::<Class:OverrideInherit>[<AttachedClass>] < ::<Class:C> () @ test/testdata/resolver/final_method.rb:41
+    type-member(+) ::<Class:OverrideInherit>::<AttachedClass> -> T.attached_class (of OverrideInherit) @ test/testdata/resolver/final_method.rb:41
+    method ::<Class:OverrideInherit>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:41
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+    method ::<Class:OverrideInherit>#bar (<blk>) @ test/testdata/resolver/final_method.rb:43
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  module ::OverrideManySteps < ::Sorbet::Private::Static::ImplicitModuleSuperclass (Step3, Step2, Step1, M1) @ test/testdata/resolver/final_method.rb:81
+    method ::OverrideManySteps#foo (<blk>) @ test/testdata/resolver/final_method.rb:83
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  class ::<Class:OverrideManySteps>[<AttachedClass>] < ::Module () @ test/testdata/resolver/final_method.rb:81
+    type-member(+) ::<Class:OverrideManySteps>::<AttachedClass> -> T.attached_class (of OverrideManySteps) @ test/testdata/resolver/final_method.rb:81
+    method ::<Class:OverrideManySteps>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:81
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  class ::Redefine < ::Object () @ test/testdata/resolver/final_method.rb:3
+    method ::Redefine#foo (<blk>) -> Sorbet::Private::Static::Void @ test/testdata/resolver/final_method.rb:28
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  class ::<Class:Redefine>[<AttachedClass>] < ::<Class:Object> (Sig) @ test/testdata/resolver/final_method.rb:3
+    type-member(+) ::<Class:Redefine>::<AttachedClass> -> T.attached_class (of Redefine) @ test/testdata/resolver/final_method.rb:3
+    method ::<Class:Redefine>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+    method ::<Class:Redefine>#bar (<blk>) -> Sorbet::Private::Static::Void @ test/testdata/resolver/final_method.rb:30
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  module ::Step1 < ::Sorbet::Private::Static::ImplicitModuleSuperclass (M1) @ test/testdata/resolver/final_method.rb:78
+  class ::<Class:Step1>[<AttachedClass>] < ::Module () @ test/testdata/resolver/final_method.rb:78
+    type-member(+) ::<Class:Step1>::<AttachedClass> -> T.attached_class (of Step1) @ test/testdata/resolver/final_method.rb:78
+    method ::<Class:Step1>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:78
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  module ::Step2 < ::Sorbet::Private::Static::ImplicitModuleSuperclass (Step1, M1) @ test/testdata/resolver/final_method.rb:79
+  class ::<Class:Step2>[<AttachedClass>] < ::Module () @ test/testdata/resolver/final_method.rb:79
+    type-member(+) ::<Class:Step2>::<AttachedClass> -> T.attached_class (of Step2) @ test/testdata/resolver/final_method.rb:79
+    method ::<Class:Step2>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:79
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+  module ::Step3 < ::Sorbet::Private::Static::ImplicitModuleSuperclass (Step2, Step1, M1) @ test/testdata/resolver/final_method.rb:80
+  class ::<Class:Step3>[<AttachedClass>] < ::Module () @ test/testdata/resolver/final_method.rb:80
+    type-member(+) ::<Class:Step3>::<AttachedClass> -> T.attached_class (of Step3) @ test/testdata/resolver/final_method.rb:80
+    method ::<Class:Step3>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:80
+      argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
+

--- a/test/testdata/resolver/final_method.rb.symbol-table.exp
+++ b/test/testdata/resolver/final_method.rb.symbol-table.exp
@@ -3,13 +3,13 @@ class ::<root> < ::Object ()
     method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:3
       argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
   class ::C < ::Object () @ test/testdata/resolver/final_method.rb:33
-    method ::C#foo (<blk>) -> Sorbet::Private::Static::Void @ test/testdata/resolver/final_method.rb:36
+    method ::C#foo : final (<blk>) -> Sorbet::Private::Static::Void @ test/testdata/resolver/final_method.rb:36
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
   class ::<Class:C>[<AttachedClass>] < ::<Class:Object> (Sig) @ test/testdata/resolver/final_method.rb:33
     type-member(+) ::<Class:C>::<AttachedClass> -> T.attached_class (of C) @ test/testdata/resolver/final_method.rb:33
     method ::<Class:C>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:33
       argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
-    method ::<Class:C>#bar (<blk>) -> Sorbet::Private::Static::Void @ test/testdata/resolver/final_method.rb:38
+    method ::<Class:C>#bar : final (<blk>) -> Sorbet::Private::Static::Void @ test/testdata/resolver/final_method.rb:38
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
   module ::ExtendAgain < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/resolver/final_method.rb:91
   class ::<Class:ExtendAgain>[<AttachedClass>] < ::Module (M1) @ test/testdata/resolver/final_method.rb:91
@@ -22,14 +22,14 @@ class ::<root> < ::Object ()
     method ::<Class:IncludeAgain>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:86
       argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
   module ::M1 < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/resolver/final_method.rb:46
-    method ::M1#foo (<blk>) -> Sorbet::Private::Static::Void @ test/testdata/resolver/final_method.rb:49
+    method ::M1#foo : final (<blk>) -> Sorbet::Private::Static::Void @ test/testdata/resolver/final_method.rb:49
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
   class ::<Class:M1>[<AttachedClass>] < ::Module (Sig) @ test/testdata/resolver/final_method.rb:46
     type-member(+) ::<Class:M1>::<AttachedClass> -> T.attached_class (of M1) @ test/testdata/resolver/final_method.rb:46
     method ::<Class:M1>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:46
       argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
   module ::M2 < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/resolver/final_method.rb:52
-    method ::M2#foo (<blk>) -> Sorbet::Private::Static::Void @ test/testdata/resolver/final_method.rb:55
+    method ::M2#foo : final (<blk>) -> Sorbet::Private::Static::Void @ test/testdata/resolver/final_method.rb:55
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
   class ::<Class:M2>[<AttachedClass>] < ::Module (Sig) @ test/testdata/resolver/final_method.rb:52
     type-member(+) ::<Class:M2>::<AttachedClass> -> T.attached_class (of M2) @ test/testdata/resolver/final_method.rb:52
@@ -76,13 +76,13 @@ class ::<root> < ::Object ()
     method ::<Class:OverrideManySteps>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:81
       argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
   class ::Redefine < ::Object () @ test/testdata/resolver/final_method.rb:3
-    method ::Redefine#foo (<blk>) -> Sorbet::Private::Static::Void @ test/testdata/resolver/final_method.rb:28
+    method ::Redefine#foo : final (<blk>) -> Sorbet::Private::Static::Void @ test/testdata/resolver/final_method.rb:28
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
   class ::<Class:Redefine>[<AttachedClass>] < ::<Class:Object> (Sig) @ test/testdata/resolver/final_method.rb:3
     type-member(+) ::<Class:Redefine>::<AttachedClass> -> T.attached_class (of Redefine) @ test/testdata/resolver/final_method.rb:3
     method ::<Class:Redefine>#<static-init> (<blk>) @ test/testdata/resolver/final_method.rb:3
       argument <blk><block> @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
-    method ::<Class:Redefine>#bar (<blk>) -> Sorbet::Private::Static::Void @ test/testdata/resolver/final_method.rb:30
+    method ::<Class:Redefine>#bar : final (<blk>) -> Sorbet::Private::Static::Void @ test/testdata/resolver/final_method.rb:30
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/final_method.rb start=??? end=???}
   module ::Step1 < ::Sorbet::Private::Static::ImplicitModuleSuperclass (M1) @ test/testdata/resolver/final_method.rb:78
   class ::<Class:Step1>[<AttachedClass>] < ::Module () @ test/testdata/resolver/final_method.rb:78

--- a/test/testdata/resolver/sig_misc.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/sig_misc.rb.symbol-table-raw.exp
@@ -27,11 +27,11 @@ class <C <U <root>>> < <C <U Object>> ()
     method <C <U A>><U public> (x, <blk>) -> T1 @ Loc {file=test/testdata/resolver/sig_misc.rb start=54:10 end=54:23}
       argument x<> -> T1 @ Loc {file=test/testdata/resolver/sig_misc.rb start=53:15 end=53:16}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/sig_misc.rb start=??? end=???}
-    method <C <U A>><U test_abstract> (<blk>) -> T1 @ Loc {file=test/testdata/resolver/sig_misc.rb start=77:3 end=77:20}
+    method <C <U A>><U test_abstract> : abstract (<blk>) -> T1 @ Loc {file=test/testdata/resolver/sig_misc.rb start=77:3 end=77:20}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/sig_misc.rb start=??? end=???}
-    method <C <U A>><U test_abstract_untyped> (<blk>) @ Loc {file=test/testdata/resolver/sig_misc.rb start=102:3 end=102:28}
+    method <C <U A>><U test_abstract_untyped> : abstract (<blk>) @ Loc {file=test/testdata/resolver/sig_misc.rb start=102:3 end=102:28}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/sig_misc.rb start=??? end=???}
-    method <C <U A>><U test_implementation> (x, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/resolver/sig_misc.rb start=82:3 end=82:29}
+    method <C <U A>><U test_implementation> : override (x, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/resolver/sig_misc.rb start=82:3 end=82:29}
       argument x<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_misc.rb start=82:27 end=82:28}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/sig_misc.rb start=??? end=???}
     method <C <U A>><U test_junk_again> (<blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/resolver/sig_misc.rb start=110:17 end=110:36}
@@ -41,11 +41,11 @@ class <C <U <root>>> < <C <U Object>> ()
     method <C <U A>><U test_kwargs> (returns, <blk>) -> T2 @ Loc {file=test/testdata/resolver/sig_misc.rb start=22:3 end=22:27}
       argument returns<> -> T1 @ Loc {file=test/testdata/resolver/sig_misc.rb start=19:12 end=19:19}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/sig_misc.rb start=??? end=???}
-    method <C <U A>><U test_overridable> (<blk>) -> T1 @ Loc {file=test/testdata/resolver/sig_misc.rb start=92:3 end=92:23}
+    method <C <U A>><U test_overridable> : overridable (<blk>) -> T1 @ Loc {file=test/testdata/resolver/sig_misc.rb start=92:3 end=92:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/sig_misc.rb start=??? end=???}
-    method <C <U A>><U test_overridable_implementation> (<blk>) -> T1 @ Loc {file=test/testdata/resolver/sig_misc.rb start=97:3 end=97:38}
+    method <C <U A>><U test_overridable_implementation> : overridable|override (<blk>) -> T1 @ Loc {file=test/testdata/resolver/sig_misc.rb start=97:3 end=97:38}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/sig_misc.rb start=??? end=???}
-    method <C <U A>><U test_override> (<blk>) -> T1 @ Loc {file=test/testdata/resolver/sig_misc.rb start=87:3 end=87:20}
+    method <C <U A>><U test_override> : override (<blk>) -> T1 @ Loc {file=test/testdata/resolver/sig_misc.rb start=87:3 end=87:20}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/sig_misc.rb start=??? end=???}
     method <C <U A>><U test_standard_untyped> (<blk>) @ Loc {file=test/testdata/resolver/sig_misc.rb start=105:11 end=105:36}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/sig_misc.rb start=??? end=???}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I chose a representation that wouldn't cause a ton of churn. Namely: if
you're a method symbol and you're public, we don't print that you're public
(this is what was already done). Also I chose to use the `|` separator
between flags because it reminds me of bitflags, which these flags actually
are under the hood.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I added some extra snapshot tests to showcase this a little better, you can see
the commit history for a before and after.