### PR TITLE
Remove TypeSyntax need for MutableContext.

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1260,8 +1260,8 @@ class ResolveTypeMembersWalk {
         auto it = std::remove_if(job.dependencies.begin(), job.dependencies.end(), [&](core::SymbolRef dep) {
             if (isGenericResolved(ctx, dep)) {
                 if (dep.data(ctx)->isClassOrModule()) {
-                    // `dep`'s dependencies are resolved. Compute its externalType here so that TypeSyntax can access
-                    // it.
+                    // `dep`'s dependencies are resolved. Compute its externalType here so that we can resolve this
+                    // type member or type alias's type.
                     dep.data(ctx)->unsafeComputeExternalType(ctx);
                 }
                 return true;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1257,13 +1257,21 @@ class ResolveTypeMembersWalk {
             return true;
         }
 
-        auto it = std::remove_if(job.dependencies.begin(), job.dependencies.end(),
-                                 [&](core::SymbolRef dep) { return isGenericResolved(ctx, dep); });
+        auto it = std::remove_if(job.dependencies.begin(), job.dependencies.end(), [&](core::SymbolRef dep) {
+            if (isGenericResolved(ctx, dep)) {
+                if (dep.data(ctx)->isClassOrModule()) {
+                    // `dep`'s dependencies are resolved. Compute its externalType here so that TypeSyntax can access
+                    // it.
+                    dep.data(ctx)->unsafeComputeExternalType(ctx);
+                }
+                return true;
+            }
+            return false;
+        });
         job.dependencies.erase(it, job.dependencies.end());
         if (!job.dependencies.empty()) {
             return false;
         }
-
         if (job.lhs.data(ctx)->isTypeMember()) {
             auto superclass = job.lhs.data(ctx)->owner.data(ctx)->superClass();
             if (!isGenericResolved(ctx, superclass)) {

--- a/resolver/type_syntax.h
+++ b/resolver/type_syntax.h
@@ -71,17 +71,15 @@ struct TypeSyntaxArgs {
 class TypeSyntax {
 public:
     static bool isSig(core::Context ctx, const ast::Send &send);
-    static ParsedSig parseSig(core::MutableContext ctx, const ast::Send &send, const ParsedSig *parent,
-                              TypeSyntaxArgs args);
+    static ParsedSig parseSig(core::Context ctx, const ast::Send &send, const ParsedSig *parent, TypeSyntaxArgs args);
 
     struct ResultType {
         core::TypePtr type;
         core::SymbolRef rebind;
     };
-    static ResultType getResultTypeAndBind(core::MutableContext ctx, ast::TreePtr &expr, const ParsedSig &,
+    static ResultType getResultTypeAndBind(core::Context ctx, ast::TreePtr &expr, const ParsedSig &,
                                            TypeSyntaxArgs args);
-    static core::TypePtr getResultType(core::MutableContext ctx, ast::TreePtr &expr, const ParsedSig &,
-                                       TypeSyntaxArgs args);
+    static core::TypePtr getResultType(core::Context ctx, ast::TreePtr &expr, const ParsedSig &, TypeSyntaxArgs args);
 
     TypeSyntax() = delete;
 };

--- a/test/testdata/infer/generic_type_template_arg.rb
+++ b/test/testdata/infer/generic_type_template_arg.rb
@@ -1,6 +1,6 @@
 # typed: true
 
-class ReferencesClassWithTypeMembers
+module ModuleTypeMemberTypeHasTypeParam
   extend T::Generic
   extend T::Sig
 

--- a/test/testdata/infer/generic_type_template_arg.rb
+++ b/test/testdata/infer/generic_type_template_arg.rb
@@ -9,6 +9,13 @@ module ModuleTypeMemberTypeHasTypeParam
   Y = type_member(:in, upper: T.class_of(A))
 end
 
+module ModuleTypeAliasTypeHasTypeParams
+  extend T::Sig 
+
+  # Same as above.
+  Z = T.type_alias{T.class_of(A)}
+end
+
 class A
   extend T::Generic
   X = type_template

--- a/test/testdata/infer/generic_type_template_arg.rb
+++ b/test/testdata/infer/generic_type_template_arg.rb
@@ -1,5 +1,14 @@
 # typed: true
 
+class ReferencesClassWithTypeMembers
+  extend T::Generic
+  extend T::Sig
+
+  # Corner case for ResolveTypeMembersWalk: The type T.class_of cannot be resolved until A is resolved, but needs
+  # to be resolved in order for Y to be resolved.
+  Y = type_member(:in, upper: T.class_of(A))
+end
+
 class A
   extend T::Generic
   X = type_template

--- a/test/testdata/resolver/type_members.rb
+++ b/test/testdata/resolver/type_members.rb
@@ -18,6 +18,17 @@ class Invalids
                            # ^ error: Unsupported type syntax
 end
 
+module TypeParamDependsOnTypeParam
+  extend T::Generic
+
+  # ResolveTypeMembersWalk corner case: The type of this type member depends on a class with a type parameter.
+  Test = type_member(:out, upper: Parent[Integer])
+end
+
+module TypeAliasDependsOnTypeParam
+  # ResolveTypeMembersWalk corner case: The type of this type alias depends on a class with a type parameter.
+  Test = T.type_alias{Parent[Integer]}
+end
 
 class Parent
   extend T::Generic


### PR DESCRIPTION
Remove `TypeSyntax` need for `MutableContext`.

Previously, `TypeSyntax::getResultType` (and friends) needed `MutableContext` in order to call the following two methods:
* `singletonClass()`, which defines a singleton class if not present.
* `unsafeComputeExternalType()`, which computes an external type if not present.

The former can be replaced with `lookupSingletonClass` with no controversy, as `TypeSyntax::getResultType()` is never called with an unfrozen symbol table, so it should not cause new symbols / singleton classes to be defined.

The latter is tougher, and required some thought. Every symbol should have an `externalType()` defined after `Resolver::computeExternalTypes` runs, but `TypeSyntax::getResultType()` is called just before that in `ResolveTypeMembersWalk`.

During `ResolveTypeMembersWalk`, every class/module symbol that _does not_ have any type members has an `externalType` thanks to a pass over the symbol table in `finalizeSymbols()` that occurs earlier. That leaves one problem case: **When `ResolveTypeMembersWalk` needs the `externalType` of a type that has at least one type member**.

Looking through the code, `externalType()` is called in `TypeSyntax::getResultType()` under two scenarios:
* To compute `T.class_of(symbol)`
* To resolve constant literals.

It turns out that `ResolveTypeMembersWalk` already collects these symbols as `dependencies` of each `job`! All we have to do is make sure they have an external type defined before we perform the job, which is exactly what this change does.

Now, `TypeSyntax::getResultType()` is called in `ResolveTypeMembersWalk` to resolve the types of type members and type alias. I've added tests that cover all four possible combinations:

| | ConstantLit of a class w/ type param | T.class_of(class w/ type param on singleton) |
|--------------|---------------------------------|-----------------------------|
| `T.type_alias` | `T.type_alias{Parent[Integer]}` | `T.type_alias{T.class_of(A)}` |
| `T.type_member` | `type_member(:out, upper: Parent[Integer])` |`type_member(:in, upper: T.class_of(A))` |

I have confirmed that all four of these cases cause an exception when I remove the new `unsafeExternalType()` call in `resolver.cc`.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Unlocks parallelization opportunities in resolve signatures walk. Now we can call `TypeSyntax::getResultType` with a non-mutable context!

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by new tests.
