### PR TITLE
Method renames: robustness in send expression handling

### DIFF
--- a/core/lsp/QueryResponse.cc
+++ b/core/lsp/QueryResponse.cc
@@ -17,6 +17,28 @@ const SendResponse *QueryResponse::isSend() const {
     return get_if<SendResponse>(&response);
 }
 
+const optional<core::Loc> SendResponse::getMethodNameLoc(const core::GlobalState &gs) const {
+    // TODO: handle dispatchResult->secondary
+    auto methodName = dispatchResult->main.method.data(gs)->name.show(gs);
+    auto expr = termLoc.source(gs);
+    // There are two possible forms of a send expression:
+    //   <receiver expr><whitespace?>.<whitespace?><method>
+    //   <method>
+    string::size_type methodNameOffset = receiverLoc.endPos() - termLoc.beginPos();
+    if (methodNameOffset != 0) {
+        methodNameOffset = expr.find_first_of(".", methodNameOffset) + 1;
+        methodNameOffset = expr.find_first_not_of(" \t", methodNameOffset);
+    }
+    auto offsets = termLoc.offsets();
+    offsets.beginLoc += methodNameOffset;
+    offsets.endLoc = offsets.beginLoc + methodName.length();
+    auto methodNameLoc = core::Loc(termLoc.file(), offsets);
+    if (offsets.endPos() > termLoc.endPos() || methodName != methodNameLoc.source(gs)) {
+        return nullopt;
+    }
+    return optional<core::Loc>(methodNameLoc);
+}
+
 const IdentResponse *QueryResponse::isIdent() const {
     return get_if<IdentResponse>(&response);
 }

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -11,14 +11,15 @@ class TypeConstraint;
 class SendResponse final {
 public:
     SendResponse(core::Loc termLoc, std::shared_ptr<core::DispatchResult> dispatchResult, core::NameRef callerSideName,
-                 bool isPrivateOk, core::SymbolRef enclosingMethod)
+                 bool isPrivateOk, core::SymbolRef enclosingMethod, core::Loc receiverLoc)
         : dispatchResult(std::move(dispatchResult)), callerSideName(callerSideName), termLoc(termLoc),
-          isPrivateOk(isPrivateOk), enclosingMethod(enclosingMethod){};
+          isPrivateOk(isPrivateOk), enclosingMethod(enclosingMethod), receiverLoc(receiverLoc){};
     const std::shared_ptr<core::DispatchResult> dispatchResult;
     const core::NameRef callerSideName;
     const core::Loc termLoc;
     const bool isPrivateOk;
     const core::SymbolRef enclosingMethod;
+    const core::Loc receiverLoc;
 };
 
 class IdentResponse final {

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -2,7 +2,6 @@
 #define SORBET_LSP_QUERYRESPONSE
 #include "core/Loc.h"
 #include "core/LocalVariable.h"
-#include "core/Symbols.h"
 #include "core/Types.h"
 #include <variant>
 
@@ -22,27 +21,7 @@ public:
     const core::SymbolRef enclosingMethod;
     const core::Loc receiverLoc;
 
-    const std::optional<core::Loc> getMethodNameLoc(const core::GlobalState &gs) const {
-        // TODO: handle dispatchResult->secondary
-        auto methodName = dispatchResult->main.method.data(gs)->name.show(gs);
-        auto expr = termLoc.source(gs);
-        // There are two possible forms of a send expression:
-        //   <receiver expr><whitespace?>.<whitespace?><method>
-        //   <method>
-        std::string::size_type methodNameOffset = receiverLoc.endPos() - termLoc.beginPos();
-        if (methodNameOffset != 0) {
-            methodNameOffset = expr.find_first_of(".", methodNameOffset) + 1;
-            methodNameOffset = expr.find_first_not_of(" \t", methodNameOffset);
-        }
-        auto offsets = termLoc.offsets();
-        offsets.beginLoc += methodNameOffset;
-        offsets.endLoc = offsets.beginLoc + methodName.length();
-        auto methodNameLoc = core::Loc(termLoc.file(), offsets);
-        if (offsets.endPos() > termLoc.endPos() || methodName != methodNameLoc.source(gs)) {
-            return std::nullopt;
-        }
-        return std::optional<core::Loc>(methodNameLoc);
-    }
+    const std::optional<core::Loc> getMethodNameLoc(const core::GlobalState &gs) const;
 };
 
 class IdentResponse final {

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -2,6 +2,7 @@
 #define SORBET_LSP_QUERYRESPONSE
 #include "core/Loc.h"
 #include "core/LocalVariable.h"
+#include "core/Symbols.h"
 #include "core/Types.h"
 #include <variant>
 
@@ -20,6 +21,28 @@ public:
     const bool isPrivateOk;
     const core::SymbolRef enclosingMethod;
     const core::Loc receiverLoc;
+
+    const std::optional<core::Loc> getMethodNameLoc(const core::GlobalState &gs) const {
+        // TODO: handle dispatchResult->secondary
+        auto methodName = dispatchResult->main.method.data(gs)->name.show(gs);
+        auto expr = termLoc.source(gs);
+        // There are two possible forms of a send expression:
+        //   <receiver expr><whitespace?>.<whitespace?><method>
+        //   <method>
+        std::string::size_type methodNameOffset = receiverLoc.endPos() - termLoc.beginPos();
+        if (methodNameOffset != 0) {
+            methodNameOffset = expr.find_first_of(".", methodNameOffset) + 1;
+            methodNameOffset = expr.find_first_not_of(" \t", methodNameOffset);
+        }
+        auto offsets = termLoc.offsets();
+        offsets.beginLoc += methodNameOffset;
+        offsets.endLoc = offsets.beginLoc + methodName.length();
+        auto methodNameLoc = core::Loc(termLoc.file(), offsets);
+        if (offsets.endPos() > termLoc.endPos() || methodName != methodNameLoc.source(gs)) {
+            return std::nullopt;
+        }
+        return std::optional<core::Loc>(methodNameLoc);
+    }
 };
 
 class IdentResponse final {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -996,8 +996,9 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 }
                 if (lspQueryMatch) {
                     core::lsp::QueryResponse::pushQueryResponse(
-                        ctx, core::lsp::SendResponse(core::Loc(ctx.file, bind.loc), retainedResult, send->fun,
-                                                     send->isPrivateOk, ctx.owner));
+                        ctx,
+                        core::lsp::SendResponse(core::Loc(ctx.file, bind.loc), retainedResult, send->fun,
+                                                send->isPrivateOk, ctx.owner, core::Loc(ctx.file, send->receiverLoc)));
                 }
                 if (send->link) {
                     // This should eventually become ENFORCEs but currently they are wrong

--- a/main/lsp/LSPTask.h
+++ b/main/lsp/LSPTask.h
@@ -35,6 +35,9 @@ protected:
     extractLocations(const core::GlobalState &gs,
                      const std::vector<std::unique_ptr<core::lsp::QueryResponse>> &queryResponses,
                      std::vector<std::unique_ptr<Location>> locations = {}) const;
+    std::vector<std::unique_ptr<core::lsp::QueryResponse>>
+    filterAndDedup(const core::GlobalState &gs,
+                   const std::vector<std::unique_ptr<core::lsp::QueryResponse>> &queryResponses) const;
 
     LSPQueryResult queryByLoc(LSPTypecheckerDelegate &typechecker, std::string_view uri, const Position &pos,
                               LSPMethod forMethod, bool errorIfFileIsUntyped = true) const;

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -127,7 +127,7 @@ public:
         string newsrc;
         if (auto sendResp = response->isSend()) {
             // sendResp->dispatchResult->main.receiver;
-            auto newsrc = replaceMethodNameInSend(source);
+            newsrc = replaceMethodNameInSend(source);
         } else {
             newsrc = replaceMethodNameInStr(source);
         }
@@ -199,7 +199,7 @@ variant<JSONNullObject, unique_ptr<WorkspaceEdit>> RenameTask::getRenameEdits(LS
 
     vector<core::SymbolRef> symbolsToRename;
     if (symbolData->isMethod()) {
-        renamer = make_unique<MethodRenamer>(originalName, newName);
+        renamer = make_unique<MethodRenamer>(gs, config, originalName, newName);
         // We have to check for methods as part of a class hierarchy: Follow superClass() links till we find the root;
         // then find the full tree; then look for methods with the same name as ours; then find all references to all
         // those methods and rename them.
@@ -221,7 +221,7 @@ variant<JSONNullObject, unique_ptr<WorkspaceEdit>> RenameTask::getRenameEdits(LS
             }
         }
     } else {
-        renamer = make_unique<ConstRenamer>(originalName, newName);
+        renamer = make_unique<ConstRenamer>(gs, config, originalName, newName);
         symbolsToRename.push_back(symbol);
     }
 

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -233,9 +233,9 @@ variant<JSONNullObject, unique_ptr<WorkspaceEdit>> RenameTask::getRenameEdits(LS
             return JSONNullObject();
         }
 
-        // We want location but also the type of the expression at that location; and for some expression types like
-        // sends, we need more than just a location, for parsing purposes (the send location is too broad and makes us
-        // parse too much).
+        // Filter for untyped files, and deduplicate responses by location.  We don't use extractLocations here because
+        // in some cases like sends, we need the SendResponse to be able to accurately find the method name in the
+        // expression.
         for (auto &response : filterAndDedup(gs, queryResult.responses)) {
             auto loc = response->getLoc();
             if (loc.file().data(gs).isPayload()) {

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -236,13 +236,9 @@ variant<JSONNullObject, unique_ptr<WorkspaceEdit>> RenameTask::getRenameEdits(LS
         // We want location but also the type of the expression at that location; and for some expression types like
         // sends, we need more than just a location, for parsing purposes (the send location is too broad and makes us
         // parse too much).
-        // TODO(soam): do we need to dedup locations?
-        for (auto &response : queryResult.responses) {
+        for (auto &response : filterAndDedup(gs, queryResult.responses)) {
             auto loc = response->getLoc();
-            if (!loc.exists() || !loc.file().exists()) {
-                continue;
-            }
-            if (response->getLoc().file().data(gs).isPayload()) {
+            if (loc.file().data(gs).isPayload()) {
                 // We don't support renaming things in payload files.
                 return JSONNullObject();
             }

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -166,9 +166,9 @@ private:
         }
         return replaceAt(def, pos);
     }
-    string replaceAt(string input, string::size_type pos) {
+    string replaceAt(string_view input, string::size_type pos) {
         auto suffixOffset = pos + oldName.length();
-        return input.substr(0, pos) + newName + input.substr(suffixOffset, input.length() - suffixOffset);
+        return absl::StrCat(input.substr(0, pos), newName, input.substr(suffixOffset, input.length() - suffixOffset));
     }
 };
 class ConstRenamer : public Renamer {

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -130,14 +130,17 @@ public:
             auto receiverLoc = sendResp->receiverLoc;
             ENFORCE(loc.contains(receiverLoc), "receiver expression not within send expression");
             ENFORCE(loc.beginPos() == receiverLoc.beginPos(), "send expression doesn't start with receiver");
+            string::size_type methodNameOffset;
             if (receiverLoc.endPos() == receiverLoc.beginPos()) {
                 // no receiver expression, method is start of loc
-                newsrc = newName + source.substr(oldName.length(), source.length() - oldName.length());
+                methodNameOffset = 0;
             } else {
-                string::size_type methodNameOffset =
-                    receiverLoc.endPos() - receiverLoc.beginPos() + 1; // +1 for the dot
-                newsrc = replaceAt(source, methodNameOffset);
+                // find the method name: <receiver expression> <whitespace?> <dot> <whitespace?> <method name>
+                methodNameOffset = receiverLoc.endPos() - receiverLoc.beginPos();
+                methodNameOffset = 1 + source.find(".", methodNameOffset);
+                methodNameOffset = source.find_first_not_of(" \t", methodNameOffset);
             }
+            newsrc = replaceAt(source, methodNameOffset);
         } else if (auto defResp = response->isDefinition()) {
             newsrc = replaceMethodNameInDef(source);
         } else {

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -125,6 +125,9 @@ public:
         auto loc = response->getLoc();
         auto source = loc.source(gs);
         auto location = config.loc2Location(gs, loc);
+        if (location == nullptr) {
+            return;
+        }
         string newsrc;
         if (auto sendResp = response->isSend()) {
             auto methodNameLoc = sendResp->getMethodNameLoc(gs);
@@ -181,6 +184,9 @@ public:
         auto loc = response->getLoc();
         auto source = loc.source(gs);
         auto location = config.loc2Location(gs, loc);
+        if (location == nullptr) {
+            return;
+        }
         vector<string> strs = absl::StrSplit(source, "::");
         strs[strs.size() - 1] = string(newName);
         auto newsrc = absl::StrJoin(strs, "::");
@@ -226,8 +232,6 @@ variant<JSONNullObject, unique_ptr<WorkspaceEdit>> RenameTask::getRenameEdits(LS
     }
 
     for (auto sym : symbolsToRename) {
-        // vector<unique_ptr<Location>> references = getReferencesToSymbol(typechecker, sym);
-
         auto queryResult = queryBySymbol(typechecker, sym);
         if (queryResult.error) {
             return JSONNullObject();

--- a/test/testdata/lsp/rename/method_fromsend.A.rbedited
+++ b/test/testdata/lsp/rename/method_fromsend.A.rbedited
@@ -1,0 +1,30 @@
+# typed: true
+# frozen_string_literal: true
+
+module M
+  class Foo
+    def baz(a=1)
+    end
+
+    def caller
+      baz(1)
+    end
+
+    def x
+      42
+    end
+  end
+end
+
+f = M::Foo.new
+f.baz(f.x)
+f.baz
+# ^ apply-rename: [A] newName: baz
+f  .  baz  (   )
+
+M::Foo.new.baz 3
+
+class Unrelated
+  # this should be left unchanged
+  def bar; end
+end

--- a/test/testdata/lsp/rename/method_fromsend.rb
+++ b/test/testdata/lsp/rename/method_fromsend.rb
@@ -1,0 +1,30 @@
+# typed: true
+# frozen_string_literal: true
+
+module M
+  class Foo
+    def bar(a=1)
+    end
+
+    def caller
+      bar(1)
+    end
+
+    def x
+      42
+    end
+  end
+end
+
+f = M::Foo.new
+f.bar(f.x)
+f.bar
+# ^ apply-rename: [A] newName: baz
+f  .  bar  (   )
+
+M::Foo.new.bar 3
+
+class Unrelated
+  # this should be left unchanged
+  def bar; end
+end

--- a/test/testdata/lsp/rename/method_names.A.rbedited
+++ b/test/testdata/lsp/rename/method_names.A.rbedited
@@ -29,6 +29,8 @@ end
 c2 = C2.new
 # only the second m1 should change
 puts c2.m1.m2.x
+puts c2.m1().m2.x
+puts c2.m1().m2().x
 
 c1 = C1.new
 # both first and second m1 should change

--- a/test/testdata/lsp/rename/method_names.rb
+++ b/test/testdata/lsp/rename/method_names.rb
@@ -29,6 +29,8 @@ end
 c2 = C2.new
 # only the second m1 should change
 puts c2.m1.m1.x
+puts c2.m1().m1.x
+puts c2.m1().m1().x
 
 c1 = C1.new
 # both first and second m1 should change

--- a/test/testdata/lsp/rename/method_simple.A.rbedited
+++ b/test/testdata/lsp/rename/method_simple.A.rbedited
@@ -20,6 +20,7 @@ end
 f = M::Foo.new
 f.baz(f.x)
 f.baz
+f  .  baz  (   )
 
 M::Foo.new.baz 3
 

--- a/test/testdata/lsp/rename/method_simple.rb
+++ b/test/testdata/lsp/rename/method_simple.rb
@@ -20,6 +20,7 @@ end
 f = M::Foo.new
 f.bar(f.x)
 f.bar
+f  .  bar  (   )
 
 M::Foo.new.bar 3
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Add receiver location info to the SendResponse query response type; use that to find the method name in a send expression more reliably. This removes the adhoc search-and-replace based stuff that the previous change had for method renames. 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When renaming a method we have to update send expressions; unfortunately a send expression as returned in a SendResponse contains the entire `<receiver>.<method><args>` expression. So the previous code was trying to parse the receiver expression to skip over it to find the method; and it was doing so incorrectly.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
