### PR TITLE
Allow changing root object in autoloader

### DIFF
--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -196,10 +196,10 @@ string DefTree::renderAutoloadSrc(const core::GlobalState &gs, const AutoloaderC
     string casgnArg;
     auto type = definitionType(gs);
     if (type == Definition::Type::Module || type == Definition::Type::Class) {
-        fullName =
-            root() ? alCfg.rootObject : fmt::format("{}", fmt::map_join(qname.nameParts, "::", [&](const auto &nr) -> string {
-                                                return nr.show(gs);
-                                            }));
+        fullName = root() ? alCfg.rootObject
+                          : fmt::format("{}", fmt::map_join(qname.nameParts, "::", [&](const auto &nr) -> string {
+                                            return nr.show(gs);
+                                        }));
         if (!root()) {
             fmt::format_to(buf, "{}.on_autoload('{}')\n", alCfg.registryModule, fullName);
             predeclare(gs, fullName, buf);

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -48,6 +48,7 @@ AutoloaderConfig AutoloaderConfig::enterConfig(core::GlobalState &gs, const real
     out.rootDir = cfg.rootDir;
     out.preamble = cfg.preamble;
     out.registryModule = cfg.registryModule;
+    out.rootObject = cfg.rootObject;
     for (auto &str : cfg.modules) {
         out.topLevelNamespaceRefs.emplace(gs.enterNameConstant(str));
     }
@@ -196,7 +197,7 @@ string DefTree::renderAutoloadSrc(const core::GlobalState &gs, const AutoloaderC
     auto type = definitionType(gs);
     if (type == Definition::Type::Module || type == Definition::Type::Class) {
         fullName =
-            root() ? "Object" : fmt::format("{}", fmt::map_join(qname.nameParts, "::", [&](const auto &nr) -> string {
+            root() ? alCfg.rootObject : fmt::format("{}", fmt::map_join(qname.nameParts, "::", [&](const auto &nr) -> string {
                                                 return nr.show(gs);
                                             }));
         if (!root()) {

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -29,6 +29,7 @@ struct AutoloaderConfig {
     std::string rootDir;
     std::string preamble;
     std::string registryModule;
+    std::string rootObject;
     UnorderedSet<core::NameRef> topLevelNamespaceRefs;
     UnorderedSet<core::NameRef> excludedRequireRefs;
     UnorderedSet<std::vector<core::NameRef>> nonCollapsableModuleNames;

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -414,6 +414,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                     cxxopts::value<string>()->default_value("autoloader"));
     options.add_options("advanced")("autogen-registry-module", "Name of Ruby module used for autoloader registry",
                                     cxxopts::value<string>()->default_value("Opus::Require"));
+    options.add_options("advanced")("autogen-root-object", "Name of Ruby object on which root autoloads should be installed",
+                                    cxxopts::value<string>()->default_value("Object"));
     options.add_options("advanced")("autogen-autoloader-samefile",
                                     "Modules that should never be collapsed into their parent. This helps break cycles "
                                     "in certain cases. (e.g. Foo::Bar::Baz)",
@@ -629,6 +631,7 @@ bool extractAutoloaderConfig(cxxopts::ParseResult &raw, Options &opts, shared_pt
     cfg.preamble = raw["autogen-autoloader-preamble"].as<string>();
     cfg.registryModule = raw["autogen-registry-module"].as<string>();
     cfg.rootDir = stripTrailingSlashes(raw["autogen-autoloader-root"].as<string>());
+    cfg.rootObject = raw["autogen-root-object"].as<string>();
     return true;
 }
 

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -414,7 +414,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                     cxxopts::value<string>()->default_value("autoloader"));
     options.add_options("advanced")("autogen-registry-module", "Name of Ruby module used for autoloader registry",
                                     cxxopts::value<string>()->default_value("Opus::Require"));
-    options.add_options("advanced")("autogen-root-object", "Name of Ruby object on which root autoloads should be installed",
+    options.add_options("advanced")("autogen-root-object",
+                                    "Name of Ruby object on which root autoloads should be installed",
                                     cxxopts::value<string>()->default_value("Object"));
     options.add_options("advanced")("autogen-autoloader-samefile",
                                     "Modules that should never be collapsed into their parent. This helps break cycles "

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -102,6 +102,7 @@ struct AutoloaderConfig {
     std::string rootDir;
     std::string preamble;
     std::string registryModule;
+    std::string rootObject;
     std::vector<std::string> requireExcludes;
     std::vector<std::vector<std::string>> sameFileModules;
     std::vector<std::string> stripPrefixes;

--- a/test/cli/autogen-autoloader/autogen-autoloader.out
+++ b/test/cli/autogen-autoloader/autogen-autoloader.out
@@ -243,3 +243,18 @@ module Foo
 end
 
 Primus::Require.for_autoload(Foo, "autogen-autoloader/inplace.rb")
+
+--- with different root object
+No errors! Great job.
+
+
+Opus::Require.autoload_map(MyRootObject, {
+  Foo: "autoloader/Foo.rb",
+})
+
+Opus::Require.on_autoload('Foo')
+
+module Foo
+end
+
+Opus::Require.for_autoload(Foo, "test/cli/autogen-autoloader/inplace.rb")

--- a/test/cli/autogen-autoloader/autogen-autoloader.sh
+++ b/test/cli/autogen-autoloader/autogen-autoloader.sh
@@ -57,3 +57,15 @@ main/sorbet --silence-dev-message --stop-after=namer \
 
 cat strip-output/root.rb
 cat strip-output/Foo.rb
+
+echo
+echo "--- with different root object"
+rm -rf root-object
+mkdir -p root-object
+main/sorbet --silence-dev-message --stop-after=namer -p autogen-autoloader:root-object \
+  --autogen-autoloader-modules=Foo \
+  --autogen-root-object=MyRootObject \
+  test/cli/autogen-autoloader/inplace.rb 2>&1
+
+cat root-object/root.rb
+cat root-object/Foo.rb

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -147,6 +147,9 @@ Usage:
       --autogen-registry-module arg
                                 Name of Ruby module used for autoloader
                                 registry (default: Opus::Require)
+      --autogen-root-object arg
+                                Name of Ruby object on which root autoloads
+                                should be installed (default: Object)
       --autogen-autoloader-samefile arg
                                 Modules that should never be collapsed into
                                 their parent. This helps break cycles in


### PR DESCRIPTION
Right now, the autoloader always installs root packages on `Object`; this allows you to pass a flag which can override this, although it defaults to `Object`.


### Motivation
Prep for packaged autoloader.


### Test plan
Included tests to show output with new flag.

See included automated tests.
