### PR TITLE
don't reload private/methods/_methods

### DIFF
--- a/gems/sorbet-runtime/lib/types/compatibility_patches.rb
+++ b/gems/sorbet-runtime/lib/types/compatibility_patches.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 # typed: ignore
 
-require_relative 'private/methods/_methods'
-
 # Work around an interaction bug with sorbet-runtime and rspec-mocks,
 # which occurs when using message expectations (*_any_instance_of,
 # expect, allow) and and_call_original.


### PR DESCRIPTION
`sorbet-runtime` loads everything from a root file, so we shouldn't need to reload things here.

### Test plan

Existing automated tests should be sufficient.