### PR TITLE
don't copy vectors when computing file hashes

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1289,7 +1289,7 @@ core::FileHash computeFileHash(shared_ptr<core::File> forWhat, spdlog::logger &l
 }
 }; // namespace
 
-void computeFileHashes(const vector<shared_ptr<core::File>> files, spdlog::logger &logger, WorkerPool &workers) {
+void computeFileHashes(const vector<shared_ptr<core::File>> &files, spdlog::logger &logger, WorkerPool &workers) {
     Timer timeit(logger, "computeFileHashes");
     shared_ptr<ConcurrentBoundedQueue<int>> fileq = make_shared<ConcurrentBoundedQueue<int>>(files.size());
     for (int i = 0; i < files.size(); i++) {
@@ -1301,7 +1301,7 @@ void computeFileHashes(const vector<shared_ptr<core::File>> files, spdlog::logge
 
     shared_ptr<BlockingBoundedQueue<vector<pair<int, unique_ptr<const core::FileHash>>>>> resultq =
         make_shared<BlockingBoundedQueue<vector<pair<int, unique_ptr<const core::FileHash>>>>>(files.size());
-    workers.multiplexJob("lspStateHash", [fileq, resultq, files, &logger]() {
+    workers.multiplexJob("lspStateHash", [fileq, resultq, &files, &logger]() {
         vector<pair<int, unique_ptr<const core::FileHash>>> threadResult;
         int processedByThread = 0;
         int job;

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -48,7 +48,7 @@ ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const 
 
 // Computes file hashes for the given files, and stores them in the files. If supplied, attempts to retrieve hashes from
 // the key-value store. Returns 'true' if it had to compute any file hashes.
-void computeFileHashes(const std::vector<std::shared_ptr<core::File>> files, spdlog::logger &logger,
+void computeFileHashes(const std::vector<std::shared_ptr<core::File>> &files, spdlog::logger &logger,
                        WorkerPool &workers);
 
 core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::FileRef file,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
When we called `pipeline::computeFileHashes` from the LSP indexer, we were copying the vector of files.  Let's not do that.

### Motivation

Epsilon performance improvements.

### Test plan

Existing automated tests should be sufficient.