### PR TITLE
always store TreePtr's tag in the upper 16 bits

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -78,7 +78,7 @@ public:
     }
 
 private:
-    static constexpr tagged_storage TAG_MASK = 0xffff000000000000;
+    static constexpr tagged_storage TAG_MASK = 0xffff;
 
     static constexpr tagged_storage PTR_MASK = ~TAG_MASK;
 
@@ -87,9 +87,9 @@ private:
     template <typename E, typename... Args> friend TreePtr make_tree(Args &&...);
 
     static tagged_storage tagPtr(Tag tag, void *expr) {
-        // Store the tag in the upper 16 bits of the pointer, regardless of size.
-        auto val = static_cast<tagged_storage>(tag) << 48;
-        auto maskedPtr = reinterpret_cast<tagged_storage>(expr) & PTR_MASK;
+        // Store the tag in the lower 16 bits of the pointer, regardless of size.
+        auto val = static_cast<tagged_storage>(tag);
+        auto maskedPtr = reinterpret_cast<tagged_storage>(expr) << 16;
 
         return maskedPtr | val;
     }
@@ -175,7 +175,7 @@ public:
         ENFORCE(ptr != 0);
 
         auto value = reinterpret_cast<tagged_storage>(ptr) & TAG_MASK;
-        return static_cast<Tag>(value >> 48);
+        return static_cast<Tag>(value);
     }
 
     Expression *get() const noexcept {
@@ -185,7 +185,7 @@ public:
             return reinterpret_cast<Expression *>(val);
         } else {
             // sign extension for the upper 16 bits
-            return reinterpret_cast<Expression *>((val << 16) >> 16);
+            return reinterpret_cast<Expression *>(val >> 16);
         }
     }
 

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -78,7 +78,7 @@ public:
     }
 
 private:
-    static constexpr tagged_storage TAG_MASK = 0xffff000000000007;
+    static constexpr tagged_storage TAG_MASK = 0xffff000000000000;
 
     static constexpr tagged_storage PTR_MASK = ~TAG_MASK;
 
@@ -87,12 +87,8 @@ private:
     template <typename E, typename... Args> friend TreePtr make_tree(Args &&...);
 
     static tagged_storage tagPtr(Tag tag, void *expr) {
-        auto val = static_cast<tagged_storage>(tag);
-        if (val >= 8) {
-            // Store the tag in the upper 16 bits of the pointer, as it won't fit in the lower three bits.
-            val <<= 48;
-        }
-
+        // Store the tag in the upper 16 bits of the pointer, regardless of size.
+        auto val = static_cast<tagged_storage>(tag) << 48;
         auto maskedPtr = reinterpret_cast<tagged_storage>(expr) & PTR_MASK;
 
         return maskedPtr | val;
@@ -179,11 +175,7 @@ public:
         ENFORCE(ptr != 0);
 
         auto value = reinterpret_cast<tagged_storage>(ptr) & TAG_MASK;
-        if (value <= 7) {
-            return static_cast<Tag>(value);
-        } else {
-            return static_cast<Tag>(value >> 48);
-        }
+        return static_cast<Tag>(value >> 48);
     }
 
     Expression *get() const noexcept {


### PR DESCRIPTION
`TreePtr`'s current tagging scheme is unnecessarily expensive, because we store the tag in potentially two different places, depending on the tag value.  We should just be storing it in the upper 16 bits, regardless of the tag value.

As an example, consider an (inlined) call to `~TreePtr`; we annotate the assembly from an opt build below:

```
# Fetch the "pointer" and check for null
 1ed:   48 8b 45 88             mov    -0x78(%rbp),%rax
 1f1:   48 85 c0                test   %rax,%rax
 1f4:   74 32                   je     228 <sorbet::realmain::pipeline::runLocalVars(sorbet::core::GlobalState&, sorbet::ast::ParsedFile)+0x228>

# We have a non-null pointer.

# Mask the tag bits
 1f6:   48 b9 07 00 00 00 00    movabs $0xffff000000000007,%rcx
 1fd:   00 ff ff
 200:   48 21 c1                and    %rax,%rcx

# Fetch the tag from either the low bits or the high bits, depending.
 203:   48 89 c7                mov    %rax,%rdi
 206:   48 c1 ef 30             shr    $0x30,%rdi
 20a:   48 83 f9 08             cmp    $0x8,%rcx
 20e:   0f 42 f9                cmovb  %ecx,%edi

# Mask the actual pointer value.
 211:   48 be f8 ff ff ff ff    movabs $0xfffffffffff8,%rsi
 218:   ff 00 00
 21b:   48 21 c6                and    %rax,%rsi

# Delete
 21e:   e8 00 00 00 00          callq  223 <sorbet::realmain::pipeline::runLocalVars(sorbet::core::GlobalState&, sorbet::ast::ParsedFile)+0x223>
                        21f: R_X86_64_PLT32     sorbet::ast::TreePtr::deleteTagged(sorbet::ast::Tag, void*)-0x4
```

For a fairly common operation, fetching the tag, we're spending 27 bytes (0x211 - 0x1f6).

If instead we always store it in the upper 16 bits, as this PR does, the (annotated) assembly looks like:

```
# Fetch the "pointer" and check for null
 1d9:   48 8b 45 88             mov    -0x78(%rbp),%rax
 1dd:   48 85 c0                test   %rax,%rax
 1e0:   74 1e                   je     200 <sorbet::realmain::pipeline::runLocalVars(sorbet::core::GlobalState&, sorbet::ast::ParsedFile)+0x200>

# We have a non-null pointer.

# Fetch the tag bits.
 1e2:   48 89 c7                mov    %rax,%rdi
 1e5:   48 c1 ef 30             shr    $0x30,%rdi

# Mask the actual pointer value
 1e9:   48 be ff ff ff ff ff    movabs $0xffffffffffff,%rsi
 1f0:   ff 00 00
 1f3:   48 21 c6                and    %rax,%rsi

# Delete
 1f6:   e8 00 00 00 00          callq  1fb <sorbet::realmain::pipeline::runLocalVars(sorbet::core::GlobalState&, sorbet::ast::ParsedFile)+0x1fb>
                        1f7: R_X86_64_PLT32     sorbet::ast::TreePtr::deleteTagged(sorbet::ast::Tag, void*)-0x4
```

Now we're down to 7 bytes for fetching the tag (0x1e9 - 0x1e2), or a savings of 20 bytes from the current scheme.  20 bytes may not seem like much, but overall (including other tag manipulations in `TreePtr`), this saves ~170K of binary size, or about 1.7% of the executable code in an opt build (!).

I have not benchmarked this change.  I suspect we should be applying the same logic to `TypePtr` as well; I'm not sure if it's complicated by inline types or not.  I am going to try and poke at that next.
 
### Motivation

The fastest code is the code you don't have to execute.

### Test plan

Existing automated tests + `ENFORCE`s should be sufficient.