### PR TITLE
Nest classes/modules inside eachother when generating hidden definitions

### DIFF
--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_5_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_5_hidden.rbi.exp
@@ -14,8 +14,6 @@ class Array
   def self.try_convert(_); end
 end
 
-BasicObject::BasicObject = BasicObject
-
 class BigDecimal
   def clone(); end
   EXCEPTION_NaN = ::T.let(nil, ::T.untyped)
@@ -30,1858 +28,6 @@ class Binding
   def clone(); end
 
   def irb(); end
-end
-
-class Bundler::Dependency
-  def branch(); end
-
-  def expanded_platforms(); end
-
-  def git(); end
-end
-
-Bundler::Deprecate = Gem::Deprecate
-
-class Bundler::Env
-end
-
-class Bundler::Env
-  def self.environment(); end
-
-  def self.report(options=T.unsafe(nil)); end
-
-  def self.write(io); end
-end
-
-class Bundler::Fetcher
-  def fetch_spec(spec); end
-
-  def fetchers(); end
-
-  def http_proxy(); end
-
-  def initialize(remote); end
-
-  def specs(gem_names, source); end
-
-  def specs_with_retry(gem_names, source); end
-
-  def uri(); end
-
-  def use_api(); end
-
-  def user_agent(); end
-  FAIL_ERRORS = ::T.let(nil, ::T.untyped)
-  FETCHERS = ::T.let(nil, ::T.untyped)
-  HTTP_ERRORS = ::T.let(nil, ::T.untyped)
-  NET_ERRORS = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Fetcher::AuthenticationRequiredError
-  def initialize(remote_uri); end
-end
-
-class Bundler::Fetcher::BadAuthenticationError
-  def initialize(remote_uri); end
-end
-
-class Bundler::Fetcher::Base
-  def api_fetcher?(); end
-
-  def available?(); end
-
-  def display_uri(); end
-
-  def downloader(); end
-
-  def fetch_uri(); end
-
-  def initialize(downloader, remote, display_uri); end
-
-  def remote(); end
-
-  def remote_uri(); end
-end
-
-class Bundler::Fetcher::Base
-end
-
-class Bundler::Fetcher::CertificateFailureError
-  def initialize(remote_uri); end
-end
-
-class Bundler::Fetcher::CompactIndex
-  def available?(*args, &blk); end
-
-  def fetch_spec(*args, &blk); end
-
-  def specs(*args, &blk); end
-
-  def specs_for_names(gem_names); end
-end
-
-class Bundler::Fetcher::CompactIndex::ClientFetcher
-  def call(path, headers); end
-
-  def fetcher(); end
-
-  def fetcher=(_); end
-
-  def ui(); end
-
-  def ui=(_); end
-end
-
-class Bundler::Fetcher::CompactIndex::ClientFetcher
-  def self.[](*_); end
-
-  def self.members(); end
-end
-
-class Bundler::Fetcher::CompactIndex
-  def self.compact_index_request(method_name); end
-end
-
-class Bundler::Fetcher::Dependency
-  def dependency_api_uri(gem_names=T.unsafe(nil)); end
-
-  def dependency_specs(gem_names); end
-
-  def get_formatted_specs_and_deps(gem_list); end
-
-  def specs(gem_names, full_dependency_list=T.unsafe(nil), last_spec_list=T.unsafe(nil)); end
-
-  def unmarshalled_dep_gems(gem_names); end
-end
-
-class Bundler::Fetcher::Dependency
-end
-
-class Bundler::Fetcher::Downloader
-  def connection(); end
-
-  def fetch(uri, headers=T.unsafe(nil), counter=T.unsafe(nil)); end
-
-  def initialize(connection, redirect_limit); end
-
-  def redirect_limit(); end
-
-  def request(uri, headers); end
-end
-
-class Bundler::Fetcher::Downloader
-end
-
-class Bundler::Fetcher::Index
-  def fetch_spec(spec); end
-
-  def specs(_gem_names); end
-end
-
-class Bundler::Fetcher::Index
-end
-
-class Bundler::Fetcher::SSLError
-  def initialize(msg=T.unsafe(nil)); end
-end
-
-class Bundler::Fetcher::TooManyRequestsError
-end
-
-class Bundler::Fetcher::TooManyRequestsError
-end
-
-class Bundler::Fetcher
-  def self.api_timeout(); end
-
-  def self.api_timeout=(api_timeout); end
-
-  def self.disable_endpoint(); end
-
-  def self.disable_endpoint=(disable_endpoint); end
-
-  def self.max_retries(); end
-
-  def self.max_retries=(max_retries); end
-
-  def self.redirect_limit(); end
-
-  def self.redirect_limit=(redirect_limit); end
-end
-
-module Bundler::FileUtils
-  VERSION = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::FileUtils::Entry_
-  def link(dest); end
-end
-
-module Bundler::FileUtils
-  def self.cp_lr(src, dest, noop: T.unsafe(nil), verbose: T.unsafe(nil), dereference_root: T.unsafe(nil), remove_destination: T.unsafe(nil)); end
-
-  def self.link_entry(src, dest, dereference_root=T.unsafe(nil), remove_destination=T.unsafe(nil)); end
-end
-
-class Bundler::GemHelper
-  def allowed_push_host(); end
-
-  def already_tagged?(); end
-
-  def base(); end
-
-  def build_gem(); end
-
-  def built_gem_path(); end
-
-  def clean?(); end
-
-  def committed?(); end
-
-  def gem_command(); end
-
-  def gem_key(); end
-
-  def gem_push?(); end
-
-  def gem_push_host(); end
-
-  def gemspec(); end
-
-  def git_push(remote=T.unsafe(nil)); end
-
-  def guard_clean(); end
-
-  def initialize(base=T.unsafe(nil), name=T.unsafe(nil)); end
-
-  def install(); end
-
-  def install_gem(built_gem_path=T.unsafe(nil), local=T.unsafe(nil)); end
-
-  def name(); end
-
-  def perform_git_push(options=T.unsafe(nil)); end
-
-  def rubygem_push(path); end
-
-  def sh(cmd, &block); end
-
-  def sh_with_input(cmd); end
-
-  def sh_with_status(cmd, &block); end
-
-  def spec_path(); end
-
-  def tag_version(); end
-
-  def version(); end
-
-  def version_tag(); end
-end
-
-class Bundler::GemHelper
-  def self.gemspec(&block); end
-
-  def self.install_tasks(opts=T.unsafe(nil)); end
-
-  def self.instance(); end
-
-  def self.instance=(instance); end
-end
-
-class Bundler::GemVersionPromoter
-  def initialize(locked_specs=T.unsafe(nil), unlock_gems=T.unsafe(nil)); end
-
-  def level(); end
-
-  def level=(value); end
-
-  def locked_specs(); end
-
-  def major?(); end
-
-  def minor?(); end
-
-  def prerelease_specified(); end
-
-  def prerelease_specified=(prerelease_specified); end
-
-  def sort_versions(dep, spec_groups); end
-
-  def strict(); end
-
-  def strict=(strict); end
-
-  def unlock_gems(); end
-  DEBUG = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::GemVersionPromoter
-end
-
-class Bundler::Graph
-  def edge_options(); end
-
-  def groups(); end
-
-  def initialize(env, output_file, show_version=T.unsafe(nil), show_requirements=T.unsafe(nil), output_format=T.unsafe(nil), without=T.unsafe(nil)); end
-
-  def node_options(); end
-
-  def output_file(); end
-
-  def output_format(); end
-
-  def relations(); end
-
-  def viz(); end
-  GRAPH_NAME = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Graph::GraphVizClient
-  def g(); end
-
-  def initialize(graph_instance); end
-
-  def run(); end
-end
-
-class Bundler::Graph::GraphVizClient
-end
-
-class Bundler::Graph
-end
-
-class Bundler::Index
-  include ::Enumerable
-end
-
-class Bundler::Injector
-  def initialize(deps, options=T.unsafe(nil)); end
-
-  def inject(gemfile_path, lockfile_path); end
-
-  def remove(gemfile_path, lockfile_path); end
-  INJECTED_GEMS = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Injector
-  def self.inject(new_deps, options=T.unsafe(nil)); end
-
-  def self.remove(gems, options=T.unsafe(nil)); end
-end
-
-class Bundler::Installer
-  def generate_bundler_executable_stubs(spec, options=T.unsafe(nil)); end
-
-  def generate_standalone_bundler_executable_stubs(spec); end
-
-  def initialize(root, definition); end
-
-  def post_install_messages(); end
-
-  def run(options); end
-end
-
-class Bundler::Installer
-  def self.ambiguous_gems(); end
-
-  def self.ambiguous_gems=(ambiguous_gems); end
-
-  def self.install(root, definition, options=T.unsafe(nil)); end
-end
-
-class Bundler::LockfileGenerator
-  def definition(); end
-
-  def generate!(); end
-
-  def initialize(definition); end
-
-  def out(); end
-end
-
-class Bundler::LockfileGenerator
-  def self.generate(definition); end
-end
-
-class Bundler::Molinillo::DependencyGraph
-  include ::Enumerable
-end
-
-class Bundler::Molinillo::DependencyGraph::Log
-  extend ::Enumerable
-end
-
-class Bundler::Molinillo::DependencyGraph::Vertex
-  def _recursive_predecessors(vertices=T.unsafe(nil)); end
-
-  def _recursive_successors(vertices=T.unsafe(nil)); end
-end
-
-module Bundler::Plugin::API::Source
-  def ==(other); end
-
-  def app_cache_dirname(); end
-
-  def app_cache_path(custom_path=T.unsafe(nil)); end
-
-  def bundler_plugin_api_source?(); end
-
-  def cache(spec, custom_path=T.unsafe(nil)); end
-
-  def cached!(); end
-
-  def can_lock?(spec); end
-
-  def dependency_names(); end
-
-  def dependency_names=(dependency_names); end
-
-  def double_check_for(*_); end
-
-  def eql?(other); end
-
-  def fetch_gemspec_files(); end
-
-  def gem_install_dir(); end
-
-  def hash(); end
-
-  def include?(other); end
-
-  def initialize(opts); end
-
-  def install(spec, opts); end
-
-  def install_path(); end
-
-  def installed?(); end
-
-  def name(); end
-
-  def options(); end
-
-  def options_to_lock(); end
-
-  def post_install(spec, disable_exts=T.unsafe(nil)); end
-
-  def remote!(); end
-
-  def root(); end
-
-  def specs(); end
-
-  def to_lock(); end
-
-  def to_s(); end
-
-  def unlock!(); end
-
-  def unmet_deps(); end
-
-  def uri(); end
-
-  def uri_hash(); end
-end
-
-module Bundler::Plugin::API::Source
-end
-
-module Bundler::Plugin::Events
-  GEM_AFTER_INSTALL = ::T.let(nil, ::T.untyped)
-  GEM_AFTER_INSTALL_ALL = ::T.let(nil, ::T.untyped)
-  GEM_BEFORE_INSTALL = ::T.let(nil, ::T.untyped)
-  GEM_BEFORE_INSTALL_ALL = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Plugin::Index
-  def installed_plugins(); end
-
-  def plugin_commands(plugin); end
-end
-
-class Bundler::Plugin::Index::CommandConflict
-  def initialize(plugin, commands); end
-end
-
-class Bundler::Plugin::Index::CommandConflict
-end
-
-class Bundler::Plugin::Index::SourceConflict
-  def initialize(plugin, sources); end
-end
-
-class Bundler::Plugin::Index::SourceConflict
-end
-
-class Bundler::Plugin::Installer
-  def install(names, options); end
-
-  def install_definition(definition); end
-end
-
-class Bundler::Plugin::Installer::Git
-  def generate_bin(spec, disable_extensions=T.unsafe(nil)); end
-end
-
-class Bundler::Plugin::Installer::Git
-end
-
-class Bundler::Plugin::Installer::Rubygems
-end
-
-class Bundler::Plugin::Installer::Rubygems
-end
-
-class Bundler::Plugin::Installer
-end
-
-class Bundler::Plugin::SourceList
-end
-
-class Bundler::Plugin::SourceList
-end
-
-module Bundler::Plugin
-  def self.list(); end
-end
-
-class Bundler::ProcessLock
-end
-
-class Bundler::ProcessLock
-  def self.lock(bundle_path=T.unsafe(nil)); end
-end
-
-class Bundler::Retry
-  def attempt(&block); end
-
-  def attempts(&block); end
-
-  def current_run(); end
-
-  def current_run=(current_run); end
-
-  def initialize(name, exceptions=T.unsafe(nil), retries=T.unsafe(nil)); end
-
-  def name(); end
-
-  def name=(name); end
-
-  def total_runs(); end
-
-  def total_runs=(total_runs); end
-end
-
-class Bundler::Retry
-  def self.attempts(); end
-
-  def self.default_attempts(); end
-
-  def self.default_retries(); end
-end
-
-class Bundler::RubyGemsGemInstaller
-end
-
-class Bundler::RubyGemsGemInstaller
-end
-
-class Bundler::RubygemsIntegration
-  def add_to_load_path(paths); end
-
-  def all_specs(); end
-
-  def backport_ext_builder_monitor(); end
-
-  def correct_for_windows_path(path); end
-
-  def default_stubs(); end
-
-  def find_name(name); end
-
-  def gem_remote_fetcher(); end
-
-  def plain_specs(); end
-
-  def plain_specs=(specs); end
-
-  def stub_rubygems(specs); end
-
-  def use_gemdeps(gemfile); end
-end
-
-class Bundler::Settings::Mirror
-  def ==(other); end
-
-  def fallback_timeout(); end
-
-  def fallback_timeout=(timeout); end
-
-  def initialize(uri=T.unsafe(nil), fallback_timeout=T.unsafe(nil)); end
-
-  def uri(); end
-
-  def uri=(uri); end
-
-  def valid?(); end
-
-  def validate!(probe=T.unsafe(nil)); end
-  DEFAULT_FALLBACK_TIMEOUT = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Settings::Mirror
-end
-
-class Bundler::Settings::Mirrors
-  def each(&blk); end
-
-  def for(uri); end
-
-  def initialize(prober=T.unsafe(nil)); end
-
-  def parse(key, value); end
-end
-
-class Bundler::Settings::Mirrors
-end
-
-class Bundler::Settings::Validator
-end
-
-class Bundler::Settings::Validator::Rule
-  def description(); end
-
-  def fail!(key, value, *reasons); end
-
-  def initialize(keys, description, &validate); end
-
-  def k(key); end
-
-  def set(settings, key, value, *reasons); end
-
-  def validate!(key, value, settings); end
-end
-
-class Bundler::Settings::Validator::Rule
-end
-
-class Bundler::Settings::Validator
-  def self.validate!(key, value, settings); end
-end
-
-class Bundler::Source::Git
-  def glob(); end
-end
-
-class Bundler::SpecSet
-  include ::Enumerable
-end
-
-class Bundler::Thor
-  include ::Bundler::Thor::Base
-  include ::Bundler::Thor::Invocation
-  include ::Bundler::Thor::Shell
-  def help(command=T.unsafe(nil), subcommand=T.unsafe(nil)); end
-  HELP_MAPPINGS = ::T.let(nil, ::T.untyped)
-  TEMPLATE_EXTNAME = ::T.let(nil, ::T.untyped)
-  THOR_RESERVED_WORDS = ::T.let(nil, ::T.untyped)
-end
-
-module Bundler::Thor::Actions
-  def _cleanup_options_and_set(options, key); end
-
-  def _shared_configuration(); end
-
-  def action(instance); end
-
-  def add_file(destination, *args, &block); end
-
-  def add_link(destination, *args); end
-
-  def append_file(path, *args, &block); end
-
-  def append_to_file(path, *args, &block); end
-
-  def apply(path, config=T.unsafe(nil)); end
-
-  def behavior(); end
-
-  def behavior=(behavior); end
-
-  def chmod(path, mode, config=T.unsafe(nil)); end
-
-  def comment_lines(path, flag, *args); end
-
-  def copy_file(source, *args, &block); end
-
-  def create_file(destination, *args, &block); end
-
-  def create_link(destination, *args); end
-
-  def destination_root(); end
-
-  def destination_root=(root); end
-
-  def directory(source, *args, &block); end
-
-  def empty_directory(destination, config=T.unsafe(nil)); end
-
-  def find_in_source_paths(file); end
-
-  def get(source, *args, &block); end
-
-  def gsub_file(path, flag, *args, &block); end
-
-  def in_root(); end
-
-  def initialize(args=T.unsafe(nil), options=T.unsafe(nil), config=T.unsafe(nil)); end
-
-  def inject_into_class(path, klass, *args, &block); end
-
-  def inject_into_file(destination, *args, &block); end
-
-  def inject_into_module(path, module_name, *args, &block); end
-
-  def insert_into_file(destination, *args, &block); end
-
-  def inside(dir=T.unsafe(nil), config=T.unsafe(nil), &block); end
-
-  def link_file(source, *args); end
-
-  def prepend_file(path, *args, &block); end
-
-  def prepend_to_file(path, *args, &block); end
-
-  def relative_to_original_destination_root(path, remove_dot=T.unsafe(nil)); end
-
-  def remove_dir(path, config=T.unsafe(nil)); end
-
-  def remove_file(path, config=T.unsafe(nil)); end
-
-  def run(command, config=T.unsafe(nil)); end
-
-  def run_ruby_script(command, config=T.unsafe(nil)); end
-
-  def source_paths(); end
-
-  def template(source, *args, &block); end
-
-  def thor(command, *args); end
-
-  def uncomment_lines(path, flag, *args); end
-  WARNINGS = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Actions::CapturableERB
-end
-
-class Bundler::Thor::Actions::CapturableERB
-end
-
-module Bundler::Thor::Actions::ClassMethods
-  def add_runtime_options!(); end
-
-  def source_paths(); end
-
-  def source_paths_for_search(); end
-
-  def source_root(path=T.unsafe(nil)); end
-end
-
-module Bundler::Thor::Actions::ClassMethods
-end
-
-class Bundler::Thor::Actions::CreateFile
-  def data(); end
-
-  def force_on_collision?(); end
-
-  def force_or_skip_or_conflict(force, skip, &block); end
-
-  def identical?(); end
-
-  def initialize(base, destination, data, config=T.unsafe(nil)); end
-
-  def on_conflict_behavior(&block); end
-
-  def render(); end
-end
-
-class Bundler::Thor::Actions::CreateFile
-end
-
-class Bundler::Thor::Actions::CreateLink
-end
-
-class Bundler::Thor::Actions::CreateLink
-end
-
-class Bundler::Thor::Actions::Directory
-  def execute!(); end
-
-  def file_level_lookup(previous_lookup); end
-
-  def files(lookup); end
-
-  def initialize(base, source, destination=T.unsafe(nil), config=T.unsafe(nil), &block); end
-
-  def source(); end
-end
-
-class Bundler::Thor::Actions::Directory
-end
-
-class Bundler::Thor::Actions::EmptyDirectory
-  def base(); end
-
-  def config(); end
-
-  def convert_encoded_instructions(filename); end
-
-  def destination(); end
-
-  def destination=(destination); end
-
-  def exists?(); end
-
-  def given_destination(); end
-
-  def initialize(base, destination, config=T.unsafe(nil)); end
-
-  def invoke!(); end
-
-  def invoke_with_conflict_check(&block); end
-
-  def on_conflict_behavior(); end
-
-  def on_file_clash_behavior(); end
-
-  def pretend?(); end
-
-  def relative_destination(); end
-
-  def revoke!(); end
-
-  def say_status(status, color); end
-end
-
-class Bundler::Thor::Actions::EmptyDirectory
-end
-
-class Bundler::Thor::Actions::InjectIntoFile
-  def behavior(); end
-
-  def flag(); end
-
-  def initialize(base, destination, data, config); end
-
-  def replace!(regexp, string, force); end
-
-  def replacement(); end
-
-  def say_status(behavior, warning: T.unsafe(nil), color: T.unsafe(nil)); end
-end
-
-class Bundler::Thor::Actions::InjectIntoFile
-end
-
-module Bundler::Thor::Actions
-  def self.included(base); end
-end
-
-class Bundler::Thor::AmbiguousCommandError
-end
-
-class Bundler::Thor::AmbiguousCommandError
-end
-
-Bundler::Thor::AmbiguousTaskError = Bundler::Thor::AmbiguousCommandError
-
-class Bundler::Thor::Argument
-  def banner(); end
-
-  def default(); end
-
-  def default_banner(); end
-
-  def description(); end
-
-  def enum(); end
-
-  def human_name(); end
-
-  def initialize(name, options=T.unsafe(nil)); end
-
-  def name(); end
-
-  def required(); end
-
-  def required?(); end
-
-  def show_default?(); end
-
-  def type(); end
-
-  def usage(); end
-
-  def valid_type?(type); end
-
-  def validate!(); end
-  VALID_TYPES = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Argument
-end
-
-class Bundler::Thor::Arguments
-  def initialize(arguments=T.unsafe(nil)); end
-
-  def parse(args); end
-
-  def remaining(); end
-  NUMERIC = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Arguments
-  def self.parse(*args); end
-
-  def self.split(args); end
-end
-
-module Bundler::Thor::Base
-  def args(); end
-
-  def args=(args); end
-
-  def initialize(args=T.unsafe(nil), local_options=T.unsafe(nil), config=T.unsafe(nil)); end
-
-  def options(); end
-
-  def options=(options); end
-
-  def parent_options(); end
-
-  def parent_options=(parent_options); end
-end
-
-module Bundler::Thor::Base::ClassMethods
-  def all_commands(); end
-
-  def all_tasks(); end
-
-  def allow_incompatible_default_type!(); end
-
-  def argument(name, options=T.unsafe(nil)); end
-
-  def arguments(); end
-
-  def attr_accessor(*_); end
-
-  def attr_reader(*_); end
-
-  def attr_writer(*_); end
-
-  def baseclass(); end
-
-  def basename(); end
-
-  def build_option(name, options, scope); end
-
-  def build_options(options, scope); end
-
-  def check_default_type(); end
-
-  def check_default_type!(); end
-
-  def check_unknown_options(); end
-
-  def check_unknown_options!(); end
-
-  def check_unknown_options?(config); end
-
-  def class_option(name, options=T.unsafe(nil)); end
-
-  def class_options(options=T.unsafe(nil)); end
-
-  def class_options_help(shell, groups=T.unsafe(nil)); end
-
-  def commands(); end
-
-  def create_command(meth); end
-
-  def create_task(meth); end
-
-  def disable_required_check?(command_name); end
-
-  def dispatch(command, given_args, given_opts, config); end
-
-  def exit_on_failure?(); end
-
-  def find_and_refresh_command(name); end
-
-  def find_and_refresh_task(name); end
-
-  def from_superclass(method, default=T.unsafe(nil)); end
-
-  def group(name=T.unsafe(nil)); end
-
-  def handle_argument_error(command, error, args, arity); end
-
-  def handle_no_command_error(command, has_namespace=T.unsafe(nil)); end
-
-  def handle_no_task_error(command, has_namespace=T.unsafe(nil)); end
-
-  def inherited(klass); end
-
-  def initialize_added(); end
-
-  def is_thor_reserved_word?(word, type); end
-
-  def method_added(meth); end
-
-  def namespace(name=T.unsafe(nil)); end
-
-  def no_commands(&block); end
-
-  def no_commands?(); end
-
-  def no_commands_context(); end
-
-  def no_tasks(&block); end
-
-  def print_options(shell, options, group_name=T.unsafe(nil)); end
-
-  def public_command(*names); end
-
-  def public_task(*names); end
-
-  def remove_argument(*names); end
-
-  def remove_class_option(*names); end
-
-  def remove_command(*names); end
-
-  def remove_task(*names); end
-
-  def start(given_args=T.unsafe(nil), config=T.unsafe(nil)); end
-
-  def stop_on_unknown_option?(command_name); end
-
-  def strict_args_position(); end
-
-  def strict_args_position!(); end
-
-  def strict_args_position?(config); end
-
-  def tasks(); end
-end
-
-module Bundler::Thor::Base::ClassMethods
-end
-
-module Bundler::Thor::Base
-  def self.included(base); end
-
-  def self.register_klass_file(klass); end
-
-  def self.shell(); end
-
-  def self.shell=(shell); end
-
-  def self.subclass_files(); end
-
-  def self.subclasses(); end
-end
-
-class Bundler::Thor::Command
-  def formatted_usage(klass, namespace=T.unsafe(nil), subcommand=T.unsafe(nil)); end
-
-  def handle_argument_error?(instance, error, caller); end
-
-  def handle_no_method_error?(instance, error, caller); end
-
-  def hidden?(); end
-
-  def initialize(name, description, long_description, usage, options=T.unsafe(nil)); end
-
-  def local_method?(instance, name); end
-
-  def not_debugging?(instance); end
-
-  def private_method?(instance); end
-
-  def public_method?(instance); end
-
-  def required_arguments_for(klass, usage); end
-
-  def required_options(); end
-
-  def run(instance, args=T.unsafe(nil)); end
-
-  def sans_backtrace(backtrace, caller); end
-  FILE_REGEXP = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Command
-end
-
-module Bundler::Thor::CoreExt
-end
-
-class Bundler::Thor::CoreExt::HashWithIndifferentAccess
-  def [](key); end
-
-  def []=(key, value); end
-
-  def convert_key(key); end
-
-  def delete(key); end
-
-  def fetch(key, *args); end
-
-  def initialize(hash=T.unsafe(nil)); end
-
-  def key?(key); end
-
-  def merge(other); end
-
-  def merge!(other); end
-
-  def method_missing(method, *args); end
-
-  def replace(other_hash); end
-
-  def reverse_merge(other); end
-
-  def reverse_merge!(other_hash); end
-
-  def values_at(*indices); end
-end
-
-class Bundler::Thor::CoreExt::HashWithIndifferentAccess
-end
-
-module Bundler::Thor::CoreExt
-end
-
-Bundler::Thor::Correctable = DidYouMean::Correctable
-
-class Bundler::Thor::DynamicCommand
-  def initialize(name, options=T.unsafe(nil)); end
-end
-
-class Bundler::Thor::DynamicCommand
-end
-
-Bundler::Thor::DynamicTask = Bundler::Thor::DynamicCommand
-
-class Bundler::Thor::Error
-end
-
-class Bundler::Thor::Error
-end
-
-class Bundler::Thor::Group
-  include ::Bundler::Thor::Base
-  include ::Bundler::Thor::Invocation
-  include ::Bundler::Thor::Shell
-  def _invoke_for_class_method(klass, command=T.unsafe(nil), *args, &block); end
-end
-
-class Bundler::Thor::Group
-  extend ::Bundler::Thor::Base::ClassMethods
-  extend ::Bundler::Thor::Invocation::ClassMethods
-  def self.banner(); end
-
-  def self.desc(description=T.unsafe(nil)); end
-
-  def self.get_options_from_invocations(group_options, base_options); end
-
-  def self.handle_argument_error(command, error, _args, arity); end
-
-  def self.help(shell); end
-
-  def self.invocation_blocks(); end
-
-  def self.invocations(); end
-
-  def self.invoke(*names, &block); end
-
-  def self.invoke_from_option(*names, &block); end
-
-  def self.printable_commands(*_); end
-
-  def self.printable_tasks(*_); end
-
-  def self.remove_invocation(*names); end
-
-  def self.self_command(); end
-
-  def self.self_task(); end
-end
-
-class Bundler::Thor::HiddenCommand
-end
-
-class Bundler::Thor::HiddenCommand
-end
-
-Bundler::Thor::HiddenTask = Bundler::Thor::HiddenCommand
-
-module Bundler::Thor::Invocation
-  def _parse_initialization_options(args, opts, config); end
-
-  def _retrieve_class_and_command(name, sent_command=T.unsafe(nil)); end
-
-  def _retrieve_class_and_task(name, sent_command=T.unsafe(nil)); end
-
-  def _shared_configuration(); end
-
-  def current_command_chain(); end
-
-  def initialize(args=T.unsafe(nil), options=T.unsafe(nil), config=T.unsafe(nil), &block); end
-
-  def invoke(name=T.unsafe(nil), *args); end
-
-  def invoke_all(); end
-
-  def invoke_command(command, *args); end
-
-  def invoke_task(command, *args); end
-
-  def invoke_with_padding(*args); end
-end
-
-module Bundler::Thor::Invocation::ClassMethods
-  def prepare_for_invocation(key, name); end
-end
-
-module Bundler::Thor::Invocation::ClassMethods
-end
-
-module Bundler::Thor::Invocation
-  def self.included(base); end
-end
-
-class Bundler::Thor::InvocationError
-end
-
-class Bundler::Thor::InvocationError
-end
-
-module Bundler::Thor::LineEditor
-end
-
-class Bundler::Thor::LineEditor::Basic
-  def initialize(prompt, options); end
-
-  def options(); end
-
-  def prompt(); end
-
-  def readline(); end
-end
-
-class Bundler::Thor::LineEditor::Basic
-  def self.available?(); end
-end
-
-class Bundler::Thor::LineEditor::Readline
-end
-
-class Bundler::Thor::LineEditor::Readline::PathCompletion
-  def initialize(text); end
-
-  def matches(); end
-end
-
-class Bundler::Thor::LineEditor::Readline::PathCompletion
-end
-
-class Bundler::Thor::LineEditor::Readline
-end
-
-module Bundler::Thor::LineEditor
-  def self.best_available(); end
-
-  def self.readline(prompt, options=T.unsafe(nil)); end
-end
-
-class Bundler::Thor::MalformattedArgumentError
-end
-
-class Bundler::Thor::MalformattedArgumentError
-end
-
-class Bundler::Thor::NestedContext
-  def enter(); end
-
-  def entered?(); end
-end
-
-class Bundler::Thor::NestedContext
-end
-
-class Bundler::Thor::NoKwargSpellChecker
-  def initialize(dictionary); end
-end
-
-class Bundler::Thor::NoKwargSpellChecker
-end
-
-class Bundler::Thor::Option
-  def aliases(); end
-
-  def array?(); end
-
-  def boolean?(); end
-
-  def dasherize(str); end
-
-  def dasherized?(); end
-
-  def group(); end
-
-  def hash?(); end
-
-  def hide(); end
-
-  def lazy_default(); end
-
-  def numeric?(); end
-
-  def repeatable(); end
-
-  def string?(); end
-
-  def switch_name(); end
-
-  def undasherize(str); end
-
-  def usage(padding=T.unsafe(nil)); end
-
-  def validate_default_type!(); end
-  VALID_TYPES = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Option
-  def self.parse(key, value); end
-end
-
-class Bundler::Thor::Options
-  def assign_result!(option, result); end
-
-  def check_unknown!(); end
-
-  def current_is_switch?(); end
-
-  def current_is_switch_formatted?(); end
-
-  def initialize(hash_options=T.unsafe(nil), defaults=T.unsafe(nil), stop_on_unknown=T.unsafe(nil), disable_required_check=T.unsafe(nil)); end
-
-  def normalize_switch(arg); end
-
-  def parse_boolean(switch); end
-
-  def parse_peek(switch, option); end
-
-  def parsing_options?(); end
-
-  def switch?(arg); end
-
-  def switch_option(arg); end
-  EQ_RE = ::T.let(nil, ::T.untyped)
-  LONG_RE = ::T.let(nil, ::T.untyped)
-  OPTS_END = ::T.let(nil, ::T.untyped)
-  SHORT_NUM = ::T.let(nil, ::T.untyped)
-  SHORT_RE = ::T.let(nil, ::T.untyped)
-  SHORT_SQ_RE = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Options
-  def self.to_switches(options); end
-end
-
-class Bundler::Thor::RequiredArgumentMissingError
-end
-
-class Bundler::Thor::RequiredArgumentMissingError
-end
-
-module Bundler::Thor::Sandbox
-end
-
-module Bundler::Thor::Sandbox
-end
-
-module Bundler::Thor::Shell
-  def _shared_configuration(); end
-
-  def ask(*args, &block); end
-
-  def error(*args, &block); end
-
-  def file_collision(*args, &block); end
-
-  def initialize(args=T.unsafe(nil), options=T.unsafe(nil), config=T.unsafe(nil)); end
-
-  def no?(*args, &block); end
-
-  def print_in_columns(*args, &block); end
-
-  def print_table(*args, &block); end
-
-  def print_wrapped(*args, &block); end
-
-  def say(*args, &block); end
-
-  def say_status(*args, &block); end
-
-  def set_color(*args, &block); end
-
-  def shell(); end
-
-  def shell=(shell); end
-
-  def terminal_width(*args, &block); end
-
-  def with_padding(); end
-
-  def yes?(*args, &block); end
-  SHELL_DELEGATED_METHODS = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Shell::Basic
-  def answer_match(possibilities, answer, case_insensitive); end
-
-  def as_unicode(); end
-
-  def ask(statement, *args); end
-
-  def ask_filtered(statement, color, options); end
-
-  def ask_simply(statement, color, options); end
-
-  def base(); end
-
-  def base=(base); end
-
-  def can_display_colors?(); end
-
-  def dynamic_width(); end
-
-  def dynamic_width_stty(); end
-
-  def dynamic_width_tput(); end
-
-  def error(statement); end
-
-  def file_collision(destination); end
-
-  def file_collision_help(); end
-
-  def git_merge_tool(); end
-
-  def indent(count=T.unsafe(nil)); end
-
-  def is?(value); end
-
-  def lookup_color(color); end
-
-  def merge(destination, content); end
-
-  def merge_tool(); end
-
-  def mute(); end
-
-  def mute?(); end
-
-  def no?(statement, color=T.unsafe(nil)); end
-
-  def padding(); end
-
-  def padding=(value); end
-
-  def prepare_message(message, *color); end
-
-  def print_in_columns(array); end
-
-  def print_table(array, options=T.unsafe(nil)); end
-
-  def print_wrapped(message, options=T.unsafe(nil)); end
-
-  def quiet?(); end
-
-  def say(message=T.unsafe(nil), color=T.unsafe(nil), force_new_line=T.unsafe(nil)); end
-
-  def say_status(status, message, log_status=T.unsafe(nil)); end
-
-  def set_color(string, *_); end
-
-  def show_diff(destination, content); end
-
-  def stderr(); end
-
-  def stdout(); end
-
-  def terminal_width(); end
-
-  def truncate(string, width); end
-
-  def unix?(); end
-
-  def yes?(statement, color=T.unsafe(nil)); end
-  DEFAULT_TERMINAL_WIDTH = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Shell::Basic
-end
-
-class Bundler::Thor::Shell::Color
-  def are_colors_disabled?(); end
-
-  def diff_lcs_loaded?(); end
-
-  def output_diff_line(diff); end
-
-  def set_color(string, *colors); end
-  BLACK = ::T.let(nil, ::T.untyped)
-  BLUE = ::T.let(nil, ::T.untyped)
-  BOLD = ::T.let(nil, ::T.untyped)
-  CLEAR = ::T.let(nil, ::T.untyped)
-  CYAN = ::T.let(nil, ::T.untyped)
-  GREEN = ::T.let(nil, ::T.untyped)
-  MAGENTA = ::T.let(nil, ::T.untyped)
-  ON_BLACK = ::T.let(nil, ::T.untyped)
-  ON_BLUE = ::T.let(nil, ::T.untyped)
-  ON_CYAN = ::T.let(nil, ::T.untyped)
-  ON_GREEN = ::T.let(nil, ::T.untyped)
-  ON_MAGENTA = ::T.let(nil, ::T.untyped)
-  ON_RED = ::T.let(nil, ::T.untyped)
-  ON_WHITE = ::T.let(nil, ::T.untyped)
-  ON_YELLOW = ::T.let(nil, ::T.untyped)
-  RED = ::T.let(nil, ::T.untyped)
-  WHITE = ::T.let(nil, ::T.untyped)
-  YELLOW = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Shell::Color
-end
-
-class Bundler::Thor::Shell::HTML
-  def ask(statement, color=T.unsafe(nil)); end
-
-  def diff_lcs_loaded?(); end
-
-  def output_diff_line(diff); end
-
-  def set_color(string, *colors); end
-  BLACK = ::T.let(nil, ::T.untyped)
-  BLUE = ::T.let(nil, ::T.untyped)
-  BOLD = ::T.let(nil, ::T.untyped)
-  CYAN = ::T.let(nil, ::T.untyped)
-  GREEN = ::T.let(nil, ::T.untyped)
-  MAGENTA = ::T.let(nil, ::T.untyped)
-  ON_BLACK = ::T.let(nil, ::T.untyped)
-  ON_BLUE = ::T.let(nil, ::T.untyped)
-  ON_CYAN = ::T.let(nil, ::T.untyped)
-  ON_GREEN = ::T.let(nil, ::T.untyped)
-  ON_MAGENTA = ::T.let(nil, ::T.untyped)
-  ON_RED = ::T.let(nil, ::T.untyped)
-  ON_WHITE = ::T.let(nil, ::T.untyped)
-  ON_YELLOW = ::T.let(nil, ::T.untyped)
-  RED = ::T.let(nil, ::T.untyped)
-  WHITE = ::T.let(nil, ::T.untyped)
-  YELLOW = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Shell::HTML
-end
-
-module Bundler::Thor::Shell
-end
-
-Bundler::Thor::Task = Bundler::Thor::Command
-
-class Bundler::Thor::UndefinedCommandError
-  include ::DidYouMean::Correctable
-  def all_commands(); end
-
-  def command(); end
-
-  def initialize(command, all_commands, namespace); end
-end
-
-class Bundler::Thor::UndefinedCommandError::SpellChecker
-  def corrections(); end
-
-  def error(); end
-
-  def initialize(error); end
-
-  def spell_checker(); end
-end
-
-class Bundler::Thor::UndefinedCommandError::SpellChecker
-end
-
-class Bundler::Thor::UndefinedCommandError
-end
-
-Bundler::Thor::UndefinedTaskError = Bundler::Thor::UndefinedCommandError
-
-class Bundler::Thor::UnknownArgumentError
-  include ::DidYouMean::Correctable
-  def initialize(switches, unknown); end
-
-  def switches(); end
-
-  def unknown(); end
-end
-
-class Bundler::Thor::UnknownArgumentError::SpellChecker
-  def corrections(); end
-
-  def error(); end
-
-  def initialize(error); end
-
-  def spell_checker(); end
-end
-
-class Bundler::Thor::UnknownArgumentError::SpellChecker
-end
-
-class Bundler::Thor::UnknownArgumentError
-end
-
-module Bundler::Thor::Util
-end
-
-module Bundler::Thor::Util
-  def self.camel_case(str); end
-
-  def self.escape_globs(path); end
-
-  def self.escape_html(string); end
-
-  def self.find_by_namespace(namespace); end
-
-  def self.find_class_and_command_by_namespace(namespace, fallback=T.unsafe(nil)); end
-
-  def self.find_class_and_task_by_namespace(namespace, fallback=T.unsafe(nil)); end
-
-  def self.globs_for(path); end
-
-  def self.load_thorfile(path, content=T.unsafe(nil), debug=T.unsafe(nil)); end
-
-  def self.namespace_from_thor_class(constant); end
-
-  def self.namespaces_in_content(contents, file=T.unsafe(nil)); end
-
-  def self.ruby_command(); end
-
-  def self.snake_case(str); end
-
-  def self.thor_classes_in(klass); end
-
-  def self.thor_root(); end
-
-  def self.thor_root_glob(); end
-
-  def self.user_home(); end
-end
-
-class Bundler::Thor
-  extend ::Bundler::Thor::Base::ClassMethods
-  extend ::Bundler::Thor::Invocation::ClassMethods
-  def self.banner(command, namespace=T.unsafe(nil), subcommand=T.unsafe(nil)); end
-
-  def self.check_unknown_options!(options=T.unsafe(nil)); end
-
-  def self.command_help(shell, command_name); end
-
-  def self.default_command(meth=T.unsafe(nil)); end
-
-  def self.default_task(meth=T.unsafe(nil)); end
-
-  def self.deprecation_warning(message); end
-
-  def self.desc(usage, description, options=T.unsafe(nil)); end
-
-  def self.disable_required_check(); end
-
-  def self.disable_required_check!(*command_names); end
-
-  def self.disable_required_check?(command); end
-
-  def self.dispatch(meth, given_args, given_opts, config); end
-
-  def self.dynamic_command_class(); end
-
-  def self.find_command_possibilities(meth); end
-
-  def self.find_task_possibilities(meth); end
-
-  def self.help(shell, subcommand=T.unsafe(nil)); end
-
-  def self.long_desc(long_description, options=T.unsafe(nil)); end
-
-  def self.map(mappings=T.unsafe(nil), **kw); end
-
-  def self.method_option(name, options=T.unsafe(nil)); end
-
-  def self.method_options(options=T.unsafe(nil)); end
-
-  def self.normalize_command_name(meth); end
-
-  def self.normalize_task_name(meth); end
-
-  def self.option(name, options=T.unsafe(nil)); end
-
-  def self.options(options=T.unsafe(nil)); end
-
-  def self.package_name(name, _=T.unsafe(nil)); end
-
-  def self.printable_commands(all=T.unsafe(nil), subcommand=T.unsafe(nil)); end
-
-  def self.printable_tasks(all=T.unsafe(nil), subcommand=T.unsafe(nil)); end
-
-  def self.register(klass, subcommand_name, usage, description, options=T.unsafe(nil)); end
-
-  def self.retrieve_command_name(args); end
-
-  def self.retrieve_task_name(args); end
-
-  def self.stop_on_unknown_option(); end
-
-  def self.stop_on_unknown_option!(*command_names); end
-
-  def self.stop_on_unknown_option?(command); end
-
-  def self.subcommand(subcommand, subcommand_class); end
-
-  def self.subcommand_classes(); end
-
-  def self.subcommand_help(cmd); end
-
-  def self.subcommands(); end
-
-  def self.subtask(subcommand, subcommand_class); end
-
-  def self.subtask_help(cmd); end
-
-  def self.subtasks(); end
-
-  def self.task_help(shell, command_name); end
-end
-
-class Bundler::UI::Shell
-  def add_color(string, *color); end
-
-  def ask(msg); end
-
-  def confirm(msg, newline=T.unsafe(nil)); end
-
-  def debug(msg, newline=T.unsafe(nil)); end
-
-  def debug?(); end
-
-  def error(msg, newline=T.unsafe(nil)); end
-
-  def info(msg, newline=T.unsafe(nil)); end
-
-  def initialize(options=T.unsafe(nil)); end
-
-  def level(name=T.unsafe(nil)); end
-
-  def level=(level); end
-
-  def no?(); end
-
-  def quiet?(); end
-
-  def shell=(shell); end
-
-  def silence(&blk); end
-
-  def trace(e, newline=T.unsafe(nil), force=T.unsafe(nil)); end
-
-  def unprinted_warnings(); end
-
-  def warn(msg, newline=T.unsafe(nil)); end
-
-  def yes?(msg); end
-  LEVELS = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::UI::Shell
-end
-
-module Bundler::VersionRanges
-end
-
-class Bundler::VersionRanges::NEq
-  def version(); end
-
-  def version=(_); end
-end
-
-class Bundler::VersionRanges::NEq
-  def self.[](*_); end
-
-  def self.members(); end
-end
-
-class Bundler::VersionRanges::ReqR
-  def cover?(v); end
-
-  def empty?(); end
-
-  def left(); end
-
-  def left=(_); end
-
-  def right(); end
-
-  def right=(_); end
-
-  def single?(); end
-  INFINITY = ::T.let(nil, ::T.untyped)
-  UNIVERSAL = ::T.let(nil, ::T.untyped)
-  ZERO = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::VersionRanges::ReqR::Endpoint
-  def inclusive(); end
-
-  def inclusive=(_); end
-
-  def version(); end
-
-  def version=(_); end
-end
-
-class Bundler::VersionRanges::ReqR::Endpoint
-  def self.[](*_); end
-
-  def self.members(); end
-end
-
-class Bundler::VersionRanges::ReqR
-  def self.[](*_); end
-
-  def self.members(); end
-end
-
-module Bundler::VersionRanges
-  def self.empty?(ranges, neqs); end
-
-  def self.for(requirement); end
-
-  def self.for_many(requirements); end
 end
 
 module Bundler
@@ -1906,102 +52,6 @@ class Delegator
   RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
 end
 
-class DidYouMean::ClassNameChecker
-  def class_name(); end
-
-  def class_names(); end
-
-  def corrections(); end
-
-  def initialize(exception); end
-
-  def scopes(); end
-end
-
-module DidYouMean::Correctable
-  def corrections(); end
-
-  def original_message(); end
-
-  def spell_checker(); end
-
-  def to_s(); end
-end
-
-class DidYouMean::DeprecatedIgnoredCallers
-  def +(*_); end
-
-  def <<(*_); end
-end
-
-class DidYouMean::DeprecatedIgnoredCallers
-end
-
-module DidYouMean::Jaro
-  def self.distance(str1, str2); end
-end
-
-module DidYouMean::JaroWinkler
-  def self.distance(str1, str2); end
-end
-
-class DidYouMean::KeyErrorChecker
-  def corrections(); end
-
-  def initialize(key_error); end
-end
-
-class DidYouMean::KeyErrorChecker
-end
-
-module DidYouMean::Levenshtein
-  def self.distance(str1, str2); end
-
-  def self.min3(a, b, c); end
-end
-
-class DidYouMean::MethodNameChecker
-  def corrections(); end
-
-  def initialize(exception); end
-
-  def method_name(); end
-
-  def method_names(); end
-
-  def receiver(); end
-end
-
-class DidYouMean::NullChecker
-  def corrections(); end
-
-  def initialize(*_); end
-end
-
-class DidYouMean::PlainFormatter
-  def message_for(corrections); end
-end
-
-class DidYouMean::PlainFormatter
-end
-
-class DidYouMean::VariableNameChecker
-  def corrections(); end
-
-  def cvar_names(); end
-
-  def initialize(exception); end
-
-  def ivar_names(); end
-
-  def lvar_names(); end
-
-  def method_names(); end
-
-  def name(); end
-  RB_PREDEFINED_OBJECTS = ::T.let(nil, ::T.untyped)
-end
-
 module DidYouMean
   def self.formatter(); end
 
@@ -2019,11 +69,11 @@ class ERB
 end
 
 class Encoding
+  class Converter
+    def initialize(*_); end
+  # wrong constant name initialize
+  end
   def _dump(*_); end
-end
-
-class Encoding::Converter
-  def initialize(*_); end
 end
 
 class Encoding
@@ -2035,75 +85,14 @@ module Enumerable
 end
 
 class Enumerator
+  class Generator
+    def each(*_, &blk); end
+
+    def initialize(*_); end
+  # wrong constant name each
+  # wrong constant name initialize
+  end
   def each_with_index(); end
-end
-
-class Enumerator::Generator
-  def each(*_, &blk); end
-
-  def initialize(*_); end
-end
-
-Errno::ECAPMODE = Errno::NOERROR
-
-Errno::EDOOFUS = Errno::NOERROR
-
-Errno::EIPSEC = Errno::NOERROR
-
-Errno::ENOTCAPABLE = Errno::NOERROR
-
-class Etc::Group
-  def gid(); end
-
-  def gid=(_); end
-
-  def mem(); end
-
-  def mem=(_); end
-
-  def name(); end
-
-  def name=(_); end
-
-  def passwd(); end
-
-  def passwd=(_); end
-end
-
-class Etc::Group
-  extend ::Enumerable
-  def self.[](*_); end
-
-  def self.each(&blk); end
-
-  def self.members(); end
-end
-
-class Etc::Passwd
-  def dir=(_); end
-
-  def gecos(); end
-
-  def gecos=(_); end
-
-  def gid=(_); end
-
-  def name=(_); end
-
-  def passwd=(_); end
-
-  def shell=(_); end
-
-  def uid=(_); end
-end
-
-class Etc::Passwd
-  extend ::Enumerable
-  def self.[](*_); end
-
-  def self.each(&blk); end
-
-  def self.members(); end
 end
 
 class ExitCalledError
@@ -2121,48 +110,56 @@ class File
 end
 
 module FileUtils
-  include ::FileUtils::StreamUtils_
-end
+  module DryRun
+    include ::FileUtils
+    include StreamUtils_
+    include LowMethods
+  # uninitialized constant FileUtils::DryRun::VERSION
+  # Did you mean?  FileUtils::DryRun::VERSION
+  #                FileUtils::VERSION
+  end
 
-module FileUtils::DryRun
-  include ::FileUtils
-  include ::FileUtils::StreamUtils_
-  include ::FileUtils::LowMethods
-end
+  module DryRun
+    extend DryRun
+    extend ::FileUtils
+    extend StreamUtils_
+    extend LowMethods
+  end
 
-module FileUtils::DryRun
-  extend ::FileUtils::DryRun
-  extend ::FileUtils
-  extend ::FileUtils::StreamUtils_
-  extend ::FileUtils::LowMethods
-end
+  module NoWrite
+    include ::FileUtils
+    include StreamUtils_
+    include LowMethods
+  # uninitialized constant FileUtils::NoWrite::VERSION
+  # Did you mean?  FileUtils::NoWrite::VERSION
+  #                FileUtils::VERSION
+  end
 
-module FileUtils::NoWrite
-  include ::FileUtils
-  include ::FileUtils::StreamUtils_
-  include ::FileUtils::LowMethods
-end
+  module NoWrite
+    extend NoWrite
+    extend ::FileUtils
+    extend StreamUtils_
+    extend LowMethods
+  end
 
-module FileUtils::NoWrite
-  extend ::FileUtils::NoWrite
-  extend ::FileUtils
-  extend ::FileUtils::StreamUtils_
-  extend ::FileUtils::LowMethods
-end
+  module Verbose
+    include ::FileUtils
+    include StreamUtils_
+  # uninitialized constant FileUtils::Verbose::VERSION
+  # Did you mean?  FileUtils::Verbose::VERSION
+  #                FileUtils::VERSION
+  end
 
-module FileUtils::Verbose
-  include ::FileUtils
-  include ::FileUtils::StreamUtils_
-end
-
-module FileUtils::Verbose
-  extend ::FileUtils::Verbose
-  extend ::FileUtils
-  extend ::FileUtils::StreamUtils_
+  module Verbose
+    extend Verbose
+    extend ::FileUtils
+    extend StreamUtils_
+  end
+  include StreamUtils_
 end
 
 module FileUtils
-  extend ::FileUtils::StreamUtils_
+  extend StreamUtils_
 end
 
 class Float
@@ -2180,501 +177,478 @@ module GC
 end
 
 module Gem
+  class Dependency
+    def pretty_print(q); end
+  # wrong constant name <=>
+  # wrong constant name pretty_print
+  end
+
+  class DependencyInstaller
+    def _deprecated_gems_to_install(); end
+
+    def add_found_dependencies(to_do, dependency_list); end
+
+    def gather_dependencies(); end
+
+    def gems_to_install(*args, &block); end
+  # wrong constant name _deprecated_gems_to_install
+  # wrong constant name add_found_dependencies
+  # wrong constant name gather_dependencies
+  # wrong constant name gems_to_install
+  end
+
+  Gem::DependencyResolver = Gem::Resolver
+
+  class Licenses
+    IDENTIFIERS = ::T.let(nil, ::T.untyped)
+  end
+
+  class List
+    def pretty_print(q); end
+  # wrong constant name pretty_print
+  end
+
+  class Package
+    class DigestIO
+      def digests(); end
+
+      def initialize(io, digests); end
+
+      def write(data); end
+    # wrong constant name digests
+    # wrong constant name initialize
+    # wrong constant name write
+    end
+
+    class DigestIO
+      def self.wrap(io, digests); end
+    # wrong constant name <static-init>
+    # wrong constant name wrap
+    end
+
+    class FileSource
+      def initialize(path); end
+
+      def path(); end
+
+      def present?(); end
+
+      def start(); end
+
+      def with_read_io(&block); end
+
+      def with_write_io(&block); end
+    # wrong constant name initialize
+    # wrong constant name path
+    # wrong constant name present?
+    # wrong constant name start
+    # wrong constant name with_read_io
+    # wrong constant name with_write_io
+    end
+
+    class FileSource
+    # wrong constant name <static-init>
+    end
+
+    class IOSource
+      def initialize(io); end
+
+      def io(); end
+
+      def path(); end
+
+      def present?(); end
+
+      def start(); end
+
+      def with_read_io(); end
+
+      def with_write_io(); end
+    # wrong constant name initialize
+    # wrong constant name io
+    # wrong constant name path
+    # wrong constant name present?
+    # wrong constant name start
+    # wrong constant name with_read_io
+    # wrong constant name with_write_io
+    end
+
+    class IOSource
+    # wrong constant name <static-init>
+    end
+
+    class Old
+      def extract_files(destination_dir); end
+
+      def file_list(io); end
+
+      def read_until_dashes(io); end
+
+      def skip_ruby(io); end
+    # wrong constant name extract_files
+    # wrong constant name file_list
+    # wrong constant name read_until_dashes
+    # wrong constant name skip_ruby
+    end
+
+    class Old
+    # wrong constant name <static-init>
+    end
+
+    class Source
+    end
+
+    class Source
+    # wrong constant name <static-init>
+    end
+
+    class TarHeader
+      def ==(other); end
+
+      def checksum(); end
+
+      def devmajor(); end
+
+      def devminor(); end
+
+      def empty?(); end
+
+      def gid(); end
+
+      def gname(); end
+
+      def initialize(vals); end
+
+      def linkname(); end
+
+      def magic(); end
+
+      def mode(); end
+
+      def mtime(); end
+
+      def name(); end
+
+      def prefix(); end
+
+      def size(); end
+
+      def typeflag(); end
+
+      def uid(); end
+
+      def uname(); end
+
+      def update_checksum(); end
+
+      def version(); end
+    # wrong constant name ==
+      FIELDS = ::T.let(nil, ::T.untyped)
+      PACK_FORMAT = ::T.let(nil, ::T.untyped)
+      UNPACK_FORMAT = ::T.let(nil, ::T.untyped)
+    # wrong constant name checksum
+    # wrong constant name devmajor
+    # wrong constant name devminor
+    # wrong constant name empty?
+    # wrong constant name gid
+    # wrong constant name gname
+    # wrong constant name initialize
+    # wrong constant name linkname
+    # wrong constant name magic
+    # wrong constant name mode
+    # wrong constant name mtime
+    # wrong constant name name
+    # wrong constant name prefix
+    # wrong constant name size
+    # wrong constant name typeflag
+    # wrong constant name uid
+    # wrong constant name uname
+    # wrong constant name update_checksum
+    # wrong constant name version
+    end
+
+    class TarHeader
+      def self.from(stream); end
+
+      def self.strict_oct(str); end
+    # wrong constant name <static-init>
+    # wrong constant name from
+    # wrong constant name strict_oct
+    end
+
+    class TarReader
+      def self.new(io); end
+    # wrong constant name new
+    end
+
+    class TarWriter
+      def self.new(io); end
+    # wrong constant name new
+    end
+    def realpath(file); end
+  # wrong constant name <Class:DigestIO>
+  # wrong constant name <Class:FileSource>
+  # wrong constant name <Class:IOSource>
+  # wrong constant name <Class:Old>
+  # wrong constant name <Class:Source>
+  # wrong constant name <Class:TarHeader>
+  # wrong constant name realpath
+  end
+
+  class Package
+    def self.new(gem, security_policy=T.unsafe(nil)); end
+  # wrong constant name new
+  end
+
+  class PathSupport
+    def home(); end
+
+    def initialize(env); end
+
+    def path(); end
+
+    def spec_cache_dir(); end
+  # wrong constant name home
+  # wrong constant name initialize
+  # wrong constant name path
+  # wrong constant name spec_cache_dir
+  end
+
+  class RemoteFetcher
+    class FetchError
+      def initialize(message, uri); end
+
+      def uri(); end
+
+      def uri=(uri); end
+    # wrong constant name initialize
+    # wrong constant name uri
+    # wrong constant name uri=
+    end
+
+    class FetchError
+    # wrong constant name <static-init>
+    end
+
+    class UnknownHostError
+    end
+
+    class UnknownHostError
+    # wrong constant name <static-init>
+    end
+    def api_endpoint(uri); end
+
+    def correct_for_windows_path(path); end
+
+    def s3_expiration(); end
+
+    def sign_s3_url(uri, expiration=T.unsafe(nil)); end
+    BASE64_URI_TRANSLATE = ::T.let(nil, ::T.untyped)
+  # wrong constant name <Class:FetchError>
+  # wrong constant name <Class:UnknownHostError>
+  # wrong constant name api_endpoint
+  # wrong constant name correct_for_windows_path
+  # wrong constant name s3_expiration
+  # wrong constant name sign_s3_url
+  end
+
+  class Request
+    extend UserInteraction
+    extend DefaultUserInteraction
+    extend Text
+  end
+
+  class RequestSet
+    Gem::RequestSet::GemDepedencyAPI = Gem::RequestSet::GemDependencyAPI
+    def pretty_print(q); end
+  # wrong constant name pretty_print
+  end
+
+  class Requirement
+    def pretty_print(q); end
+  # wrong constant name pretty_print
+  end
+
+  class RuntimeRequirementNotMetError
+    def suggestion(); end
+
+    def suggestion=(suggestion); end
+  # wrong constant name suggestion
+  # wrong constant name suggestion=
+  end
+
+  class RuntimeRequirementNotMetError
+  # wrong constant name <static-init>
+  end
+
+  # uninitialized constant Gem::S3URISigner
+  # uninitialized constant Gem::S3URISigner
+  class Source
+    def api_uri(); end
+
+    def pretty_print(q); end
+  # wrong constant name <=>
+  # wrong constant name api_uri
+  # wrong constant name pretty_print
+  end
+
+  class SpecFetcher
+    include UserInteraction
+    include DefaultUserInteraction
+    include Text
+    def available_specs(type); end
+
+    def detect(type=T.unsafe(nil)); end
+
+    def initialize(sources=T.unsafe(nil)); end
+
+    def latest_specs(); end
+
+    def prerelease_specs(); end
+
+    def search_for_dependency(dependency, matching_platform=T.unsafe(nil)); end
+
+    def sources(); end
+
+    def spec_for_dependency(dependency, matching_platform=T.unsafe(nil)); end
+
+    def specs(); end
+
+    def suggest_gems_from_name(gem_name, type=T.unsafe(nil)); end
+
+    def tuples_for(source, type, gracefully_ignore=T.unsafe(nil)); end
+  # wrong constant name available_specs
+  # wrong constant name detect
+  # wrong constant name initialize
+  # wrong constant name latest_specs
+  # wrong constant name prerelease_specs
+  # wrong constant name search_for_dependency
+  # wrong constant name sources
+  # wrong constant name spec_for_dependency
+  # wrong constant name specs
+  # wrong constant name suggest_gems_from_name
+  # wrong constant name tuples_for
+  end
+
+  class SpecFetcher
+    def self.fetcher(); end
+
+    def self.fetcher=(fetcher); end
+  # wrong constant name <static-init>
+  # wrong constant name fetcher
+  # wrong constant name fetcher=
+  end
+
+  class Specification
+    include ::Bundler::MatchPlatform
+    include ::Bundler::GemHelpers
+    def bundled_gem_in_old_ruby?(); end
+
+    def pretty_print(q); end
+
+    def rubyforge_project(); end
+
+    def to_ruby(); end
+
+    def warning(statement); end
+  # wrong constant name <=>
+  # uninitialized constant Gem::Specification::GENERICS
+  # Did you mean?  Gem::Specification::GENERICS
+  # uninitialized constant Gem::Specification::GENERIC_CACHE
+  # Did you mean?  Gem::Specification::GENERIC_CACHE
+  # wrong constant name bundled_gem_in_old_ruby?
+  # wrong constant name pretty_print
+  # wrong constant name rubyforge_project
+  # wrong constant name to_ruby
+  # wrong constant name warning
+  end
+
+  class Specification
+    extend ::Enumerable
+    extend Deprecate
+    def self.add_spec(spec); end
+
+    def self.add_specs(*specs); end
+
+    def self.remove_spec(spec); end
+  # wrong constant name add_spec
+  # wrong constant name add_specs
+  # wrong constant name remove_spec
+  end
+
+  # uninitialized constant Gem::Stream
+  # Did you mean?  Gem::StreamUI
+  # uninitialized constant Gem::Stream
+  # Did you mean?  Gem::StreamUI
+  class StubSpecification
+    class StubLine
+      def extensions(); end
+
+      def full_name(); end
+
+      def initialize(data, extensions); end
+
+      def name(); end
+
+      def platform(); end
+
+      def require_paths(); end
+
+      def version(); end
+    # wrong constant name extensions
+    # wrong constant name full_name
+    # wrong constant name initialize
+    # wrong constant name name
+    # wrong constant name platform
+    # wrong constant name require_paths
+    # wrong constant name version
+    end
+    def build_extensions(); end
+
+    def extensions(); end
+
+    def initialize(filename, base_dir, gems_dir, default_gem); end
+
+    def missing_extensions?(); end
+
+    def valid?(); end
+  # wrong constant name build_extensions
+  # wrong constant name extensions
+  # wrong constant name initialize
+  # wrong constant name missing_extensions?
+  # wrong constant name valid?
+  end
+
+  class StubSpecification
+    def self.default_gemspec_stub(filename, base_dir, gems_dir); end
+
+    def self.gemspec_stub(filename, base_dir, gems_dir); end
+  # wrong constant name default_gemspec_stub
+  # wrong constant name gemspec_stub
+  end
+
+  Gem::UnsatisfiableDepedencyError = Gem::UnsatisfiableDependencyError
+
+  # uninitialized constant Gem::UriParser
+  # uninitialized constant Gem::UriParser
+  # uninitialized constant Gem::UriParsing
+  # uninitialized constant Gem::UriParsing
+  module Util
+    NULL_DEVICE = ::T.let(nil, ::T.untyped)
+  end
+
+  class Version
+    Gem::Version::Requirement = Gem::Requirement
+    def pretty_print(q); end
+  # wrong constant name <=>
+  # wrong constant name pretty_print
+  end
   ConfigMap = ::T.let(nil, ::T.untyped)
   RbConfigPriorities = ::T.let(nil, ::T.untyped)
   RubyGemsPackageVersion = ::T.let(nil, ::T.untyped)
   RubyGemsVersion = ::T.let(nil, ::T.untyped)
   USE_BUNDLER_FOR_GEMDEPS = ::T.let(nil, ::T.untyped)
 end
-
-class Gem::Dependency
-  def pretty_print(q); end
-end
-
-class Gem::DependencyInstaller
-  def _deprecated_gems_to_install(); end
-
-  def add_found_dependencies(to_do, dependency_list); end
-
-  def gather_dependencies(); end
-
-  def gems_to_install(*args, &block); end
-end
-
-Gem::DependencyResolver = Gem::Resolver
-
-class Gem::Ext::BuildError
-end
-
-class Gem::Ext::BuildError
-end
-
-class Gem::Ext::Builder
-  def self.redirector(); end
-end
-
-class Gem::Ext::ExtConfBuilder
-end
-
-Gem::Ext::ExtConfBuilder::FileEntry = FileUtils::Entry_
-
-class Gem::Ext::ExtConfBuilder
-  def self.build(extension, directory, dest_path, results, args=T.unsafe(nil), lib_dir=T.unsafe(nil)); end
-
-  def self.get_relative_path(path); end
-end
-
-class Gem::Licenses
-  IDENTIFIERS = ::T.let(nil, ::T.untyped)
-end
-
-class Gem::List
-  def pretty_print(q); end
-end
-
-class Gem::Package
-  def realpath(file); end
-end
-
-class Gem::Package::DigestIO
-  def digests(); end
-
-  def initialize(io, digests); end
-
-  def write(data); end
-end
-
-class Gem::Package::DigestIO
-  def self.wrap(io, digests); end
-end
-
-class Gem::Package::FileSource
-  def initialize(path); end
-
-  def path(); end
-
-  def present?(); end
-
-  def start(); end
-
-  def with_read_io(&block); end
-
-  def with_write_io(&block); end
-end
-
-class Gem::Package::FileSource
-end
-
-class Gem::Package::IOSource
-  def initialize(io); end
-
-  def io(); end
-
-  def path(); end
-
-  def present?(); end
-
-  def start(); end
-
-  def with_read_io(); end
-
-  def with_write_io(); end
-end
-
-class Gem::Package::IOSource
-end
-
-class Gem::Package::Old
-  def extract_files(destination_dir); end
-
-  def file_list(io); end
-
-  def read_until_dashes(io); end
-
-  def skip_ruby(io); end
-end
-
-class Gem::Package::Old
-end
-
-class Gem::Package::Source
-end
-
-class Gem::Package::Source
-end
-
-class Gem::Package::TarHeader
-  def ==(other); end
-
-  def checksum(); end
-
-  def devmajor(); end
-
-  def devminor(); end
-
-  def empty?(); end
-
-  def gid(); end
-
-  def gname(); end
-
-  def initialize(vals); end
-
-  def linkname(); end
-
-  def magic(); end
-
-  def mode(); end
-
-  def mtime(); end
-
-  def name(); end
-
-  def prefix(); end
-
-  def size(); end
-
-  def typeflag(); end
-
-  def uid(); end
-
-  def uname(); end
-
-  def update_checksum(); end
-
-  def version(); end
-  FIELDS = ::T.let(nil, ::T.untyped)
-  PACK_FORMAT = ::T.let(nil, ::T.untyped)
-  UNPACK_FORMAT = ::T.let(nil, ::T.untyped)
-end
-
-class Gem::Package::TarHeader
-  def self.from(stream); end
-
-  def self.strict_oct(str); end
-end
-
-class Gem::Package::TarReader::Entry
-  def bytes_read(); end
-
-  def check_closed(); end
-
-  def close(); end
-
-  def closed?(); end
-
-  def directory?(); end
-
-  def eof?(); end
-
-  def file?(); end
-
-  def full_name(); end
-
-  def getc(); end
-
-  def header(); end
-
-  def initialize(header, io); end
-
-  def pos(); end
-
-  def read(len=T.unsafe(nil)); end
-
-  def readpartial(len=T.unsafe(nil)); end
-
-  def rewind(); end
-
-  def symlink?(); end
-end
-
-class Gem::Package::TarReader::Entry
-end
-
-class Gem::Package::TarReader
-  def self.new(io); end
-end
-
-class Gem::Package::TarWriter
-  def self.new(io); end
-end
-
-class Gem::Package
-  def self.new(gem, security_policy=T.unsafe(nil)); end
-end
-
-class Gem::PathSupport
-  def home(); end
-
-  def initialize(env); end
-
-  def path(); end
-
-  def spec_cache_dir(); end
-end
-
-class Gem::RemoteFetcher
-  def api_endpoint(uri); end
-
-  def correct_for_windows_path(path); end
-
-  def s3_expiration(); end
-
-  def sign_s3_url(uri, expiration=T.unsafe(nil)); end
-  BASE64_URI_TRANSLATE = ::T.let(nil, ::T.untyped)
-end
-
-class Gem::RemoteFetcher::FetchError
-  def initialize(message, uri); end
-
-  def uri(); end
-
-  def uri=(uri); end
-end
-
-class Gem::RemoteFetcher::FetchError
-end
-
-class Gem::RemoteFetcher::UnknownHostError
-end
-
-class Gem::RemoteFetcher::UnknownHostError
-end
-
-class Gem::Request
-  extend ::Gem::UserInteraction
-  extend ::Gem::DefaultUserInteraction
-  extend ::Gem::Text
-end
-
-class Gem::RequestSet
-  def pretty_print(q); end
-end
-
-Gem::RequestSet::GemDepedencyAPI = Gem::RequestSet::GemDependencyAPI
-
-class Gem::Requirement
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::APISet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::APISpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::ActivationRequest
-  def others_possible?(); end
-
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::BestSet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::Conflict
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::CurrentSet
-end
-
-class Gem::Resolver::CurrentSet
-end
-
-class Gem::Resolver::DependencyRequest
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::GitSet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::GitSpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::IndexSet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::IndexSpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::InstalledSpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::InstallerSet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::LocalSpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::LocalSpecification
-end
-
-class Gem::Resolver::LockSet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::LockSpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::Molinillo::DependencyGraph::Log
-  def add_edge_no_circular(graph, origin, destination, requirement); end
-
-  def add_vertex(graph, name, payload, root); end
-
-  def delete_edge(graph, origin_name, destination_name, requirement); end
-
-  def detach_vertex_named(graph, name); end
-
-  def each(&blk); end
-
-  def pop!(graph); end
-
-  def reverse_each(); end
-
-  def rewind_to(graph, tag); end
-
-  def set_payload(graph, name, payload); end
-
-  def tag(graph, tag); end
-end
-
-class Gem::Resolver::Molinillo::DependencyGraph::Log
-  extend ::Enumerable
-end
-
-class Gem::Resolver::VendorSet
-  def pretty_print(q); end
-end
-
-class Gem::RuntimeRequirementNotMetError
-  def suggestion(); end
-
-  def suggestion=(suggestion); end
-end
-
-class Gem::RuntimeRequirementNotMetError
-end
-
-class Gem::Source
-  def api_uri(); end
-
-  def pretty_print(q); end
-end
-
-class Gem::SpecFetcher
-  include ::Gem::UserInteraction
-  include ::Gem::DefaultUserInteraction
-  include ::Gem::Text
-  def available_specs(type); end
-
-  def detect(type=T.unsafe(nil)); end
-
-  def initialize(sources=T.unsafe(nil)); end
-
-  def latest_specs(); end
-
-  def prerelease_specs(); end
-
-  def search_for_dependency(dependency, matching_platform=T.unsafe(nil)); end
-
-  def sources(); end
-
-  def spec_for_dependency(dependency, matching_platform=T.unsafe(nil)); end
-
-  def specs(); end
-
-  def suggest_gems_from_name(gem_name, type=T.unsafe(nil)); end
-
-  def tuples_for(source, type, gracefully_ignore=T.unsafe(nil)); end
-end
-
-class Gem::SpecFetcher
-  def self.fetcher(); end
-
-  def self.fetcher=(fetcher); end
-end
-
-class Gem::Specification
-  include ::Bundler::MatchPlatform
-  include ::Bundler::GemHelpers
-  def bundled_gem_in_old_ruby?(); end
-
-  def pretty_print(q); end
-
-  def rubyforge_project(); end
-
-  def to_ruby(); end
-
-  def warning(statement); end
-end
-
-class Gem::Specification
-  extend ::Enumerable
-  extend ::Gem::Deprecate
-  def self.add_spec(spec); end
-
-  def self.add_specs(*specs); end
-
-  def self.remove_spec(spec); end
-end
-
-class Gem::StubSpecification
-  def build_extensions(); end
-
-  def extensions(); end
-
-  def initialize(filename, base_dir, gems_dir, default_gem); end
-
-  def missing_extensions?(); end
-
-  def valid?(); end
-end
-
-class Gem::StubSpecification::StubLine
-  def extensions(); end
-
-  def full_name(); end
-
-  def initialize(data, extensions); end
-
-  def name(); end
-
-  def platform(); end
-
-  def require_paths(); end
-
-  def version(); end
-end
-
-class Gem::StubSpecification
-  def self.default_gemspec_stub(filename, base_dir, gems_dir); end
-
-  def self.gemspec_stub(filename, base_dir, gems_dir); end
-end
-
-Gem::UnsatisfiableDepedencyError = Gem::UnsatisfiableDependencyError
-
-module Gem::Util
-  NULL_DEVICE = ::T.let(nil, ::T.untyped)
-end
-
-class Gem::Version
-  def pretty_print(q); end
-end
-
-Gem::Version::Requirement = Gem::Requirement
 
 module Gem
   def self._deprecated_datadir(gem_name); end
@@ -2693,6 +667,9 @@ class Hash
 end
 
 class IO
+  IO::EWOULDBLOCKWaitReadable = IO::EAGAINWaitReadable
+
+  IO::EWOULDBLOCKWaitWritable = IO::EAGAINWaitWritable
   def nread(); end
 
   def pathconf(_); end
@@ -2706,10 +683,6 @@ class IO
   def wait_writable(*_); end
 end
 
-IO::EWOULDBLOCKWaitReadable = IO::EAGAINWaitReadable
-
-IO::EWOULDBLOCKWaitWritable = IO::EAGAINWaitWritable
-
 class IPAddr
   def ==(other); end
 
@@ -2719,20 +692,6 @@ end
 class Integer
   include ::JSON::Ext::Generator::GeneratorMethods::Integer
 end
-
-class JSON::Ext::Generator::State
-  def self.from_state(_); end
-end
-
-class JSON::Ext::Parser
-  def initialize(*_); end
-end
-
-JSON::Parser = JSON::Ext::Parser
-
-JSON::State = JSON::Ext::Generator::State
-
-JSON::UnparserError = JSON::GeneratorError
 
 module Kernel
   def itself(); end
@@ -2759,13 +718,13 @@ class Monitor
 end
 
 module MonitorMixin
+  class ConditionVariable
+    def initialize(monitor); end
+  # wrong constant name initialize
+  end
   def initialize(*args); end
   EXCEPTION_IMMEDIATE = ::T.let(nil, ::T.untyped)
   EXCEPTION_NEVER = ::T.let(nil, ::T.untyped)
-end
-
-class MonitorMixin::ConditionVariable
-  def initialize(monitor); end
 end
 
 class NameError
@@ -2843,12 +802,11 @@ class SimpleDelegator
 end
 
 class Socket
-  IPV6_DONTFRAG = ::T.let(nil, ::T.untyped)
-  IPV6_PATHMTU = ::T.let(nil, ::T.untyped)
-  IPV6_RECVPATHMTU = ::T.let(nil, ::T.untyped)
-end
-
-module Socket::Constants
+  module Constants
+    IPV6_DONTFRAG = ::T.let(nil, ::T.untyped)
+    IPV6_PATHMTU = ::T.let(nil, ::T.untyped)
+    IPV6_RECVPATHMTU = ::T.let(nil, ::T.untyped)
+  end
   IPV6_DONTFRAG = ::T.let(nil, ::T.untyped)
   IPV6_PATHMTU = ::T.let(nil, ::T.untyped)
   IPV6_RECVPATHMTU = ::T.let(nil, ::T.untyped)
@@ -2873,87 +831,104 @@ class String
   extend ::JSON::Ext::Generator::GeneratorMethods::String::Extend
 end
 
-Struct::Group = Etc::Group
-
-Struct::Passwd = Etc::Passwd
-
-Struct::Tms = Process::Tms
-
 class TrueClass
   include ::JSON::Ext::Generator::GeneratorMethods::TrueClass
 end
 
 module URI
-  include ::URI::RFC2396_REGEXP
-end
+  class FTP
+    def self.new2(user, password, host, port, path, typecode=T.unsafe(nil), arg_check=T.unsafe(nil)); end
+  # wrong constant name new2
+  end
 
-class URI::FTP
-  def self.new2(user, password, host, port, path, typecode=T.unsafe(nil), arg_check=T.unsafe(nil)); end
-end
+  class LDAP
+    def attributes(); end
 
-class URI::LDAP
-  def attributes(); end
+    def attributes=(val); end
 
-  def attributes=(val); end
+    def dn(); end
 
-  def dn(); end
+    def dn=(val); end
 
-  def dn=(val); end
+    def extensions(); end
 
-  def extensions(); end
+    def extensions=(val); end
 
-  def extensions=(val); end
+    def filter(); end
 
-  def filter(); end
+    def filter=(val); end
 
-  def filter=(val); end
+    def initialize(*arg); end
 
-  def initialize(*arg); end
+    def scope(); end
 
-  def scope(); end
+    def scope=(val); end
 
-  def scope=(val); end
+    def set_attributes(val); end
 
-  def set_attributes(val); end
+    def set_dn(val); end
 
-  def set_dn(val); end
+    def set_extensions(val); end
 
-  def set_extensions(val); end
+    def set_filter(val); end
 
-  def set_filter(val); end
+    def set_scope(val); end
+  # wrong constant name attributes
+  # wrong constant name attributes=
+  # wrong constant name dn
+  # wrong constant name dn=
+  # wrong constant name extensions
+  # wrong constant name extensions=
+  # wrong constant name filter
+  # wrong constant name filter=
+  # wrong constant name initialize
+  # wrong constant name scope
+  # wrong constant name scope=
+  # wrong constant name set_attributes
+  # wrong constant name set_dn
+  # wrong constant name set_extensions
+  # wrong constant name set_filter
+  # wrong constant name set_scope
+  end
 
-  def set_scope(val); end
-end
+  class MailTo
+    def initialize(*arg); end
+  # wrong constant name initialize
+  end
 
-class URI::MailTo
-  def initialize(*arg); end
-end
+  URI::Parser = URI::RFC2396_Parser
 
-URI::Parser = URI::RFC2396_Parser
+  URI::REGEXP = URI::RFC2396_REGEXP
 
-URI::REGEXP = URI::RFC2396_REGEXP
+  class RFC2396_Parser
+    def initialize(opts=T.unsafe(nil)); end
+  # wrong constant name initialize
+  end
 
-class URI::RFC2396_Parser
-  def initialize(opts=T.unsafe(nil)); end
-end
+  class RFC3986_Parser
+    def join(*uris); end
 
-class URI::RFC3986_Parser
-  def join(*uris); end
+    def parse(uri); end
 
-  def parse(uri); end
+    def regexp(); end
 
-  def regexp(); end
+    def split(uri); end
+    RFC3986_relative_ref = ::T.let(nil, ::T.untyped)
+  # wrong constant name join
+  # wrong constant name parse
+  # wrong constant name regexp
+  # wrong constant name split
+  end
 
-  def split(uri); end
-  RFC3986_relative_ref = ::T.let(nil, ::T.untyped)
-end
-
-module URI::Util
-  def self.make_components_hash(klass, array_hash); end
+  module Util
+    def self.make_components_hash(klass, array_hash); end
+  # wrong constant name make_components_hash
+  end
+  include RFC2396_REGEXP
 end
 
 module URI
-  extend ::URI::Escape
+  extend Escape
   def self.get_encoding(label); end
 end
 

--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_hidden.rbi.exp
@@ -18,8 +18,6 @@ class Array
   def self.try_convert(_); end
 end
 
-BasicObject::BasicObject = BasicObject
-
 class BigDecimal
   def clone(); end
   EXCEPTION_NaN = ::T.let(nil, ::T.untyped)
@@ -34,1858 +32,6 @@ class Binding
   def clone(); end
 
   def irb(); end
-end
-
-class Bundler::Dependency
-  def branch(); end
-
-  def expanded_platforms(); end
-
-  def git(); end
-end
-
-Bundler::Deprecate = Gem::Deprecate
-
-class Bundler::Env
-end
-
-class Bundler::Env
-  def self.environment(); end
-
-  def self.report(options=T.unsafe(nil)); end
-
-  def self.write(io); end
-end
-
-class Bundler::Fetcher
-  def fetch_spec(spec); end
-
-  def fetchers(); end
-
-  def http_proxy(); end
-
-  def initialize(remote); end
-
-  def specs(gem_names, source); end
-
-  def specs_with_retry(gem_names, source); end
-
-  def uri(); end
-
-  def use_api(); end
-
-  def user_agent(); end
-  FAIL_ERRORS = ::T.let(nil, ::T.untyped)
-  FETCHERS = ::T.let(nil, ::T.untyped)
-  HTTP_ERRORS = ::T.let(nil, ::T.untyped)
-  NET_ERRORS = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Fetcher::AuthenticationRequiredError
-  def initialize(remote_uri); end
-end
-
-class Bundler::Fetcher::BadAuthenticationError
-  def initialize(remote_uri); end
-end
-
-class Bundler::Fetcher::Base
-  def api_fetcher?(); end
-
-  def available?(); end
-
-  def display_uri(); end
-
-  def downloader(); end
-
-  def fetch_uri(); end
-
-  def initialize(downloader, remote, display_uri); end
-
-  def remote(); end
-
-  def remote_uri(); end
-end
-
-class Bundler::Fetcher::Base
-end
-
-class Bundler::Fetcher::CertificateFailureError
-  def initialize(remote_uri); end
-end
-
-class Bundler::Fetcher::CompactIndex
-  def available?(*args, &blk); end
-
-  def fetch_spec(*args, &blk); end
-
-  def specs(*args, &blk); end
-
-  def specs_for_names(gem_names); end
-end
-
-class Bundler::Fetcher::CompactIndex::ClientFetcher
-  def call(path, headers); end
-
-  def fetcher(); end
-
-  def fetcher=(_); end
-
-  def ui(); end
-
-  def ui=(_); end
-end
-
-class Bundler::Fetcher::CompactIndex::ClientFetcher
-  def self.[](*_); end
-
-  def self.members(); end
-end
-
-class Bundler::Fetcher::CompactIndex
-  def self.compact_index_request(method_name); end
-end
-
-class Bundler::Fetcher::Dependency
-  def dependency_api_uri(gem_names=T.unsafe(nil)); end
-
-  def dependency_specs(gem_names); end
-
-  def get_formatted_specs_and_deps(gem_list); end
-
-  def specs(gem_names, full_dependency_list=T.unsafe(nil), last_spec_list=T.unsafe(nil)); end
-
-  def unmarshalled_dep_gems(gem_names); end
-end
-
-class Bundler::Fetcher::Dependency
-end
-
-class Bundler::Fetcher::Downloader
-  def connection(); end
-
-  def fetch(uri, headers=T.unsafe(nil), counter=T.unsafe(nil)); end
-
-  def initialize(connection, redirect_limit); end
-
-  def redirect_limit(); end
-
-  def request(uri, headers); end
-end
-
-class Bundler::Fetcher::Downloader
-end
-
-class Bundler::Fetcher::Index
-  def fetch_spec(spec); end
-
-  def specs(_gem_names); end
-end
-
-class Bundler::Fetcher::Index
-end
-
-class Bundler::Fetcher::SSLError
-  def initialize(msg=T.unsafe(nil)); end
-end
-
-class Bundler::Fetcher::TooManyRequestsError
-end
-
-class Bundler::Fetcher::TooManyRequestsError
-end
-
-class Bundler::Fetcher
-  def self.api_timeout(); end
-
-  def self.api_timeout=(api_timeout); end
-
-  def self.disable_endpoint(); end
-
-  def self.disable_endpoint=(disable_endpoint); end
-
-  def self.max_retries(); end
-
-  def self.max_retries=(max_retries); end
-
-  def self.redirect_limit(); end
-
-  def self.redirect_limit=(redirect_limit); end
-end
-
-module Bundler::FileUtils
-  VERSION = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::FileUtils::Entry_
-  def link(dest); end
-end
-
-module Bundler::FileUtils
-  def self.cp_lr(src, dest, noop: T.unsafe(nil), verbose: T.unsafe(nil), dereference_root: T.unsafe(nil), remove_destination: T.unsafe(nil)); end
-
-  def self.link_entry(src, dest, dereference_root=T.unsafe(nil), remove_destination=T.unsafe(nil)); end
-end
-
-class Bundler::GemHelper
-  def allowed_push_host(); end
-
-  def already_tagged?(); end
-
-  def base(); end
-
-  def build_gem(); end
-
-  def built_gem_path(); end
-
-  def clean?(); end
-
-  def committed?(); end
-
-  def gem_command(); end
-
-  def gem_key(); end
-
-  def gem_push?(); end
-
-  def gem_push_host(); end
-
-  def gemspec(); end
-
-  def git_push(remote=T.unsafe(nil)); end
-
-  def guard_clean(); end
-
-  def initialize(base=T.unsafe(nil), name=T.unsafe(nil)); end
-
-  def install(); end
-
-  def install_gem(built_gem_path=T.unsafe(nil), local=T.unsafe(nil)); end
-
-  def name(); end
-
-  def perform_git_push(options=T.unsafe(nil)); end
-
-  def rubygem_push(path); end
-
-  def sh(cmd, &block); end
-
-  def sh_with_input(cmd); end
-
-  def sh_with_status(cmd, &block); end
-
-  def spec_path(); end
-
-  def tag_version(); end
-
-  def version(); end
-
-  def version_tag(); end
-end
-
-class Bundler::GemHelper
-  def self.gemspec(&block); end
-
-  def self.install_tasks(opts=T.unsafe(nil)); end
-
-  def self.instance(); end
-
-  def self.instance=(instance); end
-end
-
-class Bundler::GemVersionPromoter
-  def initialize(locked_specs=T.unsafe(nil), unlock_gems=T.unsafe(nil)); end
-
-  def level(); end
-
-  def level=(value); end
-
-  def locked_specs(); end
-
-  def major?(); end
-
-  def minor?(); end
-
-  def prerelease_specified(); end
-
-  def prerelease_specified=(prerelease_specified); end
-
-  def sort_versions(dep, spec_groups); end
-
-  def strict(); end
-
-  def strict=(strict); end
-
-  def unlock_gems(); end
-  DEBUG = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::GemVersionPromoter
-end
-
-class Bundler::Graph
-  def edge_options(); end
-
-  def groups(); end
-
-  def initialize(env, output_file, show_version=T.unsafe(nil), show_requirements=T.unsafe(nil), output_format=T.unsafe(nil), without=T.unsafe(nil)); end
-
-  def node_options(); end
-
-  def output_file(); end
-
-  def output_format(); end
-
-  def relations(); end
-
-  def viz(); end
-  GRAPH_NAME = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Graph::GraphVizClient
-  def g(); end
-
-  def initialize(graph_instance); end
-
-  def run(); end
-end
-
-class Bundler::Graph::GraphVizClient
-end
-
-class Bundler::Graph
-end
-
-class Bundler::Index
-  include ::Enumerable
-end
-
-class Bundler::Injector
-  def initialize(deps, options=T.unsafe(nil)); end
-
-  def inject(gemfile_path, lockfile_path); end
-
-  def remove(gemfile_path, lockfile_path); end
-  INJECTED_GEMS = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Injector
-  def self.inject(new_deps, options=T.unsafe(nil)); end
-
-  def self.remove(gems, options=T.unsafe(nil)); end
-end
-
-class Bundler::Installer
-  def generate_bundler_executable_stubs(spec, options=T.unsafe(nil)); end
-
-  def generate_standalone_bundler_executable_stubs(spec); end
-
-  def initialize(root, definition); end
-
-  def post_install_messages(); end
-
-  def run(options); end
-end
-
-class Bundler::Installer
-  def self.ambiguous_gems(); end
-
-  def self.ambiguous_gems=(ambiguous_gems); end
-
-  def self.install(root, definition, options=T.unsafe(nil)); end
-end
-
-class Bundler::LockfileGenerator
-  def definition(); end
-
-  def generate!(); end
-
-  def initialize(definition); end
-
-  def out(); end
-end
-
-class Bundler::LockfileGenerator
-  def self.generate(definition); end
-end
-
-class Bundler::Molinillo::DependencyGraph
-  include ::Enumerable
-end
-
-class Bundler::Molinillo::DependencyGraph::Log
-  extend ::Enumerable
-end
-
-class Bundler::Molinillo::DependencyGraph::Vertex
-  def _recursive_predecessors(vertices=T.unsafe(nil)); end
-
-  def _recursive_successors(vertices=T.unsafe(nil)); end
-end
-
-module Bundler::Plugin::API::Source
-  def ==(other); end
-
-  def app_cache_dirname(); end
-
-  def app_cache_path(custom_path=T.unsafe(nil)); end
-
-  def bundler_plugin_api_source?(); end
-
-  def cache(spec, custom_path=T.unsafe(nil)); end
-
-  def cached!(); end
-
-  def can_lock?(spec); end
-
-  def dependency_names(); end
-
-  def dependency_names=(dependency_names); end
-
-  def double_check_for(*_); end
-
-  def eql?(other); end
-
-  def fetch_gemspec_files(); end
-
-  def gem_install_dir(); end
-
-  def hash(); end
-
-  def include?(other); end
-
-  def initialize(opts); end
-
-  def install(spec, opts); end
-
-  def install_path(); end
-
-  def installed?(); end
-
-  def name(); end
-
-  def options(); end
-
-  def options_to_lock(); end
-
-  def post_install(spec, disable_exts=T.unsafe(nil)); end
-
-  def remote!(); end
-
-  def root(); end
-
-  def specs(); end
-
-  def to_lock(); end
-
-  def to_s(); end
-
-  def unlock!(); end
-
-  def unmet_deps(); end
-
-  def uri(); end
-
-  def uri_hash(); end
-end
-
-module Bundler::Plugin::API::Source
-end
-
-module Bundler::Plugin::Events
-  GEM_AFTER_INSTALL = ::T.let(nil, ::T.untyped)
-  GEM_AFTER_INSTALL_ALL = ::T.let(nil, ::T.untyped)
-  GEM_BEFORE_INSTALL = ::T.let(nil, ::T.untyped)
-  GEM_BEFORE_INSTALL_ALL = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Plugin::Index
-  def installed_plugins(); end
-
-  def plugin_commands(plugin); end
-end
-
-class Bundler::Plugin::Index::CommandConflict
-  def initialize(plugin, commands); end
-end
-
-class Bundler::Plugin::Index::CommandConflict
-end
-
-class Bundler::Plugin::Index::SourceConflict
-  def initialize(plugin, sources); end
-end
-
-class Bundler::Plugin::Index::SourceConflict
-end
-
-class Bundler::Plugin::Installer
-  def install(names, options); end
-
-  def install_definition(definition); end
-end
-
-class Bundler::Plugin::Installer::Git
-  def generate_bin(spec, disable_extensions=T.unsafe(nil)); end
-end
-
-class Bundler::Plugin::Installer::Git
-end
-
-class Bundler::Plugin::Installer::Rubygems
-end
-
-class Bundler::Plugin::Installer::Rubygems
-end
-
-class Bundler::Plugin::Installer
-end
-
-class Bundler::Plugin::SourceList
-end
-
-class Bundler::Plugin::SourceList
-end
-
-module Bundler::Plugin
-  def self.list(); end
-end
-
-class Bundler::ProcessLock
-end
-
-class Bundler::ProcessLock
-  def self.lock(bundle_path=T.unsafe(nil)); end
-end
-
-class Bundler::Retry
-  def attempt(&block); end
-
-  def attempts(&block); end
-
-  def current_run(); end
-
-  def current_run=(current_run); end
-
-  def initialize(name, exceptions=T.unsafe(nil), retries=T.unsafe(nil)); end
-
-  def name(); end
-
-  def name=(name); end
-
-  def total_runs(); end
-
-  def total_runs=(total_runs); end
-end
-
-class Bundler::Retry
-  def self.attempts(); end
-
-  def self.default_attempts(); end
-
-  def self.default_retries(); end
-end
-
-class Bundler::RubyGemsGemInstaller
-end
-
-class Bundler::RubyGemsGemInstaller
-end
-
-class Bundler::RubygemsIntegration
-  def add_to_load_path(paths); end
-
-  def all_specs(); end
-
-  def backport_ext_builder_monitor(); end
-
-  def correct_for_windows_path(path); end
-
-  def default_stubs(); end
-
-  def find_name(name); end
-
-  def gem_remote_fetcher(); end
-
-  def plain_specs(); end
-
-  def plain_specs=(specs); end
-
-  def stub_rubygems(specs); end
-
-  def use_gemdeps(gemfile); end
-end
-
-class Bundler::Settings::Mirror
-  def ==(other); end
-
-  def fallback_timeout(); end
-
-  def fallback_timeout=(timeout); end
-
-  def initialize(uri=T.unsafe(nil), fallback_timeout=T.unsafe(nil)); end
-
-  def uri(); end
-
-  def uri=(uri); end
-
-  def valid?(); end
-
-  def validate!(probe=T.unsafe(nil)); end
-  DEFAULT_FALLBACK_TIMEOUT = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Settings::Mirror
-end
-
-class Bundler::Settings::Mirrors
-  def each(&blk); end
-
-  def for(uri); end
-
-  def initialize(prober=T.unsafe(nil)); end
-
-  def parse(key, value); end
-end
-
-class Bundler::Settings::Mirrors
-end
-
-class Bundler::Settings::Validator
-end
-
-class Bundler::Settings::Validator::Rule
-  def description(); end
-
-  def fail!(key, value, *reasons); end
-
-  def initialize(keys, description, &validate); end
-
-  def k(key); end
-
-  def set(settings, key, value, *reasons); end
-
-  def validate!(key, value, settings); end
-end
-
-class Bundler::Settings::Validator::Rule
-end
-
-class Bundler::Settings::Validator
-  def self.validate!(key, value, settings); end
-end
-
-class Bundler::Source::Git
-  def glob(); end
-end
-
-class Bundler::SpecSet
-  include ::Enumerable
-end
-
-class Bundler::Thor
-  include ::Bundler::Thor::Base
-  include ::Bundler::Thor::Invocation
-  include ::Bundler::Thor::Shell
-  def help(command=T.unsafe(nil), subcommand=T.unsafe(nil)); end
-  HELP_MAPPINGS = ::T.let(nil, ::T.untyped)
-  TEMPLATE_EXTNAME = ::T.let(nil, ::T.untyped)
-  THOR_RESERVED_WORDS = ::T.let(nil, ::T.untyped)
-end
-
-module Bundler::Thor::Actions
-  def _cleanup_options_and_set(options, key); end
-
-  def _shared_configuration(); end
-
-  def action(instance); end
-
-  def add_file(destination, *args, &block); end
-
-  def add_link(destination, *args); end
-
-  def append_file(path, *args, &block); end
-
-  def append_to_file(path, *args, &block); end
-
-  def apply(path, config=T.unsafe(nil)); end
-
-  def behavior(); end
-
-  def behavior=(behavior); end
-
-  def chmod(path, mode, config=T.unsafe(nil)); end
-
-  def comment_lines(path, flag, *args); end
-
-  def copy_file(source, *args, &block); end
-
-  def create_file(destination, *args, &block); end
-
-  def create_link(destination, *args); end
-
-  def destination_root(); end
-
-  def destination_root=(root); end
-
-  def directory(source, *args, &block); end
-
-  def empty_directory(destination, config=T.unsafe(nil)); end
-
-  def find_in_source_paths(file); end
-
-  def get(source, *args, &block); end
-
-  def gsub_file(path, flag, *args, &block); end
-
-  def in_root(); end
-
-  def initialize(args=T.unsafe(nil), options=T.unsafe(nil), config=T.unsafe(nil)); end
-
-  def inject_into_class(path, klass, *args, &block); end
-
-  def inject_into_file(destination, *args, &block); end
-
-  def inject_into_module(path, module_name, *args, &block); end
-
-  def insert_into_file(destination, *args, &block); end
-
-  def inside(dir=T.unsafe(nil), config=T.unsafe(nil), &block); end
-
-  def link_file(source, *args); end
-
-  def prepend_file(path, *args, &block); end
-
-  def prepend_to_file(path, *args, &block); end
-
-  def relative_to_original_destination_root(path, remove_dot=T.unsafe(nil)); end
-
-  def remove_dir(path, config=T.unsafe(nil)); end
-
-  def remove_file(path, config=T.unsafe(nil)); end
-
-  def run(command, config=T.unsafe(nil)); end
-
-  def run_ruby_script(command, config=T.unsafe(nil)); end
-
-  def source_paths(); end
-
-  def template(source, *args, &block); end
-
-  def thor(command, *args); end
-
-  def uncomment_lines(path, flag, *args); end
-  WARNINGS = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Actions::CapturableERB
-end
-
-class Bundler::Thor::Actions::CapturableERB
-end
-
-module Bundler::Thor::Actions::ClassMethods
-  def add_runtime_options!(); end
-
-  def source_paths(); end
-
-  def source_paths_for_search(); end
-
-  def source_root(path=T.unsafe(nil)); end
-end
-
-module Bundler::Thor::Actions::ClassMethods
-end
-
-class Bundler::Thor::Actions::CreateFile
-  def data(); end
-
-  def force_on_collision?(); end
-
-  def force_or_skip_or_conflict(force, skip, &block); end
-
-  def identical?(); end
-
-  def initialize(base, destination, data, config=T.unsafe(nil)); end
-
-  def on_conflict_behavior(&block); end
-
-  def render(); end
-end
-
-class Bundler::Thor::Actions::CreateFile
-end
-
-class Bundler::Thor::Actions::CreateLink
-end
-
-class Bundler::Thor::Actions::CreateLink
-end
-
-class Bundler::Thor::Actions::Directory
-  def execute!(); end
-
-  def file_level_lookup(previous_lookup); end
-
-  def files(lookup); end
-
-  def initialize(base, source, destination=T.unsafe(nil), config=T.unsafe(nil), &block); end
-
-  def source(); end
-end
-
-class Bundler::Thor::Actions::Directory
-end
-
-class Bundler::Thor::Actions::EmptyDirectory
-  def base(); end
-
-  def config(); end
-
-  def convert_encoded_instructions(filename); end
-
-  def destination(); end
-
-  def destination=(destination); end
-
-  def exists?(); end
-
-  def given_destination(); end
-
-  def initialize(base, destination, config=T.unsafe(nil)); end
-
-  def invoke!(); end
-
-  def invoke_with_conflict_check(&block); end
-
-  def on_conflict_behavior(); end
-
-  def on_file_clash_behavior(); end
-
-  def pretend?(); end
-
-  def relative_destination(); end
-
-  def revoke!(); end
-
-  def say_status(status, color); end
-end
-
-class Bundler::Thor::Actions::EmptyDirectory
-end
-
-class Bundler::Thor::Actions::InjectIntoFile
-  def behavior(); end
-
-  def flag(); end
-
-  def initialize(base, destination, data, config); end
-
-  def replace!(regexp, string, force); end
-
-  def replacement(); end
-
-  def say_status(behavior, warning: T.unsafe(nil), color: T.unsafe(nil)); end
-end
-
-class Bundler::Thor::Actions::InjectIntoFile
-end
-
-module Bundler::Thor::Actions
-  def self.included(base); end
-end
-
-class Bundler::Thor::AmbiguousCommandError
-end
-
-class Bundler::Thor::AmbiguousCommandError
-end
-
-Bundler::Thor::AmbiguousTaskError = Bundler::Thor::AmbiguousCommandError
-
-class Bundler::Thor::Argument
-  def banner(); end
-
-  def default(); end
-
-  def default_banner(); end
-
-  def description(); end
-
-  def enum(); end
-
-  def human_name(); end
-
-  def initialize(name, options=T.unsafe(nil)); end
-
-  def name(); end
-
-  def required(); end
-
-  def required?(); end
-
-  def show_default?(); end
-
-  def type(); end
-
-  def usage(); end
-
-  def valid_type?(type); end
-
-  def validate!(); end
-  VALID_TYPES = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Argument
-end
-
-class Bundler::Thor::Arguments
-  def initialize(arguments=T.unsafe(nil)); end
-
-  def parse(args); end
-
-  def remaining(); end
-  NUMERIC = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Arguments
-  def self.parse(*args); end
-
-  def self.split(args); end
-end
-
-module Bundler::Thor::Base
-  def args(); end
-
-  def args=(args); end
-
-  def initialize(args=T.unsafe(nil), local_options=T.unsafe(nil), config=T.unsafe(nil)); end
-
-  def options(); end
-
-  def options=(options); end
-
-  def parent_options(); end
-
-  def parent_options=(parent_options); end
-end
-
-module Bundler::Thor::Base::ClassMethods
-  def all_commands(); end
-
-  def all_tasks(); end
-
-  def allow_incompatible_default_type!(); end
-
-  def argument(name, options=T.unsafe(nil)); end
-
-  def arguments(); end
-
-  def attr_accessor(*_); end
-
-  def attr_reader(*_); end
-
-  def attr_writer(*_); end
-
-  def baseclass(); end
-
-  def basename(); end
-
-  def build_option(name, options, scope); end
-
-  def build_options(options, scope); end
-
-  def check_default_type(); end
-
-  def check_default_type!(); end
-
-  def check_unknown_options(); end
-
-  def check_unknown_options!(); end
-
-  def check_unknown_options?(config); end
-
-  def class_option(name, options=T.unsafe(nil)); end
-
-  def class_options(options=T.unsafe(nil)); end
-
-  def class_options_help(shell, groups=T.unsafe(nil)); end
-
-  def commands(); end
-
-  def create_command(meth); end
-
-  def create_task(meth); end
-
-  def disable_required_check?(command_name); end
-
-  def dispatch(command, given_args, given_opts, config); end
-
-  def exit_on_failure?(); end
-
-  def find_and_refresh_command(name); end
-
-  def find_and_refresh_task(name); end
-
-  def from_superclass(method, default=T.unsafe(nil)); end
-
-  def group(name=T.unsafe(nil)); end
-
-  def handle_argument_error(command, error, args, arity); end
-
-  def handle_no_command_error(command, has_namespace=T.unsafe(nil)); end
-
-  def handle_no_task_error(command, has_namespace=T.unsafe(nil)); end
-
-  def inherited(klass); end
-
-  def initialize_added(); end
-
-  def is_thor_reserved_word?(word, type); end
-
-  def method_added(meth); end
-
-  def namespace(name=T.unsafe(nil)); end
-
-  def no_commands(&block); end
-
-  def no_commands?(); end
-
-  def no_commands_context(); end
-
-  def no_tasks(&block); end
-
-  def print_options(shell, options, group_name=T.unsafe(nil)); end
-
-  def public_command(*names); end
-
-  def public_task(*names); end
-
-  def remove_argument(*names); end
-
-  def remove_class_option(*names); end
-
-  def remove_command(*names); end
-
-  def remove_task(*names); end
-
-  def start(given_args=T.unsafe(nil), config=T.unsafe(nil)); end
-
-  def stop_on_unknown_option?(command_name); end
-
-  def strict_args_position(); end
-
-  def strict_args_position!(); end
-
-  def strict_args_position?(config); end
-
-  def tasks(); end
-end
-
-module Bundler::Thor::Base::ClassMethods
-end
-
-module Bundler::Thor::Base
-  def self.included(base); end
-
-  def self.register_klass_file(klass); end
-
-  def self.shell(); end
-
-  def self.shell=(shell); end
-
-  def self.subclass_files(); end
-
-  def self.subclasses(); end
-end
-
-class Bundler::Thor::Command
-  def formatted_usage(klass, namespace=T.unsafe(nil), subcommand=T.unsafe(nil)); end
-
-  def handle_argument_error?(instance, error, caller); end
-
-  def handle_no_method_error?(instance, error, caller); end
-
-  def hidden?(); end
-
-  def initialize(name, description, long_description, usage, options=T.unsafe(nil)); end
-
-  def local_method?(instance, name); end
-
-  def not_debugging?(instance); end
-
-  def private_method?(instance); end
-
-  def public_method?(instance); end
-
-  def required_arguments_for(klass, usage); end
-
-  def required_options(); end
-
-  def run(instance, args=T.unsafe(nil)); end
-
-  def sans_backtrace(backtrace, caller); end
-  FILE_REGEXP = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Command
-end
-
-module Bundler::Thor::CoreExt
-end
-
-class Bundler::Thor::CoreExt::HashWithIndifferentAccess
-  def [](key); end
-
-  def []=(key, value); end
-
-  def convert_key(key); end
-
-  def delete(key); end
-
-  def fetch(key, *args); end
-
-  def initialize(hash=T.unsafe(nil)); end
-
-  def key?(key); end
-
-  def merge(other); end
-
-  def merge!(other); end
-
-  def method_missing(method, *args); end
-
-  def replace(other_hash); end
-
-  def reverse_merge(other); end
-
-  def reverse_merge!(other_hash); end
-
-  def values_at(*indices); end
-end
-
-class Bundler::Thor::CoreExt::HashWithIndifferentAccess
-end
-
-module Bundler::Thor::CoreExt
-end
-
-Bundler::Thor::Correctable = DidYouMean::Correctable
-
-class Bundler::Thor::DynamicCommand
-  def initialize(name, options=T.unsafe(nil)); end
-end
-
-class Bundler::Thor::DynamicCommand
-end
-
-Bundler::Thor::DynamicTask = Bundler::Thor::DynamicCommand
-
-class Bundler::Thor::Error
-end
-
-class Bundler::Thor::Error
-end
-
-class Bundler::Thor::Group
-  include ::Bundler::Thor::Base
-  include ::Bundler::Thor::Invocation
-  include ::Bundler::Thor::Shell
-  def _invoke_for_class_method(klass, command=T.unsafe(nil), *args, &block); end
-end
-
-class Bundler::Thor::Group
-  extend ::Bundler::Thor::Base::ClassMethods
-  extend ::Bundler::Thor::Invocation::ClassMethods
-  def self.banner(); end
-
-  def self.desc(description=T.unsafe(nil)); end
-
-  def self.get_options_from_invocations(group_options, base_options); end
-
-  def self.handle_argument_error(command, error, _args, arity); end
-
-  def self.help(shell); end
-
-  def self.invocation_blocks(); end
-
-  def self.invocations(); end
-
-  def self.invoke(*names, &block); end
-
-  def self.invoke_from_option(*names, &block); end
-
-  def self.printable_commands(*_); end
-
-  def self.printable_tasks(*_); end
-
-  def self.remove_invocation(*names); end
-
-  def self.self_command(); end
-
-  def self.self_task(); end
-end
-
-class Bundler::Thor::HiddenCommand
-end
-
-class Bundler::Thor::HiddenCommand
-end
-
-Bundler::Thor::HiddenTask = Bundler::Thor::HiddenCommand
-
-module Bundler::Thor::Invocation
-  def _parse_initialization_options(args, opts, config); end
-
-  def _retrieve_class_and_command(name, sent_command=T.unsafe(nil)); end
-
-  def _retrieve_class_and_task(name, sent_command=T.unsafe(nil)); end
-
-  def _shared_configuration(); end
-
-  def current_command_chain(); end
-
-  def initialize(args=T.unsafe(nil), options=T.unsafe(nil), config=T.unsafe(nil), &block); end
-
-  def invoke(name=T.unsafe(nil), *args); end
-
-  def invoke_all(); end
-
-  def invoke_command(command, *args); end
-
-  def invoke_task(command, *args); end
-
-  def invoke_with_padding(*args); end
-end
-
-module Bundler::Thor::Invocation::ClassMethods
-  def prepare_for_invocation(key, name); end
-end
-
-module Bundler::Thor::Invocation::ClassMethods
-end
-
-module Bundler::Thor::Invocation
-  def self.included(base); end
-end
-
-class Bundler::Thor::InvocationError
-end
-
-class Bundler::Thor::InvocationError
-end
-
-module Bundler::Thor::LineEditor
-end
-
-class Bundler::Thor::LineEditor::Basic
-  def initialize(prompt, options); end
-
-  def options(); end
-
-  def prompt(); end
-
-  def readline(); end
-end
-
-class Bundler::Thor::LineEditor::Basic
-  def self.available?(); end
-end
-
-class Bundler::Thor::LineEditor::Readline
-end
-
-class Bundler::Thor::LineEditor::Readline::PathCompletion
-  def initialize(text); end
-
-  def matches(); end
-end
-
-class Bundler::Thor::LineEditor::Readline::PathCompletion
-end
-
-class Bundler::Thor::LineEditor::Readline
-end
-
-module Bundler::Thor::LineEditor
-  def self.best_available(); end
-
-  def self.readline(prompt, options=T.unsafe(nil)); end
-end
-
-class Bundler::Thor::MalformattedArgumentError
-end
-
-class Bundler::Thor::MalformattedArgumentError
-end
-
-class Bundler::Thor::NestedContext
-  def enter(); end
-
-  def entered?(); end
-end
-
-class Bundler::Thor::NestedContext
-end
-
-class Bundler::Thor::NoKwargSpellChecker
-  def initialize(dictionary); end
-end
-
-class Bundler::Thor::NoKwargSpellChecker
-end
-
-class Bundler::Thor::Option
-  def aliases(); end
-
-  def array?(); end
-
-  def boolean?(); end
-
-  def dasherize(str); end
-
-  def dasherized?(); end
-
-  def group(); end
-
-  def hash?(); end
-
-  def hide(); end
-
-  def lazy_default(); end
-
-  def numeric?(); end
-
-  def repeatable(); end
-
-  def string?(); end
-
-  def switch_name(); end
-
-  def undasherize(str); end
-
-  def usage(padding=T.unsafe(nil)); end
-
-  def validate_default_type!(); end
-  VALID_TYPES = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Option
-  def self.parse(key, value); end
-end
-
-class Bundler::Thor::Options
-  def assign_result!(option, result); end
-
-  def check_unknown!(); end
-
-  def current_is_switch?(); end
-
-  def current_is_switch_formatted?(); end
-
-  def initialize(hash_options=T.unsafe(nil), defaults=T.unsafe(nil), stop_on_unknown=T.unsafe(nil), disable_required_check=T.unsafe(nil)); end
-
-  def normalize_switch(arg); end
-
-  def parse_boolean(switch); end
-
-  def parse_peek(switch, option); end
-
-  def parsing_options?(); end
-
-  def switch?(arg); end
-
-  def switch_option(arg); end
-  EQ_RE = ::T.let(nil, ::T.untyped)
-  LONG_RE = ::T.let(nil, ::T.untyped)
-  OPTS_END = ::T.let(nil, ::T.untyped)
-  SHORT_NUM = ::T.let(nil, ::T.untyped)
-  SHORT_RE = ::T.let(nil, ::T.untyped)
-  SHORT_SQ_RE = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Options
-  def self.to_switches(options); end
-end
-
-class Bundler::Thor::RequiredArgumentMissingError
-end
-
-class Bundler::Thor::RequiredArgumentMissingError
-end
-
-module Bundler::Thor::Sandbox
-end
-
-module Bundler::Thor::Sandbox
-end
-
-module Bundler::Thor::Shell
-  def _shared_configuration(); end
-
-  def ask(*args, &block); end
-
-  def error(*args, &block); end
-
-  def file_collision(*args, &block); end
-
-  def initialize(args=T.unsafe(nil), options=T.unsafe(nil), config=T.unsafe(nil)); end
-
-  def no?(*args, &block); end
-
-  def print_in_columns(*args, &block); end
-
-  def print_table(*args, &block); end
-
-  def print_wrapped(*args, &block); end
-
-  def say(*args, &block); end
-
-  def say_status(*args, &block); end
-
-  def set_color(*args, &block); end
-
-  def shell(); end
-
-  def shell=(shell); end
-
-  def terminal_width(*args, &block); end
-
-  def with_padding(); end
-
-  def yes?(*args, &block); end
-  SHELL_DELEGATED_METHODS = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Shell::Basic
-  def answer_match(possibilities, answer, case_insensitive); end
-
-  def as_unicode(); end
-
-  def ask(statement, *args); end
-
-  def ask_filtered(statement, color, options); end
-
-  def ask_simply(statement, color, options); end
-
-  def base(); end
-
-  def base=(base); end
-
-  def can_display_colors?(); end
-
-  def dynamic_width(); end
-
-  def dynamic_width_stty(); end
-
-  def dynamic_width_tput(); end
-
-  def error(statement); end
-
-  def file_collision(destination); end
-
-  def file_collision_help(); end
-
-  def git_merge_tool(); end
-
-  def indent(count=T.unsafe(nil)); end
-
-  def is?(value); end
-
-  def lookup_color(color); end
-
-  def merge(destination, content); end
-
-  def merge_tool(); end
-
-  def mute(); end
-
-  def mute?(); end
-
-  def no?(statement, color=T.unsafe(nil)); end
-
-  def padding(); end
-
-  def padding=(value); end
-
-  def prepare_message(message, *color); end
-
-  def print_in_columns(array); end
-
-  def print_table(array, options=T.unsafe(nil)); end
-
-  def print_wrapped(message, options=T.unsafe(nil)); end
-
-  def quiet?(); end
-
-  def say(message=T.unsafe(nil), color=T.unsafe(nil), force_new_line=T.unsafe(nil)); end
-
-  def say_status(status, message, log_status=T.unsafe(nil)); end
-
-  def set_color(string, *_); end
-
-  def show_diff(destination, content); end
-
-  def stderr(); end
-
-  def stdout(); end
-
-  def terminal_width(); end
-
-  def truncate(string, width); end
-
-  def unix?(); end
-
-  def yes?(statement, color=T.unsafe(nil)); end
-  DEFAULT_TERMINAL_WIDTH = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Shell::Basic
-end
-
-class Bundler::Thor::Shell::Color
-  def are_colors_disabled?(); end
-
-  def diff_lcs_loaded?(); end
-
-  def output_diff_line(diff); end
-
-  def set_color(string, *colors); end
-  BLACK = ::T.let(nil, ::T.untyped)
-  BLUE = ::T.let(nil, ::T.untyped)
-  BOLD = ::T.let(nil, ::T.untyped)
-  CLEAR = ::T.let(nil, ::T.untyped)
-  CYAN = ::T.let(nil, ::T.untyped)
-  GREEN = ::T.let(nil, ::T.untyped)
-  MAGENTA = ::T.let(nil, ::T.untyped)
-  ON_BLACK = ::T.let(nil, ::T.untyped)
-  ON_BLUE = ::T.let(nil, ::T.untyped)
-  ON_CYAN = ::T.let(nil, ::T.untyped)
-  ON_GREEN = ::T.let(nil, ::T.untyped)
-  ON_MAGENTA = ::T.let(nil, ::T.untyped)
-  ON_RED = ::T.let(nil, ::T.untyped)
-  ON_WHITE = ::T.let(nil, ::T.untyped)
-  ON_YELLOW = ::T.let(nil, ::T.untyped)
-  RED = ::T.let(nil, ::T.untyped)
-  WHITE = ::T.let(nil, ::T.untyped)
-  YELLOW = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Shell::Color
-end
-
-class Bundler::Thor::Shell::HTML
-  def ask(statement, color=T.unsafe(nil)); end
-
-  def diff_lcs_loaded?(); end
-
-  def output_diff_line(diff); end
-
-  def set_color(string, *colors); end
-  BLACK = ::T.let(nil, ::T.untyped)
-  BLUE = ::T.let(nil, ::T.untyped)
-  BOLD = ::T.let(nil, ::T.untyped)
-  CYAN = ::T.let(nil, ::T.untyped)
-  GREEN = ::T.let(nil, ::T.untyped)
-  MAGENTA = ::T.let(nil, ::T.untyped)
-  ON_BLACK = ::T.let(nil, ::T.untyped)
-  ON_BLUE = ::T.let(nil, ::T.untyped)
-  ON_CYAN = ::T.let(nil, ::T.untyped)
-  ON_GREEN = ::T.let(nil, ::T.untyped)
-  ON_MAGENTA = ::T.let(nil, ::T.untyped)
-  ON_RED = ::T.let(nil, ::T.untyped)
-  ON_WHITE = ::T.let(nil, ::T.untyped)
-  ON_YELLOW = ::T.let(nil, ::T.untyped)
-  RED = ::T.let(nil, ::T.untyped)
-  WHITE = ::T.let(nil, ::T.untyped)
-  YELLOW = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Shell::HTML
-end
-
-module Bundler::Thor::Shell
-end
-
-Bundler::Thor::Task = Bundler::Thor::Command
-
-class Bundler::Thor::UndefinedCommandError
-  include ::DidYouMean::Correctable
-  def all_commands(); end
-
-  def command(); end
-
-  def initialize(command, all_commands, namespace); end
-end
-
-class Bundler::Thor::UndefinedCommandError::SpellChecker
-  def corrections(); end
-
-  def error(); end
-
-  def initialize(error); end
-
-  def spell_checker(); end
-end
-
-class Bundler::Thor::UndefinedCommandError::SpellChecker
-end
-
-class Bundler::Thor::UndefinedCommandError
-end
-
-Bundler::Thor::UndefinedTaskError = Bundler::Thor::UndefinedCommandError
-
-class Bundler::Thor::UnknownArgumentError
-  include ::DidYouMean::Correctable
-  def initialize(switches, unknown); end
-
-  def switches(); end
-
-  def unknown(); end
-end
-
-class Bundler::Thor::UnknownArgumentError::SpellChecker
-  def corrections(); end
-
-  def error(); end
-
-  def initialize(error); end
-
-  def spell_checker(); end
-end
-
-class Bundler::Thor::UnknownArgumentError::SpellChecker
-end
-
-class Bundler::Thor::UnknownArgumentError
-end
-
-module Bundler::Thor::Util
-end
-
-module Bundler::Thor::Util
-  def self.camel_case(str); end
-
-  def self.escape_globs(path); end
-
-  def self.escape_html(string); end
-
-  def self.find_by_namespace(namespace); end
-
-  def self.find_class_and_command_by_namespace(namespace, fallback=T.unsafe(nil)); end
-
-  def self.find_class_and_task_by_namespace(namespace, fallback=T.unsafe(nil)); end
-
-  def self.globs_for(path); end
-
-  def self.load_thorfile(path, content=T.unsafe(nil), debug=T.unsafe(nil)); end
-
-  def self.namespace_from_thor_class(constant); end
-
-  def self.namespaces_in_content(contents, file=T.unsafe(nil)); end
-
-  def self.ruby_command(); end
-
-  def self.snake_case(str); end
-
-  def self.thor_classes_in(klass); end
-
-  def self.thor_root(); end
-
-  def self.thor_root_glob(); end
-
-  def self.user_home(); end
-end
-
-class Bundler::Thor
-  extend ::Bundler::Thor::Base::ClassMethods
-  extend ::Bundler::Thor::Invocation::ClassMethods
-  def self.banner(command, namespace=T.unsafe(nil), subcommand=T.unsafe(nil)); end
-
-  def self.check_unknown_options!(options=T.unsafe(nil)); end
-
-  def self.command_help(shell, command_name); end
-
-  def self.default_command(meth=T.unsafe(nil)); end
-
-  def self.default_task(meth=T.unsafe(nil)); end
-
-  def self.deprecation_warning(message); end
-
-  def self.desc(usage, description, options=T.unsafe(nil)); end
-
-  def self.disable_required_check(); end
-
-  def self.disable_required_check!(*command_names); end
-
-  def self.disable_required_check?(command); end
-
-  def self.dispatch(meth, given_args, given_opts, config); end
-
-  def self.dynamic_command_class(); end
-
-  def self.find_command_possibilities(meth); end
-
-  def self.find_task_possibilities(meth); end
-
-  def self.help(shell, subcommand=T.unsafe(nil)); end
-
-  def self.long_desc(long_description, options=T.unsafe(nil)); end
-
-  def self.map(mappings=T.unsafe(nil), **kw); end
-
-  def self.method_option(name, options=T.unsafe(nil)); end
-
-  def self.method_options(options=T.unsafe(nil)); end
-
-  def self.normalize_command_name(meth); end
-
-  def self.normalize_task_name(meth); end
-
-  def self.option(name, options=T.unsafe(nil)); end
-
-  def self.options(options=T.unsafe(nil)); end
-
-  def self.package_name(name, _=T.unsafe(nil)); end
-
-  def self.printable_commands(all=T.unsafe(nil), subcommand=T.unsafe(nil)); end
-
-  def self.printable_tasks(all=T.unsafe(nil), subcommand=T.unsafe(nil)); end
-
-  def self.register(klass, subcommand_name, usage, description, options=T.unsafe(nil)); end
-
-  def self.retrieve_command_name(args); end
-
-  def self.retrieve_task_name(args); end
-
-  def self.stop_on_unknown_option(); end
-
-  def self.stop_on_unknown_option!(*command_names); end
-
-  def self.stop_on_unknown_option?(command); end
-
-  def self.subcommand(subcommand, subcommand_class); end
-
-  def self.subcommand_classes(); end
-
-  def self.subcommand_help(cmd); end
-
-  def self.subcommands(); end
-
-  def self.subtask(subcommand, subcommand_class); end
-
-  def self.subtask_help(cmd); end
-
-  def self.subtasks(); end
-
-  def self.task_help(shell, command_name); end
-end
-
-class Bundler::UI::Shell
-  def add_color(string, *color); end
-
-  def ask(msg); end
-
-  def confirm(msg, newline=T.unsafe(nil)); end
-
-  def debug(msg, newline=T.unsafe(nil)); end
-
-  def debug?(); end
-
-  def error(msg, newline=T.unsafe(nil)); end
-
-  def info(msg, newline=T.unsafe(nil)); end
-
-  def initialize(options=T.unsafe(nil)); end
-
-  def level(name=T.unsafe(nil)); end
-
-  def level=(level); end
-
-  def no?(); end
-
-  def quiet?(); end
-
-  def shell=(shell); end
-
-  def silence(&blk); end
-
-  def trace(e, newline=T.unsafe(nil), force=T.unsafe(nil)); end
-
-  def unprinted_warnings(); end
-
-  def warn(msg, newline=T.unsafe(nil)); end
-
-  def yes?(msg); end
-  LEVELS = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::UI::Shell
-end
-
-module Bundler::VersionRanges
-end
-
-class Bundler::VersionRanges::NEq
-  def version(); end
-
-  def version=(_); end
-end
-
-class Bundler::VersionRanges::NEq
-  def self.[](*_); end
-
-  def self.members(); end
-end
-
-class Bundler::VersionRanges::ReqR
-  def cover?(v); end
-
-  def empty?(); end
-
-  def left(); end
-
-  def left=(_); end
-
-  def right(); end
-
-  def right=(_); end
-
-  def single?(); end
-  INFINITY = ::T.let(nil, ::T.untyped)
-  UNIVERSAL = ::T.let(nil, ::T.untyped)
-  ZERO = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::VersionRanges::ReqR::Endpoint
-  def inclusive(); end
-
-  def inclusive=(_); end
-
-  def version(); end
-
-  def version=(_); end
-end
-
-class Bundler::VersionRanges::ReqR::Endpoint
-  def self.[](*_); end
-
-  def self.members(); end
-end
-
-class Bundler::VersionRanges::ReqR
-  def self.[](*_); end
-
-  def self.members(); end
-end
-
-module Bundler::VersionRanges
-  def self.empty?(ranges, neqs); end
-
-  def self.for(requirement); end
-
-  def self.for_many(requirements); end
 end
 
 module Bundler
@@ -1904,94 +50,6 @@ end
 
 class Class
   def json_creatable?(); end
-end
-
-class DidYouMean::ClassNameChecker
-  def class_name(); end
-
-  def class_names(); end
-
-  def corrections(); end
-
-  def initialize(exception); end
-
-  def scopes(); end
-end
-
-module DidYouMean::Correctable
-  def corrections(); end
-
-  def original_message(); end
-
-  def spell_checker(); end
-
-  def to_s(); end
-end
-
-module DidYouMean::Jaro
-  def self.distance(str1, str2); end
-end
-
-module DidYouMean::JaroWinkler
-  def self.distance(str1, str2); end
-end
-
-class DidYouMean::KeyErrorChecker
-  def corrections(); end
-
-  def initialize(key_error); end
-end
-
-class DidYouMean::KeyErrorChecker
-end
-
-module DidYouMean::Levenshtein
-  def self.distance(str1, str2); end
-
-  def self.min3(a, b, c); end
-end
-
-class DidYouMean::MethodNameChecker
-  def corrections(); end
-
-  def initialize(exception); end
-
-  def method_name(); end
-
-  def method_names(); end
-
-  def receiver(); end
-  RB_RESERVED_WORDS = ::T.let(nil, ::T.untyped)
-end
-
-class DidYouMean::NullChecker
-  def corrections(); end
-
-  def initialize(*_); end
-end
-
-class DidYouMean::PlainFormatter
-  def message_for(corrections); end
-end
-
-class DidYouMean::PlainFormatter
-end
-
-class DidYouMean::VariableNameChecker
-  def corrections(); end
-
-  def cvar_names(); end
-
-  def initialize(exception); end
-
-  def ivar_names(); end
-
-  def lvar_names(); end
-
-  def method_names(); end
-
-  def name(); end
-  RB_RESERVED_WORDS = ::T.let(nil, ::T.untyped)
 end
 
 module DidYouMean
@@ -2017,11 +75,11 @@ class ERB
 end
 
 class Encoding
+  class Converter
+    def initialize(*_); end
+  # wrong constant name initialize
+  end
   def _dump(*_); end
-end
-
-class Encoding::Converter
-  def initialize(*_); end
 end
 
 class Encoding
@@ -2035,100 +93,49 @@ module Enumerable
 end
 
 class Enumerator
+  class ArithmeticSequence
+    def begin(); end
+
+    def each(&blk); end
+
+    def end(); end
+
+    def exclude_end?(); end
+
+    def last(*_); end
+
+    def step(); end
+  # uninitialized constant Enumerator::ArithmeticSequence::Elem
+  # wrong constant name begin
+  # wrong constant name each
+  # wrong constant name end
+  # wrong constant name exclude_end?
+  # wrong constant name last
+  # wrong constant name step
+  end
+
+  class ArithmeticSequence
+  # wrong constant name <static-init>
+  end
+
+  class Chain
+  # uninitialized constant Enumerator::Chain::Elem
+  end
+
+  class Chain
+  # wrong constant name <static-init>
+  end
+
+  class Generator
+    def each(*_, &blk); end
+
+    def initialize(*_); end
+  # wrong constant name each
+  # wrong constant name initialize
+  end
   def +(_); end
 
   def each_with_index(); end
-end
-
-class Enumerator::ArithmeticSequence
-  def begin(); end
-
-  def each(&blk); end
-
-  def end(); end
-
-  def exclude_end?(); end
-
-  def last(*_); end
-
-  def step(); end
-end
-
-class Enumerator::ArithmeticSequence
-end
-
-class Enumerator::Chain
-end
-
-class Enumerator::Chain
-end
-
-class Enumerator::Generator
-  def each(*_, &blk); end
-
-  def initialize(*_); end
-end
-
-Errno::ECAPMODE = Errno::NOERROR
-
-Errno::EDOOFUS = Errno::NOERROR
-
-Errno::EIPSEC = Errno::NOERROR
-
-Errno::ENOTCAPABLE = Errno::NOERROR
-
-class Etc::Group
-  def gid(); end
-
-  def gid=(_); end
-
-  def mem(); end
-
-  def mem=(_); end
-
-  def name(); end
-
-  def name=(_); end
-
-  def passwd(); end
-
-  def passwd=(_); end
-end
-
-class Etc::Group
-  extend ::Enumerable
-  def self.[](*_); end
-
-  def self.each(&blk); end
-
-  def self.members(); end
-end
-
-class Etc::Passwd
-  def dir=(_); end
-
-  def gecos(); end
-
-  def gecos=(_); end
-
-  def gid=(_); end
-
-  def name=(_); end
-
-  def passwd=(_); end
-
-  def shell=(_); end
-
-  def uid=(_); end
-end
-
-class Etc::Passwd
-  extend ::Enumerable
-  def self.[](*_); end
-
-  def self.each(&blk); end
-
-  def self.members(); end
 end
 
 class ExitCalledError
@@ -2146,48 +153,53 @@ class File
 end
 
 module FileUtils
-  include ::FileUtils::StreamUtils_
-end
+  module DryRun
+    include ::FileUtils
+    include StreamUtils_
+    include LowMethods
+  # uninitialized constant FileUtils::DryRun::VERSION
+  # Did you mean?  FileUtils::VERSION
+  end
 
-module FileUtils::DryRun
-  include ::FileUtils
-  include ::FileUtils::StreamUtils_
-  include ::FileUtils::LowMethods
-end
+  module DryRun
+    extend DryRun
+    extend ::FileUtils
+    extend StreamUtils_
+    extend LowMethods
+  end
 
-module FileUtils::DryRun
-  extend ::FileUtils::DryRun
-  extend ::FileUtils
-  extend ::FileUtils::StreamUtils_
-  extend ::FileUtils::LowMethods
-end
+  module NoWrite
+    include ::FileUtils
+    include StreamUtils_
+    include LowMethods
+  # uninitialized constant FileUtils::NoWrite::VERSION
+  # Did you mean?  FileUtils::VERSION
+  end
 
-module FileUtils::NoWrite
-  include ::FileUtils
-  include ::FileUtils::StreamUtils_
-  include ::FileUtils::LowMethods
-end
+  module NoWrite
+    extend NoWrite
+    extend ::FileUtils
+    extend StreamUtils_
+    extend LowMethods
+  end
 
-module FileUtils::NoWrite
-  extend ::FileUtils::NoWrite
-  extend ::FileUtils
-  extend ::FileUtils::StreamUtils_
-  extend ::FileUtils::LowMethods
-end
+  module Verbose
+    include ::FileUtils
+    include StreamUtils_
+  # uninitialized constant FileUtils::Verbose::VERSION
+  # Did you mean?  FileUtils::VERSION
+  end
 
-module FileUtils::Verbose
-  include ::FileUtils
-  include ::FileUtils::StreamUtils_
-end
-
-module FileUtils::Verbose
-  extend ::FileUtils::Verbose
-  extend ::FileUtils
-  extend ::FileUtils::StreamUtils_
+  module Verbose
+    extend Verbose
+    extend ::FileUtils
+    extend StreamUtils_
+  end
+  include StreamUtils_
 end
 
 module FileUtils
-  extend ::FileUtils::StreamUtils_
+  extend StreamUtils_
 end
 
 class Float
@@ -2209,534 +221,318 @@ module GC
 end
 
 module Gem
+  class Dependency
+    def pretty_print(q); end
+  # wrong constant name <=>
+  # wrong constant name pretty_print
+  end
+
+  class DependencyInstaller
+    def _deprecated_add_found_dependencies(to_do, dependency_list); end
+
+    def _deprecated_gather_dependencies(); end
+
+    def add_found_dependencies(*args, &block); end
+
+    def gather_dependencies(*args, &block); end
+  # wrong constant name _deprecated_add_found_dependencies
+  # wrong constant name _deprecated_gather_dependencies
+  # wrong constant name add_found_dependencies
+  # wrong constant name gather_dependencies
+  end
+
+  class Exception
+    extend Deprecate
+  end
+
+  class List
+    def pretty_print(q); end
+  # wrong constant name pretty_print
+  end
+
+  class Package
+    def self.new(gem, security_policy=T.unsafe(nil)); end
+  # wrong constant name new
+  end
+
+  class PathSupport
+    def home(); end
+
+    def initialize(env); end
+
+    def path(); end
+
+    def spec_cache_dir(); end
+  # wrong constant name home
+  # wrong constant name initialize
+  # wrong constant name path
+  # wrong constant name spec_cache_dir
+  end
+
+  class RemoteFetcher
+    class FetchError
+      def initialize(message, uri); end
+
+      def uri(); end
+
+      def uri=(uri); end
+    # wrong constant name initialize
+    # wrong constant name uri
+    # wrong constant name uri=
+    end
+
+    class FetchError
+    # wrong constant name <static-init>
+    end
+
+    class UnknownHostError
+    end
+
+    class UnknownHostError
+    # wrong constant name <static-init>
+    end
+    def correct_for_windows_path(path); end
+
+    def s3_expiration(); end
+
+    def sign_s3_url(uri, expiration=T.unsafe(nil)); end
+    BASE64_URI_TRANSLATE = ::T.let(nil, ::T.untyped)
+  # wrong constant name <Class:FetchError>
+  # wrong constant name <Class:UnknownHostError>
+  # wrong constant name correct_for_windows_path
+  # wrong constant name s3_expiration
+  # wrong constant name sign_s3_url
+  end
+
+  class Request
+    extend UserInteraction
+    extend DefaultUserInteraction
+    extend Text
+  end
+
+  class RequestSet
+    def pretty_print(q); end
+  # wrong constant name pretty_print
+  end
+
+  class Requirement
+    def pretty_print(q); end
+  # wrong constant name pretty_print
+  end
+
+  class RuntimeRequirementNotMetError
+    def suggestion(); end
+
+    def suggestion=(suggestion); end
+  # wrong constant name suggestion
+  # wrong constant name suggestion=
+  end
+
+  class RuntimeRequirementNotMetError
+  # wrong constant name <static-init>
+  end
+
+  # uninitialized constant Gem::S3URISigner
+  # uninitialized constant Gem::S3URISigner
+  class Source
+    def pretty_print(q); end
+  # wrong constant name <=>
+  # wrong constant name pretty_print
+  end
+
+  class SpecFetcher
+    include UserInteraction
+    include DefaultUserInteraction
+    include Text
+    def available_specs(type); end
+
+    def detect(type=T.unsafe(nil)); end
+
+    def initialize(sources=T.unsafe(nil)); end
+
+    def latest_specs(); end
+
+    def prerelease_specs(); end
+
+    def search_for_dependency(dependency, matching_platform=T.unsafe(nil)); end
+
+    def sources(); end
+
+    def spec_for_dependency(dependency, matching_platform=T.unsafe(nil)); end
+
+    def specs(); end
+
+    def suggest_gems_from_name(gem_name, type=T.unsafe(nil)); end
+
+    def tuples_for(source, type, gracefully_ignore=T.unsafe(nil)); end
+  # wrong constant name available_specs
+  # wrong constant name detect
+  # wrong constant name initialize
+  # wrong constant name latest_specs
+  # wrong constant name prerelease_specs
+  # wrong constant name search_for_dependency
+  # wrong constant name sources
+  # wrong constant name spec_for_dependency
+  # wrong constant name specs
+  # wrong constant name suggest_gems_from_name
+  # wrong constant name tuples_for
+  end
+
+  class SpecFetcher
+    def self.fetcher(); end
+
+    def self.fetcher=(fetcher); end
+  # wrong constant name <static-init>
+  # wrong constant name fetcher
+  # wrong constant name fetcher=
+  end
+
+  class Specification
+    include ::Bundler::MatchPlatform
+    include ::Bundler::GemHelpers
+    def pretty_print(q); end
+
+    def to_ruby(); end
+  # wrong constant name <=>
+  # uninitialized constant Gem::Specification::GENERICS
+  # uninitialized constant Gem::Specification::GENERIC_CACHE
+  # wrong constant name pretty_print
+  # wrong constant name to_ruby
+  end
+
+  class Specification
+    extend Deprecate
+    extend ::Enumerable
+    def self.add_spec(spec); end
+
+    def self.add_specs(*specs); end
+
+    def self.remove_spec(spec); end
+  # wrong constant name add_spec
+  # wrong constant name add_specs
+  # wrong constant name remove_spec
+  end
+
+  class SpecificationPolicy
+    def initialize(specification); end
+
+    def packaging(); end
+
+    def packaging=(packaging); end
+
+    def validate(strict=T.unsafe(nil)); end
+
+    def validate_dependencies(); end
+
+    def validate_metadata(); end
+
+    def validate_permissions(); end
+    HOMEPAGE_URI_PATTERN = ::T.let(nil, ::T.untyped)
+    LAZY = ::T.let(nil, ::T.untyped)
+    LAZY_PATTERN = ::T.let(nil, ::T.untyped)
+    METADATA_LINK_KEYS = ::T.let(nil, ::T.untyped)
+    SPECIAL_CHARACTERS = ::T.let(nil, ::T.untyped)
+    VALID_NAME_PATTERN = ::T.let(nil, ::T.untyped)
+    VALID_URI_PATTERN = ::T.let(nil, ::T.untyped)
+  # wrong constant name initialize
+  # wrong constant name packaging
+  # wrong constant name packaging=
+  # wrong constant name validate
+  # wrong constant name validate_dependencies
+  # wrong constant name validate_metadata
+  # wrong constant name validate_permissions
+  end
+
+  class SpecificationPolicy
+  # wrong constant name <static-init>
+  end
+
+  # uninitialized constant Gem::Stream
+  # Did you mean?  Gem::StreamUI
+  # uninitialized constant Gem::Stream
+  # Did you mean?  Gem::StreamUI
+  class StreamUI
+    def _deprecated_debug(statement); end
+  # wrong constant name _deprecated_debug
+  end
+
+  class StubSpecification
+    class StubLine
+      def extensions(); end
+
+      def full_name(); end
+
+      def initialize(data, extensions); end
+
+      def name(); end
+
+      def platform(); end
+
+      def require_paths(); end
+
+      def version(); end
+    # wrong constant name extensions
+    # wrong constant name full_name
+    # wrong constant name initialize
+    # wrong constant name name
+    # wrong constant name platform
+    # wrong constant name require_paths
+    # wrong constant name version
+    end
+    def build_extensions(); end
+
+    def extensions(); end
+
+    def initialize(filename, base_dir, gems_dir, default_gem); end
+
+    def missing_extensions?(); end
+
+    def valid?(); end
+  # wrong constant name build_extensions
+  # wrong constant name extensions
+  # wrong constant name initialize
+  # wrong constant name missing_extensions?
+  # wrong constant name valid?
+  end
+
+  class StubSpecification
+    def self.default_gemspec_stub(filename, base_dir, gems_dir); end
+
+    def self.gemspec_stub(filename, base_dir, gems_dir); end
+  # wrong constant name default_gemspec_stub
+  # wrong constant name gemspec_stub
+  end
+
+  class UninstallError
+    def spec(); end
+
+    def spec=(spec); end
+  # wrong constant name spec
+  # wrong constant name spec=
+  end
+
+  class UninstallError
+  # wrong constant name <static-init>
+  end
+
+  Gem::UnsatisfiableDepedencyError = Gem::UnsatisfiableDependencyError
+
+  # uninitialized constant Gem::UriParser
+  # uninitialized constant Gem::UriParser
+  # uninitialized constant Gem::UriParsing
+  # uninitialized constant Gem::UriParsing
+  class Version
+    Gem::Version::Requirement = Gem::Requirement
+    def pretty_print(q); end
+  # wrong constant name <=>
+  # wrong constant name pretty_print
+  end
   ConfigMap = ::T.let(nil, ::T.untyped)
   RbConfigPriorities = ::T.let(nil, ::T.untyped)
   RubyGemsPackageVersion = ::T.let(nil, ::T.untyped)
   RubyGemsVersion = ::T.let(nil, ::T.untyped)
   USE_BUNDLER_FOR_GEMDEPS = ::T.let(nil, ::T.untyped)
 end
-
-class Gem::Dependency
-  def pretty_print(q); end
-end
-
-class Gem::DependencyInstaller
-  def _deprecated_add_found_dependencies(to_do, dependency_list); end
-
-  def _deprecated_gather_dependencies(); end
-
-  def add_found_dependencies(*args, &block); end
-
-  def gather_dependencies(*args, &block); end
-end
-
-class Gem::Exception
-  extend ::Gem::Deprecate
-end
-
-class Gem::Ext::BuildError
-end
-
-class Gem::Ext::BuildError
-end
-
-class Gem::Ext::Builder
-  def self.redirector(); end
-end
-
-class Gem::Ext::ExtConfBuilder
-end
-
-Gem::Ext::ExtConfBuilder::FileEntry = FileUtils::Entry_
-
-class Gem::Ext::ExtConfBuilder
-  def self.build(extension, dest_path, results, args=T.unsafe(nil), lib_dir=T.unsafe(nil)); end
-
-  def self.get_relative_path(path); end
-end
-
-class Gem::List
-  def pretty_print(q); end
-end
-
-class Gem::Package::DigestIO
-  def digests(); end
-
-  def initialize(io, digests); end
-
-  def write(data); end
-end
-
-class Gem::Package::DigestIO
-  def self.wrap(io, digests); end
-end
-
-class Gem::Package::FileSource
-  def initialize(path); end
-
-  def path(); end
-
-  def present?(); end
-
-  def start(); end
-
-  def with_read_io(&block); end
-
-  def with_write_io(&block); end
-end
-
-class Gem::Package::FileSource
-end
-
-class Gem::Package::IOSource
-  def initialize(io); end
-
-  def io(); end
-
-  def path(); end
-
-  def present?(); end
-
-  def start(); end
-
-  def with_read_io(); end
-
-  def with_write_io(); end
-end
-
-class Gem::Package::IOSource
-end
-
-class Gem::Package::Old
-  def extract_files(destination_dir); end
-
-  def file_list(io); end
-
-  def read_until_dashes(io); end
-
-  def skip_ruby(io); end
-end
-
-class Gem::Package::Old
-end
-
-class Gem::Package::Source
-end
-
-class Gem::Package::Source
-end
-
-class Gem::Package::TarHeader
-  def ==(other); end
-
-  def checksum(); end
-
-  def devmajor(); end
-
-  def devminor(); end
-
-  def empty?(); end
-
-  def gid(); end
-
-  def gname(); end
-
-  def initialize(vals); end
-
-  def linkname(); end
-
-  def magic(); end
-
-  def mode(); end
-
-  def mtime(); end
-
-  def name(); end
-
-  def prefix(); end
-
-  def size(); end
-
-  def typeflag(); end
-
-  def uid(); end
-
-  def uname(); end
-
-  def update_checksum(); end
-
-  def version(); end
-  EMPTY_HEADER = ::T.let(nil, ::T.untyped)
-  FIELDS = ::T.let(nil, ::T.untyped)
-  PACK_FORMAT = ::T.let(nil, ::T.untyped)
-  UNPACK_FORMAT = ::T.let(nil, ::T.untyped)
-end
-
-class Gem::Package::TarHeader
-  def self.from(stream); end
-
-  def self.strict_oct(str); end
-end
-
-class Gem::Package::TarReader::Entry
-  def bytes_read(); end
-
-  def check_closed(); end
-
-  def close(); end
-
-  def closed?(); end
-
-  def directory?(); end
-
-  def eof?(); end
-
-  def file?(); end
-
-  def full_name(); end
-
-  def getc(); end
-
-  def header(); end
-
-  def initialize(header, io); end
-
-  def length(); end
-
-  def pos(); end
-
-  def read(len=T.unsafe(nil)); end
-
-  def readpartial(maxlen=T.unsafe(nil), outbuf=T.unsafe(nil)); end
-
-  def rewind(); end
-
-  def size(); end
-
-  def symlink?(); end
-end
-
-class Gem::Package::TarReader::Entry
-end
-
-class Gem::Package::TarReader
-  def self.new(io); end
-end
-
-class Gem::Package::TarWriter
-  def self.new(io); end
-end
-
-class Gem::Package
-  def self.new(gem, security_policy=T.unsafe(nil)); end
-end
-
-class Gem::PathSupport
-  def home(); end
-
-  def initialize(env); end
-
-  def path(); end
-
-  def spec_cache_dir(); end
-end
-
-class Gem::RemoteFetcher
-  def correct_for_windows_path(path); end
-
-  def s3_expiration(); end
-
-  def sign_s3_url(uri, expiration=T.unsafe(nil)); end
-  BASE64_URI_TRANSLATE = ::T.let(nil, ::T.untyped)
-end
-
-class Gem::RemoteFetcher::FetchError
-  def initialize(message, uri); end
-
-  def uri(); end
-
-  def uri=(uri); end
-end
-
-class Gem::RemoteFetcher::FetchError
-end
-
-class Gem::RemoteFetcher::UnknownHostError
-end
-
-class Gem::RemoteFetcher::UnknownHostError
-end
-
-class Gem::Request
-  extend ::Gem::UserInteraction
-  extend ::Gem::DefaultUserInteraction
-  extend ::Gem::Text
-end
-
-class Gem::RequestSet
-  def pretty_print(q); end
-end
-
-class Gem::Requirement
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::APISet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::APISpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::ActivationRequest
-  def others_possible?(); end
-
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::BestSet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::Conflict
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::CurrentSet
-end
-
-class Gem::Resolver::CurrentSet
-end
-
-class Gem::Resolver::DependencyRequest
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::GitSet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::GitSpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::IndexSet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::IndexSpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::InstalledSpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::InstallerSet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::LocalSpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::LocalSpecification
-end
-
-class Gem::Resolver::LockSet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::LockSpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::Molinillo::DependencyGraph::Log
-  def add_edge_no_circular(graph, origin, destination, requirement); end
-
-  def add_vertex(graph, name, payload, root); end
-
-  def delete_edge(graph, origin_name, destination_name, requirement); end
-
-  def detach_vertex_named(graph, name); end
-
-  def each(&blk); end
-
-  def pop!(graph); end
-
-  def reverse_each(); end
-
-  def rewind_to(graph, tag); end
-
-  def set_payload(graph, name, payload); end
-
-  def tag(graph, tag); end
-end
-
-class Gem::Resolver::Molinillo::DependencyGraph::Log
-  extend ::Enumerable
-end
-
-class Gem::Resolver::VendorSet
-  def pretty_print(q); end
-end
-
-class Gem::RuntimeRequirementNotMetError
-  def suggestion(); end
-
-  def suggestion=(suggestion); end
-end
-
-class Gem::RuntimeRequirementNotMetError
-end
-
-class Gem::Security::Signer
-  include ::Gem::UserInteraction
-  include ::Gem::DefaultUserInteraction
-  include ::Gem::Text
-  def options(); end
-end
-
-class Gem::Security::Signer
-  def self.re_sign_cert(expired_cert, expired_cert_path, private_key); end
-end
-
-class Gem::Source
-  def pretty_print(q); end
-end
-
-class Gem::SpecFetcher
-  include ::Gem::UserInteraction
-  include ::Gem::DefaultUserInteraction
-  include ::Gem::Text
-  def available_specs(type); end
-
-  def detect(type=T.unsafe(nil)); end
-
-  def initialize(sources=T.unsafe(nil)); end
-
-  def latest_specs(); end
-
-  def prerelease_specs(); end
-
-  def search_for_dependency(dependency, matching_platform=T.unsafe(nil)); end
-
-  def sources(); end
-
-  def spec_for_dependency(dependency, matching_platform=T.unsafe(nil)); end
-
-  def specs(); end
-
-  def suggest_gems_from_name(gem_name, type=T.unsafe(nil)); end
-
-  def tuples_for(source, type, gracefully_ignore=T.unsafe(nil)); end
-end
-
-class Gem::SpecFetcher
-  def self.fetcher(); end
-
-  def self.fetcher=(fetcher); end
-end
-
-class Gem::Specification
-  include ::Bundler::MatchPlatform
-  include ::Bundler::GemHelpers
-  def pretty_print(q); end
-
-  def to_ruby(); end
-end
-
-class Gem::Specification
-  extend ::Gem::Deprecate
-  extend ::Enumerable
-  def self.add_spec(spec); end
-
-  def self.add_specs(*specs); end
-
-  def self.remove_spec(spec); end
-end
-
-class Gem::SpecificationPolicy
-  def initialize(specification); end
-
-  def packaging(); end
-
-  def packaging=(packaging); end
-
-  def validate(strict=T.unsafe(nil)); end
-
-  def validate_dependencies(); end
-
-  def validate_metadata(); end
-
-  def validate_permissions(); end
-  HOMEPAGE_URI_PATTERN = ::T.let(nil, ::T.untyped)
-  LAZY = ::T.let(nil, ::T.untyped)
-  LAZY_PATTERN = ::T.let(nil, ::T.untyped)
-  METADATA_LINK_KEYS = ::T.let(nil, ::T.untyped)
-  SPECIAL_CHARACTERS = ::T.let(nil, ::T.untyped)
-  VALID_NAME_PATTERN = ::T.let(nil, ::T.untyped)
-  VALID_URI_PATTERN = ::T.let(nil, ::T.untyped)
-end
-
-class Gem::SpecificationPolicy
-end
-
-class Gem::StreamUI
-  def _deprecated_debug(statement); end
-end
-
-class Gem::StubSpecification
-  def build_extensions(); end
-
-  def extensions(); end
-
-  def initialize(filename, base_dir, gems_dir, default_gem); end
-
-  def missing_extensions?(); end
-
-  def valid?(); end
-end
-
-class Gem::StubSpecification::StubLine
-  def extensions(); end
-
-  def full_name(); end
-
-  def initialize(data, extensions); end
-
-  def name(); end
-
-  def platform(); end
-
-  def require_paths(); end
-
-  def version(); end
-end
-
-class Gem::StubSpecification
-  def self.default_gemspec_stub(filename, base_dir, gems_dir); end
-
-  def self.gemspec_stub(filename, base_dir, gems_dir); end
-end
-
-class Gem::UninstallError
-  def spec(); end
-
-  def spec=(spec); end
-end
-
-class Gem::UninstallError
-end
-
-Gem::UnsatisfiableDepedencyError = Gem::UnsatisfiableDependencyError
-
-class Gem::Version
-  def pretty_print(q); end
-end
-
-Gem::Version::Requirement = Gem::Requirement
 
 module Gem
   def self.default_gems_use_full_paths?(); end
@@ -2753,6 +549,9 @@ class Hash
 end
 
 class IO
+  IO::EWOULDBLOCKWaitReadable = IO::EAGAINWaitReadable
+
+  IO::EWOULDBLOCKWaitWritable = IO::EAGAINWaitWritable
   def nread(); end
 
   def pathconf(_); end
@@ -2766,10 +565,6 @@ class IO
   def wait_writable(*_); end
 end
 
-IO::EWOULDBLOCKWaitReadable = IO::EAGAINWaitReadable
-
-IO::EWOULDBLOCKWaitWritable = IO::EAGAINWaitWritable
-
 class IPAddr
   def ==(other); end
 
@@ -2779,20 +574,6 @@ end
 class Integer
   include ::JSON::Ext::Generator::GeneratorMethods::Integer
 end
-
-class JSON::Ext::Generator::State
-  def self.from_state(_); end
-end
-
-class JSON::Ext::Parser
-  def initialize(*_); end
-end
-
-JSON::Parser = JSON::Ext::Parser
-
-JSON::State = JSON::Ext::Generator::State
-
-JSON::UnparserError = JSON::GeneratorError
 
 module Kernel
   def itself(); end
@@ -2821,13 +602,13 @@ class Monitor
 end
 
 module MonitorMixin
+  class ConditionVariable
+    def initialize(monitor); end
+  # wrong constant name initialize
+  end
   def initialize(*args); end
   EXCEPTION_IMMEDIATE = ::T.let(nil, ::T.untyped)
   EXCEPTION_NEVER = ::T.let(nil, ::T.untyped)
-end
-
-class MonitorMixin::ConditionVariable
-  def initialize(monitor); end
 end
 
 class NameError
@@ -2895,17 +676,6 @@ module RbConfig
   def self.ruby(); end
 end
 
-module RubyVM::MJIT
-end
-
-module RubyVM::MJIT
-  def self.enabled?(); end
-
-  def self.pause(*_); end
-
-  def self.resume(); end
-end
-
 class RubyVM
   def self.resolve_feature_path(_); end
 end
@@ -2934,12 +704,11 @@ class Set
 end
 
 class Socket
-  IPV6_DONTFRAG = ::T.let(nil, ::T.untyped)
-  IPV6_PATHMTU = ::T.let(nil, ::T.untyped)
-  IPV6_RECVPATHMTU = ::T.let(nil, ::T.untyped)
-end
-
-module Socket::Constants
+  module Constants
+    IPV6_DONTFRAG = ::T.let(nil, ::T.untyped)
+    IPV6_PATHMTU = ::T.let(nil, ::T.untyped)
+    IPV6_RECVPATHMTU = ::T.let(nil, ::T.untyped)
+  end
   IPV6_DONTFRAG = ::T.let(nil, ::T.untyped)
   IPV6_PATHMTU = ::T.let(nil, ::T.untyped)
   IPV6_RECVPATHMTU = ::T.let(nil, ::T.untyped)
@@ -2965,14 +734,13 @@ class String
 end
 
 class Struct
+  Struct::Group = Etc::Group
+
+  Struct::Passwd = Etc::Passwd
+
+  Struct::Tms = Process::Tms
   def filter(*_); end
 end
-
-Struct::Group = Etc::Group
-
-Struct::Passwd = Etc::Passwd
-
-Struct::Tms = Process::Tms
 
 class TracePoint
   def __enable(_, _1); end
@@ -2989,91 +757,179 @@ class TrueClass
 end
 
 module URI
-  include ::URI::RFC2396_REGEXP
-end
+  class FTP
+    def self.new2(user, password, host, port, path, typecode=T.unsafe(nil), arg_check=T.unsafe(nil)); end
+  # wrong constant name new2
+  end
 
-class URI::FTP
-  def self.new2(user, password, host, port, path, typecode=T.unsafe(nil), arg_check=T.unsafe(nil)); end
-end
+  class File
+    def check_password(user); end
 
-class URI::File
-  def check_password(user); end
+    def check_user(user); end
 
-  def check_user(user); end
+    def check_userinfo(user); end
 
-  def check_userinfo(user); end
+    def set_userinfo(v); end
+  # uninitialized constant URI::File::ABS_PATH
+  # Did you mean?  URI::ABS_PATH
+  # uninitialized constant URI::File::ABS_URI
+  # Did you mean?  URI::ABS_URI
+  # uninitialized constant URI::File::ABS_URI_REF
+  # Did you mean?  URI::ABS_URI_REF
+    COMPONENT = ::T.let(nil, ::T.untyped)
+  # uninitialized constant URI::File::DEFAULT_PARSER
+  # Did you mean?  URI::File::DEFAULT_PORT
+  #                URI::DEFAULT_PARSER
+    DEFAULT_PORT = ::T.let(nil, ::T.untyped)
+  # uninitialized constant URI::File::ESCAPED
+  # Did you mean?  URI::File::Escape
+  #                URI::Escape
+  #                URI::ESCAPED
+  # uninitialized constant URI::File::FRAGMENT
+  # Did you mean?  URI::FRAGMENT
+  # uninitialized constant URI::File::HOST
+  # Did you mean?  URI::HOST
+  # uninitialized constant URI::File::OPAQUE
+  # Did you mean?  URI::OPAQUE
+  # uninitialized constant URI::File::PORT
+  # Did you mean?  URI::PORT
+  # uninitialized constant URI::File::QUERY
+  # Did you mean?  URI::QUERY
+  # uninitialized constant URI::File::REGISTRY
+  # Did you mean?  URI::REGISTRY
+  # uninitialized constant URI::File::REL_PATH
+  # Did you mean?  URI::REL_PATH
+  # uninitialized constant URI::File::REL_URI
+  # Did you mean?  URI::REL_URI
+  # uninitialized constant URI::File::REL_URI_REF
+  # Did you mean?  URI::REL_URI_REF
+  # uninitialized constant URI::File::RFC3986_PARSER
+  # Did you mean?  URI::File::RFC3986_Parser
+  #                URI::RFC3986_Parser
+  #                URI::RFC2396_Parser
+  #                URI::File::RFC2396_Parser
+  #                URI::RFC3986_PARSER
+  # uninitialized constant URI::File::SCHEME
+  # Did you mean?  URI::SCHEME
+  # uninitialized constant URI::File::TBLDECWWWCOMP_
+  # Did you mean?  URI::File::TBLENCWWWCOMP_
+  #                URI::TBLDECWWWCOMP_
+  #                URI::TBLENCWWWCOMP_
+  # uninitialized constant URI::File::TBLENCWWWCOMP_
+  # Did you mean?  URI::File::TBLDECWWWCOMP_
+  #                URI::TBLDECWWWCOMP_
+  #                URI::TBLENCWWWCOMP_
+  # uninitialized constant URI::File::UNSAFE
+  # Did you mean?  URI::UNSAFE
+  # uninitialized constant URI::File::URI_REF
+  # Did you mean?  URI::URI_REF
+  # uninitialized constant URI::File::USERINFO
+  # Did you mean?  URI::USERINFO
+  # uninitialized constant URI::File::USE_REGISTRY
+  # uninitialized constant URI::File::VERSION
+  # Did you mean?  URI::VERSION
+  # uninitialized constant URI::File::VERSION_CODE
+  # Did you mean?  URI::VERSION_CODE
+  # uninitialized constant URI::File::WEB_ENCODINGS_
+  # Did you mean?  URI::WEB_ENCODINGS_
+  # wrong constant name check_password
+  # wrong constant name check_user
+  # wrong constant name check_userinfo
+  # wrong constant name set_userinfo
+  end
 
-  def set_userinfo(v); end
-  COMPONENT = ::T.let(nil, ::T.untyped)
-  DEFAULT_PORT = ::T.let(nil, ::T.untyped)
-end
+  class File
+  # wrong constant name <static-init>
+  end
 
-class URI::File
-end
+  class LDAP
+    def attributes(); end
 
-class URI::LDAP
-  def attributes(); end
+    def attributes=(val); end
 
-  def attributes=(val); end
+    def dn(); end
 
-  def dn(); end
+    def dn=(val); end
 
-  def dn=(val); end
+    def extensions(); end
 
-  def extensions(); end
+    def extensions=(val); end
 
-  def extensions=(val); end
+    def filter(); end
 
-  def filter(); end
+    def filter=(val); end
 
-  def filter=(val); end
+    def initialize(*arg); end
 
-  def initialize(*arg); end
+    def scope(); end
 
-  def scope(); end
+    def scope=(val); end
 
-  def scope=(val); end
+    def set_attributes(val); end
 
-  def set_attributes(val); end
+    def set_dn(val); end
 
-  def set_dn(val); end
+    def set_extensions(val); end
 
-  def set_extensions(val); end
+    def set_filter(val); end
 
-  def set_filter(val); end
+    def set_scope(val); end
+  # wrong constant name attributes
+  # wrong constant name attributes=
+  # wrong constant name dn
+  # wrong constant name dn=
+  # wrong constant name extensions
+  # wrong constant name extensions=
+  # wrong constant name filter
+  # wrong constant name filter=
+  # wrong constant name initialize
+  # wrong constant name scope
+  # wrong constant name scope=
+  # wrong constant name set_attributes
+  # wrong constant name set_dn
+  # wrong constant name set_extensions
+  # wrong constant name set_filter
+  # wrong constant name set_scope
+  end
 
-  def set_scope(val); end
-end
+  class MailTo
+    def initialize(*arg); end
+  # wrong constant name initialize
+  end
 
-class URI::MailTo
-  def initialize(*arg); end
-end
+  URI::Parser = URI::RFC2396_Parser
 
-URI::Parser = URI::RFC2396_Parser
+  URI::REGEXP = URI::RFC2396_REGEXP
 
-URI::REGEXP = URI::RFC2396_REGEXP
+  class RFC2396_Parser
+    def initialize(opts=T.unsafe(nil)); end
+  # wrong constant name initialize
+  end
 
-class URI::RFC2396_Parser
-  def initialize(opts=T.unsafe(nil)); end
-end
+  class RFC3986_Parser
+    def join(*uris); end
 
-class URI::RFC3986_Parser
-  def join(*uris); end
+    def parse(uri); end
 
-  def parse(uri); end
+    def regexp(); end
 
-  def regexp(); end
+    def split(uri); end
+    RFC3986_relative_ref = ::T.let(nil, ::T.untyped)
+  # wrong constant name join
+  # wrong constant name parse
+  # wrong constant name regexp
+  # wrong constant name split
+  end
 
-  def split(uri); end
-  RFC3986_relative_ref = ::T.let(nil, ::T.untyped)
-end
-
-module URI::Util
-  def self.make_components_hash(klass, array_hash); end
+  module Util
+    def self.make_components_hash(klass, array_hash); end
+  # wrong constant name make_components_hash
+  end
+  include RFC2396_REGEXP
 end
 
 module URI
-  extend ::URI::Escape
+  extend Escape
   def self.get_encoding(label); end
 end
 

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_5_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_5_hidden.rbi.exp
@@ -14,8 +14,6 @@ class Array
   def self.try_convert(_); end
 end
 
-BasicObject::BasicObject = BasicObject
-
 class BigDecimal
   def clone(); end
   EXCEPTION_NaN = ::T.let(nil, ::T.untyped)
@@ -30,1858 +28,6 @@ class Binding
   def clone(); end
 
   def irb(); end
-end
-
-class Bundler::Dependency
-  def branch(); end
-
-  def expanded_platforms(); end
-
-  def git(); end
-end
-
-Bundler::Deprecate = Gem::Deprecate
-
-class Bundler::Env
-end
-
-class Bundler::Env
-  def self.environment(); end
-
-  def self.report(options=T.unsafe(nil)); end
-
-  def self.write(io); end
-end
-
-class Bundler::Fetcher
-  def fetch_spec(spec); end
-
-  def fetchers(); end
-
-  def http_proxy(); end
-
-  def initialize(remote); end
-
-  def specs(gem_names, source); end
-
-  def specs_with_retry(gem_names, source); end
-
-  def uri(); end
-
-  def use_api(); end
-
-  def user_agent(); end
-  FAIL_ERRORS = ::T.let(nil, ::T.untyped)
-  FETCHERS = ::T.let(nil, ::T.untyped)
-  HTTP_ERRORS = ::T.let(nil, ::T.untyped)
-  NET_ERRORS = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Fetcher::AuthenticationRequiredError
-  def initialize(remote_uri); end
-end
-
-class Bundler::Fetcher::BadAuthenticationError
-  def initialize(remote_uri); end
-end
-
-class Bundler::Fetcher::Base
-  def api_fetcher?(); end
-
-  def available?(); end
-
-  def display_uri(); end
-
-  def downloader(); end
-
-  def fetch_uri(); end
-
-  def initialize(downloader, remote, display_uri); end
-
-  def remote(); end
-
-  def remote_uri(); end
-end
-
-class Bundler::Fetcher::Base
-end
-
-class Bundler::Fetcher::CertificateFailureError
-  def initialize(remote_uri); end
-end
-
-class Bundler::Fetcher::CompactIndex
-  def available?(*args, &blk); end
-
-  def fetch_spec(*args, &blk); end
-
-  def specs(*args, &blk); end
-
-  def specs_for_names(gem_names); end
-end
-
-class Bundler::Fetcher::CompactIndex::ClientFetcher
-  def call(path, headers); end
-
-  def fetcher(); end
-
-  def fetcher=(_); end
-
-  def ui(); end
-
-  def ui=(_); end
-end
-
-class Bundler::Fetcher::CompactIndex::ClientFetcher
-  def self.[](*_); end
-
-  def self.members(); end
-end
-
-class Bundler::Fetcher::CompactIndex
-  def self.compact_index_request(method_name); end
-end
-
-class Bundler::Fetcher::Dependency
-  def dependency_api_uri(gem_names=T.unsafe(nil)); end
-
-  def dependency_specs(gem_names); end
-
-  def get_formatted_specs_and_deps(gem_list); end
-
-  def specs(gem_names, full_dependency_list=T.unsafe(nil), last_spec_list=T.unsafe(nil)); end
-
-  def unmarshalled_dep_gems(gem_names); end
-end
-
-class Bundler::Fetcher::Dependency
-end
-
-class Bundler::Fetcher::Downloader
-  def connection(); end
-
-  def fetch(uri, headers=T.unsafe(nil), counter=T.unsafe(nil)); end
-
-  def initialize(connection, redirect_limit); end
-
-  def redirect_limit(); end
-
-  def request(uri, headers); end
-end
-
-class Bundler::Fetcher::Downloader
-end
-
-class Bundler::Fetcher::Index
-  def fetch_spec(spec); end
-
-  def specs(_gem_names); end
-end
-
-class Bundler::Fetcher::Index
-end
-
-class Bundler::Fetcher::SSLError
-  def initialize(msg=T.unsafe(nil)); end
-end
-
-class Bundler::Fetcher::TooManyRequestsError
-end
-
-class Bundler::Fetcher::TooManyRequestsError
-end
-
-class Bundler::Fetcher
-  def self.api_timeout(); end
-
-  def self.api_timeout=(api_timeout); end
-
-  def self.disable_endpoint(); end
-
-  def self.disable_endpoint=(disable_endpoint); end
-
-  def self.max_retries(); end
-
-  def self.max_retries=(max_retries); end
-
-  def self.redirect_limit(); end
-
-  def self.redirect_limit=(redirect_limit); end
-end
-
-module Bundler::FileUtils
-  VERSION = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::FileUtils::Entry_
-  def link(dest); end
-end
-
-module Bundler::FileUtils
-  def self.cp_lr(src, dest, noop: T.unsafe(nil), verbose: T.unsafe(nil), dereference_root: T.unsafe(nil), remove_destination: T.unsafe(nil)); end
-
-  def self.link_entry(src, dest, dereference_root=T.unsafe(nil), remove_destination=T.unsafe(nil)); end
-end
-
-class Bundler::GemHelper
-  def allowed_push_host(); end
-
-  def already_tagged?(); end
-
-  def base(); end
-
-  def build_gem(); end
-
-  def built_gem_path(); end
-
-  def clean?(); end
-
-  def committed?(); end
-
-  def gem_command(); end
-
-  def gem_key(); end
-
-  def gem_push?(); end
-
-  def gem_push_host(); end
-
-  def gemspec(); end
-
-  def git_push(remote=T.unsafe(nil)); end
-
-  def guard_clean(); end
-
-  def initialize(base=T.unsafe(nil), name=T.unsafe(nil)); end
-
-  def install(); end
-
-  def install_gem(built_gem_path=T.unsafe(nil), local=T.unsafe(nil)); end
-
-  def name(); end
-
-  def perform_git_push(options=T.unsafe(nil)); end
-
-  def rubygem_push(path); end
-
-  def sh(cmd, &block); end
-
-  def sh_with_input(cmd); end
-
-  def sh_with_status(cmd, &block); end
-
-  def spec_path(); end
-
-  def tag_version(); end
-
-  def version(); end
-
-  def version_tag(); end
-end
-
-class Bundler::GemHelper
-  def self.gemspec(&block); end
-
-  def self.install_tasks(opts=T.unsafe(nil)); end
-
-  def self.instance(); end
-
-  def self.instance=(instance); end
-end
-
-class Bundler::GemVersionPromoter
-  def initialize(locked_specs=T.unsafe(nil), unlock_gems=T.unsafe(nil)); end
-
-  def level(); end
-
-  def level=(value); end
-
-  def locked_specs(); end
-
-  def major?(); end
-
-  def minor?(); end
-
-  def prerelease_specified(); end
-
-  def prerelease_specified=(prerelease_specified); end
-
-  def sort_versions(dep, spec_groups); end
-
-  def strict(); end
-
-  def strict=(strict); end
-
-  def unlock_gems(); end
-  DEBUG = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::GemVersionPromoter
-end
-
-class Bundler::Graph
-  def edge_options(); end
-
-  def groups(); end
-
-  def initialize(env, output_file, show_version=T.unsafe(nil), show_requirements=T.unsafe(nil), output_format=T.unsafe(nil), without=T.unsafe(nil)); end
-
-  def node_options(); end
-
-  def output_file(); end
-
-  def output_format(); end
-
-  def relations(); end
-
-  def viz(); end
-  GRAPH_NAME = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Graph::GraphVizClient
-  def g(); end
-
-  def initialize(graph_instance); end
-
-  def run(); end
-end
-
-class Bundler::Graph::GraphVizClient
-end
-
-class Bundler::Graph
-end
-
-class Bundler::Index
-  include ::Enumerable
-end
-
-class Bundler::Injector
-  def initialize(deps, options=T.unsafe(nil)); end
-
-  def inject(gemfile_path, lockfile_path); end
-
-  def remove(gemfile_path, lockfile_path); end
-  INJECTED_GEMS = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Injector
-  def self.inject(new_deps, options=T.unsafe(nil)); end
-
-  def self.remove(gems, options=T.unsafe(nil)); end
-end
-
-class Bundler::Installer
-  def generate_bundler_executable_stubs(spec, options=T.unsafe(nil)); end
-
-  def generate_standalone_bundler_executable_stubs(spec); end
-
-  def initialize(root, definition); end
-
-  def post_install_messages(); end
-
-  def run(options); end
-end
-
-class Bundler::Installer
-  def self.ambiguous_gems(); end
-
-  def self.ambiguous_gems=(ambiguous_gems); end
-
-  def self.install(root, definition, options=T.unsafe(nil)); end
-end
-
-class Bundler::LockfileGenerator
-  def definition(); end
-
-  def generate!(); end
-
-  def initialize(definition); end
-
-  def out(); end
-end
-
-class Bundler::LockfileGenerator
-  def self.generate(definition); end
-end
-
-class Bundler::Molinillo::DependencyGraph
-  include ::Enumerable
-end
-
-class Bundler::Molinillo::DependencyGraph::Log
-  extend ::Enumerable
-end
-
-class Bundler::Molinillo::DependencyGraph::Vertex
-  def _recursive_predecessors(vertices=T.unsafe(nil)); end
-
-  def _recursive_successors(vertices=T.unsafe(nil)); end
-end
-
-module Bundler::Plugin::API::Source
-  def ==(other); end
-
-  def app_cache_dirname(); end
-
-  def app_cache_path(custom_path=T.unsafe(nil)); end
-
-  def bundler_plugin_api_source?(); end
-
-  def cache(spec, custom_path=T.unsafe(nil)); end
-
-  def cached!(); end
-
-  def can_lock?(spec); end
-
-  def dependency_names(); end
-
-  def dependency_names=(dependency_names); end
-
-  def double_check_for(*_); end
-
-  def eql?(other); end
-
-  def fetch_gemspec_files(); end
-
-  def gem_install_dir(); end
-
-  def hash(); end
-
-  def include?(other); end
-
-  def initialize(opts); end
-
-  def install(spec, opts); end
-
-  def install_path(); end
-
-  def installed?(); end
-
-  def name(); end
-
-  def options(); end
-
-  def options_to_lock(); end
-
-  def post_install(spec, disable_exts=T.unsafe(nil)); end
-
-  def remote!(); end
-
-  def root(); end
-
-  def specs(); end
-
-  def to_lock(); end
-
-  def to_s(); end
-
-  def unlock!(); end
-
-  def unmet_deps(); end
-
-  def uri(); end
-
-  def uri_hash(); end
-end
-
-module Bundler::Plugin::API::Source
-end
-
-module Bundler::Plugin::Events
-  GEM_AFTER_INSTALL = ::T.let(nil, ::T.untyped)
-  GEM_AFTER_INSTALL_ALL = ::T.let(nil, ::T.untyped)
-  GEM_BEFORE_INSTALL = ::T.let(nil, ::T.untyped)
-  GEM_BEFORE_INSTALL_ALL = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Plugin::Index
-  def installed_plugins(); end
-
-  def plugin_commands(plugin); end
-end
-
-class Bundler::Plugin::Index::CommandConflict
-  def initialize(plugin, commands); end
-end
-
-class Bundler::Plugin::Index::CommandConflict
-end
-
-class Bundler::Plugin::Index::SourceConflict
-  def initialize(plugin, sources); end
-end
-
-class Bundler::Plugin::Index::SourceConflict
-end
-
-class Bundler::Plugin::Installer
-  def install(names, options); end
-
-  def install_definition(definition); end
-end
-
-class Bundler::Plugin::Installer::Git
-  def generate_bin(spec, disable_extensions=T.unsafe(nil)); end
-end
-
-class Bundler::Plugin::Installer::Git
-end
-
-class Bundler::Plugin::Installer::Rubygems
-end
-
-class Bundler::Plugin::Installer::Rubygems
-end
-
-class Bundler::Plugin::Installer
-end
-
-class Bundler::Plugin::SourceList
-end
-
-class Bundler::Plugin::SourceList
-end
-
-module Bundler::Plugin
-  def self.list(); end
-end
-
-class Bundler::ProcessLock
-end
-
-class Bundler::ProcessLock
-  def self.lock(bundle_path=T.unsafe(nil)); end
-end
-
-class Bundler::Retry
-  def attempt(&block); end
-
-  def attempts(&block); end
-
-  def current_run(); end
-
-  def current_run=(current_run); end
-
-  def initialize(name, exceptions=T.unsafe(nil), retries=T.unsafe(nil)); end
-
-  def name(); end
-
-  def name=(name); end
-
-  def total_runs(); end
-
-  def total_runs=(total_runs); end
-end
-
-class Bundler::Retry
-  def self.attempts(); end
-
-  def self.default_attempts(); end
-
-  def self.default_retries(); end
-end
-
-class Bundler::RubyGemsGemInstaller
-end
-
-class Bundler::RubyGemsGemInstaller
-end
-
-class Bundler::RubygemsIntegration
-  def add_to_load_path(paths); end
-
-  def all_specs(); end
-
-  def backport_ext_builder_monitor(); end
-
-  def correct_for_windows_path(path); end
-
-  def default_stubs(); end
-
-  def find_name(name); end
-
-  def gem_remote_fetcher(); end
-
-  def plain_specs(); end
-
-  def plain_specs=(specs); end
-
-  def stub_rubygems(specs); end
-
-  def use_gemdeps(gemfile); end
-end
-
-class Bundler::Settings::Mirror
-  def ==(other); end
-
-  def fallback_timeout(); end
-
-  def fallback_timeout=(timeout); end
-
-  def initialize(uri=T.unsafe(nil), fallback_timeout=T.unsafe(nil)); end
-
-  def uri(); end
-
-  def uri=(uri); end
-
-  def valid?(); end
-
-  def validate!(probe=T.unsafe(nil)); end
-  DEFAULT_FALLBACK_TIMEOUT = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Settings::Mirror
-end
-
-class Bundler::Settings::Mirrors
-  def each(&blk); end
-
-  def for(uri); end
-
-  def initialize(prober=T.unsafe(nil)); end
-
-  def parse(key, value); end
-end
-
-class Bundler::Settings::Mirrors
-end
-
-class Bundler::Settings::Validator
-end
-
-class Bundler::Settings::Validator::Rule
-  def description(); end
-
-  def fail!(key, value, *reasons); end
-
-  def initialize(keys, description, &validate); end
-
-  def k(key); end
-
-  def set(settings, key, value, *reasons); end
-
-  def validate!(key, value, settings); end
-end
-
-class Bundler::Settings::Validator::Rule
-end
-
-class Bundler::Settings::Validator
-  def self.validate!(key, value, settings); end
-end
-
-class Bundler::Source::Git
-  def glob(); end
-end
-
-class Bundler::SpecSet
-  include ::Enumerable
-end
-
-class Bundler::Thor
-  include ::Bundler::Thor::Base
-  include ::Bundler::Thor::Invocation
-  include ::Bundler::Thor::Shell
-  def help(command=T.unsafe(nil), subcommand=T.unsafe(nil)); end
-  HELP_MAPPINGS = ::T.let(nil, ::T.untyped)
-  TEMPLATE_EXTNAME = ::T.let(nil, ::T.untyped)
-  THOR_RESERVED_WORDS = ::T.let(nil, ::T.untyped)
-end
-
-module Bundler::Thor::Actions
-  def _cleanup_options_and_set(options, key); end
-
-  def _shared_configuration(); end
-
-  def action(instance); end
-
-  def add_file(destination, *args, &block); end
-
-  def add_link(destination, *args); end
-
-  def append_file(path, *args, &block); end
-
-  def append_to_file(path, *args, &block); end
-
-  def apply(path, config=T.unsafe(nil)); end
-
-  def behavior(); end
-
-  def behavior=(behavior); end
-
-  def chmod(path, mode, config=T.unsafe(nil)); end
-
-  def comment_lines(path, flag, *args); end
-
-  def copy_file(source, *args, &block); end
-
-  def create_file(destination, *args, &block); end
-
-  def create_link(destination, *args); end
-
-  def destination_root(); end
-
-  def destination_root=(root); end
-
-  def directory(source, *args, &block); end
-
-  def empty_directory(destination, config=T.unsafe(nil)); end
-
-  def find_in_source_paths(file); end
-
-  def get(source, *args, &block); end
-
-  def gsub_file(path, flag, *args, &block); end
-
-  def in_root(); end
-
-  def initialize(args=T.unsafe(nil), options=T.unsafe(nil), config=T.unsafe(nil)); end
-
-  def inject_into_class(path, klass, *args, &block); end
-
-  def inject_into_file(destination, *args, &block); end
-
-  def inject_into_module(path, module_name, *args, &block); end
-
-  def insert_into_file(destination, *args, &block); end
-
-  def inside(dir=T.unsafe(nil), config=T.unsafe(nil), &block); end
-
-  def link_file(source, *args); end
-
-  def prepend_file(path, *args, &block); end
-
-  def prepend_to_file(path, *args, &block); end
-
-  def relative_to_original_destination_root(path, remove_dot=T.unsafe(nil)); end
-
-  def remove_dir(path, config=T.unsafe(nil)); end
-
-  def remove_file(path, config=T.unsafe(nil)); end
-
-  def run(command, config=T.unsafe(nil)); end
-
-  def run_ruby_script(command, config=T.unsafe(nil)); end
-
-  def source_paths(); end
-
-  def template(source, *args, &block); end
-
-  def thor(command, *args); end
-
-  def uncomment_lines(path, flag, *args); end
-  WARNINGS = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Actions::CapturableERB
-end
-
-class Bundler::Thor::Actions::CapturableERB
-end
-
-module Bundler::Thor::Actions::ClassMethods
-  def add_runtime_options!(); end
-
-  def source_paths(); end
-
-  def source_paths_for_search(); end
-
-  def source_root(path=T.unsafe(nil)); end
-end
-
-module Bundler::Thor::Actions::ClassMethods
-end
-
-class Bundler::Thor::Actions::CreateFile
-  def data(); end
-
-  def force_on_collision?(); end
-
-  def force_or_skip_or_conflict(force, skip, &block); end
-
-  def identical?(); end
-
-  def initialize(base, destination, data, config=T.unsafe(nil)); end
-
-  def on_conflict_behavior(&block); end
-
-  def render(); end
-end
-
-class Bundler::Thor::Actions::CreateFile
-end
-
-class Bundler::Thor::Actions::CreateLink
-end
-
-class Bundler::Thor::Actions::CreateLink
-end
-
-class Bundler::Thor::Actions::Directory
-  def execute!(); end
-
-  def file_level_lookup(previous_lookup); end
-
-  def files(lookup); end
-
-  def initialize(base, source, destination=T.unsafe(nil), config=T.unsafe(nil), &block); end
-
-  def source(); end
-end
-
-class Bundler::Thor::Actions::Directory
-end
-
-class Bundler::Thor::Actions::EmptyDirectory
-  def base(); end
-
-  def config(); end
-
-  def convert_encoded_instructions(filename); end
-
-  def destination(); end
-
-  def destination=(destination); end
-
-  def exists?(); end
-
-  def given_destination(); end
-
-  def initialize(base, destination, config=T.unsafe(nil)); end
-
-  def invoke!(); end
-
-  def invoke_with_conflict_check(&block); end
-
-  def on_conflict_behavior(); end
-
-  def on_file_clash_behavior(); end
-
-  def pretend?(); end
-
-  def relative_destination(); end
-
-  def revoke!(); end
-
-  def say_status(status, color); end
-end
-
-class Bundler::Thor::Actions::EmptyDirectory
-end
-
-class Bundler::Thor::Actions::InjectIntoFile
-  def behavior(); end
-
-  def flag(); end
-
-  def initialize(base, destination, data, config); end
-
-  def replace!(regexp, string, force); end
-
-  def replacement(); end
-
-  def say_status(behavior, warning: T.unsafe(nil), color: T.unsafe(nil)); end
-end
-
-class Bundler::Thor::Actions::InjectIntoFile
-end
-
-module Bundler::Thor::Actions
-  def self.included(base); end
-end
-
-class Bundler::Thor::AmbiguousCommandError
-end
-
-class Bundler::Thor::AmbiguousCommandError
-end
-
-Bundler::Thor::AmbiguousTaskError = Bundler::Thor::AmbiguousCommandError
-
-class Bundler::Thor::Argument
-  def banner(); end
-
-  def default(); end
-
-  def default_banner(); end
-
-  def description(); end
-
-  def enum(); end
-
-  def human_name(); end
-
-  def initialize(name, options=T.unsafe(nil)); end
-
-  def name(); end
-
-  def required(); end
-
-  def required?(); end
-
-  def show_default?(); end
-
-  def type(); end
-
-  def usage(); end
-
-  def valid_type?(type); end
-
-  def validate!(); end
-  VALID_TYPES = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Argument
-end
-
-class Bundler::Thor::Arguments
-  def initialize(arguments=T.unsafe(nil)); end
-
-  def parse(args); end
-
-  def remaining(); end
-  NUMERIC = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Arguments
-  def self.parse(*args); end
-
-  def self.split(args); end
-end
-
-module Bundler::Thor::Base
-  def args(); end
-
-  def args=(args); end
-
-  def initialize(args=T.unsafe(nil), local_options=T.unsafe(nil), config=T.unsafe(nil)); end
-
-  def options(); end
-
-  def options=(options); end
-
-  def parent_options(); end
-
-  def parent_options=(parent_options); end
-end
-
-module Bundler::Thor::Base::ClassMethods
-  def all_commands(); end
-
-  def all_tasks(); end
-
-  def allow_incompatible_default_type!(); end
-
-  def argument(name, options=T.unsafe(nil)); end
-
-  def arguments(); end
-
-  def attr_accessor(*_); end
-
-  def attr_reader(*_); end
-
-  def attr_writer(*_); end
-
-  def baseclass(); end
-
-  def basename(); end
-
-  def build_option(name, options, scope); end
-
-  def build_options(options, scope); end
-
-  def check_default_type(); end
-
-  def check_default_type!(); end
-
-  def check_unknown_options(); end
-
-  def check_unknown_options!(); end
-
-  def check_unknown_options?(config); end
-
-  def class_option(name, options=T.unsafe(nil)); end
-
-  def class_options(options=T.unsafe(nil)); end
-
-  def class_options_help(shell, groups=T.unsafe(nil)); end
-
-  def commands(); end
-
-  def create_command(meth); end
-
-  def create_task(meth); end
-
-  def disable_required_check?(command_name); end
-
-  def dispatch(command, given_args, given_opts, config); end
-
-  def exit_on_failure?(); end
-
-  def find_and_refresh_command(name); end
-
-  def find_and_refresh_task(name); end
-
-  def from_superclass(method, default=T.unsafe(nil)); end
-
-  def group(name=T.unsafe(nil)); end
-
-  def handle_argument_error(command, error, args, arity); end
-
-  def handle_no_command_error(command, has_namespace=T.unsafe(nil)); end
-
-  def handle_no_task_error(command, has_namespace=T.unsafe(nil)); end
-
-  def inherited(klass); end
-
-  def initialize_added(); end
-
-  def is_thor_reserved_word?(word, type); end
-
-  def method_added(meth); end
-
-  def namespace(name=T.unsafe(nil)); end
-
-  def no_commands(&block); end
-
-  def no_commands?(); end
-
-  def no_commands_context(); end
-
-  def no_tasks(&block); end
-
-  def print_options(shell, options, group_name=T.unsafe(nil)); end
-
-  def public_command(*names); end
-
-  def public_task(*names); end
-
-  def remove_argument(*names); end
-
-  def remove_class_option(*names); end
-
-  def remove_command(*names); end
-
-  def remove_task(*names); end
-
-  def start(given_args=T.unsafe(nil), config=T.unsafe(nil)); end
-
-  def stop_on_unknown_option?(command_name); end
-
-  def strict_args_position(); end
-
-  def strict_args_position!(); end
-
-  def strict_args_position?(config); end
-
-  def tasks(); end
-end
-
-module Bundler::Thor::Base::ClassMethods
-end
-
-module Bundler::Thor::Base
-  def self.included(base); end
-
-  def self.register_klass_file(klass); end
-
-  def self.shell(); end
-
-  def self.shell=(shell); end
-
-  def self.subclass_files(); end
-
-  def self.subclasses(); end
-end
-
-class Bundler::Thor::Command
-  def formatted_usage(klass, namespace=T.unsafe(nil), subcommand=T.unsafe(nil)); end
-
-  def handle_argument_error?(instance, error, caller); end
-
-  def handle_no_method_error?(instance, error, caller); end
-
-  def hidden?(); end
-
-  def initialize(name, description, long_description, usage, options=T.unsafe(nil)); end
-
-  def local_method?(instance, name); end
-
-  def not_debugging?(instance); end
-
-  def private_method?(instance); end
-
-  def public_method?(instance); end
-
-  def required_arguments_for(klass, usage); end
-
-  def required_options(); end
-
-  def run(instance, args=T.unsafe(nil)); end
-
-  def sans_backtrace(backtrace, caller); end
-  FILE_REGEXP = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Command
-end
-
-module Bundler::Thor::CoreExt
-end
-
-class Bundler::Thor::CoreExt::HashWithIndifferentAccess
-  def [](key); end
-
-  def []=(key, value); end
-
-  def convert_key(key); end
-
-  def delete(key); end
-
-  def fetch(key, *args); end
-
-  def initialize(hash=T.unsafe(nil)); end
-
-  def key?(key); end
-
-  def merge(other); end
-
-  def merge!(other); end
-
-  def method_missing(method, *args); end
-
-  def replace(other_hash); end
-
-  def reverse_merge(other); end
-
-  def reverse_merge!(other_hash); end
-
-  def values_at(*indices); end
-end
-
-class Bundler::Thor::CoreExt::HashWithIndifferentAccess
-end
-
-module Bundler::Thor::CoreExt
-end
-
-Bundler::Thor::Correctable = DidYouMean::Correctable
-
-class Bundler::Thor::DynamicCommand
-  def initialize(name, options=T.unsafe(nil)); end
-end
-
-class Bundler::Thor::DynamicCommand
-end
-
-Bundler::Thor::DynamicTask = Bundler::Thor::DynamicCommand
-
-class Bundler::Thor::Error
-end
-
-class Bundler::Thor::Error
-end
-
-class Bundler::Thor::Group
-  include ::Bundler::Thor::Base
-  include ::Bundler::Thor::Invocation
-  include ::Bundler::Thor::Shell
-  def _invoke_for_class_method(klass, command=T.unsafe(nil), *args, &block); end
-end
-
-class Bundler::Thor::Group
-  extend ::Bundler::Thor::Base::ClassMethods
-  extend ::Bundler::Thor::Invocation::ClassMethods
-  def self.banner(); end
-
-  def self.desc(description=T.unsafe(nil)); end
-
-  def self.get_options_from_invocations(group_options, base_options); end
-
-  def self.handle_argument_error(command, error, _args, arity); end
-
-  def self.help(shell); end
-
-  def self.invocation_blocks(); end
-
-  def self.invocations(); end
-
-  def self.invoke(*names, &block); end
-
-  def self.invoke_from_option(*names, &block); end
-
-  def self.printable_commands(*_); end
-
-  def self.printable_tasks(*_); end
-
-  def self.remove_invocation(*names); end
-
-  def self.self_command(); end
-
-  def self.self_task(); end
-end
-
-class Bundler::Thor::HiddenCommand
-end
-
-class Bundler::Thor::HiddenCommand
-end
-
-Bundler::Thor::HiddenTask = Bundler::Thor::HiddenCommand
-
-module Bundler::Thor::Invocation
-  def _parse_initialization_options(args, opts, config); end
-
-  def _retrieve_class_and_command(name, sent_command=T.unsafe(nil)); end
-
-  def _retrieve_class_and_task(name, sent_command=T.unsafe(nil)); end
-
-  def _shared_configuration(); end
-
-  def current_command_chain(); end
-
-  def initialize(args=T.unsafe(nil), options=T.unsafe(nil), config=T.unsafe(nil), &block); end
-
-  def invoke(name=T.unsafe(nil), *args); end
-
-  def invoke_all(); end
-
-  def invoke_command(command, *args); end
-
-  def invoke_task(command, *args); end
-
-  def invoke_with_padding(*args); end
-end
-
-module Bundler::Thor::Invocation::ClassMethods
-  def prepare_for_invocation(key, name); end
-end
-
-module Bundler::Thor::Invocation::ClassMethods
-end
-
-module Bundler::Thor::Invocation
-  def self.included(base); end
-end
-
-class Bundler::Thor::InvocationError
-end
-
-class Bundler::Thor::InvocationError
-end
-
-module Bundler::Thor::LineEditor
-end
-
-class Bundler::Thor::LineEditor::Basic
-  def initialize(prompt, options); end
-
-  def options(); end
-
-  def prompt(); end
-
-  def readline(); end
-end
-
-class Bundler::Thor::LineEditor::Basic
-  def self.available?(); end
-end
-
-class Bundler::Thor::LineEditor::Readline
-end
-
-class Bundler::Thor::LineEditor::Readline::PathCompletion
-  def initialize(text); end
-
-  def matches(); end
-end
-
-class Bundler::Thor::LineEditor::Readline::PathCompletion
-end
-
-class Bundler::Thor::LineEditor::Readline
-end
-
-module Bundler::Thor::LineEditor
-  def self.best_available(); end
-
-  def self.readline(prompt, options=T.unsafe(nil)); end
-end
-
-class Bundler::Thor::MalformattedArgumentError
-end
-
-class Bundler::Thor::MalformattedArgumentError
-end
-
-class Bundler::Thor::NestedContext
-  def enter(); end
-
-  def entered?(); end
-end
-
-class Bundler::Thor::NestedContext
-end
-
-class Bundler::Thor::NoKwargSpellChecker
-  def initialize(dictionary); end
-end
-
-class Bundler::Thor::NoKwargSpellChecker
-end
-
-class Bundler::Thor::Option
-  def aliases(); end
-
-  def array?(); end
-
-  def boolean?(); end
-
-  def dasherize(str); end
-
-  def dasherized?(); end
-
-  def group(); end
-
-  def hash?(); end
-
-  def hide(); end
-
-  def lazy_default(); end
-
-  def numeric?(); end
-
-  def repeatable(); end
-
-  def string?(); end
-
-  def switch_name(); end
-
-  def undasherize(str); end
-
-  def usage(padding=T.unsafe(nil)); end
-
-  def validate_default_type!(); end
-  VALID_TYPES = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Option
-  def self.parse(key, value); end
-end
-
-class Bundler::Thor::Options
-  def assign_result!(option, result); end
-
-  def check_unknown!(); end
-
-  def current_is_switch?(); end
-
-  def current_is_switch_formatted?(); end
-
-  def initialize(hash_options=T.unsafe(nil), defaults=T.unsafe(nil), stop_on_unknown=T.unsafe(nil), disable_required_check=T.unsafe(nil)); end
-
-  def normalize_switch(arg); end
-
-  def parse_boolean(switch); end
-
-  def parse_peek(switch, option); end
-
-  def parsing_options?(); end
-
-  def switch?(arg); end
-
-  def switch_option(arg); end
-  EQ_RE = ::T.let(nil, ::T.untyped)
-  LONG_RE = ::T.let(nil, ::T.untyped)
-  OPTS_END = ::T.let(nil, ::T.untyped)
-  SHORT_NUM = ::T.let(nil, ::T.untyped)
-  SHORT_RE = ::T.let(nil, ::T.untyped)
-  SHORT_SQ_RE = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Options
-  def self.to_switches(options); end
-end
-
-class Bundler::Thor::RequiredArgumentMissingError
-end
-
-class Bundler::Thor::RequiredArgumentMissingError
-end
-
-module Bundler::Thor::Sandbox
-end
-
-module Bundler::Thor::Sandbox
-end
-
-module Bundler::Thor::Shell
-  def _shared_configuration(); end
-
-  def ask(*args, &block); end
-
-  def error(*args, &block); end
-
-  def file_collision(*args, &block); end
-
-  def initialize(args=T.unsafe(nil), options=T.unsafe(nil), config=T.unsafe(nil)); end
-
-  def no?(*args, &block); end
-
-  def print_in_columns(*args, &block); end
-
-  def print_table(*args, &block); end
-
-  def print_wrapped(*args, &block); end
-
-  def say(*args, &block); end
-
-  def say_status(*args, &block); end
-
-  def set_color(*args, &block); end
-
-  def shell(); end
-
-  def shell=(shell); end
-
-  def terminal_width(*args, &block); end
-
-  def with_padding(); end
-
-  def yes?(*args, &block); end
-  SHELL_DELEGATED_METHODS = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Shell::Basic
-  def answer_match(possibilities, answer, case_insensitive); end
-
-  def as_unicode(); end
-
-  def ask(statement, *args); end
-
-  def ask_filtered(statement, color, options); end
-
-  def ask_simply(statement, color, options); end
-
-  def base(); end
-
-  def base=(base); end
-
-  def can_display_colors?(); end
-
-  def dynamic_width(); end
-
-  def dynamic_width_stty(); end
-
-  def dynamic_width_tput(); end
-
-  def error(statement); end
-
-  def file_collision(destination); end
-
-  def file_collision_help(); end
-
-  def git_merge_tool(); end
-
-  def indent(count=T.unsafe(nil)); end
-
-  def is?(value); end
-
-  def lookup_color(color); end
-
-  def merge(destination, content); end
-
-  def merge_tool(); end
-
-  def mute(); end
-
-  def mute?(); end
-
-  def no?(statement, color=T.unsafe(nil)); end
-
-  def padding(); end
-
-  def padding=(value); end
-
-  def prepare_message(message, *color); end
-
-  def print_in_columns(array); end
-
-  def print_table(array, options=T.unsafe(nil)); end
-
-  def print_wrapped(message, options=T.unsafe(nil)); end
-
-  def quiet?(); end
-
-  def say(message=T.unsafe(nil), color=T.unsafe(nil), force_new_line=T.unsafe(nil)); end
-
-  def say_status(status, message, log_status=T.unsafe(nil)); end
-
-  def set_color(string, *_); end
-
-  def show_diff(destination, content); end
-
-  def stderr(); end
-
-  def stdout(); end
-
-  def terminal_width(); end
-
-  def truncate(string, width); end
-
-  def unix?(); end
-
-  def yes?(statement, color=T.unsafe(nil)); end
-  DEFAULT_TERMINAL_WIDTH = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Shell::Basic
-end
-
-class Bundler::Thor::Shell::Color
-  def are_colors_disabled?(); end
-
-  def diff_lcs_loaded?(); end
-
-  def output_diff_line(diff); end
-
-  def set_color(string, *colors); end
-  BLACK = ::T.let(nil, ::T.untyped)
-  BLUE = ::T.let(nil, ::T.untyped)
-  BOLD = ::T.let(nil, ::T.untyped)
-  CLEAR = ::T.let(nil, ::T.untyped)
-  CYAN = ::T.let(nil, ::T.untyped)
-  GREEN = ::T.let(nil, ::T.untyped)
-  MAGENTA = ::T.let(nil, ::T.untyped)
-  ON_BLACK = ::T.let(nil, ::T.untyped)
-  ON_BLUE = ::T.let(nil, ::T.untyped)
-  ON_CYAN = ::T.let(nil, ::T.untyped)
-  ON_GREEN = ::T.let(nil, ::T.untyped)
-  ON_MAGENTA = ::T.let(nil, ::T.untyped)
-  ON_RED = ::T.let(nil, ::T.untyped)
-  ON_WHITE = ::T.let(nil, ::T.untyped)
-  ON_YELLOW = ::T.let(nil, ::T.untyped)
-  RED = ::T.let(nil, ::T.untyped)
-  WHITE = ::T.let(nil, ::T.untyped)
-  YELLOW = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Shell::Color
-end
-
-class Bundler::Thor::Shell::HTML
-  def ask(statement, color=T.unsafe(nil)); end
-
-  def diff_lcs_loaded?(); end
-
-  def output_diff_line(diff); end
-
-  def set_color(string, *colors); end
-  BLACK = ::T.let(nil, ::T.untyped)
-  BLUE = ::T.let(nil, ::T.untyped)
-  BOLD = ::T.let(nil, ::T.untyped)
-  CYAN = ::T.let(nil, ::T.untyped)
-  GREEN = ::T.let(nil, ::T.untyped)
-  MAGENTA = ::T.let(nil, ::T.untyped)
-  ON_BLACK = ::T.let(nil, ::T.untyped)
-  ON_BLUE = ::T.let(nil, ::T.untyped)
-  ON_CYAN = ::T.let(nil, ::T.untyped)
-  ON_GREEN = ::T.let(nil, ::T.untyped)
-  ON_MAGENTA = ::T.let(nil, ::T.untyped)
-  ON_RED = ::T.let(nil, ::T.untyped)
-  ON_WHITE = ::T.let(nil, ::T.untyped)
-  ON_YELLOW = ::T.let(nil, ::T.untyped)
-  RED = ::T.let(nil, ::T.untyped)
-  WHITE = ::T.let(nil, ::T.untyped)
-  YELLOW = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Shell::HTML
-end
-
-module Bundler::Thor::Shell
-end
-
-Bundler::Thor::Task = Bundler::Thor::Command
-
-class Bundler::Thor::UndefinedCommandError
-  include ::DidYouMean::Correctable
-  def all_commands(); end
-
-  def command(); end
-
-  def initialize(command, all_commands, namespace); end
-end
-
-class Bundler::Thor::UndefinedCommandError::SpellChecker
-  def corrections(); end
-
-  def error(); end
-
-  def initialize(error); end
-
-  def spell_checker(); end
-end
-
-class Bundler::Thor::UndefinedCommandError::SpellChecker
-end
-
-class Bundler::Thor::UndefinedCommandError
-end
-
-Bundler::Thor::UndefinedTaskError = Bundler::Thor::UndefinedCommandError
-
-class Bundler::Thor::UnknownArgumentError
-  include ::DidYouMean::Correctable
-  def initialize(switches, unknown); end
-
-  def switches(); end
-
-  def unknown(); end
-end
-
-class Bundler::Thor::UnknownArgumentError::SpellChecker
-  def corrections(); end
-
-  def error(); end
-
-  def initialize(error); end
-
-  def spell_checker(); end
-end
-
-class Bundler::Thor::UnknownArgumentError::SpellChecker
-end
-
-class Bundler::Thor::UnknownArgumentError
-end
-
-module Bundler::Thor::Util
-end
-
-module Bundler::Thor::Util
-  def self.camel_case(str); end
-
-  def self.escape_globs(path); end
-
-  def self.escape_html(string); end
-
-  def self.find_by_namespace(namespace); end
-
-  def self.find_class_and_command_by_namespace(namespace, fallback=T.unsafe(nil)); end
-
-  def self.find_class_and_task_by_namespace(namespace, fallback=T.unsafe(nil)); end
-
-  def self.globs_for(path); end
-
-  def self.load_thorfile(path, content=T.unsafe(nil), debug=T.unsafe(nil)); end
-
-  def self.namespace_from_thor_class(constant); end
-
-  def self.namespaces_in_content(contents, file=T.unsafe(nil)); end
-
-  def self.ruby_command(); end
-
-  def self.snake_case(str); end
-
-  def self.thor_classes_in(klass); end
-
-  def self.thor_root(); end
-
-  def self.thor_root_glob(); end
-
-  def self.user_home(); end
-end
-
-class Bundler::Thor
-  extend ::Bundler::Thor::Base::ClassMethods
-  extend ::Bundler::Thor::Invocation::ClassMethods
-  def self.banner(command, namespace=T.unsafe(nil), subcommand=T.unsafe(nil)); end
-
-  def self.check_unknown_options!(options=T.unsafe(nil)); end
-
-  def self.command_help(shell, command_name); end
-
-  def self.default_command(meth=T.unsafe(nil)); end
-
-  def self.default_task(meth=T.unsafe(nil)); end
-
-  def self.deprecation_warning(message); end
-
-  def self.desc(usage, description, options=T.unsafe(nil)); end
-
-  def self.disable_required_check(); end
-
-  def self.disable_required_check!(*command_names); end
-
-  def self.disable_required_check?(command); end
-
-  def self.dispatch(meth, given_args, given_opts, config); end
-
-  def self.dynamic_command_class(); end
-
-  def self.find_command_possibilities(meth); end
-
-  def self.find_task_possibilities(meth); end
-
-  def self.help(shell, subcommand=T.unsafe(nil)); end
-
-  def self.long_desc(long_description, options=T.unsafe(nil)); end
-
-  def self.map(mappings=T.unsafe(nil), **kw); end
-
-  def self.method_option(name, options=T.unsafe(nil)); end
-
-  def self.method_options(options=T.unsafe(nil)); end
-
-  def self.normalize_command_name(meth); end
-
-  def self.normalize_task_name(meth); end
-
-  def self.option(name, options=T.unsafe(nil)); end
-
-  def self.options(options=T.unsafe(nil)); end
-
-  def self.package_name(name, _=T.unsafe(nil)); end
-
-  def self.printable_commands(all=T.unsafe(nil), subcommand=T.unsafe(nil)); end
-
-  def self.printable_tasks(all=T.unsafe(nil), subcommand=T.unsafe(nil)); end
-
-  def self.register(klass, subcommand_name, usage, description, options=T.unsafe(nil)); end
-
-  def self.retrieve_command_name(args); end
-
-  def self.retrieve_task_name(args); end
-
-  def self.stop_on_unknown_option(); end
-
-  def self.stop_on_unknown_option!(*command_names); end
-
-  def self.stop_on_unknown_option?(command); end
-
-  def self.subcommand(subcommand, subcommand_class); end
-
-  def self.subcommand_classes(); end
-
-  def self.subcommand_help(cmd); end
-
-  def self.subcommands(); end
-
-  def self.subtask(subcommand, subcommand_class); end
-
-  def self.subtask_help(cmd); end
-
-  def self.subtasks(); end
-
-  def self.task_help(shell, command_name); end
-end
-
-class Bundler::UI::Shell
-  def add_color(string, *color); end
-
-  def ask(msg); end
-
-  def confirm(msg, newline=T.unsafe(nil)); end
-
-  def debug(msg, newline=T.unsafe(nil)); end
-
-  def debug?(); end
-
-  def error(msg, newline=T.unsafe(nil)); end
-
-  def info(msg, newline=T.unsafe(nil)); end
-
-  def initialize(options=T.unsafe(nil)); end
-
-  def level(name=T.unsafe(nil)); end
-
-  def level=(level); end
-
-  def no?(); end
-
-  def quiet?(); end
-
-  def shell=(shell); end
-
-  def silence(&blk); end
-
-  def trace(e, newline=T.unsafe(nil), force=T.unsafe(nil)); end
-
-  def unprinted_warnings(); end
-
-  def warn(msg, newline=T.unsafe(nil)); end
-
-  def yes?(msg); end
-  LEVELS = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::UI::Shell
-end
-
-module Bundler::VersionRanges
-end
-
-class Bundler::VersionRanges::NEq
-  def version(); end
-
-  def version=(_); end
-end
-
-class Bundler::VersionRanges::NEq
-  def self.[](*_); end
-
-  def self.members(); end
-end
-
-class Bundler::VersionRanges::ReqR
-  def cover?(v); end
-
-  def empty?(); end
-
-  def left(); end
-
-  def left=(_); end
-
-  def right(); end
-
-  def right=(_); end
-
-  def single?(); end
-  INFINITY = ::T.let(nil, ::T.untyped)
-  UNIVERSAL = ::T.let(nil, ::T.untyped)
-  ZERO = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::VersionRanges::ReqR::Endpoint
-  def inclusive(); end
-
-  def inclusive=(_); end
-
-  def version(); end
-
-  def version=(_); end
-end
-
-class Bundler::VersionRanges::ReqR::Endpoint
-  def self.[](*_); end
-
-  def self.members(); end
-end
-
-class Bundler::VersionRanges::ReqR
-  def self.[](*_); end
-
-  def self.members(); end
-end
-
-module Bundler::VersionRanges
-  def self.empty?(ranges, neqs); end
-
-  def self.for(requirement); end
-
-  def self.for_many(requirements); end
 end
 
 module Bundler
@@ -1918,102 +64,6 @@ class Delegator
   RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
 end
 
-class DidYouMean::ClassNameChecker
-  def class_name(); end
-
-  def class_names(); end
-
-  def corrections(); end
-
-  def initialize(exception); end
-
-  def scopes(); end
-end
-
-module DidYouMean::Correctable
-  def corrections(); end
-
-  def original_message(); end
-
-  def spell_checker(); end
-
-  def to_s(); end
-end
-
-class DidYouMean::DeprecatedIgnoredCallers
-  def +(*_); end
-
-  def <<(*_); end
-end
-
-class DidYouMean::DeprecatedIgnoredCallers
-end
-
-module DidYouMean::Jaro
-  def self.distance(str1, str2); end
-end
-
-module DidYouMean::JaroWinkler
-  def self.distance(str1, str2); end
-end
-
-class DidYouMean::KeyErrorChecker
-  def corrections(); end
-
-  def initialize(key_error); end
-end
-
-class DidYouMean::KeyErrorChecker
-end
-
-module DidYouMean::Levenshtein
-  def self.distance(str1, str2); end
-
-  def self.min3(a, b, c); end
-end
-
-class DidYouMean::MethodNameChecker
-  def corrections(); end
-
-  def initialize(exception); end
-
-  def method_name(); end
-
-  def method_names(); end
-
-  def receiver(); end
-end
-
-class DidYouMean::NullChecker
-  def corrections(); end
-
-  def initialize(*_); end
-end
-
-class DidYouMean::PlainFormatter
-  def message_for(corrections); end
-end
-
-class DidYouMean::PlainFormatter
-end
-
-class DidYouMean::VariableNameChecker
-  def corrections(); end
-
-  def cvar_names(); end
-
-  def initialize(exception); end
-
-  def ivar_names(); end
-
-  def lvar_names(); end
-
-  def method_names(); end
-
-  def name(); end
-  RB_PREDEFINED_OBJECTS = ::T.let(nil, ::T.untyped)
-end
-
 module DidYouMean
   def self.formatter(); end
 
@@ -2031,11 +81,11 @@ class ERB
 end
 
 class Encoding
+  class Converter
+    def initialize(*_); end
+  # wrong constant name initialize
+  end
   def _dump(*_); end
-end
-
-class Encoding::Converter
-  def initialize(*_); end
 end
 
 class Encoding
@@ -2047,75 +97,14 @@ module Enumerable
 end
 
 class Enumerator
+  class Generator
+    def each(*_, &blk); end
+
+    def initialize(*_); end
+  # wrong constant name each
+  # wrong constant name initialize
+  end
   def each_with_index(); end
-end
-
-class Enumerator::Generator
-  def each(*_, &blk); end
-
-  def initialize(*_); end
-end
-
-Errno::ECAPMODE = Errno::NOERROR
-
-Errno::EDOOFUS = Errno::NOERROR
-
-Errno::EIPSEC = Errno::NOERROR
-
-Errno::ENOTCAPABLE = Errno::NOERROR
-
-class Etc::Group
-  def gid(); end
-
-  def gid=(_); end
-
-  def mem(); end
-
-  def mem=(_); end
-
-  def name(); end
-
-  def name=(_); end
-
-  def passwd(); end
-
-  def passwd=(_); end
-end
-
-class Etc::Group
-  extend ::Enumerable
-  def self.[](*_); end
-
-  def self.each(&blk); end
-
-  def self.members(); end
-end
-
-class Etc::Passwd
-  def dir=(_); end
-
-  def gecos(); end
-
-  def gecos=(_); end
-
-  def gid=(_); end
-
-  def name=(_); end
-
-  def passwd=(_); end
-
-  def shell=(_); end
-
-  def uid=(_); end
-end
-
-class Etc::Passwd
-  extend ::Enumerable
-  def self.[](*_); end
-
-  def self.each(&blk); end
-
-  def self.members(); end
 end
 
 class ExitCalledError
@@ -2133,52 +122,80 @@ class File
 end
 
 module FileUtils
-  include ::FileUtils::StreamUtils_
-end
+  module DryRun
+    include ::FileUtils
+    include StreamUtils_
+    include LowMethods
+  # uninitialized constant FileUtils::DryRun::VERSION
+  # Did you mean?  FileUtils::DryRun::VERSION
+  #                FileUtils::VERSION
+  end
 
-module FileUtils::DryRun
-  include ::FileUtils
-  include ::FileUtils::StreamUtils_
-  include ::FileUtils::LowMethods
-end
+  module DryRun
+    extend DryRun
+    extend ::FileUtils
+    extend StreamUtils_
+    extend LowMethods
+  end
 
-module FileUtils::DryRun
-  extend ::FileUtils::DryRun
-  extend ::FileUtils
-  extend ::FileUtils::StreamUtils_
-  extend ::FileUtils::LowMethods
-end
+  module NoWrite
+    include ::FileUtils
+    include StreamUtils_
+    include LowMethods
+  # uninitialized constant FileUtils::NoWrite::VERSION
+  # Did you mean?  FileUtils::NoWrite::VERSION
+  #                FileUtils::VERSION
+  end
 
-module FileUtils::NoWrite
-  include ::FileUtils
-  include ::FileUtils::StreamUtils_
-  include ::FileUtils::LowMethods
-end
+  module NoWrite
+    extend NoWrite
+    extend ::FileUtils
+    extend StreamUtils_
+    extend LowMethods
+  end
 
-module FileUtils::NoWrite
-  extend ::FileUtils::NoWrite
-  extend ::FileUtils
-  extend ::FileUtils::StreamUtils_
-  extend ::FileUtils::LowMethods
-end
+  module Verbose
+    include ::FileUtils
+    include StreamUtils_
+  # uninitialized constant FileUtils::Verbose::VERSION
+  # Did you mean?  FileUtils::Verbose::VERSION
+  #                FileUtils::VERSION
+  end
 
-module FileUtils::Verbose
-  include ::FileUtils
-  include ::FileUtils::StreamUtils_
-end
-
-module FileUtils::Verbose
-  extend ::FileUtils::Verbose
-  extend ::FileUtils
-  extend ::FileUtils::StreamUtils_
+  module Verbose
+    extend Verbose
+    extend ::FileUtils
+    extend StreamUtils_
+  end
+  include StreamUtils_
 end
 
 module FileUtils
-  extend ::FileUtils::StreamUtils_
+  extend StreamUtils_
 end
 
 class Float
   include ::JSON::Ext::Generator::GeneratorMethods::Float
+end
+
+module Foo
+  module Bar
+    module Baz
+    end
+
+    module Baz
+    # wrong constant name <static-init>
+    end
+    include Baz
+  # wrong constant name <Class:Baz>
+  end
+
+  module Bar
+  # wrong constant name <static-init>
+  end
+end
+
+module Foo
 end
 
 module GC
@@ -2186,501 +203,478 @@ module GC
 end
 
 module Gem
+  class Dependency
+    def pretty_print(q); end
+  # wrong constant name <=>
+  # wrong constant name pretty_print
+  end
+
+  class DependencyInstaller
+    def _deprecated_gems_to_install(); end
+
+    def add_found_dependencies(to_do, dependency_list); end
+
+    def gather_dependencies(); end
+
+    def gems_to_install(*args, &block); end
+  # wrong constant name _deprecated_gems_to_install
+  # wrong constant name add_found_dependencies
+  # wrong constant name gather_dependencies
+  # wrong constant name gems_to_install
+  end
+
+  Gem::DependencyResolver = Gem::Resolver
+
+  class Licenses
+    IDENTIFIERS = ::T.let(nil, ::T.untyped)
+  end
+
+  class List
+    def pretty_print(q); end
+  # wrong constant name pretty_print
+  end
+
+  class Package
+    class DigestIO
+      def digests(); end
+
+      def initialize(io, digests); end
+
+      def write(data); end
+    # wrong constant name digests
+    # wrong constant name initialize
+    # wrong constant name write
+    end
+
+    class DigestIO
+      def self.wrap(io, digests); end
+    # wrong constant name <static-init>
+    # wrong constant name wrap
+    end
+
+    class FileSource
+      def initialize(path); end
+
+      def path(); end
+
+      def present?(); end
+
+      def start(); end
+
+      def with_read_io(&block); end
+
+      def with_write_io(&block); end
+    # wrong constant name initialize
+    # wrong constant name path
+    # wrong constant name present?
+    # wrong constant name start
+    # wrong constant name with_read_io
+    # wrong constant name with_write_io
+    end
+
+    class FileSource
+    # wrong constant name <static-init>
+    end
+
+    class IOSource
+      def initialize(io); end
+
+      def io(); end
+
+      def path(); end
+
+      def present?(); end
+
+      def start(); end
+
+      def with_read_io(); end
+
+      def with_write_io(); end
+    # wrong constant name initialize
+    # wrong constant name io
+    # wrong constant name path
+    # wrong constant name present?
+    # wrong constant name start
+    # wrong constant name with_read_io
+    # wrong constant name with_write_io
+    end
+
+    class IOSource
+    # wrong constant name <static-init>
+    end
+
+    class Old
+      def extract_files(destination_dir); end
+
+      def file_list(io); end
+
+      def read_until_dashes(io); end
+
+      def skip_ruby(io); end
+    # wrong constant name extract_files
+    # wrong constant name file_list
+    # wrong constant name read_until_dashes
+    # wrong constant name skip_ruby
+    end
+
+    class Old
+    # wrong constant name <static-init>
+    end
+
+    class Source
+    end
+
+    class Source
+    # wrong constant name <static-init>
+    end
+
+    class TarHeader
+      def ==(other); end
+
+      def checksum(); end
+
+      def devmajor(); end
+
+      def devminor(); end
+
+      def empty?(); end
+
+      def gid(); end
+
+      def gname(); end
+
+      def initialize(vals); end
+
+      def linkname(); end
+
+      def magic(); end
+
+      def mode(); end
+
+      def mtime(); end
+
+      def name(); end
+
+      def prefix(); end
+
+      def size(); end
+
+      def typeflag(); end
+
+      def uid(); end
+
+      def uname(); end
+
+      def update_checksum(); end
+
+      def version(); end
+    # wrong constant name ==
+      FIELDS = ::T.let(nil, ::T.untyped)
+      PACK_FORMAT = ::T.let(nil, ::T.untyped)
+      UNPACK_FORMAT = ::T.let(nil, ::T.untyped)
+    # wrong constant name checksum
+    # wrong constant name devmajor
+    # wrong constant name devminor
+    # wrong constant name empty?
+    # wrong constant name gid
+    # wrong constant name gname
+    # wrong constant name initialize
+    # wrong constant name linkname
+    # wrong constant name magic
+    # wrong constant name mode
+    # wrong constant name mtime
+    # wrong constant name name
+    # wrong constant name prefix
+    # wrong constant name size
+    # wrong constant name typeflag
+    # wrong constant name uid
+    # wrong constant name uname
+    # wrong constant name update_checksum
+    # wrong constant name version
+    end
+
+    class TarHeader
+      def self.from(stream); end
+
+      def self.strict_oct(str); end
+    # wrong constant name <static-init>
+    # wrong constant name from
+    # wrong constant name strict_oct
+    end
+
+    class TarReader
+      def self.new(io); end
+    # wrong constant name new
+    end
+
+    class TarWriter
+      def self.new(io); end
+    # wrong constant name new
+    end
+    def realpath(file); end
+  # wrong constant name <Class:DigestIO>
+  # wrong constant name <Class:FileSource>
+  # wrong constant name <Class:IOSource>
+  # wrong constant name <Class:Old>
+  # wrong constant name <Class:Source>
+  # wrong constant name <Class:TarHeader>
+  # wrong constant name realpath
+  end
+
+  class Package
+    def self.new(gem, security_policy=T.unsafe(nil)); end
+  # wrong constant name new
+  end
+
+  class PathSupport
+    def home(); end
+
+    def initialize(env); end
+
+    def path(); end
+
+    def spec_cache_dir(); end
+  # wrong constant name home
+  # wrong constant name initialize
+  # wrong constant name path
+  # wrong constant name spec_cache_dir
+  end
+
+  class RemoteFetcher
+    class FetchError
+      def initialize(message, uri); end
+
+      def uri(); end
+
+      def uri=(uri); end
+    # wrong constant name initialize
+    # wrong constant name uri
+    # wrong constant name uri=
+    end
+
+    class FetchError
+    # wrong constant name <static-init>
+    end
+
+    class UnknownHostError
+    end
+
+    class UnknownHostError
+    # wrong constant name <static-init>
+    end
+    def api_endpoint(uri); end
+
+    def correct_for_windows_path(path); end
+
+    def s3_expiration(); end
+
+    def sign_s3_url(uri, expiration=T.unsafe(nil)); end
+    BASE64_URI_TRANSLATE = ::T.let(nil, ::T.untyped)
+  # wrong constant name <Class:FetchError>
+  # wrong constant name <Class:UnknownHostError>
+  # wrong constant name api_endpoint
+  # wrong constant name correct_for_windows_path
+  # wrong constant name s3_expiration
+  # wrong constant name sign_s3_url
+  end
+
+  class Request
+    extend UserInteraction
+    extend DefaultUserInteraction
+    extend Text
+  end
+
+  class RequestSet
+    Gem::RequestSet::GemDepedencyAPI = Gem::RequestSet::GemDependencyAPI
+    def pretty_print(q); end
+  # wrong constant name pretty_print
+  end
+
+  class Requirement
+    def pretty_print(q); end
+  # wrong constant name pretty_print
+  end
+
+  class RuntimeRequirementNotMetError
+    def suggestion(); end
+
+    def suggestion=(suggestion); end
+  # wrong constant name suggestion
+  # wrong constant name suggestion=
+  end
+
+  class RuntimeRequirementNotMetError
+  # wrong constant name <static-init>
+  end
+
+  # uninitialized constant Gem::S3URISigner
+  # uninitialized constant Gem::S3URISigner
+  class Source
+    def api_uri(); end
+
+    def pretty_print(q); end
+  # wrong constant name <=>
+  # wrong constant name api_uri
+  # wrong constant name pretty_print
+  end
+
+  class SpecFetcher
+    include UserInteraction
+    include DefaultUserInteraction
+    include Text
+    def available_specs(type); end
+
+    def detect(type=T.unsafe(nil)); end
+
+    def initialize(sources=T.unsafe(nil)); end
+
+    def latest_specs(); end
+
+    def prerelease_specs(); end
+
+    def search_for_dependency(dependency, matching_platform=T.unsafe(nil)); end
+
+    def sources(); end
+
+    def spec_for_dependency(dependency, matching_platform=T.unsafe(nil)); end
+
+    def specs(); end
+
+    def suggest_gems_from_name(gem_name, type=T.unsafe(nil)); end
+
+    def tuples_for(source, type, gracefully_ignore=T.unsafe(nil)); end
+  # wrong constant name available_specs
+  # wrong constant name detect
+  # wrong constant name initialize
+  # wrong constant name latest_specs
+  # wrong constant name prerelease_specs
+  # wrong constant name search_for_dependency
+  # wrong constant name sources
+  # wrong constant name spec_for_dependency
+  # wrong constant name specs
+  # wrong constant name suggest_gems_from_name
+  # wrong constant name tuples_for
+  end
+
+  class SpecFetcher
+    def self.fetcher(); end
+
+    def self.fetcher=(fetcher); end
+  # wrong constant name <static-init>
+  # wrong constant name fetcher
+  # wrong constant name fetcher=
+  end
+
+  class Specification
+    include ::Bundler::MatchPlatform
+    include ::Bundler::GemHelpers
+    def bundled_gem_in_old_ruby?(); end
+
+    def pretty_print(q); end
+
+    def rubyforge_project(); end
+
+    def to_ruby(); end
+
+    def warning(statement); end
+  # wrong constant name <=>
+  # uninitialized constant Gem::Specification::GENERICS
+  # Did you mean?  Gem::Specification::GENERICS
+  # uninitialized constant Gem::Specification::GENERIC_CACHE
+  # Did you mean?  Gem::Specification::GENERIC_CACHE
+  # wrong constant name bundled_gem_in_old_ruby?
+  # wrong constant name pretty_print
+  # wrong constant name rubyforge_project
+  # wrong constant name to_ruby
+  # wrong constant name warning
+  end
+
+  class Specification
+    extend ::Enumerable
+    extend Deprecate
+    def self.add_spec(spec); end
+
+    def self.add_specs(*specs); end
+
+    def self.remove_spec(spec); end
+  # wrong constant name add_spec
+  # wrong constant name add_specs
+  # wrong constant name remove_spec
+  end
+
+  # uninitialized constant Gem::Stream
+  # Did you mean?  Gem::StreamUI
+  # uninitialized constant Gem::Stream
+  # Did you mean?  Gem::StreamUI
+  class StubSpecification
+    class StubLine
+      def extensions(); end
+
+      def full_name(); end
+
+      def initialize(data, extensions); end
+
+      def name(); end
+
+      def platform(); end
+
+      def require_paths(); end
+
+      def version(); end
+    # wrong constant name extensions
+    # wrong constant name full_name
+    # wrong constant name initialize
+    # wrong constant name name
+    # wrong constant name platform
+    # wrong constant name require_paths
+    # wrong constant name version
+    end
+    def build_extensions(); end
+
+    def extensions(); end
+
+    def initialize(filename, base_dir, gems_dir, default_gem); end
+
+    def missing_extensions?(); end
+
+    def valid?(); end
+  # wrong constant name build_extensions
+  # wrong constant name extensions
+  # wrong constant name initialize
+  # wrong constant name missing_extensions?
+  # wrong constant name valid?
+  end
+
+  class StubSpecification
+    def self.default_gemspec_stub(filename, base_dir, gems_dir); end
+
+    def self.gemspec_stub(filename, base_dir, gems_dir); end
+  # wrong constant name default_gemspec_stub
+  # wrong constant name gemspec_stub
+  end
+
+  Gem::UnsatisfiableDepedencyError = Gem::UnsatisfiableDependencyError
+
+  # uninitialized constant Gem::UriParser
+  # uninitialized constant Gem::UriParser
+  # uninitialized constant Gem::UriParsing
+  # uninitialized constant Gem::UriParsing
+  module Util
+    NULL_DEVICE = ::T.let(nil, ::T.untyped)
+  end
+
+  class Version
+    Gem::Version::Requirement = Gem::Requirement
+    def pretty_print(q); end
+  # wrong constant name <=>
+  # wrong constant name pretty_print
+  end
   ConfigMap = ::T.let(nil, ::T.untyped)
   RbConfigPriorities = ::T.let(nil, ::T.untyped)
   RubyGemsPackageVersion = ::T.let(nil, ::T.untyped)
   RubyGemsVersion = ::T.let(nil, ::T.untyped)
   USE_BUNDLER_FOR_GEMDEPS = ::T.let(nil, ::T.untyped)
 end
-
-class Gem::Dependency
-  def pretty_print(q); end
-end
-
-class Gem::DependencyInstaller
-  def _deprecated_gems_to_install(); end
-
-  def add_found_dependencies(to_do, dependency_list); end
-
-  def gather_dependencies(); end
-
-  def gems_to_install(*args, &block); end
-end
-
-Gem::DependencyResolver = Gem::Resolver
-
-class Gem::Ext::BuildError
-end
-
-class Gem::Ext::BuildError
-end
-
-class Gem::Ext::Builder
-  def self.redirector(); end
-end
-
-class Gem::Ext::ExtConfBuilder
-end
-
-Gem::Ext::ExtConfBuilder::FileEntry = FileUtils::Entry_
-
-class Gem::Ext::ExtConfBuilder
-  def self.build(extension, directory, dest_path, results, args=T.unsafe(nil), lib_dir=T.unsafe(nil)); end
-
-  def self.get_relative_path(path); end
-end
-
-class Gem::Licenses
-  IDENTIFIERS = ::T.let(nil, ::T.untyped)
-end
-
-class Gem::List
-  def pretty_print(q); end
-end
-
-class Gem::Package
-  def realpath(file); end
-end
-
-class Gem::Package::DigestIO
-  def digests(); end
-
-  def initialize(io, digests); end
-
-  def write(data); end
-end
-
-class Gem::Package::DigestIO
-  def self.wrap(io, digests); end
-end
-
-class Gem::Package::FileSource
-  def initialize(path); end
-
-  def path(); end
-
-  def present?(); end
-
-  def start(); end
-
-  def with_read_io(&block); end
-
-  def with_write_io(&block); end
-end
-
-class Gem::Package::FileSource
-end
-
-class Gem::Package::IOSource
-  def initialize(io); end
-
-  def io(); end
-
-  def path(); end
-
-  def present?(); end
-
-  def start(); end
-
-  def with_read_io(); end
-
-  def with_write_io(); end
-end
-
-class Gem::Package::IOSource
-end
-
-class Gem::Package::Old
-  def extract_files(destination_dir); end
-
-  def file_list(io); end
-
-  def read_until_dashes(io); end
-
-  def skip_ruby(io); end
-end
-
-class Gem::Package::Old
-end
-
-class Gem::Package::Source
-end
-
-class Gem::Package::Source
-end
-
-class Gem::Package::TarHeader
-  def ==(other); end
-
-  def checksum(); end
-
-  def devmajor(); end
-
-  def devminor(); end
-
-  def empty?(); end
-
-  def gid(); end
-
-  def gname(); end
-
-  def initialize(vals); end
-
-  def linkname(); end
-
-  def magic(); end
-
-  def mode(); end
-
-  def mtime(); end
-
-  def name(); end
-
-  def prefix(); end
-
-  def size(); end
-
-  def typeflag(); end
-
-  def uid(); end
-
-  def uname(); end
-
-  def update_checksum(); end
-
-  def version(); end
-  FIELDS = ::T.let(nil, ::T.untyped)
-  PACK_FORMAT = ::T.let(nil, ::T.untyped)
-  UNPACK_FORMAT = ::T.let(nil, ::T.untyped)
-end
-
-class Gem::Package::TarHeader
-  def self.from(stream); end
-
-  def self.strict_oct(str); end
-end
-
-class Gem::Package::TarReader::Entry
-  def bytes_read(); end
-
-  def check_closed(); end
-
-  def close(); end
-
-  def closed?(); end
-
-  def directory?(); end
-
-  def eof?(); end
-
-  def file?(); end
-
-  def full_name(); end
-
-  def getc(); end
-
-  def header(); end
-
-  def initialize(header, io); end
-
-  def pos(); end
-
-  def read(len=T.unsafe(nil)); end
-
-  def readpartial(len=T.unsafe(nil)); end
-
-  def rewind(); end
-
-  def symlink?(); end
-end
-
-class Gem::Package::TarReader::Entry
-end
-
-class Gem::Package::TarReader
-  def self.new(io); end
-end
-
-class Gem::Package::TarWriter
-  def self.new(io); end
-end
-
-class Gem::Package
-  def self.new(gem, security_policy=T.unsafe(nil)); end
-end
-
-class Gem::PathSupport
-  def home(); end
-
-  def initialize(env); end
-
-  def path(); end
-
-  def spec_cache_dir(); end
-end
-
-class Gem::RemoteFetcher
-  def api_endpoint(uri); end
-
-  def correct_for_windows_path(path); end
-
-  def s3_expiration(); end
-
-  def sign_s3_url(uri, expiration=T.unsafe(nil)); end
-  BASE64_URI_TRANSLATE = ::T.let(nil, ::T.untyped)
-end
-
-class Gem::RemoteFetcher::FetchError
-  def initialize(message, uri); end
-
-  def uri(); end
-
-  def uri=(uri); end
-end
-
-class Gem::RemoteFetcher::FetchError
-end
-
-class Gem::RemoteFetcher::UnknownHostError
-end
-
-class Gem::RemoteFetcher::UnknownHostError
-end
-
-class Gem::Request
-  extend ::Gem::UserInteraction
-  extend ::Gem::DefaultUserInteraction
-  extend ::Gem::Text
-end
-
-class Gem::RequestSet
-  def pretty_print(q); end
-end
-
-Gem::RequestSet::GemDepedencyAPI = Gem::RequestSet::GemDependencyAPI
-
-class Gem::Requirement
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::APISet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::APISpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::ActivationRequest
-  def others_possible?(); end
-
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::BestSet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::Conflict
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::CurrentSet
-end
-
-class Gem::Resolver::CurrentSet
-end
-
-class Gem::Resolver::DependencyRequest
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::GitSet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::GitSpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::IndexSet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::IndexSpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::InstalledSpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::InstallerSet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::LocalSpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::LocalSpecification
-end
-
-class Gem::Resolver::LockSet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::LockSpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::Molinillo::DependencyGraph::Log
-  def add_edge_no_circular(graph, origin, destination, requirement); end
-
-  def add_vertex(graph, name, payload, root); end
-
-  def delete_edge(graph, origin_name, destination_name, requirement); end
-
-  def detach_vertex_named(graph, name); end
-
-  def each(&blk); end
-
-  def pop!(graph); end
-
-  def reverse_each(); end
-
-  def rewind_to(graph, tag); end
-
-  def set_payload(graph, name, payload); end
-
-  def tag(graph, tag); end
-end
-
-class Gem::Resolver::Molinillo::DependencyGraph::Log
-  extend ::Enumerable
-end
-
-class Gem::Resolver::VendorSet
-  def pretty_print(q); end
-end
-
-class Gem::RuntimeRequirementNotMetError
-  def suggestion(); end
-
-  def suggestion=(suggestion); end
-end
-
-class Gem::RuntimeRequirementNotMetError
-end
-
-class Gem::Source
-  def api_uri(); end
-
-  def pretty_print(q); end
-end
-
-class Gem::SpecFetcher
-  include ::Gem::UserInteraction
-  include ::Gem::DefaultUserInteraction
-  include ::Gem::Text
-  def available_specs(type); end
-
-  def detect(type=T.unsafe(nil)); end
-
-  def initialize(sources=T.unsafe(nil)); end
-
-  def latest_specs(); end
-
-  def prerelease_specs(); end
-
-  def search_for_dependency(dependency, matching_platform=T.unsafe(nil)); end
-
-  def sources(); end
-
-  def spec_for_dependency(dependency, matching_platform=T.unsafe(nil)); end
-
-  def specs(); end
-
-  def suggest_gems_from_name(gem_name, type=T.unsafe(nil)); end
-
-  def tuples_for(source, type, gracefully_ignore=T.unsafe(nil)); end
-end
-
-class Gem::SpecFetcher
-  def self.fetcher(); end
-
-  def self.fetcher=(fetcher); end
-end
-
-class Gem::Specification
-  include ::Bundler::MatchPlatform
-  include ::Bundler::GemHelpers
-  def bundled_gem_in_old_ruby?(); end
-
-  def pretty_print(q); end
-
-  def rubyforge_project(); end
-
-  def to_ruby(); end
-
-  def warning(statement); end
-end
-
-class Gem::Specification
-  extend ::Enumerable
-  extend ::Gem::Deprecate
-  def self.add_spec(spec); end
-
-  def self.add_specs(*specs); end
-
-  def self.remove_spec(spec); end
-end
-
-class Gem::StubSpecification
-  def build_extensions(); end
-
-  def extensions(); end
-
-  def initialize(filename, base_dir, gems_dir, default_gem); end
-
-  def missing_extensions?(); end
-
-  def valid?(); end
-end
-
-class Gem::StubSpecification::StubLine
-  def extensions(); end
-
-  def full_name(); end
-
-  def initialize(data, extensions); end
-
-  def name(); end
-
-  def platform(); end
-
-  def require_paths(); end
-
-  def version(); end
-end
-
-class Gem::StubSpecification
-  def self.default_gemspec_stub(filename, base_dir, gems_dir); end
-
-  def self.gemspec_stub(filename, base_dir, gems_dir); end
-end
-
-Gem::UnsatisfiableDepedencyError = Gem::UnsatisfiableDependencyError
-
-module Gem::Util
-  NULL_DEVICE = ::T.let(nil, ::T.untyped)
-end
-
-class Gem::Version
-  def pretty_print(q); end
-end
-
-Gem::Version::Requirement = Gem::Requirement
 
 module Gem
   def self._deprecated_datadir(gem_name); end
@@ -2699,6 +693,9 @@ class Hash
 end
 
 class IO
+  IO::EWOULDBLOCKWaitReadable = IO::EAGAINWaitReadable
+
+  IO::EWOULDBLOCKWaitWritable = IO::EAGAINWaitWritable
   def nread(); end
 
   def pathconf(_); end
@@ -2712,10 +709,6 @@ class IO
   def wait_writable(*_); end
 end
 
-IO::EWOULDBLOCKWaitReadable = IO::EAGAINWaitReadable
-
-IO::EWOULDBLOCKWaitWritable = IO::EAGAINWaitWritable
-
 class IPAddr
   def ==(other); end
 
@@ -2725,20 +718,6 @@ end
 class Integer
   include ::JSON::Ext::Generator::GeneratorMethods::Integer
 end
-
-class JSON::Ext::Generator::State
-  def self.from_state(_); end
-end
-
-class JSON::Ext::Parser
-  def initialize(*_); end
-end
-
-JSON::Parser = JSON::Ext::Parser
-
-JSON::State = JSON::Ext::Generator::State
-
-JSON::UnparserError = JSON::GeneratorError
 
 module Kernel
   def itself(); end
@@ -2765,13 +744,13 @@ class Monitor
 end
 
 module MonitorMixin
+  class ConditionVariable
+    def initialize(monitor); end
+  # wrong constant name initialize
+  end
   def initialize(*args); end
   EXCEPTION_IMMEDIATE = ::T.let(nil, ::T.untyped)
   EXCEPTION_NEVER = ::T.let(nil, ::T.untyped)
-end
-
-class MonitorMixin::ConditionVariable
-  def initialize(monitor); end
 end
 
 class NameError
@@ -2849,12 +828,11 @@ class SimpleDelegator
 end
 
 class Socket
-  IPV6_DONTFRAG = ::T.let(nil, ::T.untyped)
-  IPV6_PATHMTU = ::T.let(nil, ::T.untyped)
-  IPV6_RECVPATHMTU = ::T.let(nil, ::T.untyped)
-end
-
-module Socket::Constants
+  module Constants
+    IPV6_DONTFRAG = ::T.let(nil, ::T.untyped)
+    IPV6_PATHMTU = ::T.let(nil, ::T.untyped)
+    IPV6_RECVPATHMTU = ::T.let(nil, ::T.untyped)
+  end
   IPV6_DONTFRAG = ::T.let(nil, ::T.untyped)
   IPV6_PATHMTU = ::T.let(nil, ::T.untyped)
   IPV6_RECVPATHMTU = ::T.let(nil, ::T.untyped)
@@ -2879,87 +857,104 @@ class String
   extend ::JSON::Ext::Generator::GeneratorMethods::String::Extend
 end
 
-Struct::Group = Etc::Group
-
-Struct::Passwd = Etc::Passwd
-
-Struct::Tms = Process::Tms
-
 class TrueClass
   include ::JSON::Ext::Generator::GeneratorMethods::TrueClass
 end
 
 module URI
-  include ::URI::RFC2396_REGEXP
-end
+  class FTP
+    def self.new2(user, password, host, port, path, typecode=T.unsafe(nil), arg_check=T.unsafe(nil)); end
+  # wrong constant name new2
+  end
 
-class URI::FTP
-  def self.new2(user, password, host, port, path, typecode=T.unsafe(nil), arg_check=T.unsafe(nil)); end
-end
+  class LDAP
+    def attributes(); end
 
-class URI::LDAP
-  def attributes(); end
+    def attributes=(val); end
 
-  def attributes=(val); end
+    def dn(); end
 
-  def dn(); end
+    def dn=(val); end
 
-  def dn=(val); end
+    def extensions(); end
 
-  def extensions(); end
+    def extensions=(val); end
 
-  def extensions=(val); end
+    def filter(); end
 
-  def filter(); end
+    def filter=(val); end
 
-  def filter=(val); end
+    def initialize(*arg); end
 
-  def initialize(*arg); end
+    def scope(); end
 
-  def scope(); end
+    def scope=(val); end
 
-  def scope=(val); end
+    def set_attributes(val); end
 
-  def set_attributes(val); end
+    def set_dn(val); end
 
-  def set_dn(val); end
+    def set_extensions(val); end
 
-  def set_extensions(val); end
+    def set_filter(val); end
 
-  def set_filter(val); end
+    def set_scope(val); end
+  # wrong constant name attributes
+  # wrong constant name attributes=
+  # wrong constant name dn
+  # wrong constant name dn=
+  # wrong constant name extensions
+  # wrong constant name extensions=
+  # wrong constant name filter
+  # wrong constant name filter=
+  # wrong constant name initialize
+  # wrong constant name scope
+  # wrong constant name scope=
+  # wrong constant name set_attributes
+  # wrong constant name set_dn
+  # wrong constant name set_extensions
+  # wrong constant name set_filter
+  # wrong constant name set_scope
+  end
 
-  def set_scope(val); end
-end
+  class MailTo
+    def initialize(*arg); end
+  # wrong constant name initialize
+  end
 
-class URI::MailTo
-  def initialize(*arg); end
-end
+  URI::Parser = URI::RFC2396_Parser
 
-URI::Parser = URI::RFC2396_Parser
+  URI::REGEXP = URI::RFC2396_REGEXP
 
-URI::REGEXP = URI::RFC2396_REGEXP
+  class RFC2396_Parser
+    def initialize(opts=T.unsafe(nil)); end
+  # wrong constant name initialize
+  end
 
-class URI::RFC2396_Parser
-  def initialize(opts=T.unsafe(nil)); end
-end
+  class RFC3986_Parser
+    def join(*uris); end
 
-class URI::RFC3986_Parser
-  def join(*uris); end
+    def parse(uri); end
 
-  def parse(uri); end
+    def regexp(); end
 
-  def regexp(); end
+    def split(uri); end
+    RFC3986_relative_ref = ::T.let(nil, ::T.untyped)
+  # wrong constant name join
+  # wrong constant name parse
+  # wrong constant name regexp
+  # wrong constant name split
+  end
 
-  def split(uri); end
-  RFC3986_relative_ref = ::T.let(nil, ::T.untyped)
-end
-
-module URI::Util
-  def self.make_components_hash(klass, array_hash); end
+  module Util
+    def self.make_components_hash(klass, array_hash); end
+  # wrong constant name make_components_hash
+  end
+  include RFC2396_REGEXP
 end
 
 module URI
-  extend ::URI::Escape
+  extend Escape
   def self.get_encoding(label); end
 end
 

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_hidden.rbi.exp
@@ -18,8 +18,6 @@ class Array
   def self.try_convert(_); end
 end
 
-BasicObject::BasicObject = BasicObject
-
 class BigDecimal
   def clone(); end
   EXCEPTION_NaN = ::T.let(nil, ::T.untyped)
@@ -34,1858 +32,6 @@ class Binding
   def clone(); end
 
   def irb(); end
-end
-
-class Bundler::Dependency
-  def branch(); end
-
-  def expanded_platforms(); end
-
-  def git(); end
-end
-
-Bundler::Deprecate = Gem::Deprecate
-
-class Bundler::Env
-end
-
-class Bundler::Env
-  def self.environment(); end
-
-  def self.report(options=T.unsafe(nil)); end
-
-  def self.write(io); end
-end
-
-class Bundler::Fetcher
-  def fetch_spec(spec); end
-
-  def fetchers(); end
-
-  def http_proxy(); end
-
-  def initialize(remote); end
-
-  def specs(gem_names, source); end
-
-  def specs_with_retry(gem_names, source); end
-
-  def uri(); end
-
-  def use_api(); end
-
-  def user_agent(); end
-  FAIL_ERRORS = ::T.let(nil, ::T.untyped)
-  FETCHERS = ::T.let(nil, ::T.untyped)
-  HTTP_ERRORS = ::T.let(nil, ::T.untyped)
-  NET_ERRORS = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Fetcher::AuthenticationRequiredError
-  def initialize(remote_uri); end
-end
-
-class Bundler::Fetcher::BadAuthenticationError
-  def initialize(remote_uri); end
-end
-
-class Bundler::Fetcher::Base
-  def api_fetcher?(); end
-
-  def available?(); end
-
-  def display_uri(); end
-
-  def downloader(); end
-
-  def fetch_uri(); end
-
-  def initialize(downloader, remote, display_uri); end
-
-  def remote(); end
-
-  def remote_uri(); end
-end
-
-class Bundler::Fetcher::Base
-end
-
-class Bundler::Fetcher::CertificateFailureError
-  def initialize(remote_uri); end
-end
-
-class Bundler::Fetcher::CompactIndex
-  def available?(*args, &blk); end
-
-  def fetch_spec(*args, &blk); end
-
-  def specs(*args, &blk); end
-
-  def specs_for_names(gem_names); end
-end
-
-class Bundler::Fetcher::CompactIndex::ClientFetcher
-  def call(path, headers); end
-
-  def fetcher(); end
-
-  def fetcher=(_); end
-
-  def ui(); end
-
-  def ui=(_); end
-end
-
-class Bundler::Fetcher::CompactIndex::ClientFetcher
-  def self.[](*_); end
-
-  def self.members(); end
-end
-
-class Bundler::Fetcher::CompactIndex
-  def self.compact_index_request(method_name); end
-end
-
-class Bundler::Fetcher::Dependency
-  def dependency_api_uri(gem_names=T.unsafe(nil)); end
-
-  def dependency_specs(gem_names); end
-
-  def get_formatted_specs_and_deps(gem_list); end
-
-  def specs(gem_names, full_dependency_list=T.unsafe(nil), last_spec_list=T.unsafe(nil)); end
-
-  def unmarshalled_dep_gems(gem_names); end
-end
-
-class Bundler::Fetcher::Dependency
-end
-
-class Bundler::Fetcher::Downloader
-  def connection(); end
-
-  def fetch(uri, headers=T.unsafe(nil), counter=T.unsafe(nil)); end
-
-  def initialize(connection, redirect_limit); end
-
-  def redirect_limit(); end
-
-  def request(uri, headers); end
-end
-
-class Bundler::Fetcher::Downloader
-end
-
-class Bundler::Fetcher::Index
-  def fetch_spec(spec); end
-
-  def specs(_gem_names); end
-end
-
-class Bundler::Fetcher::Index
-end
-
-class Bundler::Fetcher::SSLError
-  def initialize(msg=T.unsafe(nil)); end
-end
-
-class Bundler::Fetcher::TooManyRequestsError
-end
-
-class Bundler::Fetcher::TooManyRequestsError
-end
-
-class Bundler::Fetcher
-  def self.api_timeout(); end
-
-  def self.api_timeout=(api_timeout); end
-
-  def self.disable_endpoint(); end
-
-  def self.disable_endpoint=(disable_endpoint); end
-
-  def self.max_retries(); end
-
-  def self.max_retries=(max_retries); end
-
-  def self.redirect_limit(); end
-
-  def self.redirect_limit=(redirect_limit); end
-end
-
-module Bundler::FileUtils
-  VERSION = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::FileUtils::Entry_
-  def link(dest); end
-end
-
-module Bundler::FileUtils
-  def self.cp_lr(src, dest, noop: T.unsafe(nil), verbose: T.unsafe(nil), dereference_root: T.unsafe(nil), remove_destination: T.unsafe(nil)); end
-
-  def self.link_entry(src, dest, dereference_root=T.unsafe(nil), remove_destination=T.unsafe(nil)); end
-end
-
-class Bundler::GemHelper
-  def allowed_push_host(); end
-
-  def already_tagged?(); end
-
-  def base(); end
-
-  def build_gem(); end
-
-  def built_gem_path(); end
-
-  def clean?(); end
-
-  def committed?(); end
-
-  def gem_command(); end
-
-  def gem_key(); end
-
-  def gem_push?(); end
-
-  def gem_push_host(); end
-
-  def gemspec(); end
-
-  def git_push(remote=T.unsafe(nil)); end
-
-  def guard_clean(); end
-
-  def initialize(base=T.unsafe(nil), name=T.unsafe(nil)); end
-
-  def install(); end
-
-  def install_gem(built_gem_path=T.unsafe(nil), local=T.unsafe(nil)); end
-
-  def name(); end
-
-  def perform_git_push(options=T.unsafe(nil)); end
-
-  def rubygem_push(path); end
-
-  def sh(cmd, &block); end
-
-  def sh_with_input(cmd); end
-
-  def sh_with_status(cmd, &block); end
-
-  def spec_path(); end
-
-  def tag_version(); end
-
-  def version(); end
-
-  def version_tag(); end
-end
-
-class Bundler::GemHelper
-  def self.gemspec(&block); end
-
-  def self.install_tasks(opts=T.unsafe(nil)); end
-
-  def self.instance(); end
-
-  def self.instance=(instance); end
-end
-
-class Bundler::GemVersionPromoter
-  def initialize(locked_specs=T.unsafe(nil), unlock_gems=T.unsafe(nil)); end
-
-  def level(); end
-
-  def level=(value); end
-
-  def locked_specs(); end
-
-  def major?(); end
-
-  def minor?(); end
-
-  def prerelease_specified(); end
-
-  def prerelease_specified=(prerelease_specified); end
-
-  def sort_versions(dep, spec_groups); end
-
-  def strict(); end
-
-  def strict=(strict); end
-
-  def unlock_gems(); end
-  DEBUG = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::GemVersionPromoter
-end
-
-class Bundler::Graph
-  def edge_options(); end
-
-  def groups(); end
-
-  def initialize(env, output_file, show_version=T.unsafe(nil), show_requirements=T.unsafe(nil), output_format=T.unsafe(nil), without=T.unsafe(nil)); end
-
-  def node_options(); end
-
-  def output_file(); end
-
-  def output_format(); end
-
-  def relations(); end
-
-  def viz(); end
-  GRAPH_NAME = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Graph::GraphVizClient
-  def g(); end
-
-  def initialize(graph_instance); end
-
-  def run(); end
-end
-
-class Bundler::Graph::GraphVizClient
-end
-
-class Bundler::Graph
-end
-
-class Bundler::Index
-  include ::Enumerable
-end
-
-class Bundler::Injector
-  def initialize(deps, options=T.unsafe(nil)); end
-
-  def inject(gemfile_path, lockfile_path); end
-
-  def remove(gemfile_path, lockfile_path); end
-  INJECTED_GEMS = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Injector
-  def self.inject(new_deps, options=T.unsafe(nil)); end
-
-  def self.remove(gems, options=T.unsafe(nil)); end
-end
-
-class Bundler::Installer
-  def generate_bundler_executable_stubs(spec, options=T.unsafe(nil)); end
-
-  def generate_standalone_bundler_executable_stubs(spec); end
-
-  def initialize(root, definition); end
-
-  def post_install_messages(); end
-
-  def run(options); end
-end
-
-class Bundler::Installer
-  def self.ambiguous_gems(); end
-
-  def self.ambiguous_gems=(ambiguous_gems); end
-
-  def self.install(root, definition, options=T.unsafe(nil)); end
-end
-
-class Bundler::LockfileGenerator
-  def definition(); end
-
-  def generate!(); end
-
-  def initialize(definition); end
-
-  def out(); end
-end
-
-class Bundler::LockfileGenerator
-  def self.generate(definition); end
-end
-
-class Bundler::Molinillo::DependencyGraph
-  include ::Enumerable
-end
-
-class Bundler::Molinillo::DependencyGraph::Log
-  extend ::Enumerable
-end
-
-class Bundler::Molinillo::DependencyGraph::Vertex
-  def _recursive_predecessors(vertices=T.unsafe(nil)); end
-
-  def _recursive_successors(vertices=T.unsafe(nil)); end
-end
-
-module Bundler::Plugin::API::Source
-  def ==(other); end
-
-  def app_cache_dirname(); end
-
-  def app_cache_path(custom_path=T.unsafe(nil)); end
-
-  def bundler_plugin_api_source?(); end
-
-  def cache(spec, custom_path=T.unsafe(nil)); end
-
-  def cached!(); end
-
-  def can_lock?(spec); end
-
-  def dependency_names(); end
-
-  def dependency_names=(dependency_names); end
-
-  def double_check_for(*_); end
-
-  def eql?(other); end
-
-  def fetch_gemspec_files(); end
-
-  def gem_install_dir(); end
-
-  def hash(); end
-
-  def include?(other); end
-
-  def initialize(opts); end
-
-  def install(spec, opts); end
-
-  def install_path(); end
-
-  def installed?(); end
-
-  def name(); end
-
-  def options(); end
-
-  def options_to_lock(); end
-
-  def post_install(spec, disable_exts=T.unsafe(nil)); end
-
-  def remote!(); end
-
-  def root(); end
-
-  def specs(); end
-
-  def to_lock(); end
-
-  def to_s(); end
-
-  def unlock!(); end
-
-  def unmet_deps(); end
-
-  def uri(); end
-
-  def uri_hash(); end
-end
-
-module Bundler::Plugin::API::Source
-end
-
-module Bundler::Plugin::Events
-  GEM_AFTER_INSTALL = ::T.let(nil, ::T.untyped)
-  GEM_AFTER_INSTALL_ALL = ::T.let(nil, ::T.untyped)
-  GEM_BEFORE_INSTALL = ::T.let(nil, ::T.untyped)
-  GEM_BEFORE_INSTALL_ALL = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Plugin::Index
-  def installed_plugins(); end
-
-  def plugin_commands(plugin); end
-end
-
-class Bundler::Plugin::Index::CommandConflict
-  def initialize(plugin, commands); end
-end
-
-class Bundler::Plugin::Index::CommandConflict
-end
-
-class Bundler::Plugin::Index::SourceConflict
-  def initialize(plugin, sources); end
-end
-
-class Bundler::Plugin::Index::SourceConflict
-end
-
-class Bundler::Plugin::Installer
-  def install(names, options); end
-
-  def install_definition(definition); end
-end
-
-class Bundler::Plugin::Installer::Git
-  def generate_bin(spec, disable_extensions=T.unsafe(nil)); end
-end
-
-class Bundler::Plugin::Installer::Git
-end
-
-class Bundler::Plugin::Installer::Rubygems
-end
-
-class Bundler::Plugin::Installer::Rubygems
-end
-
-class Bundler::Plugin::Installer
-end
-
-class Bundler::Plugin::SourceList
-end
-
-class Bundler::Plugin::SourceList
-end
-
-module Bundler::Plugin
-  def self.list(); end
-end
-
-class Bundler::ProcessLock
-end
-
-class Bundler::ProcessLock
-  def self.lock(bundle_path=T.unsafe(nil)); end
-end
-
-class Bundler::Retry
-  def attempt(&block); end
-
-  def attempts(&block); end
-
-  def current_run(); end
-
-  def current_run=(current_run); end
-
-  def initialize(name, exceptions=T.unsafe(nil), retries=T.unsafe(nil)); end
-
-  def name(); end
-
-  def name=(name); end
-
-  def total_runs(); end
-
-  def total_runs=(total_runs); end
-end
-
-class Bundler::Retry
-  def self.attempts(); end
-
-  def self.default_attempts(); end
-
-  def self.default_retries(); end
-end
-
-class Bundler::RubyGemsGemInstaller
-end
-
-class Bundler::RubyGemsGemInstaller
-end
-
-class Bundler::RubygemsIntegration
-  def add_to_load_path(paths); end
-
-  def all_specs(); end
-
-  def backport_ext_builder_monitor(); end
-
-  def correct_for_windows_path(path); end
-
-  def default_stubs(); end
-
-  def find_name(name); end
-
-  def gem_remote_fetcher(); end
-
-  def plain_specs(); end
-
-  def plain_specs=(specs); end
-
-  def stub_rubygems(specs); end
-
-  def use_gemdeps(gemfile); end
-end
-
-class Bundler::Settings::Mirror
-  def ==(other); end
-
-  def fallback_timeout(); end
-
-  def fallback_timeout=(timeout); end
-
-  def initialize(uri=T.unsafe(nil), fallback_timeout=T.unsafe(nil)); end
-
-  def uri(); end
-
-  def uri=(uri); end
-
-  def valid?(); end
-
-  def validate!(probe=T.unsafe(nil)); end
-  DEFAULT_FALLBACK_TIMEOUT = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Settings::Mirror
-end
-
-class Bundler::Settings::Mirrors
-  def each(&blk); end
-
-  def for(uri); end
-
-  def initialize(prober=T.unsafe(nil)); end
-
-  def parse(key, value); end
-end
-
-class Bundler::Settings::Mirrors
-end
-
-class Bundler::Settings::Validator
-end
-
-class Bundler::Settings::Validator::Rule
-  def description(); end
-
-  def fail!(key, value, *reasons); end
-
-  def initialize(keys, description, &validate); end
-
-  def k(key); end
-
-  def set(settings, key, value, *reasons); end
-
-  def validate!(key, value, settings); end
-end
-
-class Bundler::Settings::Validator::Rule
-end
-
-class Bundler::Settings::Validator
-  def self.validate!(key, value, settings); end
-end
-
-class Bundler::Source::Git
-  def glob(); end
-end
-
-class Bundler::SpecSet
-  include ::Enumerable
-end
-
-class Bundler::Thor
-  include ::Bundler::Thor::Base
-  include ::Bundler::Thor::Invocation
-  include ::Bundler::Thor::Shell
-  def help(command=T.unsafe(nil), subcommand=T.unsafe(nil)); end
-  HELP_MAPPINGS = ::T.let(nil, ::T.untyped)
-  TEMPLATE_EXTNAME = ::T.let(nil, ::T.untyped)
-  THOR_RESERVED_WORDS = ::T.let(nil, ::T.untyped)
-end
-
-module Bundler::Thor::Actions
-  def _cleanup_options_and_set(options, key); end
-
-  def _shared_configuration(); end
-
-  def action(instance); end
-
-  def add_file(destination, *args, &block); end
-
-  def add_link(destination, *args); end
-
-  def append_file(path, *args, &block); end
-
-  def append_to_file(path, *args, &block); end
-
-  def apply(path, config=T.unsafe(nil)); end
-
-  def behavior(); end
-
-  def behavior=(behavior); end
-
-  def chmod(path, mode, config=T.unsafe(nil)); end
-
-  def comment_lines(path, flag, *args); end
-
-  def copy_file(source, *args, &block); end
-
-  def create_file(destination, *args, &block); end
-
-  def create_link(destination, *args); end
-
-  def destination_root(); end
-
-  def destination_root=(root); end
-
-  def directory(source, *args, &block); end
-
-  def empty_directory(destination, config=T.unsafe(nil)); end
-
-  def find_in_source_paths(file); end
-
-  def get(source, *args, &block); end
-
-  def gsub_file(path, flag, *args, &block); end
-
-  def in_root(); end
-
-  def initialize(args=T.unsafe(nil), options=T.unsafe(nil), config=T.unsafe(nil)); end
-
-  def inject_into_class(path, klass, *args, &block); end
-
-  def inject_into_file(destination, *args, &block); end
-
-  def inject_into_module(path, module_name, *args, &block); end
-
-  def insert_into_file(destination, *args, &block); end
-
-  def inside(dir=T.unsafe(nil), config=T.unsafe(nil), &block); end
-
-  def link_file(source, *args); end
-
-  def prepend_file(path, *args, &block); end
-
-  def prepend_to_file(path, *args, &block); end
-
-  def relative_to_original_destination_root(path, remove_dot=T.unsafe(nil)); end
-
-  def remove_dir(path, config=T.unsafe(nil)); end
-
-  def remove_file(path, config=T.unsafe(nil)); end
-
-  def run(command, config=T.unsafe(nil)); end
-
-  def run_ruby_script(command, config=T.unsafe(nil)); end
-
-  def source_paths(); end
-
-  def template(source, *args, &block); end
-
-  def thor(command, *args); end
-
-  def uncomment_lines(path, flag, *args); end
-  WARNINGS = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Actions::CapturableERB
-end
-
-class Bundler::Thor::Actions::CapturableERB
-end
-
-module Bundler::Thor::Actions::ClassMethods
-  def add_runtime_options!(); end
-
-  def source_paths(); end
-
-  def source_paths_for_search(); end
-
-  def source_root(path=T.unsafe(nil)); end
-end
-
-module Bundler::Thor::Actions::ClassMethods
-end
-
-class Bundler::Thor::Actions::CreateFile
-  def data(); end
-
-  def force_on_collision?(); end
-
-  def force_or_skip_or_conflict(force, skip, &block); end
-
-  def identical?(); end
-
-  def initialize(base, destination, data, config=T.unsafe(nil)); end
-
-  def on_conflict_behavior(&block); end
-
-  def render(); end
-end
-
-class Bundler::Thor::Actions::CreateFile
-end
-
-class Bundler::Thor::Actions::CreateLink
-end
-
-class Bundler::Thor::Actions::CreateLink
-end
-
-class Bundler::Thor::Actions::Directory
-  def execute!(); end
-
-  def file_level_lookup(previous_lookup); end
-
-  def files(lookup); end
-
-  def initialize(base, source, destination=T.unsafe(nil), config=T.unsafe(nil), &block); end
-
-  def source(); end
-end
-
-class Bundler::Thor::Actions::Directory
-end
-
-class Bundler::Thor::Actions::EmptyDirectory
-  def base(); end
-
-  def config(); end
-
-  def convert_encoded_instructions(filename); end
-
-  def destination(); end
-
-  def destination=(destination); end
-
-  def exists?(); end
-
-  def given_destination(); end
-
-  def initialize(base, destination, config=T.unsafe(nil)); end
-
-  def invoke!(); end
-
-  def invoke_with_conflict_check(&block); end
-
-  def on_conflict_behavior(); end
-
-  def on_file_clash_behavior(); end
-
-  def pretend?(); end
-
-  def relative_destination(); end
-
-  def revoke!(); end
-
-  def say_status(status, color); end
-end
-
-class Bundler::Thor::Actions::EmptyDirectory
-end
-
-class Bundler::Thor::Actions::InjectIntoFile
-  def behavior(); end
-
-  def flag(); end
-
-  def initialize(base, destination, data, config); end
-
-  def replace!(regexp, string, force); end
-
-  def replacement(); end
-
-  def say_status(behavior, warning: T.unsafe(nil), color: T.unsafe(nil)); end
-end
-
-class Bundler::Thor::Actions::InjectIntoFile
-end
-
-module Bundler::Thor::Actions
-  def self.included(base); end
-end
-
-class Bundler::Thor::AmbiguousCommandError
-end
-
-class Bundler::Thor::AmbiguousCommandError
-end
-
-Bundler::Thor::AmbiguousTaskError = Bundler::Thor::AmbiguousCommandError
-
-class Bundler::Thor::Argument
-  def banner(); end
-
-  def default(); end
-
-  def default_banner(); end
-
-  def description(); end
-
-  def enum(); end
-
-  def human_name(); end
-
-  def initialize(name, options=T.unsafe(nil)); end
-
-  def name(); end
-
-  def required(); end
-
-  def required?(); end
-
-  def show_default?(); end
-
-  def type(); end
-
-  def usage(); end
-
-  def valid_type?(type); end
-
-  def validate!(); end
-  VALID_TYPES = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Argument
-end
-
-class Bundler::Thor::Arguments
-  def initialize(arguments=T.unsafe(nil)); end
-
-  def parse(args); end
-
-  def remaining(); end
-  NUMERIC = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Arguments
-  def self.parse(*args); end
-
-  def self.split(args); end
-end
-
-module Bundler::Thor::Base
-  def args(); end
-
-  def args=(args); end
-
-  def initialize(args=T.unsafe(nil), local_options=T.unsafe(nil), config=T.unsafe(nil)); end
-
-  def options(); end
-
-  def options=(options); end
-
-  def parent_options(); end
-
-  def parent_options=(parent_options); end
-end
-
-module Bundler::Thor::Base::ClassMethods
-  def all_commands(); end
-
-  def all_tasks(); end
-
-  def allow_incompatible_default_type!(); end
-
-  def argument(name, options=T.unsafe(nil)); end
-
-  def arguments(); end
-
-  def attr_accessor(*_); end
-
-  def attr_reader(*_); end
-
-  def attr_writer(*_); end
-
-  def baseclass(); end
-
-  def basename(); end
-
-  def build_option(name, options, scope); end
-
-  def build_options(options, scope); end
-
-  def check_default_type(); end
-
-  def check_default_type!(); end
-
-  def check_unknown_options(); end
-
-  def check_unknown_options!(); end
-
-  def check_unknown_options?(config); end
-
-  def class_option(name, options=T.unsafe(nil)); end
-
-  def class_options(options=T.unsafe(nil)); end
-
-  def class_options_help(shell, groups=T.unsafe(nil)); end
-
-  def commands(); end
-
-  def create_command(meth); end
-
-  def create_task(meth); end
-
-  def disable_required_check?(command_name); end
-
-  def dispatch(command, given_args, given_opts, config); end
-
-  def exit_on_failure?(); end
-
-  def find_and_refresh_command(name); end
-
-  def find_and_refresh_task(name); end
-
-  def from_superclass(method, default=T.unsafe(nil)); end
-
-  def group(name=T.unsafe(nil)); end
-
-  def handle_argument_error(command, error, args, arity); end
-
-  def handle_no_command_error(command, has_namespace=T.unsafe(nil)); end
-
-  def handle_no_task_error(command, has_namespace=T.unsafe(nil)); end
-
-  def inherited(klass); end
-
-  def initialize_added(); end
-
-  def is_thor_reserved_word?(word, type); end
-
-  def method_added(meth); end
-
-  def namespace(name=T.unsafe(nil)); end
-
-  def no_commands(&block); end
-
-  def no_commands?(); end
-
-  def no_commands_context(); end
-
-  def no_tasks(&block); end
-
-  def print_options(shell, options, group_name=T.unsafe(nil)); end
-
-  def public_command(*names); end
-
-  def public_task(*names); end
-
-  def remove_argument(*names); end
-
-  def remove_class_option(*names); end
-
-  def remove_command(*names); end
-
-  def remove_task(*names); end
-
-  def start(given_args=T.unsafe(nil), config=T.unsafe(nil)); end
-
-  def stop_on_unknown_option?(command_name); end
-
-  def strict_args_position(); end
-
-  def strict_args_position!(); end
-
-  def strict_args_position?(config); end
-
-  def tasks(); end
-end
-
-module Bundler::Thor::Base::ClassMethods
-end
-
-module Bundler::Thor::Base
-  def self.included(base); end
-
-  def self.register_klass_file(klass); end
-
-  def self.shell(); end
-
-  def self.shell=(shell); end
-
-  def self.subclass_files(); end
-
-  def self.subclasses(); end
-end
-
-class Bundler::Thor::Command
-  def formatted_usage(klass, namespace=T.unsafe(nil), subcommand=T.unsafe(nil)); end
-
-  def handle_argument_error?(instance, error, caller); end
-
-  def handle_no_method_error?(instance, error, caller); end
-
-  def hidden?(); end
-
-  def initialize(name, description, long_description, usage, options=T.unsafe(nil)); end
-
-  def local_method?(instance, name); end
-
-  def not_debugging?(instance); end
-
-  def private_method?(instance); end
-
-  def public_method?(instance); end
-
-  def required_arguments_for(klass, usage); end
-
-  def required_options(); end
-
-  def run(instance, args=T.unsafe(nil)); end
-
-  def sans_backtrace(backtrace, caller); end
-  FILE_REGEXP = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Command
-end
-
-module Bundler::Thor::CoreExt
-end
-
-class Bundler::Thor::CoreExt::HashWithIndifferentAccess
-  def [](key); end
-
-  def []=(key, value); end
-
-  def convert_key(key); end
-
-  def delete(key); end
-
-  def fetch(key, *args); end
-
-  def initialize(hash=T.unsafe(nil)); end
-
-  def key?(key); end
-
-  def merge(other); end
-
-  def merge!(other); end
-
-  def method_missing(method, *args); end
-
-  def replace(other_hash); end
-
-  def reverse_merge(other); end
-
-  def reverse_merge!(other_hash); end
-
-  def values_at(*indices); end
-end
-
-class Bundler::Thor::CoreExt::HashWithIndifferentAccess
-end
-
-module Bundler::Thor::CoreExt
-end
-
-Bundler::Thor::Correctable = DidYouMean::Correctable
-
-class Bundler::Thor::DynamicCommand
-  def initialize(name, options=T.unsafe(nil)); end
-end
-
-class Bundler::Thor::DynamicCommand
-end
-
-Bundler::Thor::DynamicTask = Bundler::Thor::DynamicCommand
-
-class Bundler::Thor::Error
-end
-
-class Bundler::Thor::Error
-end
-
-class Bundler::Thor::Group
-  include ::Bundler::Thor::Base
-  include ::Bundler::Thor::Invocation
-  include ::Bundler::Thor::Shell
-  def _invoke_for_class_method(klass, command=T.unsafe(nil), *args, &block); end
-end
-
-class Bundler::Thor::Group
-  extend ::Bundler::Thor::Base::ClassMethods
-  extend ::Bundler::Thor::Invocation::ClassMethods
-  def self.banner(); end
-
-  def self.desc(description=T.unsafe(nil)); end
-
-  def self.get_options_from_invocations(group_options, base_options); end
-
-  def self.handle_argument_error(command, error, _args, arity); end
-
-  def self.help(shell); end
-
-  def self.invocation_blocks(); end
-
-  def self.invocations(); end
-
-  def self.invoke(*names, &block); end
-
-  def self.invoke_from_option(*names, &block); end
-
-  def self.printable_commands(*_); end
-
-  def self.printable_tasks(*_); end
-
-  def self.remove_invocation(*names); end
-
-  def self.self_command(); end
-
-  def self.self_task(); end
-end
-
-class Bundler::Thor::HiddenCommand
-end
-
-class Bundler::Thor::HiddenCommand
-end
-
-Bundler::Thor::HiddenTask = Bundler::Thor::HiddenCommand
-
-module Bundler::Thor::Invocation
-  def _parse_initialization_options(args, opts, config); end
-
-  def _retrieve_class_and_command(name, sent_command=T.unsafe(nil)); end
-
-  def _retrieve_class_and_task(name, sent_command=T.unsafe(nil)); end
-
-  def _shared_configuration(); end
-
-  def current_command_chain(); end
-
-  def initialize(args=T.unsafe(nil), options=T.unsafe(nil), config=T.unsafe(nil), &block); end
-
-  def invoke(name=T.unsafe(nil), *args); end
-
-  def invoke_all(); end
-
-  def invoke_command(command, *args); end
-
-  def invoke_task(command, *args); end
-
-  def invoke_with_padding(*args); end
-end
-
-module Bundler::Thor::Invocation::ClassMethods
-  def prepare_for_invocation(key, name); end
-end
-
-module Bundler::Thor::Invocation::ClassMethods
-end
-
-module Bundler::Thor::Invocation
-  def self.included(base); end
-end
-
-class Bundler::Thor::InvocationError
-end
-
-class Bundler::Thor::InvocationError
-end
-
-module Bundler::Thor::LineEditor
-end
-
-class Bundler::Thor::LineEditor::Basic
-  def initialize(prompt, options); end
-
-  def options(); end
-
-  def prompt(); end
-
-  def readline(); end
-end
-
-class Bundler::Thor::LineEditor::Basic
-  def self.available?(); end
-end
-
-class Bundler::Thor::LineEditor::Readline
-end
-
-class Bundler::Thor::LineEditor::Readline::PathCompletion
-  def initialize(text); end
-
-  def matches(); end
-end
-
-class Bundler::Thor::LineEditor::Readline::PathCompletion
-end
-
-class Bundler::Thor::LineEditor::Readline
-end
-
-module Bundler::Thor::LineEditor
-  def self.best_available(); end
-
-  def self.readline(prompt, options=T.unsafe(nil)); end
-end
-
-class Bundler::Thor::MalformattedArgumentError
-end
-
-class Bundler::Thor::MalformattedArgumentError
-end
-
-class Bundler::Thor::NestedContext
-  def enter(); end
-
-  def entered?(); end
-end
-
-class Bundler::Thor::NestedContext
-end
-
-class Bundler::Thor::NoKwargSpellChecker
-  def initialize(dictionary); end
-end
-
-class Bundler::Thor::NoKwargSpellChecker
-end
-
-class Bundler::Thor::Option
-  def aliases(); end
-
-  def array?(); end
-
-  def boolean?(); end
-
-  def dasherize(str); end
-
-  def dasherized?(); end
-
-  def group(); end
-
-  def hash?(); end
-
-  def hide(); end
-
-  def lazy_default(); end
-
-  def numeric?(); end
-
-  def repeatable(); end
-
-  def string?(); end
-
-  def switch_name(); end
-
-  def undasherize(str); end
-
-  def usage(padding=T.unsafe(nil)); end
-
-  def validate_default_type!(); end
-  VALID_TYPES = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Option
-  def self.parse(key, value); end
-end
-
-class Bundler::Thor::Options
-  def assign_result!(option, result); end
-
-  def check_unknown!(); end
-
-  def current_is_switch?(); end
-
-  def current_is_switch_formatted?(); end
-
-  def initialize(hash_options=T.unsafe(nil), defaults=T.unsafe(nil), stop_on_unknown=T.unsafe(nil), disable_required_check=T.unsafe(nil)); end
-
-  def normalize_switch(arg); end
-
-  def parse_boolean(switch); end
-
-  def parse_peek(switch, option); end
-
-  def parsing_options?(); end
-
-  def switch?(arg); end
-
-  def switch_option(arg); end
-  EQ_RE = ::T.let(nil, ::T.untyped)
-  LONG_RE = ::T.let(nil, ::T.untyped)
-  OPTS_END = ::T.let(nil, ::T.untyped)
-  SHORT_NUM = ::T.let(nil, ::T.untyped)
-  SHORT_RE = ::T.let(nil, ::T.untyped)
-  SHORT_SQ_RE = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Options
-  def self.to_switches(options); end
-end
-
-class Bundler::Thor::RequiredArgumentMissingError
-end
-
-class Bundler::Thor::RequiredArgumentMissingError
-end
-
-module Bundler::Thor::Sandbox
-end
-
-module Bundler::Thor::Sandbox
-end
-
-module Bundler::Thor::Shell
-  def _shared_configuration(); end
-
-  def ask(*args, &block); end
-
-  def error(*args, &block); end
-
-  def file_collision(*args, &block); end
-
-  def initialize(args=T.unsafe(nil), options=T.unsafe(nil), config=T.unsafe(nil)); end
-
-  def no?(*args, &block); end
-
-  def print_in_columns(*args, &block); end
-
-  def print_table(*args, &block); end
-
-  def print_wrapped(*args, &block); end
-
-  def say(*args, &block); end
-
-  def say_status(*args, &block); end
-
-  def set_color(*args, &block); end
-
-  def shell(); end
-
-  def shell=(shell); end
-
-  def terminal_width(*args, &block); end
-
-  def with_padding(); end
-
-  def yes?(*args, &block); end
-  SHELL_DELEGATED_METHODS = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Shell::Basic
-  def answer_match(possibilities, answer, case_insensitive); end
-
-  def as_unicode(); end
-
-  def ask(statement, *args); end
-
-  def ask_filtered(statement, color, options); end
-
-  def ask_simply(statement, color, options); end
-
-  def base(); end
-
-  def base=(base); end
-
-  def can_display_colors?(); end
-
-  def dynamic_width(); end
-
-  def dynamic_width_stty(); end
-
-  def dynamic_width_tput(); end
-
-  def error(statement); end
-
-  def file_collision(destination); end
-
-  def file_collision_help(); end
-
-  def git_merge_tool(); end
-
-  def indent(count=T.unsafe(nil)); end
-
-  def is?(value); end
-
-  def lookup_color(color); end
-
-  def merge(destination, content); end
-
-  def merge_tool(); end
-
-  def mute(); end
-
-  def mute?(); end
-
-  def no?(statement, color=T.unsafe(nil)); end
-
-  def padding(); end
-
-  def padding=(value); end
-
-  def prepare_message(message, *color); end
-
-  def print_in_columns(array); end
-
-  def print_table(array, options=T.unsafe(nil)); end
-
-  def print_wrapped(message, options=T.unsafe(nil)); end
-
-  def quiet?(); end
-
-  def say(message=T.unsafe(nil), color=T.unsafe(nil), force_new_line=T.unsafe(nil)); end
-
-  def say_status(status, message, log_status=T.unsafe(nil)); end
-
-  def set_color(string, *_); end
-
-  def show_diff(destination, content); end
-
-  def stderr(); end
-
-  def stdout(); end
-
-  def terminal_width(); end
-
-  def truncate(string, width); end
-
-  def unix?(); end
-
-  def yes?(statement, color=T.unsafe(nil)); end
-  DEFAULT_TERMINAL_WIDTH = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Shell::Basic
-end
-
-class Bundler::Thor::Shell::Color
-  def are_colors_disabled?(); end
-
-  def diff_lcs_loaded?(); end
-
-  def output_diff_line(diff); end
-
-  def set_color(string, *colors); end
-  BLACK = ::T.let(nil, ::T.untyped)
-  BLUE = ::T.let(nil, ::T.untyped)
-  BOLD = ::T.let(nil, ::T.untyped)
-  CLEAR = ::T.let(nil, ::T.untyped)
-  CYAN = ::T.let(nil, ::T.untyped)
-  GREEN = ::T.let(nil, ::T.untyped)
-  MAGENTA = ::T.let(nil, ::T.untyped)
-  ON_BLACK = ::T.let(nil, ::T.untyped)
-  ON_BLUE = ::T.let(nil, ::T.untyped)
-  ON_CYAN = ::T.let(nil, ::T.untyped)
-  ON_GREEN = ::T.let(nil, ::T.untyped)
-  ON_MAGENTA = ::T.let(nil, ::T.untyped)
-  ON_RED = ::T.let(nil, ::T.untyped)
-  ON_WHITE = ::T.let(nil, ::T.untyped)
-  ON_YELLOW = ::T.let(nil, ::T.untyped)
-  RED = ::T.let(nil, ::T.untyped)
-  WHITE = ::T.let(nil, ::T.untyped)
-  YELLOW = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Shell::Color
-end
-
-class Bundler::Thor::Shell::HTML
-  def ask(statement, color=T.unsafe(nil)); end
-
-  def diff_lcs_loaded?(); end
-
-  def output_diff_line(diff); end
-
-  def set_color(string, *colors); end
-  BLACK = ::T.let(nil, ::T.untyped)
-  BLUE = ::T.let(nil, ::T.untyped)
-  BOLD = ::T.let(nil, ::T.untyped)
-  CYAN = ::T.let(nil, ::T.untyped)
-  GREEN = ::T.let(nil, ::T.untyped)
-  MAGENTA = ::T.let(nil, ::T.untyped)
-  ON_BLACK = ::T.let(nil, ::T.untyped)
-  ON_BLUE = ::T.let(nil, ::T.untyped)
-  ON_CYAN = ::T.let(nil, ::T.untyped)
-  ON_GREEN = ::T.let(nil, ::T.untyped)
-  ON_MAGENTA = ::T.let(nil, ::T.untyped)
-  ON_RED = ::T.let(nil, ::T.untyped)
-  ON_WHITE = ::T.let(nil, ::T.untyped)
-  ON_YELLOW = ::T.let(nil, ::T.untyped)
-  RED = ::T.let(nil, ::T.untyped)
-  WHITE = ::T.let(nil, ::T.untyped)
-  YELLOW = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::Thor::Shell::HTML
-end
-
-module Bundler::Thor::Shell
-end
-
-Bundler::Thor::Task = Bundler::Thor::Command
-
-class Bundler::Thor::UndefinedCommandError
-  include ::DidYouMean::Correctable
-  def all_commands(); end
-
-  def command(); end
-
-  def initialize(command, all_commands, namespace); end
-end
-
-class Bundler::Thor::UndefinedCommandError::SpellChecker
-  def corrections(); end
-
-  def error(); end
-
-  def initialize(error); end
-
-  def spell_checker(); end
-end
-
-class Bundler::Thor::UndefinedCommandError::SpellChecker
-end
-
-class Bundler::Thor::UndefinedCommandError
-end
-
-Bundler::Thor::UndefinedTaskError = Bundler::Thor::UndefinedCommandError
-
-class Bundler::Thor::UnknownArgumentError
-  include ::DidYouMean::Correctable
-  def initialize(switches, unknown); end
-
-  def switches(); end
-
-  def unknown(); end
-end
-
-class Bundler::Thor::UnknownArgumentError::SpellChecker
-  def corrections(); end
-
-  def error(); end
-
-  def initialize(error); end
-
-  def spell_checker(); end
-end
-
-class Bundler::Thor::UnknownArgumentError::SpellChecker
-end
-
-class Bundler::Thor::UnknownArgumentError
-end
-
-module Bundler::Thor::Util
-end
-
-module Bundler::Thor::Util
-  def self.camel_case(str); end
-
-  def self.escape_globs(path); end
-
-  def self.escape_html(string); end
-
-  def self.find_by_namespace(namespace); end
-
-  def self.find_class_and_command_by_namespace(namespace, fallback=T.unsafe(nil)); end
-
-  def self.find_class_and_task_by_namespace(namespace, fallback=T.unsafe(nil)); end
-
-  def self.globs_for(path); end
-
-  def self.load_thorfile(path, content=T.unsafe(nil), debug=T.unsafe(nil)); end
-
-  def self.namespace_from_thor_class(constant); end
-
-  def self.namespaces_in_content(contents, file=T.unsafe(nil)); end
-
-  def self.ruby_command(); end
-
-  def self.snake_case(str); end
-
-  def self.thor_classes_in(klass); end
-
-  def self.thor_root(); end
-
-  def self.thor_root_glob(); end
-
-  def self.user_home(); end
-end
-
-class Bundler::Thor
-  extend ::Bundler::Thor::Base::ClassMethods
-  extend ::Bundler::Thor::Invocation::ClassMethods
-  def self.banner(command, namespace=T.unsafe(nil), subcommand=T.unsafe(nil)); end
-
-  def self.check_unknown_options!(options=T.unsafe(nil)); end
-
-  def self.command_help(shell, command_name); end
-
-  def self.default_command(meth=T.unsafe(nil)); end
-
-  def self.default_task(meth=T.unsafe(nil)); end
-
-  def self.deprecation_warning(message); end
-
-  def self.desc(usage, description, options=T.unsafe(nil)); end
-
-  def self.disable_required_check(); end
-
-  def self.disable_required_check!(*command_names); end
-
-  def self.disable_required_check?(command); end
-
-  def self.dispatch(meth, given_args, given_opts, config); end
-
-  def self.dynamic_command_class(); end
-
-  def self.find_command_possibilities(meth); end
-
-  def self.find_task_possibilities(meth); end
-
-  def self.help(shell, subcommand=T.unsafe(nil)); end
-
-  def self.long_desc(long_description, options=T.unsafe(nil)); end
-
-  def self.map(mappings=T.unsafe(nil), **kw); end
-
-  def self.method_option(name, options=T.unsafe(nil)); end
-
-  def self.method_options(options=T.unsafe(nil)); end
-
-  def self.normalize_command_name(meth); end
-
-  def self.normalize_task_name(meth); end
-
-  def self.option(name, options=T.unsafe(nil)); end
-
-  def self.options(options=T.unsafe(nil)); end
-
-  def self.package_name(name, _=T.unsafe(nil)); end
-
-  def self.printable_commands(all=T.unsafe(nil), subcommand=T.unsafe(nil)); end
-
-  def self.printable_tasks(all=T.unsafe(nil), subcommand=T.unsafe(nil)); end
-
-  def self.register(klass, subcommand_name, usage, description, options=T.unsafe(nil)); end
-
-  def self.retrieve_command_name(args); end
-
-  def self.retrieve_task_name(args); end
-
-  def self.stop_on_unknown_option(); end
-
-  def self.stop_on_unknown_option!(*command_names); end
-
-  def self.stop_on_unknown_option?(command); end
-
-  def self.subcommand(subcommand, subcommand_class); end
-
-  def self.subcommand_classes(); end
-
-  def self.subcommand_help(cmd); end
-
-  def self.subcommands(); end
-
-  def self.subtask(subcommand, subcommand_class); end
-
-  def self.subtask_help(cmd); end
-
-  def self.subtasks(); end
-
-  def self.task_help(shell, command_name); end
-end
-
-class Bundler::UI::Shell
-  def add_color(string, *color); end
-
-  def ask(msg); end
-
-  def confirm(msg, newline=T.unsafe(nil)); end
-
-  def debug(msg, newline=T.unsafe(nil)); end
-
-  def debug?(); end
-
-  def error(msg, newline=T.unsafe(nil)); end
-
-  def info(msg, newline=T.unsafe(nil)); end
-
-  def initialize(options=T.unsafe(nil)); end
-
-  def level(name=T.unsafe(nil)); end
-
-  def level=(level); end
-
-  def no?(); end
-
-  def quiet?(); end
-
-  def shell=(shell); end
-
-  def silence(&blk); end
-
-  def trace(e, newline=T.unsafe(nil), force=T.unsafe(nil)); end
-
-  def unprinted_warnings(); end
-
-  def warn(msg, newline=T.unsafe(nil)); end
-
-  def yes?(msg); end
-  LEVELS = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::UI::Shell
-end
-
-module Bundler::VersionRanges
-end
-
-class Bundler::VersionRanges::NEq
-  def version(); end
-
-  def version=(_); end
-end
-
-class Bundler::VersionRanges::NEq
-  def self.[](*_); end
-
-  def self.members(); end
-end
-
-class Bundler::VersionRanges::ReqR
-  def cover?(v); end
-
-  def empty?(); end
-
-  def left(); end
-
-  def left=(_); end
-
-  def right(); end
-
-  def right=(_); end
-
-  def single?(); end
-  INFINITY = ::T.let(nil, ::T.untyped)
-  UNIVERSAL = ::T.let(nil, ::T.untyped)
-  ZERO = ::T.let(nil, ::T.untyped)
-end
-
-class Bundler::VersionRanges::ReqR::Endpoint
-  def inclusive(); end
-
-  def inclusive=(_); end
-
-  def version(); end
-
-  def version=(_); end
-end
-
-class Bundler::VersionRanges::ReqR::Endpoint
-  def self.[](*_); end
-
-  def self.members(); end
-end
-
-class Bundler::VersionRanges::ReqR
-  def self.[](*_); end
-
-  def self.members(); end
-end
-
-module Bundler::VersionRanges
-  def self.empty?(ranges, neqs); end
-
-  def self.for(requirement); end
-
-  def self.for_many(requirements); end
 end
 
 module Bundler
@@ -1918,94 +64,6 @@ class Class
   def json_creatable?(); end
 end
 
-class DidYouMean::ClassNameChecker
-  def class_name(); end
-
-  def class_names(); end
-
-  def corrections(); end
-
-  def initialize(exception); end
-
-  def scopes(); end
-end
-
-module DidYouMean::Correctable
-  def corrections(); end
-
-  def original_message(); end
-
-  def spell_checker(); end
-
-  def to_s(); end
-end
-
-module DidYouMean::Jaro
-  def self.distance(str1, str2); end
-end
-
-module DidYouMean::JaroWinkler
-  def self.distance(str1, str2); end
-end
-
-class DidYouMean::KeyErrorChecker
-  def corrections(); end
-
-  def initialize(key_error); end
-end
-
-class DidYouMean::KeyErrorChecker
-end
-
-module DidYouMean::Levenshtein
-  def self.distance(str1, str2); end
-
-  def self.min3(a, b, c); end
-end
-
-class DidYouMean::MethodNameChecker
-  def corrections(); end
-
-  def initialize(exception); end
-
-  def method_name(); end
-
-  def method_names(); end
-
-  def receiver(); end
-  RB_RESERVED_WORDS = ::T.let(nil, ::T.untyped)
-end
-
-class DidYouMean::NullChecker
-  def corrections(); end
-
-  def initialize(*_); end
-end
-
-class DidYouMean::PlainFormatter
-  def message_for(corrections); end
-end
-
-class DidYouMean::PlainFormatter
-end
-
-class DidYouMean::VariableNameChecker
-  def corrections(); end
-
-  def cvar_names(); end
-
-  def initialize(exception); end
-
-  def ivar_names(); end
-
-  def lvar_names(); end
-
-  def method_names(); end
-
-  def name(); end
-  RB_RESERVED_WORDS = ::T.let(nil, ::T.untyped)
-end
-
 module DidYouMean
   def self.formatter(); end
 
@@ -2029,11 +87,11 @@ class ERB
 end
 
 class Encoding
+  class Converter
+    def initialize(*_); end
+  # wrong constant name initialize
+  end
   def _dump(*_); end
-end
-
-class Encoding::Converter
-  def initialize(*_); end
 end
 
 class Encoding
@@ -2047,100 +105,49 @@ module Enumerable
 end
 
 class Enumerator
+  class ArithmeticSequence
+    def begin(); end
+
+    def each(&blk); end
+
+    def end(); end
+
+    def exclude_end?(); end
+
+    def last(*_); end
+
+    def step(); end
+  # uninitialized constant Enumerator::ArithmeticSequence::Elem
+  # wrong constant name begin
+  # wrong constant name each
+  # wrong constant name end
+  # wrong constant name exclude_end?
+  # wrong constant name last
+  # wrong constant name step
+  end
+
+  class ArithmeticSequence
+  # wrong constant name <static-init>
+  end
+
+  class Chain
+  # uninitialized constant Enumerator::Chain::Elem
+  end
+
+  class Chain
+  # wrong constant name <static-init>
+  end
+
+  class Generator
+    def each(*_, &blk); end
+
+    def initialize(*_); end
+  # wrong constant name each
+  # wrong constant name initialize
+  end
   def +(_); end
 
   def each_with_index(); end
-end
-
-class Enumerator::ArithmeticSequence
-  def begin(); end
-
-  def each(&blk); end
-
-  def end(); end
-
-  def exclude_end?(); end
-
-  def last(*_); end
-
-  def step(); end
-end
-
-class Enumerator::ArithmeticSequence
-end
-
-class Enumerator::Chain
-end
-
-class Enumerator::Chain
-end
-
-class Enumerator::Generator
-  def each(*_, &blk); end
-
-  def initialize(*_); end
-end
-
-Errno::ECAPMODE = Errno::NOERROR
-
-Errno::EDOOFUS = Errno::NOERROR
-
-Errno::EIPSEC = Errno::NOERROR
-
-Errno::ENOTCAPABLE = Errno::NOERROR
-
-class Etc::Group
-  def gid(); end
-
-  def gid=(_); end
-
-  def mem(); end
-
-  def mem=(_); end
-
-  def name(); end
-
-  def name=(_); end
-
-  def passwd(); end
-
-  def passwd=(_); end
-end
-
-class Etc::Group
-  extend ::Enumerable
-  def self.[](*_); end
-
-  def self.each(&blk); end
-
-  def self.members(); end
-end
-
-class Etc::Passwd
-  def dir=(_); end
-
-  def gecos(); end
-
-  def gecos=(_); end
-
-  def gid=(_); end
-
-  def name=(_); end
-
-  def passwd=(_); end
-
-  def shell=(_); end
-
-  def uid=(_); end
-end
-
-class Etc::Passwd
-  extend ::Enumerable
-  def self.[](*_); end
-
-  def self.each(&blk); end
-
-  def self.members(); end
 end
 
 class ExitCalledError
@@ -2158,52 +165,77 @@ class File
 end
 
 module FileUtils
-  include ::FileUtils::StreamUtils_
-end
+  module DryRun
+    include ::FileUtils
+    include StreamUtils_
+    include LowMethods
+  # uninitialized constant FileUtils::DryRun::VERSION
+  # Did you mean?  FileUtils::VERSION
+  end
 
-module FileUtils::DryRun
-  include ::FileUtils
-  include ::FileUtils::StreamUtils_
-  include ::FileUtils::LowMethods
-end
+  module DryRun
+    extend DryRun
+    extend ::FileUtils
+    extend StreamUtils_
+    extend LowMethods
+  end
 
-module FileUtils::DryRun
-  extend ::FileUtils::DryRun
-  extend ::FileUtils
-  extend ::FileUtils::StreamUtils_
-  extend ::FileUtils::LowMethods
-end
+  module NoWrite
+    include ::FileUtils
+    include StreamUtils_
+    include LowMethods
+  # uninitialized constant FileUtils::NoWrite::VERSION
+  # Did you mean?  FileUtils::VERSION
+  end
 
-module FileUtils::NoWrite
-  include ::FileUtils
-  include ::FileUtils::StreamUtils_
-  include ::FileUtils::LowMethods
-end
+  module NoWrite
+    extend NoWrite
+    extend ::FileUtils
+    extend StreamUtils_
+    extend LowMethods
+  end
 
-module FileUtils::NoWrite
-  extend ::FileUtils::NoWrite
-  extend ::FileUtils
-  extend ::FileUtils::StreamUtils_
-  extend ::FileUtils::LowMethods
-end
+  module Verbose
+    include ::FileUtils
+    include StreamUtils_
+  # uninitialized constant FileUtils::Verbose::VERSION
+  # Did you mean?  FileUtils::VERSION
+  end
 
-module FileUtils::Verbose
-  include ::FileUtils
-  include ::FileUtils::StreamUtils_
-end
-
-module FileUtils::Verbose
-  extend ::FileUtils::Verbose
-  extend ::FileUtils
-  extend ::FileUtils::StreamUtils_
+  module Verbose
+    extend Verbose
+    extend ::FileUtils
+    extend StreamUtils_
+  end
+  include StreamUtils_
 end
 
 module FileUtils
-  extend ::FileUtils::StreamUtils_
+  extend StreamUtils_
 end
 
 class Float
   include ::JSON::Ext::Generator::GeneratorMethods::Float
+end
+
+module Foo
+  module Bar
+    module Baz
+    end
+
+    module Baz
+    # wrong constant name <static-init>
+    end
+    include Baz
+  # wrong constant name <Class:Baz>
+  end
+
+  module Bar
+  # wrong constant name <static-init>
+  end
+end
+
+module Foo
 end
 
 module GC
@@ -2215,534 +247,318 @@ module GC
 end
 
 module Gem
+  class Dependency
+    def pretty_print(q); end
+  # wrong constant name <=>
+  # wrong constant name pretty_print
+  end
+
+  class DependencyInstaller
+    def _deprecated_add_found_dependencies(to_do, dependency_list); end
+
+    def _deprecated_gather_dependencies(); end
+
+    def add_found_dependencies(*args, &block); end
+
+    def gather_dependencies(*args, &block); end
+  # wrong constant name _deprecated_add_found_dependencies
+  # wrong constant name _deprecated_gather_dependencies
+  # wrong constant name add_found_dependencies
+  # wrong constant name gather_dependencies
+  end
+
+  class Exception
+    extend Deprecate
+  end
+
+  class List
+    def pretty_print(q); end
+  # wrong constant name pretty_print
+  end
+
+  class Package
+    def self.new(gem, security_policy=T.unsafe(nil)); end
+  # wrong constant name new
+  end
+
+  class PathSupport
+    def home(); end
+
+    def initialize(env); end
+
+    def path(); end
+
+    def spec_cache_dir(); end
+  # wrong constant name home
+  # wrong constant name initialize
+  # wrong constant name path
+  # wrong constant name spec_cache_dir
+  end
+
+  class RemoteFetcher
+    class FetchError
+      def initialize(message, uri); end
+
+      def uri(); end
+
+      def uri=(uri); end
+    # wrong constant name initialize
+    # wrong constant name uri
+    # wrong constant name uri=
+    end
+
+    class FetchError
+    # wrong constant name <static-init>
+    end
+
+    class UnknownHostError
+    end
+
+    class UnknownHostError
+    # wrong constant name <static-init>
+    end
+    def correct_for_windows_path(path); end
+
+    def s3_expiration(); end
+
+    def sign_s3_url(uri, expiration=T.unsafe(nil)); end
+    BASE64_URI_TRANSLATE = ::T.let(nil, ::T.untyped)
+  # wrong constant name <Class:FetchError>
+  # wrong constant name <Class:UnknownHostError>
+  # wrong constant name correct_for_windows_path
+  # wrong constant name s3_expiration
+  # wrong constant name sign_s3_url
+  end
+
+  class Request
+    extend UserInteraction
+    extend DefaultUserInteraction
+    extend Text
+  end
+
+  class RequestSet
+    def pretty_print(q); end
+  # wrong constant name pretty_print
+  end
+
+  class Requirement
+    def pretty_print(q); end
+  # wrong constant name pretty_print
+  end
+
+  class RuntimeRequirementNotMetError
+    def suggestion(); end
+
+    def suggestion=(suggestion); end
+  # wrong constant name suggestion
+  # wrong constant name suggestion=
+  end
+
+  class RuntimeRequirementNotMetError
+  # wrong constant name <static-init>
+  end
+
+  # uninitialized constant Gem::S3URISigner
+  # uninitialized constant Gem::S3URISigner
+  class Source
+    def pretty_print(q); end
+  # wrong constant name <=>
+  # wrong constant name pretty_print
+  end
+
+  class SpecFetcher
+    include UserInteraction
+    include DefaultUserInteraction
+    include Text
+    def available_specs(type); end
+
+    def detect(type=T.unsafe(nil)); end
+
+    def initialize(sources=T.unsafe(nil)); end
+
+    def latest_specs(); end
+
+    def prerelease_specs(); end
+
+    def search_for_dependency(dependency, matching_platform=T.unsafe(nil)); end
+
+    def sources(); end
+
+    def spec_for_dependency(dependency, matching_platform=T.unsafe(nil)); end
+
+    def specs(); end
+
+    def suggest_gems_from_name(gem_name, type=T.unsafe(nil)); end
+
+    def tuples_for(source, type, gracefully_ignore=T.unsafe(nil)); end
+  # wrong constant name available_specs
+  # wrong constant name detect
+  # wrong constant name initialize
+  # wrong constant name latest_specs
+  # wrong constant name prerelease_specs
+  # wrong constant name search_for_dependency
+  # wrong constant name sources
+  # wrong constant name spec_for_dependency
+  # wrong constant name specs
+  # wrong constant name suggest_gems_from_name
+  # wrong constant name tuples_for
+  end
+
+  class SpecFetcher
+    def self.fetcher(); end
+
+    def self.fetcher=(fetcher); end
+  # wrong constant name <static-init>
+  # wrong constant name fetcher
+  # wrong constant name fetcher=
+  end
+
+  class Specification
+    include ::Bundler::MatchPlatform
+    include ::Bundler::GemHelpers
+    def pretty_print(q); end
+
+    def to_ruby(); end
+  # wrong constant name <=>
+  # uninitialized constant Gem::Specification::GENERICS
+  # uninitialized constant Gem::Specification::GENERIC_CACHE
+  # wrong constant name pretty_print
+  # wrong constant name to_ruby
+  end
+
+  class Specification
+    extend Deprecate
+    extend ::Enumerable
+    def self.add_spec(spec); end
+
+    def self.add_specs(*specs); end
+
+    def self.remove_spec(spec); end
+  # wrong constant name add_spec
+  # wrong constant name add_specs
+  # wrong constant name remove_spec
+  end
+
+  class SpecificationPolicy
+    def initialize(specification); end
+
+    def packaging(); end
+
+    def packaging=(packaging); end
+
+    def validate(strict=T.unsafe(nil)); end
+
+    def validate_dependencies(); end
+
+    def validate_metadata(); end
+
+    def validate_permissions(); end
+    HOMEPAGE_URI_PATTERN = ::T.let(nil, ::T.untyped)
+    LAZY = ::T.let(nil, ::T.untyped)
+    LAZY_PATTERN = ::T.let(nil, ::T.untyped)
+    METADATA_LINK_KEYS = ::T.let(nil, ::T.untyped)
+    SPECIAL_CHARACTERS = ::T.let(nil, ::T.untyped)
+    VALID_NAME_PATTERN = ::T.let(nil, ::T.untyped)
+    VALID_URI_PATTERN = ::T.let(nil, ::T.untyped)
+  # wrong constant name initialize
+  # wrong constant name packaging
+  # wrong constant name packaging=
+  # wrong constant name validate
+  # wrong constant name validate_dependencies
+  # wrong constant name validate_metadata
+  # wrong constant name validate_permissions
+  end
+
+  class SpecificationPolicy
+  # wrong constant name <static-init>
+  end
+
+  # uninitialized constant Gem::Stream
+  # Did you mean?  Gem::StreamUI
+  # uninitialized constant Gem::Stream
+  # Did you mean?  Gem::StreamUI
+  class StreamUI
+    def _deprecated_debug(statement); end
+  # wrong constant name _deprecated_debug
+  end
+
+  class StubSpecification
+    class StubLine
+      def extensions(); end
+
+      def full_name(); end
+
+      def initialize(data, extensions); end
+
+      def name(); end
+
+      def platform(); end
+
+      def require_paths(); end
+
+      def version(); end
+    # wrong constant name extensions
+    # wrong constant name full_name
+    # wrong constant name initialize
+    # wrong constant name name
+    # wrong constant name platform
+    # wrong constant name require_paths
+    # wrong constant name version
+    end
+    def build_extensions(); end
+
+    def extensions(); end
+
+    def initialize(filename, base_dir, gems_dir, default_gem); end
+
+    def missing_extensions?(); end
+
+    def valid?(); end
+  # wrong constant name build_extensions
+  # wrong constant name extensions
+  # wrong constant name initialize
+  # wrong constant name missing_extensions?
+  # wrong constant name valid?
+  end
+
+  class StubSpecification
+    def self.default_gemspec_stub(filename, base_dir, gems_dir); end
+
+    def self.gemspec_stub(filename, base_dir, gems_dir); end
+  # wrong constant name default_gemspec_stub
+  # wrong constant name gemspec_stub
+  end
+
+  class UninstallError
+    def spec(); end
+
+    def spec=(spec); end
+  # wrong constant name spec
+  # wrong constant name spec=
+  end
+
+  class UninstallError
+  # wrong constant name <static-init>
+  end
+
+  Gem::UnsatisfiableDepedencyError = Gem::UnsatisfiableDependencyError
+
+  # uninitialized constant Gem::UriParser
+  # uninitialized constant Gem::UriParser
+  # uninitialized constant Gem::UriParsing
+  # uninitialized constant Gem::UriParsing
+  class Version
+    Gem::Version::Requirement = Gem::Requirement
+    def pretty_print(q); end
+  # wrong constant name <=>
+  # wrong constant name pretty_print
+  end
   ConfigMap = ::T.let(nil, ::T.untyped)
   RbConfigPriorities = ::T.let(nil, ::T.untyped)
   RubyGemsPackageVersion = ::T.let(nil, ::T.untyped)
   RubyGemsVersion = ::T.let(nil, ::T.untyped)
   USE_BUNDLER_FOR_GEMDEPS = ::T.let(nil, ::T.untyped)
 end
-
-class Gem::Dependency
-  def pretty_print(q); end
-end
-
-class Gem::DependencyInstaller
-  def _deprecated_add_found_dependencies(to_do, dependency_list); end
-
-  def _deprecated_gather_dependencies(); end
-
-  def add_found_dependencies(*args, &block); end
-
-  def gather_dependencies(*args, &block); end
-end
-
-class Gem::Exception
-  extend ::Gem::Deprecate
-end
-
-class Gem::Ext::BuildError
-end
-
-class Gem::Ext::BuildError
-end
-
-class Gem::Ext::Builder
-  def self.redirector(); end
-end
-
-class Gem::Ext::ExtConfBuilder
-end
-
-Gem::Ext::ExtConfBuilder::FileEntry = FileUtils::Entry_
-
-class Gem::Ext::ExtConfBuilder
-  def self.build(extension, dest_path, results, args=T.unsafe(nil), lib_dir=T.unsafe(nil)); end
-
-  def self.get_relative_path(path); end
-end
-
-class Gem::List
-  def pretty_print(q); end
-end
-
-class Gem::Package::DigestIO
-  def digests(); end
-
-  def initialize(io, digests); end
-
-  def write(data); end
-end
-
-class Gem::Package::DigestIO
-  def self.wrap(io, digests); end
-end
-
-class Gem::Package::FileSource
-  def initialize(path); end
-
-  def path(); end
-
-  def present?(); end
-
-  def start(); end
-
-  def with_read_io(&block); end
-
-  def with_write_io(&block); end
-end
-
-class Gem::Package::FileSource
-end
-
-class Gem::Package::IOSource
-  def initialize(io); end
-
-  def io(); end
-
-  def path(); end
-
-  def present?(); end
-
-  def start(); end
-
-  def with_read_io(); end
-
-  def with_write_io(); end
-end
-
-class Gem::Package::IOSource
-end
-
-class Gem::Package::Old
-  def extract_files(destination_dir); end
-
-  def file_list(io); end
-
-  def read_until_dashes(io); end
-
-  def skip_ruby(io); end
-end
-
-class Gem::Package::Old
-end
-
-class Gem::Package::Source
-end
-
-class Gem::Package::Source
-end
-
-class Gem::Package::TarHeader
-  def ==(other); end
-
-  def checksum(); end
-
-  def devmajor(); end
-
-  def devminor(); end
-
-  def empty?(); end
-
-  def gid(); end
-
-  def gname(); end
-
-  def initialize(vals); end
-
-  def linkname(); end
-
-  def magic(); end
-
-  def mode(); end
-
-  def mtime(); end
-
-  def name(); end
-
-  def prefix(); end
-
-  def size(); end
-
-  def typeflag(); end
-
-  def uid(); end
-
-  def uname(); end
-
-  def update_checksum(); end
-
-  def version(); end
-  EMPTY_HEADER = ::T.let(nil, ::T.untyped)
-  FIELDS = ::T.let(nil, ::T.untyped)
-  PACK_FORMAT = ::T.let(nil, ::T.untyped)
-  UNPACK_FORMAT = ::T.let(nil, ::T.untyped)
-end
-
-class Gem::Package::TarHeader
-  def self.from(stream); end
-
-  def self.strict_oct(str); end
-end
-
-class Gem::Package::TarReader::Entry
-  def bytes_read(); end
-
-  def check_closed(); end
-
-  def close(); end
-
-  def closed?(); end
-
-  def directory?(); end
-
-  def eof?(); end
-
-  def file?(); end
-
-  def full_name(); end
-
-  def getc(); end
-
-  def header(); end
-
-  def initialize(header, io); end
-
-  def length(); end
-
-  def pos(); end
-
-  def read(len=T.unsafe(nil)); end
-
-  def readpartial(maxlen=T.unsafe(nil), outbuf=T.unsafe(nil)); end
-
-  def rewind(); end
-
-  def size(); end
-
-  def symlink?(); end
-end
-
-class Gem::Package::TarReader::Entry
-end
-
-class Gem::Package::TarReader
-  def self.new(io); end
-end
-
-class Gem::Package::TarWriter
-  def self.new(io); end
-end
-
-class Gem::Package
-  def self.new(gem, security_policy=T.unsafe(nil)); end
-end
-
-class Gem::PathSupport
-  def home(); end
-
-  def initialize(env); end
-
-  def path(); end
-
-  def spec_cache_dir(); end
-end
-
-class Gem::RemoteFetcher
-  def correct_for_windows_path(path); end
-
-  def s3_expiration(); end
-
-  def sign_s3_url(uri, expiration=T.unsafe(nil)); end
-  BASE64_URI_TRANSLATE = ::T.let(nil, ::T.untyped)
-end
-
-class Gem::RemoteFetcher::FetchError
-  def initialize(message, uri); end
-
-  def uri(); end
-
-  def uri=(uri); end
-end
-
-class Gem::RemoteFetcher::FetchError
-end
-
-class Gem::RemoteFetcher::UnknownHostError
-end
-
-class Gem::RemoteFetcher::UnknownHostError
-end
-
-class Gem::Request
-  extend ::Gem::UserInteraction
-  extend ::Gem::DefaultUserInteraction
-  extend ::Gem::Text
-end
-
-class Gem::RequestSet
-  def pretty_print(q); end
-end
-
-class Gem::Requirement
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::APISet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::APISpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::ActivationRequest
-  def others_possible?(); end
-
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::BestSet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::Conflict
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::CurrentSet
-end
-
-class Gem::Resolver::CurrentSet
-end
-
-class Gem::Resolver::DependencyRequest
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::GitSet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::GitSpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::IndexSet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::IndexSpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::InstalledSpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::InstallerSet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::LocalSpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::LocalSpecification
-end
-
-class Gem::Resolver::LockSet
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::LockSpecification
-  def pretty_print(q); end
-end
-
-class Gem::Resolver::Molinillo::DependencyGraph::Log
-  def add_edge_no_circular(graph, origin, destination, requirement); end
-
-  def add_vertex(graph, name, payload, root); end
-
-  def delete_edge(graph, origin_name, destination_name, requirement); end
-
-  def detach_vertex_named(graph, name); end
-
-  def each(&blk); end
-
-  def pop!(graph); end
-
-  def reverse_each(); end
-
-  def rewind_to(graph, tag); end
-
-  def set_payload(graph, name, payload); end
-
-  def tag(graph, tag); end
-end
-
-class Gem::Resolver::Molinillo::DependencyGraph::Log
-  extend ::Enumerable
-end
-
-class Gem::Resolver::VendorSet
-  def pretty_print(q); end
-end
-
-class Gem::RuntimeRequirementNotMetError
-  def suggestion(); end
-
-  def suggestion=(suggestion); end
-end
-
-class Gem::RuntimeRequirementNotMetError
-end
-
-class Gem::Security::Signer
-  include ::Gem::UserInteraction
-  include ::Gem::DefaultUserInteraction
-  include ::Gem::Text
-  def options(); end
-end
-
-class Gem::Security::Signer
-  def self.re_sign_cert(expired_cert, expired_cert_path, private_key); end
-end
-
-class Gem::Source
-  def pretty_print(q); end
-end
-
-class Gem::SpecFetcher
-  include ::Gem::UserInteraction
-  include ::Gem::DefaultUserInteraction
-  include ::Gem::Text
-  def available_specs(type); end
-
-  def detect(type=T.unsafe(nil)); end
-
-  def initialize(sources=T.unsafe(nil)); end
-
-  def latest_specs(); end
-
-  def prerelease_specs(); end
-
-  def search_for_dependency(dependency, matching_platform=T.unsafe(nil)); end
-
-  def sources(); end
-
-  def spec_for_dependency(dependency, matching_platform=T.unsafe(nil)); end
-
-  def specs(); end
-
-  def suggest_gems_from_name(gem_name, type=T.unsafe(nil)); end
-
-  def tuples_for(source, type, gracefully_ignore=T.unsafe(nil)); end
-end
-
-class Gem::SpecFetcher
-  def self.fetcher(); end
-
-  def self.fetcher=(fetcher); end
-end
-
-class Gem::Specification
-  include ::Bundler::MatchPlatform
-  include ::Bundler::GemHelpers
-  def pretty_print(q); end
-
-  def to_ruby(); end
-end
-
-class Gem::Specification
-  extend ::Gem::Deprecate
-  extend ::Enumerable
-  def self.add_spec(spec); end
-
-  def self.add_specs(*specs); end
-
-  def self.remove_spec(spec); end
-end
-
-class Gem::SpecificationPolicy
-  def initialize(specification); end
-
-  def packaging(); end
-
-  def packaging=(packaging); end
-
-  def validate(strict=T.unsafe(nil)); end
-
-  def validate_dependencies(); end
-
-  def validate_metadata(); end
-
-  def validate_permissions(); end
-  HOMEPAGE_URI_PATTERN = ::T.let(nil, ::T.untyped)
-  LAZY = ::T.let(nil, ::T.untyped)
-  LAZY_PATTERN = ::T.let(nil, ::T.untyped)
-  METADATA_LINK_KEYS = ::T.let(nil, ::T.untyped)
-  SPECIAL_CHARACTERS = ::T.let(nil, ::T.untyped)
-  VALID_NAME_PATTERN = ::T.let(nil, ::T.untyped)
-  VALID_URI_PATTERN = ::T.let(nil, ::T.untyped)
-end
-
-class Gem::SpecificationPolicy
-end
-
-class Gem::StreamUI
-  def _deprecated_debug(statement); end
-end
-
-class Gem::StubSpecification
-  def build_extensions(); end
-
-  def extensions(); end
-
-  def initialize(filename, base_dir, gems_dir, default_gem); end
-
-  def missing_extensions?(); end
-
-  def valid?(); end
-end
-
-class Gem::StubSpecification::StubLine
-  def extensions(); end
-
-  def full_name(); end
-
-  def initialize(data, extensions); end
-
-  def name(); end
-
-  def platform(); end
-
-  def require_paths(); end
-
-  def version(); end
-end
-
-class Gem::StubSpecification
-  def self.default_gemspec_stub(filename, base_dir, gems_dir); end
-
-  def self.gemspec_stub(filename, base_dir, gems_dir); end
-end
-
-class Gem::UninstallError
-  def spec(); end
-
-  def spec=(spec); end
-end
-
-class Gem::UninstallError
-end
-
-Gem::UnsatisfiableDepedencyError = Gem::UnsatisfiableDependencyError
-
-class Gem::Version
-  def pretty_print(q); end
-end
-
-Gem::Version::Requirement = Gem::Requirement
 
 module Gem
   def self.default_gems_use_full_paths?(); end
@@ -2759,6 +575,9 @@ class Hash
 end
 
 class IO
+  IO::EWOULDBLOCKWaitReadable = IO::EAGAINWaitReadable
+
+  IO::EWOULDBLOCKWaitWritable = IO::EAGAINWaitWritable
   def nread(); end
 
   def pathconf(_); end
@@ -2772,10 +591,6 @@ class IO
   def wait_writable(*_); end
 end
 
-IO::EWOULDBLOCKWaitReadable = IO::EAGAINWaitReadable
-
-IO::EWOULDBLOCKWaitWritable = IO::EAGAINWaitWritable
-
 class IPAddr
   def ==(other); end
 
@@ -2785,20 +600,6 @@ end
 class Integer
   include ::JSON::Ext::Generator::GeneratorMethods::Integer
 end
-
-class JSON::Ext::Generator::State
-  def self.from_state(_); end
-end
-
-class JSON::Ext::Parser
-  def initialize(*_); end
-end
-
-JSON::Parser = JSON::Ext::Parser
-
-JSON::State = JSON::Ext::Generator::State
-
-JSON::UnparserError = JSON::GeneratorError
 
 module Kernel
   def itself(); end
@@ -2827,13 +628,13 @@ class Monitor
 end
 
 module MonitorMixin
+  class ConditionVariable
+    def initialize(monitor); end
+  # wrong constant name initialize
+  end
   def initialize(*args); end
   EXCEPTION_IMMEDIATE = ::T.let(nil, ::T.untyped)
   EXCEPTION_NEVER = ::T.let(nil, ::T.untyped)
-end
-
-class MonitorMixin::ConditionVariable
-  def initialize(monitor); end
 end
 
 class NameError
@@ -2901,17 +702,6 @@ module RbConfig
   def self.ruby(); end
 end
 
-module RubyVM::MJIT
-end
-
-module RubyVM::MJIT
-  def self.enabled?(); end
-
-  def self.pause(*_); end
-
-  def self.resume(); end
-end
-
 class RubyVM
   def self.resolve_feature_path(_); end
 end
@@ -2940,12 +730,11 @@ class Set
 end
 
 class Socket
-  IPV6_DONTFRAG = ::T.let(nil, ::T.untyped)
-  IPV6_PATHMTU = ::T.let(nil, ::T.untyped)
-  IPV6_RECVPATHMTU = ::T.let(nil, ::T.untyped)
-end
-
-module Socket::Constants
+  module Constants
+    IPV6_DONTFRAG = ::T.let(nil, ::T.untyped)
+    IPV6_PATHMTU = ::T.let(nil, ::T.untyped)
+    IPV6_RECVPATHMTU = ::T.let(nil, ::T.untyped)
+  end
   IPV6_DONTFRAG = ::T.let(nil, ::T.untyped)
   IPV6_PATHMTU = ::T.let(nil, ::T.untyped)
   IPV6_RECVPATHMTU = ::T.let(nil, ::T.untyped)
@@ -2971,14 +760,13 @@ class String
 end
 
 class Struct
+  Struct::Group = Etc::Group
+
+  Struct::Passwd = Etc::Passwd
+
+  Struct::Tms = Process::Tms
   def filter(*_); end
 end
-
-Struct::Group = Etc::Group
-
-Struct::Passwd = Etc::Passwd
-
-Struct::Tms = Process::Tms
 
 class TracePoint
   def __enable(_, _1); end
@@ -2995,91 +783,179 @@ class TrueClass
 end
 
 module URI
-  include ::URI::RFC2396_REGEXP
-end
+  class FTP
+    def self.new2(user, password, host, port, path, typecode=T.unsafe(nil), arg_check=T.unsafe(nil)); end
+  # wrong constant name new2
+  end
 
-class URI::FTP
-  def self.new2(user, password, host, port, path, typecode=T.unsafe(nil), arg_check=T.unsafe(nil)); end
-end
+  class File
+    def check_password(user); end
 
-class URI::File
-  def check_password(user); end
+    def check_user(user); end
 
-  def check_user(user); end
+    def check_userinfo(user); end
 
-  def check_userinfo(user); end
+    def set_userinfo(v); end
+  # uninitialized constant URI::File::ABS_PATH
+  # Did you mean?  URI::ABS_PATH
+  # uninitialized constant URI::File::ABS_URI
+  # Did you mean?  URI::ABS_URI
+  # uninitialized constant URI::File::ABS_URI_REF
+  # Did you mean?  URI::ABS_URI_REF
+    COMPONENT = ::T.let(nil, ::T.untyped)
+  # uninitialized constant URI::File::DEFAULT_PARSER
+  # Did you mean?  URI::File::DEFAULT_PORT
+  #                URI::DEFAULT_PARSER
+    DEFAULT_PORT = ::T.let(nil, ::T.untyped)
+  # uninitialized constant URI::File::ESCAPED
+  # Did you mean?  URI::File::Escape
+  #                URI::Escape
+  #                URI::ESCAPED
+  # uninitialized constant URI::File::FRAGMENT
+  # Did you mean?  URI::FRAGMENT
+  # uninitialized constant URI::File::HOST
+  # Did you mean?  URI::HOST
+  # uninitialized constant URI::File::OPAQUE
+  # Did you mean?  URI::OPAQUE
+  # uninitialized constant URI::File::PORT
+  # Did you mean?  URI::PORT
+  # uninitialized constant URI::File::QUERY
+  # Did you mean?  URI::QUERY
+  # uninitialized constant URI::File::REGISTRY
+  # Did you mean?  URI::REGISTRY
+  # uninitialized constant URI::File::REL_PATH
+  # Did you mean?  URI::REL_PATH
+  # uninitialized constant URI::File::REL_URI
+  # Did you mean?  URI::REL_URI
+  # uninitialized constant URI::File::REL_URI_REF
+  # Did you mean?  URI::REL_URI_REF
+  # uninitialized constant URI::File::RFC3986_PARSER
+  # Did you mean?  URI::File::RFC3986_Parser
+  #                URI::RFC3986_Parser
+  #                URI::RFC2396_Parser
+  #                URI::File::RFC2396_Parser
+  #                URI::RFC3986_PARSER
+  # uninitialized constant URI::File::SCHEME
+  # Did you mean?  URI::SCHEME
+  # uninitialized constant URI::File::TBLDECWWWCOMP_
+  # Did you mean?  URI::File::TBLENCWWWCOMP_
+  #                URI::TBLDECWWWCOMP_
+  #                URI::TBLENCWWWCOMP_
+  # uninitialized constant URI::File::TBLENCWWWCOMP_
+  # Did you mean?  URI::File::TBLDECWWWCOMP_
+  #                URI::TBLDECWWWCOMP_
+  #                URI::TBLENCWWWCOMP_
+  # uninitialized constant URI::File::UNSAFE
+  # Did you mean?  URI::UNSAFE
+  # uninitialized constant URI::File::URI_REF
+  # Did you mean?  URI::URI_REF
+  # uninitialized constant URI::File::USERINFO
+  # Did you mean?  URI::USERINFO
+  # uninitialized constant URI::File::USE_REGISTRY
+  # uninitialized constant URI::File::VERSION
+  # Did you mean?  URI::VERSION
+  # uninitialized constant URI::File::VERSION_CODE
+  # Did you mean?  URI::VERSION_CODE
+  # uninitialized constant URI::File::WEB_ENCODINGS_
+  # Did you mean?  URI::WEB_ENCODINGS_
+  # wrong constant name check_password
+  # wrong constant name check_user
+  # wrong constant name check_userinfo
+  # wrong constant name set_userinfo
+  end
 
-  def set_userinfo(v); end
-  COMPONENT = ::T.let(nil, ::T.untyped)
-  DEFAULT_PORT = ::T.let(nil, ::T.untyped)
-end
+  class File
+  # wrong constant name <static-init>
+  end
 
-class URI::File
-end
+  class LDAP
+    def attributes(); end
 
-class URI::LDAP
-  def attributes(); end
+    def attributes=(val); end
 
-  def attributes=(val); end
+    def dn(); end
 
-  def dn(); end
+    def dn=(val); end
 
-  def dn=(val); end
+    def extensions(); end
 
-  def extensions(); end
+    def extensions=(val); end
 
-  def extensions=(val); end
+    def filter(); end
 
-  def filter(); end
+    def filter=(val); end
 
-  def filter=(val); end
+    def initialize(*arg); end
 
-  def initialize(*arg); end
+    def scope(); end
 
-  def scope(); end
+    def scope=(val); end
 
-  def scope=(val); end
+    def set_attributes(val); end
 
-  def set_attributes(val); end
+    def set_dn(val); end
 
-  def set_dn(val); end
+    def set_extensions(val); end
 
-  def set_extensions(val); end
+    def set_filter(val); end
 
-  def set_filter(val); end
+    def set_scope(val); end
+  # wrong constant name attributes
+  # wrong constant name attributes=
+  # wrong constant name dn
+  # wrong constant name dn=
+  # wrong constant name extensions
+  # wrong constant name extensions=
+  # wrong constant name filter
+  # wrong constant name filter=
+  # wrong constant name initialize
+  # wrong constant name scope
+  # wrong constant name scope=
+  # wrong constant name set_attributes
+  # wrong constant name set_dn
+  # wrong constant name set_extensions
+  # wrong constant name set_filter
+  # wrong constant name set_scope
+  end
 
-  def set_scope(val); end
-end
+  class MailTo
+    def initialize(*arg); end
+  # wrong constant name initialize
+  end
 
-class URI::MailTo
-  def initialize(*arg); end
-end
+  URI::Parser = URI::RFC2396_Parser
 
-URI::Parser = URI::RFC2396_Parser
+  URI::REGEXP = URI::RFC2396_REGEXP
 
-URI::REGEXP = URI::RFC2396_REGEXP
+  class RFC2396_Parser
+    def initialize(opts=T.unsafe(nil)); end
+  # wrong constant name initialize
+  end
 
-class URI::RFC2396_Parser
-  def initialize(opts=T.unsafe(nil)); end
-end
+  class RFC3986_Parser
+    def join(*uris); end
 
-class URI::RFC3986_Parser
-  def join(*uris); end
+    def parse(uri); end
 
-  def parse(uri); end
+    def regexp(); end
 
-  def regexp(); end
+    def split(uri); end
+    RFC3986_relative_ref = ::T.let(nil, ::T.untyped)
+  # wrong constant name join
+  # wrong constant name parse
+  # wrong constant name regexp
+  # wrong constant name split
+  end
 
-  def split(uri); end
-  RFC3986_relative_ref = ::T.let(nil, ::T.untyped)
-end
-
-module URI::Util
-  def self.make_components_hash(klass, array_hash); end
+  module Util
+    def self.make_components_hash(klass, array_hash); end
+  # wrong constant name make_components_hash
+  end
+  include RFC2396_REGEXP
 end
 
 module URI
-  extend ::URI::Escape
+  extend Escape
   def self.get_encoding(label); end
 end
 

--- a/gems/sorbet/test/hidden-method-finder/thorough/src/thorough.rb
+++ b/gems/sorbet/test/hidden-method-finder/thorough/src/thorough.rb
@@ -13,3 +13,17 @@ end
 
 class C3; end
 C3.const_set('X', 5)
+
+Object.const_set(
+  :Foo,
+  Module.new do |m_foo|
+    m_foo.const_set(
+      :Bar,
+      Module.new do |m_bar|
+        m_bar.const_set(:Baz, Module.new)
+        m_bar.private_constant(:Baz)
+        m_bar.include(m_bar.const_get(:Baz))
+      end
+    )
+  end
+)


### PR DESCRIPTION
After #3565 got merged, sorbet would error out on auto-generated hidden definitions that contained private constants. This happened since hidden definitions would always write out the fully-qualified name of constants instead of opening up modules/classes and using the shortest possible name for the lookup.
E.g. given the following code:

```ruby
Object.const_set(
  :Foo,
  Module.new do |m_foo|
    m_foo.const_set(
      :Bar,
      Module.new do |m_bar|
        m_bar.const_set(:Baz, Module.new)
        m_bar.private_constant(:Baz)
        m_bar.include(m_bar.const_get(:Baz))
      end
    )
  end
)
```

hidden definitions would generate the following code:

```ruby
module Foo; end
module Foo::Bar
  include ::Foo::Bar::Baz
end
module Foo::Bar::Baz; end
```

which in certain cases would error out on the `include` above.

this PR changes the output of hidden definitions to:

```ruby
module Foo
  module Bar
    module Baz; end

    include Baz
  end
end
```

for the example above.

### Test plan

See included automated tests.
