### PR TITLE
Forbid making final method public in child

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -142,8 +142,10 @@ module T::Private::Methods
         # method_to_key(ancestor.instance_method(method_name)) is not (just) an optimization, but also required for
         # correctness, since ancestor.method_defined?(method_name) may return true even if method_name is not defined
         # directly on ancestor but instead an ancestor of ancestor.
-        if (ancestor.method_defined?(method_name) || ancestor.private_method_defined?(method_name)) &&
-            final_method?(method_owner_and_name_to_key(ancestor, method_name))
+        if (ancestor.method_defined?(method_name) ||
+            ancestor.private_method_defined?(method_name) ||
+            ancestor.protected_method_defined?(method_name)) &&
+              final_method?(method_owner_and_name_to_key(ancestor, method_name))
           raise(
             "The method `#{method_name}` on #{ancestor} was declared as final and cannot be " +
             (target == ancestor ? "redefined" : "overridden in #{target}")

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -142,7 +142,8 @@ module T::Private::Methods
         # method_to_key(ancestor.instance_method(method_name)) is not (just) an optimization, but also required for
         # correctness, since ancestor.method_defined?(method_name) may return true even if method_name is not defined
         # directly on ancestor but instead an ancestor of ancestor.
-        if ancestor.method_defined?(method_name) && final_method?(method_owner_and_name_to_key(ancestor, method_name))
+        if (ancestor.method_defined?(method_name) || ancestor.private_method_defined?(method_name)) &&
+            final_method?(method_owner_and_name_to_key(ancestor, method_name))
           raise(
             "The method `#{method_name}` on #{ancestor} was declared as final and cannot be " +
             (target == ancestor ? "redefined" : "overridden in #{target}")

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -171,6 +171,9 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
 
       sig(:final) {void}
       def becomes_private; end
+
+      sig(:final) {void}
+      protected def protected_becomes_private; end
     end
     err = assert_raises(RuntimeError) do
       Class.new(c) do
@@ -184,6 +187,12 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
       end
     end
     assert_match(/^The method `becomes_private` on #<Class:0x[0-9a-f]+> was declared as final and cannot be overridden in #<Class:0x[0-9a-f]+>$/, err.message)
+    err = assert_raises(RuntimeError) do
+      Class.new(c) do
+        private :protected_becomes_private
+      end
+    end
+    assert_match(/^The method `protected_becomes_private` on #<Class:0x[0-9a-f]+> was declared as final and cannot be overridden in #<Class:0x[0-9a-f]+>$/, err.message)
   end
 
   it "forbids overriding a final method from an included module" do


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This would already raise:

```ruby
class Parent
  sig(:final) {void}
  def foo; end
end

class Child < Parent
  private :foo
end
```

(public in parent made private in child)

But if that were flipped around (private in parent, public in child),
for some reason that was allowed.

I don't think this should be asymmetrical. If something is final, it
should not be modifiable.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.