### PR TITLE
store TypePtr's tag in the lower 8 bits and payload in the upper 56

### DIFF
--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -75,10 +75,10 @@ private:
 
     // We use a 0 to indicate not inlined so that nullptr (which has counter value 0) is naturally viewed as
     // 'inlined'.
-    static constexpr tagged_storage NOT_INLINED_MASK = 0x100;
+    static constexpr tagged_storage NOT_INLINED_MASK = 0x0100;
     // We use a 8-bit tag mask so that tags can be efficiently extracted via
     // movzx on x86.
-    static constexpr tagged_storage TAG_MASK = 0xFF;
+    static constexpr tagged_storage TAG_MASK = 0x00FF;
 
     static constexpr tagged_storage PTR_MASK = ~(NOT_INLINED_MASK | TAG_MASK);
 

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -90,7 +90,9 @@ private:
     static tagged_storage tagValue(Tag tag, u4 inlinedValue) {
         auto val = tagToMask(tag);
 
-        // Store value into val.
+        // Store value into val.  It doesn't much matter where we put it in
+        // the upper 48 bits, but we put it in the uppermost 32 bits to
+        // ensure that retrieve it requires only a shift and no masking.
         val |= static_cast<tagged_storage>(inlinedValue) << 32;
 
         // Asserts that tag isn't using the bit which we use to indicate that value is _not_ inlined.

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -73,30 +73,27 @@ private:
     };
     tagged_storage store;
 
-    // Top bit indicates if value is inlined into pointer.
-    // We use a 0 in top bit to indicate not inlined so that nullptr (which has counter value 0) is naturally viewed as
+    // We use a 0 to indicate not inlined so that nullptr (which has counter value 0) is naturally viewed as
     // 'inlined'.
-    static constexpr tagged_storage NOT_INLINED_MASK = 0x8000000000000000;
-    static constexpr tagged_storage TAG_MASK = 0x7FFF000000000007;
+    static constexpr tagged_storage NOT_INLINED_MASK = 0x100;
+    // We use a 8-bit tag mask so that tags can be efficiently extracted via
+    // movzx on x86.
+    static constexpr tagged_storage TAG_MASK = 0xFF;
 
     static constexpr tagged_storage PTR_MASK = ~(NOT_INLINED_MASK | TAG_MASK);
 
     static tagged_storage tagToMask(Tag tag) {
-        auto val = static_cast<tagged_storage>(tag);
-        if (val >= 8) {
-            // Store the tag in the upper 16 bits of the pointer, as it won't fit in the lower three bits.
-            val <<= 48;
-        }
-        return val;
+        // Store the tag in the lower bits of the pointer, regardless of size.
+        return static_cast<tagged_storage>(tag);
     }
 
     static tagged_storage tagValue(Tag tag, u4 inlinedValue) {
         auto val = tagToMask(tag);
 
         // Store value into val.
-        val |= static_cast<tagged_storage>(inlinedValue) << 3;
+        val |= static_cast<tagged_storage>(inlinedValue) << 32;
 
-        // Asserts that tag isn't using top bit which we use to indicate that value is _not_ inlined.
+        // Asserts that tag isn't using the bit which we use to indicate that value is _not_ inlined.
         ENFORCE((val & NOT_INLINED_MASK) == 0);
 
         return val;
@@ -105,7 +102,7 @@ private:
     static tagged_storage tagPtr(Tag tag, void *expr) {
         auto val = tagToMask(tag);
 
-        auto maskedPtr = reinterpret_cast<tagged_storage>(expr) & PTR_MASK;
+        auto maskedPtr = reinterpret_cast<tagged_storage>(expr) << 16;
 
         return maskedPtr | val | NOT_INLINED_MASK;
     }
@@ -160,7 +157,7 @@ private:
 
     u4 inlinedValue() const {
         ENFORCE_NO_TIMER(!containsPtr());
-        auto val = (store & PTR_MASK) >> 3;
+        auto val = store >> 32;
         return static_cast<u4>(val);
     }
 
@@ -170,7 +167,7 @@ private:
             return reinterpret_cast<void *>(val);
         } else {
             // sign extension for the upper 16 bits
-            return reinterpret_cast<void *>((val << 16) >> 16);
+            return reinterpret_cast<void *>(val >> 16);
         }
     }
 
@@ -248,11 +245,7 @@ public:
         ENFORCE_NO_TIMER(store != 0);
 
         auto value = reinterpret_cast<tagged_storage>(store) & TAG_MASK;
-        if (value <= 7) {
-            return static_cast<Tag>(value);
-        } else {
-            return static_cast<Tag>(value >> 48);
-        }
+        return static_cast<Tag>(value);
     }
 
     bool operator!=(const TypePtr &other) const {


### PR DESCRIPTION
This change is just like #3694, but for `TypePtr` instead.  We have to do things slightly differently because we have the "not inlined" bit to deal with.  So we store the tag in the lower 8 bits, which is sufficient space and still permits easy extraction with `movzx`.

### Motivation

The fastest code is the code you don't execute.

### Test plan

Existing automated tests.