### PR TITLE
remove useless virtual declarations from {Self,Literal}Type.showValue

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -433,7 +433,7 @@ public:
     SelfType();
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
-    virtual std::string showValue(const GlobalState &gs) const final;
+    std::string showValue(const GlobalState &gs) const;
 
     TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const;
 
@@ -470,12 +470,12 @@ public:
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
-    virtual std::string showValue(const GlobalState &gs) const final;
+    std::string showValue(const GlobalState &gs) const;
 
     bool equals(const LiteralType &rhs) const;
     void _sanityCheck(const GlobalState &gs) const;
 };
-CheckSize(LiteralType, 24, 8);
+CheckSize(LiteralType, 16, 8);
 
 template <> inline TypePtr make_type<LiteralType, double &>(double &val) {
     return TypePtr(TypePtr::Tag::LiteralType, static_cast<u4>(LiteralType::LiteralTypeKind::Float),


### PR DESCRIPTION
`{Self,Literal}Type` declare `showValue` as virtual, but as they are both standalone classes with no inheritance, all the `virtual` declaration does is give the class a useless vtable.

### Motivation

Clearer code, slightly less space.

### Test plan

Existing tests should be sufficient.