### PR TITLE
Revert "always store TreePtr's tag in the lower 16 bits (#3694)"

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -78,7 +78,7 @@ public:
     }
 
 private:
-    static constexpr tagged_storage TAG_MASK = 0xffff;
+    static constexpr tagged_storage TAG_MASK = 0xffff000000000007;
 
     static constexpr tagged_storage PTR_MASK = ~TAG_MASK;
 
@@ -87,9 +87,13 @@ private:
     template <typename E, typename... Args> friend TreePtr make_tree(Args &&...);
 
     static tagged_storage tagPtr(Tag tag, void *expr) {
-        // Store the tag in the lower 16 bits of the pointer, regardless of size.
         auto val = static_cast<tagged_storage>(tag);
-        auto maskedPtr = reinterpret_cast<tagged_storage>(expr) << 16;
+        if (val >= 8) {
+            // Store the tag in the upper 16 bits of the pointer, as it won't fit in the lower three bits.
+            val <<= 48;
+        }
+
+        auto maskedPtr = reinterpret_cast<tagged_storage>(expr) & PTR_MASK;
 
         return maskedPtr | val;
     }
@@ -175,7 +179,11 @@ public:
         ENFORCE(ptr != 0);
 
         auto value = reinterpret_cast<tagged_storage>(ptr) & TAG_MASK;
-        return static_cast<Tag>(value);
+        if (value <= 7) {
+            return static_cast<Tag>(value);
+        } else {
+            return static_cast<Tag>(value >> 48);
+        }
     }
 
     Expression *get() const noexcept {
@@ -185,7 +193,7 @@ public:
             return reinterpret_cast<Expression *>(val);
         } else {
             // sign extension for the upper 16 bits
-            return reinterpret_cast<Expression *>(val >> 16);
+            return reinterpret_cast<Expression *>((val << 16) >> 16);
         }
     }
 


### PR DESCRIPTION
This reverts commit 4546cbb0022aaebf88de76278d6df3cedba71081.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fix sorbet.run

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.