### PR TITLE
Add Sorbet::Private::Static::VERSION

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -414,6 +414,10 @@ void GlobalState::initEmpty() {
     Symbols::root().dataAllowingNone(*this)->members()[core::Names::Constants::Top()] = Symbols::top();
     Symbols::root().dataAllowingNone(*this)->members()[core::Names::Constants::Bottom()] = Symbols::bottom();
 
+    // Sorbet::Private::Static::VERSION
+    id = enterStaticFieldSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), Names::Constants::VERSION());
+    id.data(*this)->resultType = make_type<LiteralType>(Symbols::String(), enterNameUTF8(sorbet_full_version_string));
+
     // Synthesize <Magic>.<build-hash>(*vs : T.untyped) => Hash
     SymbolRef method = enterMethodSymbol(Loc::none(), Symbols::MagicSingleton(), Names::buildHash());
     {

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -565,7 +565,7 @@ public:
 
     static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 200;
     static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 32;
-    static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 1;
+    static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 2;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 2;
     static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 99;
 };

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -451,6 +451,7 @@ NameDef names[] = {
     {"Singleton", "Singleton", true},
     {"AttachedClass", "<AttachedClass>", true},
     {"NonForcingConstants", "NonForcingConstants", true},
+    {"VERSION", "VERSION", true},
 };
 
 void emit_name_header(ostream &out, NameDef &name) {

--- a/test/testdata/resolver/sorbet_version.rb
+++ b/test/testdata/resolver/sorbet_version.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+# Version number is obviously brittle, so we show just enough here to know that
+# this constant is set to a string literal.
+
+T.reveal_type(Sorbet::Private::Static::VERSION) # error: Revealed type: `String("


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This constant only exists statically, so it is in the
`Sorbet::Private::Static` namespace. Any attempt to read from this variable
will raise a `NameError` at runtime.

This is useful for testing things like sorbet.run, where you want to
check what version we're on (e.g., did the WASM redownload or am I still
testing a cached version).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.