### PR TITLE
Always validate `override` if the parent method has a signature

### DIFF
--- a/test/testdata/resolver/overrides.rb
+++ b/test/testdata/resolver/overrides.rb
@@ -55,3 +55,29 @@ class B5 < A5
   sig { override.void }
   def foo; end
 end
+
+class A6
+  extend T::Sig
+  sig {void}
+  def foo; end
+end
+
+class B6 < A6
+  extend T::Sig
+  sig {override.params(x: String).void}
+  def foo(x); end
+# ^^^^^^^^^^ error: Override of method `A6#foo` must accept no more than `0` required argument(s)
+end
+
+class A7
+  extend T::Sig
+  sig {void}
+  def foo; end
+end
+
+class B7 < A7
+  extend T::Sig
+  sig {override.returns(String)}
+  def foo; 'foo' end
+# ^^^^^^^ error: Return type `String` does not match return type of overridden method `A7#foo`
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
When methods are declared as `override` and their parent method has a signature, always validate the override against that signature.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Partially addresses #2746; this only handles the case where the subclass method is marked `override`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
