### PR TITLE
Introduce ConstSymbolData for const references to Symbols.

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -534,7 +534,7 @@ string MethodDef::toStringWithTabs(const core::GlobalState &gs, int tabs) const 
         fmt::format_to(buf, "def ");
     }
     fmt::format_to(buf, "{}", name.data(gs)->toString(gs));
-    auto &data = this->symbol.dataAllowingNone(gs);
+    const auto data = this->symbol.dataAllowingNone(gs);
     if (name != data->name) {
         fmt::format_to(buf, "<{}>", data->name.data(gs)->toString(gs));
     }

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -47,7 +47,7 @@ LocalRef global2Local(CFGContext cctx, core::SymbolRef what) {
     // Note: this will add an empty local to aliases if 'what' is not there
     LocalRef &alias = cctx.aliases[what];
     if (!alias.exists()) {
-        const core::SymbolData data = what.data(cctx.ctx);
+        auto data = what.data(cctx.ctx);
         alias = cctx.newTemporary(data->name);
     }
     return alias;

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -841,7 +841,7 @@ constexpr decltype(GlobalState::STRINGS_PAGE_SIZE) GlobalState::STRINGS_PAGE_SIZ
 SymbolRef GlobalState::lookupMethodSymbolWithHash(SymbolRef owner, NameRef name, const vector<u4> &methodHash) const {
     ENFORCE(owner.exists(), "looking up symbol from non-existing owner");
     ENFORCE(name.exists(), "looking up symbol with non-existing name");
-    SymbolData ownerScope = owner.dataAllowingNone(*this);
+    auto ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_lookup_by_name", ownerScope->members().size());
 
     NameRef lookupName = name;
@@ -870,7 +870,7 @@ SymbolRef GlobalState::lookupMethodSymbolWithHash(SymbolRef owner, NameRef name,
 SymbolRef GlobalState::lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 flags) const {
     ENFORCE(owner.exists(), "looking up symbol from non-existing owner");
     ENFORCE(name.exists(), "looking up symbol with non-existing name");
-    SymbolData ownerScope = owner.dataAllowingNone(*this);
+    auto ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_lookup_by_name", ownerScope->members().size());
 
     NameRef lookupName = name;
@@ -898,7 +898,7 @@ SymbolRef GlobalState::findRenamedSymbol(SymbolRef owner, SymbolRef sym) const {
     ENFORCE(sym.exists(), "lookup up previous name of non-existing symbol");
     NameRef name = sym.data(*this)->name;
     NameData nameData = name.data(*this);
-    SymbolData ownerScope = owner.dataAllowingNone(*this);
+    auto ownerScope = owner.dataAllowingNone(*this);
 
     if (nameData->kind == NameKind::UNIQUE) {
         if (nameData->unique.uniqueNameKind != UniqueNameKind::MangleRename) {
@@ -913,9 +913,9 @@ SymbolRef GlobalState::findRenamedSymbol(SymbolRef owner, SymbolRef sym) const {
             if (!nm.exists()) {
                 return Symbols::noSymbol();
             }
-            auto res = ownerScope->members()[nm];
-            ENFORCE(res.exists());
-            return res;
+            auto res = ownerScope->members().find(nm);
+            ENFORCE(res != ownerScope->members().end());
+            return res->second;
         }
     } else {
         u4 unique = 1;
@@ -2028,7 +2028,7 @@ SymbolRef GlobalState::staticInitForClass(SymbolRef klass, Loc loc) {
 }
 
 SymbolRef GlobalState::lookupStaticInitForClass(SymbolRef klass) const {
-    auto &classData = klass.data(*this);
+    auto classData = klass.data(*this);
     ENFORCE(classData->isClassOrModule());
     auto ref = classData->lookupSingletonClass(*this).data(*this)->findMember(*this, core::Names::staticInit());
     ENFORCE(ref.exists(), "looking up non-existent <static-init> for {}", klass.toString(*this));

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -15,7 +15,7 @@ struct SymbolDataDebugCheck {
     void check() const;
 };
 
-/** This class is indended to be a safe way to pass `Symbol &` around.
+/** This class is intended to be a safe way to pass `Symbol &` around.
  *  Entering new symbols can invalidate `Symbol &`s and thus they are generally unsafe.
  *  This class ensures that all accesses are safe in debug builds and effectively is a `Symbol &` in optimized builds.
  */
@@ -23,11 +23,22 @@ class SymbolData : private DebugOnlyCheck<SymbolDataDebugCheck> {
     Symbol &symbol;
 
 public:
-    SymbolData(Symbol &ref, const GlobalState &gs);
+    SymbolData(Symbol &ref, GlobalState &gs);
+
     Symbol *operator->();
     const Symbol *operator->() const;
 };
 CheckSize(SymbolData, 8, 8);
+
+class ConstSymbolData : private DebugOnlyCheck<SymbolDataDebugCheck> {
+    const Symbol &symbol;
+
+public:
+    ConstSymbolData(const Symbol &ref, const GlobalState &gs);
+
+    const Symbol *operator->() const;
+};
+CheckSize(ConstSymbolData, 8, 8);
 
 class Symbol;
 
@@ -111,9 +122,9 @@ public:
     bool isSynthetic() const;
 
     SymbolData data(GlobalState &gs) const;
-    const SymbolData data(const GlobalState &gs) const;
+    ConstSymbolData data(const GlobalState &gs) const;
     SymbolData dataAllowingNone(GlobalState &gs) const;
-    const SymbolData dataAllowingNone(const GlobalState &gs) const;
+    ConstSymbolData dataAllowingNone(const GlobalState &gs) const;
 
     bool operator==(const SymbolRef &rhs) const;
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -180,28 +180,28 @@ SymbolData SymbolRef::dataAllowingNone(GlobalState &gs) const {
     }
 }
 
-const SymbolData SymbolRef::data(const GlobalState &gs) const {
+ConstSymbolData SymbolRef::data(const GlobalState &gs) const {
     ENFORCE_NO_TIMER(this->exists());
     return dataAllowingNone(gs);
 }
 
-const SymbolData SymbolRef::dataAllowingNone(const GlobalState &gs) const {
+ConstSymbolData SymbolRef::dataAllowingNone(const GlobalState &gs) const {
     switch (kind()) {
         case SymbolRef::Kind::ClassOrModule:
             ENFORCE_NO_TIMER(classOrModuleIndex() < gs.classAndModules.size());
-            return SymbolData(const_cast<Symbol &>(gs.classAndModules[classOrModuleIndex()]), gs);
+            return ConstSymbolData(gs.classAndModules[classOrModuleIndex()], gs);
         case SymbolRef::Kind::Method:
             ENFORCE_NO_TIMER(methodIndex() < gs.methods.size());
-            return SymbolData(const_cast<Symbol &>(gs.methods[methodIndex()]), gs);
+            return ConstSymbolData(gs.methods[methodIndex()], gs);
         case SymbolRef::Kind::Field:
             ENFORCE_NO_TIMER(fieldIndex() < gs.fields.size());
-            return SymbolData(const_cast<Symbol &>(gs.fields[fieldIndex()]), gs);
+            return ConstSymbolData(gs.fields[fieldIndex()], gs);
         case SymbolRef::Kind::TypeArgument:
             ENFORCE_NO_TIMER(typeArgumentIndex() < gs.typeArguments.size());
-            return SymbolData(const_cast<Symbol &>(gs.typeArguments[typeArgumentIndex()]), gs);
+            return ConstSymbolData(gs.typeArguments[typeArgumentIndex()], gs);
         case SymbolRef::Kind::TypeMember:
             ENFORCE_NO_TIMER(typeMemberIndex() < gs.typeMembers.size());
-            return SymbolData(const_cast<Symbol &>(gs.typeMembers[typeMemberIndex()]), gs);
+            return ConstSymbolData(gs.typeMembers[typeMemberIndex()], gs);
     }
 }
 
@@ -1400,7 +1400,9 @@ vector<std::pair<NameRef, SymbolRef>> Symbol::membersStableOrderSlow(const Globa
     return result;
 }
 
-SymbolData::SymbolData(Symbol &ref, const GlobalState &gs) : DebugOnlyCheck(gs), symbol(ref) {}
+SymbolData::SymbolData(Symbol &ref, GlobalState &gs) : DebugOnlyCheck(gs), symbol(ref) {}
+
+ConstSymbolData::ConstSymbolData(const Symbol &ref, const GlobalState &gs) : DebugOnlyCheck(gs), symbol(ref) {}
 
 SymbolDataDebugCheck::SymbolDataDebugCheck(const GlobalState &gs)
     : gs(gs), symbolCountAtCreation(gs.symbolsUsedTotal()) {}
@@ -1415,6 +1417,11 @@ Symbol *SymbolData::operator->() {
 };
 
 const Symbol *SymbolData::operator->() const {
+    runDebugOnlyCheck();
+    return &symbol;
+};
+
+const Symbol *ConstSymbolData::operator->() const {
     runDebugOnlyCheck();
     return &symbol;
 };

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -656,7 +656,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
     component.receiver = args.selfType;
     component.method = method;
 
-    const SymbolData data = method.data(gs);
+    auto data = method.data(gs);
     unique_ptr<TypeConstraint> &maybeConstraint = result.main.constr;
     TypeConstraint *constr;
     if (args.block || data->isGenericMethod()) {
@@ -1110,7 +1110,7 @@ TypePtr getMethodArguments(const GlobalState &gs, SymbolRef klass, NameRef name,
     if (!method.exists()) {
         return nullptr;
     }
-    const SymbolData data = method.data(gs);
+    auto data = method.data(gs);
 
     vector<TypePtr> args;
     args.reserve(data->arguments().size());

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -15,7 +15,7 @@ ast::TreePtr DefLocSaver::postTransformMethodDef(core::Context ctx, ast::TreePtr
 
     if (lspQueryMatch) {
         // Query matches against the method definition as a whole.
-        auto &symbolData = methodDef.symbol.data(ctx);
+        auto symbolData = methodDef.symbol.data(ctx);
         auto &argTypes = symbolData->arguments();
         core::TypeAndOrigins tp;
 

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -85,7 +85,7 @@ string prettySigForMethod(const core::GlobalState &gs, core::SymbolRef method, c
     vector<string> typeAndArgNames;
 
     vector<string> flags;
-    const core::SymbolData &sym = method.data(gs);
+    auto sym = method.data(gs);
     string sigCall = "sig";
     if (sym->isMethod()) {
         if (sym->isFinalMethod()) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1406,6 +1406,7 @@ public:
 
         auto sym = id->symbol;
         auto data = sym.data(ctx);
+
         if (data->isTypeAlias() || data->isTypeMember()) {
             ENFORCE(!data->isTypeMember() || send->recv.isSelfReference());
 
@@ -1418,7 +1419,8 @@ public:
             // >   Boolean = T.let(nil, T.untyped)
             // > end
             if (data->isTypeAlias() && send->fun == core::Names::let()) {
-                data->resultType = core::Types::untypedUntracked();
+                // TODO(jvilk): Fix this.
+                const_cast<core::TypePtr &>(data->resultType) = core::Types::untypedUntracked();
                 return tree;
             }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1419,7 +1419,7 @@ public:
             // >   Boolean = T.let(nil, T.untyped)
             // > end
             if (data->isTypeAlias() && send->fun == core::Names::let()) {
-                // TODO(jvilk): Fix this.
+                // TODO(jvilk): This mutates the symbol table from an immutable context due to a const bug in Symbols.cc. DO NOT COPY THIS
                 const_cast<core::TypePtr &>(data->resultType) = core::Types::untypedUntracked();
                 return tree;
             }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1419,7 +1419,8 @@ public:
             // >   Boolean = T.let(nil, T.untyped)
             // > end
             if (data->isTypeAlias() && send->fun == core::Names::let()) {
-                // TODO(jvilk): This mutates the symbol table from an immutable context due to a const bug in Symbols.cc. DO NOT COPY THIS
+                // TODO(jvilk): This mutates the symbol table from an immutable context due to a const bug in
+                // Symbols.cc. DO NOT COPY THIS
                 const_cast<core::TypePtr &>(data->resultType) = core::Types::untypedUntracked();
                 return tree;
             }


### PR DESCRIPTION
Introduce ConstSymbolData for const references to Symbols.

`const SymbolData` is trivially convertable to a `SymbolData`, which permits mutations to `Symbol`s even with a `const GlobalState&`!

This change locks that down so that this escape hatch is not viable. Instead of relying on `const SymbolData` to protect the symbol against mutation, introduce a new class called `ConstSymbolData`.

It includes an explicit `const_cast` to permit code that relied on this behavior until it can be fully fixed.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Prevent code from mutating symbol table with a `const GlobalState`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Compiles and tests pass.
