### PR TITLE
Use alias method visibility for private methods

### DIFF
--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -501,6 +501,7 @@ public:
     SymbolRef findMember(const GlobalState &gs, NameRef name) const;
     SymbolRef findMemberNoDealias(const GlobalState &gs, NameRef name) const;
     SymbolRef findMemberTransitive(const GlobalState &gs, NameRef name) const;
+    SymbolRef findMemberTransitiveNoDealias(const GlobalState &gs, NameRef name) const;
     SymbolRef findConcreteMethodTransitive(const GlobalState &gs, NameRef name) const;
 
     /* transitively finds a member with the most similar name */
@@ -661,7 +662,7 @@ private:
     InlinedVector<SymbolRef, 4> typeParams;
     InlinedVector<Loc, 2> locs_;
 
-    SymbolRef findMemberTransitiveInternal(const GlobalState &gs, NameRef name, u4 mask, u4 flags,
+    SymbolRef findMemberTransitiveInternal(const GlobalState &gs, NameRef name, u4 mask, u4 flags, bool dealias,
                                            int maxDepth = 100) const;
 
     inline void unsetClassOrModuleLinearizationComputed() {

--- a/core/Types.h
+++ b/core/Types.h
@@ -812,6 +812,8 @@ struct DispatchArgs {
 struct DispatchComponent {
     TypePtr receiver;
     SymbolRef method;
+    // The method whose Symbol should be used for computing visibility-related behaviors
+    SymbolRef visibilityMethod;
     std::vector<std::unique_ptr<Error>> errors;
     TypePtr sendTp;
     TypePtr blockReturnType;
@@ -829,9 +831,15 @@ struct DispatchResult {
 
     DispatchResult() = default;
     DispatchResult(TypePtr returnType, TypePtr receiverType, core::SymbolRef method)
-        : returnType(returnType),
-          main(DispatchComponent{
-              std::move(receiverType), method, {}, std::move(returnType), nullptr, nullptr, ArgInfo{}, nullptr}){};
+        : returnType(returnType), main(DispatchComponent{std::move(receiverType),
+                                                         method,
+                                                         method,
+                                                         {},
+                                                         std::move(returnType),
+                                                         nullptr,
+                                                         nullptr,
+                                                         ArgInfo{},
+                                                         nullptr}){};
     DispatchResult(TypePtr returnType, DispatchComponent comp)
         : returnType(std::move(returnType)), main(std::move(comp)){};
     DispatchResult(TypePtr returnType, DispatchComponent comp, std::unique_ptr<DispatchResult> secondary,

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -117,7 +117,7 @@ DispatchResult ShapeType::dispatchCall(const GlobalState &gs, const DispatchArgs
     categoryCounterInc("dispatch_call", "shapetype");
     auto method = Symbols::Shape().data(gs)->findMember(gs, args.name);
     if (method.exists() && method.data(gs)->intrinsic != nullptr) {
-        DispatchComponent comp{args.selfType, method, {}, nullptr, nullptr, nullptr, ArgInfo{}, nullptr};
+        DispatchComponent comp{args.selfType, method, method, {}, nullptr, nullptr, nullptr, ArgInfo{}, nullptr};
         DispatchResult res{nullptr, std::move(comp)};
         method.data(gs)->intrinsic->apply(gs, args, res);
         if (res.returnType != nullptr) {
@@ -131,7 +131,7 @@ DispatchResult TupleType::dispatchCall(const GlobalState &gs, const DispatchArgs
     categoryCounterInc("dispatch_call", "tupletype");
     auto method = Symbols::Tuple().data(gs)->findMember(gs, args.name);
     if (method.exists() && method.data(gs)->intrinsic != nullptr) {
-        DispatchComponent comp{args.selfType, method, {}, nullptr, nullptr, nullptr, ArgInfo{}, nullptr};
+        DispatchComponent comp{args.selfType, method, method, {}, nullptr, nullptr, nullptr, ArgInfo{}, nullptr};
         DispatchResult res{nullptr, std::move(comp)};
         method.data(gs)->intrinsic->apply(gs, args, res);
         if (res.returnType != nullptr) {
@@ -516,9 +516,9 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
         return DispatchResult(Types::untypedUntracked(), std::move(args.selfType), Symbols::noSymbol());
     }
 
-    SymbolRef mayBeOverloaded = symbol.data(gs)->findMemberTransitive(gs, args.name);
+    auto visibilityMethod = symbol.data(gs)->findMemberTransitiveNoDealias(gs, args.name);
 
-    if (!mayBeOverloaded.exists()) {
+    if (!visibilityMethod.exists()) {
         if (args.name == Names::initialize()) {
             // Special-case initialize(). We should define this on
             // `BasicObject`, but our method-resolution order is wrong, and
@@ -646,15 +646,18 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
         return result;
     }
 
-    SymbolRef method = mayBeOverloaded.data(gs)->isOverloaded()
-                           ? guessOverload(gs, symbol, mayBeOverloaded, args.numPosArgs, args.args, args.fullType,
-                                           targs, args.block != nullptr)
-                           : mayBeOverloaded;
+    auto mayBeOverloaded = visibilityMethod.data(gs)->dealias(gs);
+
+    auto method = mayBeOverloaded.data(gs)->isOverloaded()
+                      ? guessOverload(gs, symbol, mayBeOverloaded, args.numPosArgs, args.args, args.fullType, targs,
+                                      args.block != nullptr)
+                      : mayBeOverloaded;
 
     DispatchResult result;
     auto &component = result.main;
     component.receiver = args.selfType;
     component.method = method;
+    component.visibilityMethod = visibilityMethod;
 
     const SymbolData data = method.data(gs);
     unique_ptr<TypeConstraint> &maybeConstraint = result.main.constr;
@@ -1353,17 +1356,21 @@ public:
             dispatched.main.errors.emplace_back(std::move(err));
         }
         res.main.errors.clear();
+
         res.returnType = instanceTy;
-        res.main = move(dispatched.main);
-        if (!res.main.method.exists()) {
+
+        dispatched.main.visibilityMethod = res.main.visibilityMethod;
+        if (!dispatched.main.method.exists()) {
             // If we actually dispatched to some `initialize` method, use that method as the result,
             // because it will be more interesting to people downstream who want to look at the
             // result.
             //
             // But if this class hasn't defined a custom `initialize` method, still record that we
-            // dispatched to *something*, namely `Class#new`.
-            res.main.method = core::Symbols::Class_new();
+            // dispatched to *something*, namely whatever it started with.
+            dispatched.main.method = res.main.method;
         }
+        res.main = move(dispatched.main);
+
         res.main.sendTp = instanceTy;
     }
 } Class_new;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -977,11 +977,17 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     //  - When a method doesn't exist.
                     //
                     // In all of these cases, we bail out and skip the non-private checking.
-                    if (it->main.method.exists() && it->main.method.data(ctx)->isMethodPrivate() &&
+                    if (it->main.visibilityMethod.exists() && it->main.visibilityMethod.data(ctx)->isMethodPrivate() &&
                         !send->isPrivateOk) {
+                        ENFORCE(it->main.method.exists());
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::PrivateMethod)) {
-                            e.setHeader("Non-private call to private method `{}`", it->main.method.show(ctx));
-                            e.addErrorLine(it->main.method.data(ctx)->loc(), "Defined as");
+                            e.setHeader("Non-private call to private method `{}`", it->main.visibilityMethod.show(ctx));
+                            e.addErrorLine(it->main.method.data(ctx)->loc(), "Defined in `{}` here",
+                                           it->main.method.data(ctx)->owner.data(ctx)->show(ctx));
+                            if (it->main.method != it->main.visibilityMethod) {
+                                e.addErrorLine(it->main.visibilityMethod.data(ctx)->loc(), "Made private in `{}` here",
+                                               it->main.visibilityMethod.data(ctx)->owner.data(ctx)->show(ctx));
+                            }
                         }
                     }
 

--- a/test/testdata/infer/private_alias_method.rb
+++ b/test/testdata/infer/private_alias_method.rb
@@ -1,0 +1,10 @@
+# typed: true
+
+class A < T::Struct
+  const :foo, Integer
+  alias_method :foo_DEPRECATED_BUT_PUBLIC, :foo
+  private :foo
+end
+
+A.new(foo: 0).foo_DEPRECATED_BUT_PUBLIC # error: Non-private call to private method `foo_DEPRECATED_BUT_PUBLIC`
+A.new(foo: 0).foo # error: Non-private call to private method `A#foo`

--- a/test/testdata/infer/private_alias_method.rb
+++ b/test/testdata/infer/private_alias_method.rb
@@ -6,5 +6,5 @@ class A < T::Struct
   private :foo
 end
 
-A.new(foo: 0).foo_DEPRECATED_BUT_PUBLIC # error: Non-private call to private method `foo_DEPRECATED_BUT_PUBLIC`
+A.new(foo: 0).foo_DEPRECATED_BUT_PUBLIC
 A.new(foo: 0).foo # error: Non-private call to private method `A#foo`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

If an `alias_method` maps to a private method but the method entry for the
alias method itself is public, it's ok to call the method.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.