### PR TITLE
Fix some locs on T::Struct

### DIFF
--- a/test/testdata/rewriter/t_struct/positional.rb
+++ b/test/testdata/rewriter/t_struct/positional.rb
@@ -1,0 +1,10 @@
+# typed: true
+
+class A < T::Struct
+
+  # If you're seeing this in an error message, it means you printed loc instead
+  # of declLoc somewhere.
+
+end
+
+A.new(0) # error: Too many arguments


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There was a point during my work on #3666 where I was using the loc of `new` on a T::Struct to enter a positional arg into the Symbol table (🙈 it doesn't work that way anymore don't worry). But a side effect of that was that it made me realize that we had bad locs for this.

Pulling this out to land it anyways.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The test doesn't actually catch a regression, but I didn't feel like writing a
CLI test just for this. Here's a screenshot of the behavior on the provided
test case before and after:

**Before**

<img width="1027" alt="Screen Shot 2020-11-20 at 10 40 49 PM" src="https://user-images.githubusercontent.com/5544532/99869664-a5f4ee00-2b81-11eb-89f2-ee5eea211004.png">

**After**

<img width="1023" alt="Screen Shot 2020-11-20 at 10 41 02 PM" src="https://user-images.githubusercontent.com/5544532/99869663-a4c3c100-2b81-11eb-9492-8891607e0f52.png">
