### PR TITLE
Show specific components in the private dispatch error

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -983,12 +983,11 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::PrivateMethod)) {
                             if (multipleComponents) {
                                 e.setHeader("Non-private call to private method `{}` on `{}` component of `{}`",
-                                            it->main.method.data(ctx)->name.data(ctx)->show(ctx),
-                                            it->main.receiver.show(ctx), recvType.type.show(ctx));
+                                            it->main.method.data(ctx)->name.show(ctx), it->main.receiver.show(ctx),
+                                            recvType.type.show(ctx));
                             } else {
                                 e.setHeader("Non-private call to private method `{}` on `{}`",
-                                            it->main.method.data(ctx)->name.data(ctx)->show(ctx),
-                                            it->main.receiver.show(ctx));
+                                            it->main.method.data(ctx)->name.show(ctx), it->main.receiver.show(ctx));
                             }
                             e.addErrorLine(it->main.method.data(ctx)->loc(), "Defined in `{}` here",
                                            it->main.method.data(ctx)->owner.data(ctx)->show(ctx));

--- a/test/testdata/infer/private_class_methods.rb
+++ b/test/testdata/infer/private_class_methods.rb
@@ -34,15 +34,15 @@ class Test
   extend ClassMethods
 end
 
-Object.bar # error: Non-private call to private method `Object.bar`
+Object.bar # error: Non-private call to private method `bar` on `T.class_of(Object)`
 
 Test.method_a
-Test.method_b # error: Non-private call to private method `Test.method_b`
-Test.method_c # error: Non-private call to private method `Test.method_c`
-Test.method_d # error: Non-private call to private method `Test.method_d`
-Test.method_e # error: Non-private call to private method `Test.method_e`
-Test.method_g # error: Non-private call to private method `Test::ClassMethods#method_g`
-Test.method_h # error: Non-private call to private method `Test::ClassMethods#method_h`
+Test.method_b # error: Non-private call to private method `method_b` on `T.class_of(Test)`
+Test.method_c # error: Non-private call to private method `method_c` on `T.class_of(Test)`
+Test.method_d # error: Non-private call to private method `method_d` on `T.class_of(Test)`
+Test.method_e # error: Non-private call to private method `method_e` on `T.class_of(Test)`
+Test.method_g # error: Non-private call to private method `method_g` on `T.class_of(Test)`
+Test.method_h # error: Non-private call to private method `method_h` on `T.class_of(Test)`
 
 # TODO: The following methods should contain errors. Sorbet currently does not support setting method
 # visibility using the private/protected keywords that affect the visibility of subsequent methods.

--- a/test/testdata/infer/private_methods.rb
+++ b/test/testdata/infer/private_methods.rb
@@ -26,7 +26,7 @@ class Test
     using_symbol
     self.using_symbol
     assigned_self = self
-    assigned_self.using_symbol # error: Non-private call to private method `Test#using_symbol`
+    assigned_self.using_symbol # error: Non-private call to private method `using_symbol` on `Test`
   end
 
   private
@@ -40,21 +40,21 @@ class TestChild < Test
     using_symbol
     self.using_symbol
     assigned_self = self
-    assigned_self.using_symbol # error: Non-private call to private method `Test#using_symbol`
+    assigned_self.using_symbol # error: Non-private call to private method `using_symbol` on `TestChild`
   end
 end
 
-Object.new.foo # error: Non-private call to private method `Object#foo`
+Object.new.foo # error: Non-private call to private method `foo` on `Object`
 
-Test.new.using_symbol # error: Non-private call to private method `Test#using_symbol`
-Test.new.using_symbol_returned_by_def # error: Non-private call to private method `Test#using_symbol_returned_by_def`
+Test.new.using_symbol # error: Non-private call to private method `using_symbol` on `Test`
+Test.new.using_symbol_returned_by_def # error: Non-private call to private method `using_symbol_returned_by_def` on `Test`
 Test.new.calling_private
-Test.new.using_symbol { 123 } # error: Non-private call to private method `Test#using_symbol`
-Test.new.block_call # error: Non-private call to private method `Test#block_call`
-Test.new.block_call { 123 } # error: Non-private call to private method `Test#block_call`
-Test.new.block_call(&:foo) # error: Non-private call to private method `Test#block_call`
+Test.new.using_symbol { 123 } # error: Non-private call to private method `using_symbol` on `Test`
+Test.new.block_call # error: Non-private call to private method `block_call` on `Test`
+Test.new.block_call { 123 } # error: Non-private call to private method `block_call` on `Test`
+Test.new.block_call(&:foo) # error: Non-private call to private method `block_call` on `Test`
 
-TestChild.new.using_symbol # error: Non-private call to private method `Test#using_symbol`
+TestChild.new.using_symbol # error: Non-private call to private method `using_symbol` on `TestChild`
 
 T.unsafe(Test.new).using_symbol
 

--- a/test/testdata/infer/private_methods_any_all.rb
+++ b/test/testdata/infer/private_methods_any_all.rb
@@ -15,12 +15,12 @@ end
 
 sig {params(left_or_right: T.any(Left, Right)).void}
 def test_left_or_right(left_or_right)
-  left_or_right.foo # error: Non-private call to private method `Left#foo`
+  left_or_right.foo # error: Non-private call to private method `foo` on `Left` component of `T.any(Left, Right)`
 end
 
 sig {params(right_or_left: T.any(Right, Left)).void}
 def test_right_or_left(right_or_left)
-  right_or_left.foo # error: Non-private call to private method `Left#foo`
+  right_or_left.foo # error: Non-private call to private method `foo` on `Left` component of `T.any(Right, Left)`
 end
 
 module PrivateBar
@@ -37,11 +37,11 @@ end
 
 sig {params(bar_and_qux: T.all(PrivateBar, PublicQux)).void}
 def test_bar_and_qux(bar_and_qux)
-  bar_and_qux.bar # error: Non-private call to private method `PrivateBar#bar`
+  bar_and_qux.bar # error: Non-private call to private method `bar` on `T.all(PrivateBar, PublicQux)`
 end
 
 sig {params(qux_and_bar: T.all(PublicQux, PrivateBar)).void}
 def test_qux_and_bar(qux_and_bar)
-  qux_and_bar.bar # error: Non-private call to private method `PrivateBar#bar`
+  qux_and_bar.bar # error: Non-private call to private method `bar` on `T.all(PublicQux, PrivateBar)`
 end
 

--- a/test/testdata/resolver/sig_generated.rb
+++ b/test/testdata/resolver/sig_generated.rb
@@ -4,6 +4,6 @@ extend T::Sig
 
 sig {returns(NilClass).generated}
 #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Malformed signature: `generated` is invalid in this context
-#    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Non-private call to private method `Object#generated`
+#    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Non-private call to private method `generated` on `T::Private::Methods::DeclBuilder`
 def generated
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I noticed when testing #3666 on pay-server that the private method
errors are confusing when you have a `T.any` of three things, and the
method is `private` in one of those methods but not the other two.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.