### PR TITLE
Overloads should copy the visibility of the method they overload

### DIFF
--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -32,6 +32,12 @@ public:
 
 enum class Variance { CoVariant = 1, ContraVariant = -1, Invariant = 0 };
 
+enum class Visibility : u1 {
+    Public = 1,
+    Protected,
+    Private,
+};
+
 class Symbol final {
 public:
     Symbol(const Symbol &) = delete;
@@ -271,6 +277,18 @@ public:
         return (flags & Symbol::Flags::METHOD_PRIVATE) != 0;
     }
 
+    Visibility methodVisibility() const {
+        if (this->isMethodPublic()) {
+            return Visibility::Public;
+        } else if (this->isMethodProtected()) {
+            return Visibility::Protected;
+        } else if (this->isMethodPrivate()) {
+            return Visibility::Private;
+        } else {
+            Exception::raise("Expected method to have visibility");
+        }
+    }
+
     inline bool isClassOrModuleModule() const {
         ENFORCE_NO_TIMER(isClassOrModule());
         if (flags & Symbol::Flags::CLASS_OR_MODULE_MODULE)
@@ -442,6 +460,21 @@ public:
     inline void setMethodPrivate() {
         ENFORCE(isMethod());
         flags |= Symbol::Flags::METHOD_PRIVATE;
+    }
+
+    void setMethodVisibility(Visibility visibility) {
+        ENFORCE(isMethod());
+        switch (visibility) {
+            case Visibility::Public:
+                this->setMethodPublic();
+                break;
+            case Visibility::Protected:
+                this->setMethodProtected();
+                break;
+            case Visibility::Private:
+                this->setMethodPrivate();
+                break;
+        }
     }
 
     inline void setClassOrModuleAbstract() {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1858,6 +1858,7 @@ private:
                             }
                             overloadSym = ctx.state.enterNewMethodOverload(core::Loc(ctx.file, lastSigs[i]->loc),
                                                                            mdef.symbol, originalName, i, argsToKeep);
+                            overloadSym.data(ctx)->setMethodVisibility(mdef.symbol.data(ctx)->methodVisibility());
                             if (i != lastSigs.size() - 1) {
                                 overloadSym.data(ctx)->setOverloaded();
                             }

--- a/test/testdata/infer/overloads_test.rb
+++ b/test/testdata/infer/overloads_test.rb
@@ -88,3 +88,17 @@ class Foo
     T.assert_type!(g.overloaded(4), Integer)
   end
 end
+
+class PrivateOverloads
+  extend T::Sig
+
+  sig {returns(NilClass)}
+  sig {params(x: Integer).returns(Integer)}
+  private def foo(x=nil); end
+end
+
+po1 = PrivateOverloads.new.foo
+T.reveal_type(po1) # error: Revealed type: `NilClass`
+
+po2 = PrivateOverloads.new.foo(0)
+T.reveal_type(po2) # error: Revealed type: `Integer`

--- a/test/testdata/infer/overloads_test.rb
+++ b/test/testdata/infer/overloads_test.rb
@@ -97,8 +97,8 @@ class PrivateOverloads
   private def foo(x=nil); end
 end
 
-po1 = PrivateOverloads.new.foo
+po1 = PrivateOverloads.new.foo # error: Non-private call to private method
 T.reveal_type(po1) # error: Revealed type: `NilClass`
 
-po2 = PrivateOverloads.new.foo(0)
+po2 = PrivateOverloads.new.foo(0) # error: Non-private call to private method
 T.reveal_type(po2) # error: Revealed type: `Integer`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I don't actually think this affects any real world, because I'm not sure that
we set private in any RBIs right now, and you can't write overloads in normal
files.

Pulling this out of #3666 to make for a smaller diff.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.