### PR TITLE
Introduce alternative naming for `--error-{white,black}-list` options

### DIFF
--- a/docs/suggest-sig.md
+++ b/docs/suggest-sig.md
@@ -140,7 +140,7 @@ To opt all files into this strictness level and insert as many sigs as Sorbet
 can guess, run this:
 
 ```
-srb tc --typed=strict --error-white-list=7017 --autocorrect
+srb tc --typed=strict --isolate-error-code=7017 --autocorrect
 ```
 
 This
@@ -163,4 +163,3 @@ Some tips:
 
 - Run your test suite. This is one area where having `sig`s checked at runtime
   helps: if Sorbet's guess was wrong, it's likely that the tests will catch it.
-

--- a/test/cli/error-blacklist/error-blacklist.sh
+++ b/test/cli/error-blacklist/error-blacklist.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 main/sorbet --silence-dev-message test/cli/error-blacklist/error-blacklist.rb 2>&1
 main/sorbet --silence-dev-message test/cli/error-blacklist/error-blacklist.rb --error-black-list=7002 2>&1
+main/sorbet --silence-dev-message test/cli/error-blacklist/error-blacklist.rb --suppress-error-code=7002 2>&1

--- a/test/cli/error-whitelist/error-whitelist.sh
+++ b/test/cli/error-whitelist/error-whitelist.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
 main/sorbet --silence-dev-message test/cli/error-whitelist/error-whitelist.rb --error-white-list=7017 2>&1
+main/sorbet --silence-dev-message test/cli/error-whitelist/error-whitelist.rb --isolate-error-code=7017 2>&1

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -209,10 +209,19 @@ Usage:
                                 Error code to whitelist into reporting.
                                 Errors not mentioned will be silenced. This option
                                 can be passed multiple times.
+      --isolate-error-code errorCode
+                                Error code to report. Errors not mentioned will
+                                be silenced. This option can be passed multiple
+                                times. An alternative to --error-white-list.
       --error-black-list errorCode
                                 Error code to blacklist from reporting.
                                 Errors mentioned will be silenced. This option can
                                 be passed multiple times.
+      --suppress-error-code errorCode
+                                Error code to not report. Errors not mentioned
+                                will be silenced. This option can be passed
+                                multiple times. An alternative to
+                                --error-black-list.
       --typed {false,true,strict,strong,[auto]}
                                 Force all code to specified strictness level
                                 (default: auto)

--- a/test/cli/suggest-typed-true/suggest-typed-true.sh
+++ b/test/cli/suggest-typed-true/suggest-typed-true.sh
@@ -10,79 +10,79 @@ separator() {
 cp "$cwd"/test/cli/suggest-typed-true/*.rb "$tmp/"
 
 
-"$cwd/main/sorbet" --silence-dev-message --suggest-typed --typed=false --error-white-list=7022 does-not-exist.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message --suggest-typed --typed=false --isolate-error-code=7022 does-not-exist.rb 2>&1
 separator
 
-"$cwd/main/sorbet" --silence-dev-message --suggest-typed --typed=true --error-white-list=7022 does-not-exist.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message --suggest-typed --typed=true --isolate-error-code=7022 does-not-exist.rb 2>&1
 separator
 
-"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --error-white-list=7022 --typed=strict does-not-exist.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --isolate-error-code=7022 --typed=strict does-not-exist.rb 2>&1
 separator
 
-"$cwd/main/sorbet" --silence-dev-message --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-true.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-true.rb 2>&1
 separator
 
 # Avoid error when repeating options
-"$cwd/main/sorbet" --silence-dev-message --suggest-typed --error-white-list=7022 --typed=strict --error-white-list=7022 suggest-typed-true.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message --suggest-typed --isolate-error-code=7022 --typed=strict --isolate-error-code=7022 suggest-typed-true.rb 2>&1
 separator
 
-"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-ignore.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-ignore.rb 2>&1
 cat suggest-typed-ignore.rb
-"$cwd/main/sorbet" --silence-dev-message --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-ignore.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-ignore.rb 2>&1
 separator
 
-"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-false.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-false.rb 2>&1
 cat suggest-typed-false.rb
-"$cwd/main/sorbet" --silence-dev-message --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-false.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-false.rb 2>&1
 separator
 
-"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-true.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-true.rb 2>&1
 cat suggest-typed-true.rb
-"$cwd/main/sorbet" --silence-dev-message --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-true.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-true.rb 2>&1
 separator
 
-"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-strict.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-strict.rb 2>&1
 cat suggest-typed-strict.rb
-"$cwd/main/sorbet" --silence-dev-message --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-strict.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-strict.rb 2>&1
 separator
 
-"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-strong.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-strong.rb 2>&1
 cat suggest-typed-strong.rb
-"$cwd/main/sorbet" --silence-dev-message --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-strong.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-strong.rb 2>&1
 separator
 
-"$cwd/main/sorbet" --silence-dev-message --suggest-typed --error-white-list=7022 --typed=strict empty.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message --suggest-typed --isolate-error-code=7022 --typed=strict empty.rb 2>&1
 separator
 
-"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-with-too-low.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-with-too-low.rb 2>&1
 cat suggest-typed-with-too-low.rb
 separator
 
-"$cwd/main/sorbet" --silence-dev-message --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-with-too-low.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-with-too-low.rb 2>&1
 separator
 
-"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-already-ignore.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-already-ignore.rb 2>&1
 cat suggest-typed-already-ignore.rb
 separator
 
-"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-already-autogenerated.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-already-autogenerated.rb 2>&1
 cat suggest-typed-already-autogenerated.rb
 separator
 
-"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-shabang.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-shabang.rb 2>&1
 cat suggest-typed-shabang.rb
-"$cwd/main/sorbet" --silence-dev-message --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-shabang.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-shabang.rb 2>&1
 separator
 
-"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-behaviour-over-multiple-1.rb suggest-typed-behaviour-over-multiple-2.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-behaviour-over-multiple-1.rb suggest-typed-behaviour-over-multiple-2.rb 2>&1
 cat suggest-typed-behaviour-over-multiple-1.rb
 cat suggest-typed-behaviour-over-multiple-2.rb
-"$cwd/main/sorbet" --silence-dev-message --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-behaviour-over-multiple-1.rb suggest-typed-behaviour-over-multiple-2.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-behaviour-over-multiple-1.rb suggest-typed-behaviour-over-multiple-2.rb 2>&1
 separator
 
-"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-and-type.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message -a --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-and-type.rb 2>&1
 cat suggest-typed-and-type.rb
-"$cwd/main/sorbet" --silence-dev-message --suggest-typed --error-white-list=7022 --typed=strict suggest-typed-and-type.rb 2>&1
+"$cwd/main/sorbet" --silence-dev-message --suggest-typed --isolate-error-code=7022 --typed=strict suggest-typed-and-type.rb 2>&1
 separator
 
 rm -r "$tmp"


### PR DESCRIPTION
# Motivation

- This makes the naming of these options more inclusive, while not being a breaking change by removing the other ones entirely.

- I was going to go for `error-{allow,block}-list`, but I asked in the Sorbet Slack and `isolate-error-code` and `suppress-error-code` were suggested as better names that have easier to understand intent (they work for a single error code, but can be passed multiple times).

- This keeps the old names around so this doesn't have to be a breaking change, but switches docs and tests to use the new names.

### Test plan

See included automated tests. I also built Sorbet with these changes locally and tested the exclusivity of both sets of options with each other.

### Other

Relevant Sorbet Slack conversation (for however long the history lasts): https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1605983741147100. I'll mark this as not-draft when the tests pass - unfortunately, I couldn't figure out how to run them running locally.
