### PR TITLE
Fix signature for `IO.open`.

### DIFF
--- a/rbi/core/io.rbi
+++ b/rbi/core/io.rbi
@@ -980,7 +980,7 @@ class IO < Object
       fd: T.any(String, Integer),
       mode: T.any(Integer, String),
       opt: T.nilable(T::Hash[Symbol, T.untyped]),
-      blk: T.proc.params(io: IO).returns(T.type_parameter(:U))
+      blk: T.proc.params(io: T.attached_class).returns(T.type_parameter(:U))
     ).returns(T.type_parameter(:U))
   end
   def self.open(fd, mode='r', opt=nil, &blk); end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The following does not currently type-check:

```ruby
UNIXSocket.open('/var/my.sock', &:recv_io)
```

See:

https://sorbet.run/#%23%20typed%3A%20strict%0A%0AUNIXSocket.open('%2Fvar%2Fmy.sock'%2C%20%26%3Arecv_io)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a