### PR TITLE
redo tagging scheme for {Tree,Type}Ptr

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -180,13 +180,7 @@ public:
 
     Expression *get() const noexcept {
         auto val = ptr & PTR_MASK;
-
-        if constexpr (sizeof(void *) == 4) {
-            return reinterpret_cast<Expression *>(val);
-        } else {
-            // sign extension for the upper 16 bits
-            return reinterpret_cast<Expression *>(val >> 16);
-        }
+        return reinterpret_cast<Expression *>(val >> 16);
     }
 
     // Fetch the tagged pointer. This is needed for:

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -78,7 +78,7 @@ public:
     }
 
 private:
-    static constexpr tagged_storage TAG_MASK = 0xffff000000000007;
+    static constexpr tagged_storage TAG_MASK = 0xffff;
 
     static constexpr tagged_storage PTR_MASK = ~TAG_MASK;
 
@@ -87,13 +87,9 @@ private:
     template <typename E, typename... Args> friend TreePtr make_tree(Args &&...);
 
     static tagged_storage tagPtr(Tag tag, void *expr) {
+        // Store the tag in the lower 16 bits of the pointer, regardless of size.
         auto val = static_cast<tagged_storage>(tag);
-        if (val >= 8) {
-            // Store the tag in the upper 16 bits of the pointer, as it won't fit in the lower three bits.
-            val <<= 48;
-        }
-
-        auto maskedPtr = reinterpret_cast<tagged_storage>(expr) & PTR_MASK;
+        auto maskedPtr = reinterpret_cast<tagged_storage>(expr) << 16;
 
         return maskedPtr | val;
     }
@@ -179,11 +175,7 @@ public:
         ENFORCE(ptr != 0);
 
         auto value = reinterpret_cast<tagged_storage>(ptr) & TAG_MASK;
-        if (value <= 7) {
-            return static_cast<Tag>(value);
-        } else {
-            return static_cast<Tag>(value >> 48);
-        }
+        return static_cast<Tag>(value);
     }
 
     Expression *get() const noexcept {
@@ -193,7 +185,7 @@ public:
             return reinterpret_cast<Expression *>(val);
         } else {
             // sign extension for the upper 16 bits
-            return reinterpret_cast<Expression *>((val << 16) >> 16);
+            return reinterpret_cast<Expression *>(val >> 16);
         }
     }
 

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -92,7 +92,7 @@ private:
 
         // Store value into val.  It doesn't much matter where we put it in
         // the upper 48 bits, but we put it in the uppermost 32 bits to
-        // ensure that retrieve it requires only a shift and no masking.
+        // ensure that retrieving it requires only a shift and no masking.
         val |= static_cast<tagged_storage>(inlinedValue) << 32;
 
         // Asserts that tag isn't using the bit which we use to indicate that value is _not_ inlined.

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -73,30 +73,29 @@ private:
     };
     tagged_storage store;
 
-    // Top bit indicates if value is inlined into pointer.
-    // We use a 0 in top bit to indicate not inlined so that nullptr (which has counter value 0) is naturally viewed as
+    // We use a 0 to indicate not inlined so that nullptr (which has counter value 0) is naturally viewed as
     // 'inlined'.
-    static constexpr tagged_storage NOT_INLINED_MASK = 0x8000000000000000;
-    static constexpr tagged_storage TAG_MASK = 0x7FFF000000000007;
+    static constexpr tagged_storage NOT_INLINED_MASK = 0x0100;
+    // We use a 8-bit tag mask so that tags can be efficiently extracted via
+    // movzx on x86.
+    static constexpr tagged_storage TAG_MASK = 0x00FF;
 
     static constexpr tagged_storage PTR_MASK = ~(NOT_INLINED_MASK | TAG_MASK);
 
     static tagged_storage tagToMask(Tag tag) {
-        auto val = static_cast<tagged_storage>(tag);
-        if (val >= 8) {
-            // Store the tag in the upper 16 bits of the pointer, as it won't fit in the lower three bits.
-            val <<= 48;
-        }
-        return val;
+        // Store the tag in the lower bits of the pointer, regardless of size.
+        return static_cast<tagged_storage>(tag);
     }
 
     static tagged_storage tagValue(Tag tag, u4 inlinedValue) {
         auto val = tagToMask(tag);
 
-        // Store value into val.
-        val |= static_cast<tagged_storage>(inlinedValue) << 3;
+        // Store value into val.  It doesn't much matter where we put it in
+        // the upper 48 bits, but we put it in the uppermost 32 bits to
+        // ensure that retrieve it requires only a shift and no masking.
+        val |= static_cast<tagged_storage>(inlinedValue) << 32;
 
-        // Asserts that tag isn't using top bit which we use to indicate that value is _not_ inlined.
+        // Asserts that tag isn't using the bit which we use to indicate that value is _not_ inlined.
         ENFORCE((val & NOT_INLINED_MASK) == 0);
 
         return val;
@@ -105,7 +104,7 @@ private:
     static tagged_storage tagPtr(Tag tag, void *expr) {
         auto val = tagToMask(tag);
 
-        auto maskedPtr = reinterpret_cast<tagged_storage>(expr) & PTR_MASK;
+        auto maskedPtr = reinterpret_cast<tagged_storage>(expr) << 16;
 
         return maskedPtr | val | NOT_INLINED_MASK;
     }
@@ -160,7 +159,7 @@ private:
 
     u4 inlinedValue() const {
         ENFORCE_NO_TIMER(!containsPtr());
-        auto val = (store & PTR_MASK) >> 3;
+        auto val = store >> 32;
         return static_cast<u4>(val);
     }
 
@@ -170,7 +169,7 @@ private:
             return reinterpret_cast<void *>(val);
         } else {
             // sign extension for the upper 16 bits
-            return reinterpret_cast<void *>((val << 16) >> 16);
+            return reinterpret_cast<void *>(val >> 16);
         }
     }
 
@@ -248,11 +247,7 @@ public:
         ENFORCE_NO_TIMER(store != 0);
 
         auto value = reinterpret_cast<tagged_storage>(store) & TAG_MASK;
-        if (value <= 7) {
-            return static_cast<Tag>(value);
-        } else {
-            return static_cast<Tag>(value >> 48);
-        }
+        return static_cast<Tag>(value);
     }
 
     bool operator!=(const TypePtr &other) const {

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -165,12 +165,7 @@ private:
 
     void *get() const {
         auto val = store & PTR_MASK;
-        if constexpr (sizeof(void *) == 4) {
-            return reinterpret_cast<void *>(val);
-        } else {
-            // sign extension for the upper 16 bits
-            return reinterpret_cast<void *>(val >> 16);
-        }
+        return reinterpret_cast<void *>(val >> 16);
     }
 
 public:


### PR DESCRIPTION
This PR redoes the `TreePtr` changes and `TypePtr` changes from their respective PRs (the commits here are cherry-picked from master), but with fixes for Emscripten and one small typo fix.  The fix was obvious (5eb1900), figuring out how to debug it properly took waaaay too long.

### Motivation

The fastest code is the code you don't execute...but it helps if the replacement code is actually correct in all cases.

### Test plan

Existing automated tests.