### PR TITLE
Don't mutate Symbol mixins in incremental resolver.

### DIFF
--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -134,11 +134,7 @@ public:
         return mixins_;
     }
 
-    void addMixin(SymbolRef sym) {
-        ENFORCE(isClassOrModule());
-        mixins_.emplace_back(sym);
-        unsetClassOrModuleLinearizationComputed();
-    }
+    void addMixin(const GlobalState &gs, SymbolRef sym);
 
     inline InlinedVector<SymbolRef, 4> &typeMembers() {
         ENFORCE(isClassOrModule());

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -312,6 +312,8 @@ vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, vector<ast::Pa
             // Cancellation cannot occur during incremental namer.
             ENFORCE(result.hasResult());
             what = move(result.result());
+
+            // Required for autogen tests, which need to control which phase to stop after.
             if (opts.stopAfterPhase == options::Phase::NAMER) {
                 return what;
             }
@@ -320,6 +322,8 @@ vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, vector<ast::Pa
         {
             Timer timeit(gs.tracer(), "incremental_resolve");
             gs.tracer().trace("Resolving (incremental pass)...");
+            // TODO: We should eventually be able to freeze the symbol and name tables, but overloads currently pose
+            // a problem.
             core::UnfreezeSymbolTable symbolTable(gs);
             core::UnfreezeNameTable nameTable(gs);
 
@@ -327,6 +331,8 @@ vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, vector<ast::Pa
             // incrementalResolve is not cancelable.
             ENFORCE(result.hasResult());
             what = move(result.result());
+
+            // Required for autogen tests, which need to control which phase to stop after.
             if (opts.stopAfterPhase == options::Phase::RESOLVER) {
                 return what;
             }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -312,6 +312,9 @@ vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, vector<ast::Pa
             // Cancellation cannot occur during incremental namer.
             ENFORCE(result.hasResult());
             what = move(result.result());
+            if (opts.stopAfterPhase == options::Phase::NAMER) {
+                return what;
+            }
         }
 
         {
@@ -324,6 +327,9 @@ vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, vector<ast::Pa
             // incrementalResolve is not cancelable.
             ENFORCE(result.hasResult());
             what = move(result.result());
+            if (opts.stopAfterPhase == options::Phase::RESOLVER) {
+                return what;
+            }
         }
     } catch (SorbetException &) {
         if (auto e = gs.beginError(sorbet::core::Loc::none(), sorbet::core::errors::Internal::InternalError)) {

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -390,7 +390,7 @@ void Resolver::finalizeSymbols(core::GlobalState &gs) {
             if (!singleton.exists()) {
                 singleton = sym.data(gs)->singletonClass(gs);
             }
-            singleton.data(gs)->addMixin(classMethods);
+            singleton.data(gs)->addMixin(gs, classMethods);
         }
     }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -465,8 +465,7 @@ private:
         }
     }
 
-    static bool resolveAncestorJob(core::MutableContext ctx, AncestorResolutionItem &job, bool lastRun,
-                                   bool isIncrementalResolver) {
+    static bool resolveAncestorJob(core::MutableContext ctx, AncestorResolutionItem &job, bool lastRun) {
         auto ancestorSym = job.ancestor->symbol;
         if (!ancestorSym.exists()) {
             return false;
@@ -528,10 +527,7 @@ private:
             }
         } else {
             ENFORCE(resolved.data(ctx)->isClassOrModule());
-            // Don't mutate mixins during incremental resolver.
-            if (!isIncrementalResolver) {
-                job.klass.data(ctx)->addMixin(resolved);
-            }
+            job.klass.data(ctx)->addMixin(ctx, resolved);
         }
 
         if (ancestorPresent) {
@@ -812,7 +808,7 @@ public:
     }
 
     static vector<ast::ParsedFile> resolveConstants(core::GlobalState &gs, vector<ast::ParsedFile> trees,
-                                                    WorkerPool &workers, bool isIncrementalResolver) {
+                                                    WorkerPool &workers) {
         Timer timeit(gs.tracer(), "resolver.resolve_constants");
         const core::GlobalState &igs = gs;
         auto resultq = make_shared<BlockingBoundedQueue<ResolveWalkResult>>(trees.size());
@@ -909,15 +905,15 @@ public:
                 // We try to resolve most ancestors second because this makes us much more likely to resolve everything
                 // else.
                 int origSize = todoAncestors.size();
-                auto it = remove_if(todoAncestors.begin(), todoAncestors.end(),
-                                    [&gs, isIncrementalResolver](AncestorResolutionItem &job) -> bool {
-                                        core::MutableContext ctx(gs, core::Symbols::root(), job.file);
-                                        auto resolved = resolveAncestorJob(ctx, job, false, isIncrementalResolver);
-                                        if (resolved) {
-                                            tryRegisterSealedSubclass(ctx, job);
-                                        }
-                                        return resolved;
-                                    });
+                auto it =
+                    remove_if(todoAncestors.begin(), todoAncestors.end(), [&gs](AncestorResolutionItem &job) -> bool {
+                        core::MutableContext ctx(gs, core::Symbols::root(), job.file);
+                        auto resolved = resolveAncestorJob(ctx, job, false);
+                        if (resolved) {
+                            tryRegisterSealedSubclass(ctx, job);
+                        }
+                        return resolved;
+                    });
                 todoAncestors.erase(it, todoAncestors.end());
                 progress = (origSize != todoAncestors.size());
                 categoryCounterAdd("resolve.constants.ancestor", "retry", origSize - todoAncestors.size());
@@ -1020,9 +1016,9 @@ public:
 
             for (auto &job : todoAncestors) {
                 core::MutableContext ctx(gs, core::Symbols::root(), job.file);
-                auto resolved = resolveAncestorJob(ctx, job, true, isIncrementalResolver);
+                auto resolved = resolveAncestorJob(ctx, job, true);
                 if (!resolved) {
-                    resolved = resolveAncestorJob(ctx, job, true, isIncrementalResolver);
+                    resolved = resolveAncestorJob(ctx, job, true);
                     ENFORCE(resolved);
                 }
             }
@@ -2498,7 +2494,7 @@ void computeExternalTypes(core::GlobalState &gs) {
 
 ast::ParsedFilesOrCancelled Resolver::run(core::GlobalState &gs, vector<ast::ParsedFile> trees, WorkerPool &workers) {
     const auto &epochManager = *gs.epochManager;
-    trees = ResolveConstantsWalk::resolveConstants(gs, std::move(trees), workers, false);
+    trees = ResolveConstantsWalk::resolveConstants(gs, std::move(trees), workers);
     if (epochManager.wasTypecheckingCanceled()) {
         return ast::ParsedFilesOrCancelled();
     }
@@ -2557,8 +2553,15 @@ void Resolver::sanityCheck(core::GlobalState &gs, vector<ast::ParsedFile> &trees
 
 ast::ParsedFilesOrCancelled Resolver::runIncremental(core::GlobalState &gs, vector<ast::ParsedFile> trees) {
     auto workers = WorkerPool::create(0, gs.tracer());
-    trees = ResolveConstantsWalk::resolveConstants(gs, std::move(trees), *workers, true);
+    trees = ResolveConstantsWalk::resolveConstants(gs, std::move(trees), *workers);
     // NOTE: Linearization does not need to be recomputed as we do not mutate mixins() during incremental resolve.
+    if (debug_mode) {
+        for (auto i = 1; i < gs.classAndModulesUsed(); i++) {
+            core::SymbolRef sym(gs, core::SymbolRef::Kind::ClassOrModule, i);
+            // If class is not marked as 'linearization computed', then we added a mixin to it since the last slow path.
+            ENFORCE_NO_TIMER(sym.data(gs)->isClassOrModuleLinearizationComputed(), sym.toString(gs));
+        }
+    }
     trees = ResolveTypeMembersWalk::run(gs, std::move(trees), *workers);
     computeExternalTypes(gs);
     auto result = resolveSigs(gs, std::move(trees));
@@ -2575,7 +2578,7 @@ ast::ParsedFilesOrCancelled Resolver::runIncremental(core::GlobalState &gs, vect
 
 vector<ast::ParsedFile> Resolver::runConstantResolution(core::GlobalState &gs, vector<ast::ParsedFile> trees,
                                                         WorkerPool &workers) {
-    trees = ResolveConstantsWalk::resolveConstants(gs, std::move(trees), workers, false);
+    trees = ResolveConstantsWalk::resolveConstants(gs, std::move(trees), workers);
     sanityCheck(gs, trees);
 
     return trees;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2555,13 +2555,11 @@ ast::ParsedFilesOrCancelled Resolver::runIncremental(core::GlobalState &gs, vect
     auto workers = WorkerPool::create(0, gs.tracer());
     trees = ResolveConstantsWalk::resolveConstants(gs, std::move(trees), *workers);
     // NOTE: Linearization does not need to be recomputed as we do not mutate mixins() during incremental resolve.
-    if (debug_mode) {
-        for (auto i = 1; i < gs.classAndModulesUsed(); i++) {
-            core::SymbolRef sym(gs, core::SymbolRef::Kind::ClassOrModule, i);
-            // If class is not marked as 'linearization computed', then we added a mixin to it since the last slow path.
-            ENFORCE_NO_TIMER(sym.data(gs)->isClassOrModuleLinearizationComputed(), sym.toString(gs));
-        }
-    }
+    DEBUG_ONLY(for (auto i = 1; i < gs.classAndModulesUsed(); i++) {
+        core::SymbolRef sym(gs, core::SymbolRef::Kind::ClassOrModule, i);
+        // If class is not marked as 'linearization computed', then we added a mixin to it since the last slow path.
+        ENFORCE_NO_TIMER(sym.data(gs)->isClassOrModuleLinearizationComputed(), sym.toString(gs));
+    })
     trees = ResolveTypeMembersWalk::run(gs, std::move(trees), *workers);
     computeExternalTypes(gs);
     auto result = resolveSigs(gs, std::move(trees));

--- a/test/testdata/lsp/fast_path/linearization.1.rbupdate
+++ b/test/testdata/lsp/fast_path/linearization.1.rbupdate
@@ -1,0 +1,26 @@
+# typed: true
+# frozen_string_literal: true
+# assert-slow-path: linearization.rb
+
+module Base
+end
+
+module BaseWithMethod
+  include Base
+  def foo
+
+  end
+end
+
+module OtherModuleWithMethod
+  def foo(i)
+
+  end
+end
+
+class E
+  include BaseWithMethod
+  include OtherModuleWithMethod
+end
+
+E.new.foo(1) #

--- a/test/testdata/lsp/fast_path/linearization.2.rbupdate
+++ b/test/testdata/lsp/fast_path/linearization.2.rbupdate
@@ -1,0 +1,26 @@
+# typed: true
+# frozen_string_literal: true
+# assert-slow-path: linearization.rb
+
+module Base
+end
+
+module BaseWithMethod
+  include Base
+  def foo
+
+  end
+end
+
+module OtherModuleWithMethod
+  def foo(i)
+
+  end
+end
+
+class E
+  include BaseWithMethod
+  include OtherModuleWithMethod
+end
+
+E.new.foo(1) # more comment

--- a/test/testdata/lsp/fast_path/linearization.rb
+++ b/test/testdata/lsp/fast_path/linearization.rb
@@ -1,0 +1,25 @@
+# typed: true
+# frozen_string_literal: true
+
+module Base
+end
+
+module BaseWithMethod
+  include Base
+  def foo
+
+  end
+end
+
+module OtherModuleWithMethod
+  def foo(i)
+
+  end
+end
+
+class E
+  include BaseWithMethod
+  include OtherModuleWithMethod
+end
+
+E.new.foo(1)

--- a/test/testdata/resolver/bad_sealed_module__1.rb
+++ b/test/testdata/resolver/bad_sealed_module__1.rb
@@ -1,5 +1,4 @@
 # typed: false
-# disable-fast-path: true
 
 module Parent
   extend T::Helpers

--- a/test/testdata/resolver/bad_sealed_module__2.rb
+++ b/test/testdata/resolver/bad_sealed_module__2.rb
@@ -1,5 +1,4 @@
 # typed: false
-# disable-fast-path: true
 
 class ChildBad3
   include Parent # error: `Parent` is sealed and cannot be included in `ChildBad3`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Don't mutate Symbol mixins in incremental resolver.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

[Watch an error flip on and off.](https://sorbet.run/#%23%20typed%3A%20true%0A%23%20frozen_string_literal%3A%20true%0A%0Amodule%20Base%0Aend%0A%0Amodule%20BaseWithMethod%0A%20%20include%20Base%0A%20%20def%20foo%0A%0A%20%20end%0Aend%0A%0Amodule%20OtherModuleWithMethod%0A%20%20def%20foo(i)%0A%0A%20%20end%0Aend%0A%0Aclass%20E%0A%20%20include%20BaseWithMethod%0A%20%20include%20OtherModuleWithMethod%0Aend%0A%0AE.new.foo(1)%20%23%20put%20a%20space%20in%20this%20comment%20once.%20then%20twice.%20then%20three%20times.%0A) This bug occurs because the incremental path is (incorrectly) recomputing mixins. However, we shouldn't be adding mixins at all on the incremental path.

We discovered this bug while trying to implement method rename on mixins.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
