### PR TITLE
ResolveTypeMembersWalk: Store resultType outside of walk.

### DIFF
--- a/core/Context.cc
+++ b/core/Context.cc
@@ -83,7 +83,7 @@ GlobalSubstitution::GlobalSubstitution(const GlobalState &from, GlobalState &to,
     ENFORCE(from.typeArguments.size() == to.typeArguments.size(), "Can't substitute symbols yet");
     ENFORCE(from.typeMembers.size() == to.typeMembers.size(), "Can't substitute symbols yet");
 
-    const_cast<GlobalState &>(from).sanityCheck();
+    from.sanityCheck();
     {
         UnfreezeFileTable unfreezeFiles(to);
         int fileIdx = 0; // Skip file 0


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

ResolveTypeMembersWalk: Store resultType outside of walk.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Removes a hacky const_cast.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
