### PR TITLE
Fix signature for `Kernel.system`.

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -2783,6 +2783,13 @@ module Kernel
   # ```
   #
   # See `Kernel.exec` for the standard shell.
-  sig { params(args: String).returns(T.any(NilClass, FalseClass, TrueClass)) }
-  def system(*args); end
+  sig do
+    params(
+      env: T.any(String, [String, String], T::Hash[String, T.nilable(String)]),
+      argv0: T.any(String, [String, String]),
+      args: String,
+      options: T.untyped,
+    ).returns(T.nilable(T::Boolean))
+  end
+  def system(env, argv0 = T.unsafe(nil), *args, **options); end
 end

--- a/test/testdata/rbi/kernel.rb
+++ b/test/testdata/rbi/kernel.rb
@@ -24,6 +24,25 @@ end
 define_singleton_method(:foo) { puts '' }
 define_singleton_method('foo') { puts '' }
 
+# make sure we don't regress and mark these as errors
+env = {'VAR' => 'VAL'}
+system('echo')
+system('echo', err: File::NULL)
+system('echo', out: :err)
+system('echo', 'hello')
+system('echo', 'hello', err: File::NULL)
+system('echo', 'hello', out: :err)
+system(['echo', 'echo'])
+system(['echo', 'echo'], 'hello')
+system(['echo', 'echo'], out: :err)
+system(['echo', 'echo'], 'hello', out: :err)
+system(env, 'echo')
+system(env, 'echo', out: :err)
+system(env, ['echo', 'echo'])
+system(env, ['echo', 'echo'], out: :err)
+system(env, ['echo', 'echo'], 'hello')
+system(env, ['echo', 'echo'], 'hello', out: :err)
+
 y = loop do
 end
 puts y # error: This code is unreachable


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`Kernel.system` has some functionality which is not covered by the current signature at all.

Currently, out of these

```ruby
system('echo')
system('echo', err: File::NULL)
system('echo', out: :err)
system('echo', 'hello')
system('echo', 'hello', err: File::NULL)
system('echo', 'hello', out: :err)
system(['echo', 'echo'])
system(['echo', 'echo'], 'hello')
system(['echo', 'echo'], out: :err)
system(['echo', 'echo'], 'hello', out: :err)
system(({'VAR' => 'VAL'}), 'echo')
system(({'VAR' => 'VAL'}), 'echo', out: :err)
system(({'VAR' => 'VAL'}), ['echo', 'echo'])
system(({'VAR' => 'VAL'}), ['echo', 'echo'], out: :err)
system(({'VAR' => 'VAL'}), ['echo', 'echo'], 'hello')
system(({'VAR' => 'VAL'}), ['echo', 'echo'], 'hello', out: :err)
```

only

```ruby
system('echo')
system('echo', 'hello')
```

type-check. The fixed signature should cover all of these, however it also accepts some configurations which are wrong, i.e.

```ruby
system('echo', ['echo', 'echo'])
system(['echo', 'echo'], ['hello', 'hello'])
```

I'm not quite sure if there is a way to make the second argument depend on the first argument, i.e. only allow `[String, String]` as the second if the first is `T::Hash[String, T.nilable(String)]`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a
