### PR TITLE
`chown` arguments can be `nil`.

### DIFF
--- a/rbi/core/file.rbi
+++ b/rbi/core/file.rbi
@@ -227,8 +227,8 @@ class File < IO
   # ```
   sig do
     params(
-        owner: Integer,
-        group: Integer,
+        owner: T.nilable(Integer),
+        group: T.nilable(Integer),
         files: String,
     )
     .returns(Integer)
@@ -612,8 +612,8 @@ class File < IO
   # link). Often not available. Returns number of files in the argument list.
   sig do
     params(
-        owner: Integer,
-        group: Integer,
+        owner: T.nilable(Integer),
+        group: T.nilable(Integer),
         files: String,
     )
     .returns(Integer)
@@ -1132,8 +1132,8 @@ class File < IO
   # ```
   sig do
     params(
-        owner: Integer,
-        group: Integer,
+        owner: T.nilable(Integer),
+        group: T.nilable(Integer),
     )
     .returns(Integer)
   end

--- a/rbi/stdlib/pathname.rbi
+++ b/rbi/stdlib/pathname.rbi
@@ -497,8 +497,8 @@ class Pathname < Object
   # [`File.chown`](https://docs.ruby-lang.org/en/2.6.0/File.html#method-c-chown).
   sig do
     params(
-        owner: Integer,
-        group: Integer,
+        owner: T.nilable(Integer),
+        group: T.nilable(Integer),
     )
     .returns(Integer)
   end
@@ -889,8 +889,8 @@ class Pathname < Object
   # [`File.lchown`](https://docs.ruby-lang.org/en/2.6.0/File.html#method-c-lchown).
   sig do
     params(
-        owner: Integer,
-        group: Integer,
+        owner: T.nilable(Integer),
+        group: T.nilable(Integer),
     )
     .returns(Integer)
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Documentation states that `owner` or `group` can be ignored by passing `nil` or `-1`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a
