### PR TITLE
Correct return type of Ruby Core Hash#any?

### DIFF
--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -308,7 +308,7 @@ class Hash < Object
   sig {returns(T::Boolean)}
   sig do
     params(
-        blk: T.proc.params(arg0: K, arg1: V).returns(BasicObject),
+        blk: T.proc.params(arg0: Elem).returns(BasicObject),
     )
     .returns(T::Boolean)
   end

--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -305,7 +305,15 @@ class Hash < Object
 
   # See also
   # [`Enumerable#any?`](https://docs.ruby-lang.org/en/2.6.0/Enumerable.html#method-i-any-3F)
-  def any?(*_); end
+  sig {returns(T::Boolean)}
+  sig do
+    params(
+        blk: T.proc.params(arg0: K, arg1: V).returns(BasicObject),
+    )
+    .returns(T::Boolean)
+  end
+  sig { params(pattern: T.untyped).returns(T::Boolean) }
+  def any?(pattern = nil, &blk); end
 
   # Removes all key-value pairs from *hsh*.
   #

--- a/test/testdata/rbi/hash.rb
+++ b/test/testdata/rbi/hash.rb
@@ -89,8 +89,11 @@ initial_hash.transform_values!.with_index do |v, i|
 end
 
 T.assert_type!({}.any?, T::Boolean)
-T.assert_type!({ a: 'ant', b: 'bear', c: 'cat' }.any?(/d/), T::Boolean)
-T.assert_type!(
-  { a: 'ant', b: 'bear', c: 'cat' }.any? { |key, value| key == value },
-  T::Boolean
-)
+T.reveal_type(T::Hash[Symbol, Integer].new.any? do |key, value| # error: Revealed type: `T::Boolean`
+  T.reveal_type(key) # error: Revealed type: `Symbol`
+  T.reveal_type(value) # error: Revealed type: `Integer`
+end)
+T.reveal_type(T::Hash[Symbol, Integer].new.any? do |(key, value)| # error: Revealed type: `T::Boolean`
+  T.reveal_type(key) # error: Revealed type: `Symbol`
+  T.reveal_type(value) # error: Revealed type: `Integer`
+end)

--- a/test/testdata/rbi/hash.rb
+++ b/test/testdata/rbi/hash.rb
@@ -87,3 +87,10 @@ initial_hash.transform_values!.with_index do |v, i|
   T.assert_type!(v, Float)
   T.assert_type!(i, Integer)
 end
+
+T.assert_type!({}.any?, T::Boolean)
+T.assert_type!({ a: 'ant', b: 'bear', c: 'cat' }.any?(/d/), T::Boolean)
+T.assert_type!(
+  { a: 'ant', b: 'bear', c: 'cat' }.any? { |key, value| key == value },
+  T::Boolean
+)


### PR DESCRIPTION
### Motivation

The core Hash rbi previously contained a method definition for Hash#any?
without any type definitions associated with it. This would lead to the
return value of Hash#any? to be T.untyped:

```
T.reveal_type({}.any?) # Revealed type: T.untyped https://srb.help/7014
```

This now provides types for all the potential invocations of Hash#any?

```
T.reveal_type({}.any?) # Revealed type: T::Boolean
```


### Test plan

This PR provides this update and a regression test in the Hash test data.