### PR TITLE
Fix signature for `Module#define_method`.

### DIFF
--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -730,7 +730,7 @@ class Module < Object
   sig do
     params(
         arg0: T.any(Symbol, String),
-        blk: BasicObject,
+        blk: T.proc.bind(T.untyped).returns(T.untyped),
     )
     .returns(Symbol)
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When calling `define_method` inside of a class, it thinks the receiver the block binds to is `T.class_of(T.self_type)`.

See https://sorbet.run/#%23%20typed%3A%20true%0A%0Aclass%20A%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20def%20my_method%3B%20end%0A%0A%20%20define_method(%3Amy_method)%20%7B%0A%20%20%20%20my_method%0A%20%20%7D%0Aend%0A


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a