### PR TITLE
Make `Only modules can be included` error appear in incremental resolver.

### DIFF
--- a/core/Error.cc
+++ b/core/Error.cc
@@ -155,6 +155,13 @@ void ErrorBuilder::addAutocorrect(AutocorrectSuggestion &&autocorrect) {
     this->autocorrects.emplace_back(move(autocorrect));
 }
 
+ErrorBuilder::ErrorBuilder(ErrorBuilder &&other)
+    : gs(other.gs), state(other.state), loc(other.loc), what(other.what), header(move(other.header)),
+      sections(move(other.sections)), autocorrects(move(other.autocorrects)) {
+    // Do not report the moved ErrorBuilder.
+    other.state = ErrorBuilder::State::DidBuild;
+}
+
 // This will sometimes be bypassed in lieu of just calling build() so put your
 // logic in build() instead.
 ErrorBuilder::~ErrorBuilder() {

--- a/core/Error.cc
+++ b/core/Error.cc
@@ -155,13 +155,6 @@ void ErrorBuilder::addAutocorrect(AutocorrectSuggestion &&autocorrect) {
     this->autocorrects.emplace_back(move(autocorrect));
 }
 
-ErrorBuilder::ErrorBuilder(ErrorBuilder &&other)
-    : gs(other.gs), state(other.state), loc(other.loc), what(other.what), header(move(other.header)),
-      sections(move(other.sections)), autocorrects(move(other.autocorrects)) {
-    // Do not report the moved ErrorBuilder.
-    other.state = ErrorBuilder::State::DidBuild;
-}
-
 // This will sometimes be bypassed in lieu of just calling build() so put your
 // logic in build() instead.
 ErrorBuilder::~ErrorBuilder() {

--- a/core/Error.h
+++ b/core/Error.h
@@ -137,7 +137,9 @@ class ErrorBuilder {
 
 public:
     ErrorBuilder(const ErrorBuilder &) = delete;
-    ErrorBuilder(ErrorBuilder &&);
+    // If you undelete this, you will need to make sure the moved ErrorBuilder is marked as 'DidBuild' so Sorbet does
+    // not report an empty error.
+    ErrorBuilder(ErrorBuilder &&) = delete;
     ErrorBuilder(const GlobalState &gs, bool willBuild, Loc loc, ErrorClass what);
     ~ErrorBuilder();
 

--- a/core/Error.h
+++ b/core/Error.h
@@ -137,7 +137,7 @@ class ErrorBuilder {
 
 public:
     ErrorBuilder(const ErrorBuilder &) = delete;
-    ErrorBuilder(ErrorBuilder &&) = default;
+    ErrorBuilder(ErrorBuilder &&);
     ErrorBuilder(const GlobalState &gs, bool willBuild, Loc loc, ErrorClass what);
     ~ErrorBuilder();
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -134,7 +134,9 @@ public:
         return mixins_;
     }
 
-    void addMixin(const GlobalState &gs, SymbolRef sym);
+    // Attempts to add the given mixin to the symbol. If the mixin is invalid, it returns an error message that should
+    // be reported to the user. Otherwise, returns nullptr.
+    [[nodiscard]] std::unique_ptr<ErrorBuilder> addMixin(const GlobalState &gs, SymbolRef sym);
 
     inline InlinedVector<SymbolRef, 4> &typeMembers() {
         ENFORCE(isClassOrModule());

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -134,7 +134,7 @@ public:
         return mixins_;
     }
 
-    // Attempts to add the given mixin to the symbol. If the mixin is invalid, it returns an error message that should
+    // Attempts to add the given mixin to the symbol. If the mixin is invalid, it returns an error that should
     // be reported to the user. Otherwise, returns nullptr.
     [[nodiscard]] std::unique_ptr<ErrorBuilder> addMixin(const GlobalState &gs, SymbolRef sym);
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -134,9 +134,9 @@ public:
         return mixins_;
     }
 
-    // Attempts to add the given mixin to the symbol. If the mixin is invalid, it returns an error that should
-    // be reported to the user. Otherwise, returns nullptr.
-    [[nodiscard]] std::unique_ptr<ErrorBuilder> addMixin(const GlobalState &gs, SymbolRef sym);
+    // Attempts to add the given mixin to the symbol. If the mixin is invalid because it is not a module, it returns
+    // `false` (but still adds the mixin for processing during linearization) and the caller should report an error.
+    [[nodiscard]] bool addMixin(const GlobalState &gs, SymbolRef sym);
 
     inline InlinedVector<SymbolRef, 4> &typeMembers() {
         ENFORCE(isClassOrModule());

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -384,7 +384,9 @@ void Resolver::finalizeSymbols(core::GlobalState &gs) {
             if (!singleton.exists()) {
                 singleton = sym.data(gs)->singletonClass(gs);
             }
-            singleton.data(gs)->addMixin(gs, classMethods);
+            if (auto e = singleton.data(gs)->addMixin(gs, classMethods)) {
+                // Report error as-is; no further details to add.
+            }
         }
     }
 

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -384,8 +384,10 @@ void Resolver::finalizeSymbols(core::GlobalState &gs) {
             if (!singleton.exists()) {
                 singleton = sym.data(gs)->singletonClass(gs);
             }
-            if (auto e = singleton.data(gs)->addMixin(gs, classMethods)) {
-                // Report error as-is; no further details to add.
+            if (!singleton.data(gs)->addMixin(gs, classMethods)) {
+                // Should never happen. We check in ResolveConstantsWalk that classMethods are a module before adding it
+                // as a member.
+                ENFORCE(false);
             }
         }
     }

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -303,12 +303,6 @@ ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, 
             ParentLinearizationInformation mixinLinearization = computeClassLinearization(gs, mixin);
 
             if (!mixin.data(gs)->isClassOrModuleModule()) {
-                if (mixin != core::Symbols::BasicObject()) {
-                    if (auto e = gs.beginError(data->loc(), core::errors::Resolver::IncludesNonModule)) {
-                        e.setHeader("Only modules can be `{}`d. This module or class includes `{}`", "include",
-                                    mixin.data(gs)->show(gs));
-                    }
-                }
                 // insert all transitive parents of class to bring methods back.
                 auto allMixins = mixinLinearization.fullLinearizationSlow(gs);
                 newMixins.insert(newMixins.begin(), allMixins.begin(), allMixins.end());

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -122,6 +122,7 @@ private:
         core::FileRef file;
 
         bool isSuperclass; // true if superclass, false for mixin
+        bool isInclude;    // true if include, false if extend
 
         AncestorResolutionItem() = default;
         AncestorResolutionItem(AncestorResolutionItem &&rhs) noexcept = default;
@@ -527,8 +528,11 @@ private:
             }
         } else {
             ENFORCE(resolved.data(ctx)->isClassOrModule());
-            if (auto e = job.klass.data(ctx)->addMixin(ctx, resolved)) {
-                e->addErrorLine(core::Loc(ctx.file, job.ancestor->loc), "`{}` included here", resolved.show(ctx));
+            if (!job.klass.data(ctx)->addMixin(ctx, resolved)) {
+                if (auto e = ctx.beginError(job.ancestor->loc, core::errors::Resolver::IncludesNonModule)) {
+                    e.setHeader("Only modules can be `{}`d, but `{}` is a class", job.isInclude ? "include" : "extend",
+                                resolved.data(ctx)->show(ctx));
+                }
             }
         }
 
@@ -600,7 +604,7 @@ private:
         ancestorSym.data(ctx)->recordSealedSubclass(ctx, job.klass);
     }
 
-    void transformAncestor(core::Context ctx, core::SymbolRef klass, ast::TreePtr &ancestor,
+    void transformAncestor(core::Context ctx, core::SymbolRef klass, ast::TreePtr &ancestor, bool isInclude,
                            bool isSuperclass = false) {
         if (auto *constScope = ast::cast_tree<ast::UnresolvedConstantLit>(ancestor)) {
             auto scopeTmp = nesting_;
@@ -614,6 +618,7 @@ private:
         job.klass = klass;
         job.isSuperclass = isSuperclass;
         job.file = ctx.file;
+        job.isInclude = isInclude;
 
         if (auto *cnst = ast::cast_tree<ast::ConstantLit>(ancestor)) {
             auto sym = cnst->symbol;
@@ -677,16 +682,18 @@ public:
 
         core::SymbolRef klass = original.symbol;
 
+        bool isInclude = true;
         for (auto &ancst : original.ancestors) {
             bool isSuperclass = (original.kind == ast::ClassDef::Kind::Class && &ancst == &original.ancestors.front() &&
                                  !klass.data(ctx)->isSingletonClass(ctx));
-            transformAncestor(isSuperclass ? ctx : ctx.withOwner(klass), klass, ancst, isSuperclass);
+            transformAncestor(isSuperclass ? ctx : ctx.withOwner(klass), klass, ancst, isInclude, isSuperclass);
         }
 
         auto singleton = klass.data(ctx)->lookupSingletonClass(ctx);
+        isInclude = false;
         for (auto &ancst : original.singletonAncestors) {
             ENFORCE(singleton.exists());
-            transformAncestor(ctx.withOwner(klass), singleton, ancst);
+            transformAncestor(ctx.withOwner(klass), singleton, ancst, isInclude);
         }
 
         nesting_ = nesting_->parent;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -527,7 +527,9 @@ private:
             }
         } else {
             ENFORCE(resolved.data(ctx)->isClassOrModule());
-            job.klass.data(ctx)->addMixin(ctx, resolved);
+            if (auto e = job.klass.data(ctx)->addMixin(ctx, resolved)) {
+                e->addErrorLine(core::Loc(ctx.file, job.ancestor->loc), "`{}` included here", resolved.show(ctx));
+            }
         }
 
         if (ancestorPresent) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -532,6 +532,8 @@ private:
                 if (auto e = ctx.beginError(job.ancestor->loc, core::errors::Resolver::IncludesNonModule)) {
                     e.setHeader("Only modules can be `{}`d, but `{}` is a class", job.isInclude ? "include" : "extend",
                                 resolved.data(ctx)->show(ctx));
+                    e.addErrorLine(resolved.data(ctx)->loc(), "`{}` defined as a class here",
+                                   resolved.data(ctx)->show(ctx));
                 }
             }
         }

--- a/test/testdata/packager/invalid_imports_and_exports/__package.rb
+++ b/test/testdata/packager/invalid_imports_and_exports/__package.rb
@@ -32,6 +32,6 @@ class A < PackageSpec
                     # ^^^^^^^ error: Argument to `export_methods` must be a constant
                              # ^^^^^^ error: Argument to `export_methods` must be a constant
                              # ^^^^^^ error: Not enough arguments
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Only modules can be `include`d. This module or class includes `A::AClass`
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Only modules can be `include`d. This module or class includes `A::ASecondClass`
+#                                      ^^^^^^^^^ error: Only modules can be `include`d, but `A::ASecondClass` is a class
+#                                                          ^^^^^^ error: Only modules can be `include`d, but `A::AClass` is a class
 end

--- a/test/testdata/packager/invalid_imports_and_exports/__package.rb
+++ b/test/testdata/packager/invalid_imports_and_exports/__package.rb
@@ -1,8 +1,5 @@
 # typed: strict
 # enable-packager: true
-# disable-fast-path: true
-# ^ The "Only modules can be `include`d." error, unfortunately, doesn't surface the same errors on the fast path.
-# This is a restriction in other tests.
 
 class A < PackageSpec
   import 123

--- a/test/testdata/resolver/linearization/includes_class.rb
+++ b/test/testdata/resolver/linearization/includes_class.rb
@@ -1,5 +1,4 @@
 # typed: true
-# disable-fast-path: true
 class Sup
 end
 class A < Sup

--- a/test/testdata/resolver/linearization/includes_class.rb
+++ b/test/testdata/resolver/linearization/includes_class.rb
@@ -5,12 +5,14 @@ end
 class A < Sup
 end
 
-class B # error: Only modules can be `include`d
-  include A
+class B
+  include A # error: Only modules can be `include`d, but `A` is a class
+  extend A # error: Only modules can be `extend`d, but `A` is a class
 end
 
-module C # error: Only modules can be `include`d
-  include A
+module C
+  include A # error: Only modules can be `include`d, but `A` is a class
+  extend A # error: Only modules can be `extend`d, but `A` is a class
   def bla
     raise "s"
   end

--- a/test/testdata/resolver/linearization/includes_class.rb
+++ b/test/testdata/resolver/linearization/includes_class.rb
@@ -1,4 +1,5 @@
 # typed: true
+
 class Sup
 end
 class A < Sup

--- a/test/testdata/resolver/linearization/includes_class.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/linearization/includes_class.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=3:1 end=21:4}
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=3:1 end=23:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=??? end=???}
   class <C <U A>> < <C <U Sup>> () @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=5:1 end=5:14}
   class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Sup>> $1> () @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=5:7 end=5:8}
@@ -8,21 +8,21 @@ class <C <U <root>>> < <C <U Object>> ()
     method <S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=5:1 end=6:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=??? end=???}
   class <C <U B>> < <C <U Object>> (<C <U A>>, <C <U Sup>>, <C <U Object>>, <C <U Kernel>>, <C <U BasicObject>>) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=8:1 end=8:8}
-  class <S <C <U B>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=8:7 end=8:8}
+  class <S <C <U B>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U A>>, <C <U Sup>>, <C <U Object>>, <C <U Kernel>>, <C <U BasicObject>>) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=8:7 end=8:8}
     type-member(+) <S <C <U B>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U B>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=B) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=8:7 end=8:8}
-    method <S <C <U B>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=8:1 end=10:4}
+    method <S <C <U B>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=8:1 end=11:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=??? end=???}
-  module <C <U C>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> (<C <U A>>, <C <U Sup>>, <C <U Object>>, <C <U Kernel>>, <C <U BasicObject>>) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=12:1 end=12:9}
-    method <C <U C>><U bla> (<blk>) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=14:3 end=14:10}
+  module <C <U C>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> (<C <U A>>, <C <U Sup>>, <C <U Object>>, <C <U Kernel>>, <C <U BasicObject>>) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=13:1 end=13:9}
+    method <C <U C>><U bla> (<blk>) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=16:3 end=16:10}
       argument <blk><block> @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=??? end=???}
-  class <S <C <U C>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=12:8 end=12:9}
-    type-member(+) <S <C <U C>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U C>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=C) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=12:8 end=12:9}
-    method <S <C <U C>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=12:1 end=17:4}
+  class <S <C <U C>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> (<C <U A>>, <C <U Sup>>, <C <U Object>>, <C <U Kernel>>, <C <U BasicObject>>) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=13:8 end=13:9}
+    type-member(+) <S <C <U C>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U C>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=C) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=13:8 end=13:9}
+    method <S <C <U C>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=13:1 end=19:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=??? end=???}
-  module <C <U IncludesBO>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> (<C <U BasicObject>>) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=19:1 end=19:18}
-  class <S <C <U IncludesBO>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=19:8 end=19:18}
-    type-member(+) <S <C <U IncludesBO>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U IncludesBO>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=IncludesBO) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=19:8 end=19:18}
-    method <S <C <U IncludesBO>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=19:1 end=21:4}
+  module <C <U IncludesBO>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> (<C <U BasicObject>>) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=21:1 end=21:18}
+  class <S <C <U IncludesBO>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=21:8 end=21:18}
+    type-member(+) <S <C <U IncludesBO>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U IncludesBO>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=IncludesBO) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=21:8 end=21:18}
+    method <S <C <U IncludesBO>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=21:1 end=23:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=??? end=???}
   class <C <U Sup>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=3:1 end=3:10}
   class <S <C <U Sup>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/resolver/linearization/includes_class.rb start=3:7 end=3:10}


### PR DESCRIPTION
Make `Only modules can be included` error appear in incremental resolver. Also updates the error message to specify `include` or `extend`.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

One fewer difference between resolver and incremental resolver.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
