### PR TITLE
Don't force redefinition of fixed type members

### DIFF
--- a/rbi/gems/msgpack.rbi
+++ b/rbi/gems/msgpack.rbi
@@ -146,7 +146,6 @@ end
 
 class MessagePack::ExtensionValue < Struct
   include ::MessagePack::CoreExt
-  Elem = type_member(fixed: T.untyped)
 
   sig {returns(::T.untyped)}
   def payload(); end

--- a/rbi/stdlib/bundler.rbi
+++ b/rbi/stdlib/bundler.rbi
@@ -4034,9 +4034,6 @@ module Bundler::GemHelpers
 end
 
 class Bundler::GemHelpers::PlatformMatch < Struct
-  extend T::Generic
-  Elem = type_member(fixed: T.untyped)
-
   EXACT_MATCH = ::T.let(nil, T.untyped)
   WORST_MATCH = ::T.let(nil, T.untyped)
 
@@ -4508,9 +4505,6 @@ end
 
 class Bundler::LazySpecification::Identifier < Struct
   include ::Comparable
-  extend ::T::Generic
-
-  Elem = type_member(fixed: T.untyped)
 
   sig do
     params(
@@ -5322,9 +5316,6 @@ end
 # directed edge @attr [Vertex] destination The destination of the directed edge
 # @attr [Object] requirement The requirement the directed edge represents
 class Bundler::Molinillo::DependencyGraph::Edge < Struct
-  extend T::Generic
-  Elem = type_member(fixed: T.untyped)
-
   sig {returns(T.untyped)}
   def destination(); end
 
@@ -5822,9 +5813,6 @@ end
 # A state that encapsulates a set of {#requirements} with an {Array} of
 # possibilities
 class Bundler::Molinillo::DependencyState < Bundler::Molinillo::ResolutionState
-  extend T::Generic
-  Elem = type_member(fixed: T.untyped)
-
   # Removes a possibility from `self` @return [PossibilityState] a state with a
   # single possibility,
   #
@@ -5882,14 +5870,9 @@ end
 # A state that encapsulates a single possibility to fulfill the given
 # {#requirement}
 class Bundler::Molinillo::PossibilityState < Bundler::Molinillo::ResolutionState
-  extend T::Generic
-  Elem = type_member(fixed: T.untyped)
 end
 
 class Bundler::Molinillo::ResolutionState < Struct
-  extend T::Generic
-  Elem = type_member(fixed: T.untyped)
-
   sig {returns(T.untyped)}
   def activated(); end
 
@@ -6145,9 +6128,6 @@ class Bundler::Molinillo::Resolver::Resolution
 end
 
 class Bundler::Molinillo::Resolver::Resolution::Conflict < Struct
-  extend T::Generic
-  Elem = type_member(fixed: T.untyped)
-
   sig {returns(T.untyped)}
   def activated_by_name(); end
 
@@ -6261,9 +6241,6 @@ class Bundler::Molinillo::Resolver::Resolution::Conflict < Struct
 end
 
 class Bundler::Molinillo::Resolver::Resolution::PossibilitySet < Struct
-  extend T::Generic
-  Elem = type_member(fixed: T.untyped)
-
   sig {returns(T.untyped)}
   def dependencies(); end
 
@@ -6317,8 +6294,6 @@ end
 
 class Bundler::Molinillo::Resolver::Resolution::UnwindDetails < Struct
   include ::Comparable
-  extend T::Generic
-  Elem = type_member(fixed: T.untyped)
 
   # We compare
   # [`UnwindDetails`](https://docs.ruby-lang.org/en/2.6.0/Bundler/Molinillo/Resolver/Resolution/UnwindDetails.html)
@@ -8521,9 +8496,6 @@ class Bundler::Settings
 end
 
 class Bundler::Settings::Path < Struct
-  extend T::Generic
-  Elem = type_member(fixed: T.untyped)
-
   sig {returns(T.untyped)}
   def append_ruby_scope(); end
 

--- a/rbi/stdlib/net.rbi
+++ b/rbi/stdlib/net.rbi
@@ -4294,8 +4294,6 @@ end
 # :   nil indicates [RFC-822] group syntax. Otherwise, returns [RFC-822] domain
 #     name.
 class Net::IMAP::Address < Struct
-  Elem = type_member(fixed: T.untyped)
-
   def host(); end
 
   def host=(_); end
@@ -4725,8 +4723,6 @@ end
 # :   Returns a hash that represents parameters of the Content-Disposition
 #     field.
 class Net::IMAP::ContentDisposition < Struct
-  Elem = type_member(fixed: T.untyped)
-
   def dsp_type(); end
 
   def dsp_type=(_); end
@@ -4762,8 +4758,6 @@ end
 # raw\_data
 # :   Returns the raw data string.
 class Net::IMAP::ContinuationRequest < Struct
-  Elem = type_member(fixed: T.untyped)
-
   def data(); end
 
   def data=(_); end
@@ -4847,8 +4841,6 @@ end
 # message\_id
 # :   Returns a string that represents the message-id.
 class Net::IMAP::Envelope < Struct
-  Elem = type_member(fixed: T.untyped)
-
   def bcc(); end
 
   def bcc=(_); end
@@ -4947,8 +4939,6 @@ end
 #     UID
 # :       A number expressing the unique identifier of the message.
 class Net::IMAP::FetchData < Struct
-  Elem = type_member(fixed: T.untyped)
-
   def attr(); end
 
   def attr=(_); end
@@ -5006,8 +4996,6 @@ end
 # rights
 # :   The access rights the indicated user has to the mailbox.
 class Net::IMAP::MailboxACLItem < Struct
-  Elem = type_member(fixed: T.untyped)
-
   def mailbox(); end
 
   def mailbox=(_); end
@@ -5050,8 +5038,6 @@ end
 # name
 # :   Returns the mailbox name.
 class Net::IMAP::MailboxList < Struct
-  Elem = type_member(fixed: T.untyped)
-
   def attr(); end
 
   def attr=(_); end
@@ -5095,8 +5081,6 @@ end
 # quota
 # :   Quota limit imposed on the mailbox.
 class Net::IMAP::MailboxQuota < Struct
-  Elem = type_member(fixed: T.untyped)
-
   def mailbox(); end
 
   def mailbox=(_); end
@@ -5132,8 +5116,6 @@ end
 # quotaroots
 # :   Zero or more quotaroots that affect the quota on the specified mailbox.
 class Net::IMAP::MailboxQuotaRoot < Struct
-  Elem = type_member(fixed: T.untyped)
-
   def mailbox(); end
 
   def mailbox=(_); end
@@ -5220,8 +5202,6 @@ end
 # data
 # :   Returns the data, if it exists.
 class Net::IMAP::ResponseCode < Struct
-  Elem = type_member(fixed: T.untyped)
-
   def data(); end
 
   def data=(_); end
@@ -5291,8 +5271,6 @@ class Net::IMAP::ResponseParser
 end
 
 class Net::IMAP::ResponseParser::Token < Struct
-  Elem = type_member(fixed: T.untyped)
-
   def symbol(); end
 
   def symbol=(_); end
@@ -5324,8 +5302,6 @@ end
 # text
 # :   Returns the text.
 class Net::IMAP::ResponseText < Struct
-  Elem = type_member(fixed: T.untyped)
-
   def code(); end
 
   def code=(_); end
@@ -5353,8 +5329,6 @@ end
 # :   Returns a hash. Each key is one of "MESSAGES", "RECENT", "UIDNEXT",
 #     "UIDVALIDITY", "UNSEEN". Each value is a number.
 class Net::IMAP::StatusData < Struct
-  Elem = type_member(fixed: T.untyped)
-
   def attr(); end
 
   def attr=(_); end
@@ -5399,8 +5373,6 @@ end
 # raw\_data
 # :   Returns the raw data string.
 class Net::IMAP::TaggedResponse < Struct
-  Elem = type_member(fixed: T.untyped)
-
   def data(); end
 
   def data=(_); end
@@ -5438,8 +5410,6 @@ end
 #     [`Net::IMAP::ThreadMember`](https://docs.ruby-lang.org/en/2.6.0/Net/IMAP.html#ThreadMember)
 #     objects for mail items that are children of this in the thread.
 class Net::IMAP::ThreadMember < Struct
-  Elem = type_member(fixed: T.untyped)
-
   def children(); end
 
   def children=(_); end
@@ -5480,8 +5450,6 @@ end
 # raw\_data
 # :   Returns the raw data string.
 class Net::IMAP::UntaggedResponse < Struct
-  Elem = type_member(fixed: T.untyped)
-
   def data(); end
 
   def data=(_); end
@@ -6229,8 +6197,6 @@ class Net::SFTP::Operations::Download
 end
 
 class Net::SFTP::Operations::Download::Entry < Struct
-  Elem = type_member(fixed: T.untyped)
-
   def directory(); end
 
   def directory=(_); end
@@ -6338,8 +6304,6 @@ class Net::SFTP::Operations::Upload
 end
 
 class Net::SFTP::Operations::Upload::LiveFile < Struct
-  Elem = type_member(fixed: T.untyped)
-
   def handle(); end
 
   def handle=(_); end
@@ -6610,8 +6574,6 @@ class Net::SFTP::Protocol::V04::Attributes < Net::SFTP::Protocol::V01::Attribute
 end
 
 class Net::SFTP::Protocol::V04::Attributes::ACL < Struct
-  Elem = type_member(fixed: T.untyped)
-
   def flag(); end
 
   def flag=(_); end
@@ -8579,8 +8541,6 @@ class Net::SSH::Service::Forward
 end
 
 class Net::SSH::Service::Forward::Remote < Struct
-  Elem = type_member(fixed: T.untyped)
-
   def host(); end
 
   def host=(_); end

--- a/rbi/stdlib/openssl.rbi
+++ b/rbi/stdlib/openssl.rbi
@@ -1607,11 +1607,9 @@ class OpenSSL::ASN1::PrintableString < OpenSSL::ASN1::Primitive
 end
 
 class OpenSSL::ASN1::Sequence < OpenSSL::ASN1::Constructive
-  Elem = type_member(fixed: T.untyped)
 end
 
 class OpenSSL::ASN1::Set < OpenSSL::ASN1::Constructive
-  Elem = type_member(fixed: T.untyped)
 end
 
 class OpenSSL::ASN1::T61String < OpenSSL::ASN1::Primitive

--- a/rbi/stdlib/rexml.rbi
+++ b/rbi/stdlib/rexml.rbi
@@ -643,8 +643,6 @@ end
 class REXML::DocType < ::REXML::Parent
   include(::REXML::XMLTokens)
 
-  Elem = type_member(fixed: REXML::Child)
-
   DEFAULT_ENTITIES = T.let(T.unsafe(nil), T::Hash[T.untyped, T.untyped])
 
   PUBLIC = T.let(T.unsafe(nil), String)
@@ -755,9 +753,6 @@ end
 # [`REXML`](https://docs.ruby-lang.org/en/2.6.0/REXML.html) documents do not
 # write a default declaration for you. See |DECLARATION| and |write|.
 class REXML::Document < ::REXML::Element
-
-  Elem = type_member(fixed: REXML::Child)
-
   # A convenient default [`XML`](https://docs.ruby-lang.org/en/2.6.0/XML.html)
   # declaration. If you want an
   # [`XML`](https://docs.ruby-lang.org/en/2.6.0/XML.html) declaration, the

--- a/test/cli/symbol-table/symbol-table.out
+++ b/test/cli/symbol-table/symbol-table.out
@@ -4,8 +4,8 @@ class ::<root> < ::Object ()
     method ::<Class:<root>>#<static-init> (<blk>) @ test/cli/symbol-table/symbol-table.rb:2
       argument <blk><block> @ Loc {file=test/cli/symbol-table/symbol-table.rb start=??? end=???}
   module ::Net < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#L3
-    module ::Net::SSH < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#L7654
-      module ::Net::SSH::Authentication < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#L7664
+    module ::Net::SSH < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#L7616
+      module ::Net::SSH::Authentication < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#L7626
         module ::Net::SSH::Authentication::CustomModule < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/cli/symbol-table/symbol-table.rb:2
         class ::Net::SSH::Authentication::<Class:CustomModule>[<AttachedClass>] < ::Module () @ test/cli/symbol-table/symbol-table.rb:2
           type-member(+) ::Net::SSH::Authentication::<Class:CustomModule>::<AttachedClass> -> T.attached_class (of Net::SSH::Authentication::CustomModule) @ test/cli/symbol-table/symbol-table.rb:2

--- a/test/testdata/resolver/fuzz_type_member_forget.rb
+++ b/test/testdata/resolver/fuzz_type_member_forget.rb
@@ -9,4 +9,4 @@ class DifferentArityChild < Parent # error: Type `TParent` declared by parent `P
   TChild = type_member(fixed: String)
 end
 
-T.cast(1, DifferentArityChild[Integer, String, Symbol]) # error-with-dupes: Wrong number of type parameters for `DifferentArityChild`. Expected: `0`, got: `3`
+T.cast(1, DifferentArityChild[Integer, String, Symbol]) # error-with-dupes: Wrong number of type parameters for `DifferentArityChild`. Expected: `1`, got: `3`

--- a/test/testdata/resolver/redefinition_of_subclass_type_member.rb
+++ b/test/testdata/resolver/redefinition_of_subclass_type_member.rb
@@ -28,4 +28,5 @@ class Bar < Foo # error: Type `V` declared by parent `Foo` must be re-declared i
   K = Bar[String,String].new.foo('a', 2)
 # ^ error: Type variable `K` needs to be declared as `= type_member(SOMETHING)`
     # ^^^^^^^^^^^^^^^^^^ error: Wrong number of type parameters
+                                    # ^ error: Expected `String` but found `Integer(2)` for argument `v`
 end

--- a/test/testdata/resolver/type_member_missing.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/type_member_missing.rb.symbol-table-raw.exp
@@ -8,8 +8,8 @@ class <C <U <root>>> < <C <U Object>> ()
     type-member(+) <S <C <U Base>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Base>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U Base>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/resolver/type_member_missing.rb start=3:7 end=3:11}
     method <S <C <U Base>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/type_member_missing.rb start=3:1 end=7:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/type_member_missing.rb start=??? end=???}
-  class <C <U Child>> < <C <U Base>> () @ Loc {file=test/testdata/resolver/type_member_missing.rb start=9:1 end=9:19}
-    type-member(=) <C <U Child>><C <U Elem>> -> LambdaParam(<C <U Child>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/resolver/type_member_missing.rb start=9:1 end=9:19}
+  class <C <U Child>>[<C <U Elem>>] < <C <U Base>> () @ Loc {file=test/testdata/resolver/type_member_missing.rb start=9:1 end=9:19}
+    type-member(=) <C <U Child>><C <U Elem>> -> LambdaParam(<C <U Child>><C <U Elem>>, lower=T.untyped, upper=T.untyped) @ Loc {file=test/testdata/resolver/type_member_missing.rb start=9:1 end=9:19}
   class <S <C <U Child>> $1>[<C <U <AttachedClass>>>] < <S <C <U Base>> $1> () @ Loc {file=test/testdata/resolver/type_member_missing.rb start=9:7 end=9:12}
     type-member(+) <S <C <U Child>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Child>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U Child>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/resolver/type_member_missing.rb start=9:7 end=9:12}
     method <S <C <U Child>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/type_member_missing.rb start=9:1 end=12:4}

--- a/test/testdata/resolver/type_members_fixed.rb
+++ b/test/testdata/resolver/type_members_fixed.rb
@@ -1,0 +1,22 @@
+# typed: true
+
+class G
+  extend T::Generic
+
+  MYPARAM = type_member
+end
+
+class Correct1 < G
+  extend T::Generic
+
+  MYPARAM = type_member(fixed: String)
+end
+
+class Correct2 < Correct1
+end
+
+class Correct3 < Correct2
+end
+
+class Correct4 < Correct3
+end

--- a/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
@@ -152,7 +152,7 @@ class <C <U <root>>> < <C <U Object>> ()
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
   class <C <U RealStructDesugar>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=18:1 end=18:24}
     class <C <U RealStructDesugar>><C <U A>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=19:5 end=19:21}
-      type-member(=) <C <U RealStructDesugar>><C <U A>><C <U Elem>> -> LambdaParam(<C <U RealStructDesugar>><C <U A>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=19:5 end=19:21}
+      type-member(=) <C <U RealStructDesugar>><C <U A>><C <U Elem>> -> LambdaParam(<C <U Struct>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=19:5 end=19:21}
       method <C <U RealStructDesugar>><C <U A>><U bar> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=22:9 end=22:16}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
       method <C <U RealStructDesugar>><C <U A>><U bar=> (arg0, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=24:9 end=24:23}


### PR DESCRIPTION
### Motivation

With its current behaviour, Sorbet forces users to redefine every fixed type members used in one of the ancestors.

As shown in the example below, introducing a fixed type member "pollute" the class hierarchy and requires a lot of boilerplate code to be added in all the descendants.

Furthermore, since Sorbet implicitly copies the type member when it's not found locally, error messages point to the wrong place and one has to go up the hierarchy class by class to find the real introduction:

```ruby
# typed: true

class Base
  extend T::Generic

  MYPARAM = type_member(fixed: String)
end

class C1 < Base # error: Type MYPARAM declared by parent Base must be re-declared in C1
end

class C2 < C1 # error: Type MYPARAM declared by parent C1 must be re-declared in C2
end

class C3 < C2 # error: Type MYPARAM declared by parent C2 must be re-declared in C3
end

class C4 < C3 # error: Type MYPARAM declared by parent C4 must be re-declared in C3
end
```

This pull-request makes it optional to redefine a type member which is already fixed by an ancestor, then silencing the errors.

Now, the type member is implicitly copied with the fixed bound from the parent and marked as invariant:

```ruby
# typed: true

class Base
  extend T::Generic

  MYPARAM = type_member(fixed: String)
end

class C1 < Base
  MYPARAM = type_member(fixed: String) # Implicitly copied from Base
end

class C2 < C1
  MYPARAM = type_member(fixed: String) # Implicitly copied from C1
end

# ...
```

This PR also cleans all the unnecessary type members from the core/stdlib RBIs.

Note that this doesn't change anything to the behaviour of non-fixed type members.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.