### PR TITLE
don't check abstract methods on singleton classes

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -579,6 +579,8 @@ public:
         auto singleton = sym.data(ctx)->lookupSingletonClass(ctx);
         validateTStructNotGrandparent(ctx, sym);
         if (!sym.data(ctx)->isSingletonClass(ctx)) {
+            // Only validateAbstract for this class if we haven't already (we already have if this
+            // is a `class << self` ClassDef)
             validateAbstract(ctx, sym);
         }
         validateAbstract(ctx, singleton);

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -578,7 +578,9 @@ public:
         auto sym = classDef.symbol;
         auto singleton = sym.data(ctx)->lookupSingletonClass(ctx);
         validateTStructNotGrandparent(ctx, sym);
-        validateAbstract(ctx, sym);
+        if (!sym.data(ctx)->isSingletonClass(ctx)) {
+            validateAbstract(ctx, sym);
+        }
         validateAbstract(ctx, singleton);
         validateFinal(ctx, sym, classDef);
         validateSealed(ctx, sym, classDef);

--- a/test/testdata/duplicate_abstract_errors.rb
+++ b/test/testdata/duplicate_abstract_errors.rb
@@ -1,0 +1,15 @@
+# typed: true
+class Parent
+  extend T::Sig
+  extend T::Helpers
+  abstract!
+
+  sig {abstract.returns(Integer)}
+  def self.foo; end
+end
+
+class Child < Parent
+  class << self # error: Missing definition for abstract method `Parent.foo`
+    extend T::Sig
+  end
+end


### PR DESCRIPTION
When we are validating abstract methods, we shouldn't validate them if the classDef's symbol is a singleton class; we will have validated against the same class elsewhere, and we don't want to issue duplicate errors.

### Motivation

Fixes #3692 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
