### PR TITLE
Fix double free heap corruption bug.

### DIFF
--- a/main/lsp/LSPTask.h
+++ b/main/lsp/LSPTask.h
@@ -33,11 +33,11 @@ protected:
     void addLocIfExists(const core::GlobalState &gs, std::vector<std::unique_ptr<Location>> &locs, core::Loc loc) const;
     std::vector<std::unique_ptr<Location>>
     extractLocations(const core::GlobalState &gs,
-                     const std::vector<std::unique_ptr<core::lsp::QueryResponse>> &queryResponses,
+                     std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&queryResponses,
                      std::vector<std::unique_ptr<Location>> locations = {}) const;
     std::vector<std::unique_ptr<core::lsp::QueryResponse>>
     filterAndDedup(const core::GlobalState &gs,
-                   const std::vector<std::unique_ptr<core::lsp::QueryResponse>> &queryResponses) const;
+                   std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&queryResponses) const;
 
     LSPQueryResult queryByLoc(LSPTypecheckerDelegate &typechecker, std::string_view uri, const Position &pos,
                               LSPMethod forMethod, bool errorIfFileIsUntyped = true) const;

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -70,7 +70,7 @@ unique_ptr<ResponseMessage> DocumentHighlightTask::runRequest(LSPTypecheckerDele
                     auto run2 = typechecker.query(
                         core::lsp::Query::createVarQuery(identResp->enclosingMethod, identResp->variable),
                         {loc.file()});
-                    auto locations = extractLocations(gs, run2.responses);
+                    auto locations = extractLocations(gs, move(run2.responses));
                     response->result = locationsToDocumentHighlights(uri, move(locations));
                 }
             } else if (fileIsTyped && resp->isSend()) {

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -51,7 +51,7 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &t
                     auto run2 = typechecker.query(
                         core::lsp::Query::createVarQuery(identResp->enclosingMethod, identResp->variable),
                         {loc.file()});
-                    response->result = extractLocations(gs, run2.responses);
+                    response->result = extractLocations(gs, move(run2.responses));
                 }
             } else if (fileIsTyped && resp->isSend()) {
                 auto sendResp = resp->isSend();

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -240,7 +240,7 @@ variant<JSONNullObject, unique_ptr<WorkspaceEdit>> RenameTask::getRenameEdits(LS
         // Filter for untyped files, and deduplicate responses by location.  We don't use extractLocations here because
         // in some cases like sends, we need the SendResponse to be able to accurately find the method name in the
         // expression.
-        for (auto &response : filterAndDedup(gs, queryResult.responses)) {
+        for (auto &response : filterAndDedup(gs, move(queryResult.responses))) {
             auto loc = response->getLoc();
             if (loc.file().data(gs).isPayload()) {
                 // We don't support renaming things in payload files.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Fix double free heap corruption bug. We had code that passed a raw pointer from one `unique_ptr` to another `unique_ptr`, causing that pointer to be freed twice.

Changes `filterAndDedup` to filter and dedup in place, and to consume the input vector.

cc @soam-stripe 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I believe this will fix https://github.com/sorbet/sorbet/issues/3737

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

idk why CI didn't catch this before.
