### PR TITLE
Adds support for prop/const/attr_* in Find All References / Document Highlight

### DIFF
--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -98,6 +98,9 @@ public:
     SymbolRef lookupStaticFieldSymbol(SymbolRef owner, NameRef name) const {
         return lookupSymbolWithFlags(owner, name, Symbol::Flags::STATIC_FIELD);
     }
+    SymbolRef lookupFieldSymbol(SymbolRef owner, NameRef name) const {
+        return lookupSymbolWithFlags(owner, name, Symbol::Flags::FIELD);
+    }
     SymbolRef findRenamedSymbol(SymbolRef owner, SymbolRef name) const;
 
     SymbolRef staticInitForFile(Loc loc);

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -261,8 +261,7 @@ LSPTask::getReferencesToSymbol(LSPTypecheckerDelegate &typechecker, core::Symbol
                                vector<unique_ptr<core::lsp::QueryResponse>> &&priorRefs) const {
     if (symbol.exists()) {
         auto run2 = queryBySymbol(typechecker, symbol);
-        priorRefs.insert(priorRefs.end(), make_move_iterator(run2.responses.begin()),
-                         make_move_iterator(run2.responses.end()));
+        absl::c_move(run2.responses, back_inserter(priorRefs));
     }
     return move(priorRefs);
 }

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -224,9 +224,9 @@ LSPTask::filterAndDedup(const core::GlobalState &gs,
               [](const unique_ptr<core::lsp::QueryResponse> &a, const unique_ptr<core::lsp::QueryResponse> &b) -> bool {
                   auto aLoc = a->getLoc();
                   auto bLoc = b->getLoc();
-                  auto cmp = aLoc.file().id() - bLoc.file().id();
+                  int cmp = aLoc.file().id() - bLoc.file().id();
                   if (cmp == 0) {
-                      cmp = (aLoc.beginPos() - bLoc.beginPos());
+                      cmp = aLoc.beginPos() - bLoc.beginPos();
                   }
                   if (cmp == 0) {
                       cmp = aLoc.endPos() - bLoc.endPos();

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -288,7 +288,7 @@ LSPTask::getHighlights(LSPTypecheckerDelegate &typechecker,
     auto locations = extractLocations(typechecker.state(), queryResponses);
     for (auto const &location : locations) {
         auto highlight = make_unique<DocumentHighlight>(move(location->range));
-        highlights.push_back(move(highlight));
+        highlights.emplace_back(move(highlight));
     }
     return highlights;
 }

--- a/main/lsp/LSPTask.h
+++ b/main/lsp/LSPTask.h
@@ -38,9 +38,13 @@ protected:
     std::vector<std::unique_ptr<core::lsp::QueryResponse>>
     getReferencesToSymbol(LSPTypecheckerDelegate &typechecker, core::SymbolRef symbol,
                           std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&priorRefs = {}) const;
+    std::vector<std::unique_ptr<core::lsp::QueryResponse>>
+    getReferencesToSymbolInFile(LSPTypecheckerDelegate &typechecker, core::FileRef file, core::SymbolRef symbol,
+                                std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&priorRefs = {}) const;
+
     std::vector<std::unique_ptr<DocumentHighlight>>
-    getHighlightsToSymbolInFile(LSPTypecheckerDelegate &typechecker, std::string_view uri, core::SymbolRef symbol,
-                                std::vector<std::unique_ptr<DocumentHighlight>> highlights = {}) const;
+    getHighlights(LSPTypecheckerDelegate &typechecker,
+                  const std::vector<std::unique_ptr<core::lsp::QueryResponse>> &responses) const;
     void addLocIfExists(const core::GlobalState &gs, std::vector<std::unique_ptr<Location>> &locs, core::Loc loc) const;
     std::vector<std::unique_ptr<Location>>
     extractLocations(const core::GlobalState &gs,
@@ -62,14 +66,15 @@ protected:
 
     // Get references to the given accessor. If `info.accessorType` is `None`, it returns references to `fallback` only.
     std::vector<std::unique_ptr<core::lsp::QueryResponse>>
-    getReferencesForAccessor(LSPTypecheckerDelegate &typechecker, const AccessorInfo info, core::SymbolRef fallback,
-                             std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&priorRefs = {}) const;
+    getReferencesToAccessor(LSPTypecheckerDelegate &typechecker, const AccessorInfo info, core::SymbolRef fallback,
+                            std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&priorRefs = {}) const;
 
-    // Get highlights to the given accessor. If `info.accessorType` is `None`, it returns highlights to `fallback` only.
-    std::vector<std::unique_ptr<DocumentHighlight>>
-    getHighlightsForAccessorInFile(LSPTypecheckerDelegate &typechecker, std::string_view uri, const AccessorInfo info,
-                                   core::SymbolRef fallback,
-                                   std::vector<std::unique_ptr<DocumentHighlight>> &&highlights = {}) const;
+    // Get references to the given accessor in the given file. If `info.accessorType` is `None`, it returns highlights
+    // to `fallback` only.
+    std::vector<std::unique_ptr<core::lsp::QueryResponse>>
+    getReferencesToAccessorInFile(LSPTypecheckerDelegate &typechecker, core::FileRef fref, const AccessorInfo info,
+                                  core::SymbolRef fallback,
+                                  std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&priorRefs = {}) const;
 
     LSPTask(const LSPConfiguration &config, LSPMethod method);
 

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -45,6 +45,10 @@ unique_ptr<ResponseMessage> DocumentHighlightTask::runRequest(LSPTypecheckerDele
         // An explicit null indicates that we don't support this request (or that nothing was at the location).
         // Note: Need to correctly type variant here so it goes into right 'slot' of result variant.
         response->result = variant<JSONNullObject, vector<unique_ptr<DocumentHighlight>>>(JSONNullObject());
+        auto fref = config.uri2FileRef(typechecker.state(), uri);
+        if (!fref.exists()) {
+            return response;
+        }
         auto &queryResponses = result.responses;
         if (!queryResponses.empty()) {
             auto file = config.uri2FileRef(gs, uri);
@@ -56,16 +60,21 @@ unique_ptr<ResponseMessage> DocumentHighlightTask::runRequest(LSPTypecheckerDele
             // N.B.: Ignores literals.
             // If file is untyped, only supports find reference requests from constants and class definitions.
             if (auto constResp = resp->isConstant()) {
-                response->result = getHighlightsToSymbolInFile(typechecker, uri, constResp->symbol);
+                response->result =
+                    getHighlights(typechecker, getReferencesToSymbolInFile(typechecker, fref, constResp->symbol));
             } else if (auto fieldResp = resp->isField()) {
                 // This could be a `prop` or `attr_*`, which have multiple associated symbols.
-                response->result = getHighlightsForAccessorInFile(
-                    typechecker, uri, getAccessorInfo(typechecker.state(), fieldResp->symbol), fieldResp->symbol);
+                response->result = getHighlights(
+                    typechecker, getReferencesToAccessorInFile(typechecker, fref,
+                                                               getAccessorInfo(typechecker.state(), fieldResp->symbol),
+                                                               fieldResp->symbol));
             } else if (auto defResp = resp->isDefinition()) {
                 if (fileIsTyped || defResp->symbol.data(gs)->isClassOrModule()) {
                     // This could be a `prop` or `attr_*`, which have multiple associated symbols.
-                    response->result = getHighlightsForAccessorInFile(
-                        typechecker, uri, getAccessorInfo(typechecker.state(), defResp->symbol), defResp->symbol);
+                    response->result = getHighlights(
+                        typechecker,
+                        getReferencesToAccessorInFile(
+                            typechecker, fref, getAccessorInfo(typechecker.state(), defResp->symbol), defResp->symbol));
                 }
             } else if (fileIsTyped && resp->isIdent()) {
                 auto identResp = resp->isIdent();
@@ -80,17 +89,17 @@ unique_ptr<ResponseMessage> DocumentHighlightTask::runRequest(LSPTypecheckerDele
             } else if (fileIsTyped && resp->isSend()) {
                 auto sendResp = resp->isSend();
                 auto start = sendResp->dispatchResult.get();
-                vector<unique_ptr<DocumentHighlight>> highlights;
+                vector<unique_ptr<core::lsp::QueryResponse>> references;
                 while (start != nullptr) {
                     if (start->main.method.exists() && !start->main.receiver.isUntyped()) {
                         // This could be a `prop` or `attr_*`, which have multiple associated symbols.
-                        highlights = getHighlightsForAccessorInFile(
-                            typechecker, uri, getAccessorInfo(typechecker.state(), start->main.method),
-                            start->main.method);
+                        references = getReferencesToAccessorInFile(
+                            typechecker, fref, getAccessorInfo(typechecker.state(), start->main.method),
+                            start->main.method, move(references));
                     }
                     start = start->secondary.get();
                 }
-                response->result = move(highlights);
+                response->result = getHighlights(typechecker, references);
             }
         }
     }

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -1,5 +1,4 @@
 #include "main/lsp/requests/references.h"
-#include "absl/strings/match.h"
 #include "core/lsp/QueryResponse.h"
 #include "main/lsp/ShowOperation.h"
 #include "main/lsp/json_types.h"
@@ -37,12 +36,21 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &t
             // N.B.: Ignores literals.
             // If file is untyped, only supports find reference requests from constants and class definitions.
             if (auto constResp = resp->isConstant()) {
-                response->result = getReferencesToSymbol(typechecker, constResp->symbol);
+                response->result =
+                    extractLocations(typechecker.state(), getReferencesToSymbol(typechecker, constResp->symbol));
             } else if (auto fieldResp = resp->isField()) {
-                response->result = getReferencesToSymbol(typechecker, fieldResp->symbol);
+                // This could be a `prop` or `attr_*`, which have multiple associated symbols.
+                response->result = extractLocations(
+                    typechecker.state(),
+                    getReferencesForAccessor(typechecker, getAccessorInfo(typechecker.state(), fieldResp->symbol),
+                                             fieldResp->symbol));
             } else if (auto defResp = resp->isDefinition()) {
                 if (fileIsTyped || defResp->symbol.data(gs)->isClassOrModule()) {
-                    response->result = getReferencesToSymbol(typechecker, defResp->symbol);
+                    // This could be a `prop` or `attr_*`, which have multiple associated symbols.
+                    response->result = extractLocations(
+                        typechecker.state(),
+                        getReferencesForAccessor(typechecker, getAccessorInfo(typechecker.state(), defResp->symbol),
+                                                 defResp->symbol));
                 }
             } else if (fileIsTyped && resp->isIdent()) {
                 auto identResp = resp->isIdent();
@@ -56,14 +64,17 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &t
             } else if (fileIsTyped && resp->isSend()) {
                 auto sendResp = resp->isSend();
                 auto start = sendResp->dispatchResult.get();
-                vector<unique_ptr<Location>> locations;
+                vector<unique_ptr<core::lsp::QueryResponse>> responses;
                 while (start != nullptr) {
                     if (start->main.method.exists() && !start->main.receiver.isUntyped()) {
-                        locations = getReferencesToSymbol(typechecker, start->main.method, move(locations));
+                        // This could be a `prop` or `attr_*`, which has multiple associated symbols.
+                        responses = getReferencesForAccessor(typechecker,
+                                                             getAccessorInfo(typechecker.state(), start->main.method),
+                                                             start->main.method, move(responses));
                     }
                     start = start->secondary.get();
                 }
-                response->result = move(locations);
+                response->result = extractLocations(typechecker.state(), responses);
             }
         }
     }

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -42,15 +42,15 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &t
                 // This could be a `prop` or `attr_*`, which have multiple associated symbols.
                 response->result = extractLocations(
                     typechecker.state(),
-                    getReferencesForAccessor(typechecker, getAccessorInfo(typechecker.state(), fieldResp->symbol),
-                                             fieldResp->symbol));
+                    getReferencesToAccessor(typechecker, getAccessorInfo(typechecker.state(), fieldResp->symbol),
+                                            fieldResp->symbol));
             } else if (auto defResp = resp->isDefinition()) {
                 if (fileIsTyped || defResp->symbol.data(gs)->isClassOrModule()) {
                     // This could be a `prop` or `attr_*`, which have multiple associated symbols.
                     response->result = extractLocations(
                         typechecker.state(),
-                        getReferencesForAccessor(typechecker, getAccessorInfo(typechecker.state(), defResp->symbol),
-                                                 defResp->symbol));
+                        getReferencesToAccessor(typechecker, getAccessorInfo(typechecker.state(), defResp->symbol),
+                                                defResp->symbol));
                 }
             } else if (fileIsTyped && resp->isIdent()) {
                 auto identResp = resp->isIdent();
@@ -68,9 +68,9 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &t
                 while (start != nullptr) {
                     if (start->main.method.exists() && !start->main.receiver.isUntyped()) {
                         // This could be a `prop` or `attr_*`, which has multiple associated symbols.
-                        responses = getReferencesForAccessor(typechecker,
-                                                             getAccessorInfo(typechecker.state(), start->main.method),
-                                                             start->main.method, move(responses));
+                        responses = getReferencesToAccessor(typechecker,
+                                                            getAccessorInfo(typechecker.state(), start->main.method),
+                                                            start->main.method, move(responses));
                     }
                     start = start->secondary.get();
                 }

--- a/test/testdata/lsp/prop_support.rb
+++ b/test/testdata/lsp/prop_support.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+# Note: We use versions below to denote the field (2) and method (1) defined by `const`.
+class Computer < T::Struct
+  const :make, String
+# ^^^^^^^^^^^^^^^^^^^ def: make 1
+  #      ^^^^ def: make 2
+
+  def get_make
+    @make
+    #^^^^ usage: make 2
+  end
+end
+Computer.new(make: "Gateway").make 
+#                             ^^^^ usage: make 1

--- a/test/testdata/lsp/prop_support.rb
+++ b/test/testdata/lsp/prop_support.rb
@@ -1,15 +1,93 @@
-# typed: true
+# typed: strict
 
-# Note: We use versions below to denote the field (2) and method (1) defined by `const`.
-class Computer < T::Struct
+# Note: We use versions below to denote the field (2) and method (1) defined by the accessor
+class Item < T::Struct
+  extend T::Sig
+
   const :make, String
 # ^^^^^^^^^^^^^^^^^^^ def: make 1
   #      ^^^^ def: make 2
 
-  def get_make
+
+  prop :model, String
+# ^^^^^^^^^^^^^^^^^^^ def: model 1
+  #     ^^^^^ def: model 2
+
+  sig {void}
+  def write_accessors
+    self.model = "newmodel"
+  #      ^^^^^ usage: model 1
+  end
+
+  sig {void}
+  def read_accessors
+    self.make
+  #      ^^^^ usage: make 1
+    self.model
+  #      ^^^^^ usage: model 1
+  end
+
+  sig {void}
+  def read_fields
     @make
     #^^^^ usage: make 2
+    @model
+    #^^^^^ usage: model 2
   end
 end
-Computer.new(make: "Gateway").make 
-#                             ^^^^ usage: make 1
+
+class ItemMetadata
+  extend T::Sig
+  
+  sig {returns(String)}
+  attr_reader :serial
+# ^^^^^^^^^^^^^^^^^^^ def: serial 1
+  #            ^^^^^^ def: serial 2
+
+  sig {params(owner: String).returns(String)}
+  attr_writer :owner
+# ^^^^^^^^^^^^^^^^^^ def: owner 1
+  #            ^^^^^ def: owner 2
+
+  sig {returns(String)}
+  attr_accessor :region
+# ^^^^^^^^^^^^^^^^^^^^^ def: region 1
+  #              ^^^^^^ def: region 2
+
+  sig {void}
+  def initialize
+    @serial = T.let("", String)
+    #^^^^^^ usage: serial 2
+    @owner = T.let("", String)
+    #^^^^^ usage: owner 2
+    @region = T.let("", String)
+    #^^^^^^ usage: region 2
+  end
+
+  sig {void}
+  def write_accessors
+    self.owner = "garfield"
+  #      ^^^^^ usage: owner 1
+    self.region = "USA"
+  #      ^^^^^^ usage: region 1
+  end
+
+  sig {void}
+  def read_accessors
+    self.serial
+  #      ^^^^^^ usage: serial 1
+    self.region
+  #      ^^^^^^ usage: region 1
+  end
+
+  sig {void}
+  def read_fields
+    @serial
+    #^^^^^^ usage: serial 2
+    @owner
+    #^^^^^ usage: owner 2
+    @region
+    #^^^^^^ usage: region 2
+  end
+end
+

--- a/test/testdata/lsp/prop_support.rb
+++ b/test/testdata/lsp/prop_support.rb
@@ -42,26 +42,26 @@ class ItemMetadata
   sig {returns(String)}
   attr_reader :serial
 # ^^^^^^^^^^^^^^^^^^^ def: serial 1
-  #            ^^^^^^ def: serial 2
+  #            ^^^^^^ usage: serial 2
 
   sig {params(owner: String).returns(String)}
   attr_writer :owner
 # ^^^^^^^^^^^^^^^^^^ def: owner 1
-  #            ^^^^^ def: owner 2
+  #            ^^^^^ usage: owner 2
 
   sig {returns(String)}
   attr_accessor :region
 # ^^^^^^^^^^^^^^^^^^^^^ def: region 1
-  #              ^^^^^^ def: region 2
+  #              ^^^^^^ usage: region 2
 
   sig {void}
   def initialize
     @serial = T.let("", String)
-    #^^^^^^ usage: serial 2
+    #^^^^^^ def: serial 2
     @owner = T.let("", String)
-    #^^^^^ usage: owner 2
+    #^^^^^ def: owner 2
     @region = T.let("", String)
-    #^^^^^^ usage: region 2
+    #^^^^^^ def: region 2
   end
 
   sig {void}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Adds support for prop/const/attr_* in Find All References / Document Highlight. Involves rejiggering document highlight's helper functions a bit so they can cleanly re-use deduping functionality. Also fixes a bug in deduping where `auto` inferred an unsigned type when it should've been an `int`.

When you Find All References on a field reference, method call, or a method definition site, you could plausibly be pointing at a method or a field defined by a `prop` or an `attr_reader`. The code does the following to detect if this is true:
* Extracts the base name of the thing you're pointing at (e.g. `@foo` => `foo`, `foo=` => `foo`)
* Ensures one of method `foo` or `foo=` exists on the owning class.
* Checks the definition site of `foo` or `foo=`.
  * If it begins with `prop`/etc, we're in business.
* Returns a struct containing the type of accessor (reader / writer / both / none) and symbols for the field, reader, and writer.

I've added code that consumes this struct and returns all references that refer to any of the items defined by `prop` et al.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Users want this feature.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
