### PR TITLE
Add documentation for `T::Sig::WithoutRuntime.sig`

### DIFF
--- a/website/docs/runtime.md
+++ b/website/docs/runtime.md
@@ -284,6 +284,17 @@ For example, this should probably be placed as the first line of any `rake test`
 target, as well as any other entry point to a project's tests. If this line is
 absent, `.checked(:tests)` sigs behave as if they had been `.checked(:never)`.
 
+## T::Sig::WithoutRuntime.sig
+
+Even with `.checked(:never)` you are opting into evaluating the sig at runtime.
+If you want to minimize runtime overhead but keep utilizing the static
+checks you can use `T::Sig::WithoutRuntime.sig` instead of `sig`.
+
+```ruby
+# Never runs runtime checks and does not evaluate the sig at runtime
+T::Sig::WithoutRuntime.sig {params(xs: T::Array[String]).void}
+```
+
 ## What's next?
 
 - [Signatures](sigs.md)

--- a/website/docs/runtime.md
+++ b/website/docs/runtime.md
@@ -287,8 +287,8 @@ absent, `.checked(:tests)` sigs behave as if they had been `.checked(:never)`.
 ## T::Sig::WithoutRuntime.sig
 
 Even with `.checked(:never)` you are opting into evaluating the sig at runtime.
-If you want to minimize runtime overhead but keep utilizing the static
-checks you can use `T::Sig::WithoutRuntime.sig` instead of `sig`.
+If you want to minimize runtime overhead but still statically check the sig when
+running srb tc, you can use `T::Sig::WithoutRuntime.sig` instead of `sig`.
 
 ```ruby
 # Never runs runtime checks and does not evaluate the sig at runtime

--- a/website/docs/runtime.md
+++ b/website/docs/runtime.md
@@ -291,8 +291,19 @@ If you want to minimize runtime overhead but still statically check the sig when
 running srb tc, you can use `T::Sig::WithoutRuntime.sig` instead of `sig`.
 
 ```ruby
-# Never runs runtime checks and does not evaluate the sig at runtime
-T::Sig::WithoutRuntime.sig {params(xs: T::Array[String]).void}
+# typed: true
+require "sorbet-runtime"
+
+class Foo
+  extend T::Sig
+  # This signature will raise both statically and at runtime because `NotFound` doesn't exist
+  sig { params(x: NotFound).void.checked(:never) }
+  def foo(x); end
+
+  # This signature will only raise statically, the sig block isn't evaluated at runtime
+  T::Sig::WithoutRuntime.sig { params(x: NotFound).void }
+  def bar(x); end
+end
 ```
 
 ## What's next?


### PR DESCRIPTION
Adds a brief documentation on `T::Sig::WithoutRuntime.sig` right after `.checked()`. It's placed here since at this point docs have mentioned why runtime checks are important and we already mentioned one way to disable runtime checks on a per sig basis. 

### Motivation
`T::Sig::WithoutRuntime.sig` is an important part of Sorbet and should be available for users to learn about in the docs similar to `checked(:never)`.


<img width="881" alt="Screen Shot 2020-11-27 at 12 29 02 PM" src="https://user-images.githubusercontent.com/16736048/100473355-25b41880-30ac-11eb-8885-ceb8dc00049e.png">
