### PR TITLE
Watchman: Ignore rsync tempfiles.

### DIFF
--- a/main/lsp/watchman/WatchmanProcess.cc
+++ b/main/lsp/watchman/WatchmanProcess.cc
@@ -38,19 +38,22 @@ void WatchmanProcess::start() {
         // laptops have 4.9.0. Thus, we use [ "anyof", [ "suffix", "suffix1" ], [ "suffix", "suffix2" ], ... ].
         // Note 2: `empty_on_fresh_instance` prevents Watchman from sending entire contents of folder if this
         // subscription starts the daemon / causes the daemon to watch this folder for the first time.
-        string subscribeCommand = fmt::format("[\"subscribe\", \"{}\", \"{}\", {{\n"
-                                              "  \"expression\": [\"allof\", "
-                                              "    [\"type\", \"f\"],\n"
-                                              "    [\"anyof\", {}]"
-                                              "  ],\n"
-                                              "  \"defer_vcs\": false,\n"
-                                              "  \"fields\": [\"name\"],\n"
-                                              "  \"empty_on_fresh_instance\": true\n"
-                                              "}}]\n",
-                                              workSpace, subscriptionName,
-                                              fmt::map_join(extensions, ",", [](const std::string &ext) -> string {
-                                                  return fmt::format("[\"suffix\", \"{}\"]", ext);
-                                              }));
+        string subscribeCommand = fmt::format(
+            "[\"subscribe\", \"{}\", \"{}\", {{\n"
+            "  \"expression\": [\"allof\", "
+            "    [\"type\", \"f\"],\n"
+            "    [\"anyof\", {}],\n"
+            "    [\"not\", [\"match\", \"**/.~tmp~/**\", \"wholename\", {{\"includedotfiles\": true}}]]\n" // Exclude
+                                                                                                           // rsync
+                                                                                                           // tmpfiles
+            "  ],\n"
+            "  \"defer_vcs\": false,\n"
+            "  \"fields\": [\"name\"],\n"
+            "  \"empty_on_fresh_instance\": true\n"
+            "}}]\n",
+            workSpace, subscriptionName, fmt::map_join(extensions, ",", [](const std::string &ext) -> string {
+                return fmt::format("[\"suffix\", \"{}\"]", ext);
+            }));
         p.send(subscribeCommand.c_str(), subscribeCommand.size());
         logger->debug(subscribeCommand);
 

--- a/main/lsp/watchman/WatchmanProcess.cc
+++ b/main/lsp/watchman/WatchmanProcess.cc
@@ -43,9 +43,8 @@ void WatchmanProcess::start() {
             "  \"expression\": [\"allof\", "
             "    [\"type\", \"f\"],\n"
             "    [\"anyof\", {}],\n"
-            "    [\"not\", [\"match\", \"**/.~tmp~/**\", \"wholename\", {{\"includedotfiles\": true}}]]\n" // Exclude
-                                                                                                           // rsync
-                                                                                                           // tmpfiles
+            // Exclude rsync tmpfiles
+            "    [\"not\", [\"match\", \"**/.~tmp~/**\", \"wholename\", {{\"includedotfiles\": true}}]]\n"
             "  ],\n"
             "  \"defer_vcs\": false,\n"
             "  \"fields\": [\"name\"],\n"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Watchman: Ignore rsync tempfiles.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Stripe uses rsync to keep development boxes in sync with user laptops. I noticed logs where watchman would overwhelm Sorbet with tmp files created during prolonged rsyncs.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

We don't have tests that run Watchman in CI. I tested manually in a local folder, and verified that Sorbet could see updates to files outside of `.~tmp~` folders and could not see updates to files inside those folders.
