### PR TITLE
WIP: Preallocate Symbol and Name tables during index.

### DIFF
--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -760,35 +760,35 @@ void SerializerImpl::unpickleGS(UnPickler &p, GlobalState &result) {
 
         int classAndModuleSize = p.getU4();
         ENFORCE(classAndModuleSize > 0);
-        classAndModules.reserve(nearestPowerOf2(classAndModuleSize));
+        classAndModules.reserve(classAndModuleSize);
         for (int i = 0; i < classAndModuleSize; i++) {
             classAndModules.emplace_back(unpickleSymbol(p, &result));
         }
 
         int methodSize = p.getU4();
         ENFORCE(methodSize > 0);
-        methods.reserve(nearestPowerOf2(methodSize));
+        methods.reserve(methodSize);
         for (int i = 0; i < methodSize; i++) {
             methods.emplace_back(unpickleSymbol(p, &result));
         }
 
         int fieldSize = p.getU4();
         ENFORCE(fieldSize > 0);
-        fields.reserve(nearestPowerOf2(fieldSize));
+        fields.reserve(fieldSize);
         for (int i = 0; i < fieldSize; i++) {
             fields.emplace_back(unpickleSymbol(p, &result));
         }
 
         int typeArgumentSize = p.getU4();
         ENFORCE(typeArgumentSize > 0);
-        typeArguments.reserve(nearestPowerOf2(typeArgumentSize));
+        typeArguments.reserve(typeArgumentSize);
         for (int i = 0; i < typeArgumentSize; i++) {
             typeArguments.emplace_back(unpickleSymbol(p, &result));
         }
 
         int typeMemberSize = p.getU4();
         ENFORCE(typeMemberSize > 0);
-        typeMembers.reserve(nearestPowerOf2(typeMemberSize));
+        typeMembers.reserve(typeMemberSize);
         for (int i = 0; i < typeMemberSize; i++) {
             typeMembers.emplace_back(unpickleSymbol(p, &result));
         }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -520,6 +520,12 @@ IndexResult mergeIndexResults(const shared_ptr<core::GlobalState> cgs, const opt
                 ENFORCE(ret.trees.empty());
                 ret.trees = move(threadResult.res.trees);
                 ret.pluginGeneratedFiles = move(threadResult.res.pluginGeneratedFiles);
+                // Preallocate name and symbol tables. We do so now so that we don't have to pay the memory overhead
+                // across all cores, which can get quite expensive.
+                ret.gs->preallocateTables(opts.reserveClassTableCapacity, opts.reserveMethodTableCapacity,
+                                          opts.reserveFieldTableCapacity, opts.reserveTypeArgumentTableCapacity,
+                                          opts.reserveTypeMemberTableCapacity, opts.reserveNameTableCapacity);
+
             } else {
                 core::GlobalSubstitution substitution(*threadResult.res.gs, *ret.gs, cgs.get());
                 {

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -442,9 +442,6 @@ int realmain(int argc, char *argv[]) {
     if (opts.sleepInSlowPath) {
         gs->sleepInSlowPath = true;
     }
-    gs->preallocateTables(opts.reserveClassTableCapacity, opts.reserveMethodTableCapacity,
-                          opts.reserveFieldTableCapacity, opts.reserveTypeArgumentTableCapacity,
-                          opts.reserveTypeMemberTableCapacity, opts.reserveNameTableCapacity);
     for (auto code : opts.errorCodeWhiteList) {
         gs->onlyShowErrorClass(code);
     }


### PR DESCRIPTION
Preallocate Symbol and Name tables during index.

In a multi-core environment, preallocating all of these tables to their maximal sizes imposes memory overhead that increases with the number of cores.

This change resizes the name and symbol tables only during the procedure that merges symbol and name tables together which should substantially reduce memory consumption on many core machines but may increase per-core runtime slightly due to resizing.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Reduce max RSS.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

N/A
