### PR TITLE
ActiveSupport::TestCase support through a rewriter

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -261,6 +261,8 @@ NameDef names[] = {
 
     {"raise"},
     {"rewriterRaiseUnimplemented", "Sorbet rewriter pass partially unimplemented"},
+
+    {"test1", "test"},
     // end DSL methods
 
     // The next two names are used as keys in SymbolInfo::members to store

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -262,7 +262,7 @@ NameDef names[] = {
     {"raise"},
     {"rewriterRaiseUnimplemented", "Sorbet rewriter pass partially unimplemented"},
 
-    {"test1", "test"},
+    {"test"},
     // end DSL methods
 
     // The next two names are used as keys in SymbolInfo::members to store

--- a/rewriter/TestCase.cc
+++ b/rewriter/TestCase.cc
@@ -12,11 +12,11 @@ std::vector<ast::TreePtr> TestCase::run(core::MutableContext ctx, ast::Send *sen
     }
 
     std::cout << "Checking method name" << std::endl;
-    if (send->fun != core::Names::test1()) {
+    if (send->fun != core::Names::test()) {
         return stats;
     }
 
-    std::cout << "Checking nunmber of args" << std::endl;
+    std::cout << "Checking number of args" << std::endl;
     if (send->args.size() != 1) {
         return stats;
     }

--- a/rewriter/TestCase.cc
+++ b/rewriter/TestCase.cc
@@ -1,0 +1,51 @@
+#include "rewriter/TestCase.h"
+#include "ast/Helpers.h"
+#include "core/GlobalState.h"
+
+namespace sorbet::rewriter {
+
+std::vector<ast::TreePtr> TestCase::run(core::MutableContext ctx, ast::Send *send) {
+    std::vector<ast::TreePtr> stats;
+    if (ctx.state.runningUnderAutogen) {
+        return stats;
+    }
+
+    std::cout << "Checking method name" << std::endl;
+    if (send->fun != core::Names::test1()) {
+        return stats;
+    }
+
+    std::cout << "Checking nunmber of args" << std::endl;
+    if (send->args.size() != 1) {
+        return stats;
+    }
+
+    std::cout << "Checking number of posArgs" << std::endl;
+    if (send->numPosArgs != 1) {
+        return stats;
+    }
+
+    std::cout << "Checking if block argument" << std::endl;
+    if (!send->block) {
+        return stats;
+    }
+
+    std::cout << "Checking if first arg is string" << std::endl;
+    auto *arg0 = ast::cast_tree<ast::Literal>(send->args[0]);
+    if (!arg0 || !arg0->isString(ctx)) {
+        return stats;
+    }
+
+    auto name = arg0->asString(ctx);
+    // Generate sigs?
+    //
+    std::cout << "Generate method" << std::endl;
+    auto loc = send->loc;
+    auto block = ast::cast_tree<ast::Block>(send->block);
+    auto method = ast::MK::SyntheticMethod0(loc, loc, name, std::move(block->body));
+    stats.emplace_back(std::move(method));
+
+    return stats;
+}
+
+}; // namespace sorbet::rewriter

--- a/rewriter/TestCase.cc
+++ b/rewriter/TestCase.cc
@@ -1,4 +1,5 @@
 #include "rewriter/TestCase.h"
+#include "absl/strings/str_replace.h"
 #include "ast/Helpers.h"
 #include "core/GlobalState.h"
 
@@ -36,7 +37,13 @@ std::vector<ast::TreePtr> TestCase::run(core::MutableContext ctx, ast::Send *sen
         return stats;
     }
 
-    auto name = arg0->asString(ctx);
+    // auto formatted_name = fmt::format("test_{0}", arg0->asString(ctx).toString(ctx));
+    // auto name = arg0->asString(ctx).data(ctx);
+    // std::cout << "name: " << name->toString(ctx) << std::endl;
+
+    auto snake_case_name = absl::StrReplaceAll(arg0->asString(ctx).toString(ctx), {{" ", "_"}});
+    auto name = ctx.state.enterNameUTF8("test_" + snake_case_name);
+
     // Generate sigs?
     //
     std::cout << "Generate method" << std::endl;

--- a/rewriter/TestCase.cc
+++ b/rewriter/TestCase.cc
@@ -32,19 +32,14 @@ std::vector<ast::TreePtr> TestCase::run(core::MutableContext ctx, ast::Send *sen
         return stats;
     }
 
-    // auto formatted_name = fmt::format("test_{0}", arg0->asString(ctx).toString(ctx));
-    // auto name = arg0->asString(ctx).data(ctx);
-    // std::cout << "name: " << name->toString(ctx) << std::endl;
-
-    auto snake_case_name = absl::StrReplaceAll(arg0->asString(ctx).toString(ctx), {{" ", "_"}});
-    auto name = ctx.state.enterNameUTF8("test_" + snake_case_name);
-
-    // Generate sigs?
-    //
     auto loc = send->loc;
     auto block = ast::cast_tree<ast::Block>(send->block);
+    auto snake_case_name = absl::StrReplaceAll(arg0->asString(ctx).toString(ctx), {{" ", "_"}});
+    auto name = ctx.state.enterNameUTF8("test_" + snake_case_name);
     auto method = ast::MK::SyntheticMethod0(loc, loc, name, std::move(block->body));
-    stats.emplace_back(std::move(method));
+    auto method_with_sig = ast::MK::InsSeq1(method.loc(), ast::MK::SigVoid(method.loc(), {}), std::move(method));
+
+    stats.emplace_back(std::move(method_with_sig));
 
     return stats;
 }

--- a/rewriter/TestCase.cc
+++ b/rewriter/TestCase.cc
@@ -11,27 +11,22 @@ std::vector<ast::TreePtr> TestCase::run(core::MutableContext ctx, ast::Send *sen
         return stats;
     }
 
-    std::cout << "Checking method name" << std::endl;
     if (send->fun != core::Names::test()) {
         return stats;
     }
 
-    std::cout << "Checking number of args" << std::endl;
     if (send->args.size() != 1) {
         return stats;
     }
 
-    std::cout << "Checking number of posArgs" << std::endl;
     if (send->numPosArgs != 1) {
         return stats;
     }
 
-    std::cout << "Checking if block argument" << std::endl;
     if (!send->block) {
         return stats;
     }
 
-    std::cout << "Checking if first arg is string" << std::endl;
     auto *arg0 = ast::cast_tree<ast::Literal>(send->args[0]);
     if (!arg0 || !arg0->isString(ctx)) {
         return stats;
@@ -46,7 +41,6 @@ std::vector<ast::TreePtr> TestCase::run(core::MutableContext ctx, ast::Send *sen
 
     // Generate sigs?
     //
-    std::cout << "Generate method" << std::endl;
     auto loc = send->loc;
     auto block = ast::cast_tree<ast::Block>(send->block);
     auto method = ast::MK::SyntheticMethod0(loc, loc, name, std::move(block->body));

--- a/rewriter/TestCase.cc
+++ b/rewriter/TestCase.cc
@@ -23,12 +23,12 @@ std::vector<ast::TreePtr> TestCase::run(core::MutableContext ctx, ast::Send *sen
         return stats;
     }
 
-    if (!send->block) {
+    if (send->block == nullptr) {
         return stats;
     }
 
     auto *arg0 = ast::cast_tree<ast::Literal>(send->args[0]);
-    if (!arg0 || !arg0->isString(ctx)) {
+    if (arg0 == nullptr || !arg0->isString(ctx)) {
         return stats;
     }
 

--- a/rewriter/TestCase.h
+++ b/rewriter/TestCase.h
@@ -1,0 +1,33 @@
+#ifndef SORBET_REWRITER_TESTCASE_H
+#define SORBET_REWRITER_TESTCASE_H
+#include "ast/ast.h"
+
+namespace sorbet::rewriter {
+
+/**
+ * This class desugars things of the form
+ *
+ *    class MyTest < ActiveSupport::TestCase
+ *      test "the truth" do
+ *          assert true
+ *      end
+ *    end
+ *
+ * into
+ *
+ *    class MyTest < ActiveSupport::TestCase
+ *      def test_the_truth
+ *        assert true
+ *      end
+ *    end
+ */
+class TestCase final {
+public:
+    static std::vector<ast::TreePtr> run(core::MutableContext ctx, ast::Send *send);
+
+    TestCase() = delete;
+};
+
+} // namespace sorbet::rewriter
+
+#endif

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -27,6 +27,7 @@
 #include "rewriter/Singleton.h"
 #include "rewriter/Struct.h"
 #include "rewriter/TEnum.h"
+#include "rewriter/TestCase.h"
 #include "rewriter/TypeMembers.h"
 
 using namespace std;
@@ -113,6 +114,12 @@ public:
                     }
 
                     nodes = Delegate::run(ctx, &send);
+                    if (!nodes.empty()) {
+                        replaceNodes[stat.get()] = std::move(nodes);
+                        return;
+                    }
+
+                    nodes = TestCase::run(ctx, &send);
                     if (!nodes.empty()) {
                         replaceNodes[stat.get()] = std::move(nodes);
                         return;

--- a/test/testdata/rewriter/test_case.rb
+++ b/test/testdata/rewriter/test_case.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+class MyTest < ActiveSupport::TestCase
+  # Test cases where rewriter shouldn't modify the code
+  tesst "invalid", "method name" do
+  end
+
+  test "invalid", "parameter count" do
+  end
+
+  test "no block argument"
+
+  test :not_a_string do
+  end
+end

--- a/test/testdata/rewriter/test_case.rb
+++ b/test/testdata/rewriter/test_case.rb
@@ -1,8 +1,19 @@
 # typed: true
+module ActiveSupport::TestCase
+end
 
 class MyTest < ActiveSupport::TestCase
-  # Test cases where rewriter shouldn't modify the code
-  tesst "invalid", "method name" do
+  # Helper instance method
+  def assert(test)
+    test ? true : false
+  end
+
+  # Helper method to direct calls to `test` instead of Kernel#test
+  def self.test(*args)
+  end
+
+  # Method calls that shouldn't be rewritten
+  tesst "invalid", "method name" do # error: Method `tesst` does not exist on `T.class_of(MyTest)`
   end
 
   test "invalid", "parameter count" do
@@ -11,5 +22,17 @@ class MyTest < ActiveSupport::TestCase
   test "no block argument"
 
   test :not_a_string do
+  end
+
+  test :not_a_string do
+    assert true # error: Method `assert` does not exist on `T.class_of(MyTest)`
+  end
+  # end unmodified method calls
+
+  test "valid method call" do
+  end
+
+  test "block is evaluated in the context of an instance" do
+    assert true
   end
 end

--- a/test/testdata/rewriter/test_case.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/test_case.rb.rewrite-tree.exp
@@ -1,0 +1,52 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C ActiveSupport>::<C TestCase><<C <todo sym>>> < ()
+  end
+
+  class <emptyTree>::<C MyTest><<C <todo sym>>> < (<emptyTree>::<C ActiveSupport>::<C TestCase>)
+    def assert<<C <todo sym>>>(test, &<blk>)
+      if test
+        true
+      else
+        false
+      end
+    end
+
+    def self.test<<C <todo sym>>>(*args, &<blk>)
+      <emptyTree>
+    end
+
+    def test_valid_method_call<<C <todo sym>>>(&<blk>)
+      <emptyTree>
+    end
+
+    def test_block_is_evaluated_in_the_context_of_an_instance<<C <todo sym>>>(&<blk>)
+      <self>.assert(true)
+    end
+
+    ::Sorbet::Private::Static.keep_def(<self>, :assert)
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :test)
+
+    <self>.tesst("invalid", "method name") do ||
+      <emptyTree>
+    end
+
+    <self>.test("invalid", "parameter count") do ||
+      <emptyTree>
+    end
+
+    <self>.test("no block argument")
+
+    <self>.test(:not_a_string) do ||
+      <emptyTree>
+    end
+
+    <self>.test(:not_a_string) do ||
+      <self>.assert(true)
+    end
+
+    ::Sorbet::Private::Static.keep_def(<self>, :test_valid_method_call)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :test_block_is_evaluated_in_the_context_of_an_instance)
+  end
+end

--- a/test/testdata/rewriter/test_case.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/test_case.rb.rewrite-tree.exp
@@ -15,8 +15,16 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
     def test_valid_method_call<<C <todo sym>>>(&<blk>)
       <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
     end
 
     def test_block_is_evaluated_in_the_context_of_an_instance<<C <todo sym>>>(&<blk>)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Implemented a simple rewriter to rewrite calls to methods called `test`, with a single positional argument (String) and a block argument. These calls are converted into a method definition using the argument as a method name and block argument as the method body.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This rewriter is motivated by common usages of `ActiveSupport::TestCase` in Rails applications. As described [here](https://jonathanpike.net/2016/02/03/activesupport-vs-minitest), `ActiveSupport::TestCase` provides the means to declare a test case using a block format (via [`ActiveSupport::Testing::Declarative`](https://api.rubyonrails.org/classes/ActiveSupport/Testing/Declarative.html)). Since the block passed to the `test` method is called on the instance of the concrete test subclass, this was impossible to type externally.

With this rewriter we are able to expose the block to Sorbet in an instance method body and Sorbet can correctly typecheck the body. As a result there is a high chance that existing applications that were using `#typed: true` strictness in their `ActiveSupport::TestCase` test files will get new typechecking errors.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
