### PR TITLE
Method renames: test for untyped files, operator overload renames

### DIFF
--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -133,8 +133,20 @@ public:
     MethodRenamer(const core::GlobalState &gs, const LSPConfiguration &config, const string oldName,
                   const string newName)
         : Renamer(gs, config, oldName, newName) {
-        if (oldName == "initialize") {
-            invalid = true;
+        const vector<string> invalidNames = {"initialize", "call"};
+        for (auto name : invalidNames) {
+            if (oldName == name) {
+                invalid = true;
+                error = fmt::format("The `{}` method cannot be renamed.", oldName);
+                return;
+            }
+        }
+        // block any method not in /[a-zA-Z0-9_]+/. This blocks operator overloads.
+        for (auto c : oldName) {
+            if (!isalnum(c) && c != '_') {
+                error = fmt::format("The `{}` method cannot be renamed.", oldName);
+                invalid = true;
+            }
         }
     }
     ~MethodRenamer() {}
@@ -152,7 +164,13 @@ public:
         if (auto sendResp = response->isSend()) {
             auto methodNameLoc = sendResp->getMethodNameLoc(gs);
             if (!methodNameLoc) {
-                ENFORCE(0, "Method name not found in send expression")
+                // If there are locations we don't know how to rename, fail the entire rename operation
+                invalid = true;
+                if (methodNameLoc->file().exists()) {
+                    auto path = methodNameLoc->file().data(gs).path();
+                    error = fmt::format("Failed to rename `{}` method call at {}:{}", oldName, path,
+                                        methodNameLoc->position(gs).first.line);
+                }
                 return;
             }
             string::size_type methodNameOffset = methodNameLoc->beginPos() - sendResp->termLoc.beginPos();

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -141,12 +141,10 @@ public:
                 return;
             }
         }
-        // block any method not in /[a-zA-Z0-9_]+/. This blocks operator overloads.
-        for (auto c : oldName) {
-            if (!isalnum(c) && c != '_') {
-                error = fmt::format("The `{}` method cannot be renamed.", oldName);
-                invalid = true;
-            }
+        // block any method not starting with /[a-zA-Z0-9_]+/. This blocks operator overloads.
+        if (!isalnum(oldName[0]) && oldName[0] != '_') {
+            error = fmt::format("The `{}` method cannot be renamed.", oldName);
+            invalid = true;
         }
     }
     ~MethodRenamer() {}

--- a/test/testdata/lsp/rename/method_operator_renames.rb
+++ b/test/testdata/lsp/rename/method_operator_renames.rb
@@ -1,0 +1,27 @@
+# typed: true
+
+class Foo
+  def call
+#     ^ apply-rename: [A] newName: foo invalid: true expectedErrorMessage: The `call` method cannot be renamed.
+  end
+
+  def [](a)
+#     ^ apply-rename: [B] newName: foo invalid: true expectedErrorMessage: The `[]` method cannot be renamed.
+  end
+
+  def +(a)
+#     ^ apply-rename: [C] newName: foo invalid: true expectedErrorMessage: The `+` method cannot be renamed.
+  end
+end
+
+class Bar
+  # not called
+  def call
+#     ^ apply-rename: [D] newName: foo invalid: true expectedErrorMessage: The `call` method cannot be renamed.
+  end
+end
+
+f = Foo.new
+f.()
+f[1]
+f + f

--- a/test/testdata/lsp/rename/method_untyped.rb
+++ b/test/testdata/lsp/rename/method_untyped.rb
@@ -1,0 +1,10 @@
+# typed: false
+
+class Foo
+  def foo
+    puts "hi"
+  end
+end
+
+Foo.new.foo
+#        ^ apply-rename: [A] invalid: true


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Block some invalid renames -- untyped files, and operator overloads.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We can't rename methods with sends in untyped files; it doesn't make much sense to rename operators.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
