### PR TITLE
Add accessors to LiteralKind and make value/floatval private

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1186,14 +1186,14 @@ string Literal::nodeName() {
 core::NameRef Literal::asString(const core::GlobalState &gs) const {
     ENFORCE(isString(gs));
     auto t = core::cast_type_nonnull<core::LiteralType>(value);
-    core::NameRef res(gs, t.value);
+    core::NameRef res = t.asName();
     return res;
 }
 
 core::NameRef Literal::asSymbol(const core::GlobalState &gs) const {
     ENFORCE(isSymbol(gs));
     auto t = core::cast_type_nonnull<core::LiteralType>(value);
-    core::NameRef res(gs, t.value);
+    core::NameRef res = t.asName();
     return res;
 }
 

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1186,14 +1186,14 @@ string Literal::nodeName() {
 core::NameRef Literal::asString(const core::GlobalState &gs) const {
     ENFORCE(isString(gs));
     auto t = core::cast_type_nonnull<core::LiteralType>(value);
-    core::NameRef res = t.asName();
+    core::NameRef res = t.asName(gs);
     return res;
 }
 
 core::NameRef Literal::asSymbol(const core::GlobalState &gs) const {
     ENFORCE(isSymbol(gs));
     auto t = core::cast_type_nonnull<core::LiteralType>(value);
-    core::NameRef res = t.asName();
+    core::NameRef res = t.asName(gs);
     return res;
 }
 

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -318,7 +318,7 @@ TreePtr symbol2Proc(DesugarContext dctx, TreePtr expr) {
     ENFORCE(lit && lit->isSymbol(dctx.ctx));
 
     // &:foo => {|temp| temp.foo() }
-    core::NameRef name(dctx.ctx, core::cast_type_nonnull<core::LiteralType>(lit->value).value);
+    core::NameRef name = core::cast_type_nonnull<core::LiteralType>(lit->value).asName();
     // `temp` does not refer to any specific source text, so give it a 0-length Loc so LSP ignores it.
     auto zeroLengthLoc = loc.copyWithZeroLength();
     TreePtr recv = MK::Local(zeroLengthLoc, temp);

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -318,7 +318,7 @@ TreePtr symbol2Proc(DesugarContext dctx, TreePtr expr) {
     ENFORCE(lit && lit->isSymbol(dctx.ctx));
 
     // &:foo => {|temp| temp.foo() }
-    core::NameRef name = core::cast_type_nonnull<core::LiteralType>(lit->value).asName();
+    core::NameRef name = core::cast_type_nonnull<core::LiteralType>(lit->value).asName(dctx.ctx);
     // `temp` does not refer to any specific source text, so give it a 0-length Loc so LSP ignores it.
     auto zeroLengthLoc = loc.copyWithZeroLength();
     TreePtr recv = MK::Local(zeroLengthLoc, temp);

--- a/core/Types.h
+++ b/core/Types.h
@@ -453,12 +453,12 @@ template <> inline SelfType cast_type_nonnull<SelfType>(const TypePtr &what) {
 }
 
 TYPE_INLINED(LiteralType) final {
-public:
     union {
         const int64_t value;
         const double floatval;
     };
 
+public:
     enum class LiteralTypeKind : u1 { Integer, String, Symbol, Float };
     const LiteralTypeKind literalKind;
     LiteralType(int64_t val);
@@ -467,6 +467,9 @@ public:
     TypePtr underlying() const;
     bool derivesFrom(const GlobalState &gs, core::SymbolRef klass) const;
     DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) const;
+    int64_t asInteger() const;
+    double asFloat() const;
+    core::NameRef asName() const;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
@@ -506,12 +509,12 @@ template <> inline TypePtr make_type<LiteralType, float>(float &&val) {
 
 template <> inline TypePtr make_type<LiteralType, SymbolRef, NameRef &>(SymbolRef &&klass, NameRef &val) {
     LiteralType type(klass, val);
-    return TypePtr(TypePtr::Tag::LiteralType, static_cast<u4>(type.literalKind), absl::bit_cast<u8>(type.value));
+    return TypePtr(TypePtr::Tag::LiteralType, static_cast<u4>(type.literalKind), val._id);
 }
 
 template <> inline TypePtr make_type<LiteralType, SymbolRef, NameRef>(SymbolRef &&klass, NameRef &&val) {
     LiteralType type(klass, val);
-    return TypePtr(TypePtr::Tag::LiteralType, static_cast<u4>(type.literalKind), absl::bit_cast<u8>(type.value));
+    return TypePtr(TypePtr::Tag::LiteralType, static_cast<u4>(type.literalKind), val._id);
 }
 
 template <> inline LiteralType cast_type_nonnull<LiteralType>(const TypePtr &what) {

--- a/core/Types.h
+++ b/core/Types.h
@@ -469,7 +469,8 @@ public:
     DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) const;
     int64_t asInteger() const;
     double asFloat() const;
-    core::NameRef asName() const;
+    core::NameRef asName(const core::GlobalState &gs) const;
+    core::NameRef unsafeAsName() const;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -151,11 +151,11 @@ com::stripe::rubytyper::Type::Literal Proto::toProto(const GlobalState &gs, cons
             break;
         case LiteralType::LiteralTypeKind::String:
             proto.set_kind(com::stripe::rubytyper::Type::Literal::STRING);
-            proto.set_string(lit.asName().show(gs));
+            proto.set_string(lit.asName(gs).show(gs));
             break;
         case LiteralType::LiteralTypeKind::Symbol:
             proto.set_kind(com::stripe::rubytyper::Type::Literal::SYMBOL);
-            proto.set_symbol(lit.asName().show(gs));
+            proto.set_symbol(lit.asName(gs).show(gs));
             break;
         case LiteralType::LiteralTypeKind::Float:
             proto.set_kind(com::stripe::rubytyper::Type::Literal::FLOAT);

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -147,19 +147,19 @@ com::stripe::rubytyper::Type::Literal Proto::toProto(const GlobalState &gs, cons
     switch (lit.literalKind) {
         case LiteralType::LiteralTypeKind::Integer:
             proto.set_kind(com::stripe::rubytyper::Type::Literal::INTEGER);
-            proto.set_integer(lit.value);
+            proto.set_integer(lit.asInteger());
             break;
         case LiteralType::LiteralTypeKind::String:
             proto.set_kind(com::stripe::rubytyper::Type::Literal::STRING);
-            proto.set_string(NameRef(gs, lit.value).show(gs));
+            proto.set_string(lit.asName().show(gs));
             break;
         case LiteralType::LiteralTypeKind::Symbol:
             proto.set_kind(com::stripe::rubytyper::Type::Literal::SYMBOL);
-            proto.set_symbol(NameRef(gs, lit.value).show(gs));
+            proto.set_symbol(lit.asName().show(gs));
             break;
         case LiteralType::LiteralTypeKind::Float:
             proto.set_kind(com::stripe::rubytyper::Type::Literal::FLOAT);
-            proto.set_float_(lit.floatval);
+            proto.set_float_(lit.asFloat());
             break;
     }
     return proto;

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -366,7 +366,7 @@ void SerializerImpl::pickle(Pickler &p, const TypePtr &what) {
                     break;
                 case LiteralType::LiteralTypeKind::Symbol:
                 case LiteralType::LiteralTypeKind::String:
-                    p.putS8(c.asName()._id);
+                    p.putS8(c.unsafeAsName()._id);
                     break;
             }
             break;

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -357,7 +357,18 @@ void SerializerImpl::pickle(Pickler &p, const TypePtr &what) {
         case TypePtr::Tag::LiteralType: {
             auto c = cast_type_nonnull<LiteralType>(what);
             p.putU1((u1)c.literalKind);
-            p.putS8(c.value);
+            switch (c.literalKind) {
+                case LiteralType::LiteralTypeKind::Float:
+                    p.putS8(absl::bit_cast<int64_t>(c.asFloat()));
+                    break;
+                case LiteralType::LiteralTypeKind::Integer:
+                    p.putS8(c.asInteger());
+                    break;
+                case LiteralType::LiteralTypeKind::Symbol:
+                case LiteralType::LiteralTypeKind::String:
+                    p.putS8(c.asName()._id);
+                    break;
+            }
             break;
         }
         case TypePtr::Tag::AndType: {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -904,7 +904,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                             continue;
                         }
 
-                        NameRef arg = key.asName();
+                        NameRef arg = key.asName(gs);
                         if (consumed.find(arg) != consumed.end()) {
                             continue;
                         }
@@ -930,7 +930,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 auto arg = absl::c_find_if(hash->keys, [&](const TypePtr &litType) {
                     auto lit = cast_type_nonnull<LiteralType>(litType);
                     return cast_type_nonnull<ClassType>(lit.underlying()).symbol == Symbols::Symbol() &&
-                           lit.asName() == spec.name;
+                           lit.asName(gs) == spec.name;
                 });
                 if (arg == hash->keys.end()) {
                     if (!spec.flags.isDefault) {
@@ -955,10 +955,10 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
             for (auto &keyType : hash->keys) {
                 auto key = cast_type_nonnull<LiteralType>(keyType);
                 SymbolRef klass = cast_type_nonnull<ClassType>(key.underlying()).symbol;
-                if (klass == Symbols::Symbol() && consumed.find(key.asName()) != consumed.end()) {
+                if (klass == Symbols::Symbol() && consumed.find(key.asName(gs)) != consumed.end()) {
                     continue;
                 }
-                NameRef arg = key.asName();
+                NameRef arg = key.asName(gs);
 
                 if (auto e = gs.beginError(core::Loc(args.locs.file, args.locs.call),
                                            errors::Infer::MethodArgumentCountMismatch)) {
@@ -1710,7 +1710,7 @@ public:
             return;
         }
 
-        NameRef fn = lit.asName();
+        NameRef fn = lit.asName(gs);
         if (args.args[2]->type.isUntyped()) {
             res.returnType = args.args[2]->type;
             return;
@@ -1960,7 +1960,7 @@ public:
             return;
         }
 
-        NameRef fn = lit.asName();
+        NameRef fn = lit.asName(gs);
 
         u2 numPosArgs = args.numPosArgs - 3;
         InlinedVector<TypeAndOrigins, 2> sendArgStore;
@@ -2028,7 +2028,7 @@ public:
             return;
         }
 
-        NameRef fn = lit.asName();
+        NameRef fn = lit.asName(gs);
 
         if (args.args[2]->type.isUntyped()) {
             res.returnType = args.args[2]->type;

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -904,8 +904,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                             continue;
                         }
 
-                        NameRef arg(gs, key.value);
-                        if (consumed.find(NameRef(gs, key.value)) != consumed.end()) {
+                        NameRef arg = key.asName();
+                        if (consumed.find(arg) != consumed.end()) {
                             continue;
                         }
                         consumed.insert(arg);
@@ -930,7 +930,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 auto arg = absl::c_find_if(hash->keys, [&](const TypePtr &litType) {
                     auto lit = cast_type_nonnull<LiteralType>(litType);
                     return cast_type_nonnull<ClassType>(lit.underlying()).symbol == Symbols::Symbol() &&
-                           lit.value == spec.name._id;
+                           lit.asName() == spec.name;
                 });
                 if (arg == hash->keys.end()) {
                     if (!spec.flags.isDefault) {
@@ -955,10 +955,10 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
             for (auto &keyType : hash->keys) {
                 auto key = cast_type_nonnull<LiteralType>(keyType);
                 SymbolRef klass = cast_type_nonnull<ClassType>(key.underlying()).symbol;
-                if (klass == Symbols::Symbol() && consumed.find(NameRef(gs, key.value)) != consumed.end()) {
+                if (klass == Symbols::Symbol() && consumed.find(key.asName()) != consumed.end()) {
                     continue;
                 }
-                NameRef arg(gs, key.value);
+                NameRef arg = key.asName();
 
                 if (auto e = gs.beginError(core::Loc(args.locs.file, args.locs.call),
                                            errors::Infer::MethodArgumentCountMismatch)) {
@@ -1638,8 +1638,8 @@ public:
             res.returnType = Types::untypedUntracked();
             return;
         }
-        int before = (int)beforeLit.value;
-        int after = (int)afterLit.value;
+        int before = (int)beforeLit.asInteger();
+        int after = (int)afterLit.asInteger();
         res.returnType = expandArray(gs, val, before + after);
     }
 } Magic_expandSplat;
@@ -1710,7 +1710,7 @@ public:
             return;
         }
 
-        NameRef fn(gs, (u4)lit.value);
+        NameRef fn = lit.asName();
         if (args.args[2]->type.isUntyped()) {
             res.returnType = args.args[2]->type;
             return;
@@ -1960,7 +1960,7 @@ public:
             return;
         }
 
-        NameRef fn(gs, (u4)lit.value);
+        NameRef fn = lit.asName();
 
         u2 numPosArgs = args.numPosArgs - 3;
         InlinedVector<TypeAndOrigins, 2> sendArgStore;
@@ -2028,7 +2028,7 @@ public:
             return;
         }
 
-        NameRef fn(gs, (u4)lit.value);
+        NameRef fn = lit.asName();
 
         if (args.args[2]->type.isUntyped()) {
             res.returnType = args.args[2]->type;
@@ -2215,7 +2215,7 @@ public:
             return;
         }
 
-        auto idx = lit.value;
+        auto idx = lit.asInteger();
         if (idx < 0) {
             idx = tuple->elems.size() + idx;
         }
@@ -2439,8 +2439,8 @@ public:
             auto lt = cast_type_nonnull<LiteralType>(argTyp);
             ENFORCE(lt.literalKind == LiteralType::LiteralTypeKind::Integer, "depth arg must be an Integer literal");
 
-            if (lt.value >= 0) {
-                depth = lt.value;
+            if (lt.asInteger() >= 0) {
+                depth = lt.asInteger();
             } else {
                 // Negative values behave like no depth was given
                 depth = INT64_MAX;

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -131,7 +131,7 @@ string ShapeType::show(const GlobalState &gs) const {
         }
         SymbolRef undSymbol = cast_type_nonnull<ClassType>(cast_type_nonnull<LiteralType>(key).underlying()).symbol;
         if (undSymbol == Symbols::Symbol()) {
-            fmt::format_to(buf, "{}: {}", NameRef(gs, cast_type_nonnull<LiteralType>(key).value).show(gs),
+            fmt::format_to(buf, "{}: {}", cast_type_nonnull<LiteralType>(key).asName().show(gs),
                            (*valueIterator).show(gs));
         } else {
             fmt::format_to(buf, "{} => {}", key.show(gs), (*valueIterator).show(gs));

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -131,7 +131,7 @@ string ShapeType::show(const GlobalState &gs) const {
         }
         SymbolRef undSymbol = cast_type_nonnull<ClassType>(cast_type_nonnull<LiteralType>(key).underlying()).symbol;
         if (undSymbol == Symbols::Symbol()) {
-            fmt::format_to(buf, "{}: {}", cast_type_nonnull<LiteralType>(key).asName().show(gs),
+            fmt::format_to(buf, "{}: {}", cast_type_nonnull<LiteralType>(key).asName(gs).show(gs),
                            (*valueIterator).show(gs));
         } else {
             fmt::format_to(buf, "{} => {}", key.show(gs), (*valueIterator).show(gs));

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -348,7 +348,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                                 auto fnd = absl::c_find_if(h1.keys, [&](auto &candidate) -> bool {
                                     auto el1l = cast_type_nonnull<LiteralType>(candidate);
                                     auto u1 = cast_type_nonnull<ClassType>(el1l.underlying());
-                                    return el1l.value == el2l.value && u1.symbol == u2.symbol; // from lambda
+                                    return el1l.equals(el2l) && u1.symbol == u2.symbol; // from lambda
                                 });
                                 if (fnd != h1.keys.end()) {
                                     auto &inserted = valueLubs.emplace_back(
@@ -380,7 +380,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         auto u1 = cast_type_nonnull<ClassType>(l1.underlying());
                         auto u2 = cast_type_nonnull<ClassType>(l2.underlying());
                         if (u1.symbol == u2.symbol) {
-                            if (l1.value == l2.value) {
+                            if (l1.equals(l2)) {
                                 result = t1;
                             } else {
                                 result = l1.underlying();
@@ -695,7 +695,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                             auto fnd = absl::c_find_if(h1.keys, [&](auto &candidate) -> bool {
                                 auto el1l = cast_type_nonnull<LiteralType>(candidate);
                                 auto u1 = cast_type_nonnull<ClassType>(el1l.underlying());
-                                return el1l.value == el2l.value && u1.symbol == u2.symbol; // from lambda
+                                return el1l.equals(el2l) && u1.symbol == u2.symbol; // from lambda
                             });
                             if (fnd != h1.keys.end()) {
                                 auto left = h1.values[fnd - h1.keys.begin()];
@@ -730,7 +730,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                     auto u1 = cast_type_nonnull<ClassType>(l1.underlying());
                     auto u2 = cast_type_nonnull<ClassType>(l2.underlying());
                     if (u1.symbol == u2.symbol) {
-                        if (l1.value == l2.value) {
+                        if (l1.equals(l2)) {
                             result = t1;
                         } else {
                             result = Types::bottom();
@@ -1181,7 +1181,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                         auto fnd = absl::c_find_if(h1.keys, [&](auto &candidate) -> bool {
                             auto el1l = cast_type_nonnull<LiteralType>(candidate);
                             auto u1 = cast_type_nonnull<ClassType>(el1l.underlying());
-                            return el1l.value == el2l.value && u1.symbol == u2.symbol; // from lambda
+                            return el1l.equals(el2l) && u1.symbol == u2.symbol; // from lambda
                         });
                         result = fnd != h1.keys.end() &&
                                  Types::isSubTypeUnderConstraint(gs, constr, h1.values[fnd - h1.keys.begin()],
@@ -1201,7 +1201,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                     auto l2 = cast_type_nonnull<LiteralType>(t2);
                     auto u1 = cast_type_nonnull<ClassType>(l1.underlying());
                     auto u2 = cast_type_nonnull<ClassType>(l2.underlying());
-                    result = u1.symbol == u2.symbol && l1.value == l2.value;
+                    result = u1.symbol == u2.symbol && l1.equals(l2);
                 },
                 [&](const MetaType &m1) {
                     auto *m2 = cast_type<MetaType>(t2);

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -344,11 +344,9 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                             for (auto &el2 : h2->keys) {
                                 ++i;
                                 auto el2l = cast_type_nonnull<LiteralType>(el2);
-                                auto u2 = cast_type_nonnull<ClassType>(el2l.underlying());
                                 auto fnd = absl::c_find_if(h1.keys, [&](auto &candidate) -> bool {
                                     auto el1l = cast_type_nonnull<LiteralType>(candidate);
-                                    auto u1 = cast_type_nonnull<ClassType>(el1l.underlying());
-                                    return el1l.equals(el2l) && u1.symbol == u2.symbol; // from lambda
+                                    return el1l.equals(el2l); // from lambda
                                 });
                                 if (fnd != h1.keys.end()) {
                                     auto &inserted = valueLubs.emplace_back(
@@ -691,11 +689,9 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         for (auto &el2 : h2.keys) {
                             ++i;
                             auto el2l = cast_type_nonnull<LiteralType>(el2);
-                            auto u2 = cast_type_nonnull<ClassType>(el2l.underlying());
                             auto fnd = absl::c_find_if(h1.keys, [&](auto &candidate) -> bool {
                                 auto el1l = cast_type_nonnull<LiteralType>(candidate);
-                                auto u1 = cast_type_nonnull<ClassType>(el1l.underlying());
-                                return el1l.equals(el2l) && u1.symbol == u2.symbol; // from lambda
+                                return el1l.equals(el2l); // from lambda
                             });
                             if (fnd != h1.keys.end()) {
                                 auto left = h1.values[fnd - h1.keys.begin()];
@@ -1177,11 +1173,9 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                     for (auto &el2 : h2->keys) {
                         ++i;
                         auto el2l = cast_type_nonnull<LiteralType>(el2);
-                        auto u2 = cast_type_nonnull<ClassType>(el2l.underlying());
                         auto fnd = absl::c_find_if(h1.keys, [&](auto &candidate) -> bool {
                             auto el1l = cast_type_nonnull<LiteralType>(candidate);
-                            auto u1 = cast_type_nonnull<ClassType>(el1l.underlying());
-                            return el1l.equals(el2l) && u1.symbol == u2.symbol; // from lambda
+                            return el1l.equals(el2l); // from lambda
                         });
                         result = fnd != h1.keys.end() &&
                                  Types::isSubTypeUnderConstraint(gs, constr, h1.values[fnd - h1.keys.begin()],
@@ -1199,9 +1193,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                     }
 
                     auto l2 = cast_type_nonnull<LiteralType>(t2);
-                    auto u1 = cast_type_nonnull<ClassType>(l1.underlying());
-                    auto u2 = cast_type_nonnull<ClassType>(l2.underlying());
-                    result = u1.symbol == u2.symbol && l1.equals(l2);
+                    result = l1.equals(l2);
                 },
                 [&](const MetaType &m1) {
                     auto *m2 = cast_type<MetaType>(t2);

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -344,7 +344,12 @@ double LiteralType::asFloat() const {
     return floatval;
 }
 
-core::NameRef LiteralType::asName() const {
+core::NameRef LiteralType::asName(const core::GlobalState &gs) const {
+    ENFORCE_NO_TIMER(literalKind == LiteralTypeKind::Symbol || literalKind == LiteralTypeKind::String);
+    return NameRef(gs, value);
+}
+
+core::NameRef LiteralType::unsafeAsName() const {
     ENFORCE_NO_TIMER(literalKind == LiteralTypeKind::Symbol || literalKind == LiteralTypeKind::String);
     return NameRef(NameRef::WellKnown{}, value);
 }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2146,7 +2146,7 @@ private:
         // non-null
         ENFORCE((!send.hasKwArgs() && !packageType) || (send.hasKwArgs() && packageType));
 
-        auto name = core::NameRef(ctx.state, literal.value);
+        auto name = literal.asName();
         auto shortName = name.data(ctx)->shortName(ctx);
         if (shortName.empty()) {
             if (auto e = ctx.beginError(stringLoc, core::errors::Resolver::LazyResolve)) {
@@ -2185,7 +2185,7 @@ private:
                     }
 
                     auto package = core::cast_type_nonnull<core::LiteralType>(packageType);
-                    auto packageName = core::NameRef(ctx.state, package.value);
+                    auto packageName = package.asName();
                     auto mangledName = packageName.lookupMangledPackageName(ctx.state);
                     // if the mangled name doesn't exist, then this means probably there's no package named this
                     if (!mangledName.exists()) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2146,7 +2146,7 @@ private:
         // non-null
         ENFORCE((!send.hasKwArgs() && !packageType) || (send.hasKwArgs() && packageType));
 
-        auto name = literal.asName();
+        auto name = literal.asName(ctx);
         auto shortName = name.data(ctx)->shortName(ctx);
         if (shortName.empty()) {
             if (auto e = ctx.beginError(stringLoc, core::errors::Resolver::LazyResolve)) {
@@ -2185,7 +2185,7 @@ private:
                     }
 
                     auto package = core::cast_type_nonnull<core::LiteralType>(packageType);
-                    auto packageName = package.asName();
+                    auto packageName = package.asName(ctx);
                     auto mangledName = packageName.lookupMangledPackageName(ctx.state);
                     // if the mangled name doesn't exist, then this means probably there's no package named this
                     if (!mangledName.exists()) {

--- a/rewriter/Rails.cc
+++ b/rewriter/Rails.cc
@@ -48,7 +48,7 @@ void Rails::run(core::MutableContext ctx, ast::ClassDef *cdef) {
         return;
     }
     char version[5];
-    snprintf(version, sizeof(version), "V%.1f", value.floatval);
+    snprintf(version, sizeof(version), "V%.1f", value.asFloat());
     absl::c_replace(version, '.', '_');
 
     cdef->ancestors.emplace_back(ast::MK::UnresolvedConstant(


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Add accessors to LiteralKind. Makes it safer to extract the inner double/int/NameRef contained within.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Delurk lurky code that directly accesses LiteralType's value and floatval properties without the benefit of ENFORCEs checking that the literal is the expected kind of literal.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
