### PR TITLE
Method renames: handle secondary dispatch components (union types)

### DIFF
--- a/core/lsp/QueryResponse.cc
+++ b/core/lsp/QueryResponse.cc
@@ -18,12 +18,12 @@ const SendResponse *QueryResponse::isSend() const {
 }
 
 const optional<core::Loc> SendResponse::getMethodNameLoc(const core::GlobalState &gs) const {
-    // TODO: handle dispatchResult->secondary
-    auto methodName = dispatchResult->main.method.data(gs)->name.show(gs);
+    auto methodName = this->callerSideName.data(gs)->show(gs);
     auto expr = termLoc.source(gs);
-    // There are two possible forms of a send expression:
+    // We parse two forms of send expressions:
     //   <receiver expr><whitespace?>.<whitespace?><method>
     //   <method>
+    // All other forms (operator overloads etc) cause nullopt to be returned.
     string::size_type methodNameOffset = receiverLoc.endPos() - termLoc.beginPos();
     if (methodNameOffset != 0) {
         methodNameOffset = expr.find_first_of(".", methodNameOffset) + 1;

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -92,7 +92,7 @@ core::SymbolRef findRootClassWithMethod(const core::GlobalState &gs, core::Symbo
 
 class UniqueSymbolQueue {
 public:
-    UniqueSymbolQueue() : iter(0) {}
+    UniqueSymbolQueue() {}
 
     bool tryEnqueue(core::SymbolRef s) {
         auto insertResult = set.insert(s);
@@ -104,17 +104,16 @@ public:
     }
 
     core::SymbolRef pop() {
-        if (iter < symbols.size()) {
-            auto result = symbols[iter];
-            iter++;
-            return result;
+        if (!symbols.empty()) {
+            auto s = symbols.front();
+            symbols.pop_front();
+            return s;
         }
         return core::SymbolRef();
     }
 
 private:
-    int iter;
-    vector<core::SymbolRef> symbols;
+    deque<core::SymbolRef> symbols;
     UnorderedSet<core::SymbolRef> set;
 };
 

--- a/test/testdata/lsp/rename/method_nilable.A.rbedited
+++ b/test/testdata/lsp/rename/method_nilable.A.rbedited
@@ -1,0 +1,18 @@
+# typed: true
+# frozen_string_literal: true
+
+class C1
+  def m2
+#      ^ apply-rename: [A] newName: m2
+  end
+end
+
+class CallerClass
+  extend T::Sig
+
+  sig { params(c: T.nilable(C1)).void }
+  def caller(c)
+    c&.m2
+#      ^ apply-rename: [B] newName: m2
+  end
+end

--- a/test/testdata/lsp/rename/method_nilable.B.rbedited
+++ b/test/testdata/lsp/rename/method_nilable.B.rbedited
@@ -1,0 +1,18 @@
+# typed: true
+# frozen_string_literal: true
+
+class C1
+  def m2
+#      ^ apply-rename: [A] newName: m2
+  end
+end
+
+class CallerClass
+  extend T::Sig
+
+  sig { params(c: T.nilable(C1)).void }
+  def caller(c)
+    c&.m2
+#      ^ apply-rename: [B] newName: m2
+  end
+end

--- a/test/testdata/lsp/rename/method_nilable.rb
+++ b/test/testdata/lsp/rename/method_nilable.rb
@@ -1,0 +1,18 @@
+# typed: true
+# frozen_string_literal: true
+
+class C1
+  def m1
+#      ^ apply-rename: [A] newName: m2
+  end
+end
+
+class CallerClass
+  extend T::Sig
+
+  sig { params(c: T.nilable(C1)).void }
+  def caller(c)
+    c&.m1
+#      ^ apply-rename: [B] newName: m2
+  end
+end

--- a/test/testdata/lsp/rename/method_union_types.A.rbedited
+++ b/test/testdata/lsp/rename/method_union_types.A.rbedited
@@ -1,0 +1,41 @@
+# typed: true
+# frozen_string_literal: true
+
+class C1
+  def m2
+#      ^ apply-rename: [A] newName: m2
+  end
+end
+
+class C2
+  def m2
+#      ^ apply-rename: [B] newName: m2
+  end
+end
+
+class C11 < C1
+  def m2
+#      ^ apply-rename: [D] newName: m2
+  end
+end
+
+class C3
+  def m2
+#      ^ apply-rename: [E] newName: m2
+  end
+end
+
+class CallerClass
+  extend T::Sig
+
+  sig { params(c: T.any(C1, C2)).void }
+  def caller(c)
+    c.m2
+#      ^ apply-rename: [C] newName: m2
+  end
+
+  sig { params(c: T.any(C11, C3)).void }
+  def caller2(c)
+    c.m2
+  end
+end

--- a/test/testdata/lsp/rename/method_union_types.B.rbedited
+++ b/test/testdata/lsp/rename/method_union_types.B.rbedited
@@ -1,0 +1,41 @@
+# typed: true
+# frozen_string_literal: true
+
+class C1
+  def m2
+#      ^ apply-rename: [A] newName: m2
+  end
+end
+
+class C2
+  def m2
+#      ^ apply-rename: [B] newName: m2
+  end
+end
+
+class C11 < C1
+  def m2
+#      ^ apply-rename: [D] newName: m2
+  end
+end
+
+class C3
+  def m2
+#      ^ apply-rename: [E] newName: m2
+  end
+end
+
+class CallerClass
+  extend T::Sig
+
+  sig { params(c: T.any(C1, C2)).void }
+  def caller(c)
+    c.m2
+#      ^ apply-rename: [C] newName: m2
+  end
+
+  sig { params(c: T.any(C11, C3)).void }
+  def caller2(c)
+    c.m2
+  end
+end

--- a/test/testdata/lsp/rename/method_union_types.C.rbedited
+++ b/test/testdata/lsp/rename/method_union_types.C.rbedited
@@ -1,0 +1,41 @@
+# typed: true
+# frozen_string_literal: true
+
+class C1
+  def m2
+#      ^ apply-rename: [A] newName: m2
+  end
+end
+
+class C2
+  def m2
+#      ^ apply-rename: [B] newName: m2
+  end
+end
+
+class C11 < C1
+  def m2
+#      ^ apply-rename: [D] newName: m2
+  end
+end
+
+class C3
+  def m2
+#      ^ apply-rename: [E] newName: m2
+  end
+end
+
+class CallerClass
+  extend T::Sig
+
+  sig { params(c: T.any(C1, C2)).void }
+  def caller(c)
+    c.m2
+#      ^ apply-rename: [C] newName: m2
+  end
+
+  sig { params(c: T.any(C11, C3)).void }
+  def caller2(c)
+    c.m2
+  end
+end

--- a/test/testdata/lsp/rename/method_union_types.D.rbedited
+++ b/test/testdata/lsp/rename/method_union_types.D.rbedited
@@ -1,0 +1,41 @@
+# typed: true
+# frozen_string_literal: true
+
+class C1
+  def m2
+#      ^ apply-rename: [A] newName: m2
+  end
+end
+
+class C2
+  def m2
+#      ^ apply-rename: [B] newName: m2
+  end
+end
+
+class C11 < C1
+  def m2
+#      ^ apply-rename: [D] newName: m2
+  end
+end
+
+class C3
+  def m2
+#      ^ apply-rename: [E] newName: m2
+  end
+end
+
+class CallerClass
+  extend T::Sig
+
+  sig { params(c: T.any(C1, C2)).void }
+  def caller(c)
+    c.m2
+#      ^ apply-rename: [C] newName: m2
+  end
+
+  sig { params(c: T.any(C11, C3)).void }
+  def caller2(c)
+    c.m2
+  end
+end

--- a/test/testdata/lsp/rename/method_union_types.E.rbedited
+++ b/test/testdata/lsp/rename/method_union_types.E.rbedited
@@ -1,0 +1,41 @@
+# typed: true
+# frozen_string_literal: true
+
+class C1
+  def m2
+#      ^ apply-rename: [A] newName: m2
+  end
+end
+
+class C2
+  def m2
+#      ^ apply-rename: [B] newName: m2
+  end
+end
+
+class C11 < C1
+  def m2
+#      ^ apply-rename: [D] newName: m2
+  end
+end
+
+class C3
+  def m2
+#      ^ apply-rename: [E] newName: m2
+  end
+end
+
+class CallerClass
+  extend T::Sig
+
+  sig { params(c: T.any(C1, C2)).void }
+  def caller(c)
+    c.m2
+#      ^ apply-rename: [C] newName: m2
+  end
+
+  sig { params(c: T.any(C11, C3)).void }
+  def caller2(c)
+    c.m2
+  end
+end

--- a/test/testdata/lsp/rename/method_union_types.rb
+++ b/test/testdata/lsp/rename/method_union_types.rb
@@ -1,0 +1,41 @@
+# typed: true
+# frozen_string_literal: true
+
+class C1
+  def m1
+#      ^ apply-rename: [A] newName: m2
+  end
+end
+
+class C2
+  def m1
+#      ^ apply-rename: [B] newName: m2
+  end
+end
+
+class C11 < C1
+  def m1
+#      ^ apply-rename: [D] newName: m2
+  end
+end
+
+class C3
+  def m1
+#      ^ apply-rename: [E] newName: m2
+  end
+end
+
+class CallerClass
+  extend T::Sig
+
+  sig { params(c: T.any(C1, C2)).void }
+  def caller(c)
+    c.m1
+#      ^ apply-rename: [C] newName: m2
+  end
+
+  sig { params(c: T.any(C11, C3)).void }
+  def caller2(c)
+    c.m1
+  end
+end


### PR DESCRIPTION
While searching for related symbols in method renames, handle multiple dispatch results in sends. When we find a secondary dispatch result, we follow the dispatch result linked list, adding any new methods we find. You can think of this code as the traversal of a graph where nodes are methods, and edges exist between methods that are related either by overriding or by being used in a union type.

(previous PR: #3746)

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #3665 -- the current code doesn't handle cases where there is more than one dispatch result for a send.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
