### PR TITLE
remove Instruction's vtable

### DIFF
--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -105,8 +105,7 @@ CFG::ReadsAndWrites CFG::findAllReadsAndWrites(core::Context ctx) {
              * assignment. Treating every write as also reading from the
              * variable serves to represent this.
              */
-            if (bind.bind.variable.isAliasForGlobal(ctx, *this) &&
-                cast_instruction<Alias>(bind.value) == nullptr) {
+            if (bind.bind.variable.isAliasForGlobal(ctx, *this) && cast_instruction<Alias>(bind.value) == nullptr) {
                 blockReads.add(bind.bind.variable.id());
             }
 

--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -330,7 +330,7 @@ string BasicBlock::toTextualString(const core::GlobalState &gs, const CFG &cfg) 
         fmt::format_to(std::back_inserter(buf), "outerLoops: {}\n", this->outerLoops);
     }
     for (const Binding &exp : this->exprs) {
-        fmt::format_to(std::back_inserter(buf), "{} = {}\n", exp.bind.toString(gs, cfg), exp.value->toString(gs, cfg));
+        fmt::format_to(std::back_inserter(buf), "{} = {}\n", exp.bind.toString(gs, cfg), exp.value.toString(gs, cfg));
     }
     fmt::format_to(std::back_inserter(buf), "{}", this->bexit.cond.toString(gs, cfg));
     return to_string(buf);
@@ -348,7 +348,7 @@ string BasicBlock::showRaw(const core::GlobalState &gs, const CFG &cfg) const {
     }
     for (const Binding &exp : this->exprs) {
         fmt::format_to(std::back_inserter(buf), "Binding {{\n&nbsp;bind = {},\n&nbsp;value = {},\n}}\n",
-                       exp.bind.showRaw(gs, cfg, 1), exp.value->showRaw(gs, cfg, 1));
+                       exp.bind.showRaw(gs, cfg, 1), exp.value.showRaw(gs, cfg, 1));
     }
     fmt::format_to(std::back_inserter(buf), "{}", this->bexit.cond.showRaw(gs, cfg));
     return to_string(buf);

--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -129,7 +129,7 @@ CFG::ReadsAndWrites CFG::findAllReadsAndWrites(core::Context ctx) {
                 blockReads.add(v->fallback.id());
             } else if (auto *v = cast_instruction<SolveConstraint>(bind.value)) {
                 blockReads.add(v->send.id());
-            } else if (auto *v = cast_instruction<YieldLoadArg>(bind.value.get())) {
+            } else if (auto *v = cast_instruction<YieldLoadArg>(bind.value)) {
                 blockReads.add(v->yieldParam.variable.id());
             }
 

--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -106,28 +106,28 @@ CFG::ReadsAndWrites CFG::findAllReadsAndWrites(core::Context ctx) {
              * variable serves to represent this.
              */
             if (bind.bind.variable.isAliasForGlobal(ctx, *this) &&
-                cast_instruction<Alias>(bind.value.get()) == nullptr) {
+                cast_instruction<Alias>(bind.value) == nullptr) {
                 blockReads.add(bind.bind.variable.id());
             }
 
-            if (auto *v = cast_instruction<Ident>(bind.value.get())) {
+            if (auto *v = cast_instruction<Ident>(bind.value)) {
                 blockReads.add(v->what.id());
-            } else if (auto *v = cast_instruction<Send>(bind.value.get())) {
+            } else if (auto *v = cast_instruction<Send>(bind.value)) {
                 blockReads.add(v->recv.variable.id());
                 for (auto &arg : v->args) {
                     blockReads.add(arg.variable.id());
                 }
-            } else if (auto *v = cast_instruction<TAbsurd>(bind.value.get())) {
+            } else if (auto *v = cast_instruction<TAbsurd>(bind.value)) {
                 blockReads.add(v->what.variable.id());
-            } else if (auto *v = cast_instruction<Return>(bind.value.get())) {
+            } else if (auto *v = cast_instruction<Return>(bind.value)) {
                 blockReads.add(v->what.variable.id());
-            } else if (auto *v = cast_instruction<BlockReturn>(bind.value.get())) {
+            } else if (auto *v = cast_instruction<BlockReturn>(bind.value)) {
                 blockReads.add(v->what.variable.id());
-            } else if (auto *v = cast_instruction<Cast>(bind.value.get())) {
+            } else if (auto *v = cast_instruction<Cast>(bind.value)) {
                 blockReads.add(v->value.variable.id());
-            } else if (auto *v = cast_instruction<LoadSelf>(bind.value.get())) {
+            } else if (auto *v = cast_instruction<LoadSelf>(bind.value)) {
                 blockReads.add(v->fallback.id());
-            } else if (auto *v = cast_instruction<SolveConstraint>(bind.value.get())) {
+            } else if (auto *v = cast_instruction<SolveConstraint>(bind.value)) {
                 blockReads.add(v->send.id());
             } else if (auto *v = cast_instruction<YieldLoadArg>(bind.value.get())) {
                 blockReads.add(v->yieldParam.variable.id());

--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -354,7 +354,7 @@ string BasicBlock::showRaw(const core::GlobalState &gs, const CFG &cfg) const {
     return to_string(buf);
 }
 
-Binding::Binding(LocalRef bind, core::LocOffsets loc, InsnPtr value)
+Binding::Binding(LocalRef bind, core::LocOffsets loc, InstructionPtr value)
     : bind(bind), loc(loc), value(std::move(value)) {}
 
 } // namespace sorbet::cfg

--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -313,7 +313,7 @@ string BasicBlock::toString(const core::GlobalState &gs, const CFG &cfg) const {
         fmt::format_to(std::back_inserter(buf), "outerLoops: {}\n", this->outerLoops);
     }
     for (const Binding &exp : this->exprs) {
-        fmt::format_to(std::back_inserter(buf), "{} = {}\n", exp.bind.toString(gs, cfg), exp.value->toString(gs, cfg));
+        fmt::format_to(std::back_inserter(buf), "{} = {}\n", exp.bind.toString(gs, cfg), exp.value.toString(gs, cfg));
     }
     fmt::format_to(std::back_inserter(buf), "{}", this->bexit.cond.toString(gs, cfg));
     return to_string(buf);

--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -354,7 +354,7 @@ string BasicBlock::showRaw(const core::GlobalState &gs, const CFG &cfg) const {
     return to_string(buf);
 }
 
-Binding::Binding(LocalRef bind, core::LocOffsets loc, unique_ptr<Instruction> value)
+Binding::Binding(LocalRef bind, core::LocOffsets loc, InsnPtr value)
     : bind(bind), loc(loc), value(std::move(value)) {}
 
 } // namespace sorbet::cfg

--- a/cfg/CFG.h
+++ b/cfg/CFG.h
@@ -40,9 +40,9 @@ public:
     VariableUseSite bind;
     core::LocOffsets loc;
 
-    std::unique_ptr<Instruction> value;
+    InsnPtr value;
 
-    Binding(LocalRef bind, core::LocOffsets loc, std::unique_ptr<Instruction> value);
+    Binding(LocalRef bind, core::LocOffsets loc, InsnPtr value);
     Binding(Binding &&other) = default;
     Binding() = default;
 

--- a/cfg/CFG.h
+++ b/cfg/CFG.h
@@ -40,9 +40,9 @@ public:
     VariableUseSite bind;
     core::LocOffsets loc;
 
-    InsnPtr value;
+    InstructionPtr value;
 
-    Binding(LocalRef bind, core::LocOffsets loc, InsnPtr value);
+    Binding(LocalRef bind, core::LocOffsets loc, InstructionPtr value);
     Binding(Binding &&other) = default;
     Binding() = default;
 

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -45,7 +45,7 @@ string spacesForTabLevel(int tabs) {
             CASE_STATEMENT(body, TAbsurd)                               \
             }
 
-std::string InsnPtr::toString(const core::GlobalState &gs, const CFG &cfg) const {
+std::string InstructionPtr::toString(const core::GlobalState &gs, const CFG &cfg) const {
     auto *ptr = get();
 
 #define TO_STRING(name) return static_cast<const name *>(ptr)->toString(gs, cfg);
@@ -53,7 +53,7 @@ std::string InsnPtr::toString(const core::GlobalState &gs, const CFG &cfg) const
 #undef TO_STRING
 }
 
-std::string InsnPtr::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
+std::string InstructionPtr::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
     auto *ptr = get();
 
 #define SHOW_RAW(name) return static_cast<const name *>(ptr)->showRaw(gs, cfg, tabs);
@@ -61,7 +61,7 @@ std::string InsnPtr::showRaw(const core::GlobalState &gs, const CFG &cfg, int ta
 #undef SHOW_RAW
 }
 
-void InsnPtr::deleteTagged(Tag tag, void *expr) noexcept {
+void InstructionPtr::deleteTagged(Tag tag, void *expr) noexcept {
     ENFORCE(expr != nullptr);
 
 #define DELETE_INSN(name) delete static_cast<name *>(expr);

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -70,7 +70,7 @@ void InsnPtr::deleteTagged(Tag tag, void *expr) noexcept {
 #undef DELETE_INSN
 }
 
-Return::Return(LocalRef what, core::LocOffsets whatLoc) : Instruction(Tag::Return), what(what), whatLoc(whatLoc) {
+Return::Return(LocalRef what, core::LocOffsets whatLoc) : what(what), whatLoc(whatLoc) {
     categoryCounterInc("cfg", "return");
 }
 
@@ -91,7 +91,7 @@ string Return::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) co
                        this->what.showRaw(gs, cfg, tabs + 1));
 }
 
-BlockReturn::BlockReturn(shared_ptr<core::SendAndBlockLink> link, LocalRef what) : Instruction(Tag::BlockReturn), link(std::move(link)), what(what) {
+BlockReturn::BlockReturn(shared_ptr<core::SendAndBlockLink> link, LocalRef what) : link(std::move(link)), what(what) {
     categoryCounterInc("cfg", "blockreturn");
 }
 
@@ -105,7 +105,7 @@ string BlockReturn::showRaw(const core::GlobalState &gs, const CFG &cfg, int tab
 }
 
 LoadSelf::LoadSelf(shared_ptr<core::SendAndBlockLink> link, LocalRef fallback)
-    : Instruction(Tag::LoadSelf), fallback(fallback), link(std::move(link)) {
+    : fallback(fallback), link(std::move(link)) {
     categoryCounterInc("cfg", "loadself");
 }
 
@@ -120,7 +120,7 @@ string LoadSelf::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) 
 Send::Send(LocalRef recv, core::NameRef fun, core::LocOffsets receiverLoc, u2 numPosArgs,
            const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> argLocs, bool isPrivateOk,
            const shared_ptr<core::SendAndBlockLink> &link)
-    : Instruction(Tag::Send), isPrivateOk(isPrivateOk), numPosArgs(numPosArgs), fun(fun), recv(recv), receiverLoc(receiverLoc),
+    : isPrivateOk(isPrivateOk), numPosArgs(numPosArgs), fun(fun), recv(recv), receiverLoc(receiverLoc),
       argLocs(std::move(argLocs)), link(move(link)) {
     ENFORCE(numPosArgs <= args.size(), "Expected {} positional arguments, but only have {} args", numPosArgs,
             args.size());
@@ -135,7 +135,7 @@ Send::Send(LocalRef recv, core::NameRef fun, core::LocOffsets receiverLoc, u2 nu
     histogramInc("cfg.send.args", this->args.size());
 }
 
-Literal::Literal(const core::TypePtr &value) : Instruction(Tag::Literal), value(move(value)) {
+Literal::Literal(const core::TypePtr &value) : value(move(value)) {
     categoryCounterInc("cfg", "literal");
 }
 
@@ -162,11 +162,11 @@ string Literal::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) c
     return fmt::format("Literal {{ value = {} }}", this->value.show(gs));
 }
 
-Ident::Ident(LocalRef what) : Instruction(Tag::Ident), what(what) {
+Ident::Ident(LocalRef what) : what(what) {
     categoryCounterInc("cfg", "ident");
 }
 
-Alias::Alias(core::SymbolRef what, core::NameRef name) : Instruction(Tag::Alias), what(what), name(name) {
+Alias::Alias(core::SymbolRef what, core::NameRef name) : what(what), name(name) {
     // what == undeclaredFieldStub -> name.exists()
     ENFORCE(what != core::Symbols::Magic_undeclaredFieldStub() || name.exists(),
             "Missing name for undeclared field alias!");

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -26,25 +26,25 @@ string spacesForTabLevel(int tabs) {
         break;                       \
     }
 
-#define GENERATE_TAG_SWITCH(tag, body)                                  \
-    switch (tag) {                                                      \
-        CASE_STATEMENT(body, Ident)                                     \
-            CASE_STATEMENT(body, Alias)                                 \
-            CASE_STATEMENT(body, SolveConstraint)                       \
-            CASE_STATEMENT(body, Send)                                  \
-            CASE_STATEMENT(body, Return)                                \
-            CASE_STATEMENT(body, BlockReturn)                           \
-            CASE_STATEMENT(body, LoadSelf)                              \
-            CASE_STATEMENT(body, Literal)                               \
-            CASE_STATEMENT(body, GetCurrentException)                   \
-            CASE_STATEMENT(body, LoadArg)                               \
-            CASE_STATEMENT(body, ArgPresent)                            \
-            CASE_STATEMENT(body, LoadYieldParams)                       \
-            CASE_STATEMENT(body, YieldParamPresent)                     \
-            CASE_STATEMENT(body, YieldLoadArg)                          \
-            CASE_STATEMENT(body, Cast)                                  \
-            CASE_STATEMENT(body, TAbsurd)                               \
-            }
+#define GENERATE_TAG_SWITCH(tag, body)            \
+    switch (tag) {                                \
+        CASE_STATEMENT(body, Ident)               \
+        CASE_STATEMENT(body, Alias)               \
+        CASE_STATEMENT(body, SolveConstraint)     \
+        CASE_STATEMENT(body, Send)                \
+        CASE_STATEMENT(body, Return)              \
+        CASE_STATEMENT(body, BlockReturn)         \
+        CASE_STATEMENT(body, LoadSelf)            \
+        CASE_STATEMENT(body, Literal)             \
+        CASE_STATEMENT(body, GetCurrentException) \
+        CASE_STATEMENT(body, LoadArg)             \
+        CASE_STATEMENT(body, ArgPresent)          \
+        CASE_STATEMENT(body, LoadYieldParams)     \
+        CASE_STATEMENT(body, YieldParamPresent)   \
+        CASE_STATEMENT(body, YieldLoadArg)        \
+        CASE_STATEMENT(body, Cast)                \
+        CASE_STATEMENT(body, TAbsurd)             \
+    }
 
 std::string InstructionPtr::toString(const core::GlobalState &gs, const CFG &cfg) const {
     auto *ptr = get();

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -22,7 +22,7 @@ string spacesForTabLevel(int tabs) {
 }
 } // namespace
 
-Return::Return(LocalRef what, core::LocOffsets whatLoc) : what(what), whatLoc(whatLoc) {
+Return::Return(LocalRef what, core::LocOffsets whatLoc) : Instruction(Tag::Return), what(what), whatLoc(whatLoc) {
     categoryCounterInc("cfg", "return");
 }
 
@@ -43,7 +43,7 @@ string Return::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) co
                        this->what.showRaw(gs, cfg, tabs + 1));
 }
 
-BlockReturn::BlockReturn(shared_ptr<core::SendAndBlockLink> link, LocalRef what) : link(std::move(link)), what(what) {
+BlockReturn::BlockReturn(shared_ptr<core::SendAndBlockLink> link, LocalRef what) : Instruction(Tag::BlockReturn), link(std::move(link)), what(what) {
     categoryCounterInc("cfg", "blockreturn");
 }
 
@@ -57,7 +57,7 @@ string BlockReturn::showRaw(const core::GlobalState &gs, const CFG &cfg, int tab
 }
 
 LoadSelf::LoadSelf(shared_ptr<core::SendAndBlockLink> link, LocalRef fallback)
-    : fallback(fallback), link(std::move(link)) {
+    : Instruction(Tag::LoadSelf), fallback(fallback), link(std::move(link)) {
     categoryCounterInc("cfg", "loadself");
 }
 
@@ -72,7 +72,7 @@ string LoadSelf::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) 
 Send::Send(LocalRef recv, core::NameRef fun, core::LocOffsets receiverLoc, u2 numPosArgs,
            const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> argLocs, bool isPrivateOk,
            const shared_ptr<core::SendAndBlockLink> &link)
-    : isPrivateOk(isPrivateOk), numPosArgs(numPosArgs), fun(fun), recv(recv), receiverLoc(receiverLoc),
+    : Instruction(Tag::Send), isPrivateOk(isPrivateOk), numPosArgs(numPosArgs), fun(fun), recv(recv), receiverLoc(receiverLoc),
       argLocs(std::move(argLocs)), link(move(link)) {
     ENFORCE(numPosArgs <= args.size(), "Expected {} positional arguments, but only have {} args", numPosArgs,
             args.size());
@@ -87,7 +87,7 @@ Send::Send(LocalRef recv, core::NameRef fun, core::LocOffsets receiverLoc, u2 nu
     histogramInc("cfg.send.args", this->args.size());
 }
 
-Literal::Literal(const core::TypePtr &value) : value(move(value)) {
+Literal::Literal(const core::TypePtr &value) : Instruction(Tag::Literal), value(move(value)) {
     categoryCounterInc("cfg", "literal");
 }
 
@@ -114,11 +114,11 @@ string Literal::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) c
     return fmt::format("Literal {{ value = {} }}", this->value.show(gs));
 }
 
-Ident::Ident(LocalRef what) : what(what) {
+Ident::Ident(LocalRef what) : Instruction(Tag::Ident), what(what) {
     categoryCounterInc("cfg", "ident");
 }
 
-Alias::Alias(core::SymbolRef what, core::NameRef name) : what(what), name(name) {
+Alias::Alias(core::SymbolRef what, core::NameRef name) : Instruction(Tag::Alias), what(what), name(name) {
     // what == undeclaredFieldStub -> name.exists()
     ENFORCE(what != core::Symbols::Magic_undeclaredFieldStub() || name.exists(),
             "Missing name for undeclared field alias!");

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -40,6 +40,7 @@ string spacesForTabLevel(int tabs) {
             CASE_STATEMENT(body, LoadArg)                               \
             CASE_STATEMENT(body, ArgPresent)                            \
             CASE_STATEMENT(body, LoadYieldParams)                       \
+            CASE_STATEMENT(body, YieldParamPresent)                     \
             CASE_STATEMENT(body, Cast)                                  \
             CASE_STATEMENT(body, TAbsurd)                               \
             }

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -46,15 +46,19 @@ string spacesForTabLevel(int tabs) {
             CASE_STATEMENT(body, TAbsurd)                               \
             }
 
-std::string Instruction::toString(const core::GlobalState &gs, const CFG &cfg) const {
-#define TO_STRING(name) return static_cast<const name *>(this)->toString(gs, cfg);
-    GENERATE_TAG_SWITCH(tag, TO_STRING)
+std::string InsnPtr::toString(const core::GlobalState &gs, const CFG &cfg) const {
+    auto *ptr = get();
+
+#define TO_STRING(name) return static_cast<const name *>(ptr)->toString(gs, cfg);
+    GENERATE_TAG_SWITCH(tag(), TO_STRING)
 #undef TO_STRING
 }
 
-std::string Instruction::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
-#define SHOW_RAW(name) return static_cast<const name *>(this)->showRaw(gs, cfg, tabs);
-    GENERATE_TAG_SWITCH(tag, SHOW_RAW)
+std::string InsnPtr::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
+    auto *ptr = get();
+
+#define SHOW_RAW(name) return static_cast<const name *>(ptr)->showRaw(gs, cfg, tabs);
+    GENERATE_TAG_SWITCH(tag(), SHOW_RAW)
 #undef SHOW_RAW
 }
 

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -5,8 +5,6 @@
 #include "core/Names.h"
 #include "core/TypeConstraint.h"
 #include <utility>
-// helps debugging
-template class std::unique_ptr<sorbet::cfg::Instruction>;
 
 using namespace std;
 

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -58,6 +58,12 @@ std::string Instruction::showRaw(const core::GlobalState &gs, const CFG &cfg, in
 #undef SHOW_RAW
 }
 
+void Instruction::deleteTagged() {
+#define DELETE_INSN(name) delete static_cast<name *>(this);
+    GENERATE_TAG_SWITCH(tag, DELETE_INSN)
+#undef DELETE_INSN
+}
+
 Return::Return(LocalRef what, core::LocOffsets whatLoc) : Instruction(Tag::Return), what(what), whatLoc(whatLoc) {
     categoryCounterInc("cfg", "return");
 }

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -22,6 +22,42 @@ string spacesForTabLevel(int tabs) {
 }
 } // namespace
 
+#define CASE_STATEMENT(CASE_BODY, T) \
+    case Tag::T: {                   \
+        CASE_BODY(T)                 \
+        break;                       \
+    }
+
+#define GENERATE_TAG_SWITCH(tag, body)                                  \
+    switch (tag) {                                                      \
+        CASE_STATEMENT(body, Ident)                                     \
+            CASE_STATEMENT(body, Alias)                                 \
+            CASE_STATEMENT(body, SolveConstraint)                       \
+            CASE_STATEMENT(body, Send)                                  \
+            CASE_STATEMENT(body, Return)                                \
+            CASE_STATEMENT(body, BlockReturn)                           \
+            CASE_STATEMENT(body, LoadSelf)                              \
+            CASE_STATEMENT(body, Literal)                               \
+            CASE_STATEMENT(body, GetCurrentException)                   \
+            CASE_STATEMENT(body, LoadArg)                               \
+            CASE_STATEMENT(body, ArgPresent)                            \
+            CASE_STATEMENT(body, LoadYieldParams)                       \
+            CASE_STATEMENT(body, Cast)                                  \
+            CASE_STATEMENT(body, TAbsurd)                               \
+            }
+
+std::string Instruction::toString(const core::GlobalState &gs, const CFG &cfg) const {
+#define TO_STRING(name) return static_cast<const name *>(this)->toString(gs, cfg);
+    GENERATE_TAG_SWITCH(tag, TO_STRING)
+#undef TO_STRING
+}
+
+std::string Instruction::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
+#define SHOW_RAW(name) return static_cast<const name *>(this)->showRaw(gs, cfg, tabs);
+    GENERATE_TAG_SWITCH(tag, SHOW_RAW)
+#undef SHOW_RAW
+}
+
 Return::Return(LocalRef what, core::LocOffsets whatLoc) : Instruction(Tag::Return), what(what), whatLoc(whatLoc) {
     categoryCounterInc("cfg", "return");
 }

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -41,6 +41,7 @@ string spacesForTabLevel(int tabs) {
             CASE_STATEMENT(body, ArgPresent)                            \
             CASE_STATEMENT(body, LoadYieldParams)                       \
             CASE_STATEMENT(body, YieldParamPresent)                     \
+            CASE_STATEMENT(body, YieldLoadArg)                          \
             CASE_STATEMENT(body, Cast)                                  \
             CASE_STATEMENT(body, TAbsurd)                               \
             }

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -58,8 +58,10 @@ std::string Instruction::showRaw(const core::GlobalState &gs, const CFG &cfg, in
 #undef SHOW_RAW
 }
 
-void Instruction::deleteTagged() {
-#define DELETE_INSN(name) delete static_cast<name *>(this);
+void InsnPtr::deleteTagged(Tag tag, void *expr) noexcept {
+    ENFORCE(expr != nullptr);
+
+#define DELETE_INSN(name) delete static_cast<name *>(expr);
     GENERATE_TAG_SWITCH(tag, DELETE_INSN)
 #undef DELETE_INSN
 }

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -46,10 +46,11 @@ enum class Tag : u1 {
     TAbsurd,
 };
 
+struct InsnDeleter;
+
 // When adding a new subtype, see if you need to add it to fillInBlockArguments
 class Instruction {
 public:
-    virtual ~Instruction() = default;
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
     bool isSynthetic = false;
@@ -57,6 +58,11 @@ public:
 
 protected:
     Instruction(Tag tag) : tag(tag) {}
+    virtual ~Instruction() = default;
+
+private:
+    friend InsnDeleter;
+    void deleteTagged();
 };
 
 template <class To> To *cast_instruction(Instruction *what) {
@@ -271,7 +277,7 @@ CheckSize(TAbsurd, 40, 8);
 
 struct InsnDeleter {
     void operator()(Instruction *insn) {
-        delete insn;
+        insn->deleteTagged();
     }
 };
 

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -29,6 +29,23 @@ public:
 // implicitly numbered: result of every instruction can be uniquely referenced
 // by its position in a linear array.
 
+enum class Tag : u1 {
+    Ident = 1,
+    Alias,
+    SolveConstraint,
+    Send,
+    Return,
+    BlockReturn,
+    LoadSelf,
+    Literal,
+    GetCurrentException,
+    LoadArg,
+    ArgPresent,
+    LoadYieldParams,
+    Cast,
+    TAbsurd,
+};
+
 // When adding a new subtype, see if you need to add it to fillInBlockArguments
 class Instruction {
 public:

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -50,8 +50,8 @@ enum class Tag : u1 {
 class Instruction {
 public:
     virtual ~Instruction() = default;
-    virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const = 0;
-    virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const = 0;
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
     bool isSynthetic = false;
     const Tag tag;
 
@@ -75,8 +75,8 @@ public:
     LocalRef what;
 
     Ident(LocalRef what);
-    virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
-    virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
 CheckSize(Ident, 16, 8);
 
@@ -87,8 +87,8 @@ public:
 
     Alias(core::SymbolRef what, core::NameRef name = core::NameRef::noName());
 
-    virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
-    virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
 CheckSize(Alias, 24, 8);
 
@@ -97,8 +97,8 @@ public:
     LocalRef send;
     std::shared_ptr<core::SendAndBlockLink> link;
     SolveConstraint(const std::shared_ptr<core::SendAndBlockLink> &link, LocalRef send) : Instruction(Tag::SolveConstraint), send(send), link(link){};
-    virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
-    virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
 CheckSize(SolveConstraint, 32, 8);
 
@@ -117,8 +117,8 @@ public:
          const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> argLocs, bool isPrivateOk = false,
          const std::shared_ptr<core::SendAndBlockLink> &link = nullptr);
 
-    virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
-    virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
 CheckSize(Send, 152, 8);
 
@@ -128,8 +128,8 @@ public:
     core::LocOffsets whatLoc;
 
     Return(LocalRef what, core::LocOffsets whatLoc);
-    virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
-    virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
 CheckSize(Return, 48, 8);
 
@@ -139,8 +139,8 @@ public:
     VariableUseSite what;
 
     BlockReturn(std::shared_ptr<core::SendAndBlockLink> link, LocalRef what);
-    virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
-    virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
 CheckSize(BlockReturn, 56, 8);
 
@@ -149,8 +149,8 @@ public:
     LocalRef fallback;
     std::shared_ptr<core::SendAndBlockLink> link;
     LoadSelf(std::shared_ptr<core::SendAndBlockLink> link, LocalRef fallback);
-    virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
-    virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
 CheckSize(LoadSelf, 32, 8);
 
@@ -159,8 +159,8 @@ public:
     core::TypePtr value;
 
     Literal(const core::TypePtr &value);
-    virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
-    virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
 CheckSize(Literal, 32, 8);
 
@@ -169,8 +169,8 @@ public:
     GetCurrentException() : Instruction(Tag::GetCurrentException) {
         categoryCounterInc("cfg", "GetCurrentException");
     };
-    virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
-    virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
 CheckSize(GetCurrentException, 16, 8);
 
@@ -184,8 +184,8 @@ public:
     };
 
     const core::ArgInfo &argument(const core::GlobalState &gs) const;
-    virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
-    virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
 CheckSize(LoadArg, 16, 8);
 
@@ -199,8 +199,8 @@ public:
     }
 
     const core::ArgInfo &argument(const core::GlobalState &gs) const;
-    virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
-    virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
 CheckSize(ArgPresent, 16, 8);
 
@@ -211,8 +211,8 @@ public:
     LoadYieldParams(const std::shared_ptr<core::SendAndBlockLink> &link) : Instruction(Tag::LoadYieldParams), link(link) {
         categoryCounterInc("cfg", "loadarg");
     };
-    virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
-    virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
 CheckSize(LoadYieldParams, 32, 8);
 
@@ -251,8 +251,8 @@ public:
 
     Cast(LocalRef value, const core::TypePtr &type, core::NameRef cast) : Instruction(Tag::Cast), cast(cast), value(value), type(type) {}
 
-    virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
-    virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
 CheckSize(Cast, 56, 8);
 
@@ -264,8 +264,8 @@ public:
         categoryCounterInc("cfg", "tabsurd");
     }
 
-    virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
-    virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
 CheckSize(TAbsurd, 40, 8);
 

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -56,8 +56,6 @@ template <class To> To *cast_instruction(Instruction *what);
 // When adding a new subtype, see if you need to add it to fillInBlockArguments
 class Instruction {
 public:
-    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
-    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
     bool isSynthetic = false;
 
 protected:
@@ -389,6 +387,9 @@ public:
 
         return static_cast<Tag>(ptr & TAG_MASK);
     }
+
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
 
 template <class To> inline bool InsnPtr::isa(const InsnPtr &what) {

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -67,8 +67,8 @@ private:
     friend InstructionPtr;
 };
 
-#define INSN(name)                              \
-    class name;                                 \
+#define INSN(name)                                                                  \
+    class name;                                                                     \
     template <> struct InsnToTag<name> { static constexpr Tag value = Tag::name; }; \
     class __attribute__((aligned(8))) name final
 
@@ -412,8 +412,7 @@ template <> inline const InstructionPtr &InstructionPtr::cast(const InstructionP
     return what;
 }
 
-template <typename T, class... Args>
-InstructionPtr make_insn(Args&& ...arg) {
+template <typename T, class... Args> InstructionPtr make_insn(Args &&...arg) {
     return InstructionPtr(InsnToTag<T>::value, new T(std::forward<Args>(arg)...));
 }
 

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -269,6 +269,8 @@ public:
 };
 CheckSize(TAbsurd, 40, 8);
 
+using InsnPtr = std::unique_ptr<Instruction>;
+
 } // namespace sorbet::cfg
 
 #endif // SORBET_CFG_H

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -63,7 +63,7 @@ public:
 
 protected:
     Instruction(Tag tag) : tag(tag) {}
-    virtual ~Instruction() = default;
+    ~Instruction() = default;
 
 private:
     friend InsnDeleter;
@@ -105,7 +105,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Ident, 16, 8);
+CheckSize(Ident, 8, 8);
 
 INSN(Alias) : public Instruction {
 public:
@@ -117,7 +117,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Alias, 24, 8);
+CheckSize(Alias, 16, 8);
 
 INSN(SolveConstraint) : public Instruction {
 public:
@@ -127,7 +127,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(SolveConstraint, 32, 8);
+CheckSize(SolveConstraint, 24, 8);
 
 INSN(Send) : public Instruction {
 public:
@@ -147,7 +147,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Send, 152, 8);
+CheckSize(Send, 144, 8);
 
 INSN(Return) : public Instruction {
 public:
@@ -158,7 +158,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Return, 48, 8);
+CheckSize(Return, 40, 8);
 
 INSN(BlockReturn) : public Instruction {
 public:
@@ -169,7 +169,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(BlockReturn, 56, 8);
+CheckSize(BlockReturn, 48, 8);
 
 INSN(LoadSelf) : public Instruction {
 public:
@@ -179,7 +179,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(LoadSelf, 32, 8);
+CheckSize(LoadSelf, 24, 8);
 
 INSN(Literal) : public Instruction {
 public:
@@ -189,7 +189,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Literal, 32, 8);
+CheckSize(Literal, 24, 8);
 
 INSN(GetCurrentException) : public Instruction {
 public:
@@ -199,7 +199,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(GetCurrentException, 16, 8);
+CheckSize(GetCurrentException, 8, 8);
 
 INSN(LoadArg) : public Instruction {
 public:
@@ -214,7 +214,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(LoadArg, 16, 8);
+CheckSize(LoadArg, 8, 8);
 
 INSN(ArgPresent) : public Instruction {
 public:
@@ -229,7 +229,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(ArgPresent, 16, 8);
+CheckSize(ArgPresent, 8, 8);
 
 INSN(LoadYieldParams) : public Instruction {
 public:
@@ -241,7 +241,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(LoadYieldParams, 32, 8);
+CheckSize(LoadYieldParams, 24, 8);
 
 INSN(YieldParamPresent) : public Instruction {
 public:
@@ -281,7 +281,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Cast, 56, 8);
+CheckSize(Cast, 48, 8);
 
 INSN(TAbsurd) : public Instruction {
 public:
@@ -294,7 +294,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(TAbsurd, 40, 8);
+CheckSize(TAbsurd, 32, 8);
 
 struct InsnDeleter {
     void operator()(Instruction *insn) {

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -43,6 +43,7 @@ enum class Tag : u1 {
     ArgPresent,
     LoadYieldParams,
     YieldParamPresent,
+    YieldLoadArg,
     Cast,
     TAbsurd,
 };
@@ -239,10 +240,10 @@ public:
         : flags(flags), argId(argId), yieldParam(yieldParam) {
         categoryCounterInc("cfg", "yieldloadarg");
     }
-    virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
-    virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(YieldLoadArg, 40, 8);
+CheckSize(YieldLoadArg, 32, 8);
 
 INSN(Cast) : public Instruction {
 public:

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -53,9 +53,10 @@ public:
     virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const = 0;
     virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const = 0;
     bool isSynthetic = false;
+    const Tag tag;
 
 protected:
-    Instruction() = default;
+    Instruction(Tag tag) : tag(tag) {}
 };
 
 template <class To> To *cast_instruction(Instruction *what) {
@@ -95,7 +96,7 @@ class SolveConstraint final : public Instruction {
 public:
     LocalRef send;
     std::shared_ptr<core::SendAndBlockLink> link;
-    SolveConstraint(const std::shared_ptr<core::SendAndBlockLink> &link, LocalRef send) : send(send), link(link){};
+    SolveConstraint(const std::shared_ptr<core::SendAndBlockLink> &link, LocalRef send) : Instruction(Tag::SolveConstraint), send(send), link(link){};
     virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
@@ -119,7 +120,7 @@ public:
     virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Send, 144, 8);
+CheckSize(Send, 152, 8);
 
 class Return final : public Instruction {
 public:
@@ -165,7 +166,7 @@ CheckSize(Literal, 32, 8);
 
 class GetCurrentException : public Instruction {
 public:
-    GetCurrentException() {
+    GetCurrentException() : Instruction(Tag::GetCurrentException) {
         categoryCounterInc("cfg", "GetCurrentException");
     };
     virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
@@ -178,7 +179,7 @@ public:
     u2 argId;
     core::MethodRef method;
 
-    LoadArg(core::MethodRef method, u2 argId) : argId(argId), method(method) {
+    LoadArg(core::MethodRef method, u2 argId) : Instruction(Tag::LoadArg), argId(argId), method(method) {
         categoryCounterInc("cfg", "loadarg");
     };
 
@@ -193,7 +194,7 @@ public:
     u2 argId;
     core::MethodRef method;
 
-    ArgPresent(core::MethodRef method, u2 argId) : argId(argId), method(method) {
+    ArgPresent(core::MethodRef method, u2 argId) : Instruction(Tag::ArgPresent), argId(argId), method(method) {
         categoryCounterInc("cfg", "argpresent");
     }
 
@@ -207,7 +208,7 @@ class LoadYieldParams final : public Instruction {
 public:
     std::shared_ptr<core::SendAndBlockLink> link;
 
-    LoadYieldParams(const std::shared_ptr<core::SendAndBlockLink> &link) : link(link) {
+    LoadYieldParams(const std::shared_ptr<core::SendAndBlockLink> &link) : Instruction(Tag::LoadYieldParams), link(link) {
         categoryCounterInc("cfg", "loadarg");
     };
     virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
@@ -248,7 +249,7 @@ public:
     VariableUseSite value;
     core::TypePtr type;
 
-    Cast(LocalRef value, const core::TypePtr &type, core::NameRef cast) : cast(cast), value(value), type(type) {}
+    Cast(LocalRef value, const core::TypePtr &type, core::NameRef cast) : Instruction(Tag::Cast), cast(cast), value(value), type(type) {}
 
     virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
@@ -259,7 +260,7 @@ class TAbsurd final : public Instruction {
 public:
     VariableUseSite what;
 
-    TAbsurd(LocalRef what) : what(what) {
+    TAbsurd(LocalRef what) : Instruction(Tag::TAbsurd), what(what) {
         categoryCounterInc("cfg", "tabsurd");
     }
 

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -269,7 +269,18 @@ public:
 };
 CheckSize(TAbsurd, 40, 8);
 
-using InsnPtr = std::unique_ptr<Instruction>;
+struct InsnDeleter {
+    void operator()(Instruction *insn) {
+        delete insn;
+    }
+};
+
+using InsnPtr = std::unique_ptr<Instruction, InsnDeleter>;
+
+template <typename T, class... Args>
+InsnPtr make_insn(Args&& ...arg) {
+    return InsnPtr(new T(std::forward<Args>(arg)...));
+}
 
 } // namespace sorbet::cfg
 

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -35,8 +35,10 @@ public:
     virtual ~Instruction() = default;
     virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const = 0;
     virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const = 0;
-    Instruction() = default;
     bool isSynthetic = false;
+
+protected:
+    Instruction() = default;
 };
 
 template <class To> To *cast_instruction(Instruction *what) {

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -42,6 +42,7 @@ enum class Tag : u1 {
     LoadArg,
     ArgPresent,
     LoadYieldParams,
+    YieldParamPresent,
     Cast,
     TAbsurd,
 };
@@ -223,10 +224,10 @@ public:
     YieldParamPresent(u2 argId) : argId{argId} {
         categoryCounterInc("cfg", "argpresent");
     };
-    virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
-    virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(YieldParamPresent, 16, 8);
+CheckSize(YieldParamPresent, 8, 8);
 
 INSN(YieldLoadArg) : public Instruction {
 public:

--- a/cfg/builder/builder.h
+++ b/cfg/builder/builder.h
@@ -25,7 +25,7 @@ private:
                                 core::LocOffsets loc);
     static void unconditionalJump(BasicBlock *from, BasicBlock *to, CFG &inWhat, core::LocOffsets loc);
     static void jumpToDead(BasicBlock *from, CFG &inWhat, core::LocOffsets loc);
-    static void synthesizeExpr(BasicBlock *bb, LocalRef var, core::LocOffsets loc, std::unique_ptr<Instruction> inst);
+    static void synthesizeExpr(BasicBlock *bb, LocalRef var, core::LocOffsets loc, InsnPtr inst);
     static BasicBlock *walkHash(CFGContext cctx, ast::Hash &h, BasicBlock *current, core::NameRef method);
     static std::tuple<LocalRef, BasicBlock *, BasicBlock *>
     walkDefault(CFGContext cctx, int argIndex, const core::ArgInfo &argInfo, LocalRef argLocal, core::LocOffsets argLoc,

--- a/cfg/builder/builder.h
+++ b/cfg/builder/builder.h
@@ -25,7 +25,7 @@ private:
                                 core::LocOffsets loc);
     static void unconditionalJump(BasicBlock *from, BasicBlock *to, CFG &inWhat, core::LocOffsets loc);
     static void jumpToDead(BasicBlock *from, CFG &inWhat, core::LocOffsets loc);
-    static void synthesizeExpr(BasicBlock *bb, LocalRef var, core::LocOffsets loc, InsnPtr inst);
+    static void synthesizeExpr(BasicBlock *bb, LocalRef var, core::LocOffsets loc, InstructionPtr inst);
     static BasicBlock *walkHash(CFGContext cctx, ast::Hash &h, BasicBlock *current, core::NameRef method);
     static std::tuple<LocalRef, BasicBlock *, BasicBlock *>
     walkDefault(CFGContext cctx, int argIndex, const core::ArgInfo &argInfo, LocalRef argLocal, core::LocOffsets argLoc,

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -33,7 +33,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
         }
         synthesizeExpr(
             entry, LocalRef::selfVariable(), core::LocOffsets::none(),
-            make_unique<Cast>(LocalRef::selfVariable(), selfClaz.data(ctx)->selfType(ctx), core::Names::cast()));
+            make_insn<Cast>(LocalRef::selfVariable(), selfClaz.data(ctx)->selfType(ctx), core::Names::cast()));
 
         BasicBlock *presentCont = entry;
         BasicBlock *defaultCont = nullptr;
@@ -67,14 +67,14 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
                     auto [result, presentNext, defaultNext] =
                         walkDefault(cctx, i, argInfo, local, a->loc, opt->default_, presentCont, defaultCont);
 
-                    synthesizeExpr(defaultNext, local, a->loc, make_unique<Ident>(result));
+                    synthesizeExpr(defaultNext, local, a->loc, make_insn<Ident>(result));
 
                     presentCont = presentNext;
                     defaultCont = defaultNext;
                 }
             }
 
-            synthesizeExpr(presentCont, local, a->loc, make_unique<LoadArg>(md.symbol, i));
+            synthesizeExpr(presentCont, local, a->loc, make_insn<LoadArg>(md.symbol, i));
         }
 
         // Join the presentCont and defaultCont paths together
@@ -101,14 +101,14 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
     } else {
         rvLoc = cont->exprs.back().loc;
     }
-    synthesizeExpr(cont, retSym1, rvLoc, make_unique<Return>(retSym, rvLoc)); // dead assign.
+    synthesizeExpr(cont, retSym1, rvLoc, make_insn<Return>(retSym, rvLoc)); // dead assign.
     jumpToDead(cont, *res.get(), rvLoc);
 
     vector<Binding> aliasesPrefix;
     for (auto kv : aliases) {
         core::SymbolRef global = kv.first;
         LocalRef local = kv.second;
-        aliasesPrefix.emplace_back(local, core::LocOffsets::none(), make_unique<Alias>(global));
+        aliasesPrefix.emplace_back(local, core::LocOffsets::none(), make_insn<Alias>(global));
         if (global.isFieldOrStaticField()) {
             res->minLoops[local.id()] = CFG::MIN_LOOP_FIELD;
         } else {
@@ -117,7 +117,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
     }
     for (auto kv : discoveredUndeclaredFields) {
         aliasesPrefix.emplace_back(kv.second, core::LocOffsets::none(),
-                                   make_unique<Alias>(core::Symbols::Magic_undeclaredFieldStub(), kv.first));
+                                   make_insn<Alias>(core::Symbols::Magic_undeclaredFieldStub(), kv.first));
         res->minLoops[kv.second.id()] = CFG::MIN_LOOP_FIELD;
     }
     histogramInc("cfgbuilder.aliases", aliasesPrefix.size());

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -89,7 +89,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
     LocalRef retSym1 = LocalRef::finalReturn();
 
     core::LocOffsets rvLoc;
-    if (cont->exprs.empty() || isa_instruction<LoadArg>(cont->exprs.back().value.get())) {
+    if (cont->exprs.empty() || isa_instruction<LoadArg>(cont->exprs.back().value)) {
         auto beginAdjust = md.loc.endPos() - md.loc.beginPos() - 3;
         auto endLoc = core::Loc(ctx.file, md.loc).adjust(ctx, beginAdjust, 0);
         if (endLoc.source(ctx) == "end") {

--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -189,7 +189,7 @@ void CFGBuilder::dealias(core::Context ctx, CFG &cfg) {
         }
 
         for (Binding &bind : bb->exprs) {
-            if (auto *i = cast_instruction<Ident>(bind.value.get())) {
+            if (auto *i = cast_instruction<Ident>(bind.value)) {
                 i->what = maybeDealias(ctx, cfg, i->what, current);
             }
             if (mayHaveAlias.contains(bind.bind.variable.id())) {
@@ -207,22 +207,22 @@ void CFGBuilder::dealias(core::Context ctx, CFG &cfg) {
             if (!bind.value->isSynthetic) {
                 // we don't allow dealiasing values into synthetic instructions
                 // as otherwise it fools dead code analysis.
-                if (auto *v = cast_instruction<Ident>(bind.value.get())) {
+                if (auto *v = cast_instruction<Ident>(bind.value)) {
                     v->what = maybeDealias(ctx, cfg, v->what, current);
-                } else if (auto *v = cast_instruction<Send>(bind.value.get())) {
+                } else if (auto *v = cast_instruction<Send>(bind.value)) {
                     v->recv = maybeDealias(ctx, cfg, v->recv.variable, current);
                     for (auto &arg : v->args) {
                         arg = maybeDealias(ctx, cfg, arg.variable, current);
                     }
-                } else if (auto *v = cast_instruction<TAbsurd>(bind.value.get())) {
+                } else if (auto *v = cast_instruction<TAbsurd>(bind.value)) {
                     v->what = maybeDealias(ctx, cfg, v->what.variable, current);
-                } else if (auto *v = cast_instruction<Return>(bind.value.get())) {
+                } else if (auto *v = cast_instruction<Return>(bind.value)) {
                     v->what = maybeDealias(ctx, cfg, v->what.variable, current);
                 }
             }
 
             // record new aliases
-            if (auto *i = cast_instruction<Ident>(bind.value.get())) {
+            if (auto *i = cast_instruction<Ident>(bind.value)) {
                 current[bind.bind.variable] = i->what;
                 mayHaveAlias.add(i->what.id());
             }
@@ -269,11 +269,11 @@ void CFGBuilder::removeDeadAssigns(core::Context ctx, const CFG::ReadsAndWrites 
                                           // shorter to list the converse set -- those which *do* have
                                           // side effects -- but doing it this way is more robust to us
                                           // adding more instruction types in the future.
-                                          if (isa_instruction<Ident>(bind.value.get()) ||
-                                              isa_instruction<Literal>(bind.value.get()) ||
-                                              isa_instruction<LoadSelf>(bind.value.get()) ||
-                                              isa_instruction<LoadArg>(bind.value.get()) ||
-                                              isa_instruction<LoadYieldParams>(bind.value.get())) {
+                                          if (isa_instruction<Ident>(bind.value) ||
+                                              isa_instruction<Literal>(bind.value) ||
+                                              isa_instruction<LoadSelf>(bind.value) ||
+                                              isa_instruction<LoadArg>(bind.value) ||
+                                              isa_instruction<LoadYieldParams>(bind.value)) {
                                               return true;
                                           }
                                       }

--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -253,33 +253,32 @@ void CFGBuilder::removeDeadAssigns(core::Context ctx, const CFG::ReadsAndWrites 
     Timer timeit(ctx.state.tracer(), "removeDeadAssigns");
     for (auto &it : cfg.basicBlocks) {
         /* remove dead variables */
-        it->exprs.erase(remove_if(it->exprs.begin(), it->exprs.end(),
-                                  [&ctx, &cfg, &RnW, &blockArgs, &it](auto &bind) -> bool {
-                                      if (bind.bind.variable.isAliasForGlobal(ctx, cfg)) {
-                                          return false;
-                                      }
-                                      bool wasRead = RnW.reads[it->id].contains(
-                                                         bind.bind.variable.id()) || // read in the same block
-                                                     blockArgs[it->bexit.thenb->id].contains(bind.bind.variable.id()) ||
-                                                     blockArgs[it->bexit.elseb->id].contains(bind.bind.variable.id());
+        it->exprs.erase(
+            remove_if(it->exprs.begin(), it->exprs.end(),
+                      [&ctx, &cfg, &RnW, &blockArgs, &it](auto &bind) -> bool {
+                          if (bind.bind.variable.isAliasForGlobal(ctx, cfg)) {
+                              return false;
+                          }
+                          bool wasRead =
+                              RnW.reads[it->id].contains(bind.bind.variable.id()) || // read in the same block
+                              blockArgs[it->bexit.thenb->id].contains(bind.bind.variable.id()) ||
+                              blockArgs[it->bexit.elseb->id].contains(bind.bind.variable.id());
 
-                                      if (!wasRead) {
-                                          // These are all instructions with no side effects, which can be
-                                          // deleted if the assignment is dead. It would be slightly
-                                          // shorter to list the converse set -- those which *do* have
-                                          // side effects -- but doing it this way is more robust to us
-                                          // adding more instruction types in the future.
-                                          if (isa_instruction<Ident>(bind.value) ||
-                                              isa_instruction<Literal>(bind.value) ||
-                                              isa_instruction<LoadSelf>(bind.value) ||
-                                              isa_instruction<LoadArg>(bind.value) ||
-                                              isa_instruction<LoadYieldParams>(bind.value)) {
-                                              return true;
-                                          }
-                                      }
-                                      return false;
-                                  }),
-                        it->exprs.end());
+                          if (!wasRead) {
+                              // These are all instructions with no side effects, which can be
+                              // deleted if the assignment is dead. It would be slightly
+                              // shorter to list the converse set -- those which *do* have
+                              // side effects -- but doing it this way is more robust to us
+                              // adding more instruction types in the future.
+                              if (isa_instruction<Ident>(bind.value) || isa_instruction<Literal>(bind.value) ||
+                                  isa_instruction<LoadSelf>(bind.value) || isa_instruction<LoadArg>(bind.value) ||
+                                  isa_instruction<LoadYieldParams>(bind.value)) {
+                                  return true;
+                              }
+                          }
+                          return false;
+                      }),
+            it->exprs.end());
     }
 }
 

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -425,7 +425,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                     }
                     auto link = make_shared<core::SendAndBlockLink>(s.fun, move(argFlags), newRubyBlockId);
                     auto send = make_insn<Send>(recv, s.fun, s.recv.loc(), s.numPosArgs, args, argLocs,
-                                                  !!s.flags.isPrivateOk, link);
+                                                !!s.flags.isPrivateOk, link);
                     LocalRef sendTemp = cctx.newTemporary(core::Names::blockPreCallTemp());
                     auto solveConstraint = make_insn<SolveConstraint>(link, sendTemp);
                     current->exprs.emplace_back(sendTemp, s.loc, move(send));
@@ -530,9 +530,9 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                      *
                      */
                 } else {
-                    current->exprs.emplace_back(cctx.target, s.loc,
-                                                make_insn<Send>(recv, s.fun, s.recv.loc(), s.numPosArgs, args,
-                                                                  argLocs, !!s.flags.isPrivateOk));
+                    current->exprs.emplace_back(
+                        cctx.target, s.loc,
+                        make_insn<Send>(recv, s.fun, s.recv.loc(), s.numPosArgs, args, argLocs, !!s.flags.isPrivateOk));
                 }
 
                 ret = current;
@@ -595,8 +595,8 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 // by the VM itself; and b) may not actually happen depending on the frames
                 // that the break unwinds through.
                 synthesizeExpr(afterBreak, ignored, core::LocOffsets::none(),
-                               make_insn<Send>(magic, core::Names::blockBreak(), core::LocOffsets::none(),
-                                                 args.size(), args, locs, isPrivateOk));
+                               make_insn<Send>(magic, core::Names::blockBreak(), core::LocOffsets::none(), args.size(),
+                                               args, locs, isPrivateOk));
 
                 afterBreak->exprs.emplace_back(cctx.blockBreakTarget, a.loc, make_insn<Ident>(blockBreakAssign));
 
@@ -621,15 +621,14 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                     unconditionalJump(current, cctx.inWhat.deadBlock(), cctx.inWhat, a.loc);
                 } else {
                     auto magic = cctx.newTemporary(core::Names::magic());
-                    synthesizeExpr(current, magic, core::LocOffsets::none(),
-                                   make_insn<Alias>(core::Symbols::Magic()));
+                    synthesizeExpr(current, magic, core::LocOffsets::none(), make_insn<Alias>(core::Symbols::Magic()));
                     auto retryTemp = cctx.newTemporary(core::Names::retryTemp());
                     InlinedVector<cfg::LocalRef, 2> args{};
                     InlinedVector<core::LocOffsets, 2> argLocs{};
                     auto isPrivateOk = false;
                     synthesizeExpr(current, retryTemp, core::LocOffsets::none(),
-                                   make_insn<Send>(magic, core::Names::retry(), what.loc(), args.size(), args,
-                                                     argLocs, isPrivateOk));
+                                   make_insn<Send>(magic, core::Names::retry(), what.loc(), args.size(), args, argLocs,
+                                                   isPrivateOk));
                     unconditionalJump(current, cctx.rescueScope, cctx.inWhat, a.loc);
                 }
                 ret = cctx.inWhat.deadBlock();
@@ -696,8 +695,8 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                     auto args = {exceptionValue};
                     auto argLocs = {what.loc()};
                     synthesizeExpr(caseBody, res, rescueCase->loc,
-                                   make_insn<Send>(magic, core::Names::keepForCfg(), rescueCase->loc, args.size(),
-                                                     args, argLocs, isPrivateOk));
+                                   make_insn<Send>(magic, core::Names::keepForCfg(), rescueCase->loc, args.size(), args,
+                                                   argLocs, isPrivateOk));
 
                     if (exceptions.empty()) {
                         // rescue without a class catches StandardError
@@ -718,8 +717,8 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                         auto isPrivateOk = false;
                         rescueHandlersBlock->exprs.emplace_back(isaCheck, loc,
                                                                 make_insn<Send>(localVar, core::Names::isA_p(), loc,
-                                                                                  args.size(), args, argLocs,
-                                                                                  isPrivateOk));
+                                                                                args.size(), args, argLocs,
+                                                                                isPrivateOk));
 
                         auto otherHandlerBlock = cctx.inWhat.freshBlock(cctx.loops, handlersRubyBlockId);
                         conditionalJump(rescueHandlersBlock, isaCheck, caseBody, otherHandlerBlock, cctx.inWhat, loc);
@@ -737,8 +736,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 // and if so, after the ensure runs, we should jump to dead
                 // since in Ruby the exception would propagate up the statck.
                 auto gotoDeadTemp = cctx.newTemporary(core::Names::gotoDeadTemp());
-                synthesizeExpr(rescueHandlersBlock, gotoDeadTemp, a.loc,
-                               make_insn<Literal>(core::Types::trueClass()));
+                synthesizeExpr(rescueHandlersBlock, gotoDeadTemp, a.loc, make_insn<Literal>(core::Types::trueClass()));
                 unconditionalJump(rescueHandlersBlock, ensureBody, cctx.inWhat, a.loc);
 
                 auto throwAway = cctx.newTemporary(core::Names::throwAwayTemp());

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -110,7 +110,7 @@ void CFGBuilder::jumpToDead(BasicBlock *from, CFG &inWhat, core::LocOffsets loc)
     }
 }
 
-void CFGBuilder::synthesizeExpr(BasicBlock *bb, LocalRef var, core::LocOffsets loc, unique_ptr<Instruction> inst) {
+void CFGBuilder::synthesizeExpr(BasicBlock *bb, LocalRef var, core::LocOffsets loc, InsnPtr inst) {
     auto &inserted = bb->exprs.emplace_back(var, loc, move(inst));
     inserted.value->isSynthetic = true;
 }

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -110,7 +110,7 @@ void CFGBuilder::jumpToDead(BasicBlock *from, CFG &inWhat, core::LocOffsets loc)
     }
 }
 
-void CFGBuilder::synthesizeExpr(BasicBlock *bb, LocalRef var, core::LocOffsets loc, InsnPtr inst) {
+void CFGBuilder::synthesizeExpr(BasicBlock *bb, LocalRef var, core::LocOffsets loc, InstructionPtr inst) {
     auto &inserted = bb->exprs.emplace_back(var, loc, move(inst));
     inserted.value->isSynthetic = true;
 }

--- a/compiler/IREmitter/IREmitterContext.cc
+++ b/compiler/IREmitter/IREmitterContext.cc
@@ -23,7 +23,7 @@ namespace sorbet::compiler {
 
 namespace {
 
-optional<string_view> isSymbol(const core::GlobalState &gs, const cfg::InsnPtr &insn) {
+optional<string_view> isSymbol(const core::GlobalState &gs, const cfg::InstructionPtr &insn) {
     auto *liti = cfg::cast_instruction<cfg::Literal>(insn);
     if (liti == nullptr) {
         return std::nullopt;
@@ -829,7 +829,7 @@ IREmitterContext IREmitterContext::getSorbetBlocks2LLVMBlockMapping(CompilerStat
             }
             ENFORCE(backId >= 0);
 
-            cfg::InsnPtr *expected = nullptr;
+            cfg::InstructionPtr *expected = nullptr;
             for (auto i = b->backEdges[backId]->exprs.rbegin(); i != b->backEdges[backId]->exprs.rend(); ++i) {
                 if (i->bind.variable.data(cfg)._name == core::Names::blockPreCallTemp()) {
                     expected = &i->value;

--- a/compiler/IREmitter/IREmitterContext.cc
+++ b/compiler/IREmitter/IREmitterContext.cc
@@ -23,7 +23,7 @@ namespace sorbet::compiler {
 
 namespace {
 
-optional<string_view> isSymbol(const core::GlobalState &gs, cfg::Instruction *insn) {
+optional<string_view> isSymbol(const core::GlobalState &gs, const cfg::InsnPtr &insn) {
     auto *liti = cfg::cast_instruction<cfg::Literal>(insn);
     if (liti == nullptr) {
         return std::nullopt;
@@ -52,7 +52,7 @@ AliasesAndKeywords setupAliasesAndKeywords(CompilerState &cs, const cfg::CFG &cf
 
     for (auto &bb : cfg.basicBlocks) {
         for (auto &bind : bb->exprs) {
-            if (auto *i = cfg::cast_instruction<cfg::Alias>(bind.value.get())) {
+            if (auto *i = cfg::cast_instruction<cfg::Alias>(bind.value)) {
                 ENFORCE(res.aliases.find(bind.bind.variable) == res.aliases.end(),
                         "Overwriting an entry in the aliases map");
 
@@ -88,7 +88,7 @@ AliasesAndKeywords setupAliasesAndKeywords(CompilerState &cs, const cfg::CFG &cf
                         res.aliases[bind.bind.variable] = Alias::forConstant(i->what);
                     }
                 }
-            } else if (auto sym = isSymbol(cs, bind.value.get())) {
+            } else if (auto sym = isSymbol(cs, bind.value)) {
                 res.symbols[bind.bind.variable] = sym.value();
             }
         }
@@ -238,31 +238,31 @@ findCaptures(CompilerState &cs, const ast::MethodDef &mdef, cfg::CFG &cfg,
         for (cfg::Binding &bind : bb->exprs) {
             usage.trackBlockUsage(bb.get(), bind.bind.variable);
             typecase(
-                bind.value.get(), [&](cfg::Ident *i) { usage.trackBlockUsage(bb.get(), i->what); },
-                [&](cfg::Alias *i) { /* nothing */
+                bind.value, [&](cfg::Ident &i) { usage.trackBlockUsage(bb.get(), i.what); },
+                [&](cfg::Alias &i) { /* nothing */
                 },
-                [&](cfg::SolveConstraint *i) { /* nothing*/ },
-                [&](cfg::Send *i) {
-                    for (auto &arg : i->args) {
+                [&](cfg::SolveConstraint &i) { /* nothing*/ },
+                [&](cfg::Send &i) {
+                    for (auto &arg : i.args) {
                         usage.trackBlockUsage(bb.get(), arg.variable);
                     }
-                    usage.trackBlockUsage(bb.get(), i->recv.variable);
+                    usage.trackBlockUsage(bb.get(), i.recv.variable);
                 },
-                [&](cfg::GetCurrentException *i) {
+                [&](cfg::GetCurrentException &i) {
                     // if the current block is an exception header, record a usage of the variable in the else block
                     // (the body block of the exception handling) to force it to escape.
                     if (exceptionHandlingBlockHeaders[bb->id] != 0) {
                         usage.trackBlockUsage(bb->bexit.elseb, bind.bind.variable);
                     }
                 },
-                [&](cfg::Return *i) { usage.trackBlockUsage(bb.get(), i->what.variable); },
-                [&](cfg::BlockReturn *i) { usage.trackBlockUsage(bb.get(), i->what.variable); },
-                [&](cfg::LoadSelf *i) { /*nothing*/ /*todo: how does instance exec pass self?*/ },
-                [&](cfg::Literal *i) { /* nothing*/ }, [&](cfg::ArgPresent *i) { /*nothing*/ },
-                [&](cfg::LoadArg *i) { /*nothing*/ }, [&](cfg::LoadYieldParams *i) { /*nothing*/ },
-                [&](cfg::YieldParamPresent *i) { /* nothing */ }, [&](cfg::YieldLoadArg *i) { /* nothing */ },
-                [&](cfg::Cast *i) { usage.trackBlockUsage(bb.get(), i->value.variable); },
-                [&](cfg::TAbsurd *i) { usage.trackBlockUsage(bb.get(), i->what.variable); });
+                [&](cfg::Return &i) { usage.trackBlockUsage(bb.get(), i.what.variable); },
+                [&](cfg::BlockReturn &i) { usage.trackBlockUsage(bb.get(), i.what.variable); },
+                [&](cfg::LoadSelf &i) { /*nothing*/ /*todo: how does instance exec pass self?*/ },
+                [&](cfg::Literal &i) { /* nothing*/ }, [&](cfg::ArgPresent &i) { /*nothing*/ },
+                [&](cfg::LoadArg &i) { /*nothing*/ }, [&](cfg::LoadYieldParams &i) { /*nothing*/ },
+                [&](cfg::YieldParamPresent &i) { /* nothing */ }, [&](cfg::YieldLoadArg &i) { /* nothing */ },
+                [&](cfg::Cast &i) { usage.trackBlockUsage(bb.get(), i.value.variable); },
+                [&](cfg::TAbsurd &i) { usage.trackBlockUsage(bb.get(), i.what.variable); });
         }
 
         // no need to track the condition variable if the jump is unconditional
@@ -278,7 +278,7 @@ int getMaxSendArgCount(cfg::CFG &cfg) {
     int maxSendArgCount = 0;
     for (auto &bb : cfg.basicBlocks) {
         for (cfg::Binding &bind : bb->exprs) {
-            if (auto snd = cfg::cast_instruction<cfg::Send>(bind.value.get())) {
+            if (auto snd = cfg::cast_instruction<cfg::Send>(bind.value)) {
                 int numPosArgs = snd->numPosArgs;
                 int numKwArgs = snd->args.size() - numPosArgs;
 
@@ -502,7 +502,7 @@ void determineBlockTypes(CompilerState &cs, cfg::CFG &cfg, vector<FunctionType> 
 bool returnAcrossBlockIsPresent(CompilerState &cs, cfg::CFG &cfg, const vector<int> &blockNestingLevels) {
     for (auto &bb : cfg.basicBlocks) {
         for (auto &bind : bb->exprs) {
-            if (cfg::isa_instruction<cfg::Return>(bind.value.get())) {
+            if (cfg::isa_instruction<cfg::Return>(bind.value)) {
                 // This will be non-zero if there was a block in any of our parent blocks.
                 if (blockNestingLevels[bb->rubyBlockId] != 0) {
                     return true;
@@ -666,7 +666,7 @@ void collectRubyBlockArgs(const cfg::CFG &cfg, const cfg::BasicBlock *b, vector<
 
     while (true) {
         for (auto &expr : b->exprs) {
-            auto loadArg = cfg::cast_instruction<cfg::YieldLoadArg>(expr.value.get());
+            auto loadArg = cfg::cast_instruction<cfg::YieldLoadArg>(expr.value);
             if (loadArg == nullptr) {
                 continue;
             }
@@ -829,16 +829,16 @@ IREmitterContext IREmitterContext::getSorbetBlocks2LLVMBlockMapping(CompilerStat
             }
             ENFORCE(backId >= 0);
 
-            cfg::Instruction *expected = nullptr;
+            cfg::InsnPtr *expected = nullptr;
             for (auto i = b->backEdges[backId]->exprs.rbegin(); i != b->backEdges[backId]->exprs.rend(); ++i) {
                 if (i->bind.variable.data(cfg)._name == core::Names::blockPreCallTemp()) {
-                    expected = i->value.get();
+                    expected = &i->value;
                     break;
                 }
             }
             ENFORCE(expected);
 
-            auto expectedSend = cfg::cast_instruction<cfg::Send>(expected);
+            auto expectedSend = cfg::cast_instruction<cfg::Send>(*expected);
             ENFORCE(expectedSend);
             ENFORCE(expectedSend->link);
             blockLinks[b->rubyBlockId] = expectedSend->link;
@@ -880,17 +880,15 @@ IREmitterContext IREmitterContext::getSorbetBlocks2LLVMBlockMapping(CompilerStat
             int argId = -1;
             auto &bind = b->exprs.back();
             typecase(
-                bind.value.get(),
-                [&](cfg::ArgPresent *i) {
+                bind.value,
+                [&](cfg::ArgPresent &i) {
                     ENFORCE(bind.bind.variable == b->bexit.cond.variable);
-                    argId = i->argId;
+                    argId = i.argId;
                 },
-                [&](cfg::YieldParamPresent *i) {
+                [&](cfg::YieldParamPresent &i) {
                     ENFORCE(bind.bind.variable == b->bexit.cond.variable);
-                    argId = i->argId;
-                },
-                [](cfg::Instruction *i) { /* do nothing */ });
-
+                    argId = i.argId;
+                });
             ENFORCE(argId >= 0, "Missing an index for argPresent condition variable");
 
             argPresentVariables[b->rubyBlockId][argId] = b->bexit.cond.variable;

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -234,14 +234,14 @@ UnorderedMap<core::NameRef, core::TypePtr> guessArgumentTypes(core::Context ctx,
             }
             InlinedVector<core::NameRef, 1> newInsert;
 
-            if (auto load = cfg::cast_instruction<cfg::LoadArg>(bind.value.get())) {
+            if (auto load = cfg::cast_instruction<cfg::LoadArg>(bind.value)) {
                 newInsert.emplace_back(load->argument(ctx).name);
-            } else if (auto ident = cfg::cast_instruction<cfg::Ident>(bind.value.get())) {
+            } else if (auto ident = cfg::cast_instruction<cfg::Ident>(bind.value)) {
                 auto fnd = blockLocals.find(ident->what);
                 if (fnd != blockLocals.end()) {
                     newInsert.insert(newInsert.end(), fnd->second.begin(), fnd->second.end());
                 }
-            } else if (auto snd = cfg::cast_instruction<cfg::Send>(bind.value.get())) {
+            } else if (auto snd = cfg::cast_instruction<cfg::Send>(bind.value)) {
                 // see if we have at least a single call argument that is a method argument
                 bool shouldFindArgumentTypes = false;
                 for (auto &arg : snd->args) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -966,7 +966,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 auto suppressErrors = false;
                 core::DispatchArgs dispatchArgs{
                     send.fun, locs,          send.numPosArgs, args,     recvType.type,
-                    recvType,  recvType.type, send.link,       ownerLoc, send.isPrivateOk suppressErrors};
+                        recvType,  recvType.type, send.link,       ownerLoc, send.isPrivateOk, suppressErrors};
                 auto dispatched = recvType.type.dispatchCall(ctx, dispatchArgs);
 
                 auto it = &dispatched;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -965,8 +965,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 // that we want to report all errors (supressing nothing).
                 auto suppressErrors = false;
                 core::DispatchArgs dispatchArgs{
-                    send.fun, locs,          send.numPosArgs, args,     recvType.type,
-                        recvType,  recvType.type, send.link,       ownerLoc, send.isPrivateOk, suppressErrors};
+                    send.fun,  locs,     send.numPosArgs,  args,          recvType.type, recvType, recvType.type,
+                    send.link, ownerLoc, send.isPrivateOk, suppressErrors};
                 auto dispatched = recvType.type.dispatchCall(ctx, dispatchArgs);
 
                 auto it = &dispatched;
@@ -986,8 +986,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     //  - When a method doesn't exist.
                     //
                     // In all of these cases, we bail out and skip the non-private checking.
-                    if (it->main.method.exists() && it->main.method.data(ctx)->isMethodPrivate() &&
-                        !send.isPrivateOk) {
+                    if (it->main.method.exists() && it->main.method.data(ctx)->isMethodPrivate() && !send.isPrivateOk) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::PrivateMethod)) {
                             if (multipleComponents) {
                                 e.setHeader("Non-private call to private method `{}` on `{}` component of `{}`",

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1391,7 +1391,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 }
             });
 
-        ENFORCE(tp.type != nullptr, "Inferencer did not assign type: {}", bind.value->toString(ctx, inWhat));
+        ENFORCE(tp.type != nullptr, "Inferencer did not assign type: {}", bind.value.toString(ctx, inWhat));
         tp.type.sanityCheck(ctx);
 
         if (checkFullyDefined && !tp.type.isFullyDefined()) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1248,8 +1248,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         e.addErrorSection(
                             core::TypeAndOrigins::explainExpected(ctx, methodReturnType, ownerData->loc(), for_));
                         e.addErrorSection(typeAndOrigin.explainGot(ctx, ownerLoc));
-                        if (i->whatLoc != inWhat.implicitReturnLoc) {
-                            auto replaceLoc = core::Loc(ctx.file, i->whatLoc);
+                        if (i.whatLoc != inWhat.implicitReturnLoc) {
+                            auto replaceLoc = core::Loc(ctx.file, i.whatLoc);
                             core::TypeDrivenAutocorrect::maybeAutocorrect(ctx, e, replaceLoc, constr, methodReturnType,
                                                                           typeAndOrigin.type);
                         }
@@ -1278,7 +1278,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         e.setHeader("Expected `{}` but found `{}` for block result type", expectedType.show(ctx),
                                     typeAndOrigin.type.show(ctx));
 
-                        const auto &bspec = i->link->result->main.method.data(ctx)->arguments().back();
+                        const auto &bspec = i.link->result->main.method.data(ctx)->arguments().back();
                         ENFORCE(bspec.flags.isBlock, "The last symbol must be the block arg");
                         e.addErrorSection(
                             core::TypeAndOrigins::explainExpected(ctx, expectedType, bspec.loc, "block result type"));
@@ -1341,7 +1341,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     noLoopChecking = true;
                 }
 
-                const core::TypeAndOrigins &ty = getAndFillTypeAndOrigin(ctx, c->value);
+                const core::TypeAndOrigins &ty = getAndFillTypeAndOrigin(ctx, c.value);
                 ENFORCE(c.cast != core::Names::uncheckedLet() && c.cast != core::Names::bind());
 
                 if (c.cast != core::Names::cast()) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -92,12 +92,12 @@ KnowledgeFilter::KnowledgeFilter(core::Context ctx, unique_ptr<cfg::CFG> &cfg) {
         changed = false;
         for (auto &bb : cfg->forwardsTopoSort) {
             for (auto &bind : bb->exprs) {
-                if (auto *id = cfg::cast_instruction<cfg::Ident>(bind.value.get())) {
+                if (auto *id = cfg::cast_instruction<cfg::Ident>(bind.value)) {
                     if (isNeeded(bind.bind.variable) && !isNeeded(id->what)) {
                         used_vars[id->what.id()] = true;
                         changed = true;
                     }
-                } else if (auto *send = cfg::cast_instruction<cfg::Send>(bind.value.get())) {
+                } else if (auto *send = cfg::cast_instruction<cfg::Send>(bind.value)) {
                     if (send->fun == core::Names::bang()) {
                         if (send->args.empty()) {
                             if (isNeeded(bind.bind.variable) && !isNeeded(send->recv.variable)) {
@@ -932,8 +932,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                           core::TypeConstraint &constr, core::TypePtr &methodReturnType) {
     try {
         core::TypeAndOrigins tp;
-        bool noLoopChecking = cfg::isa_instruction<cfg::Alias>(bind.value.get()) ||
-                              cfg::isa_instruction<cfg::LoadArg>(bind.value.get()) ||
+        bool noLoopChecking = cfg::isa_instruction<cfg::Alias>(bind.value) ||
+                              cfg::isa_instruction<cfg::LoadArg>(bind.value) ||
                               bind.bind.variable == cfg::LocalRef::selfVariable();
 
         bool checkFullyDefined = true;
@@ -1446,7 +1446,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         break;
                     default: {
                         if (!asGoodAs || (tp.type.isUntyped() && !cur.type.isUntyped())) {
-                            if (auto ident = cfg::cast_instruction<cfg::Ident>(bind.value.get())) {
+                            if (auto ident = cfg::cast_instruction<cfg::Ident>(bind.value)) {
                                 // See cfg/builder/builder_walk.cc for an explanation of why this is here.
                                 if (ident->what.data(inWhat)._name == core::Names::blockBreakAssign()) {
                                     break;
@@ -1494,9 +1494,9 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
         setTypeAndOrigin(bind.bind.variable, tp);
 
         clearKnowledge(ctx, bind.bind.variable, knowledgeFilter);
-        if (auto *send = cfg::cast_instruction<cfg::Send>(bind.value.get())) {
+        if (auto *send = cfg::cast_instruction<cfg::Send>(bind.value)) {
             updateKnowledge(ctx, bind.bind.variable, core::Loc(ctx.file, bind.loc), send, knowledgeFilter);
-        } else if (auto *i = cfg::cast_instruction<cfg::Ident>(bind.value.get())) {
+        } else if (auto *i = cfg::cast_instruction<cfg::Ident>(bind.value)) {
             propagateKnowledge(ctx, bind.bind.variable, i->what, knowledgeFilter);
         }
 

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -155,12 +155,12 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
 
                         auto send = cfg::cast_instruction<cfg::Send>(expr.value);
                         if (send != nullptr && send->fun == core::Names::nilForSafeNavigation()) {
-                            unreachableInstruction = expr.value.get();
+                            unreachableInstruction = &expr.value;
                             locForUnreachable = expr.loc;
                             dueToSafeNavigation = true;
                             break;
                         } else if (unreachableInstruction == nullptr) {
-                            unreachableInstruction = expr.value.get();
+                            unreachableInstruction = &expr.value;
                             locForUnreachable = expr.loc;
                         } else {
                             // Expand the loc to cover the entire dead basic block

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -140,7 +140,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                 //   4. Otherwise, we want to issue a DeadBranchInferencer error, taking the first
                 //      (non-synthetic, non-"T.absurd") instruction in the block as the loc of the
                 //      error.
-                cfg::InsnPtr *unreachableInstruction = nullptr;
+                cfg::InstructionPtr *unreachableInstruction = nullptr;
                 core::LocOffsets locForUnreachable;
                 bool dueToSafeNavigation = false;
 

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -140,7 +140,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                 //   4. Otherwise, we want to issue a DeadBranchInferencer error, taking the first
                 //      (non-synthetic, non-"T.absurd") instruction in the block as the loc of the
                 //      error.
-                cfg::Instruction *unreachableInstruction = nullptr;
+                cfg::InsnPtr *unreachableInstruction = nullptr;
                 core::LocOffsets locForUnreachable;
                 bool dueToSafeNavigation = false;
 
@@ -149,11 +149,11 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                         if (expr.value->isSynthetic) {
                             continue;
                         }
-                        if (cfg::isa_instruction<cfg::TAbsurd>(expr.value.get())) {
+                        if (cfg::isa_instruction<cfg::TAbsurd>(expr.value)) {
                             continue;
                         }
 
-                        auto send = cfg::cast_instruction<cfg::Send>(expr.value.get());
+                        auto send = cfg::cast_instruction<cfg::Send>(expr.value);
                         if (send != nullptr && send->fun == core::Names::nilForSafeNavigation()) {
                             unreachableInstruction = expr.value.get();
                             locForUnreachable = expr.loc;
@@ -170,8 +170,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                 }
 
                 if (unreachableInstruction != nullptr) {
-                    auto send = cfg::cast_instruction<cfg::Send>(unreachableInstruction);
-
+                    auto *send = cfg::cast_instruction<cfg::Send>(*unreachableInstruction);
                     if (dueToSafeNavigation && send != nullptr) {
                         if (auto e =
                                 ctx.beginError(locForUnreachable, core::errors::Infer::UnnecessarySafeNavigation)) {
@@ -230,7 +229,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                 bind.bind.type =
                     current.processBinding(ctx, *cfg, bind, bb->outerLoops, bind.bind.variable.minLoops(*cfg),
                                            knowledgeFilter, *constr, methodReturnType);
-                if (cfg::isa_instruction<cfg::Send>(bind.value.get())) {
+                if (cfg::isa_instruction<cfg::Send>(bind.value)) {
                     totalSendCount++;
                     if (bind.bind.type && !bind.bind.type.isUntyped()) {
                         typedSendCount++;

--- a/plugin_injector/plugin_injector.cc
+++ b/plugin_injector/plugin_injector.cc
@@ -143,7 +143,7 @@ class LLVMSemanticExtension : public SemanticExtension {
             UnorderedSet<cfg::LocalRef> refsToDelete;
             for (auto i = block->exprs.rbegin(), e = block->exprs.rend(); i != e; ++i) {
                 auto &binding = *i;
-                if (auto *send = cfg::cast_instruction<cfg::Send>(binding.value.get())) {
+                if (auto *send = cfg::cast_instruction<cfg::Send>(binding.value)) {
                     switch (send->fun.rawId()) {
                         case core::Names::keepForIde().rawId():
                         case core::Names::keepForTypechecking().rawId():


### PR DESCRIPTION
These changes apply similar techniques from `TreePtr` and `TypePtr` to convert `Instruction` to a tag-based typing scheme, which means we can dispense with virtual dispatch for the three virtual methods that we have  We don't quite go all the way to full tagged pointers, but ideally this makes it a lot simpler to do so, though we'll only gain 8 bytes on `cfg::Send`.

### Motivation

Smaller instructions are better for everybody.  We shouldn't pay 8 bytes of vtable pointer just for some debugging methods.

### Test plan

Existing tests should be sufficient.