### PR TITLE
Introduce safe accessors for Name subtypes.

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1367,14 +1367,14 @@ TreePtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) {
             },
             [&](parser::Complex *complex) {
                 auto kernel = MK::Constant(loc, core::Symbols::Kernel());
-                core::NameRef complex_name = core::Names::Constants::Complex().cnst(dctx.ctx)->original;
+                core::NameRef complex_name = core::Names::Constants::Complex().dataCnst(dctx.ctx)->original;
                 core::NameRef value = dctx.ctx.state.enterNameUTF8(complex->value);
                 auto send = MK::Send2(loc, std::move(kernel), complex_name, MK::Int(loc, 0), MK::String(loc, value));
                 result = std::move(send);
             },
             [&](parser::Rational *complex) {
                 auto kernel = MK::Constant(loc, core::Symbols::Kernel());
-                core::NameRef complex_name = core::Names::Constants::Rational().cnst(dctx.ctx)->original;
+                core::NameRef complex_name = core::Names::Constants::Rational().dataCnst(dctx.ctx)->original;
                 core::NameRef value = dctx.ctx.state.enterNameUTF8(complex->val);
                 auto send = MK::Send1(loc, std::move(kernel), complex_name, MK::String(loc, value));
                 result = std::move(send);

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1367,14 +1367,14 @@ TreePtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) {
             },
             [&](parser::Complex *complex) {
                 auto kernel = MK::Constant(loc, core::Symbols::Kernel());
-                core::NameRef complex_name = core::Names::Constants::Complex().data(dctx.ctx)->cnst.original;
+                core::NameRef complex_name = core::Names::Constants::Complex().cnst(dctx.ctx)->original;
                 core::NameRef value = dctx.ctx.state.enterNameUTF8(complex->value);
                 auto send = MK::Send2(loc, std::move(kernel), complex_name, MK::Int(loc, 0), MK::String(loc, value));
                 result = std::move(send);
             },
             [&](parser::Rational *complex) {
                 auto kernel = MK::Constant(loc, core::Symbols::Kernel());
-                core::NameRef complex_name = core::Names::Constants::Rational().data(dctx.ctx)->cnst.original;
+                core::NameRef complex_name = core::Names::Constants::Rational().cnst(dctx.ctx)->original;
                 core::NameRef value = dctx.ctx.state.enterNameUTF8(complex->val);
                 auto send = MK::Send1(loc, std::move(kernel), complex_name, MK::String(loc, value));
                 result = std::move(send);

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -904,7 +904,7 @@ SymbolRef GlobalState::findRenamedSymbol(SymbolRef owner, SymbolRef sym) const {
     auto ownerScope = owner.dataAllowingNone(*this);
 
     if (name.kind(*this) == NameKind::UNIQUE) {
-        auto uniqueData = name.unique(*this);
+        auto uniqueData = name.dataUnique(*this);
         if (uniqueData->uniqueNameKind != UniqueNameKind::MangleRename) {
             return Symbols::noSymbol();
         }
@@ -1057,7 +1057,7 @@ SymbolRef GlobalState::enterTypeArgument(Loc loc, SymbolRef owner, NameRef name,
 }
 
 SymbolRef GlobalState::enterMethodSymbol(Loc loc, SymbolRef owner, NameRef name) {
-    bool isBlock = name.kind(*this) == NameKind::UNIQUE && name.unique(*this)->original == Names::blockTemp();
+    bool isBlock = name.kind(*this) == NameKind::UNIQUE && name.dataUnique(*this)->original == Names::blockTemp();
     ENFORCE(isBlock || owner.data(*this)->isClassOrModule(), "entering method symbol into not-a-class");
 
     auto flags = Symbol::Flags::METHOD;
@@ -1323,8 +1323,8 @@ NameRef GlobalState::enterNameConstant(NameRef original) {
     ENFORCE(original.exists(), "making a constant name over non-existing name");
     ENFORCE(original.kind(*this) == NameKind::UTF8 ||
                 (original.kind(*this) == NameKind::UNIQUE &&
-                 (original.unique(*this)->uniqueNameKind == UniqueNameKind::ResolverMissingClass ||
-                  original.unique(*this)->uniqueNameKind == UniqueNameKind::TEnum)),
+                 (original.dataUnique(*this)->uniqueNameKind == UniqueNameKind::ResolverMissingClass ||
+                  original.dataUnique(*this)->uniqueNameKind == UniqueNameKind::TEnum)),
             "making a constant name over wrong name kind");
 
     const auto hs = _hash_mix_constant(NameKind::CONSTANT, original.id());
@@ -1390,8 +1390,8 @@ NameRef GlobalState::lookupNameConstant(NameRef original) const {
     }
     ENFORCE(original.kind(*this) == NameKind::UTF8 ||
                 (original.kind(*this) == NameKind::UNIQUE &&
-                 (original.unique(*this)->uniqueNameKind == UniqueNameKind::ResolverMissingClass ||
-                  original.unique(*this)->uniqueNameKind == UniqueNameKind::TEnum)),
+                 (original.dataUnique(*this)->uniqueNameKind == UniqueNameKind::ResolverMissingClass ||
+                  original.dataUnique(*this)->uniqueNameKind == UniqueNameKind::TEnum)),
             "looking up a constant name over wrong name kind");
 
     const auto hs = _hash_mix_constant(NameKind::CONSTANT, original.id());

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -901,19 +901,18 @@ SymbolRef GlobalState::findRenamedSymbol(SymbolRef owner, SymbolRef sym) const {
     // it'll be whatever the largest `x$n` that exists is, if any; otherwise, there will be none.
     ENFORCE(sym.exists(), "lookup up previous name of non-existing symbol");
     NameRef name = sym.data(*this)->name;
-    NameData nameData = name.data(*this);
     auto ownerScope = owner.dataAllowingNone(*this);
 
-    if (nameData->kind == NameKind::UNIQUE) {
-        if (nameData->unique.uniqueNameKind != UniqueNameKind::MangleRename) {
+    if (name.kind(*this) == NameKind::UNIQUE) {
+        auto uniqueData = name.unique(*this);
+        if (uniqueData->uniqueNameKind != UniqueNameKind::MangleRename) {
             return Symbols::noSymbol();
         }
-        if (nameData->unique.num == 1) {
+        if (uniqueData->num == 1) {
             return Symbols::noSymbol();
         } else {
-            ENFORCE(nameData->unique.num > 1);
-            auto nm =
-                lookupNameUnique(UniqueNameKind::MangleRename, nameData->unique.original, nameData->unique.num - 1);
+            ENFORCE(uniqueData->num > 1);
+            auto nm = lookupNameUnique(UniqueNameKind::MangleRename, uniqueData->original, uniqueData->num - 1);
             if (!nm.exists()) {
                 return Symbols::noSymbol();
             }
@@ -1058,8 +1057,7 @@ SymbolRef GlobalState::enterTypeArgument(Loc loc, SymbolRef owner, NameRef name,
 }
 
 SymbolRef GlobalState::enterMethodSymbol(Loc loc, SymbolRef owner, NameRef name) {
-    bool isBlock =
-        name.data(*this)->kind == NameKind::UNIQUE && name.data(*this)->unique.original == Names::blockTemp();
+    bool isBlock = name.kind(*this) == NameKind::UNIQUE && name.unique(*this)->original == Names::blockTemp();
     ENFORCE(isBlock || owner.data(*this)->isClassOrModule(), "entering method symbol into not-a-class");
 
     auto flags = Symbol::Flags::METHOD;
@@ -1323,10 +1321,10 @@ NameRef GlobalState::enterNameUTF8(string_view nm) {
 
 NameRef GlobalState::enterNameConstant(NameRef original) {
     ENFORCE(original.exists(), "making a constant name over non-existing name");
-    ENFORCE(original.data(*this)->kind == NameKind::UTF8 ||
-                (original.data(*this)->kind == NameKind::UNIQUE &&
-                 (original.data(*this)->unique.uniqueNameKind == UniqueNameKind::ResolverMissingClass ||
-                  original.data(*this)->unique.uniqueNameKind == UniqueNameKind::TEnum)),
+    ENFORCE(original.kind(*this) == NameKind::UTF8 ||
+                (original.kind(*this) == NameKind::UNIQUE &&
+                 (original.unique(*this)->uniqueNameKind == UniqueNameKind::ResolverMissingClass ||
+                  original.unique(*this)->uniqueNameKind == UniqueNameKind::TEnum)),
             "making a constant name over wrong name kind");
 
     const auto hs = _hash_mix_constant(NameKind::CONSTANT, original.id());
@@ -1390,10 +1388,10 @@ NameRef GlobalState::lookupNameConstant(NameRef original) const {
     if (!original.exists()) {
         return core::NameRef::noName();
     }
-    ENFORCE(original.data(*this)->kind == NameKind::UTF8 ||
-                (original.data(*this)->kind == NameKind::UNIQUE &&
-                 (original.data(*this)->unique.uniqueNameKind == UniqueNameKind::ResolverMissingClass ||
-                  original.data(*this)->unique.uniqueNameKind == UniqueNameKind::TEnum)),
+    ENFORCE(original.kind(*this) == NameKind::UTF8 ||
+                (original.kind(*this) == NameKind::UNIQUE &&
+                 (original.unique(*this)->uniqueNameKind == UniqueNameKind::ResolverMissingClass ||
+                  original.unique(*this)->uniqueNameKind == UniqueNameKind::TEnum)),
             "looking up a constant name over wrong name kind");
 
     const auto hs = _hash_mix_constant(NameKind::CONSTANT, original.id());

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1322,9 +1322,8 @@ NameRef GlobalState::enterNameUTF8(string_view nm) {
 NameRef GlobalState::enterNameConstant(NameRef original) {
     ENFORCE(original.exists(), "making a constant name over non-existing name");
     ENFORCE(original.kind(*this) == NameKind::UTF8 ||
-                (original.kind(*this) == NameKind::UNIQUE &&
-                 (original.dataUnique(*this)->uniqueNameKind == UniqueNameKind::ResolverMissingClass ||
-                  original.dataUnique(*this)->uniqueNameKind == UniqueNameKind::TEnum)),
+                original.dataUnique(*this)->uniqueNameKind == UniqueNameKind::ResolverMissingClass ||
+                original.dataUnique(*this)->uniqueNameKind == UniqueNameKind::TEnum,
             "making a constant name over wrong name kind");
 
     const auto hs = _hash_mix_constant(NameKind::CONSTANT, original.id());
@@ -1389,9 +1388,8 @@ NameRef GlobalState::lookupNameConstant(NameRef original) const {
         return core::NameRef::noName();
     }
     ENFORCE(original.kind(*this) == NameKind::UTF8 ||
-                (original.kind(*this) == NameKind::UNIQUE &&
-                 (original.dataUnique(*this)->uniqueNameKind == UniqueNameKind::ResolverMissingClass ||
-                  original.dataUnique(*this)->uniqueNameKind == UniqueNameKind::TEnum)),
+                original.dataUnique(*this)->uniqueNameKind == UniqueNameKind::ResolverMissingClass ||
+                original.dataUnique(*this)->uniqueNameKind == UniqueNameKind::TEnum,
             "looking up a constant name over wrong name kind");
 
     const auto hs = _hash_mix_constant(NameKind::CONSTANT, original.id());

--- a/core/LocalVariable.cc
+++ b/core/LocalVariable.cc
@@ -11,7 +11,7 @@ bool LocalVariable::exists() const {
 }
 
 bool LocalVariable::isSyntheticTemporary(const GlobalState &gs) const {
-    if (_name.data(gs)->kind == NameKind::UNIQUE) {
+    if (_name.kind(gs) == NameKind::UNIQUE) {
         return true;
     }
     if (unique == 0) {

--- a/core/NameRef.h
+++ b/core/NameRef.h
@@ -106,6 +106,8 @@ public:
 
     NameKind kind(const GlobalState &gs) const;
 
+    /* Names are one of three different kinds: unique, utf8, or constant. */
+
     const UniqueNameData dataUnique(const GlobalState &gs) const;
     const UTF8NameData dataUtf8(const GlobalState &gs) const;
     const ConstantNameData dataCnst(const GlobalState &gs) const;

--- a/core/NameRef.h
+++ b/core/NameRef.h
@@ -8,7 +8,7 @@ class GlobalSubstitution;
 class Name;
 struct UniqueName;
 struct ConstantName;
-struct RawName;
+struct UTF8Name;
 
 enum class NameKind : u1 {
     UTF8 = 1,
@@ -43,12 +43,12 @@ public:
     const ConstantName *operator->() const;
 };
 
-class RawNameData : private DebugOnlyCheck<NameDataDebugCheck> {
-    const RawName &name;
+class UTF8NameData : private DebugOnlyCheck<NameDataDebugCheck> {
+    const UTF8Name &name;
 
 public:
-    RawNameData(const RawName &ref, const GlobalState &gs);
-    const RawName *operator->() const;
+    UTF8NameData(const UTF8Name &ref, const GlobalState &gs);
+    const UTF8Name *operator->() const;
 };
 
 constexpr size_t sizeof__UniqueName = sizeof(UniqueName *);
@@ -106,9 +106,9 @@ public:
 
     NameKind kind(const GlobalState &gs) const;
 
-    const UniqueNameData unique(const GlobalState &gs) const;
-    const RawNameData raw(const GlobalState &gs) const;
-    const ConstantNameData cnst(const GlobalState &gs) const;
+    const UniqueNameData dataUnique(const GlobalState &gs) const;
+    const UTF8NameData dataUtf8(const GlobalState &gs) const;
+    const ConstantNameData dataCnst(const GlobalState &gs) const;
 
     // Returns the `0` NameRef, used to indicate non-existence of a name
     static NameRef noName() {

--- a/core/NameRef.h
+++ b/core/NameRef.h
@@ -6,6 +6,17 @@ namespace sorbet::core {
 class GlobalState;
 class GlobalSubstitution;
 class Name;
+struct UniqueName;
+struct ConstantName;
+struct RawName;
+
+enum class NameKind : u1 {
+    UTF8 = 1,
+    UNIQUE = 2,
+    CONSTANT = 3,
+};
+
+CheckSize(NameKind, 1, 1);
 
 struct NameDataDebugCheck {
     const GlobalState &gs;
@@ -16,17 +27,33 @@ struct NameDataDebugCheck {
 };
 
 /** This is to `NameRef &` what SymbolData is to `SymbolRef &`. Read docs on SymbolData */
-class NameData : private DebugOnlyCheck<NameDataDebugCheck> {
-    Name &name;
+class UniqueNameData : private DebugOnlyCheck<NameDataDebugCheck> {
+    const UniqueName &name;
 
 public:
-    NameData(Name &ref, const GlobalState &gs);
-    Name *operator->();
-    const Name *operator->() const;
+    UniqueNameData(const UniqueName &ref, const GlobalState &gs);
+    const UniqueName *operator->() const;
 };
-constexpr size_t sizeof__Name = sizeof(Name *);
-constexpr size_t alignof__Name = alignof(Name *);
-CheckSize(NameData, sizeof__Name, alignof__Name);
+
+class ConstantNameData : private DebugOnlyCheck<NameDataDebugCheck> {
+    const ConstantName &name;
+
+public:
+    ConstantNameData(const ConstantName &ref, const GlobalState &gs);
+    const ConstantName *operator->() const;
+};
+
+class RawNameData : private DebugOnlyCheck<NameDataDebugCheck> {
+    const RawName &name;
+
+public:
+    RawNameData(const RawName &ref, const GlobalState &gs);
+    const RawName *operator->() const;
+};
+
+constexpr size_t sizeof__UniqueName = sizeof(UniqueName *);
+constexpr size_t alignof__UniqueName = alignof(UniqueName *);
+CheckSize(UniqueNameData, sizeof__UniqueName, alignof__UniqueName);
 
 struct NameRefDebugCheck {
     int globalStateId;
@@ -40,6 +67,9 @@ struct NameRefDebugCheck {
 };
 
 class NameRef final : private DebugOnlyCheck<NameRefDebugCheck> {
+private:
+    const Name &data(const GlobalState &gs) const;
+
 public:
     friend GlobalState;
     friend Name;
@@ -74,9 +104,11 @@ public:
         return _id;
     }
 
-    NameData data(GlobalState &gs) const;
+    NameKind kind(const GlobalState &gs) const;
 
-    const NameData data(const GlobalState &gs) const;
+    const UniqueNameData unique(const GlobalState &gs) const;
+    const RawNameData raw(const GlobalState &gs) const;
+    const ConstantNameData cnst(const GlobalState &gs) const;
 
     // Returns the `0` NameRef, used to indicate non-existence of a name
     static NameRef noName() {

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -25,26 +25,26 @@ Name::~Name() noexcept {
 unsigned int NameRef::hash(const GlobalState &gs) const {
     // TODO: use https://github.com/Cyan4973/xxHash
     // !!! keep this in sync with GlobalState.enter*
-    auto name = data(gs);
-    switch (name->kind) {
+    auto &name = data(gs);
+    switch (name.kind) {
         case NameKind::UTF8:
-            return _hash(name->raw.utf8);
+            return _hash(name.raw.utf8);
         case NameKind::UNIQUE:
-            return _hash_mix_unique((u2)name->unique.uniqueNameKind, NameKind::UNIQUE, name->unique.num,
-                                    name->unique.original.id());
+            return _hash_mix_unique((u2)name.unique.uniqueNameKind, NameKind::UNIQUE, name.unique.num,
+                                    name.unique.original.id());
         case NameKind::CONSTANT:
-            return _hash_mix_constant(NameKind::CONSTANT, name->cnst.original.id());
+            return _hash_mix_constant(NameKind::CONSTANT, name.cnst.original.id());
     }
 }
 
 string NameRef::showRaw(const GlobalState &gs) const {
-    auto name = data(gs);
-    switch (name->kind) {
+    auto &name = data(gs);
+    switch (name.kind) {
         case NameKind::UTF8:
-            return fmt::format("<U {}>", string(name->raw.utf8.begin(), name->raw.utf8.end()));
+            return fmt::format("<U {}>", string(name.raw.utf8.begin(), name.raw.utf8.end()));
         case NameKind::UNIQUE: {
             string kind;
-            switch (name->unique.uniqueNameKind) {
+            switch (name.unique.uniqueNameKind) {
                 case UniqueNameKind::Parser:
                     kind = "P";
                     break;
@@ -79,71 +79,71 @@ string NameRef::showRaw(const GlobalState &gs) const {
                     kind = "E";
                     break;
             }
-            if (gs.censorForSnapshotTests && name->unique.uniqueNameKind == UniqueNameKind::Namer &&
-                name->unique.original == core::Names::staticInit()) {
-                return fmt::format("<{} {} ${}>", kind, name->unique.original.showRaw(gs), "CENSORED");
+            if (gs.censorForSnapshotTests && name.unique.uniqueNameKind == UniqueNameKind::Namer &&
+                name.unique.original == core::Names::staticInit()) {
+                return fmt::format("<{} {} ${}>", kind, name.unique.original.showRaw(gs), "CENSORED");
             } else {
-                return fmt::format("<{} {} ${}>", kind, name->unique.original.showRaw(gs), name->unique.num);
+                return fmt::format("<{} {} ${}>", kind, name.unique.original.showRaw(gs), name.unique.num);
             }
         }
         case NameKind::CONSTANT:
-            return fmt::format("<C {}>", name->cnst.original.showRaw(gs));
+            return fmt::format("<C {}>", name.cnst.original.showRaw(gs));
     }
 }
 
 string NameRef::toString(const GlobalState &gs) const {
-    auto name = data(gs);
-    switch (name->kind) {
+    auto &name = data(gs);
+    switch (name.kind) {
         case NameKind::UTF8:
-            return string(name->raw.utf8.begin(), name->raw.utf8.end());
+            return string(name.raw.utf8.begin(), name.raw.utf8.end());
         case NameKind::UNIQUE:
-            if (name->unique.uniqueNameKind == UniqueNameKind::Singleton) {
-                return fmt::format("<Class:{}>", name->unique.original.show(gs));
-            } else if (name->unique.uniqueNameKind == UniqueNameKind::Overload) {
-                return absl::StrCat(name->unique.original.show(gs), " (overload.", name->unique.num, ")");
+            if (name.unique.uniqueNameKind == UniqueNameKind::Singleton) {
+                return fmt::format("<Class:{}>", name.unique.original.show(gs));
+            } else if (name.unique.uniqueNameKind == UniqueNameKind::Overload) {
+                return absl::StrCat(name.unique.original.show(gs), " (overload.", name.unique.num, ")");
             }
-            if (gs.censorForSnapshotTests && name->unique.uniqueNameKind == UniqueNameKind::Namer &&
-                name->unique.original == core::Names::staticInit()) {
-                return fmt::format("{}${}", name->unique.original.show(gs), "CENSORED");
+            if (gs.censorForSnapshotTests && name.unique.uniqueNameKind == UniqueNameKind::Namer &&
+                name.unique.original == core::Names::staticInit()) {
+                return fmt::format("{}${}", name.unique.original.show(gs), "CENSORED");
             } else {
-                return fmt::format("{}${}", name->unique.original.show(gs), name->unique.num);
+                return fmt::format("{}${}", name.unique.original.show(gs), name.unique.num);
             }
         case NameKind::CONSTANT:
-            return fmt::format("<C {}>", name->cnst.original.toString(gs));
+            return fmt::format("<C {}>", name.cnst.original.toString(gs));
     }
 }
 
 string NameRef::show(const GlobalState &gs) const {
-    auto name = data(gs);
-    switch (name->kind) {
+    auto &name = data(gs);
+    switch (name.kind) {
         case NameKind::UTF8:
-            return string(name->raw.utf8.begin(), name->raw.utf8.end());
+            return string(name.raw.utf8.begin(), name.raw.utf8.end());
         case NameKind::UNIQUE:
-            if (name->unique.uniqueNameKind == UniqueNameKind::Singleton) {
-                return fmt::format("<Class:{}>", name->unique.original.show(gs));
-            } else if (name->unique.uniqueNameKind == UniqueNameKind::Overload) {
-                return absl::StrCat(name->unique.original.show(gs), " (overload.", name->unique.num, ")");
-            } else if (name->unique.uniqueNameKind == UniqueNameKind::MangleRename) {
-                return name->unique.original.show(gs);
-            } else if (name->unique.uniqueNameKind == UniqueNameKind::TEnum) {
+            if (name.unique.uniqueNameKind == UniqueNameKind::Singleton) {
+                return fmt::format("<Class:{}>", name.unique.original.show(gs));
+            } else if (name.unique.uniqueNameKind == UniqueNameKind::Overload) {
+                return absl::StrCat(name.unique.original.show(gs), " (overload.", name.unique.num, ")");
+            } else if (name.unique.uniqueNameKind == UniqueNameKind::MangleRename) {
+                return name.unique.original.show(gs);
+            } else if (name.unique.uniqueNameKind == UniqueNameKind::TEnum) {
                 // The entire goal of UniqueNameKind::TEnum is to have Name::show print the name as if on the
                 // original name, so that our T::Enum DSL-synthesized class names are kept as an implementation detail.
                 // Thus, we fall through.
             }
-            return name->unique.original.show(gs);
+            return name.unique.original.show(gs);
         case NameKind::CONSTANT:
-            return name->cnst.original.show(gs);
+            return name.cnst.original.show(gs);
     }
 }
 string_view NameRef::shortName(const GlobalState &gs) const {
-    auto name = data(gs);
-    switch (name->kind) {
+    auto &name = data(gs);
+    switch (name.kind) {
         case NameKind::UTF8:
-            return string_view(name->raw.utf8.begin(), name->raw.utf8.end() - name->raw.utf8.begin());
+            return string_view(name.raw.utf8.begin(), name.raw.utf8.end() - name.raw.utf8.begin());
         case NameKind::UNIQUE:
-            return name->unique.original.shortName(gs);
+            return name.unique.original.shortName(gs);
         case NameKind::CONSTANT:
-            return name->cnst.original.shortName(gs);
+            return name.cnst.original.shortName(gs);
     }
 }
 
@@ -151,56 +151,56 @@ void NameRef::sanityCheck(const GlobalState &gs) const {
     if (!debug_mode) {
         return;
     }
-    auto name = data(gs);
-    switch (name->kind) {
+    auto &name = data(gs);
+    switch (name.kind) {
         case NameKind::UTF8:
-            ENFORCE_NO_TIMER(*this == const_cast<GlobalState &>(gs).enterNameUTF8(name->raw.utf8),
+            ENFORCE_NO_TIMER(*this == const_cast<GlobalState &>(gs).enterNameUTF8(name.raw.utf8),
                              "Name table corrupted, re-entering UTF8 name gives different id");
             break;
         case NameKind::UNIQUE: {
-            ENFORCE_NO_TIMER(name->unique.original._id < this->_id, "unique name id not bigger than original");
-            ENFORCE_NO_TIMER(name->unique.num > 0, "unique num == 0");
-            NameRef current2 = const_cast<GlobalState &>(gs).freshNameUnique(name->unique.uniqueNameKind,
-                                                                             name->unique.original, name->unique.num);
+            ENFORCE_NO_TIMER(name.unique.original._id < this->_id, "unique name id not bigger than original");
+            ENFORCE_NO_TIMER(name.unique.num > 0, "unique num == 0");
+            NameRef current2 = const_cast<GlobalState &>(gs).freshNameUnique(name.unique.uniqueNameKind,
+                                                                             name.unique.original, name.unique.num);
             ENFORCE_NO_TIMER(*this == current2, "Name table corrupted, re-entering UNIQUE name gives different id");
             break;
         }
         case NameKind::CONSTANT:
-            ENFORCE_NO_TIMER(name->cnst.original._id < this->_id, "constant name id not bigger than original");
-            ENFORCE_NO_TIMER(*this == const_cast<GlobalState &>(gs).enterNameConstant(name->cnst.original),
+            ENFORCE_NO_TIMER(name.cnst.original._id < this->_id, "constant name id not bigger than original");
+            ENFORCE_NO_TIMER(*this == const_cast<GlobalState &>(gs).enterNameConstant(name.cnst.original),
                              "Name table corrupted, re-entering CONSTANT name gives different id");
             break;
     }
 }
 
 bool NameRef::isClassName(const GlobalState &gs) const {
-    auto name = data(gs);
-    switch (name->kind) {
+    auto &name = data(gs);
+    switch (name.kind) {
         case NameKind::UTF8:
             return false;
         case NameKind::UNIQUE: {
-            return (name->unique.uniqueNameKind == UniqueNameKind::Singleton ||
-                    name->unique.uniqueNameKind == UniqueNameKind::MangleRename ||
-                    name->unique.uniqueNameKind == UniqueNameKind::TEnum) &&
-                   name->unique.original.isClassName(gs);
+            return (name.unique.uniqueNameKind == UniqueNameKind::Singleton ||
+                    name.unique.uniqueNameKind == UniqueNameKind::MangleRename ||
+                    name.unique.uniqueNameKind == UniqueNameKind::TEnum) &&
+                   name.unique.original.isClassName(gs);
         }
         case NameKind::CONSTANT:
-            ENFORCE(name->cnst.original.data(gs)->kind == NameKind::UTF8 ||
-                    name->cnst.original.data(gs)->kind == NameKind::UNIQUE &&
-                        (name->cnst.original.data(gs)->unique.uniqueNameKind == UniqueNameKind::ResolverMissingClass ||
-                         name->cnst.original.data(gs)->unique.uniqueNameKind == UniqueNameKind::TEnum));
+            ENFORCE(name.cnst.original.data(gs).kind == NameKind::UTF8 ||
+                    name.cnst.original.data(gs).kind == NameKind::UNIQUE &&
+                        (name.cnst.original.data(gs).unique.uniqueNameKind == UniqueNameKind::ResolverMissingClass ||
+                         name.cnst.original.data(gs).unique.uniqueNameKind == UniqueNameKind::TEnum));
             return true;
     }
 }
 
 bool NameRef::isTEnumName(const GlobalState &gs) const {
-    auto name = data(gs);
-    if (name->kind != NameKind::CONSTANT) {
+    auto &name = data(gs);
+    if (name.kind != NameKind::CONSTANT) {
         return false;
     }
-    auto original = name->cnst.original;
-    return original.data(gs)->kind == NameKind::UNIQUE &&
-           original.data(gs)->unique.uniqueNameKind == UniqueNameKind::TEnum;
+    auto original = name.cnst.original;
+    return original.data(gs).kind == NameKind::UNIQUE &&
+           original.data(gs).unique.uniqueNameKind == UniqueNameKind::TEnum;
 }
 
 NameRefDebugCheck::NameRefDebugCheck(const GlobalState &gs, u4 _id) {
@@ -245,52 +245,62 @@ void NameRef::sanityCheckSubstitution(const GlobalSubstitution &subst) const {
     runDebugOnlyCheck(subst);
 }
 
-NameData NameRef::data(GlobalState &gs) const {
-    ENFORCE(_id < gs.names.size(), "name id out of bounds");
-    ENFORCE(exists(), "non existing name");
-    enforceCorrectGlobalState(gs);
-    return NameData(gs.names[_id], gs);
+NameKind NameRef::kind(const GlobalState &gs) const {
+    return data(gs).kind;
 }
 
-const NameData NameRef::data(const GlobalState &gs) const {
+const Name &NameRef::data(const GlobalState &gs) const {
     ENFORCE(_id < gs.names.size(), "name {} id out of bounds {}", _id, gs.names.size());
     ENFORCE(exists(), "non existing name");
     enforceCorrectGlobalState(gs);
-    return NameData(const_cast<Name &>(gs.names[_id]), gs);
+    return gs.names[_id];
+}
+
+const UniqueNameData NameRef::unique(const GlobalState &gs) const {
+    auto &name = data(gs);
+    ENFORCE(name.kind == NameKind::UNIQUE);
+    return UniqueNameData(name.unique, gs);
+}
+
+const RawNameData NameRef::raw(const GlobalState &gs) const {
+    auto &name = data(gs);
+    ENFORCE(name.kind == NameKind::UTF8);
+    return RawNameData(name.raw, gs);
+}
+
+const ConstantNameData NameRef::cnst(const GlobalState &gs) const {
+    auto &name = data(gs);
+    ENFORCE(name.kind == NameKind::CONSTANT);
+    return ConstantNameData(name.cnst, gs);
 }
 
 NameRef NameRef::addEq(GlobalState &gs) const {
-    auto name = this->data(gs);
-    ENFORCE(name->kind == NameKind::UTF8, "addEq over non-utf8 name");
-    string nameEq = absl::StrCat(name->raw.utf8, "=");
+    auto name = this->raw(gs);
+    string nameEq = absl::StrCat(name->utf8, "=");
     return gs.enterNameUTF8(nameEq);
 }
 
 NameRef NameRef::addQuestion(GlobalState &gs) const {
-    auto name = this->data(gs);
-    ENFORCE(name->kind == NameKind::UTF8, "addQuestion over non-utf8 name");
-    string nameEq = absl::StrCat(name->raw.utf8, "?");
+    auto name = this->raw(gs);
+    string nameEq = absl::StrCat(name->utf8, "?");
     return gs.enterNameUTF8(nameEq);
 }
 
 NameRef NameRef::addAt(GlobalState &gs) const {
-    auto name = this->data(gs);
-    ENFORCE(name->kind == NameKind::UTF8, "addAt over non-utf8 name");
-    string nameEq = absl::StrCat("@", name->raw.utf8);
+    auto name = this->raw(gs);
+    string nameEq = absl::StrCat("@", name->utf8);
     return gs.enterNameUTF8(nameEq);
 }
 
 NameRef NameRef::prepend(GlobalState &gs, string_view s) const {
-    auto name = this->data(gs);
-    ENFORCE(name->kind == NameKind::UTF8, "prepend over non-utf8 name");
-    string nameEq = absl::StrCat(s, name->raw.utf8);
+    auto name = this->raw(gs);
+    string nameEq = absl::StrCat(s, name->utf8);
     return gs.enterNameUTF8(nameEq);
 }
 
 NameRef NameRef::lookupMangledPackageName(const GlobalState &gs) const {
-    auto name = this->data(gs);
-    ENFORCE(name->kind == NameKind::UTF8, "manglePackageName over non-utf8 name");
-    auto parts = absl::StrSplit(name->raw.utf8, "::");
+    auto name = this->raw(gs);
+    auto parts = absl::StrSplit(name->utf8, "::");
     string nameEq = absl::StrCat(absl::StrJoin(parts, "_"), "_Package");
     return gs.lookupNameConstant(nameEq);
 }
@@ -318,7 +328,9 @@ Name Name::deepCopy(const GlobalState &to) const {
     return out;
 }
 
-NameData::NameData(Name &ref, const GlobalState &gs) : DebugOnlyCheck(gs), name(ref) {}
+UniqueNameData::UniqueNameData(const UniqueName &ref, const GlobalState &gs) : DebugOnlyCheck(gs), name(ref) {}
+ConstantNameData::ConstantNameData(const ConstantName &ref, const GlobalState &gs) : DebugOnlyCheck(gs), name(ref) {}
+RawNameData::RawNameData(const RawName &ref, const GlobalState &gs) : DebugOnlyCheck(gs), name(ref) {}
 
 NameDataDebugCheck::NameDataDebugCheck(const GlobalState &gs) : gs(gs), nameCountAtCreation(gs.namesUsed()) {}
 
@@ -326,12 +338,17 @@ void NameDataDebugCheck::check() const {
     ENFORCE(nameCountAtCreation == gs.namesUsed());
 }
 
-Name *NameData::operator->() {
+const UniqueName *UniqueNameData::operator->() const {
     runDebugOnlyCheck();
     return &name;
 };
 
-const Name *NameData::operator->() const {
+const ConstantName *ConstantNameData::operator->() const {
+    runDebugOnlyCheck();
+    return &name;
+};
+
+const RawName *RawNameData::operator->() const {
     runDebugOnlyCheck();
     return &name;
 };

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -275,31 +275,31 @@ const ConstantNameData NameRef::dataCnst(const GlobalState &gs) const {
 }
 
 NameRef NameRef::addEq(GlobalState &gs) const {
-    auto name = this->raw(gs);
+    auto name = this->dataUtf8(gs);
     string nameEq = absl::StrCat(name->utf8, "=");
     return gs.enterNameUTF8(nameEq);
 }
 
 NameRef NameRef::addQuestion(GlobalState &gs) const {
-    auto name = this->raw(gs);
+    auto name = this->dataUtf8(gs);
     string nameEq = absl::StrCat(name->utf8, "?");
     return gs.enterNameUTF8(nameEq);
 }
 
 NameRef NameRef::addAt(GlobalState &gs) const {
-    auto name = this->raw(gs);
+    auto name = this->dataUtf8(gs);
     string nameEq = absl::StrCat("@", name->utf8);
     return gs.enterNameUTF8(nameEq);
 }
 
 NameRef NameRef::prepend(GlobalState &gs, string_view s) const {
-    auto name = this->raw(gs);
+    auto name = this->dataUtf8(gs);
     string nameEq = absl::StrCat(s, name->utf8);
     return gs.enterNameUTF8(nameEq);
 }
 
 NameRef NameRef::lookupMangledPackageName(const GlobalState &gs) const {
-    auto name = this->raw(gs);
+    auto name = this->dataUtf8(gs);
     auto parts = absl::StrSplit(name->utf8, "::");
     string nameEq = absl::StrCat(absl::StrJoin(parts, "_"), "_Package");
     return gs.lookupNameConstant(nameEq);

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -256,19 +256,19 @@ const Name &NameRef::data(const GlobalState &gs) const {
     return gs.names[_id];
 }
 
-const UniqueNameData NameRef::unique(const GlobalState &gs) const {
+const UniqueNameData NameRef::dataUnique(const GlobalState &gs) const {
     auto &name = data(gs);
     ENFORCE(name.kind == NameKind::UNIQUE);
     return UniqueNameData(name.unique, gs);
 }
 
-const RawNameData NameRef::raw(const GlobalState &gs) const {
+const UTF8NameData NameRef::dataUtf8(const GlobalState &gs) const {
     auto &name = data(gs);
     ENFORCE(name.kind == NameKind::UTF8);
-    return RawNameData(name.raw, gs);
+    return UTF8NameData(name.raw, gs);
 }
 
-const ConstantNameData NameRef::cnst(const GlobalState &gs) const {
+const ConstantNameData NameRef::dataCnst(const GlobalState &gs) const {
     auto &name = data(gs);
     ENFORCE(name.kind == NameKind::CONSTANT);
     return ConstantNameData(name.cnst, gs);
@@ -330,7 +330,7 @@ Name Name::deepCopy(const GlobalState &to) const {
 
 UniqueNameData::UniqueNameData(const UniqueName &ref, const GlobalState &gs) : DebugOnlyCheck(gs), name(ref) {}
 ConstantNameData::ConstantNameData(const ConstantName &ref, const GlobalState &gs) : DebugOnlyCheck(gs), name(ref) {}
-RawNameData::RawNameData(const RawName &ref, const GlobalState &gs) : DebugOnlyCheck(gs), name(ref) {}
+UTF8NameData::UTF8NameData(const UTF8Name &ref, const GlobalState &gs) : DebugOnlyCheck(gs), name(ref) {}
 
 NameDataDebugCheck::NameDataDebugCheck(const GlobalState &gs) : gs(gs), nameCountAtCreation(gs.namesUsed()) {}
 
@@ -348,7 +348,7 @@ const ConstantName *ConstantNameData::operator->() const {
     return &name;
 };
 
-const RawName *RawNameData::operator->() const {
+const UTF8Name *UTF8NameData::operator->() const {
     runDebugOnlyCheck();
     return &name;
 };

--- a/core/Names.h
+++ b/core/Names.h
@@ -11,13 +11,6 @@
 namespace sorbet::core {
 class GlobalState;
 class Name;
-enum class NameKind : u1 {
-    UTF8 = 1,
-    UNIQUE = 2,
-    CONSTANT = 3,
-};
-
-CheckSize(NameKind, 1, 1);
 
 inline int _NameKind2Id_UTF8(NameKind nm) {
     ENFORCE(nm == NameKind::UTF8);

--- a/core/Names.h
+++ b/core/Names.h
@@ -27,10 +27,10 @@ inline int _NameKind2Id_CONSTANT(NameKind nm) {
     return 3;
 }
 
-struct RawName final {
+struct UTF8Name final {
     std::string_view utf8;
 };
-CheckSize(RawName, 16, 8);
+CheckSize(UTF8Name, 16, 8);
 
 enum class UniqueNameKind : u1 {
     Parser,
@@ -71,7 +71,7 @@ private:
 public:
     union { // todo: can discriminate this union through the pointer to Name
         // itself using lower bits
-        RawName raw;
+        UTF8Name raw;
         UniqueName unique;
         ConstantName cnst;
     };

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -480,9 +480,9 @@ vector<Symbol::FuzzySearchResult> Symbol::findMemberFuzzyMatchConstant(const Glo
             for (const auto scope : candidateScopes) {
                 for (auto member : scope.data(gs)->membersStableOrderSlow(gs)) {
                     if (member.first.kind(gs) == NameKind::CONSTANT &&
-                        member.first.cnst(gs)->original.kind(gs) == NameKind::UTF8 && member.second.exists()) {
+                        member.first.dataCnst(gs)->original.kind(gs) == NameKind::UTF8 && member.second.exists()) {
                         auto thisDistance = Levenstein::distance(
-                            currentName, member.first.cnst(gs)->original.raw(gs)->utf8, best.distance);
+                            currentName, member.first.dataCnst(gs)->original.dataUtf8(gs)->utf8, best.distance);
                         if (thisDistance <= best.distance) {
                             best.distance = thisDistance;
                             best.symbol = member.second;
@@ -514,13 +514,13 @@ vector<Symbol::FuzzySearchResult> Symbol::findMemberFuzzyMatchConstant(const Glo
             ENFORCE(thisIter.data(gs)->isClassOrModule());
             for (auto member : thisIter.data(gs)->membersStableOrderSlow(gs)) {
                 if (member.second.exists() && member.first.exists() && member.first.kind(gs) == NameKind::CONSTANT &&
-                    member.first.cnst(gs)->original.kind(gs) == NameKind::UTF8) {
+                    member.first.dataCnst(gs)->original.kind(gs) == NameKind::UTF8) {
                     if (member.second.data(gs)->isClassOrModule() &&
                         member.second.data(gs)->derivesFrom(gs, core::Symbols::StubModule())) {
                         continue;
                     }
-                    auto thisDistance =
-                        Levenstein::distance(currentName, member.first.cnst(gs)->original.raw(gs)->utf8, best.distance);
+                    auto thisDistance = Levenstein::distance(
+                        currentName, member.first.dataCnst(gs)->original.dataUtf8(gs)->utf8, best.distance);
                     if (thisDistance <= globalBestDistance) {
                         if (thisDistance < globalBestDistance) {
                             globalBest.clear();
@@ -551,7 +551,7 @@ Symbol::FuzzySearchResult Symbol::findMemberFuzzyMatchUTF8(const GlobalState &gs
     result.name = NameRef::noName();
     result.distance = betterThan;
 
-    auto currentName = name.raw(gs)->utf8;
+    auto currentName = name.dataUtf8(gs)->utf8;
     if (result.distance < 0) {
         result.distance = 1 + (currentName.size() / 2);
     }
@@ -561,7 +561,7 @@ Symbol::FuzzySearchResult Symbol::findMemberFuzzyMatchUTF8(const GlobalState &gs
         if (thisName.kind(gs) != NameKind::UTF8) {
             continue;
         }
-        auto utf8 = thisName.raw(gs)->utf8;
+        auto utf8 = thisName.dataUtf8(gs)->utf8;
         int thisDistance = Levenstein::distance(currentName, utf8, result.distance);
         if (thisDistance < result.distance ||
             (thisDistance == result.distance && result.symbol._id > pair.second._id)) {
@@ -929,12 +929,12 @@ string ArgInfo::argumentName(const GlobalState &gs) const {
 
 namespace {
 bool isSingletonName(const GlobalState &gs, core::NameRef name) {
-    return name.kind(gs) == NameKind::UNIQUE && name.unique(gs)->uniqueNameKind == UniqueNameKind::Singleton;
+    return name.kind(gs) == NameKind::UNIQUE && name.dataUnique(gs)->uniqueNameKind == UniqueNameKind::Singleton;
 }
 
 bool isMangledSingletonName(const GlobalState &gs, core::NameRef name) {
-    return name.kind(gs) == NameKind::UNIQUE && name.unique(gs)->uniqueNameKind == UniqueNameKind::MangleRename &&
-           isSingletonName(gs, name.unique(gs)->original);
+    return name.kind(gs) == NameKind::UNIQUE && name.dataUnique(gs)->uniqueNameKind == UniqueNameKind::MangleRename &&
+           isSingletonName(gs, name.dataUnique(gs)->original);
 }
 } // namespace
 
@@ -1349,7 +1349,7 @@ bool Symbol::ignoreInHashing(const GlobalState &gs) const {
     if (isClassOrModule()) {
         return superClass() == core::Symbols::StubModule();
     } else if (isMethod()) {
-        return name.kind(gs) == NameKind::UNIQUE && name.unique(gs)->original == core::Names::staticInit();
+        return name.kind(gs) == NameKind::UNIQUE && name.dataUnique(gs)->original == core::Names::staticInit();
     }
     return false;
 }

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -23,7 +23,7 @@ com::stripe::rubytyper::Name Proto::toProto(const GlobalState &gs, NameRef name)
             break;
         case NameKind::UNIQUE:
             protoName.set_kind(com::stripe::rubytyper::Name::UNIQUE);
-            switch (name.unique(gs)->uniqueNameKind) {
+            switch (name.dataUnique(gs)->uniqueNameKind) {
                 case UniqueNameKind::Parser:
                     protoName.set_unique(com::stripe::rubytyper::Name::PARSER);
                     break;

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -17,13 +17,13 @@ com::stripe::rubytyper::Name Proto::toProto(const GlobalState &gs, NameRef name)
     com::stripe::rubytyper::Name protoName;
     protoName.set_name(name.show(gs));
     protoName.set_unique(com::stripe::rubytyper::Name::NOT_UNIQUE);
-    switch (name.data(gs)->kind) {
+    switch (name.kind(gs)) {
         case NameKind::UTF8:
             protoName.set_kind(com::stripe::rubytyper::Name::UTF8);
             break;
         case NameKind::UNIQUE:
             protoName.set_kind(com::stripe::rubytyper::Name::UNIQUE);
-            switch (name.data(gs)->unique.uniqueNameKind) {
+            switch (name.unique(gs)->uniqueNameKind) {
                 case UniqueNameKind::Parser:
                     protoName.set_unique(com::stripe::rubytyper::Name::PARSER);
                     break;

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -132,7 +132,7 @@ TEST_CASE("Substitute") { // NOLINT
 
     auto other2 = subst.substitute(other1);
     REQUIRE(other2.exists());
-    REQUIRE(other2.data(gs2)->kind == NameKind::UTF8);
+    REQUIRE(other2.kind(gs2) == NameKind::UTF8);
     REQUIRE_EQ("<U other>", other2.showRaw(gs2));
 }
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -146,7 +146,7 @@ bool isSetter(const GlobalState &gs, NameRef fun) {
     if (fun.kind(gs) != NameKind::UTF8) {
         return false;
     }
-    const string_view rawName = fun.raw(gs)->utf8;
+    const string_view rawName = fun.dataUtf8(gs)->utf8;
     if (rawName.size() < 2) {
         return false;
     }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -143,10 +143,10 @@ DispatchResult TupleType::dispatchCall(const GlobalState &gs, const DispatchArgs
 
 namespace {
 bool isSetter(const GlobalState &gs, NameRef fun) {
-    if (fun.data(gs)->kind != NameKind::UTF8) {
+    if (fun.kind(gs) != NameKind::UTF8) {
         return false;
     }
-    const string_view rawName = fun.data(gs)->raw.utf8;
+    const string_view rawName = fun.raw(gs)->utf8;
     if (rawName.size() < 2) {
         return false;
     }

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -549,9 +549,9 @@ There are a handful of such paired data structures: `Symbol`/`SymbolRef`, and
 
 Why not just use pointers? `Ref`s are usually smaller than an 8-byte pointer.
 It's also nice to have the distinction reinforced in the type system. Also the
-"dereference" operation on these types is written `foo.data()` instead of `*foo`
-or `foo->`. Sorbet subscribes to the philosophy that slow operations should be
-longer to type.
+"dereference" operation on these types is written `foo.data*()` instead of
+`*foo` or `foo->`. Sorbet subscribes to the philosophy that slow operations
+should be longer to type.
 
 We use various `.enterFoo` methods on `GlobalState` to create new
 objects owned directly by `GlobalState`. These methods return `FooRef`s. These

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -39,7 +39,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
     core::TypePtr methodReturnType = cfg->symbol.data(ctx)->resultType;
     auto missingReturnType = methodReturnType == nullptr;
 
-    if (cfg->symbol.data(ctx)->name.data(ctx)->kind != core::NameKind::UTF8 ||
+    if (cfg->symbol.data(ctx)->name.kind(ctx) != core::NameKind::UTF8 ||
         cfg->symbol.data(ctx)->name == core::Names::staticInit() || !cfg->symbol.data(ctx)->loc().exists()) {
         guessTypes = false;
     }

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -29,11 +29,13 @@ bool hideSymbol(const core::GlobalState &gs, core::SymbolRef sym) {
         return true;
     }
     // static-init for a file
-    if (data->name.kind(gs) == core::NameKind::UNIQUE && data->name.unique(gs)->original == core::Names::staticInit()) {
+    if (data->name.kind(gs) == core::NameKind::UNIQUE &&
+        data->name.dataUnique(gs)->original == core::Names::staticInit()) {
         return true;
     }
     // <block>
-    if (data->name.kind(gs) == core::NameKind::UNIQUE && data->name.unique(gs)->original == core::Names::blockTemp()) {
+    if (data->name.kind(gs) == core::NameKind::UNIQUE &&
+        data->name.dataUnique(gs)->original == core::Names::blockTemp()) {
         return true;
     }
     return false;

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -29,13 +29,11 @@ bool hideSymbol(const core::GlobalState &gs, core::SymbolRef sym) {
         return true;
     }
     // static-init for a file
-    if (data->name.data(gs)->kind == core::NameKind::UNIQUE &&
-        data->name.data(gs)->unique.original == core::Names::staticInit()) {
+    if (data->name.kind(gs) == core::NameKind::UNIQUE && data->name.unique(gs)->original == core::Names::staticInit()) {
         return true;
     }
     // <block>
-    if (data->name.data(gs)->kind == core::NameKind::UNIQUE &&
-        data->name.data(gs)->unique.original == core::Names::blockTemp()) {
+    if (data->name.kind(gs) == core::NameKind::UNIQUE && data->name.unique(gs)->original == core::Names::blockTemp()) {
         return true;
     }
     return false;

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -812,7 +812,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
         auto deduped = vector<SimilarMethod>{};
         for (auto &[methodName, similarMethods] : similarMethodsByName) {
             if (methodName.kind(gs) == core::NameKind::UNIQUE &&
-                methodName.unique(gs)->uniqueNameKind == core::UniqueNameKind::MangleRename) {
+                methodName.dataUnique(gs)->uniqueNameKind == core::UniqueNameKind::MangleRename) {
                 // It's possible we want to ignore more things here. But note that we *don't* want to ignore all
                 // unique names, because we want each overload to show up but those use unique names.
                 continue;

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -620,7 +620,7 @@ bool isSimilarConstant(const core::GlobalState &gs, string_view prefix, core::Sy
     }
 
     auto name = sym.data(gs)->name;
-    if (name.data(gs)->kind != core::NameKind::CONSTANT) {
+    if (name.kind(gs) != core::NameKind::CONSTANT) {
         return false;
     }
 
@@ -811,8 +811,8 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
 
         auto deduped = vector<SimilarMethod>{};
         for (auto &[methodName, similarMethods] : similarMethodsByName) {
-            if (methodName.data(gs)->kind == core::NameKind::UNIQUE &&
-                methodName.data(gs)->unique.uniqueNameKind == core::UniqueNameKind::MangleRename) {
+            if (methodName.kind(gs) == core::NameKind::UNIQUE &&
+                methodName.unique(gs)->uniqueNameKind == core::UniqueNameKind::MangleRename) {
                 // It's possible we want to ignore more things here. But note that we *don't* want to ignore all
                 // unique names, because we want each overload to show up but those use unique names.
                 continue;

--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -109,8 +109,8 @@ inline bool canMatchWordBoundary(char ch) {
     return isspace(ch);
 }
 
-inline bool isEligibleSymbol(const core::NameData &nameData) {
-    if (nameData->kind == core::NameKind::UNIQUE) {
+inline bool isEligibleSymbol(core::NameRef name, const core::GlobalState &gs) {
+    if (name.kind(gs) == core::NameKind::UNIQUE) {
         return false;
     }
     return true;
@@ -187,8 +187,7 @@ PartialMatch partialMatchSymbol(string_view symbol, string_view::const_iterator 
 void SymbolMatcher::updatePartialMatch(core::SymbolRef symbolRef, string_view::const_iterator queryBegin,
                                        string_view::const_iterator queryEnd, size_t &ceilingScore) {
     auto symbolData = symbolRef.data(gs);
-    auto nameData = symbolData->name.data(gs);
-    if (!isEligibleSymbol(nameData)) {
+    if (!isEligibleSymbol(symbolData->name, gs)) {
         return;
     }
     auto shortName = symbolData->name.shortName(gs);
@@ -266,8 +265,7 @@ vector<unique_ptr<SymbolInformation>> SymbolMatcher::doQuery(string_view query_v
                     continue;
                 }
                 auto symbolData = symbolRef.data(gs);
-                auto nameData = symbolData->name.data(gs);
-                if (!isEligibleSymbol(nameData)) {
+                if (!isEligibleSymbol(symbolData->name, gs)) {
                     continue;
                 }
                 auto shortName = symbolData->name.shortName(gs);

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -145,8 +145,7 @@ public:
 
     unique_ptr<Node> accessible(unique_ptr<Node> node) {
         if (auto *id = parser::cast_node<Ident>(node.get())) {
-            auto name = id->name.data(gs_);
-            ENFORCE(name->kind == core::NameKind::UTF8);
+            ENFORCE(id->name.kind(gs_) == core::NameKind::UTF8);
             auto name_str = id->name.show(gs_);
             if (isNumberedParameterName(name_str) && driver_->lex.context.inDynamicBlock()) {
                 if (driver_->numparam_stack.seen_ordinary_params()) {


### PR DESCRIPTION
Introduce safe accessors for Name subtypes.

Delurks NameRef.data, introduces NameRef.{raw, cnst, unique} and NameRef.kind(). Also delurks the ability to get a mutable reference to a Name given a mutable GlobalState (this feature was never used anywhere, and never should be used).

This change ensures that ~all references to the union field on `Name` are checked in debug builds (e.g., if you try to call NameRef.raw() on a non-UTF8 Name, an ENFORCE will trigger).

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Prerequisite for breaking up the name table.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
