### PR TITLE
Ignore private constants inside RBI files

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -242,10 +242,11 @@ private:
             core::SymbolRef result = resolved.data(ctx)->findMember(ctx, c.cnst);
 
             // Private constants are allowed to be resolved, when there is no scope set (the scope is checked above),
-            // otherwise we should error out:
+            // otherwise we should error out. Private constant references _are not_ enforced inside RBI files.
             if (result.exists() &&
                 ((result.data(ctx)->isClassOrModule() && result.data(ctx)->isClassOrModulePrivate()) ||
-                 (result.data(ctx)->isStaticField() && result.data(ctx)->isStaticFieldPrivate()))) {
+                 (result.data(ctx)->isStaticField() && result.data(ctx)->isStaticFieldPrivate())) &&
+                !ctx.file.data(ctx).isRBI()) {
                 if (auto e = ctx.beginError(c.loc, core::errors::Resolver::PrivateConstantReferenced)) {
                     e.setHeader("Non-private reference to private constant `{}` referenced",
                                 result.data(ctx)->show(ctx));

--- a/test/testdata/infer/private_constant_in_rbi.rb.symbol-table.exp
+++ b/test/testdata/infer/private_constant_in_rbi.rb.symbol-table.exp
@@ -1,0 +1,58 @@
+class ::<root> < ::Object ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/infer/private_constant_in_rbi__1.rbi:3
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_constant_in_rbi__1.rbi start=??? end=???}
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/infer/private_constant_in_rbi__2.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_constant_in_rbi__2.rb start=??? end=???}
+  module ::Foo < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/infer/private_constant_in_rbi__1.rbi:3
+    static-field ::Foo::ANOTHER_PRIVATE_CONST : private -> TrueClass @ test/testdata/infer/private_constant_in_rbi__1.rbi:10
+    static-field ::Foo::A_PRIVATE_CONST : private -> String("private") @ test/testdata/infer/private_constant_in_rbi__1.rbi:7
+    static-field ::Foo::A_PUBLIC_CONST -> String("public") @ test/testdata/infer/private_constant_in_rbi__1.rbi:6
+    class ::Foo::AnotherPrivateClass < ::Object () : private @ test/testdata/infer/private_constant_in_rbi__1.rbi:22
+    class ::Foo::<Class:AnotherPrivateClass>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/infer/private_constant_in_rbi__1.rbi:22
+      type-member(+) ::Foo::<Class:AnotherPrivateClass>::<AttachedClass> -> T.attached_class (of Foo::AnotherPrivateClass) @ test/testdata/infer/private_constant_in_rbi__1.rbi:22
+      method ::Foo::<Class:AnotherPrivateClass>#<static-init> (<blk>) @ test/testdata/infer/private_constant_in_rbi__1.rbi:22
+        argument <blk><block> @ Loc {file=test/testdata/infer/private_constant_in_rbi__1.rbi start=??? end=???}
+    module ::Foo::AnotherPrivateModule < ::Sorbet::Private::Static::ImplicitModuleSuperclass () : private @ test/testdata/infer/private_constant_in_rbi__1.rbi:35
+    class ::Foo::<Class:AnotherPrivateModule>[<AttachedClass>] < ::Module () @ test/testdata/infer/private_constant_in_rbi__1.rbi:35
+      type-member(+) ::Foo::<Class:AnotherPrivateModule>::<AttachedClass> -> T.attached_class (of Foo::AnotherPrivateModule) @ test/testdata/infer/private_constant_in_rbi__1.rbi:35
+      method ::Foo::<Class:AnotherPrivateModule>#<static-init> (<blk>) @ test/testdata/infer/private_constant_in_rbi__1.rbi:35
+        argument <blk><block> @ Loc {file=test/testdata/infer/private_constant_in_rbi__1.rbi start=??? end=???}
+    class ::Foo::PrivateClass < ::Object () : private @ test/testdata/infer/private_constant_in_rbi__1.rbi:19
+    class ::Foo::<Class:PrivateClass>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/infer/private_constant_in_rbi__1.rbi:19
+      type-member(+) ::Foo::<Class:PrivateClass>::<AttachedClass> -> T.attached_class (of Foo::PrivateClass) @ test/testdata/infer/private_constant_in_rbi__1.rbi:19
+      method ::Foo::<Class:PrivateClass>#<static-init> (<blk>) @ test/testdata/infer/private_constant_in_rbi__1.rbi:19
+        argument <blk><block> @ Loc {file=test/testdata/infer/private_constant_in_rbi__1.rbi start=??? end=???}
+    static-field ::Foo::PrivateInt : private -> <Alias: ::Integer > @ test/testdata/infer/private_constant_in_rbi__1.rbi:16
+    static-field-type-alias ::Foo::PrivateIntTypeAlias : private -> Integer @ test/testdata/infer/private_constant_in_rbi__1.rbi:13
+    module ::Foo::PrivateModule < ::Sorbet::Private::Static::ImplicitModuleSuperclass () : private @ test/testdata/infer/private_constant_in_rbi__1.rbi:25
+      class ::Foo::PrivateModule::ClassInsidePrivateModule < ::Object () @ test/testdata/infer/private_constant_in_rbi__1.rbi:29
+      class ::Foo::PrivateModule::<Class:ClassInsidePrivateModule>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/infer/private_constant_in_rbi__1.rbi:29
+        type-member(+) ::Foo::PrivateModule::<Class:ClassInsidePrivateModule>::<AttachedClass> -> T.attached_class (of Foo::PrivateModule::ClassInsidePrivateModule) @ test/testdata/infer/private_constant_in_rbi__1.rbi:29
+        method ::Foo::PrivateModule::<Class:ClassInsidePrivateModule>#<static-init> (<blk>) @ test/testdata/infer/private_constant_in_rbi__1.rbi:29
+          argument <blk><block> @ Loc {file=test/testdata/infer/private_constant_in_rbi__1.rbi start=??? end=???}
+        method ::Foo::PrivateModule::<Class:ClassInsidePrivateModule>#also_ok_private_usage (<blk>) @ test/testdata/infer/private_constant_in_rbi__1.rbi:30
+          argument <blk><block> @ Loc {file=test/testdata/infer/private_constant_in_rbi__1.rbi start=??? end=???}
+    class ::Foo::<Class:PrivateModule>[<AttachedClass>] < ::Module () @ test/testdata/infer/private_constant_in_rbi__1.rbi:25
+      type-member(+) ::Foo::<Class:PrivateModule>::<AttachedClass> -> T.attached_class (of Foo::PrivateModule) @ test/testdata/infer/private_constant_in_rbi__1.rbi:25
+      method ::Foo::<Class:PrivateModule>#<static-init> (<blk>) @ test/testdata/infer/private_constant_in_rbi__1.rbi:25
+        argument <blk><block> @ Loc {file=test/testdata/infer/private_constant_in_rbi__1.rbi start=??? end=???}
+      method ::Foo::<Class:PrivateModule>#ok_private_usage (<blk>) @ test/testdata/infer/private_constant_in_rbi__1.rbi:26
+        argument <blk><block> @ Loc {file=test/testdata/infer/private_constant_in_rbi__1.rbi start=??? end=???}
+  class ::<Class:Foo>[<AttachedClass>] < ::Module (Sig) @ test/testdata/infer/private_constant_in_rbi__1.rbi:3
+    type-member(+) ::<Class:Foo>::<AttachedClass> -> T.attached_class (of Foo) @ test/testdata/infer/private_constant_in_rbi__1.rbi:3
+    method ::<Class:Foo>#<static-init> (<blk>) @ test/testdata/infer/private_constant_in_rbi__1.rbi:3
+      argument <blk><block> @ Loc {file=test/testdata/infer/private_constant_in_rbi__1.rbi start=??? end=???}
+    method ::<Class:Foo>#not_ok_private_usage (<blk>) -> Foo::PrivateClass @ test/testdata/infer/private_constant_in_rbi__1.rbi:39
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/infer/private_constant_in_rbi__1.rbi start=??? end=???}
+    method ::<Class:Foo>#using_private_class (x, <blk>) -> Sorbet::Private::Static::Void @ test/testdata/infer/private_constant_in_rbi__1.rbi:46
+      argument x<> -> Foo::PrivateClass @ Loc {file=test/testdata/infer/private_constant_in_rbi__1.rbi start=45:16 end=45:17}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/infer/private_constant_in_rbi__1.rbi start=??? end=???}
+    method ::<Class:Foo>#using_private_ints (x, y, <blk>) -> Sorbet::Private::Static::Void @ test/testdata/infer/private_constant_in_rbi__1.rbi:43
+      argument x<> -> Integer @ Loc {file=test/testdata/infer/private_constant_in_rbi__1.rbi start=42:16 end=42:17}
+      argument y<> -> Integer @ Loc {file=test/testdata/infer/private_constant_in_rbi__1.rbi start=42:40 end=42:41}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/infer/private_constant_in_rbi__1.rbi start=??? end=???}
+    method ::<Class:Foo>#using_private_module (x, <blk>) -> Sorbet::Private::Static::Void @ test/testdata/infer/private_constant_in_rbi__1.rbi:49
+      argument x<> -> T.class_of(Foo::PrivateModule) @ Loc {file=test/testdata/infer/private_constant_in_rbi__1.rbi start=48:16 end=48:17}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/infer/private_constant_in_rbi__1.rbi start=??? end=???}
+

--- a/test/testdata/infer/private_constant_in_rbi__1.rbi
+++ b/test/testdata/infer/private_constant_in_rbi__1.rbi
@@ -1,0 +1,56 @@
+# typed: true
+
+module Foo
+  extend T::Sig
+
+  A_PUBLIC_CONST = 'public'
+  A_PRIVATE_CONST = 'private'
+  private_constant :A_PRIVATE_CONST
+
+  ANOTHER_PRIVATE_CONST = true
+  private_constant 'ANOTHER_PRIVATE_CONST'
+
+  PrivateIntTypeAlias = T.type_alias { Integer }
+  private_constant :PrivateIntTypeAlias
+
+  PrivateInt = Integer
+  private_constant :PrivateInt
+
+  class PrivateClass; end
+  private_constant :PrivateClass
+
+  class AnotherPrivateClass; end
+  private_constant 'AnotherPrivateClass'
+
+  module PrivateModule
+    def self.ok_private_usage
+    end
+
+    class ClassInsidePrivateModule
+      def self.also_ok_private_usage; end
+    end
+  end
+  private_constant :PrivateModule
+
+  module AnotherPrivateModule; end
+  private_constant 'AnotherPrivateModule'
+
+  sig { returns(::Foo::PrivateClass) }
+  def self.not_ok_private_usage
+  end
+
+  sig { params(x: PrivateIntTypeAlias, y: PrivateInt).void }
+  def self.using_private_ints(x, y); end
+
+  sig { params(x: PrivateClass).void }
+  def self.using_private_class(x); end
+
+  sig { params(x: T.class_of(PrivateModule)).void }
+  def self.using_private_module(x); end
+end
+
+Foo::A_PUBLIC_CONST
+Foo::A_PRIVATE_CONST
+Foo::PrivateClass
+Foo::PrivateModule
+Foo::PrivateModule::ClassInsidePrivateModule

--- a/test/testdata/infer/private_constant_in_rbi__2.rb
+++ b/test/testdata/infer/private_constant_in_rbi__2.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+Foo::A_PUBLIC_CONST
+Foo::A_PRIVATE_CONST # error: Non-private reference to private constant `Foo::A_PRIVATE_CONST` referenced
+Foo::PrivateClass # error: Non-private reference to private constant `Foo::PrivateClass` referenced
+Foo::PrivateModule # error: Non-private reference to private constant `Foo::PrivateModule` referenced
+Foo::PrivateModule::ClassInsidePrivateModule.also_ok_private_usage # error: Non-private reference to private constant `Foo::PrivateModule` referenced
+
+Foo.using_private_ints(1, 2)
+Foo.using_private_class(1) # error: Expected `Foo::PrivateClass` but found `Integer(1)` for argument `x`
+Foo.using_private_module(1) # error: Expected `T.class_of(Foo::PrivateModule)` but found `Integer(1)` for argument `x`


### PR DESCRIPTION
This came out of a [discussion in slack](https://sorbet-ruby.slack.com/archives/CFT8Y4909/p1606946244031900?thread_ts=1605834003.026000&cid=CFT8Y4909) about referencing private constants in RBI. 

### Motivation

_Mostly extracted from that thread_

I feel like it might have to be all-or-nothing (i.e. either you can reference private constants with any usage inside RBI or you can't). If it's allowed then you can always generate "compact" RBI:

```ruby
module Public::Something
  include Public::PrivateModule # Currently error: Non-private reference

  sig { returns(Public::PrivateClass) } # Currently error: Non-private reference
  def foo; end
end
```

if it's not allowed in even just one circumstance then you'd have to always generate the "nested" RBI (or somehow intelligently know what's private or not) to be safe:

```ruby
module Public
  class Something
    include PrivateModule

    sig { returns(PrivateClass) }
    def foo; end
  end
end
```

The argument for why it ought to be allowed is that RBIs simply tell sorbet what already exists. It happens to be valid ruby which is nice for readers/writers but aside from being valid syntax it doesn't have to run without error. For instance:
- you don't need `extend T::Sig` when you're defining sigs in RBI but in source code that would raise an exception
- you can define classes out of order (e.g. `class A < B; end` can be defined before `class B; end` even though that would raise at runtime)

The argument against is that it might be a slippery slope of behavior differences between parsing source code vs RBI.

It seemed agreeable to simply allow it in RBI so that's what this PR does.


### Test plan

I'm not sure how to test RBI but I'd be happy to add some if someone wants to point me in the right direction.