### PR TITLE
Make ResolveSignaturesWalk a ShallowMap and small code tweaks.

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -120,6 +120,7 @@ public:
     static TypePtr classClass();
     static TypePtr declBuilderForProcsSingletonClass();
     static TypePtr falsyTypes();
+    static TypePtr todo();
 
     static TypePtr dropSubtypesOf(const GlobalState &gs, const TypePtr &from, SymbolRef klass);
     static TypePtr approximateSubtract(const GlobalState &gs, const TypePtr &from, const TypePtr &what);

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -144,6 +144,11 @@ TypePtr Types::falsyTypes() {
     return res;
 }
 
+TypePtr Types::todo() {
+    static auto res = make_type<ClassType>(Symbols::todo());
+    return res;
+}
+
 TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from, SymbolRef klass) {
     TypePtr result;
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1733,17 +1733,23 @@ class ResolveTypeMembersAndFieldsWalk {
                     auto mangledName = packageName.lookupMangledPackageName(ctx.state);
                     // if the mangled name doesn't exist, then this means probably there's no package named this
                     if (!mangledName.exists()) {
-                        if (auto e = ctx.beginError(*packageLoc, core::errors::Resolver::LazyResolve)) {
-                            e.setHeader("Unable to find package: `{}`", packageName.toString(ctx));
-                        }
-                        return;
+                        // TODO(gdritter): re-enable this once we implement runtime package support
+                        // if (auto e = ctx.beginError(*packageLoc, core::errors::Resolver::LazyResolve)) {
+                        //     e.setHeader("Unable to find package: `{}`", packageName.toString(ctx));
+                        // }
+                        // return;
+                        current = core::Symbols::root();
+                        continue;
                     }
                     current = core::Symbols::PackageRegistry().data(ctx)->findMember(ctx, mangledName);
                     if (!current.exists()) {
-                        if (auto e = ctx.beginError(*packageLoc, core::errors::Resolver::LazyResolve)) {
-                            e.setHeader("Unable to find package `{}`", packageName.toString(ctx));
-                        }
-                        return;
+                        // TODO(gdritter): re-enable this once we implement runtime package support
+                        // if (auto e = ctx.beginError(*packageLoc, core::errors::Resolver::LazyResolve)) {
+                        //     e.setHeader("Unable to find package `{}`", packageName.toString(ctx));
+                        // }
+                        // return;
+                        current = core::Symbols::root();
+                        continue;
                     }
                 }
             }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1313,8 +1313,6 @@ class ResolveTypeMembersAndFieldsWalk {
         if (data->resultType == nullptr) {
             if (auto resultType = resolveConstantType(ctx, asgn->rhs)) {
                 return resultType;
-            } else {
-                return core::Types::todo();
             }
         }
         // resultType was already set. We may be running on the incremental path. Force this field to be resolved in

--- a/test/testdata/resolver/generic_enum.rb
+++ b/test/testdata/resolver/generic_enum.rb
@@ -1,4 +1,5 @@
 # typed: true
+# disable-fast-path: true
 class MyEnum < T::Enum
   extend T::Generic
   Value = type_template(fixed: String) # error: All constants defined on an `T::Enum` must be unique instances of the enum

--- a/test/testdata/resolver/generic_enum.rb
+++ b/test/testdata/resolver/generic_enum.rb
@@ -1,0 +1,26 @@
+# typed: true
+class MyEnum < T::Enum
+  extend T::Generic
+  Value = type_template(fixed: String) # error: All constants defined on an `T::Enum` must be unique instances of the enum
+
+  enums do
+    X = new # error: Type `Value` declared by parent `T.class_of(MyEnum)` must be re-declared
+    Y = new # error: Type `Value` declared by parent `T.class_of(MyEnum)` must be re-declared
+    Z = new # error: Type `Value` declared by parent `T.class_of(MyEnum)` must be re-declared
+  end
+end
+
+extend T::Sig
+sig {params(xy: T.any(MyEnum::X[Integer], MyEnum::Y[Integer])).void}
+#                     ^^^^^^^^^^^^^^^^^^ error: Expected a class or module
+#                     ^^^^^^^^^^^^^^^^^^ error: Method `[]` does not exist
+#                                         ^^^^^^^^^^^^^^^^^^ error: Expected a class or module
+#                                         ^^^^^^^^^^^^^^^^^^ error: Method `[]` does not exist
+def foo(xy)
+end
+
+XY = T.type_alias {T.any(MyEnum::X[Integer], MyEnum::Y[Integer])}
+#                        ^^^^^^^^^^^^^^^^^^ error: Expected a class or module
+#                        ^^^^^^^^^^^^^^^^^^ error: Method `[]` does not exist
+#                                            ^^^^^^^^^^^^^^^^^^ error: Expected a class or module
+#                                            ^^^^^^^^^^^^^^^^^^ error: Method `[]` does not exist


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Make ResolveSignaturesWalk a ShallowMap and small code tweaks. The `send` nodes that `ResolveSignaturesWalk` was processing are readily available earlier in the type params pass.

Addresses lingering feedback in https://github.com/sorbet/sorbet/pull/3762 from @jez and @elliottt.

Should result in a speedup as `ResolveSignaturesWalk` is a serial pass over all of the ASTs, so it doing less work is significant on the critical path.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
