### PR TITLE
Add missing static error for abstract.override

### DIFF
--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -314,9 +314,19 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                             e.setHeader("Method that is both `{}` and `{}` cannot be implemented", "final", "abstract");
                         }
                     }
+                    if (sig.seen.override_) {
+                        if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                            e.setHeader("`{}` cannot be combined with `{}`", "override", "abstract");
+                        }
+                    }
                     sig.seen.abstract = true;
                     break;
                 case core::Names::override_()._id: {
+                    if (sig.seen.abstract) {
+                        if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
+                            e.setHeader("`{}` cannot be combined with `{}`", "abstract", "override");
+                        }
+                    }
                     sig.seen.override_ = true;
 
                     if (send->numPosArgs > 0) {

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -316,7 +316,7 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                     }
                     if (sig.seen.override_) {
                         if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
-                            e.setHeader("`{}` cannot be combined with `{}`", "override", "abstract");
+                            e.setHeader("`{}` cannot be combined with `{}`", "abstract", "override");
                         }
                     }
                     sig.seen.abstract = true;
@@ -324,7 +324,7 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                 case core::Names::override_()._id: {
                     if (sig.seen.abstract) {
                         if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
-                            e.setHeader("`{}` cannot be combined with `{}`", "abstract", "override");
+                            e.setHeader("`{}` cannot be combined with `{}`", "override", "abstract");
                         }
                     }
                     sig.seen.override_ = true;

--- a/test/testdata/resolver/abstract_override_exclusive.rb
+++ b/test/testdata/resolver/abstract_override_exclusive.rb
@@ -1,0 +1,38 @@
+# typed: false
+
+class AbstractGrandParent
+  extend T::Sig
+  extend T::Helpers
+
+  abstract!
+
+  sig {abstract.returns(Object)}
+  def foo; end
+
+  sig {abstract.returns(Object)}
+  def bar; end
+end
+
+class AbstractParent < AbstractGrandParent
+  abstract!
+
+  sig {abstract.override.returns(T::Boolean)} # error: `abstract` cannot be combined with `override`
+  def foo; end
+
+  sig {override.abstract.returns(T::Boolean)} # error: `override` cannot be combined with `abstract`
+  def bar; end
+end
+
+class ConcreteChild < AbstractParent
+  sig {override.returns(T::Boolean)}
+  def foo
+    true
+  end
+
+  sig {override.returns(T::Boolean)}
+  def bar
+    true
+  end
+end
+
+ConcreteChild.new.foo


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This already raises at runtime. We should have a static error. This caused a
problem in production at Stripe.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.