### PR TITLE
add frozen string declarations to package tests

### DIFF
--- a/test/testdata/packager/circular_imports/a/__package.rb
+++ b/test/testdata/packager/circular_imports/a/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 # enable-packager: true
 

--- a/test/testdata/packager/circular_imports/a/a.rb
+++ b/test/testdata/packager/circular_imports/a/a.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class AClass

--- a/test/testdata/packager/circular_imports/b/__package.rb
+++ b/test/testdata/packager/circular_imports/b/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class B < PackageSpec

--- a/test/testdata/packager/circular_imports/b/b.rb
+++ b/test/testdata/packager/circular_imports/b/b.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class BClass

--- a/test/testdata/packager/duplicate_package_name/a/__package.rb
+++ b/test/testdata/packager/duplicate_package_name/a/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 # enable-packager: true
 

--- a/test/testdata/packager/duplicate_package_name/b/__package.rb
+++ b/test/testdata/packager/duplicate_package_name/b/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class A < PackageSpec; end # error: Redefinition of package `A`

--- a/test/testdata/packager/export_imported/a/__package.rb
+++ b/test/testdata/packager/export_imported/a/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 # enable-packager: true
 

--- a/test/testdata/packager/export_imported/b/__package.rb
+++ b/test/testdata/packager/export_imported/b/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class B < PackageSpec

--- a/test/testdata/packager/export_imported/b/b.rb
+++ b/test/testdata/packager/export_imported/b/b.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class BClass

--- a/test/testdata/packager/import_self/__package.rb
+++ b/test/testdata/packager/import_self/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 # enable-packager: true
 

--- a/test/testdata/packager/invalid_imports_and_exports/__package.rb
+++ b/test/testdata/packager/invalid_imports_and_exports/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 # enable-packager: true
 

--- a/test/testdata/packager/invalid_imports_and_exports/a.rb
+++ b/test/testdata/packager/invalid_imports_and_exports/a.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 REFERENCE = ASecondClass

--- a/test/testdata/packager/invalid_imports_and_exports/b/__package.rb
+++ b/test/testdata/packager/invalid_imports_and_exports/b/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 # Despite A having invalid imports, B should still typecheck fine.

--- a/test/testdata/packager/invalid_imports_and_exports/b/b.rb
+++ b/test/testdata/packager/invalid_imports_and_exports/b/b.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class BClass

--- a/test/testdata/packager/invalid_package_control_flow/__package.rb
+++ b/test/testdata/packager/invalid_package_control_flow/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 # enable-packager: true
 

--- a/test/testdata/packager/invalid_package_control_flow/package_spec_additions.rb
+++ b/test/testdata/packager/invalid_package_control_flow/package_spec_additions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: true
 
 class ::PackageSpec

--- a/test/testdata/packager/invalid_package_name/__package.rb
+++ b/test/testdata/packager/invalid_package_name/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 # enable-packager: true
 

--- a/test/testdata/packager/lsp_features/__package.rb
+++ b/test/testdata/packager/lsp_features/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 # enable-packager: true
 

--- a/test/testdata/packager/lsp_features/bart/__package.rb
+++ b/test/testdata/packager/lsp_features/bart/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 # Bart package description

--- a/test/testdata/packager/lsp_features/bart/bart.rb
+++ b/test/testdata/packager/lsp_features/bart/bart.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
     CatchPhrase = "Don't have a cow, man."

--- a/test/testdata/packager/lsp_features/bart/bart.rb.document-symbols.exp
+++ b/test/testdata/packager/lsp_features/bart/bart.rb.document-symbols.exp
@@ -9,21 +9,21 @@
             "kind": 5,
             "range": {
                 "start": {
-                    "line": 7,
+                    "line": 8,
                     "character": 0
                 },
                 "end": {
-                    "line": 7,
+                    "line": 8,
                     "character": 15
                 }
             },
             "selectionRange": {
                 "start": {
-                    "line": 7,
+                    "line": 8,
                     "character": 0
                 },
                 "end": {
-                    "line": 7,
+                    "line": 8,
                     "character": 15
                 }
             },
@@ -34,21 +34,21 @@
                     "kind": 9,
                     "range": {
                         "start": {
-                            "line": 14,
+                            "line": 15,
                             "character": 4
                         },
                         "end": {
-                            "line": 14,
+                            "line": 15,
                             "character": 18
                         }
                     },
                     "selectionRange": {
                         "start": {
-                            "line": 14,
+                            "line": 15,
                             "character": 4
                         },
                         "end": {
-                            "line": 14,
+                            "line": 15,
                             "character": 18
                         }
                     },
@@ -61,21 +61,21 @@
             "kind": 14,
             "range": {
                 "start": {
-                    "line": 2,
+                    "line": 3,
                     "character": 4
                 },
                 "end": {
-                    "line": 2,
+                    "line": 3,
                     "character": 15
                 }
             },
             "selectionRange": {
                 "start": {
-                    "line": 2,
+                    "line": 3,
                     "character": 4
                 },
                 "end": {
-                    "line": 2,
+                    "line": 3,
                     "character": 15
                 }
             },

--- a/test/testdata/packager/lsp_features/family.rb
+++ b/test/testdata/packager/lsp_features/family.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: true
 
 class Family

--- a/test/testdata/packager/lsp_update_package/__package.rb
+++ b/test/testdata/packager/lsp_update_package/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 # enable-packager: true
 

--- a/test/testdata/packager/lsp_update_package/a.rb
+++ b/test/testdata/packager/lsp_update_package/a.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class A

--- a/test/testdata/packager/lsp_update_package/dep/__package.rb
+++ b/test/testdata/packager/lsp_update_package/dep/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class Dep < PackageSpec

--- a/test/testdata/packager/lsp_update_package/dep/exported.rb
+++ b/test/testdata/packager/lsp_update_package/dep/exported.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class ExportedItem

--- a/test/testdata/packager/lsp_update_packaged_file/__package.rb
+++ b/test/testdata/packager/lsp_update_packaged_file/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 # enable-packager: true
 

--- a/test/testdata/packager/lsp_update_packaged_file/a.rb
+++ b/test/testdata/packager/lsp_update_packaged_file/a.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class A

--- a/test/testdata/packager/lsp_update_packaged_file/dep/__package.rb
+++ b/test/testdata/packager/lsp_update_packaged_file/dep/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class Dep < PackageSpec

--- a/test/testdata/packager/lsp_update_packaged_file/dep/exported.rb
+++ b/test/testdata/packager/lsp_update_packaged_file/dep/exported.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class ExportedItem

--- a/test/testdata/packager/multiple_export_methods/__package.rb
+++ b/test/testdata/packager/multiple_export_methods/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 # enable-packager: true
 

--- a/test/testdata/packager/multiple_export_methods/main.rb
+++ b/test/testdata/packager/multiple_export_methods/main.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: true
 
 module A

--- a/test/testdata/packager/multiple_export_methods/subpkg/__package.rb
+++ b/test/testdata/packager/multiple_export_methods/subpkg/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class Subpackage < PackageSpec

--- a/test/testdata/packager/multiple_export_methods/subpkg/klass.rb
+++ b/test/testdata/packager/multiple_export_methods/subpkg/klass.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: true
 
 class Klass

--- a/test/testdata/packager/multiple_packages_in_file/__package.rb
+++ b/test/testdata/packager/multiple_packages_in_file/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 # enable-packager: true
 

--- a/test/testdata/packager/nested_packages/__package.rb
+++ b/test/testdata/packager/nested_packages/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 # enable-packager: true
 

--- a/test/testdata/packager/nested_packages/mainpackage.rb
+++ b/test/testdata/packager/nested_packages/mainpackage.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class PackageClass

--- a/test/testdata/packager/nested_packages/subpackage/__package.rb
+++ b/test/testdata/packager/nested_packages/subpackage/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class Package::Subpackage < PackageSpec

--- a/test/testdata/packager/nested_packages/subpackage/subpackage.rb
+++ b/test/testdata/packager/nested_packages/subpackage/subpackage.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class SubpackageClass

--- a/test/testdata/packager/non_forcing_constants/bar/__package.rb
+++ b/test/testdata/packager/non_forcing_constants/bar/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 # enable-packager: true
 

--- a/test/testdata/packager/non_forcing_constants/bar/bar.rb
+++ b/test/testdata/packager/non_forcing_constants/bar/bar.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class Bar

--- a/test/testdata/packager/non_forcing_constants/bar/bar_methods.rb
+++ b/test/testdata/packager/non_forcing_constants/bar/bar_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 module BarMethods

--- a/test/testdata/packager/non_forcing_constants/foo/__package.rb
+++ b/test/testdata/packager/non_forcing_constants/foo/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class Project::Foo < PackageSpec

--- a/test/testdata/packager/non_forcing_constants/foo/foo.rb
+++ b/test/testdata/packager/non_forcing_constants/foo/foo.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class Foo

--- a/test/testdata/packager/non_forcing_constants/foo/foo_methods.rb
+++ b/test/testdata/packager/non_forcing_constants/foo/foo_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 module FooMethods

--- a/test/testdata/packager/package-must-be-strict/__package.rb
+++ b/test/testdata/packager/package-must-be-strict/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # error: Package files must be at least `# typed: strict`
 # typed: true
 # enable-packager: true

--- a/test/testdata/packager/package-no-spec/__package.rb
+++ b/test/testdata/packager/package-no-spec/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # error: Package file must contain a package definition
 # typed: strict
 # enable-packager: true

--- a/test/testdata/packager/package_with_rbi/__package.rb
+++ b/test/testdata/packager/package_with_rbi/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 # enable-packager: true
 

--- a/test/testdata/packager/package_with_rbi/a.rb
+++ b/test/testdata/packager/package_with_rbi/a.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class A

--- a/test/testdata/packager/package_with_rbi/rbi/__package.rb
+++ b/test/testdata/packager/package_with_rbi/rbi/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class RBI < PackageSpec

--- a/test/testdata/packager/simple_package/bar/__package.rb
+++ b/test/testdata/packager/simple_package/bar/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 # enable-packager: true
 

--- a/test/testdata/packager/simple_package/bar/bar.rb
+++ b/test/testdata/packager/simple_package/bar/bar.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class Bar

--- a/test/testdata/packager/simple_package/bar/bar_methods.rb
+++ b/test/testdata/packager/simple_package/bar/bar_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 module BarMethods

--- a/test/testdata/packager/simple_package/foo/__package.rb
+++ b/test/testdata/packager/simple_package/foo/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class Project::Foo < PackageSpec

--- a/test/testdata/packager/simple_package/foo/foo.rb
+++ b/test/testdata/packager/simple_package/foo/foo.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 class Foo

--- a/test/testdata/packager/simple_package/foo/foo_methods.rb
+++ b/test/testdata/packager/simple_package/foo/foo_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 module FooMethods

--- a/test/testdata/packager/typed_ignore/__package.rb
+++ b/test/testdata/packager/typed_ignore/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 # enable-packager: true
 

--- a/test/testdata/packager/typed_ignore/ignored.rb
+++ b/test/testdata/packager/typed_ignore/ignored.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: ignore
 # This file is parsed with an EmptyTree and shouldn't be wrapped in a package namespace by Packager.
 

--- a/test/testdata/packager/unpackaged-error/packaged/__package.rb
+++ b/test/testdata/packager/unpackaged-error/packaged/__package.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 # This should not have an unpackaged error since it is a package file.

--- a/test/testdata/packager/unpackaged-error/packaged/packaged-file.rb
+++ b/test/testdata/packager/unpackaged-error/packaged/packaged-file.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # typed: strict
 
 # This should not have an unpackaged error since it is a packaged file.

--- a/test/testdata/packager/unpackaged-error/unpackaged-error.rb
+++ b/test/testdata/packager/unpackaged-error/unpackaged-error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # error: File `
 # ^ We can’t assert the full pathname; see https://github.com/sorbet/sorbet/pull/3310
 # typed: true


### PR DESCRIPTION
Done with:

```sh
for f in $(find test/testdata/packager/ -name \*.rb)
do
  cat <(echo '# frozen_string_literal: true') $f |sponge $f
done
```

### Motivation

A little extra strictness never hurt.


### Test plan

Existing tests should be sufficient.