### PR TITLE
Temporarily ignore packages that aren't found in non_forcing_is_a?

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2465,17 +2465,23 @@ private:
                     auto mangledName = packageName.lookupMangledPackageName(ctx.state);
                     // if the mangled name doesn't exist, then this means probably there's no package named this
                     if (!mangledName.exists()) {
-                        if (auto e = ctx.beginError(*packageLoc, core::errors::Resolver::LazyResolve)) {
-                            e.setHeader("Unable to find package: `{}`", packageName.toString(ctx));
-                        }
-                        return;
+                        // TODO(gdritter): re-enable this once we implement runtime package support
+                        // if (auto e = ctx.beginError(*packageLoc, core::errors::Resolver::LazyResolve)) {
+                        //     e.setHeader("Unable to find package: `{}`", packageName.toString(ctx));
+                        // }
+                        // return;
+                        current = core::Symbols::root();
+                        continue;
                     }
                     current = core::Symbols::PackageRegistry().data(ctx)->findMember(ctx, mangledName);
                     if (!current.exists()) {
-                        if (auto e = ctx.beginError(*packageLoc, core::errors::Resolver::LazyResolve)) {
-                            e.setHeader("Unable to find package `{}`", packageName.toString(ctx));
-                        }
-                        return;
+                        // TODO(gdritter): re-enable this once we implement runtime package support
+                        // if (auto e = ctx.beginError(*packageLoc, core::errors::Resolver::LazyResolve)) {
+                        //     e.setHeader("Unable to find package `{}`", packageName.toString(ctx));
+                        // }
+                        // return;
+                        current = core::Symbols::root();
+                        continue;
                     }
                 }
             }

--- a/test/testdata/packager/non_forcing_constants/foo/foo_methods.rb
+++ b/test/testdata/packager/non_forcing_constants/foo/foo_methods.rb
@@ -51,7 +51,9 @@ module FooMethods
 
   sig {params(arg: T.untyped).returns(T::Boolean)}
   def bad_non_existent_package(arg)
-    if T::NonForcingConstants.non_forcing_is_a?(arg, "Bar", package: "Project::Quux") # error: Unable to find package
+    # this is /temporarily/ okay because of #3778, but once we back it
+    # out this will fail with `Unable to find package`
+    if T::NonForcingConstants.non_forcing_is_a?(arg, "Bar", package: "Project::Quux")
       true
     else
       false


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Right now, it's not possible for code to be simultaneously valid packaged or valid unpackaged if it uses `non_forcing_is_a?`. This temporary change allows us to "fall back" to the unpackaged workflow. We probably want to re-enable it in the future, since "simultaneously unpackaged and packaged" is not a state that will make sense once we finish implementing the runtime: it's only transitional.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
