### PR TITLE
Parallelize ResolveSignaturesWalk.

### DIFF
--- a/core/Context.cc
+++ b/core/Context.cc
@@ -42,6 +42,10 @@ bool Context::permitOverloadDefinitions(const core::GlobalState &gs, FileRef sig
     return FileOps::getFileName(sigLoc.data(gs).path()) == whitelistedTest;
 }
 
+bool Context::permitOverloadDefinitions(FileRef sigLoc) const {
+    return Context::permitOverloadDefinitions(state, sigLoc, owner);
+}
+
 bool MutableContext::permitOverloadDefinitions(FileRef sigLoc) const {
     return Context::permitOverloadDefinitions(state, sigLoc, owner);
 }

--- a/core/Context.h
+++ b/core/Context.h
@@ -30,6 +30,7 @@ public:
     Context(const MutableContext &other) noexcept;
 
     ErrorBuilder beginError(LocOffsets loc, ErrorClass what) const;
+    bool permitOverloadDefinitions(FileRef sigLoc) const;
     static bool permitOverloadDefinitions(const core::GlobalState &gs, FileRef sigLoc, core::SymbolRef owner);
 
     Context withOwner(SymbolRef sym) const;

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1090,7 +1090,7 @@ SymbolRef GlobalState::enterMethodSymbol(Loc loc, SymbolRef owner, NameRef name)
 }
 
 SymbolRef GlobalState::enterNewMethodOverload(Loc sigLoc, SymbolRef original, core::NameRef originalName, u4 num,
-                                              const vector<int> &argsToKeep) {
+                                              const vector<bool> &argsToKeep) {
     NameRef name = num == 0 ? originalName : freshNameUnique(UniqueNameKind::Overload, originalName, num);
     core::Loc loc = num == 0 ? original.data(*this)->loc()
                              : sigLoc; // use original Loc for main overload so that we get right jump-to-def for it.
@@ -1105,7 +1105,7 @@ SymbolRef GlobalState::enterNewMethodOverload(Loc sigLoc, SymbolRef original, co
         for (auto &arg : originalArguments) {
             i += 1;
             Loc loc = arg.loc;
-            if (!absl::c_linear_search(argsToKeep, i)) {
+            if (!argsToKeep[i]) {
                 if (arg.flags.isBlock) {
                     loc = Loc::none();
                 } else {

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -77,7 +77,7 @@ public:
     SymbolRef enterTypeArgument(Loc loc, SymbolRef owner, NameRef name, Variance variance);
     SymbolRef enterMethodSymbol(Loc loc, SymbolRef owner, NameRef name);
     SymbolRef enterNewMethodOverload(Loc loc, SymbolRef original, core::NameRef originalName, u4 num,
-                                     const std::vector<int> &argsToKeep);
+                                     const std::vector<bool> &argsToKeep);
     SymbolRef enterFieldSymbol(Loc loc, SymbolRef owner, NameRef name);
     SymbolRef enterStaticFieldSymbol(Loc loc, SymbolRef owner, NameRef name);
     ArgInfo &enterMethodArgumentSymbol(Loc loc, SymbolRef owner, NameRef name);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2282,7 +2282,7 @@ private:
         }
     }
 
-    static void handleAbstractOrInterfaceMethods(core::Context ctx, ast::MethodDef &mdef) {
+    static void handleAbstractMethod(core::Context ctx, ast::MethodDef &mdef) {
         if (mdef.symbol.data(ctx)->isAbstract()) {
             if (!ast::isa_tree<ast::EmptyTree>(mdef.rhs)) {
                 if (auto e = ctx.beginError(mdef.rhs.loc(), core::errors::Resolver::AbstractMethodWithBody)) {
@@ -2639,7 +2639,7 @@ private:
                     // OVERLOAD
                     lastSigs.clear();
                 } else {
-                    handleAbstractOrInterfaceMethods(ctx, mdef);
+                    handleAbstractMethod(ctx, mdef);
                 }
             },
             [&](const ast::ClassDef &cdef) {
@@ -2681,7 +2681,7 @@ public:
             }
             fillInInfoFromSig(ctx, overloadSym, sig.loc, move(sig.sig), isOverloaded, mdef);
         }
-        handleAbstractOrInterfaceMethods(ctx, mdef);
+        handleAbstractMethod(ctx, mdef);
     }
 
     ast::TreePtr postTransformClassDef(core::Context ctx, ast::TreePtr tree) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2245,9 +2245,29 @@ public:
 };
 
 class ResolveSignaturesWalk {
+public:
+    struct MethodSignature {
+        core::LocOffsets loc;
+        ParsedSig sig;
+        vector<bool> argsToKeep;
+    };
+    struct ResolveMethodSignaturesJob {
+        core::FileRef file;
+        core::SymbolRef owner;
+        ast::MethodDef *mdef;
+        InlinedVector<MethodSignature, 1> sigs;
+    };
+
+    struct ResolveSignaturesWalkResult {
+        vector<ResolveMethodSignaturesJob> methodSignatureJobs;
+        vector<ast::ParsedFile> trees;
+    };
+
+    vector<ResolveMethodSignaturesJob> methodSignatureJobs;
+
 private:
-    ast::Local const *getArgLocal(core::Context ctx, const core::ArgInfo &argSym, const ast::MethodDef &mdef, int pos,
-                                  bool isOverloaded) {
+    static ast::Local const *getArgLocal(core::Context ctx, const core::ArgInfo &argSym, const ast::MethodDef &mdef,
+                                         int pos, bool isOverloaded) {
         if (!isOverloaded) {
             return ast::MK::arg2Local(mdef.args[pos]);
         } else {
@@ -2262,8 +2282,64 @@ private:
         }
     }
 
-    void fillInInfoFromSig(core::MutableContext ctx, core::SymbolRef method, core::LocOffsets exprLoc, ParsedSig sig,
-                           bool isOverloaded, const ast::MethodDef &mdef) {
+    static void handleAbstractOrInterfaceMethods(core::Context ctx, ast::MethodDef &mdef) {
+        if (mdef.symbol.data(ctx)->isAbstract()) {
+            if (!ast::isa_tree<ast::EmptyTree>(mdef.rhs)) {
+                if (auto e = ctx.beginError(mdef.rhs.loc(), core::errors::Resolver::AbstractMethodWithBody)) {
+                    e.setHeader("Abstract methods must not contain any code in their body");
+                    e.replaceWith("Delete the body", core::Loc(ctx.file, mdef.rhs.loc()), "");
+                }
+
+                mdef.rhs = ast::MK::EmptyTree();
+            }
+            if (!mdef.symbol.data(ctx)->enclosingClass(ctx).data(ctx)->isClassOrModuleAbstract()) {
+                if (auto e = ctx.beginError(mdef.loc, core::errors::Resolver::AbstractMethodOutsideAbstract)) {
+                    e.setHeader("Before declaring an abstract method, you must mark your class/module "
+                                "as abstract using `abstract!` or `interface!`");
+                }
+            }
+
+            // Rewrite the empty body of the abstract method to forward all arguments to `super`, mirroring the
+            // behavior of the runtime.
+            ast::Send::ARGS_store args;
+
+            auto argIdx = -1;
+            auto numPosArgs = 0;
+            for (auto &arg : mdef.args) {
+                ++argIdx;
+
+                const ast::Local *local = nullptr;
+                if (auto *opt = ast::cast_tree<ast::OptionalArg>(arg)) {
+                    local = ast::cast_tree<ast::Local>(opt->expr);
+                } else {
+                    local = ast::cast_tree<ast::Local>(arg);
+                }
+
+                auto &info = mdef.symbol.data(ctx)->arguments()[argIdx];
+                if (info.flags.isKeyword) {
+                    args.emplace_back(ast::MK::Symbol(local->loc, info.name));
+                    args.emplace_back(local->deepCopy());
+                } else if (info.flags.isRepeated || info.flags.isBlock) {
+                    // Explicitly skip for now.
+                    // Involves synthesizing a call to callWithSplat, callWithBlock, or
+                    // callWithSplatAndBlock
+                } else {
+                    args.emplace_back(local->deepCopy());
+                    ++numPosArgs;
+                }
+            }
+
+            auto self = ast::MK::Self(mdef.loc);
+            mdef.rhs = ast::MK::Send(mdef.loc, std::move(self), core::Names::super(), numPosArgs, std::move(args));
+        } else if (mdef.symbol.data(ctx)->enclosingClass(ctx).data(ctx)->isClassOrModuleInterface()) {
+            if (auto e = ctx.beginError(mdef.loc, core::errors::Resolver::ConcreteMethodInInterface)) {
+                e.setHeader("All methods in an interface must be declared abstract");
+            }
+        }
+    }
+
+    static void fillInInfoFromSig(core::MutableContext ctx, core::SymbolRef method, core::LocOffsets exprLoc,
+                                  ParsedSig sig, bool isOverloaded, const ast::MethodDef &mdef) {
         ENFORCE(isOverloaded || mdef.symbol == method);
         ENFORCE(isOverloaded || method.data(ctx)->arguments().size() == mdef.args.size());
 
@@ -2402,7 +2478,7 @@ private:
 
     // Force errors from any signatures that didn't attach to methods.
     // `lastSigs` will always be empty after this function is called.
-    void processLeftoverSigs(core::MutableContext ctx, InlinedVector<ast::Send *, 1> &lastSigs) {
+    void processLeftoverSigs(core::Context ctx, InlinedVector<ast::Send *, 1> &lastSigs) {
         if (!lastSigs.empty()) {
             // These sigs won't have been parsed, as there was no methods to
             // attach them to -- parse them here manually to force any errors.
@@ -2423,7 +2499,7 @@ private:
         }
     }
 
-    void processClassBody(core::MutableContext ctx, ast::ClassDef &klass) {
+    void processClassBody(core::Context ctx, ast::ClassDef &klass) {
         InlinedVector<ast::Send *, 1> lastSigs;
         for (auto &stat : klass.rhs) {
             processStatement(ctx, stat, lastSigs);
@@ -2436,7 +2512,7 @@ private:
         klass.rhs.erase(toRemove, klass.rhs.end());
     }
 
-    void processInSeq(core::MutableContext ctx, ast::InsSeq &seq) {
+    void processInSeq(core::Context ctx, ast::InsSeq &seq) {
         InlinedVector<ast::Send *, 1> lastSigs;
 
         // Explicitly check in the contxt of the class, not <static-init>
@@ -2456,7 +2532,7 @@ private:
         seq.stats.erase(toRemove, seq.stats.end());
     }
 
-    void processStatement(core::MutableContext ctx, ast::TreePtr &stat, InlinedVector<ast::Send *, 1> &lastSigs) {
+    void processStatement(core::Context ctx, ast::TreePtr &stat, InlinedVector<ast::Send *, 1> &lastSigs) {
         typecase(
             stat,
 
@@ -2510,11 +2586,9 @@ private:
                 }
 
                 if (!lastSigs.empty()) {
-                    prodCounterInc("types.sig.count");
-
-                    auto loc = lastSigs[0]->loc;
                     if (ctx.file.data(ctx).originalSigil == core::StrictLevel::None &&
                         !lastSigs.front()->flags.isRewriterSynthesized) {
+                        auto loc = lastSigs.front()->loc;
                         if (auto e = ctx.beginError(loc, core::errors::Resolver::SigInFileWithoutSigil)) {
                             e.setHeader("To use `{}`, this file must declare an explicit `{}` sigil (found: "
                                         "none). If you're not sure which one to use, start with `{}`",
@@ -2522,115 +2596,50 @@ private:
                         }
                     }
 
-                    bool isOverloaded = lastSigs.size() > 1 && ctx.permitOverloadDefinitions(ctx.file);
-                    auto originalName = mdef.symbol.data(ctx)->name;
-                    if (isOverloaded) {
-                        ctx.state.mangleRenameSymbol(mdef.symbol, originalName);
-                    }
-                    int i = 0;
-
                     // process signatures in the context of either the current
                     // class, or the current singleton class, depending on if
                     // the current method is a self method.
                     core::SymbolRef sigOwner;
                     if (mdef.flags.isSelfMethod) {
-                        sigOwner = ctx.owner.data(ctx)->singletonClass(ctx);
+                        sigOwner = ctx.owner.data(ctx)->lookupSingletonClass(ctx);
                     } else {
                         sigOwner = ctx.owner;
                     }
 
-                    while (i < lastSigs.size()) {
+                    bool isOverloaded = lastSigs.size() > 1 && ctx.permitOverloadDefinitions(ctx.file);
+
+                    InlinedVector<MethodSignature, 1> sigs;
+                    sigs.reserve(lastSigs.size());
+
+                    for (auto &lastSig : lastSigs) {
                         auto allowSelfType = true;
                         auto allowRebind = false;
                         auto allowTypeMember = true;
                         auto sig = TypeSyntax::parseSig(
-                            ctx.withOwner(sigOwner), *lastSigs[i], nullptr,
+                            ctx.withOwner(sigOwner), *lastSig, nullptr,
                             TypeSyntaxArgs{allowSelfType, allowRebind, allowTypeMember, mdef.symbol});
-                        core::SymbolRef overloadSym;
+
+                        vector<bool> argsToKeep;
                         if (isOverloaded) {
-                            vector<int> argsToKeep;
-                            int argId = -1;
                             for (auto &argTree : mdef.args) {
-                                argId++;
                                 const auto local = ast::MK::arg2Local(argTree);
                                 auto treeArgName = local->localVariable._name;
                                 ENFORCE(local != nullptr);
-                                auto spec =
-                                    absl::c_find_if(sig.argTypes, [&](auto &spec) { return spec.name == treeArgName; });
-                                if (spec != sig.argTypes.end()) {
-                                    argsToKeep.emplace_back(argId);
-                                }
+                                argsToKeep.emplace_back(absl::c_find_if(sig.argTypes, [&](auto &spec) {
+                                                            return spec.name == treeArgName;
+                                                        }) != sig.argTypes.end());
                             }
-                            overloadSym = ctx.state.enterNewMethodOverload(core::Loc(ctx.file, lastSigs[i]->loc),
-                                                                           mdef.symbol, originalName, i, argsToKeep);
-                            overloadSym.data(ctx)->setMethodVisibility(mdef.symbol.data(ctx)->methodVisibility());
-                            if (i != lastSigs.size() - 1) {
-                                overloadSym.data(ctx)->setOverloaded();
-                            }
-                        } else {
-                            overloadSym = mdef.symbol;
                         }
-                        fillInInfoFromSig(ctx, overloadSym, lastSigs[i]->loc, move(sig), isOverloaded, mdef);
-                        i++;
+                        sigs.emplace_back(MethodSignature{lastSig->loc, move(sig), move(argsToKeep)});
                     }
+
+                    methodSignatureJobs.emplace_back(
+                        ResolveMethodSignaturesJob{ctx.file, ctx.owner, &mdef, std::move(sigs)});
 
                     // OVERLOAD
                     lastSigs.clear();
-                }
-
-                if (mdef.symbol.data(ctx)->isAbstract()) {
-                    if (!ast::isa_tree<ast::EmptyTree>(mdef.rhs)) {
-                        if (auto e = ctx.beginError(mdef.rhs.loc(), core::errors::Resolver::AbstractMethodWithBody)) {
-                            e.setHeader("Abstract methods must not contain any code in their body");
-                            e.replaceWith("Delete the body", core::Loc(ctx.file, mdef.rhs.loc()), "");
-                        }
-
-                        mdef.rhs = ast::MK::EmptyTree();
-                    }
-                    if (!mdef.symbol.data(ctx)->enclosingClass(ctx).data(ctx)->isClassOrModuleAbstract()) {
-                        if (auto e = ctx.beginError(mdef.loc, core::errors::Resolver::AbstractMethodOutsideAbstract)) {
-                            e.setHeader("Before declaring an abstract method, you must mark your class/module "
-                                        "as abstract using `abstract!` or `interface!`");
-                        }
-                    }
-
-                    // Rewrite the empty body of the abstract method to forward all arguments to `super`, mirroring the
-                    // behavior of the runtime.
-                    ast::Send::ARGS_store args;
-
-                    auto argIdx = -1;
-                    auto numPosArgs = 0;
-                    for (auto &arg : mdef.args) {
-                        ++argIdx;
-
-                        const ast::Local *local = nullptr;
-                        if (auto *opt = ast::cast_tree<ast::OptionalArg>(arg)) {
-                            local = ast::cast_tree<ast::Local>(opt->expr);
-                        } else {
-                            local = ast::cast_tree<ast::Local>(arg);
-                        }
-
-                        auto &info = mdef.symbol.data(ctx)->arguments()[argIdx];
-                        if (info.flags.isKeyword) {
-                            args.emplace_back(ast::MK::Symbol(local->loc, info.name));
-                            args.emplace_back(local->deepCopy());
-                        } else if (info.flags.isRepeated || info.flags.isBlock) {
-                            // Explicitly skip for now.
-                            // Involves synthesizing a call to callWithSplat, callWithBlock, or
-                            // callWithSplatAndBlock
-                        } else {
-                            args.emplace_back(local->deepCopy());
-                            ++numPosArgs;
-                        }
-                    }
-
-                    auto self = ast::MK::Self(mdef.loc);
-                    mdef.rhs =
-                        ast::MK::Send(mdef.loc, std::move(self), core::Names::super(), numPosArgs, std::move(args));
-                } else if (mdef.symbol.data(ctx)->enclosingClass(ctx).data(ctx)->isClassOrModuleInterface()) {
-                    if (auto e = ctx.beginError(mdef.loc, core::errors::Resolver::ConcreteMethodInInterface)) {
-                        e.setHeader("All methods in an interface must be declared abstract");
-                    }
+                } else {
+                    handleAbstractOrInterfaceMethods(ctx, mdef);
                 }
             },
             [&](const ast::ClassDef &cdef) {
@@ -2643,13 +2652,45 @@ private:
     }
 
 public:
-    ast::TreePtr postTransformClassDef(core::MutableContext ctx, ast::TreePtr tree) {
+    static void resolveMethodSignaturesJob(core::MutableContext ctx, const ResolveMethodSignaturesJob &job) {
+        auto &sigs = job.sigs;
+        auto &mdef = *job.mdef;
+        ENFORCE_NO_TIMER(!sigs.empty());
+
+        prodCounterInc("types.sig.count");
+
+        bool isOverloaded = sigs.size() > 1 && ctx.permitOverloadDefinitions(ctx.file);
+        auto originalName = mdef.symbol.data(ctx)->name;
+        if (isOverloaded) {
+            ctx.state.mangleRenameSymbol(mdef.symbol, originalName);
+        }
+
+        int i = -1;
+        for (auto &sig : sigs) {
+            i++;
+            core::SymbolRef overloadSym;
+            if (isOverloaded) {
+                overloadSym = ctx.state.enterNewMethodOverload(core::Loc(ctx.file, sig.loc), mdef.symbol, originalName,
+                                                               i, sig.argsToKeep);
+                overloadSym.data(ctx)->setMethodVisibility(mdef.symbol.data(ctx)->methodVisibility());
+                if (i != sigs.size() - 1) {
+                    overloadSym.data(ctx)->setOverloaded();
+                }
+            } else {
+                overloadSym = mdef.symbol;
+            }
+            fillInInfoFromSig(ctx, overloadSym, sig.loc, move(sig.sig), isOverloaded, mdef);
+        }
+        handleAbstractOrInterfaceMethods(ctx, mdef);
+    }
+
+    ast::TreePtr postTransformClassDef(core::Context ctx, ast::TreePtr tree) {
         auto &klass = ast::cast_tree_nonnull<ast::ClassDef>(tree);
         processClassBody(ctx.withOwner(klass.symbol), klass);
         return tree;
     }
 
-    ast::TreePtr postTransformInsSeq(core::MutableContext ctx, ast::TreePtr tree) {
+    ast::TreePtr postTransformInsSeq(core::Context ctx, ast::TreePtr tree) {
         processInSeq(ctx, ast::cast_tree_nonnull<ast::InsSeq>(tree));
         return tree;
     }
@@ -2711,7 +2752,7 @@ ast::ParsedFilesOrCancelled Resolver::run(core::GlobalState &gs, vector<ast::Par
         return ast::ParsedFilesOrCancelled();
     }
 
-    auto result = resolveSigs(gs, std::move(trees));
+    auto result = resolveSigs(gs, std::move(trees), workers);
     if (!result.hasResult()) {
         return result;
     }
@@ -2720,22 +2761,64 @@ ast::ParsedFilesOrCancelled Resolver::run(core::GlobalState &gs, vector<ast::Par
     return result;
 }
 
-ast::ParsedFilesOrCancelled Resolver::resolveSigs(core::GlobalState &gs, vector<ast::ParsedFile> trees) {
-    ResolveSignaturesWalk sigs;
-    const auto &epochManager = gs.epochManager;
+ast::ParsedFilesOrCancelled Resolver::resolveSigs(core::GlobalState &gs, vector<ast::ParsedFile> trees,
+                                                  WorkerPool &workers) {
     Timer timeit(gs.tracer(), "resolver.sigs_vars_and_flatten");
-    u4 count = 0;
+    auto inputq = make_shared<ConcurrentBoundedQueue<ast::ParsedFile>>(trees.size());
+    auto outputq = make_shared<BlockingBoundedQueue<ResolveSignaturesWalk::ResolveSignaturesWalkResult>>(trees.size());
+
     for (auto &tree : trees) {
-        count++;
-        // Don't check every turn of the loop. We want to be responsive to cancelation without harming throughput.
-        if (count % 250 == 0 && epochManager->wasTypecheckingCanceled()) {
-            return ast::ParsedFilesOrCancelled();
-        }
-        core::MutableContext ctx(gs, core::Symbols::root(), tree.file);
-        tree.tree = ast::ShallowMap::apply(ctx, sigs, std::move(tree.tree));
+        inputq->push(move(tree), 1);
     }
 
-    return trees;
+    workers.multiplexJob("resolveSignaturesWalk", [&gs, inputq, outputq]() -> void {
+        Timer timeit(gs.tracer(), "resolveSignaturesWalkWorker");
+        ResolveSignaturesWalk walk;
+        ResolveSignaturesWalk::ResolveSignaturesWalkResult output;
+        ast::ParsedFile job;
+        for (auto result = inputq->try_pop(job); !result.done(); result = inputq->try_pop(job)) {
+            if (result.gotItem()) {
+                core::Context ctx(gs, core::Symbols::root(), job.file);
+                job.tree = ast::TreeMap::apply(ctx, walk, std::move(job.tree));
+                output.trees.emplace_back(move(job));
+            }
+        }
+        if (!output.trees.empty()) {
+            output.methodSignatureJobs = move(walk.methodSignatureJobs);
+            auto count = output.trees.size();
+            outputq->push(move(output), count);
+        }
+    });
+
+    ResolveSignaturesWalk::ResolveSignaturesWalkResult combined;
+    {
+        ResolveSignaturesWalk::ResolveSignaturesWalkResult threadResult;
+        for (auto result = outputq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer());
+             !result.done();
+             result = outputq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
+            if (result.gotItem()) {
+                if (combined.trees.empty()) {
+                    combined = move(threadResult);
+                } else {
+                    combined.trees.insert(combined.trees.end(), make_move_iterator(threadResult.trees.begin()),
+                                          make_move_iterator(threadResult.trees.end()));
+                    combined.methodSignatureJobs.insert(combined.methodSignatureJobs.end(),
+                                                        make_move_iterator(threadResult.methodSignatureJobs.begin()),
+                                                        make_move_iterator(threadResult.methodSignatureJobs.end()));
+                }
+            }
+        }
+    }
+
+    {
+        Timer timeit(gs.tracer(), "resolver.resolve_sigs");
+        for (auto &job : combined.methodSignatureJobs) {
+            core::MutableContext ctx(gs, job.owner, job.file);
+            ResolveSignaturesWalk::resolveMethodSignaturesJob(ctx, job);
+        }
+    }
+
+    return move(combined.trees);
 }
 
 void Resolver::sanityCheck(core::GlobalState &gs, vector<ast::ParsedFile> &trees) {
@@ -2759,7 +2842,7 @@ ast::ParsedFilesOrCancelled Resolver::runIncremental(core::GlobalState &gs, vect
         ENFORCE_NO_TIMER(sym.data(gs)->isClassOrModuleLinearizationComputed(), sym.toString(gs));
     })
     trees = ResolveTypeMembersAndFieldsWalk::run(gs, std::move(trees), *workers);
-    auto result = resolveSigs(gs, std::move(trees));
+    auto result = resolveSigs(gs, std::move(trees), *workers);
     if (!result.hasResult()) {
         return result;
     }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2774,7 +2774,6 @@ ast::ParsedFilesOrCancelled Resolver::resolveSigs(core::GlobalState &gs, vector<
     }
 
     workers.multiplexJob("resolveSignaturesWalk", [&gs, inputq, outputq]() -> void {
-        Timer timeit(gs.tracer(), "resolveSignaturesWalkWorker");
         ResolveSignaturesWalk walk;
         ResolveSignaturesWalk::ResolveSignaturesWalkResult output;
         ast::ParsedFile job;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2602,6 +2602,8 @@ private:
                     core::SymbolRef sigOwner;
                     if (mdef.flags.isSelfMethod) {
                         sigOwner = ctx.owner.data(ctx)->lookupSingletonClass(ctx);
+                        // namer ensures that all method owners are defined.
+                        ENFORCE_NO_TIMER(sigOwner.exists());
                     } else {
                         sigOwner = ctx.owner;
                     }

--- a/resolver/resolver.h
+++ b/resolver/resolver.h
@@ -26,7 +26,8 @@ private:
     static void finalizeAncestors(core::GlobalState &gs);
     static void finalizeSymbols(core::GlobalState &gs);
     static void computeLinearization(core::GlobalState &gs);
-    static ast::ParsedFilesOrCancelled resolveSigs(core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
+    static ast::ParsedFilesOrCancelled resolveSigs(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
+                                                   WorkerPool &workers);
     static void sanityCheck(core::GlobalState &gs, std::vector<ast::ParsedFile> &trees);
 };
 


### PR DESCRIPTION
Parallelize ResolveSignaturesWalk.

It gathers parsed sigs during the parallel walk, and resolves them serially.

Also changes the `argsToKeep` argument to `enterNewMethodOverload` into a `vector<bool>` to make it smaller and cheaper to look up arguments in.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed++

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
