### PR TITLE
Fixes typo in an LSP operation's description

### DIFF
--- a/main/lsp/ShowOperation.cc
+++ b/main/lsp/ShowOperation.cc
@@ -40,7 +40,7 @@ string_view kindToDescription(ShowOperation::Kind kind) {
         case ShowOperation::Kind::SlowPathBlocking:
             return "Typechecking...";
         case ShowOperation::Kind::SlowPathNonBlocking:
-            return "Typchecking in background";
+            return "Typechecking in background";
         case ShowOperation::Kind::References:
             return "Finding all references...";
         case ShowOperation::Kind::SymbolSearch:


### PR DESCRIPTION
This quick PR fixes a small typo in one of the descriptions of `ShowOperation.cc`'s `kindToDescription`.  The LSP operation's  description should be `Typechecking` instead of `Typchecking`.

### Motivation

To correct a misspelled word in my editor :)  

### Test plan

AFAICT no changes in tests should be necessary.
