### PR TITLE
Avoid allocating a string and string comparison for every parameter in every sig.

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2487,8 +2487,7 @@ private:
                 auto param = defParams[j];
                 auto sname = spec.name;
                 auto dname = param->localVariable._name;
-                // Common case: NameRefs match. Uncommon case: NameRefs don't match but their show strings are
-                // identical.
+                // TODO(jvilk): Do we need to check .show? Typically NameRef equality is equal to string equality.
                 if (sname != dname && sname.show(ctx) != dname.show(ctx)) {
                     if (auto e = ctx.beginError(param->loc, core::errors::Resolver::BadParameterOrdering)) {
                         e.setHeader("Bad parameter ordering for `{}`, expected `{}` instead", dname.show(ctx),

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2485,11 +2485,14 @@ private:
             int j = 0;
             for (auto spec : sigParams) {
                 auto param = defParams[j];
-                auto sname = spec.name.show(ctx);
-                auto dname = param->localVariable._name.show(ctx);
-                if (sname != dname) {
+                auto sname = spec.name;
+                auto dname = param->localVariable._name;
+                // Common case: NameRefs match. Uncommon case: NameRefs don't match but their show strings are
+                // identical.
+                if (sname != dname && sname.show(ctx) != dname.show(ctx)) {
                     if (auto e = ctx.beginError(param->loc, core::errors::Resolver::BadParameterOrdering)) {
-                        e.setHeader("Bad parameter ordering for `{}`, expected `{}` instead", dname, sname);
+                        e.setHeader("Bad parameter ordering for `{}`, expected `{}` instead", dname.show(ctx),
+                                    sname.show(ctx));
                         e.addErrorLine(spec.loc, "Expected index in signature:");
                     }
                 }


### PR DESCRIPTION
Avoid allocating a string and performing string comparison for every parameter in every sig.

Compare NameRefs instead.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed up resolver.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
