### PR TITLE
Break up name table by name type.

### DIFF
--- a/core/Context.cc
+++ b/core/Context.cc
@@ -150,10 +150,9 @@ GlobalSubstitution::GlobalSubstitution(const GlobalState &from, GlobalState &to,
                     to.freshNameUnique(nm.uniqueNameKind, substitute(nm.original), nm.num));
                 ENFORCE(!fastPath || uniqueNameSubstitution.back().uniqueIndex() == i);
             }
-            i = constantNameSubstitution.size() - 1;
-            for (const ConstantName &nm : from.constantNames) {
-                i++;
+            for (i = constantNameSubstitution.size(); i < from.constantNames.size(); i++) {
                 ENFORCE_NO_TIMER(constantNameSubstitution.size() == i, "Constant name substitution has wrong size");
+                auto &nm = from.constantNames[i];
                 constantNameSubstitution.emplace_back(to.enterNameConstant(substitute(nm.original)));
                 ENFORCE(!fastPath || constantNameSubstitution.back().constantIndex() == i);
             }

--- a/core/Context.cc
+++ b/core/Context.cc
@@ -136,6 +136,7 @@ GlobalSubstitution::GlobalSubstitution(const GlobalState &from, GlobalState &to,
                 ENFORCE(uniqueNameSubstitution.size() == i, "Unique name substitution has wrong size");
                 if (nm.original.kind() == NameKind::CONSTANT &&
                     nm.original.constantIndex() >= constantNameSubstitution.size()) {
+                    // Note: Duplicate of loop body below. If you change one, change the other!
                     for (u4 i = constantNameSubstitution.size(); i <= nm.original.constantIndex(); i++) {
                         auto &cnst = from.constantNames[i];
                         ENFORCE_NO_TIMER(constantNameSubstitution.size() == i,

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -13,7 +13,6 @@
 
 namespace sorbet::core {
 
-class Name;
 class NameRef;
 class Symbol;
 class SymbolRef;
@@ -32,7 +31,6 @@ class SerializerImpl;
 } // namespace serialize
 
 class GlobalState final {
-    friend Name;
     friend NameRef;
     friend Symbol;
     friend SymbolRef;
@@ -53,7 +51,9 @@ public:
 
     // Empirically determined to be the smallest powers of two larger than the
     // values required by the payload. Enforced in payload.cc.
-    static constexpr unsigned int PAYLOAD_MAX_NAME_COUNT = 32768;
+    static constexpr unsigned int PAYLOAD_MAX_UTF8_NAME_COUNT = 16384;
+    static constexpr unsigned int PAYLOAD_MAX_CONSTANT_NAME_COUNT = 4096;
+    static constexpr unsigned int PAYLOAD_MAX_UNIQUE_NAME_COUNT = 4096;
     static constexpr unsigned int PAYLOAD_MAX_CLASS_AND_MODULE_COUNT = 8192;
     static constexpr unsigned int PAYLOAD_MAX_METHOD_COUNT = 32768;
     static constexpr unsigned int PAYLOAD_MAX_FIELD_COUNT = 4096;
@@ -65,7 +65,7 @@ public:
 
     // Expand symbol and name tables to the given lengths. Does nothing if the value is <= current capacity.
     void preallocateTables(u4 classAndModulesSize, u4 methodsSize, u4 fieldsSize, u4 typeArgumentsSize,
-                           u4 typeMembersSize, u4 nameSize);
+                           u4 typeMembersSize, u4 utf8NameSize, u4 constantNameSize, u4 uniqueNameSize);
 
     GlobalState(const GlobalState &) = delete;
     GlobalState(GlobalState &&) = delete;
@@ -131,7 +131,10 @@ public:
 
     void mangleRenameSymbol(SymbolRef what, NameRef origName);
     spdlog::logger &tracer() const;
-    unsigned int namesUsed() const;
+    unsigned int namesUsedTotal() const;
+    unsigned int utf8NamesUsed() const;
+    unsigned int constantNamesUsed() const;
+    unsigned int uniqueNamesUsed() const;
 
     unsigned int classAndModulesUsed() const;
     unsigned int methodsUsed() const;
@@ -245,7 +248,9 @@ private:
     bool shouldReportErrorOn(Loc loc, ErrorClass what) const;
     struct DeepCloneHistoryEntry {
         int globalStateId;
-        unsigned int lastNameKnownByParentGlobalState;
+        unsigned int lastUTF8NameKnownByParentGlobalState;
+        unsigned int lastConstantNameKnownByParentGlobalState;
+        unsigned int lastUniqueNameKnownByParentGlobalState;
     };
     std::vector<DeepCloneHistoryEntry> deepCloneHistory;
 
@@ -253,7 +258,9 @@ private:
     std::vector<std::shared_ptr<std::vector<char>>> strings;
     std::string_view enterString(std::string_view nm);
     u2 stringsLastPageUsed = STRINGS_PAGE_SIZE + 1;
-    std::vector<Name> names;
+    std::vector<UTF8Name> utf8Names;
+    std::vector<ConstantName> constantNames;
+    std::vector<UniqueName> uniqueNames;
     UnorderedMap<std::string, FileRef> fileRefByPath;
     std::vector<Symbol> classAndModules;
     std::vector<Symbol> methods;
@@ -278,7 +285,7 @@ private:
     bool symbolTableFrozen = true;
     bool fileTableFrozen = true;
 
-    void expandNames(u4 newSize);
+    void expandNames(u4 utf8NameSize, u4 constantNameSize, u4 uniqueNameSize);
 
     SymbolRef synthesizeClass(NameRef nameID, u4 superclass = Symbols::todo().classOrModuleIndex(),
                               bool isModule = false);

--- a/core/GlobalSubstitution.h
+++ b/core/GlobalSubstitution.h
@@ -19,20 +19,20 @@ public:
         }
         switch (from.kind()) {
             case NameKind::UTF8:
-                ENFORCE(from.unsafeTableIndex() < utf8NameSubstitution.size(),
+                ENFORCE(from.utf8Index() < utf8NameSubstitution.size(),
                         "utf8 name substitution index out of bounds, got {} where subsitution size is {}",
                         std::to_string(from.rawId()), std::to_string(utf8NameSubstitution.size()));
-                return utf8NameSubstitution[from.unsafeTableIndex()];
+                return utf8NameSubstitution[from.utf8Index()];
             case NameKind::CONSTANT:
-                ENFORCE(from.unsafeTableIndex() < constantNameSubstitution.size(),
+                ENFORCE(from.constantIndex() < constantNameSubstitution.size(),
                         "constant name substitution index out of bounds, got {} where subsitution size is {}",
                         std::to_string(from.rawId()), std::to_string(constantNameSubstitution.size()));
-                return constantNameSubstitution[from.unsafeTableIndex()];
+                return constantNameSubstitution[from.constantIndex()];
             case NameKind::UNIQUE:
-                ENFORCE(from.unsafeTableIndex() < uniqueNameSubstitution.size(),
+                ENFORCE(from.uniqueIndex() < uniqueNameSubstitution.size(),
                         "unique name substitution index out of bounds, got {} where subsitution size is {}",
                         std::to_string(from.rawId()), std::to_string(uniqueNameSubstitution.size()));
-                return uniqueNameSubstitution[from.unsafeTableIndex()];
+                return uniqueNameSubstitution[from.uniqueIndex()];
         }
     }
 

--- a/core/GlobalSubstitution.h
+++ b/core/GlobalSubstitution.h
@@ -17,10 +17,23 @@ public:
         if (!allowSameFromTo) {
             from.sanityCheckSubstitution(*this);
         }
-        ENFORCE(from.unsafeTableIndex() < nameSubstitution.size(),
-                "name substitution index out of bounds, got {} where subsitution size is {}",
-                std::to_string(from.rawId()), std::to_string(nameSubstitution.size()));
-        return nameSubstitution[from.unsafeTableIndex()];
+        switch (from.kind()) {
+            case NameKind::UTF8:
+                ENFORCE(from.unsafeTableIndex() < utf8NameSubstitution.size(),
+                        "utf8 name substitution index out of bounds, got {} where subsitution size is {}",
+                        std::to_string(from.rawId()), std::to_string(utf8NameSubstitution.size()));
+                return utf8NameSubstitution[from.unsafeTableIndex()];
+            case NameKind::CONSTANT:
+                ENFORCE(from.unsafeTableIndex() < constantNameSubstitution.size(),
+                        "constant name substitution index out of bounds, got {} where subsitution size is {}",
+                        std::to_string(from.rawId()), std::to_string(constantNameSubstitution.size()));
+                return constantNameSubstitution[from.unsafeTableIndex()];
+            case NameKind::UNIQUE:
+                ENFORCE(from.unsafeTableIndex() < uniqueNameSubstitution.size(),
+                        "unique name substitution index out of bounds, got {} where subsitution size is {}",
+                        std::to_string(from.rawId()), std::to_string(uniqueNameSubstitution.size()));
+                return uniqueNameSubstitution[from.unsafeTableIndex()];
+        }
     }
 
     bool useFastPath() const;
@@ -28,7 +41,9 @@ public:
 private:
     friend NameRefDebugCheck;
 
-    std::vector<NameRef> nameSubstitution;
+    std::vector<NameRef> utf8NameSubstitution;
+    std::vector<NameRef> constantNameSubstitution;
+    std::vector<NameRef> uniqueNameSubstitution;
     // set if no substitution is actually necessary
     bool fastPath;
 

--- a/core/NameRef.h
+++ b/core/NameRef.h
@@ -80,10 +80,6 @@ private:
     }
 
 public:
-    friend GlobalState;
-    // TODO(jvilk): Delurk this friend once name table is broken up.
-    friend GlobalSubstitution;
-
     // The value `0` implies that there is no NameKind tag present (NameKind begin at 1) and is a special-value used to
     // indicate a non-existant NameRef.
     constexpr NameRef() : _id(0){};

--- a/core/NameRef.h
+++ b/core/NameRef.h
@@ -5,7 +5,6 @@
 namespace sorbet::core {
 class GlobalState;
 class GlobalSubstitution;
-class Name;
 struct UniqueName;
 struct ConstantName;
 struct UTF8Name;
@@ -61,16 +60,14 @@ struct NameRefDebugCheck {
 
     constexpr NameRefDebugCheck() : globalStateId(-1) {}
 
-    NameRefDebugCheck(const GlobalState &gs, u4 id);
+    NameRefDebugCheck(const GlobalState &gs, NameKind kind, u4 id);
 
-    void check(const GlobalState &gs, u4 id) const;
+    void check(const GlobalState &gs, NameKind kind, u4 id) const;
     void check(const GlobalSubstitution &subst) const;
 };
 
 class NameRef final : private DebugOnlyCheck<NameRefDebugCheck> {
 private:
-    const Name &data(const GlobalState &gs) const;
-
     // NameKind takes up this many bits in _id.
     static constexpr u4 KIND_BITS = 2;
     static constexpr u4 ID_BITS = 32 - KIND_BITS;
@@ -84,7 +81,6 @@ private:
 
 public:
     friend GlobalState;
-    friend Name;
     // TODO(jvilk): Delurk this friend once name table is broken up.
     friend GlobalSubstitution;
 

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -274,7 +274,6 @@ void NameRefDebugCheck::check(const GlobalState &gs, NameKind kind, u4 index) co
                     }
                     break;
             }
-            return;
         }
     }
     ENFORCE(false, "NameRef not owned by correct GlobalState");
@@ -294,23 +293,23 @@ void NameRef::sanityCheckSubstitution(const GlobalSubstitution &subst) const {
 
 const UniqueNameData NameRef::dataUnique(const GlobalState &gs) const {
     ENFORCE_NO_TIMER(kind() == NameKind::UNIQUE);
-    ENFORCE_NO_TIMER(unsafeTableIndex() < gs.uniqueNames.size(), "unique name {} id out of bounds {}",
-                     unsafeTableIndex(), gs.uniqueNames.size());
-    return UniqueNameData(gs.uniqueNames[unsafeTableIndex()], gs);
+    ENFORCE_NO_TIMER(uniqueIndex() < gs.uniqueNames.size(), "unique name {} id out of bounds {}", uniqueIndex(),
+                     gs.uniqueNames.size());
+    return UniqueNameData(gs.uniqueNames[uniqueIndex()], gs);
 }
 
 const UTF8NameData NameRef::dataUtf8(const GlobalState &gs) const {
     ENFORCE_NO_TIMER(kind() == NameKind::UTF8);
-    ENFORCE_NO_TIMER(unsafeTableIndex() < gs.utf8Names.size(), "utf8 name {} id out of bounds {}", unsafeTableIndex(),
+    ENFORCE_NO_TIMER(utf8Index() < gs.utf8Names.size(), "utf8 name {} id out of bounds {}", utf8Index(),
                      gs.utf8Names.size());
-    return UTF8NameData(gs.utf8Names[unsafeTableIndex()], gs);
+    return UTF8NameData(gs.utf8Names[utf8Index()], gs);
 }
 
 const ConstantNameData NameRef::dataCnst(const GlobalState &gs) const {
     ENFORCE_NO_TIMER(kind() == NameKind::CONSTANT);
-    ENFORCE_NO_TIMER(unsafeTableIndex() < gs.constantNames.size(), "constant name {} id out of bounds {}",
-                     unsafeTableIndex(), gs.constantNames.size());
-    return ConstantNameData(gs.constantNames[unsafeTableIndex()], gs);
+    ENFORCE_NO_TIMER(constantIndex() < gs.constantNames.size(), "constant name {} id out of bounds {}", constantIndex(),
+                     gs.constantNames.size());
+    return ConstantNameData(gs.constantNames[constantIndex()], gs);
 }
 
 NameRef NameRef::addEq(GlobalState &gs) const {

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -44,8 +44,10 @@ unsigned int NameRef::hash(const GlobalState &gs) const {
 
 string NameRef::showRaw(const GlobalState &gs) const {
     switch (kind()) {
-        case NameKind::UTF8:
-            return fmt::format("<U {}>", dataUtf8(gs)->utf8);
+        case NameKind::UTF8: {
+            auto raw = dataUtf8(gs);
+            return fmt::format("<U {}>", string(raw->utf8.begin(), raw->utf8.end()));
+        }
         case NameKind::UNIQUE: {
             auto unique = dataUnique(gs);
             string kind;
@@ -98,8 +100,10 @@ string NameRef::showRaw(const GlobalState &gs) const {
 
 string NameRef::toString(const GlobalState &gs) const {
     switch (kind()) {
-        case NameKind::UTF8:
-            return string(dataUtf8(gs)->utf8);
+        case NameKind::UTF8: {
+            auto raw = dataUtf8(gs);
+            return string(raw->utf8.begin(), raw->utf8.end());
+        }
         case NameKind::UNIQUE: {
             auto unique = dataUnique(gs);
             if (unique->uniqueNameKind == UniqueNameKind::Singleton) {
@@ -121,8 +125,10 @@ string NameRef::toString(const GlobalState &gs) const {
 
 string NameRef::show(const GlobalState &gs) const {
     switch (kind()) {
-        case NameKind::UTF8:
-            return string(dataUtf8(gs)->utf8);
+        case NameKind::UTF8: {
+            auto raw = dataUtf8(gs);
+            return string(raw->utf8.begin(), raw->utf8.end());
+        }
         case NameKind::UNIQUE: {
             auto unique = dataUnique(gs);
             if (unique->uniqueNameKind == UniqueNameKind::Singleton) {
@@ -144,8 +150,10 @@ string NameRef::show(const GlobalState &gs) const {
 }
 string_view NameRef::shortName(const GlobalState &gs) const {
     switch (kind()) {
-        case NameKind::UTF8:
-            return dataUtf8(gs)->utf8;
+        case NameKind::UTF8: {
+            auto raw = dataUtf8(gs);
+            return string_view(raw->utf8.begin(), raw->utf8.end() - raw->utf8.begin());
+        }
         case NameKind::UNIQUE:
             return dataUnique(gs)->original.shortName(gs);
         case NameKind::CONSTANT:

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -15,45 +15,41 @@ using namespace std;
 namespace sorbet::core {
 
 NameRef::NameRef(const GlobalState &gs, NameKind kind, u4 id)
-    : DebugOnlyCheck(gs, id), _id{(id & ID_MASK) | (static_cast<u4>(kind) << ID_BITS)} {
+    : DebugOnlyCheck(gs, kind, id), _id{(id & ID_MASK) | (static_cast<u4>(kind) << ID_BITS)} {
     // If this fails, the symbol table is too big :(
     ENFORCE_NO_TIMER(id <= ID_MASK);
 }
 
-NameRef::NameRef(const GlobalState &gs, NameRef ref) : DebugOnlyCheck(gs, ref.unsafeTableIndex()), _id(ref.rawId()) {
+NameRef::NameRef(const GlobalState &gs, NameRef ref)
+    : DebugOnlyCheck(gs, ref.kind(), ref.unsafeTableIndex()), _id(ref.rawId()) {
     // If this fails, the symbol table is too big :(
     ENFORCE_NO_TIMER(this->unsafeTableIndex() <= ID_MASK);
-}
-
-Name::~Name() noexcept {
-    if (kind == NameKind::UNIQUE) {
-        unique.~UniqueName();
-    }
 }
 
 unsigned int NameRef::hash(const GlobalState &gs) const {
     // TODO: use https://github.com/Cyan4973/xxHash
     // !!! keep this in sync with GlobalState.enter*
-    auto &name = data(gs);
-    switch (name.kind) {
+    switch (kind()) {
         case NameKind::UTF8:
-            return _hash(name.raw.utf8);
-        case NameKind::UNIQUE:
-            return _hash_mix_unique((u2)name.unique.uniqueNameKind, NameKind::UNIQUE, name.unique.num,
-                                    name.unique.original.rawId());
+            return _hash(dataUtf8(gs)->utf8);
+        case NameKind::UNIQUE: {
+            auto unique = dataUnique(gs);
+            return _hash_mix_unique((u2)unique->uniqueNameKind, NameKind::UNIQUE, unique->num,
+                                    unique->original.rawId());
+        }
         case NameKind::CONSTANT:
-            return _hash_mix_constant(NameKind::CONSTANT, name.cnst.original.rawId());
+            return _hash_mix_constant(NameKind::CONSTANT, dataCnst(gs)->original.rawId());
     }
 }
 
 string NameRef::showRaw(const GlobalState &gs) const {
-    auto &name = data(gs);
-    switch (name.kind) {
+    switch (kind()) {
         case NameKind::UTF8:
-            return fmt::format("<U {}>", string(name.raw.utf8.begin(), name.raw.utf8.end()));
+            return fmt::format("<U {}>", dataUtf8(gs)->utf8);
         case NameKind::UNIQUE: {
+            auto unique = dataUnique(gs);
             string kind;
-            switch (name.unique.uniqueNameKind) {
+            switch (unique->uniqueNameKind) {
                 case UniqueNameKind::Parser:
                     kind = "P";
                     break;
@@ -88,71 +84,72 @@ string NameRef::showRaw(const GlobalState &gs) const {
                     kind = "E";
                     break;
             }
-            if (gs.censorForSnapshotTests && name.unique.uniqueNameKind == UniqueNameKind::Namer &&
-                name.unique.original == core::Names::staticInit()) {
-                return fmt::format("<{} {} ${}>", kind, name.unique.original.showRaw(gs), "CENSORED");
+            if (gs.censorForSnapshotTests && unique->uniqueNameKind == UniqueNameKind::Namer &&
+                unique->original == core::Names::staticInit()) {
+                return fmt::format("<{} {} ${}>", kind, unique->original.showRaw(gs), "CENSORED");
             } else {
-                return fmt::format("<{} {} ${}>", kind, name.unique.original.showRaw(gs), name.unique.num);
+                return fmt::format("<{} {} ${}>", kind, unique->original.showRaw(gs), unique->num);
             }
         }
         case NameKind::CONSTANT:
-            return fmt::format("<C {}>", name.cnst.original.showRaw(gs));
+            return fmt::format("<C {}>", dataCnst(gs)->original.showRaw(gs));
     }
 }
 
 string NameRef::toString(const GlobalState &gs) const {
-    auto &name = data(gs);
-    switch (name.kind) {
+    switch (kind()) {
         case NameKind::UTF8:
-            return string(name.raw.utf8.begin(), name.raw.utf8.end());
-        case NameKind::UNIQUE:
-            if (name.unique.uniqueNameKind == UniqueNameKind::Singleton) {
-                return fmt::format("<Class:{}>", name.unique.original.show(gs));
-            } else if (name.unique.uniqueNameKind == UniqueNameKind::Overload) {
-                return absl::StrCat(name.unique.original.show(gs), " (overload.", name.unique.num, ")");
+            return string(dataUtf8(gs)->utf8);
+        case NameKind::UNIQUE: {
+            auto unique = dataUnique(gs);
+            if (unique->uniqueNameKind == UniqueNameKind::Singleton) {
+                return fmt::format("<Class:{}>", unique->original.show(gs));
+            } else if (unique->uniqueNameKind == UniqueNameKind::Overload) {
+                return absl::StrCat(unique->original.show(gs), " (overload.", unique->num, ")");
             }
-            if (gs.censorForSnapshotTests && name.unique.uniqueNameKind == UniqueNameKind::Namer &&
-                name.unique.original == core::Names::staticInit()) {
-                return fmt::format("{}${}", name.unique.original.show(gs), "CENSORED");
+            if (gs.censorForSnapshotTests && unique->uniqueNameKind == UniqueNameKind::Namer &&
+                unique->original == core::Names::staticInit()) {
+                return fmt::format("{}${}", unique->original.show(gs), "CENSORED");
             } else {
-                return fmt::format("{}${}", name.unique.original.show(gs), name.unique.num);
+                return fmt::format("{}${}", unique->original.show(gs), unique->num);
             }
+        }
         case NameKind::CONSTANT:
-            return fmt::format("<C {}>", name.cnst.original.toString(gs));
+            return fmt::format("<C {}>", dataCnst(gs)->original.toString(gs));
     }
 }
 
 string NameRef::show(const GlobalState &gs) const {
-    auto &name = data(gs);
-    switch (name.kind) {
+    switch (kind()) {
         case NameKind::UTF8:
-            return string(name.raw.utf8.begin(), name.raw.utf8.end());
-        case NameKind::UNIQUE:
-            if (name.unique.uniqueNameKind == UniqueNameKind::Singleton) {
-                return fmt::format("<Class:{}>", name.unique.original.show(gs));
-            } else if (name.unique.uniqueNameKind == UniqueNameKind::Overload) {
-                return absl::StrCat(name.unique.original.show(gs), " (overload.", name.unique.num, ")");
-            } else if (name.unique.uniqueNameKind == UniqueNameKind::MangleRename) {
-                return name.unique.original.show(gs);
-            } else if (name.unique.uniqueNameKind == UniqueNameKind::TEnum) {
+            return string(dataUtf8(gs)->utf8);
+        case NameKind::UNIQUE: {
+            auto unique = dataUnique(gs);
+            if (unique->uniqueNameKind == UniqueNameKind::Singleton) {
+                return fmt::format("<Class:{}>", unique->original.show(gs));
+            } else if (unique->uniqueNameKind == UniqueNameKind::Overload) {
+                return absl::StrCat(unique->original.show(gs), " (overload.", unique->num, ")");
+            } else if (unique->uniqueNameKind == UniqueNameKind::MangleRename) {
+                return unique->original.show(gs);
+            } else if (unique->uniqueNameKind == UniqueNameKind::TEnum) {
                 // The entire goal of UniqueNameKind::TEnum is to have Name::show print the name as if on the
                 // original name, so that our T::Enum DSL-synthesized class names are kept as an implementation detail.
                 // Thus, we fall through.
             }
-            return name.unique.original.show(gs);
+            return unique->original.show(gs);
+        }
         case NameKind::CONSTANT:
-            return name.cnst.original.show(gs);
+            return dataCnst(gs)->original.show(gs);
     }
 }
 string_view NameRef::shortName(const GlobalState &gs) const {
-    auto &name = data(gs);
-    switch (name.kind) {
+    switch (kind()) {
         case NameKind::UTF8:
-            return string_view(name.raw.utf8.begin(), name.raw.utf8.end() - name.raw.utf8.begin());
+            return dataUtf8(gs)->utf8;
         case NameKind::UNIQUE:
-            return name.unique.original.shortName(gs);
+            return dataUnique(gs)->original.shortName(gs);
         case NameKind::CONSTANT:
-            return name.cnst.original.shortName(gs);
+            return dataCnst(gs)->original.shortName(gs);
     }
 }
 
@@ -160,83 +157,115 @@ void NameRef::sanityCheck(const GlobalState &gs) const {
     if (!debug_mode) {
         return;
     }
-    auto &name = data(gs);
-    switch (name.kind) {
+    switch (kind()) {
         case NameKind::UTF8:
-            ENFORCE_NO_TIMER(*this == const_cast<GlobalState &>(gs).enterNameUTF8(name.raw.utf8),
+            ENFORCE_NO_TIMER(*this == const_cast<GlobalState &>(gs).enterNameUTF8(dataUtf8(gs)->utf8),
                              "Name table corrupted, re-entering UTF8 name gives different id");
             break;
         case NameKind::UNIQUE: {
-            ENFORCE_NO_TIMER(name.unique.original.unsafeTableIndex() < this->unsafeTableIndex(),
-                             "unique name id not bigger than original");
-            ENFORCE_NO_TIMER(name.unique.num > 0, "unique num == 0");
-            NameRef current2 = const_cast<GlobalState &>(gs).freshNameUnique(name.unique.uniqueNameKind,
-                                                                             name.unique.original, name.unique.num);
+            auto unique = dataUnique(gs);
+            ENFORCE_NO_TIMER(unique->num > 0, "unique num == 0");
+            NameRef current2 =
+                const_cast<GlobalState &>(gs).freshNameUnique(unique->uniqueNameKind, unique->original, unique->num);
             ENFORCE_NO_TIMER(*this == current2, "Name table corrupted, re-entering UNIQUE name gives different id");
             break;
         }
         case NameKind::CONSTANT:
-            ENFORCE_NO_TIMER(name.cnst.original.unsafeTableIndex() < this->unsafeTableIndex(),
-                             "constant name id not bigger than original");
-            ENFORCE_NO_TIMER(*this == const_cast<GlobalState &>(gs).enterNameConstant(name.cnst.original),
+            ENFORCE_NO_TIMER(*this == const_cast<GlobalState &>(gs).enterNameConstant(dataCnst(gs)->original),
                              "Name table corrupted, re-entering CONSTANT name gives different id");
             break;
     }
 }
 
 bool NameRef::isClassName(const GlobalState &gs) const {
-    auto &name = data(gs);
-    switch (name.kind) {
+    switch (kind()) {
         case NameKind::UTF8:
             return false;
         case NameKind::UNIQUE: {
-            return (name.unique.uniqueNameKind == UniqueNameKind::Singleton ||
-                    name.unique.uniqueNameKind == UniqueNameKind::MangleRename ||
-                    name.unique.uniqueNameKind == UniqueNameKind::TEnum) &&
-                   name.unique.original.isClassName(gs);
+            auto unique = dataUnique(gs);
+            return (unique->uniqueNameKind == UniqueNameKind::Singleton ||
+                    unique->uniqueNameKind == UniqueNameKind::MangleRename ||
+                    unique->uniqueNameKind == UniqueNameKind::TEnum) &&
+                   unique->original.isClassName(gs);
         }
-        case NameKind::CONSTANT:
-            ENFORCE(name.cnst.original.kind() == NameKind::UTF8 ||
-                    name.cnst.original.dataUnique(gs)->uniqueNameKind == UniqueNameKind::ResolverMissingClass ||
-                    name.cnst.original.dataUnique(gs)->uniqueNameKind == UniqueNameKind::TEnum);
+        case NameKind::CONSTANT: {
+            auto cnst = dataCnst(gs);
+            ENFORCE(cnst->original.kind() == NameKind::UTF8 ||
+                    cnst->original.dataUnique(gs)->uniqueNameKind == UniqueNameKind::ResolverMissingClass ||
+                    cnst->original.dataUnique(gs)->uniqueNameKind == UniqueNameKind::TEnum);
             return true;
+        }
     }
 }
 
 bool NameRef::isTEnumName(const GlobalState &gs) const {
-    auto &name = data(gs);
-    if (name.kind != NameKind::CONSTANT) {
+    if (kind() != NameKind::CONSTANT) {
         return false;
     }
-    auto original = name.cnst.original;
-    return original.data(gs).kind == NameKind::UNIQUE &&
-           original.data(gs).unique.uniqueNameKind == UniqueNameKind::TEnum;
+    auto original = dataCnst(gs)->original;
+    return original.kind() == NameKind::UNIQUE && original.dataUnique(gs)->uniqueNameKind == UniqueNameKind::TEnum;
 }
 
-NameRefDebugCheck::NameRefDebugCheck(const GlobalState &gs, u4 _id) {
+NameRefDebugCheck::NameRefDebugCheck(const GlobalState &gs, NameKind kind, u4 index) {
     // store the globalStateId of the creating global state to allow sharing refs between siblings
     // when the ref refers to a name in the common ancestor
     globalStateId = gs.globalStateId;
     for (const auto &deepCloneInfo : gs.deepCloneHistory) {
-        if (_id < deepCloneInfo.lastNameKnownByParentGlobalState) {
-            globalStateId = deepCloneInfo.globalStateId;
-            break;
+        switch (kind) {
+            case NameKind::UTF8:
+                if (index < deepCloneInfo.lastUTF8NameKnownByParentGlobalState) {
+                    globalStateId = deepCloneInfo.globalStateId;
+                    return;
+                }
+                break;
+            case NameKind::CONSTANT:
+                if (index < deepCloneInfo.lastConstantNameKnownByParentGlobalState) {
+                    globalStateId = deepCloneInfo.globalStateId;
+                    return;
+                }
+                break;
+            case NameKind::UNIQUE:
+                if (index < deepCloneInfo.lastUniqueNameKnownByParentGlobalState) {
+                    globalStateId = deepCloneInfo.globalStateId;
+                    return;
+                }
+                break;
         }
     }
 }
 
-void NameRefDebugCheck::check(const GlobalState &gs, u4 _id) const {
+void NameRefDebugCheck::check(const GlobalState &gs, NameKind kind, u4 index) const {
     if (globalStateId == -1) {
         return;
     }
-    if (_id <= Names::LAST_WELL_KNOWN_NAME) {
+    if (kind == NameKind::UTF8 && index <= Names::LAST_WELL_KNOWN_UTF8_NAME) {
+        return;
+    }
+    if (kind == NameKind::CONSTANT && index <= Names::LAST_WELL_KNOWN_CONSTANT_NAME) {
         return;
     }
     if (globalStateId == gs.globalStateId) {
         return;
     }
     for (const auto &deepCloneInfo : gs.deepCloneHistory) {
-        if (globalStateId == deepCloneInfo.globalStateId && _id < deepCloneInfo.lastNameKnownByParentGlobalState) {
+        if (globalStateId == deepCloneInfo.globalStateId) {
+            switch (kind) {
+                case NameKind::UTF8:
+                    if (index < deepCloneInfo.lastUTF8NameKnownByParentGlobalState) {
+                        return;
+                    }
+                    break;
+                case NameKind::CONSTANT:
+                    if (index < deepCloneInfo.lastConstantNameKnownByParentGlobalState) {
+                        return;
+                    }
+                    break;
+                case NameKind::UNIQUE:
+                    if (index < deepCloneInfo.lastUniqueNameKnownByParentGlobalState) {
+                        return;
+                    }
+                    break;
+            }
             return;
         }
     }
@@ -248,39 +277,32 @@ void NameRefDebugCheck::check(const GlobalSubstitution &subst) const {
 }
 
 void NameRef::enforceCorrectGlobalState(const GlobalState &gs) const {
-    runDebugOnlyCheck(gs, unsafeTableIndex());
+    runDebugOnlyCheck(gs, kind(), unsafeTableIndex());
 }
 
 void NameRef::sanityCheckSubstitution(const GlobalSubstitution &subst) const {
     runDebugOnlyCheck(subst);
 }
 
-const Name &NameRef::data(const GlobalState &gs) const {
-    ENFORCE(unsafeTableIndex() < gs.names.size(), "name {} id out of bounds {}", _id, gs.names.size());
-    ENFORCE(exists(), "non existing name");
-    enforceCorrectGlobalState(gs);
-    return gs.names[unsafeTableIndex()];
-}
-
 const UniqueNameData NameRef::dataUnique(const GlobalState &gs) const {
     ENFORCE_NO_TIMER(kind() == NameKind::UNIQUE);
-    auto &name = data(gs);
-    ENFORCE_NO_TIMER(name.kind == NameKind::UNIQUE);
-    return UniqueNameData(name.unique, gs);
+    ENFORCE_NO_TIMER(unsafeTableIndex() < gs.uniqueNames.size(), "unique name {} id out of bounds {}",
+                     unsafeTableIndex(), gs.uniqueNames.size());
+    return UniqueNameData(gs.uniqueNames[unsafeTableIndex()], gs);
 }
 
 const UTF8NameData NameRef::dataUtf8(const GlobalState &gs) const {
     ENFORCE_NO_TIMER(kind() == NameKind::UTF8);
-    auto &name = data(gs);
-    ENFORCE(name.kind == NameKind::UTF8);
-    return UTF8NameData(name.raw, gs);
+    ENFORCE_NO_TIMER(unsafeTableIndex() < gs.utf8Names.size(), "utf8 name {} id out of bounds {}", unsafeTableIndex(),
+                     gs.utf8Names.size());
+    return UTF8NameData(gs.utf8Names[unsafeTableIndex()], gs);
 }
 
 const ConstantNameData NameRef::dataCnst(const GlobalState &gs) const {
     ENFORCE_NO_TIMER(kind() == NameKind::CONSTANT);
-    auto &name = data(gs);
-    ENFORCE_NO_TIMER(name.kind == NameKind::CONSTANT);
-    return ConstantNameData(name.cnst, gs);
+    ENFORCE_NO_TIMER(unsafeTableIndex() < gs.constantNames.size(), "constant name {} id out of bounds {}",
+                     unsafeTableIndex(), gs.constantNames.size());
+    return ConstantNameData(gs.constantNames[unsafeTableIndex()], gs);
 }
 
 NameRef NameRef::addEq(GlobalState &gs) const {
@@ -314,37 +336,26 @@ NameRef NameRef::lookupMangledPackageName(const GlobalState &gs) const {
     return gs.lookupNameConstant(nameEq);
 }
 
-Name Name::deepCopy(const GlobalState &to) const {
-    Name out;
-    out.kind = this->kind;
+UTF8Name UTF8Name::deepCopy(const GlobalState &to) const {
+    return UTF8Name{this->utf8};
+}
 
-    switch (this->kind) {
-        case NameKind::UTF8:
-            out.raw = this->raw;
-            break;
+ConstantName ConstantName::deepCopy(const GlobalState &to) const {
+    return ConstantName{NameRef(to, this->original)};
+}
 
-        case NameKind::UNIQUE:
-            out.unique.uniqueNameKind = this->unique.uniqueNameKind;
-            out.unique.num = this->unique.num;
-            out.unique.original = NameRef(to, this->unique.original);
-            break;
-
-        case NameKind::CONSTANT:
-            out.cnst.original = NameRef(to, this->cnst.original);
-            break;
-    }
-
-    return out;
+UniqueName UniqueName::deepCopy(const GlobalState &to) const {
+    return UniqueName{NameRef(to, this->original), this->num, this->uniqueNameKind};
 }
 
 UniqueNameData::UniqueNameData(const UniqueName &ref, const GlobalState &gs) : DebugOnlyCheck(gs), name(ref) {}
 ConstantNameData::ConstantNameData(const ConstantName &ref, const GlobalState &gs) : DebugOnlyCheck(gs), name(ref) {}
 UTF8NameData::UTF8NameData(const UTF8Name &ref, const GlobalState &gs) : DebugOnlyCheck(gs), name(ref) {}
 
-NameDataDebugCheck::NameDataDebugCheck(const GlobalState &gs) : gs(gs), nameCountAtCreation(gs.namesUsed()) {}
+NameDataDebugCheck::NameDataDebugCheck(const GlobalState &gs) : gs(gs), nameCountAtCreation(gs.namesUsedTotal()) {}
 
 void NameDataDebugCheck::check() const {
-    ENFORCE(nameCountAtCreation == gs.namesUsed());
+    ENFORCE(nameCountAtCreation == gs.namesUsedTotal());
 }
 
 const UniqueName *UniqueNameData::operator->() const {

--- a/core/Names.h
+++ b/core/Names.h
@@ -10,7 +10,6 @@
 
 namespace sorbet::core {
 class GlobalState;
-class Name;
 
 inline int _NameKind2Id_UTF8(NameKind nm) {
     ENFORCE(nm == NameKind::UTF8);
@@ -29,6 +28,8 @@ inline int _NameKind2Id_CONSTANT(NameKind nm) {
 
 struct UTF8Name final {
     std::string_view utf8;
+
+    UTF8Name deepCopy(const core::GlobalState &gs) const;
 };
 CheckSize(UTF8Name, 16, 8);
 
@@ -51,43 +52,19 @@ struct UniqueName final {
     NameRef original;
     u4 num;
     UniqueNameKind uniqueNameKind;
+
+    UniqueName deepCopy(const core::GlobalState &gs) const;
 };
 
 CheckSize(UniqueName, 12, 4);
 
 struct ConstantName final {
     NameRef original;
+
+    ConstantName deepCopy(const core::GlobalState &gs) const;
 };
+CheckSize(ConstantName, 4, 4);
 
-class Name final {
-public:
-    friend GlobalState;
-
-    NameKind kind;
-
-private:
-    unsigned char UNUSED(_fill[3]);
-
-public:
-    union { // todo: can discriminate this union through the pointer to Name
-        // itself using lower bits
-        UTF8Name raw;
-        UniqueName unique;
-        ConstantName cnst;
-    };
-
-    Name() noexcept {};
-
-    Name(Name &&other) noexcept = default;
-
-    Name(const Name &other) = delete;
-
-    ~Name() noexcept;
-
-    Name deepCopy(const GlobalState &to) const;
-};
-
-CheckSize(Name, 24, 8);
 } // namespace sorbet::core
 
 #endif // SORBET_NAMES_H

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -110,8 +110,8 @@ TEST_CASE("Substitute") { // NOLINT
     GlobalState gs2(errorQueue);
     gs2.initEmpty();
 
-    NameRef foo1, bar1, other1;
-    NameRef foo2, bar2;
+    NameRef foo1, bar1, other1, cnstBaz1, uniqueBaz1, otherCnstBart1;
+    NameRef foo2, bar2, cnstBaz2, uniqueBaz2;
     {
         UnfreezeNameTable thaw1(gs1);
         UnfreezeNameTable thaw2(gs2);
@@ -119,16 +119,23 @@ TEST_CASE("Substitute") { // NOLINT
         foo1 = gs1.enterNameUTF8("foo");
         bar1 = gs1.enterNameUTF8("bar");
         other1 = gs1.enterNameUTF8("other");
+        cnstBaz1 = gs1.enterNameConstant("Baz");
+        uniqueBaz1 = gs1.freshNameUnique(UniqueNameKind::Namer, cnstBaz1, 1);
+        otherCnstBart1 = gs1.enterNameConstant("Bart");
 
         foo2 = gs2.enterNameUTF8("foo");
+        bar2 = gs2.enterNameUTF8("bar");
+        cnstBaz2 = gs2.enterNameConstant("Baz");
+        uniqueBaz2 = gs2.freshNameUnique(UniqueNameKind::Namer, cnstBaz1, 1);
         gs1.enterNameUTF8("name");
-        bar2 = gs1.enterNameUTF8("bar");
     }
 
     GlobalSubstitution subst(gs1, gs2);
 
     CHECK_EQ(subst.substitute(foo1), foo2);
     CHECK_EQ(subst.substitute(bar1), bar2);
+    CHECK_EQ(subst.substitute(uniqueBaz1), uniqueBaz2);
+    CHECK_EQ(subst.substitute(cnstBaz1), cnstBaz2);
 
     auto other2 = subst.substitute(other1);
     REQUIRE(other2.exists());

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -495,14 +495,18 @@ void emit_register(ostream &out) {
 }
 
 int main(int argc, char **argv) {
-    int i = 0;
+    int constantI = 0;
+    int utf8I = 0;
     for (auto &name : names) {
         if (name.isConstant) {
-            i++;
+            utf8I++;
+            name.id = constantI++;
+        } else {
+            name.id = utf8I++;
         }
-        name.id = i++;
     }
-    int lastId = i;
+    int lastConstantId = constantI;
+    int lastUtf8Id = utf8I;
 
     // emit header file
     {
@@ -531,9 +535,14 @@ int main(int argc, char **argv) {
         }
         header << "}" << '\n';
 
-        header << "#ifndef NAME_LAST_WELL_KNOWN_NAME" << '\n';
-        header << "#define NAME_LAST_WELL_KNOWN_NAME" << '\n';
-        header << "constexpr int LAST_WELL_KNOWN_NAME = " << lastId << ";" << '\n';
+        header << "#ifndef NAME_LAST_WELL_KNOWN_CONSTANT_NAME" << '\n';
+        header << "#define NAME_LAST_WELL_KNOWN_CONSTANT_NAME" << '\n';
+        header << "constexpr int LAST_WELL_KNOWN_CONSTANT_NAME = " << lastConstantId << ";" << '\n';
+        header << "#endif" << '\n';
+
+        header << "#ifndef NAME_LAST_WELL_KNOWN_UTF8_NAME" << '\n';
+        header << "#define NAME_LAST_WELL_KNOWN_UTF8_NAME" << '\n';
+        header << "constexpr int LAST_WELL_KNOWN_UTF8_NAME = " << lastUtf8Id << ";" << '\n';
         header << "#endif" << '\n';
 
         header << "    void registerNames(GlobalState &gs);" << '\n';

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -348,8 +348,15 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
         "reserve-type-member-table-capacity", "Preallocate the specified number of entries in the type member table",
         cxxopts::value<u4>()->default_value(fmt::format("{}", empty.reserveTypeMemberTableCapacity)));
     options.add_options("advanced")(
-        "reserve-name-table-capacity", "Preallocate the specified number of entries in the name table",
-        cxxopts::value<u4>()->default_value(fmt::format("{}", empty.reserveNameTableCapacity)));
+        "reserve-utf8-name-table-capacity", "Preallocate the specified number of entries in the UTF8 name table",
+        cxxopts::value<u4>()->default_value(fmt::format("{}", empty.reserveUtf8NameTableCapacity)));
+    options.add_options("advanced")(
+        "reserve-constant-name-table-capacity",
+        "Preallocate the specified number of entries in the constant name table",
+        cxxopts::value<u4>()->default_value(fmt::format("{}", empty.reserveConstantNameTableCapacity)));
+    options.add_options("advanced")(
+        "reserve-unique-name-table-capacity", "Preallocate the specified number of entries in the unique name table",
+        cxxopts::value<u4>()->default_value(fmt::format("{}", empty.reserveUniqueNameTableCapacity)));
     options.add_options("advanced")("stdout-hup-hack", "Monitor STDERR for HUP and exit on hangup");
     options.add_options("advanced")("remove-path-prefix",
                                     "Remove the provided path prefix from all printed paths. Defaults to the input "
@@ -860,7 +867,9 @@ void readOptions(Options &opts,
                 }
             }
         }
-        opts.reserveNameTableCapacity = raw["reserve-name-table-capacity"].as<u4>();
+        opts.reserveUtf8NameTableCapacity = raw["reserve-utf8-name-table-capacity"].as<u4>();
+        opts.reserveConstantNameTableCapacity = raw["reserve-constant-name-table-capacity"].as<u4>();
+        opts.reserveUniqueNameTableCapacity = raw["reserve-unique-name-table-capacity"].as<u4>();
         opts.reserveClassTableCapacity = raw["reserve-class-table-capacity"].as<u4>();
         opts.reserveMethodTableCapacity = raw["reserve-method-table-capacity"].as<u4>();
         opts.reserveFieldTableCapacity = raw["reserve-field-table-capacity"].as<u4>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -169,7 +169,9 @@ struct Options {
     u4 reserveFieldTableCapacity = 0;
     u4 reserveTypeArgumentTableCapacity = 0;
     u4 reserveTypeMemberTableCapacity = 0;
-    u4 reserveNameTableCapacity = 0;
+    u4 reserveUtf8NameTableCapacity = 0;
+    u4 reserveConstantNameTableCapacity = 0;
+    u4 reserveUniqueNameTableCapacity = 0;
 
     std::string statsdHost;
     std::string statsdPrefix = "ruby_typer.unknown";

--- a/main/options/test/options_test.cc
+++ b/main/options/test/options_test.cc
@@ -52,7 +52,9 @@ TEST_CASE("DefaultConstructorMatchesReadOptions") {
     CHECK_EQ(empty.errorCodeWhiteList, opts.errorCodeWhiteList);
     CHECK_EQ(empty.errorCodeBlackList, opts.errorCodeBlackList);
     CHECK_EQ(empty.pathPrefix, opts.pathPrefix);
-    CHECK_EQ(empty.reserveNameTableCapacity, opts.reserveNameTableCapacity);
+    CHECK_EQ(empty.reserveUtf8NameTableCapacity, opts.reserveUtf8NameTableCapacity);
+    CHECK_EQ(empty.reserveConstantNameTableCapacity, opts.reserveConstantNameTableCapacity);
+    CHECK_EQ(empty.reserveUniqueNameTableCapacity, opts.reserveUniqueNameTableCapacity);
     CHECK_EQ(empty.reserveClassTableCapacity, opts.reserveClassTableCapacity);
     CHECK_EQ(empty.reserveMethodTableCapacity, opts.reserveMethodTableCapacity);
     CHECK_EQ(empty.reserveFieldTableCapacity, opts.reserveFieldTableCapacity);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -461,7 +461,8 @@ int realmain(int argc, char *argv[]) {
     }
     gs->preallocateTables(opts.reserveClassTableCapacity, opts.reserveMethodTableCapacity,
                           opts.reserveFieldTableCapacity, opts.reserveTypeArgumentTableCapacity,
-                          opts.reserveTypeMemberTableCapacity, opts.reserveNameTableCapacity);
+                          opts.reserveTypeMemberTableCapacity, opts.reserveUtf8NameTableCapacity,
+                          opts.reserveConstantNameTableCapacity, opts.reserveUniqueNameTableCapacity);
     for (auto code : opts.errorCodeWhiteList) {
         gs->onlyShowErrorClass(code);
     }

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -77,7 +77,7 @@ TEST_CASE("namer tests") {
     SUBCASE("Idempotent") { // NOLINT
         auto baseSymbols = gs.symbolsUsedTotal();
         auto baseMethods = gs.methodsUsed();
-        auto baseNames = gs.namesUsed();
+        auto baseNames = gs.namesUsedTotal();
 
         auto tree = hello_world(gs);
         ast::ParsedFile treeCopy{tree.tree.deepCopy(), tree.file};
@@ -94,7 +94,7 @@ TEST_CASE("namer tests") {
 
         REQUIRE_EQ(baseSymbols + extraSymbols, gs.symbolsUsedTotal());
         REQUIRE_EQ(baseMethods + extraSymbols, gs.methodsUsed());
-        REQUIRE_EQ(baseNames + 2, gs.namesUsed());
+        REQUIRE_EQ(baseNames + 2, gs.namesUsedTotal());
 
         // Run it again and get the same numbers
         auto localTree = sorbet::local_vars::LocalVars::run(gs, move(treeCopy));
@@ -102,7 +102,7 @@ TEST_CASE("namer tests") {
 
         REQUIRE_EQ(baseSymbols + extraSymbols, gs.symbolsUsedTotal());
         REQUIRE_EQ(baseMethods + extraSymbols, gs.methodsUsed());
-        REQUIRE_EQ(baseNames + 2, gs.namesUsed());
+        REQUIRE_EQ(baseNames + 2, gs.namesUsedTotal());
     }
 
     SUBCASE("NameClass") { // NOLINT

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -732,10 +732,10 @@ vector<ast::ParsedFile> Packager::runIncremental(core::GlobalState &gs, vector<a
     // TODO(jvilk): This incremental pass reprocesses every package file in the project. It should instead only process
     // the packages needed to understand file changes.
     ENFORCE(checkContainsAllPackages(gs, files));
-    auto namesUsed = gs.namesUsed();
+    auto namesUsed = gs.namesUsedTotal();
     auto emptyWorkers = WorkerPool::create(0, gs.tracer());
     files = Packager::run(gs, *emptyWorkers, move(files));
-    ENFORCE(gs.namesUsed() == namesUsed);
+    ENFORCE(gs.namesUsedTotal() == namesUsed);
     return files;
 }
 

--- a/payload/payload.cc
+++ b/payload/payload.cc
@@ -42,10 +42,19 @@ void createInitialGlobalState(unique_ptr<core::GlobalState> &gs, const realmain:
         Timer timeit(gs->tracer(), "read_global_state.binary");
         core::serialize::Serializer::loadGlobalState(*gs, nameTablePayload);
     }
-    ENFORCE(gs->namesUsed() < core::GlobalState::PAYLOAD_MAX_NAME_COUNT,
-            "Payload defined `{}` names, which is greater than the expected maximum of `{}`. Consider updating "
-            "`PAYLOAD_MAX_NAME_COUNT` in `GlobalState`.",
-            gs->namesUsed(), core::GlobalState::PAYLOAD_MAX_NAME_COUNT);
+    ENFORCE(gs->utf8NamesUsed() < core::GlobalState::PAYLOAD_MAX_UTF8_NAME_COUNT,
+            "Payload defined `{}` UTF8 names, which is greater than the expected maximum of `{}`. Consider updating "
+            "`PAYLOAD_MAX_UTF8_NAME_COUNT` in `GlobalState`.",
+            gs->utf8NamesUsed(), core::GlobalState::PAYLOAD_MAX_UTF8_NAME_COUNT);
+    ENFORCE(
+        gs->constantNamesUsed() < core::GlobalState::PAYLOAD_MAX_CONSTANT_NAME_COUNT,
+        "Payload defined `{}` Constant names, which is greater than the expected maximum of `{}`. Consider updating "
+        "`PAYLOAD_MAX_CONSTANT_NAME_COUNT` in `GlobalState`.",
+        gs->constantNamesUsed(), core::GlobalState::PAYLOAD_MAX_CONSTANT_NAME_COUNT);
+    ENFORCE(gs->uniqueNamesUsed() < core::GlobalState::PAYLOAD_MAX_UNIQUE_NAME_COUNT,
+            "Payload defined `{}` Unique names, which is greater than the expected maximum of `{}`. Consider updating "
+            "`PAYLOAD_MAX_UNIQUE_NAME_COUNT` in `GlobalState`.",
+            gs->uniqueNamesUsed(), core::GlobalState::PAYLOAD_MAX_UNIQUE_NAME_COUNT);
     ENFORCE(gs->fieldsUsed() < core::GlobalState::PAYLOAD_MAX_FIELD_COUNT,
             "Payload defined `{}` fields, which is greater than the expected maximum of `{}`. Consider updating "
             "`PAYLOAD_MAX_FIELD_COUNT` in `GlobalState`.",

--- a/test/cli/cache-reserve-mem/cache-reserve-mem.sh
+++ b/test/cli/cache-reserve-mem/cache-reserve-mem.sh
@@ -5,6 +5,6 @@ cleanup() {
 }
 trap cleanup EXIT
 set -e
-main/sorbet --silence-dev-message -vvv --reserve-class-table-capacity 4000 --reserve-method-table-capacity 4000 --reserve-field-table-capacity 4000 --reserve-type-argument-table-capacity 4000 --reserve-type-member-table-capacity 4000 --reserve-name-table-capacity 4000 --cache-dir "$dir" test/cli/cache-reserve-mem/input.rb
-main/sorbet --silence-dev-message -vvv --reserve-class-table-capacity 4000 --reserve-method-table-capacity 4000 --reserve-field-table-capacity 4000 --reserve-type-argument-table-capacity 4000 --reserve-type-member-table-capacity 4000 --reserve-name-table-capacity 4000 --cache-dir "$dir" test/cli/cache-reserve-mem/input.rb
+main/sorbet --silence-dev-message -vvv --reserve-class-table-capacity 4000 --reserve-method-table-capacity 4000 --reserve-field-table-capacity 4000 --reserve-type-argument-table-capacity 4000 --reserve-type-member-table-capacity 4000 --reserve-utf8-name-table-capacity 4000 --reserve-constant-name-table-capacity 4000 --reserve-unique-name-table-capacity 4000 --cache-dir "$dir" test/cli/cache-reserve-mem/input.rb
+main/sorbet --silence-dev-message -vvv --reserve-class-table-capacity 4000 --reserve-method-table-capacity 4000 --reserve-field-table-capacity 4000 --reserve-type-argument-table-capacity 4000 --reserve-type-member-table-capacity 4000 --reserve-utf8-name-table-capacity 4000 --reserve-constant-name-table-capacity 4000 --reserve-unique-name-table-capacity 4000 --cache-dir "$dir" test/cli/cache-reserve-mem/input.rb
 echo '--reserve-*-table-capacity OK'

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -67,9 +67,15 @@ Usage:
       --reserve-type-member-table-capacity arg
                                 Preallocate the specified number of entries
                                 in the type member table (default: 0)
-      --reserve-name-table-capacity arg
+      --reserve-utf8-name-table-capacity arg
                                 Preallocate the specified number of entries
-                                in the name table (default: 0)
+                                in the UTF8 name table (default: 0)
+      --reserve-constant-name-table-capacity arg
+                                Preallocate the specified number of entries
+                                in the constant name table (default: 0)
+      --reserve-unique-name-table-capacity arg
+                                Preallocate the specified number of entries
+                                in the unique name table (default: 0)
       --stdout-hup-hack         Monitor STDERR for HUP and exit on hangup
       --remove-path-prefix prefix
                                 Remove the provided path prefix from all


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Break up name table by name type.

The name table currently contains a vector of 24-byte Name objects. A full 8 bytes of this object is devoted to a one-byte tag, which indicates if the name is a UTF8Name, ConstantName, or a UniqueName. Furthermore, ConstantName and UniqueNames take fewer than 16 bytes and have even more padding.

This PR splits the name table into separate vectors for UTF8Names, ConstantNames, and UniqueNames. UTF8Names are 16 bytes (33% savings), ConstantNames are 4 bytes (83% savings), and UniqueNames are 12 bytes (50% savings).

On large codebases typechecked on machines with many cores and with a cached name table, this PR reduces max RSS induced during the parallel indexing phase, which duplicates the name table once per core. This change also causes a small typechecking speedup.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Reduce max RSS.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests. The GlobalSubstitution test has been updated to cover an additional corner case.
