### PR TITLE
Skip syntactically invalid class names when serializing

### DIFF
--- a/gems/sorbet/lib/serialize.rb
+++ b/gems/sorbet/lib/serialize.rb
@@ -253,7 +253,7 @@ class Sorbet::Private::Serialize
 
   def valid_class_name(name)
     name.split("::").each do |piece|
-      return false if piece[0].upcase != piece[0]
+      return false unless piece =~ /^[[:upper:]][[:word:]]*$/
     end
     return false if [
       'Sorbet::Private::GemGeneratorTracepoint::Tracer::ClassOverride',


### PR DESCRIPTION
When running `srb rbi hidden-definitions` in my project, I was encountering a persistent error:
```
Generating /tmp/d20201212-15780-1vce1q8/reflection.rbi with 6155 modules and 132 aliases
Printing your code's symbol table into /tmp/d20201212-15780-1vce1q8/from-source.json
Printing /tmp/d20201212-15780-1vce1q8/reflection.rbi's symbol table into /tmp/d20201212-15780-1vce1q8/reflection.json
Traceback (most recent call last):
	5: from /home/chris/.rvm/gems/ruby-2.6.6@mixdr/gems/sorbet-0.5.6134/bin/srb-rbi:237:in `<main>'
	4: from /home/chris/.rvm/gems/ruby-2.6.6@mixdr/gems/sorbet-0.5.6134/bin/srb-rbi:224:in `main'
	3: from /home/chris/.rvm/gems/ruby-2.6.6@mixdr/gems/sorbet-0.5.6134/bin/srb-rbi:232:in `block in make_step'
	2: from /home/chris/.rvm/gems/ruby-2.6.6@mixdr/gems/sorbet-0.5.6134/lib/hidden-definition-finder.rb:38:in `main'
	1: from /home/chris/.rvm/gems/ruby-2.6.6@mixdr/gems/sorbet-0.5.6134/lib/hidden-definition-finder.rb:47:in `main'
/home/chris/.rvm/gems/ruby-2.6.6@mixdr/gems/sorbet-0.5.6134/lib/hidden-definition-finder.rb:151:in `write_constants': /tmp/d20201212-15780-1vce1q8/reflection.rbi had unexpected errors. Check this file for a clue: /tmp/d20201212-15780-1vce1q8/reflection.json.err (RuntimeError)
```

The error details show it's a syntax problem in the generated file:
```
/tmp/d20201212-15780-1vce1q8/reflection.rbi:13: unexpected token tNL https://srb.help/2001
    13 |  end
    14 |  def proper_table_name(*args); end

/tmp/d20201212-15780-1vce1q8/reflection.rbi:15: unexpected token "end" https://srb.help/2001
    15 |end
...
```

And in the generated file, we can see we've written out a class name that is interpreted as a comment:
```ruby
module #<Class:0x000056403a83ee08>::ProperTableNameWithHashAwarenessSupport
  # Skipping `extend Sorbet::Private::GemGeneratorTracepoint::Tracer::ModuleOverride` because it is an invalid name
  sig do
    params(
      args: ::T.untyped,
    )
    .returns(::T.untyped)
  end
  def proper_table_name(*args); end
end
```

This appears to be related to [this file](https://github.com/jenseng/hair_trigger/blob/89eefa2afdfaf6bec634bb9c411ce4500b8fcc97/lib/hair_trigger/migrator.rb) in the `hairtrigger` gem.

I couldn't figure out the right way to reproduce this in tests; but my proposed change does solve the problem in my actual project. I'm happy to add a test case if someone can point me to the right example to emulate.