### PR TITLE
Add a packager test for nested inner package namespaces.

### DIFF
--- a/test/testdata/packager/nested_inner_namespaces/__package.rb
+++ b/test/testdata/packager/nested_inner_namespaces/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class RootPackage < PackageSpec
+  import RootPackage::Foo
+end

--- a/test/testdata/packager/nested_inner_namespaces/__package.rb.package-tree.exp
+++ b/test/testdata/packager/nested_inner_namespaces/__package.rb.package-tree.exp
@@ -1,0 +1,67 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C RootPackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C RootPackage>::<C Foo>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Package><<C <todo sym>>> < ()
+    module <emptyTree>::<C RootPackage>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package>::<C Foo>
+
+      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package>::<C Foo>::<C Bar>
+
+      <emptyTree>::<C Baz> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package>::<C Foo>::<C Bar>::<C Baz>
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Package><<C <todo sym>>> < ()
+    module <emptyTree>::<C Bar><<C <todo sym>>> < ()
+      ::Sorbet::Private::Static.sig(<self>) do ||
+        <self>.params(:a, <emptyTree>::<C Integer>).returns(<emptyTree>::<C String>)
+      end
+
+      def main<<C <todo sym>>>(a, &<blk>)
+        if a.>(10)
+          <emptyTree>::<C RootPackage>::<C Foo>::<C Foo>::<C Constant>
+        else
+          if a.<(4)
+            <emptyTree>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>
+          else
+            <emptyTree>::<C RootPackage>::<C Foo>::<C Baz>::<C Constant>
+          end
+        end
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      ::Sorbet::Private::Static.keep_def(<self>, :main)
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C RootPackage>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package>::<C Foo>)
+
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package>::<C Foo>::<C Bar>)
+
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package>::<C Foo>::<C Bar>::<C Baz>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package><<C <todo sym>>> < ()
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package><<C <todo sym>>> < ()
+    module <emptyTree>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C Constant> = "Foo"
+
+      module <emptyTree>::<C Bar><<C <todo sym>>> < ()
+        <emptyTree>::<C Constant> = "Bar"
+
+        module <emptyTree>::<C Baz><<C <todo sym>>> < ()
+          <emptyTree>::<C Constant> = "Baz"
+        end
+      end
+    end
+  end
+end

--- a/test/testdata/packager/nested_inner_namespaces/bar.rb
+++ b/test/testdata/packager/nested_inner_namespaces/bar.rb
@@ -1,0 +1,19 @@
+# typed: strict
+
+module Bar
+  extend T::Sig
+
+  sig {params(a: Integer).returns(String)}
+  def main(a)
+    if a > 10
+      RootPackage::Foo::Foo::Constant
+      #                      ^^^^^^^^ hover: String("Foo")
+    elsif a < 4
+      RootPackage::Foo::Bar::Constant
+      #                      ^^^^^^^^ hover: String("Bar")
+    else
+      RootPackage::Foo::Baz::Constant
+      #                      ^^^^^^^^ hover: String("Baz")
+    end
+  end
+end

--- a/test/testdata/packager/nested_inner_namespaces/foo/__package.rb
+++ b/test/testdata/packager/nested_inner_namespaces/foo/__package.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class RootPackage::Foo < PackageSpec
+  export Foo
+  export Foo::Bar
+  export Foo::Bar::Baz
+end

--- a/test/testdata/packager/nested_inner_namespaces/foo/foo.rb
+++ b/test/testdata/packager/nested_inner_namespaces/foo/foo.rb
@@ -1,0 +1,11 @@
+# typed: strict
+
+module Foo
+  Constant = "Foo"
+  module Bar
+    Constant = "Bar"
+    module Baz
+      Constant = "Baz"
+    end
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Add a packager test for nested inner package namespaces.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

@nroman-stripe and @jez were confused as to how the packager pass dealt with inner package namespaces that get exported. I added the following test and confirmed that exports are flattened as expected.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This is just a test; no code has changed. :)
