### PR TITLE
Fix signature for `Kernel.raise`.

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -2663,7 +2663,7 @@ module Kernel
     params(
         arg0: Class,
         arg1: T.untyped,
-        arg2: T::Array[String],
+        arg2: T.nilable(T::Array[String]),
     )
     .returns(T.noreturn)
   end
@@ -2671,7 +2671,7 @@ module Kernel
     params(
         arg0: Exception,
         arg1: T.untyped,
-        arg2: T::Array[String],
+        arg2: T.nilable(T::Array[String]),
     )
     .returns(T.noreturn)
   end

--- a/test/testdata/rbi/kernel.rb
+++ b/test/testdata/rbi/kernel.rb
@@ -24,6 +24,10 @@ end
 define_singleton_method(:foo) { puts '' }
 define_singleton_method('foo') { puts '' }
 
+def raise_test
+  raise ArgumentError, 'bad argument', nil
+end
+
 # make sure we don't regress and mark these as errors
 env = {'VAR' => 'VAL'}
 system('echo')


### PR DESCRIPTION
### Motivation

The three-argument form permits a `nil` third argument.

https://sorbet.run/#%23%20typed%3A%20true%0A%0Adef%20bar(x)%0A%20%20%20%20raise%20ArgumentError%2C%20%22bad%20arguments%3A%20%23%7Bx%7D%22%2C%20nil%20unless%20x%20%3D%3D%201%0A%20%20%20%20raise%20ArgumentError%2C%20%22bad%20arguments%3A%20%23%7Bx%7D%22%0Aend%0A%0Abar(40)

```ruby
# typed: true

def bar(x)
    raise ArgumentError, "bad arguments: #{x}", nil unless x == 1
    raise ArgumentError, "bad arguments: #{x}"
end

bar(40)
```

Returns:

```
editor.rb:4: Expected T::Array[String] but found NilClass for argument arg2 https://srb.help/7002
     4 |    raise ArgumentError, "bad arguments: #{x}", nil unless x == 1
                                                        ^^^
    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2666: Method Kernel#raise (overload.2) has specified arg2 as T::Array[String]
    2666 |        arg2: T::Array[String],
                  ^^^^
  Got NilClass originating from:
    editor.rb:4:
     4 |    raise ArgumentError, "bad arguments: #{x}", nil unless x == 1
                                                        ^^^
Errors: 1
```

But this is valid Ruby code:

```console
% ruby -e 'raise ArgumentError, "bad arguments", nil'
Traceback (most recent call last):
-e:1:in `<main>': bad arguments (ArgumentError)
```

### Test plan

See included tests.