### PR TITLE
WIP Resolve constants: Create per-file vectors to make serial sorting faster

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -938,7 +938,7 @@ public:
             {
                 Timer timeit(gs.tracer(), "resolver.resolve_constants.fixed_point.constants");
                 u4 retry = 0;
-                for (auto &todosForFile : todos) {
+                auto it = remove_if(todos.begin(), todos.end(), [&gs, &retry](auto &todosForFile) -> bool {
                     auto &todo = todosForFile.todo;
                     auto file = todosForFile.file;
                     int origSize = todo.size();
@@ -948,7 +948,9 @@ public:
                     });
                     todo.erase(it, todo.end());
                     retry += origSize - todo.size();
-                }
+                    return todosForFile.todo.empty() && todosForFile.todoAncestors.empty();
+                });
+                todos.erase(it, todos.end());
                 progress = progress || retry > 0;
                 categoryCounterAdd("resolve.constants.nonancestor", "retry", retry);
             }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -869,6 +869,7 @@ public:
         vector<ClassMethodsResolutionItem> todoClassMethods;
 
         {
+            Timer timeit1(gs.tracer(), "resolver.resolve_constants.merging");
             ResolveWalkResult threadResult;
             for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer());
                  !result.done();
@@ -891,17 +892,20 @@ public:
             }
         }
 
-        fast_sort(todos, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
-        fast_sort(todoClassAliases, [](const auto &lhs, const auto &rhs) -> bool {
-            return locCompare(core::Loc(lhs.file, lhs.rhs->loc), core::Loc(rhs.file, rhs.rhs->loc));
-        });
-        fast_sort(todoTypeAliases, [](const auto &lhs, const auto &rhs) -> bool {
-            return locCompare(core::Loc(lhs.file, (*lhs.rhs).loc()), core::Loc(rhs.file, (*rhs.rhs).loc()));
-        });
-        fast_sort(todoClassMethods, [](const auto &lhs, const auto &rhs) -> bool {
-            return locCompare(core::Loc(lhs.file, lhs.send->loc), core::Loc(rhs.file, rhs.send->loc));
-        });
-        fast_sort(trees, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
+        {
+            Timer timeit1(gs.tracer(), "resolver.resolve_constants.sorting");
+            fast_sort(todos, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
+            fast_sort(todoClassAliases, [](const auto &lhs, const auto &rhs) -> bool {
+                return locCompare(core::Loc(lhs.file, lhs.rhs->loc), core::Loc(rhs.file, rhs.rhs->loc));
+            });
+            fast_sort(todoTypeAliases, [](const auto &lhs, const auto &rhs) -> bool {
+                return locCompare(core::Loc(lhs.file, (*lhs.rhs).loc()), core::Loc(rhs.file, (*rhs.rhs).loc()));
+            });
+            fast_sort(todoClassMethods, [](const auto &lhs, const auto &rhs) -> bool {
+                return locCompare(core::Loc(lhs.file, lhs.send->loc), core::Loc(rhs.file, rhs.send->loc));
+            });
+            fast_sort(trees, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
+        }
 
         Timer timeit1(gs.tracer(), "resolver.resolve_constants.fixed_point");
 


### PR DESCRIPTION
WIP Resolve constants: Create per-file vectors to make serial sorting faster.

Attempts to reduce a serial bottleneck on large codebases (appending and sorting very large arrays).

Since the previous vectors were sorted by file first followed by loc, this does not change behavior/sort order 🎉  As a bonus, we can sort the per-file vectors in parallel, and stash fref on the struct holding the vectors.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I noticed that vector insertion/sorting takes up a noticeable amount of time on Stripe's codebase. This type of solution worked well for the other resolver passes which previously had the same problem.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
