### PR TITLE
Make ResolveSignaturesWalk a shallow map.

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2835,7 +2835,7 @@ ast::ParsedFilesOrCancelled Resolver::resolveSigs(core::GlobalState &gs, vector<
         for (auto result = inputq->try_pop(job); !result.done(); result = inputq->try_pop(job)) {
             if (result.gotItem()) {
                 core::Context ctx(gs, core::Symbols::root(), job.file);
-                job.tree = ast::TreeMap::apply(ctx, walk, std::move(job.tree));
+                job.tree = ast::ShallowMap::apply(ctx, walk, std::move(job.tree));
                 output.trees.emplace_back(move(job));
             }
         }


### PR DESCRIPTION
Make ResolveSignaturesWalk a shallow map.

I accidentally reverted this change with my parallelization work.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed!

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
