### PR TITLE
Add T::Configuration#module_name_mangler

### DIFF
--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -363,7 +363,16 @@ module T::Configuration
     @scalar_types || @default_scalar_types
   end
 
+  # Guard against overrides of `name` or `to_s`
+  MODULE_NAME = Module.instance_method(:name)
+  private_constant :MODULE_NAME
+
+  @default_module_name_mangler = ->(type) {MODULE_NAME.bind(type).call}
   @module_name_mangler = nil
+
+  def self.module_name_mangler
+    @module_name_mangler || @default_module_name_mangler
+  end
 
   # Set to override the default behavior for converting types
   #   to names in generated code. Used by the runtime implementation
@@ -373,10 +382,6 @@ module T::Configuration
   #   to a String (pass nil to reset to default behavior)
   def self.module_name_mangler=(handler)
     @module_name_mangler = handler
-  end
-
-  def self.module_name_mangler
-    @module_name_mangler
   end
 
   # Temporarily disable ruby warnings while executing the given block. This is

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -363,6 +363,22 @@ module T::Configuration
     @scalar_types || @default_scalar_types
   end
 
+  @module_name_mangler = nil
+
+  # Set to override the default behavior for converting types
+  #   to names in generated code. Used by the runtime implementation
+  #   associated with `--stripe-packages` mode.
+  #
+  # @param [Lambda, Proc, nil] value Proc that converts a type (Class/Module)
+  #   to a String (pass nil to reset to default behavior)
+  def self.module_name_mangler=(handler)
+    @module_name_mangler = handler
+  end
+
+  def self.module_name_mangler
+    @module_name_mangler
+  end
+
   # Temporarily disable ruby warnings while executing the given block. This is
   # useful when doing something that would normally cause a warning to be
   # emitted in Ruby verbose mode ($VERBOSE = true).

--- a/gems/sorbet-runtime/lib/types/props/private/serde_transform.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/serde_transform.rb
@@ -183,7 +183,12 @@ module T::Props
 
       sig {params(type: Module).returns(T.nilable(String)).checked(:never)}
       private_class_method def self.module_name(type)
-        MODULE_NAME.bind(type).call
+        mangler = T::Configuration.module_name_mangler
+        if mangler
+          mangler.call(type)
+        else
+          MODULE_NAME.bind(type).call
+        end
       end
     end
   end

--- a/gems/sorbet-runtime/lib/types/props/private/serde_transform.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/serde_transform.rb
@@ -177,18 +177,9 @@ module T::Props
         end
       end
 
-      # Guard against overrides of `name` or `to_s`
-      MODULE_NAME = T.let(Module.instance_method(:name), UnboundMethod)
-      private_constant :MODULE_NAME
-
       sig {params(type: Module).returns(T.nilable(String)).checked(:never)}
       private_class_method def self.module_name(type)
-        mangler = T::Configuration.module_name_mangler
-        if mangler
-          mangler.call(type)
-        else
-          MODULE_NAME.bind(type).call
-        end
+        T::Configuration.module_name_mangler.call(type)
       end
     end
   end

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -773,6 +773,23 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
           T::Props::GeneratedCodeValidation.validate_deserialize(src)
         end
       end
+
+      describe 'with custom module_name_mangler' do
+        before do
+          T::Configuration.module_name_mangler = ->(type) {"MANGLED::#{type}"}
+        end
+
+        after do
+          T::Configuration.module_name_mangler = nil
+        end
+
+        it 'mangles the custom type names in generated code' do
+          src = ComplexStruct.decorator.send(:generate_deserialize_source).to_s
+          T::Props::GeneratedCodeValidation.validate_deserialize(src)
+          assert_includes(src, "MANGLED::#{MySerializable}")
+          assert_includes(src, "MANGLED::#{CustomType}")
+        end
+      end
     end
 
     describe 'disabling evaluation' do


### PR DESCRIPTION
Add a configuration hook that allows a customized type -> string transform to be provided that's used during prop code-generation.


### Motivation
The runtime implementation of `--stripe-packages` mode loads classes in anonymous modules (one per package) instead of at the root-level in order to constant resolution within each package. The names returned by `Module#name` are not resolvable from the scope from which the generated code is `class_eval`d. 

The hook here allows us to manipulate the name into one that is resolvable. Default behavior of using `Module#name` implementation is unchanged.
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
Added automated test