### PR TITLE
Consider methods defined with `override` to also be `overridable`

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -329,8 +329,9 @@ void validateOverriding(const core::Context ctx, core::SymbolRef method) {
         }
         auto isRBI = absl::c_any_of(method.data(ctx)->locs(), [&](auto &loc) { return loc.file().data(ctx).isRBI(); });
         if (!method.data(ctx)->isOverride() && method.data(ctx)->hasSig() &&
-            overridenMethod.data(ctx)->isOverridable() && !anyIsInterface && overridenMethod.data(ctx)->hasSig() &&
-            !method.data(ctx)->isRewriterSynthesized() && !isRBI) {
+            (overridenMethod.data(ctx)->isOverridable() || overridenMethod.data(ctx)->isOverride()) &&
+            !anyIsInterface && overridenMethod.data(ctx)->hasSig() && !method.data(ctx)->isRewriterSynthesized() &&
+            !isRBI) {
             if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::UndeclaredOverride)) {
                 e.setHeader("Method `{}` overrides an overridable method `{}` but is not declared with `{}`",
                             method.data(ctx)->show(ctx), overridenMethod.data(ctx)->show(ctx), "override.");

--- a/test/testdata/resolver/overrides.rb
+++ b/test/testdata/resolver/overrides.rb
@@ -56,6 +56,14 @@ class B5 < A5
   def foo; end
 end
 
+# however, not using override when overriding B5#foo should be an error
+class C5 < B5
+  extend T::Sig
+  sig {void}
+  def foo; end
+# ^^^^^^^ error: Method `C5#foo` overrides an overridable method
+end
+
 class A6
   extend T::Sig
   sig {void}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
When overriding a method whose signature is marked as `override`, require that signature to also have `override`. The reasoning here is that if the parent signature is valid then it must either be overriding something that is `abstract` or `overridable`, or be overriding something that is marked `override` in which case we proceed recursively.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Incrementally work towards stricter override checking.

Partially addresses #2746.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
