### PR TITLE
Move the rename feature out of experimental status

### DIFF
--- a/main/lsp/requests/initialize.cc
+++ b/main/lsp/requests/initialize.cc
@@ -39,9 +39,7 @@ unique_ptr<ResponseMessage> InitializeTask::runRequest(LSPTypecheckerDelegate &t
         serverCap->signatureHelpProvider = move(sigHelpProvider);
     }
 
-    if (opts.lspRenameEnabled) {
-        serverCap->renameProvider = make_unique<RenameOptions>(true);
-    }
+    serverCap->renameProvider = make_unique<RenameOptions>(true);
 
     auto completionProvider = make_unique<CompletionOptions>();
     completionProvider->triggerCharacters = {"."};

--- a/main/lsp/requests/prepare_rename.cc
+++ b/main/lsp/requests/prepare_rename.cc
@@ -52,11 +52,6 @@ unique_ptr<ResponseMessage> PrepareRenameTask::runRequest(LSPTypecheckerDelegate
     const core::GlobalState &gs = typechecker.state();
 
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentPrepareRename);
-    if (!config.opts.lspRenameEnabled) {
-        response->error = make_unique<ResponseError>(
-            (int)LSPErrorCodes::InvalidRequest, "The `Rename` LSP feature is experimental and disabled by default.");
-        return response;
-    }
 
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.prepareRename");
     auto result = queryByLoc(typechecker, params->textDocument->uri, *params->position,

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -378,11 +378,6 @@ unique_ptr<ResponseMessage> RenameTask::runRequest(LSPTypecheckerDelegate &typec
     const core::GlobalState &gs = typechecker.state();
 
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentRename);
-    if (!config.opts.lspRenameEnabled) {
-        response->error = make_unique<ResponseError>(
-            (int)LSPErrorCodes::InvalidRequest, "The `Rename` LSP feature is experimental and disabled by default.");
-        return response;
-    }
 
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.rename");
 

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -159,7 +159,6 @@ void LSPWrapper::enableAllExperimentalFeatures() {
     enableExperimentalFeature(LSPExperimentalFeature::DocumentSymbol);
     enableExperimentalFeature(LSPExperimentalFeature::SignatureHelp);
     enableExperimentalFeature(LSPExperimentalFeature::DocumentFormat);
-    enableExperimentalFeature(LSPExperimentalFeature::Rename);
 }
 
 void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
@@ -175,9 +174,6 @@ void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
             break;
         case LSPExperimentalFeature::DocumentFormat:
             opts->lspDocumentFormatRubyfmtEnabled = true;
-            break;
-        case LSPExperimentalFeature::Rename:
-            opts->lspRenameEnabled = true;
             break;
     }
 }

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -52,7 +52,6 @@ public:
         SignatureHelp = 7,
         DocumentHighlight = 9,
         DocumentFormat = 10,
-        Rename = 11,
     };
 
     // N.B.: Sorbet assumes we 'own' this object; keep it alive to avoid memory errors.

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -382,7 +382,6 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                     "Enable experimental LSP feature: Document Highlight");
     options.add_options("advanced")("enable-experimental-lsp-signature-help",
                                     "Enable experimental LSP feature: Signature Help");
-    options.add_options("advanced")("enable-experimental-lsp-rename", "Enable experimental LSP feature: Rename");
 
     options.add_options("advanced")(
         "enable-all-experimental-lsp-features",
@@ -740,7 +739,6 @@ void readOptions(Options &opts,
         opts.lspSignatureHelpEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-signature-help"].as<bool>();
         opts.lspDocumentFormatRubyfmtEnabled =
             enableAllLSPFeatures || raw["enable-experimental-lsp-document-formatting-rubyfmt"].as<bool>();
-        opts.lspRenameEnabled = opts.lspAllBetaFeaturesEnabled || raw["enable-experimental-lsp-rename"].as<bool>();
 
         if (raw.count("lsp-directories-missing-from-client") > 0) {
             auto lspDirsMissingFromClient = raw["lsp-directories-missing-from-client"].as<vector<string>>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -212,7 +212,6 @@ struct Options {
     bool lspDocumentSymbolEnabled = false;
     bool lspDocumentFormatRubyfmtEnabled = false;
     bool lspSignatureHelpEnabled = false;
-    bool lspRenameEnabled = false;
 
     std::string inlineInput; // passed via -e
     std::string debugLogFile;

--- a/main/options/test/options_test.cc
+++ b/main/options/test/options_test.cc
@@ -82,5 +82,4 @@ TEST_CASE("DefaultConstructorMatchesReadOptions") {
     CHECK_EQ(empty.webTraceFile, opts.webTraceFile);
     CHECK_EQ(empty.stripeMode, opts.stripeMode);
     CHECK_EQ(empty.stripePackages, opts.stripePackages);
-    CHECK_EQ(empty.lspRenameEnabled, opts.lspRenameEnabled);
 }

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -106,8 +106,6 @@ Usage:
       --enable-experimental-lsp-signature-help
                                 Enable experimental LSP feature: Signature
                                 Help
-      --enable-experimental-lsp-rename
-                                Enable experimental LSP feature: Rename
       --enable-all-experimental-lsp-features
                                 Enable every experimental LSP feature.
                                 (WARNING: can be crashy; for developer use only. End

--- a/test/cli/lsp-common-case-exit/lsp-common-case-exit.out
+++ b/test/cli/lsp-common-case-exit/lsp-common-case-exit.out
@@ -1,5 +1,5 @@
-Content-Length: 462
+Content-Length: 504
 
-{"jsonrpc":"2.0","id":0,"requestMethod":"initialize","result":{"capabilities":{"textDocumentSync":1,"hoverProvider":true,"completionProvider":{"triggerCharacters":["."]},"definitionProvider":true,"typeDefinitionProvider":true,"referencesProvider":true,"documentHighlightProvider":false,"documentSymbolProvider":false,"workspaceSymbolProvider":true,"codeActionProvider":{"codeActionKinds":["quickfix","source.fixAll.sorbet"]},"documentFormattingProvider":false}}}Content-Length: 65
+{"jsonrpc":"2.0","id":0,"requestMethod":"initialize","result":{"capabilities":{"textDocumentSync":1,"hoverProvider":true,"completionProvider":{"triggerCharacters":["."]},"definitionProvider":true,"typeDefinitionProvider":true,"referencesProvider":true,"documentHighlightProvider":false,"documentSymbolProvider":false,"workspaceSymbolProvider":true,"codeActionProvider":{"codeActionKinds":["quickfix","source.fixAll.sorbet"]},"documentFormattingProvider":false,"renameProvider":{"prepareProvider":true}}}}Content-Length: 65
 
 {"jsonrpc":"2.0","id":1,"requestMethod":"shutdown","result":null}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Remove Renames from the set of experimental features; remove the config flag which enables it.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The rename feature has been tested in beta; we're ready to promote it to being always enabled.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Manually tested with VS code.
