### PR TITLE
Revert "Revert "Process all arguments to private modifiers (#3704)" (#3712)"

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -469,59 +469,59 @@ public:
     ast::TreePtr postTransformSend(core::Context ctx, ast::TreePtr tree) {
         auto &original = ast::cast_tree_nonnull<ast::Send>(tree);
 
-        if (original.args.size() == 1) {
-            // Common case: Send is not to a modifier.
-            switch (original.fun.rawId()) {
-                case core::Names::private_().rawId():
-                case core::Names::privateClassMethod().rawId():
-                case core::Names::protected_().rawId():
-                case core::Names::public_().rawId():
-                    addMethodModifier(ctx, original);
-                    break;
-                case core::Names::privateConstant().rawId():
-                    addConstantModifier(ctx, original);
-                    break;
-                default:
-                    return tree;
-            }
+        switch (original.fun.rawId()) {
+            case core::Names::private_().rawId():
+            case core::Names::privateClassMethod().rawId():
+            case core::Names::protected_().rawId():
+            case core::Names::public_().rawId():
+                for (const auto &arg : original.args) {
+                    addMethodModifier(ctx, original.fun, arg);
+                }
+                break;
+            case core::Names::privateConstant().rawId():
+                for (const auto &arg : original.args) {
+                    addConstantModifier(ctx, original.fun, arg);
+                }
+                break;
         }
         return tree;
     }
 
-    void addMethodModifier(core::Context ctx, ast::Send &original) {
-        Modifier methodModifier;
-        methodModifier.kind = Modifier::Kind::Method;
-        methodModifier.owner = getOwner();
-        methodModifier.loc = original.loc;
-        methodModifier.name = original.fun;
-        methodModifier.target = unwrapLiteralToMethodName(ctx, original, original.args[0]);
-
-        if (methodModifier.target.exists()) {
-            foundDefs->addModifier(move(methodModifier));
+    void addMethodModifier(core::Context ctx, core::NameRef modifierName, const ast::TreePtr &arg) {
+        auto target = unwrapLiteralToMethodName(ctx, arg);
+        if (target.exists()) {
+            foundDefs->addModifier(Modifier{
+                Modifier::Kind::Method,
+                getOwner(),
+                arg.loc(),
+                /*name*/ modifierName,
+                target,
+            });
         }
     }
 
-    void addConstantModifier(core::Context ctx, ast::Send &original) {
-        Modifier constantModifier;
-        constantModifier.kind = Modifier::Kind::ClassOrStaticField;
-        constantModifier.owner = getOwner();
-        constantModifier.loc = original.loc;
-        constantModifier.name = original.fun;
-        if (auto sym = ast::cast_tree<ast::Literal>(original.args[0])) {
+    void addConstantModifier(core::Context ctx, core::NameRef modifierName, const ast::TreePtr &arg) {
+        auto target = core::NameRef::noName();
+        if (auto sym = ast::cast_tree<ast::Literal>(arg)) {
             if (sym->isSymbol(ctx)) {
-                constantModifier.target = sym->asSymbol(ctx);
+                target = sym->asSymbol(ctx);
             } else if (sym->isString(ctx)) {
-                constantModifier.target = sym->asString(ctx);
-            } else {
-                constantModifier.target = core::NameRef::noName();
+                target = sym->asString(ctx);
             }
         }
-        if (constantModifier.target.exists()) {
-            foundDefs->addModifier(move(constantModifier));
+
+        if (target.exists()) {
+            foundDefs->addModifier(Modifier{
+                Modifier::Kind::ClassOrStaticField,
+                getOwner(),
+                arg.loc(),
+                /*name*/ modifierName,
+                target,
+            });
         }
     }
 
-    core::NameRef unwrapLiteralToMethodName(core::Context ctx, const ast::Send &original, ast::TreePtr &expr) {
+    core::NameRef unwrapLiteralToMethodName(core::Context ctx, const ast::TreePtr &expr) {
         if (auto sym = ast::cast_tree<ast::Literal>(expr)) {
             // this handles the `private :foo` case
             if (!sym->isSymbol(ctx)) {
@@ -546,7 +546,7 @@ public:
                 return core::NameRef::noName();
             }
 
-            return unwrapLiteralToMethodName(ctx, original, send->args[1]);
+            return unwrapLiteralToMethodName(ctx, send->args[1]);
         } else {
             ENFORCE(!ast::isa_tree<ast::MethodDef>(expr), "methods inside sends should be gone");
             return core::NameRef::noName();

--- a/test/testdata/namer/private_multiple.rb
+++ b/test/testdata/namer/private_multiple.rb
@@ -1,0 +1,23 @@
+# typed: true
+
+class A
+  def foo; end
+  def bar; end
+  def qux; end
+
+  private :foo, :bar, :qux
+
+  X = 1
+  Y = 2
+  Z = 3
+
+  private_constant :X, :Y, :Z
+end
+
+A.new.foo # error: Non-private call to private method `A#foo`
+A.new.bar # error: Non-private call to private method `A#bar`
+A.new.qux # error: Non-private call to private method `A#qux`
+
+p A::X # error: Non-private reference to private constant `A::X`
+p A::Y # error: Non-private reference to private constant `A::Y`
+p A::Z # error: Non-private reference to private constant `A::Z`

--- a/test/testdata/namer/private_multiple.rb
+++ b/test/testdata/namer/private_multiple.rb
@@ -14,9 +14,9 @@ class A
   private_constant :X, :Y, :Z
 end
 
-A.new.foo # error: Non-private call to private method `A#foo`
-A.new.bar # error: Non-private call to private method `A#bar`
-A.new.qux # error: Non-private call to private method `A#qux`
+A.new.foo # error: Non-private call to private method `foo`
+A.new.bar # error: Non-private call to private method `bar`
+A.new.qux # error: Non-private call to private method `qux`
 
 p A::X # error: Non-private reference to private constant `A::X`
 p A::Y # error: Non-private reference to private constant `A::Y`


### PR DESCRIPTION
This reverts commit 4b08b9ae0f117ac54c33c1152a7e787630ff6c02.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #3661

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.