### PR TITLE
Add ability to exclude values in runtime TypeError

### DIFF
--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -42,6 +42,34 @@ module T::Configuration
     T::Private::Methods.set_final_checks_on_hooks(false)
   end
 
+  @include_value_in_type_errors = true
+  # Whether to include values in TypeError messages.
+  #
+  # Including values is useful for debugging, but can potentially leak
+  # sensitive information to logs.
+  #
+  # @return [T::Boolean]
+  def self.include_value_in_type_errors?
+    @include_value_in_type_errors
+  end
+
+  # Configure if type errors excludes the value of the problematic type.
+  #
+  # The default is to include values in type errors:
+  #   TypeError: Expected type Integer, got String with value "foo"
+  #
+  # When values are excluded from type errors:
+  #   TypeError: Expected type Integer, got String
+  def self.exclude_value_in_type_errors
+    @include_value_in_type_errors = false
+  end
+
+  # Opposite of exclude_value_in_type_errors.
+  # (Including values in type errors is the default)
+  def self.include_value_in_type_errors
+    @include_value_in_type_errors = true
+  end
+
   # Configure the default checked level for a sig with no explicit `.checked`
   # builder. When unset, the default checked level is `:always`.
   #
@@ -424,21 +452,5 @@ module T::Configuration
     if !value.nil? && !value.respond_to?(:call)
       raise ArgumentError.new("Provided value must respond to :call")
     end
-  end
-
-  # Configure if type errors excludes the value of the problematic type.
-  #
-  # When true, the value is left out
-  # Example: 'Expected type Integer, got String'
-  #
-  # When false (default), the value of the problematic type is excluded in exceptions:
-  # Example: 'Expected type Integer, got String with value "foo"'
-  #
-  # @param [Boolean] exclude_value
-  def self.exclude_value_in_type_errors=(exclude_value)
-    @exclude_value = exclude_value
-  end
-  def self.exclude_value_in_type_errors
-    !!@exclude_value
   end
 end

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -425,4 +425,20 @@ module T::Configuration
       raise ArgumentError.new("Provided value must respond to :call")
     end
   end
+
+  # Configure if type errors excludes the value of the problematic type.
+  #
+  # When true, the value is left out
+  # Example: 'Expected type Integer, got String'
+  #
+  # When false (default), the value of the problematic type is excluded in exceptions:
+  # Example: 'Expected type Integer, got String with value "foo"'
+  #
+  # @param [Boolean] exclude_value
+  def self.exclude_value_in_type_errors=(exclude_value)
+    @exclude_value = exclude_value
+  end
+  def self.exclude_value_in_type_errors
+    !!@exclude_value
+  end
 end

--- a/gems/sorbet-runtime/lib/types/types/base.rb
+++ b/gems/sorbet-runtime/lib/types/types/base.rb
@@ -119,6 +119,8 @@ module T::Types
         # Default inspect behavior of, eg; `#<Object:0x0...>` is ugly; just print the hash instead, which is more concise/readable.
         if obj.method(:inspect).owner == Kernel
           "type #{obj.class} with hash #{obj.hash}"
+        elsif T::Configuration.exclude_value_in_type_errors
+          "type #{obj.class}"
         else
           "type #{obj.class} with value #{T::Utils.string_truncate_middle(obj.inspect, 30, 30)}"
         end

--- a/gems/sorbet-runtime/lib/types/types/base.rb
+++ b/gems/sorbet-runtime/lib/types/types/base.rb
@@ -119,10 +119,10 @@ module T::Types
         # Default inspect behavior of, eg; `#<Object:0x0...>` is ugly; just print the hash instead, which is more concise/readable.
         if obj.method(:inspect).owner == Kernel
           "type #{obj.class} with hash #{obj.hash}"
-        elsif T::Configuration.exclude_value_in_type_errors
-          "type #{obj.class}"
-        else
+        elsif T::Configuration.include_value_in_type_errors?
           "type #{obj.class} with value #{T::Utils.string_truncate_middle(obj.inspect, 30, 30)}"
+        else
+          "type #{obj.class}"
         end
       rescue StandardError, SystemStackError
         "type #{obj.class} with unprintable value"

--- a/gems/sorbet-runtime/test/types/configuration.rb
+++ b/gems/sorbet-runtime/test/types/configuration.rb
@@ -205,5 +205,50 @@ module Opus::Types::Test
         end
       end
     end
+
+    describe 'exclude_value_in_type_errors' do
+      describe 'when in default state' do
+        it 'raises an error with a message including the value' do
+          e = assert_raises(TypeError) do
+            T.let("foo", Integer)
+          end
+          assert_equal('T.let: Expected type Integer, got type String with value "foo"', e.message.split("\n").first)
+        end
+      end
+
+      describe 'when false' do
+        before do
+          T::Configuration.exclude_value_in_type_errors = false
+        end
+
+        after do
+          T::Configuration.exclude_value_in_type_errors = nil
+        end
+
+        it 'raises an error with a message including the value' do
+          e = assert_raises(TypeError) do
+            T.let("foo", Integer)
+          end
+          assert_equal('T.let: Expected type Integer, got type String with value "foo"', e.message.split("\n").first)
+        end
+      end
+
+      describe 'when true' do
+        before do
+          T::Configuration.exclude_value_in_type_errors = true
+        end
+
+        after do
+          T::Configuration.exclude_value_in_type_errors = nil
+        end
+
+        it 'raises an error with a message including the value' do
+          e = assert_raises(TypeError) do
+            T.let("foo", Integer)
+          end
+          assert_equal('T.let: Expected type Integer, got type String', e.message.split("\n").first)
+        end
+      end
+    end
   end
 end

--- a/gems/sorbet-runtime/test/types/configuration.rb
+++ b/gems/sorbet-runtime/test/types/configuration.rb
@@ -216,16 +216,9 @@ module Opus::Types::Test
         end
       end
 
-      describe 'when false' do
-        before do
-          T::Configuration.exclude_value_in_type_errors = false
-        end
-
-        after do
-          T::Configuration.exclude_value_in_type_errors = nil
-        end
-
+      describe 'when explicitly include' do
         it 'raises an error with a message including the value' do
+          T::Configuration.include_value_in_type_errors
           e = assert_raises(TypeError) do
             T.let("foo", Integer)
           end
@@ -233,13 +226,12 @@ module Opus::Types::Test
         end
       end
 
-      describe 'when true' do
+      describe 'when exclude' do
         before do
-          T::Configuration.exclude_value_in_type_errors = true
+          T::Configuration.exclude_value_in_type_errors
         end
-
         after do
-          T::Configuration.exclude_value_in_type_errors = nil
+          T::Configuration.include_value_in_type_errors
         end
 
         it 'raises an error with a message including the value' do

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -119,6 +119,12 @@ module T::Configuration
   def self.enable_final_checks_on_hooks; end
   def self.enable_legacy_t_enum_migration_mode; end
   def self.reset_final_checks_on_hooks; end
+  sig {returns(T::Boolean)}
+  def self.include_value_in_type_errors?; end
+  sig {void}
+  def self.exclude_value_in_type_errors; end
+  sig {void}
+  def self.include_value_in_type_errors; end
   def self.hard_assert_handler(str, extra); end
   def self.hard_assert_handler=(value); end
   def self.inline_type_error_handler(error); end


### PR DESCRIPTION
This adds a new configuration option `T::Configuration.exclude_value_in_type_errors` that when true will exclude values from messages in `TypeError`s.

### Motivation
It is important for Gusto that we don't leak any user data to our error tracker. We are currently relying on filtering out the data of the error message before we send it to our error tracker. Any problems with that filtering and we might be sending user data by mistake. This instead will make sure the user data isn't included in the exception in the first place.

### Test plan
See included automated tests.
