### PR TITLE
Use ShallowMap for namer's TreeSymbolizer pass.

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1910,7 +1910,7 @@ vector<ast::ParsedFile> symbolizeTrees(const core::GlobalState &gs, vector<ast::
             if (result.gotItem()) {
                 Timer timeit(gs.tracer(), "naming.symbolizeTreesOne", {{"file", (string)job.file.data(gs).path()}});
                 core::Context ctx(gs, core::Symbols::root(), job.file);
-                job.tree = ast::TreeMap::apply(ctx, inserter, std::move(job.tree));
+                job.tree = ast::ShallowMap::apply(ctx, inserter, std::move(job.tree));
                 output.emplace_back(move(job));
             }
         }


### PR DESCRIPTION
Use ShallowMap for namer's TreeSymbolizer pass.

Now that https://github.com/sorbet/sorbet/pull/3815 has landed and SymbolFinder is using a ShallowMap, TreeSymbolizer can use a ShallowMap too.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

namer go brrrrr

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
