### PR TITLE
Bump up MAX_SUBQUEUE_SIZE to fix occasional crashes.

### DIFF
--- a/common/concurrency/WorkerPoolImpl.h
+++ b/common/concurrency/WorkerPoolImpl.h
@@ -65,7 +65,7 @@ class WorkerPoolImpl : public WorkerPool {
         // Enqueue operations that would cause this limit to be surpassed will fail. Note
         // that this limit is enforced at the block level (for performance reasons), i.e.
         // it's rounded up to the nearest block size.
-        static const size_t MAX_SUBQUEUE_SIZE = 8;
+        static const size_t MAX_SUBQUEUE_SIZE = 16;
 
         // Memory allocation can be customized if needed.
         // malloc should return nullptr on failure, and handle alignment like std::malloc.


### PR DESCRIPTION
Bump up MAX_SUBQUEUE_SIZE to fix occasional crashes.

Fixes this crash: https://buildkite.com/sorbet/sorbet/builds/14044#8f5362c6-a83e-46c0-b4c8-9a457c8e71d5

Background:

* WorkerPool has per-thread queues for lambdas.
* These queues are fixed-size.
* We are now calling multiplexJob more, so if a thread gets left behind in, say, index, we may enqueue 8 more lambdas to that thread and fill its queue.

16 > the number of multiplexJob callsites in Sorbet today

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fix crashes.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No tests currently. We could bake in a special command line option to test this out which occupies exactly one thread for the duration of Sorbet's execution?
