### PR TITLE
wip: Implement intrinsics for [] and []= on shape types

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2348,24 +2348,33 @@ public:
 class Shape_squareBracketsEq : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
-        // auto &shape = cast_type_nonnull<ShapeType>(args.thisType);
+        auto &shape = cast_type_nonnull<ShapeType>(args.thisType);
 
-        // if (args.args.size() != 2) {
-        //     // Skip over cases for which arg matching should report errors
-        //     return;
-        // }
+        if (args.args.size() != 2) {
+            // Skip over cases for which arg matching should report errors
+            return;
+        }
 
-        // if (!isa_type<LiteralType>(args.args.front()->type)) {
-        //     return;
-        // }
+        if (!isa_type<LiteralType>(args.args.front()->type)) {
+            return;
+        }
 
-        // auto argLit = cast_type_nonnull<LiteralType>(args.args.front()->type);
-        // if (auto idx = indexForKey(shape, argLit)) {
-        //     res.returnType = shape.values[*idx];
-        // } else {
-        //     // TODO(jez) This could be another "if you're in `typed: strict` you have to have better hashes"
-        //     res.returnType = Types::untypedUntracked();
-        // }
+        auto argLit = cast_type_nonnull<LiteralType>(args.args.front()->type);
+        if (auto idx = indexForKey(shape, argLit)) {
+            // Returning here without setting res.resultType will cause dispatchCall to fall back to
+            // Hash#[]=, which will have the effect of checking the arg types.
+            //
+            // TODO(jez) We could do something smarter here, like check that the new value is
+            // compatible with the old value.
+            return;
+        } else {
+            // Key not found. To preserve legacy compatibility, allow any arguments here.
+            // I would love to remove this one day, but we'll have to figure out a way to migrate
+            // people's codebases to it.
+            //
+            // TODO(jez) This could be another "if you're in `typed: strict` you need typed shapes"
+            res.returnType = Types::untypedUntracked();
+        }
     }
 } Shape_squareBracketsEq;
 

--- a/test/testdata/infer/shape_square_brackets.rb
+++ b/test/testdata/infer/shape_square_brackets.rb
@@ -1,0 +1,37 @@
+# typed: true
+
+extend T::Sig
+
+def test1
+  x = {foo: 1}
+
+  T.reveal_type(x[:foo]) # error: Revealed type: `Integer(1)`
+
+  # This is untyped for backwards compatibility with the original shape implementation.
+  # We didn't want to introduce so many errors all at once, because the migration effort was huge.
+  T.reveal_type(x[:bar]) # error: Revealed type: `T.untyped`
+
+  # This doesn't raise an error either (String access, not Symbol access)
+  T.reveal_type(x['bar']) # error: Revealed type: `T.untyped`
+end
+
+sig {params(x: {foo: Integer}).void}
+def test2(x)
+  x[:foo] = 1
+  x[:foo] = '' # error:
+
+  # Likewise, neither of these report errors, for backwards compatibility
+  x[:bar] = 1
+  x[:bar] = ''
+end
+
+sig {params(x: {foo: Integer, 'bar' => Float}).void}
+def test3(x)
+  # could make this better, e.g.: only allow setting to `Integer`
+  x[:foo] = 0.0
+  # ... especially because the type remains the same as before:
+  T.reveal_type(x[:foo]) # error: Revealed type: `Integer`
+
+  # This might end up being too restrictive.  This used to not error at all.
+  x[true] = nil # error: Expected `T.any(Integer, Float)` but found `NilClass` for argument `arg1`
+end


### PR DESCRIPTION
SEO: square brackets index square_brackets squareBrackets squareBracketsEq eq

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This should help ease the pain of #3822.

Right now I've implemented it stacked on top, but we might want to land them in
the opposite order, or at the same time.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.