### PR TITLE
Introduces MethodRef

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -391,7 +391,7 @@ public:
                     std::move(block));
     }
 
-    static TreePtr DefineTopClassOrModule(core::LocOffsets loc, core::SymbolRef klass) {
+    static TreePtr DefineTopClassOrModule(core::LocOffsets loc, core::ClassOrModuleRef klass) {
         auto magic = Constant(loc, core::Symbols::Magic());
         Send::ARGS_store args;
         args.emplace_back(Constant(loc, klass));

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -226,7 +226,8 @@ public:
             args.emplace_back(make_tree<ast::BlockArg>(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
         }
         MethodDef::Flags flags;
-        return make_tree<MethodDef>(loc, declLoc, core::Symbols::todo(), name, std::move(args), std::move(rhs), flags);
+        return make_tree<MethodDef>(loc, declLoc, core::Symbols::todoMethod(), name, std::move(args), std::move(rhs),
+                                    flags);
     }
 
     static TreePtr SyntheticMethod(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -185,7 +185,7 @@ ClassDef::ClassDef(core::LocOffsets loc, core::LocOffsets declLoc, core::ClassOr
     _sanityCheck();
 }
 
-MethodDef::MethodDef(core::LocOffsets loc, core::LocOffsets declLoc, core::SymbolRef symbol, core::NameRef name,
+MethodDef::MethodDef(core::LocOffsets loc, core::LocOffsets declLoc, core::MethodRef symbol, core::NameRef name,
                      ARGS_store args, TreePtr rhs, Flags flags)
     : loc(loc), declLoc(declLoc), symbol(symbol), rhs(std::move(rhs)), args(std::move(args)), name(name), flags(flags) {
     categoryCounterInc("trees", "methoddef");
@@ -534,13 +534,13 @@ string MethodDef::toStringWithTabs(const core::GlobalState &gs, int tabs) const 
         fmt::format_to(buf, "def ");
     }
     fmt::format_to(buf, "{}", name.toString(gs));
-    const auto data = this->symbol.dataAllowingNone(gs);
+    const auto data = this->symbol.data(gs);
     if (name != data->name) {
         fmt::format_to(buf, "<{}>", data->name.toString(gs));
     }
     fmt::format_to(buf, "(");
     bool first = true;
-    if (this->symbol == core::Symbols::todo()) {
+    if (this->symbol == core::Symbols::todoMethod()) {
         for (auto &a : this->args) {
             if (!first) {
                 fmt::format_to(buf, ", ");
@@ -580,11 +580,11 @@ string MethodDef::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::format_to(buf, "flags = {{{}}}\n", fmt::join(stringifiedFlags, ", "));
 
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "name = {}<{}>\n", name.showRaw(gs), this->symbol.dataAllowingNone(gs)->name.showRaw(gs));
+    fmt::format_to(buf, "name = {}<{}>\n", name.showRaw(gs), this->symbol.data(gs)->name.showRaw(gs));
     printTabs(buf, tabs + 1);
     fmt::format_to(buf, "args = [");
     bool first = true;
-    if (this->symbol == core::Symbols::todo()) {
+    if (this->symbol == core::Symbols::todoMethod()) {
         for (auto &a : this->args) {
             if (!first) {
                 fmt::format_to(buf, ", ");

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -340,7 +340,7 @@ TREE(MethodDef) {
 public:
     const core::LocOffsets loc;
     core::LocOffsets declLoc;
-    core::SymbolRef symbol;
+    core::MethodRef symbol;
 
     TreePtr rhs;
 
@@ -360,7 +360,7 @@ public:
 
     Flags flags;
 
-    MethodDef(core::LocOffsets loc, core::LocOffsets declLoc, core::SymbolRef symbol, core::NameRef name,
+    MethodDef(core::LocOffsets loc, core::LocOffsets declLoc, core::MethodRef symbol, core::NameRef name,
               ARGS_store args, TreePtr rhs, Flags flags);
 
     TreePtr deepCopy() const;

--- a/cfg/CFG.h
+++ b/cfg/CFG.h
@@ -93,7 +93,7 @@ public:
      * CFG owns all the BasicBlocks, and then they have raw unmanaged pointers to and between each other,
      * because they all have lifetime identical with each other and the CFG.
      */
-    core::SymbolRef symbol;
+    core::MethodRef symbol;
     int maxBasicBlockId = 0;
     int maxRubyBlockId = 0;
 

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -156,9 +156,9 @@ CheckSize(GetCurrentException, 16, 8);
 class LoadArg final : public Instruction {
 public:
     u2 argId;
-    core::SymbolRef method;
+    core::MethodRef method;
 
-    LoadArg(core::SymbolRef method, u2 argId) : argId(argId), method(method) {
+    LoadArg(core::MethodRef method, u2 argId) : argId(argId), method(method) {
         categoryCounterInc("cfg", "loadarg");
     };
 
@@ -171,9 +171,9 @@ CheckSize(LoadArg, 16, 8);
 class ArgPresent final : public Instruction {
 public:
     u2 argId;
-    core::SymbolRef method;
+    core::MethodRef method;
 
-    ArgPresent(core::SymbolRef method, u2 argId) : argId(argId), method(method) {
+    ArgPresent(core::MethodRef method, u2 argId) : argId(argId), method(method) {
         categoryCounterInc("cfg", "argpresent");
     }
 

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -13,7 +13,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
     ENFORCE(!md.symbol.data(ctx)->isOverloaded());
     unique_ptr<CFG> res(new CFG); // private constructor
     res->file = ctx.file;
-    res->symbol = md.symbol.data(ctx)->dealiasMethod(ctx).asMethodRef();
+    res->symbol = md.symbol.data(ctx)->dealiasMethod(ctx);
     u4 temporaryCounter = 1;
     UnorderedMap<core::SymbolRef, LocalRef> aliases;
     UnorderedMap<core::NameRef, LocalRef> discoveredUndeclaredFields;

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -13,7 +13,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
     ENFORCE(!md.symbol.data(ctx)->isOverloaded());
     unique_ptr<CFG> res(new CFG); // private constructor
     res->file = ctx.file;
-    res->symbol = md.symbol.data(ctx)->dealiasMethod(ctx);
+    res->symbol = md.symbol.data(ctx)->dealiasMethod(ctx).asMethodRef();
     u4 temporaryCounter = 1;
     UnorderedMap<core::SymbolRef, LocalRef> aliases;
     UnorderedMap<core::NameRef, LocalRef> discoveredUndeclaredFields;

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -155,7 +155,7 @@ tuple<LocalRef, BasicBlock *, BasicBlock *> CFGBuilder::walkDefault(CFGContext c
 
     auto present = cctx.newTemporary(core::Names::argPresent());
     auto methodSymbol = cctx.inWhat.symbol;
-    synthesizeExpr(presentCont, present, argLoc, make_unique<ArgPresent>(methodSymbol.asMethodRef(), argIndex));
+    synthesizeExpr(presentCont, present, argLoc, make_unique<ArgPresent>(methodSymbol, argIndex));
     conditionalJump(presentCont, present, presentNext, defaultNext, cctx.inWhat, argLoc);
 
     if (defaultCont != nullptr) {

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -155,7 +155,7 @@ tuple<LocalRef, BasicBlock *, BasicBlock *> CFGBuilder::walkDefault(CFGContext c
 
     auto present = cctx.newTemporary(core::Names::argPresent());
     auto methodSymbol = cctx.inWhat.symbol;
-    synthesizeExpr(presentCont, present, argLoc, make_unique<ArgPresent>(methodSymbol, argIndex));
+    synthesizeExpr(presentCont, present, argLoc, make_unique<ArgPresent>(methodSymbol.asMethodRef(), argIndex));
     conditionalJump(presentCont, present, presentNext, defaultNext, cctx.inWhat, argLoc);
 
     if (defaultCont != nullptr) {

--- a/class_flatten/class_flatten.cc
+++ b/class_flatten/class_flatten.cc
@@ -109,8 +109,9 @@ public:
         ast::MethodDef::ARGS_store args;
         args.emplace_back(ast::make_tree<ast::Local>(blkLoc, blkLocalVar));
 
-        auto init = ast::make_tree<ast::MethodDef>(loc.offsets(), loc.offsets(), sym, core::Names::staticInit(),
-                                                   std::move(args), std::move(inits), ast::MethodDef::Flags());
+        auto init =
+            ast::make_tree<ast::MethodDef>(loc.offsets(), loc.offsets(), sym.asMethodRef(), core::Names::staticInit(),
+                                           std::move(args), std::move(inits), ast::MethodDef::Flags());
         ast::cast_tree_nonnull<ast::MethodDef>(init).flags.isRewriterSynthesized = false;
         ast::cast_tree_nonnull<ast::MethodDef>(init).flags.isSelfMethod = true;
 

--- a/class_flatten/class_flatten.cc
+++ b/class_flatten/class_flatten.cc
@@ -76,7 +76,7 @@ public:
         auto *classDef = ast::cast_tree<ast::ClassDef>(tree);
         auto inits = extractClassInit(ctx, classDef);
 
-        core::SymbolRef sym;
+        core::MethodRef sym;
         auto loc = core::Loc(ctx.file, classDef->declLoc);
         ast::TreePtr replacement;
         if (classDef->symbol == core::Symbols::root()) {
@@ -109,9 +109,8 @@ public:
         ast::MethodDef::ARGS_store args;
         args.emplace_back(ast::make_tree<ast::Local>(blkLoc, blkLocalVar));
 
-        auto init =
-            ast::make_tree<ast::MethodDef>(loc.offsets(), loc.offsets(), sym.asMethodRef(), core::Names::staticInit(),
-                                           std::move(args), std::move(inits), ast::MethodDef::Flags());
+        auto init = ast::make_tree<ast::MethodDef>(loc.offsets(), loc.offsets(), sym, core::Names::staticInit(),
+                                                   std::move(args), std::move(inits), ast::MethodDef::Flags());
         ast::cast_tree_nonnull<ast::MethodDef>(init).flags.isRewriterSynthesized = false;
         ast::cast_tree_nonnull<ast::MethodDef>(init).flags.isSelfMethod = true;
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1017,7 +1017,7 @@ SymbolRef GlobalState::enterTypeMember(Loc loc, ClassOrModuleRef owner, NameRef 
     return result;
 }
 
-SymbolRef GlobalState::enterTypeArgument(Loc loc, SymbolRef owner, NameRef name, Variance variance) {
+SymbolRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef name, Variance variance) {
     ENFORCE(owner.exists() || name == Names::Constants::NoTypeArgument());
     ENFORCE(name.exists());
     u4 flags;
@@ -1033,7 +1033,7 @@ SymbolRef GlobalState::enterTypeArgument(Loc loc, SymbolRef owner, NameRef name,
 
     flags = flags | Symbol::Flags::TYPE_ARGUMENT;
 
-    SymbolData ownerScope = owner.dataAllowingNone(*this);
+    SymbolData ownerScope = core::SymbolRef(*this, core::SymbolRef::Kind::Method, owner.id()).dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
     auto &store = ownerScope->members()[name];
@@ -1056,7 +1056,10 @@ SymbolRef GlobalState::enterTypeArgument(Loc loc, SymbolRef owner, NameRef name,
     DEBUG_ONLY(categoryCounterInc("symbols", "type_argument"));
     wasModified_ = true;
 
-    owner.dataAllowingNone(*this)->typeArguments().emplace_back(result);
+    core::SymbolRef(*this, core::SymbolRef::Kind::Method, owner.id())
+        .dataAllowingNone(*this)
+        ->typeArguments()
+        .emplace_back(result);
     return result;
 }
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -303,16 +303,16 @@ void GlobalState::initEmpty() {
     ENFORCE(id == Symbols::T_Enum());
 
     // T::Sig#sig
-    id = enterMethodSymbol(Loc::none(), Symbols::T_Sig(), Names::sig());
+    auto method = enterMethodSymbol(Loc::none(), Symbols::T_Sig(), Names::sig());
     {
-        auto &arg = enterMethodArgumentSymbol(Loc::none(), id, Names::arg0());
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg0());
         arg.flags.isDefault = true;
     }
     {
-        auto &arg = enterMethodArgumentSymbol(Loc::none(), id, Names::blkArg());
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
         arg.flags.isBlock = true;
     }
-    ENFORCE(id == Symbols::sig());
+    ENFORCE(method == Symbols::sig());
 
     // Enumerable::Lazy
     id = enterClassSymbol(Loc::none(), Symbols::Enumerator(), core::Names::Constants::Lazy());
@@ -335,16 +335,16 @@ void GlobalState::initEmpty() {
     ENFORCE(id == Symbols::T_Sig_WithoutRuntimeSingleton());
 
     // T::Sig::WithoutRuntime.sig
-    id = enterMethodSymbol(Loc::none(), Symbols::T_Sig_WithoutRuntimeSingleton(), Names::sig());
+    method = enterMethodSymbol(Loc::none(), Symbols::T_Sig_WithoutRuntimeSingleton(), Names::sig());
     {
-        auto &arg = enterMethodArgumentSymbol(Loc::none(), id, Names::arg0());
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg0());
         arg.flags.isDefault = true;
     }
     {
-        auto &arg = enterMethodArgumentSymbol(Loc::none(), id, Names::blkArg());
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
         arg.flags.isBlock = true;
     }
-    ENFORCE(id == Symbols::sigWithoutRuntime());
+    ENFORCE(method == Symbols::sigWithoutRuntime());
 
     id = enterClassSymbol(Loc::none(), Symbols::T(), Names::Constants::NonForcingConstants());
     ENFORCE(id == Symbols::T_NonForcingConstants());
@@ -355,17 +355,17 @@ void GlobalState::initEmpty() {
     id = enterClassSymbol(Loc::none(), Symbols::Chalk_ODM(), Names::Constants::DocumentDecoratorHelper());
     ENFORCE(id == Symbols::Chalk_ODM_DocumentDecoratorHelper());
 
-    id = enterMethodSymbol(Loc::none(), Symbols::Sorbet_Private_StaticSingleton(), Names::sig());
-    { enterMethodArgumentSymbol(Loc::none(), id, Names::arg0()); }
+    method = enterMethodSymbol(Loc::none(), Symbols::Sorbet_Private_StaticSingleton(), Names::sig());
+    { enterMethodArgumentSymbol(Loc::none(), method, Names::arg0()); }
     {
-        auto &arg = enterMethodArgumentSymbol(Loc::none(), id, Names::arg1());
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg1());
         arg.flags.isDefault = true;
     }
     {
-        auto &arg = enterMethodArgumentSymbol(Loc::none(), id, Names::blkArg());
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
         arg.flags.isBlock = true;
     }
-    ENFORCE(id == Symbols::SorbetPrivateStaticSingleton_sig());
+    ENFORCE(method == Symbols::SorbetPrivateStaticSingleton_sig());
 
     id = enterClassSymbol(Loc::none(), Symbols::root(), Names::Constants::PackageRegistry());
     ENFORCE(id == Symbols::PackageRegistry());
@@ -378,30 +378,30 @@ void GlobalState::initEmpty() {
     id = id.data(*this)->singletonClass(*this);
     ENFORCE(id == Symbols::PackageSpecSingleton());
 
-    id = enterMethodSymbol(Loc::none(), Symbols::PackageSpecSingleton(), Names::import());
-    ENFORCE(id == Symbols::PackageSpec_import());
+    method = enterMethodSymbol(Loc::none(), Symbols::PackageSpecSingleton(), Names::import());
+    ENFORCE(method == Symbols::PackageSpec_import());
     {
-        auto &importArg = enterMethodArgumentSymbol(Loc::none(), id, Names::arg0());
+        auto &importArg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg0());
         // T.class_of(PackageSpec)
         importArg.type = make_type<ClassType>(Symbols::PackageSpecSingleton());
-        auto &arg = enterMethodArgumentSymbol(Loc::none(), id, Names::blkArg());
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
         arg.flags.isBlock = true;
     }
 
-    id = enterMethodSymbol(Loc::none(), Symbols::PackageSpecSingleton(), Names::export_());
-    ENFORCE(id == Symbols::PackageSpec_export());
+    method = enterMethodSymbol(Loc::none(), Symbols::PackageSpecSingleton(), Names::export_());
+    ENFORCE(method == Symbols::PackageSpec_export());
     {
-        enterMethodArgumentSymbol(Loc::none(), id, Names::arg0());
-        auto &arg = enterMethodArgumentSymbol(Loc::none(), id, Names::blkArg());
+        enterMethodArgumentSymbol(Loc::none(), method, Names::arg0());
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
         arg.flags.isBlock = true;
     }
 
-    id = enterMethodSymbol(Loc::none(), Symbols::PackageSpecSingleton(), Names::exportMethods());
-    ENFORCE(id == Symbols::PackageSpec_export_methods());
+    method = enterMethodSymbol(Loc::none(), Symbols::PackageSpecSingleton(), Names::exportMethods());
+    ENFORCE(method == Symbols::PackageSpec_export_methods());
     {
-        auto &arg = enterMethodArgumentSymbol(Loc::none(), id, Names::arg0());
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg0());
         arg.flags.isRepeated = true;
-        auto &blkArg = enterMethodArgumentSymbol(Loc::none(), id, Names::blkArg());
+        auto &blkArg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
         blkArg.flags.isBlock = true;
     }
 
@@ -409,20 +409,20 @@ void GlobalState::initEmpty() {
     ENFORCE(id == Symbols::Encoding());
 
     // Class#new
-    id = enterMethodSymbol(Loc::none(), Symbols::Class(), Names::new_());
+    method = enterMethodSymbol(Loc::none(), Symbols::Class(), Names::new_());
     {
-        auto &arg = enterMethodArgumentSymbol(Loc::none(), id, Names::args());
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::args());
         arg.flags.isRepeated = true;
     }
     {
-        auto &arg = enterMethodArgumentSymbol(Loc::none(), id, Names::blkArg());
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
         arg.flags.isBlock = true;
     }
-    ENFORCE(id == Symbols::Class_new());
+    ENFORCE(method == Symbols::Class_new());
 
-    id = enterMethodSymbol(Loc::none(), Symbols::noClassOrModule(), Names::TodoMethod());
-    enterMethodArgumentSymbol(Loc::none(), id, Names::args());
-    ENFORCE(id == Symbols::todoMethod());
+    method = enterMethodSymbol(Loc::none(), Symbols::noClassOrModule(), Names::TodoMethod());
+    enterMethodArgumentSymbol(Loc::none(), method, Names::args());
+    ENFORCE(method == Symbols::todoMethod());
 
     // Root members
     Symbols::root().data(*this)->members()[core::Names::Constants::NoSymbol()] = Symbols::noSymbol();
@@ -434,7 +434,7 @@ void GlobalState::initEmpty() {
     id.data(*this)->resultType = make_type<LiteralType>(Symbols::String(), enterNameUTF8(sorbet_full_version_string));
 
     // Synthesize <Magic>.<build-hash>(*vs : T.untyped) => Hash
-    auto method = enterMethodSymbol(Loc::none(), Symbols::MagicSingleton(), Names::buildHash());
+    method = enterMethodSymbol(Loc::none(), Symbols::MagicSingleton(), Names::buildHash());
     {
         auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg0());
         arg.flags.isRepeated = true;
@@ -810,7 +810,7 @@ void GlobalState::installIntrinsics() {
                 break;
         }
         auto countBefore = methodsUsed();
-        SymbolRef method = enterMethodSymbol(Loc::none(), symbol, entry.method);
+        auto method = enterMethodSymbol(Loc::none(), symbol, entry.method);
         method.data(*this)->intrinsic = entry.impl;
         if (countBefore != methodsUsed()) {
             auto &blkArg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
@@ -1099,8 +1099,8 @@ SymbolRef GlobalState::enterNewMethodOverload(Loc sigLoc, SymbolRef original, co
     core::Loc loc = num == 0 ? original.data(*this)->loc()
                              : sigLoc; // use original Loc for main overload so that we get right jump-to-def for it.
     auto owner = original.data(*this)->owner;
-    SymbolRef res = enterMethodSymbol(loc, owner, name);
-    ENFORCE(res != original);
+    auto res = enterMethodSymbol(loc, owner, name);
+    ENFORCE(res != original.asMethodRef());
     if (res.data(*this)->arguments().size() != original.data(*this)->arguments().size()) {
         ENFORCE(res.data(*this)->arguments().empty());
         res.data(*this)->arguments().reserve(original.data(*this)->arguments().size());
@@ -1189,11 +1189,10 @@ SymbolRef GlobalState::enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, N
     return ret;
 }
 
-ArgInfo &GlobalState::enterMethodArgumentSymbol(Loc loc, SymbolRef owner, NameRef name) {
+ArgInfo &GlobalState::enterMethodArgumentSymbol(Loc loc, MethodRef owner, NameRef name) {
     ENFORCE(owner.exists(), "entering symbol in to non-existing owner");
-    ENFORCE(owner.data(*this)->isMethod(), "entering method argument symbol into not-a-method");
     ENFORCE(name.exists(), "entering symbol with non-existing name");
-    SymbolData ownerScope = owner.dataAllowingNone(*this);
+    SymbolData ownerScope = owner.data(*this);
 
     for (auto &arg : ownerScope->arguments()) {
         if (arg.name == name) {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1093,14 +1093,14 @@ MethodRef GlobalState::enterMethodSymbol(Loc loc, SymbolRef owner, NameRef name)
     return result;
 }
 
-SymbolRef GlobalState::enterNewMethodOverload(Loc sigLoc, SymbolRef original, core::NameRef originalName, u4 num,
+SymbolRef GlobalState::enterNewMethodOverload(Loc sigLoc, MethodRef original, core::NameRef originalName, u4 num,
                                               const vector<bool> &argsToKeep) {
     NameRef name = num == 0 ? originalName : freshNameUnique(UniqueNameKind::Overload, originalName, num);
     core::Loc loc = num == 0 ? original.data(*this)->loc()
                              : sigLoc; // use original Loc for main overload so that we get right jump-to-def for it.
     auto owner = original.data(*this)->owner;
     auto res = enterMethodSymbol(loc, owner, name);
-    ENFORCE(res != original.asMethodRef());
+    ENFORCE(res != original);
     if (res.data(*this)->arguments().size() != original.data(*this)->arguments().size()) {
         ENFORCE(res.data(*this)->arguments().empty());
         res.data(*this)->arguments().reserve(original.data(*this)->arguments().size());

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -420,6 +420,10 @@ void GlobalState::initEmpty() {
     }
     ENFORCE(id == Symbols::Class_new());
 
+    id = enterMethodSymbol(Loc::none(), Symbols::noClassOrModule(), Names::TodoMethod());
+    enterMethodArgumentSymbol(Loc::none(), id, Names::args());
+    ENFORCE(id == Symbols::todoMethod());
+
     // Root members
     Symbols::root().data(*this)->members()[core::Names::Constants::NoSymbol()] = Symbols::noSymbol();
     Symbols::root().data(*this)->members()[core::Names::Constants::Top()] = Symbols::top();
@@ -430,7 +434,7 @@ void GlobalState::initEmpty() {
     id.data(*this)->resultType = make_type<LiteralType>(Symbols::String(), enterNameUTF8(sorbet_full_version_string));
 
     // Synthesize <Magic>.<build-hash>(*vs : T.untyped) => Hash
-    SymbolRef method = enterMethodSymbol(Loc::none(), Symbols::MagicSingleton(), Names::buildHash());
+    auto method = enterMethodSymbol(Loc::none(), Symbols::MagicSingleton(), Names::buildHash());
     {
         auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg0());
         arg.flags.isRepeated = true;

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1093,7 +1093,7 @@ MethodRef GlobalState::enterMethodSymbol(Loc loc, SymbolRef owner, NameRef name)
     return result;
 }
 
-SymbolRef GlobalState::enterNewMethodOverload(Loc sigLoc, MethodRef original, core::NameRef originalName, u4 num,
+MethodRef GlobalState::enterNewMethodOverload(Loc sigLoc, MethodRef original, core::NameRef originalName, u4 num,
                                               const vector<bool> &argsToKeep) {
     NameRef name = num == 0 ? originalName : freshNameUnique(UniqueNameKind::Overload, originalName, num);
     core::Loc loc = num == 0 ? original.data(*this)->loc()

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1056,9 +1056,7 @@ SymbolRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef name,
     DEBUG_ONLY(categoryCounterInc("symbols", "type_argument"));
     wasModified_ = true;
 
-    core::SymbolRef(owner).dataAllowingNone(*this)
-        ->typeArguments()
-        .emplace_back(result);
+    core::SymbolRef(owner).dataAllowingNone(*this)->typeArguments().emplace_back(result);
     return result;
 }
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2060,7 +2060,7 @@ const vector<shared_ptr<File>> &GlobalState::getFiles() const {
     return files;
 }
 
-SymbolRef GlobalState::staticInitForClass(ClassOrModuleRef klass, Loc loc) {
+MethodRef GlobalState::staticInitForClass(ClassOrModuleRef klass, Loc loc) {
     auto prevCount = methodsUsed();
     auto sym = enterMethodSymbol(loc, klass.data(*this)->singletonClass(*this), core::Names::staticInit());
     if (prevCount != methodsUsed()) {
@@ -2071,14 +2071,14 @@ SymbolRef GlobalState::staticInitForClass(ClassOrModuleRef klass, Loc loc) {
     return sym;
 }
 
-SymbolRef GlobalState::lookupStaticInitForClass(ClassOrModuleRef klass) const {
+MethodRef GlobalState::lookupStaticInitForClass(ClassOrModuleRef klass) const {
     auto classData = klass.data(*this);
     auto ref = classData->lookupSingletonClass(*this).data(*this)->findMember(*this, core::Names::staticInit());
     ENFORCE(ref.exists(), "looking up non-existent <static-init> for {}", klass.data(*this)->toString(*this));
-    return ref;
+    return ref.asMethodRef();
 }
 
-SymbolRef GlobalState::staticInitForFile(Loc loc) {
+MethodRef GlobalState::staticInitForFile(Loc loc) {
     auto nm = freshNameUnique(core::UniqueNameKind::Namer, core::Names::staticInit(), loc.file().id());
     auto prevCount = this->methodsUsed();
     auto sym = enterMethodSymbol(loc, core::Symbols::rootSingleton(), nm);
@@ -2090,11 +2090,11 @@ SymbolRef GlobalState::staticInitForFile(Loc loc) {
     return sym;
 }
 
-SymbolRef GlobalState::lookupStaticInitForFile(Loc loc) const {
+MethodRef GlobalState::lookupStaticInitForFile(Loc loc) const {
     auto nm = lookupNameUnique(core::UniqueNameKind::Namer, core::Names::staticInit(), loc.file().id());
     auto ref = core::Symbols::rootSingleton().data(*this)->findMember(*this, nm);
     ENFORCE(ref.exists(), "looking up non-existent <static-init> for {}", loc.toString(*this));
-    return ref;
+    return ref.asMethodRef();
 }
 
 spdlog::logger &GlobalState::tracer() const {

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -89,10 +89,10 @@ public:
     SymbolRef lookupSymbol(SymbolRef owner, NameRef name) const {
         return lookupSymbolWithFlags(owner, name, 0);
     }
-    SymbolRef lookupTypeMemberSymbol(SymbolRef owner, NameRef name) const {
+    SymbolRef lookupTypeMemberSymbol(ClassOrModuleRef owner, NameRef name) const {
         return lookupSymbolWithFlags(owner, name, Symbol::Flags::TYPE_MEMBER);
     }
-    ClassOrModuleRef lookupClassSymbol(SymbolRef owner, NameRef name) const {
+    ClassOrModuleRef lookupClassSymbol(ClassOrModuleRef owner, NameRef name) const {
         return lookupSymbolWithFlags(owner, name, Symbol::Flags::CLASS_OR_MODULE).asClassOrModuleRef();
     }
     MethodRef lookupMethodSymbol(SymbolRef owner, NameRef name) const {

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -96,7 +96,13 @@ public:
         return lookupSymbolWithFlags(owner, name, Symbol::Flags::CLASS_OR_MODULE).asClassOrModuleRef();
     }
     MethodRef lookupMethodSymbol(SymbolRef owner, NameRef name) const {
-        return lookupSymbolWithFlags(owner, name, Symbol::Flags::METHOD).asMethodRef();
+        // TODO: Maybe lookupSymbolWithFlags should accept a default symbol argument?
+        auto sym = lookupSymbolWithFlags(owner, name, Symbol::Flags::METHOD);
+        if (!sym.exists()) {
+            return Symbols::noMethod();
+        } else {
+            return sym.asMethodRef();
+        }
     }
     MethodRef lookupMethodSymbolWithHash(SymbolRef owner, NameRef name, const std::vector<u4> &methodHash) const;
     SymbolRef lookupStaticFieldSymbol(SymbolRef owner, NameRef name) const {

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -17,6 +17,7 @@ class NameRef;
 class Symbol;
 class SymbolRef;
 class ClassOrModuleRef;
+class MethodRef;
 class GlobalSubstitution;
 class ErrorQueue;
 struct GlobalStateHash;
@@ -36,6 +37,7 @@ class GlobalState final {
     friend Symbol;
     friend SymbolRef;
     friend ClassOrModuleRef;
+    friend MethodRef;
     friend File;
     friend FileRef;
     friend GlobalSubstitution;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -113,11 +113,11 @@ public:
     }
     SymbolRef findRenamedSymbol(SymbolRef owner, SymbolRef name) const;
 
-    SymbolRef staticInitForFile(Loc loc);
-    SymbolRef staticInitForClass(ClassOrModuleRef klass, Loc loc);
+    MethodRef staticInitForFile(Loc loc);
+    MethodRef staticInitForClass(ClassOrModuleRef klass, Loc loc);
 
-    SymbolRef lookupStaticInitForFile(Loc loc) const;
-    SymbolRef lookupStaticInitForClass(ClassOrModuleRef klass) const;
+    MethodRef lookupStaticInitForFile(Loc loc) const;
+    MethodRef lookupStaticInitForClass(ClassOrModuleRef klass) const;
 
     NameRef enterNameUTF8(std::string_view nm);
     NameRef lookupNameUTF8(std::string_view nm) const;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -79,7 +79,7 @@ public:
     ClassOrModuleRef enterClassSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);
     SymbolRef enterTypeMember(Loc loc, ClassOrModuleRef owner, NameRef name, Variance variance);
     SymbolRef enterTypeArgument(Loc loc, MethodRef owner, NameRef name, Variance variance);
-    MethodRef enterMethodSymbol(Loc loc, SymbolRef owner, NameRef name);
+    MethodRef enterMethodSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);
     MethodRef enterNewMethodOverload(Loc loc, MethodRef original, core::NameRef originalName, u4 num,
                                      const std::vector<bool> &argsToKeep);
     SymbolRef enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -80,7 +80,7 @@ public:
     SymbolRef enterTypeMember(Loc loc, ClassOrModuleRef owner, NameRef name, Variance variance);
     SymbolRef enterTypeArgument(Loc loc, SymbolRef owner, NameRef name, Variance variance);
     MethodRef enterMethodSymbol(Loc loc, SymbolRef owner, NameRef name);
-    SymbolRef enterNewMethodOverload(Loc loc, SymbolRef original, core::NameRef originalName, u4 num,
+    SymbolRef enterNewMethodOverload(Loc loc, MethodRef original, core::NameRef originalName, u4 num,
                                      const std::vector<bool> &argsToKeep);
     SymbolRef enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);
     SymbolRef enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -84,7 +84,7 @@ public:
                                      const std::vector<bool> &argsToKeep);
     SymbolRef enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);
     SymbolRef enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);
-    ArgInfo &enterMethodArgumentSymbol(Loc loc, SymbolRef owner, NameRef name);
+    ArgInfo &enterMethodArgumentSymbol(Loc loc, MethodRef owner, NameRef name);
 
     SymbolRef lookupSymbol(SymbolRef owner, NameRef name) const {
         return lookupSymbolWithFlags(owner, name, 0);

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -79,7 +79,7 @@ public:
     ClassOrModuleRef enterClassSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);
     SymbolRef enterTypeMember(Loc loc, ClassOrModuleRef owner, NameRef name, Variance variance);
     SymbolRef enterTypeArgument(Loc loc, SymbolRef owner, NameRef name, Variance variance);
-    SymbolRef enterMethodSymbol(Loc loc, SymbolRef owner, NameRef name);
+    MethodRef enterMethodSymbol(Loc loc, SymbolRef owner, NameRef name);
     SymbolRef enterNewMethodOverload(Loc loc, SymbolRef original, core::NameRef originalName, u4 num,
                                      const std::vector<bool> &argsToKeep);
     SymbolRef enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);
@@ -95,10 +95,10 @@ public:
     ClassOrModuleRef lookupClassSymbol(SymbolRef owner, NameRef name) const {
         return lookupSymbolWithFlags(owner, name, Symbol::Flags::CLASS_OR_MODULE).asClassOrModuleRef();
     }
-    SymbolRef lookupMethodSymbol(SymbolRef owner, NameRef name) const {
-        return lookupSymbolWithFlags(owner, name, Symbol::Flags::METHOD);
+    MethodRef lookupMethodSymbol(SymbolRef owner, NameRef name) const {
+        return lookupSymbolWithFlags(owner, name, Symbol::Flags::METHOD).asMethodRef();
     }
-    SymbolRef lookupMethodSymbolWithHash(SymbolRef owner, NameRef name, const std::vector<u4> &methodHash) const;
+    MethodRef lookupMethodSymbolWithHash(SymbolRef owner, NameRef name, const std::vector<u4> &methodHash) const;
     SymbolRef lookupStaticFieldSymbol(SymbolRef owner, NameRef name) const {
         return lookupSymbolWithFlags(owner, name, Symbol::Flags::STATIC_FIELD);
     }

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -78,7 +78,7 @@ public:
 
     ClassOrModuleRef enterClassSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);
     SymbolRef enterTypeMember(Loc loc, ClassOrModuleRef owner, NameRef name, Variance variance);
-    SymbolRef enterTypeArgument(Loc loc, SymbolRef owner, NameRef name, Variance variance);
+    SymbolRef enterTypeArgument(Loc loc, MethodRef owner, NameRef name, Variance variance);
     MethodRef enterMethodSymbol(Loc loc, SymbolRef owner, NameRef name);
     MethodRef enterNewMethodOverload(Loc loc, MethodRef original, core::NameRef originalName, u4 num,
                                      const std::vector<bool> &argsToKeep);

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -80,7 +80,7 @@ public:
     SymbolRef enterTypeMember(Loc loc, ClassOrModuleRef owner, NameRef name, Variance variance);
     SymbolRef enterTypeArgument(Loc loc, SymbolRef owner, NameRef name, Variance variance);
     MethodRef enterMethodSymbol(Loc loc, SymbolRef owner, NameRef name);
-    SymbolRef enterNewMethodOverload(Loc loc, MethodRef original, core::NameRef originalName, u4 num,
+    MethodRef enterNewMethodOverload(Loc loc, MethodRef original, core::NameRef originalName, u4 num,
                                      const std::vector<bool> &argsToKeep);
     SymbolRef enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);
     SymbolRef enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -217,7 +217,10 @@ public:
     }
 
     // If Kind is Method, returns a MethodRef.
-    MethodRef asMethodRef() const;
+    MethodRef asMethodRef() const {
+        ENFORCE_NO_TIMER(kind() == Kind::Method);
+        return MethodRef::fromRaw(unsafeTableIndex());
+    }
 
     SymbolData data(GlobalState &gs) const;
     ConstSymbolData data(const GlobalState &gs) const;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -74,6 +74,36 @@ public:
 };
 CheckSize(ClassOrModuleRef, 4, 4);
 
+class MethodRef final {
+    u4 _id;
+
+public:
+    MethodRef() : _id(0){};
+    MethodRef(const GlobalState &from, u4 id);
+
+    u4 id() const {
+        return _id;
+    }
+
+    bool exists() const {
+        return _id != 0;
+    }
+
+    static MethodRef fromRaw(u4 id) {
+        MethodRef ref;
+        ref._id = id;
+        return ref;
+    }
+
+    SymbolData data(GlobalState &gs) const;
+    ConstSymbolData data(const GlobalState &gs) const;
+
+    bool operator==(const MethodRef &rhs) const;
+
+    bool operator!=(const MethodRef &rhs) const;
+};
+CheckSize(MethodRef, 4, 4);
+
 class SymbolRef final {
     friend class GlobalState;
     friend class Symbol;
@@ -160,6 +190,7 @@ public:
     // This constructor is not marked explicit so that we can implicitly convert ClassOrModuleRef to SymbolRefs as
     // method arguments. This conversion is always safe and never throws.
     SymbolRef(ClassOrModuleRef kls);
+    SymbolRef(MethodRef kls);
     SymbolRef() : _id(0){};
 
     // From experimentation, in the common case, methods typically have 2 or fewer arguments.
@@ -184,6 +215,9 @@ public:
         ENFORCE_NO_TIMER(kind() == Kind::ClassOrModule);
         return ClassOrModuleRef::fromRaw(unsafeTableIndex());
     }
+
+    // If Kind is Method, returns a MethodRef.
+    MethodRef asMethodRef() const;
 
     SymbolData data(GlobalState &gs) const;
     ConstSymbolData data(const GlobalState &gs) const;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -497,8 +497,8 @@ public:
         return ClassOrModuleRef::fromRaw(61);
     }
 
-    static SymbolRef noMethod() {
-        return SymbolRef(nullptr, SymbolRef::Kind::Method, 0);
+    static MethodRef noMethod() {
+        return MethodRef();
     }
 
     static SymbolRef noField() {
@@ -513,8 +513,8 @@ public:
         return SymbolRef(nullptr, SymbolRef::Kind::TypeMember, 0);
     }
 
-    static SymbolRef Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder() {
-        return SymbolRef(nullptr, SymbolRef::Kind::Method, 1);
+    static MethodRef Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder() {
+        return MethodRef::fromRaw(1);
     }
 
     static SymbolRef
@@ -534,8 +534,8 @@ public:
         return SymbolRef(nullptr, SymbolRef::Kind::FieldOrStaticField, 1);
     }
 
-    static SymbolRef Sorbet_Private_Static_badAliasMethodStub() {
-        return SymbolRef(nullptr, SymbolRef::Kind::Method, 2);
+    static MethodRef Sorbet_Private_Static_badAliasMethodStub() {
+        return MethodRef::fromRaw(2);
     }
 
     static ClassOrModuleRef T_Helpers() {
@@ -586,8 +586,8 @@ public:
         return ClassOrModuleRef::fromRaw(74);
     }
 
-    static SymbolRef sig() {
-        return SymbolRef(nullptr, SymbolRef::Kind::Method, 3);
+    static MethodRef sig() {
+        return MethodRef::fromRaw(3);
     }
 
     static ClassOrModuleRef Enumerator_Lazy() {
@@ -618,8 +618,8 @@ public:
         return ClassOrModuleRef::fromRaw(81);
     }
 
-    static SymbolRef sigWithoutRuntime() {
-        return SymbolRef(nullptr, SymbolRef::Kind::Method, 4);
+    static MethodRef sigWithoutRuntime() {
+        return MethodRef::fromRaw(4);
     }
 
     static ClassOrModuleRef T_NonForcingConstants() {
@@ -634,8 +634,8 @@ public:
         return ClassOrModuleRef::fromRaw(84);
     }
 
-    static SymbolRef SorbetPrivateStaticSingleton_sig() {
-        return SymbolRef(nullptr, SymbolRef::Kind::Method, 5);
+    static MethodRef SorbetPrivateStaticSingleton_sig() {
+        return MethodRef::fromRaw(5);
     }
 
     static ClassOrModuleRef PackageRegistry() {
@@ -650,24 +650,24 @@ public:
         return ClassOrModuleRef::fromRaw(87);
     }
 
-    static SymbolRef PackageSpec_import() {
-        return SymbolRef(nullptr, SymbolRef::Kind::Method, 6);
+    static MethodRef PackageSpec_import() {
+        return MethodRef::fromRaw(6);
     }
 
-    static SymbolRef PackageSpec_export() {
-        return SymbolRef(nullptr, SymbolRef::Kind::Method, 7);
+    static MethodRef PackageSpec_export() {
+        return MethodRef::fromRaw(7);
     }
 
-    static SymbolRef PackageSpec_export_methods() {
-        return SymbolRef(nullptr, SymbolRef::Kind::Method, 8);
+    static MethodRef PackageSpec_export_methods() {
+        return MethodRef::fromRaw(8);
     }
 
     static ClassOrModuleRef Encoding() {
         return ClassOrModuleRef::fromRaw(88);
     }
 
-    static SymbolRef Class_new() {
-        return SymbolRef(nullptr, SymbolRef::Kind::Method, 9);
+    static MethodRef Class_new() {
+        return MethodRef::fromRaw(9);
     }
 
     static constexpr int MAX_PROC_ARITY = 10;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -670,6 +670,10 @@ public:
         return MethodRef::fromRaw(9);
     }
 
+    static MethodRef todoMethod() {
+        return MethodRef::fromRaw(10);
+    }
+
     static constexpr int MAX_PROC_ARITY = 10;
     static ClassOrModuleRef Proc0() {
         return ClassOrModuleRef::fromRaw(MAX_SYNTHETIC_CLASS_SYMBOLS - MAX_PROC_ARITY * 2 - 2);
@@ -693,7 +697,7 @@ public:
     }
 
     static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 200;
-    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 33;
+    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 34;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 3;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 3;
     static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 100;

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1292,8 +1292,8 @@ void Symbol::sanityCheck(const GlobalState &gs) const {
                 }
                 break;
             case SymbolRef::Kind::TypeArgument:
-                current2 = const_cast<GlobalState &>(gs).enterTypeArgument(this->loc(), this->owner, this->name,
-                                                                           this->variance());
+                current2 = const_cast<GlobalState &>(gs).enterTypeArgument(this->loc(), this->owner.asMethodRef(),
+                                                                           this->name, this->variance());
                 break;
             case SymbolRef::Kind::TypeMember:
                 current2 = const_cast<GlobalState &>(gs).enterTypeMember(this->loc(), this->owner.asClassOrModuleRef(),

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1280,7 +1280,8 @@ void Symbol::sanityCheck(const GlobalState &gs) const {
                                                                           this->name);
                 break;
             case SymbolRef::Kind::Method:
-                current2 = const_cast<GlobalState &>(gs).enterMethodSymbol(this->loc(), this->owner, this->name);
+                current2 = const_cast<GlobalState &>(gs).enterMethodSymbol(
+                    this->loc(), this->owner.asClassOrModuleRef(), this->name);
                 break;
             case SymbolRef::Kind::FieldOrStaticField:
                 if (isField()) {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -526,8 +526,8 @@ vector<Symbol::FuzzySearchResult> Symbol::findMemberFuzzyMatchConstant(const Glo
             // follow outer scopes
 
             // find scopes that would be considered for search
-            vector<SymbolRef> candidateScopes;
-            candidateScopes.emplace_back(base);
+            vector<ClassOrModuleRef> candidateScopes;
+            candidateScopes.emplace_back(base.asClassOrModuleRef());
             int i = 0;
             // this is quadratic in number of scopes that we traverse, but YOLO, this should rarely run
             while (i < candidateScopes.size()) {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1319,18 +1319,6 @@ void Symbol::sanityCheck(const GlobalState &gs) const {
     }
 }
 
-SymbolRef Symbol::enclosingMethod(const GlobalState &gs) const {
-    if (isMethod()) {
-        return ref(gs);
-    }
-    SymbolRef owner = this->owner;
-    while (owner != Symbols::root() && !owner.data(gs)->isMethod()) {
-        ENFORCE(owner.exists(), "non-existing owner in enclosingMethod");
-        owner = owner.data(gs)->owner;
-    }
-    return owner;
-}
-
 ClassOrModuleRef Symbol::enclosingClass(const GlobalState &gs) const {
     SymbolRef owner = ref(gs);
     while (!owner.isClassOrModule()) {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -233,11 +233,6 @@ SymbolData ClassOrModuleRef::dataAllowingNone(GlobalState &gs) const {
     return SymbolData(gs.classAndModules[_id], gs);
 }
 
-MethodRef SymbolRef::asMethodRef() const {
-    ENFORCE_NO_TIMER(kind() == Kind::Method);
-    return MethodRef::fromRaw(unsafeTableIndex());
-}
-
 SymbolData ClassOrModuleRef::data(GlobalState &gs) const {
     ENFORCE_NO_TIMER(this->exists());
     return dataAllowingNone(gs);

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -587,8 +587,10 @@ public:
         return dealiasWithDefault(gs, depthLimit, Symbols::untyped());
     }
     // if dealiasing fails here, then we return a bad alias method stub instead
-    SymbolRef dealiasMethod(const GlobalState &gs, int depthLimit = 42) const {
-        return dealiasWithDefault(gs, depthLimit, core::Symbols::Sorbet_Private_Static_badAliasMethodStub());
+    MethodRef dealiasMethod(const GlobalState &gs, int depthLimit = 42) const {
+        ENFORCE_NO_TIMER(isMethod());
+        return dealiasWithDefault(gs, depthLimit, core::Symbols::Sorbet_Private_Static_badAliasMethodStub())
+            .asMethodRef();
     }
 
     SymbolRef dealiasWithDefault(const GlobalState &gs, int depthLimit, SymbolRef def) const;

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -655,7 +655,6 @@ public:
 
     Symbol deepCopy(const GlobalState &to, bool keepGsId = false) const;
     void sanityCheck(const GlobalState &gs) const;
-    SymbolRef enclosingMethod(const GlobalState &gs) const;
 
     ClassOrModuleRef enclosingClass(const GlobalState &gs) const;
 

--- a/core/Types.h
+++ b/core/Types.h
@@ -181,7 +181,7 @@ struct Intrinsic {
         Instance = 1,
         Singleton = 2,
     };
-    const SymbolRef symbol;
+    const ClassOrModuleRef symbol;
     const Kind singleton;
     const NameRef method;
     const IntrinsicMethod *impl;

--- a/core/Types.h
+++ b/core/Types.h
@@ -128,11 +128,11 @@ public:
     static bool canBeFalsy(const GlobalState &gs, const TypePtr &what);
     enum class Combinator { OR, AND };
 
-    static TypePtr resultTypeAsSeenFrom(const GlobalState &gs, const TypePtr &what, SymbolRef fromWhat,
-                                        SymbolRef inWhat, const std::vector<TypePtr> &targs);
+    static TypePtr resultTypeAsSeenFrom(const GlobalState &gs, const TypePtr &what, ClassOrModuleRef fromWhat,
+                                        ClassOrModuleRef inWhat, const std::vector<TypePtr> &targs);
 
-    static InlinedVector<SymbolRef, 4> alignBaseTypeArgs(const GlobalState &gs, SymbolRef what,
-                                                         const std::vector<TypePtr> &targs, SymbolRef asIf);
+    static InlinedVector<SymbolRef, 4> alignBaseTypeArgs(const GlobalState &gs, ClassOrModuleRef what,
+                                                         const std::vector<TypePtr> &targs, ClassOrModuleRef asIf);
     // Extract the return value type from a proc.
     static TypePtr getProcReturnType(const GlobalState &gs, const TypePtr &procType);
     static TypePtr instantiate(const GlobalState &gs, const TypePtr &what, const InlinedVector<SymbolRef, 4> &params,

--- a/core/Types.h
+++ b/core/Types.h
@@ -817,7 +817,7 @@ struct DispatchArgs {
 
 struct DispatchComponent {
     TypePtr receiver;
-    SymbolRef method;
+    MethodRef method;
     std::vector<std::unique_ptr<Error>> errors;
     TypePtr sendTp;
     TypePtr blockReturnType;
@@ -834,7 +834,7 @@ struct DispatchResult {
     Combinator secondaryKind;
 
     DispatchResult() = default;
-    DispatchResult(TypePtr returnType, TypePtr receiverType, core::SymbolRef method)
+    DispatchResult(TypePtr returnType, TypePtr receiverType, core::MethodRef method)
         : returnType(returnType),
           main(DispatchComponent{
               std::move(receiverType), method, {}, std::move(returnType), nullptr, nullptr, ArgInfo{}, nullptr}){};

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -11,14 +11,14 @@ class TypeConstraint;
 class SendResponse final {
 public:
     SendResponse(core::Loc termLoc, std::shared_ptr<core::DispatchResult> dispatchResult, core::NameRef callerSideName,
-                 bool isPrivateOk, core::SymbolRef enclosingMethod, core::Loc receiverLoc)
+                 bool isPrivateOk, core::MethodRef enclosingMethod, core::Loc receiverLoc)
         : dispatchResult(std::move(dispatchResult)), callerSideName(callerSideName), termLoc(termLoc),
           isPrivateOk(isPrivateOk), enclosingMethod(enclosingMethod), receiverLoc(receiverLoc){};
     const std::shared_ptr<core::DispatchResult> dispatchResult;
     const core::NameRef callerSideName;
     const core::Loc termLoc;
     const bool isPrivateOk;
-    const core::SymbolRef enclosingMethod;
+    const core::MethodRef enclosingMethod;
     const core::Loc receiverLoc;
 
     const std::optional<core::Loc> getMethodNameLoc(const core::GlobalState &gs) const;

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -27,12 +27,12 @@ public:
 class IdentResponse final {
 public:
     IdentResponse(core::Loc termLoc, core::LocalVariable variable, core::TypeAndOrigins retType,
-                  core::SymbolRef enclosingMethod)
+                  core::MethodRef enclosingMethod)
         : termLoc(termLoc), variable(variable), retType(std::move(retType)), enclosingMethod(enclosingMethod){};
     const core::Loc termLoc;
     const core::LocalVariable variable;
     const core::TypeAndOrigins retType;
-    const core::SymbolRef enclosingMethod;
+    const core::MethodRef enclosingMethod;
 };
 
 class LiteralResponse final {

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1100,7 +1100,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::TreePtr &what) {
             memcpy(&flags, &c.flags, sizeof(flags));
             p.putU1(flags);
             p.putU4(c.name.rawId());
-            p.putU4(c.symbol.rawId());
+            p.putU4(c.symbol.id());
             p.putU4(c.args.size());
             pickle(p, c.rhs);
             for (auto &a : c.args) {
@@ -1373,7 +1373,7 @@ ast::TreePtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const GlobalS
             // Can replace this with std::bit_cast in C++20
             memcpy(&flags, &flagsU1, sizeof(flags));
             NameRef name = unpickleNameRef(p, gs);
-            auto symbol = SymbolRef::fromRaw(p.getU4());
+            auto symbol = MethodRef::fromRaw(p.getU4());
             auto argsSize = p.getU4();
             auto rhs = unpickleExpr(p, gs, file);
             ast::MethodDef::ARGS_store args(argsSize);

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -403,6 +403,7 @@ NameDef names[] = {
     {"Class", "Class", true},
     {"Module", "Module", true},
     {"Todo", "<todo sym>", true},
+    {"TodoMethod", "<todo method>", false},
     {"NoSymbol", "<none>", true},
     {"noFieldOrStaticField", "<no-field-or-static-field>", false},
     {"noMethod", "<no-method>", false},

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -936,10 +936,8 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
     return glbGround(gs, t1, t2);
 }
 
-bool classSymbolIsAsGoodAs(const GlobalState &gs, SymbolRef c1, SymbolRef c2) {
-    ENFORCE(c1.isClassOrModule());
-    ENFORCE(c2.isClassOrModule());
-    return c1 == c2 || c1.data(gs)->derivesFrom(gs, c2.asClassOrModuleRef());
+bool classSymbolIsAsGoodAs(const GlobalState &gs, ClassOrModuleRef c1, ClassOrModuleRef c2) {
+    return c1 == c2 || c1.data(gs)->derivesFrom(gs, c2);
 }
 
 void compareToUntyped(const GlobalState &gs, TypeConstraint &constr, const TypePtr &ty, const TypePtr &blame) {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -495,12 +495,9 @@ void ClassType::_sanityCheck(const GlobalState &gs) const {
 /** Returns type parameters of what reordered in the order of type parameters of asIf
  * If some typeArgs are not present, return NoSymbol
  * */
-InlinedVector<SymbolRef, 4> Types::alignBaseTypeArgs(const GlobalState &gs, SymbolRef what,
-                                                     const vector<TypePtr> &targs, SymbolRef asIf) {
-    ENFORCE(asIf.isClassOrModule());
-    ENFORCE(what.isClassOrModule());
-    ENFORCE(what == asIf || what.data(gs)->derivesFrom(gs, asIf.asClassOrModuleRef()) ||
-                asIf.data(gs)->derivesFrom(gs, what.asClassOrModuleRef()),
+InlinedVector<SymbolRef, 4> Types::alignBaseTypeArgs(const GlobalState &gs, ClassOrModuleRef what,
+                                                     const vector<TypePtr> &targs, ClassOrModuleRef asIf) {
+    ENFORCE(what == asIf || what.data(gs)->derivesFrom(gs, asIf) || asIf.data(gs)->derivesFrom(gs, what),
             what.data(gs)->name.showRaw(gs), asIf.data(gs)->name.showRaw(gs));
     InlinedVector<SymbolRef, 4> currentAlignment;
     if (targs.empty()) {
@@ -536,11 +533,9 @@ InlinedVector<SymbolRef, 4> Types::alignBaseTypeArgs(const GlobalState &gs, Symb
  * fromWhat - where the generic type was written
  * inWhat   - where the generic type is observed
  */
-TypePtr Types::resultTypeAsSeenFrom(const GlobalState &gs, const TypePtr &what, SymbolRef fromWhat, SymbolRef inWhat,
-                                    const vector<TypePtr> &targs) {
-    SymbolRef originalOwner = fromWhat;
-    ENFORCE(fromWhat.isClassOrModule());
-    ENFORCE(inWhat.isClassOrModule());
+TypePtr Types::resultTypeAsSeenFrom(const GlobalState &gs, const TypePtr &what, ClassOrModuleRef fromWhat,
+                                    ClassOrModuleRef inWhat, const vector<TypePtr> &targs) {
+    auto originalOwner = fromWhat;
 
     // TODO: the ENFORCE below should be above this conditional, but there is
     // currently a problem with the handling of `module_function` that causes it
@@ -549,8 +544,8 @@ TypePtr Types::resultTypeAsSeenFrom(const GlobalState &gs, const TypePtr &what, 
         return what;
     }
 
-    ENFORCE(inWhat == fromWhat || inWhat.data(gs)->derivesFrom(gs, fromWhat.asClassOrModuleRef()) ||
-                fromWhat.data(gs)->derivesFrom(gs, inWhat.asClassOrModuleRef()),
+    ENFORCE(inWhat == fromWhat || inWhat.data(gs)->derivesFrom(gs, fromWhat) ||
+                fromWhat.data(gs)->derivesFrom(gs, inWhat),
             "\n{}\nis unrelated to\n\n{}", fromWhat.data(gs)->toString(gs), inWhat.data(gs)->toString(gs));
 
     auto currentAlignment = alignBaseTypeArgs(gs, originalOwner, targs, inWhat);

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -270,7 +270,7 @@ void validateOverriding(const core::Context ctx, core::MethodRef method) {
     auto name = method.data(ctx)->name;
     ENFORCE(klass.isClassOrModule());
     auto klassData = klass.data(ctx);
-    InlinedVector<core::SymbolRef, 4> overridenMethods;
+    InlinedVector<core::MethodRef, 4> overridenMethods;
 
     // both of these match the behavior of the runtime checks, which will only allow public methods to be defined in
     // interfaces
@@ -299,13 +299,13 @@ void validateOverriding(const core::Context ctx, core::MethodRef method) {
     if (klassData->superClass().exists()) {
         auto superMethod = klassData->superClass().data(ctx)->findMemberTransitive(ctx, name);
         if (superMethod.exists()) {
-            overridenMethods.emplace_back(superMethod);
+            overridenMethods.emplace_back(superMethod.asMethodRef());
         }
     }
     for (const auto &mixin : klassData->mixins()) {
         auto superMethod = mixin.data(ctx)->findMember(ctx, name);
         if (superMethod.exists()) {
-            overridenMethods.emplace_back(superMethod);
+            overridenMethods.emplace_back(superMethod.asMethodRef());
         }
     }
 

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -503,10 +503,10 @@ void validateSealed(core::Context ctx, const core::SymbolRef klass, const ast::C
 
 class ValidateWalk {
 private:
-    UnorderedMap<core::SymbolRef, vector<core::SymbolRef>> abstractCache;
+    UnorderedMap<core::ClassOrModuleRef, vector<core::MethodRef>> abstractCache;
 
-    const vector<core::SymbolRef> &getAbstractMethods(const core::GlobalState &gs, core::SymbolRef klass) {
-        vector<core::SymbolRef> abstract;
+    const vector<core::MethodRef> &getAbstractMethods(const core::GlobalState &gs, core::ClassOrModuleRef klass) {
+        vector<core::MethodRef> abstract;
         auto ent = abstractCache.find(klass);
         if (ent != abstractCache.end()) {
             return ent->second;
@@ -530,7 +530,7 @@ private:
         if (isAbstract) {
             for (auto [name, sym] : klass.data(gs)->members()) {
                 if (sym.exists() && sym.data(gs)->isMethod() && sym.data(gs)->isAbstract()) {
-                    abstract.emplace_back(sym);
+                    abstract.emplace_back(sym.asMethodRef());
                 }
             }
         }
@@ -558,7 +558,7 @@ private:
         }
     }
 
-    void validateAbstract(const core::GlobalState &gs, core::SymbolRef sym) {
+    void validateAbstract(const core::GlobalState &gs, core::ClassOrModuleRef sym) {
         if (sym.data(gs)->isClassOrModuleAbstract()) {
             return;
         }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -265,7 +265,7 @@ void validateCompatibleOverride(const core::Context ctx, core::SymbolRef superMe
     }
 }
 
-void validateOverriding(const core::Context ctx, core::SymbolRef method) {
+void validateOverriding(const core::Context ctx, core::MethodRef method) {
     auto klass = method.data(ctx)->owner;
     auto name = method.data(ctx)->name;
     ENFORCE(klass.isClassOrModule());
@@ -276,13 +276,13 @@ void validateOverriding(const core::Context ctx, core::SymbolRef method) {
     // interfaces
     if (klassData->isClassOrModuleInterface() && method.data(ctx)->isMethodPrivate()) {
         if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::NonPublicAbstract)) {
-            e.setHeader("Interface method `{}` cannot be private", method.show(ctx));
+            e.setHeader("Interface method `{}` cannot be private", method.data(ctx)->show(ctx));
         }
     }
 
     if (klassData->isClassOrModuleInterface() && method.data(ctx)->isMethodProtected()) {
         if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::NonPublicAbstract)) {
-            e.setHeader("Interface method `{}` cannot be protected", method.show(ctx));
+            e.setHeader("Interface method `{}` cannot be protected", method.data(ctx)->show(ctx));
         }
     }
 

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -173,7 +173,7 @@ private:
                 // current implementation will alias an instance method as a
                 // class method.
                 if (aliasSym.data(ctx)->isMethod()) {
-                    validateMethod(ctx, polarity, aliasSym);
+                    validateMethod(ctx, polarity, aliasSym.asMethodRef());
                 } else {
                     Exception::raise("Unexpected type alias: {}", type.toString(ctx));
                 }
@@ -193,7 +193,7 @@ public:
 
     // Variance checking, parameterized on the external polarity of the method
     // context.
-    static void validateMethod(const core::Context ctx, const Polarity polarity, const core::SymbolRef method) {
+    static void validateMethod(const core::Context ctx, const Polarity polarity, const core::MethodRef method) {
         auto methodData = method.data(ctx);
 
         // Negate the polarity for checking arguments in a ContraVariant
@@ -213,7 +213,7 @@ public:
 };
 
 // Validates uses of type members according to their variance.
-void validateMethodVariance(const core::Context ctx, const core::SymbolRef method) {
+void validateMethodVariance(const core::Context ctx, const core::MethodRef method) {
     VarianceValidator::validateMethod(ctx, Polarity::Positive, method);
 }
 

--- a/definition_validator/variance.h
+++ b/definition_validator/variance.h
@@ -5,7 +5,7 @@
 
 namespace sorbet::definition_validator::variance {
 
-void validateMethodVariance(const core::Context ctx, const core::SymbolRef method);
+void validateMethodVariance(const core::Context ctx, const core::MethodRef method);
 
 };
 

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -57,7 +57,7 @@ optional<core::AutocorrectSuggestion::Edit> maybeSuggestExtendTSig(core::Context
 }
 
 core::TypePtr extractArgType(core::Context ctx, cfg::Send &send, core::DispatchComponent &component, int argId) {
-    ENFORCE(component.method.exists() && component.method != core::Symbols::untyped());
+    ENFORCE(component.method.exists());
     const auto &args = component.method.data(ctx)->arguments();
     if (argId >= args.size()) {
         return nullptr;
@@ -110,7 +110,7 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
         core::TypePtr thisType;
         auto iter = &dispatchInfo;
         while (iter != nullptr) {
-            if (iter->main.method.exists() && iter->main.method != core::Symbols::untyped()) {
+            if (iter->main.method.exists()) {
                 auto argType = extractArgType(ctx, *snd, iter->main, i);
                 if (argType && !argType.isUntyped()) {
                     if (!thisType) {

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -247,27 +247,26 @@ UnorderedMap<core::NameRef, core::TypePtr> guessArgumentTypes(core::Context ctx,
     return argTypesForBBToPass[cfg->deadBlock()->id];
 }
 
-core::SymbolRef closestOverridenMethod(core::Context ctx, core::SymbolRef enclosingClassSymbol, core::NameRef name) {
+core::MethodRef closestOverridenMethod(core::Context ctx, core::ClassOrModuleRef enclosingClassSymbol,
+                                       core::NameRef name) {
     auto enclosingClass = enclosingClassSymbol.data(ctx);
     ENFORCE(enclosingClass->isClassOrModuleLinearizationComputed(), "Should have been linearized by resolver");
 
     for (const auto &mixin : enclosingClass->mixins()) {
         auto mixinMethod = mixin.data(ctx)->findMember(ctx, name);
         if (mixinMethod.exists()) {
-            ENFORCE(mixinMethod.data(ctx)->isMethod());
-            return mixinMethod;
+            return mixinMethod.asMethodRef();
         }
     }
 
     auto superClass = enclosingClass->superClass();
     if (!superClass.exists()) {
-        core::SymbolRef none;
-        return none;
+        return core::Symbols::noMethod();
     }
 
     auto superMethod = superClass.data(ctx)->findMember(ctx, name);
     if (superMethod.exists()) {
-        return superMethod;
+        return superMethod.asMethodRef();
     } else {
         return closestOverridenMethod(ctx, superClass, name);
     }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1062,7 +1062,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                             }
                         } else if (data->isField()) {
                             tp.type = core::Types::resultTypeAsSeenFrom(
-                                ctx, symbol.data(ctx)->resultType, symbol.data(ctx)->owner,
+                                ctx, symbol.data(ctx)->resultType, symbol.data(ctx)->owner.asClassOrModuleRef(),
                                 ctx.owner.data(ctx)->enclosingClass(ctx),
                                 ctx.owner.data(ctx)->enclosingClass(ctx).data(ctx)->selfTypeArgs(ctx));
                         } else {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1034,8 +1034,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
 
                 if (lspQueryMatch && !bind.value->isSynthetic) {
                     core::lsp::QueryResponse::pushQueryResponse(
-                        ctx,
-                        core::lsp::IdentResponse(core::Loc(ctx.file, bind.loc), i->what.data(inWhat), tp, ctx.owner));
+                        ctx, core::lsp::IdentResponse(core::Loc(ctx.file, bind.loc), i->what.data(inWhat), tp,
+                                                      ctx.owner.asMethodRef()));
                 }
 
                 ENFORCE(ctx.file.data(ctx).hasParseErrors || !tp.origins.empty(), "Inferencer did not assign location");

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1009,9 +1009,9 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 }
                 if (lspQueryMatch) {
                     core::lsp::QueryResponse::pushQueryResponse(
-                        ctx,
-                        core::lsp::SendResponse(core::Loc(ctx.file, bind.loc), retainedResult, send->fun,
-                                                send->isPrivateOk, ctx.owner, core::Loc(ctx.file, send->receiverLoc)));
+                        ctx, core::lsp::SendResponse(core::Loc(ctx.file, bind.loc), retainedResult, send->fun,
+                                                     send->isPrivateOk, ctx.owner.asMethodRef(),
+                                                     core::Loc(ctx.file, send->receiverLoc)));
                 }
                 if (send->link) {
                     // This should eventually become ENFORCEs but currently they are wrong

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -63,8 +63,9 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
         auto enclosingClass = cfg->symbol.data(ctx)->enclosingClass(ctx);
         methodReturnType = core::Types::instantiate(
             ctx,
-            core::Types::resultTypeAsSeenFrom(ctx, cfg->symbol.data(ctx)->resultType, cfg->symbol.data(ctx)->owner,
-                                              enclosingClass, enclosingClass.data(ctx)->selfTypeArgs(ctx)),
+            core::Types::resultTypeAsSeenFrom(ctx, cfg->symbol.data(ctx)->resultType,
+                                              cfg->symbol.data(ctx)->owner.asClassOrModuleRef(), enclosingClass,
+                                              enclosingClass.data(ctx)->selfTypeArgs(ctx)),
             *constr);
         methodReturnType = core::Types::replaceSelfType(ctx, methodReturnType, enclosingClass.data(ctx)->selfType(ctx));
     }

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -14,7 +14,7 @@ namespace sorbet::infer {
 unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg) {
     Timer timeit(ctx.state.tracer(), "Inference::run",
                  {{"func", (string)cfg->symbol.data(ctx)->toStringFullName(ctx)}});
-    ENFORCE(cfg->symbol == ctx.owner);
+    ENFORCE(cfg->symbol == ctx.owner.asMethodRef());
     auto methodLoc = cfg->symbol.data(ctx)->loc();
     prodCounterInc("types.input.methods.typechecked");
     int typedSendCount = 0;

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -52,11 +52,11 @@ ast::TreePtr DefLocSaver::postTransformMethodDef(core::Context ctx, ast::TreePtr
 ast::TreePtr DefLocSaver::postTransformUnresolvedIdent(core::Context ctx, ast::TreePtr tree) {
     auto &id = ast::cast_tree_nonnull<ast::UnresolvedIdent>(tree);
     if (id.kind == ast::UnresolvedIdent::Kind::Instance || id.kind == ast::UnresolvedIdent::Kind::Class) {
-        core::SymbolRef klass;
+        core::ClassOrModuleRef klass;
         // Logic cargo culted from `global2Local` in `walker_build.cc`.
         if (id.kind == ast::UnresolvedIdent::Kind::Instance) {
             ENFORCE(ctx.owner.data(ctx)->isMethod());
-            klass = ctx.owner.data(ctx)->owner;
+            klass = ctx.owner.data(ctx)->owner.asClassOrModuleRef();
         } else {
             // Class var.
             klass = ctx.owner.data(ctx)->enclosingClass(ctx);

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -14,7 +14,6 @@
 #include "main/lsp/ErrorReporter.h"
 #include "main/lsp/LSPMessage.h"
 #include "main/lsp/LSPOutput.h"
-#include "main/lsp/LocalVarFinder.h"
 #include "main/lsp/LocalVarSaver.h"
 #include "main/lsp/QueryCollector.h"
 #include "main/lsp/ShowOperation.h"

--- a/main/lsp/LocalVarFinder.cc
+++ b/main/lsp/LocalVarFinder.cc
@@ -27,11 +27,11 @@ ast::TreePtr LocalVarFinder::preTransformMethodDef(core::Context ctx, ast::TreeP
     auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
 
     ENFORCE(methodDef.symbol.exists());
-    ENFORCE(methodDef.symbol != core::Symbols::todo());
+    ENFORCE(methodDef.symbol != core::Symbols::todoMethod());
 
     auto currentMethod = methodDef.symbol;
 
-    if (currentMethod == this->targetMethod) {
+    if (currentMethod == this->targetMethod.asMethodRef()) {
         auto parsedArgs = ast::ArgParsing::parseArgs(methodDef.args);
         for (const auto &parsedArg : parsedArgs) {
             this->result_.emplace_back(parsedArg.local);

--- a/main/lsp/LocalVarFinder.cc
+++ b/main/lsp/LocalVarFinder.cc
@@ -31,7 +31,7 @@ ast::TreePtr LocalVarFinder::preTransformMethodDef(core::Context ctx, ast::TreeP
 
     auto currentMethod = methodDef.symbol;
 
-    if (currentMethod == this->targetMethod.asMethodRef()) {
+    if (currentMethod == this->targetMethod) {
         auto parsedArgs = ast::ArgParsing::parseArgs(methodDef.args);
         for (const auto &parsedArg : parsedArgs) {
             this->result_.emplace_back(parsedArg.local);

--- a/main/lsp/LocalVarFinder.h
+++ b/main/lsp/LocalVarFinder.h
@@ -7,7 +7,7 @@
 namespace sorbet::realmain::lsp {
 
 class LocalVarFinder {
-    core::SymbolRef targetMethod;
+    core::MethodRef targetMethod;
 
     // We go through the effort of keeping track of a method stack so as to not rely on trees having been
     // flattened at this point. (LSP code should try to make minimal assumptions to be robust to changes.)
@@ -16,7 +16,7 @@ class LocalVarFinder {
     std::vector<core::LocalVariable> result_;
 
 public:
-    LocalVarFinder(core::SymbolRef targetMethod) : targetMethod(targetMethod) {}
+    LocalVarFinder(core::MethodRef targetMethod) : targetMethod(targetMethod) {}
 
     ast::TreePtr postTransformAssign(core::Context ctx, ast::TreePtr assign);
     ast::TreePtr preTransformMethodDef(core::Context ctx, ast::TreePtr methodDef);

--- a/main/lsp/LocalVarSaver.cc
+++ b/main/lsp/LocalVarSaver.cc
@@ -8,30 +8,20 @@ namespace sorbet::realmain::lsp {
 ast::TreePtr LocalVarSaver::postTransformLocal(core::Context ctx, ast::TreePtr tree) {
     auto &local = ast::cast_tree_nonnull<ast::Local>(tree);
 
-    core::MethodRef owner;
+    core::MethodRef enclosingMethod;
     if (ctx.owner.data(ctx)->isMethod()) {
-        owner = ctx.owner.asMethodRef();
+        enclosingMethod = ctx.owner.asMethodRef();
     } else if (ctx.owner == core::Symbols::root()) {
-        owner = ctx.state.lookupStaticInitForFile(core::Loc(ctx.file, local.loc));
+        enclosingMethod = ctx.state.lookupStaticInitForFile(core::Loc(ctx.file, local.loc));
     } else {
-        owner = ctx.state.lookupStaticInitForClass(ctx.owner.asClassOrModuleRef());
+        enclosingMethod = ctx.state.lookupStaticInitForClass(ctx.owner.asClassOrModuleRef());
     }
 
-    bool lspQueryMatch = ctx.state.lspQuery.matchesVar(owner, local.localVariable);
+    bool lspQueryMatch = ctx.state.lspQuery.matchesVar(enclosingMethod, local.localVariable);
     if (lspQueryMatch) {
         // No need for type information; this is for a reference request.
         // Let the default constructor make tp.type an empty shared_ptr and tp.origins an empty vector
         core::TypeAndOrigins tp;
-
-        core::MethodRef enclosingMethod;
-        if (ctx.owner.isClassOrModule()) {
-            enclosingMethod = ctx.owner == core::Symbols::root()
-                                  ? ctx.state.lookupStaticInitForFile(core::Loc(ctx.file, local.loc))
-                                  : ctx.state.lookupStaticInitForClass(ctx.owner.asClassOrModuleRef());
-        } else {
-            enclosingMethod = ctx.owner.asMethodRef();
-        }
-
         core::lsp::QueryResponse::pushQueryResponse(
             ctx, core::lsp::IdentResponse(core::Loc(ctx.file, local.loc), local.localVariable, tp, enclosingMethod));
     }

--- a/main/lsp/NextMethodFinder.cc
+++ b/main/lsp/NextMethodFinder.cc
@@ -8,7 +8,7 @@ namespace sorbet::realmain::lsp {
 ast::TreePtr NextMethodFinder::preTransformMethodDef(core::Context ctx, ast::TreePtr tree) {
     auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
     ENFORCE(methodDef.symbol.exists());
-    ENFORCE(methodDef.symbol != core::Symbols::todo());
+    ENFORCE(methodDef.symbol != core::Symbols::todoMethod());
 
     auto currentMethod = methodDef.symbol;
 

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -16,6 +16,9 @@ bool hideSymbol(const core::GlobalState &gs, core::SymbolRef sym) {
         return true;
     }
     auto data = sym.data(gs);
+    if (!data->owner.exists()) {
+        return true;
+    }
     if (data->isClassOrModule() && data->attachedClass(gs).exists()) {
         return true;
     }

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -446,7 +446,7 @@ unique_ptr<CompletionItem> getCompletionItemForLocal(const core::GlobalState &gs
 }
 
 vector<core::LocalVariable> localsForMethod(const core::GlobalState &gs, LSPTypecheckerDelegate &typechecker,
-                                            const core::SymbolRef method) {
+                                            const core::MethodRef method) {
     auto files = vector<core::FileRef>{};
     for (auto loc : method.data(gs)->locs()) {
         files.emplace_back(loc.file());

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -98,7 +98,7 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerDelegat
         {core::SymbolRef::Kind::TypeMember, gs.typeMembersUsed()},
     };
     for (auto [kind, used] : symbolTypes) {
-        for (u4 idx = 0; idx < used; idx++) {
+        for (u4 idx = 1; idx < used; idx++) {
             core::SymbolRef ref(gs, kind, idx);
             if (!hideSymbol(gs, ref) &&
                 // a bit counter-intuitive, but this actually should be `!= fref`, as it prevents duplicates.

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -76,9 +76,9 @@ vector<core::SymbolRef> getSubclasses(const core::GlobalState &gs, core::SymbolR
 
 // Follow superClass links until we find the highest class that contains the given method. In other words we find the
 // "root" of the tree of classes that define a method.
-core::SymbolRef findRootClassWithMethod(const core::GlobalState &gs, core::SymbolRef klass, core::NameRef methodName) {
+core::SymbolRef findRootClassWithMethod(const core::GlobalState &gs, core::ClassOrModuleRef klass,
+                                        core::NameRef methodName) {
     auto root = klass;
-    ENFORCE(klass.isClassOrModule());
     while (true) {
         auto tmp = root.data(gs)->superClass();
         ENFORCE(tmp.exists()); // everything derives from Kernel::Object so we can't ever reach the actual top type

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -36,37 +36,37 @@ bool isValidRenameLocation(const core::SymbolRef &symbol, const core::GlobalStat
 }
 
 // Checks if s is a subclass of root or contains root as a mixin, and updates visited and memoized vectors.
-bool isSubclassOrMixin(const core::GlobalState &gs, core::SymbolRef root, core::SymbolRef s, vector<bool> &memoized,
-                       vector<bool> &visited) {
+bool isSubclassOrMixin(const core::GlobalState &gs, core::ClassOrModuleRef root, core::ClassOrModuleRef s,
+                       vector<bool> &memoized, vector<bool> &visited) {
     // don't visit the same class twice
-    if (visited[s.classOrModuleIndex()] == true) {
-        return memoized[s.classOrModuleIndex()];
+    if (visited[s.id()] == true) {
+        return memoized[s.id()];
     }
-    visited[s.classOrModuleIndex()] = true;
+    visited[s.id()] = true;
 
-    for (core::SymbolRef a : s.data(gs)->mixins()) {
+    for (core::ClassOrModuleRef a : s.data(gs)->mixins()) {
         if (a == root) {
-            memoized[s.classOrModuleIndex()] = true;
+            memoized[s.id()] = true;
             return true;
         }
     }
     if (s.data(gs)->superClass().exists()) {
-        memoized[s.classOrModuleIndex()] = isSubclassOrMixin(gs, root, s.data(gs)->superClass(), memoized, visited);
+        memoized[s.id()] = isSubclassOrMixin(gs, root, s.data(gs)->superClass(), memoized, visited);
     }
 
-    return memoized[s.classOrModuleIndex()];
+    return memoized[s.id()];
 }
 
 // Returns all subclasses of root (including root)
-vector<core::SymbolRef> getSubclasses(const core::GlobalState &gs, core::SymbolRef root) {
+vector<core::ClassOrModuleRef> getSubclasses(const core::GlobalState &gs, core::ClassOrModuleRef root) {
     vector<bool> memoized(gs.classAndModulesUsed());
     vector<bool> visited(gs.classAndModulesUsed());
-    memoized[root.classOrModuleIndex()] = true;
-    visited[root.classOrModuleIndex()] = true;
+    memoized[root.id()] = true;
+    visited[root.id()] = true;
 
-    vector<core::SymbolRef> subclasses;
+    vector<core::ClassOrModuleRef> subclasses;
     for (u4 i = 1; i < gs.classAndModulesUsed(); ++i) {
-        auto s = core::SymbolRef(&gs, core::SymbolRef::Kind::ClassOrModule, i);
+        auto s = core::ClassOrModuleRef(gs, i);
         if (isSubclassOrMixin(gs, root, s, memoized, visited)) {
             subclasses.emplace_back(s);
         }
@@ -76,8 +76,8 @@ vector<core::SymbolRef> getSubclasses(const core::GlobalState &gs, core::SymbolR
 
 // Follow superClass links until we find the highest class that contains the given method. In other words we find the
 // "root" of the tree of classes that define a method.
-core::SymbolRef findRootClassWithMethod(const core::GlobalState &gs, core::ClassOrModuleRef klass,
-                                        core::NameRef methodName) {
+core::ClassOrModuleRef findRootClassWithMethod(const core::GlobalState &gs, core::ClassOrModuleRef klass,
+                                               core::NameRef methodName) {
     auto root = klass;
     while (true) {
         auto tmp = root.data(gs)->superClass();
@@ -118,7 +118,7 @@ private:
 };
 
 // Add subclass-related methods (methods overriding and overridden by `symbol`) to the `methods` vector.
-void addSubclassRelatedMethods(const core::GlobalState &gs, core::SymbolRef symbol, UniqueSymbolQueue &methods) {
+void addSubclassRelatedMethods(const core::GlobalState &gs, core::MethodRef symbol, UniqueSymbolQueue &methods) {
     auto symbolData = symbol.data(gs);
 
     // We have to check for methods as part of a class hierarchy: Follow superClass() links till we find the root;
@@ -140,7 +140,7 @@ void addSubclassRelatedMethods(const core::GlobalState &gs, core::SymbolRef symb
         if (!member.exists()) {
             continue;
         }
-        methods.tryEnqueue(member);
+        methods.tryEnqueue(member.asMethodRef());
     }
 }
 
@@ -336,7 +336,7 @@ void RenameTask::getRenameEdits(LSPTypecheckerDelegate &typechecker, core::Symbo
     UniqueSymbolQueue symbolQueue;
     if (symbolData->isMethod()) {
         renamer = make_unique<MethodRenamer>(gs, config, symbolQueue, originalName, newName);
-        addSubclassRelatedMethods(gs, symbol, symbolQueue);
+        addSubclassRelatedMethods(gs, symbol.asMethodRef(), symbolQueue);
     } else {
         renamer = make_unique<ConstRenamer>(gs, config, originalName, newName);
         symbolQueue.tryEnqueue(symbol);

--- a/namer/configatron/configatron.cc
+++ b/namer/configatron/configatron.cc
@@ -216,7 +216,7 @@ void configatron::fillInFromFileSystem(core::GlobalState &gs, const vector<strin
         handleFile(gs, file, rootNode);
     }
 
-    core::SymbolRef configatron =
+    auto configatron =
         gs.enterMethodSymbol(core::Loc::none(), core::Symbols::Kernel(), gs.enterNameUTF8("configatron"));
     rootNode->enter(gs, configatron, core::Symbols::root());
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -841,7 +841,8 @@ class SymbolDefiner {
         }
         // we know right now that pos >= arguments().size() because otherwise we would have hit the early return at the
         // beginning of this method
-        auto &argInfo = ctx.state.enterMethodArgumentSymbol(core::Loc(ctx.file, parsedArg.loc), ctx.owner, name);
+        auto &argInfo =
+            ctx.state.enterMethodArgumentSymbol(core::Loc(ctx.file, parsedArg.loc), ctx.owner.asMethodRef(), name);
         // if enterMethodArgumentSymbol did not emplace a new argument into the list, then it means it's reusing an
         // existing one, which means we've seen a repeated kwarg (as it treats identically named kwargs as
         // identical). We know that we need to match the arity of the function as written, so if we don't have as many

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -985,7 +985,7 @@ class SymbolDefiner {
     }
 
     core::SymbolRef defineMethod(core::MutableContext ctx, const FoundMethod &method) {
-        core::SymbolRef owner = methodOwner(ctx, method.flags);
+        auto owner = methodOwner(ctx, method.flags);
 
         // There are three symbols in play here, because there's:
         //

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -787,7 +787,8 @@ class SymbolDefiner {
         }
 
         // Check if class was already mangled.
-        auto klassSymbol = ctx.state.lookupClassSymbol(scope.data(ctx)->owner, scope.data(ctx)->name);
+        auto klassSymbol =
+            ctx.state.lookupClassSymbol(scope.data(ctx)->owner.asClassOrModuleRef(), scope.data(ctx)->name);
         if (klassSymbol.exists()) {
             return klassSymbol;
         }
@@ -1112,7 +1113,8 @@ class SymbolDefiner {
         auto declLoc = core::Loc(ctx.file, klass.declLoc);
         if (!symbol.isClassOrModule()) {
             // we might have already mangled the class symbol, so see if we have a symbol that is a class already
-            auto klassSymbol = ctx.state.lookupClassSymbol(symbol.data(ctx)->owner, symbol.data(ctx)->name);
+            auto klassSymbol =
+                ctx.state.lookupClassSymbol(symbol.data(ctx)->owner.asClassOrModuleRef(), symbol.data(ctx)->name);
             if (klassSymbol.exists()) {
                 return klassSymbol;
             }
@@ -1447,7 +1449,7 @@ class TreeSymbolizer {
 
         const bool firstNameRecursive = false;
         auto newOwner = squashNamesInner(ctx, owner, constLit->scope, firstNameRecursive);
-        core::SymbolRef existing = ctx.state.lookupClassSymbol(newOwner, constLit->cnst);
+        core::SymbolRef existing = ctx.state.lookupClassSymbol(newOwner.asClassOrModuleRef(), constLit->cnst);
         if (firstName && !existing.exists()) {
             existing = ctx.state.lookupStaticFieldSymbol(newOwner, constLit->cnst);
             if (existing.exists()) {
@@ -1560,7 +1562,8 @@ public:
                 ENFORCE(symbol == core::Symbols::root());
             }
             if (!symbol.isClassOrModule()) {
-                klass.symbol = ctx.state.lookupClassSymbol(klass.symbol.data(ctx)->owner, klass.symbol.data(ctx)->name);
+                klass.symbol = ctx.state.lookupClassSymbol(klass.symbol.data(ctx)->owner.asClassOrModuleRef(),
+                                                           klass.symbol.data(ctx)->name);
                 ENFORCE(klass.symbol.exists());
             } else {
                 klass.symbol = symbol.asClassOrModuleRef();
@@ -1686,7 +1689,7 @@ public:
         core::SymbolRef scope = squashNames(ctx, contextClass(ctx, ctx.owner), lhs.scope);
         if (!scope.isClassOrModule()) {
             auto scopeName = scope.data(ctx)->name;
-            scope = ctx.state.lookupClassSymbol(scope.data(ctx)->owner, scopeName);
+            scope = ctx.state.lookupClassSymbol(scope.data(ctx)->owner.asClassOrModuleRef(), scopeName);
         }
 
         core::SymbolRef cnst = ctx.state.lookupStaticFieldSymbol(scope, lhs.cnst);
@@ -1734,7 +1737,7 @@ public:
             bool isTypeTemplate = send->fun == core::Names::typeTemplate();
             auto onSymbol = isTypeTemplate ? ctx.owner.data(ctx)->lookupSingletonClass(ctx) : ctx.owner;
             ENFORCE(onSymbol.exists());
-            core::SymbolRef sym = ctx.state.lookupTypeMemberSymbol(onSymbol, typeName->cnst);
+            core::SymbolRef sym = ctx.state.lookupTypeMemberSymbol(onSymbol.asClassOrModuleRef(), typeName->cnst);
             ENFORCE(sym.exists());
 
             if (send->hasKwArgs()) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1544,9 +1544,11 @@ class ResolveTypeMembersAndFieldsWalk {
     }
 
     static void resolveMethodAlias(core::MutableContext ctx, const ResolveMethodAliasItem &job) {
-        core::SymbolRef toMethod = ctx.owner.data(ctx)->findMemberNoDealias(ctx, job.toName);
-        if (toMethod.exists()) {
-            toMethod = toMethod.data(ctx)->dealiasMethod(ctx);
+        core::SymbolRef member = ctx.owner.data(ctx)->findMemberNoDealias(ctx, job.toName);
+        // TODO(jvilk): Would be nice to have findMember that returned MethodRef.
+        core::MethodRef toMethod = core::Symbols::noMethod();
+        if (member.exists()) {
+            toMethod = member.data(ctx)->dealiasMethod(ctx);
         }
 
         if (!toMethod.exists()) {
@@ -1558,7 +1560,7 @@ class ResolveTypeMembersAndFieldsWalk {
         }
 
         core::SymbolRef fromMethod = ctx.owner.data(ctx)->findMemberNoDealias(ctx, job.fromName);
-        if (fromMethod.exists() && fromMethod.data(ctx)->dealiasMethod(ctx) != toMethod.asMethodRef()) {
+        if (fromMethod.exists() && fromMethod.data(ctx)->dealiasMethod(ctx) != toMethod) {
             if (auto e = ctx.beginError(job.loc, core::errors::Resolver::BadAliasMethod)) {
                 auto dealiased = fromMethod.data(ctx)->dealiasMethod(ctx);
                 if (fromMethod == dealiased) {
@@ -1582,7 +1584,7 @@ class ResolveTypeMembersAndFieldsWalk {
         }
 
         core::SymbolRef alias = ctx.state.enterMethodSymbol(core::Loc(ctx.file, job.loc), job.owner, job.fromName);
-        alias.data(ctx)->resultType = core::make_type<core::AliasType>(toMethod);
+        alias.data(ctx)->resultType = core::make_type<core::AliasType>(core::SymbolRef(toMethod));
     }
 
     // Returns `true` if `asgn` is a field declaration.

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2365,9 +2365,9 @@ private:
         }
     }
 
-    static void fillInInfoFromSig(core::MutableContext ctx, core::SymbolRef method, core::LocOffsets exprLoc,
+    static void fillInInfoFromSig(core::MutableContext ctx, core::MethodRef method, core::LocOffsets exprLoc,
                                   ParsedSig sig, bool isOverloaded, const ast::MethodDef &mdef) {
-        ENFORCE(isOverloaded || mdef.symbol == method.asMethodRef());
+        ENFORCE(isOverloaded || mdef.symbol == method);
         ENFORCE(isOverloaded || method.data(ctx)->arguments().size() == mdef.args.size());
 
         if (!sig.seen.returns && !sig.seen.void_) {
@@ -2723,7 +2723,7 @@ public:
         int i = -1;
         for (auto &sig : sigs) {
             i++;
-            core::SymbolRef overloadSym;
+            core::MethodRef overloadSym;
             if (isOverloaded) {
                 overloadSym = ctx.state.enterNewMethodOverload(core::Loc(ctx.file, sig.loc), mdef.symbol, originalName,
                                                                i, sig.argsToKeep);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1582,7 +1582,7 @@ class ResolveTypeMembersAndFieldsWalk {
             return;
         }
 
-        core::SymbolRef alias = ctx.state.enterMethodSymbol(core::Loc(ctx.file, job.loc), job.owner, job.fromName);
+        auto alias = ctx.state.enterMethodSymbol(core::Loc(ctx.file, job.loc), job.owner, job.fromName);
         alias.data(ctx)->resultType = core::make_type<core::AliasType>(core::SymbolRef(toMethod));
     }
 
@@ -1622,7 +1622,7 @@ class ResolveTypeMembersAndFieldsWalk {
         Timer timeit(gs.tracer(), "resolver.computeExternalType");
         // Ensure all symbols have `externalType` computed.
         for (u4 i = 1; i < gs.classAndModulesUsed(); i++) {
-            core::SymbolRef(gs, core::SymbolRef::Kind::ClassOrModule, i).data(gs)->unsafeComputeExternalType(gs);
+            core::ClassOrModuleRef(gs, i).data(gs)->unsafeComputeExternalType(gs);
         }
     }
 
@@ -2580,7 +2580,7 @@ private:
         seq.stats.erase(toRemove, seq.stats.end());
     }
 
-    ParsedSig parseSig(core::Context ctx, core::SymbolRef sigOwner, ast::Send &send, ast::MethodDef &mdef) {
+    ParsedSig parseSig(core::Context ctx, core::ClassOrModuleRef sigOwner, ast::Send &send, ast::MethodDef &mdef) {
         auto allowSelfType = true;
         auto allowRebind = false;
         auto allowTypeMember = true;
@@ -2655,13 +2655,13 @@ private:
                     // process signatures in the context of either the current
                     // class, or the current singleton class, depending on if
                     // the current method is a self method.
-                    core::SymbolRef sigOwner;
+                    core::ClassOrModuleRef sigOwner;
                     if (mdef.flags.isSelfMethod) {
                         sigOwner = ctx.owner.data(ctx)->lookupSingletonClass(ctx);
                         // namer ensures that all method owners are defined.
                         ENFORCE_NO_TIMER(sigOwner.exists());
                     } else {
-                        sigOwner = ctx.owner;
+                        sigOwner = ctx.owner.asClassOrModuleRef();
                     }
 
                     if (lastSigs.size() == 1) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2365,7 +2365,7 @@ private:
 
     static void fillInInfoFromSig(core::MutableContext ctx, core::SymbolRef method, core::LocOffsets exprLoc,
                                   ParsedSig sig, bool isOverloaded, const ast::MethodDef &mdef) {
-        ENFORCE(isOverloaded || mdef.symbol == method);
+        ENFORCE(isOverloaded || mdef.symbol == method.asMethodRef());
         ENFORCE(isOverloaded || method.data(ctx)->arguments().size() == mdef.args.size());
 
         if (!sig.seen.returns && !sig.seen.void_) {
@@ -2771,7 +2771,7 @@ public:
     }
     ast::TreePtr postTransformMethodDef(core::MutableContext ctx, ast::TreePtr tree) {
         auto &original = ast::cast_tree_nonnull<ast::MethodDef>(tree);
-        ENFORCE(original.symbol != core::Symbols::todo(), "These should have all been resolved: {}",
+        ENFORCE(original.symbol != core::Symbols::todoMethod(), "These should have all been resolved: {}",
                 tree.toString(ctx));
         return tree;
     }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1558,7 +1558,7 @@ class ResolveTypeMembersAndFieldsWalk {
         }
 
         core::SymbolRef fromMethod = ctx.owner.data(ctx)->findMemberNoDealias(ctx, job.fromName);
-        if (fromMethod.exists() && fromMethod.data(ctx)->dealiasMethod(ctx) != toMethod) {
+        if (fromMethod.exists() && fromMethod.data(ctx)->dealiasMethod(ctx) != toMethod.asMethodRef()) {
             if (auto e = ctx.beginError(job.loc, core::errors::Resolver::BadAliasMethod)) {
                 auto dealiased = fromMethod.data(ctx)->dealiasMethod(ctx);
                 if (fromMethod == dealiased) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2261,7 +2261,7 @@ class ResolveSignaturesWalk {
 public:
     struct ResolveSignatureJob {
         core::FileRef file;
-        core::SymbolRef owner;
+        core::ClassOrModuleRef owner;
         ast::MethodDef *mdef;
         core::LocOffsets loc;
         ParsedSig sig;
@@ -2276,7 +2276,7 @@ public:
 
     struct ResolveMultiSignatureJob {
         core::FileRef file;
-        core::SymbolRef owner;
+        core::ClassOrModuleRef owner;
         ast::MethodDef *mdef;
         bool isOverloaded;
         InlinedVector<OverloadedMethodSignature, 2> sigs;
@@ -2666,7 +2666,8 @@ private:
 
                     if (lastSigs.size() == 1) {
                         auto &lastSig = lastSigs.front();
-                        signatureJobs.emplace_back(ResolveSignatureJob{ctx.file, ctx.owner, &mdef, lastSig->loc,
+                        signatureJobs.emplace_back(ResolveSignatureJob{ctx.file, ctx.owner.asClassOrModuleRef(), &mdef,
+                                                                       lastSig->loc,
                                                                        parseSig(ctx, sigOwner, *lastSig, mdef)});
                     } else {
                         bool isOverloaded = ctx.permitOverloadDefinitions(ctx.file);
@@ -2687,8 +2688,8 @@ private:
                             sigs.emplace_back(OverloadedMethodSignature{lastSig->loc, move(sig), move(argsToKeep)});
                         }
 
-                        multiSignatureJobs.emplace_back(
-                            ResolveMultiSignatureJob{ctx.file, ctx.owner, &mdef, isOverloaded, std::move(sigs)});
+                        multiSignatureJobs.emplace_back(ResolveMultiSignatureJob{
+                            ctx.file, ctx.owner.asClassOrModuleRef(), &mdef, isOverloaded, std::move(sigs)});
                     }
 
                     lastSigs.clear();

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -447,8 +447,7 @@ private:
         auto ancestorType =
             core::make_type<core::UnresolvedClassType>(unresolvedPath->first, move(unresolvedPath->second));
 
-        core::SymbolRef uaSym =
-            ctx.state.enterMethodSymbol(core::Loc::none(), item.klass, core::Names::unresolvedAncestors());
+        auto uaSym = ctx.state.enterMethodSymbol(core::Loc::none(), item.klass, core::Names::unresolvedAncestors());
         core::TypePtr resultType = uaSym.data(ctx)->resultType;
         if (!resultType) {
             uaSym.data(ctx)->resultType = core::TupleType::build(ctx, {ancestorType});
@@ -1098,7 +1097,7 @@ class ResolveTypeMembersAndFieldsWalk {
 
     struct ResolveMethodAliasItem {
         core::FileRef file;
-        core::SymbolRef owner;
+        core::ClassOrModuleRef owner;
         core::LocOffsets loc;
         core::LocOffsets toNameLoc;
         core::NameRef toName;
@@ -1790,8 +1789,8 @@ class ResolveTypeMembersAndFieldsWalk {
         }
     }
 
-    core::SymbolRef methodOwner(core::Context ctx) {
-        core::SymbolRef owner = ctx.owner.data(ctx)->enclosingClass(ctx);
+    core::ClassOrModuleRef methodOwner(core::Context ctx) {
+        core::ClassOrModuleRef owner = ctx.owner.data(ctx)->enclosingClass(ctx);
         if (owner == core::Symbols::root()) {
             // Root methods end up going on object
             owner = core::Symbols::Object();

--- a/test/testdata/cfg/blocks.rb.desugar-tree.exp
+++ b/test/testdata/cfg/blocks.rb.desugar-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C BlockTest><<C <todo sym>>> < (::<todo sym>)
-    def blockPass<<C <todo sym>>>(&<blk>)
+    def blockPass<<todo method>>(&<blk>)
       <self>.foo(1, 2, 3) do |x, y|
         x
       end

--- a/test/testdata/cfg/examples.rb.desugar-tree.exp
+++ b/test/testdata/cfg/examples.rb.desugar-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Examples><<C <todo sym>>> < (::<todo sym>)
-    def i_like_ifs<<C <todo sym>>>(&<blk>)
+    def i_like_ifs<<todo method>>(&<blk>)
       if true
         return 1
       else
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    def i_like_exps<<C <todo sym>>>(&<blk>)
+    def i_like_exps<<todo method>>(&<blk>)
       if true
         1
       else
@@ -16,7 +16,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    def return_in_one_branch1<<C <todo sym>>>(&<blk>)
+    def return_in_one_branch1<<todo method>>(&<blk>)
       if true
         return 1
       else
@@ -24,7 +24,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    def return_in_one_branch2<<C <todo sym>>>(&<blk>)
+    def return_in_one_branch2<<todo method>>(&<blk>)
       if true
         1
       else
@@ -32,7 +32,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    def variables<<C <todo sym>>>(&<blk>)
+    def variables<<todo method>>(&<blk>)
       begin
         if true
           a = 1
@@ -48,7 +48,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    def variables_and_loop<<C <todo sym>>>(cond, &<blk>)
+    def variables_and_loop<<todo method>>(cond, &<blk>)
       begin
         if true
           a = 1
@@ -66,7 +66,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    def variables_loop_if<<C <todo sym>>>(cond, &<blk>)
+    def variables_loop_if<<todo method>>(cond, &<blk>)
       begin
         while true
           if cond
@@ -79,7 +79,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    def take_arguments<<C <todo sym>>>(i, &<blk>)
+    def take_arguments<<todo method>>(i, &<blk>)
       if false
         2
       else

--- a/test/testdata/cfg/floats.rb.desugar-tree.exp
+++ b/test/testdata/cfg/floats.rb.desugar-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def test_large_float<<C <todo sym>>>(&<blk>)
+  def test_large_float<<todo method>>(&<blk>)
     begin
       a = 3.141593
       a = 0.000001

--- a/test/testdata/cfg/rescue.rb.desugar-tree-raw.exp
+++ b/test/testdata/cfg/rescue.rb.desugar-tree-raw.exp
@@ -8,7 +8,7 @@ ClassDef{
   rhs = [
     MethodDef{
       flags = {}
-      name = <U main><<C <U <todo sym>>>>
+      name = <U main><<U <todo method>>>
       args = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
@@ -69,7 +69,7 @@ ClassDef{
 
     MethodDef{
       flags = {}
-      name = <U a><<C <U <todo sym>>>>
+      name = <U a><<U <todo method>>>
       args = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
@@ -79,7 +79,7 @@ ClassDef{
 
     MethodDef{
       flags = {}
-      name = <U b><<C <U <todo sym>>>>
+      name = <U b><<U <todo method>>>
       args = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
@@ -89,7 +89,7 @@ ClassDef{
 
     MethodDef{
       flags = {}
-      name = <U c><<C <U <todo sym>>>>
+      name = <U c><<U <todo method>>>
       args = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
@@ -99,7 +99,7 @@ ClassDef{
 
     MethodDef{
       flags = {}
-      name = <U d><<C <U <todo sym>>>>
+      name = <U d><<U <todo method>>>
       args = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>

--- a/test/testdata/cfg/rescue.rb.desugar-tree.exp
+++ b/test/testdata/cfg/rescue.rb.desugar-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def main<<C <todo sym>>>(&<blk>)
+  def main<<todo method>>(&<blk>)
     <self>.a()
   rescue => <rescueTemp>$2
     <self>.b()
@@ -9,19 +9,19 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.d()
   end
 
-  def a<<C <todo sym>>>(&<blk>)
+  def a<<todo method>>(&<blk>)
     <emptyTree>
   end
 
-  def b<<C <todo sym>>>(&<blk>)
+  def b<<todo method>>(&<blk>)
     <emptyTree>
   end
 
-  def c<<C <todo sym>>>(&<blk>)
+  def c<<todo method>>(&<blk>)
     <emptyTree>
   end
 
-  def d<<C <todo sym>>>(&<blk>)
+  def d<<todo method>>(&<blk>)
     <emptyTree>
   end
 

--- a/test/testdata/cfg/rescue_complex.rb.desugar-tree.exp
+++ b/test/testdata/cfg/rescue_complex.rb.desugar-tree.exp
@@ -1,30 +1,30 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C TestRescue><<C <todo sym>>> < (::<todo sym>)
-    def meth<<C <todo sym>>>(&<blk>)
+    def meth<<todo method>>(&<blk>)
       0
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       1
     end
 
-    def bar<<C <todo sym>>>(&<blk>)
+    def bar<<todo method>>(&<blk>)
       2
     end
 
-    def baz<<C <todo sym>>>(&<blk>)
+    def baz<<todo method>>(&<blk>)
       3
     end
 
-    def take_arg<<C <todo sym>>>(x, &<blk>)
+    def take_arg<<todo method>>(x, &<blk>)
       x
     end
 
-    def initialize<<C <todo sym>>>(&<blk>)
+    def initialize<<todo method>>(&<blk>)
       @ex = <emptyTree>::<C T>.let(nil, <emptyTree>::<C T>.nilable(<emptyTree>::<C StandardError>))
     end
 
-    def multiple_rescue<<C <todo sym>>>(&<blk>)
+    def multiple_rescue<<todo method>>(&<blk>)
       <self>.meth()
     rescue => <rescueTemp>$2
       <self>.baz()
@@ -32,13 +32,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.bar()
     end
 
-    def multiple_rescue_classes<<C <todo sym>>>(&<blk>)
+    def multiple_rescue_classes<<todo method>>(&<blk>)
       <self>.meth()
     rescue <emptyTree>::<C Foo>, <emptyTree>::<C Bar> => baz
       baz
     end
 
-    def parse_rescue_ensure<<C <todo sym>>>(&<blk>)
+    def parse_rescue_ensure<<todo method>>(&<blk>)
       <self>.meth()
     rescue => <rescueTemp>$2
       <self>.baz()
@@ -46,31 +46,31 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.bar()
     end
 
-    def parse_bug_rescue_empty_else<<C <todo sym>>>(&<blk>)
+    def parse_bug_rescue_empty_else<<todo method>>(&<blk>)
       <emptyTree>
     rescue <emptyTree>::<C LoadError> => <rescueTemp>$2
       <emptyTree>
     end
 
-    def parse_ruby_bug_12686<<C <todo sym>>>(&<blk>)
+    def parse_ruby_bug_12686<<todo method>>(&<blk>)
       <self>.take_arg(<self>.bar()
       rescue => <rescueTemp>$2
         nil)
     end
 
-    def parse_rescue_mod<<C <todo sym>>>(&<blk>)
+    def parse_rescue_mod<<todo method>>(&<blk>)
       <self>.meth()
     rescue => <rescueTemp>$2
       <self>.bar()
     end
 
-    def parse_resbody_list_var<<C <todo sym>>>(&<blk>)
+    def parse_resbody_list_var<<todo method>>(&<blk>)
       <self>.meth()
     rescue <self>.foo() => ex
       <self>.bar()
     end
 
-    def parse_rescue_else_ensure<<C <todo sym>>>(&<blk>)
+    def parse_rescue_else_ensure<<todo method>>(&<blk>)
       <self>.meth()
     rescue => <rescueTemp>$2
       <self>.baz()
@@ -80,19 +80,19 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.bar()
     end
 
-    def parse_rescue<<C <todo sym>>>(&<blk>)
+    def parse_rescue<<todo method>>(&<blk>)
       <self>.meth()
     rescue => <rescueTemp>$2
       <self>.foo()
     end
 
-    def parse_resbody_var<<C <todo sym>>>(&<blk>)
+    def parse_resbody_var<<todo method>>(&<blk>)
       <self>.meth()
     rescue => ex
       <self>.bar()
     end
 
-    def parse_resbody_var_1<<C <todo sym>>>(&<blk>)
+    def parse_resbody_var_1<<todo method>>(&<blk>)
       <self>.meth()
     rescue => <rescueTemp>$2
       begin
@@ -101,25 +101,25 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    def parse_rescue_mod_op_assign<<C <todo sym>>>(&<blk>)
+    def parse_rescue_mod_op_assign<<todo method>>(&<blk>)
       foo = foo.+(<self>.meth()
       rescue => <rescueTemp>$2
         <self>.bar())
     end
 
-    def parse_ruby_bug_12402<<C <todo sym>>>(&<blk>)
+    def parse_ruby_bug_12402<<todo method>>(&<blk>)
       foo = <self>.raise(<self>.bar())
     rescue => <rescueTemp>$2
       nil
     end
 
-    def parse_ruby_bug_12402_1<<C <todo sym>>>(&<blk>)
+    def parse_ruby_bug_12402_1<<todo method>>(&<blk>)
       foo = foo.+(<self>.raise(<self>.bar())
       rescue => <rescueTemp>$2
         nil)
     end
 
-    def parse_ruby_bug_12402_2<<C <todo sym>>>(&<blk>)
+    def parse_ruby_bug_12402_2<<todo method>>(&<blk>)
       begin
         []$3 = <self>.foo()
         []$4 = 0

--- a/test/testdata/cfg/retry.rb.desugar-tree-raw.exp
+++ b/test/testdata/cfg/retry.rb.desugar-tree-raw.exp
@@ -8,7 +8,7 @@ ClassDef{
   rhs = [
     MethodDef{
       flags = {}
-      name = <U main><<C <U <todo sym>>>>
+      name = <U main><<U <todo method>>>
       args = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>

--- a/test/testdata/cfg/retry.rb.desugar-tree.exp
+++ b/test/testdata/cfg/retry.rb.desugar-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def main<<C <todo sym>>>(&<blk>)
+  def main<<todo method>>(&<blk>)
     begin
       try = 0
       if try.<(3)

--- a/test/testdata/desugar/blockpass.rb.desugar-tree.exp
+++ b/test/testdata/desugar/blockpass.rb.desugar-tree.exp
@@ -1,43 +1,43 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C HasMeth><<C <todo sym>>> < (::<todo sym>)
-    def meth<<C <todo sym>>>(&<blk>)
+    def meth<<todo method>>(&<blk>)
       "meth"
     end
   end
 
-  def returns_lambda<<C <todo sym>>>(&<blk>)
+  def returns_lambda<<todo method>>(&<blk>)
     <self>.lambda() do |x|
       "returns_lambda"
     end
   end
 
   class <emptyTree>::<C HasToProc><<C <todo sym>>> < (::<todo sym>)
-    def to_proc<<C <todo sym>>>(&<blk>)
+    def to_proc<<todo method>>(&<blk>)
       <self>.returns_lambda()
     end
   end
 
-  def calls_arg_with_object<<C <todo sym>>>(arg, &blk)
+  def calls_arg_with_object<<todo method>>(arg, &blk)
     blk.call(arg)
   end
 
-  def calls_with_object<<C <todo sym>>>(&blk)
+  def calls_with_object<<todo method>>(&blk)
     ::<Magic>.<call-with-block>(<self>, :calls_arg_with_object, blk, <emptyTree>::<C HasMeth>.new())
   end
 
   class <emptyTree>::<C CallsWithObject><<C <todo sym>>> < (::<todo sym>)
-    def self.calls_with_object<<C <todo sym>>>(&blk)
+    def self.calls_with_object<<todo method>>(&blk)
       blk.call(<emptyTree>::<C HasMeth>.new())
     end
   end
 
   class <emptyTree>::<C CallsWithObjectChild><<C <todo sym>>> < (<emptyTree>::<C CallsWithObject>)
-    def self.calls_with_object<<C <todo sym>>>(&blk)
+    def self.calls_with_object<<todo method>>(&blk)
       ::<Magic>.<call-with-block>(<self>, :super, blk)
     end
   end
 
-  def foo<<C <todo sym>>>(&blk)
+  def foo<<todo method>>(&blk)
     begin
       <self>.calls_with_object() do |<block-pass>$2|
         <block-pass>$2.meth()

--- a/test/testdata/desugar/complex.rb.desugar-tree.exp
+++ b/test/testdata/desugar/complex.rb.desugar-tree.exp
@@ -6,7 +6,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:x, <emptyTree>::<C Complex>).void()
     end
 
-    def foo<<C <todo sym>>>(x, &<blk>)
+    def foo<<todo method>>(x, &<blk>)
       <emptyTree>::<C Kernel>.puts(x)
     end
 
@@ -14,7 +14,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Complex>)
     end
 
-    def bar<<C <todo sym>>>(&<blk>)
+    def bar<<todo method>>(&<blk>)
       ::Kernel.Complex(0, "11")
     end
 
@@ -22,7 +22,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def baz<<C <todo sym>>>(&<blk>)
+    def baz<<todo method>>(&<blk>)
       <emptyTree>::<C Kernel>.puts(::Kernel.Complex(0, "2"))
     end
   end
@@ -34,7 +34,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:x, <emptyTree>::<C Complex>).void()
     end
 
-    def foo<<C <todo sym>>>(x, &<blk>)
+    def foo<<todo method>>(x, &<blk>)
       <self>.puts(x)
     end
   end

--- a/test/testdata/desugar/csend.rb.desugar-tree.exp
+++ b/test/testdata/desugar/csend.rb.desugar-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def test_csend<<C <todo sym>>>(&<blk>)
+  def test_csend<<todo method>>(&<blk>)
     begin
       begin
         <assignTemp>$2 = <self>.foo()
@@ -89,7 +89,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:x, <emptyTree>::<C T>.any(<emptyTree>::<C FalseClass>, <emptyTree>::<C NilClass>)).returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C TrueClass>))
     end
 
-    def foo<<C <todo sym>>>(x, &<blk>)
+    def foo<<todo method>>(x, &<blk>)
       begin
         <assignTemp>$2 = x
         if ::NilClass.===(<assignTemp>$2)

--- a/test/testdata/desugar/defs_not_self.rb.desugar-tree.exp
+++ b/test/testdata/desugar/defs_not_self.rb.desugar-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def self.method<<C <todo sym>>>(&<blk>)
+  def self.method<<todo method>>(&<blk>)
     <emptyTree>
   end
 end

--- a/test/testdata/desugar/defs_not_self_in_class.rb.desugar-tree.exp
+++ b/test/testdata/desugar/defs_not_self_in_class.rb.desugar-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
-    <self>.private_class_method(def self.a<<C <todo sym>>>(&<blk>)
+    <self>.private_class_method(def self.a<<todo method>>(&<blk>)
         5
       end)
   end

--- a/test/testdata/desugar/ensure_without_rescue.rb.desugar-tree.exp
+++ b/test/testdata/desugar/ensure_without_rescue.rb.desugar-tree.exp
@@ -1,15 +1,15 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def main<<C <todo sym>>>(&<blk>)
+  def main<<todo method>>(&<blk>)
     <self>.a()
   ensure
     <self>.b()
   end
 
-  def a<<C <todo sym>>>(&<blk>)
+  def a<<todo method>>(&<blk>)
     <emptyTree>
   end
 
-  def b<<C <todo sym>>>(&<blk>)
+  def b<<todo method>>(&<blk>)
     <emptyTree>
   end
 

--- a/test/testdata/desugar/for.rb.desugar-tree.exp
+++ b/test/testdata/desugar/for.rb.desugar-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
-    def self.each<<C <todo sym>>>(&<blk>)
+    def self.each<<todo method>>(&<blk>)
       begin
         <blk>.call(1, 2, 3, 4, 5)
         <blk>.call(6, 7, 8, 9, 0)
@@ -9,17 +9,17 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C E><<C <todo sym>>> < (::<todo sym>)
-    def self.e=<<C <todo sym>>>(e, &<blk>)
+    def self.e=<<todo method>>(e, &<blk>)
       @e = e
     end
 
-    def self.e<<C <todo sym>>>(&<blk>)
+    def self.e<<todo method>>(&<blk>)
       @e
     end
   end
 
   class <emptyTree>::<C Main><<C <todo sym>>> < (::<todo sym>)
-    def self.main<<C <todo sym>>>(&<blk>)
+    def self.main<<todo method>>(&<blk>)
       begin
         <emptyTree>::<C A>.each() do |a|
           <self>.puts(a.inspect())

--- a/test/testdata/desugar/forward_args.rb.desugar-tree.exp
+++ b/test/testdata/desugar/forward_args.rb.desugar-tree.exp
@@ -1,14 +1,14 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Foo><<C <todo sym>>> < (::<todo sym>)
-    def bar<<C <todo sym>>>(a, b, k1:, k2:, &block)
+    def bar<<todo method>>(a, b, k1:, k2:, &block)
       <emptyTree>
     end
 
-    def foo<<C <todo sym>>>(*<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
+    def foo<<todo method>>(*<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
       ::<Magic>.<call-with-splat-and-block>(<emptyTree>::<C T>.unsafe(<self>), :bar, <fwd-args>.to_a().concat([<fwd-kwargs>.to_hash()]), nil, <fwd-block>)
     end
 
-    def foo2<<C <todo sym>>>(*args, *kwargs:, &block)
+    def foo2<<todo method>>(*args, *kwargs:, &block)
       ::<Magic>.<call-with-splat-and-block>(<emptyTree>::<C T>.unsafe(<self>), :bar, args.to_a().concat([kwargs.to_hash()]), nil, block)
     end
   end

--- a/test/testdata/desugar/integers.rb.desugar-tree.exp
+++ b/test/testdata/desugar/integers.rb.desugar-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def test_large_int<<C <todo sym>>>(&<blk>)
+  def test_large_int<<todo method>>(&<blk>)
     [0, 0, 0, 9223372036854775807, -9223372036854775808, 0, 51966, 0, 1]
   end
 end

--- a/test/testdata/desugar/lambda.rb.desugar-tree.exp
+++ b/test/testdata/desugar/lambda.rb.desugar-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def test_lambda<<C <todo sym>>>(&<blk>)
+  def test_lambda<<todo method>>(&<blk>)
     <emptyTree>::<C Kernel>.lambda() do |x|
       x.*(x)
     end

--- a/test/testdata/desugar/multi_assign.rb.desugar-tree.exp
+++ b/test/testdata/desugar/multi_assign.rb.desugar-tree.exp
@@ -9,7 +9,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C Test><<C <todo sym>>> < (::<todo sym>)
-    def some_method<<C <todo sym>>>(array, &<blk>)
+    def some_method<<todo method>>(array, &<blk>)
       begin
         begin
           <assignTemp>$2 = array

--- a/test/testdata/desugar/numbered_parameters.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/numbered_parameters.rb.desugar-tree-raw.exp
@@ -8,7 +8,7 @@ ClassDef{
   rhs = [
     MethodDef{
       flags = {}
-      name = <U foo><<C <U <todo sym>>>>
+      name = <U foo><<U <todo method>>>
       args = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>

--- a/test/testdata/desugar/numbered_parameters.rb.desugar-tree.exp
+++ b/test/testdata/desugar/numbered_parameters.rb.desugar-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def foo<<C <todo sym>>>(&<blk>)
+  def foo<<todo method>>(&<blk>)
     <emptyTree>
   end
 

--- a/test/testdata/desugar/op_eq.rb.desugar-tree.exp
+++ b/test/testdata/desugar/op_eq.rb.desugar-tree.exp
@@ -1,22 +1,22 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C OpEq><<C <todo sym>>> < (::<todo sym>)
-    def b<<C <todo sym>>>(&<blk>)
+    def b<<todo method>>(&<blk>)
       <emptyTree>
     end
 
-    def b=<<C <todo sym>>>(_, &<blk>)
+    def b=<<todo method>>(_, &<blk>)
       <emptyTree>
     end
 
-    def y<<C <todo sym>>>(&<blk>)
+    def y<<todo method>>(&<blk>)
       <emptyTree>
     end
 
-    def z<<C <todo sym>>>(&<blk>)
+    def z<<todo method>>(&<blk>)
       <emptyTree>
     end
 
-    def example<<C <todo sym>>>(a, &<blk>)
+    def example<<todo method>>(a, &<blk>)
       begin
         if a
           a = :a

--- a/test/testdata/desugar/opasgn.rb.desugar-tree.exp
+++ b/test/testdata/desugar/opasgn.rb.desugar-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def foo<<C <todo sym>>>(&<blk>)
+  def foo<<todo method>>(&<blk>)
     begin
       a = a.+(a)
       begin

--- a/test/testdata/desugar/ops.rb.desugar-tree.exp
+++ b/test/testdata/desugar/ops.rb.desugar-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def test_ops<<C <todo sym>>>(&<blk>)
+  def test_ops<<todo method>>(&<blk>)
     begin
       begin
         ||$2 = <self>.a()

--- a/test/testdata/desugar/range.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/range.rb.desugar-tree-raw.exp
@@ -8,7 +8,7 @@ ClassDef{
   rhs = [
     MethodDef{
       flags = {}
-      name = <U foo><<C <U <todo sym>>>>
+      name = <U foo><<U <todo method>>>
       args = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>

--- a/test/testdata/desugar/regexp.rb.desugar-tree.exp
+++ b/test/testdata/desugar/regexp.rb.desugar-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def foo<<C <todo sym>>>(&<blk>)
+  def foo<<todo method>>(&<blk>)
     begin
       ::Regexp.new("abc", 0)
       <emptyTree>::<C Regexp>.new("abc")

--- a/test/testdata/desugar/sclass.rb.desugar-tree.exp
+++ b/test/testdata/desugar/sclass.rb.desugar-tree.exp
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C B><<C <todo sym>>> < (::<todo sym>)
     class <singleton class><<C <todo sym>>> < ()
-      def b<<C <todo sym>>>(&<blk>)
+      def b<<todo method>>(&<blk>)
         "b"
       end
     end
@@ -20,7 +20,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C D><<C <todo sym>>> < (::<todo sym>)
     class <singleton class><<C <todo sym>>> < ()
       class <singleton class><<C <todo sym>>> < ()
-        def d<<C <todo sym>>>(&<blk>)
+        def d<<todo method>>(&<blk>)
           "d"
         end
       end
@@ -29,8 +29,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C E><<C <todo sym>>> < (::<todo sym>)
     class <singleton class><<C <todo sym>>> < ()
-      def wrapper<<C <todo sym>>>(&<blk>)
-        def e<<C <todo sym>>>(&<blk>)
+      def wrapper<<todo method>>(&<blk>)
+        def e<<todo method>>(&<blk>)
           "e"
         end
       end
@@ -41,7 +41,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C F><<C <todo sym>>> < (::<todo sym>)
     class <singleton class><<C <todo sym>>> < ()
-      def initialize<<C <todo sym>>>(&<blk>)
+      def initialize<<todo method>>(&<blk>)
         @f = <emptyTree>::<C T>.let(0, <emptyTree>::<C Integer>)
       end
 
@@ -56,10 +56,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C G><<C <todo sym>>> < (::<todo sym>)
-    def wrapper<<C <todo sym>>>(&<blk>)
+    def wrapper<<todo method>>(&<blk>)
       begin
         class <singleton class><<C <todo sym>>> < ()
-          def inner<<C <todo sym>>>(&<blk>)
+          def inner<<todo method>>(&<blk>)
             <emptyTree>::<C T>.reveal_type(<self>)
           end
         end
@@ -67,7 +67,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    def self.g<<C <todo sym>>>(&<blk>)
+    def self.g<<todo method>>(&<blk>)
       "g"
     end
   end
@@ -75,14 +75,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C H><<C <todo sym>>> < (::<todo sym>)
     class <singleton class><<C <todo sym>>> < ()
       class <emptyTree>::<C H2><<C <todo sym>>> < (::<todo sym>)
-        def self.h<<C <todo sym>>>(&<blk>)
+        def self.h<<todo method>>(&<blk>)
           "h"
         end
       end
     end
   end
 
-  def main<<C <todo sym>>>(&<blk>)
+  def main<<todo method>>(&<blk>)
     begin
       <self>.puts(<emptyTree>::<C A>.a())
       <self>.puts(<emptyTree>::<C B>.b())

--- a/test/testdata/desugar/sclass_inheritance.rb.desugar-tree.exp
+++ b/test/testdata/desugar/sclass_inheritance.rb.desugar-tree.exp
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     class <singleton class><<C <todo sym>>> < ()
       <self>.include(<emptyTree>::<C MM>)
 
-      def newer<<C <todo sym>>>(&<blk>)
+      def newer<<todo method>>(&<blk>)
         <self>.new()
       end
     end
@@ -16,20 +16,20 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C B><<C <todo sym>>> < (::<todo sym>)
     <self>.extend(<emptyTree>::<C MM>)
 
-    def self.newer<<C <todo sym>>>(&<blk>)
+    def self.newer<<todo method>>(&<blk>)
       <self>.new()
     end
   end
 
   class <emptyTree>::<C C><<C <todo sym>>> < (<emptyTree>::<C A>)
     class <singleton class><<C <todo sym>>> < ()
-      def newerer<<C <todo sym>>>(&<blk>)
+      def newerer<<todo method>>(&<blk>)
         <self>.newer()
       end
     end
   end
 
-  def main<<C <todo sym>>>(&<blk>)
+  def main<<todo method>>(&<blk>)
     begin
       <self>.puts(<emptyTree>::<C A>.newer())
       <self>.puts(<emptyTree>::<C B>.newer())

--- a/test/testdata/desugar/splat.rb.desugar-tree.exp
+++ b/test/testdata/desugar/splat.rb.desugar-tree.exp
@@ -1,28 +1,28 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def bar<<C <todo sym>>>(a, &<blk>)
+  def bar<<todo method>>(a, &<blk>)
     a
   end
 
   class <emptyTree>::<C Splatable><<C <todo sym>>> < (::<todo sym>)
-    def to_a<<C <todo sym>>>(&<blk>)
+    def to_a<<todo method>>(&<blk>)
       [1]
     end
   end
 
   class <emptyTree>::<C Rescueable><<C <todo sym>>> < (::<todo sym>)
-    def to_a<<C <todo sym>>>(&<blk>)
+    def to_a<<todo method>>(&<blk>)
       [<emptyTree>::<C String>, <emptyTree>::<C RuntimeError>]
     end
   end
 
   class <emptyTree>::<C Parent><<C <todo sym>>> < (::<todo sym>)
-    def foo<<C <todo sym>>>(a, b, &<blk>)
+    def foo<<todo method>>(a, b, &<blk>)
       [b, a]
     end
   end
 
   class <emptyTree>::<C Child><<C <todo sym>>> < (<emptyTree>::<C Parent>)
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       begin
         a = [1, 2]
         ::<Magic>.<call-with-splat>(<self>, :super, a.to_a(), nil)
@@ -30,7 +30,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  def foo<<C <todo sym>>>(&<blk>)
+  def foo<<todo method>>(&<blk>)
     begin
       a = [1]
       a.to_a().concat([2])

--- a/test/testdata/desugar/star_in_block_arg.rb.desugar-tree.exp
+++ b/test/testdata/desugar/star_in_block_arg.rb.desugar-tree.exp
@@ -5,7 +5,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.params(:blk, <emptyTree>::<C T>.proc().params(:args, <emptyTree>::<C Integer>).void()).void()
   end
 
-  def foo<<C <todo sym>>>(&blk)
+  def foo<<todo method>>(&blk)
     <emptyTree>
   end
 

--- a/test/testdata/desugar/strings.rb.desugar-tree.exp
+++ b/test/testdata/desugar/strings.rb.desugar-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def test_strings<<C <todo sym>>>(&<blk>)
+  def test_strings<<todo method>>(&<blk>)
     begin
       ""
       "foo"

--- a/test/testdata/infer/infer1.rb.desugar-tree.exp
+++ b/test/testdata/infer/infer1.rb.desugar-tree.exp
@@ -1,27 +1,27 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def baz1<<C <todo sym>>>(&<blk>)
+  def baz1<<todo method>>(&<blk>)
     begin
       a = "foo"
       b = a.getbyte(a)
     end
   end
 
-  def baz2<<C <todo sym>>>(&<blk>)
+  def baz2<<todo method>>(&<blk>)
     begin
       a = "foo"
       b = a.getbyte("foo")
     end
   end
 
-  def baz3<<C <todo sym>>>(&<blk>)
+  def baz3<<todo method>>(&<blk>)
     b = "foo".getbyte("foo")
   end
 
-  def baz4<<C <todo sym>>>(&<blk>)
+  def baz4<<todo method>>(&<blk>)
     b = <self>.a().getbyte("foo")
   end
 
-  def baz5<<C <todo sym>>>(cond, &<blk>)
+  def baz5<<todo method>>(cond, &<blk>)
     begin
       if cond
         b = 1
@@ -32,7 +32,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  def baz6<<C <todo sym>>>(cond, &<blk>)
+  def baz6<<todo method>>(cond, &<blk>)
     begin
       if cond
         b = 1
@@ -43,7 +43,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  def baz7<<C <todo sym>>>(cond, &<blk>)
+  def baz7<<todo method>>(cond, &<blk>)
     begin
       if cond
         b = 1
@@ -54,7 +54,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  def baz8<<C <todo sym>>>(&<blk>)
+  def baz8<<todo method>>(&<blk>)
     while true
       b = 1
     end

--- a/test/testdata/infer/massign_return_rhs.rb.desugar-tree.exp
+++ b/test/testdata/infer/massign_return_rhs.rb.desugar-tree.exp
@@ -5,7 +5,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C Integer>)))
   end
 
-  def foo<<C <todo sym>>>(&<blk>)
+  def foo<<todo method>>(&<blk>)
     nil
   end
 

--- a/test/testdata/infer/yield_multiple.rb.desugar-tree-raw.exp
+++ b/test/testdata/infer/yield_multiple.rb.desugar-tree-raw.exp
@@ -97,7 +97,7 @@ ClassDef{
 
     MethodDef{
       flags = {}
-      name = <U yield_two><<C <U <todo sym>>>>
+      name = <U yield_two><<U <todo method>>>
       args = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U blk>

--- a/test/testdata/local_vars/z_super_args.rb.index-tree.exp
+++ b/test/testdata/local_vars/z_super_args.rb.index-tree.exp
@@ -1,36 +1,36 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Parent><<C <todo sym>>> < (::<todo sym>)
-    def takes_positional<<C <todo sym>>>(arg0, &<blk>)
+    def takes_positional<<todo method>>(arg0, &<blk>)
       <self>.p(arg0)
     end
 
-    def takes_keyword<<C <todo sym>>>(arg0:, &<blk>)
+    def takes_keyword<<todo method>>(arg0:, &<blk>)
       <self>.p(arg0)
     end
 
-    def takes_two_keyword<<C <todo sym>>>(arg0:, arg1:, &<blk>)
+    def takes_two_keyword<<todo method>>(arg0:, arg1:, &<blk>)
       begin
         <self>.p(arg0)
         <self>.p(arg1)
       end
     end
 
-    def takes_positional_then_keyword<<C <todo sym>>>(arg0, arg1:, &<blk>)
+    def takes_positional_then_keyword<<todo method>>(arg0, arg1:, &<blk>)
       begin
         <self>.p(arg0)
         <self>.p(arg1)
       end
     end
 
-    def takes_rest<<C <todo sym>>>(*args, &<blk>)
+    def takes_rest<<todo method>>(*args, &<blk>)
       <self>.p(args)
     end
 
-    def takes_keyword_rest<<C <todo sym>>>(*args:, &<blk>)
+    def takes_keyword_rest<<todo method>>(*args:, &<blk>)
       <self>.p(args)
     end
 
-    def takes_block<<C <todo sym>>>(&blk)
+    def takes_block<<todo method>>(&blk)
       <self>.p(blk)
     end
 
@@ -50,31 +50,31 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C Child><<C <todo sym>>> < (<emptyTree>::<C Parent>)
-    def takes_positional<<C <todo sym>>>(arg0, &<blk>)
+    def takes_positional<<todo method>>(arg0, &<blk>)
       <self>.super(arg0)
     end
 
-    def takes_keyword<<C <todo sym>>>(arg0:, &<blk>)
+    def takes_keyword<<todo method>>(arg0:, &<blk>)
       <self>.super(:arg0, arg0)
     end
 
-    def takes_two_keyword<<C <todo sym>>>(arg0:, arg1:, &<blk>)
+    def takes_two_keyword<<todo method>>(arg0:, arg1:, &<blk>)
       <self>.super(:arg0, arg0, :arg1, arg1)
     end
 
-    def takes_positional_then_keyword<<C <todo sym>>>(arg0, arg1:, &<blk>)
+    def takes_positional_then_keyword<<todo method>>(arg0, arg1:, &<blk>)
       <self>.super(arg0, :arg1, arg1)
     end
 
-    def takes_rest<<C <todo sym>>>(*args, &<blk>)
+    def takes_rest<<todo method>>(*args, &<blk>)
       <self>.super()
     end
 
-    def takes_keyword_rest<<C <todo sym>>>(*args:, &<blk>)
+    def takes_keyword_rest<<todo method>>(*args:, &<blk>)
       <self>.super()
     end
 
-    def takes_block<<C <todo sym>>>(&blk)
+    def takes_block<<todo method>>(&blk)
       <self>.super()
     end
 

--- a/test/testdata/namer/arguments.rb.desugar-tree-raw.exp
+++ b/test/testdata/namer/arguments.rb.desugar-tree-raw.exp
@@ -19,7 +19,7 @@ ClassDef{
       rhs = [
         MethodDef{
           flags = {}
-          name = <U take_arguments><<C <U <todo sym>>>>
+          name = <U take_arguments><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U a>

--- a/test/testdata/namer/arguments.rb.desugar-tree.exp
+++ b/test/testdata/namer/arguments.rb.desugar-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
-    def take_arguments<<C <todo sym>>>(a, b = 1, *c, d:, e: = 2, *f:, &g)
+    def take_arguments<<todo method>>(a, b = 1, *c, d:, e: = 2, *f:, &g)
       begin
         [a, b, c, d, e, f, g]
         h = 1

--- a/test/testdata/namer/simple.rb.desugar-tree.exp
+++ b/test/testdata/namer/simple.rb.desugar-tree.exp
@@ -1,10 +1,10 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C NormalClass><<C <todo sym>>> < (::<todo sym>)
-    def normal_method<<C <todo sym>>>(&<blk>)
+    def normal_method<<todo method>>(&<blk>)
       <emptyTree>
     end
 
-    def self.normal_static_method<<C <todo sym>>>(&<blk>)
+    def self.normal_static_method<<todo method>>(&<blk>)
       <emptyTree>
     end
 

--- a/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
@@ -53,7 +53,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.returns(<emptyTree>::<C AClass>)
       end
 
-      def get_a<<C <todo sym>>>(&<blk>)
+      def get_a<<todo method>>(&<blk>)
         <emptyTree>::<C B>.get_a()
       end
 
@@ -67,7 +67,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.returns(<emptyTree>::<C Integer>)
       end
 
-      def one<<C <todo sym>>>(&<blk>)
+      def one<<todo method>>(&<blk>)
         1
       end
 
@@ -107,7 +107,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.returns(<emptyTree>::<C Integer>)
       end
 
-      def get_one<<C <todo sym>>>(&<blk>)
+      def get_one<<todo method>>(&<blk>)
         <emptyTree>::<C A>.one()
       end
 
@@ -121,7 +121,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.returns(<emptyTree>::<C A>::<C AClass>)
       end
 
-      def get_a<<C <todo sym>>>(&<blk>)
+      def get_a<<todo method>>(&<blk>)
         <emptyTree>::<C A>::<C AClass>.new()
       end
 

--- a/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
@@ -6,7 +6,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def package_method<<C <todo sym>>>(&<blk>)
+    def package_method<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -14,7 +14,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def self.static_method<<C <todo sym>>>(&<blk>)
+    def self.static_method<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -51,11 +51,11 @@ end
 class <emptyTree><<C <root>>> < (::<todo sym>)
   module <emptyTree>::<C <PackageRegistry>>::<C MyPackage_Package><<C <todo sym>>> < ()
     class ::<root>::<C PackageSpec><<C <todo sym>>> < (::<todo sym>)
-      def self.some_method<<C <todo sym>>>(x, &<blk>)
+      def self.some_method<<todo method>>(x, &<blk>)
         <emptyTree>
       end
 
-      def self.method_call_arg<<C <todo sym>>>(&<blk>)
+      def self.method_call_arg<<todo method>>(&<blk>)
         <emptyTree>
       end
 

--- a/test/testdata/packager/nested_inner_namespaces/__package.rb.package-tree.exp
+++ b/test/testdata/packager/nested_inner_namespaces/__package.rb.package-tree.exp
@@ -20,7 +20,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.params(:a, <emptyTree>::<C Integer>).returns(<emptyTree>::<C String>)
       end
 
-      def main<<C <todo sym>>>(a, &<blk>)
+      def main<<todo method>>(a, &<blk>)
         if a.>(10)
           <emptyTree>::<C RootPackage>::<C Foo>::<C Foo>::<C Constant>
         else

--- a/test/testdata/packager/nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/nested_packages/pass.package-tree.exp
@@ -18,7 +18,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.returns(<emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass>)
       end
 
-      def self.subpkg_class<<C <todo sym>>>(&<blk>)
+      def self.subpkg_class<<todo method>>(&<blk>)
         <emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass>.new()
       end
 
@@ -48,7 +48,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.returns(<emptyTree>::<C Package>::<C PackageClass>)
       end
 
-      def self.package_class<<C <todo sym>>>(&<blk>)
+      def self.package_class<<todo method>>(&<blk>)
         return <emptyTree>::<C Package>::<C PackageClass>.new()
       end
 

--- a/test/testdata/packager/simple_package/pass.package-tree.exp
+++ b/test/testdata/packager/simple_package/pass.package-tree.exp
@@ -26,7 +26,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.params(:value, <emptyTree>::<C Integer>).void()
       end
 
-      def initialize<<C <todo sym>>>(value, &<blk>)
+      def initialize<<todo method>>(value, &<blk>)
         @value = <emptyTree>::<C T>.let(value, <emptyTree>::<C Integer>)
       end
 
@@ -43,7 +43,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.returns(<emptyTree>::<C Project>::<C Foo>::<C Foo>)
       end
 
-      def build_foo<<C <todo sym>>>(&<blk>)
+      def build_foo<<todo method>>(&<blk>)
         <emptyTree>::<C Project>::<C Foo>::<C Foo>.new(10)
       end
 
@@ -51,7 +51,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.returns(<emptyTree>::<C Bar>)
       end
 
-      def build_bar<<C <todo sym>>>(&<blk>)
+      def build_bar<<todo method>>(&<blk>)
         <emptyTree>::<C Project>::<C Foo>.build_bar()
       end
 
@@ -91,7 +91,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.params(:value, <emptyTree>::<C Integer>).void()
       end
 
-      def initialize<<C <todo sym>>>(value, &<blk>)
+      def initialize<<todo method>>(value, &<blk>)
         @value = <emptyTree>::<C T>.let(value, <emptyTree>::<C Integer>)
       end
 
@@ -108,7 +108,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.returns(<emptyTree>::<C Project>::<C Bar>::<C Bar>)
       end
 
-      def build_bar<<C <todo sym>>>(&<blk>)
+      def build_bar<<todo method>>(&<blk>)
         <emptyTree>::<C Project>::<C Bar>::<C Bar>.new(10)
       end
 
@@ -116,7 +116,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.returns(<emptyTree>::<C Foo>)
       end
 
-      def build_foo<<C <todo sym>>>(&<blk>)
+      def build_foo<<todo method>>(&<blk>)
         <emptyTree>::<C Project>::<C Bar>.build_foo()
       end
 

--- a/test/testdata/parser/misc.rb.desugar-tree.exp
+++ b/test/testdata/parser/misc.rb.desugar-tree.exp
@@ -34,7 +34,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.b()
   end
 
-  def bfoo<<C <todo sym>>>(&x)
+  def bfoo<<todo method>>(&x)
     <emptyTree>
   end
 
@@ -59,7 +59,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   ::Kernel.Complex(0, "1.5")
 
-  def self.classmeth<<C <todo sym>>>(&<blk>)
+  def self.classmeth<<todo method>>(&<blk>)
     <emptyTree>
   end
 
@@ -102,7 +102,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   <self>.super(ZSuperArgs)
 
-  def kwfoo<<C <todo sym>>>(x:, y: = 1, *z:, &<blk>)
+  def kwfoo<<todo method>>(x:, y: = 1, *z:, &<blk>)
     <emptyTree>
   end
 
@@ -163,7 +163,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   4
 
-  def optfoo<<C <todo sym>>>(x = 1, *y, &<blk>)
+  def optfoo<<todo method>>(x = 1, *y, &<blk>)
     <emptyTree>
   end
 
@@ -214,16 +214,16 @@ rescue <emptyTree>::<C E> => x
       <emptyTree>
     end)
 
-  def sfoo<<C <todo sym>>>(**$2, &<blk>)
+  def sfoo<<todo method>>(**$2, &<blk>)
     <emptyTree>
   end
 
-  def ssfoo<<C <todo sym>>>(***$3:, &<blk>)
+  def ssfoo<<todo method>>(***$3:, &<blk>)
     <emptyTree>
   end
 
   module <emptyTree>::<C Foo><<C <todo sym>>> < ()
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       <emptyTree>::<C Kernel>.lambda() do |a, b|
         a.+(b)
       end

--- a/test/testdata/rewriter/attr_multi.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/attr_multi.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
     end
 
-    def a<<C <todo sym>>>(&<blk>)
+    def a<<todo method>>(&<blk>)
       @a
     end
 
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:a, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>)).returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
     end
 
-    def a=<<C <todo sym>>>(a, &<blk>)
+    def a=<<todo method>>(a, &<blk>)
       @a = ::T.let(a, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
     end
 
@@ -20,7 +20,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
-    def b<<C <todo sym>>>(&<blk>)
+    def b<<todo method>>(&<blk>)
       @b
     end
 
@@ -28,7 +28,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
-    def c<<C <todo sym>>>(&<blk>)
+    def c<<todo method>>(&<blk>)
       @c
     end
 
@@ -36,7 +36,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:b, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>)).returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
-    def b=<<C <todo sym>>>(b, &<blk>)
+    def b=<<todo method>>(b, &<blk>)
       @b = ::T.let(b, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
@@ -44,7 +44,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:c, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>)).returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
-    def c=<<C <todo sym>>>(c, &<blk>)
+    def c=<<todo method>>(c, &<blk>)
       @c = ::T.let(c, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
@@ -52,7 +52,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def d<<C <todo sym>>>(&<blk>)
+    def d<<todo method>>(&<blk>)
       @d
     end
 
@@ -60,7 +60,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def e<<C <todo sym>>>(&<blk>)
+    def e<<todo method>>(&<blk>)
       @e
     end
 
@@ -68,7 +68,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def f<<C <todo sym>>>(&<blk>)
+    def f<<todo method>>(&<blk>)
       @f
     end
 
@@ -76,7 +76,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:g, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
     end
 
-    def g=<<C <todo sym>>>(g, &<blk>)
+    def g=<<todo method>>(g, &<blk>)
       @g = g
     end
 
@@ -84,7 +84,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:h, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
     end
 
-    def h=<<C <todo sym>>>(h, &<blk>)
+    def h=<<todo method>>(h, &<blk>)
       @h = h
     end
 
@@ -92,7 +92,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:i, <emptyTree>::<C String>).params(:h, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
     end
 
-    def i=<<C <todo sym>>>(i, &<blk>)
+    def i=<<todo method>>(i, &<blk>)
       @i = i
     end
 

--- a/test/testdata/rewriter/chalk_odm_document.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/chalk_odm_document.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def my_parent_method<<C <todo sym>>>(&<blk>)
+    def my_parent_method<<todo method>>(&<blk>)
       <self>.instance_variable_get(:@my_parent_method)
     end
 
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
     end
 
-    def my_parent_method=<<C <todo sym>>>(arg0, &<blk>)
+    def my_parent_method=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :my_parent_method)
@@ -35,7 +35,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
-    def my_child_method<<C <todo sym>>>(&<blk>)
+    def my_child_method<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@my_child_method)
         <self>.class().decorator().prop_get_logic(<self>, :my_child_method, arg2)
@@ -46,7 +46,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C Integer>).returns(<emptyTree>::<C Integer>)
     end
 
-    def my_child_method=<<C <todo sym>>>(arg0, &<blk>)
+    def my_child_method=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :my_child_method)

--- a/test/testdata/rewriter/class_new.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/class_new.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -18,7 +18,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
-    def bar<<C <todo sym>>>(&<blk>)
+    def bar<<todo method>>(&<blk>)
       0
     end
 
@@ -41,7 +41,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def self.qux<<C <todo sym>>>(&<blk>)
+    def self.qux<<todo method>>(&<blk>)
       <emptyTree>
     end
 

--- a/test/testdata/rewriter/command.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/command.rb.rewrite-tree.exp
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:x, <emptyTree>::<C Integer>).returns(<emptyTree>::<C String>)
     end
 
-    def call<<C <todo sym>>>(x, &<blk>)
+    def call<<todo method>>(x, &<blk>)
       x.to_s()
     end
 
@@ -16,7 +16,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:x, <emptyTree>::<C Integer>).returns(<emptyTree>::<C String>)
     end
 
-    def self.call<<C <todo sym>>>(x, &<blk>)
+    def self.call<<todo method>>(x, &<blk>)
       ::T.unsafe(nil)
     end
 
@@ -32,7 +32,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:x, <emptyTree>::<C String>).returns(<emptyTree>::<C Integer>)
     end
 
-    def call<<C <todo sym>>>(x, &<blk>)
+    def call<<todo method>>(x, &<blk>)
       <self>.Integer(x)
     end
 
@@ -40,7 +40,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:x, <emptyTree>::<C String>).returns(<emptyTree>::<C Integer>)
     end
 
-    def self.call<<C <todo sym>>>(x, &<blk>)
+    def self.call<<todo method>>(x, &<blk>)
       ::T.unsafe(nil)
     end
 
@@ -56,7 +56,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:x, <emptyTree>::<C String>).returns(<emptyTree>::<C Integer>)
     end
 
-    def call<<C <todo sym>>>(x, &<blk>)
+    def call<<todo method>>(x, &<blk>)
       <self>.Integer(x)
     end
 
@@ -68,7 +68,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C NotACommand>.call()
 
   class <emptyTree>::<C CallNoSig><<C <todo sym>>> < (<emptyTree>::<C Opus>::<C Command>)
-    def call<<C <todo sym>>>(x, &<blk>)
+    def call<<todo method>>(x, &<blk>)
       <self>.Integer(x)
     end
 

--- a/test/testdata/rewriter/def_delegator.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/def_delegator.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
-    def foo<<C <todo sym>>>(*arg0, &<blk>)
+    def foo<<todo method>>(*arg0, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
-    def aliased_bar<<C <todo sym>>>(*arg0, &<blk>)
+    def aliased_bar<<todo method>>(*arg0, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -20,7 +20,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def usages<<C <todo sym>>>(&<blk>)
+    def usages<<todo method>>(&<blk>)
       begin
         <self>.foo() do ||
           <emptyTree>
@@ -76,7 +76,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
-    def foo<<C <todo sym>>>(*arg0, &<blk>)
+    def foo<<todo method>>(*arg0, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -84,7 +84,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
-    def aliased_bar<<C <todo sym>>>(*arg0, &<blk>)
+    def aliased_bar<<todo method>>(*arg0, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -104,7 +104,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
-    def foo<<C <todo sym>>>(*arg0, &<blk>)
+    def foo<<todo method>>(*arg0, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -112,7 +112,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
-    def aliased_bar<<C <todo sym>>>(*arg0, &<blk>)
+    def aliased_bar<<todo method>>(*arg0, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -156,7 +156,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
-    def each<<C <todo sym>>>(*arg0, &<blk>)
+    def each<<todo method>>(*arg0, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 

--- a/test/testdata/rewriter/default_args.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/default_args.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:a, <emptyTree>::<C String>, :b, <emptyTree>::<C Integer>, :c, <emptyTree>::<C Integer>).void()
     end
 
-    def foo<<C <todo sym>>>(a, b = 1, c = 2, &<blk>)
+    def foo<<todo method>>(a, b = 1, c = 2, &<blk>)
       <emptyTree>
     end
 
@@ -18,7 +18,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       @foo
     end
 
@@ -26,7 +26,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:x, <emptyTree>::<C String>).void()
     end
 
-    def initialize<<C <todo sym>>>(x = "", &<blk>)
+    def initialize<<todo method>>(x = "", &<blk>)
       begin
         @foo = "test"
         @x = ::T.let(x, <emptyTree>::<C String>)
@@ -37,7 +37,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:x, <emptyTree>::<C Integer>).void()
     end
 
-    def test<<C <todo sym>>>(x = 297, &<blk>)
+    def test<<todo method>>(x = 297, &<blk>)
       <emptyTree>
     end
 

--- a/test/testdata/rewriter/dsl_builder.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/dsl_builder.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:opt_string, <emptyTree>::<C String>).returns(::NilClass)
     end
 
-    def self.opt_string<<C <todo sym>>>(opt_string, &<blk>)
+    def self.opt_string<<todo method>>(opt_string, &<blk>)
       <emptyTree>
     end
 
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.nilable(<emptyTree>::<C String>))
     end
 
-    def self.get_opt_string<<C <todo sym>>>(&<blk>)
+    def self.get_opt_string<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -20,7 +20,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.nilable(<emptyTree>::<C String>))
     end
 
-    def opt_string<<C <todo sym>>>(&<blk>)
+    def opt_string<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -28,7 +28,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:opt_int_defaulted, <emptyTree>::<C Integer>).returns(::NilClass)
     end
 
-    def self.opt_int_defaulted<<C <todo sym>>>(opt_int_defaulted, &<blk>)
+    def self.opt_int_defaulted<<todo method>>(opt_int_defaulted, &<blk>)
       <emptyTree>
     end
 
@@ -36,7 +36,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
-    def self.get_opt_int_defaulted<<C <todo sym>>>(&<blk>)
+    def self.get_opt_int_defaulted<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -44,7 +44,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
-    def opt_int_defaulted<<C <todo sym>>>(&<blk>)
+    def opt_int_defaulted<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -52,7 +52,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:req_string, <emptyTree>::<C String>).returns(::NilClass)
     end
 
-    def self.req_string<<C <todo sym>>>(req_string, &<blk>)
+    def self.req_string<<todo method>>(req_string, &<blk>)
       <emptyTree>
     end
 
@@ -60,7 +60,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def self.get_req_string<<C <todo sym>>>(&<blk>)
+    def self.get_req_string<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -68,7 +68,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def req_string<<C <todo sym>>>(&<blk>)
+    def req_string<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -76,7 +76,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:implied_string, <emptyTree>::<C String>).returns(::NilClass)
     end
 
-    def self.implied_string<<C <todo sym>>>(implied_string = ::T.unsafe(nil), &<blk>)
+    def self.implied_string<<todo method>>(implied_string = ::T.unsafe(nil), &<blk>)
       <emptyTree>
     end
 
@@ -84,7 +84,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def self.get_implied_string<<C <todo sym>>>(&<blk>)
+    def self.get_implied_string<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -92,7 +92,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def implied_string<<C <todo sym>>>(&<blk>)
+    def implied_string<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -100,7 +100,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:no_getter, <emptyTree>::<C String>).returns(::NilClass)
     end
 
-    def self.no_getter<<C <todo sym>>>(no_getter, &<blk>)
+    def self.no_getter<<todo method>>(no_getter, &<blk>)
       <emptyTree>
     end
 
@@ -108,7 +108,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.nilable(<emptyTree>::<C String>))
     end
 
-    def self.get_no_setter<<C <todo sym>>>(&<blk>)
+    def self.get_no_setter<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -116,7 +116,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.nilable(<emptyTree>::<C String>))
     end
 
-    def no_setter<<C <todo sym>>>(&<blk>)
+    def no_setter<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -124,7 +124,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:class_of, <emptyTree>::<C T>.class_of(<emptyTree>::<C Integer>)).returns(::NilClass)
     end
 
-    def self.class_of<<C <todo sym>>>(class_of, &<blk>)
+    def self.class_of<<todo method>>(class_of, &<blk>)
       <emptyTree>
     end
 
@@ -132,7 +132,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.nilable(<emptyTree>::<C T>.class_of(<emptyTree>::<C Integer>)))
     end
 
-    def self.get_class_of<<C <todo sym>>>(&<blk>)
+    def self.get_class_of<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -140,7 +140,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.nilable(<emptyTree>::<C T>.class_of(<emptyTree>::<C Integer>)))
     end
 
-    def class_of<<C <todo sym>>>(&<blk>)
+    def class_of<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -148,7 +148,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:root_const, ::<root>::<C Integer>).returns(::NilClass)
     end
 
-    def self.root_const<<C <todo sym>>>(root_const, &<blk>)
+    def self.root_const<<todo method>>(root_const, &<blk>)
       <emptyTree>
     end
 
@@ -156,7 +156,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.nilable(::<root>::<C Integer>))
     end
 
-    def self.get_root_const<<C <todo sym>>>(&<blk>)
+    def self.get_root_const<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -164,7 +164,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.nilable(::<root>::<C Integer>))
     end
 
-    def root_const<<C <todo sym>>>(&<blk>)
+    def root_const<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -214,7 +214,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C TestChild><<C <todo sym>>> < (<emptyTree>::<C TestDSLBuilder>)
-    def test_instance_methods<<C <todo sym>>>(&<blk>)
+    def test_instance_methods<<todo method>>(&<blk>)
       begin
         <emptyTree>::<C T>.assert_type!(<self>.opt_string(), <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
         <emptyTree>::<C T>.assert_type!(<self>.opt_int_defaulted(), <emptyTree>::<C Integer>)

--- a/test/testdata/rewriter/flatfile_dsl.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/flatfile_dsl.rb.rewrite-tree.exp
@@ -1,18 +1,18 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Record><<C <todo sym>>> < (::<todo sym>)
-    def self.flatfile<<C <todo sym>>>(&<blk>)
+    def self.flatfile<<todo method>>(&<blk>)
       <emptyTree>
     end
 
-    def self.from<<C <todo sym>>>(*_, &<blk>)
+    def self.from<<todo method>>(*_, &<blk>)
       <emptyTree>
     end
 
-    def self.pattern<<C <todo sym>>>(*_, &<blk>)
+    def self.pattern<<todo method>>(*_, &<blk>)
       <emptyTree>
     end
 
-    def self.field<<C <todo sym>>>(*_, &<blk>)
+    def self.field<<todo method>>(*_, &<blk>)
       <emptyTree>
     end
 
@@ -30,7 +30,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       nil
     end
 
@@ -38,7 +38,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def foo=<<C <todo sym>>>(arg0, &<blk>)
+    def foo=<<todo method>>(arg0, &<blk>)
       nil
     end
 
@@ -46,7 +46,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def bar<<C <todo sym>>>(&<blk>)
+    def bar<<todo method>>(&<blk>)
       nil
     end
 
@@ -54,7 +54,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def bar=<<C <todo sym>>>(arg0, &<blk>)
+    def bar=<<todo method>>(arg0, &<blk>)
       nil
     end
 
@@ -62,7 +62,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def baz<<C <todo sym>>>(&<blk>)
+    def baz<<todo method>>(&<blk>)
       nil
     end
 
@@ -70,7 +70,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def baz=<<C <todo sym>>>(arg0, &<blk>)
+    def baz=<<todo method>>(arg0, &<blk>)
       nil
     end
 

--- a/test/testdata/rewriter/interface_wrapper.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/interface_wrapper.rb.rewrite-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def testit<<C <todo sym>>>(&<blk>)
+  def testit<<todo method>>(&<blk>)
     begin
       s = <emptyTree>::<C SomeClass>.new()
       wrap = ::T.let(s, <emptyTree>::<C Interface>)
@@ -13,7 +13,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C Interface><<C <todo sym>>> < ()
-    def some_method<<C <todo sym>>>(&<blk>)
+    def some_method<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C SomeClass><<C <todo sym>>> < (::<todo sym>)
-    def other_method<<C <todo sym>>>(&<blk>)
+    def other_method<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -31,7 +31,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C Other><<C <todo sym>>> < (::<todo sym>)
-    def self.wrap_instance<<C <todo sym>>>(x, y = nil, &<blk>)
+    def self.wrap_instance<<todo method>>(x, y = nil, &<blk>)
       <emptyTree>
     end
 

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -1,10 +1,10 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def junk<<C <todo sym>>>(&<blk>)
+  def junk<<todo method>>(&<blk>)
     <emptyTree>
   end
 
   class <emptyTree>::<C MyTest><<C <todo sym>>> < (::<todo sym>)
-    def outside_method<<C <todo sym>>>(&<blk>)
+    def outside_method<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def <it 'works outside'><<C <todo sym>>>(&<blk>)
+    def <it 'works outside'><<todo method>>(&<blk>)
       <self>.outside_method()
     end
 
@@ -20,7 +20,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def <it 'allows constants inside of IT'><<C <todo sym>>>(&<blk>)
+    def <it 'allows constants inside of IT'><<todo method>>(&<blk>)
       ::Module.const_set(:CONST, 10)
     end
 
@@ -28,7 +28,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def <it 'allows let-ed constants inside of IT'><<C <todo sym>>>(&<blk>)
+    def <it 'allows let-ed constants inside of IT'><<todo method>>(&<blk>)
       ::Module.const_set(:C2, <emptyTree>::<C T>.let(10, <emptyTree>::<C Integer>))
     end
 
@@ -36,7 +36,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def <it 'allows path constants inside of IT'><<C <todo sym>>>(&<blk>)
+    def <it 'allows path constants inside of IT'><<todo method>>(&<blk>)
       <emptyTree>::<C C3>.new()
     end
 
@@ -44,11 +44,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def <it '::<Magic>.<string-interpolate>("finds errors in the test name: ", <self>.bad_variable())'><<C <todo sym>>>(&<blk>)
+    def <it '::<Magic>.<string-interpolate>("finds errors in the test name: ", <self>.bad_variable())'><<todo method>>(&<blk>)
       <emptyTree>
     end
 
-    def instance_helper<<C <todo sym>>>(&<blk>)
+    def instance_helper<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -56,7 +56,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def initialize<<C <todo sym>>>(&<blk>)
+    def initialize<<todo method>>(&<blk>)
       begin
         @foo = <emptyTree>::<C T>.let(3, <emptyTree>::<C Integer>)
         <self>.instance_helper()
@@ -67,7 +67,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def <after><<C <todo sym>>>(&<blk>)
+    def <after><<todo method>>(&<blk>)
       begin
         @foo = nil
         <self>.instance_helper()
@@ -78,18 +78,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def <it 'can read foo'><<C <todo sym>>>(&<blk>)
+    def <it 'can read foo'><<todo method>>(&<blk>)
       begin
         <emptyTree>::<C T>.assert_type!(@foo, <emptyTree>::<C Integer>)
         <self>.instance_helper()
       end
     end
 
-    def self.random_method<<C <todo sym>>>(&<blk>)
+    def self.random_method<<todo method>>(&<blk>)
       <emptyTree>
     end
 
-    def self.it<<C <todo sym>>>(*args, &<blk>)
+    def self.it<<todo method>>(*args, &<blk>)
       <emptyTree>
     end
 
@@ -130,7 +130,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C <describe 'some inner tests'>><<C <todo sym>>> < (<self>)
-      def inside_method<<C <todo sym>>>(&<blk>)
+      def inside_method<<todo method>>(&<blk>)
         <emptyTree>
       end
 
@@ -138,7 +138,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.void()
       end
 
-      def <it 'works inside'><<C <todo sym>>>(&<blk>)
+      def <it 'works inside'><<todo method>>(&<blk>)
         begin
           <self>.outside_method()
           <self>.inside_method()
@@ -176,7 +176,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.void()
       end
 
-      def <it 'Object'><<C <todo sym>>>(&<blk>)
+      def <it 'Object'><<todo method>>(&<blk>)
         <emptyTree>
       end
 
@@ -184,7 +184,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.void()
       end
 
-      def <it 'Object'><<C <todo sym>>>(&<blk>)
+      def <it 'Object'><<todo method>>(&<blk>)
         <emptyTree>
       end
 
@@ -213,7 +213,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.void()
       end
 
-      def <it 'contains nested describes'><<C <todo sym>>>(&<blk>)
+      def <it 'contains nested describes'><<todo method>>(&<blk>)
         <emptyTree>
       end
 

--- a/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Parent><<C <todo sym>>> < (::<todo sym>)
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -11,7 +11,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C MyTest><<C <todo sym>>> < (::<todo sym>)
-    def outside_method<<C <todo sym>>>(&<blk>)
+    def outside_method<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -19,7 +19,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.type_parameters(:U).params(:arg, <emptyTree>::<C T>::<C Enumerable>.[](<emptyTree>::<C T>.type_parameter(:U)), :blk, <emptyTree>::<C T>.proc().params(:arg0, <emptyTree>::<C T>.type_parameter(:U)).void()).void()
     end
 
-    def self.test_each<<C <todo sym>>>(arg, &blk)
+    def self.test_each<<todo method>>(arg, &blk)
       <emptyTree>
     end
 
@@ -27,7 +27,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.type_parameters(:K, :V).params(:arg, <emptyTree>::<C T>::<C Hash>.[](<emptyTree>::<C T>.type_parameter(:K), <emptyTree>::<C T>.type_parameter(:V)), :blk, <emptyTree>::<C T>.proc().params(:arg0, <emptyTree>::<C T>.type_parameter(:K), :arg1, <emptyTree>::<C T>.type_parameter(:V)).void()).void()
     end
 
-    def self.test_each_hash<<C <todo sym>>>(arg, &blk)
+    def self.test_each_hash<<todo method>>(arg, &blk)
       <emptyTree>
     end
 
@@ -35,7 +35,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:name, <emptyTree>::<C String>, :blk, <emptyTree>::<C T>.proc().void()).void()
     end
 
-    def self.it<<C <todo sym>>>(name, &blk)
+    def self.it<<todo method>>(name, &blk)
       <emptyTree>
     end
 
@@ -43,7 +43,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def <it 'works with instance methods'><<C <todo sym>>>(&<blk>)
+    def <it 'works with instance methods'><<todo method>>(&<blk>)
       [<emptyTree>::<C Parent>.new(), <emptyTree>::<C Child>.new()].each() do |value|
         begin
           <self>.puts(value.foo())
@@ -57,7 +57,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def <it 'succeeds with a constant list'><<C <todo sym>>>(&<blk>)
+    def <it 'succeeds with a constant list'><<todo method>>(&<blk>)
       <emptyTree>::<C CONST_LIST>.each() do |value|
         begin
           <self>.puts(value.foo())
@@ -70,7 +70,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def <it 'succeeds with a typed constant list'><<C <todo sym>>>(&<blk>)
+    def <it 'succeeds with a typed constant list'><<todo method>>(&<blk>)
       <emptyTree>::<C ANOTHER_CONST_LIST>.each() do |value|
         begin
           <self>.puts(value.foo())
@@ -83,7 +83,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def <it 'succeed with a local variable but cannot type it'><<C <todo sym>>>(&<blk>)
+    def <it 'succeed with a local variable but cannot type it'><<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented").each() do |value|
         begin
           <self>.puts(value.foo())
@@ -96,7 +96,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def <it 'fails with non-it statements'><<C <todo sym>>>(&<blk>)
+    def <it 'fails with non-it statements'><<todo method>>(&<blk>)
       <emptyTree>::<C CONST_LIST>.each() do |value|
         <self>.puts(x)
       end
@@ -106,7 +106,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def <it 'handles lists with several types'><<C <todo sym>>>(&<blk>)
+    def <it 'handles lists with several types'><<todo method>>(&<blk>)
       ["foo", 5, {:x => false}].each() do |v|
         <emptyTree>::<C T>.reveal_type(v)
       end
@@ -116,7 +116,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def <it 'handles lists with several types'><<C <todo sym>>>(&<blk>)
+    def <it 'handles lists with several types'><<todo method>>(&<blk>)
       {:foo => 1, :bar => 2, :baz => 3}.each() do |k, v|
         begin
           <emptyTree>::<C T>.reveal_type(k)
@@ -129,7 +129,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def <it 'fails to typecheck with non-hash arguments to `test_each-hash`'><<C <todo sym>>>(&<blk>)
+    def <it 'fails to typecheck with non-hash arguments to `test_each-hash`'><<todo method>>(&<blk>)
       [1, 2, 3].each() do |k, v|
         <self>.puts(k, v)
       end

--- a/test/testdata/rewriter/not_prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/not_prop.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Array>)
     end
 
-    def array_of_explicit<<C <todo sym>>>(&<blk>)
+    def array_of_explicit<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@array_of_explicit)
         <self>.class().decorator().prop_get_logic(<self>, :array_of_explicit, arg2)
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C Array>).returns(<emptyTree>::<C Array>)
     end
 
-    def array_of_explicit=<<C <todo sym>>>(arg0, &<blk>)
+    def array_of_explicit=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :array_of_explicit)

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -8,7 +8,7 @@ ClassDef{
   rhs = [
     MethodDef{
       flags = {}
-      name = <U main><<C <U <todo sym>>>>
+      name = <U main><<U <todo method>>>
       args = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
@@ -1023,7 +1023,7 @@ ClassDef{
       rhs = [
         MethodDef{
           flags = {self}
-          name = <U prop><<C <U <todo sym>>>>
+          name = <U prop><<U <todo method>>>
           args = [RestArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U args>
@@ -1326,7 +1326,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U foo><<C <U <todo sym>>>>
+          name = <U foo><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -1433,7 +1433,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U foo=><<C <U <todo sym>>>>
+          name = <U foo=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -1540,7 +1540,7 @@ ClassDef{
 
         MethodDef{
           flags = {}
-          name = <U foo2><<C <U <todo sym>>>>
+          name = <U foo2><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -1631,7 +1631,7 @@ ClassDef{
 
         MethodDef{
           flags = {}
-          name = <U foo2=><<C <U <todo sym>>>>
+          name = <U foo2=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -1837,7 +1837,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U default><<C <U <todo sym>>>>
+          name = <U default><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -1944,7 +1944,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U default=><<C <U <todo sym>>>>
+          name = <U default=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -2052,7 +2052,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U t_nilable><<C <U <todo sym>>>>
+          name = <U t_nilable><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -2181,7 +2181,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U t_nilable=><<C <U <todo sym>>>>
+          name = <U t_nilable=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -2278,7 +2278,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U array><<C <U <todo sym>>>>
+          name = <U array><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -2385,7 +2385,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U array=><<C <U <todo sym>>>>
+          name = <U array=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -2496,7 +2496,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U t_array><<C <U <todo sym>>>>
+          name = <U t_array><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -2631,7 +2631,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U t_array=><<C <U <todo sym>>>>
+          name = <U t_array=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -2746,7 +2746,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U hash_of><<C <U <todo sym>>>>
+          name = <U hash_of><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -2889,7 +2889,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U hash_of=><<C <U <todo sym>>>>
+          name = <U hash_of=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -2986,7 +2986,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U const_explicit><<C <U <todo sym>>>>
+          name = <U const_explicit><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -3081,7 +3081,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U const><<C <U <todo sym>>>>
+          name = <U const><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -3176,7 +3176,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U enum_prop><<C <U <todo sym>>>>
+          name = <U enum_prop><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -3283,7 +3283,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U enum_prop=><<C <U <todo sym>>>>
+          name = <U enum_prop=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -3351,7 +3351,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U foreign><<C <U <todo sym>>>>
+          name = <U foreign><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -3458,7 +3458,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U foreign=><<C <U <todo sym>>>>
+          name = <U foreign=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -3585,7 +3585,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U foreign_><<C <U <todo sym>>>>
+          name = <U foreign_><<U <todo method>>>
           args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U opts>
@@ -3672,7 +3672,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U foreign_!><<C <U <todo sym>>>>
+          name = <U foreign_!><<U <todo method>>>
           args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U opts>
@@ -3740,7 +3740,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U foreign_lazy><<C <U <todo sym>>>>
+          name = <U foreign_lazy><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -3847,7 +3847,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U foreign_lazy=><<C <U <todo sym>>>>
+          name = <U foreign_lazy=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -3974,7 +3974,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U foreign_lazy_><<C <U <todo sym>>>>
+          name = <U foreign_lazy_><<U <todo method>>>
           args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U opts>
@@ -4061,7 +4061,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U foreign_lazy_!><<C <U <todo sym>>>>
+          name = <U foreign_lazy_!><<U <todo method>>>
           args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U opts>
@@ -4129,7 +4129,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U foreign_proc><<C <U <todo sym>>>>
+          name = <U foreign_proc><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -4236,7 +4236,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U foreign_proc=><<C <U <todo sym>>>>
+          name = <U foreign_proc=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -4363,7 +4363,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U foreign_proc_><<C <U <todo sym>>>>
+          name = <U foreign_proc_><<U <todo method>>>
           args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U opts>
@@ -4450,7 +4450,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U foreign_proc_!><<C <U <todo sym>>>>
+          name = <U foreign_proc_!><<U <todo method>>>
           args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U opts>
@@ -4518,7 +4518,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U foreign_invalid><<C <U <todo sym>>>>
+          name = <U foreign_invalid><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -4625,7 +4625,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U foreign_invalid=><<C <U <todo sym>>>>
+          name = <U foreign_invalid=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -4748,7 +4748,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U foreign_invalid_><<C <U <todo sym>>>>
+          name = <U foreign_invalid_><<U <todo method>>>
           args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U opts>
@@ -4842,7 +4842,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U foreign_invalid_!><<C <U <todo sym>>>>
+          name = <U foreign_invalid_!><<U <todo method>>>
           args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U opts>
@@ -4910,7 +4910,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U ifunset><<C <U <todo sym>>>>
+          name = <U ifunset><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -4987,7 +4987,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U ifunset=><<C <U <todo sym>>>>
+          name = <U ifunset=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -5095,7 +5095,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U ifunset_nilable><<C <U <todo sym>>>>
+          name = <U ifunset_nilable><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -5194,7 +5194,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U ifunset_nilable=><<C <U <todo sym>>>>
+          name = <U ifunset_nilable=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -5291,7 +5291,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U empty_hash_rules><<C <U <todo sym>>>>
+          name = <U empty_hash_rules><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -5398,7 +5398,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U empty_hash_rules=><<C <U <todo sym>>>>
+          name = <U empty_hash_rules=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -5495,7 +5495,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U hash_rules><<C <U <todo sym>>>>
+          name = <U hash_rules><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -5602,7 +5602,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U hash_rules=><<C <U <todo sym>>>>
+          name = <U hash_rules=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -6711,7 +6711,7 @@ ClassDef{
       rhs = [
         MethodDef{
           flags = {self}
-          name = <U token_prop><<C <U <todo sym>>>>
+          name = <U token_prop><<U <todo method>>>
           args = [OptionalArg{
               expr = UnresolvedIdent{
                 kind = Local
@@ -6730,7 +6730,7 @@ ClassDef{
 
         MethodDef{
           flags = {self}
-          name = <U created_prop><<C <U <todo sym>>>>
+          name = <U created_prop><<U <todo method>>>
           args = [OptionalArg{
               expr = UnresolvedIdent{
                 kind = Local
@@ -6782,7 +6782,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U token><<C <U <todo sym>>>>
+          name = <U token><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -6889,7 +6889,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U token=><<C <U <todo sym>>>>
+          name = <U token=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -6986,7 +6986,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U created><<C <U <todo sym>>>>
+          name = <U created><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -7093,7 +7093,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U created=><<C <U <todo sym>>>>
+          name = <U created=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -7310,7 +7310,7 @@ ClassDef{
       rhs = [
         MethodDef{
           flags = {self}
-          name = <U timestamped_token_prop><<C <U <todo sym>>>>
+          name = <U timestamped_token_prop><<U <todo method>>>
           args = [OptionalArg{
               expr = UnresolvedIdent{
                 kind = Local
@@ -7329,7 +7329,7 @@ ClassDef{
 
         MethodDef{
           flags = {self}
-          name = <U created_prop><<C <U <todo sym>>>>
+          name = <U created_prop><<U <todo method>>>
           args = [OptionalArg{
               expr = UnresolvedIdent{
                 kind = Local
@@ -7381,7 +7381,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U token><<C <U <todo sym>>>>
+          name = <U token><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -7488,7 +7488,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U token=><<C <U <todo sym>>>>
+          name = <U token=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -7585,7 +7585,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U created><<C <U <todo sym>>>>
+          name = <U created><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -7786,7 +7786,7 @@ ClassDef{
       rhs = [
         MethodDef{
           flags = {self}
-          name = <U merchant_prop><<C <U <todo sym>>>>
+          name = <U merchant_prop><<U <todo method>>>
           args = [OptionalArg{
               expr = UnresolvedIdent{
                 kind = Local
@@ -7838,7 +7838,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U merchant><<C <U <todo sym>>>>
+          name = <U merchant><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -7976,7 +7976,7 @@ ClassDef{
       rhs = [
         MethodDef{
           flags = {self}
-          name = <U encrypted_prop><<C <U <todo sym>>>>
+          name = <U encrypted_prop><<U <todo method>>>
           args = [OptionalArg{
               expr = UnresolvedIdent{
                 kind = Local
@@ -8039,7 +8039,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U foo><<C <U <todo sym>>>>
+          name = <U foo><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -8130,7 +8130,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U encrypted_foo><<C <U <todo sym>>>>
+          name = <U encrypted_foo><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -8229,7 +8229,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U foo=><<C <U <todo sym>>>>
+          name = <U foo=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -8361,7 +8361,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U encrypted_foo=><<C <U <todo sym>>>>
+          name = <U encrypted_foo=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
@@ -8440,7 +8440,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U bar><<C <U <todo sym>>>>
+          name = <U bar><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
@@ -8531,7 +8531,7 @@ ClassDef{
 
         MethodDef{
           flags = {rewriter}
-          name = <U encrypted_bar><<C <U <todo sym>>>>
+          name = <U encrypted_bar><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>

--- a/test/testdata/rewriter/prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def main<<C <todo sym>>>(&<blk>)
+  def main<<todo method>>(&<blk>)
     begin
       <emptyTree>::<C T>.reveal_type(<emptyTree>::<C SomeODM>.new().foo())
       <emptyTree>::<C T>.reveal_type(<emptyTree>::<C SomeODM>.new().foo=("b"))
@@ -45,7 +45,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C NotAODM><<C <todo sym>>> < (::<todo sym>)
-    def self.prop<<C <todo sym>>>(*args, &<blk>)
+    def self.prop<<todo method>>(*args, &<blk>)
       <emptyTree>
     end
 
@@ -77,7 +77,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@foo)
         <self>.class().decorator().prop_get_logic(<self>, :foo, arg2)
@@ -88,7 +88,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
     end
 
-    def foo=<<C <todo sym>>>(arg0, &<blk>)
+    def foo=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :foo)
@@ -103,7 +103,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
     end
 
-    def foo2<<C <todo sym>>>(&<blk>)
+    def foo2<<todo method>>(&<blk>)
       <emptyTree>::<C T>.cast(<emptyTree>::<C T>.unsafe(nil), <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
     end
 
@@ -111,7 +111,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
     end
 
-    def foo2=<<C <todo sym>>>(arg0, &<blk>)
+    def foo2=<<todo method>>(arg0, &<blk>)
       <emptyTree>::<C T>.cast(nil, <emptyTree>::<C String>)
     end
 
@@ -138,7 +138,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def default<<C <todo sym>>>(&<blk>)
+    def default<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@default)
         <self>.class().decorator().prop_get_logic(<self>, :default, arg2)
@@ -149,7 +149,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
     end
 
-    def default=<<C <todo sym>>>(arg0, &<blk>)
+    def default=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :default)
@@ -164,7 +164,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
     end
 
-    def t_nilable<<C <todo sym>>>(&<blk>)
+    def t_nilable<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@t_nilable)
         <self>.class().decorator().prop_get_logic(<self>, :t_nilable, arg2)
@@ -175,7 +175,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>)).returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
     end
 
-    def t_nilable=<<C <todo sym>>>(arg0, &<blk>)
+    def t_nilable=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :t_nilable)
@@ -190,7 +190,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Array>)
     end
 
-    def array<<C <todo sym>>>(&<blk>)
+    def array<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@array)
         <self>.class().decorator().prop_get_logic(<self>, :array, arg2)
@@ -201,7 +201,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C Array>).returns(<emptyTree>::<C Array>)
     end
 
-    def array=<<C <todo sym>>>(arg0, &<blk>)
+    def array=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :array)
@@ -216,7 +216,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C String>))
     end
 
-    def t_array<<C <todo sym>>>(&<blk>)
+    def t_array<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@t_array)
         <self>.class().decorator().prop_get_logic(<self>, :t_array, arg2)
@@ -227,7 +227,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C String>)).returns(<emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C String>))
     end
 
-    def t_array=<<C <todo sym>>>(arg0, &<blk>)
+    def t_array=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :t_array)
@@ -242,7 +242,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C T>::<C Hash>.[](<emptyTree>::<C Symbol>, <emptyTree>::<C String>))
     end
 
-    def hash_of<<C <todo sym>>>(&<blk>)
+    def hash_of<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@hash_of)
         <self>.class().decorator().prop_get_logic(<self>, :hash_of, arg2)
@@ -253,7 +253,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C T>::<C Hash>.[](<emptyTree>::<C Symbol>, <emptyTree>::<C String>)).returns(<emptyTree>::<C T>::<C Hash>.[](<emptyTree>::<C Symbol>, <emptyTree>::<C String>))
     end
 
-    def hash_of=<<C <todo sym>>>(arg0, &<blk>)
+    def hash_of=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :hash_of)
@@ -268,7 +268,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def const_explicit<<C <todo sym>>>(&<blk>)
+    def const_explicit<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@const_explicit)
         <self>.class().decorator().prop_get_logic(<self>, :const_explicit, arg2)
@@ -279,7 +279,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def const<<C <todo sym>>>(&<blk>)
+    def const<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@const)
         <self>.class().decorator().prop_get_logic(<self>, :const, arg2)
@@ -290,7 +290,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def enum_prop<<C <todo sym>>>(&<blk>)
+    def enum_prop<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@enum_prop)
         <self>.class().decorator().prop_get_logic(<self>, :enum_prop, arg2)
@@ -301,7 +301,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
     end
 
-    def enum_prop=<<C <todo sym>>>(arg0, &<blk>)
+    def enum_prop=<<todo method>>(arg0, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -309,7 +309,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def foreign<<C <todo sym>>>(&<blk>)
+    def foreign<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@foreign)
         <self>.class().decorator().prop_get_logic(<self>, :foreign, arg2)
@@ -320,7 +320,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
     end
 
-    def foreign=<<C <todo sym>>>(arg0, &<blk>)
+    def foreign=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :foreign)
@@ -335,7 +335,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:opts, ::T.untyped()).returns(::T.nilable(<emptyTree>::<C ForeignClass>))
     end
 
-    def foreign_<<C <todo sym>>>(*opts:, &<blk>)
+    def foreign_<<todo method>>(*opts:, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -343,7 +343,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:opts, ::T.untyped()).returns(<emptyTree>::<C ForeignClass>)
     end
 
-    def foreign_!<<C <todo sym>>>(*opts:, &<blk>)
+    def foreign_!<<todo method>>(*opts:, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -351,7 +351,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def foreign_lazy<<C <todo sym>>>(&<blk>)
+    def foreign_lazy<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@foreign_lazy)
         <self>.class().decorator().prop_get_logic(<self>, :foreign_lazy, arg2)
@@ -362,7 +362,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
     end
 
-    def foreign_lazy=<<C <todo sym>>>(arg0, &<blk>)
+    def foreign_lazy=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :foreign_lazy)
@@ -377,7 +377,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:opts, ::T.untyped()).returns(::T.nilable(<emptyTree>::<C ForeignClass>))
     end
 
-    def foreign_lazy_<<C <todo sym>>>(*opts:, &<blk>)
+    def foreign_lazy_<<todo method>>(*opts:, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -385,7 +385,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:opts, ::T.untyped()).returns(<emptyTree>::<C ForeignClass>)
     end
 
-    def foreign_lazy_!<<C <todo sym>>>(*opts:, &<blk>)
+    def foreign_lazy_!<<todo method>>(*opts:, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -393,7 +393,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def foreign_proc<<C <todo sym>>>(&<blk>)
+    def foreign_proc<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@foreign_proc)
         <self>.class().decorator().prop_get_logic(<self>, :foreign_proc, arg2)
@@ -404,7 +404,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
     end
 
-    def foreign_proc=<<C <todo sym>>>(arg0, &<blk>)
+    def foreign_proc=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :foreign_proc)
@@ -419,7 +419,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:opts, ::T.untyped()).returns(::T.nilable(<emptyTree>::<C ForeignClass>))
     end
 
-    def foreign_proc_<<C <todo sym>>>(*opts:, &<blk>)
+    def foreign_proc_<<todo method>>(*opts:, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -427,7 +427,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:opts, ::T.untyped()).returns(<emptyTree>::<C ForeignClass>)
     end
 
-    def foreign_proc_!<<C <todo sym>>>(*opts:, &<blk>)
+    def foreign_proc_!<<todo method>>(*opts:, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -435,7 +435,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def foreign_invalid<<C <todo sym>>>(&<blk>)
+    def foreign_invalid<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@foreign_invalid)
         <self>.class().decorator().prop_get_logic(<self>, :foreign_invalid, arg2)
@@ -446,7 +446,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
     end
 
-    def foreign_invalid=<<C <todo sym>>>(arg0, &<blk>)
+    def foreign_invalid=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :foreign_invalid)
@@ -461,7 +461,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:opts, ::T.untyped()).returns(::T.untyped())
     end
 
-    def foreign_invalid_<<C <todo sym>>>(*opts:, &<blk>)
+    def foreign_invalid_<<todo method>>(*opts:, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -469,7 +469,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:opts, ::T.untyped()).returns(::T.untyped())
     end
 
-    def foreign_invalid_!<<C <todo sym>>>(*opts:, &<blk>)
+    def foreign_invalid_!<<todo method>>(*opts:, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -477,7 +477,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def ifunset<<C <todo sym>>>(&<blk>)
+    def ifunset<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -485,7 +485,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
     end
 
-    def ifunset=<<C <todo sym>>>(arg0, &<blk>)
+    def ifunset=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :ifunset)
@@ -500,7 +500,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
     end
 
-    def ifunset_nilable<<C <todo sym>>>(&<blk>)
+    def ifunset_nilable<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -508,7 +508,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>)).returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
     end
 
-    def ifunset_nilable=<<C <todo sym>>>(arg0, &<blk>)
+    def ifunset_nilable=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :ifunset_nilable)
@@ -523,7 +523,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def empty_hash_rules<<C <todo sym>>>(&<blk>)
+    def empty_hash_rules<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@empty_hash_rules)
         <self>.class().decorator().prop_get_logic(<self>, :empty_hash_rules, arg2)
@@ -534,7 +534,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
     end
 
-    def empty_hash_rules=<<C <todo sym>>>(arg0, &<blk>)
+    def empty_hash_rules=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :empty_hash_rules)
@@ -549,7 +549,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def hash_rules<<C <todo sym>>>(&<blk>)
+    def hash_rules<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@hash_rules)
         <self>.class().decorator().prop_get_logic(<self>, :hash_rules, arg2)
@@ -560,7 +560,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
     end
 
-    def hash_rules=<<C <todo sym>>>(arg0, &<blk>)
+    def hash_rules=<<todo method>>(arg0, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -682,11 +682,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C PropHelpers><<C <todo sym>>> < (::<todo sym>)
-    def self.token_prop<<C <todo sym>>>(opts = {}, &<blk>)
+    def self.token_prop<<todo method>>(opts = {}, &<blk>)
       <emptyTree>
     end
 
-    def self.created_prop<<C <todo sym>>>(opts = {}, &<blk>)
+    def self.created_prop<<todo method>>(opts = {}, &<blk>)
       <emptyTree>
     end
 
@@ -694,7 +694,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::String)
     end
 
-    def token<<C <todo sym>>>(&<blk>)
+    def token<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@token)
         <self>.class().decorator().prop_get_logic(<self>, :token, arg2)
@@ -705,7 +705,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::String).returns(::String)
     end
 
-    def token=<<C <todo sym>>>(arg0, &<blk>)
+    def token=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :token)
@@ -720,7 +720,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::Float)
     end
 
-    def created<<C <todo sym>>>(&<blk>)
+    def created<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@created)
         <self>.class().decorator().prop_get_logic(<self>, :created, arg2)
@@ -731,7 +731,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::Float).returns(::Float)
     end
 
-    def created=<<C <todo sym>>>(arg0, &<blk>)
+    def created=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :created)
@@ -762,11 +762,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C PropHelpers2><<C <todo sym>>> < (::<todo sym>)
-    def self.timestamped_token_prop<<C <todo sym>>>(opts = {}, &<blk>)
+    def self.timestamped_token_prop<<todo method>>(opts = {}, &<blk>)
       <emptyTree>
     end
 
-    def self.created_prop<<C <todo sym>>>(opts = {}, &<blk>)
+    def self.created_prop<<todo method>>(opts = {}, &<blk>)
       <emptyTree>
     end
 
@@ -774,7 +774,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::String)
     end
 
-    def token<<C <todo sym>>>(&<blk>)
+    def token<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@token)
         <self>.class().decorator().prop_get_logic(<self>, :token, arg2)
@@ -785,7 +785,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::String).returns(::String)
     end
 
-    def token=<<C <todo sym>>>(arg0, &<blk>)
+    def token=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :token)
@@ -800,7 +800,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::Float)
     end
 
-    def created<<C <todo sym>>>(&<blk>)
+    def created<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@created)
         <self>.class().decorator().prop_get_logic(<self>, :created, arg2)
@@ -825,7 +825,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C ShardingProp><<C <todo sym>>> < (::<todo sym>)
-    def self.merchant_prop<<C <todo sym>>>(opts = {}, &<blk>)
+    def self.merchant_prop<<todo method>>(opts = {}, &<blk>)
       <emptyTree>
     end
 
@@ -833,7 +833,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::String)
     end
 
-    def merchant<<C <todo sym>>>(&<blk>)
+    def merchant<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@merchant)
         <self>.class().decorator().prop_get_logic(<self>, :merchant, arg2)
@@ -850,7 +850,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C EncryptedProp><<C <todo sym>>> < (::<todo sym>)
-    def self.encrypted_prop<<C <todo sym>>>(opts = {}, &<blk>)
+    def self.encrypted_prop<<todo method>>(opts = {}, &<blk>)
       <emptyTree>
     end
 
@@ -858,7 +858,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.nilable(::String))
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -866,7 +866,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.nilable(<emptyTree>::<C Opus>::<C DB>::<C Model>::<C Mixins>::<C Encryptable>::<C EncryptedValue>))
     end
 
-    def encrypted_foo<<C <todo sym>>>(&<blk>)
+    def encrypted_foo<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -874,7 +874,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.nilable(::String)).returns(::T.nilable(::String))
     end
 
-    def foo=<<C <todo sym>>>(arg0, &<blk>)
+    def foo=<<todo method>>(arg0, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -882,7 +882,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.nilable(<emptyTree>::<C Opus>::<C DB>::<C Model>::<C Mixins>::<C Encryptable>::<C EncryptedValue>)).returns(::T.nilable(<emptyTree>::<C Opus>::<C DB>::<C Model>::<C Mixins>::<C Encryptable>::<C EncryptedValue>))
     end
 
-    def encrypted_foo=<<C <todo sym>>>(arg0, &<blk>)
+    def encrypted_foo=<<todo method>>(arg0, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -890,7 +890,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.nilable(::String))
     end
 
-    def bar<<C <todo sym>>>(&<blk>)
+    def bar<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -898,7 +898,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.nilable(<emptyTree>::<C Opus>::<C DB>::<C Model>::<C Mixins>::<C Encryptable>::<C EncryptedValue>))
     end
 
-    def encrypted_bar<<C <todo sym>>>(&<blk>)
+    def encrypted_bar<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 

--- a/test/testdata/rewriter/prop_computed_by.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_computed_by.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
-    def num_ok<<C <todo sym>>>(&<blk>)
+    def num_ok<<todo method>>(&<blk>)
       begin
         ::T.assert_type!(<self>.class().compute_num_ok(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <emptyTree>::<C Integer>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:n, <emptyTree>::<C Integer>).returns(<emptyTree>::<C Integer>)
     end
 
-    def self.compute_num_ok<<C <todo sym>>>(n, &<blk>)
+    def self.compute_num_ok<<todo method>>(n, &<blk>)
       10
     end
 
@@ -23,7 +23,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
-    def missing<<C <todo sym>>>(&<blk>)
+    def missing<<todo method>>(&<blk>)
       begin
         ::T.assert_type!(<self>.class().compute_missing(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <emptyTree>::<C Integer>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
@@ -34,7 +34,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
-    def num_wrong_value<<C <todo sym>>>(&<blk>)
+    def num_wrong_value<<todo method>>(&<blk>)
       begin
         ::T.assert_type!(<self>.class().compute_num_wrong_value(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <emptyTree>::<C Integer>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
@@ -45,7 +45,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:inputs, <emptyTree>::<C T>.untyped()).returns(<emptyTree>::<C String>)
     end
 
-    def self.compute_num_wrong_value<<C <todo sym>>>(inputs, &<blk>)
+    def self.compute_num_wrong_value<<todo method>>(inputs, &<blk>)
       "not_an_integer"
     end
 
@@ -53,7 +53,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
-    def num_wrong_type<<C <todo sym>>>(&<blk>)
+    def num_wrong_type<<todo method>>(&<blk>)
       begin
         ::T.assert_type!(<self>.class().compute_num_wrong_type(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <emptyTree>::<C Integer>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
@@ -64,7 +64,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:inputs, <emptyTree>::<C T>.untyped()).returns(<emptyTree>::<C Integer>)
     end
 
-    def self.compute_num_wrong_type<<C <todo sym>>>(inputs, &<blk>)
+    def self.compute_num_wrong_type<<todo method>>(inputs, &<blk>)
       "not_an_integer"
     end
 
@@ -72,7 +72,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def not_a_symbol<<C <todo sym>>>(&<blk>)
+    def not_a_symbol<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@not_a_symbol)
         <self>.class().decorator().prop_get_logic(<self>, :not_a_symbol, arg2)
@@ -83,7 +83,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def symbol_in_variable<<C <todo sym>>>(&<blk>)
+    def symbol_in_variable<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@symbol_in_variable)
         <self>.class().decorator().prop_get_logic(<self>, :symbol_in_variable, arg2)
@@ -94,14 +94,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
-    def num_unknown_type<<C <todo sym>>>(&<blk>)
+    def num_unknown_type<<todo method>>(&<blk>)
       begin
         ::T.assert_type!(<self>.class().compute_num_unknown_type(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <emptyTree>::<C Integer>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
     end
 
-    def self.compute_num_unknown_type<<C <todo sym>>>(inputs, &<blk>)
+    def self.compute_num_unknown_type<<todo method>>(inputs, &<blk>)
       <emptyTree>::<C T>.untyped()
     end
 

--- a/test/testdata/rewriter/prop_in_module.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_in_module.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
     end
 
-    def foo=<<C <todo sym>>>(arg0, &<blk>)
+    def foo=<<todo method>>(arg0, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 

--- a/test/testdata/rewriter/prop_missing.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_missing.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@foo)
         <self>.class().decorator().prop_get_logic(<self>, :foo, arg2)
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C Integer>).returns(<emptyTree>::<C Integer>)
     end
 
-    def foo=<<C <todo sym>>>(arg0, &<blk>)
+    def foo=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :foo)
@@ -30,7 +30,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
-    def bar<<C <todo sym>>>(&<blk>)
+    def bar<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@bar)
         <self>.class().decorator().prop_get_logic(<self>, :bar, arg2)

--- a/test/testdata/rewriter/rails/cattr_accessor.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rails/cattr_accessor.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def both<<C <todo sym>>>(&<blk>)
+    def both<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.both<<C <todo sym>>>(&<blk>)
+    def self.both<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -20,7 +20,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def both=<<C <todo sym>>>(arg0, &<blk>)
+    def both=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -28,7 +28,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.both=<<C <todo sym>>>(arg0, &<blk>)
+    def self.both=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -36,7 +36,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -44,7 +44,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.foo<<C <todo sym>>>(&<blk>)
+    def self.foo<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -52,7 +52,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def foo=<<C <todo sym>>>(arg0, &<blk>)
+    def foo=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -60,7 +60,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.foo=<<C <todo sym>>>(arg0, &<blk>)
+    def self.foo=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -68,7 +68,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.no_instance<<C <todo sym>>>(&<blk>)
+    def self.no_instance<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -76,7 +76,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.no_instance=<<C <todo sym>>>(arg0, &<blk>)
+    def self.no_instance=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -84,7 +84,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.no_instance_reader<<C <todo sym>>>(&<blk>)
+    def self.no_instance_reader<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -92,7 +92,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def no_instance_reader=<<C <todo sym>>>(arg0, &<blk>)
+    def no_instance_reader=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -100,7 +100,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.no_instance_reader=<<C <todo sym>>>(arg0, &<blk>)
+    def self.no_instance_reader=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -108,7 +108,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def bar<<C <todo sym>>>(&<blk>)
+    def bar<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -116,7 +116,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.bar<<C <todo sym>>>(&<blk>)
+    def self.bar<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -124,7 +124,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.bar=<<C <todo sym>>>(arg0, &<blk>)
+    def self.bar=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -132,7 +132,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def no_instance_writer<<C <todo sym>>>(&<blk>)
+    def no_instance_writer<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -140,7 +140,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.no_instance_writer<<C <todo sym>>>(&<blk>)
+    def self.no_instance_writer<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -148,7 +148,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.no_instance_writer=<<C <todo sym>>>(arg0, &<blk>)
+    def self.no_instance_writer=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -156,7 +156,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def usages<<C <todo sym>>>(&<blk>)
+    def usages<<todo method>>(&<blk>)
       begin
         <self>.both()
         <self>.both=(1)

--- a/test/testdata/rewriter/rails/cattr_reader.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rails/cattr_reader.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def both<<C <todo sym>>>(&<blk>)
+    def both<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.both<<C <todo sym>>>(&<blk>)
+    def self.both<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -20,7 +20,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -28,7 +28,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.foo<<C <todo sym>>>(&<blk>)
+    def self.foo<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -36,7 +36,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.no_instance<<C <todo sym>>>(&<blk>)
+    def self.no_instance<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -44,7 +44,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.bar<<C <todo sym>>>(&<blk>)
+    def self.bar<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -52,7 +52,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.no_reader<<C <todo sym>>>(&<blk>)
+    def self.no_reader<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -60,7 +60,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def usages<<C <todo sym>>>(&<blk>)
+    def usages<<todo method>>(&<blk>)
       begin
         <self>.both()
         <self>.no_instance()

--- a/test/testdata/rewriter/rails/cattr_writer.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rails/cattr_writer.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def both=<<C <todo sym>>>(arg0, &<blk>)
+    def both=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.both=<<C <todo sym>>>(arg0, &<blk>)
+    def self.both=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -20,7 +20,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def foo=<<C <todo sym>>>(arg0, &<blk>)
+    def foo=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -28,7 +28,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.foo=<<C <todo sym>>>(arg0, &<blk>)
+    def self.foo=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -36,7 +36,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.no_instance=<<C <todo sym>>>(arg0, &<blk>)
+    def self.no_instance=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -44,7 +44,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.bar=<<C <todo sym>>>(arg0, &<blk>)
+    def self.bar=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -52,7 +52,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.no_instance_writer=<<C <todo sym>>>(arg0, &<blk>)
+    def self.no_instance_writer=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -60,7 +60,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def usages<<C <todo sym>>>(&<blk>)
+    def usages<<todo method>>(&<blk>)
       begin
         <self>.both=(1)
         <self>.no_instance=(1)

--- a/test/testdata/rewriter/rails/class_attribute.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rails/class_attribute.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def read_write_predicate<<C <todo sym>>>(&<blk>)
+    def read_write_predicate<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.read_write_predicate<<C <todo sym>>>(&<blk>)
+    def self.read_write_predicate<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -20,7 +20,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def read_write_predicate=<<C <todo sym>>>(arg0, &<blk>)
+    def read_write_predicate=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -28,7 +28,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.read_write_predicate=<<C <todo sym>>>(arg0, &<blk>)
+    def self.read_write_predicate=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -36,7 +36,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T::<C Boolean>)
     end
 
-    def read_write_predicate?<<C <todo sym>>>(&<blk>)
+    def read_write_predicate?<<todo method>>(&<blk>)
       false
     end
 
@@ -44,7 +44,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T::<C Boolean>)
     end
 
-    def self.read_write_predicate?<<C <todo sym>>>(&<blk>)
+    def self.read_write_predicate?<<todo method>>(&<blk>)
       false
     end
 
@@ -52,7 +52,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -60,7 +60,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.foo<<C <todo sym>>>(&<blk>)
+    def self.foo<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -68,7 +68,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def foo=<<C <todo sym>>>(arg0, &<blk>)
+    def foo=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -76,7 +76,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.foo=<<C <todo sym>>>(arg0, &<blk>)
+    def self.foo=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -84,7 +84,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T::<C Boolean>)
     end
 
-    def foo?<<C <todo sym>>>(&<blk>)
+    def foo?<<todo method>>(&<blk>)
       false
     end
 
@@ -92,7 +92,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T::<C Boolean>)
     end
 
-    def self.foo?<<C <todo sym>>>(&<blk>)
+    def self.foo?<<todo method>>(&<blk>)
       false
     end
 
@@ -100,7 +100,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.no_instance<<C <todo sym>>>(&<blk>)
+    def self.no_instance<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -108,7 +108,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.no_instance=<<C <todo sym>>>(arg0, &<blk>)
+    def self.no_instance=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -116,7 +116,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T::<C Boolean>)
     end
 
-    def self.no_instance?<<C <todo sym>>>(&<blk>)
+    def self.no_instance?<<todo method>>(&<blk>)
       false
     end
 
@@ -124,7 +124,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.no_instance_reader<<C <todo sym>>>(&<blk>)
+    def self.no_instance_reader<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -132,7 +132,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def no_instance_reader=<<C <todo sym>>>(arg0, &<blk>)
+    def no_instance_reader=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -140,7 +140,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.no_instance_reader=<<C <todo sym>>>(arg0, &<blk>)
+    def self.no_instance_reader=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -148,7 +148,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T::<C Boolean>)
     end
 
-    def self.no_instance_reader?<<C <todo sym>>>(&<blk>)
+    def self.no_instance_reader?<<todo method>>(&<blk>)
       false
     end
 
@@ -156,7 +156,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def no_instance_writer<<C <todo sym>>>(&<blk>)
+    def no_instance_writer<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -164,7 +164,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.no_instance_writer<<C <todo sym>>>(&<blk>)
+    def self.no_instance_writer<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -172,7 +172,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.no_instance_writer=<<C <todo sym>>>(arg0, &<blk>)
+    def self.no_instance_writer=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -180,7 +180,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T::<C Boolean>)
     end
 
-    def no_instance_writer?<<C <todo sym>>>(&<blk>)
+    def no_instance_writer?<<todo method>>(&<blk>)
       false
     end
 
@@ -188,7 +188,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T::<C Boolean>)
     end
 
-    def self.no_instance_writer?<<C <todo sym>>>(&<blk>)
+    def self.no_instance_writer?<<todo method>>(&<blk>)
       false
     end
 
@@ -196,7 +196,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def bar<<C <todo sym>>>(&<blk>)
+    def bar<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -204,7 +204,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.bar<<C <todo sym>>>(&<blk>)
+    def self.bar<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -212,7 +212,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def bar=<<C <todo sym>>>(arg0, &<blk>)
+    def bar=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -220,7 +220,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.bar=<<C <todo sym>>>(arg0, &<blk>)
+    def self.bar=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -228,7 +228,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def no_predicate<<C <todo sym>>>(&<blk>)
+    def no_predicate<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -236,7 +236,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.no_predicate<<C <todo sym>>>(&<blk>)
+    def self.no_predicate<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -244,7 +244,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def no_predicate=<<C <todo sym>>>(arg0, &<blk>)
+    def no_predicate=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -252,7 +252,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.no_predicate=<<C <todo sym>>>(arg0, &<blk>)
+    def self.no_predicate=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -260,7 +260,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def usages<<C <todo sym>>>(&<blk>)
+    def usages<<todo method>>(&<blk>)
       begin
         <self>.read_write_predicate()
         <self>.read_write_predicate?()

--- a/test/testdata/rewriter/rails/delegate.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rails/delegate.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
-    def foo<<C <todo sym>>>(*arg0, &<blk>)
+    def foo<<todo method>>(*arg0, &<blk>)
       <emptyTree>
     end
 
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
-    def bar<<C <todo sym>>>(*arg0, &<blk>)
+    def bar<<todo method>>(*arg0, &<blk>)
       <emptyTree>
     end
 
@@ -20,7 +20,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
-    def baz<<C <todo sym>>>(*arg0, &<blk>)
+    def baz<<todo method>>(*arg0, &<blk>)
       <emptyTree>
     end
 
@@ -28,7 +28,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
-    def ball<<C <todo sym>>>(*arg0, &<blk>)
+    def ball<<todo method>>(*arg0, &<blk>)
       <emptyTree>
     end
 
@@ -36,7 +36,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
-    def string_foo<<C <todo sym>>>(*arg0, &<blk>)
+    def string_foo<<todo method>>(*arg0, &<blk>)
       <emptyTree>
     end
 
@@ -44,7 +44,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
-    def string_bar<<C <todo sym>>>(*arg0, &<blk>)
+    def string_bar<<todo method>>(*arg0, &<blk>)
       <emptyTree>
     end
 
@@ -52,7 +52,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
-    def symbol_foo<<C <todo sym>>>(*arg0, &<blk>)
+    def symbol_foo<<todo method>>(*arg0, &<blk>)
       <emptyTree>
     end
 
@@ -60,7 +60,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
-    def symbol_bar<<C <todo sym>>>(*arg0, &<blk>)
+    def symbol_bar<<todo method>>(*arg0, &<blk>)
       <emptyTree>
     end
 
@@ -68,7 +68,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
-    def true_foo<<C <todo sym>>>(*arg0, &<blk>)
+    def true_foo<<todo method>>(*arg0, &<blk>)
       <emptyTree>
     end
 
@@ -76,7 +76,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
-    def true_bar<<C <todo sym>>>(*arg0, &<blk>)
+    def true_bar<<todo method>>(*arg0, &<blk>)
       <emptyTree>
     end
 
@@ -84,7 +84,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def usages<<C <todo sym>>>(&<blk>)
+    def usages<<todo method>>(&<blk>)
       begin
         <self>.foo() do ||
           <emptyTree>
@@ -137,7 +137,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
-    def foo<<C <todo sym>>>(*arg0, &<blk>)
+    def foo<<todo method>>(*arg0, &<blk>)
       <emptyTree>
     end
 
@@ -145,7 +145,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
-    def bar<<C <todo sym>>>(*arg0, &<blk>)
+    def bar<<todo method>>(*arg0, &<blk>)
       <emptyTree>
     end
 
@@ -185,7 +185,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
     end
 
-    def each<<C <todo sym>>>(*arg0, &<blk>)
+    def each<<todo method>>(*arg0, &<blk>)
       <emptyTree>
     end
 

--- a/test/testdata/rewriter/rails/mattr_accessor.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rails/mattr_accessor.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def both<<C <todo sym>>>(&<blk>)
+    def both<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.both<<C <todo sym>>>(&<blk>)
+    def self.both<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -20,7 +20,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def both=<<C <todo sym>>>(arg0, &<blk>)
+    def both=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -28,7 +28,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.both=<<C <todo sym>>>(arg0, &<blk>)
+    def self.both=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -36,7 +36,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -44,7 +44,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.foo<<C <todo sym>>>(&<blk>)
+    def self.foo<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -52,7 +52,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def foo=<<C <todo sym>>>(arg0, &<blk>)
+    def foo=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -60,7 +60,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.foo=<<C <todo sym>>>(arg0, &<blk>)
+    def self.foo=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -68,7 +68,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.no_instance<<C <todo sym>>>(&<blk>)
+    def self.no_instance<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -76,7 +76,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.no_instance=<<C <todo sym>>>(arg0, &<blk>)
+    def self.no_instance=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -84,7 +84,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.no_instance_reader<<C <todo sym>>>(&<blk>)
+    def self.no_instance_reader<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -92,7 +92,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def no_instance_reader=<<C <todo sym>>>(arg0, &<blk>)
+    def no_instance_reader=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -100,7 +100,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.no_instance_reader=<<C <todo sym>>>(arg0, &<blk>)
+    def self.no_instance_reader=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -108,7 +108,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def bar<<C <todo sym>>>(&<blk>)
+    def bar<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -116,7 +116,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.bar<<C <todo sym>>>(&<blk>)
+    def self.bar<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -124,7 +124,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.bar=<<C <todo sym>>>(arg0, &<blk>)
+    def self.bar=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -132,7 +132,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def no_instance_writer<<C <todo sym>>>(&<blk>)
+    def no_instance_writer<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -140,7 +140,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.no_instance_writer<<C <todo sym>>>(&<blk>)
+    def self.no_instance_writer<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -148,7 +148,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.no_instance_writer=<<C <todo sym>>>(arg0, &<blk>)
+    def self.no_instance_writer=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -156,7 +156,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def usages<<C <todo sym>>>(&<blk>)
+    def usages<<todo method>>(&<blk>)
       begin
         <self>.both()
         <self>.both=(1)

--- a/test/testdata/rewriter/rails/mattr_reader.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rails/mattr_reader.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def both<<C <todo sym>>>(&<blk>)
+    def both<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.both<<C <todo sym>>>(&<blk>)
+    def self.both<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -20,7 +20,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -28,7 +28,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.foo<<C <todo sym>>>(&<blk>)
+    def self.foo<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -36,7 +36,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.no_instance<<C <todo sym>>>(&<blk>)
+    def self.no_instance<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -44,7 +44,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.bar<<C <todo sym>>>(&<blk>)
+    def self.bar<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -52,7 +52,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.untyped())
     end
 
-    def self.no_instance_reader<<C <todo sym>>>(&<blk>)
+    def self.no_instance_reader<<todo method>>(&<blk>)
       <emptyTree>
     end
 
@@ -60,7 +60,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def usages<<C <todo sym>>>(&<blk>)
+    def usages<<todo method>>(&<blk>)
       begin
         <self>.both()
         <self>.no_instance()

--- a/test/testdata/rewriter/rails/mattr_writer.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rails/mattr_writer.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def both=<<C <todo sym>>>(arg0, &<blk>)
+    def both=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.both=<<C <todo sym>>>(arg0, &<blk>)
+    def self.both=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -20,7 +20,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def foo=<<C <todo sym>>>(arg0, &<blk>)
+    def foo=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -28,7 +28,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.foo=<<C <todo sym>>>(arg0, &<blk>)
+    def self.foo=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -36,7 +36,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.no_instance=<<C <todo sym>>>(arg0, &<blk>)
+    def self.no_instance=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -44,7 +44,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.bar=<<C <todo sym>>>(arg0, &<blk>)
+    def self.bar=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -52,7 +52,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
     end
 
-    def self.no_instance_writer=<<C <todo sym>>>(arg0, &<blk>)
+    def self.no_instance_writer=<<todo method>>(arg0, &<blk>)
       <emptyTree>
     end
 
@@ -60,7 +60,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def usages<<C <todo sym>>>(&<blk>)
+    def usages<<todo method>>(&<blk>)
       begin
         <self>.both=(1)
         <self>.no_instance=(1)

--- a/test/testdata/rewriter/singleton.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/singleton.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.attached_class())
     end
 
-    def self.instance<<C <todo sym>>>(&<blk>)
+    def self.instance<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -25,7 +25,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::T.attached_class())
     end
 
-    def self.instance<<C <todo sym>>>(&<blk>)
+    def self.instance<<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 

--- a/test/testdata/rewriter/struct.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/struct.rb.rewrite-tree.exp
@@ -14,19 +14,19 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C RealStruct><<C <todo sym>>> < (::<todo sym>)
     class <emptyTree>::<C A><<C <todo sym>>> < (::<root>::<C Struct>)
-      def foo<<C <todo sym>>>(&<blk>)
+      def foo<<todo method>>(&<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
-      def foo=<<C <todo sym>>>(foo, &<blk>)
+      def foo=<<todo method>>(foo, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
-      def bar<<C <todo sym>>>(&<blk>)
+      def bar<<todo method>>(&<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
-      def bar=<<C <todo sym>>>(bar, &<blk>)
+      def bar=<<todo method>>(bar, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
@@ -34,7 +34,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.params(:foo, ::BasicObject, :bar, ::BasicObject).void()
       end
 
-      def initialize<<C <todo sym>>>(foo = nil, bar = nil, &<blk>)
+      def initialize<<todo method>>(foo = nil, bar = nil, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
@@ -52,19 +52,19 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C KeywordInit><<C <todo sym>>> < (::<root>::<C Struct>)
-      def foo<<C <todo sym>>>(&<blk>)
+      def foo<<todo method>>(&<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
-      def foo=<<C <todo sym>>>(foo, &<blk>)
+      def foo=<<todo method>>(foo, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
-      def bar<<C <todo sym>>>(&<blk>)
+      def bar<<todo method>>(&<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
-      def bar=<<C <todo sym>>>(bar, &<blk>)
+      def bar=<<todo method>>(bar, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
@@ -72,7 +72,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.params(:foo, ::BasicObject, :bar, ::BasicObject).void()
       end
 
-      def initialize<<C <todo sym>>>(foo: = nil, bar: = nil, &<blk>)
+      def initialize<<todo method>>(foo: = nil, bar: = nil, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
@@ -92,19 +92,19 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C RealStructDesugar><<C <todo sym>>> < (::<todo sym>)
     class <emptyTree>::<C A><<C <todo sym>>> < (<emptyTree>::<C Struct>)
-      def foo<<C <todo sym>>>(&<blk>)
+      def foo<<todo method>>(&<blk>)
         <emptyTree>
       end
 
-      def bar<<C <todo sym>>>(&<blk>)
+      def bar<<todo method>>(&<blk>)
         <emptyTree>
       end
 
-      def foo=<<C <todo sym>>>(arg0, &<blk>)
+      def foo=<<todo method>>(arg0, &<blk>)
         arg0
       end
 
-      def bar=<<C <todo sym>>>(arg0, &<blk>)
+      def bar=<<todo method>>(arg0, &<blk>)
         arg0
       end
 
@@ -112,7 +112,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.params(:foo, <emptyTree>::<C BasicObject>, :bar, <emptyTree>::<C BasicObject>).returns(<emptyTree>::<C A>)
       end
 
-      def self.new<<C <todo sym>>>(foo = nil, bar = nil, &<blk>)
+      def self.new<<todo method>>(foo = nil, bar = nil, &<blk>)
         <emptyTree>::<C T>.cast(nil, <emptyTree>::<C A>)
       end
 
@@ -132,11 +132,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C TwoStructs><<C <todo sym>>> < (::<todo sym>)
     class <emptyTree>::<C A><<C <todo sym>>> < (::<root>::<C Struct>)
-      def foo<<C <todo sym>>>(&<blk>)
+      def foo<<todo method>>(&<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
-      def foo=<<C <todo sym>>>(foo, &<blk>)
+      def foo=<<todo method>>(foo, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
@@ -144,7 +144,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.params(:foo, ::BasicObject).void()
       end
 
-      def initialize<<C <todo sym>>>(foo = nil, &<blk>)
+      def initialize<<todo method>>(foo = nil, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
@@ -158,11 +158,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C B><<C <todo sym>>> < (::<root>::<C Struct>)
-      def foo<<C <todo sym>>>(&<blk>)
+      def foo<<todo method>>(&<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
-      def foo=<<C <todo sym>>>(foo, &<blk>)
+      def foo=<<todo method>>(foo, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
@@ -170,7 +170,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.params(:foo, ::BasicObject).void()
       end
 
-      def initialize<<C <todo sym>>>(foo = nil, &<blk>)
+      def initialize<<todo method>>(foo = nil, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
@@ -189,19 +189,19 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C A><<C <todo sym>>> < (::<root>::<C Struct>)
-      def foo<<C <todo sym>>>(&<blk>)
+      def foo<<todo method>>(&<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
-      def foo=<<C <todo sym>>>(foo, &<blk>)
+      def foo=<<todo method>>(foo, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
-      def bar<<C <todo sym>>>(&<blk>)
+      def bar<<todo method>>(&<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
-      def bar=<<C <todo sym>>>(bar, &<blk>)
+      def bar=<<todo method>>(bar, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
@@ -209,7 +209,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.params(:foo, ::BasicObject, :bar, ::BasicObject).void()
       end
 
-      def initialize<<C <todo sym>>>(foo = nil, bar = nil, &<blk>)
+      def initialize<<todo method>>(foo = nil, bar = nil, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
@@ -229,7 +229,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C MixinStruct><<C <todo sym>>> < (::<todo sym>)
     module <emptyTree>::<C MyMixin><<C <todo sym>>> < ()
-      def foo<<C <todo sym>>>(&<blk>)
+      def foo<<todo method>>(&<blk>)
         <emptyTree>
       end
 
@@ -237,11 +237,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C MyStruct><<C <todo sym>>> < (::<root>::<C Struct>)
-      def x<<C <todo sym>>>(&<blk>)
+      def x<<todo method>>(&<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
-      def x=<<C <todo sym>>>(x, &<blk>)
+      def x=<<todo method>>(x, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
@@ -249,7 +249,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.params(:x, ::BasicObject).void()
       end
 
-      def initialize<<C <todo sym>>>(x = nil, &<blk>)
+      def initialize<<todo method>>(x = nil, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
@@ -269,11 +269,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C MyKeywordInitStruct><<C <todo sym>>> < (::<root>::<C Struct>)
-      def x<<C <todo sym>>>(&<blk>)
+      def x<<todo method>>(&<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
-      def x=<<C <todo sym>>>(x, &<blk>)
+      def x=<<todo method>>(x, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
@@ -281,7 +281,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.params(:x, ::BasicObject).void()
       end
 
-      def initialize<<C <todo sym>>>(x: = nil, &<blk>)
+      def initialize<<todo method>>(x: = nil, &<blk>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
 
@@ -328,7 +328,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C Main><<C <todo sym>>> < (::<todo sym>)
-    def main<<C <todo sym>>>(&<blk>)
+    def main<<todo method>>(&<blk>)
       begin
         a = <emptyTree>::<C Struct>.new(:foo)
         <emptyTree>::<C T>.assert_type!(a, <emptyTree>::<C Struct>)

--- a/test/testdata/rewriter/t_enum_snapshot.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_enum_snapshot.rb.rewrite-tree.exp
@@ -32,7 +32,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C EnumsDoEnum><<C <todo sym>>> < (<emptyTree>::<C T>::<C Enum>)
-    def something_outside<<C <todo sym>>>(&<blk>)
+    def something_outside<<todo method>>(&<blk>)
       <emptyTree>
     end
 

--- a/test/testdata/rewriter/t_struct/default.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/default.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:foo, <emptyTree>::<C Integer>).void()
     end
 
-    def initialize<<C <todo sym>>>(foo: = 3, &<blk>)
+    def initialize<<todo method>>(foo: = 3, &<blk>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C Integer>)
         <self>.super(ZSuperArgs)
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       @foo
     end
 
@@ -23,7 +23,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C Integer>).returns(<emptyTree>::<C Integer>)
     end
 
-    def foo=<<C <todo sym>>>(arg0, &<blk>)
+    def foo=<<todo method>>(arg0, &<blk>)
       @foo = arg0
     end
 
@@ -49,7 +49,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def initialize<<C <todo sym>>>(&<blk>)
+    def initialize<<todo method>>(&<blk>)
       <self>.super(ZSuperArgs)
     end
 

--- a/test/testdata/rewriter/t_struct/inexact.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/inexact.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       <self>.instance_variable_get(:@foo)
     end
 
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C Integer>).returns(<emptyTree>::<C Integer>)
     end
 
-    def foo=<<C <todo sym>>>(arg0, &<blk>)
+    def foo=<<todo method>>(arg0, &<blk>)
       <self>.instance_variable_set(:@foo, arg0)
     end
 
@@ -20,7 +20,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def bar<<C <todo sym>>>(&<blk>)
+    def bar<<todo method>>(&<blk>)
       <self>.instance_variable_get(:@bar)
     end
 
@@ -28,7 +28,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
     end
 
-    def bar=<<C <todo sym>>>(arg0, &<blk>)
+    def bar=<<todo method>>(arg0, &<blk>)
       <self>.instance_variable_set(:@bar, arg0)
     end
 
@@ -56,7 +56,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Symbol>)
     end
 
-    def qux<<C <todo sym>>>(&<blk>)
+    def qux<<todo method>>(&<blk>)
       begin
         arg2 = <self>.instance_variable_get(:@qux)
         <self>.class().decorator().prop_get_logic(<self>, :qux, arg2)
@@ -67,7 +67,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C Symbol>).returns(<emptyTree>::<C Symbol>)
     end
 
-    def qux=<<C <todo sym>>>(arg0, &<blk>)
+    def qux=<<todo method>>(arg0, &<blk>)
       begin
         if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
           ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :qux)

--- a/test/testdata/rewriter/t_struct/nilable.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/nilable.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:foo, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>)).void()
     end
 
-    def initialize<<C <todo sym>>>(foo: = nil, &<blk>)
+    def initialize<<todo method>>(foo: = nil, &<blk>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
         <self>.super(ZSuperArgs)
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       @foo
     end
 
@@ -23,7 +23,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>)).returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
-    def foo=<<C <todo sym>>>(arg0, &<blk>)
+    def foo=<<todo method>>(arg0, &<blk>)
       @foo = arg0
     end
 

--- a/test/testdata/rewriter/t_struct/none.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/none.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def initialize<<C <todo sym>>>(&<blk>)
+    def initialize<<todo method>>(&<blk>)
       <self>.super(ZSuperArgs)
     end
 

--- a/test/testdata/rewriter/t_struct/normal.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/normal.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:foo, <emptyTree>::<C Integer>).void()
     end
 
-    def initialize<<C <todo sym>>>(foo:, &<blk>)
+    def initialize<<todo method>>(foo:, &<blk>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C Integer>)
         <self>.super(ZSuperArgs)
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       @foo
     end
 
@@ -23,7 +23,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C Integer>).returns(<emptyTree>::<C Integer>)
     end
 
-    def foo=<<C <todo sym>>>(arg0, &<blk>)
+    def foo=<<todo method>>(arg0, &<blk>)
       @foo = arg0
     end
 

--- a/test/testdata/rewriter/t_struct/override.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/override.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:foo, <emptyTree>::<C String>).void()
     end
 
-    def initialize<<C <todo sym>>>(foo:, &<blk>)
+    def initialize<<todo method>>(foo:, &<blk>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C String>)
         <self>.super(ZSuperArgs)
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C String>)
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       @foo
     end
 
@@ -23,7 +23,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
     end
 
-    def foo=<<C <todo sym>>>(arg0, &<blk>)
+    def foo=<<todo method>>(arg0, &<blk>)
       @foo = arg0
     end
 
@@ -31,7 +31,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:foo, <emptyTree>::<C Integer>).void()
     end
 
-    def initialize<<C <todo sym>>>(foo:, &<blk>)
+    def initialize<<todo method>>(foo:, &<blk>)
       <self>.puts("override")
     end
 

--- a/test/testdata/rewriter/t_struct/param_order.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/param_order.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:bar, <emptyTree>::<C Integer>, :foo, <emptyTree>::<C Integer>).void()
     end
 
-    def initialize<<C <todo sym>>>(bar:, foo: = 3, &<blk>)
+    def initialize<<todo method>>(bar:, foo: = 3, &<blk>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C Integer>)
         @bar = ::T.let(bar, <emptyTree>::<C Integer>)
@@ -16,7 +16,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       @foo
     end
 
@@ -24,7 +24,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C Integer>).returns(<emptyTree>::<C Integer>)
     end
 
-    def foo=<<C <todo sym>>>(arg0, &<blk>)
+    def foo=<<todo method>>(arg0, &<blk>)
       @foo = arg0
     end
 
@@ -32,7 +32,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
-    def bar<<C <todo sym>>>(&<blk>)
+    def bar<<todo method>>(&<blk>)
       @bar
     end
 
@@ -40,7 +40,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C Integer>).returns(<emptyTree>::<C Integer>)
     end
 
-    def bar=<<C <todo sym>>>(arg0, &<blk>)
+    def bar=<<todo method>>(arg0, &<blk>)
       @bar = arg0
     end
 

--- a/test/testdata/rewriter/t_struct/root.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/root.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:foo, <emptyTree>::<C Integer>).void()
     end
 
-    def initialize<<C <todo sym>>>(foo:, &<blk>)
+    def initialize<<todo method>>(foo:, &<blk>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C Integer>)
         <self>.super(ZSuperArgs)
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       @foo
     end
 
@@ -23,7 +23,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C Integer>).returns(<emptyTree>::<C Integer>)
     end
 
-    def foo=<<C <todo sym>>>(arg0, &<blk>)
+    def foo=<<todo method>>(arg0, &<blk>)
       @foo = arg0
     end
 

--- a/test/testdata/rewriter/t_struct/some_default.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/some_default.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:foo, <emptyTree>::<C Integer>, :bar, <emptyTree>::<C T>::<C Boolean>).void()
     end
 
-    def initialize<<C <todo sym>>>(foo:, bar: = false, &<blk>)
+    def initialize<<todo method>>(foo:, bar: = false, &<blk>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C Integer>)
         @bar = ::T.let(bar, <emptyTree>::<C T>::<C Boolean>)
@@ -16,7 +16,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
-    def foo<<C <todo sym>>>(&<blk>)
+    def foo<<todo method>>(&<blk>)
       @foo
     end
 
@@ -24,7 +24,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C Integer>).returns(<emptyTree>::<C Integer>)
     end
 
-    def foo=<<C <todo sym>>>(arg0, &<blk>)
+    def foo=<<todo method>>(arg0, &<blk>)
       @foo = arg0
     end
 
@@ -32,7 +32,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C T>::<C Boolean>)
     end
 
-    def bar<<C <todo sym>>>(&<blk>)
+    def bar<<todo method>>(&<blk>)
       @bar
     end
 
@@ -40,7 +40,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:arg0, <emptyTree>::<C T>::<C Boolean>).returns(<emptyTree>::<C T>::<C Boolean>)
     end
 
-    def bar=<<C <todo sym>>>(arg0, &<blk>)
+    def bar=<<todo method>>(arg0, &<blk>)
       @bar = arg0
     end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Introduces MethodRef, the method-specialized form of SymbolRef (like the new ClassOrModuleRef). In addition, `todoMethod` is now used as the method symbol for todo methods, which changes some of the test exp files.

This PR also uses MethodRef where it makes sense throughout the codebase. While working on this change, I also found a few extra places to use ClassOrModuleRef. In some cases, this change turned up dead code! :D 

I tried to put each change into a commit, so I can back out any controversial changes.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

A prerequisite to specializing symbol classes is to delurk SymbolRef::data. These specialized ref classes are necessary.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
