### PR TITLE
disallow cast_type and friends on rvalue references

### DIFF
--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -57,6 +57,9 @@ public:
     template <class To> static bool isa(const TypePtr &what);
 
     template <class To> static typename TypeToCastType<To, TypeToIsInlined<To>::value>::type cast(const TypePtr &what);
+    // We disallow casting on temporary values because the lifetime of the returned value is
+    // tied to the temporary, but it is possible for the temporary to be destroyed at the end
+    // of the current statement, leading to use-after-free bugs.
     template <class To>
     static typename TypeToCastType<To, TypeToIsInlined<To>::value>::type cast(TypePtr &&what) = delete;
 

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -57,6 +57,8 @@ public:
     template <class To> static bool isa(const TypePtr &what);
 
     template <class To> static typename TypeToCastType<To, TypeToIsInlined<To>::value>::type cast(const TypePtr &what);
+    template <class To>
+    static typename TypeToCastType<To, TypeToIsInlined<To>::value>::type cast(TypePtr &&what) = delete;
 
     template <class To> static auto cast(TypePtr &what) {
         return const_cast_type<To>(cast<To>(static_cast<const TypePtr &>(what)));

--- a/core/Types.h
+++ b/core/Types.h
@@ -277,11 +277,17 @@ template <class To> To *cast_type(TypePtr &what) {
     return const_cast<To *>(cast_type<To>(static_cast<const TypePtr &>(what)));
 }
 
+template <class To> To *cast_type(TypePtr &&what) = delete;
+
 template <class To>
 typename TypePtr::TypeToCastType<To, TypePtr::TypeToIsInlined<To>::value>::type cast_type_nonnull(const TypePtr &what) {
     ENFORCE_NO_TIMER(isa_type<To>(what));
     return *reinterpret_cast<const To *>(what.get());
 }
+
+template <class To>
+typename TypePtr::TypeToCastType<To, TypePtr::TypeToIsInlined<To>::value>::type
+cast_type_nonnull(TypePtr &&what) = delete;
 
 // Simple forwarders defined on TypePtr which make `typecase` work.
 template <class To> inline bool TypePtr::isa(const TypePtr &what) {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -899,7 +899,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 } else if (spec.flags.isRepeated) {
                     for (auto it = hash->keys.begin(); it != hash->keys.end(); ++it) {
                         auto key = cast_type_nonnull<LiteralType>(*it);
-                        SymbolRef klass = cast_type_nonnull<ClassType>(key.underlying()).symbol;
+                        auto underlying = key.underlying();
+                        SymbolRef klass = cast_type_nonnull<ClassType>(underlying).symbol;
                         if (klass != Symbols::Symbol()) {
                             continue;
                         }
@@ -929,7 +930,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
 
                 auto arg = absl::c_find_if(hash->keys, [&](const TypePtr &litType) {
                     auto lit = cast_type_nonnull<LiteralType>(litType);
-                    return cast_type_nonnull<ClassType>(lit.underlying()).symbol == Symbols::Symbol() &&
+                    auto underlying = lit.underlying();
+                    return cast_type_nonnull<ClassType>(underlying).symbol == Symbols::Symbol() &&
                            lit.asName(gs) == spec.name;
                 });
                 if (arg == hash->keys.end()) {
@@ -954,7 +956,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
             }
             for (auto &keyType : hash->keys) {
                 auto key = cast_type_nonnull<LiteralType>(keyType);
-                SymbolRef klass = cast_type_nonnull<ClassType>(key.underlying()).symbol;
+                auto underlying = key.underlying();
+                SymbolRef klass = cast_type_nonnull<ClassType>(underlying).symbol;
                 if (klass == Symbols::Symbol() && consumed.find(key.asName(gs)) != consumed.end()) {
                     continue;
                 }

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -57,7 +57,8 @@ string LiteralType::show(const GlobalState &gs) const {
 }
 
 string LiteralType::showValue(const GlobalState &gs) const {
-    SymbolRef undSymbol = cast_type_nonnull<ClassType>(this->underlying()).symbol;
+    auto underlying = this->underlying();
+    SymbolRef undSymbol = cast_type_nonnull<ClassType>(underlying).symbol;
     if (undSymbol == Symbols::String()) {
         return fmt::format("\"{}\"", absl::CEscape(asName(gs).show(gs)));
     } else if (undSymbol == Symbols::Symbol()) {
@@ -128,7 +129,8 @@ string ShapeType::show(const GlobalState &gs) const {
         } else {
             fmt::format_to(buf, ", ");
         }
-        SymbolRef undSymbol = cast_type_nonnull<ClassType>(cast_type_nonnull<LiteralType>(key).underlying()).symbol;
+        auto underlying = cast_type_nonnull<LiteralType>(key).underlying();
+        SymbolRef undSymbol = cast_type_nonnull<ClassType>(underlying).symbol;
         if (undSymbol == Symbols::Symbol()) {
             fmt::format_to(buf, "{}: {}", cast_type_nonnull<LiteralType>(key).asName(gs).show(gs),
                            (*valueIterator).show(gs));

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -375,8 +375,10 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                 [&](const LiteralType &l1) {
                     if (isa_type<LiteralType>(t2)) {
                         auto l2 = cast_type_nonnull<LiteralType>(t2);
-                        auto u1 = cast_type_nonnull<ClassType>(l1.underlying());
-                        auto u2 = cast_type_nonnull<ClassType>(l2.underlying());
+                        auto underlyingL1 = l1.underlying();
+                        auto underlyingL2 = l2.underlying();
+                        auto u1 = cast_type_nonnull<ClassType>(underlyingL1);
+                        auto u2 = cast_type_nonnull<ClassType>(underlyingL2);
                         if (u1.symbol == u2.symbol) {
                             if (l1.equals(l2)) {
                                 result = t1;
@@ -723,8 +725,10 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                 },
                 [&](const LiteralType &l1) {
                     auto l2 = cast_type_nonnull<LiteralType>(t2);
-                    auto u1 = cast_type_nonnull<ClassType>(l1.underlying());
-                    auto u2 = cast_type_nonnull<ClassType>(l2.underlying());
+                    auto underlyingL1 = l1.underlying();
+                    auto underlyingL2 = l2.underlying();
+                    auto u1 = cast_type_nonnull<ClassType>(underlyingL1);
+                    auto u2 = cast_type_nonnull<ClassType>(underlyingL2);
                     if (u1.symbol == u2.symbol) {
                         if (l1.equals(l2)) {
                             result = t1;

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -412,7 +412,8 @@ OrType::OrType(const TypePtr &left, const TypePtr &right) : left(move(left)), ri
 
 void TupleType::_sanityCheck(const GlobalState &gs) const {
     sanityCheckProxyType(gs, underlying());
-    auto *applied = cast_type<AppliedType>(this->underlying());
+    auto underlying = this->underlying();
+    auto *applied = cast_type<AppliedType>(underlying);
     ENFORCE(applied);
     ENFORCE(applied->klass == Symbols::Array());
 }
@@ -665,7 +666,8 @@ optional<int> SendAndBlockLink::fixedArity() const {
 }
 
 TypePtr TupleType::elementType() const {
-    auto *ap = cast_type<AppliedType>(this->underlying());
+    auto underlying = this->underlying();
+    auto *ap = cast_type<AppliedType>(underlying);
     ENFORCE(ap);
     ENFORCE(ap->klass == Symbols::Array());
     ENFORCE(ap->targs.size() == 1);


### PR DESCRIPTION
Don't permit `cast_type` and various similar functions on rvalue references, because such operations may not be safe.  If `cast_type` and `cast_type_nonnull` were written as member functions, we'd do this with reference qualifiers on the relevant member functions, which might be slightly clearer?

### Motivation

@jez had to fix a couple problems related to this in #3822, but enforcing this at compile time a) catches more cases and b) ensures we don't have to do debugging like this again.

I left `isa` as still working on rvalue references (overload resolution on rvalue references selects the `const &` overload) since there's no safety problems, but I can be convinced to apply similar changes there for symmetry's sake.

I didn't do the same thing for `TreePtr`, but can do the same thing as a followup.

### Test plan

Existing automated tests should be sufficient.