### PR TITLE
add ./ to bazel invocations to ensure we use our bazel

### DIFF
--- a/tools/scripts/build_compilation_db.sh
+++ b/tools/scripts/build_compilation_db.sh
@@ -4,7 +4,7 @@ set -e
 
 cd "$(dirname "$0")/../.."
 
-bazel build //tools:compdb -c opt
+./bazel build //tools:compdb -c opt
 
 execution_root="$(bazel info execution_root)"
 

--- a/tools/scripts/format_cxx.sh
+++ b/tools/scripts/format_cxx.sh
@@ -10,7 +10,7 @@ fi
 
 cd "$(dirname "$0")/../.."
 
-bazel build //tools:clang-format &> /dev/null
+./bazel build //tools:clang-format &> /dev/null
 
 # shellcheck disable=SC2207
 cxx_src=(

--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -25,7 +25,7 @@ target="$1"
 shift
 
 echo "building $target"
-bazel build "//test/fuzz:$target" --config=fuzz -c opt
+./bazel build "//test/fuzz:$target" --config=fuzz -c opt
 
 # we want the bazel build command to run before this check so that bazel can download itself.
 export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain/bin"

--- a/tools/scripts/fuzz_minimize_all.sh
+++ b/tools/scripts/fuzz_minimize_all.sh
@@ -25,7 +25,7 @@ target="$1"
 shift
 
 echo "building $target"
-bazel build "//test/fuzz:$target" --config=fuzz -c opt
+./bazel build "//test/fuzz:$target" --config=fuzz -c opt
 
 echo "making command file"
 cmds="$(mktemp)"

--- a/tools/scripts/lint_cxx.sh
+++ b/tools/scripts/lint_cxx.sh
@@ -4,7 +4,7 @@ set -e
 
 cd "$(dirname "$0")/../.."
 
-bazel build //tools:clang-tidy
+./bazel build //tools:clang-tidy
 ./tools/scripts/build_compilation_db.sh
 
 got_cc=

--- a/tools/scripts/regen-emscripten-cache.sh
+++ b/tools/scripts/regen-emscripten-cache.sh
@@ -4,5 +4,5 @@ set -e
 
 cd "$(dirname "$0")/../.."
 
-bazel build //tools/toolchain/webasm-darwin:generate_em_cache
+./bazel build //tools/toolchain/webasm-darwin:generate_em_cache
 cp bazel-genfiles/tools/toolchain/webasm-darwin/em_cache.tar.gz tools/toolchain/webasm-darwin/em_cache_existing.tar.gz

--- a/tools/scripts/update-sorbet.run.sh
+++ b/tools/scripts/update-sorbet.run.sh
@@ -4,7 +4,7 @@ set -e
 
 cd "$(dirname "$0")/../.."
 
-bazel build //emscripten:sorbet-wasm.tar --config=webasm-darwin --strip=always
+./bazel build //emscripten:sorbet-wasm.tar --config=webasm-darwin --strip=always
 
 echo
 echo "./bazel-bin/emscripten:sorbet-wasm.tar should contain \".wasm\" and \".js\" file"

--- a/tools/scripts/update_exp_files.sh
+++ b/tools/scripts/update_exp_files.sh
@@ -6,7 +6,7 @@ cd "$(dirname "$0")"
 cd ../..
 # we are now at the repo root.
 
-bazel build \
+./bazel build \
   //gems/sorbet/test/snapshot:update \
   //test/cli:update //test/lsp:update \
   -c opt "$@"
@@ -14,6 +14,6 @@ bazel build \
 tools/scripts/update_testdata_exp.sh
 gems/sorbet/test/hidden-method-finder/update_hidden_methods_exp.sh "$@"
 
-bazel test \
+./bazel test \
   //gems/sorbet/test/snapshot:update \
   //test/cli:update //test/lsp:update -c opt "$@"

--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -40,7 +40,7 @@ passes=(
   package-tree
 )
 
-bazel build //main:sorbet //test:print_document_symbols -c opt
+./bazel build //main:sorbet //test:print_document_symbols -c opt
 
 if [ $# -eq 0 ]; then
   paths=(test/testdata)


### PR DESCRIPTION
I noticed these invocations broke on a local machine that didn't have bazel installed.

### Motivation

More robust utility scripts.

### Test plan

Existing automated tests should be sufficient.