### PR TITLE
srb init: Ignore gem RBIs when generating the symbol table of reflection.rbi

### DIFF
--- a/gems/sorbet/lib/hidden-definition-finder.rb
+++ b/gems/sorbet/lib/hidden-definition-finder.rb
@@ -121,6 +121,7 @@ class Sorbet::Private::HiddenMethodFinder
     puts "Printing #{TMP_RBI}'s symbol table into #{RBI_CONSTANTS}"
     io = IO.popen(
       [
+        {'SRB_SKIP_GEM_RBIS' => 'true'},
         File.realpath("#{__dir__}/../bin/srb"),
         'tc',
         # Make sure we don't load a sorbet/config in your cwd


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

srb init: Ignore gem RBIs when generating the symbol table of reflection.rbi

Unfortunately, I am unsure how to test this. We would need the ability to have gem tests that pull in gemfile dependencies. Is that possible?

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes https://github.com/sorbet/sorbet/issues/3792

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Not covered by any tests. Tested manually using repro case from https://github.com/sorbet/sorbet/issues/3792
