### PR TITLE
WIP: Use InlinedVector rather than shared_ptr for Nesting in ResolveConstantsWalk

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -96,7 +96,7 @@ class ResolveConstantsWalk {
 
 private:
     // TODO: Figure out ideal size.
-    typedef InlinedVector<core::ClassOrModuleRef, 4> Nesting;
+    typedef InlinedVector<core::ClassOrModuleRef, 6> Nesting;
     Nesting nesting_;
 
     struct ResolutionItem {
@@ -112,7 +112,7 @@ private:
         ResolutionItem(const ResolutionItem &rhs) = delete;
         const ResolutionItem &operator=(const ResolutionItem &rhs) = delete;
     };
-    CheckSize(ResolutionItem, 48, 8);
+    CheckSize(ResolutionItem, 56, 8);
     struct AncestorResolutionItem {
         ast::ConstantLit *ancestor;
         core::ClassOrModuleRef klass;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -665,6 +665,8 @@ public:
         }
         auto loc = c.loc;
         auto out = ast::make_tree<ast::ConstantLit>(loc, core::Symbols::noSymbol(), std::move(tree));
+        // TODO: Remove once I collect metrics.
+        prodHistogramInc("nesting_size", nesting_.size());
         ResolutionItem job{nesting_, ctx.file, ast::cast_tree<ast::ConstantLit>(out)};
         if (resolveJob(ctx, job)) {
             categoryCounterInc("resolve.constants.nonancestor", "firstpass");


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

https://github.com/sorbet/sorbet/pull/3805 speeds up ResolveConstantsWalk, but I noticed that it spends a lot of time destructing. I can't tell what (since it's all inlined in production builds), but my theory is that shared_ptr destruction is expensive.

I think an InlinedVector will be a lot cheaper. SymbolRefs are 4 bytes each, so an InlinedVector of 4 has 16 bytes of storage (the same size as a shared_ptr!) plus normal vector overheads. It inflates the size of the `ResolutionItem` struct by 8 bytes.

WIP while I benchmark and determine if a size of 4 is sufficient (I think it is).

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed!

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
