### PR TITLE
De-duplicate rename edits

### DIFF
--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -228,6 +228,19 @@ public:
         if (location == nullptr) {
             return;
         }
+
+        // Have we already edited this exact location?
+        // If we're renaming the exact same place twice, silently ignore it. We reach this condition when we find the
+        // same method send through multiple definitions (e.g. in the case of union types)
+        auto it = edits.find(location->uri);
+        if (it != edits.end()) {
+            for (auto &textedit : it->second) {
+                if (location->range->cmp(*textedit->range) == 0) {
+                    return;
+                }
+            }
+        }
+
         string newsrc;
         if (auto sendResp = response->isSend()) {
             newsrc = replaceMethodNameInSend(source, sendResp);

--- a/test/testdata/lsp/rename/method_simple.A.rbedited
+++ b/test/testdata/lsp/rename/method_simple.A.rbedited
@@ -3,12 +3,12 @@
 
 module M
   class Foo
-    def baz(a=1)
-#     ^ apply-rename: [A] newName: baz
+    def bazz(a=1)
+#     ^ apply-rename: [A] newName: bazz
     end
 
     def caller
-      baz(1)
+      bazz(1)
     end
 
     def x
@@ -18,11 +18,11 @@ module M
 end
 
 f = M::Foo.new
-f.baz(f.x)
-f.baz
-f  .  baz  (   )
+f.bazz(f.x)
+f.bazz
+f  .  bazz  (   )
 
-M::Foo.new.baz 3
+M::Foo.new.bazz 3
 
 class Unrelated
   # this should be left unchanged

--- a/test/testdata/lsp/rename/method_simple.rb
+++ b/test/testdata/lsp/rename/method_simple.rb
@@ -4,7 +4,7 @@
 module M
   class Foo
     def bar(a=1)
-#     ^ apply-rename: [A] newName: baz
+#     ^ apply-rename: [A] newName: bazz
     end
 
     def caller

--- a/test/testdata/lsp/rename/method_union_2.A.rbedited
+++ b/test/testdata/lsp/rename/method_union_2.A.rbedited
@@ -1,0 +1,14 @@
+# typed: true
+# frozen_string_literal: true
+
+class Dog
+  def sound_new; "Bark"; end
+end
+class Cat
+  def sound_new; "Meow"; end
+end
+
+animal = T.let(Cat.new, T.any(Dog, Cat))
+animal.sound_new
+#      ^ apply-rename: [A] newName: sound_new
+

--- a/test/testdata/lsp/rename/method_union_2.rb
+++ b/test/testdata/lsp/rename/method_union_2.rb
@@ -1,0 +1,14 @@
+# typed: true
+# frozen_string_literal: true
+
+class Dog
+  def sound; "Bark"; end
+end
+class Cat
+  def sound; "Meow"; end
+end
+
+animal = T.let(Cat.new, T.any(Dog, Cat))
+animal.sound
+#      ^ apply-rename: [A] newName: sound_new
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This change adds checks to deduplicate the edits created by method renames. Duplicate edits are created when we reach the same method send through multiple definitions. VS Code rejects duplicate edits with an unhelpful "failed to apply edits" error (and they also cause sorbet.run to silently ignore the edits).

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Method renames for union types were broken. Earlier tests failed to catch this because the length of the old and new names were the same. 🤦  

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
