### PR TITLE
Require GlobalState in underlying

### DIFF
--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -221,7 +221,7 @@ TypePtr TypePtr::getCallArguments(const GlobalState &gs, NameRef name) const {
         case Tag::TupleType:
         case Tag::ShapeType:
         case Tag::LiteralType: {
-            return this->underlying().getCallArguments(gs, name);
+            return this->underlying(gs).getCallArguments(gs, name);
         }
         case Tag::OrType: {
             auto &orType = cast_type_nonnull<OrType>(*this);

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -51,9 +51,9 @@ GENERATE_CALL_MEMBER(_replaceSelfType, return nullptr, declval<const GlobalState
 GENERATE_CALL_MEMBER(_approximate, return nullptr, declval<const GlobalState &>(), declval<const TypeConstraint &>())
 
 GENERATE_CALL_MEMBER(underlying,
-                     Exception::raise("should never happen: underlying on {}",
+                     Exception::raise("TypePtr::underlying called on non-proxy-type `{}`",
                                       TypePtr::tagToString(TypePtr::TypeToTag<typename remove_const<T>::type>::value));
-                     return nullptr);
+                     return nullptr, std::declval<const GlobalState &>());
 
 } // namespace
 
@@ -346,8 +346,9 @@ DispatchResult TypePtr::dispatchCall(const GlobalState &gs, DispatchArgs args) c
 #undef DISPATCH_CALL
 }
 
-TypePtr TypePtr::underlying() const {
-#define UNDERLYING(T) return CALL_MEMBER_underlying<const T>::call(cast_type_nonnull<T>(*this));
+TypePtr TypePtr::underlying(const GlobalState &gs) const {
+    ENFORCE(is_proxy_type(*this), "underlying() only makes sense on a proxy type");
+#define UNDERLYING(T) return CALL_MEMBER_underlying<const T>::call(cast_type_nonnull<T>(*this), gs);
     GENERATE_TAG_SWITCH(tag(), UNDERLYING)
 #undef UNDERLYING
 }

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -304,7 +304,7 @@ public:
                          const std::vector<TypePtr> &targs) const;
 
     // If this TypePtr `is_proxy_type`, returns its underlying type.
-    TypePtr underlying() const;
+    TypePtr underlying(const GlobalState &gs) const;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string toString(const GlobalState &gs) const {

--- a/core/Types.h
+++ b/core/Types.h
@@ -150,7 +150,7 @@ public:
      */
     static TypePtr approximate(const GlobalState &gs, const TypePtr &what, const TypeConstraint &tc);
     static TypePtr dispatchCallWithoutBlock(const GlobalState &gs, const TypePtr &recv, const DispatchArgs &args);
-    static TypePtr dropLiteral(const TypePtr &tp);
+    static TypePtr dropLiteral(const GlobalState &gs, const TypePtr &tp);
 
     /** Internal implementation. You should probably use all(). */
     static TypePtr glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
@@ -472,7 +472,7 @@ public:
     LiteralType(int64_t val);
     LiteralType(double val);
     LiteralType(ClassOrModuleRef klass, NameRef val);
-    TypePtr underlying() const;
+    TypePtr underlying(const GlobalState &gs) const;
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
     DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) const;
     int64_t asInteger() const;
@@ -667,7 +667,7 @@ public:
                          const std::vector<TypePtr> &targs) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
-    TypePtr underlying() const;
+    TypePtr underlying(const GlobalState &gs) const;
     bool derivesFrom(const GlobalState &gs, core::ClassOrModuleRef klass) const;
 };
 CheckSize(ShapeType, 64, 8);
@@ -694,8 +694,8 @@ public:
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
 
     // Return the type of the underlying array that this tuple decays into
-    TypePtr elementType() const;
-    TypePtr underlying() const;
+    TypePtr elementType(const GlobalState &gs) const;
+    TypePtr underlying(const GlobalState &gs) const;
     bool derivesFrom(const GlobalState &gs, core::ClassOrModuleRef klass) const;
 };
 CheckSize(TupleType, 40, 8);
@@ -744,7 +744,7 @@ public:
     void _sanityCheck(const GlobalState &gs) const;
 
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
-    TypePtr underlying() const;
+    TypePtr underlying(const GlobalState &gs) const;
 };
 CheckSize(MetaType, 16, 8);
 

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -376,7 +376,7 @@ void SerializerImpl::pickle(Pickler &p, const TypePtr &what) {
         }
         case TypePtr::Tag::TupleType: {
             auto &arr = cast_type_nonnull<TupleType>(what);
-            pickle(p, arr.underlying());
+            pickle(p, arr.underlying_);
             p.putU4(arr.elems.size());
             for (auto &el : arr.elems) {
                 pickle(p, el);
@@ -385,7 +385,7 @@ void SerializerImpl::pickle(Pickler &p, const TypePtr &what) {
         }
         case TypePtr::Tag::ShapeType: {
             auto &hash = cast_type_nonnull<ShapeType>(what);
-            pickle(p, hash.underlying());
+            pickle(p, hash.underlying_);
             p.putU4(hash.keys.size());
             ENFORCE(hash.keys.size() == hash.values.size());
             for (auto &el : hash.keys) {

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -57,7 +57,7 @@ string LiteralType::show(const GlobalState &gs) const {
 }
 
 string LiteralType::showValue(const GlobalState &gs) const {
-    auto underlying = this->underlying();
+    auto underlying = this->underlying(gs);
     SymbolRef undSymbol = cast_type_nonnull<ClassType>(underlying).symbol;
     if (undSymbol == Symbols::String()) {
         return fmt::format("\"{}\"", absl::CEscape(asName(gs).show(gs)));

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -49,11 +49,11 @@ string UnresolvedAppliedType::show(const GlobalState &gs) const {
 }
 
 string LiteralType::toStringWithTabs(const GlobalState &gs, int tabs) const {
-    return fmt::format("{}({})", this->underlying().toStringWithTabs(gs, tabs), showValue(gs));
+    return fmt::format("{}({})", this->underlying(gs).toStringWithTabs(gs, tabs), showValue(gs));
 }
 
 string LiteralType::show(const GlobalState &gs) const {
-    return fmt::format("{}({})", this->underlying().show(gs), showValue(gs));
+    return fmt::format("{}({})", this->underlying(gs).show(gs), showValue(gs));
 }
 
 string LiteralType::showValue(const GlobalState &gs) const {
@@ -129,7 +129,7 @@ string ShapeType::show(const GlobalState &gs) const {
         } else {
             fmt::format_to(buf, ", ");
         }
-        auto underlying = cast_type_nonnull<LiteralType>(key).underlying();
+        auto underlying = cast_type_nonnull<LiteralType>(key).underlying(gs);
         SymbolRef undSymbol = cast_type_nonnull<ClassType>(underlying).symbol;
         if (undSymbol == Symbols::Symbol()) {
             fmt::format_to(buf, "{}: {}", cast_type_nonnull<LiteralType>(key).asName(gs).show(gs),

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -379,7 +379,7 @@ TupleType::TupleType(TypePtr underlying, vector<TypePtr> elements)
 }
 
 TypePtr TupleType::build(const GlobalState &gs, vector<TypePtr> elements) {
-    TypePtr underlying = Types::arrayOf(gs, Types::dropLiteral(Types::lubAll(gs, elements)));
+    TypePtr underlying = Types::arrayOf(gs, Types::dropLiteral(gs, Types::lubAll(gs, elements)));
     return make_type<TupleType>(move(underlying), move(elements));
 }
 
@@ -411,8 +411,8 @@ OrType::OrType(const TypePtr &left, const TypePtr &right) : left(move(left)), ri
 }
 
 void TupleType::_sanityCheck(const GlobalState &gs) const {
-    sanityCheckProxyType(gs, underlying());
-    auto underlying = this->underlying();
+    sanityCheckProxyType(gs, underlying(gs));
+    auto underlying = this->underlying(gs);
     auto *applied = cast_type<AppliedType>(underlying);
     ENFORCE(applied);
     ENFORCE(applied->klass == Symbols::Array());
@@ -428,11 +428,11 @@ ShapeType::ShapeType(TypePtr underlying, vector<TypePtr> keys, vector<TypePtr> v
     categoryCounterInc("types.allocated", "shapetype");
 }
 
-TypePtr ShapeType::underlying() const {
+TypePtr ShapeType::underlying(const GlobalState &gs) const {
     return this->underlying_;
 }
 
-TypePtr TupleType::underlying() const {
+TypePtr TupleType::underlying(const GlobalState &gs) const {
     return this->underlying_;
 }
 
@@ -660,8 +660,8 @@ optional<int> SendAndBlockLink::fixedArity() const {
     return arity;
 }
 
-TypePtr TupleType::elementType() const {
-    auto underlying = this->underlying();
+TypePtr TupleType::elementType(const GlobalState &gs) const {
+    auto underlying = this->underlying(gs);
     auto *ap = cast_type<AppliedType>(underlying);
     ENFORCE(ap);
     ENFORCE(ap->klass == Symbols::Array());

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -901,7 +901,7 @@ core::TypePtr flattenArrays(core::Context ctx, const core::TypePtr &type) {
             result = a.targs.front();
         },
 
-        [&](const core::TupleType &t) { result = t.elementType(); },
+        [&](const core::TupleType &t) { result = t.elementType(ctx); },
 
         [&](const core::TypePtr &t) { result = std::move(type); });
     return result;
@@ -1314,8 +1314,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
             const core::TypeAndOrigins &cur =
                 (pin != pinnedTypes.end()) ? pin->second : getTypeAndOrigin(ctx, bind.bind.variable);
 
-            bool asGoodAs =
-                core::Types::isSubType(ctx, core::Types::dropLiteral(tp.type), core::Types::dropLiteral(cur.type));
+            bool asGoodAs = core::Types::isSubType(ctx, core::Types::dropLiteral(ctx, tp.type),
+                                                   core::Types::dropLiteral(ctx, cur.type));
 
             {
                 switch (bindMinLoops) {

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -247,7 +247,7 @@ core::TypePtr getResultType(const core::GlobalState &gs, const core::TypePtr &ty
                             core::TypePtr receiver, const core::TypeConstraint *constr) {
     auto resultType = type;
     if (core::is_proxy_type(receiver)) {
-        receiver = receiver.underlying();
+        receiver = receiver.underlying(gs);
     }
     if (auto *applied = core::cast_type<core::AppliedType>(receiver)) {
         /* instantiate generic classes */

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -179,7 +179,7 @@ SimilarMethodsByName similarMethodsForReceiver(const core::GlobalState &gs, cons
         },
         [&](const core::TypePtr &type) {
             if (is_proxy_type(receiver)) {
-                result = similarMethodsForReceiver(gs, receiver.underlying(), prefix);
+                result = similarMethodsForReceiver(gs, receiver.underlying(gs), prefix);
             }
         });
 

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -1001,7 +1001,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
             }
         },
         [&](const ast::Literal &lit) {
-            auto underlying = core::isa_type<core::LiteralType>(lit.value) ? lit.value.underlying() : lit.value;
+            auto underlying = core::isa_type<core::LiteralType>(lit.value) ? lit.value.underlying(ctx) : lit.value;
             if (auto e = ctx.beginError(lit.loc, core::errors::Resolver::InvalidMethodSignature)) {
                 e.setHeader("Unsupported literal in type syntax", lit.value.show(ctx));
                 e.replaceWith("Replace with underlying type", core::Loc(ctx.file, lit.loc), "{}", underlying.show(ctx));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is the annoying-to-maintain, quickly-goes-stale parts of #3822.

It has no behavior changes—it just threads through an entirely unused (for now)
`GlobalState` parameter.

I would like to land this, because it will make it easier to start iterating with small fixes to
shapes and tuples.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.