### PR TITLE
Remove ShapeType::underlying_ field

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -656,7 +656,6 @@ public:
     std::vector<TypePtr> keys; // TODO: store sorted by whatever
     std::vector<TypePtr> values;
     const TypePtr underlying_;
-    ShapeType();
     ShapeType(TypePtr underlying, std::vector<TypePtr> keys, std::vector<TypePtr> values);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;

--- a/core/Types.h
+++ b/core/Types.h
@@ -655,8 +655,7 @@ TYPE(ShapeType) final {
 public:
     std::vector<TypePtr> keys; // TODO: store sorted by whatever
     std::vector<TypePtr> values;
-    const TypePtr underlying_;
-    ShapeType(TypePtr underlying, std::vector<TypePtr> keys, std::vector<TypePtr> values);
+    ShapeType(std::vector<TypePtr> keys, std::vector<TypePtr> values);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
@@ -669,7 +668,7 @@ public:
     TypePtr underlying(const GlobalState &gs) const;
     bool derivesFrom(const GlobalState &gs, core::ClassOrModuleRef klass) const;
 };
-CheckSize(ShapeType, 64, 8);
+CheckSize(ShapeType, 48, 8);
 
 TYPE(TupleType) final {
 private:

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -385,7 +385,6 @@ void SerializerImpl::pickle(Pickler &p, const TypePtr &what) {
         }
         case TypePtr::Tag::ShapeType: {
             auto &hash = cast_type_nonnull<ShapeType>(what);
-            pickle(p, hash.underlying_);
             p.putU4(hash.keys.size());
             ENFORCE(hash.keys.size() == hash.values.size());
             for (auto &el : hash.keys) {
@@ -475,7 +474,6 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
             return result;
         }
         case TypePtr::Tag::ShapeType: {
-            auto underlying = unpickleType(p, gs);
             int sz = p.getU4();
             vector<TypePtr> keys(sz);
             vector<TypePtr> values(sz);
@@ -485,7 +483,7 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
             for (auto &value : values) {
                 value = unpickleType(p, gs);
             }
-            auto result = make_type<ShapeType>(underlying, move(keys), move(values));
+            auto result = make_type<ShapeType>(move(keys), move(values));
             return result;
         }
         case TypePtr::Tag::AliasType:

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -409,7 +409,7 @@ TypePtr unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
         for (auto &value : shapeType->values) {
             unwrappedValues.emplace_back(unwrapType(gs, loc, value));
         }
-        return make_type<ShapeType>(Types::hashOfUntyped(), shapeType->keys, move(unwrappedValues));
+        return make_type<ShapeType>(shapeType->keys, move(unwrappedValues));
     } else if (auto *tupleType = cast_type<TupleType>(tp)) {
         vector<TypePtr> unwrappedElems;
         unwrappedElems.reserve(tupleType->elems.size());
@@ -786,7 +786,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 if (auto *hash = cast_type<ShapeType>(kwSplatType)) {
                     absl::c_copy(hash->keys, back_inserter(keys));
                     absl::c_copy(hash->values, back_inserter(values));
-                    kwargs = make_type<ShapeType>(Types::hashOfUntyped(), move(keys), move(values));
+                    kwargs = make_type<ShapeType>(move(keys), move(values));
                     --aend;
                 } else {
                     if (kwSplatType.isUntyped()) {
@@ -819,7 +819,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 --aend;
             }
         } else {
-            kwargs = make_type<ShapeType>(Types::hashOfUntyped(), move(keys), move(values));
+            kwargs = make_type<ShapeType>(move(keys), move(values));
         }
 
         // Detect the case where not all positional arguments were supplied, causing the keyword args to be consumed as
@@ -1550,7 +1550,7 @@ public:
             keys.emplace_back(args.args[i]->type);
             values.emplace_back(args.args[i + 1]->type);
         }
-        res.returnType = make_type<ShapeType>(Types::hashOfUntyped(), move(keys), move(values));
+        res.returnType = make_type<ShapeType>(move(keys), move(values));
     }
 } Magic_buildHashOrKeywordArgs;
 
@@ -2366,7 +2366,7 @@ public:
             }
         }
 
-        res.returnType = make_type<ShapeType>(Types::hashOfUntyped(), std::move(keys), std::move(values));
+        res.returnType = make_type<ShapeType>(std::move(keys), std::move(values));
     }
 } Shape_merge;
 

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -363,7 +363,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                             } else if (!differ2) {
                                 result = t2;
                             } else {
-                                result = make_type<ShapeType>(Types::hashOfUntyped(), h2->keys, move(valueLubs));
+                                result = make_type<ShapeType>(h2->keys, move(valueLubs));
                             }
                         } else {
                             result = Types::hashOfUntyped();
@@ -716,7 +716,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         } else if (canReuseT2) {
                             result = t2;
                         } else {
-                            result = make_type<ShapeType>(Types::hashOfUntyped(), h2.keys, move(valueLubs));
+                            result = make_type<ShapeType>(h2.keys, move(valueLubs));
                         }
                     } else {
                         result = Types::bottom();

--- a/core/types/typemaps.cc
+++ b/core/types/typemaps.cc
@@ -150,7 +150,7 @@ TypePtr ShapeType::_instantiate(const GlobalState &gs, const InlinedVector<Symbo
     if (!newValues) {
         return nullptr;
     }
-    return make_type<ShapeType>(Types::hashOfUntyped(), this->keys, move(*newValues));
+    return make_type<ShapeType>(this->keys, move(*newValues));
 }
 
 TypePtr ShapeType::_instantiate(const GlobalState &gs, const TypeConstraint &tc) const {
@@ -158,7 +158,7 @@ TypePtr ShapeType::_instantiate(const GlobalState &gs, const TypeConstraint &tc)
     if (!newValues) {
         return nullptr;
     }
-    return make_type<ShapeType>(Types::hashOfUntyped(), this->keys, move(*newValues));
+    return make_type<ShapeType>(this->keys, move(*newValues));
 }
 
 TypePtr ShapeType::_approximate(const GlobalState &gs, const TypeConstraint &tc) const {
@@ -166,7 +166,7 @@ TypePtr ShapeType::_approximate(const GlobalState &gs, const TypeConstraint &tc)
     if (!newValues) {
         return nullptr;
     }
-    return make_type<ShapeType>(Types::hashOfUntyped(), this->keys, move(*newValues));
+    return make_type<ShapeType>(this->keys, move(*newValues));
 }
 
 TypePtr OrType::_instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -418,10 +418,6 @@ void TupleType::_sanityCheck(const GlobalState &gs) const {
     ENFORCE(applied->klass == Symbols::Array());
 }
 
-ShapeType::ShapeType() : underlying_(Types::hashOfUntyped()) {
-    categoryCounterInc("types.allocated", "shapetype");
-}
-
 ShapeType::ShapeType(TypePtr underlying, vector<TypePtr> keys, vector<TypePtr> values)
     : keys(move(keys)), values(move(values)), underlying_(std::move(underlying)) {
     DEBUG_ONLY(for (auto &k : this->keys) { ENFORCE(isa_type<LiteralType>(k)); };);

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -425,7 +425,7 @@ ShapeType::ShapeType(TypePtr underlying, vector<TypePtr> keys, vector<TypePtr> v
 }
 
 TypePtr ShapeType::underlying(const GlobalState &gs) const {
-    return this->underlying_;
+    return Types::hashOfUntyped();
 }
 
 TypePtr TupleType::underlying(const GlobalState &gs) const {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -418,8 +418,7 @@ void TupleType::_sanityCheck(const GlobalState &gs) const {
     ENFORCE(applied->klass == Symbols::Array());
 }
 
-ShapeType::ShapeType(TypePtr underlying, vector<TypePtr> keys, vector<TypePtr> values)
-    : keys(move(keys)), values(move(values)), underlying_(std::move(underlying)) {
+ShapeType::ShapeType(vector<TypePtr> keys, vector<TypePtr> values) : keys(move(keys)), values(move(values)) {
     DEBUG_ONLY(for (auto &k : this->keys) { ENFORCE(isa_type<LiteralType>(k)); };);
     categoryCounterInc("types.allocated", "shapetype");
 }
@@ -728,10 +727,7 @@ TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &type) {
         [&](const OrType &orType) {
             ret = OrType::make_shared(unwrapSelfTypeParam(ctx, orType.left), unwrapSelfTypeParam(ctx, orType.right));
         },
-        [&](const ShapeType &shape) {
-            ret = make_type<ShapeType>(unwrapSelfTypeParam(ctx, shape.underlying_), shape.keys,
-                                       unwrapTypeVector(ctx, shape.values));
-        },
+        [&](const ShapeType &shape) { ret = make_type<ShapeType>(shape.keys, unwrapTypeVector(ctx, shape.values)); },
         [&](const TupleType &tuple) {
             ret = make_type<TupleType>(unwrapSelfTypeParam(ctx, tuple.underlying_), unwrapTypeVector(ctx, tuple.elems));
         },

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -659,7 +659,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
                     }
                 }
             }
-            result.type = core::make_type<core::ShapeType>(core::Types::hashOfUntyped(), move(keys), move(values));
+            result.type = core::make_type<core::ShapeType>(move(keys), move(values));
         },
         [&](const ast::ConstantLit &i) {
             auto maybeAliased = i.symbol;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This breaks another change out of #3822.

It should have zero behavior change, so it will let us more easily experiment
with small tweaks to how shape types are checked, so that we can land
incremental updates.

If anything, this should just be a performance win, as it drops the size of
ShapeType's by 25% (64 bytes -> 48 bytes).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No behavior change.