### PR TITLE
Remove TupleType::underlying_ field

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -676,10 +676,8 @@ private:
 
 public:
     std::vector<TypePtr> elems;
-    const TypePtr underlying_;
 
-    TupleType(TypePtr underlying, std::vector<TypePtr> elements);
-    static TypePtr build(const GlobalState &gs, std::vector<TypePtr> elements);
+    TupleType(std::vector<TypePtr> elements);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
@@ -696,7 +694,7 @@ public:
     TypePtr underlying(const GlobalState &gs) const;
     bool derivesFrom(const GlobalState &gs, core::ClassOrModuleRef klass) const;
 };
-CheckSize(TupleType, 40, 8);
+CheckSize(TupleType, 24, 8);
 
 TYPE(AppliedType) final {
 public:

--- a/core/Types.h
+++ b/core/Types.h
@@ -157,7 +157,7 @@ public:
     /** Internal implementation. You should probably use any(). */
     static TypePtr lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
 
-    static TypePtr lubAll(const GlobalState &gs, std::vector<TypePtr> &elements);
+    static TypePtr lubAll(const GlobalState &gs, const std::vector<TypePtr> &elements);
     static TypePtr arrayOf(const GlobalState &gs, const TypePtr &elem);
     static TypePtr rangeOf(const GlobalState &gs, const TypePtr &elem);
     static TypePtr hashOf(const GlobalState &gs, const TypePtr &elem);

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -376,7 +376,6 @@ void SerializerImpl::pickle(Pickler &p, const TypePtr &what) {
         }
         case TypePtr::Tag::TupleType: {
             auto &arr = cast_type_nonnull<TupleType>(what);
-            pickle(p, arr.underlying_);
             p.putU4(arr.elems.size());
             for (auto &el : arr.elems) {
                 pickle(p, el);
@@ -464,13 +463,12 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
         case TypePtr::Tag::AndType:
             return AndType::make_shared(unpickleType(p, gs), unpickleType(p, gs));
         case TypePtr::Tag::TupleType: {
-            auto underlying = unpickleType(p, gs);
             int sz = p.getU4();
             vector<TypePtr> elems(sz);
             for (auto &elem : elems) {
                 elem = unpickleType(p, gs);
             }
-            auto result = make_type<TupleType>(underlying, std::move(elems));
+            auto result = make_type<TupleType>(std::move(elems));
             return result;
         }
         case TypePtr::Tag::ShapeType: {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -416,7 +416,7 @@ TypePtr unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
         for (auto &elem : tupleType->elems) {
             unwrappedElems.emplace_back(unwrapType(gs, loc, elem));
         }
-        return TupleType::build(gs, move(unwrappedElems));
+        return make_type<TupleType>(move(unwrappedElems));
     } else if (isa_type<LiteralType>(tp)) {
         if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
             e.setHeader("Unsupported usage of literal type");
@@ -1133,7 +1133,7 @@ TypePtr getMethodArguments(const GlobalState &gs, ClassOrModuleRef klass, NameRe
         }
         args.emplace_back(Types::resultTypeAsSeenFrom(gs, arg.type, data->owner.asClassOrModuleRef(), klass, targs));
     }
-    return TupleType::build(gs, move(args));
+    return make_type<TupleType>(move(args));
 }
 
 TypePtr ClassType::getCallArguments(const GlobalState &gs, NameRef name) const {
@@ -1495,7 +1495,7 @@ public:
                 ++it;
             } else if (attachedClass == Symbols::Hash() && i == 2) {
                 auto tupleArgs = targs;
-                targs.emplace_back(TupleType::build(gs, tupleArgs));
+                targs.emplace_back(make_type<TupleType>(tupleArgs));
             } else {
                 targs.emplace_back(Types::untypedUntracked());
             }
@@ -1574,7 +1574,7 @@ public:
             }
         }
 
-        auto tuple = TupleType::build(gs, move(elems));
+        auto tuple = make_type<TupleType>(move(elems));
         if (isType) {
             tuple = make_type<MetaType>(move(tuple));
         }
@@ -1630,7 +1630,7 @@ class Magic_expandSplat : public IntrinsicMethod {
             types.resize(expandTo, Types::nilClass());
         }
 
-        return TupleType::build(gs, move(types));
+        return make_type<TupleType>(move(types));
     }
 
 public:
@@ -2304,7 +2304,7 @@ public:
                 return;
             }
         }
-        res.returnType = TupleType::build(gs, std::move(elems));
+        res.returnType = make_type<TupleType>(std::move(elems));
     }
 } Tuple_concat;
 
@@ -2497,7 +2497,7 @@ public:
             }
         }
 
-        res.returnType = Types::arrayOf(gs, TupleType::build(gs, move(unwrappedElems)));
+        res.returnType = Types::arrayOf(gs, make_type<TupleType>(move(unwrappedElems)));
     }
 } Array_product;
 

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -323,7 +323,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                             } else if (!differ2) {
                                 result = t2;
                             } else {
-                                result = TupleType::build(gs, move(elemLubs));
+                                result = make_type<TupleType>(move(elemLubs));
                             }
                         } else {
                             result = Types::arrayOfUntyped();
@@ -672,7 +672,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         } else if (absl::c_equal(a2.elems, elemGlbs)) {
                             result = t2;
                         } else {
-                            result = TupleType::build(gs, move(elemGlbs));
+                            result = make_type<TupleType>(move(elemGlbs));
                         }
                     } else {
                         result = Types::bottom();

--- a/core/types/typemaps.cc
+++ b/core/types/typemaps.cc
@@ -125,7 +125,7 @@ TypePtr TupleType::_instantiate(const GlobalState &gs, const InlinedVector<Symbo
     if (!newElems) {
         return nullptr;
     }
-    return TupleType::build(gs, move(*newElems));
+    return make_type<TupleType>(move(*newElems));
 }
 
 TypePtr TupleType::_instantiate(const GlobalState &gs, const TypeConstraint &tc) const {
@@ -133,7 +133,7 @@ TypePtr TupleType::_instantiate(const GlobalState &gs, const TypeConstraint &tc)
     if (!newElems) {
         return nullptr;
     }
-    return TupleType::build(gs, move(*newElems));
+    return make_type<TupleType>(move(*newElems));
 }
 
 TypePtr TupleType::_approximate(const GlobalState &gs, const TypeConstraint &tc) const {
@@ -141,7 +141,7 @@ TypePtr TupleType::_approximate(const GlobalState &gs, const TypeConstraint &tc)
     if (!newElems) {
         return nullptr;
     }
-    return TupleType::build(gs, move(*newElems));
+    return make_type<TupleType>(move(*newElems));
 };
 
 TypePtr ShapeType::_instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -276,7 +276,7 @@ TypePtr Types::dropLiteral(const GlobalState &gs, const TypePtr &tp) {
     return tp;
 }
 
-TypePtr Types::lubAll(const GlobalState &gs, vector<TypePtr> &elements) {
+TypePtr Types::lubAll(const GlobalState &gs, const vector<TypePtr> &elements) {
     TypePtr acc = Types::bottom();
     for (auto &el : elements) {
         acc = Types::lub(gs, acc, el);
@@ -378,11 +378,6 @@ TupleType::TupleType(TypePtr underlying, vector<TypePtr> elements)
     categoryCounterInc("types.allocated", "tupletype");
 }
 
-TypePtr TupleType::build(const GlobalState &gs, vector<TypePtr> elements) {
-    TypePtr underlying = Types::arrayOf(gs, Types::dropLiteral(gs, Types::lubAll(gs, elements)));
-    return make_type<TupleType>(move(underlying), move(elements));
-}
-
 AndType::AndType(const TypePtr &left, const TypePtr &right) : left(move(left)), right(move(right)) {
     categoryCounterInc("types.allocated", "andtype");
 }
@@ -428,7 +423,7 @@ TypePtr ShapeType::underlying(const GlobalState &gs) const {
 }
 
 TypePtr TupleType::underlying(const GlobalState &gs) const {
-    return this->underlying_;
+    return Types::arrayOf(gs, Types::dropLiteral(gs, Types::lubAll(gs, this->elems)));
 }
 
 void ShapeType::_sanityCheck(const GlobalState &gs) const {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -450,7 +450,7 @@ private:
         auto uaSym = ctx.state.enterMethodSymbol(core::Loc::none(), item.klass, core::Names::unresolvedAncestors());
         core::TypePtr resultType = uaSym.data(ctx)->resultType;
         if (!resultType) {
-            uaSym.data(ctx)->resultType = core::TupleType::build(ctx, {ancestorType});
+            uaSym.data(ctx)->resultType = core::make_type<core::TupleType>(vector<core::TypePtr>{ancestorType});
         } else if (auto tt = core::cast_type<core::TupleType>(resultType)) {
             tt->elems.push_back(ancestorType);
         } else {

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -639,7 +639,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
             for (auto &el : arr.elems) {
                 elems.emplace_back(getResultTypeWithSelfTypeParams(ctx, el, sigBeingParsed, args.withoutSelfType()));
             }
-            result.type = core::TupleType::build(ctx, move(elems));
+            result.type = core::make_type<core::TupleType>(move(elems));
         },
         [&](const ast::Hash &hash) {
             vector<core::TypePtr> keys;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Basically the same change as #3833, but for TupleType instead of ShapeType.

Same motivation:

- prework broken out of #3822
- no behavior changes
- drops TupleType size

Has one unique downside:

- we're doing lubAll inside underlying, so we could potentially be doing more
  lubbing work over and over again. if this ends up being too slow, we can
  always memoize the result of this function.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.