### PR TITLE
Add ShapeType::showWithMoreInfo

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -659,6 +659,7 @@ public:
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
+    std::string showWithMoreInfo(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -143,6 +143,10 @@ string ShapeType::show(const GlobalState &gs) const {
     return to_string(buf);
 }
 
+string ShapeType::showWithMoreInfo(const GlobalState &gs) const {
+    return fmt::format("{} (shape of {})", show(gs), this->underlying(gs).show(gs));
+}
+
 string AliasType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return fmt::format("AliasType {{ symbol = {} }}", this->symbol.data(gs)->toStringFullName(gs));
 }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1276,8 +1276,9 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     } else if (!core::Types::isSubType(ctx, ty.type, castType)) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::CastTypeMismatch)) {
                             e.setHeader("Argument does not have asserted type `{}`", castType.show(ctx));
-                            e.addErrorSection(core::ErrorSection("Got " + ty.type.show(ctx) + " originating from:",
-                                                                 ty.origins2Explanations(ctx, ownerLoc)));
+                            e.addErrorSection(
+                                core::ErrorSection("Got " + ty.type.showWithMoreInfo(ctx) + " originating from:",
+                                                   ty.origins2Explanations(ctx, ownerLoc)));
                         }
                     }
                 } else if (!c->isSynthetic) {

--- a/test/testdata/infer/shape_to_hash.rb
+++ b/test/testdata/infer/shape_to_hash.rb
@@ -12,8 +12,8 @@ class A
 end
 
 foo = {x: "hello", y: 333, z: A.new}
-T.reveal_type(foo) # error: Revealed type: `{x: String("hello"), y: Integer(333), z: A}`
-T.reveal_type(foo.to_hash) # error: Revealed type: `{x: String("hello"), y: Integer(333), z: A}`
+T.reveal_type(foo) # error: Revealed type: `{x: String("hello"), y: Integer(333), z: A} (shape of T::Hash[T.untyped, T.untyped])`
+T.reveal_type(foo.to_hash) # error: Revealed type: `{x: String("hello"), y: Integer(333), z: A} (shape of T::Hash[T.untyped, T.untyped])`
 
 bar = {x: "yolo", y: 209, z: "hello again"}
 
@@ -23,8 +23,8 @@ else
   baz = bar
 end
 
-T.reveal_type(baz) # error: Revealed type: `{x: String, y: Integer, z: T.any(A, String)}`
-T.reveal_type(baz.to_hash) # error: Revealed type: `{x: String, y: Integer, z: T.any(A, String)}`
+T.reveal_type(baz) # error: Revealed type: `{x: String, y: Integer, z: T.any(A, String)} (shape of T::Hash[T.untyped, T.untyped])`
+T.reveal_type(baz.to_hash) # error: Revealed type: `{x: String, y: Integer, z: T.any(A, String)} (shape of T::Hash[T.untyped, T.untyped])`
 
 if T.unsafe(false)
   qux = baz

--- a/test/testdata/lsp/hover_method_for_building_arrays_and_hashes.rb
+++ b/test/testdata/lsp/hover_method_for_building_arrays_and_hashes.rb
@@ -14,7 +14,7 @@ class Issue1777
 
       # Test hovering over comment
       # ^ hover: [String("foo"), Integer(123)] (2-tuple)
-      
+
       # Test hovering over last item in array
       123
       # ^ hover: Integer(123)
@@ -25,23 +25,23 @@ class Issue1777
   end
 
   def hash_hover
-    T.reveal_type({ # error: {foo: String("foo"), bar: Integer(123)}
-      #           ^ hover: {foo: String("foo"), bar: Integer(123)}
+    T.reveal_type({ # error: {foo: String("foo"), bar: Integer(123)} (shape of T::Hash[T.untyped, T.untyped])
+      #           ^ hover: {foo: String("foo"), bar: Integer(123)} (shape of T::Hash[T.untyped, T.untyped])
       # Test hovering over first item in array
       foo: "foo",
       #        ^ hover: String("foo")
       #         ^ hover: String("foo")
-      #          ^ hover: {foo: String("foo"), bar: Integer(123)}
+      #          ^ hover: {foo: String("foo"), bar: Integer(123)} (shape of T::Hash[T.untyped, T.untyped])
 
       # Test hovering over comment
-      # ^ hover: {foo: String("foo"), bar: Integer(123)}
-      
+      # ^ hover: {foo: String("foo"), bar: Integer(123)} (shape of T::Hash[T.untyped, T.untyped])
+
       # Test hovering over last item in array
       bar: 123
       #      ^ hover: Integer(123)
       #       ^ hover: Integer(123)
-      #        ^ hover: {foo: String("foo"), bar: Integer(123)}
+      #        ^ hover: {foo: String("foo"), bar: Integer(123)} (shape of T::Hash[T.untyped, T.untyped])
       })
-    # ^ hover: {foo: String("foo"), bar: Integer(123)}
+    # ^ hover: {foo: String("foo"), bar: Integer(123)} (shape of T::Hash[T.untyped, T.untyped])
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I noticed that we had a `showWithMoreInfo` for `TupleType`, but we didn't
have one for `ShapeType`. That felt inconsistent, and also helped me make
sense of some of the tests when working on #3822.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No behavior change--only error messages change.