### PR TITLE
Improve slow duplicate location check in renamer

### DIFF
--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -198,7 +198,7 @@ variant<JSONNullObject, unique_ptr<WorkspaceEdit>> Renamer::buildEdit() {
         if (location == nullptr) {
             continue;
         }
-        tmpEdits[location->uri].push_back(make_unique<TextEdit>(move(location->range), newsrc));
+        tmpEdits[location->uri].push_back(make_unique<TextEdit>(move(location->range), move(newsrc)));
     }
     for (auto &item : tmpEdits) {
         // TODO: Version.

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -198,7 +198,6 @@ variant<JSONNullObject, unique_ptr<WorkspaceEdit>> Renamer::buildEdit() {
         if (location == nullptr) {
             continue;
         }
-        auto textedit = make_unique<TextEdit>(move(location->range), newsrc);
         tmpEdits[location->uri].push_back(make_unique<TextEdit>(move(location->range), newsrc));
     }
     for (auto &item : tmpEdits) {
@@ -209,7 +208,7 @@ variant<JSONNullObject, unique_ptr<WorkspaceEdit>> Renamer::buildEdit() {
     auto we = make_unique<WorkspaceEdit>();
     we->documentChanges = move(textDocEdits);
     return we;
-} // namespace
+}
 
 class MethodRenamer : public Renamer {
 public:

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -177,7 +177,7 @@ protected:
     const LSPConfiguration &config;
     string oldName;
     string newName;
-    UnorderedMap<string, vector<unique_ptr<TextEdit>>> edits;
+    UnorderedMap<core::Loc, string> edits;
     bool invalid;
     string error;
 };
@@ -187,16 +187,29 @@ variant<JSONNullObject, unique_ptr<WorkspaceEdit>> Renamer::buildEdit() {
         return JSONNullObject();
     }
 
-    auto we = make_unique<WorkspaceEdit>();
+    UnorderedMap<string, vector<unique_ptr<TextEdit>>> tmpEdits;
     vector<unique_ptr<TextDocumentEdit>> textDocEdits;
+    // collect changes per file
     for (auto &item : edits) {
+        core::Loc loc = item.first;
+        string newsrc = item.second;
+        auto location = config.loc2Location(gs, loc);
+        ENFORCE(location != nullptr); // loc should always exist
+        if (location == nullptr) {
+            continue;
+        }
+        auto textedit = make_unique<TextEdit>(move(location->range), newsrc);
+        tmpEdits[location->uri].push_back(make_unique<TextEdit>(move(location->range), newsrc));
+    }
+    for (auto &item : tmpEdits) {
         // TODO: Version.
         textDocEdits.push_back(make_unique<TextDocumentEdit>(
             make_unique<VersionedTextDocumentIdentifier>(item.first, JSONNullObject()), move(item.second)));
     }
+    auto we = make_unique<WorkspaceEdit>();
     we->documentChanges = move(textDocEdits);
     return we;
-}
+} // namespace
 
 class MethodRenamer : public Renamer {
 public:
@@ -223,24 +236,15 @@ public:
             return;
         }
         auto loc = response->getLoc();
-        auto source = loc.source(gs);
-        auto location = config.loc2Location(gs, loc);
-        if (location == nullptr) {
+
+        // If we're renaming the exact same place twice, silently ignore it. We reach this condition when we find the
+        // same method send through multiple definitions (e.g. in the case of union types)
+        auto it = edits.find(loc);
+        if (it != edits.end()) {
             return;
         }
 
-        // Have we already edited this exact location?
-        // If we're renaming the exact same place twice, silently ignore it. We reach this condition when we find the
-        // same method send through multiple definitions (e.g. in the case of union types)
-        auto it = edits.find(location->uri);
-        if (it != edits.end()) {
-            for (auto &textedit : it->second) {
-                if (location->range->cmp(*textedit->range) == 0) {
-                    return;
-                }
-            }
-        }
-
+        auto source = loc.source(gs);
         string newsrc;
         if (auto sendResp = response->isSend()) {
             newsrc = replaceMethodNameInSend(source, sendResp);
@@ -250,7 +254,7 @@ public:
             ENFORCE(0, "Unexpected query response type while renaming method");
             return;
         }
-        edits[location->uri].push_back(make_unique<TextEdit>(move(location->range), newsrc));
+        edits[loc] = newsrc;
     }
 
 private:
@@ -316,7 +320,7 @@ private:
         auto suffixOffset = pos + oldName.length();
         return absl::StrCat(input.substr(0, pos), newName, input.substr(suffixOffset, input.length() - suffixOffset));
     }
-};
+}; // namespace
 class ConstRenamer : public Renamer {
 public:
     ConstRenamer(const core::GlobalState &gs, const LSPConfiguration &config, const string oldName,
@@ -326,14 +330,10 @@ public:
     void rename(unique_ptr<core::lsp::QueryResponse> &response) override {
         auto loc = response->getLoc();
         auto source = loc.source(gs);
-        auto location = config.loc2Location(gs, loc);
-        if (location == nullptr) {
-            return;
-        }
         vector<string> strs = absl::StrSplit(source, "::");
         strs[strs.size() - 1] = string(newName);
         auto newsrc = absl::StrJoin(strs, "::");
-        edits[location->uri].push_back(make_unique<TextEdit>(move(location->range), newsrc));
+        edits[loc] = newsrc;
     }
 };
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Removes the expensive duplicate location check in the method renamer and replaces it with a hashmap.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Deferred review comments from previous PR #3831 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests; also tested manually through vs code.
