### PR TITLE
[wip] model foreign key props more accurately

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -205,6 +205,7 @@ NameDef names[] = {
     {"Types", "Types", true},
     {"DocumentDecoratorHelper", "DocumentDecoratorHelper", true},
     {"Chalk_ODM_Document", "::Chalk::ODM::Document"},
+    {"allowDirectMutation", "allow_direct_mutation"},
 
     {"prefix"},
     {"to"},

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -3538,16 +3538,23 @@ ClassDef{
                 block = nullptr
                 pos_args = 0
                 args = [
-                  Literal{ value = :opts }
+                  Literal{ value = :allow_direct_mutation }
                   Send{
                     recv = ConstantLit{
                       orig = nullptr
                       symbol = (module ::T)
                     }
-                    fun = <U untyped>
+                    fun = <U nilable>
                     block = nullptr
-                    pos_args = 0
+                    pos_args = 1
                     args = [
+                      UnresolvedConstantLit{
+                        scope = ConstantLit{
+                          orig = nullptr
+                          symbol = (module ::T)
+                        }
+                        cnst = <C <U Boolean>>
+                      }
                     ]
                   }
                 ]
@@ -3586,10 +3593,13 @@ ClassDef{
         MethodDef{
           flags = {rewriter}
           name = <U foreign_><<U <todo method>>>
-          args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
-              kind = Local
-              name = <U opts>
-            } } }, BlockArg{ expr = UnresolvedIdent{
+          args = [OptionalArg{
+              expr = KeywordArg{ expr = UnresolvedIdent{
+                kind = Local
+                name = <U allow_direct_mutation>
+              } }
+              default_ = Literal{ value = nil }
+            }, BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -3636,16 +3646,23 @@ ClassDef{
                 block = nullptr
                 pos_args = 0
                 args = [
-                  Literal{ value = :opts }
+                  Literal{ value = :allow_direct_mutation }
                   Send{
                     recv = ConstantLit{
                       orig = nullptr
                       symbol = (module ::T)
                     }
-                    fun = <U untyped>
+                    fun = <U nilable>
                     block = nullptr
-                    pos_args = 0
+                    pos_args = 1
                     args = [
+                      UnresolvedConstantLit{
+                        scope = ConstantLit{
+                          orig = nullptr
+                          symbol = (module ::T)
+                        }
+                        cnst = <C <U Boolean>>
+                      }
                     ]
                   }
                 ]
@@ -3673,10 +3690,13 @@ ClassDef{
         MethodDef{
           flags = {rewriter}
           name = <U foreign_!><<U <todo method>>>
-          args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
-              kind = Local
-              name = <U opts>
-            } } }, BlockArg{ expr = UnresolvedIdent{
+          args = [OptionalArg{
+              expr = KeywordArg{ expr = UnresolvedIdent{
+                kind = Local
+                name = <U allow_direct_mutation>
+              } }
+              default_ = Literal{ value = nil }
+            }, BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -3927,16 +3947,23 @@ ClassDef{
                 block = nullptr
                 pos_args = 0
                 args = [
-                  Literal{ value = :opts }
+                  Literal{ value = :allow_direct_mutation }
                   Send{
                     recv = ConstantLit{
                       orig = nullptr
                       symbol = (module ::T)
                     }
-                    fun = <U untyped>
+                    fun = <U nilable>
                     block = nullptr
-                    pos_args = 0
+                    pos_args = 1
                     args = [
+                      UnresolvedConstantLit{
+                        scope = ConstantLit{
+                          orig = nullptr
+                          symbol = (module ::T)
+                        }
+                        cnst = <C <U Boolean>>
+                      }
                     ]
                   }
                 ]
@@ -3975,10 +4002,13 @@ ClassDef{
         MethodDef{
           flags = {rewriter}
           name = <U foreign_lazy_><<U <todo method>>>
-          args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
-              kind = Local
-              name = <U opts>
-            } } }, BlockArg{ expr = UnresolvedIdent{
+          args = [OptionalArg{
+              expr = KeywordArg{ expr = UnresolvedIdent{
+                kind = Local
+                name = <U allow_direct_mutation>
+              } }
+              default_ = Literal{ value = nil }
+            }, BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -4025,16 +4055,23 @@ ClassDef{
                 block = nullptr
                 pos_args = 0
                 args = [
-                  Literal{ value = :opts }
+                  Literal{ value = :allow_direct_mutation }
                   Send{
                     recv = ConstantLit{
                       orig = nullptr
                       symbol = (module ::T)
                     }
-                    fun = <U untyped>
+                    fun = <U nilable>
                     block = nullptr
-                    pos_args = 0
+                    pos_args = 1
                     args = [
+                      UnresolvedConstantLit{
+                        scope = ConstantLit{
+                          orig = nullptr
+                          symbol = (module ::T)
+                        }
+                        cnst = <C <U Boolean>>
+                      }
                     ]
                   }
                 ]
@@ -4062,10 +4099,13 @@ ClassDef{
         MethodDef{
           flags = {rewriter}
           name = <U foreign_lazy_!><<U <todo method>>>
-          args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
-              kind = Local
-              name = <U opts>
-            } } }, BlockArg{ expr = UnresolvedIdent{
+          args = [OptionalArg{
+              expr = KeywordArg{ expr = UnresolvedIdent{
+                kind = Local
+                name = <U allow_direct_mutation>
+              } }
+              default_ = Literal{ value = nil }
+            }, BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -4316,16 +4356,23 @@ ClassDef{
                 block = nullptr
                 pos_args = 0
                 args = [
-                  Literal{ value = :opts }
+                  Literal{ value = :allow_direct_mutation }
                   Send{
                     recv = ConstantLit{
                       orig = nullptr
                       symbol = (module ::T)
                     }
-                    fun = <U untyped>
+                    fun = <U nilable>
                     block = nullptr
-                    pos_args = 0
+                    pos_args = 1
                     args = [
+                      UnresolvedConstantLit{
+                        scope = ConstantLit{
+                          orig = nullptr
+                          symbol = (module ::T)
+                        }
+                        cnst = <C <U Boolean>>
+                      }
                     ]
                   }
                 ]
@@ -4364,10 +4411,13 @@ ClassDef{
         MethodDef{
           flags = {rewriter}
           name = <U foreign_proc_><<U <todo method>>>
-          args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
-              kind = Local
-              name = <U opts>
-            } } }, BlockArg{ expr = UnresolvedIdent{
+          args = [OptionalArg{
+              expr = KeywordArg{ expr = UnresolvedIdent{
+                kind = Local
+                name = <U allow_direct_mutation>
+              } }
+              default_ = Literal{ value = nil }
+            }, BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -4414,16 +4464,23 @@ ClassDef{
                 block = nullptr
                 pos_args = 0
                 args = [
-                  Literal{ value = :opts }
+                  Literal{ value = :allow_direct_mutation }
                   Send{
                     recv = ConstantLit{
                       orig = nullptr
                       symbol = (module ::T)
                     }
-                    fun = <U untyped>
+                    fun = <U nilable>
                     block = nullptr
-                    pos_args = 0
+                    pos_args = 1
                     args = [
+                      UnresolvedConstantLit{
+                        scope = ConstantLit{
+                          orig = nullptr
+                          symbol = (module ::T)
+                        }
+                        cnst = <C <U Boolean>>
+                      }
                     ]
                   }
                 ]
@@ -4451,10 +4508,13 @@ ClassDef{
         MethodDef{
           flags = {rewriter}
           name = <U foreign_proc_!><<U <todo method>>>
-          args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
-              kind = Local
-              name = <U opts>
-            } } }, BlockArg{ expr = UnresolvedIdent{
+          args = [OptionalArg{
+              expr = KeywordArg{ expr = UnresolvedIdent{
+                kind = Local
+                name = <U allow_direct_mutation>
+              } }
+              default_ = Literal{ value = nil }
+            }, BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -4705,16 +4765,23 @@ ClassDef{
                 block = nullptr
                 pos_args = 0
                 args = [
-                  Literal{ value = :opts }
+                  Literal{ value = :allow_direct_mutation }
                   Send{
                     recv = ConstantLit{
                       orig = nullptr
                       symbol = (module ::T)
                     }
-                    fun = <U untyped>
+                    fun = <U nilable>
                     block = nullptr
-                    pos_args = 0
+                    pos_args = 1
                     args = [
+                      UnresolvedConstantLit{
+                        scope = ConstantLit{
+                          orig = nullptr
+                          symbol = (module ::T)
+                        }
+                        cnst = <C <U Boolean>>
+                      }
                     ]
                   }
                 ]
@@ -4749,10 +4816,13 @@ ClassDef{
         MethodDef{
           flags = {rewriter}
           name = <U foreign_invalid_><<U <todo method>>>
-          args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
-              kind = Local
-              name = <U opts>
-            } } }, BlockArg{ expr = UnresolvedIdent{
+          args = [OptionalArg{
+              expr = KeywordArg{ expr = UnresolvedIdent{
+                kind = Local
+                name = <U allow_direct_mutation>
+              } }
+              default_ = Literal{ value = nil }
+            }, BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -4799,16 +4869,23 @@ ClassDef{
                 block = nullptr
                 pos_args = 0
                 args = [
-                  Literal{ value = :opts }
+                  Literal{ value = :allow_direct_mutation }
                   Send{
                     recv = ConstantLit{
                       orig = nullptr
                       symbol = (module ::T)
                     }
-                    fun = <U untyped>
+                    fun = <U nilable>
                     block = nullptr
-                    pos_args = 0
+                    pos_args = 1
                     args = [
+                      UnresolvedConstantLit{
+                        scope = ConstantLit{
+                          orig = nullptr
+                          symbol = (module ::T)
+                        }
+                        cnst = <C <U Boolean>>
+                      }
                     ]
                   }
                 ]
@@ -4843,10 +4920,13 @@ ClassDef{
         MethodDef{
           flags = {rewriter}
           name = <U foreign_invalid_!><<U <todo method>>>
-          args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
-              kind = Local
-              name = <U opts>
-            } } }, BlockArg{ expr = UnresolvedIdent{
+          args = [OptionalArg{
+              expr = KeywordArg{ expr = UnresolvedIdent{
+                kind = Local
+                name = <U allow_direct_mutation>
+              } }
+              default_ = Literal{ value = nil }
+            }, BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]

--- a/test/testdata/rewriter/prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree.exp
@@ -332,18 +332,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:opts, ::T.untyped()).returns(::T.nilable(<emptyTree>::<C ForeignClass>))
+      <self>.params(:allow_direct_mutation, ::T.nilable(::T::<C Boolean>)).returns(::T.nilable(<emptyTree>::<C ForeignClass>))
     end
 
-    def foreign_<<todo method>>(*opts:, &<blk>)
+    def foreign_<<todo method>>(allow_direct_mutation: = nil, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:opts, ::T.untyped()).returns(<emptyTree>::<C ForeignClass>)
+      <self>.params(:allow_direct_mutation, ::T.nilable(::T::<C Boolean>)).returns(<emptyTree>::<C ForeignClass>)
     end
 
-    def foreign_!<<todo method>>(*opts:, &<blk>)
+    def foreign_!<<todo method>>(allow_direct_mutation: = nil, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -374,18 +374,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:opts, ::T.untyped()).returns(::T.nilable(<emptyTree>::<C ForeignClass>))
+      <self>.params(:allow_direct_mutation, ::T.nilable(::T::<C Boolean>)).returns(::T.nilable(<emptyTree>::<C ForeignClass>))
     end
 
-    def foreign_lazy_<<todo method>>(*opts:, &<blk>)
+    def foreign_lazy_<<todo method>>(allow_direct_mutation: = nil, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:opts, ::T.untyped()).returns(<emptyTree>::<C ForeignClass>)
+      <self>.params(:allow_direct_mutation, ::T.nilable(::T::<C Boolean>)).returns(<emptyTree>::<C ForeignClass>)
     end
 
-    def foreign_lazy_!<<todo method>>(*opts:, &<blk>)
+    def foreign_lazy_!<<todo method>>(allow_direct_mutation: = nil, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -416,18 +416,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:opts, ::T.untyped()).returns(::T.nilable(<emptyTree>::<C ForeignClass>))
+      <self>.params(:allow_direct_mutation, ::T.nilable(::T::<C Boolean>)).returns(::T.nilable(<emptyTree>::<C ForeignClass>))
     end
 
-    def foreign_proc_<<todo method>>(*opts:, &<blk>)
+    def foreign_proc_<<todo method>>(allow_direct_mutation: = nil, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:opts, ::T.untyped()).returns(<emptyTree>::<C ForeignClass>)
+      <self>.params(:allow_direct_mutation, ::T.nilable(::T::<C Boolean>)).returns(<emptyTree>::<C ForeignClass>)
     end
 
-    def foreign_proc_!<<todo method>>(*opts:, &<blk>)
+    def foreign_proc_!<<todo method>>(allow_direct_mutation: = nil, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
@@ -458,18 +458,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:opts, ::T.untyped()).returns(::T.untyped())
+      <self>.params(:allow_direct_mutation, ::T.nilable(::T::<C Boolean>)).returns(::T.untyped())
     end
 
-    def foreign_invalid_<<todo method>>(*opts:, &<blk>)
+    def foreign_invalid_<<todo method>>(allow_direct_mutation: = nil, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:opts, ::T.untyped()).returns(::T.untyped())
+      <self>.params(:allow_direct_mutation, ::T.nilable(::T::<C Boolean>)).returns(::T.untyped())
     end
 
-    def foreign_invalid_!<<todo method>>(*opts:, &<blk>)
+    def foreign_invalid_!<<todo method>>(allow_direct_mutation: = nil, &<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 

--- a/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
@@ -32,44 +32,44 @@ class <C <U <root>>> < <C <U Object>> ()
     method <C <U AdvancedODM>><U foreign=> (foreign, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
       argument foreign<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
+    method <C <U AdvancedODM>><U foreign_> (allow_direct_mutation, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
+      argument allow_direct_mutation<optional, keyword> -> T.nilable(T::Boolean) @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
+    method <C <U AdvancedODM>><U foreign_!> (allow_direct_mutation, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
+      argument allow_direct_mutation<optional, keyword> -> T.nilable(T::Boolean) @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>><U foreign_invalid> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>><U foreign_invalid=> (foreign_invalid, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
       argument foreign_invalid<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_invalid_> (opts, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
+    method <C <U AdvancedODM>><U foreign_invalid_> (allow_direct_mutation, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
+      argument allow_direct_mutation<optional, keyword> -> T.nilable(T::Boolean) @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_invalid_!> (opts, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
+    method <C <U AdvancedODM>><U foreign_invalid_!> (allow_direct_mutation, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
+      argument allow_direct_mutation<optional, keyword> -> T.nilable(T::Boolean) @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>><U foreign_lazy> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>><U foreign_lazy=> (foreign_lazy, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
       argument foreign_lazy<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_lazy_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
+    method <C <U AdvancedODM>><U foreign_lazy_> (allow_direct_mutation, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
+      argument allow_direct_mutation<optional, keyword> -> T.nilable(T::Boolean) @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_lazy_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
+    method <C <U AdvancedODM>><U foreign_lazy_!> (allow_direct_mutation, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
+      argument allow_direct_mutation<optional, keyword> -> T.nilable(T::Boolean) @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>><U foreign_proc> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>><U foreign_proc=> (foreign_proc, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
       argument foreign_proc<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_proc_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
+    method <C <U AdvancedODM>><U foreign_proc_> (allow_direct_mutation, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
+      argument allow_direct_mutation<optional, keyword> -> T.nilable(T::Boolean) @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_proc_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
+    method <C <U AdvancedODM>><U foreign_proc_!> (allow_direct_mutation, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
+      argument allow_direct_mutation<optional, keyword> -> T.nilable(T::Boolean) @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>><U hash_of> (<blk>) -> AppliedType {       klass = <C <U Hash>>       targs = [         <C <U K>> = Symbol         <C <U V>> = String         <C <U Elem>> = TupleType {             0 = Symbol             1 = String           }       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=45:5 end=45:43}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}


### PR DESCRIPTION
Sorbet's modeling for props with foreign keys has some differences with how `sorbet-runtime` models them at runtime.  It would be better if the static and dynamic views matched up.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

More accuracy is more better.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
