### PR TITLE
Implement Shape_squareBracketsEq intrinsic

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2365,7 +2365,6 @@ optional<Loc> locOfValueForKey(const GlobalState &gs, const Loc origin, const Na
 
 } // namespace
 
-// TODO(jez) Add tests for this
 class Shape_squareBracketsEq : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2385,8 +2385,6 @@ public:
             auto valueType = shape.values[*idx];
             auto expectedType = valueType;
             auto actualType = *args.args[1];
-            // TODO(jez) I'm almost certain this doesn't handle generics properly
-
             // This check (with the dropLiteral's) mimicks what we do for pinning errors in environment.cc
             if (!Types::isSubType(gs, Types::dropLiteral(gs, actualType.type), Types::dropLiteral(gs, expectedType))) {
                 auto argLoc = Loc(args.locs.file, args.locs.args[1]);
@@ -2414,8 +2412,6 @@ public:
             // Returning here without setting res.resultType will cause dispatchCall to fall back to
             // Hash#[]=, which will have the effect of checking the arg types.
             //
-            // TODO(jez) We could do something smarter here, like check that the new value is
-            // compatible with the old value.
             // TODO(jez) Right now ShapeType::underlying always returns T::Hash[T.untyped, T.untyped]
             // so it doesn't matter whether we return or not.
             return;

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2391,8 +2391,9 @@ public:
                 if (auto e = gs.beginError(argLoc, errors::Infer::MethodArgumentMismatch)) {
                     e.setHeader("Expected `{}` but found `{}` for key `{}`", expectedType.show(gs),
                                 actualType.type.show(gs), shape.keys[*idx].show(gs));
-                    e.addErrorSection(ErrorSection("Shape initialized here:", args.fullType.origins2Explanations(
-                                                                                  gs, args.originForUninitialized)));
+                    e.addErrorSection(
+                        ErrorSection("Shape originates from here:",
+                                     args.fullType.origins2Explanations(gs, args.originForUninitialized)));
                     e.addErrorSection(actualType.explainGot(gs, args.originForUninitialized));
 
                     if (args.fullType.origins.size() == 1 &&

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2319,7 +2319,7 @@ optional<size_t> indexForKey(const ShapeType &shape, const LiteralType &argLit) 
     if (fnd == shape.keys.end()) {
         return nullopt;
     } else {
-        return fnd - shape.keys.begin();
+        return std::distance(shape.keys.begin(), fnd);
     }
 }
 
@@ -2331,7 +2331,7 @@ optional<Loc> locOfValueForKey(const GlobalState &gs, const Loc origin, const Na
 
     // Unlike with normal `T.let` autocorrects, we don't have location information for "the value
     // for a specific key". To make up for this, we hard-code the most common pinning errors by
-    // scannign the source directly.
+    // scanning the source directly.
 
     const char *valueStr;
     if (ct.symbol == core::Symbols::NilClass()) {

--- a/test/cli/autocorrect-shape-square-brackets-eq/autocorrect-shape-square-brackets-eq.out
+++ b/test/cli/autocorrect-shape-square-brackets-eq/autocorrect-shape-square-brackets-eq.out
@@ -1,0 +1,71 @@
+autocorrect-shape-square-brackets-eq.rb:9: Expected `NilClass` but found `Integer(1)` for key `Symbol(:foo)` https://srb.help/7002
+     9 |xs[:foo] = 1
+                   ^
+  Shape initialized here:
+    autocorrect-shape-square-brackets-eq.rb:3:
+     3 |xs = {
+     4 |  foo: nil,
+     5 |  bar: false,
+     6 |  qux: true,
+     7 |}
+  Got `Integer(1)` originating from:
+    autocorrect-shape-square-brackets-eq.rb:9:
+     9 |xs[:foo] = 1
+                   ^
+  Autocorrect: Done
+    autocorrect-shape-square-brackets-eq.rb:4: Replaced with `T.let(nil, T.nilable(Integer))`
+     4 |  foo: nil,
+               ^^^
+
+autocorrect-shape-square-brackets-eq.rb:10: Expected `FalseClass` but found `TrueClass` for key `Symbol(:bar)` https://srb.help/7002
+    10 |xs[:bar] = true
+                   ^^^^
+  Shape initialized here:
+    autocorrect-shape-square-brackets-eq.rb:3:
+     3 |xs = {
+     4 |  foo: nil,
+     5 |  bar: false,
+     6 |  qux: true,
+     7 |}
+  Got `TrueClass` originating from:
+    autocorrect-shape-square-brackets-eq.rb:10:
+    10 |xs[:bar] = true
+                   ^^^^
+  Autocorrect: Done
+    autocorrect-shape-square-brackets-eq.rb:5: Replaced with `T.let(false, T::Boolean)`
+     5 |  bar: false,
+               ^^^^^
+
+autocorrect-shape-square-brackets-eq.rb:11: Expected `TrueClass` but found `FalseClass` for key `Symbol(:qux)` https://srb.help/7002
+    11 |xs[:qux] = false
+                   ^^^^^
+  Shape initialized here:
+    autocorrect-shape-square-brackets-eq.rb:3:
+     3 |xs = {
+     4 |  foo: nil,
+     5 |  bar: false,
+     6 |  qux: true,
+     7 |}
+  Got `FalseClass` originating from:
+    autocorrect-shape-square-brackets-eq.rb:11:
+    11 |xs[:qux] = false
+                   ^^^^^
+  Autocorrect: Done
+    autocorrect-shape-square-brackets-eq.rb:6: Replaced with `T.let(true, T::Boolean)`
+     6 |  qux: true,
+               ^^^^
+Errors: 3
+
+--------------------------------------------------------------------------
+
+# typed: strict
+
+xs = {
+  foo: T.let(nil, T.nilable(Integer)),
+  bar: T.let(false, T::Boolean),
+  qux: T.let(true, T::Boolean),
+}
+
+xs[:foo] = 1
+xs[:bar] = true
+xs[:qux] = false

--- a/test/cli/autocorrect-shape-square-brackets-eq/autocorrect-shape-square-brackets-eq.out
+++ b/test/cli/autocorrect-shape-square-brackets-eq/autocorrect-shape-square-brackets-eq.out
@@ -54,7 +54,93 @@ autocorrect-shape-square-brackets-eq.rb:11: Expected `TrueClass` but found `Fals
     autocorrect-shape-square-brackets-eq.rb:6: Replaced with `T.let(true, T::Boolean)`
      6 |  qux: true,
                ^^^^
-Errors: 3
+
+autocorrect-shape-square-brackets-eq.rb:17: Expected `[]` but found `T::Array[Integer]` for key `Symbol(:first)` https://srb.help/7002
+    17 |ys[:first] = T::Array[Integer].new
+                     ^^^^^^^^^^^^^^^^^^^^^
+  Shape initialized here:
+    autocorrect-shape-square-brackets-eq.rb:13:
+    13 |ys = {
+    14 |  first: [],
+    15 |  second: {},
+    16 |}
+  Got `T::Array[Integer]` originating from:
+    autocorrect-shape-square-brackets-eq.rb:17:
+    17 |ys[:first] = T::Array[Integer].new
+                     ^^^^^^^^^^^^^^^^^^^^^
+
+autocorrect-shape-square-brackets-eq.rb:18: Expected `{}` but found `T::Hash[Symbol, String]` for key `Symbol(:second)` https://srb.help/7002
+    18 |ys[:second] = T::Hash[Symbol, String].new
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Shape initialized here:
+    autocorrect-shape-square-brackets-eq.rb:13:
+    13 |ys = {
+    14 |  first: [],
+    15 |  second: {},
+    16 |}
+  Got `T::Hash[Symbol, String]` originating from:
+    autocorrect-shape-square-brackets-eq.rb:18:
+    18 |ys[:second] = T::Hash[Symbol, String].new
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+autocorrect-shape-square-brackets-eq.rb:24: Expected `FalseClass` but found `TrueClass` for key `String("foo")` https://srb.help/7002
+    24 |zs['foo'] = true
+                    ^^^^
+  Shape initialized here:
+    autocorrect-shape-square-brackets-eq.rb:20:
+    20 |zs = {
+    21 |  'foo' => false,
+    22 |  :bar => false,
+    23 |}
+  Got `TrueClass` originating from:
+    autocorrect-shape-square-brackets-eq.rb:24:
+    24 |zs['foo'] = true
+                    ^^^^
+
+autocorrect-shape-square-brackets-eq.rb:25: Expected `FalseClass` but found `TrueClass` for key `Symbol(:bar)` https://srb.help/7002
+    25 |zs[:bar] = true
+                   ^^^^
+  Shape initialized here:
+    autocorrect-shape-square-brackets-eq.rb:20:
+    20 |zs = {
+    21 |  'foo' => false,
+    22 |  :bar => false,
+    23 |}
+  Got `TrueClass` originating from:
+    autocorrect-shape-square-brackets-eq.rb:25:
+    25 |zs[:bar] = true
+                   ^^^^
+
+autocorrect-shape-square-brackets-eq.rb:30: Expected `NilClass` but found `Integer(1)` for key `Symbol(:foo)` https://srb.help/7002
+    30 |spacing_is_important[:foo] = 1
+                                     ^
+  Shape initialized here:
+    autocorrect-shape-square-brackets-eq.rb:27:
+    27 |spacing_is_important = {
+    28 |  foo:nil,
+    29 |}
+  Got `Integer(1)` originating from:
+    autocorrect-shape-square-brackets-eq.rb:30:
+    30 |spacing_is_important[:foo] = 1
+                                     ^
+
+autocorrect-shape-square-brackets-eq.rb:41: Expected `T.nilable(FalseClass)` but found `TrueClass` for key `Symbol(:foo)` https://srb.help/7002
+    41 |initialized_twice[:foo] = true
+                                  ^^^^
+  Shape initialized here:
+    autocorrect-shape-square-brackets-eq.rb:33:
+    33 |  initialized_twice = {
+    34 |    foo: nil,
+    35 |  }
+    autocorrect-shape-square-brackets-eq.rb:37:
+    37 |  initialized_twice = {
+    38 |    foo: false,
+    39 |  }
+  Got `TrueClass` originating from:
+    autocorrect-shape-square-brackets-eq.rb:41:
+    41 |initialized_twice[:foo] = true
+                                  ^^^^
+Errors: 9
 
 --------------------------------------------------------------------------
 
@@ -69,3 +155,33 @@ xs = {
 xs[:foo] = 1
 xs[:bar] = true
 xs[:qux] = false
+
+ys = {
+  first: [],
+  second: {},
+}
+ys[:first] = T::Array[Integer].new
+ys[:second] = T::Hash[Symbol, String].new
+
+zs = {
+  'foo' => false,
+  :bar => false,
+}
+zs['foo'] = true
+zs[:bar] = true
+
+spacing_is_important = {
+  foo:nil,
+}
+spacing_is_important[:foo] = 1
+
+if T.unsafe(nil)
+  initialized_twice = {
+    foo: nil,
+  }
+else
+  initialized_twice = {
+    foo: false,
+  }
+end
+initialized_twice[:foo] = true

--- a/test/cli/autocorrect-shape-square-brackets-eq/autocorrect-shape-square-brackets-eq.out
+++ b/test/cli/autocorrect-shape-square-brackets-eq/autocorrect-shape-square-brackets-eq.out
@@ -140,7 +140,25 @@ autocorrect-shape-square-brackets-eq.rb:41: Expected `T.nilable(FalseClass)` but
     autocorrect-shape-square-brackets-eq.rb:41:
     41 |initialized_twice[:foo] = true
                                   ^^^^
-Errors: 9
+
+autocorrect-shape-square-brackets-eq.rb:48: Expected `NilClass` but found `Integer(1)` for key `Symbol(:suffix)` https://srb.help/7002
+    48 |ws[:suffix] = 1
+                      ^
+  Shape originates from here:
+    autocorrect-shape-square-brackets-eq.rb:44:
+    44 |ws = {
+    45 |  another_key_with_suffix: nil,
+    46 |  suffix: nil,
+    47 |}
+  Got `Integer(1)` originating from:
+    autocorrect-shape-square-brackets-eq.rb:48:
+    48 |ws[:suffix] = 1
+                      ^
+  Autocorrect: Done
+    autocorrect-shape-square-brackets-eq.rb:45: Replaced with `T.let(nil, T.nilable(Integer))`
+    45 |  another_key_with_suffix: nil,
+                                   ^^^
+Errors: 10
 
 --------------------------------------------------------------------------
 
@@ -185,3 +203,10 @@ else
   }
 end
 initialized_twice[:foo] = true
+
+# This one currently picks the wrong key, because the heuristic is naive.
+ws = {
+  another_key_with_suffix: T.let(nil, T.nilable(Integer)),
+  suffix: nil,
+}
+ws[:suffix] = 1

--- a/test/cli/autocorrect-shape-square-brackets-eq/autocorrect-shape-square-brackets-eq.out
+++ b/test/cli/autocorrect-shape-square-brackets-eq/autocorrect-shape-square-brackets-eq.out
@@ -1,7 +1,7 @@
 autocorrect-shape-square-brackets-eq.rb:9: Expected `NilClass` but found `Integer(1)` for key `Symbol(:foo)` https://srb.help/7002
      9 |xs[:foo] = 1
                    ^
-  Shape initialized here:
+  Shape originates from here:
     autocorrect-shape-square-brackets-eq.rb:3:
      3 |xs = {
      4 |  foo: nil,
@@ -20,7 +20,7 @@ autocorrect-shape-square-brackets-eq.rb:9: Expected `NilClass` but found `Intege
 autocorrect-shape-square-brackets-eq.rb:10: Expected `FalseClass` but found `TrueClass` for key `Symbol(:bar)` https://srb.help/7002
     10 |xs[:bar] = true
                    ^^^^
-  Shape initialized here:
+  Shape originates from here:
     autocorrect-shape-square-brackets-eq.rb:3:
      3 |xs = {
      4 |  foo: nil,
@@ -39,7 +39,7 @@ autocorrect-shape-square-brackets-eq.rb:10: Expected `FalseClass` but found `Tru
 autocorrect-shape-square-brackets-eq.rb:11: Expected `TrueClass` but found `FalseClass` for key `Symbol(:qux)` https://srb.help/7002
     11 |xs[:qux] = false
                    ^^^^^
-  Shape initialized here:
+  Shape originates from here:
     autocorrect-shape-square-brackets-eq.rb:3:
      3 |xs = {
      4 |  foo: nil,
@@ -58,7 +58,7 @@ autocorrect-shape-square-brackets-eq.rb:11: Expected `TrueClass` but found `Fals
 autocorrect-shape-square-brackets-eq.rb:17: Expected `[]` but found `T::Array[Integer]` for key `Symbol(:first)` https://srb.help/7002
     17 |ys[:first] = T::Array[Integer].new
                      ^^^^^^^^^^^^^^^^^^^^^
-  Shape initialized here:
+  Shape originates from here:
     autocorrect-shape-square-brackets-eq.rb:13:
     13 |ys = {
     14 |  first: [],
@@ -72,7 +72,7 @@ autocorrect-shape-square-brackets-eq.rb:17: Expected `[]` but found `T::Array[In
 autocorrect-shape-square-brackets-eq.rb:18: Expected `{}` but found `T::Hash[Symbol, String]` for key `Symbol(:second)` https://srb.help/7002
     18 |ys[:second] = T::Hash[Symbol, String].new
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Shape initialized here:
+  Shape originates from here:
     autocorrect-shape-square-brackets-eq.rb:13:
     13 |ys = {
     14 |  first: [],
@@ -86,7 +86,7 @@ autocorrect-shape-square-brackets-eq.rb:18: Expected `{}` but found `T::Hash[Sym
 autocorrect-shape-square-brackets-eq.rb:24: Expected `FalseClass` but found `TrueClass` for key `String("foo")` https://srb.help/7002
     24 |zs['foo'] = true
                     ^^^^
-  Shape initialized here:
+  Shape originates from here:
     autocorrect-shape-square-brackets-eq.rb:20:
     20 |zs = {
     21 |  'foo' => false,
@@ -100,7 +100,7 @@ autocorrect-shape-square-brackets-eq.rb:24: Expected `FalseClass` but found `Tru
 autocorrect-shape-square-brackets-eq.rb:25: Expected `FalseClass` but found `TrueClass` for key `Symbol(:bar)` https://srb.help/7002
     25 |zs[:bar] = true
                    ^^^^
-  Shape initialized here:
+  Shape originates from here:
     autocorrect-shape-square-brackets-eq.rb:20:
     20 |zs = {
     21 |  'foo' => false,
@@ -114,7 +114,7 @@ autocorrect-shape-square-brackets-eq.rb:25: Expected `FalseClass` but found `Tru
 autocorrect-shape-square-brackets-eq.rb:30: Expected `NilClass` but found `Integer(1)` for key `Symbol(:foo)` https://srb.help/7002
     30 |spacing_is_important[:foo] = 1
                                      ^
-  Shape initialized here:
+  Shape originates from here:
     autocorrect-shape-square-brackets-eq.rb:27:
     27 |spacing_is_important = {
     28 |  foo:nil,
@@ -127,7 +127,7 @@ autocorrect-shape-square-brackets-eq.rb:30: Expected `NilClass` but found `Integ
 autocorrect-shape-square-brackets-eq.rb:41: Expected `T.nilable(FalseClass)` but found `TrueClass` for key `Symbol(:foo)` https://srb.help/7002
     41 |initialized_twice[:foo] = true
                                   ^^^^
-  Shape initialized here:
+  Shape originates from here:
     autocorrect-shape-square-brackets-eq.rb:33:
     33 |  initialized_twice = {
     34 |    foo: nil,

--- a/test/cli/autocorrect-shape-square-brackets-eq/autocorrect-shape-square-brackets-eq.rb
+++ b/test/cli/autocorrect-shape-square-brackets-eq/autocorrect-shape-square-brackets-eq.rb
@@ -1,0 +1,11 @@
+# typed: strict
+
+xs = {
+  foo: nil,
+  bar: false,
+  qux: true,
+}
+
+xs[:foo] = 1
+xs[:bar] = true
+xs[:qux] = false

--- a/test/cli/autocorrect-shape-square-brackets-eq/autocorrect-shape-square-brackets-eq.rb
+++ b/test/cli/autocorrect-shape-square-brackets-eq/autocorrect-shape-square-brackets-eq.rb
@@ -9,3 +9,33 @@ xs = {
 xs[:foo] = 1
 xs[:bar] = true
 xs[:qux] = false
+
+ys = {
+  first: [],
+  second: {},
+}
+ys[:first] = T::Array[Integer].new
+ys[:second] = T::Hash[Symbol, String].new
+
+zs = {
+  'foo' => false,
+  :bar => false,
+}
+zs['foo'] = true
+zs[:bar] = true
+
+spacing_is_important = {
+  foo:nil,
+}
+spacing_is_important[:foo] = 1
+
+if T.unsafe(nil)
+  initialized_twice = {
+    foo: nil,
+  }
+else
+  initialized_twice = {
+    foo: false,
+  }
+end
+initialized_twice[:foo] = true

--- a/test/cli/autocorrect-shape-square-brackets-eq/autocorrect-shape-square-brackets-eq.rb
+++ b/test/cli/autocorrect-shape-square-brackets-eq/autocorrect-shape-square-brackets-eq.rb
@@ -39,3 +39,10 @@ else
   }
 end
 initialized_twice[:foo] = true
+
+# This one currently picks the wrong key, because the heuristic is naive.
+ws = {
+  another_key_with_suffix: nil,
+  suffix: nil,
+}
+ws[:suffix] = 1

--- a/test/cli/autocorrect-shape-square-brackets-eq/autocorrect-shape-square-brackets-eq.sh
+++ b/test/cli/autocorrect-shape-square-brackets-eq/autocorrect-shape-square-brackets-eq.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+tmp="$(mktemp -d)"
+infile="test/cli/autocorrect-shape-square-brackets-eq/autocorrect-shape-square-brackets-eq.rb"
+cp "$infile" "$tmp"
+
+cwd="$(pwd)"
+cd "$tmp" || exit 1
+
+if "$cwd/main/sorbet" --silence-dev-message -a autocorrect-shape-square-brackets-eq.rb 2>&1; then
+  echo "Expected to fail, but didn't"
+  exit 1
+fi
+
+echo
+echo --------------------------------------------------------------------------
+echo
+
+# Also cat the file, to make sure that 'extend' is only added once per class.
+cat autocorrect-shape-square-brackets-eq.rb
+
+rm autocorrect-shape-square-brackets-eq.rb
+rm "$tmp"

--- a/test/testdata/infer/shape_square_brackets.rb
+++ b/test/testdata/infer/shape_square_brackets.rb
@@ -20,6 +20,9 @@ def test2(x)
   opts[:foo] = 'world'
   # This type is wrong, because the key `foo:` is now `String("world")`, but that's no worse than normal pinned variables
   T.reveal_type(opts) # error: Revealed type: `{foo: String("hello")} (shape of T::Hash[T.untyped, T.untyped])`
+
+  # Non-literal type for key
+  opts[String.new] = 0
 end
 
 sig {params(x: {foo: Integer, 'bar' => Float}).void}

--- a/test/testdata/infer/shape_square_brackets.rb
+++ b/test/testdata/infer/shape_square_brackets.rb
@@ -1,0 +1,24 @@
+# typed: true
+
+extend T::Sig
+
+sig {params(x: {foo: Integer}).void}
+def test2(x)
+  x[:foo] = 1
+  x[:foo] = '' # error:
+
+  # Likewise, neither of these report errors, for backwards compatibility
+  x[:bar] = 1
+  x[:bar] = ''
+end
+
+sig {params(x: {foo: Integer, 'bar' => Float}).void}
+def test3(x)
+  # could make this better, e.g.: only allow setting to `Integer`
+  x[:foo] = 0.0
+  # ... especially because the type remains the same as before:
+  T.reveal_type(x[:foo]) # error: Revealed type: `Integer`
+
+  # This might end up being too restrictive.  This used to not error at all.
+  x[true] = nil # error: Expected `T.any(Integer, Float)` but found `NilClass` for argument `arg1`
+end

--- a/test/testdata/infer/shape_square_brackets.rb
+++ b/test/testdata/infer/shape_square_brackets.rb
@@ -11,6 +11,15 @@ def test2(x)
   # We should work to make this stricter.
   x[:bar] = 1
   x[:bar] = ''
+
+  # Re-assigning a literal type doesn't need to be pinned, by analogy with normal pinned variables.
+  opts = {
+    foo: 'hello'
+  }
+  T.reveal_type(opts) # error: Revealed type: `{foo: String("hello")} (shape of T::Hash[T.untyped, T.untyped])`
+  opts[:foo] = 'world'
+  # This type is wrong, because the key `foo:` is now `String("world")`, but that's no worse than normal pinned variables
+  T.reveal_type(opts) # error: Revealed type: `{foo: String("hello")} (shape of T::Hash[T.untyped, T.untyped])`
 end
 
 sig {params(x: {foo: Integer, 'bar' => Float}).void}

--- a/test/testdata/infer/shape_square_brackets.rb
+++ b/test/testdata/infer/shape_square_brackets.rb
@@ -5,20 +5,19 @@ extend T::Sig
 sig {params(x: {foo: Integer}).void}
 def test2(x)
   x[:foo] = 1
-  x[:foo] = '' # error:
+  x[:foo] = '' # error: Expected `Integer` but found `String("")` for key `Symbol(:foo)`
 
   # Likewise, neither of these report errors, for backwards compatibility
+  # We should work to make this stricter.
   x[:bar] = 1
   x[:bar] = ''
 end
 
 sig {params(x: {foo: Integer, 'bar' => Float}).void}
 def test3(x)
-  # could make this better, e.g.: only allow setting to `Integer`
-  x[:foo] = 0.0
-  # ... especially because the type remains the same as before:
-  T.reveal_type(x[:foo]) # error: Revealed type: `Integer`
+  x[:foo] = '' # error: Expected `Integer` but found `String("")` for key `Symbol(:foo)`
+  T.reveal_type(x[:foo]) # error: Revealed type: `T.untyped`
 
-  # This might end up being too restrictive.  This used to not error at all.
-  x[true] = nil # error: Expected `T.any(Integer, Float)` but found `NilClass` for argument `arg1`
+  # This won't error until we change the `underlying` on Shape types to be stricter
+  x[true] = nil
 end

--- a/test/testdata/infer/super_strict_shapes.rb
+++ b/test/testdata/infer/super_strict_shapes.rb
@@ -1,0 +1,84 @@
+# typed: strict
+
+extend T::Sig
+
+xs = {
+  foo: T.let(nil, T.nilable(Integer)),
+  bar: nil,
+}
+
+T.reveal_type(xs) # error: Revealed type: `{foo: T.nilable(Integer), bar: NilClass} (shape of T::Hash[T.untyped, T.untyped])`
+
+xs[:foo] = 1
+xs[:bar] = 1 # error: Expected `NilClass` but found `Integer(1)` for key `Symbol(:bar)`
+xs[:qux]
+
+options = {
+  enable_foo: T.let(false, T::Boolean),
+  enable_bar: T.let(false, T::Boolean),
+  enable_qux: false,
+}
+
+T.reveal_type(options) # error: Revealed type: `{enable_foo: T::Boolean, enable_bar: T::Boolean, enable_qux: FalseClass} (shape of T::Hash[T.untyped, T.untyped])`
+
+ARGV.each do |arg|
+  case arg
+  when 'enable_foo' then options[:enable_foo] = true
+  when 'enable_bar' then options[:enable_bar] = true
+  when 'enable_qux' then options[:enable_qux] = true # error: Expected `FalseClass` but found `TrueClass` for key `Symbol(:enable_qux)`
+  end
+end
+
+T.reveal_type(options) # error: Revealed type: `{enable_foo: T::Boolean, enable_bar: T::Boolean, enable_qux: FalseClass} (shape of T::Hash[T.untyped, T.untyped])`
+
+# These merge algorithms more or less assume exact shape types.
+#
+# Otherwise, if you were assuming inexact, you'd have to widen the keys of the
+# first shape (like `:one` and `:three`) because if the second shape is
+# inexact, you don't know that it doesn't also have a `:one` or `:three` key
+# with a completely unrelated type.
+
+evens = {
+  one: 1,
+  three: 3,
+}
+odds = {
+  two: 2,
+  four: 4,
+}
+T.reveal_type(evens.merge(odds)) # error: Revealed type: `{one: Integer(1), three: Integer(3), two: Integer(2), four: Integer(4)} (shape of T::Hash[T.untyped, T.untyped])`
+
+# Looks like our Shape_merge intrinsic hardcodes one positional argument
+T.reveal_type({}.merge(evens, odds)) # error: Revealed type: `{} (shape of T::Hash[T.untyped, T.untyped])`
+
+one_three = {
+  one: 1,
+  three: 3,
+}
+three_five = {
+  three: '3',
+  five: '5',
+}
+T.reveal_type(one_three.merge(three_five)) # error: Revealed type: `{one: Integer(1), three: String("3"), five: String("5")} (shape of T::Hash[T.untyped, T.untyped])`
+
+# Fixes https://github.com/sorbet/sorbet/issues/3751
+sig {params(xs: T::Array[Integer]).void}
+def test1(xs = [])
+  T.reveal_type(xs) # error: Revealed type: `T::Array[Integer]`
+end
+
+sig {params(x: T::Array[String]).void}
+def test2(x)
+  x = []
+  T.reveal_type(x) # error: Revealed type: `[] (0-tuple)`
+
+  if T.unsafe(nil)
+    y = []
+    z = T::Array[Integer].new
+  else
+    y = T::Array[Integer].new
+    z = []
+  end
+  T.reveal_type(y) # error: Revealed type: `T::Array[Integer]`
+  T.reveal_type(z) # error: Revealed type: `T::Array[Integer]`
+end


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Better typing for shape types.

Some notes:

- This only caused about ~200 errors on Stripe's codebase, about ~170 of which were fixed immediately by the included autocorrect.
- I suspect (haven't confirmed yet) that landing an intrinsic for `[]=` before `[]` on shapes will significantly reduce the pain of rolling out an intrinsic for `[]`.

  Why? Because this PR will find places where sorbet was inferring `{foo: NilClass}` for `{foo: nil}` when it should have inferred something like `{foo: T.nilable(String)}`.
  
  A lot of the initial errors when I did it the other way were spurious dead code errors or type errors of this sort.

- The work in #3876 introduced a `TypeAndOrigins` data structure for the receiver.

  In addition to the immediate benefit in that PR (better "method does not exist" errors), it is the crucial piece that powers better error messages and enables an autocorrect in the first place for this change.

- This PR is based off of #3902, which adds a convenient helper for generating "Got {} originating from:" error sections.

Overall, I think that even if we did no more work on shape types, this would improve the state of the world, and thus we should merge it.

I have further plans to improve other parts of shape types, but this change's value stands on its own.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.