### PR TITLE
WIP: Add timers to resolveConstants to track how much time we spend merging and sorting vectors

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -863,6 +863,7 @@ public:
         vector<ClassMethodsResolutionItem> todoClassMethods;
 
         {
+            Timer timeit1(gs.tracer(), "resolver.resolve_constants.parallel_phase");
             ResolveWalkResult threadResult;
             for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer());
                  !result.done();
@@ -887,24 +888,27 @@ public:
             }
         }
 
-        fast_sort(todo, [](const auto &lhs, const auto &rhs) -> bool {
-            return locCompare(core::Loc(lhs.file, lhs.out->loc), core::Loc(rhs.file, rhs.out->loc));
-        });
-        fast_sort(todoAncestors, [](const auto &lhs, const auto &rhs) -> bool {
-            return locCompare(core::Loc(lhs.file, lhs.ancestor->loc), core::Loc(rhs.file, rhs.ancestor->loc));
-        });
-        fast_sort(todoClassAliases, [](const auto &lhs, const auto &rhs) -> bool {
-            return locCompare(core::Loc(lhs.file, lhs.rhs->loc), core::Loc(rhs.file, rhs.rhs->loc));
-        });
-        fast_sort(todoTypeAliases, [](const auto &lhs, const auto &rhs) -> bool {
-            return locCompare(core::Loc(lhs.file, (*lhs.rhs).loc()), core::Loc(rhs.file, (*rhs.rhs).loc()));
-        });
-        fast_sort(todoClassMethods, [](const auto &lhs, const auto &rhs) -> bool {
-            return locCompare(core::Loc(lhs.file, lhs.send->loc), core::Loc(rhs.file, rhs.send->loc));
-        });
-        fast_sort(trees, [](const auto &lhs, const auto &rhs) -> bool {
-            return locCompare(core::Loc(lhs.file, lhs.tree.loc()), core::Loc(rhs.file, rhs.tree.loc()));
-        });
+        {
+            Timer timeit1(gs.tracer(), "resolver.resolve_constants.sorting");
+            fast_sort(todo, [](const auto &lhs, const auto &rhs) -> bool {
+                return locCompare(core::Loc(lhs.file, lhs.out->loc), core::Loc(rhs.file, rhs.out->loc));
+            });
+            fast_sort(todoAncestors, [](const auto &lhs, const auto &rhs) -> bool {
+                return locCompare(core::Loc(lhs.file, lhs.ancestor->loc), core::Loc(rhs.file, rhs.ancestor->loc));
+            });
+            fast_sort(todoClassAliases, [](const auto &lhs, const auto &rhs) -> bool {
+                return locCompare(core::Loc(lhs.file, lhs.rhs->loc), core::Loc(rhs.file, rhs.rhs->loc));
+            });
+            fast_sort(todoTypeAliases, [](const auto &lhs, const auto &rhs) -> bool {
+                return locCompare(core::Loc(lhs.file, (*lhs.rhs).loc()), core::Loc(rhs.file, (*rhs.rhs).loc()));
+            });
+            fast_sort(todoClassMethods, [](const auto &lhs, const auto &rhs) -> bool {
+                return locCompare(core::Loc(lhs.file, lhs.send->loc), core::Loc(rhs.file, rhs.send->loc));
+            });
+            fast_sort(trees, [](const auto &lhs, const auto &rhs) -> bool {
+                return locCompare(core::Loc(lhs.file, lhs.tree.loc()), core::Loc(rhs.file, rhs.tree.loc()));
+            });
+        }
 
         Timer timeit1(gs.tracer(), "resolver.resolve_constants.fixed_point");
 


### PR DESCRIPTION
Add timers to resolveConstants to track how much time we spend merging and sorting vectors.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In Stripe's codebase, there is a gap between when the parallel threads finish processing files and the serial phase of resolve_constants begins. I do not know if this is attributable to sorting or insertion overhead.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Does not change behavior.
