### PR TITLE
Fix sysread sig

### DIFF
--- a/rbi/core/io.rbi
+++ b/rbi/core/io.rbi
@@ -1621,7 +1621,7 @@ class IO < Object
     )
     .returns(String)
   end
-  def sysread(maxlen, outbuf); end
+  def sysread(maxlen, outbuf=T.unsafe(nil)); end
 
   # Seeks to a given *offset* in the stream according to the value of *whence*
   # (see `IO#seek` for values of *whence*). Returns the new offset into the


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Documentation says:
> If the optional *outbuf* argument is present, it must reference a

so make the 2nd outbuf param optional


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Existing code that does `some_file.sysread(8)` is failing typecheck

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
Only change is to rbi
