### PR TITLE
Fix Sorbet LSP tree copying crash in large codebases.

### DIFF
--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -236,14 +236,14 @@ LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit) {
 
     // Index changes in initialGS. pipeline::index sorts output by file id, but we need to reorder to match the order of
     // other fields.
-    UnorderedMap<u2, int> fileToPos;
+    UnorderedMap<core::FileRef, int> fileToPos;
     {
         int i = -1;
         for (auto fref : frefs) {
             // We should have ensured before reaching here that there are no duplicates.
-            ENFORCE(!fileToPos.contains(fref.id()));
+            ENFORCE(!fileToPos.contains(fref));
             i++;
-            fileToPos[fref.id()] = i;
+            fileToPos[fref] = i;
         }
     }
 
@@ -257,7 +257,7 @@ LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit) {
         auto trees = pipeline::index(initialGS, frefs, config->opts, *emptyWorkers, kvstore);
         update.updatedFileIndexes.resize(trees.size());
         for (auto &ast : trees) {
-            const int i = fileToPos[ast.file.id()];
+            const int i = fileToPos[ast.file];
             update.updatedFileIndexes[i] = move(ast);
         }
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Fix Sorbet LSP tree copying crash in large codebases.

core::FileRef ids are u4s now.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes a crash.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Not possible to easily test w/o a super large input to Sorbet.
