### PR TITLE
Fix return type for Array#zip when more than 1 arguments are passed

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -355,10 +355,11 @@ NameDef names[] = {
     // Enumerable#flat_map has special-case logic in Infer
     {"flatMap", "flat_map"},
 
-    // Array#flatten, #product and #compact are also custom-implemented
+    // Array#flatten, #product, #compact and #zip are also custom-implemented
     {"flatten"},
     {"product"},
     {"compact"},
+    {"zip"},
 
     // Pattern matching
     {"patternMatch", "<pattern-match>"},

--- a/test/testdata/intrinsics/zip.rb
+++ b/test/testdata/intrinsics/zip.rb
@@ -1,0 +1,3 @@
+# typed: true
+s = [1].zip([2], [3])
+T.reveal_type(s) # error: Revealed type: `T::Array[[Integer, T.nilable(Integer), T.nilable(Integer)]]`


### PR DESCRIPTION
Used the "intrinsic method" approach instead of modifying RBIs based on this comment from the linked issue:

> Removing RBI label as this will have to be intrinsified

This is based on the [existing Array#product](https://github.com/sorbet/sorbet/blob/8eb243fd44f5260a985aacad38b12b4ea6a1bc40/core/types/calls.cc#L2461) intrinsic method code. I'm still getting familiar with the codebase so there are a few details that aren't fully clear to me yet, such as why `{AppliedType, TupleType}` is the full set of types to check for here. Any pointers around this area are appreciated.

### Motivation

Fixes https://github.com/sorbet/sorbet/issues/3411

### Test plan

See included automated tests.