### PR TITLE
Support T.proc.bind when block is nilable

### DIFF
--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -464,21 +464,23 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
     return sig;
 }
 
-core::TypePtr interpretTCombinator(core::Context ctx, const ast::Send &send, const ParsedSig &sig,
-                                   TypeSyntaxArgs args) {
+TypeSyntax::ResultType interpretTCombinator(core::Context ctx, const ast::Send &send, const ParsedSig &sig,
+                                            TypeSyntaxArgs args) {
     switch (send.fun.rawId()) {
         case core::Names::nilable().rawId():
             if (send.numPosArgs != 1 || send.hasKwArgs()) {
-                return core::Types::untypedUntracked(); // error will be reported in infer.
+                return {.type = core::Types::untypedUntracked()}; // error will be reported in infer.
             }
-            return core::Types::any(ctx,
-                                    getResultTypeAndBindWithSelfTypeParams(ctx, send.args[0], sig,
-                                        isNilableTProc(ctx, &send) ? args.withRebind() : args.withoutRebind()).type,
-                                    core::Types::nilClass());
+            if (isNilableTProc(ctx, &send)) {
+                auto tproc = getResultTypeAndBindWithSelfTypeParams(ctx, send.args[0], sig, args.withRebind());
+                return {.type = core::Types::any(ctx, tproc.type, core::Types::nilClass()), .rebind = tproc.rebind};
+            }
+            return {.type = core::Types::any(ctx, getResultTypeWithSelfTypeParams(ctx, send.args[0], sig, args),
+                                             core::Types::nilClass())};
         case core::Names::all().rawId(): {
             if (send.args.empty()) {
                 // Error will be reported in infer
-                return core::Types::untypedUntracked();
+                return {.type = core::Types::untypedUntracked()};
             }
             auto result = getResultTypeWithSelfTypeParams(ctx, send.args[0], sig, args);
             int i = 1;
@@ -486,12 +488,12 @@ core::TypePtr interpretTCombinator(core::Context ctx, const ast::Send &send, con
                 result = core::Types::all(ctx, result, getResultTypeWithSelfTypeParams(ctx, send.args[i], sig, args));
                 i++;
             }
-            return result;
+            return {.type = result};
         }
         case core::Names::any().rawId(): {
             if (send.args.empty()) {
                 // Error will be reported in infer
-                return core::Types::untypedUntracked();
+                return {.type = core::Types::untypedUntracked()};
             }
             auto result = getResultTypeWithSelfTypeParams(ctx, send.args[0], sig, args);
             int i = 1;
@@ -499,48 +501,48 @@ core::TypePtr interpretTCombinator(core::Context ctx, const ast::Send &send, con
                 result = core::Types::any(ctx, result, getResultTypeWithSelfTypeParams(ctx, send.args[i], sig, args));
                 i++;
             }
-            return result;
+            return {.type = result};
         }
         case core::Names::typeParameter().rawId(): {
             if (send.args.size() != 1) {
                 // Error will be reported in infer
-                return core::Types::untypedUntracked();
+                return {.type = core::Types::untypedUntracked()};
             }
             auto arr = ast::cast_tree<ast::Literal>(send.args[0]);
             if (!arr || !arr->isSymbol(ctx)) {
                 if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("type_parameter requires a symbol");
                 }
-                return core::Types::untypedUntracked();
+                return {.type = core::Types::untypedUntracked()};
             }
             auto fnd = sig.findTypeArgByName(arr->asSymbol(ctx));
             if (!fnd.type) {
                 if (auto e = ctx.beginError(arr->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("Unspecified type parameter");
                 }
-                return core::Types::untypedUntracked();
+                return {.type = core::Types::untypedUntracked()};
             }
-            return fnd.type;
+            return {.type = fnd.type};
         }
         case core::Names::enum_().rawId(): {
             if (send.args.size() != 1) {
                 // Error will be reported in infer
-                return core::Types::untypedUntracked();
+                return {.type = core::Types::untypedUntracked()};
             }
             auto arr = ast::cast_tree<ast::Array>(send.args[0]);
             if (arr == nullptr) {
                 // TODO(pay-server) unsilence this error and support enums from pay-server
-                { return core::Types::Object(); }
+                { return {.type = core::Types::Object()}; }
                 if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("enum must be passed a literal array. e.g. enum([1,\"foo\",MyClass])");
                 }
-                return core::Types::untypedUntracked();
+                return {.type = core::Types::untypedUntracked()};
             }
             if (arr->elems.empty()) {
                 if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("enum([]) is invalid");
                 }
-                return core::Types::untypedUntracked();
+                return {.type = core::Types::untypedUntracked()};
             }
             auto result = getResultLiteral(ctx, arr->elems[0]);
             int i = 1;
@@ -548,12 +550,12 @@ core::TypePtr interpretTCombinator(core::Context ctx, const ast::Send &send, con
                 result = core::Types::any(ctx, result, getResultLiteral(ctx, arr->elems[i]));
                 i++;
             }
-            return result;
+            return {.type = result};
         }
         case core::Names::classOf().rawId(): {
             if (send.args.size() != 1) {
                 // Error will be reported in infer
-                return core::Types::untypedUntracked();
+                return {.type = core::Types::untypedUntracked()};
             }
 
             auto *obj = ast::cast_tree<ast::ConstantLit>(send.args[0]);
@@ -561,27 +563,27 @@ core::TypePtr interpretTCombinator(core::Context ctx, const ast::Send &send, con
                 if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("T.class_of needs a Class as its argument");
                 }
-                return core::Types::untypedUntracked();
+                return {.type = core::Types::untypedUntracked()};
             }
             auto maybeAliased = obj->symbol;
             if (maybeAliased.data(ctx)->isTypeAlias()) {
                 if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("T.class_of can't be used with a T.type_alias");
                 }
-                return core::Types::untypedUntracked();
+                return {.type = core::Types::untypedUntracked()};
             }
             if (maybeAliased.isTypeMember()) {
                 if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("T.class_of can't be used with a T.type_member");
                 }
-                return core::Types::untypedUntracked();
+                return {.type = core::Types::untypedUntracked()};
             }
             auto sym = maybeAliased.data(ctx)->dealias(ctx);
             if (sym.isStaticField(ctx)) {
                 if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("T.class_of can't be used with a constant field");
                 }
-                return core::Types::untypedUntracked();
+                return {.type = core::Types::untypedUntracked()};
             }
 
             auto singleton = sym.data(ctx)->lookupSingletonClass(ctx);
@@ -589,20 +591,20 @@ core::TypePtr interpretTCombinator(core::Context ctx, const ast::Send &send, con
                 if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("Unknown class");
                 }
-                return core::Types::untypedUntracked();
+                return {.type = core::Types::untypedUntracked()};
             }
-            return singleton.data(ctx)->externalType();
+            return {.type = singleton.data(ctx)->externalType()};
         }
         case core::Names::untyped().rawId():
-            return core::Types::untyped(ctx, args.untypedBlame);
+            return {.type = core::Types::untyped(ctx, args.untypedBlame)};
         case core::Names::selfType().rawId():
             if (args.allowSelfType) {
-                return core::make_type<core::SelfType>();
+                return {.type = core::make_type<core::SelfType>()};
             }
             if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                 e.setHeader("Only top-level T.self_type is supported");
             }
-            return core::Types::untypedUntracked();
+            return {.type = core::Types::untypedUntracked()};
         case core::Names::experimentalAttachedClass().rawId():
         case core::Names::attachedClass().rawId():
             if (send.fun == core::Names::experimentalAttachedClass()) {
@@ -618,21 +620,21 @@ core::TypePtr interpretTCombinator(core::Context ctx, const ast::Send &send, con
                     e.setHeader("`{}` may only be used in a singleton class method context",
                                 "T." + core::Names::attachedClass().show(ctx));
                 }
-                return core::Types::untypedUntracked();
+                return {.type = core::Types::untypedUntracked()};
             } else {
                 // All singletons have an AttachedClass type member, created by
                 // `singletonClass`
                 auto attachedClass = ctx.owner.data(ctx)->findMember(ctx, core::Names::Constants::AttachedClass());
-                return attachedClass.data(ctx)->resultType;
+                return {.type = attachedClass.data(ctx)->resultType};
             }
         case core::Names::noreturn().rawId():
-            return core::Types::bottom();
+            return {.type = core::Types::bottom()};
 
         default:
             if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                 e.setHeader("Unsupported method `{}`", "T." + send.fun.show(ctx));
             }
-            return core::Types::untypedUntracked();
+            return {.type = core::Types::untypedUntracked()};
     }
 }
 
@@ -879,10 +881,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
                 return;
             }
             if (recvi->symbol == core::Symbols::T()) {
-                result.type = interpretTCombinator(ctx, s, sigBeingParsed, args);
-                if (isNilableTProc(ctx, &s)) {
-                    result.rebind = getResultTypeAndBindWithSelfTypeParams(ctx, s.args[0], sigBeingParsed, args.withRebind()).rebind;
-                }
+                result = interpretTCombinator(ctx, s, sigBeingParsed, args);
                 return;
             }
 

--- a/test/testdata/resolver/proc_bind.rb
+++ b/test/testdata/resolver/proc_bind.rb
@@ -1,0 +1,34 @@
+# typed: true
+
+class TestProcBind
+  extend T::Sig
+
+  sig { params(blk: T.nilable(T.proc.bind(String).void)).void }
+  def nilable_bind(&blk)
+    0
+  end
+
+  sig { params(blk: T.proc.bind(String).void).void }
+  def bind(&blk)
+    0
+  end
+
+  sig { params(blk: T.nilable(T.proc.void)).void }
+  def nilable(&blk)
+    0
+  end
+end
+
+TestProcBind.new.nilable_bind
+
+TestProcBind.new.nilable_bind do
+  T.reveal_type(self) # error: Revealed type: `String`
+end
+
+TestProcBind.new.bind do
+  T.reveal_type(self) # error: Revealed type: `String`
+end
+
+TestProcBind.new.nilable do
+  T.reveal_type(self) # error: Revealed type: `T.class_of(<root>)`
+end

--- a/test/testdata/resolver/proc_bind.rb
+++ b/test/testdata/resolver/proc_bind.rb
@@ -17,6 +17,16 @@ class TestProcBind
   def nilable(&blk)
     0
   end
+
+  sig { params(blk: T.nilable(T.nilable(T.proc.void))).void }
+  def double_nilable(&blk)
+    0
+  end
+
+  sig { params(blk: T.nilable(T.nilable(T.proc.bind(String).void))).void }
+  def double_nilable_bind(&blk)
+    0
+  end
 end
 
 TestProcBind.new.nilable_bind
@@ -31,4 +41,12 @@ end
 
 TestProcBind.new.nilable do
   T.reveal_type(self) # error: Revealed type: `T.class_of(<root>)`
+end
+
+TestProcBind.new.double_nilable do
+  T.reveal_type(self) # error: Revealed type: `T.class_of(<root>)`
+end
+
+TestProcBind.new.double_nilable_bind do
+  T.reveal_type(self) # error: Revealed type: `String`
 end


### PR DESCRIPTION
Attempting to specify a binding for a nilable block currently results in an error in the resolver stage. The reason for this appears to be that a bare `T.proc` is resolved w/ rebinding enabled, while all other `T.*` uses are resolved without. There is a method, `isTProc`, that is used to identify the former case; all others are passed to `interpretTCombinator`, which attempts to resolve using recursive calls back into the outer resolver. These recursive calls do not support rebinding and I believe this is why it is not currently possible to specify a binding when using a nilable T.proc.

This patch adds a companion helper function, `isNilableTProc`, and uses it to branch interpretTCombinator logic so that nilable T.procs allow rebinding. I don't believe that we can simply add nilable T procs to the current `isTProc` block because the resolver needs to bind the outer type -- the T.nilable -- not the inner type -- the T.proc. But I'm happy for feedback on this.

There are 2 commits included, each solving this problem in a different way. The first commit is a less intrusive change that identifies nilable procs prior to calling interpretTCombinator. It does not modify interpretTCombinator but instead adds a binding after receiving the type from the current implementation. The downside of this approach is that it needs to resolve the T.proc 2x and this causes some errors to be reported multiple times. To avoid 2x resolver calls here requires a bigger change, and that is implemented in the second commit. This commit changes the return type of `interpretTCombinator` from its current signature: returning a type only, to a new signature: return a full Result (a struct of type + binding). This change requires updating every return case and is a bit more intrusive. It's also uglier, and forgive me as I'm not a C++ expert!

Anywho, let me know if this approach makes sense, whether you think there's a better alternative here, and/or whether you'd prefer the commit 1 or commit 2 approach.

Happy trails, and thanks for all your work on this project!

### Motivation
Issue  #498 . Like other commenters on the issue, flexport uses graphql-ruby and would like to improve sorbet coverage. The use of nilable blocks for optional configuration is a common pattern in that and other libraries.

### Test plan
See included automated tests.