### PR TITLE
Small improvement to serde of T::Struct union props

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/private/serde_transform.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/serde_transform.rb
@@ -99,18 +99,21 @@ module T::Props
             else
               "#{varname}.nil? ? nil : #{inner}"
             end
-          elsif type.types.all? {|t| generate(t, mode, varname).nil?}
-            # Handle, e.g., T::Boolean
-            nil
           else
-            # We currently deep_clone_object if the type was T.any(Integer, Float).
-            # When we get better support for union types (maybe this specific
-            # union type, because it would be a replacement for
-            # Chalk::ODM::DeprecatedNumemric), we could opt to special case
-            # this union to have no specific serde transform (the only reason
-            # why Float has a special case is because round tripping through
-            # JSON might normalize Floats to Integers)
-            "T::Props::Utils.deep_clone_object(#{varname})"
+            inners = type.types.map {|t| generate(t, mode, varname)}.uniq
+            if inners.length <= 1
+              # Handle, e.g., T::Boolean
+              inners.first
+            else
+              # We currently deep_clone_object if the type was T.any(Integer, Float).
+              # When we get better support for union types (maybe this specific
+              # union type, because it would be a replacement for
+              # Chalk::ODM::DeprecatedNumemric), we could opt to special case
+              # this union to have no specific serde transform (the only reason
+              # why Float has a special case is because round tripping through
+              # JSON might normalize Floats to Integers)
+              "T::Props::Utils.deep_clone_object(#{varname})"
+            end
           end
         when T::Types::Intersection
           dynamic_fallback = "T::Props::Utils.deep_clone_object(#{varname})"

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -461,9 +461,10 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
   end
 
   describe 'unions of two different serializables' do
-    it 'are just cloned on serde' do
+    it 'are cloned on deser but not serialize' do
       obj = MyNilableSerializable.new
-      T::Props::Utils.expects(:deep_clone_object).with(obj).at_least_once.returns(obj)
+      T::Props::Utils.expects(:deep_clone_object).with(obj).never
+      T::Props::Utils.expects(:deep_clone_object).with(obj.serialize).returns(obj)
 
       s = MultipleStructUnionStruct.new(prop: obj)
       assert_equal(obj, MultipleStructUnionStruct.from_hash(s.serialize).prop)


### PR DESCRIPTION
Generalize the solution that avoids deep clone for `T::Boolean` to avoid deep clone for any union where all the inner types need the same treatment.

### Motivation
I was looking at this code to confirm that there's support for unions at all and noticed that it could be cleaned up a little.

### Test plan
Updated test (and the existing T::Boolean test covers the other case)
