### PR TITLE
constify ast::MK::isRootScope and use it in a few places

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -411,7 +411,7 @@ public:
         return ret;
     }
 
-    static bool isRootScope(ast::TreePtr &scope) {
+    static bool isRootScope(const ast::TreePtr &scope) {
         if (ast::isa_tree<ast::EmptyTree>(scope)) {
             return true;
         }

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -56,12 +56,7 @@ bool isT(const ast::TreePtr &expr) {
     if (t == nullptr || t->cnst != core::Names::Constants::T()) {
         return false;
     }
-    auto &scope = t->scope;
-    if (ast::isa_tree<ast::EmptyTree>(scope)) {
-        return true;
-    }
-    auto root = ast::cast_tree<ast::ConstantLit>(scope);
-    return root != nullptr && root->symbol == core::Symbols::root();
+    return ast::MK::isRootScope(t->scope);
 }
 
 bool isTNilableOrUntyped(const ast::TreePtr &expr) {

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -28,14 +28,7 @@ bool isCommand(core::MutableContext ctx, ast::ClassDef *klass) {
     if (scope->cnst != core::Names::Constants::Opus()) {
         return false;
     }
-    if (ast::isa_tree<ast::EmptyTree>(scope->scope)) {
-        return true;
-    }
-    auto *id = ast::cast_tree<ast::ConstantLit>(scope->scope);
-    if (id == nullptr) {
-        return false;
-    }
-    return id->symbol == core::Symbols::root();
+    return ast::MK::isRootScope(scope->scope);
 }
 
 void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -36,14 +36,7 @@ bool isTEnum(core::MutableContext ctx, ast::ClassDef *klass) {
     if (scope->cnst != core::Names::Constants::T()) {
         return false;
     }
-    if (ast::isa_tree<ast::EmptyTree>(scope->scope)) {
-        return true;
-    }
-    auto *id = ast::cast_tree<ast::ConstantLit>(scope->scope);
-    if (id == nullptr) {
-        return false;
-    }
-    return id->symbol == core::Symbols::root();
+    return ast::MK::isRootScope(scope->scope);
 }
 
 ast::Send *asEnumsDo(ast::TreePtr &stat) {


### PR DESCRIPTION
See `$SUBJECT`.

### Motivation

Clearer code and a little more `const` is usually a good thing.

### Test plan

Existing automated tests.