### PR TITLE
add a variadic template helper for building Send::ARGS_store

### DIFF
--- a/rewriter/DefDelegator.cc
+++ b/rewriter/DefDelegator.cc
@@ -48,12 +48,9 @@ vector<ast::TreePtr> DefDelegator::run(core::MutableContext ctx, const ast::Send
     }
 
     // sig {params(arg0: T.untyped, blk: Proc).returns(T.untyped)}
-    ast::Send::ARGS_store sigArgs;
-    sigArgs.emplace_back(ast::MK::Symbol(loc, core::Names::arg0()));
-    sigArgs.emplace_back(ast::MK::Untyped(loc));
-
-    sigArgs.emplace_back(ast::MK::Symbol(loc, core::Names::blkArg()));
-    sigArgs.emplace_back(ast::MK::Nilable(loc, ast::MK::Constant(loc, core::Symbols::Proc())));
+    auto sigArgs = ast::MK::SendArgs(ast::MK::Symbol(loc, core::Names::arg0()), ast::MK::Untyped(loc),
+                                     ast::MK::Symbol(loc, core::Names::blkArg()),
+                                     ast::MK::Nilable(loc, ast::MK::Constant(loc, core::Symbols::Proc())));
 
     methodStubs.push_back(ast::MK::Sig(loc, std::move(sigArgs), ast::MK::Untyped(loc)));
 

--- a/rewriter/Delegate.cc
+++ b/rewriter/Delegate.cc
@@ -110,12 +110,9 @@ vector<ast::TreePtr> Delegate::run(core::MutableContext ctx, const ast::Send *se
             methodName = lit->asSymbol(ctx);
         }
         // sig {params(arg0: T.untyped, blk: Proc).returns(T.untyped)}
-        ast::Send::ARGS_store sigArgs;
-        sigArgs.emplace_back(ast::MK::Symbol(loc, core::Names::arg0()));
-        sigArgs.emplace_back(ast::MK::Untyped(loc));
-
-        sigArgs.emplace_back(ast::MK::Symbol(loc, core::Names::blkArg()));
-        sigArgs.emplace_back(ast::MK::Nilable(loc, ast::MK::Constant(loc, core::Symbols::Proc())));
+        auto sigArgs = ast::MK::SendArgs(ast::MK::Symbol(loc, core::Names::arg0()), ast::MK::Untyped(loc),
+                                         ast::MK::Symbol(loc, core::Names::blkArg()),
+                                         ast::MK::Nilable(loc, ast::MK::Constant(loc, core::Symbols::Proc())));
 
         methodStubs.push_back(ast::MK::Sig(loc, std::move(sigArgs), ast::MK::Untyped(loc)));
 

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -256,10 +256,8 @@ ast::TreePtr runSingle(core::MutableContext ctx, ast::Send *send) {
         // can freely copy into methoddef scope
         auto iteratee = getIteratee(send->args.front());
         // and then reconstruct the send but with a modified body
-        ast::Send::ARGS_store args;
-        args.emplace_back(move(send->args.front()));
         return ast::MK::Send(
-            send->loc, ast::MK::Self(send->loc), send->fun, 1, std::move(args), send->flags,
+            send->loc, ast::MK::Self(send->loc), send->fun, 1, ast::MK::SendArgs(move(send->args.front())), send->flags,
             ast::MK::Block(send->block.loc(),
                            prepareTestEachBody(ctx, send->fun, std::move(block->body), block->args, iteratee),
                            std::move(block->args)));

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -113,12 +113,12 @@ vector<ast::TreePtr> Struct::run(core::MutableContext ctx, ast::Assign *asgn) {
 
     // Elem = type_member(fixed: T.untyped)
     {
-        ast::Send::ARGS_store typeMemberArgs;
-        typeMemberArgs.emplace_back(ast::MK::Symbol(loc, core::Names::fixed()));
-        typeMemberArgs.emplace_back(ast::MK::Untyped(loc));
-        body.emplace_back(ast::MK::Assign(
-            loc, ast::MK::UnresolvedConstant(loc, ast::MK::EmptyTree(), core::Names::Constants::Elem()),
-            ast::MK::Send(loc, ast::MK::Self(loc), core::Names::typeMember(), 0, std::move(typeMemberArgs))));
+        auto typeMember =
+            ast::MK::Send(loc, ast::MK::Self(loc), core::Names::typeMember(), 0,
+                          ast::MK::SendArgs(ast::MK::Symbol(loc, core::Names::fixed()), ast::MK::Untyped(loc)));
+        body.emplace_back(
+            ast::MK::Assign(loc, ast::MK::UnresolvedConstant(loc, ast::MK::EmptyTree(), core::Names::Constants::Elem()),
+                            std::move(typeMember)));
     }
 
     if (send->block != nullptr) {


### PR DESCRIPTION
Building `Send::ARGS_store` by hand is a little tedious, so let's add a variadic template helper to automate some of the work for us.  (Thank you, C++ 17, for fold expressions!)

### Motivation

For more accurate modeling of foreign props, I've had to build a number of send arglists manually, and it's a little bit annoying.  This helper (and accompanying changes in the rewriter to use it) would make things somewhat easier.  I think it mostly makes the code clearer, even if `clang-format` makes some things a bit harder to match up to the comments.

I didn't add the same for `MethodDef::ARGS_store` yet because the existing uses don't seem to warrant it, and I haven't needed it in the foreign props.

### Test plan

Existing automated tests.