### PR TITLE
fix types for foreign prop stub methods

### DIFF
--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -386,16 +386,16 @@ vector<ast::TreePtr> processProp(core::MutableContext ctx, PropInfo &ret, PropCo
     if (ret.foreign) {
         ast::TreePtr type;
         ast::TreePtr nonNilType;
-        if (ASTUtil::dupType(ret.foreign) == nullptr) {
+        if (ASTUtil::dupType(ret.type) == nullptr) {
             // If it's not a valid type, just use untyped
             type = ast::MK::Untyped(loc);
             nonNilType = ast::MK::Untyped(loc);
         } else {
-            type = ast::MK::Nilable(loc, ASTUtil::dupType(ret.foreign));
-            nonNilType = ASTUtil::dupType(ret.foreign);
+            type = ast::MK::Nilable(loc, ASTUtil::dupType(ret.type));
+            nonNilType = ASTUtil::dupType(ret.type);
         }
 
-        // sig {params(opts: T.untyped).returns(T.nilable($foreign))}
+        // sig {params(opts: T.untyped).returns(T.nilable($type))}
         nodes.emplace_back(
             ast::MK::Sig1(loc, ast::MK::Symbol(nameLoc, core::Names::opts()), ast::MK::Untyped(loc), std::move(type)));
 
@@ -410,7 +410,7 @@ vector<ast::TreePtr> processProp(core::MutableContext ctx, PropInfo &ret, PropCo
         nodes.emplace_back(
             ast::MK::SyntheticMethod1(loc, loc, fkMethod, std::move(arg), ast::MK::RaiseUnimplemented(loc)));
 
-        // sig {params(opts: T.untyped).returns($foreign)}
+        // sig {params(opts: T.untyped).returns($type)}
         nodes.emplace_back(ast::MK::Sig1(loc, ast::MK::Symbol(nameLoc, core::Names::opts()), ast::MK::Untyped(loc),
                                          std::move(nonNilType)));
 

--- a/test/testdata/rewriter/prop.rb
+++ b/test/testdata/rewriter/prop.rb
@@ -110,9 +110,10 @@ def main
     T.reveal_type(AdvancedODM.new.enum_prop) # error: Revealed type: `String`
     AdvancedODM.new.enum_prop = "hello"
 
-    T.reveal_type(AdvancedODM.new.foreign_) # error: Revealed type: `T.nilable(ForeignClass)`
-    T.reveal_type(AdvancedODM.new.foreign_!) # error: Revealed type: `ForeignClass`
-    T.reveal_type(AdvancedODM.new.foreign_lazy_) # error: Revealed type: `T.nilable(ForeignClass)`
+    T.reveal_type(AdvancedODM.new.foreign_) # error: Revealed type: `T.nilable(String)`
+    T.reveal_type(AdvancedODM.new.foreign_!) # error: Revealed type: `String`
+    T.reveal_type(AdvancedODM.new.foreign_lazy_) # error: Revealed type: `T.nilable(String)`
+    T.reveal_type(AdvancedODM.new.foreign_proc_) # error: Revealed type: `T.nilable(String)`
 
     # Check that the method still exists even if we can't parse the type
     AdvancedODM.new.foreign_invalid_

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -481,6 +481,35 @@ ClassDef{
             ]
           }
           Send{
+            recv = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U T>>
+            }
+            fun = <U reveal_type>
+            block = nullptr
+            pos_args = 1
+            args = [
+              Send{
+                recv = Send{
+                  recv = UnresolvedConstantLit{
+                    scope = EmptyTree
+                    cnst = <C <U AdvancedODM>>
+                  }
+                  fun = <U new>
+                  block = nullptr
+                  pos_args = 0
+                  args = [
+                  ]
+                }
+                fun = <U foreign_proc_>
+                block = nullptr
+                pos_args = 0
+                args = [
+                ]
+              }
+            ]
+          }
+          Send{
             recv = Send{
               recv = UnresolvedConstantLit{
                 scope = EmptyTree
@@ -3567,7 +3596,7 @@ ClassDef{
                   args = [
                     UnresolvedConstantLit{
                       scope = EmptyTree
-                      cnst = <C <U ForeignClass>>
+                      cnst = <C <U String>>
                     }
                   ]
                 }
@@ -3656,7 +3685,7 @@ ClassDef{
               args = [
                 UnresolvedConstantLit{
                   scope = EmptyTree
-                  cnst = <C <U ForeignClass>>
+                  cnst = <C <U String>>
                 }
               ]
             }
@@ -3956,7 +3985,7 @@ ClassDef{
                   args = [
                     UnresolvedConstantLit{
                       scope = EmptyTree
-                      cnst = <C <U ForeignClass>>
+                      cnst = <C <U String>>
                     }
                   ]
                 }
@@ -4045,7 +4074,7 @@ ClassDef{
               args = [
                 UnresolvedConstantLit{
                   scope = EmptyTree
-                  cnst = <C <U ForeignClass>>
+                  cnst = <C <U String>>
                 }
               ]
             }
@@ -4345,7 +4374,7 @@ ClassDef{
                   args = [
                     UnresolvedConstantLit{
                       scope = EmptyTree
-                      cnst = <C <U ForeignClass>>
+                      cnst = <C <U String>>
                     }
                   ]
                 }
@@ -4434,7 +4463,7 @@ ClassDef{
               args = [
                 UnresolvedConstantLit{
                   scope = EmptyTree
-                  cnst = <C <U ForeignClass>>
+                  cnst = <C <U String>>
                 }
               ]
             }
@@ -4728,10 +4757,14 @@ ClassDef{
                     orig = nullptr
                     symbol = (module ::T)
                   }
-                  fun = <U untyped>
+                  fun = <U nilable>
                   block = nullptr
-                  pos_args = 0
+                  pos_args = 1
                   args = [
+                    UnresolvedConstantLit{
+                      scope = EmptyTree
+                      cnst = <C <U String>>
+                    }
                   ]
                 }
               ]
@@ -4817,16 +4850,9 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Send{
-                  recv = ConstantLit{
-                    orig = nullptr
-                    symbol = (module ::T)
-                  }
-                  fun = <U untyped>
-                  block = nullptr
-                  pos_args = 0
-                  args = [
-                  ]
+                UnresolvedConstantLit{
+                  scope = EmptyTree
+                  cnst = <C <U String>>
                 }
               ]
             }

--- a/test/testdata/rewriter/prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree.exp
@@ -18,6 +18,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C T>.reveal_type(<emptyTree>::<C AdvancedODM>.new().foreign_())
       <emptyTree>::<C T>.reveal_type(<emptyTree>::<C AdvancedODM>.new().foreign_!())
       <emptyTree>::<C T>.reveal_type(<emptyTree>::<C AdvancedODM>.new().foreign_lazy_())
+      <emptyTree>::<C T>.reveal_type(<emptyTree>::<C AdvancedODM>.new().foreign_proc_())
       <emptyTree>::<C AdvancedODM>.new().foreign_invalid_()
       <emptyTree>::<C T>.reveal_type(<emptyTree>::<C PropHelpers>.new().token())
       <emptyTree>::<C PropHelpers>.new().token=("tok_token")
@@ -332,7 +333,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:opts, ::T.untyped()).returns(::T.nilable(<emptyTree>::<C ForeignClass>))
+      <self>.params(:opts, ::T.untyped()).returns(::T.nilable(<emptyTree>::<C String>))
     end
 
     def foreign_<<todo method>>(*opts:, &<blk>)
@@ -340,7 +341,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:opts, ::T.untyped()).returns(<emptyTree>::<C ForeignClass>)
+      <self>.params(:opts, ::T.untyped()).returns(<emptyTree>::<C String>)
     end
 
     def foreign_!<<todo method>>(*opts:, &<blk>)
@@ -374,7 +375,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:opts, ::T.untyped()).returns(::T.nilable(<emptyTree>::<C ForeignClass>))
+      <self>.params(:opts, ::T.untyped()).returns(::T.nilable(<emptyTree>::<C String>))
     end
 
     def foreign_lazy_<<todo method>>(*opts:, &<blk>)
@@ -382,7 +383,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:opts, ::T.untyped()).returns(<emptyTree>::<C ForeignClass>)
+      <self>.params(:opts, ::T.untyped()).returns(<emptyTree>::<C String>)
     end
 
     def foreign_lazy_!<<todo method>>(*opts:, &<blk>)
@@ -416,7 +417,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:opts, ::T.untyped()).returns(::T.nilable(<emptyTree>::<C ForeignClass>))
+      <self>.params(:opts, ::T.untyped()).returns(::T.nilable(<emptyTree>::<C String>))
     end
 
     def foreign_proc_<<todo method>>(*opts:, &<blk>)
@@ -424,7 +425,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:opts, ::T.untyped()).returns(<emptyTree>::<C ForeignClass>)
+      <self>.params(:opts, ::T.untyped()).returns(<emptyTree>::<C String>)
     end
 
     def foreign_proc_!<<todo method>>(*opts:, &<blk>)
@@ -458,7 +459,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:opts, ::T.untyped()).returns(::T.untyped())
+      <self>.params(:opts, ::T.untyped()).returns(::T.nilable(<emptyTree>::<C String>))
     end
 
     def foreign_invalid_<<todo method>>(*opts:, &<blk>)
@@ -466,7 +467,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:opts, ::T.untyped()).returns(::T.untyped())
+      <self>.params(:opts, ::T.untyped()).returns(<emptyTree>::<C String>)
     end
 
     def foreign_invalid_!<<todo method>>(*opts:, &<blk>)

--- a/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=148:4}
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=149:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U AdvancedODM>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=38:1 end=38:18}
     method <C <U AdvancedODM>><U array> (<blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=43:5 end=43:23}
@@ -32,10 +32,10 @@ class <C <U <root>>> < <C <U Object>> ()
     method <C <U AdvancedODM>><U foreign=> (foreign, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
       argument foreign<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
+    method <C <U AdvancedODM>><U foreign_> (opts, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
       argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
+    method <C <U AdvancedODM>><U foreign_!> (opts, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
       argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>><U foreign_invalid> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
@@ -43,10 +43,10 @@ class <C <U <root>>> < <C <U Object>> ()
     method <C <U AdvancedODM>><U foreign_invalid=> (foreign_invalid, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
       argument foreign_invalid<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_invalid_> (opts, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
+    method <C <U AdvancedODM>><U foreign_invalid_> (opts, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
       argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_invalid_!> (opts, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
+    method <C <U AdvancedODM>><U foreign_invalid_!> (opts, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
       argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>><U foreign_lazy> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
@@ -54,10 +54,10 @@ class <C <U <root>>> < <C <U Object>> ()
     method <C <U AdvancedODM>><U foreign_lazy=> (foreign_lazy, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
       argument foreign_lazy<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_lazy_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
+    method <C <U AdvancedODM>><U foreign_lazy_> (opts, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
       argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_lazy_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
+    method <C <U AdvancedODM>><U foreign_lazy_!> (opts, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
       argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>><U foreign_proc> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
@@ -65,10 +65,10 @@ class <C <U <root>>> < <C <U Object>> ()
     method <C <U AdvancedODM>><U foreign_proc=> (foreign_proc, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
       argument foreign_proc<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_proc_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
+    method <C <U AdvancedODM>><U foreign_proc_> (opts, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
       argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_proc_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
+    method <C <U AdvancedODM>><U foreign_proc_!> (opts, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
       argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>><U hash_of> (<blk>) -> AppliedType {       klass = <C <U Hash>>       targs = [         <C <U K>> = Symbol         <C <U V>> = String         <C <U Elem>> = TupleType {             0 = Symbol             1 = String           }       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=45:5 end=45:43}


### PR DESCRIPTION
We were using the type of the  loader for the return type of the foreign prop stub methods, which is not correct; they should be returning the type of the prop instead.

### Motivation

This probably doesn't matter much at the moment, but it does matter when/if foreign prop methods expand into something larger than stubs.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  I snuck in an extra test as well.
