### PR TITLE
Fix the signature in Find::find

### DIFF
--- a/rbi/stdlib/find.rbi
+++ b/rbi/stdlib/find.rbi
@@ -33,8 +33,8 @@ module Find
     params(
       paths: String,
       ignore_error: T::Boolean,
-      blk: T.proc.params(path: String).void
-    ).void
+      blk: T.nilable(T.proc.params(path: String).void)
+    ).returns(T.nilable(T::Enumerator[String]))
   end
   def self.find(*paths, ignore_error: true, &blk); end
 


### PR DESCRIPTION
As per the docs included in the file it "Returns an enumerator if no block is given." This allows it to be used in that way. This is still not ideal as it then requires use as, e.g.

```
T.must(Find.find(some_path)).filter { ... }
```

even though we should allow

```
Find.find(some_path).filter
```

since the use of it without a block ensures that an enumerator will be returned. It also gives an explicit return of `nil` when used with a block though the original `void` is more accurate.

Ideally, we'd have a mechanism for alternate signatures:

```
sig do
  T::Sig.any(
    params(paths: String, ignore_error: T::Boolean).returns(Enumerator),
    params(paths: String, ignore_error: T::Boolean, blk: T.proc.params(path: String).void).void,
  )
end
```

Does something like that exist?

cc @Morriar 