### PR TITLE
Remove optional `base` parameter for `Float#to_s` in `float.rbi`

### DIFF
--- a/rbi/core/float.rbi
+++ b/rbi/core/float.rbi
@@ -1181,8 +1181,8 @@ class Float < Numeric
   #
   # Also aliased as:
   # [`inspect`](https://docs.ruby-lang.org/en/2.6.0/Float.html#method-i-inspect)
-  sig {params(base: Integer).returns(String)}
-  def to_s(base=10); end
+  sig {returns(String)}
+  def to_s(); end
 
   # Returns `float` truncated (toward zero) to a precision of `ndigits` decimal
   # digits (default: 0).

--- a/test/testdata/rbi/float.rb
+++ b/test/testdata/rbi/float.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+1.0.to_s(10) # error: Too many arguments provided for method `Float#to_s`. Expected: `0`, got: `1`


### PR DESCRIPTION
Currently `to_s` in the RBI for the `Float` class specifies that an optional parameter `base` can be passed. This is accurate for `Integer#to_s` but not `Float#to_s`.
Docs: https://ruby-doc.org/core-2.7.0/Float.html#method-i-to_s
![image](https://user-images.githubusercontent.com/13454550/103480543-d3fa5e80-4dcc-11eb-8e8b-ca555f4eebe6.png)

### Motivation
Sorbet is unable to pick up on `Float#to_s` calls that could potentially cause errors during runtime.

### Test plan
See included automated tests.

Redo of https://github.com/sorbet/sorbet/pull/3857