### PR TITLE
Add more information to error message

### DIFF
--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -20,7 +20,7 @@ namespace {
 string getRootPath(const shared_ptr<LSPOutput> &output, const options::Options &opts,
                    const shared_ptr<spdlog::logger> &logger) {
     if (opts.rawInputDirNames.size() != 1) {
-        auto msg = fmt::format("Sorbet's language server requires a single input directory. {} are configured: {}", opts.rawInputDirNames.size(), opts.rawInputDirNames);
+        auto msg = fmt::format("Sorbet's language server requires a single input directory. However, {} are configured: {}", opts.rawInputDirNames.size(), opts.rawInputDirNames);
         logger->error(msg);
         auto params = make_unique<ShowMessageParams>(MessageType::Error, msg);
         output->write(make_unique<LSPMessage>(

--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -20,7 +20,7 @@ namespace {
 string getRootPath(const shared_ptr<LSPOutput> &output, const options::Options &opts,
                    const shared_ptr<spdlog::logger> &logger) {
     if (opts.rawInputDirNames.size() != 1) {
-        auto msg = "Sorbet's language server requires a single input directory.";
+        auto msg = fmt::format("Sorbet's language server requires a single input directory. {} are configured: {}", opts.rawInputDirNames.size(), opts.rawInputDirNames);
         logger->error(msg);
         auto params = make_unique<ShowMessageParams>(MessageType::Error, msg);
         output->write(make_unique<LSPMessage>(

--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -1,5 +1,6 @@
 #include "main/lsp/LSPConfiguration.h"
 #include "absl/strings/match.h"
+#include "absl/strings/str_join.h"
 #include "absl/strings/str_replace.h"
 #include "common/FileOps.h"
 #include "main/lsp/LSPMessage.h"
@@ -20,7 +21,9 @@ namespace {
 string getRootPath(const shared_ptr<LSPOutput> &output, const options::Options &opts,
                    const shared_ptr<spdlog::logger> &logger) {
     if (opts.rawInputDirNames.size() != 1) {
-        auto msg = fmt::format("Sorbet's language server requires a single input directory. However, {} are configured: {}", opts.rawInputDirNames.size(), opts.rawInputDirNames);
+        auto msg =
+            fmt::format("Sorbet's language server requires a single input directory. However, {} are configured: [{}]",
+                        opts.rawInputDirNames.size(), absl::StrJoin(opts.rawInputDirNames, ", "));
         logger->error(msg);
         auto params = make_unique<ShowMessageParams>(MessageType::Error, msg);
         output->write(make_unique<LSPMessage>(

--- a/test/cli/lsp-requires-input-dir/lsp-requires-input-dir.out
+++ b/test/cli/lsp-requires-input-dir/lsp-requires-input-dir.out
@@ -1,4 +1,8 @@
-Sorbet's language server requires a single input directory.
-Content-Length: 139
+Sorbet's language server requires a single input directory. However, 0 are configured: []
+Content-Length: 169
 
-{"jsonrpc":"2.0","method":"window/showMessage","params":{"type":1,"message":"Sorbet's language server requires a single input directory."}}
+{"jsonrpc":"2.0","method":"window/showMessage","params":{"type":1,"message":"Sorbet's language server requires a single input directory. However, 0 are configured: []"}}--------------------------------------------------------------------------
+Sorbet's language server requires a single input directory. However, 2 are configured: [foo, bar]
+Content-Length: 177
+
+{"jsonrpc":"2.0","method":"window/showMessage","params":{"type":1,"message":"Sorbet's language server requires a single input directory. However, 2 are configured: [foo, bar]"}}

--- a/test/cli/lsp-requires-input-dir/lsp-requires-input-dir.sh
+++ b/test/cli/lsp-requires-input-dir/lsp-requires-input-dir.sh
@@ -1,1 +1,24 @@
-main/sorbet --silence-dev-message --lsp --disable-watchman test/cli/lsp-requires-input-dir/lsp-requires-input-dir.sh 2>&1
+#!/bin/bash
+
+set -euo pipefail
+
+if main/sorbet --silence-dev-message --lsp --disable-watchman test/cli/lsp-requires-input-dir/lsp-requires-input-dir.sh 2>&1; then
+  echo "expected to fail, but it didn't!"
+  exit 1
+fi
+
+echo --------------------------------------------------------------------------
+
+tmpdir=$(mktemp -d)
+# shellcheck disable=SC2064
+trap "rm -rf $tmpdir" EXIT
+
+old_pwd="$(pwd)"
+cd "$tmpdir"
+
+mkdir -p foo bar
+
+if "$old_pwd/main/sorbet" --silence-dev-message --lsp --disable-watchman foo bar 2>&1; then
+  echo "expected to fail, but it didn't!"
+  exit 1
+fi

--- a/test/cli/lsp-two-input-dirs/lsp-two-input-dirs.out
+++ b/test/cli/lsp-two-input-dirs/lsp-two-input-dirs.out
@@ -1,3 +1,0 @@
-Content-Length: 139
-
-{"jsonrpc":"2.0","method":"window/showMessage","params":{"type":1,"message":"Sorbet's language server requires a single input directory."}}

--- a/test/cli/lsp-two-input-dirs/lsp-two-input-dirs.sh
+++ b/test/cli/lsp-two-input-dirs/lsp-two-input-dirs.sh
@@ -1,2 +1,0 @@
-# Pass two directories (it doesn't matter what they are), and verify that we get the right error back
-main/sorbet --silence-dev-message --lsp --dir test/cli/lsp-two-input-dirs --dir test/cli 2>/dev/null


### PR DESCRIPTION
Currently:

```
Sorbet's language server requires a single input directory.
```

With this PR:

```
Sorbet's language server requires a single input directory. However, 2 are configured: /x/y/z, /w/x/y/z
```


### Motivation

I'm personally getting the above message, and I can only guess why it's happening. However, the code has all the context info to help debug the problem.


### Test plan

I'm completely guessing how to implement this. I'm not set up for C++ development, and I took a stab at the proper way to output this info. I appreciate any touch-ups needed!