### PR TITLE
Fix more than one unnamed parameter in method definition

### DIFF
--- a/gems/sorbet/lib/serialize.rb
+++ b/gems/sorbet/lib/serialize.rb
@@ -197,7 +197,7 @@ class Sorbet::Private::Serialize
 
   def blacklisted_method(method)
     return true if /__validator__[0-9]{8}/ || method.name =~ /.*:.*/
-    return true if method.parameters.map { |(kind, name)| name }.filter { |name| name.to_s == "_" }.length >= 2
+    return true if method.parameters.map { |(kind, name)| name }.select { |name| name.to_s == "_" }.length >= 2
     false
   end
 

--- a/gems/sorbet/lib/serialize.rb
+++ b/gems/sorbet/lib/serialize.rb
@@ -328,7 +328,7 @@ class Sorbet::Private::Serialize
   def from_method(method)
     uniq = 0
     method.parameters.map.with_index do |(kind, name), index|
-      if !name
+      if !name || name.to_s == "_"
         arg_name = method.name.to_s[0...-1]
         if (!KEYWORDS.include?(arg_name.to_sym)) && method.name.to_s.end_with?('=') && arg_name =~ /\A[a-z_][a-z0-9A-Z_]*\Z/ && index == 0
           name = arg_name

--- a/gems/sorbet/lib/serialize.rb
+++ b/gems/sorbet/lib/serialize.rb
@@ -196,7 +196,7 @@ class Sorbet::Private::Serialize
   end
 
   def blacklisted_method(method)
-    return true if /__validator__[0-9]{8}/ || method.name =~ /.*:.*/
+    return true if method.name =~ /__validator__[0-9]{8}/ || method.name =~ /.*:.*/
     return true if method.parameters.map { |(kind, name)| name }.select { |name| name.to_s == "_" }.length >= 2
     false
   end

--- a/gems/sorbet/lib/serialize.rb
+++ b/gems/sorbet/lib/serialize.rb
@@ -196,7 +196,9 @@ class Sorbet::Private::Serialize
   end
 
   def blacklisted_method(method)
-    method.name =~ /__validator__[0-9]{8}/ || method.name =~ /.*:.*/
+    return true if /__validator__[0-9]{8}/ || method.name =~ /.*:.*/
+    return true if method.parameters.map { |(kind, name)| name }.filter { |name| name.to_s == "_" }.length >= 2
+    false
   end
 
   def valid_method_name(name)
@@ -328,7 +330,7 @@ class Sorbet::Private::Serialize
   def from_method(method)
     uniq = 0
     method.parameters.map.with_index do |(kind, name), index|
-      if !name || name.to_s == "_"
+      if !name
         arg_name = method.name.to_s[0...-1]
         if (!KEYWORDS.include?(arg_name.to_sym)) && method.name.to_s.end_with?('=') && arg_name =~ /\A[a-z_][a-z0-9A-Z_]*\Z/ && index == 0
           name = arg_name

--- a/gems/sorbet/test/snapshot/partial/unnamed_arguments/src/Gemfile.lock
+++ b/gems/sorbet/test/snapshot/partial/unnamed_arguments/src/Gemfile.lock
@@ -1,0 +1,11 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+
+BUNDLED WITH
+   2.1.4

--- a/gems/sorbet/test/snapshot/partial/unnamed_arguments/src/src.rb
+++ b/gems/sorbet/test/snapshot/partial/unnamed_arguments/src/src.rb
@@ -1,0 +1,5 @@
+class UnnamedArguments
+  def first_method(_, _)
+    nil
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Hi, first thanks for Sorbet, an amazing tool for ruby developers. :+1: 

In this change, i'm looking at the number of parameters equal to underscore because it is the only parameter that can occur multiple times in a same function in ruby.
Looking at this comment https://github.com/sorbet/sorbet/issues/3674#issuecomment-728674364, a suggestion was to remove the function from hidden-definitions, that's what i've done in this PR.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Since we're upgraded sorbet-runtime from 0.5.5944 to the latest version, we're unable to regenerate rbis anymore. We have the error describe in the issue above.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
