### PR TITLE
Fix `T::Struct#with` behavior for nested structs and enums

### DIFF
--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -90,6 +90,7 @@ class T::Enum
   # @raise [KeyError] if serialized value does not match any instance.
   sig {overridable.params(serialized_val: SerializedVal).returns(T.attached_class).checked(:never)}
   def self.from_serialized(serialized_val)
+    return serialized_val if serialized_val.is_a?(self)
     res = try_deserialize(serialized_val)
     if res.nil?
       raise KeyError.new("Enum #{self} key not found: #{serialized_val.inspect}")

--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -90,7 +90,6 @@ class T::Enum
   # @raise [KeyError] if serialized value does not match any instance.
   sig {overridable.params(serialized_val: SerializedVal).returns(T.attached_class).checked(:never)}
   def self.from_serialized(serialized_val)
-    return serialized_val if serialized_val.is_a?(self)
     res = try_deserialize(serialized_val)
     if res.nil?
       raise KeyError.new("Enum #{self} key not found: #{serialized_val.inspect}")

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -112,7 +112,7 @@ module T::Props::Serializable
       end
     elsif obj.is_a?(Array)
       new_obj = obj.map {|v| recursive_stringify_keys(v)}
-    elsif obj.is_a?(T::Enum)
+    elsif obj.is_a?(T::Enum) || obj.is_a?(T::Struct)
       new_obj = obj.serialize
     else
       new_obj = obj

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -112,6 +112,8 @@ module T::Props::Serializable
       end
     elsif obj.is_a?(Array)
       new_obj = obj.map {|v| recursive_stringify_keys(v)}
+    elsif obj.is_a?(T::Enum)
+      new_obj = obj.serialize
     else
       new_obj = obj
     end

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -513,4 +513,19 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
   it 'can be used with an assert' do
     assert(CardSuit::SPADE, 'some message')
   end
+
+  class Card < T::Struct
+    prop :rank, Integer
+    prop :suit, CardSuit
+  end
+
+  # This test previously didn't work because T::Struct#with relies on
+  # the #deserialize method being able to robustly handle being handed
+  # a value that was already of the correct type and needed no
+  # deserialization, which enums did not do
+  it "works correctly when used in #with on a T::Struct" do
+    card = Card.new(rank: 5, suit: CardSuit::CLUB)
+    card.with(suit: CardSuit::SPADE)
+    assert_equal(CardSuite::SPADE, card.suit)
+  end
 end

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -525,7 +525,7 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
   # deserialization, which enums did not do
   it "works correctly when used in #with on a T::Struct" do
     card = Card.new(rank: 5, suit: CardSuit::CLUB)
-    card.with(suit: CardSuit::SPADE)
-    assert_equal(CardSuite::SPADE, card.suit)
+    new_card = card.with(suit: CardSuit::SPADE)
+    assert_equal(CardSuit::SPADE, new_card.suit)
   end
 end

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -514,18 +514,4 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
     assert(CardSuit::SPADE, 'some message')
   end
 
-  class Card < T::Struct
-    prop :rank, Integer
-    prop :suit, CardSuit
-  end
-
-  # This test previously didn't work because T::Struct#with relies on
-  # the #deserialize method being able to robustly handle being handed
-  # a value that was already of the correct type and needed no
-  # deserialization, which enums did not do
-  it "works correctly when used in #with on a T::Struct" do
-    card = Card.new(rank: 5, suit: CardSuit::CLUB)
-    new_card = card.with(suit: CardSuit::SPADE)
-    assert_equal(CardSuit::SPADE, new_card.suit)
-  end
 end

--- a/gems/sorbet-runtime/test/types/struct.rb
+++ b/gems/sorbet-runtime/test/types/struct.rb
@@ -28,4 +28,38 @@ class Opus::Types::Test::StructValidationTest < Critic::Unit::UnitTest
       c.arr = [1, 2]
     end
   end
+
+  class SimpleStruct < T::Struct
+    prop :value, Integer
+  end
+
+  class SimpleEnum < T::Enum
+    enums do
+      This = new
+      That = new
+    end
+  end
+
+  class Outer < T::Struct
+    prop :struct, SimpleStruct
+    prop :enum, SimpleEnum
+  end
+
+  describe "T::Struct#with" do
+    it "works correctly when a value is a T::Struct" do
+      c = Outer.new(struct: SimpleStruct.new(value: 5), enum: SimpleEnum::This)
+      d = c.with(struct: SimpleStruct.new(value: 8))
+      assert_equal(8, d.struct.value)
+      # this should be unchanged by #with
+      assert_equal(SimpleEnum::This, d.enum)
+    end
+
+    it "works correctly when a value is a T::Enum" do
+      c = Outer.new(struct: SimpleStruct.new(value: 5), enum: SimpleEnum::This)
+      d = c.with(enum: SimpleEnum::That)
+      assert_equal(SimpleEnum::That, d.enum)
+      # this should be unchanged by #with
+      assert_equal(5, d.struct.value)
+    end
+  end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Right now, if you use `T::Struct#with` to update a field whose type is an enum, it fails: this is because it uses the deserialization code to implement `#with` but enums do not robustly handle being asked to deserialize a version of themselves (rather than the actual serialized format). This adds a special case to enum deserialization that handles this, which makes `#with` work again.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
Added a runtime test: [here is what this test looks like when it fails](https://buildkite.com/sorbet/sorbet/builds/14306#01b704c8-c126-482b-a44c-b3e6d2571901).

See included automated tests.
