### PR TITLE
only allow symbol-typed names for props and consts

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/_props.rb
+++ b/gems/sorbet-runtime/lib/types/props/_props.rb
@@ -100,6 +100,7 @@ module T::Props
     #   form.
     #
     # @return [void]
+    sig {params(name: Symbol, cls: T.untyped, rules: T.untyped).void}
     def prop(name, cls, rules={})
       cls = T::Utils.coerce(cls) if !cls.is_a?(Module)
       decorator.prop_defined(name, cls, rules)

--- a/gems/sorbet-runtime/lib/types/props/_props.rb
+++ b/gems/sorbet-runtime/lib/types/props/_props.rb
@@ -124,7 +124,7 @@ module T::Props
     end
 
     # Shorthand helper to define a `prop` with `immutable => true`
-    sig {params(name: T.any(Symbol, String), cls_or_args: T.untyped, args: T::Hash[Symbol, T.untyped]).void}
+    sig {params(name: Symbol, cls_or_args: T.untyped, args: T::Hash[Symbol, T.untyped]).void}
     def const(name, cls_or_args, args={})
       if (cls_or_args.is_a?(Hash) && cls_or_args.key?(:immutable)) || args.key?(:immutable)
         Kernel.raise ArgumentError.new("Cannot pass 'immutable' argument when using 'const' keyword to define a prop")

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -52,19 +52,6 @@ module T::Utils
     end.uniq
   end
 
-  # Associates a signature with a forwarder method that matches the signature of the method it
-  # forwards to. This is necessary because forwarder methods are often declared with catch-all
-  # splat parameters, rather than the exact set of parameters ultimately used by the target method,
-  # so they cannot be validated as strictly.
-  #
-  # The caller of this method must ensure that the forwarder method properly forwards all parameters
-  # such that the signature is accurate.
-  def self.register_forwarder(from_method, to_method, remove_first_param: false)
-    T::Private::Methods.register_forwarder(
-      from_method, to_method, remove_first_param: remove_first_param
-    )
-  end
-
   # Returns the signature for the instance method on the supplied module, or nil if it's not found or not typed.
   #
   # @example T::Utils.signature_for_instance_method(MyClass, :my_method)

--- a/gems/sorbet-runtime/test/types/struct.rb
+++ b/gems/sorbet-runtime/test/types/struct.rb
@@ -28,4 +28,20 @@ class Opus::Types::Test::StructValidationTest < Critic::Unit::UnitTest
       c.arr = [1, 2]
     end
   end
+
+  it "errors when using string typed props" do
+    assert_raises(TypeError) do
+      Class.new(T::Struct) do
+        prop "foo", T::Array[String]
+      end
+    end
+  end
+
+  it "errors when using string typed const" do
+    assert_raises(TypeError) do
+      Class.new(T::Struct) do
+        const "foo", T::Array[String]
+      end
+    end
+  end
 end

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -166,8 +166,6 @@ module T::Utils
 
   # only one caller; delete
   def self.methods_excluding_object(mod); end
-  # only one caller; delete
-  def self.register_forwarder(from_method, to_method, remove_first_param: nil); end
 end
 
 

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -18,9 +18,9 @@ module T::Props
 end
 
 module T::Props::ClassMethods
-  sig {params(name: T.any(Symbol, String), cls_or_args: T.untyped, args: T::Hash[Symbol, T.untyped]).void}
+  sig {params(name: Symbol, cls_or_args: T.untyped, args: T::Hash[Symbol, T.untyped]).void}
   def const(name, cls_or_args, args={}, &blk); end
-  sig {params(name: T.any(Symbol, String), cls: T.untyped, rules: T.untyped).void}
+  sig {params(name: Symbol, cls: T.untyped, rules: T.untyped).void}
   def prop(name, cls, rules = nil); end
   def decorator; end
   def decorator_class; end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Narrow the allowable types for names of the `prop` and `const` DSLs. In practice, name-types that do not repond to `to_sym` already fail, since they are symbolized internally.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
There are no non-symbol prop or const names internally at Stripe, and we'd like to keep it that way.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Not yet tested integrated with internal Stripe code due to issues with Github. While resolving that, I wanted to open the PR and ensure this is a change we want. It is technically a breaking change, and I don't know if users outside of Stripe are relying on String typed `prop` and `const` names. This might not be the right layer of the stack to enforce our preferences.