### PR TITLE
Revert "Fix `T::Struct#with` behavior for nested structs and enums"

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -112,8 +112,6 @@ module T::Props::Serializable
       end
     elsif obj.is_a?(Array)
       new_obj = obj.map {|v| recursive_stringify_keys(v)}
-    elsif obj.is_a?(T::Enum) || obj.is_a?(T::Struct)
-      new_obj = obj.serialize
     else
       new_obj = obj
     end

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -513,5 +513,4 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
   it 'can be used with an assert' do
     assert(CardSuit::SPADE, 'some message')
   end
-
 end

--- a/gems/sorbet-runtime/test/types/struct.rb
+++ b/gems/sorbet-runtime/test/types/struct.rb
@@ -28,38 +28,4 @@ class Opus::Types::Test::StructValidationTest < Critic::Unit::UnitTest
       c.arr = [1, 2]
     end
   end
-
-  class SimpleStruct < T::Struct
-    prop :value, Integer
-  end
-
-  class SimpleEnum < T::Enum
-    enums do
-      This = new
-      That = new
-    end
-  end
-
-  class Outer < T::Struct
-    prop :struct, SimpleStruct
-    prop :enum, SimpleEnum
-  end
-
-  describe "T::Struct#with" do
-    it "works correctly when a value is a T::Struct" do
-      c = Outer.new(struct: SimpleStruct.new(value: 5), enum: SimpleEnum::This)
-      d = c.with(struct: SimpleStruct.new(value: 8))
-      assert_equal(8, d.struct.value)
-      # this should be unchanged by #with
-      assert_equal(SimpleEnum::This, d.enum)
-    end
-
-    it "works correctly when a value is a T::Enum" do
-      c = Outer.new(struct: SimpleStruct.new(value: 5), enum: SimpleEnum::This)
-      d = c.with(enum: SimpleEnum::That)
-      assert_equal(SimpleEnum::That, d.enum)
-      # this should be unchanged by #with
-      assert_equal(5, d.struct.value)
-    end
-  end
 end


### PR DESCRIPTION
Reverts sorbet/sorbet#3880

This causes some anomalous behavior with nested structs which didn't show up in my testing. I'm going to revert it and do more testing to see if I can figure out a proper solution.