### PR TITLE
Add `module_function` to various modules

### DIFF
--- a/rbi/stdlib/drb.rbi
+++ b/rbi/stdlib/drb.rbi
@@ -314,7 +314,7 @@ module DRb
   # [`current_server`](https://docs.ruby-lang.org/en/2.6.0/DRb.html#method-i-current_server)
   # and DRbServer::make\_config.
   sig { returns(T::Hash[Symbol, T.untyped]) }
-  def self.config; end
+  module_function def config; end
 
   # Get the 'current' server.
   #
@@ -326,7 +326,7 @@ module DRb
   # If the above rule fails to find a server, a DRbServerNotFound error is
   # raised.
   sig { returns(DRb::DRbServer) }
-  def self.current_server; end
+  module_function def current_server; end
 
   # Retrieves the server with the given `uri`.
   #
@@ -334,19 +334,19 @@ module DRb
   # [`regist_server`](https://docs.ruby-lang.org/en/2.6.0/DRb.html#method-c-regist_server)
   # and remove\_server.
   sig { params(uri: String).returns(T.nilable(DRb::DRbServer)) }
-  def self.fetch_server(uri); end
+  module_function def fetch_server(uri); end
 
   # Get the front object of the current server.
   #
   # This raises a DRbServerNotFound error if there is no current server. See
   # [`current_server`](https://docs.ruby-lang.org/en/2.6.0/DRb.html#method-i-current_server).
   sig { returns(T.nilable(Object)) }
-  def self.front; end
+  module_function def front; end
 
   # Is `uri` the [`URI`](https://docs.ruby-lang.org/en/2.6.0/URI.html) for the
   # current local server?
   sig { params(uri: String).returns(T::Boolean) }
-  def self.here?(uri); end
+  module_function def here?(uri); end
 
   # [`Set`](https://docs.ruby-lang.org/en/2.6.0/Set.html) the default
   # [`ACL`](https://docs.ruby-lang.org/en/2.6.0/ACL.html) to `acl`.
@@ -354,7 +354,7 @@ module DRb
   # See
   # [`DRb::DRbServer.default_acl`](https://docs.ruby-lang.org/en/2.6.0/DRb/DRbServer.html#method-c-default_acl).
   sig { params(acl: T.nilable(Object)).returns(T.nilable(Object)) }
-  def self.install_acl(acl); end
+  module_function def install_acl(acl); end
 
   # [`Set`](https://docs.ruby-lang.org/en/2.6.0/Set.html) the default id
   # conversion object.
@@ -369,7 +369,7 @@ module DRb
   #
   # See DRbServer#default\_id\_conv.
   sig { params(idconv: T.nilable(Object)).returns(T.nilable(Object)) }
-  def self.install_id_conv(idconv); end
+  module_function def install_id_conv(idconv); end
 
   # The primary local dRuby server.
   #
@@ -377,7 +377,7 @@ module DRb
   # [`start_service`](https://docs.ruby-lang.org/en/2.6.0/DRb.html#method-i-start_service)
   # call.
   sig { returns(T.nilable(DRb::DRbServer)) }
-  def self.primary_server; end
+  module_function def primary_server; end
 
   # The primary local dRuby server.
   #
@@ -385,7 +385,7 @@ module DRb
   # [`start_service`](https://docs.ruby-lang.org/en/2.6.0/DRb.html#method-i-start_service)
   # call.
   sig { params(server: T.nilable(DRb::DRbServer)).returns(T.nilable(DRb::DRbServer)) }
-  def self.primary_server=(server); end
+  module_function def primary_server=(server); end
 
   # Registers `server` with
   # [`DRb`](https://docs.ruby-lang.org/en/2.6.0/DRb.html).
@@ -405,11 +405,11 @@ module DRb
   # DRb.fetch_server s.uri #=> #<DRb::DRbServer:0x...>
   # ```
   sig { params(server: DRb::DRbServer).void }
-  def self.regist_server(server); end
+  module_function def regist_server(server); end
 
   # Removes `server` from the list of registered servers.
   sig { params(server: DRb::DRbServer).void }
-  def self.remove_server(server); end
+  module_function def remove_server(server); end
 
   # Start a dRuby server locally.
   #
@@ -432,35 +432,35 @@ module DRb
       config: T.nilable(T::Hash[Symbol, T.untyped])
     ).returns(DRb::DRbServer)
   end
-  def self.start_service(uri = _, front = _, config = _); end
+  module_function def start_service(uri = _, front = _, config = _); end
 
   # Stop the local dRuby server.
   #
   # This operates on the primary server. If there is no primary server currently
   # running, it is a noop.
   sig { void }
-  def self.stop_service; end
+  module_function def stop_service; end
 
   # Get the thread of the primary server.
   #
   # This returns nil if there is no primary server. See
   # [`primary_server`](https://docs.ruby-lang.org/en/2.6.0/DRb.html#attribute-i-primary_server).
   sig { returns(T.nilable(Thread)) }
-  def self.thread; end
+  module_function def thread; end
 
   # Get a reference id for an object using the current server.
   #
   # This raises a DRbServerNotFound error if there is no current server. See
   # [`current_server`](https://docs.ruby-lang.org/en/2.6.0/DRb.html#method-i-current_server).
   sig { params(obj: T.nilable(Object)).returns(T.nilable(Integer)) }
-  def self.to_id(obj); end
+  module_function def to_id(obj); end
 
   # Convert a reference into an object using the current server.
   #
   # This raises a DRbServerNotFound error if there is no current server. See
   # [`current_server`](https://docs.ruby-lang.org/en/2.6.0/DRb.html#method-i-current_server).
   sig { params(ref: T.nilable(Integer)).returns(T.nilable(Object)) }
-  def self.to_obj(ref); end
+  module_function def to_obj(ref); end
 
   # Get the [`URI`](https://docs.ruby-lang.org/en/2.6.0/URI.html) defining the
   # local dRuby space.
@@ -469,7 +469,7 @@ module DRb
   # current server. See
   # [`current_server`](https://docs.ruby-lang.org/en/2.6.0/DRb.html#method-i-current_server).
   sig { returns(String) }
-  def self.uri; end
+  module_function def uri; end
 end
 
 # An [`Array`](https://docs.ruby-lang.org/en/2.6.0/Array.html) wrapper that can
@@ -742,7 +742,7 @@ module DRb::DRbProtocol
   # [`DRbProtocol`](https://docs.ruby-lang.org/en/2.6.0/DRb/DRbProtocol.html)
   # module.
   sig { params(prot: T.nilable(Object)).returns(T::Array[T.nilable(Object)]) }
-  def self.add_protocol(prot); end
+  module_function def add_protocol(prot); end
 
   # Open a client connection to `uri` with the configuration `config`.
   #
@@ -764,7 +764,7 @@ module DRb::DRbProtocol
       first: T::Boolean
     ).returns(DRb::DRbTCPSocket)
   end
-  def self.open(uri, config, first = true); end
+  module_function def open(uri, config, first = true); end
 
   # Open a server listening for connections at `uri` with configuration
   # `config`.
@@ -787,7 +787,7 @@ module DRb::DRbProtocol
       first: T::Boolean
     ).returns(DRb::DRbTCPSocket)
   end
-  def self.open_server(uri, config, first = true); end
+  module_function def open_server(uri, config, first = true); end
 
   # Parse `uri` into a [uri, option] pair.
   #
@@ -807,7 +807,7 @@ module DRb::DRbProtocol
       first: T::Boolean
     ).returns([String, T.nilable(Object)])
   end
-  def self.uri_option(uri, config, first = _); end
+  module_function def uri_option(uri, config, first = _); end
 end
 
 # An exception wrapping an error object

--- a/rbi/stdlib/find.rbi
+++ b/rbi/stdlib/find.rbi
@@ -36,7 +36,7 @@ module Find
       blk: T.nilable(T.proc.params(path: String).void)
     ).returns(T.nilable(T::Enumerator[String]))
   end
-  def self.find(*paths, ignore_error: true, &blk); end
+  module_function def find(*paths, ignore_error: true, &blk); end
 
   # Skips the current file or directory, restarting the loop with the next
   # entry. If the current file is a directory, that directory will not be
@@ -45,5 +45,5 @@ module Find
   #
   # See the `Find` module documentation for an example.
   sig { void }
-  def self.prune; end
+  module_function def prune; end
 end

--- a/rbi/stdlib/kconv.rbi
+++ b/rbi/stdlib/kconv.rbi
@@ -29,58 +29,58 @@ module Kconv
   # Guess input encoding by
   # [`NKF.guess`](https://docs.ruby-lang.org/en/2.6.0/NKF.html#method-c-guess)
   sig { params(str: String).returns(Encoding) }
-  def self.guess(str); end
+  module_function def guess(str); end
 
   # Returns whether input encoding is EUC-JP or not.
   #
   # **Note** don't expect this return value is
   # [`MatchData`](https://docs.ruby-lang.org/en/2.6.0/MatchData.html).
   sig { params(str: String).returns(T::Boolean) }
-  def self.iseuc(str); end
+  module_function def iseuc(str); end
 
   # Returns whether input encoding is ISO-2022-JP or not.
   sig { params(str: String).returns(T::Boolean) }
-  def self.isjis(str); end
+  module_function def isjis(str); end
 
   # Returns whether input encoding is Shift\_JIS or not.
   sig { params(str: String).returns(T::Boolean) }
-  def self.issjis(str); end
+  module_function def issjis(str); end
 
   # Returns whether input encoding is UTF-8 or not.
   sig { params(str: String).returns(T::Boolean) }
-  def self.isutf8(str); end
+  module_function def isutf8(str); end
 
   # Convert `str` to `to_enc`. `to_enc` and `from_enc` are given as constants of
   # [`Kconv`](https://docs.ruby-lang.org/en/2.6.0/Kconv.html) or
   # [`Encoding`](https://docs.ruby-lang.org/en/2.6.0/Encoding.html) objects.
   sig { params(str: String, to_enc: Encoding, from_enc: Encoding).returns(String) }
-  def self.kconv(str, to_enc, from_enc = to_enc); end
+  module_function def kconv(str, to_enc, from_enc = to_enc); end
 
   # Convert `str` to EUC-JP
   sig { params(str: String).returns(String) }
-  def self.toeuc(str); end
+  module_function def toeuc(str); end
 
   # Convert `str` to ISO-2022-JP
   sig { params(str: String).returns(String) }
-  def self.tojis(str); end
+  module_function def tojis(str); end
 
   # Convert `self` to locale encoding
   sig { params(str: String).returns(String) }
-  def self.tolocale(str); end
+  module_function def tolocale(str); end
 
   # Convert `str` to Shift\_JIS
   sig { params(str: String).returns(String) }
-  def self.tosjis(str); end
+  module_function def tosjis(str); end
 
   # Convert `str` to UTF-16
   sig { params(str: String).returns(String) }
-  def self.toutf16(str); end
+  module_function def toutf16(str); end
 
   # Convert `str` to UTF-32
   sig { params(str: String).returns(String) }
-  def self.toutf32(str); end
+  module_function def toutf32(str); end
 
   # Convert `str` to UTF-8
   sig { params(str: String).returns(String) }
-  def self.toutf8(str); end
+  module_function def toutf8(str); end
 end

--- a/rbi/stdlib/open3.rbi
+++ b/rbi/stdlib/open3.rbi
@@ -103,7 +103,7 @@ module Open3
       block: T.nilable(T.proc.params(stdin: IO, stdout: IO, stderr: IO, wait_thr: Process::Waiter).void)
     ).returns([IO, IO, IO, Process::Waiter])
   end
-  def self.popen3(*cmd, **opts, &block); end
+  module_function def popen3(*cmd, **opts, &block); end
 
   # [`Open3.popen2`](https://docs.ruby-lang.org/en/2.6.0/Open3.html#method-c-popen2)
   # is similar to
@@ -161,7 +161,7 @@ module Open3
       block: T.nilable(T.proc.params(stdin: IO, stdout: IO, wait_thr: Process::Waiter).void)
     ).returns([IO, IO, Process::Waiter])
   end
-  def self.popen2(*cmd, **opts, &block); end
+  module_function def popen2(*cmd, **opts, &block); end
 
   # [`Open3.popen2e`](https://docs.ruby-lang.org/en/2.6.0/Open3.html#method-c-popen2e)
   # is similar to
@@ -212,7 +212,7 @@ module Open3
       block: T.nilable(T.proc.params(stdin: IO, stdout_and_stderr: IO, wait_thr: Process::Waiter).void)
     ).returns([IO, IO, Process::Waiter])
   end
-  def self.popen2e(*cmd, **opts, &block); end
+  module_function def popen2e(*cmd, **opts, &block); end
 
   # [`Open3.capture3`](https://docs.ruby-lang.org/en/2.6.0/Open3.html#method-c-capture3)
   # captures the standard output and the standard error of a command.
@@ -268,7 +268,7 @@ module Open3
       opts: T::Hash[Symbol, T.untyped]
     ).returns([String, String, Process::Status])
   end
-  def self.capture3(*cmd, stdin_data: '', binmode: false, **opts); end
+  module_function def capture3(*cmd, stdin_data: '', binmode: false, **opts); end
 
   # [`Open3.capture2`](https://docs.ruby-lang.org/en/2.6.0/Open3.html#method-c-capture2)
   # captures the standard output of a command.
@@ -314,7 +314,7 @@ module Open3
       opts: T::Hash[Symbol, T.untyped]
     ).returns([String, Process::Status])
   end
-  def self.capture2(*cmd, stdin_data: nil, binmode: false, **opts); end
+  module_function def capture2(*cmd, stdin_data: nil, binmode: false, **opts); end
 
   # [`Open3.capture2e`](https://docs.ruby-lang.org/en/2.6.0/Open3.html#method-c-capture2e)
   # captures the standard output and the standard error of a command.
@@ -347,7 +347,7 @@ module Open3
       opts: T::Hash[Symbol, T.untyped]
     ).returns([String, Process::Status])
   end
-  def self.capture2e(*cmd, stdin_data: nil, binmode: false, **opts); end
+  module_function def capture2e(*cmd, stdin_data: nil, binmode: false, **opts); end
 
   # [`Open3.pipeline_rw`](https://docs.ruby-lang.org/en/2.6.0/Open3.html#method-c-pipeline_rw)
   # starts a list of commands as a pipeline with pipes which connect to stdin of
@@ -407,7 +407,7 @@ module Open3
       block: T.nilable(T.proc.params(first_stdin: IO, last_stdout: IO, wait_threads: T::Array[Process::Waiter]).void)
     ).returns([IO, IO, T::Array[Process::Waiter]])
   end
-  def self.pipeline_rw(*cmds, **opts, &block); end
+  module_function def pipeline_rw(*cmds, **opts, &block); end
 
   # [`Open3.pipeline_r`](https://docs.ruby-lang.org/en/2.6.0/Open3.html#method-c-pipeline_r)
   # starts a list of commands as a pipeline with a pipe which connects to stdout
@@ -461,7 +461,7 @@ module Open3
       block: T.nilable(T.proc.params(last_stdout: IO, wait_threads: T::Array[Process::Waiter]).void)
     ).returns([IO, T::Array[Process::Waiter]])
   end
-  def self.pipeline_r(*cmds, **opts, &block); end
+  module_function def pipeline_r(*cmds, **opts, &block); end
 
   # [`Open3.pipeline_w`](https://docs.ruby-lang.org/en/2.6.0/Open3.html#method-c-pipeline_w)
   # starts a list of commands as a pipeline with a pipe which connects to stdin
@@ -505,7 +505,7 @@ module Open3
       block: T.nilable(T.proc.params(first_stdin: IO, wait_threads: T::Array[Process::Waiter]).void)
     ).returns([IO, T::Array[Process::Waiter]])
   end
-  def self.pipeline_w(*cmds, **opts, &block); end
+  module_function def pipeline_w(*cmds, **opts, &block); end
 
   # [`Open3.pipeline_start`](https://docs.ruby-lang.org/en/2.6.0/Open3.html#method-c-pipeline_start)
   # starts a list of commands as a pipeline. No pipes are created for stdin of
@@ -564,7 +564,7 @@ module Open3
       block: T.nilable(T.proc.params(wait_threads: T::Array[Process::Waiter]).void)
     ).returns(T::Array[Process::Waiter])
   end
-  def self.pipeline_start(*cmds, **opts, &block); end
+  module_function def pipeline_start(*cmds, **opts, &block); end
 
   # [`Open3.pipeline`](https://docs.ruby-lang.org/en/2.6.0/Open3.html#method-c-pipeline)
   # starts a list of commands as a pipeline. It waits for the completion of the
@@ -630,5 +630,5 @@ module Open3
       opts: T::Hash[Symbol, T.untyped]
     ).returns(T::Array[Process::Status])
   end
-  def self.pipeline(*cmds, **opts); end
+  module_function def pipeline(*cmds, **opts); end
 end

--- a/rbi/stdlib/shellwords.rbi
+++ b/rbi/stdlib/shellwords.rbi
@@ -133,7 +133,7 @@ module Shellwords
   # Also aliased as:
   # [`escape`](https://docs.ruby-lang.org/en/2.6.0/Shellwords.html#method-c-escape)
   sig { params(str: String).returns(String) }
-  def self.shellescape(str); end
+  module_function def shellescape(str); end
   
   # Builds a command line string from an argument list, `array`.
   #
@@ -167,7 +167,7 @@ module Shellwords
   # Also aliased as:
   # [`join`](https://docs.ruby-lang.org/en/2.6.0/Shellwords.html#method-c-join)
   sig { params(str: T::Array[String]).returns(String) }
-  def self.shelljoin(str); end
+  module_function def shelljoin(str); end
 
   # Splits a string into an array of tokens in the same way the UNIX Bourne
   # shell does.
@@ -200,12 +200,12 @@ module Shellwords
   # [`shellwords`](https://docs.ruby-lang.org/en/2.6.0/Shellwords.html#method-c-shellwords),
   # [`split`](https://docs.ruby-lang.org/en/2.6.0/Shellwords.html#method-c-split)
   sig { params(str: String).returns(T::Array[String]) }
-  def self.shellsplit(str); end
+  module_function def shellsplit(str); end
 
   # Alias for:
   # [`shellsplit`](https://docs.ruby-lang.org/en/2.6.0/Shellwords.html#method-i-shellsplit)
   sig { params(str: String).returns(T::Array[String]) }
-  def self.shellwords(str); end
+  module_function def shellwords(str); end
 
   # Alias for:
   # [`shellsplit`](https://docs.ruby-lang.org/en/2.6.0/Shellwords.html#method-c-shellsplit)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR marks the following as `module_function`:
- `Find::find` and `Find::prune` - https://github.com/ruby/ruby/blob/v2_6_0/lib/find.rb#L87
- `Kconv` methods - https://github.com/ruby/ruby/blob/v2_6_0/ext/nkf/lib/kconv.rb
- `Open3` methods
- Some `Shellwords` methods
- Some `Drb` methods

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

<!-- This allows `include Find` / `include Kconv` / `include Open3` --> Parity with Ruby standard library

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

None
