### PR TITLE
Define sigs in a stable order.

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2873,7 +2873,7 @@ ast::ParsedFilesOrCancelled Resolver::resolveSigs(core::GlobalState &gs, vector<
             if (result.gotItem()) {
                 core::Context ctx(gs, core::Symbols::root(), job.file);
                 job.tree = ast::ShallowMap::apply(ctx, walk, std::move(job.tree));
-                if (!walk.multiSignatureJobs.empty() || !walk.multiSignatureJobs.empty()) {
+                if (!walk.signatureJobs.empty() || !walk.multiSignatureJobs.empty()) {
                     output.fileSigs.emplace_back(ResolveSignaturesWalk::ResolveFileSignatures{
                         job.file, move(walk.signatureJobs), move(walk.multiSignatureJobs)});
                 }

--- a/test/cli/sig-definition-flakiness/dsl.rbi
+++ b/test/cli/sig-definition-flakiness/dsl.rbi
@@ -1,0 +1,8 @@
+# typed: true
+
+module Test
+  sig { returns(String) } # conflicts with shims.rbi
+  def foo
+  end
+end
+

--- a/test/cli/sig-definition-flakiness/shims.rbi
+++ b/test/cli/sig-definition-flakiness/shims.rbi
@@ -1,0 +1,8 @@
+# typed: true
+
+module Test
+  sig { returns(Integer) } # conflicts with dsl.rbi
+  def foo
+  end
+end
+

--- a/test/cli/sig-definition-flakiness/sig-definition-flakiness.out
+++ b/test/cli/sig-definition-flakiness/sig-definition-flakiness.out
@@ -1,0 +1,1 @@
+No errors! Great job.

--- a/test/cli/sig-definition-flakiness/sig-definition-flakiness.sh
+++ b/test/cli/sig-definition-flakiness/sig-definition-flakiness.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+exec 2>&1
+
+# Will flakily fail if sigs are not defined in a deterministic order.
+main/sorbet --silence-dev-message test/cli/sig-definition-flakiness/*.rbi test/cli/sig-definition-flakiness/test.rb
+

--- a/test/cli/sig-definition-flakiness/test.rb
+++ b/test/cli/sig-definition-flakiness/test.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+module Test
+  def foo
+    42
+  end
+end 
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

WIP: Define sigs in a stable order.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes nondeterminism when two RBI files define conflicting sigs for the same method (the last sig wins). Shopify reported this bug.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I tried to conjure up a flaky test but couldn't.

Tested in Stripe's codebase; no measurable speed regression.
