### PR TITLE
Ignore vendor/bundle in default config

### DIFF
--- a/gems/sorbet/lib/create-config.rb
+++ b/gems/sorbet/lib/create-config.rb
@@ -24,8 +24,7 @@ class Sorbet::Private::CreateConfig
     File.open(SORBET_CONFIG_FILE, 'w') do |f|
       f.puts('--dir')
       f.puts('.')
-      f.puts('--ignore')
-      f.puts('vendor/bundle')
+      f.puts('--ignore=/vendor/bundle')
     end
   end
 

--- a/gems/sorbet/lib/create-config.rb
+++ b/gems/sorbet/lib/create-config.rb
@@ -24,6 +24,8 @@ class Sorbet::Private::CreateConfig
     File.open(SORBET_CONFIG_FILE, 'w') do |f|
       f.puts('--dir')
       f.puts('.')
+      f.puts('--ignore')
+      f.puts('vendor/bundle')
     end
   end
 

--- a/gems/sorbet/test/snapshot/partial/bad-hash/expected/sorbet/config
+++ b/gems/sorbet/test/snapshot/partial/bad-hash/expected/sorbet/config
@@ -1,4 +1,3 @@
 --dir
 .
---ignore
-vendor/bundle
+--ignore=/vendor/bundle

--- a/gems/sorbet/test/snapshot/partial/bad-hash/expected/sorbet/config
+++ b/gems/sorbet/test/snapshot/partial/bad-hash/expected/sorbet/config
@@ -1,2 +1,4 @@
 --dir
 .
+--ignore
+vendor/bundle

--- a/gems/sorbet/test/snapshot/partial/bad_gem/expected/sorbet/config
+++ b/gems/sorbet/test/snapshot/partial/bad_gem/expected/sorbet/config
@@ -1,4 +1,3 @@
 --dir
 .
---ignore
-vendor/bundle
+--ignore=/vendor/bundle

--- a/gems/sorbet/test/snapshot/partial/bad_gem/expected/sorbet/config
+++ b/gems/sorbet/test/snapshot/partial/bad_gem/expected/sorbet/config
@@ -1,2 +1,4 @@
 --dir
 .
+--ignore
+vendor/bundle

--- a/gems/sorbet/test/snapshot/partial/create-config/expected/sorbet/config
+++ b/gems/sorbet/test/snapshot/partial/create-config/expected/sorbet/config
@@ -1,4 +1,3 @@
 --dir
 .
---ignore
-vendor/bundle
+--ignore=/vendor/bundle

--- a/gems/sorbet/test/snapshot/partial/create-config/expected/sorbet/config
+++ b/gems/sorbet/test/snapshot/partial/create-config/expected/sorbet/config
@@ -1,2 +1,4 @@
 --dir
 .
+--ignore
+vendor/bundle

--- a/gems/sorbet/test/snapshot/partial/non-utf-8-file/expected/sorbet/config
+++ b/gems/sorbet/test/snapshot/partial/non-utf-8-file/expected/sorbet/config
@@ -1,4 +1,3 @@
 --dir
 .
---ignore
-vendor/bundle
+--ignore=/vendor/bundle

--- a/gems/sorbet/test/snapshot/partial/non-utf-8-file/expected/sorbet/config
+++ b/gems/sorbet/test/snapshot/partial/non-utf-8-file/expected/sorbet/config
@@ -1,2 +1,4 @@
 --dir
 .
+--ignore
+vendor/bundle

--- a/gems/sorbet/test/snapshot/total/empty/expected/sorbet/config
+++ b/gems/sorbet/test/snapshot/total/empty/expected/sorbet/config
@@ -1,4 +1,3 @@
 --dir
 .
---ignore
-vendor/bundle
+--ignore=/vendor/bundle

--- a/gems/sorbet/test/snapshot/total/empty/expected/sorbet/config
+++ b/gems/sorbet/test/snapshot/total/empty/expected/sorbet/config
@@ -1,2 +1,4 @@
 --dir
 .
+--ignore
+vendor/bundle

--- a/gems/sorbet/test/snapshot/total/sorbet-runtime/expected/sorbet/config
+++ b/gems/sorbet/test/snapshot/total/sorbet-runtime/expected/sorbet/config
@@ -1,4 +1,3 @@
 --dir
 .
---ignore
-vendor/bundle
+--ignore=/vendor/bundle

--- a/gems/sorbet/test/snapshot/total/sorbet-runtime/expected/sorbet/config
+++ b/gems/sorbet/test/snapshot/total/sorbet-runtime/expected/sorbet/config
@@ -1,2 +1,4 @@
 --dir
 .
+--ignore
+vendor/bundle

--- a/test/cli/config-file-recursive/sorbet/other-config
+++ b/test/cli/config-file-recursive/sorbet/other-config
@@ -1,4 +1,3 @@
 --dir
 .
---ignore
-vendor/bundle
+--ignore=/vendor/bundle

--- a/test/cli/config-file-recursive/sorbet/other-config
+++ b/test/cli/config-file-recursive/sorbet/other-config
@@ -1,2 +1,4 @@
 --dir
 .
+--ignore
+vendor/bundle

--- a/test/cli/config-file/sorbet/config
+++ b/test/cli/config-file/sorbet/config
@@ -2,3 +2,5 @@
 --typed=true
 --dir
 .
+--ignore
+vendor/bundle

--- a/test/cli/config-file/sorbet/config
+++ b/test/cli/config-file/sorbet/config
@@ -2,5 +2,4 @@
 --typed=true
 --dir
 .
---ignore
-vendor/bundle
+--ignore=/vendor/bundle


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The `vendor/bundle` directory is used by projects that bundle gems for production, and it's generally assumed the code there won't/shouldn't be touched. Thus it's a surprising cause of sorbet failures, when `srb` fails by attempting to typecheck the `vendor` code:

https://github.com/sorbet/sorbet/issues/3884
https://github.com/sorbet/sorbet/issues/2985#issuecomment-663904639 (note the reacji)
https://github.com/sorbet/sorbet/issues/2898
https://github.com/sorbet/sorbet/issues/2110#issuecomment-553822953
https://github.com/sorbet/sorbet/issues/1744
https://github.com/sorbet/sorbet/issues/975#issuecomment-638324635 (might not specifically be a `vendor` issue)
https://github.com/sorbet/sorbet/issues/945#issuecomment-504374837

I propose that sorbet ignores the `vendor/bundle` directory by default, which I've attempted to implement in this PR.

(Note that I've used `vendor/bundle`, to be consistent with what github [puts](https://github.com/github/gitignore/blob/master/Ruby.gitignore#L43) in the `.gitignore` of Ruby projects by default, but `vendor` is probably fine.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Updated existing tests. (It might be a good idea to have an e2e test that bundles some gems and does a srb init, but i'd need some hand-holding to figure out how to write it.)

I've also confirmed it works in an [existing](https://github.com/dduugg/yard-sorbet/blob/f219c08/sorbet/config#L7) project.
