### PR TITLE
Push entries to the visbility stack for blocks as well

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -452,6 +452,16 @@ public:
         return tree;
     }
 
+    ast::TreePtr preTransformBlock(core::Context ctx, ast::TreePtr block) {
+        methodVisiStack.emplace_back(nullopt);
+        return block;
+    }
+
+    ast::TreePtr postTransformBlock(core::Context ctx, ast::TreePtr block) {
+        methodVisiStack.pop_back();
+        return block;
+    }
+
     ast::TreePtr preTransformMethodDef(core::Context ctx, ast::TreePtr tree) {
         auto &method = ast::cast_tree_nonnull<ast::MethodDef>(tree);
         FoundMethod foundMethod;

--- a/test/testdata/namer/private_inside_block.rb
+++ b/test/testdata/namer/private_inside_block.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+class Foo
+  def self.foo(&blk); end
+
+  foo do
+    private
+
+    def bar; end
+  end
+
+  def baz; end
+end
+
+Foo.new.baz


### PR DESCRIPTION
This PR adds `preTransformBlock` to the `SymbolFinder` class in `namer.cc` so that entries can be pushed to the visibility stack for blocks.

I feel like the fix shouldn't be this simple, but it seemingly works

### Motivation

https://github.com/sorbet/sorbet/issues/3872

### Test plan

```rb
# typed: true

class Foo
  def self.foo(&blk); end

  foo do
    private

    def bar; end
  end

  def baz; end
end

Foo.new.baz # Non-private call to private method baz on Foo https://srb.help/7031
```

Before:

```
foo.rb:15: Non-private call to private method baz on Foo https://srb.help/7031
    15 |Foo.new.baz # Non-private call to private method baz on Foo https://srb.help/7031
        ^^^^^^^^^^^
    foo.rb:12: Defined in Foo here
    12 |  def baz; end
          ^^^^^^^
Errors: 1
```

After:

```
No errors! Great job.
```