### PR TITLE
Don't use a full completion snippet when completing a method with existing args or block

### DIFF
--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -11,15 +11,16 @@ class TypeConstraint;
 class SendResponse final {
 public:
     SendResponse(core::Loc termLoc, std::shared_ptr<core::DispatchResult> dispatchResult, core::NameRef callerSideName,
-                 bool isPrivateOk, core::MethodRef enclosingMethod, core::Loc receiverLoc)
+                 bool isPrivateOk, core::MethodRef enclosingMethod, core::Loc receiverLoc, u2 totalArgs)
         : dispatchResult(std::move(dispatchResult)), callerSideName(callerSideName), termLoc(termLoc),
-          isPrivateOk(isPrivateOk), enclosingMethod(enclosingMethod), receiverLoc(receiverLoc){};
+          isPrivateOk(isPrivateOk), enclosingMethod(enclosingMethod), receiverLoc(receiverLoc), totalArgs(totalArgs){};
     const std::shared_ptr<core::DispatchResult> dispatchResult;
     const core::NameRef callerSideName;
     const core::Loc termLoc;
     const bool isPrivateOk;
     const core::MethodRef enclosingMethod;
     const core::Loc receiverLoc;
+    const u2 totalArgs;
 
     const std::optional<core::Loc> getMethodNameLoc(const core::GlobalState &gs) const;
 };

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -11,7 +11,7 @@ class TypeConstraint;
 class SendResponse final {
 public:
     SendResponse(core::Loc termLoc, std::shared_ptr<core::DispatchResult> dispatchResult, core::NameRef callerSideName,
-                 bool isPrivateOk, core::MethodRef enclosingMethod, core::Loc receiverLoc, u2 totalArgs)
+                 bool isPrivateOk, core::MethodRef enclosingMethod, core::Loc receiverLoc, size_t totalArgs)
         : dispatchResult(std::move(dispatchResult)), callerSideName(callerSideName), termLoc(termLoc),
           isPrivateOk(isPrivateOk), enclosingMethod(enclosingMethod), receiverLoc(receiverLoc), totalArgs(totalArgs){};
     const std::shared_ptr<core::DispatchResult> dispatchResult;
@@ -20,7 +20,7 @@ public:
     const bool isPrivateOk;
     const core::MethodRef enclosingMethod;
     const core::Loc receiverLoc;
-    const u2 totalArgs;
+    const size_t totalArgs;
 
     const std::optional<core::Loc> getMethodNameLoc(const core::GlobalState &gs) const;
 };

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1011,7 +1011,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     core::lsp::QueryResponse::pushQueryResponse(
                         ctx, core::lsp::SendResponse(core::Loc(ctx.file, bind.loc), retainedResult, send->fun,
                                                      send->isPrivateOk, ctx.owner.asMethodRef(),
-                                                     core::Loc(ctx.file, send->receiverLoc)));
+                                                     core::Loc(ctx.file, send->receiverLoc),
+                                                     static_cast<u2>(dispatchArgs.args.size())));
                 }
                 if (send->link) {
                     // This should eventually become ENFORCEs but currently they are wrong

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1011,8 +1011,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     core::lsp::QueryResponse::pushQueryResponse(
                         ctx, core::lsp::SendResponse(core::Loc(ctx.file, bind.loc), retainedResult, send->fun,
                                                      send->isPrivateOk, ctx.owner.asMethodRef(),
-                                                     core::Loc(ctx.file, send->receiverLoc),
-                                                     static_cast<u2>(dispatchArgs.args.size())));
+                                                     core::Loc(ctx.file, send->receiverLoc), send->args.size()));
                 }
                 if (send->link) {
                     // This should eventually become ENFORCEs but currently they are wrong

--- a/main/lsp/requests/completion.h
+++ b/main/lsp/requests/completion.h
@@ -14,10 +14,11 @@ class CompletionTask final : public LSPRequestTask {
                               std::vector<std::unique_ptr<CompletionItem>> &items) const;
 
     std::unique_ptr<CompletionItem> getCompletionItemForMethod(LSPTypecheckerDelegate &typechecker,
+                                                               core::DispatchResult &dispatchResult,
                                                                core::SymbolRef what, const core::TypePtr &receiverType,
                                                                const core::TypeConstraint *constraint,
                                                                core::Loc queryLoc, std::string_view prefix,
-                                                               size_t sortIdx) const;
+                                                               size_t sortIdx, u2 totalArgs) const;
 
 public:
     CompletionTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<CompletionParams> params);

--- a/test/testdata/lsp/completion/sig_already_typed.A.rbedited
+++ b/test/testdata/lsp/completion/sig_already_typed.A.rbedited
@@ -3,9 +3,7 @@
 class A
   extend T::Sig
 
-  sig do
-  ${1}
-end${0} {void}
+  sig${0} {void}
   #  ^ apply-completion: [A] item: 0
   def already_sigged
     42

--- a/test/testdata/lsp/completion/snippet_existing_args.A.rbedited
+++ b/test/testdata/lsp/completion/snippet_existing_args.A.rbedited
@@ -1,0 +1,20 @@
+# typed: true
+
+class Test
+  extend T::Sig
+
+  def test_method_args(foo, bar); end
+
+  sig {params(blk: T.proc.void).void}
+  def test_method_block(&blk); end
+end
+
+Test.new.test_method_args${0}(1, 2) # error: does not exist
+#                     ^ apply-completion: [A] item: 0
+
+Test.new.test_method_b { } # error: does not exist
+#                     ^ apply-completion: [B] item: 0
+
+Test.new.test_method_b do # error: does not exist
+#                     ^ apply-completion: [C] item: 0
+end

--- a/test/testdata/lsp/completion/snippet_existing_args.B.rbedited
+++ b/test/testdata/lsp/completion/snippet_existing_args.B.rbedited
@@ -1,0 +1,20 @@
+# typed: true
+
+class Test
+  extend T::Sig
+
+  def test_method_args(foo, bar); end
+
+  sig {params(blk: T.proc.void).void}
+  def test_method_block(&blk); end
+end
+
+Test.new.test_method_a(1, 2) # error: does not exist
+#                     ^ apply-completion: [A] item: 0
+
+Test.new.test_method_block${0} { } # error: does not exist
+#                     ^ apply-completion: [B] item: 0
+
+Test.new.test_method_b do # error: does not exist
+#                     ^ apply-completion: [C] item: 0
+end

--- a/test/testdata/lsp/completion/snippet_existing_args.C.rbedited
+++ b/test/testdata/lsp/completion/snippet_existing_args.C.rbedited
@@ -1,0 +1,20 @@
+# typed: true
+
+class Test
+  extend T::Sig
+
+  def test_method_args(foo, bar); end
+
+  sig {params(blk: T.proc.void).void}
+  def test_method_block(&blk); end
+end
+
+Test.new.test_method_a(1, 2) # error: does not exist
+#                     ^ apply-completion: [A] item: 0
+
+Test.new.test_method_b { } # error: does not exist
+#                     ^ apply-completion: [B] item: 0
+
+Test.new.test_method_block${0} do # error: does not exist
+#                     ^ apply-completion: [C] item: 0
+end

--- a/test/testdata/lsp/completion/snippet_existing_args.rb
+++ b/test/testdata/lsp/completion/snippet_existing_args.rb
@@ -1,0 +1,20 @@
+# typed: true
+
+class Test
+  extend T::Sig
+
+  def test_method_args(foo, bar); end
+
+  sig {params(blk: T.proc.void).void}
+  def test_method_block(&blk); end
+end
+
+Test.new.test_method_a(1, 2) # error: does not exist
+#                     ^ apply-completion: [A] item: 0
+
+Test.new.test_method_b { } # error: does not exist
+#                     ^ apply-completion: [B] item: 0
+
+Test.new.test_method_b do # error: does not exist
+#                     ^ apply-completion: [C] item: 0
+end


### PR DESCRIPTION
Previously when completing a method name that already had an argument list or a block attached, our snippet would do double duty and re-add a whole new set of them.

With this change we first check that the send site we are completing doesn't already have those specified and in that case simply focus on completing the name.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
When trying to complete the name of an otherwise fully-formed method call, having another set of parameter or block template added ruins the typing flow and causes frustration.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
